### PR TITLE
fish analyzers can also be used to perform fish scanning experiments.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_fish.dm
+++ b/code/__DEFINES/dcs/signals/signals_fish.dm
@@ -31,3 +31,6 @@
 
 /// Sent when the challenge is to be interrupted: (reason)
 #define COMSIG_FISHING_SOURCE_INTERRUPT_CHALLENGE "fishing_spot_interrupt_challenge"
+
+/// From /obj/item/fish_analyzer/proc/analyze_status: (fish, user)
+#define COMSIG_FISH_ANALYZER_ANALYZE_STATUS "fish_analyzer_analyze_status"

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -283,3 +283,9 @@
 	desc = "A less cheap imported climbing hook. Absolutely no use outside of planetary stations."
 	cost = PAYCHECK_CREW * 5
 	contains = list(/obj/item/climbing_hook)
+
+/datum/supply_pack/goody/fish_analyzer
+	name = "Fish Analyzer"
+	desc = "A single analyzer to monitor fish's status and traits with, in case you don't have the technology to print one."
+	cost = CARGO_CRATE_VALUE * 2.5
+	contains = list(/obj/item/fish_analyzer)

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -68,13 +68,6 @@
 	contains = list(/obj/item/storage/fish_case/tiziran = 2)
 	crate_name = "tiziran fish crate"
 
-/datum/supply_pack/misc/fish_analyzers
-	name = "Fish Analyzers"
-	desc = "A pack containing three analyzers to monitor fish's status and traits with."
-	cost = CARGO_CRATE_VALUE * 2.5
-	contains = list(/obj/item/fish_analyzer = 3)
-	crate_name = "fish analyzers crate"
-
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"
 	desc = "Nanotrasen reminds all employees to never toy with powers outside their control."
@@ -221,7 +214,7 @@
 					/obj/item/clothing/under/misc/burial = 2,
 				)
 	crate_name = "religious supplies crate"
-	
+
 /datum/supply_pack/misc/candles_bulk
 	name = "Candle Box Crate"
 	desc = "Keep your local chapel lit with three candle boxes!"

--- a/code/modules/fishing/aquarium/fish_analyzer.dm
+++ b/code/modules/fishing/aquarium/fish_analyzer.dm
@@ -33,6 +33,17 @@
 	case_color = rgb(rand(16, 255), rand(16, 255), rand(16, 255))
 	set_greyscale(colors = list(case_color))
 	. = ..()
+
+	var/static/list/fishe_signals = list(
+		COMSIG_FISH_ANALYZER_ANALYZE_STATUS = TYPE_PROC_REF(/datum/component/experiment_handler, try_run_handheld_experiment),
+	)
+	AddComponent(/datum/component/experiment_handler, \
+		config_mode = EXPERIMENT_CONFIG_ALTCLICK, \
+		allowed_experiments = list(/datum/experiment/scanning/fish), \
+		config_flags = EXPERIMENT_CONFIG_SILENT_FAIL|EXPERIMENT_CONFIG_IMMEDIATE_ACTION, \
+		experiment_signals = fishe_signals, \
+	)
+
 	register_item_context()
 	update_appearance()
 
@@ -41,6 +52,10 @@
 		QDEL_NULL(fish_menu)
 	radial_choices = null
 	return ..()
+
+/obj/item/fish_analyzer/examine(mob/user)
+	. = ..()
+	. += span_notice("<b>Alt-Click</b> to access the Experiment Configuration UI")
 
 /obj/item/fish_analyzer/update_icon_state()
 	. = ..()
@@ -205,6 +220,8 @@
 		render_list += "<span class='info ml-1'>Time until it can breed: [time_left] seconds</span>"
 
 	to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
+
+	SEND_SIGNAL(src, COMSIG_FISH_ANALYZER_ANALYZE_STATUS, fish, user)
 
 /**
  * Called when a fish or a menu choice is left-clicked.


### PR DESCRIPTION
## About The Pull Request
I recently read of someone being confused that they couldn't use them to perform fish-related experiments, so I thought it would be a good idea to add that. Also, I've converted the related misc supply pack to a goodie one, like other fishing supplies.

## Why It's Good For The Game
It makes sense, and a fair amount of players doesn't even know experiments exists until they play the scientist role a couple times.

## Changelog

:cl:
add: Fish analyzers can now be used to perform fish scanning experiments.
balance: They can now be singularly bought as a goodie pack for 125 cr each, instead of a crate of three for 500 cr.
/:cl:
