### PR TITLE
QoL improvements to the mob damage unit tests

### DIFF
--- a/code/modules/unit_tests/mob_damage.dm
+++ b/code/modules/unit_tests/mob_damage.dm
@@ -37,15 +37,47 @@
 	// testing with godmode enabled
 	test_godmode(dummy)
 
+/**
+ * Test whether the adjust damage procs return the correct values and that the mob's health is the expected value afterwards.
+ *
+ * By default this calls apply_damage(amount) followed by verify_damage(amount_after) and returns TRUE if both succeeded.
+ * amount_after defaults to the mob's current stamina loss but can be overridden as needed.
+ *
+ * Arguments:
+ * * testing_mob - the mob to apply the damage to
+ * * amount - the amount of damage to apply to the mob
+ * * expected - what the expected return value of the damage proc is
+ * * amount_after - in case you want to specify what the damage amount on the mob should be afterwards
+ * * included_types - Bitflag of damage types to apply
+ * * biotypes - the biotypes of damage to apply
+ * * bodytypes - the bodytypes of damage to apply
+ * * forced - whether or not this is forced damage
+ */
 /datum/unit_test/mob_damage/proc/test_apply_damage(mob/living/testing_mob, amount, expected = -amount, amount_after, included_types, biotypes, bodytypes, forced)
 	if(isnull(amount_after))
-		amount_after = testing_mob.getStaminaLoss() - expected
+		amount_after = testing_mob.getStaminaLoss() - expected // stamina loss applies to both carbon and basic mobs the same way, so that's why we're using it here
 	if(!apply_damage(testing_mob, amount, expected, included_types, biotypes, bodytypes, forced))
 		return FALSE
 	if(!verify_damage(testing_mob, amount_after, included_types))
 		return FALSE
 	return TRUE
 
+/**
+ * Test whether the set damage procs return the correct values and that the mob's health is the expected value afterwards.
+ *
+ * By default this calls set_damage(amount) followed by verify_damage(amount_after) and returns TRUE if both succeeded.
+ * amount_after defaults to the mob's current stamina loss but can be overridden as needed.
+ *
+ * Arguments:
+ * * testing_mob - the mob to apply the damage to
+ * * amount - the amount of damage to apply to the mob
+ * * expected - what the expected return value of the damage proc is
+ * * amount_after - in case you want to specify what the damage amount on the mob should be afterwards
+ * * included_types - Bitflag of damage types to apply
+ * * biotypes - the biotypes of damage to apply
+ * * bodytypes - the bodytypes of damage to apply
+ * * forced - whether or not this is forced damage
+ */
 /datum/unit_test/mob_damage/proc/test_set_damage(mob/living/testing_mob, amount, expected, amount_after, included_types, biotypes, bodytypes, forced)
 	if(isnull(amount_after))
 		amount_after = testing_mob.getStaminaLoss() - expected

--- a/code/modules/unit_tests/mob_damage.dm
+++ b/code/modules/unit_tests/mob_damage.dm
@@ -297,7 +297,7 @@
 		"heal_overall_damage() should have returned 100, but returned [damage_returned] instead!")
 
 	if(!verify_damage(dummy, 0, included_types = BRUTELOSS|FIRELOSS))
-		TEST_FAIL("heal_overall_damage did not apply its dhealing correctly on the mob!")
+		TEST_FAIL("heal_overall_damage did not apply its healing correctly on the mob!")
 
 ///	Tests damage procs with godmode on
 /datum/unit_test/mob_damage/proc/test_godmode(mob/living/carbon/human/consistent/dummy)
@@ -456,7 +456,7 @@
 	TEST_ASSERT_EQUAL(dummy.getFireLoss(), 10, \
 		"[src] should have 10 burn damage, but has [dummy.getFireLoss()] instead!")
 	TEST_ASSERT_EQUAL(dummy.getToxLoss(), 20, \
-		"[src] should have 2 toxin damage, but has [dummy.getToxLoss()] instead!")
+		"[src] should have 20 toxin damage, but has [dummy.getToxLoss()] instead!")
 
 	// Now heal the remaining 30, overhealing by 5.
 	damage_returned = round(dummy.heal_ordered_damage(35, list(BRUTE, BURN, TOX)), 1)

--- a/code/modules/unit_tests/mob_damage.dm
+++ b/code/modules/unit_tests/mob_damage.dm
@@ -210,7 +210,7 @@
 
 	// Apply 15 damage and heal 3
 	if(!test_apply_damage(dummy, amount = 15))
-		TEST_FAIL("ABOVE FAILURE: failed test_sanity_simple! healing was not applied correctly")
+		TEST_FAIL("ABOVE FAILURE: failed test_sanity_simple! damage was not applied correctly")
 
 	if(!test_apply_damage(dummy, amount = -3))
 		TEST_FAIL("ABOVE FAILURE: failed test_sanity_simple! underhealing was not applied correctly")


### PR DESCRIPTION
## About The Pull Request

This is something that I meant to do because it was a minor annoyance as I was creating the tests but I never got around to it.

Because many of the failures occurred in procs it could be difficult to pinpoint the exact line of the test where they were failing. It would just be the line within the proc, and not the line where the proc was called. So you'd have to sort of infer which one it was from the values of `x` and `y` in `Expected x to be equal to y`.

Now each test failure will have a brief description and a line number where `apply_damage()` / `verify_damage()` actually got called to make it clearer. Like shown below.

![Code_r6N3XSAb3m](https://github.com/tgstation/tgstation/assets/13398309/92ac5a91-3c3f-4b3b-90de-09fe0d9891f1)

## Why It's Good For The Game

Just a small QoL update for coders. Some typos fixed, too. 

## Changelog

Nothing player facing though.