### PR TITLE
replaces the engineering outpost on icemoon with a new ruin, unlucky engineer.

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -195,7 +195,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "co" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/ruin/unlucky_engineer/turbine)
 "cs" = (
@@ -382,11 +382,11 @@
 /area/ruin/unlucky_engineer/maints)
 "dZ" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible,
-/obj/machinery/portable_atmospherics/canister,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "ec" = (
@@ -595,6 +595,7 @@
 "hn" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/unlucky_engineer/smes)
 "hr" = (
@@ -812,10 +813,10 @@
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/ce)
 "kl" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "kq" = (
@@ -1395,7 +1396,7 @@
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "sF" = (
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/ruin/unlucky_engineer/turbine)
 "sO" = (
@@ -2427,7 +2428,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Jm" = (
-/obj/machinery/atmospherics/miner/plasma,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
 /area/ruin/unlucky_engineer/turbine)
 "Jn" = (
@@ -3376,6 +3377,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/unlucky_engineer/turbine)
+"XY" = (
+/obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
+/turf/open/floor/engine/vacuum,
+/area/ruin/unlucky_engineer/turbine)
 "Yb" = (
 /obj/machinery/atmospherics/components/binary/pump/on/cyan/visible/layer2{
 	dir = 8
@@ -4174,7 +4179,7 @@ WP
 Df
 Ah
 oH
-lS
+XY
 ps
 "}
 (21,1,1) = {"

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -209,11 +209,19 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"cu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/rust,
+/area/ruin/planetengi)
 "cE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/airlock/engineering,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "unlucky_solars"
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "cL" = (
@@ -484,7 +492,6 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "fE" = (
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -510,6 +517,7 @@
 /obj/machinery/duct,
 /obj/structure/mirror/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/iron/freezer,
 /area/ruin/planetengi)
 "gs" = (
@@ -578,6 +586,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/basic/legion_brood/snow,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "hs" = (
@@ -648,7 +657,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/spawner/random/trash/food_packaging,
-/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "iR" = (
@@ -668,12 +676,15 @@
 /area/ruin/planetengi)
 "iY" = (
 /obj/structure/broken_flooring/plating/directional/north,
-/obj/item/shard,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/airlock/engineering,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "unlucky_solars"
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "je" = (
@@ -696,8 +707,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -825,17 +834,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/mob_spawn/corpse/human/plasmaman,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "le" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/corpse/human/assistant,
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/mob/living/basic/legion_brood/snow,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
@@ -883,8 +891,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -1602,18 +1608,11 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "xU" = (
-/obj/structure/sign/warning/xeno_mining/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/utility/hardhat,
-/obj/item/shovel,
-/obj/item/storage/medkit/emergency,
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/closed/wall/rust,
 /area/ruin/planetengi)
 "yr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -1673,11 +1672,12 @@
 /obj/machinery/door/airlock/external/ruin{
 	name = "Turbine Exhaust Chamber Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/mapping_helpers/airlock_note_placer{
 	note_info = "You are expected to build the cooling system for the exhaust yourself."
 	},
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "zi" = (
@@ -2060,6 +2060,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/xeno_mining/directional/north,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Fq" = (
@@ -2390,16 +2391,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/planetengi)
-"KN" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/open/floor/plating,
-/area/ruin/planetengi)
 "KR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/blood,
@@ -2540,13 +2531,19 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
+"OZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/ice,
+/area/ruin/planetengi)
 "Pg" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/reagent_containers/medigel/libital,
 /obj/item/storage/toolbox/emergency,
 /obj/item/modular_computer/pda/clear,
-/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/effect/mob_spawn/corpse/human/assistant{
+	mob_species = /datum/species/human/felinid
+	},
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -2607,6 +2604,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/emcloset,
+/obj/item/storage/medkit/emergency,
+/obj/item/shovel,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/utility/hardhat,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Qe" = (
@@ -2755,15 +2758,14 @@
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Quarters"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Sz" = (
@@ -2772,7 +2774,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/asteroid/wolf,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -2797,7 +2798,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/rust,
 /area/ruin/planetengi)
 "ST" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2997,7 +2998,10 @@
 "VU" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/no_charge,
-/obj/effect/mob_spawn/corpse/human/engineer/mod,
+/obj/effect/mob_spawn/corpse/human/engineer/mod{
+	mob_species = /datum/species/moth;
+	mob_type = /mob/living/carbon/species/moth
+	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
@@ -3044,6 +3048,7 @@
 /obj/structure/cable,
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/item/shard,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Wu" = (
@@ -3235,6 +3240,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/mob/living/simple_animal/hostile/asteroid/wolf,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "YL" = (
@@ -3321,10 +3327,9 @@
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "unlucky_solars"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ZQ" = (
@@ -3658,7 +3663,7 @@ Ae
 Wn
 tp
 SV
-vf
+OZ
 SM
 iY
 Rc
@@ -3720,7 +3725,7 @@ SV
 pO
 SV
 tp
-Ur
+xP
 Qa
 WH
 jW
@@ -3751,7 +3756,7 @@ tp
 zE
 tp
 oc
-vf
+cu
 Fp
 Sz
 FB
@@ -3782,7 +3787,7 @@ pO
 im
 Wn
 Qo
-KN
+ZE
 pF
 Or
 dK
@@ -3813,7 +3818,7 @@ SV
 pO
 tt
 tp
-Ur
+xP
 xU
 cE
 YP
@@ -3844,7 +3849,7 @@ tp
 zE
 SV
 SV
-Ur
+xP
 SK
 LI
 YP

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -132,7 +132,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "bO" = (
 /obj/structure/broken_flooring/side/directional,
@@ -165,7 +165,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "bR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -270,7 +271,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "cV" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main{
@@ -339,7 +340,6 @@
 /turf/closed/mineral/random/snow,
 /area/icemoon/surface/outdoors/nospawn)
 "dO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
 /obj/item/flashlight/flare,
 /obj/item/trash/energybar,
@@ -387,7 +387,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "ec" = (
 /obj/structure/broken_flooring/singular/directional/east,
@@ -406,7 +406,7 @@
 	dir = 1
 	},
 /obj/structure/broken_flooring/side/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "eG" = (
 /obj/structure/table,
@@ -465,7 +465,8 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "fe" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -527,7 +528,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "fX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -538,7 +539,6 @@
 /obj/machinery/duct,
 /obj/structure/mirror/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/iron/freezer,
 /area/ruin/unlucky_engineer/rest)
 "gs" = (
@@ -558,7 +558,8 @@
 "gJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "gO" = (
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -620,7 +621,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "hQ" = (
 /turf/closed/wall/ice,
@@ -665,7 +666,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "iE" = (
 /obj/structure/grille/broken,
@@ -756,7 +757,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "jx" = (
 /obj/effect/decal/cleanable/blood,
@@ -764,7 +765,7 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "jC" = (
 /obj/effect/decal/cleanable/plastic,
@@ -815,7 +816,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "kq" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -850,7 +851,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "kX" = (
 /obj/effect/decal/cleanable/blood/gibs/bubblegum,
@@ -860,7 +861,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/mob_spawn/corpse/human/plasmaman,
+/obj/effect/mob_spawn/corpse/human/plasmaman{
+	name = "Ananke 'Bones' CLXVI"
+	},
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/foyer)
 "le" = (
@@ -980,7 +983,7 @@
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "mT" = (
 /obj/structure/cable,
@@ -1058,7 +1061,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/east,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "nM" = (
 /obj/structure/toilet{
@@ -1100,7 +1103,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "nV" = (
 /turf/open/floor/engine/vacuum,
@@ -1210,16 +1214,17 @@
 /area/ruin/unlucky_engineer/foyer)
 "pI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/east,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "pN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "qb" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -1325,7 +1330,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "rS" = (
 /obj/structure/table,
@@ -1340,7 +1346,7 @@
 /obj/item/reagent_containers/medigel/aiuri{
 	pixel_x = 7
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "rW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1353,7 +1359,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "rZ" = (
 /mob/living/basic/legion_brood/snow{
@@ -1371,7 +1378,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "sB" = (
 /obj/structure/broken_flooring,
@@ -1385,7 +1392,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "sF" = (
 /obj/machinery/atmospherics/miner/nitrogen,
@@ -1411,7 +1418,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "tp" = (
 /obj/machinery/power/solar{
@@ -1424,13 +1431,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/south,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "tH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "tY" = (
 /obj/structure/closet/toolcloset,
@@ -1454,13 +1463,20 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
+"uh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
+/area/ruin/unlucky_engineer/turbine)
 "us" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "uD" = (
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_interior,
@@ -1575,7 +1591,7 @@
 "vZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "wa" = (
 /obj/structure/cable,
@@ -1602,7 +1618,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "wm" = (
 /obj/structure/bed{
@@ -1668,7 +1684,7 @@
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "xN" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -1684,7 +1700,8 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "yr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -1781,7 +1798,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "zB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
@@ -1796,7 +1813,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/plating/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "zI" = (
 /turf/closed/wall/ice,
@@ -1910,7 +1927,7 @@
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/end,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Bf" = (
 /obj/machinery/air_sensor{
@@ -1934,6 +1951,9 @@
 /area/ruin/unlucky_engineer/smes)
 "BJ" = (
 /turf/closed/wall,
+/area/ruin/unlucky_engineer/turbine)
+"Cg" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Cs" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -1960,7 +1980,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "CN" = (
 /obj/structure/table,
@@ -1974,7 +1995,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Df" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
@@ -1988,7 +2011,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Dp" = (
 /obj/structure/cable,
@@ -2032,12 +2056,15 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/moth_epi/directional/north,
-/obj/effect/mob_spawn/corpse/human/engineer,
-/obj/item/storage/toolbox/emergency,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/effect/mob_spawn/corpse/human/engineer{
+	mob_species = /datum/species/lizard;
+	name = "Lights-the-Way"
+	},
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/foyer)
 "DI" = (
@@ -2079,7 +2106,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Ea" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2163,13 +2190,14 @@
 "Fr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/greenglow,
-/obj/structure/sign/warning/no_smoking/directional/west,
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/south,
+/obj/structure/broken_flooring/pile/directional/north,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "FB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -2192,7 +2220,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "FX" = (
 /obj/effect/spawner/random/structure/shipping_container,
@@ -2242,12 +2271,14 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/south,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "GK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "GM" = (
 /obj/structure/fence/door/opened{
@@ -2262,7 +2293,7 @@
 	pixel_x = -16
 	},
 /obj/structure/broken_flooring/singular/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "GT" = (
 /obj/structure/chair/office/light{
@@ -2284,7 +2315,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Ho" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2292,7 +2323,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Hv" = (
 /obj/structure/rack,
@@ -2371,12 +2402,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "IP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "IU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2493,7 +2524,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "KY" = (
 /obj/machinery/computer/atmos_control/noreconnect{
@@ -2502,7 +2533,8 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/structure/sign/warning/no_smoking/directional/south,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "KZ" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -2535,6 +2567,14 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"LA" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/effect/mapping_helpers/damaged_window,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/icemoon,
+/area/ruin/unlucky_engineer/ce)
 "LF" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
@@ -2572,7 +2612,8 @@
 /obj/structure/fluff/paper/stack,
 /obj/structure/broken_flooring/plating/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Nq" = (
 /obj/machinery/computer/turbine_computer{
@@ -2581,7 +2622,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Nu" = (
 /obj/effect/decal/cleanable/plastic,
@@ -2637,6 +2678,9 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/unlucky_engineer/foyer)
 "OZ" = (
@@ -2670,7 +2714,8 @@
 "Ps" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "PJ" = (
 /obj/structure/broken_flooring/corner/directional/east,
@@ -2721,6 +2766,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/utility/hardhat,
 /obj/item/tank/internals/emergency_oxygen/engi,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/ruin/unlucky_engineer/foyer)
 "Qe" = (
@@ -2768,7 +2814,8 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Qu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
@@ -2844,7 +2891,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
 /mob/living/basic/mining/legion/snow,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Rr" = (
 /obj/structure/table_frame,
@@ -2969,7 +3017,8 @@
 /obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Uf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2977,7 +3026,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Ur" = (
 /turf/closed/wall/rust,
@@ -3001,7 +3050,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/north,
 /mob/living/basic/mining/basilisk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "UO" = (
 /turf/closed/wall,
@@ -3102,15 +3151,16 @@
 /mob/living/basic/legion_brood/snow{
 	lifetime = 0
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "VD" = (
 /obj/machinery/atmospherics/components/trinary/mixer/layer2{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/broken_flooring/pile/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "VF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3143,7 +3193,8 @@
 	dir = 4
 	},
 /obj/effect/mob_spawn/corpse/human/engineer/mod{
-	mob_species = /datum/species/moth
+	mob_species = /datum/species/moth;
+	name = "Gary Lamp"
 	},
 /turf/open/floor/plating,
 /area/ruin/unlucky_engineer/gear)
@@ -3235,7 +3286,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Xc" = (
 /obj/machinery/air_sensor{
@@ -3249,7 +3301,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Xg" = (
 /obj/structure/closet/emcloset,
@@ -3334,7 +3386,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Yj" = (
 /obj/structure/cable,
@@ -3342,7 +3396,8 @@
 /obj/structure/broken_flooring/singular/directional/north,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Yx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3364,7 +3419,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "YI" = (
 /obj/machinery/air_sensor{
@@ -3421,7 +3476,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "Zl" = (
 /obj/structure/table/reinforced,
@@ -3458,7 +3514,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/turbine)
 "ZB" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -3829,7 +3885,7 @@ gO
 nO
 dO
 Yx
-xh
+LA
 Az
 ps
 HB
@@ -4081,7 +4137,7 @@ CJ
 CN
 rS
 QN
-jW
+Cg
 jW
 lS
 jW
@@ -4168,7 +4224,7 @@ VU
 aL
 lS
 sQ
-tH
+uh
 zH
 Uf
 tH

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -102,6 +102,7 @@
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "bK" = (
@@ -223,6 +224,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "unlucky_solars"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "cL" = (
@@ -288,6 +290,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dw" = (
@@ -317,10 +320,10 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "dN" = (
@@ -458,11 +461,11 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/flare,
 /obj/machinery/firealarm/directional/west,
-/obj/item/reagent_containers/cup/glass/waterbottle/empty,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/turf_decal/weather/snow,
+/obj/item/pizzabox,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "fo" = (
@@ -494,6 +497,7 @@
 /area/ruin/planetengi)
 "fE" = (
 /obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "fW" = (
@@ -580,7 +584,7 @@
 "hn" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "hr" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -651,6 +655,7 @@
 /area/ruin/planetengi)
 "iE" = (
 /obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "iF" = (
@@ -687,6 +692,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "unlucky_solars"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "je" = (
@@ -765,6 +771,7 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/door/airlock/material,
 /obj/item/hatchet,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "jW" = (
@@ -774,7 +781,6 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "kg" = (
@@ -786,6 +792,7 @@
 "kj" = (
 /obj/structure/broken_flooring/side/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "kl" = (
@@ -800,6 +807,9 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/lavaland/surface/outdoors)
+"kw" = (
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "kz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -1485,6 +1495,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "vV" = (
@@ -1568,7 +1579,6 @@
 /obj/structure/table_frame,
 /obj/item/stock_parts/micro_laser,
 /obj/item/storage/toolbox/electrical,
-/obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -1860,6 +1870,7 @@
 "CC" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "CF" = (
@@ -1999,8 +2010,8 @@
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Turbine Generator Access"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Ev" = (
@@ -2066,7 +2077,7 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Fr" = (
@@ -2206,7 +2217,7 @@
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/storage/medkit/fire,
 /obj/item/stock_parts/cell/high/empty,
-/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/reagent_containers/hypospray/medipen/survival,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "HB" = (
@@ -2283,6 +2294,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Jb" = (
@@ -2296,19 +2308,18 @@
 "Jn" = (
 /obj/structure/rack,
 /obj/machinery/status_display/ai/directional/north,
-/obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/item/wrench,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/obj/item/rcl/pre_loaded,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/gps/engineering{
 	gpstag = "CE0"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
 	},
 /obj/item/rcd_ammo/large,
 /turf/open/floor/plating/icemoon,
@@ -2318,13 +2329,14 @@
 /obj/item/reagent_containers/cup/glass/waterbottle/empty,
 /obj/item/stack/ducts/fifty,
 /obj/item/reagent_containers/cup/bucket,
-/obj/effect/spawner/random/trash/janitor_supplies,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
 /obj/item/coffee_cartridge/bootleg,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/item/storage/box/lights/mixed,
+/obj/item/reagent_containers/medigel/libital,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Jz" = (
@@ -2541,13 +2553,12 @@
 "Pg" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/item/reagent_containers/medigel/libital,
-/obj/item/storage/toolbox/emergency,
-/obj/item/modular_computer/pda/clear,
 /obj/effect/mob_spawn/corpse/human/assistant{
 	mob_species = /datum/species/human/felinid
 	},
 /obj/effect/turf_decal/weather/snow,
+/obj/item/modular_computer/pda/clear,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Pi" = (
@@ -2576,6 +2587,7 @@
 /obj/item/stock_parts/capacitor,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "PN" = (
@@ -2802,6 +2814,7 @@
 /area/ruin/planetengi)
 "ST" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "SV" = (
@@ -2917,6 +2930,7 @@
 "Vg" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Vj" = (
@@ -2993,19 +3007,23 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
+"VQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/mapping_helpers/damaged_window,
+/turf/open/floor/plating/icemoon,
+/area/ruin/planetengi)
 "VU" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/no_charge,
-/obj/effect/mob_spawn/corpse/human/engineer/mod{
-	mob_species = /datum/species/moth;
-	mob_type = /mob/living/carbon/species/moth
-	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
+	},
+/obj/effect/mob_spawn/corpse/human/engineer/mod{
+	mob_species = /datum/species/moth
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -3016,6 +3034,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Wi" = (
@@ -3263,6 +3282,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/broken_flooring/side/directional/north,
+/obj/item/pen/survival,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Zg" = (
@@ -3288,6 +3308,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Zn" = (
@@ -3295,6 +3316,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/weather/snow,
+/obj/item/flashlight/flare,
 /turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Zu" = (
@@ -3328,6 +3350,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "unlucky_solars"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ZQ" = (
@@ -3344,7 +3367,7 @@
 /area/ruin/planetengi)
 
 (1,1,1) = {"
-qt
+kw
 qt
 qt
 qt
@@ -3361,7 +3384,7 @@ aF
 Gl
 dN
 dN
-hs
+Rn
 dN
 dN
 hs
@@ -3392,9 +3415,9 @@ Gl
 hs
 hs
 Gl
-Jb
-dN
 hs
+dN
+Jb
 hs
 aF
 Gl
@@ -3595,10 +3618,10 @@ qt
 hs
 Qo
 xP
-xP
+VQ
 vf
 hu
-vf
+VQ
 Ur
 Qy
 YJ
@@ -3876,7 +3899,7 @@ Qo
 Ur
 Rc
 CC
-Ur
+VQ
 hn
 YP
 YP

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -31,7 +31,7 @@
 "aF" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "aH" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/structure/broken_flooring/singular/directional/south,
@@ -59,6 +59,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron,
 /area/ruin/unlucky_engineer/gear)
 "aT" = (
@@ -109,6 +110,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/foyer)
+"bI" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "bK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "lavalandsyndien2";
@@ -184,10 +189,10 @@
 /obj/item/pickaxe/rusted,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "cj" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "co" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
@@ -235,7 +240,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/sign/poster/ripped/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "cN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/north,
@@ -259,7 +264,7 @@
 "cP" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "cU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/orange/visible{
 	dir = 8
@@ -332,7 +337,7 @@
 /area/ruin/unlucky_engineer/foyer)
 "dN" = (
 /turf/closed/mineral/random/snow,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "dO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -470,8 +475,13 @@
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/turf_decal/weather/snow,
-/obj/item/pizzabox,
-/obj/item/reagent_containers/cup/glass/waterbottle/empty,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/item/trash/flare,
+/obj/item/pen/survival,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "fo" = (
@@ -544,7 +554,7 @@
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "gJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -566,27 +576,21 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/simple_animal/hostile/asteroid/wolf,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "hg" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/dorms{
-	dir = 4
-	},
-/obj/item/pillow/random,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/corpse/human/assistant,
 /obj/structure/cable,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/digital_clock/directional/north,
+/obj/structure/broken_flooring/pile,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/ready_donk,
+/obj/structure/fireplace,
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "hi" = (
 /obj/structure/flora/rock/pile/style_random,
 /mob/living/basic/mining/legion/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "hn" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -670,10 +674,11 @@
 /area/ruin/unlucky_engineer/rest)
 "iF" = (
 /obj/effect/decal/cleanable/blood,
-/obj/structure/fireplace,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/spawner/random/trash/food_packaging,
+/obj/item/pizzabox,
+/obj/machinery/digital_clock/directional/north,
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "iR" = (
@@ -815,7 +820,7 @@
 "kq" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "kz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -891,6 +896,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unlucky_engineer/maints)
+"lH" = (
+/mob/living/basic/mining/goldgrub,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "lL" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/cobweb,
@@ -929,20 +938,27 @@
 "lP" = (
 /mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "lS" = (
 /turf/closed/wall/r_wall,
 /area/ruin/unlucky_engineer/turbine)
 "lV" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
 /obj/structure/sign/poster/ripped/directional/east,
-/obj/effect/spawner/random/entertainment/deck,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
-/obj/structure/broken_flooring/corner/directional/west,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/pillow/random,
+/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/weather/snow,
+/obj/structure/broken_flooring/side,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "lZ" = (
@@ -1014,23 +1030,28 @@
 /area/ruin/unlucky_engineer/maints)
 "nF" = (
 /obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -7;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/energybar,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/spawner/random/trash/crushed_can{
-	pixel_x = 7;
-	pixel_y = 7
-	},
 /obj/effect/mapping_helpers/apc/no_charge,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /obj/structure/sign/poster/official/pda_ad/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lantern/jade{
+	on = 1;
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/trash/energybar,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 7
+	},
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "nH" = (
@@ -1087,7 +1108,7 @@
 "nW" = (
 /mob/living/basic/mining_drone,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "oc" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/snowed/icemoon,
@@ -1155,15 +1176,15 @@
 /obj/structure/flora/grass/brown/style_random,
 /mob/living/basic/legion_brood/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "ps" = (
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "pB" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/basic/legion_brood/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "pF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/plating/directional/south,
@@ -1219,7 +1240,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "qt" = (
 /turf/open/genturf,
 /area/icemoon/underground/unexplored/rivers)
@@ -1339,7 +1360,7 @@
 	lifetime = 0
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "sA" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/broken_flooring/singular/directional/west,
@@ -1399,10 +1420,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
-"tt" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors)
 "tA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -1429,6 +1446,14 @@
 	},
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/foyer)
+"ue" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/mining,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "us" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -1448,7 +1473,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/statue/snow/snowman,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "uR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -1546,7 +1571,7 @@
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "vZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -1636,7 +1661,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "xu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -1649,7 +1674,7 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "xP" = (
 /turf/closed/wall/ice,
 /area/ruin/unlucky_engineer/maints)
@@ -1702,6 +1727,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/greenglow,
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating/icemoon,
 /area/ruin/unlucky_engineer/foyer)
 "zc" = (
@@ -1841,6 +1867,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unlucky_engineer/foyer)
+"Az" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "AA" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -1909,7 +1939,7 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "CC" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
@@ -1919,7 +1949,7 @@
 "CF" = (
 /obj/structure/fence,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "CJ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -1997,7 +2027,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "DF" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -2014,7 +2044,7 @@
 /obj/structure/flora/rock/pile/style_random,
 /mob/living/simple_animal/hostile/asteroid/wolf,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "DK" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/engine/vacuum,
@@ -2099,15 +2129,12 @@
 "Fb" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/flashlight/lantern/jade{
-	on = 1
-	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/unlucky_engineer/maints)
 "Fj" = (
 /mob/living/basic/mining/legion/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Fp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -2170,7 +2197,7 @@
 "FX" = (
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Gc" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -2189,8 +2216,9 @@
 /area/ruin/unlucky_engineer/foyer)
 "Gl" = (
 /obj/structure/flora/grass/brown/style_random,
+/mob/living/basic/mining/basilisk,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Go" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -2207,7 +2235,7 @@
 "GD" = (
 /obj/structure/flora/tree/dead,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "GG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2226,7 +2254,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "GO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2284,7 +2312,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "HC" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/snowed/icemoon,
@@ -2296,11 +2324,11 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/ready_donk,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/effect/turf_decal/weather/snow,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "HN" = (
@@ -2366,7 +2394,7 @@
 "Jb" = (
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Jm" = (
 /obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
@@ -2425,7 +2453,7 @@
 	dir = 9
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Kc" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -2496,7 +2524,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Lw" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/icemoon,
@@ -2506,7 +2534,7 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "LF" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
@@ -2538,7 +2566,7 @@
 /obj/structure/flora/grass/brown/style_random,
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Ng" = (
 /obj/structure/cable,
 /obj/structure/fluff/paper/stack,
@@ -2576,7 +2604,7 @@
 "NU" = (
 /obj/structure/statue/snow/snowlegion,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Og" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2629,7 +2657,7 @@
 "Pi" = (
 /obj/structure/flora/rock/pile/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
@@ -2726,7 +2754,7 @@
 "Qn" = (
 /mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Qo" = (
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
@@ -2734,7 +2762,7 @@
 "Qp" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Qt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -2810,7 +2838,7 @@
 "Rn" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Rq" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2879,7 +2907,7 @@
 /obj/structure/flora/grass/brown/style_random,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "SK" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/poster/official/safety_internals/directional/north,
@@ -2928,7 +2956,12 @@
 	lifetime = 0
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
+"TH" = (
+/obj/structure/flora/grass/brown/style_random,
+/mob/living/basic/mining/goldgrub,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "TK" = (
 /turf/closed/wall,
 /area/ruin/unlucky_engineer/gear)
@@ -2992,6 +3025,7 @@
 /obj/item/rcd_ammo,
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/ruin/unlucky_engineer/maints)
 "UY" = (
@@ -3238,7 +3272,7 @@
 /obj/structure/flora/rock/pile/style_random,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/nospawn)
 "Xu" = (
 /obj/item/radio/intercom/command/directional/west,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -3250,6 +3284,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/ce)
 "XF" = (
@@ -3372,7 +3407,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/broken_flooring/side/directional/north,
-/obj/item/pen/survival,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/unlucky_engineer/rest)
 "Zg" = (
@@ -3401,6 +3435,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/ce)
+"Zm" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/effect/spawner/random/entertainment/deck,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/icemoon,
+/area/ruin/unlucky_engineer/rest)
 "Zn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -3465,7 +3507,7 @@ qt
 qt
 qt
 dN
-Gl
+Az
 ps
 ps
 ps
@@ -3474,14 +3516,14 @@ ps
 dN
 dN
 aF
-Gl
+Az
 dN
 dN
 Rn
 dN
 dN
 ps
-Gl
+Az
 qt
 qt
 qt
@@ -3495,25 +3537,25 @@ qt
 qt
 aF
 ps
-Gl
+Az
 Pi
 FQ
 jn
 Dv
 FQ
-Gl
+Az
 dN
 ps
-Gl
+Az
 ps
 ps
-Gl
+Az
 ps
 dN
 Jb
 ps
 aF
-Gl
+Az
 qt
 qt
 qt
@@ -3533,13 +3575,13 @@ cN
 Xg
 Dv
 Rn
-Gl
+Az
 ps
 lP
 ps
 dN
 Rn
-Gl
+Az
 ps
 ps
 Pi
@@ -3574,18 +3616,18 @@ JP
 GM
 CF
 Lz
-Gl
+Az
 ps
 Pi
 qt
-Gl
+Az
 qt
 qt
 qt
 "}
 (5,1,1) = {"
 qt
-Gl
+Az
 FQ
 Yy
 eG
@@ -3606,9 +3648,9 @@ uM
 gQ
 xt
 ps
-Gl
+TH
 ps
-Gl
+Az
 Rn
 qt
 qt
@@ -3641,12 +3683,12 @@ ps
 GD
 Jb
 ps
-Gl
+Az
 qt
 qt
 "}
 (7,1,1) = {"
-Gl
+Az
 ps
 FQ
 tY
@@ -3668,7 +3710,7 @@ pB
 cj
 HB
 Rn
-Gl
+Az
 nW
 ps
 ps
@@ -3677,7 +3719,7 @@ qt
 qt
 "}
 (8,1,1) = {"
-Gl
+Az
 gz
 Vg
 VW
@@ -3696,13 +3738,13 @@ zp
 IU
 xh
 cj
-Gl
+Az
 Lv
-Gl
+Az
 ps
 ps
 NU
-Gl
+Az
 qt
 qt
 qt
@@ -3739,7 +3781,7 @@ qt
 qt
 "}
 (10,1,1) = {"
-Gl
+Az
 Qo
 tp
 tp
@@ -3760,11 +3802,11 @@ Wq
 ps
 TA
 qi
-Gl
+Az
 hi
-Gl
+Az
 rZ
-Gl
+Az
 Rn
 qt
 qt
@@ -3788,11 +3830,11 @@ nO
 dO
 Yx
 xh
-Gl
+Az
 ps
 HB
 Jb
-Gl
+Az
 ps
 FX
 ps
@@ -3832,7 +3874,7 @@ qt
 qt
 "}
 (13,1,1) = {"
-Gl
+Az
 Qo
 tp
 SV
@@ -3859,7 +3901,7 @@ ps
 ps
 vW
 ps
-Gl
+Az
 qt
 "}
 (14,1,1) = {"
@@ -3899,7 +3941,7 @@ vN
 Qo
 Wn
 im
-Wn
+ue
 Qo
 ZE
 pF
@@ -3925,12 +3967,12 @@ ps
 dN
 "}
 (16,1,1) = {"
-Gl
+Az
 Qo
 tp
 SV
 Wn
-tt
+SV
 tp
 FQ
 Dv
@@ -3956,12 +3998,12 @@ dN
 dN
 "}
 (17,1,1) = {"
-ps
+bI
 Qo
 oc
 tp
 Qo
-SV
+lH
 SV
 FQ
 SK
@@ -3981,13 +4023,13 @@ aF
 Fj
 ps
 ps
-Gl
+Az
 ps
 dN
 GD
 "}
 (18,1,1) = {"
-Gl
+Az
 Qo
 oT
 HC
@@ -4009,7 +4051,7 @@ Ur
 QN
 QN
 Rn
-Gl
+Az
 ps
 Rn
 ps
@@ -4018,7 +4060,7 @@ Rn
 ps
 "}
 (19,1,1) = {"
-Gl
+Az
 Jb
 zI
 Gc
@@ -4080,7 +4122,7 @@ lS
 ps
 "}
 (21,1,1) = {"
-Gl
+Az
 aF
 oT
 iR
@@ -4108,11 +4150,11 @@ ok
 bl
 Yz
 jW
-Gl
+Az
 "}
 (22,1,1) = {"
 Rn
-Gl
+Az
 zI
 oT
 NA
@@ -4200,7 +4242,7 @@ Nq
 lS
 eT
 jW
-Gl
+Az
 dN
 "}
 (25,1,1) = {"
@@ -4213,7 +4255,7 @@ fe
 zc
 nF
 vb
-Gl
+Az
 lS
 xm
 iW
@@ -4277,7 +4319,7 @@ YS
 iE
 ps
 aF
-Gl
+Az
 Rn
 jW
 jW
@@ -4300,15 +4342,15 @@ dN
 dN
 vb
 hQ
-hQ
+Zm
 lV
 aT
 Pg
 wm
 Rc
-Gl
+Az
 NU
-Gl
+Az
 ps
 aF
 jW
@@ -4325,12 +4367,12 @@ lS
 jW
 jW
 jW
-Gl
+Az
 "}
 (29,1,1) = {"
 qt
 Pi
-Gl
+hQ
 hQ
 vb
 hQ
@@ -4338,7 +4380,7 @@ Rc
 Nu
 hQ
 dN
-Gl
+Az
 Jb
 ps
 ps
@@ -4353,7 +4395,7 @@ Xk
 Jm
 jW
 Jb
-Gl
+Az
 Rn
 dN
 qt
@@ -4364,8 +4406,8 @@ qt
 ps
 ps
 DI
-Gl
-Gl
+Az
+Az
 ps
 ps
 aF
@@ -4406,14 +4448,14 @@ ps
 dN
 Pi
 ps
-Gl
+Az
 ps
 dN
 dN
-Gl
-Gl
+Az
+Az
 dN
-Gl
+Az
 dN
 qt
 qt

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -23,7 +23,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/fluff/paper/stack,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "aF" = (
 /obj/structure/flora/tree/pine/style_random,
@@ -70,7 +70,8 @@
 /obj/item/coffee_cartridge/bootleg,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
+/obj/structure/broken_flooring/side/directional/south,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "aY" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -101,7 +102,7 @@
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "bK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
@@ -130,7 +131,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "bQ" = (
 /obj/effect/turf_decal/stripes/line,
@@ -165,7 +166,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bX" = (
 /obj/structure/bed/maint,
@@ -194,7 +195,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ct" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -247,7 +248,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "cP" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -280,14 +281,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "db" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dw" = (
 /obj/effect/decal/cleanable/blood,
@@ -310,7 +311,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "dK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -334,7 +335,7 @@
 	pixel_x = 7;
 	pixel_y = 7
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "dV" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -384,7 +385,7 @@
 /obj/item/storage/fancy/cigarettes/cigpack_uplift,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "ed" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -411,7 +412,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "eS" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -462,7 +463,7 @@
 /obj/item/reagent_containers/cup/glass/waterbottle/empty,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "fo" = (
 /obj/structure/cable,
@@ -473,7 +474,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "fy" = (
 /obj/structure/table/reinforced,
@@ -489,11 +490,11 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "fE" = (
 /obj/item/stack/sheet/cardboard,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "fW" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible{
@@ -527,7 +528,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "gz" = (
 /obj/effect/decal/cleanable/generic,
@@ -549,7 +550,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "gQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -569,7 +570,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/digital_clock/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "hi" = (
 /obj/structure/flora/rock/pile/style_random,
@@ -578,7 +579,8 @@
 /area/lavaland/surface/outdoors)
 "hn" = (
 /obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "hr" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -587,7 +589,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/legion_brood/snow,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "hs" = (
 /turf/open/misc/asteroid/snow/icemoon,
@@ -596,7 +598,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "hA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -616,7 +618,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/legion_brood/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "ii" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -625,15 +627,14 @@
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "im" = (
-/obj/structure/lattice/catwalk,
 /obj/item/trash/energybar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk/mining,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "iw" = (
 /obj/structure/broken_flooring/pile/directional,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "iz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -649,7 +650,8 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "iE" = (
-/turf/open/floor/plating,
+/obj/structure/grille/broken,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "iF" = (
 /obj/effect/decal/cleanable/blood,
@@ -657,7 +659,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "iR" = (
 /obj/machinery/power/smes,
@@ -666,7 +668,7 @@
 	dir = 5
 	},
 /obj/structure/sign/poster/official/moth_hardhat/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "iW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
@@ -695,13 +697,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "jf" = (
 /obj/structure/broken_flooring/side/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "jn" = (
 /obj/machinery/door/airlock/external{
@@ -722,9 +724,10 @@
 "jr" = (
 /obj/structure/broken_flooring/plating/directional,
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 16
+	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/machinery/holopad,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "ju" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
@@ -745,7 +748,7 @@
 "jC" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "jJ" = (
 /obj/structure/tank_holder/oxygen/yellow,
@@ -754,14 +757,15 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "jU" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/item/hatchet,
-/obj/structure/door_assembly,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/door/airlock/material,
+/obj/item/hatchet,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "jW" = (
 /turf/closed/wall/r_wall/rust,
@@ -776,12 +780,13 @@
 "kg" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "kj" = (
 /obj/structure/broken_flooring/side/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "kl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
@@ -805,7 +810,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "kD" = (
 /obj/effect/decal/cleanable/blood,
@@ -835,7 +840,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/mob_spawn/corpse/human/plasmaman,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "le" = (
 /obj/effect/decal/cleanable/blood,
@@ -845,7 +850,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "lz" = (
 /obj/structure/broken_flooring,
@@ -857,7 +865,7 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "lF" = (
 /obj/structure/broken_flooring/plating/directional/north,
@@ -885,7 +893,7 @@
 	pixel_x = -6;
 	pixel_y = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "lM" = (
 /obj/machinery/door/airlock/external{
@@ -917,8 +925,9 @@
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
+/obj/structure/broken_flooring/corner/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "lZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -965,7 +974,8 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "nv" = (
 /obj/machinery/space_heater,
@@ -975,7 +985,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "nA" = (
 /obj/effect/decal/cleanable/robot_debris/old,
@@ -984,7 +994,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "nF" = (
 /obj/structure/table,
@@ -1004,7 +1014,8 @@
 	dir = 10
 	},
 /obj/structure/sign/poster/official/pda_ad/directional/west,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "nH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1027,7 +1038,7 @@
 /obj/item/pai_card{
 	pixel_x = -6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "nQ" = (
 /obj/structure/table,
@@ -1044,7 +1055,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "nS" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
@@ -1062,7 +1073,7 @@
 /area/lavaland/surface/outdoors)
 "oc" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "ok" = (
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
@@ -1081,7 +1092,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "oH" = (
 /obj/machinery/igniter/incinerator_syndicatelava,
@@ -1112,11 +1123,11 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "pd" = (
-/obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
 /mob/living/basic/legion_brood/snow,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk/mining,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "pg" = (
 /obj/structure/flora/grass/brown/style_random,
@@ -1126,7 +1137,7 @@
 "pB" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/basic/legion_brood/snow,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "pF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1161,11 +1172,6 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
-"pO" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
 "qb" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -1178,7 +1184,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "qi" = (
 /obj/structure/fence/cut/large{
@@ -1206,7 +1212,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "qD" = (
 /obj/structure/table/reinforced,
@@ -1215,7 +1221,7 @@
 	pixel_y = 6
 	},
 /obj/item/paper/crumpled/bloody,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "qW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1224,7 +1230,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "qX" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -1239,13 +1245,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "rD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "rG" = (
 /obj/machinery/light/small/directional/west,
@@ -1255,7 +1261,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "rH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1316,7 +1322,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "sD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
@@ -1336,7 +1342,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "sQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1355,11 +1361,11 @@
 	id = "forestarboard";
 	name = "Fore-Starboard Solar Array"
 	},
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "tt" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "tA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
@@ -1385,7 +1391,7 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "us" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -1429,7 +1435,7 @@
 "vf" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "vg" = (
 /obj/structure/sign/poster/official/wtf_is_co2/directional/north{
@@ -1439,7 +1445,7 @@
 /area/ruin/planetengi)
 "vh" = (
 /obj/machinery/modular_computer/preset/civilian,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "vl" = (
 /obj/structure/grille/broken,
@@ -1449,7 +1455,7 @@
 /obj/structure/broken_flooring/plating/directional,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "vr" = (
 /obj/structure/sign/warning/engine_safety/directional/west,
@@ -1460,7 +1466,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "vM" = (
 /obj/structure/table_frame,
@@ -1479,7 +1485,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "vV" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1489,7 +1495,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "vW" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear,
@@ -1535,7 +1541,8 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/legion_brood/snow,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
+/obj/structure/broken_flooring/singular/directional/south,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "wq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1543,7 +1550,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "wr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1566,12 +1573,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "xh" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/effect/mapping_helpers/damaged_window,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "xm" = (
 /obj/machinery/atmospherics/miner/carbon_dioxide,
@@ -1607,13 +1614,6 @@
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
-"xU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/closed/wall/rust,
-/area/ruin/planetengi)
 "yr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -1622,9 +1622,6 @@
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
-"yF" = (
-/turf/closed/wall/rust,
-/area/lavaland/surface/outdoors)
 "yH" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/broken_flooring/side/directional/east,
@@ -1658,7 +1655,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "zc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1666,7 +1663,8 @@
 /obj/structure/broken_flooring/corner/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "ze" = (
 /obj/machinery/door/airlock/external/ruin{
@@ -1687,7 +1685,7 @@
 /obj/structure/broken_flooring/side/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "zp" = (
 /obj/structure/broken_flooring/pile/directional/south,
@@ -1696,7 +1694,7 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "zA" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -1719,11 +1717,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/planetengi)
-"zE" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
 "zH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1740,14 +1733,16 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/microwave,
-/turf/open/floor/plating,
+/obj/structure/broken_flooring/corner/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "zM" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "zW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -1757,10 +1752,7 @@
 "Ae" = (
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/mining/legion/snow,
-/turf/open/floor/iron/solarpanel,
-/area/lavaland/surface/outdoors)
-"Af" = (
-/turf/closed/wall/ice,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "Ag" = (
 /obj/item/cigbutt/cigarbutt{
@@ -1774,7 +1766,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Ah" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -1805,7 +1797,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/trash/flare,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "AB" = (
 /obj/structure/table_frame,
@@ -1825,7 +1817,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "AZ" = (
 /obj/structure/cable,
@@ -1850,7 +1842,7 @@
 "Bm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Bq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1858,7 +1850,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Cs" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -1867,8 +1859,8 @@
 /area/lavaland/surface/outdoors)
 "CC" = (
 /obj/structure/grille/broken,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/item/shard,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "CF" = (
 /obj/structure/fence,
@@ -1904,11 +1896,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/closed/wall/r_wall,
 /area/ruin/planetengi)
-"Dh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
 "Dl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -1928,7 +1915,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Dz" = (
 /obj/structure/broken_flooring/plating/directional/north,
@@ -1964,7 +1951,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "DI" = (
 /obj/structure/flora/rock/pile/style_random,
@@ -2028,6 +2015,11 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"EE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/icemoon,
+/area/ruin/planetengi)
 "EO" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2038,7 +2030,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/legion_brood/snow,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Fb" = (
 /obj/effect/spawner/random/trash/moisture_trap,
@@ -2116,14 +2108,14 @@
 	dir = 9
 	},
 /obj/machinery/digital_clock/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Gg" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Gl" = (
 /obj/structure/flora/grass/brown/style_random,
@@ -2132,7 +2124,7 @@
 "Go" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Gu" = (
 /obj/structure/cable,
@@ -2181,7 +2173,7 @@
 /obj/structure/broken_flooring/plating/directional/south,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Hk" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -2215,7 +2207,7 @@
 /obj/item/storage/medkit/fire,
 /obj/item/stock_parts/cell/high/empty,
 /obj/item/reagent_containers/hypospray/medipen,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "HB" = (
 /obj/structure/fence{
@@ -2232,7 +2224,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "HN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2242,7 +2234,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "HV" = (
 /obj/machinery/shower/directional/south,
@@ -2284,14 +2276,14 @@
 "IU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "IV" = (
 /obj/machinery/computer/monitor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Jb" = (
 /obj/structure/flora/rock/icy/style_random,
@@ -2319,7 +2311,7 @@
 	dir = 5
 	},
 /obj/item/rcd_ammo/large,
-/turf/open/floor/iron,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Jx" = (
 /obj/effect/spawner/random/trash/box,
@@ -2333,7 +2325,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Jz" = (
 /obj/structure/cable,
@@ -2371,7 +2363,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Ky" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2382,7 +2374,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "KL" = (
 /obj/structure/grille/broken,
@@ -2414,12 +2406,13 @@
 "Lk" = (
 /obj/item/shard,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Lp" = (
 /obj/structure/broken_flooring,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Lv" = (
 /obj/structure/fence/cut/medium{
@@ -2427,6 +2420,10 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/lavaland/surface/outdoors)
+"Lw" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating/icemoon,
+/area/ruin/planetengi)
 "Lz" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -2460,6 +2457,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"MN" = (
+/obj/structure/flora/grass/brown/style_random,
+/mob/living/simple_animal/hostile/asteroid/polarbear,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "Ng" = (
 /obj/structure/cable,
 /obj/structure/fluff/paper/stack,
@@ -2478,7 +2480,8 @@
 /area/ruin/planetengi)
 "Nu" = (
 /obj/effect/decal/cleanable/plastic,
-/turf/open/misc/asteroid/snow/icemoon,
+/obj/structure/grille/broken,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/planetengi)
 "NA" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -2491,7 +2494,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "NU" = (
 /obj/structure/statue/snow/snowlegion,
@@ -2545,7 +2548,7 @@
 	mob_species = /datum/species/human/felinid
 	},
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Pi" = (
 /obj/structure/flora/rock/pile/icy/style_random,
@@ -2558,7 +2561,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Ps" = (
 /obj/structure/cable,
@@ -2573,7 +2576,7 @@
 /obj/item/stock_parts/capacitor,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plating,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "PN" = (
 /obj/structure/closet/crate/engineering,
@@ -2590,11 +2593,10 @@
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "PP" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk/mining,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "Qa" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
@@ -2635,9 +2637,13 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"Qn" = (
+/mob/living/basic/mining/legion/snow,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
 "Qo" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk/mining,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "Qp" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -2664,14 +2670,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "QG" = (
 /obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "QH" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2707,11 +2713,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Rc" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Rn" = (
 /obj/structure/flora/rock/pile/style_random,
@@ -2730,7 +2736,7 @@
 /obj/effect/spawner/random/entertainment/wallet_storage,
 /obj/item/binoculars,
 /obj/item/computer_disk/engineering,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Rw" = (
 /obj/effect/decal/cleanable/ash{
@@ -2743,7 +2749,9 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/plastic,
 /obj/item/trash/flare,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
+/obj/structure/broken_flooring/pile/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "RD" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -2752,7 +2760,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "RJ" = (
 /obj/machinery/door/airlock/command{
@@ -2792,21 +2800,12 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
-"SM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/broken_flooring/side/directional/west,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/closed/wall/rust,
-/area/ruin/planetengi)
 "ST" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "SV" = (
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "Tl" = (
 /obj/structure/cable,
@@ -2833,7 +2832,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "TA" = (
 /mob/living/basic/legion_brood/snow,
@@ -2865,7 +2864,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "UJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -2885,7 +2884,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "US" = (
 /obj/structure/closet/crate/rcd,
@@ -2913,13 +2912,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Vg" = (
 /obj/structure/grille/broken,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Vj" = (
 /obj/structure/broken_flooring/side/directional/north,
@@ -2929,7 +2927,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Vm" = (
 /obj/structure/cable,
@@ -2941,7 +2939,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Vo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2952,7 +2950,7 @@
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Vq" = (
 /obj/structure/cable,
@@ -2993,7 +2991,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "VU" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -3018,7 +3016,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Wi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
@@ -3027,16 +3025,15 @@
 /turf/open/floor/engine/co2,
 /area/ruin/planetengi)
 "Wn" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk/mining,
+/turf/open/floor/plating/snowed/icemoon,
 /area/lavaland/surface/outdoors)
 "Wq" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Ws" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -3049,7 +3046,7 @@
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "Wu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3144,7 +3141,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "XF" = (
 /obj/structure/broken_flooring/singular/directional/east,
@@ -3154,7 +3151,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "XQ" = (
 /obj/effect/spawner/random/entertainment/lighter,
@@ -3162,7 +3159,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /mob/living/basic/mining/basilisk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "XR" = (
 /obj/structure/closet/crate/engineering,
@@ -3207,7 +3204,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Yy" = (
 /obj/structure/fireaxecabinet/empty,
@@ -3241,7 +3238,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /mob/living/simple_animal/hostile/asteroid/wolf,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "YL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3249,7 +3246,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/planetengi)
 "YP" = (
 /turf/closed/wall,
@@ -3265,7 +3262,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/iron,
+/obj/structure/broken_flooring/side/directional/north,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/planetengi)
 "Zg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3273,7 +3271,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -3290,14 +3288,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Zn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Zu" = (
 /obj/effect/decal/cleanable/ash,
@@ -3342,7 +3340,7 @@
 	pixel_x = -4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 
 (1,1,1) = {"
@@ -3453,7 +3451,7 @@ lS
 jW
 Lk
 xh
-qb
+Lw
 jW
 lS
 JP
@@ -3537,7 +3535,7 @@ hs
 xP
 tY
 jf
-vZ
+EE
 yT
 Vo
 hr
@@ -3549,7 +3547,7 @@ AA
 Rr
 ZQ
 IU
-qb
+Lw
 pB
 cj
 HB
@@ -3557,7 +3555,7 @@ Rn
 Gl
 nW
 hs
-NU
+hs
 qt
 qt
 qt
@@ -3573,9 +3571,9 @@ sO
 HN
 XQ
 le
-qb
+Lw
 Zl
-vZ
+EE
 cO
 vh
 zp
@@ -3587,15 +3585,15 @@ Lv
 Gl
 hs
 hs
-hs
+NU
 Gl
 qt
 qt
 qt
 "}
 (9,1,1) = {"
-dN
-zE
+hs
+Qo
 xP
 xP
 vf
@@ -3612,7 +3610,7 @@ qD
 GT
 zM
 kg
-Fj
+Qn
 cj
 DB
 hs
@@ -3626,10 +3624,10 @@ qt
 "}
 (10,1,1) = {"
 Gl
-Dh
+Qo
 tp
 tp
-zE
+Qo
 SV
 SV
 Go
@@ -3643,7 +3641,7 @@ fy
 jC
 kj
 Wq
-cj
+hs
 TA
 qi
 Gl
@@ -3664,9 +3662,9 @@ Wn
 tp
 SV
 OZ
-SM
+Ur
 iY
-Rc
+lS
 Vj
 Bm
 gO
@@ -3675,7 +3673,7 @@ dO
 Yx
 xh
 Gl
-cj
+hs
 HB
 Jb
 Gl
@@ -3689,10 +3687,10 @@ qt
 (12,1,1) = {"
 hs
 pd
-zE
+Qo
 PP
-zE
-pO
+Qo
+Wn
 Wn
 ZE
 Wu
@@ -3719,10 +3717,10 @@ qt
 "}
 (13,1,1) = {"
 Gl
-zE
+Qo
 tp
 SV
-pO
+Wn
 SV
 tp
 xP
@@ -3749,11 +3747,11 @@ Gl
 qt
 "}
 (14,1,1) = {"
-dN
-zE
+hs
+Qo
 SV
 tp
-zE
+Qo
 tp
 oc
 cu
@@ -3780,10 +3778,10 @@ Xo
 qt
 "}
 (15,1,1) = {"
-dN
-zE
+hs
 Qo
-pO
+Qo
+Wn
 im
 Wn
 Qo
@@ -3812,14 +3810,14 @@ dN
 "}
 (16,1,1) = {"
 Gl
-zE
+Qo
 tp
 SV
-pO
+Wn
 tt
 tp
 xP
-xU
+Ur
 cE
 YP
 WL
@@ -3843,10 +3841,10 @@ dN
 "}
 (17,1,1) = {"
 hs
-zE
+Qo
 oc
 tp
-zE
+Qo
 SV
 SV
 xP
@@ -3874,7 +3872,7 @@ GD
 "}
 (18,1,1) = {"
 Gl
-zE
+Qo
 Ur
 Rc
 CC
@@ -4184,8 +4182,8 @@ dN
 "}
 (28,1,1) = {"
 dN
-yF
-Af
+Ur
+xP
 xP
 lV
 aT
@@ -4257,7 +4255,7 @@ hs
 aF
 hs
 GD
-Gl
+MN
 dN
 jW
 jW

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -2,7 +2,7 @@
 "ac" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "al" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13,7 +13,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "ay" = (
 /obj/item/clipboard{
 	pixel_x = 4;
@@ -24,7 +24,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
+"aA" = (
+/turf/closed/wall,
+/area/ruin/unlucky_engineer/maints)
 "aF" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -44,7 +47,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "aL" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/item/paper/guides/jobs/engi/solars,
@@ -55,8 +58,9 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "aT" = (
 /obj/structure/bed{
 	dir = 4
@@ -72,7 +76,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/south,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "aY" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -86,32 +90,32 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "bf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "lavalandsyndieplasma";
 	dir = 8
 	},
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/plasma,
+/area/ruin/unlucky_engineer/turbine)
 "bl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "bF" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "bK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "lavalandsyndien2";
 	dir = 8
 	},
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/n2,
+/area/ruin/unlucky_engineer/turbine)
 "bM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -124,7 +128,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "bO" = (
 /obj/structure/broken_flooring/side/directional,
 /obj/effect/decal/cleanable/dirt,
@@ -133,7 +137,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "bQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airlock_controller/incinerator_syndicatelava{
@@ -157,7 +161,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "bR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toner,
@@ -168,14 +172,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "bX" = (
 /obj/structure/bed/maint,
 /obj/effect/spawner/random/entertainment/drugs,
 /obj/item/reagent_containers/cup/glass/bottle/hooch,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "ch" = (
 /obj/item/pickaxe/rusted,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -187,7 +191,7 @@
 "co" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "cs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -197,7 +201,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "ct" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -210,11 +214,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "cu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "cE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/north,
@@ -226,7 +230,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "cL" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/sign/poster/ripped/directional/north,
@@ -243,7 +247,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "cO" = (
 /obj/structure/broken_flooring/singular/directional,
 /obj/structure/broken_flooring/plating/directional/north,
@@ -251,7 +255,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "cP" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -262,13 +266,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "cV" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main{
 	id = "syndicatelava_mainvent_outer"
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "cW" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
@@ -284,7 +288,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "db" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -292,7 +296,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "dw" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/suit_storage_unit/open,
@@ -300,13 +304,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "dB" = (
 /obj/machinery/duct,
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "dH" = (
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/structure/broken_flooring/corner/directional/south,
@@ -315,7 +319,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "dK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
@@ -325,7 +329,7 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "dN" = (
 /turf/closed/mineral/random/snow,
 /area/lavaland/surface/outdoors)
@@ -339,7 +343,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "dV" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood,
@@ -353,9 +357,11 @@
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "dY" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -368,7 +374,7 @@
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "dZ" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible,
 /obj/machinery/portable_atmospherics/canister,
@@ -377,7 +383,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "ec" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -389,14 +395,14 @@
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "ed" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/structure/broken_flooring/side/directional/west,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "eG" = (
 /obj/structure/table,
 /obj/item/holosign_creator/atmos{
@@ -416,7 +422,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "eS" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -433,13 +439,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "eT" = (
 /obj/machinery/power/turbine/turbine_outlet{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "eX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
@@ -449,13 +455,13 @@
 	target_pressure = 4500
 	},
 /turf/closed/wall/r_wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "fc" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "fe" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/broken_flooring/singular/directional/east,
@@ -467,7 +473,7 @@
 /obj/item/pizzabox,
 /obj/item/reagent_containers/cup/glass/waterbottle/empty,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "fo" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -478,7 +484,7 @@
 	},
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "fy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
@@ -494,12 +500,12 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "fE" = (
 /obj/item/stack/sheet/cardboard,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "fW" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 8
@@ -512,11 +518,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "fX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/r_wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "gh" = (
 /obj/structure/sink/directional/south,
 /obj/machinery/duct,
@@ -524,7 +530,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/bot/medbot,
 /turf/open/floor/iron/freezer,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "gs" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/plastic,
@@ -533,7 +539,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "gz" = (
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/mining/lobstrosity,
@@ -543,7 +549,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "gO" = (
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
 	pixel_x = 7;
@@ -555,7 +561,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "gQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/simple_animal/hostile/asteroid/wolf,
@@ -575,7 +581,7 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "hi" = (
 /obj/structure/flora/rock/pile/style_random,
 /mob/living/basic/mining/legion/snow,
@@ -585,16 +591,18 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "hr" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "hs" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
@@ -603,7 +611,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "hA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -612,7 +620,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
+"hQ" = (
+/turf/closed/wall/ice,
+/area/ruin/unlucky_engineer/rest)
 "hV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -621,25 +632,27 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/generic,
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/space)
 "ii" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "im" = (
 /obj/item/trash/energybar,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "iw" = (
 /obj/structure/broken_flooring/pile/directional,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "iz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -652,12 +665,12 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "iE" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "iF" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/fireplace,
@@ -665,7 +678,7 @@
 /obj/item/radio/intercom/directional/west,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "iR" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -674,13 +687,13 @@
 	},
 /obj/structure/sign/poster/official/moth_hardhat/directional/north,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "iW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	chamber_id = "lavalandsyndieco2"
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "iY" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -694,7 +707,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "je" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/bench/left{
@@ -704,13 +717,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "jf" = (
 /obj/structure/broken_flooring/side/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "jn" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
@@ -726,7 +739,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "jr" = (
 /obj/structure/broken_flooring/plating/directional,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -734,7 +747,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "ju" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -742,7 +755,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "jx" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/bubblegum,
@@ -750,12 +763,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "jC" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "jJ" = (
 /obj/structure/tank_holder/oxygen/yellow,
 /obj/structure/cable,
@@ -764,7 +777,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "jU" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/dirt,
@@ -773,36 +786,35 @@
 /obj/item/hatchet,
 /obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "jW" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "jY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "kg" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "kj" = (
 /obj/structure/broken_flooring/side/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "kl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "kq" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -821,7 +833,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "kD" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -829,7 +841,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "kN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -840,7 +852,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "kX" = (
 /obj/effect/decal/cleanable/blood/gibs/bubblegum,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -851,7 +863,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/mob_spawn/corpse/human/plasmaman,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "le" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/fuel_pool,
@@ -864,7 +876,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "lz" = (
 /obj/structure/broken_flooring,
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -876,7 +888,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "lF" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/structure/broken_flooring/pile/directional/north,
@@ -884,7 +896,7 @@
 	pixel_x = -7
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "lL" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/cobweb,
@@ -904,7 +916,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "lM" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
@@ -919,14 +931,14 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "lP" = (
 /mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "lS" = (
 /turf/closed/wall/r_wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "lV" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -938,7 +950,7 @@
 /obj/structure/broken_flooring/corner/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "lZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -951,7 +963,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "mJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -959,7 +971,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "mT" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -975,7 +987,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "ng" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -986,7 +998,7 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "nv" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -996,7 +1008,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "nA" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/item/flashlight/flare,
@@ -1005,7 +1017,7 @@
 /obj/effect/spawner/random/trash/graffiti,
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "nF" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -1026,20 +1038,20 @@
 /obj/structure/sign/poster/official/pda_ad/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "nH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "nM" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "nO" = (
 /obj/structure/table_frame,
 /obj/item/reagent_containers/medigel/aiuri{
@@ -1049,11 +1061,10 @@
 	pixel_x = -6
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "nQ" = (
 /obj/structure/table,
 /obj/item/crowbar/red,
-/obj/item/clothing/mask/gas/atmos,
 /obj/machinery/recharger{
 	pixel_x = -6;
 	pixel_y = 2
@@ -1065,18 +1076,20 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/item/wrench,
+/obj/item/clothing/mask/gas/atmos,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "nS" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "nV" = (
 /turf/open/floor/engine/vacuum,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "nW" = (
 /mob/living/basic/mining_drone,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -1084,7 +1097,7 @@
 "oc" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "ok" = (
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -1094,7 +1107,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "oG" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -1103,18 +1116,21 @@
 	dir = 4
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "oH" = (
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "oQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/item/trash/flare,
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
+"oT" = (
+/turf/closed/wall/rust,
+/area/ruin/unlucky_engineer/smes)
 "oW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1122,7 +1138,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "oY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/build/directional/north,
@@ -1131,14 +1147,16 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "pd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
-/mob/living/basic/legion_brood/snow,
 /obj/structure/lattice/catwalk/mining,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "pg" = (
 /obj/structure/flora/grass/brown/style_random,
 /mob/living/basic/legion_brood/snow,
@@ -1154,12 +1172,15 @@
 /obj/structure/broken_flooring/plating/directional/south,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/turf_decal/caution,
-/mob/living/basic/legion_brood/snow,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/east,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "pH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1168,24 +1189,24 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "pI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "pN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "qb" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "qg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -1195,7 +1216,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "qi" = (
 /obj/structure/fence/cut/large{
 	dir = 4
@@ -1212,7 +1233,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/broken_flooring/singular/directional/west,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "qB" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
@@ -1223,7 +1244,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "qD" = (
 /obj/structure/table/reinforced,
 /obj/item/radio{
@@ -1232,7 +1253,10 @@
 	},
 /obj/item/paper/crumpled/bloody,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
+"qG" = (
+/turf/closed/wall/rust,
+/area/ruin/unlucky_engineer/gear)
 "qW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -1240,8 +1264,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "qX" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/wirebrush,
@@ -1256,13 +1281,13 @@
 	dir = 5
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "rD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "rG" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -1272,7 +1297,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "rH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -1283,7 +1308,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "rS" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -1295,7 +1320,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "rW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
@@ -1308,13 +1333,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "rZ" = (
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "sA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/broken_flooring/singular/directional/west,
 /obj/effect/decal/cleanable/cobweb{
@@ -1325,7 +1351,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "sB" = (
 /obj/structure/broken_flooring,
 /obj/effect/decal/cleanable/dirt,
@@ -1333,17 +1359,17 @@
 	dir = 4
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "sD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "sF" = (
 /obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/n2,
+/area/ruin/unlucky_engineer/turbine)
 "sO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
@@ -1353,7 +1379,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "sQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -1365,30 +1391,30 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "tp" = (
 /obj/machinery/power/solar{
 	id = "forestarboard";
 	name = "Fore-Starboard Solar Array"
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "tt" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "tA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/south,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "tH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "tY" = (
 /obj/structure/closet/toolcloset,
 /obj/item/pickaxe/emergency,
@@ -1402,7 +1428,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "us" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -1410,14 +1436,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "uD" = (
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_interior,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "uM" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/statue/snow/snowman,
@@ -1431,7 +1457,10 @@
 /obj/structure/broken_flooring/plating/directional/south,
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
+"vb" = (
+/turf/closed/wall/rust,
+/area/ruin/unlucky_engineer/rest)
 "ve" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -1441,22 +1470,22 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "vf" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "vg" = (
 /obj/structure/sign/poster/official/wtf_is_co2/directional/north{
 	dir = 1
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "vh" = (
 /obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "vl" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1466,7 +1495,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "vr" = (
 /obj/structure/sign/warning/engine_safety/directional/west,
 /obj/item/kirbyplants/random/dead,
@@ -1477,7 +1506,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "vM" = (
 /obj/structure/table_frame,
 /obj/structure/closet/mini_fridge/grimy{
@@ -1497,7 +1526,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
+"vN" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/icemoon,
+/area/ruin/unlucky_engineer/solars)
 "vV" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/broken_flooring/plating/directional/south,
@@ -1507,7 +1541,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "vW" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /obj/effect/decal/cleanable/blood,
@@ -1517,7 +1551,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "wa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1534,7 +1568,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "wd" = (
 /obj/structure/sign/warning/fire/directional/east,
 /obj/effect/turf_decal/stripes/line,
@@ -1544,17 +1578,19 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "wm" = (
 /obj/structure/bed{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/legion_brood/snow,
 /obj/structure/broken_flooring/singular/directional/south,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "wq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -1562,7 +1598,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "wr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1572,28 +1608,29 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "ws" = (
 /obj/structure/broken_flooring/side/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
 /obj/item/stock_parts/micro_laser,
-/obj/item/storage/toolbox/electrical,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "xh" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/effect/mapping_helpers/damaged_window,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "xm" = (
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "xt" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -1607,7 +1644,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "xN" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/blood,
@@ -1615,7 +1652,7 @@
 /area/lavaland/surface/outdoors)
 "xP" = (
 /turf/closed/wall/ice,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "xS" = (
 /obj/effect/decal/cleanable/ash{
 	pixel_x = 2;
@@ -1623,7 +1660,7 @@
 	},
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "yr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -1631,7 +1668,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "yH" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/broken_flooring/side/directional/east,
@@ -1647,7 +1684,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "yJ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1658,7 +1695,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "yT" = (
 /obj/structure/broken_flooring/corner/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -1666,7 +1703,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "zc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1675,7 +1712,7 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "ze" = (
 /obj/machinery/door/airlock/external/ruin{
 	name = "Turbine Exhaust Chamber Access"
@@ -1687,7 +1724,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "zi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1696,7 +1733,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "zp" = (
 /obj/structure/broken_flooring/pile/directional/south,
 /obj/item/stamp/head/ce{
@@ -1705,7 +1742,7 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "zA" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -1719,14 +1756,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "zB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 8;
 	chamber_id = "lavalandsyndien2"
 	},
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/n2,
+/area/ruin/unlucky_engineer/turbine)
 "zH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1734,7 +1771,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/plating/directional/north,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
+"zI" = (
+/turf/closed/wall/ice,
+/area/ruin/unlucky_engineer/smes)
 "zL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/blood/hitsplatter{
@@ -1746,24 +1786,24 @@
 /obj/structure/broken_flooring/corner/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "zM" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "zW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Ae" = (
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "Ag" = (
 /obj/item/cigbutt/cigarbutt{
 	pixel_x = 5;
@@ -1777,20 +1817,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Ah" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Ar" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 8;
 	chamber_id = "lavalandsyndieo2"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Aw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1800,7 +1840,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "AA" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -1808,7 +1848,7 @@
 /obj/item/trash/flare,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "AB" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/blood,
@@ -1818,7 +1858,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "AR" = (
 /obj/structure/broken_flooring/side/directional/south,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -1828,7 +1868,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "AZ" = (
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor{
@@ -1841,19 +1881,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/end,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Bf" = (
 /obj/machinery/air_sensor{
 	chamber_id = "lavalandsyndien2"
 	},
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/n2,
+/area/ruin/unlucky_engineer/turbine)
 "Bm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Bq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -1861,7 +1901,10 @@
 	dir = 1
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
+"BJ" = (
+/turf/closed/wall,
+/area/ruin/unlucky_engineer/turbine)
 "Cs" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/structure/flora/grass/brown/style_random,
@@ -1872,7 +1915,7 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "CF" = (
 /obj/structure/fence,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -1888,7 +1931,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "CN" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1902,11 +1945,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Df" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/closed/wall/r_wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Dl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -1916,7 +1959,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Dp" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -1927,7 +1970,10 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
+"Dv" = (
+/turf/closed/wall/rust,
+/area/ruin/unlucky_engineer/foyer)
 "Dz" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -1945,7 +1991,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "DB" = (
 /obj/structure/fence{
 	dir = 4
@@ -1963,7 +2009,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "DI" = (
 /obj/structure/flora/rock/pile/style_random,
 /mob/living/simple_animal/hostile/asteroid/wolf,
@@ -1972,7 +2018,7 @@
 "DK" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/engine/vacuum,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "DT" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1984,7 +2030,7 @@
 /obj/structure/cable,
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "DY" = (
 /obj/structure/table,
 /obj/machinery/status_display/ai/directional/north,
@@ -2004,7 +2050,12 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
+"Ea" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/icemoon,
+/area/ruin/unlucky_engineer/foyer)
 "Ec" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -2013,36 +2064,38 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "Ev" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/sign/poster/official/work_for_a_future/directional/east,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Ey" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "EE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "EO" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "ES" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "Fb" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/decal/cleanable/blood/old,
@@ -2050,7 +2103,7 @@
 	on = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "Fj" = (
 /mob/living/basic/mining/legion/snow,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2065,7 +2118,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/xeno_mining/directional/north,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Fq" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2079,7 +2132,7 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "Fr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/effect/turf_decal/stripes/line,
@@ -2090,7 +2143,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "FB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
@@ -2101,13 +2154,19 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
+"FF" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unlucky_engineer/ce)
+"FQ" = (
+/turf/closed/wall/ice,
+/area/ruin/unlucky_engineer/foyer)
 "FS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "FX" = (
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2120,14 +2179,14 @@
 	},
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "Gg" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Gl" = (
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2136,7 +2195,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Gu" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine/core_rotor{
@@ -2144,7 +2203,7 @@
 	mapping_id = "syndie_lavaland_incineratorturbine"
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "GD" = (
 /obj/structure/flora/tree/dead,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2156,12 +2215,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/south,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "GK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "GM" = (
 /obj/structure/fence/door/opened{
 	dir = 4
@@ -2176,7 +2235,7 @@
 	},
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "GT" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -2185,7 +2244,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Hk" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -2198,7 +2257,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Ho" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -2206,7 +2265,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Hv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -2219,13 +2278,20 @@
 /obj/item/stock_parts/cell/high/empty,
 /obj/item/reagent_containers/hypospray/medipen/survival,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "HB" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
+"HC" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating/snowed/icemoon,
+/area/ruin/unlucky_engineer/smes)
+"HH" = (
+/turf/closed/wall/r_wall,
+/area/ruin/unlucky_engineer/ce)
 "HK" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/cable,
@@ -2236,7 +2302,7 @@
 	},
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "HN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/broken_flooring/singular/directional/north,
@@ -2246,7 +2312,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "HV" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
@@ -2262,7 +2328,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "IG" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 8
@@ -2278,17 +2344,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "IP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "IU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "IV" = (
 /obj/machinery/computer/monitor,
 /obj/effect/turf_decal/stripes/line{
@@ -2296,15 +2362,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "Jb" = (
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "Jm" = (
 /obj/machinery/atmospherics/miner/plasma,
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/plasma,
+/area/ruin/unlucky_engineer/turbine)
 "Jn" = (
 /obj/structure/rack,
 /obj/machinery/status_display/ai/directional/north,
@@ -2323,7 +2389,7 @@
 	},
 /obj/item/rcd_ammo/large,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Jx" = (
 /obj/effect/spawner/random/trash/box,
 /obj/item/reagent_containers/cup/glass/waterbottle/empty,
@@ -2338,7 +2404,7 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/reagent_containers/medigel/libital,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "Jz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2354,7 +2420,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "JP" = (
 /obj/structure/fence/corner{
 	dir = 9
@@ -2366,7 +2432,7 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "Kq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -2376,7 +2442,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "Ky" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2387,21 +2453,21 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "KL" = (
 /obj/structure/grille/broken,
 /obj/item/assembly/mousetrap,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/generic,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "KR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "KY" = (
 /obj/machinery/computer/atmos_control/noreconnect{
 	dir = 1;
@@ -2410,22 +2476,22 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "KZ" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "Lk" = (
 /obj/item/shard,
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Lp" = (
 /obj/structure/broken_flooring,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Lv" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -2435,7 +2501,7 @@
 "Lw" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Lz" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -2445,7 +2511,7 @@
 "LF" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "LI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2457,7 +2523,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Mf" = (
 /obj/item/stack/cable_coil/cut,
 /obj/structure/broken_flooring/side/directional/west,
@@ -2468,7 +2534,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "MN" = (
 /obj/structure/flora/grass/brown/style_random,
 /mob/living/simple_animal/hostile/asteroid/polarbear,
@@ -2480,7 +2546,7 @@
 /obj/structure/broken_flooring/plating/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Nq" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -2489,12 +2555,12 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Nu" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/grille/broken,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "NA" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
@@ -2507,7 +2573,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "NU" = (
 /obj/structure/statue/snow/snowlegion,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2520,7 +2586,7 @@
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "Oh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2531,25 +2597,25 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Om" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Or" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "OZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/ice,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Pg" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -2560,7 +2626,7 @@
 /obj/item/modular_computer/pda/clear,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "Pi" = (
 /obj/structure/flora/rock/pile/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2573,12 +2639,12 @@
 	dir = 10
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Ps" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "PJ" = (
 /obj/structure/broken_flooring/corner/directional/east,
 /obj/structure/cable,
@@ -2589,7 +2655,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "PN" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/storage/toolbox/mechanical,
@@ -2602,14 +2668,18 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "PP" = (
 /obj/structure/cable,
 /obj/structure/fluff/paper/stack,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
+"PS" = (
+/turf/closed/wall,
+/area/ruin/unlucky_engineer/smes)
 "Qa" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -2625,14 +2695,19 @@
 /obj/item/clothing/head/utility/hardhat,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Qe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
+"Qi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/mapping_helpers/damaged_window,
+/turf/open/floor/plating/icemoon,
+/area/ruin/unlucky_engineer/smes)
 "Qj" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Utilities Closet"
@@ -2648,7 +2723,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer)
 "Qn" = (
 /mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -2656,7 +2731,7 @@
 "Qo" = (
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "Qp" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2667,14 +2742,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Qu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 8;
 	chamber_id = "lavalandsyndieplasma"
 	},
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/plasma,
+/area/ruin/unlucky_engineer/turbine)
 "Qy" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -2683,14 +2758,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "QG" = (
 /obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "QH" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -2699,10 +2774,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/broken_flooring/singular/directional/east,
-/obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
+"QN" = (
+/turf/closed/wall/ice,
+/area/ruin/unlucky_engineer/turbine)
 "QR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/cable,
@@ -2715,7 +2792,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "QV" = (
 /obj/item/kirbyplants/random/dead,
 /obj/machinery/airalarm/directional/east,
@@ -2726,11 +2803,11 @@
 	dir = 6
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Rc" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "Rn" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2741,7 +2818,7 @@
 /obj/structure/broken_flooring/corner/directional/south,
 /mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Rr" = (
 /obj/structure/table_frame,
 /obj/structure/broken_flooring/plating/directional/north,
@@ -2749,13 +2826,13 @@
 /obj/item/binoculars,
 /obj/item/computer_disk/engineering,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Rw" = (
 /obj/effect/decal/cleanable/ash{
 	pixel_x = -16
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "RC" = (
 /obj/item/pillow/random,
 /obj/structure/cable,
@@ -2764,7 +2841,7 @@
 /obj/structure/broken_flooring/pile/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "RD" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -2773,7 +2850,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "RJ" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Quarters"
@@ -2787,7 +2864,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Sz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2798,7 +2875,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "SD" = (
 /obj/structure/flora/grass/brown/style_random,
 /obj/effect/decal/cleanable/blood/footprints,
@@ -2811,15 +2888,15 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "ST" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "SV" = (
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "Tl" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/atmos/glass{
@@ -2835,7 +2912,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Tv" = (
 /obj/structure/broken_flooring/side/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -2846,17 +2923,22 @@
 	},
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "TA" = (
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/lavaland/surface/outdoors)
+"TK" = (
+/turf/closed/wall,
+/area/ruin/unlucky_engineer/gear)
 "TQ" = (
 /obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Uf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2864,10 +2946,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Ur" = (
 /turf/closed/wall/rust,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "UH" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
@@ -2878,7 +2960,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "UJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -2888,7 +2970,10 @@
 /obj/structure/broken_flooring/singular/directional/north,
 /mob/living/basic/mining/basilisk,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
+"UO" = (
+/turf/closed/wall,
+/area/ruin/unlucky_engineer/rest)
 "UP" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -2898,7 +2983,7 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "US" = (
 /obj/structure/closet/crate/rcd,
 /obj/effect/decal/cleanable/dirt,
@@ -2909,13 +2994,13 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "UY" = (
 /obj/machinery/power/turbine/inlet_compressor{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Vb" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2926,13 +3011,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "Vg" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Vj" = (
 /obj/structure/broken_flooring/side/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -2942,7 +3027,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Vm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2954,7 +3039,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/smes)
 "Vo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2965,7 +3050,7 @@
 	},
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Vq" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -2977,13 +3062,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
 "VB" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/legion_brood/snow,
+/mob/living/basic/legion_brood/snow{
+	lifetime = 0
+	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "VD" = (
 /obj/machinery/atmospherics/components/trinary/mixer/layer2{
 	dir = 8
@@ -2991,7 +3078,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "VF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3006,12 +3093,12 @@
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "VQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/mapping_helpers/damaged_window,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "VU" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/no_charge,
@@ -3026,7 +3113,10 @@
 	mob_species = /datum/species/moth
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/gear)
+"VV" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unlucky_engineer/foyer)
 "VW" = (
 /obj/structure/broken_flooring/side/directional/north,
 /obj/item/assembly/mousetrap/armed,
@@ -3036,24 +3126,24 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Wi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "lavalandsyndieco2"
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Wn" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/ruin/unlucky_engineer/solars)
 "Wq" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Ws" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -3066,7 +3156,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/item/shard,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Wu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -3075,19 +3165,20 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "WH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "WL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/rust,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/maints)
 "WP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 8
@@ -3096,14 +3187,14 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "WQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "lavalandsyndieo2";
 	dir = 8
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "WX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -3112,21 +3203,21 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Xc" = (
 /obj/machinery/air_sensor{
 	chamber_id = "lavalandsyndieo2"
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Xf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Xg" = (
 /obj/structure/closet/emcloset,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -3136,14 +3227,14 @@
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/end,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Xk" = (
 /obj/machinery/air_sensor{
 	chamber_id = "lavalandsyndieplasma"
 	},
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/engine/o2,
-/area/ruin/planetengi)
+/turf/open/floor/engine/plasma,
+/area/ruin/unlucky_engineer/turbine)
 "Xo" = (
 /obj/structure/flora/rock/pile/style_random,
 /obj/effect/decal/cleanable/blood/footprints,
@@ -3161,7 +3252,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "XF" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -3171,7 +3262,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "XQ" = (
 /obj/effect/spawner/random/entertainment/lighter,
 /obj/effect/decal/cleanable/blood,
@@ -3179,7 +3270,7 @@
 /obj/structure/cable,
 /mob/living/basic/mining/basilisk,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "XR" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/pipe_dispenser,
@@ -3198,7 +3289,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Yb" = (
 /obj/machinery/atmospherics/components/binary/pump/on/cyan/visible/layer2{
 	dir = 8
@@ -3210,7 +3301,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Yj" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -3218,35 +3309,35 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Yx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Yy" = (
 /obj/structure/fireaxecabinet/empty,
 /turf/closed/wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "Yz" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "YF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "YI" = (
 /obj/machinery/air_sensor{
 	id_tag = "lavalandsyndieturbinecool"
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "YJ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3258,7 +3349,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /mob/living/simple_animal/hostile/asteroid/wolf,
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "YL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/coffee,
@@ -3266,10 +3357,10 @@
 	dir = 8
 	},
 /turf/open/floor/plating/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "YP" = (
 /turf/closed/wall,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "YS" = (
 /obj/item/bedsheet/dorms{
 	dir = 4
@@ -3284,7 +3375,7 @@
 /obj/structure/broken_flooring/side/directional/north,
 /obj/item/pen/survival,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "Zg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/pdapainter/engineering,
@@ -3292,13 +3383,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "Zl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
@@ -3310,7 +3401,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
 "Zn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -3318,7 +3409,7 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/item/flashlight/flare,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/rest)
 "Zu" = (
 /obj/effect/decal/cleanable/ash,
 /obj/structure/cable,
@@ -3327,7 +3418,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/turbine)
 "ZB" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3342,7 +3433,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "ZE" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -3352,7 +3443,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/foyer)
 "ZQ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -3364,7 +3455,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/icemoon,
-/area/ruin/planetengi)
+/area/ruin/unlucky_engineer/ce)
+"ZZ" = (
+/turf/closed/wall/ice,
+/area/ruin/unlucky_engineer/gear)
 
 (1,1,1) = {"
 kw
@@ -3404,10 +3498,10 @@ aF
 hs
 Gl
 Pi
-xP
+FQ
 jn
-Ur
-xP
+Dv
+FQ
 Gl
 dN
 hs
@@ -3435,10 +3529,10 @@ hs
 hs
 hs
 aF
-xP
+FQ
 cN
 Xg
-Ur
+Dv
 Rn
 Gl
 hs
@@ -3463,20 +3557,20 @@ qt
 qt
 NU
 GD
-xP
+FQ
 YP
-Ur
-Ur
+Dv
+Dv
 lM
-jW
-jW
-lS
-jW
+VV
+VV
+HH
+FF
 Lk
 xh
 Lw
-jW
-lS
+FF
+HH
 JP
 GM
 CF
@@ -3493,7 +3587,7 @@ qt
 (5,1,1) = {"
 qt
 Gl
-xP
+FQ
 Yy
 eG
 nQ
@@ -3501,14 +3595,14 @@ jJ
 cs
 YL
 Pr
-jW
+FF
 lL
 RD
 UP
 Zg
 Xu
-lS
-jW
+HH
+FF
 uM
 gQ
 xt
@@ -3524,7 +3618,7 @@ qt
 (6,1,1) = {"
 Jb
 hs
-Ur
+Dv
 DF
 XF
 bF
@@ -3532,14 +3626,14 @@ ST
 Gg
 dH
 rD
-jW
+FF
 cW
 Lp
 fE
 iw
 wq
 vr
-jW
+FF
 cL
 xN
 DB
@@ -3555,15 +3649,15 @@ qt
 (7,1,1) = {"
 Gl
 hs
-xP
+FQ
 tY
 jf
-EE
+Ea
 yT
 Vo
 hr
 kX
-lS
+HH
 vM
 ay
 AA
@@ -3617,12 +3711,12 @@ qt
 (9,1,1) = {"
 hs
 Qo
-xP
+FQ
 VQ
 vf
 hu
 VQ
-Ur
+Dv
 Qy
 YJ
 xh
@@ -3685,9 +3779,9 @@ Wn
 tp
 SV
 OZ
-Ur
+Dv
 iY
-lS
+HH
 Vj
 Bm
 gO
@@ -3718,14 +3812,14 @@ Wn
 ZE
 Wu
 oW
-jW
+FF
 Jn
 Hv
 Ky
 AR
 sB
 QV
-lS
+HH
 xP
 Ur
 xP
@@ -3746,17 +3840,17 @@ SV
 Wn
 SV
 tp
-xP
+FQ
 Qa
 WH
-jW
-jW
-jW
+FF
+FF
+FF
 RJ
-lS
+HH
 qb
-jW
-jW
+FF
+FF
 nv
 bX
 qg
@@ -3802,7 +3896,7 @@ qt
 "}
 (15,1,1) = {"
 hs
-Qo
+vN
 Qo
 Wn
 im
@@ -3839,17 +3933,17 @@ SV
 Wn
 tt
 tp
-xP
-Ur
+FQ
+Dv
 cE
-YP
+aA
 WL
 Ur
 DT
-YP
+aA
 jY
 Ur
-YP
+aA
 xP
 xP
 KZ
@@ -3870,10 +3964,10 @@ tp
 Qo
 SV
 SV
-xP
+FQ
 SK
 LI
-YP
+aA
 dV
 qA
 dY
@@ -3896,12 +3990,12 @@ GD
 (18,1,1) = {"
 Gl
 Qo
-Ur
-Rc
+oT
+HC
 CC
-VQ
+Qi
 hn
-YP
+PS
 YP
 Mf
 Ur
@@ -3910,11 +4004,11 @@ Dz
 Ur
 Ur
 Ec
-YP
-YP
+aA
+aA
 Ur
-xP
-xP
+QN
+QN
 Rn
 Gl
 hs
@@ -3927,25 +4021,25 @@ hs
 (19,1,1) = {"
 Gl
 Jb
-xP
+zI
 Gc
 Dp
 ws
 UH
 rG
-YP
+TK
 QR
-YP
+aA
 Fq
-YP
-YP
+aA
+BJ
 DY
 Zu
 zA
 CJ
 CN
 rS
-xP
+QN
 jW
 jW
 lS
@@ -3958,18 +4052,18 @@ Gl
 (20,1,1) = {"
 hs
 hs
-xP
+zI
 IV
 hV
 kz
 vV
 ec
-Ur
+qG
 aH
 ct
 lZ
 PN
-YP
+BJ
 Hk
 nH
 TQ
@@ -3989,7 +4083,7 @@ hs
 (21,1,1) = {"
 Gl
 aF
-Ur
+oT
 iR
 fo
 Kq
@@ -4020,13 +4114,13 @@ Gl
 (22,1,1) = {"
 Rn
 Gl
-xP
-Ur
+zI
+oT
 NA
 Bq
 ES
 PJ
-Ur
+qG
 oY
 dw
 VU
@@ -4050,15 +4144,15 @@ dN
 "}
 (23,1,1) = {"
 dN
-xP
-xP
-xP
+hQ
+hQ
+zI
 qB
 Vb
 oG
 QG
-xP
-xP
+ZZ
+ZZ
 lS
 jW
 jW
@@ -4081,14 +4175,14 @@ dN
 "}
 (24,1,1) = {"
 dN
-xP
+hQ
 HV
-Ur
-YP
-Ur
+vb
+UO
+vb
 al
-Ur
-YP
+vb
+UO
 Jb
 jW
 vg
@@ -4112,14 +4206,14 @@ dN
 "}
 (25,1,1) = {"
 dN
-xP
+hQ
 gh
-Ur
+vb
 iF
 fe
 zc
 nF
-Ur
+vb
 Gl
 lS
 xm
@@ -4143,14 +4237,14 @@ Rn
 "}
 (26,1,1) = {"
 hs
-Ur
+vb
 dB
 jU
 Tv
 Zn
 ng
 zL
-xP
+hQ
 Rn
 jW
 lS
@@ -4174,9 +4268,9 @@ hs
 "}
 (27,1,1) = {"
 dN
-xP
+hQ
 nM
-Ur
+vb
 hg
 HK
 RC
@@ -4205,9 +4299,9 @@ dN
 "}
 (28,1,1) = {"
 dN
-Ur
-xP
-xP
+vb
+hQ
+hQ
 lV
 aT
 Pg
@@ -4238,12 +4332,12 @@ Gl
 qt
 Pi
 Gl
-xP
-Ur
-xP
+hQ
+vb
+hQ
 Rc
 Nu
-xP
+hQ
 dN
 Gl
 Jb

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -31,7 +31,7 @@
 "aF" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "aH" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/structure/broken_flooring/singular/directional/south,
@@ -184,10 +184,10 @@
 /obj/item/pickaxe/rusted,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "cj" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "co" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
@@ -235,7 +235,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/sign/poster/ripped/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "cN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/north,
@@ -259,7 +259,7 @@
 "cP" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "cU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/orange/visible{
 	dir = 8
@@ -332,7 +332,7 @@
 /area/ruin/unlucky_engineer/foyer)
 "dN" = (
 /turf/closed/mineral/random/snow,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "dO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -544,7 +544,7 @@
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "gJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -566,7 +566,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/simple_animal/hostile/asteroid/wolf,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "hg" = (
 /obj/structure/bed{
 	dir = 4
@@ -586,7 +586,7 @@
 /obj/structure/flora/rock/pile/style_random,
 /mob/living/basic/mining/legion/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "hn" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -603,9 +603,6 @@
 	},
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/foyer)
-"hs" = (
-/turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
 "hu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -636,7 +633,7 @@
 	lifetime = 0
 	},
 /turf/open/floor/plating/icemoon,
-/area/space)
+/area/ruin/unlucky_engineer/smes)
 "ii" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -647,7 +644,7 @@
 /obj/item/trash/energybar,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "iw" = (
 /obj/structure/broken_flooring/pile/directional,
 /obj/effect/decal/cleanable/dirt,
@@ -818,10 +815,7 @@
 "kq" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
-"kw" = (
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/unexplored/rivers)
+/area/icemoon/surface/outdoors)
 "kz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -935,7 +929,7 @@
 "lP" = (
 /mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "lS" = (
 /turf/closed/wall/r_wall,
 /area/ruin/unlucky_engineer/turbine)
@@ -1054,11 +1048,11 @@
 /area/ruin/unlucky_engineer/rest)
 "nO" = (
 /obj/structure/table_frame,
-/obj/item/reagent_containers/medigel/aiuri{
-	pixel_x = 7
-	},
 /obj/item/pai_card{
 	pixel_x = -6
+	},
+/obj/item/reagent_containers/medigel/libital{
+	pixel_x = 7
 	},
 /turf/open/floor/iron/icemoon,
 /area/ruin/unlucky_engineer/ce)
@@ -1093,11 +1087,11 @@
 "nW" = (
 /mob/living/basic/mining_drone,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "oc" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "ok" = (
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -1156,17 +1150,20 @@
 	lifetime = 0
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "pg" = (
 /obj/structure/flora/grass/brown/style_random,
 /mob/living/basic/legion_brood/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
+"ps" = (
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "pB" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/basic/legion_brood/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "pF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/plating/directional/south,
@@ -1222,7 +1219,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "qt" = (
 /turf/open/genturf,
 /area/icemoon/underground/unexplored/rivers)
@@ -1319,6 +1316,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
+/obj/item/reagent_containers/medigel/aiuri{
+	pixel_x = 7
+	},
 /turf/open/floor/iron,
 /area/ruin/unlucky_engineer/turbine)
 "rW" = (
@@ -1339,7 +1339,7 @@
 	lifetime = 0
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "sA" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/broken_flooring/singular/directional/west,
@@ -1398,11 +1398,11 @@
 	name = "Fore-Starboard Solar Array"
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "tt" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "tA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -1448,7 +1448,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/statue/snow/snowman,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "uR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -1531,7 +1531,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "vV" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/broken_flooring/plating/directional/south,
@@ -1546,7 +1546,7 @@
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "vZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -1636,7 +1636,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "xu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -1649,7 +1649,7 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "xP" = (
 /turf/closed/wall/ice,
 /area/ruin/unlucky_engineer/maints)
@@ -1803,7 +1803,7 @@
 /obj/effect/decal/cleanable/generic,
 /mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "Ag" = (
 /obj/item/cigbutt/cigarbutt{
 	pixel_x = 5;
@@ -1909,7 +1909,7 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "CC" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
@@ -1919,7 +1919,7 @@
 "CF" = (
 /obj/structure/fence,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "CJ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -1997,7 +1997,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "DF" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -2014,7 +2014,7 @@
 /obj/structure/flora/rock/pile/style_random,
 /mob/living/simple_animal/hostile/asteroid/wolf,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "DK" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/engine/vacuum,
@@ -2107,7 +2107,7 @@
 "Fj" = (
 /mob/living/basic/mining/legion/snow,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Fp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -2170,7 +2170,7 @@
 "FX" = (
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Gc" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -2190,7 +2190,7 @@
 "Gl" = (
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Go" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -2207,7 +2207,7 @@
 "GD" = (
 /obj/structure/flora/tree/dead,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "GG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2226,7 +2226,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "GO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2284,7 +2284,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "HC" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/snowed/icemoon,
@@ -2366,7 +2366,7 @@
 "Jb" = (
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Jm" = (
 /obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
@@ -2402,7 +2402,6 @@
 	dir = 4
 	},
 /obj/item/storage/box/lights/mixed,
-/obj/item/reagent_containers/medigel/libital,
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/unlucky_engineer/maints)
 "Jz" = (
@@ -2426,7 +2425,7 @@
 	dir = 9
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Kc" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -2497,7 +2496,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Lw" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/icemoon,
@@ -2507,7 +2506,7 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "LF" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
@@ -2539,7 +2538,7 @@
 /obj/structure/flora/grass/brown/style_random,
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Ng" = (
 /obj/structure/cable,
 /obj/structure/fluff/paper/stack,
@@ -2577,7 +2576,7 @@
 "NU" = (
 /obj/structure/statue/snow/snowlegion,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Og" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2630,7 +2629,7 @@
 "Pi" = (
 /obj/structure/flora/rock/pile/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
@@ -2676,7 +2675,7 @@
 /obj/structure/fluff/paper/stack,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "PS" = (
 /turf/closed/wall,
 /area/ruin/unlucky_engineer/smes)
@@ -2727,15 +2726,15 @@
 "Qn" = (
 /mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Qo" = (
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "Qp" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Qt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -2811,7 +2810,7 @@
 "Rn" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Rq" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2880,7 +2879,7 @@
 /obj/structure/flora/grass/brown/style_random,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "SK" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/poster/official/safety_internals/directional/north,
@@ -2896,7 +2895,7 @@
 /area/ruin/unlucky_engineer/foyer)
 "SV" = (
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "Tl" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/atmos/glass{
@@ -2929,7 +2928,7 @@
 	lifetime = 0
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "TK" = (
 /turf/closed/wall,
 /area/ruin/unlucky_engineer/gear)
@@ -3137,7 +3136,7 @@
 /obj/structure/cable,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/floor/plating/snowed/icemoon,
-/area/ruin/unlucky_engineer/solars)
+/area/icemoon/surface/outdoors)
 "Wq" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
@@ -3239,7 +3238,7 @@
 /obj/structure/flora/rock/pile/style_random,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
+/area/icemoon/surface/outdoors)
 "Xu" = (
 /obj/item/radio/intercom/command/directional/west,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -3461,17 +3460,17 @@
 /area/ruin/unlucky_engineer/gear)
 
 (1,1,1) = {"
-kw
+ps
 qt
 qt
 qt
 dN
 Gl
-hs
-hs
-hs
+ps
+ps
+ps
 dN
-hs
+ps
 dN
 dN
 aF
@@ -3481,21 +3480,21 @@ dN
 Rn
 dN
 dN
-hs
+ps
 Gl
 qt
 qt
 qt
 qt
 qt
-qt
-qt
+ps
+ps
 "}
 (2,1,1) = {"
 qt
 qt
 aF
-hs
+ps
 Gl
 Pi
 FQ
@@ -3504,15 +3503,15 @@ Dv
 FQ
 Gl
 dN
-hs
+ps
 Gl
-hs
-hs
+ps
+ps
 Gl
-hs
+ps
 dN
 Jb
-hs
+ps
 aF
 Gl
 qt
@@ -3520,14 +3519,14 @@ qt
 qt
 qt
 qt
-qt
+ps
 "}
 (3,1,1) = {"
 qt
 qt
-hs
-hs
-hs
+ps
+ps
+ps
 aF
 FQ
 cN
@@ -3535,16 +3534,16 @@ Xg
 Dv
 Rn
 Gl
-hs
+ps
 lP
-hs
+ps
 dN
 Rn
 Gl
-hs
-hs
+ps
+ps
 Pi
-hs
+ps
 qt
 qt
 qt
@@ -3576,7 +3575,7 @@ GM
 CF
 Lz
 Gl
-hs
+ps
 Pi
 qt
 Gl
@@ -3606,9 +3605,9 @@ FF
 uM
 gQ
 xt
-hs
+ps
 Gl
-hs
+ps
 Gl
 Rn
 qt
@@ -3617,7 +3616,7 @@ qt
 "}
 (6,1,1) = {"
 Jb
-hs
+ps
 Dv
 DF
 XF
@@ -3637,18 +3636,18 @@ FF
 cL
 xN
 DB
-hs
-hs
+ps
+ps
 GD
 Jb
-hs
+ps
 Gl
 qt
 qt
 "}
 (7,1,1) = {"
 Gl
-hs
+ps
 FQ
 tY
 jf
@@ -3671,8 +3670,8 @@ HB
 Rn
 Gl
 nW
-hs
-hs
+ps
+ps
 qt
 qt
 qt
@@ -3700,8 +3699,8 @@ cj
 Gl
 Lv
 Gl
-hs
-hs
+ps
+ps
 NU
 Gl
 qt
@@ -3709,7 +3708,7 @@ qt
 qt
 "}
 (9,1,1) = {"
-hs
+ps
 Qo
 FQ
 VQ
@@ -3730,12 +3729,12 @@ kg
 Qn
 cj
 DB
-hs
+ps
 cj
-hs
+ps
 aF
-hs
-hs
+ps
+ps
 qt
 qt
 "}
@@ -3758,7 +3757,7 @@ fy
 jC
 kj
 Wq
-hs
+ps
 TA
 qi
 Gl
@@ -3790,19 +3789,19 @@ dO
 Yx
 xh
 Gl
-hs
+ps
 HB
 Jb
 Gl
-hs
+ps
 FX
-hs
+ps
 qt
 qt
 qt
 "}
 (12,1,1) = {"
-hs
+ps
 pd
 Qo
 PP
@@ -3824,11 +3823,11 @@ xP
 Ur
 xP
 xP
-hs
-hs
-hs
-hs
-hs
+ps
+ps
+ps
+ps
+ps
 qt
 qt
 "}
@@ -3855,16 +3854,16 @@ nv
 bX
 qg
 xP
-hs
-hs
-hs
+ps
+ps
+ps
 vW
-hs
+ps
 Gl
 qt
 "}
 (14,1,1) = {"
-hs
+ps
 Qo
 SV
 tp
@@ -3887,15 +3886,15 @@ nA
 ac
 EO
 GD
-hs
+ps
 Cs
-hs
+ps
 ch
 Xo
 qt
 "}
 (15,1,1) = {"
-hs
+ps
 vN
 Qo
 Wn
@@ -3922,7 +3921,7 @@ rZ
 SD
 cP
 pg
-hs
+ps
 dN
 "}
 (16,1,1) = {"
@@ -3948,16 +3947,16 @@ xP
 xP
 KZ
 xP
-hs
-hs
-hs
+ps
+ps
+ps
 aF
 Qp
 dN
 dN
 "}
 (17,1,1) = {"
-hs
+ps
 Qo
 oc
 tp
@@ -3980,10 +3979,10 @@ Ur
 kq
 aF
 Fj
-hs
-hs
+ps
+ps
 Gl
-hs
+ps
 dN
 GD
 "}
@@ -4011,12 +4010,12 @@ QN
 QN
 Rn
 Gl
-hs
+ps
 Rn
-hs
-hs
+ps
+ps
 Rn
-hs
+ps
 "}
 (19,1,1) = {"
 Gl
@@ -4050,8 +4049,8 @@ lS
 Gl
 "}
 (20,1,1) = {"
-hs
-hs
+ps
+ps
 zI
 IV
 hV
@@ -4078,7 +4077,7 @@ Df
 Ah
 oH
 lS
-hs
+ps
 "}
 (21,1,1) = {"
 Gl
@@ -4236,7 +4235,7 @@ lS
 Rn
 "}
 (26,1,1) = {"
-hs
+ps
 vb
 dB
 jU
@@ -4264,7 +4263,7 @@ ze
 DK
 nV
 cV
-hs
+ps
 "}
 (27,1,1) = {"
 dN
@@ -4276,7 +4275,7 @@ HK
 RC
 YS
 iE
-hs
+ps
 aF
 Gl
 Rn
@@ -4310,7 +4309,7 @@ Rc
 Gl
 NU
 Gl
-hs
+ps
 aF
 jW
 bK
@@ -4341,8 +4340,8 @@ hQ
 dN
 Gl
 Jb
-hs
-hs
+ps
+ps
 lS
 Bf
 sF
@@ -4362,15 +4361,15 @@ qt
 (30,1,1) = {"
 qt
 qt
-hs
-hs
+ps
+ps
 DI
 Gl
 Gl
-hs
-hs
+ps
+ps
 aF
-hs
+ps
 GD
 MN
 dN
@@ -4385,7 +4384,7 @@ lS
 jW
 jW
 Rn
-hs
+ps
 qt
 qt
 qt
@@ -4394,21 +4393,21 @@ qt
 qt
 qt
 qt
-hs
+ps
 aF
 dN
 Rn
 dN
 dN
-hs
+ps
 dN
-hs
-hs
+ps
+ps
 dN
 Pi
-hs
+ps
 Gl
-hs
+ps
 dN
 dN
 Gl

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -22,6 +22,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/fluff/paper/stack,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "aF" = (
@@ -35,6 +36,13 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "aL" = (
@@ -43,7 +51,26 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
+/area/ruin/planetengi)
+"aT" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/item/pillow/random,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/airalarm/directional/east,
+/obj/item/coffee_cartridge/bootleg,
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/planetengi)
 "aY" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -54,6 +81,9 @@
 	dir = 8
 	},
 /obj/structure/mop_bucket,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "bf" = (
@@ -67,28 +97,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/ruin/planetengi)
-"bv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/broken_flooring/corner/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/planetengi)
 "bF" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
-"bH" = (
-/obj/item/bedsheet/dorms{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/ruin/planetengi)
 "bK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
@@ -102,6 +115,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "bO" = (
@@ -134,6 +153,7 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "bR" = (
@@ -141,6 +161,9 @@
 /obj/item/toner,
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
@@ -163,13 +186,26 @@
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/ruin/planetengi)
+"cs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
 "ct" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/suit_storage_unit/radsuit,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -177,14 +213,24 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "cL" = (
-/obj/structure/sign/poster/official/safety_internals/directional/north,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/sign/poster/ripped/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/lavaland/surface/outdoors)
 "cN" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/corner/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "cO" = (
@@ -196,8 +242,7 @@
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "cP" = (
-/mob/living/basic/bear/snow,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "cU" = (
@@ -224,26 +269,31 @@
 	pixel_x = 5;
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "db" = (
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "dw" = (
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/suit_storage_unit/radsuit,
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "dB" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
+/obj/machinery/duct,
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
-/area/ruin/planetengi)
-"dC" = (
-/obj/effect/mapping_helpers/apc/no_charge,
-/turf/closed/wall/r_wall/rust,
 /area/ruin/planetengi)
 "dH" = (
 /obj/effect/decal/cleanable/fuel_pool,
@@ -254,17 +304,27 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"dK" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
 "dN" = (
 /turf/closed/mineral/random/snow,
 /area/lavaland/surface/outdoors)
 "dO" = (
-/obj/structure/table_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame,
 /obj/item/flashlight/flare,
 /obj/item/trash/energybar,
 /obj/effect/spawner/random/trash/crushed_can{
 	pixel_x = 7;
-	pixel_y = 5
+	pixel_y = 7
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -279,9 +339,9 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/trash/crushed_can{
 	pixel_x = 7;
-	pixel_y = 5
+	pixel_y = 8
 	},
-/mob/living/basic/regal_rat,
+/mob/living/basic/legion_brood/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "dY" = (
@@ -301,15 +361,21 @@
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible,
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "ec" = (
-/obj/structure/table_frame,
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/plastic,
-/obj/item/stock_parts/capacitor,
-/obj/item/t_scanner,
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ed" = (
@@ -324,13 +390,18 @@
 /obj/item/holosign_creator/atmos{
 	pixel_x = -5
 	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = 7
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/item/flashlight/flare,
 /obj/effect/spawner/random/trash/crushed_can{
 	pixel_x = 7
+	},
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/item/clothing/glasses/meson/engine{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
@@ -343,6 +414,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "eT" = (
@@ -368,9 +445,16 @@
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "fe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/broken_flooring/plating/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/item/flashlight/flare,
+/obj/machinery/firealarm/directional/west,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating,
 /area/ruin/planetengi)
 "fo" = (
 /obj/structure/cable,
@@ -383,11 +467,6 @@
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
-"fu" = (
-/obj/structure/flora/grass/brown/style_random,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/lavaland/surface/outdoors)
 "fy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
@@ -406,7 +485,7 @@
 /area/ruin/planetengi)
 "fE" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/spawner/random/engineering/material_cheap,
+/obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "fW" = (
@@ -417,6 +496,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "fX" = (
@@ -424,19 +506,24 @@
 /turf/closed/wall/r_wall,
 /area/ruin/planetengi)
 "gh" = (
+/obj/structure/sink/directional/south,
 /obj/machinery/duct,
-/obj/machinery/light/small/directional/north,
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/ruin/planetengi)
 "gs" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "gz" = (
 /obj/effect/decal/cleanable/generic,
-/mob/living/simple_animal/hostile/asteroid/wolf,
+/mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "gJ" = (
@@ -456,16 +543,31 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"gQ" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
 "hg" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/sign/poster/ripped/directional/east,
-/obj/effect/spawner/random/entertainment/deck,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
+/obj/structure/bed{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/item/pillow/random,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/structure/cable,
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/digital_clock/directional/north,
+/turf/open/floor/plating,
 /area/ruin/planetengi)
+"hi" = (
+/obj/structure/flora/rock/pile/style_random,
+/mob/living/basic/mining/legion/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "hn" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
@@ -504,6 +606,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/generic,
+/mob/living/basic/legion_brood/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ii" = (
@@ -516,8 +619,8 @@
 /obj/structure/lattice/catwalk,
 /obj/item/trash/energybar,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "iw" = (
 /obj/structure/broken_flooring/pile/directional,
 /obj/effect/decal/cleanable/dirt,
@@ -530,16 +633,23 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "iE" = (
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "iF" = (
-/obj/structure/broken_flooring/side/directional/east,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/fireplace,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/assembly/igniter,
-/turf/open/floor/plating,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/spawner/random/trash/food_packaging,
+/mob/living/simple_animal/bot/medbot,
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "iR" = (
 /obj/machinery/power/smes,
@@ -547,6 +657,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/sign/poster/official/moth_hardhat/directional/north,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "iW" = (
@@ -562,12 +673,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "je" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -587,6 +702,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/crude/snow,
+/obj/structure/broken_flooring/side/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "jr" = (
@@ -617,25 +738,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
-"jD" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/energybar,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/spawner/random/trash/crushed_can{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/iron,
-/area/ruin/planetengi)
 "jJ" = (
 /obj/structure/tank_holder/oxygen/yellow,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jU" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/item/hatchet,
+/obj/structure/door_assembly,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "jW" = (
@@ -655,11 +771,15 @@
 /area/ruin/planetengi)
 "kj" = (
 /obj/structure/broken_flooring/side/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "kl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "kq" = (
@@ -672,11 +792,18 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "kD" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "kN" = (
@@ -684,6 +811,10 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "kX" = (
@@ -693,6 +824,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "le" = (
@@ -703,6 +835,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/mob/living/basic/legion_brood/snow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "lz" = (
@@ -729,10 +863,19 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/directional/west,
-/obj/item/food/energybar,
-/obj/item/reagent_containers/cup/soda_cans/volt_energy,
 /obj/structure/noticeboard/directional/north{
 	name = "Chief Engineer's Notice Board"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/folder/blue{
+	pixel_x = -6;
+	pixel_y = 2
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -746,10 +889,30 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"lP" = (
+/mob/living/basic/mining/lobstrosity,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "lS" = (
 /turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"lV" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/structure/sign/poster/ripped/directional/east,
+/obj/effect/spawner/random/entertainment/deck,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "lZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -759,6 +922,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "mJ" = (
@@ -766,6 +932,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "mT" = (
@@ -774,15 +941,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/plastic,
+/obj/item/reagent_containers/hypospray/medipen{
+	icon_state = "medipen0"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ng" = (
-/obj/item/pillow/random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/structure/broken_flooring/singular/directional/south,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/plastic,
-/obj/item/trash/flare,
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "nv" = (
@@ -790,6 +966,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "nA" = (
@@ -801,11 +980,38 @@
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"nF" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/energybar,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/structure/sign/poster/official/pda_ad/directional/west,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
 "nH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
+/area/ruin/planetengi)
+"nM" = (
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
 /area/ruin/planetengi)
 "nO" = (
 /obj/structure/table_frame,
@@ -828,6 +1034,10 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "nS" = (
@@ -847,7 +1057,7 @@
 "oc" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/iron/solarpanel,
-/area/ruin/planetengi)
+/area/lavaland/surface/outdoors)
 "ok" = (
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -857,6 +1067,15 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
+/area/ruin/planetengi)
+"oG" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "oH" = (
 /obj/machinery/igniter/incinerator_syndicatelava,
@@ -874,31 +1093,53 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "oY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/build/directional/north,
 /obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "pd" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/mob/living/basic/legion_brood/snow,
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
+"pg" = (
+/obj/structure/flora/grass/brown/style_random,
+/mob/living/basic/legion_brood/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"pB" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/basic/legion_brood/snow,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
 "pF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/plating/directional/south,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/turf_decal/caution,
+/mob/living/basic/legion_brood/snow,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "pH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "pI" = (
@@ -917,8 +1158,8 @@
 "pO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "qb" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -928,6 +1169,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "qi" = (
@@ -936,6 +1180,9 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
+"qt" = (
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers)
 "qA" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood,
@@ -943,6 +1190,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/broken_flooring/singular/directional/west,
 /turf/open/floor/plating,
+/area/ruin/planetengi)
+"qB" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/noticeboard/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "qD" = (
 /obj/structure/table/reinforced,
@@ -957,6 +1215,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/vomit/old/black_bile,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "qX" = (
@@ -966,25 +1227,28 @@
 /obj/structure/sign/poster/official/soft_cap_pop_art/directional/north,
 /obj/effect/spawner/random/trash/crushed_can{
 	pixel_x = 7;
-	pixel_y = 5
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "rD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "rG" = (
-/obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/plasma/thirty,
-/obj/item/stack/sheet/mineral/plasma/thirty,
-/obj/item/stock_parts/micro_laser,
-/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "rH" = (
@@ -993,6 +1257,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "rS" = (
@@ -1001,6 +1268,10 @@
 /obj/item/analyzer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "rW" = (
@@ -1011,14 +1282,33 @@
 /obj/effect/decal/cleanable/plastic,
 /obj/item/trash/energybar,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"rZ" = (
+/mob/living/basic/legion_brood/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "sA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/broken_flooring/singular/directional/west,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
+	},
+/obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"sB" = (
+/obj/structure/broken_flooring,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
@@ -1037,6 +1327,9 @@
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/structure/cable,
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "sQ" = (
@@ -1046,6 +1339,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "tp" = (
@@ -1054,7 +1350,11 @@
 	name = "Fore-Starboard Solar Array"
 	},
 /turf/open/floor/iron/solarpanel,
-/area/ruin/planetengi)
+/area/lavaland/surface/outdoors)
+"tt" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear,
+/turf/open/floor/iron/solarpanel,
+/area/lavaland/surface/outdoors)
 "tA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -1072,19 +1372,14 @@
 /obj/item/pickaxe/emergency,
 /obj/item/airlock_painter/decal,
 /obj/item/storage/belt/utility,
-/turf/open/floor/iron,
-/area/ruin/planetengi)
-"ue" = (
-/obj/machinery/shower/directional/south,
-/obj/structure/curtain,
-/obj/machinery/duct,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/freezer,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "us" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -1102,7 +1397,8 @@
 /turf/open/floor/engine,
 /area/ruin/planetengi)
 "uM" = (
-/obj/structure/sign/poster/ripped/directional/north,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/statue/snow/snowman,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "uR" = (
@@ -1119,6 +1415,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
 /obj/structure/broken_flooring/singular/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "vf" = (
@@ -1133,15 +1432,7 @@
 /turf/open/floor/engine/co2,
 /area/ruin/planetengi)
 "vh" = (
-/obj/structure/table_frame,
-/obj/item/folder/blue{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/folder/yellow{
-	pixel_x = -2;
-	pixel_y = 1
-	},
+/obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "vl" = (
@@ -1160,14 +1451,28 @@
 /obj/structure/broken_flooring/pile/directional/south,
 /obj/item/reagent_containers/cup/glass/waterbottle/empty,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "vM" = (
 /obj/structure/table_frame,
-/obj/structure/closet/mini_fridge/grimy,
+/obj/structure/closet/mini_fridge/grimy{
+	pixel_x = -5
+	},
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/coffee_cartridge/fancy,
 /obj/item/stack/sheet/mineral/plasma/five,
+/obj/item/reagent_containers/cup/soda_cans/volt_energy,
+/obj/item/food/energybar,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/item/storage/fancy/coffee_cart_rack{
+	pixel_x = 8;
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "vV" = (
@@ -1180,6 +1485,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"vW" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear,
+/obj/effect/decal/cleanable/blood,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "vZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -1194,6 +1504,12 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "wd" = (
@@ -1201,23 +1517,54 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/flashlight/flare,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "wm" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/basic/legion_brood/snow,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/ruin/planetengi)
+"wq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "wr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "ws" = (
 /obj/structure/broken_flooring/side/directional/south,
-/obj/item/radio/intercom/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame,
+/obj/item/stock_parts/micro_laser,
+/obj/item/storage/toolbox/electrical,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"xh" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/effect/mapping_helpers/damaged_window,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "xm" = (
@@ -1239,9 +1586,13 @@
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "xN" = (
-/mob/living/basic/bear/snow,
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
+"xP" = (
+/turf/closed/wall/ice,
+/area/ruin/planetengi)
 "xS" = (
 /obj/effect/decal/cleanable/ash{
 	pixel_x = 2;
@@ -1251,18 +1602,18 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "xU" = (
-/obj/structure/closet/emcloset,
 /obj/structure/sign/warning/xeno_mining/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/utility/hardhat,
 /obj/item/shovel,
+/obj/item/storage/medkit/emergency,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
-"ye" = (
-/obj/effect/mapping_helpers/airalarm/all_access,
-/turf/closed/wall,
 /area/ruin/planetengi)
 "yr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -1272,6 +1623,9 @@
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"yF" = (
+/turf/closed/wall/rust,
+/area/lavaland/surface/outdoors)
 "yH" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/broken_flooring/side/directional/east,
@@ -1280,9 +1634,12 @@
 	},
 /obj/effect/spawner/random/trash/crushed_can{
 	pixel_x = 7;
-	pixel_y = 5
+	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "yJ" = (
@@ -1290,6 +1647,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "yT" = (
@@ -1303,10 +1664,9 @@
 "zc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/blood/gibs/core,
-/obj/structure/broken_flooring/singular/directional/south,
+/obj/structure/broken_flooring/corner/directional/north,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ze" = (
@@ -1347,6 +1707,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "zB" = (
@@ -1356,6 +1719,11 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/planetengi)
+"zE" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "zH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1378,6 +1746,7 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "zW" = (
@@ -1385,6 +1754,14 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/ruin/planetengi)
+"Ae" = (
+/obj/effect/decal/cleanable/generic,
+/mob/living/basic/mining/legion/snow,
+/turf/open/floor/iron/solarpanel,
+/area/lavaland/surface/outdoors)
+"Af" = (
+/turf/closed/wall/ice,
+/area/lavaland/surface/outdoors)
 "Ag" = (
 /obj/item/cigbutt/cigarbutt{
 	pixel_x = 5;
@@ -1417,12 +1794,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "AA" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/trash/flare,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "AB" = (
@@ -1430,12 +1812,19 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "AR" = (
 /obj/structure/broken_flooring/side/directional/south,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "AZ" = (
@@ -1448,6 +1837,7 @@
 	},
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/end,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Bf" = (
@@ -1463,12 +1853,18 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Bq" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
+"Cs" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "CC" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -1485,6 +1881,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "CN" = (
@@ -1496,6 +1895,9 @@
 	pixel_y = 5
 	},
 /obj/structure/sign/poster/official/safety_eye_protection/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Df" = (
@@ -1504,13 +1906,17 @@
 /area/ruin/planetengi)
 "Dh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "Dl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Dp" = (
@@ -1536,6 +1942,10 @@
 	pixel_x = 3;
 	pixel_y = -8
 	},
+/obj/item/reagent_containers/hypospray/medipen{
+	icon_state = "medipen0"
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "DB" = (
@@ -1551,8 +1961,16 @@
 /obj/effect/mob_spawn/corpse/human/engineer,
 /obj/item/storage/toolbox/emergency,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
+"DI" = (
+/obj/structure/flora/rock/pile/style_random,
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "DK" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/engine/vacuum,
@@ -1584,6 +2002,9 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Ec" = (
@@ -1616,17 +2037,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/basic/legion_brood/snow,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Fb" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/decal/cleanable/blood/old,
+/obj/item/flashlight/lantern/jade{
+	on = 1
+	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/planetengi)
+"Fj" = (
+/mob/living/basic/mining/legion/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
 "Fp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/frame/computer,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Fq" = (
@@ -1649,6 +2082,9 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "FB" = (
@@ -1657,6 +2093,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "FS" = (
@@ -1675,6 +2114,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/digital_clock/directional/north,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Gg" = (
@@ -1743,27 +2183,38 @@
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Hk" = (
-/obj/structure/sign/poster/official/moth_hardhat/directional/north,
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/closet/crate/bin,
 /obj/item/coupon,
+/obj/structure/sign/poster/official/moth_piping/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Ho" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Hv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/item/mod/module/plasma_stabilizer,
 /obj/item/storage/medkit/fire,
 /obj/item/stock_parts/cell/high/empty,
-/obj/item/rcd_ammo/large,
+/obj/item/reagent_containers/hypospray/medipen,
 /turf/open/floor/plating,
-/area/ruin/planetengi)
-"Hw" = (
-/obj/effect/mapping_helpers/apc/no_charge,
-/turf/closed/wall/r_wall,
 /area/ruin/planetengi)
 "HB" = (
 /obj/structure/fence{
@@ -1772,29 +2223,40 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/lavaland/surface/outdoors)
 "HK" = (
-/obj/structure/bed{
-	dir = 4
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/ready_donk,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/item/bedsheet/dorms{
-	dir = 4
-	},
-/obj/item/pillow/random,
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/airalarm/directional/east,
-/obj/item/coffee_cartridge/bootleg,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "HN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/broken_flooring/singular/directional/north,
 /obj/structure/cable,
 /obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "HV" = (
-/obj/structure/sink/directional/south,
+/obj/machinery/shower/directional/south,
+/obj/structure/curtain,
 /obj/machinery/duct,
-/obj/structure/mirror/directional/north,
+/obj/structure/fluff{
+	desc = "What, you think the water just magically soaks into the metallic flooring?";
+	icon = 'icons/obj/mining_zones/survival_pod.dmi';
+	icon_state = "fan_tiny";
+	name = "shower drain"
+	},
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/ruin/planetengi)
 "IG" = (
@@ -1820,6 +2282,7 @@
 /area/ruin/planetengi)
 "IU" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "IV" = (
@@ -1851,6 +2314,10 @@
 /obj/item/gps/engineering{
 	gpstag = "CE0"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/obj/item/rcd_ammo/large,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Jx" = (
@@ -1862,6 +2329,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
 /obj/item/coffee_cartridge/bootleg,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Jz" = (
@@ -1872,6 +2342,12 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "JP" = (
@@ -1890,6 +2366,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Ky" = (
@@ -1897,6 +2377,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/cut,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "KL" = (
@@ -1929,17 +2413,12 @@
 	atmos_chambers = list("lavalandsyndieo2"="Oxygen Supply","lavalandsyndien2"="Nitrogen Supply","lavalandsyndieco2"="Carbon Dioxide Supply","lavalandsyndieplasma"="Plasma Supply")
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "KZ" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/ruin/planetengi)
-"Lh" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/item/hatchet,
-/obj/structure/door_assembly,
-/turf/open/floor/plating,
 /area/ruin/planetengi)
 "Lk" = (
 /obj/item/shard,
@@ -1973,6 +2452,10 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/firealarm/directional/south,
 /obj/item/storage/fancy/cigarettes/cigpack_carp,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Mf" = (
@@ -1980,20 +2463,17 @@
 /obj/structure/broken_flooring/side/directional/west,
 /obj/structure/sign/poster/ripped/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/ruin/planetengi)
-"ML" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/fireplace,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron,
 /area/ruin/planetengi)
 "Ng" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack,
 /obj/structure/broken_flooring/plating/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Nq" = (
@@ -2002,14 +2482,23 @@
 	mapping_id = "syndie_lavaland_incineratorturbine"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
+/area/ruin/planetengi)
+"Nu" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/planetengi)
 "NA" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/coffeemaker,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
+	},
+/obj/machinery/rnd/production/circuit_imprinter/offstation,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
@@ -2032,6 +2521,9 @@
 /obj/structure/broken_flooring/side/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Om" = (
@@ -2045,7 +2537,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
+/area/ruin/planetengi)
+"Pg" = (
+/obj/effect/spawner/random/structure/closet_private,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/reagent_containers/medigel/libital,
+/obj/item/storage/toolbox/emergency,
+/obj/item/modular_computer/pda/clear,
+/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating,
 /area/ruin/planetengi)
 "Pi" = (
 /obj/structure/flora/rock/pile/icy/style_random,
@@ -2055,6 +2558,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Ps" = (
@@ -2063,12 +2569,13 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "PJ" = (
-/obj/structure/table_frame,
 /obj/structure/broken_flooring/corner/directional/east,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/item/storage/toolbox/electrical,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame,
+/obj/item/stock_parts/capacitor,
+/obj/item/t_scanner,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "PN" = (
@@ -2079,12 +2586,27 @@
 /obj/item/stack/cable_coil/five,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/utility/hardhat,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"PP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "Qa" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Qe" = (
@@ -2101,13 +2623,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/barricade/wooden/snowed,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Qo" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "Qp" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -2130,11 +2658,17 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/walk/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "QG" = (
-/obj/effect/mapping_helpers/apc/no_charge,
-/turf/closed/wall/rust,
+/obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "QH" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2155,6 +2689,10 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "QV" = (
@@ -2162,6 +2700,10 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/digital_clock/directional/south,
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Rc" = (
@@ -2176,6 +2718,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
+/mob/living/basic/mining/legion/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Rr" = (
@@ -2183,6 +2726,7 @@
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/effect/spawner/random/entertainment/wallet_storage,
 /obj/item/binoculars,
+/obj/item/computer_disk/engineering,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Rw" = (
@@ -2192,15 +2736,19 @@
 /turf/open/floor/engine/vacuum,
 /area/ruin/planetengi)
 "RC" = (
-/obj/effect/spawner/random/structure/closet_private,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/item/reagent_containers/medigel/libital,
-/turf/open/floor/plating,
+/obj/item/pillow/random,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/plastic,
+/obj/item/trash/flare,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/planetengi)
 "RD" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/trash/flare,
-/obj/effect/decal/cleanable/generic,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "RJ" = (
@@ -2212,6 +2760,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Sz" = (
@@ -2221,17 +2773,9 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/asteroid/wolf,
-/turf/open/floor/plating,
-/area/ruin/planetengi)
-"SC" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/broken_flooring/singular/directional/east,
-/obj/structure/broken_flooring/plating/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/flare,
-/obj/machinery/firealarm/directional/west,
-/obj/item/reagent_containers/cup/glass/waterbottle/empty,
-/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "SD" = (
@@ -2241,26 +2785,28 @@
 /area/lavaland/surface/outdoors)
 "SK" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/sign/poster/official/safety_internals/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "SM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/side/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "SV" = (
 /turf/open/floor/iron/solarpanel,
-/area/ruin/planetengi)
-"SX" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/area/lavaland/surface/outdoors)
 "Tl" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/atmos/glass{
@@ -2269,21 +2815,29 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Tv" = (
-/obj/structure/bed{
-	dir = 4
+/obj/structure/broken_flooring/side/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/assembly/igniter,
+/obj/item/paper/crumpled/muddy{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/obj/item/bedsheet/dorms{
-	dir = 4
-	},
-/obj/item/pillow/random,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/corpse/human/assistant,
-/obj/structure/cable,
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"TA" = (
+/mob/living/basic/legion_brood/snow,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
 "TQ" = (
 /obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/dirt,
@@ -2305,7 +2859,11 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/plastic,
+/obj/item/circuitboard/machine/coffeemaker,
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "UJ" = (
@@ -2315,13 +2873,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/north,
-/mob/living/basic/mining/legion/snow,
+/mob/living/basic/mining/basilisk,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "UP" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/frame/machine,
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "US" = (
@@ -2330,9 +2892,9 @@
 /obj/item/stock_parts/cell/lead,
 /obj/item/stack/cable_coil/five,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/toolbox/emergency,
 /obj/item/rcd_ammo,
 /obj/effect/decal/cleanable/greenglow,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "UY" = (
@@ -2342,8 +2904,15 @@
 /turf/open/floor/engine,
 /area/ruin/planetengi)
 "Vb" = (
-/obj/effect/mapping_helpers/airalarm/all_access,
-/turf/closed/wall/rust,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "Vg" = (
 /obj/structure/grille/broken,
@@ -2356,6 +2925,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Vm" = (
@@ -2363,6 +2935,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Vo" = (
@@ -2371,7 +2948,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/crushed_can{
 	pixel_x = 7;
-	pixel_y = 5
+	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating,
@@ -2409,6 +2986,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "VU" = (
@@ -2419,12 +3002,18 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "VW" = (
 /obj/structure/broken_flooring/side/directional/north,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Wi" = (
@@ -2437,8 +3026,8 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/airless,
-/area/ruin/planetengi)
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "Wq" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
@@ -2454,12 +3043,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/broken_flooring/pile/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Wu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/turf_decal/caution,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "WH" = (
@@ -2467,6 +3060,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "WL" = (
@@ -2495,6 +3089,7 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Xc" = (
@@ -2517,6 +3112,8 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/utility/hardhat,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/pile/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/end,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "Xk" = (
@@ -2539,7 +3136,9 @@
 /obj/structure/closet/crate/bin,
 /obj/item/blank_coffee_cartridge,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/computer_disk/engineering,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "XF" = (
@@ -2547,6 +3146,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/item/mining_scanner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "XQ" = (
@@ -2554,6 +3156,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/mob/living/basic/mining/basilisk,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "XR" = (
@@ -2573,7 +3176,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/rcd_ammo,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Yb" = (
@@ -2596,6 +3198,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
+"Yx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
 "Yy" = (
 /obj/structure/fireaxecabinet/empty,
 /turf/closed/wall,
@@ -2609,6 +3217,7 @@
 "YF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "YI" = (
@@ -2625,26 +3234,39 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "YL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "YP" = (
 /turf/closed/wall,
 /area/ruin/planetengi)
 "YS" = (
-/obj/structure/bed{
+/obj/item/bedsheet/dorms{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron,
 /area/ruin/planetengi)
 "Zg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/pdapainter/engineering,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Zh" = (
@@ -2659,27 +3281,26 @@
 	fax_name = "Chief Engineer's Office";
 	name = "Chief Engineer's Fax Machine"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Zn" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/ready_donk,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "Zu" = (
 /obj/effect/decal/cleanable/ash,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/ruin/planetengi)
-"Zz" = (
-/obj/effect/mapping_helpers/airalarm/all_access,
-/turf/closed/wall/r_wall/rust,
 /area/ruin/planetengi)
 "ZB" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2691,6 +3312,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/broken_flooring/corner/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/planetengi)
 "ZE" = (
@@ -2717,105 +3341,105 @@
 /area/ruin/planetengi)
 
 (1,1,1) = {"
+qt
+qt
+qt
+qt
 dN
-Pi
-hs
-Gl
-hs
 Gl
 hs
 hs
 hs
+dN
 hs
-hs
-hs
-hs
+dN
+dN
 aF
 Gl
+dN
+dN
 hs
-hs
-hs
-hs
-hs
+dN
+dN
 hs
 Gl
-hs
-dN
-dN
-dN
-dN
-dN
-dN
+qt
+qt
+qt
+qt
+qt
+qt
+qt
 "}
 (2,1,1) = {"
-hs
-hs
+qt
+qt
 aF
 hs
 Gl
 Pi
-Ur
+xP
 jn
 Ur
-YP
+xP
 Gl
-hs
+dN
 hs
 Gl
 hs
 hs
 Gl
 Jb
-hs
+dN
 hs
 hs
 aF
 Gl
-hs
-dN
-hs
-dN
-dN
-dN
+qt
+qt
+qt
+qt
+qt
+qt
 "}
 (3,1,1) = {"
-dN
-Gl
+qt
+qt
 hs
 hs
 hs
 aF
-YP
+xP
 cN
 Xg
 Ur
 Rn
 Gl
 hs
+lP
 hs
-hs
-Gl
+dN
 Rn
 Gl
 hs
 hs
 Pi
 hs
-hs
-hs
-hs
-hs
-hs
-dN
-dN
+qt
+qt
+qt
+qt
+qt
+qt
+qt
 "}
 (4,1,1) = {"
-Gl
-hs
+qt
+NU
 GD
+xP
+YP
 Ur
-ye
-QG
 Ur
 lM
 jW
@@ -2823,7 +3447,7 @@ jW
 lS
 jW
 Lk
-Rc
+xh
 qb
 jW
 lS
@@ -2834,21 +3458,21 @@ Lz
 Gl
 hs
 Pi
-hs
+qt
 Gl
-GD
-hs
-dN
+qt
+qt
+qt
 "}
 (5,1,1) = {"
-Rn
+qt
 Gl
-YP
+xP
 Yy
 eG
 nQ
 jJ
-IU
+cs
 YL
 Pr
 jW
@@ -2860,16 +3484,16 @@ Xu
 lS
 jW
 uM
-cj
+gQ
 xt
 hs
 Gl
 hs
 Gl
 Rn
-hs
-hs
-dN
+qt
+qt
+qt
 "}
 (6,1,1) = {"
 Jb
@@ -2887,25 +3511,25 @@ cW
 Lp
 fE
 iw
-vZ
+wq
 vr
 jW
 cL
 xN
 DB
 hs
-aF
 hs
+GD
 Jb
 hs
 Gl
-hs
-hs
+qt
+qt
 "}
 (7,1,1) = {"
 Gl
 hs
-Ur
+xP
 tY
 jf
 vZ
@@ -2921,17 +3545,17 @@ Rr
 ZQ
 IU
 qb
-cj
+pB
 cj
 HB
 Rn
 Gl
 nW
 hs
-hs
-hs
-hs
-hs
+NU
+qt
+qt
+qt
 "}
 (8,1,1) = {"
 Gl
@@ -2951,31 +3575,31 @@ cO
 vh
 zp
 IU
-qb
+xh
 cj
-hs
+Gl
 Lv
-hs
+Gl
 hs
 hs
 hs
 Gl
-hs
-Gl
-hs
+qt
+qt
+qt
 "}
 (9,1,1) = {"
-hs
-Qo
-Ur
-YP
+dN
+zE
+xP
+xP
 vf
 hu
 vf
 Ur
 Qy
 YJ
-qb
+xh
 db
 jr
 lz
@@ -2983,7 +3607,7 @@ qD
 GT
 zM
 kg
-hs
+Fj
 cj
 DB
 hs
@@ -2992,15 +3616,15 @@ hs
 aF
 hs
 hs
-hs
-Gl
+qt
+qt
 "}
 (10,1,1) = {"
 Gl
 Dh
 tp
 tp
-Qo
+zE
 SV
 SV
 Go
@@ -3015,22 +3639,22 @@ jC
 kj
 Wq
 cj
-cj
+TA
 qi
 Gl
-Rn
+hi
 Gl
-hs
+rZ
 Gl
 Rn
-hs
-dN
+qt
+qt
 "}
 (11,1,1) = {"
 Rn
-SX
+Qo
 tp
-oc
+Ae
 Wn
 tp
 SV
@@ -3043,26 +3667,26 @@ Bm
 gO
 nO
 dO
-vZ
-qb
-hs
+Yx
+xh
+Gl
 cj
 HB
 Jb
 Gl
 hs
-hs
 FX
 hs
-hs
-dN
+qt
+qt
+qt
 "}
 (12,1,1) = {"
 hs
 pd
-Qo
-Wn
-Qo
+zE
+PP
+zE
 pO
 Wn
 ZE
@@ -3073,24 +3697,24 @@ Jn
 Hv
 Ky
 AR
-Lp
+sB
 QV
 lS
+xP
 Ur
-Ur
-YP
-YP
+xP
+xP
 hs
 hs
 hs
 hs
 hs
-hs
-dN
+qt
+qt
 "}
 (13,1,1) = {"
 Gl
-Qo
+zE
 tp
 SV
 pO
@@ -3103,28 +3727,28 @@ jW
 jW
 jW
 RJ
-Hw
+lS
 qb
-Zz
+jW
 jW
 nv
 bX
 qg
-Ur
+xP
 hs
-Rn
 hs
+hs
+vW
 hs
 Gl
-Gl
-dN
+qt
 "}
 (14,1,1) = {"
-hs
-Qo
+dN
+zE
 SV
 tp
-Qo
+zE
 tp
 oc
 vf
@@ -3144,16 +3768,16 @@ ac
 EO
 GD
 hs
+Cs
 hs
-fu
 ch
-Rn
-dN
+Xo
+qt
 "}
 (15,1,1) = {"
-hs
+dN
+zE
 Qo
-SX
 pO
 im
 Wn
@@ -3161,7 +3785,7 @@ Qo
 KN
 pF
 Or
-jY
+dK
 ve
 yH
 ZB
@@ -3174,20 +3798,20 @@ Jx
 Fb
 KL
 Xo
-hs
+rZ
 SD
 cP
-Gl
-dN
+pg
+hs
 dN
 "}
 (16,1,1) = {"
 Gl
-Qo
+zE
 tp
 SV
 pO
-SV
+tt
 tp
 Ur
 xU
@@ -3200,10 +3824,10 @@ YP
 jY
 Ur
 YP
-Ur
-Ur
+xP
+xP
 KZ
-Ur
+xP
 hs
 hs
 hs
@@ -3214,10 +3838,10 @@ dN
 "}
 (17,1,1) = {"
 hs
-Qo
+zE
 oc
 tp
-Qo
+zE
 SV
 SV
 Ur
@@ -3235,7 +3859,7 @@ US
 Ur
 kq
 aF
-NU
+Fj
 hs
 hs
 Gl
@@ -3245,7 +3869,7 @@ GD
 "}
 (18,1,1) = {"
 Gl
-Qo
+zE
 Ur
 Rc
 CC
@@ -3263,8 +3887,8 @@ Ec
 YP
 YP
 Ur
-Vb
-Ur
+xP
+xP
 Rn
 Gl
 hs
@@ -3277,7 +3901,7 @@ hs
 (19,1,1) = {"
 Gl
 Jb
-YP
+xP
 Gc
 Dp
 ws
@@ -3295,7 +3919,7 @@ zA
 CJ
 CN
 rS
-YP
+xP
 jW
 jW
 lS
@@ -3308,13 +3932,13 @@ Gl
 (20,1,1) = {"
 hs
 hs
-YP
+xP
 IV
 hV
 kz
 vV
 ec
-Vb
+Ur
 aH
 ct
 lZ
@@ -3369,9 +3993,9 @@ Gl
 "}
 (22,1,1) = {"
 Rn
+Gl
+xP
 Ur
-Ur
-YP
 NA
 Bq
 ES
@@ -3399,20 +4023,20 @@ jW
 dN
 "}
 (23,1,1) = {"
-hs
-YP
-ue
-Ur
-YP
+dN
+xP
+xP
+xP
+qB
 Vb
-al
+oG
 QG
-YP
-Ur
+xP
+xP
 lS
-dC
 jW
-Hw
+jW
+lS
 kN
 Xf
 VB
@@ -3430,15 +4054,15 @@ Rn
 dN
 "}
 (24,1,1) = {"
-hs
-YP
+dN
+xP
 HV
 Ur
-ML
-SC
-bv
-jD
-QG
+YP
+Ur
+al
+Ur
+YP
 Jb
 jW
 vg
@@ -3461,14 +4085,14 @@ Gl
 dN
 "}
 (25,1,1) = {"
-hs
-YP
+dN
+xP
 gh
-Lh
+Ur
 iF
 fe
 zc
-zL
+nF
 Ur
 Gl
 lS
@@ -3495,12 +4119,12 @@ Rn
 hs
 Ur
 dB
-Ur
+jU
 Tv
 Zn
 ng
-bH
-iE
+zL
+xP
 Rn
 jW
 lS
@@ -3514,7 +4138,7 @@ IG
 Qt
 fc
 fW
-vZ
+Ho
 wd
 ze
 DK
@@ -3523,15 +4147,15 @@ cV
 hs
 "}
 (27,1,1) = {"
-hs
+dN
+xP
+nM
 Ur
-YP
-YP
 hg
 HK
 RC
 YS
-Rc
+iE
 hs
 aF
 Gl
@@ -3551,20 +4175,20 @@ jW
 YI
 Rw
 jW
-hs
+dN
 "}
 (28,1,1) = {"
-hs
-Pi
-Gl
-Ur
-Ur
-Vb
-Rc
+dN
+yF
+Af
+xP
+lV
+aT
+Pg
 wm
-Ur
+Rc
 Gl
-hs
+NU
 Gl
 hs
 aF
@@ -3585,16 +4209,16 @@ jW
 Gl
 "}
 (29,1,1) = {"
+qt
+Pi
+Gl
+xP
+Ur
+xP
+Rc
+Nu
+xP
 dN
-Gl
-hs
-hs
-Rn
-Gl
-Gl
-hs
-hs
-hs
 Gl
 Jb
 hs
@@ -3612,24 +4236,24 @@ jW
 Jb
 Gl
 Rn
-hs
 dN
+qt
 "}
 (30,1,1) = {"
-dN
-dN
+qt
+qt
 hs
 hs
-aF
-hs
-Rn
+DI
+Gl
+Gl
 hs
 hs
 aF
 hs
 GD
 Gl
-hs
+dN
 jW
 jW
 lS
@@ -3642,38 +4266,38 @@ jW
 jW
 Rn
 hs
-hs
-dN
-dN
+qt
+qt
+qt
 "}
 (31,1,1) = {"
+qt
+qt
+qt
+hs
+aF
+dN
+Rn
 dN
 dN
+hs
 dN
+hs
+hs
 dN
-hs
-Jb
-hs
-Gl
-hs
-hs
-hs
-hs
-hs
-hs
 Pi
 hs
 Gl
 hs
-hs
-hs
+dN
+dN
 Gl
 Gl
-hs
-hs
-hs
-hs
 dN
+Gl
 dN
-dN
+qt
+qt
+qt
+qt
 "}

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
@@ -1,0 +1,3679 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/ruin/planetengi)
+"al" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering{
+	name = "Power Access Hatch"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"ay" = (
+/obj/item/clipboard{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"aF" = (
+/obj/structure/flora/tree/pine/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"aH" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/structure/broken_flooring/singular/directional/south,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"aL" = (
+/obj/structure/closet/crate/solarpanel_small,
+/obj/item/paper/guides/jobs/engi/solars,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"aY" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/item/mop,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/mop_bucket,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"bf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "lavalandsyndieplasma";
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"bl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"bv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/corner/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"bF" = (
+/obj/item/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"bH" = (
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"bK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "lavalandsyndien2";
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"bM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"bO" = (
+/obj/structure/broken_flooring/side/directional,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"bQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airlock_controller/incinerator_syndicatelava{
+	pixel_x = -8;
+	pixel_y = -26
+	},
+/obj/machinery/button/door/incinerator_vent_syndicatelava_aux{
+	pixel_x = -8;
+	pixel_y = -40
+	},
+/obj/machinery/button/door/incinerator_vent_syndicatelava_main{
+	pixel_x = 6;
+	pixel_y = -40
+	},
+/obj/machinery/button/ignition/incinerator/syndicatelava{
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"bR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toner,
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"bX" = (
+/obj/structure/bed/maint,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/item/reagent_containers/cup/glass/bottle/hooch,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/ruin/planetengi)
+"ch" = (
+/obj/item/pickaxe/rusted,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"cj" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
+"co" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"ct" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/suit_storage_unit/radsuit,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"cE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"cL" = (
+/obj/structure/sign/poster/official/safety_internals/directional/north,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
+"cN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"cO" = (
+/obj/structure/broken_flooring/singular/directional,
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"cP" = (
+/mob/living/basic/bear/snow,
+/obj/effect/decal/cleanable/blood,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"cU" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/orange/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"cV" = (
+/obj/machinery/door/poddoor/incinerator_syndicatelava_main{
+	id = "syndicatelava_mainvent_outer"
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/planetengi)
+"cW" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/machinery/incident_display/delam/directional/north,
+/obj/item/reagent_containers/cup/glass/coffee_cup{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"db" = (
+/obj/machinery/photocopier,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"dw" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/suit_storage_unit/radsuit,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"dB" = (
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/planetengi)
+"dC" = (
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/closed/wall/r_wall/rust,
+/area/ruin/planetengi)
+"dH" = (
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/structure/broken_flooring/corner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"dN" = (
+/turf/closed/mineral/random/snow,
+/area/lavaland/surface/outdoors)
+"dO" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/flare,
+/obj/item/trash/energybar,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"dV" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/mob/living/basic/regal_rat,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"dY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/item/assembly/mousetrap/armed,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"dZ" = (
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"ec" = (
+/obj/structure/table_frame,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/item/stock_parts/capacitor,
+/obj/item/t_scanner,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ed" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/structure/broken_flooring/side/directional/west,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"eG" = (
+/obj/structure/table,
+/obj/item/holosign_creator/atmos{
+	pixel_x = -5
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = 7
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/item/flashlight/flare,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"eS" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"eT" = (
+/obj/machinery/power/turbine/turbine_outlet{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"eX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	target_pressure = 4500
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"fc" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"fe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"fo" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"fu" = (
+/obj/structure/flora/grass/brown/style_random,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"fy" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = -6
+	},
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"fE" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/spawner/random/engineering/material_cheap,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"fW" = (
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/orange/visible/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"fX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"gh" = (
+/obj/machinery/duct,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/freezer,
+/area/ruin/planetengi)
+"gs" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"gz" = (
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"gJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"gO" = (
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/structure/broken_flooring/corner/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"hg" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/structure/sign/poster/ripped/directional/east,
+/obj/effect/spawner/random/entertainment/deck,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"hn" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"hr" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"hs" = (
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"hu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"hA" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"hV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ii" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"im" = (
+/obj/structure/lattice/catwalk,
+/obj/item/trash/energybar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"iw" = (
+/obj/structure/broken_flooring/pile/directional,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"iz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"iE" = (
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"iF" = (
+/obj/structure/broken_flooring/side/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/assembly/igniter,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"iR" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"iW" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "lavalandsyndieco2"
+	},
+/turf/open/floor/engine/co2,
+/area/ruin/planetengi)
+"iY" = (
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/item/shard,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"je" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jf" = (
+/obj/structure/broken_flooring/side/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jn" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jr" = (
+/obj/structure/broken_flooring/plating/directional,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 16
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ju" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jx" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jC" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"jD" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/energybar,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"jJ" = (
+/obj/structure/tank_holder/oxygen/yellow,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"jW" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/planetengi)
+"jY" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"kg" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"kj" = (
+/obj/structure/broken_flooring/side/directional/west,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"kl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"kq" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
+"kz" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"kD" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"kN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"kX" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"le" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"lz" = (
+/obj/structure/broken_flooring,
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"lF" = (
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/structure/broken_flooring/pile/directional/north,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = -7
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"lL" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light/directional/west,
+/obj/item/food/energybar,
+/obj/item/reagent_containers/cup/soda_cans/volt_energy,
+/obj/structure/noticeboard/directional/north{
+	name = "Chief Engineer's Notice Board"
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"lM" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"lS" = (
+/turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"lZ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"mJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"mT" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ng" = (
+/obj/item/pillow/random,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/item/trash/flare,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"nv" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"nA" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/item/flashlight/flare,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"nH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/corner/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"nO" = (
+/obj/structure/table_frame,
+/obj/item/reagent_containers/medigel/aiuri{
+	pixel_x = 7
+	},
+/obj/item/pai_card{
+	pixel_x = -6
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"nQ" = (
+/obj/structure/table,
+/obj/item/crowbar/red,
+/obj/item/clothing/mask/gas/atmos,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"nS" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"nV" = (
+/turf/open/floor/engine/vacuum,
+/area/ruin/planetengi)
+"nW" = (
+/mob/living/basic/mining_drone,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"oc" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/iron/solarpanel,
+/area/ruin/planetengi)
+"ok" = (
+/obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"oH" = (
+/obj/machinery/igniter/incinerator_syndicatelava,
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"oQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/item/trash/flare,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"oW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"oY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/build/directional/north,
+/obj/structure/tank_dispenser,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"pd" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/decoration/glowstick,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"pF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/plating/directional/south,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"pH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"pI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"pN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/south,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"pO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"qb" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"qg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"qi" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"qA" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/singular/directional/west,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"qD" = (
+/obj/structure/table/reinforced,
+/obj/item/radio{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"qW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/vomit/old/black_bile,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"qX" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/wirebrush,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/soft_cap_pop_art/directional/north,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"rD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"rG" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stock_parts/micro_laser,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"rH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"rS" = (
+/obj/structure/table,
+/obj/item/weldingtool,
+/obj/item/analyzer,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"rW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/item/trash/energybar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"sA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/broken_flooring/singular/directional/west,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"sD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/corner/directional/south,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"sF" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"sO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/south,
+/obj/structure/cable,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"sQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/north,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"tp" = (
+/obj/machinery/power/solar{
+	id = "forestarboard";
+	name = "Fore-Starboard Solar Array"
+	},
+/turf/open/floor/iron/solarpanel,
+/area/ruin/planetengi)
+"tA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/south,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"tH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"tY" = (
+/obj/structure/closet/toolcloset,
+/obj/item/pickaxe/emergency,
+/obj/item/airlock_painter/decal,
+/obj/item/storage/belt/utility,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"ue" = (
+/obj/machinery/shower/directional/south,
+/obj/structure/curtain,
+/obj/machinery/duct,
+/obj/structure/fluff{
+	desc = "What, you think the water just magically soaks into the metallic flooring?";
+	icon = 'icons/obj/mining_zones/survival_pod.dmi';
+	icon_state = "fan_tiny";
+	name = "shower drain"
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/planetengi)
+"us" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"uD" = (
+/obj/machinery/door/airlock/glass/incinerator/syndicatelava_interior,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"uM" = (
+/obj/structure/sign/poster/ripped/directional/north,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"uR" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/broken_flooring/plating/directional/south,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ve" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/obj/structure/broken_flooring/singular/directional/south,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"vf" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"vg" = (
+/obj/structure/sign/poster/official/wtf_is_co2/directional/north{
+	dir = 1
+	},
+/turf/open/floor/engine/co2,
+/area/ruin/planetengi)
+"vh" = (
+/obj/structure/table_frame,
+/obj/item/folder/blue{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"vl" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/structure/broken_flooring/plating/directional,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"vr" = (
+/obj/structure/sign/warning/engine_safety/directional/west,
+/obj/item/kirbyplants/random/dead,
+/obj/structure/broken_flooring/pile/directional/south,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"vM" = (
+/obj/structure/table_frame,
+/obj/structure/closet/mini_fridge/grimy,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/coffee_cartridge/fancy,
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"vV" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/broken_flooring/plating/directional/south,
+/obj/item/flashlight/flare,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"vZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"wa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage"
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"wd" = (
+/obj/structure/sign/warning/fire/directional/east,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/flashlight/flare,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"wm" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"wr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"ws" = (
+/obj/structure/broken_flooring/side/directional/south,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"xm" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/ruin/planetengi)
+"xt" = (
+/obj/structure/fence/cut/medium{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"xu" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"xN" = (
+/mob/living/basic/bear/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"xS" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"xU" = (
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/xeno_mining/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/utility/hardhat,
+/obj/item/shovel,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"ye" = (
+/obj/effect/mapping_helpers/airalarm/all_access,
+/turf/closed/wall,
+/area/ruin/planetengi)
+"yr" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"yH" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/broken_flooring/side/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"yJ" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/singular/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"yT" = (
+/obj/structure/broken_flooring/corner/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/structure/broken_flooring/singular/directional/south,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ze" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Turbine Exhaust Chamber Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock_note_placer{
+	note_info = "You are expected to build the cooling system for the exhaust yourself."
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/side/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zp" = (
+/obj/structure/broken_flooring/pile/directional/south,
+/obj/item/stamp/head/ce{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zA" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/plating/directional/east,
+/obj/machinery/light_switch/directional/west,
+/obj/item/trash/shok_roks/lanternfruit,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zB" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	dir = 8;
+	chamber_id = "lavalandsyndien2"
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"zH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/plating/directional/north,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/hitsplatter{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/microwave,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zM" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"zW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"Ag" = (
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Ah" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"Ar" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	dir = 8;
+	chamber_id = "lavalandsyndieo2"
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"Aw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"AA" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"AB" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"AR" = (
+/obj/structure/broken_flooring/side/directional/south,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"AZ" = (
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor{
+	name = "Turbine Access"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Bf" = (
+/obj/machinery/air_sensor{
+	chamber_id = "lavalandsyndien2"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"Bm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Bq" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"CC" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"CF" = (
+/obj/structure/fence,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"CJ" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"CN" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/clothing/head/utility/welding{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/structure/sign/poster/official/safety_eye_protection/directional/west,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Df" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"Dh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"Dl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Dp" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Dz" = (
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/closet/crate/trashcart/filled,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 3;
+	pixel_y = -8
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"DB" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
+"DF" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/moth_epi/directional/north,
+/obj/effect/mob_spawn/corpse/human/engineer,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"DK" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/engine/vacuum,
+/area/ruin/planetengi)
+"DT" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/broken_flooring/singular/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"DY" = (
+/obj/structure/table,
+/obj/machinery/status_display/ai/directional/north,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/machinery/firealarm/directional/west,
+/obj/item/geiger_counter{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Ec" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Turbine Generator Access"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Ev" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/sign/poster/official/work_for_a_future/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Ey" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"EO" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/ruin/planetengi)
+"ES" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Fb" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/ruin/planetengi)
+"Fp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/frame/computer,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Fq" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Fr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/sign/warning/no_smoking/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"FB" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Engineering Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"FS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"FX" = (
+/obj/effect/spawner/random/structure/shipping_container,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Gc" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Gg" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Gl" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Go" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Gu" = (
+/obj/structure/cable,
+/obj/machinery/power/turbine/core_rotor{
+	dir = 4;
+	mapping_id = "syndie_lavaland_incineratorturbine"
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"GD" = (
+/obj/structure/flora/tree/dead,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"GG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/south,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"GK" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"GM" = (
+/obj/structure/fence/door/opened{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"GO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -16
+	},
+/obj/structure/broken_flooring/singular/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"GT" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/structure/broken_flooring/plating/directional/south,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Hk" = (
+/obj/structure/sign/poster/official/moth_hardhat/directional/north,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/closet/crate/bin,
+/obj/item/coupon,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Hv" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/east,
+/obj/item/storage/medkit/fire,
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/rcd_ammo/large,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Hw" = (
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/closed/wall/r_wall,
+/area/ruin/planetengi)
+"HB" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"HK" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/item/pillow/random,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/airalarm/directional/east,
+/obj/item/coffee_cartridge/bootleg,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"HN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/singular/directional/north,
+/obj/structure/cable,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"HV" = (
+/obj/structure/sink/directional/south,
+/obj/machinery/duct,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron/freezer,
+/area/ruin/planetengi)
+"IG" = (
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/cyan/visible/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/orange/visible/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"IP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"IU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"IV" = (
+/obj/machinery/computer/monitor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Jb" = (
+/obj/structure/flora/rock/icy/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Jm" = (
+/obj/machinery/atmospherics/miner/plasma,
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"Jn" = (
+/obj/structure/rack,
+/obj/machinery/status_display/ai/directional/north,
+/obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/wrench,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/gps/engineering{
+	gpstag = "CE0"
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Jx" = (
+/obj/effect/spawner/random/trash/box,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty,
+/obj/item/stack/ducts/fifty,
+/obj/item/reagent_containers/cup/bucket,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow,
+/obj/item/coffee_cartridge/bootleg,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Jz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/trash/flare,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"JP" = (
+/obj/structure/fence/corner{
+	dir = 9
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Kc" = (
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/effect/spawner/random/trash/caution_sign,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Kq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Ky" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"KL" = (
+/obj/structure/grille/broken,
+/obj/item/assembly/mousetrap,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/generic,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/ruin/planetengi)
+"KN" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"KR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/south,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"KY" = (
+/obj/machinery/computer/atmos_control/noreconnect{
+	dir = 1;
+	atmos_chambers = list("lavalandsyndieo2"="Oxygen Supply","lavalandsyndien2"="Nitrogen Supply","lavalandsyndieco2"="Carbon Dioxide Supply","lavalandsyndieplasma"="Plasma Supply")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"KZ" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/ruin/planetengi)
+"Lh" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/item/hatchet,
+/obj/structure/door_assembly,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Lk" = (
+/obj/item/shard,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Lp" = (
+/obj/structure/broken_flooring,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Lv" = (
+/obj/structure/fence/cut/medium{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/lavaland/surface/outdoors)
+"Lz" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"LF" = (
+/obj/machinery/door/poddoor/incinerator_syndicatelava_main,
+/turf/open/floor/engine/vacuum,
+/area/ruin/planetengi)
+"LI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/firealarm/directional/south,
+/obj/item/storage/fancy/cigarettes/cigpack_carp,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Mf" = (
+/obj/item/stack/cable_coil/cut,
+/obj/structure/broken_flooring/side/directional/west,
+/obj/structure/sign/poster/ripped/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ML" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/fireplace,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Ng" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/plating/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Nq" = (
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	mapping_id = "syndie_lavaland_incineratorturbine"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"NA" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/circuitboard/machine/coffeemaker,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"NU" = (
+/obj/structure/statue/snow/snowlegion,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Og" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Oh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/side/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Om" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Or" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Pi" = (
+/obj/structure/flora/rock/pile/icy/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Pr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Ps" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"PJ" = (
+/obj/structure/table_frame,
+/obj/structure/broken_flooring/corner/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/item/storage/toolbox/electrical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"PN" = (
+/obj/structure/closet/crate/engineering,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/light_switch/directional/west,
+/obj/item/stack/cable_coil/five,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/utility/hardhat,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Qa" = (
+/obj/structure/sign/warning/cold_temp/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Qe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"Qj" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Utilities Closet"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Qo" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"Qp" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Qt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Qu" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	dir = 8;
+	chamber_id = "lavalandsyndieplasma"
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"Qy" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/walk/directional/north,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"QG" = (
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/closed/wall/rust,
+/area/ruin/planetengi)
+"QH" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"QR" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage"
+	},
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"QV" = (
+/obj/item/kirbyplants/random/dead,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/digital_clock/directional/south,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Rc" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Rn" = (
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Rq" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/corner/directional/south,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Rr" = (
+/obj/structure/table_frame,
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/effect/spawner/random/entertainment/wallet_storage,
+/obj/item/binoculars,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Rw" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -16
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/planetengi)
+"RC" = (
+/obj/effect/spawner/random/structure/closet_private,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/reagent_containers/medigel/libital,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"RD" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/trash/flare,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"RJ" = (
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Quarters"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Sz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"SC" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/broken_flooring/plating/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/flare,
+/obj/machinery/firealarm/directional/west,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"SD" = (
+/obj/structure/flora/grass/brown/style_random,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"SK" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"SM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/side/directional/west,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ST" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"SV" = (
+/turf/open/floor/iron/solarpanel,
+/area/ruin/planetengi)
+"SX" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"Tl" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Turbine Generator Access"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Tv" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/item/pillow/random,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"TQ" = (
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Uf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Ur" = (
+/turf/closed/wall/rust,
+/area/ruin/planetengi)
+"UH" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"UJ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/north,
+/mob/living/basic/mining/legion/snow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"UP" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"US" = (
+/obj/structure/closet/crate/rcd,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/cell/lead,
+/obj/item/stack/cable_coil/five,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/toolbox/emergency,
+/obj/item/rcd_ammo,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"UY" = (
+/obj/machinery/power/turbine/inlet_compressor{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"Vb" = (
+/obj/effect/mapping_helpers/airalarm/all_access,
+/turf/closed/wall/rust,
+/area/ruin/planetengi)
+"Vg" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Vj" = (
+/obj/structure/broken_flooring/side/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Vm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Vo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Vq" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/knife/combat/survival,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"VB" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/basic/legion_brood/snow,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"VD" = (
+/obj/machinery/atmospherics/components/trinary/mixer/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"VF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/trash/can/food/envirochow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"VU" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/mob_spawn/corpse/human/engineer/mod,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"VW" = (
+/obj/structure/broken_flooring/side/directional/north,
+/obj/item/assembly/mousetrap/armed,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Wi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "lavalandsyndieco2"
+	},
+/turf/open/floor/engine/co2,
+/area/ruin/planetengi)
+"Wn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/planetengi)
+"Wq" = (
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Ws" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/broken_flooring/pile/directional/east,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Wu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"WH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"WL" = (
+/obj/effect/decal/cleanable/blood,
+/turf/closed/wall/rust,
+/area/ruin/planetengi)
+"WP" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"WQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "lavalandsyndieo2";
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"WX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Xc" = (
+/obj/machinery/air_sensor{
+	chamber_id = "lavalandsyndieo2"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"Xf" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Xg" = (
+/obj/structure/closet/emcloset,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/utility/hardhat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Xk" = (
+/obj/machinery/air_sensor{
+	chamber_id = "lavalandsyndieplasma"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine/o2,
+/area/ruin/planetengi)
+"Xo" = (
+/obj/structure/flora/rock/pile/style_random,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/lavaland/surface/outdoors)
+"Xu" = (
+/obj/item/radio/intercom/command/directional/west,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/closet/crate/bin,
+/obj/item/blank_coffee_cartridge,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/computer_disk/engineering,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"XF" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/item/mining_scanner,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"XQ" = (
+/obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"XR" = (
+/obj/structure/closet/crate/engineering,
+/obj/item/pipe_dispenser,
+/obj/item/turbine_parts/compressor{
+	current_tier = 3
+	},
+/obj/item/turbine_parts/stator{
+	current_tier = 2
+	},
+/obj/item/turbine_parts/rotor{
+	current_tier = 3
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/rcd_ammo,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Yb" = (
+/obj/machinery/atmospherics/components/binary/pump/on/cyan/visible/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Yj" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/north,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Yy" = (
+/obj/structure/fireaxecabinet/empty,
+/turf/closed/wall,
+/area/ruin/planetengi)
+"Yz" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/planetengi)
+"YF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"YI" = (
+/obj/machinery/air_sensor{
+	id_tag = "lavalandsyndieturbinecool"
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/planetengi)
+"YJ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"YL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/coffee,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"YP" = (
+/turf/closed/wall,
+/area/ruin/planetengi)
+"YS" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"Zg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/pdapainter/engineering,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Zh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Zl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	fax_name = "Chief Engineer's Office";
+	name = "Chief Engineer's Fax Machine"
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Zn" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/ready_donk,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Zu" = (
+/obj/effect/decal/cleanable/ash,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+"Zz" = (
+/obj/effect/mapping_helpers/airalarm/all_access,
+/turf/closed/wall/r_wall/rust,
+/area/ruin/planetengi)
+"ZB" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/broken_flooring/corner/directional/north,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ZE" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating,
+/area/ruin/planetengi)
+"ZQ" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/pen/screwdriver{
+	pixel_x = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/planetengi)
+
+(1,1,1) = {"
+dN
+Pi
+hs
+Gl
+hs
+Gl
+hs
+hs
+hs
+hs
+hs
+hs
+hs
+aF
+Gl
+hs
+hs
+hs
+hs
+hs
+hs
+Gl
+hs
+dN
+dN
+dN
+dN
+dN
+dN
+"}
+(2,1,1) = {"
+hs
+hs
+aF
+hs
+Gl
+Pi
+Ur
+jn
+Ur
+YP
+Gl
+hs
+hs
+Gl
+hs
+hs
+Gl
+Jb
+hs
+hs
+hs
+aF
+Gl
+hs
+dN
+hs
+dN
+dN
+dN
+"}
+(3,1,1) = {"
+dN
+Gl
+hs
+hs
+hs
+aF
+YP
+cN
+Xg
+Ur
+Rn
+Gl
+hs
+hs
+hs
+Gl
+Rn
+Gl
+hs
+hs
+Pi
+hs
+hs
+hs
+hs
+hs
+hs
+dN
+dN
+"}
+(4,1,1) = {"
+Gl
+hs
+GD
+Ur
+ye
+QG
+Ur
+lM
+jW
+jW
+lS
+jW
+Lk
+Rc
+qb
+jW
+lS
+JP
+GM
+CF
+Lz
+Gl
+hs
+Pi
+hs
+Gl
+GD
+hs
+dN
+"}
+(5,1,1) = {"
+Rn
+Gl
+YP
+Yy
+eG
+nQ
+jJ
+IU
+YL
+Pr
+jW
+lL
+RD
+UP
+Zg
+Xu
+lS
+jW
+uM
+cj
+xt
+hs
+Gl
+hs
+Gl
+Rn
+hs
+hs
+dN
+"}
+(6,1,1) = {"
+Jb
+hs
+Ur
+DF
+XF
+bF
+ST
+Gg
+dH
+rD
+jW
+cW
+Lp
+fE
+iw
+vZ
+vr
+jW
+cL
+xN
+DB
+hs
+aF
+hs
+Jb
+hs
+Gl
+hs
+hs
+"}
+(7,1,1) = {"
+Gl
+hs
+Ur
+tY
+jf
+vZ
+yT
+Vo
+hr
+kX
+lS
+vM
+ay
+AA
+Rr
+ZQ
+IU
+qb
+cj
+cj
+HB
+Rn
+Gl
+nW
+hs
+hs
+hs
+hs
+hs
+"}
+(8,1,1) = {"
+Gl
+gz
+Vg
+VW
+bR
+je
+sO
+HN
+XQ
+le
+qb
+Zl
+vZ
+cO
+vh
+zp
+IU
+qb
+cj
+hs
+Lv
+hs
+hs
+hs
+hs
+Gl
+hs
+Gl
+hs
+"}
+(9,1,1) = {"
+hs
+Qo
+Ur
+YP
+vf
+hu
+vf
+Ur
+Qy
+YJ
+qb
+db
+jr
+lz
+qD
+GT
+zM
+kg
+hs
+cj
+DB
+hs
+cj
+hs
+aF
+hs
+hs
+hs
+Gl
+"}
+(10,1,1) = {"
+Gl
+Dh
+tp
+tp
+Qo
+SV
+SV
+Go
+qW
+Ws
+vl
+gs
+bO
+Ag
+fy
+jC
+kj
+Wq
+cj
+cj
+qi
+Gl
+Rn
+Gl
+hs
+Gl
+Rn
+hs
+dN
+"}
+(11,1,1) = {"
+Rn
+SX
+tp
+oc
+Wn
+tp
+SV
+vf
+SM
+iY
+Rc
+Vj
+Bm
+gO
+nO
+dO
+vZ
+qb
+hs
+cj
+HB
+Jb
+Gl
+hs
+hs
+FX
+hs
+hs
+dN
+"}
+(12,1,1) = {"
+hs
+pd
+Qo
+Wn
+Qo
+pO
+Wn
+ZE
+Wu
+oW
+jW
+Jn
+Hv
+Ky
+AR
+Lp
+QV
+lS
+Ur
+Ur
+YP
+YP
+hs
+hs
+hs
+hs
+hs
+hs
+dN
+"}
+(13,1,1) = {"
+Gl
+Qo
+tp
+SV
+pO
+SV
+tp
+Ur
+Qa
+WH
+jW
+jW
+jW
+RJ
+Hw
+qb
+Zz
+jW
+nv
+bX
+qg
+Ur
+hs
+Rn
+hs
+hs
+Gl
+Gl
+dN
+"}
+(14,1,1) = {"
+hs
+Qo
+SV
+tp
+Qo
+tp
+oc
+vf
+Fp
+Sz
+FB
+Aw
+wr
+eS
+pH
+Oh
+yJ
+Qj
+VF
+nA
+ac
+EO
+GD
+hs
+hs
+fu
+ch
+Rn
+dN
+"}
+(15,1,1) = {"
+hs
+Qo
+SX
+pO
+im
+Wn
+Qo
+KN
+pF
+Or
+jY
+ve
+yH
+ZB
+aY
+kD
+AB
+YP
+qX
+Jx
+Fb
+KL
+Xo
+hs
+SD
+cP
+Gl
+dN
+dN
+"}
+(16,1,1) = {"
+Gl
+Qo
+tp
+SV
+pO
+SV
+tp
+Ur
+xU
+cE
+YP
+WL
+Ur
+DT
+YP
+jY
+Ur
+YP
+Ur
+Ur
+KZ
+Ur
+hs
+hs
+hs
+aF
+Qp
+dN
+dN
+"}
+(17,1,1) = {"
+hs
+Qo
+oc
+tp
+Qo
+SV
+SV
+Ur
+SK
+LI
+YP
+dV
+qA
+dY
+uR
+oQ
+Kc
+lF
+US
+Ur
+kq
+aF
+NU
+hs
+hs
+Gl
+hs
+dN
+GD
+"}
+(18,1,1) = {"
+Gl
+Qo
+Ur
+Rc
+CC
+Ur
+hn
+YP
+YP
+Mf
+Ur
+QH
+Dz
+Ur
+Ur
+Ec
+YP
+YP
+Ur
+Vb
+Ur
+Rn
+Gl
+hs
+Rn
+hs
+hs
+Rn
+hs
+"}
+(19,1,1) = {"
+Gl
+Jb
+YP
+Gc
+Dp
+ws
+UH
+rG
+YP
+QR
+YP
+Fq
+YP
+YP
+DY
+Zu
+zA
+CJ
+CN
+rS
+YP
+jW
+jW
+lS
+jW
+jW
+jW
+lS
+Gl
+"}
+(20,1,1) = {"
+hs
+hs
+YP
+IV
+hV
+kz
+vV
+ec
+Vb
+aH
+ct
+lZ
+PN
+YP
+Hk
+nH
+TQ
+FS
+xS
+GK
+Dl
+Fr
+Df
+WP
+Df
+Ah
+oH
+lS
+hs
+"}
+(21,1,1) = {"
+Gl
+aF
+Ur
+iR
+fo
+Kq
+zi
+Vm
+wa
+Jz
+Og
+Vq
+mT
+Tl
+bM
+mJ
+xu
+Yj
+Ps
+Ng
+Rq
+WX
+uD
+Qe
+ok
+bl
+Yz
+jW
+Gl
+"}
+(22,1,1) = {"
+Rn
+Ur
+Ur
+YP
+NA
+Bq
+ES
+PJ
+Ur
+oY
+dw
+VU
+aL
+lS
+sQ
+tH
+zH
+Uf
+tH
+GG
+Zh
+bQ
+fX
+eX
+zW
+UY
+jW
+jW
+dN
+"}
+(23,1,1) = {"
+hs
+YP
+ue
+Ur
+YP
+Vb
+al
+QG
+YP
+Ur
+lS
+dC
+jW
+Hw
+kN
+Xf
+VB
+jx
+ju
+cU
+pI
+rW
+rH
+iz
+AZ
+Gu
+lS
+Rn
+dN
+"}
+(24,1,1) = {"
+hs
+YP
+HV
+Ur
+ML
+SC
+bv
+jD
+QG
+Jb
+jW
+vg
+Wi
+ii
+dZ
+ed
+KR
+YF
+VD
+nS
+tA
+gJ
+GO
+Nq
+lS
+eT
+jW
+Gl
+dN
+"}
+(25,1,1) = {"
+hs
+YP
+gh
+Lh
+iF
+fe
+zc
+zL
+Ur
+Gl
+lS
+xm
+iW
+Ey
+kl
+UJ
+IP
+vZ
+hA
+sD
+VB
+us
+pN
+KY
+jW
+LF
+lS
+lS
+Rn
+"}
+(26,1,1) = {"
+hs
+Ur
+dB
+Ur
+Tv
+Zn
+ng
+bH
+iE
+Rn
+jW
+lS
+jW
+lS
+sA
+Yb
+XR
+Ev
+IG
+Qt
+fc
+fW
+vZ
+wd
+ze
+DK
+nV
+cV
+hs
+"}
+(27,1,1) = {"
+hs
+Ur
+YP
+YP
+hg
+HK
+RC
+YS
+Rc
+hs
+aF
+Gl
+Rn
+jW
+jW
+Om
+yr
+lS
+Om
+Om
+lS
+yr
+Om
+lS
+jW
+YI
+Rw
+jW
+hs
+"}
+(28,1,1) = {"
+hs
+Pi
+Gl
+Ur
+Ur
+Vb
+Rc
+wm
+Ur
+Gl
+hs
+Gl
+hs
+aF
+jW
+bK
+zB
+jW
+WQ
+Ar
+lS
+bf
+Qu
+jW
+lS
+jW
+jW
+jW
+Gl
+"}
+(29,1,1) = {"
+dN
+Gl
+hs
+hs
+Rn
+Gl
+Gl
+hs
+hs
+hs
+Gl
+Jb
+hs
+hs
+lS
+Bf
+sF
+jW
+Xc
+co
+jW
+Xk
+Jm
+jW
+Jb
+Gl
+Rn
+hs
+dN
+"}
+(30,1,1) = {"
+dN
+dN
+hs
+hs
+aF
+hs
+Rn
+hs
+hs
+aF
+hs
+GD
+Gl
+hs
+jW
+jW
+lS
+lS
+jW
+jW
+jW
+lS
+jW
+jW
+Rn
+hs
+hs
+dN
+dN
+"}
+(31,1,1) = {"
+dN
+dN
+dN
+dN
+hs
+Jb
+hs
+Gl
+hs
+hs
+hs
+hs
+hs
+hs
+Pi
+hs
+Gl
+hs
+hs
+hs
+Gl
+Gl
+hs
+hs
+hs
+hs
+dN
+dN
+dN
+"}

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -24,12 +24,6 @@
 	description = "Surprised to see us here?"
 	suffix = "icemoon_surface_asteroid.dmm"
 
-/datum/map_template/ruin/icemoon/engioutpost
-	name = "Engineer Outpost"
-	id = "engioutpost"
-	description = "Blown up by an unfortunate accident."
-	suffix = "icemoon_surface_engioutpost.dmm"
-
 /datum/map_template/ruin/icemoon/fountain
 	name = "Fountain Hall"
 	id = "ice_fountain"
@@ -66,6 +60,13 @@
 	id = "smoking_room"
 	description = "Here lies Charles Morlbaro. He died the way he lived."
 	suffix = "icemoon_surface_smoking_room.dmm"
+
+/datum/map_template/ruin/icemoon/underground/unlucky_engineer
+	name = "Ruined Engineering Outpost"
+	id = "unlucky_engineer"
+	description = "A bloody hand reaches for a ruined APC. Is whoever - or whatever destroyed this place still lurking in its shadows?"
+	suffix = "icemoon_unlucky_engineer.dmm"
+	always_place = TRUE
 
 // above and below ground together
 

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -61,11 +61,11 @@
 	description = "Here lies Charles Morlbaro. He died the way he lived."
 	suffix = "icemoon_surface_smoking_room.dmm"
 
-/datum/map_template/ruin/icemoon/underground/unlucky_engineer
+/datum/map_template/ruin/icemoon/unlucky_engineer
 	name = "Ruined Engineering Outpost"
 	id = "unlucky_engineer"
 	description = "A bloody hand reaches for a ruined APC. Is whoever - or whatever destroyed this place still lurking in its shadows?"
-	suffix = "icemoon_unlucky_engineer.dmm"
+	suffix = "icemoon_surface_unlucky_engineer.dmm"
 	always_place = TRUE
 
 // above and below ground together

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -70,7 +70,7 @@
 /area/ruin/unlucky_engineer/turbine
 	name = "\improper Ruined Turbine"
 	sound_environment = SOUND_ENVIRONMENT_DIZZY
-	mood_bonus = -1
+	mood_bonus = -2
 	mood_message = "Those creatures must've burst the pipes... It's so hard to think in here..."
 
 /area/ruin/unlucky_engineer/ce
@@ -90,8 +90,8 @@
 /area/ruin/unlucky_engineer/rest
 	name = "\improper Frozen Bunk Room"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
-	mood_bonus = 1
-	mood_message = "It's cold in here... But I can bear it and press on."
+	mood_bonus = -1
+	mood_message = "It's even colder in here... I don't think I can bear it."
 
 /area/ruin/unlucky_engineer/maints
 	name = "\improper Decrepit Passageway"

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -42,9 +42,6 @@
 /area/ruin/pizzeria/kitchen
 	name = "\improper Moffuchi's Kitchen"
 
-/area/ruin/planetengi
-	name = "\improper Engineering Outpost"
-
 /area/ruin/smoking_room/house
 	name = "\improper Tobacco House"
 	sound_environment = SOUND_ENVIRONMENT_CITY
@@ -63,3 +60,41 @@
 /area/ruin/powered/hermit
 	name = "\improper Hermit's Cabin"
 
+/area/ruin/unlucky_engineer/foyer
+	name = "\improper Abandoned Engineering Foyer"
+	sound_environment = SOUND_AREA_STANDARD_STATION
+
+/area/ruin/unlucky_engineer/solars
+	name = "\improper Desolate Solars"
+
+/area/ruin/unlucky_engineer/turbine
+	name = "\improper Ruined Turbine"
+	sound_environment = SOUND_ENVIRONMENT_DIZZY
+	mood_bonus = -1
+	mood_message = "Those creatures must've burst the pipes... It's so hard to think in here..."
+
+/area/ruin/unlucky_engineer/ce
+	name = "\improper Ransacked Chief Engineer's Office"
+	sound_environment = SOUND_AREA_STANDARD_STATION
+	mood_bonus = -3
+	mood_message = "It's so cold in here... Do I hear something scratching around, outside?"
+
+/area/ruin/unlucky_engineer/gear
+	name = "\improper Looted Gear Storage"
+	sound_environment = SOUND_AREA_STANDARD_STATION
+
+/area/ruin/unlucky_engineer/smes
+	name = "\improper Burnt Out Work Room"
+	sound_environment = SOUND_AREA_STANDARD_STATION
+
+/area/ruin/unlucky_engineer/rest
+	name = "\improper Frozen Bunk Room"
+	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	mood_bonus = 1
+	mood_message = "It's cold in here... But I can bear it and press on."
+
+/area/ruin/unlucky_engineer/maints
+	name = "\improper Decrepit Passageway"
+	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	mood_bonus = -4
+	mood_message = "It's so cold and dark in here... I want to leave."

--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -31,6 +31,8 @@
 	ai_controller = /datum/ai_controller/basic_controller/legion_brood
 	/// Reference to a guy who made us
 	var/mob/living/created_by
+	//determines if we have an automatic death timer
+	var/lifetime = 10 SECONDS
 
 /mob/living/basic/legion_brood/Initialize(mapload)
 	. = ..()
@@ -38,7 +40,8 @@
 	AddElement(/datum/element/simple_flying)
 	AddComponent(/datum/component/swarming)
 	AddComponent(/datum/component/clickbox, icon_state = "sphere", max_scale = 2)
-	addtimer(CALLBACK(src, PROC_REF(death)), 10 SECONDS)
+	if(lifetime)
+		addtimer(CALLBACK(src, PROC_REF(death)), lifetime)
 
 /mob/living/basic/legion_brood/death(gibbed)
 	if (!gibbed)

--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -15,10 +15,10 @@
 ##MISC
 #_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
-#_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_phonebooth.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_smoking_room.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_unlucky_engineer.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_puzzle.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm


### PR DESCRIPTION
## About The Pull Request
still wip. i made an ice themed engineering ruin and then realized there was a kind of dated one already on icebox. so i decided to rotate it out in favor of a new ruin, Unlucky Engineer.
a heavily damaged engineering outpost, that's still repairable, but infested by fauna. surviving here will take your wits, and the payoff is a nice increase to the power grid - as well as many other engineering themed goodies.
also allows mappers to set the lifetime of legion broods to any value, so you can place them down as easy to kill mobs. needed to use this here, but i hope it comes in handy.
old ruin:
![image](https://github.com/tgstation/tgstation/assets/110322848/c360a6a8-e997-4b15-abcc-d254e840b8e7)
new ruin: 
![2023-10-06 04 28 33](https://github.com/tgstation/tgstation/assets/110322848/b95d654a-011c-478c-97c3-56b4ababb0d7)
## Why It's Good For The Game
more interesting ruin design, implements a lot of helpers, decals, and mobs we didn't have years ago. makes be best loot a bit harder to get by putting obstacles in the way of it in the form of more mobs
## Changelog
:cl:
add: replaces engineering outpost on icemoon with unlucky engineer
/:cl:
