### PR TITLE
offical to official

### DIFF
--- a/code/game/objects/items/tail_pin.dm
+++ b/code/game/objects/items/tail_pin.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/obj/poster.dmi'
 	icon_state = "tailpin"
 	name = "tail pin"
-	desc = "Offically branded 'pin the tail on the corgi' style party implement. Not intended to be used on people."
+	desc = "Officially branded 'pin the tail on the corgi' style party implement. Not intended to be used on people."
 	force = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 0

--- a/code/modules/admin/verbs/admin_newscaster.dm
+++ b/code/modules/admin/verbs/admin_newscaster.dm
@@ -304,7 +304,7 @@
 		return TRUE
 	var/choice = tgui_alert(usr, "Please confirm feed channel creation","Network Channel Handler", list("Confirm","Cancel"))
 	if(choice == "Confirm")
-		GLOB.news_network.create_feed_channel(channel_name, "Centcom Offical", channel_desc, locked = channel_locked)
+		GLOB.news_network.create_feed_channel(channel_name, "Centcom Official", channel_desc, locked = channel_locked)
 		SSblackbox.record_feedback("text", "newscaster_channels", 1, "[channel_name]")
 	creating_channel = FALSE
 
@@ -316,7 +316,7 @@
 		creating_comment = FALSE
 		return TRUE
 	var/datum/feed_comment/new_feed_comment = new /datum/feed_comment
-	new_feed_comment.author = "Centcom Offical"
+	new_feed_comment.author = "Centcom Official"
 	new_feed_comment.body = comment_text
 	new_feed_comment.time_stamp = station_time_timestamp()
 	current_message.comments += new_feed_comment

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -249,7 +249,7 @@
 	painting_metadata.patron_name = user.real_name
 	painting_metadata.credit_value = offer_amount
 	last_patron = WEAKREF(user.mind)
-	to_chat(user, span_notice("Nanotrasen Trust Foundation thanks you for your contribution. You're now offical patron of this painting."))
+	to_chat(user, span_notice("Nanotrasen Trust Foundation thanks you for your contribution. You're now an official patron of this painting."))
 	var/list/possible_frames = SSpersistent_paintings.get_available_frames(offer_amount)
 	if(possible_frames.len <= 1) // Not much room for choices here.
 		return

--- a/config/blanks.json
+++ b/config/blanks.json
@@ -545,7 +545,7 @@
 			"<hr />",
 			"<font color=\"grey\"><div align=\"justify\">By writing and signing this form, you consent to the processing of your personal data by Nanotrasen Corporation.</div></font></p>",
 			"<hr />",
-			"<p><strong>Name of offical to take action:</strong></p>",
+			"<p><strong>Name of official to take action:</strong></p>",
 			"<p>[___________________________________]</span></p>",
 			"<p><strong>Official Decision:</strong></p>",
 			"<p>[___________________________________]</span></p>",

--- a/tgui/packages/tgui/interfaces/AdminFax.js
+++ b/tgui/packages/tgui/interfaces/AdminFax.js
@@ -91,7 +91,7 @@ export const FaxMainPanel = (props, context) => {
             icon="n"
             mr="7px"
             width="49%"
-            onClick={() => setPaperName('Nanotrasen Offical Report')}>
+            onClick={() => setPaperName('Nanotrasen Official Report')}>
             Nanotrasen
           </Button>
           <Button

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -195,6 +195,11 @@ if $grep 'NanoTrasen' $code_files; then
     echo -e "${RED}ERROR: Misspelling(s) of Nanotrasen detected in code, please uncapitalize the T(s).${NC}"
     st=1
 fi;
+if $grep -i 'offical' $code_files; then
+	echo
+    echo -e "${RED}ERROR: Misspelling(s) of official detected in code, please add the missing I(s).${NC}"
+    st=1
+fi;
 part "map json naming"
 if ls _maps/*.json | $grep "[A-Z]"; then
 	echo


### PR DESCRIPTION
## About The Pull Request
Fixes "offical" to "official" in several locations - admin fax panel, admin newscaster, art patron text, a photocopier template, and a corgi tail pin item description. Adds this common misspelling to the check_grep.sh ci tool.
## Why It's Good For The Game
I have corrected the typo manually every single time I have sent a fax from Central Command.
## Changelog
:cl:
spellcheck: "offical" has been officially corrected to "official" in several official locations.
/:cl:
