### PR TITLE
gibbing ghosts you before you get deleted by gibbing

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -14,6 +14,7 @@
 	if(!prev_lying)
 		gib_animation()
 
+	ghostize()
 	spill_organs(no_brain, no_organs, no_bodyparts)
 
 	if(!no_bodyparts)


### PR DESCRIPTION

## About The Pull Request

### previously

https://github.com/tgstation/tgstation/assets/70376633/714aca88-23a8-47f0-8ff2-c61408cf5cf1


### with this pr
https://github.com/tgstation/tgstation/assets/70376633/8363c5fc-5766-469f-8095-7ea97bbccf56


also you can revive the victim with their heads brain as normal

## Why It's Good For The Game

its faster for the recipient and also less of a delay

also if i remember correctly deleting mobs with a client stacktraces so im calling this a stracktrace fix

## Changelog
:cl:
fix: you are now made a ghost faster if you get gibbed
/:cl:
