### PR TITLE
Fixes the HEAL_NEGATIVE_MUTATIONS revive flag

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -687,7 +687,7 @@
 	if(heal_flags & HEAL_NEGATIVE_MUTATIONS)
 		for(var/datum/mutation/human/existing_mutation in dna.mutations)
 			if(existing_mutation.quality != POSITIVE)
-				dna.remove_mutation(existing_mutation.name)
+				dna.remove_mutation(existing_mutation)
 
 	if(heal_flags & HEAL_TEMP)
 		set_coretemperature(get_body_temp_normal(apply_change = FALSE))


### PR DESCRIPTION

## About The Pull Request

There is a flag for the revive proc called `HEAL_NEGATIVE_MUTATIONS`. It is supposed to make the revive heal negative and minor negative (e.g. chav, medieval) mutations, but not positive mutations. However, it was bugged and wouldn't heal any mutations. This PR just fixes it. Closes #43547.
## Why It's Good For The Game

Its a bugfix.
## Changelog
:cl:
fix: Adminheal will now properly clear negative mutations as intended.
/:cl:
