### PR TITLE
Adds sanity checking to the tippable component

### DIFF
--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -133,6 +133,8 @@
 /datum/component/tippable/proc/do_tip(mob/living/tipped_mob, mob/tipper)
 	if(QDELETED(tipped_mob))
 		CRASH("Tippable component: do_tip() called with QDELETED tipped_mob!")
+	if (is_tipped == TRUE) // sanity check in case multiple people try to tip at the same time
+		return
 
 	to_chat(tipper, span_warning("You tip over [tipped_mob]."))
 	if (!isnull(tipped_mob.client))
@@ -184,6 +186,8 @@
  */
 /datum/component/tippable/proc/do_untip(mob/living/tipped_mob, mob/untipper)
 	if(QDELETED(tipped_mob))
+		return
+	if (is_tipped == FALSE) // sanity check in case multiple people try to untip at the same time
 		return
 
 	to_chat(untipper, span_notice("You right [tipped_mob]."))

--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -133,7 +133,7 @@
 /datum/component/tippable/proc/do_tip(mob/living/tipped_mob, mob/tipper)
 	if(QDELETED(tipped_mob))
 		CRASH("Tippable component: do_tip() called with QDELETED tipped_mob!")
-	if (is_tipped == TRUE) // sanity check in case multiple people try to tip at the same time
+	if (is_tipped) // sanity check in case multiple people try to tip at the same time
 		return
 
 	to_chat(tipper, span_warning("You tip over [tipped_mob]."))
@@ -187,7 +187,7 @@
 /datum/component/tippable/proc/do_untip(mob/living/tipped_mob, mob/untipper)
 	if(QDELETED(tipped_mob))
 		return
-	if (is_tipped == FALSE) // sanity check in case multiple people try to untip at the same time
+	if (!is_tipped) // sanity check in case multiple people try to untip at the same time
 		return
 
 	to_chat(untipper, span_notice("You right [tipped_mob]."))


### PR DESCRIPTION

## About The Pull Request

The tippable component doesn't actually have any sanity checking for if the tippable thing has already been tipped. This means that if two people try to tip something over at the same time, it will appear untipped but be immobilized as though it were tipped. The sprite will also stay permanently flipped until the bug is preformed again. Now that doesn't happen. Closes #64232.
## Why It's Good For The Game

As funny as it is to see upside-down borgs running around, its still a bug.
## Changelog
:cl:
fix: Borgs will no longer become permanently upside-down if tipped over by multiple people at the same time.
/:cl:
