### PR TITLE
Engineering Borgs can no longer grab their own iron module

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -56,9 +56,9 @@
 	stored.forceMove(user.drop_location())
 
 /obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
-	// Checking for TRAIT_NODROP prevents edge cases where borgs can grab their own modules.
 	if(!stored)
-		if(!HAS_TRAIT(atom, TRAIT_NODROP))
+		// Borgs should not be grabbing their own modules
+		if(!istype(atom.loc, /mob/living/silicon/robot))
 			var/itemcheck = FALSE
 			for(var/storable_type in storable)
 				if(istype(atom, storable_type))

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -56,19 +56,21 @@
 	stored.forceMove(user.drop_location())
 
 /obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
+	// Checking for TRAIT_NODROP prevents edge cases where borgs can grab their own modules.
 	if(!stored)
-		var/itemcheck = FALSE
-		for(var/storable_type in storable)
-			if(istype(atom, storable_type))
-				itemcheck = TRUE
-				break
-		if(itemcheck)
-			var/obj/item/item = atom
-			item.forceMove(src)
-			stored = item
-			RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
-			update_appearance()
-			return TRUE
+		if(!HAS_TRAIT(atom, TRAIT_NODROP))
+			var/itemcheck = FALSE
+			for(var/storable_type in storable)
+				if(istype(atom, storable_type))
+					itemcheck = TRUE
+					break
+			if(itemcheck)
+				var/obj/item/item = atom
+				item.forceMove(src)
+				stored = item
+				RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
+				update_appearance()
+				return TRUE
 	else
 		stored.melee_attack_chain(user, atom, params)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Borgs apparatus modules can no longer pick up items located inside themselves (or another borg, technically). I can't think of any situation where a borg would legitimately need to do this, and it can cause bugs. Closes #76699. Closes #77659.
## Why It's Good For The Game

This is a major borg that can result in humans having un-droppable borg modules in their hands.
## Changelog
:cl:
fix: Engineering borgs can no longer grab and drop their own iron/glass sheet module.
/:cl:
