### PR TITLE
Moves silicon camera (photos, not mob cameras) out of click code

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -73,10 +73,6 @@
 	if(world.time <= next_move)
 		return
 
-	if(aicamera.in_camera_mode)
-		aicamera.toggle_camera_mode(sound = FALSE)
-		aicamera.captureimage(pixel_turf, usr)
-		return
 	if(waypoint_mode)
 		waypoint_mode = 0
 		set_waypoint(A)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -48,11 +48,6 @@
 
 	face_atom(A) // change direction to face what you clicked on
 
-	if(aicamera.in_camera_mode) //Cyborg picture taking
-		aicamera.toggle_camera_mode(sound = FALSE)
-		aicamera.captureimage(A, usr)
-		return
-
 	var/obj/item/W = get_active_held_item()
 
 	if(!W && get_dist(src,A) <= interaction_range)

--- a/code/modules/pai/camera.dm
+++ b/code/modules/pai/camera.dm
@@ -1,10 +1,3 @@
-/mob/living/silicon/pai/ClickOn(atom/target, params)
-	. = ..()
-	if(aicamera && aicamera.in_camera_mode)
-		aicamera.toggle_camera_mode(sound = FALSE)
-		aicamera.captureimage(target, usr)
-	return TRUE
-
 /obj/item/camera/siliconcam/pai_camera
 	name = "pAI photo camera"
 	light_color = COLOR_PAI_GREEN
@@ -13,7 +6,7 @@
 	var/number = length(stored)
 	picture.picture_name = "Image [number] (taken by [loc.name])"
 	stored[picture] = TRUE
-	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, TRUE, -3)
+	playsound(src, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, TRUE, -3)
 	balloon_alert(user, "image recorded")
 
 /**

--- a/code/modules/pai/hud.dm
+++ b/code/modules/pai/hud.dm
@@ -147,7 +147,8 @@
 	required_software = "Photography Module"
 
 /atom/movable/screen/pai/image_take/Click()
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/silicon/pai/pAI = usr
 	pAI.aicamera.toggle_camera_mode(usr)

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -62,6 +62,11 @@
 	name = "AI photo camera"
 	flash_enabled = FALSE
 
+/obj/item/camera/siliconcam/ai_camera/can_take_picture(mob/living/silicon/ai/clicker)
+	if(clicker.control_disabled)
+		return FALSE
+	return ..()
+
 /obj/item/camera/siliconcam/ai_camera/balloon_alert(mob/viewer, text)
 	if(isAI(loc))
 		// redirects balloon alerts on us to balloon alerts on our ai eye

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -1,23 +1,47 @@
 
 /obj/item/camera/siliconcam
 	name = "silicon photo camera"
-	var/in_camera_mode = FALSE
+	resistance_flags = INDESTRUCTIBLE
+	/// List of all pictures taken by this camera.
 	var/list/datum/picture/stored = list()
 
-/obj/item/camera/siliconcam/ai_camera
-	name = "AI photo camera"
-	flash_enabled = FALSE
+/// Checks if we can take a picture at this moment. Returns TRUE if we can, FALSE if we can't.
+/obj/item/camera/siliconcam/proc/can_take_picture(mob/living/silicon/clicker)
+	if(clicker.stat != CONSCIOUS || clicker.incapacitated() || clicker.IsParalyzed() || clicker.IsStun())
+		return FALSE
+	return TRUE
 
+/obj/item/camera/siliconcam/proc/InterceptClickOn(mob/living/silicon/clicker, params, atom/clicked_on)
+	if(!can_take_picture(clicker))
+		return
+	clicker.face_atom(clicked_on)
+	captureimage(clicked_on, clicker)
+	toggle_camera_mode(clicker, sound = FALSE)
+
+/// Toggles the camera mode on or off.
+/// If sound is TRUE, plays a sound effect and displays a message on successful toggle
 /obj/item/camera/siliconcam/proc/toggle_camera_mode(mob/user, sound = TRUE)
-	in_camera_mode = !in_camera_mode
+	if(user.click_intercept == src)
+		user.click_intercept = null
+
+	else if(isnull(user.click_intercept))
+		user.click_intercept = src
+
+	else
+		// Trying to turn on camera mode while you have another click intercept active, such as malf abilities
+		if(sound)
+			balloon_alert(user, "can't enable camera mode!")
+			playsound(user, 'sound/machines/buzz-sigh.ogg', 25, TRUE)
+		return
+
 	if(sound)
-		playsound(src, 'sound/items/wirecutter.ogg', 50, TRUE)
-	to_chat(user, span_notice("Camera mode: [in_camera_mode ? "Activated" : "Deactivated"]."))
+		playsound(user, 'sound/items/wirecutter.ogg', 50, TRUE)
+		balloon_alert(user, "camera mode [user.click_intercept == src ? "activated" : "deactivated"]")
 
 /obj/item/camera/siliconcam/proc/selectpicture(mob/user)
 	RETURN_TYPE(/datum/picture)
 	if(!length(stored))
-		to_chat(user, span_notice("ERROR: No stored photos located."))
+		user.balloon_alert(user, "no stored photos!")
 		return
 	var/list/nametemp = list()
 	var/list/temp = list()
@@ -25,9 +49,7 @@
 		nametemp += stored_photo.picture_name
 		temp[stored_photo.picture_name] = stored_photo
 	var/find = tgui_input_list(user, "Select image", "Storage", nametemp)
-	if(isnull(find))
-		return
-	if(isnull(temp[find]))
+	if(isnull(find) || isnull(temp[find]))
 		return
 	return temp[find]
 
@@ -36,48 +58,66 @@
 	if(istype(selection))
 		show_picture(user, selection)
 
+/obj/item/camera/siliconcam/ai_camera
+	name = "AI photo camera"
+	flash_enabled = FALSE
+
+/obj/item/camera/siliconcam/ai_camera/balloon_alert(mob/viewer, text)
+	if(isAI(loc))
+		// redirects balloon alerts on us to balloon alerts on our ai eye
+		var/mob/living/silicon/ai/ai = loc
+		return ai.eyeobj.balloon_alert(viewer, text)
+
+	return ..()
+
 /obj/item/camera/siliconcam/ai_camera/after_picture(mob/user, datum/picture/picture)
 	var/number = length(stored)
 	picture.picture_name = "Image [number] (taken by [loc.name])"
 	stored[picture] = TRUE
-	to_chat(user, span_notice("Image recorded."))
+	balloon_alert(user, "image recorded")
+	user.playsound_local(get_turf(user), pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 50, TRUE, -3)
 
 /obj/item/camera/siliconcam/robot_camera
 	name = "Cyborg photo camera"
 	var/printcost = 2
 
-/obj/item/camera/siliconcam/robot_camera/after_picture(mob/user, datum/picture/picture)
-	var/mob/living/silicon/robot/C = loc
-	if(istype(C) && istype(C.connected_ai))
-		var/number = C.connected_ai.aicamera.stored.len
+/obj/item/camera/siliconcam/robot_camera/can_take_picture(mob/living/silicon/robot/clicker)
+	if(clicker.lockcharge)
+		return FALSE
+	return ..()
+
+/obj/item/camera/siliconcam/robot_camera/after_picture(mob/living/silicon/robot/user, datum/picture/picture)
+	if(istype(user) && istype(user.connected_ai))
+		var/number = user.connected_ai.aicamera.stored.len
 		picture.picture_name = "Image [number] (taken by [loc.name])"
-		C.connected_ai.aicamera.stored[picture] = TRUE
-		to_chat(usr, span_notice("Image recorded and saved to remote database."))
+		user.connected_ai.aicamera.stored[picture] = TRUE
+		balloon_alert(user, "image recorded and uploaded")
 	else
 		var/number = stored.len
 		picture.picture_name = "Image [number] (taken by [loc.name])"
 		stored[picture] = TRUE
-		to_chat(usr, span_notice("Image recorded and saved to local storage. Upload will happen automatically if unit is lawsynced."))
+		balloon_alert(user, "image recorded and saved locally")
+	playsound(src, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, TRUE, -3)
 
-/obj/item/camera/siliconcam/robot_camera/selectpicture(mob/user)
+/obj/item/camera/siliconcam/robot_camera/selectpicture(mob/living/silicon/robot/user)
 	var/mob/living/silicon/robot/R = loc
-	if(istype(R) && R.connected_ai)
-		R.picturesync()
-		return R.connected_ai.aicamera.selectpicture(user)
-	else
-		return ..()
+	if(istype(user) && user.connected_ai)
+		user.picturesync()
+		return user.connected_ai.aicamera.selectpicture(user)
+	return ..()
 
-/obj/item/camera/siliconcam/robot_camera/proc/borgprint(mob/user)
-	var/mob/living/silicon/robot/C = loc
-	if(!istype(C) || C.toner < 20)
-		to_chat(user, span_warning("Insufficent toner to print image."))
+/obj/item/camera/siliconcam/robot_camera/proc/borgprint(mob/living/silicon/robot/user)
+	if(!istype(user) || user.toner < printcost)
+		balloon_alert(user, "not enough toner!")
 		return
 	var/datum/picture/selection = selectpicture(user)
 	if(!istype(selection))
-		to_chat(user, span_warning("Invalid Image."))
+		balloon_alert(user, "invalid image!")
 		return
-	var/obj/item/photo/p = new /obj/item/photo(C.loc, selection)
-	p.pixel_x = p.base_pixel_x + rand(-10, 10)
-	p.pixel_y = p.base_pixel_y + rand(-10, 10)
-	C.toner -= printcost  //All fun allowed.
-	user.visible_message(span_notice("[C.name] spits out a photograph from a narrow slot on its chassis."), span_notice("You print a photograph."))
+	var/obj/item/photo/printed = new(user.drop_location(), selection)
+	printed.pixel_x = printed.base_pixel_x + rand(-10, 10)
+	printed.pixel_y = printed.base_pixel_y + rand(-10, 10)
+	user.toner -= printcost  //All fun allowed.
+	user.visible_message(span_notice("[user.name] spits out a photograph from a narrow slot on its chassis."), span_notice("You print a photograph."))
+	balloon_alert(user, "photograph printed")
+	playsound(src, 'sound/items/taperecorder/taperecorder_print.ogg', 50, TRUE, -3)

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -7,7 +7,7 @@
 
 /// Checks if we can take a picture at this moment. Returns TRUE if we can, FALSE if we can't.
 /obj/item/camera/siliconcam/proc/can_take_picture(mob/living/silicon/clicker)
-	if(clicker.stat != CONSCIOUS || clicker.incapacitated() || clicker.IsParalyzed() || clicker.IsStun())
+	if(clicker.stat != CONSCIOUS || clicker.incapacitated())
 		return FALSE
 	return TRUE
 
@@ -100,7 +100,6 @@
 	playsound(src, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, TRUE, -3)
 
 /obj/item/camera/siliconcam/robot_camera/selectpicture(mob/living/silicon/robot/user)
-	var/mob/living/silicon/robot/R = loc
 	if(istype(user) && user.connected_ai)
 		user.picturesync()
 		return user.connected_ai.aicamera.selectpicture(user)


### PR DESCRIPTION
## About The Pull Request

Atomized from the swing branch. 

Moves silicon camera (taking photos, not mob camera stuff) out of their core click code. It now uses click intercepts. 

(There's an argument to be made to use signals rather than click intercept as it's rather antiquated but w/e.) 

- [x] I tested this PR 

## Why It's Good For The Game

Makes it easier to unifiy click a bit more in the future. Reduces surface area of a feature. 

## Changelog

:cl: Melbert
qol: AI, cyborg, and PAI camera (photo taking) behavior now uses balloon alerts and has sound effects associated
refactor: Refactored AI, cyborg, and PAI camera (photo taking) code
fix: fixed being unable to print photos as a cyborg when below 50% toner, even though photos only take 5%
/:cl:
