### PR TITLE
fixed wierd TGUI crash

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -43,19 +43,23 @@ export const NtosMessenger = (props, context) => {
     const openChat = saved_chats[open_chat];
     const temporaryRecipient = messengers[open_chat];
 
-    content = (
-      <ChatScreen
-        storedPhotos={stored_photos}
-        selectedPhoto={selected_photo_path}
-        isSilicon={is_silicon}
-        sendingVirus={sending_virus}
-        canReply={openChat ? openChat.can_reply : !!temporaryRecipient}
-        messages={openChat ? openChat.messages : []}
-        recipient={openChat ? openChat.recipient : temporaryRecipient}
-        unreads={openChat ? openChat.unread_messages : 0}
-        chatRef={openChat?.ref}
-      />
-    );
+    if (!openChat && !temporaryRecipient) {
+      content = <ContactsScreen />;
+    } else {
+      content = (
+        <ChatScreen
+          storedPhotos={stored_photos}
+          selectedPhoto={selected_photo_path}
+          isSilicon={is_silicon}
+          sendingVirus={sending_virus}
+          canReply={openChat ? openChat.can_reply : !!temporaryRecipient}
+          messages={openChat ? openChat.messages : []}
+          recipient={openChat ? openChat.recipient : temporaryRecipient}
+          unreads={openChat ? openChat.unread_messages : 0}
+          chatRef={openChat?.ref}
+        />
+      );
+    }
   } else {
     content = <ContactsScreen />;
   }


### PR DESCRIPTION
## About The Pull Request
There is a weird bug, that happens if you're writing your first PDA message to someone, and his PDA gets destroyed (abus/cryo/blows up), your messenger app will recieve unfixable TGUI error, due to being unable to recieve recipient name. So i added another check on TGUI side of app ¯\_(ツ)_/¯
## Why It's Good For The Game
Your PDA's wont stuck in TGUI blue screen of death, if someone went to cryo during you writing a message to him.
## Changelog
:cl:
fix: fixed a PDA's messenger TGUI issue with handling of destroyed recipients.
/:cl:
