### PR TITLE
Bleeding has been subtly broken for 3+ years, let's fix that yeah?

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -223,6 +223,7 @@
 	var/drips = 1
 	dryname = "drips of blood"
 	drydesc = "It's red."
+	mergeable_decal = FALSE
 
 /obj/effect/decal/cleanable/blood/drip/can_bloodcrawl_in()
 	return TRUE

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -223,7 +223,6 @@
 	var/drips = 1
 	dryname = "drips of blood"
 	drydesc = "It's red."
-	mergeable_decal = FALSE
 
 /obj/effect/decal/cleanable/blood/drip/can_bloodcrawl_in()
 	return TRUE

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -94,7 +94,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD))
-		add_splatter_floor(loc, (amt >= 10))
+		add_splatter_floor(loc, (amt <= 10))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod


### PR DESCRIPTION

## About The Pull Request
the `drip` argument was being passed an inverted value.
Broke in https://github.com/tgstation/tgstation/pull/56056
## Changelog

:cl:
fix: Blood once again appears as small drops instead of splatters during minor bleeding.
/:cl:
