### PR TITLE
Fixes Slaughter/Laughter Demon Melee Cooldowns

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/demon/demon.dm
+++ b/code/modules/mob/living/basic/space_fauna/demon/demon.dm
@@ -32,6 +32,7 @@
 	obj_damage = 40
 	melee_damage_lower = 10
 	melee_damage_upper = 15
+	melee_attack_cooldown = CLICK_CD_MELEE
 	death_message = "screams in agony as it sublimates into a sulfurous smoke."
 	death_sound = 'sound/magic/demon_dies.ogg'
 


### PR DESCRIPTION
## About The Pull Request

This PR reverts the slaughter/laughter demon melee speed to be the default for player characters.

## Why It's Good For The Game

These guys are solely player-controlled, and I don't think this change was intentional.

## Changelog
:cl:
fix: Slaughter/Laughter demon melee cooldowns have been fixed and now attack at the regular player character attack speed
/:cl: