### PR TITLE
Frosty's factions are now defines

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/statue/statue.dm
+++ b/code/modules/mob/living/basic/space_fauna/statue/statue.dm
@@ -162,7 +162,7 @@
 	maxHealth = 5000
 	melee_damage_lower = 65
 	melee_damage_upper = 65
-	faction = list("statue","mining")
+	faction = list(FACTION_STATUE,FACTION_MINING)
 
 /mob/living/basic/statue/frosty/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Saw that Frosty the Snowman's factions were strings instead of defines, so I have made them use defines.

## Why It's Good For The Game

Defines are much safer and cleaner than using strings.

## Changelog

Nothing player facing