### PR TITLE
Reduces the average delay between random events, cleans up event subsystem code

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -11,9 +11,9 @@ SUBSYSTEM_DEF(events)
 	///The next world.time that a naturally occuring random event can be selected.
 	var/scheduled = 0
 	///The lower bound for how soon another random event can be scheduled.
-	var/frequency_lower = 3 MINUTES
+	var/frequency_lower = 2.5 MINUTES
 	///The upper bound for how soon another random event can be scheduled.
-	var/frequency_upper = 10 MINUTES
+	var/frequency_upper = 7 MINUTES
 	///Will wizard events be included in the event pool?
 	var/wizardmode = FALSE
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -2,15 +2,19 @@ SUBSYSTEM_DEF(events)
 	name = "Events"
 	init_order = INIT_ORDER_EVENTS
 	runlevels = RUNLEVEL_GAME
-
-	var/list/control = list() //list of all datum/round_event_control. Used for selecting events based on weight and occurrences.
-	var/list/running = list() //list of all existing /datum/round_event
+	///list of all datum/round_event_control. Used for selecting events based on weight and occurrences.
+	var/list/control = list()
+	///list of all existing /datum/round_event currently being run.
+	var/list/running = list()
+	///cache of currently running events, for lag checking.
 	var/list/currentrun = list()
-
-	var/scheduled = 0 //The next world.time that a naturally occuring random event can be selected.
-	var/frequency_lower = 1800 //3 minutes lower bound.
-	var/frequency_upper = 6000 //10 minutes upper bound. Basically an event will happen every 3 to 10 minutes.
-
+	///The next world.time that a naturally occuring random event can be selected.
+	var/scheduled = 0
+	///The lower bound for how soon another random event can be scheduled.
+	var/frequency_lower = 3 MINUTES
+	///The upper bound for how soon another random event can be scheduled.
+	var/frequency_upper = 10 MINUTES
+	///Will wizard events be included in the event pool?
 	var/wizardmode = FALSE
 
 /datum/controller/subsystem/events/Initialize()
@@ -24,7 +28,6 @@ SUBSYSTEM_DEF(events)
 	if(isnull(GLOB.holidays))
 		fill_holidays()
 	return SS_INIT_SUCCESS
-
 
 /datum/controller/subsystem/events/fire(resumed = FALSE)
 	if(!resumed)
@@ -60,46 +63,41 @@ SUBSYSTEM_DEF(events)
 	if(!CONFIG_GET(flag/allow_random_events))
 		return
 
-	var/players_amt = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
+	var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 	// Only alive, non-AFK human players count towards this.
 
-	var/sum_of_weights = 0
-	for(var/datum/round_event_control/E in control)
-		if(!E.can_spawn_event(players_amt))
+	var/list/event_roster = list()
+
+	for(var/datum/round_event_control/event_to_check in control)
+		if(!event_to_check.can_spawn_event(players_amt))
 			continue
-		if(E.weight < 0) //for round-start events etc.
-			var/res = TriggerEvent(E)
+		if(event_to_check.weight < 0) //for round-start events etc.
+			var/res = TriggerEvent(event_to_check)
 			if(res == EVENT_INTERRUPTED)
 				continue //like it never happened
 			if(res == EVENT_CANT_RUN)
 				return
-		sum_of_weights += E.weight
+		else
+			event_roster[event_to_check] = event_to_check.weight
 
-	sum_of_weights = rand(0,sum_of_weights) //reusing this variable. It now represents the 'weight' we want to select
+	var/datum/round_event_control/event_to_run = pick_weight(event_roster)
+	TriggerEvent(event_to_run)
 
-	for(var/datum/round_event_control/E in control)
-		if(!E.can_spawn_event(players_amt))
-			continue
-		sum_of_weights -= E.weight
-
-		if(sum_of_weights <= 0) //we've hit our goal
-			if(TriggerEvent(E))
-				return
-
-/datum/controller/subsystem/events/proc/TriggerEvent(datum/round_event_control/E)
-	. = E.preRunEvent()
+///Does the last pre-flight checks for the passed event, and runs it if the event is ready.
+/datum/controller/subsystem/events/proc/TriggerEvent(datum/round_event_control/event_to_trigger)
+	. = event_to_trigger.preRunEvent()
 	if(. == EVENT_CANT_RUN)//we couldn't run this event for some reason, set its max_occurrences to 0
-		E.max_occurrences = 0
+		event_to_trigger.max_occurrences = 0
 	else if(. == EVENT_READY)
-		E.run_event(random = TRUE)
+		event_to_trigger.run_event(random = TRUE)
 
-
+///Toggles whether or not wizard events will be in the event pool, and sends a notification to the admins.
 /datum/controller/subsystem/events/proc/toggleWizardmode()
 	wizardmode = !wizardmode
 	message_admins("Summon Events has been [wizardmode ? "enabled, events will occur every [SSevents.frequency_lower / 600] to [SSevents.frequency_upper / 600] minutes" : "disabled"]!")
 	log_game("Summon Events was [wizardmode ? "enabled" : "disabled"]!")
 
-
+///Sets the event frequency bounds back to their initial value.
 /datum/controller/subsystem/events/proc/resetFrequency()
 	frequency_lower = initial(frequency_lower)
 	frequency_upper = initial(frequency_upper)


### PR DESCRIPTION
## About The Pull Request

Alright first thing's first -- 

`frequency_lower = 3 minutes -> 2.5 minutes`
`frequency_upper = 10 minutes -> 7 minutes`

There's also some autodocing/unsinglenamevaring of the events subsystem, and the event selection code has been moved to a pick_weight().

This should have no effect on summon events, since that sets the frequencies manually when triggered.
## Why It's Good For The Game

The benign, fluffy events now heavily outweigh the truly destructive events in the pool. Even situationally destructive ones like the Supermatter Surge or Brand Intelligence provide players with a meaningful diversion to keep themselves occupied with.

Having more things going on, and more for players to do, is a good thing. Reducing the potentially lengthy delay between random events should accomplish this without increasing the amount of chaos between rounds.

Also, these values were changed 8 years ago, under the reasoning that "there are more random events now". We can safely say that there are even MORE random events now. I know changing something because it was changed in the past isn't a valid reason, but it's what set me down this road in the first place.

As a reminder, ghost antag events are handled through dynamic (unless dynamic is out of threat), meaning this won't seriously affect how frequently you see antags.

These values are, of course, subject to change in response to feedback, discussion, and maintainers yelling at me.
## Changelog
:cl: Rhials
balance: Random event frequency has been adjusted to fire events more often.
code: The event subsystem has been prettied up with comments and longer variable names.
/:cl:
