### PR TITLE
Recaches the icons generated in the `changeling` unit test

### DIFF
--- a/code/modules/unit_tests/changeling.dm
+++ b/code/modules/unit_tests/changeling.dm
@@ -48,6 +48,10 @@
 	if(isnull(final_icon))
 		final_icon = icon('icons/effects/effects.dmi', "nothing")
 
+	// If we have a lot of dna features with a lot of parts (icons)
+	// This'll eventually runtime into a bad icon operation
+	// So we're recaching the icons here to prevent it from failing
+	final_icon = icon(final_icon)
 	final_icon.Insert(getFlatIcon(ling, no_anim = TRUE), dir = SOUTH, frame = last_frame)
 	final_icon.Insert(getFlatIcon(victim, no_anim = TRUE), dir = NORTH, frame = last_frame)
 


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Fixes: #78673 

Hi. I run one of the two downstreams and was working on Melberts ling transformation PR.1

Turns out, if you have a lot of DNA features that have a lot of icons associated with them, this unit test just shits itself with a bad icon operation.

I spoke with Lemons over this and he helped point me in the right direction, which lead to recaching the icons to prevent issues.

As it stands, this *probably* wouldn't happen on base /tg/ since DNA features and their associated parts aren't a lot (compared to elsewhere). But if/when more features gets added this should prevent any issues.

## Changelog
Not player facing.