### PR TITLE
Fix virtual gondola meat

### DIFF
--- a/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
@@ -28,7 +28,7 @@
 
 /datum/reagent/gondola_mutation_toxin/virtual_domain
 	name = "Advanced Tranquility"
-	gondolaDisease = /datum/disease/transformation/gondola/virtual_domain
+	gondola_disease = /datum/disease/transformation/gondola/virtual_domain
 
 /datum/disease/transformation/gondola/virtual_domain
 	stage_prob = 9

--- a/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
@@ -28,11 +28,7 @@
 
 /datum/reagent/gondola_mutation_toxin/virtual_domain
 	name = "Advanced Tranquility"
-
-/datum/reagent/gondola_mutation_toxin/virtual_domain/expose_mob(mob/living/exposed_mob, methods = TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
-	. = ..()
-	if((methods & (PATCH|INGEST|INJECT)) || ((methods & VAPOR) && prob(min(reac_volume,100)*(1 - touch_protection))))
-		exposed_mob.ForceContractDisease(new /datum/disease/transformation/gondola/virtual_domain(), FALSE, TRUE)
+	gondolaDisease = /datum/disease/transformation/gondola/virtual_domain
 
 /datum/disease/transformation/gondola/virtual_domain
 	stage_prob = 9

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2567,7 +2567,7 @@
 /datum/reagent/gondola_mutation_toxin/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if((methods & (PATCH|INGEST|INJECT)) || ((methods & VAPOR) && prob(min(reac_volume,100)*(1 - touch_protection))))
-		exposed_mob.ForceContractDisease(new gondola_disease(), FALSE, TRUE)
+		exposed_mob.ForceContractDisease(new gondola_disease, FALSE, TRUE)
 
 
 /datum/reagent/spider_extract

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2567,7 +2567,7 @@
 /datum/reagent/gondola_mutation_toxin/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if((methods & (PATCH|INGEST|INJECT)) || ((methods & VAPOR) && prob(min(reac_volume,100)*(1 - touch_protection))))
-		exposed_mob.ForceContractDisease(new gondolaDisease(), FALSE, TRUE)
+		exposed_mob.ForceContractDisease(new gondola_disease(), FALSE, TRUE)
 
 
 /datum/reagent/spider_extract

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2562,7 +2562,7 @@
 	color = "#9A6750" //RGB: 154, 103, 80
 	taste_description = "inner peace"
 	penetrates_skin = NONE
-	var/datum/disease/transformation/gondolaDisease = /datum/disease/transformation/gondola
+	var/datum/disease/transformation/gondola_disease = /datum/disease/transformation/gondola
 
 /datum/reagent/gondola_mutation_toxin/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2562,11 +2562,12 @@
 	color = "#9A6750" //RGB: 154, 103, 80
 	taste_description = "inner peace"
 	penetrates_skin = NONE
+	var/datum/disease/transformation/gondolaDisease = /datum/disease/transformation/gondola
 
 /datum/reagent/gondola_mutation_toxin/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if((methods & (PATCH|INGEST|INJECT)) || ((methods & VAPOR) && prob(min(reac_volume,100)*(1 - touch_protection))))
-		exposed_mob.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
+		exposed_mob.ForceContractDisease(new gondolaDisease(), FALSE, TRUE)
 
 
 /datum/reagent/spider_extract


### PR DESCRIPTION

## About The Pull Request
Instead of having a copy-pasted snowflake function for virtual gondola mutation toxin, lets just move the difference to a variable.
Fixes the "Be unable to push the crate" part of #78804, because it was applying both versions of the gondola disease, and the slower one could finish first if you got unlucky.
## Why It's Good For The Game
Bugs bad, duplicate code bad.
## Changelog
:cl:
fix: Virtual domain gondola meat will no longer have a small chance to turn you into a weaker gondola variant
/:cl:
