### PR TITLE
Warm donk-pockets once again have omnizine in them

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -74,9 +74,8 @@
 	if(baked_result.reagents && positive_result) //make space and tranfer reagents if it has any & the resulting item isn't bad food or other bad baking result
 		baked_result.reagents.clear_reagents()
 		original_object.reagents.trans_to(baked_result, original_object.reagents.total_volume)
-		if(added_reagents)
-			for (var/reagent in added_reagents) // Add any new reagents that should be added
-				baked_result.reagents.add_reagent(reagent, added_reagents[reagent])
+		if(added_reagents) // Add any new reagents that should be added
+			baked_result.reagents.add_reagent_list(added_reagents)
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -17,7 +17,7 @@
 	/// Reagents that should be added to the result
 	var/list/added_reagents
 
-/datum/component/bakeable/Initialize(bake_result, required_bake_time, positive_result, use_large_steam_sprit, list/added_reagents = list())
+/datum/component/bakeable/Initialize(bake_result, required_bake_time, positive_result, use_large_steam_sprit, list/added_reagents)
 	. = ..()
 	if(!isitem(parent)) //Only items support baking at the moment
 		return COMPONENT_INCOMPATIBLE
@@ -74,8 +74,9 @@
 	if(baked_result.reagents && positive_result) //make space and tranfer reagents if it has any & the resulting item isn't bad food or other bad baking result
 		baked_result.reagents.clear_reagents()
 		original_object.reagents.trans_to(baked_result, original_object.reagents.total_volume)
-		for (var/reagent in added_reagents) // Add any new reagents that should be added
-			baked_result.reagents.add_reagent(reagent, added_reagents[reagent])
+		if(added_reagents)
+			for (var/reagent in added_reagents) // Add any new reagents that should be added
+				baked_result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -14,7 +14,10 @@
 	/// REF() to the mind which placed us in an oven
 	var/who_baked_us
 
-/datum/component/bakeable/Initialize(bake_result, required_bake_time, positive_result, use_large_steam_sprite)
+	/// Reagents that should be added to the result
+	var/list/added_reagents
+
+/datum/component/bakeable/Initialize(bake_result, required_bake_time, positive_result, use_large_steam_sprit, list/added_reagents = list())
 	. = ..()
 	if(!isitem(parent)) //Only items support baking at the moment
 		return COMPONENT_INCOMPATIBLE
@@ -22,6 +25,7 @@
 	src.bake_result = bake_result
 	src.required_bake_time = required_bake_time
 	src.positive_result = positive_result
+	src.added_reagents = added_reagents
 
 // Inherit the new values passed to the component
 /datum/component/bakeable/InheritComponent(datum/component/bakeable/new_comp, original, bake_result, required_bake_time, positive_result, use_large_steam_sprite)
@@ -70,6 +74,8 @@
 	if(baked_result.reagents && positive_result) //make space and tranfer reagents if it has any & the resulting item isn't bad food or other bad baking result
 		baked_result.reagents.clear_reagents()
 		original_object.reagents.trans_to(baked_result, original_object.reagents.total_volume)
+		for (var/reagent in added_reagents) // Add any new reagents that should be added
+			baked_result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -106,9 +106,8 @@
 		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
 		grilled_result.reagents.clear_reagents()
 		original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
-		if(added_reagents)
-			for (var/reagent in added_reagents) // Add any new reagents that should be added
-				grilled_result.reagents.add_reagent(reagent, added_reagents[reagent])
+		if(added_reagents) // Add any new reagents that should be added
+			grilled_result.reagents.add_reagent_list(added_reagents)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	if(who_placed_us)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -15,7 +15,7 @@
 	/// Reagents that should be added to the result
 	var/list/added_reagents
 
-/datum/component/grillable/Initialize(cook_result, required_cook_time, positive_result, use_large_steam_sprite, list/added_reagents = list())
+/datum/component/grillable/Initialize(cook_result, required_cook_time, positive_result, use_large_steam_sprite, list/added_reagents)
 	. = ..()
 	if(!isitem(parent)) //Only items support grilling at the moment
 		return COMPONENT_INCOMPATIBLE
@@ -106,8 +106,9 @@
 		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
 		grilled_result.reagents.clear_reagents()
 		original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
-		for (var/reagent in added_reagents) // Add any new reagents that should be added
-			grilled_result.reagents.add_reagent(reagent, added_reagents[reagent])
+		if(added_reagents)
+			for (var/reagent in added_reagents) // Add any new reagents that should be added
+				grilled_result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	if(who_placed_us)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -12,8 +12,10 @@
 	var/use_large_steam_sprite = FALSE
 	/// REF() to the mind which placed us on the griddle
 	var/who_placed_us
+	/// Reagents that should be added to the result
+	var/list/added_reagents
 
-/datum/component/grillable/Initialize(cook_result, required_cook_time, positive_result, use_large_steam_sprite)
+/datum/component/grillable/Initialize(cook_result, required_cook_time, positive_result, use_large_steam_sprite, list/added_reagents = list())
 	. = ..()
 	if(!isitem(parent)) //Only items support grilling at the moment
 		return COMPONENT_INCOMPATIBLE
@@ -22,6 +24,7 @@
 	src.required_cook_time = required_cook_time
 	src.positive_result = positive_result
 	src.use_large_steam_sprite = use_large_steam_sprite
+	src.added_reagents = added_reagents
 
 /datum/component/grillable/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_GRILL_PLACED, PROC_REF(on_grill_placed))
@@ -103,6 +106,8 @@
 		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
 		grilled_result.reagents.clear_reagents()
 		original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
+		for (var/reagent in added_reagents) // Add any new reagents that should be added
+			grilled_result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	if(who_placed_us)

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -9,7 +9,7 @@
 	/// Reagents that should be added to the result
 	var/list/added_reagents
 
-/datum/element/microwavable/Attach(datum/target, microwave_type, list/reagents = list())
+/datum/element/microwavable/Attach(datum/target, microwave_type, list/reagents)
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
@@ -49,8 +49,9 @@
 		BLACKBOX_LOG_FOOD_MADE(result.type)
 		result.reagents.clear_reagents()
 		source.reagents?.trans_to(result, source.reagents.total_volume)
-		for (var/reagent in added_reagents) // Add any new reagents that should be added
-			result.reagents.add_reagent(reagent, added_reagents[reagent])
+		if(added_reagents)
+			for (var/reagent in added_reagents) // Add any new reagents that should be added
+				result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 		if(microwaver && microwaver.mind)
 			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -49,9 +49,8 @@
 		BLACKBOX_LOG_FOOD_MADE(result.type)
 		result.reagents.clear_reagents()
 		source.reagents?.trans_to(result, source.reagents.total_volume)
-		if(added_reagents)
-			for (var/reagent in added_reagents) // Add any new reagents that should be added
-				result.reagents.add_reagent(reagent, added_reagents[reagent])
+		if(added_reagents) // Add any new reagents that should be added
+			result.reagents.add_reagent_list(added_reagents)
 
 		if(microwaver && microwaver.mind)
 			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -6,13 +6,16 @@
 	var/atom/default_typepath = /obj/item/food/badrecipe
 	/// Resulting atom typepath on a completed microwave.
 	var/atom/result_typepath
+	var/list/added_reagents
 
-/datum/element/microwavable/Attach(datum/target, microwave_type)
+/datum/element/microwavable/Attach(datum/target, microwave_type, list/reagents = list())
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 
 	result_typepath = microwave_type || default_typepath
+
+	added_reagents = reagents
 
 	RegisterSignal(target, COMSIG_ITEM_MICROWAVE_ACT, PROC_REF(on_microwaved))
 
@@ -45,6 +48,8 @@
 		BLACKBOX_LOG_FOOD_MADE(result.type)
 		result.reagents.clear_reagents()
 		source.reagents?.trans_to(result, source.reagents.total_volume)
+		for (var/reagent in added_reagents)
+			result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 		if(microwaver && microwaver.mind)
 			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -6,6 +6,7 @@
 	var/atom/default_typepath = /obj/item/food/badrecipe
 	/// Resulting atom typepath on a completed microwave.
 	var/atom/result_typepath
+	/// Reagents that should be added to the result
 	var/list/added_reagents
 
 /datum/element/microwavable/Attach(datum/target, microwave_type, list/reagents = list())
@@ -48,7 +49,7 @@
 		BLACKBOX_LOG_FOOD_MADE(result.type)
 		result.reagents.clear_reagents()
 		source.reagents?.trans_to(result, source.reagents.total_volume)
-		for (var/reagent in added_reagents)
+		for (var/reagent in added_reagents) // Add any new reagents that should be added
 			result.reagents.add_reagent(reagent, added_reagents[reagent])
 
 		if(microwaver && microwaver.mind)

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -21,7 +21,9 @@
 	/// The upper end for how long it takes to bake
 	var/baking_time_long = 30 SECONDS
 	/// The reagents added when microwaved. Needed since microwaving ignores food_reagents
-	var/added_reagents = list(/datum/reagent/medicine/omnizine = 6)
+	var/static/list/added_reagents = list(/datum/reagent/medicine/omnizine = 6)
+	/// The reagents that most child types add when microwaved. Needed because you can't override static lists.
+	var/static/list/child_added_reagents = list(/datum/reagent/medicine/omnizine = 2)
 
 /obj/item/food/donkpocket/make_bakeable()
 	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, added_reagents)
@@ -70,7 +72,12 @@
 	tastes = list("meat" = 2, "dough" = 2, "spice" = 1)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/spicy
-	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
+
+/obj/item/food/donkpocket/spicy/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
+
+/obj/item/food/donkpocket/spicy/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
 
 /obj/item/food/donkpocket/warm/spicy
 	name = "warm Spicy-pocket"
@@ -97,7 +104,12 @@
 	tastes = list("meat" = 2, "dough" = 2, "soy sauce" = 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/teriyaki
-	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
+
+/obj/item/food/donkpocket/teriyaki/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
+
+/obj/item/food/donkpocket/teriyaki/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
 
 /obj/item/food/donkpocket/warm/teriyaki
 	name = "warm Teriyaki-pocket"
@@ -124,7 +136,12 @@
 	tastes = list("meat" = 2, "dough" = 2, "cheese"= 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/pizza
-	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
+
+/obj/item/food/donkpocket/pizza/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
+
+/obj/item/food/donkpocket/pizza/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
 
 /obj/item/food/donkpocket/warm/pizza
 	name = "warm Pizza-pocket"
@@ -151,10 +168,16 @@
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/honk
 	crafting_complexity = FOOD_COMPLEXITY_3
-	added_reagents = list(
+	var/static/list/honk_added_reagents = list(
 		/datum/reagent/medicine/omnizine = 2,
 		/datum/reagent/consumable/laughter = 6,
 	)
+
+/obj/item/food/donkpocket/honk/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, honk_added_reagents)
+
+/obj/item/food/donkpocket/honk/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type, honk_added_reagents)
 
 /obj/item/food/donkpocket/warm/honk
 	name = "warm Honk-pocket"
@@ -181,7 +204,12 @@
 	tastes = list("dough" = 2, "jam" = 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/berry
-	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
+
+/obj/item/food/donkpocket/berry/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
+
+/obj/item/food/donkpocket/berry/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
 
 /obj/item/food/donkpocket/warm/berry
 	name = "warm Berry-pocket"
@@ -208,10 +236,16 @@
 	foodtypes = GRAIN
 
 	warm_type = /obj/item/food/donkpocket/warm/gondola
-	added_reagents = list(
+	var/static/list/gondola_added_reagents = list(
 		/datum/reagent/medicine/omnizine = 2,
 		/datum/reagent/gondola_mutation_toxin = 5,
 	)
+
+/obj/item/food/donkpocket/gondola/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, gondola_added_reagents)
+
+/obj/item/food/donkpocket/gondola/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type, gondola_added_reagents)
 
 /obj/item/food/donkpocket/warm/gondola
 	name = "warm Gondola-pocket"

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -24,7 +24,7 @@
 	var/added_reagents = list(/datum/reagent/medicine/omnizine = 6)
 
 /obj/item/food/donkpocket/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE)
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, added_reagents)
 
 /obj/item/food/donkpocket/make_microwaveable()
 	AddElement(/datum/element/microwavable, warm_type, added_reagents)

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -20,12 +20,14 @@
 	var/baking_time_short = 25 SECONDS
 	/// The upper end for how long it takes to bake
 	var/baking_time_long = 30 SECONDS
+	/// The reagents added when microwaved. Needed since microwaving ignores food_reagents
+	var/added_reagents = list(/datum/reagent/medicine/omnizine = 6)
 
 /obj/item/food/donkpocket/make_bakeable()
 	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE)
 
 /obj/item/food/donkpocket/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type)
+	AddElement(/datum/element/microwavable, warm_type, added_reagents)
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"
@@ -68,6 +70,7 @@
 	tastes = list("meat" = 2, "dough" = 2, "spice" = 1)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/spicy
+	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
 
 /obj/item/food/donkpocket/warm/spicy
 	name = "warm Spicy-pocket"
@@ -94,6 +97,7 @@
 	tastes = list("meat" = 2, "dough" = 2, "soy sauce" = 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/teriyaki
+	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
 
 /obj/item/food/donkpocket/warm/teriyaki
 	name = "warm Teriyaki-pocket"
@@ -120,6 +124,7 @@
 	tastes = list("meat" = 2, "dough" = 2, "cheese"= 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/pizza
+	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
 
 /obj/item/food/donkpocket/warm/pizza
 	name = "warm Pizza-pocket"
@@ -146,6 +151,10 @@
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/honk
 	crafting_complexity = FOOD_COMPLEXITY_3
+	added_reagents = list(
+		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/consumable/laughter = 6,
+	)
 
 /obj/item/food/donkpocket/warm/honk
 	name = "warm Honk-pocket"
@@ -172,6 +181,7 @@
 	tastes = list("dough" = 2, "jam" = 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/berry
+	added_reagents = list(/datum/reagent/medicine/omnizine = 2)
 
 /obj/item/food/donkpocket/warm/berry
 	name = "warm Berry-pocket"
@@ -198,6 +208,10 @@
 	foodtypes = GRAIN
 
 	warm_type = /obj/item/food/donkpocket/warm/gondola
+	added_reagents = list(
+		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/gondola_mutation_toxin = 5,
+	)
 
 /obj/item/food/donkpocket/warm/gondola
 	name = "warm Gondola-pocket"

--- a/code/game/objects/items/food/packaged.dm
+++ b/code/game/objects/items/food/packaged.dm
@@ -210,7 +210,7 @@
 	var/warm_type = /obj/item/food/ready_donk/warm
 
 	/// What reagents should be added when this item is warmed?
-	var/added_reagents = list(/datum/reagent/medicine/omnizine = 3)
+	var/static/list/added_reagents = list(/datum/reagent/medicine/omnizine = 3)
 
 /obj/item/food/ready_donk/make_bakeable()
 	AddComponent(/datum/component/bakeable, warm_type, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE, added_reagents)

--- a/code/game/objects/items/food/packaged.dm
+++ b/code/game/objects/items/food/packaged.dm
@@ -209,8 +209,11 @@
 	/// What type of ready-donk are we warmed into?
 	var/warm_type = /obj/item/food/ready_donk/warm
 
+	/// What reagents should be added when this item is warmed?
+	var/added_reagents = list(/datum/reagent/medicine/omnizine = 3)
+
 /obj/item/food/ready_donk/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+	AddComponent(/datum/component/bakeable, warm_type, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE, added_reagents)
 
 /obj/item/food/ready_donk/make_microwaveable()
 	AddElement(/datum/element/microwavable, warm_type)

--- a/code/game/objects/items/food/packaged.dm
+++ b/code/game/objects/items/food/packaged.dm
@@ -216,7 +216,7 @@
 	AddComponent(/datum/component/bakeable, warm_type, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE, added_reagents)
 
 /obj/item/food/ready_donk/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type)
+	AddElement(/datum/element/microwavable, warm_type, added_reagents)
 
 /obj/item/food/ready_donk/examine_more(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

One of the post-foodening cleanup PRs inadvertently prevented warm donk-pockets from getting the omnizine they were supposed to have. This PR fixes it by adding a new argument to the microwaveable and bakeable elements, which donk-pockets now use. The new argument has also been added to the grillable element for future use.
## Why It's Good For The Game

Bugs aren't good.
## Changelog
:cl:
fix: Warm donk-pockets should now have omnizine in them again.
/:cl:
