### PR TITLE
Fixes ai shell deployment not unregistering a death signal properly

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1112,7 +1112,6 @@
 	SIGNAL_HANDLER
 	if(deployed_shell) //Forcibly call back AI in event of things such as damage, EMP or power loss.
 		to_chat(src, span_danger("Your remote connection has been reset!"))
-		UnregisterSignal(deployed_shell, COMSIG_LIVING_DEATH)
 		deployed_shell.undeploy()
 	diag_hud_set_deployed()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1112,8 +1112,8 @@
 	SIGNAL_HANDLER
 	if(deployed_shell) //Forcibly call back AI in event of things such as damage, EMP or power loss.
 		to_chat(src, span_danger("Your remote connection has been reset!"))
-		deployed_shell.undeploy()
 		UnregisterSignal(deployed_shell, COMSIG_LIVING_DEATH)
+		deployed_shell.undeploy()
 	diag_hud_set_deployed()
 
 /mob/living/silicon/ai/resist()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -895,13 +895,14 @@
 		return FALSE
 	var/mob/living/silicon/robot/shell_to_disconnect = owner
 
-	shell_to_disconnect.mainframe.disconnect_shell()
+	shell_to_disconnect.undeploy()
 	return TRUE
 
 
 /mob/living/silicon/robot/proc/undeploy()
 	if(!deployed || !mind || !mainframe)
 		return
+	mainframe.UnregisterSignal(src, COMSIG_LIVING_DEATH)
 	mainframe.redeploy_action.Grant(mainframe)
 	mainframe.redeploy_action.last_used_shell = src
 	mind.transfer_to(mainframe)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -893,9 +893,9 @@
 /datum/action/innate/undeployment/Trigger(trigger_flags)
 	if(!..())
 		return FALSE
-	var/mob/living/silicon/robot/R = owner
+	var/mob/living/silicon/robot/shell_to_disconnect = owner
 
-	R.undeploy()
+	shell_to_disconnect.mainframe.disconnect_shell()
 	return TRUE
 
 


### PR DESCRIPTION
it was screaming runtimes each time an ai disconnected or reconnected to an ai shell because it never unregistered the death disconnect signal properly.

```
[2023-10-01 14:56:38.191] RUNTIME: runtime error: living_death overridden. Use override = TRUE to suppress this warning.
 - Target: Calaban Default Shell-980 (/mob/living/silicon/robot/shell) Proc: disconnect_shell (code/datums/signals.dm:39)
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: code/__HELPERS/stack_trace.dm,4
 -   usr: Calaban (/mob/living/silicon/ai)
 -   src: null
 -   usr.loc: the floor (150,25,4) (/turf/open/floor/circuit)
 -   call stack:
 -  stack trace("living_death overridden. Use o...", "code/datums/signals.dm", 39)
 - Calaban (/mob/living/silicon/ai): RegisterSignal(Calaban Default Shell-980 (/mob/living/silicon/robot/shell), "living_death", "disconnect_shell", 0)
 - Calaban (/mob/living/silicon/ai): Deploy to Shell(Calaban Default Shell-980 (/mob/living/silicon/robot/shell))
 - Reconnect to shell (/datum/action/innate/deploy_last_shell): Trigger(null)
 - Reconnect to shell (/atom/movable/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=12;icon-y=17;left=1;but...")
 - Reconnect to shell (/atom/movable/screen/movable/action_button):  Click(null, "mapwindow.map", "icon-x=12;icon-y=17;left=1;but...")
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(Calaban (/mob/living/silicon/ai), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```

shouldn't be player facing i think but who knows maybe we've missed something here on an empty shell death. ai eye resets to the shell's position? no clue lmao it was just fucking annoying
