### PR TITLE
Fix MetaStation Trash Disposals Loop

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18503,6 +18503,7 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/mail_sorting/supply/disposals,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "gQw" = (


### PR DESCRIPTION

## About The Pull Request
This adds a mail sorting helper to the sorting pipe leading to disposals.  Without this helper, trash recycles through the station's delivery system and returns back to the delivery room.

Verified that trash flows to disposals and mail marked for other destinations is sent correctly.

https://github.com/tgstation/tgstation/assets/1784495/0e288740-b0af-40d7-b53c-bc9078d70103

fixes #78811 

## Why It's Good For The Game
Fixes a bug in the map; trash is piling up in Cargo otherwise.

## Changelog
:cl: Tek022
fix: Trash no longer recirculates back to MetaStation mail room.
/:cl:
