### PR TITLE
Fixes fleeing behaviour

### DIFF
--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -80,8 +80,8 @@
 ///List of mobs who have damaged us
 #define BB_BASIC_MOB_RETALIATE_LIST "BB_basic_mob_shitlist"
 
-/// Flag to set on or off if you want your mob to prioritise running away
-#define BB_BASIC_MOB_FLEEING "BB_basic_fleeing"
+/// Flag to set on if you want your mob to STOP running away
+#define BB_BASIC_MOB_STOP_FLEEING "BB_basic_stop_fleeing"
 
 ///list of foods this mob likes
 #define BB_BASIC_FOODS "BB_basic_foods"

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/run_away_from_target.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/run_away_from_target.dm
@@ -25,7 +25,7 @@
 	if (QDELETED(target) || !can_see(controller.pawn, target, run_distance))
 		finish_action(controller, succeeded = TRUE, target_key = target_key, hiding_location_key = hiding_location_key)
 		return
-	if (get_dist(controller.pawn, controller.current_movement_target) >= required_distance)
+	if (get_dist(controller.pawn, controller.current_movement_target) > required_distance)
 		return // Still heading over
 	if (plot_path_away_from(controller, target))
 		return

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/run_away_from_target.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/run_away_from_target.dm
@@ -19,7 +19,7 @@
 
 /datum/ai_behavior/run_away_from_target/perform(seconds_per_tick, datum/ai_controller/controller, target_key, hiding_location_key)
 	. = ..()
-	if (!controller.blackboard[BB_BASIC_MOB_FLEEING])
+	if (controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		return
 	var/atom/target = controller.blackboard[hiding_location_key] || controller.blackboard[target_key]
 	if (QDELETED(target) || !can_see(controller.pawn, target, run_distance))

--- a/code/datums/ai/basic_mobs/basic_subtrees/flee_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/flee_target.dm
@@ -10,7 +10,7 @@
 /datum/ai_planning_subtree/flee_target/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	. = ..()
 	var/atom/flee_from = controller.blackboard[target_key]
-	if (!controller.blackboard[BB_BASIC_MOB_FLEEING] || QDELETED(flee_from))
+	if (controller.blackboard[BB_BASIC_MOB_STOP_FLEEING] || QDELETED(flee_from))
 		return
 	var/flee_distance = controller.blackboard[BB_BASIC_MOB_FLEE_DISTANCE] || DEFAULT_BASIC_FLEE_DISTANCE
 	if (get_dist(controller.pawn, flee_from) >= flee_distance)

--- a/code/datums/ai/basic_mobs/basic_subtrees/simple_find_nearest_target_to_flee.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/simple_find_nearest_target_to_flee.dm
@@ -3,7 +3,7 @@
 
 /datum/ai_planning_subtree/simple_find_nearest_target_to_flee/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	. = ..()
-	if (!controller.blackboard[BB_BASIC_MOB_FLEEING])
+	if (controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		return
 	controller.queue_behavior(/datum/ai_behavior/find_potential_targets/nearest, BB_BASIC_MOB_CURRENT_TARGET, BB_TARGETTING_DATUM, BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION)
 
@@ -13,7 +13,7 @@
 
 /datum/ai_planning_subtree/find_nearest_thing_which_attacked_me_to_flee/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	. = ..()
-	if (!controller.blackboard[BB_BASIC_MOB_FLEEING])
+	if (controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		return
 	controller.queue_behavior(/datum/ai_behavior/target_from_retaliate_list/nearest, BB_BASIC_MOB_RETALIATE_LIST, BB_BASIC_MOB_CURRENT_TARGET, targeting_key, BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION)
 

--- a/code/datums/ai/dog/dog_controller.dm
+++ b/code/datums/ai/dog/dog_controller.dm
@@ -18,8 +18,6 @@
 /datum/ai_controller/basic_controller/dog/corgi
 	blackboard = list(
 		BB_DOG_HARASS_HARM = TRUE,
-		// IF you dont have this fleeing behavviour will just refuse to work, isn't that funny ha ha
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_VISION_RANGE = AI_DOG_VISION_RANGE,
 		BB_PET_TARGETTING_DATUM = new /datum/targetting_datum/not_friends(),
 		// Find nearby mobs with tongs in hand.

--- a/code/datums/elements/ai_flee_while_injured.dm
+++ b/code/datums/elements/ai_flee_while_injured.dm
@@ -32,14 +32,14 @@
 		return
 
 	var/current_health_percentage = source.health / source.maxHealth
-	if (source.ai_controller.blackboard[BB_BASIC_MOB_FLEEING])
-		if (current_health_percentage < stop_fleeing_at)
+	if (source.ai_controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
+		if (current_health_percentage > start_fleeing_below)
 			return
-		source.ai_controller.CancelActions() // Stop fleeing go back to whatever you were doing
-		source.ai_controller.set_blackboard_key(BB_BASIC_MOB_FLEEING, FALSE)
+		source.ai_controller.CancelActions()
+		source.ai_controller.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, FALSE)
 		return
 
-	if (current_health_percentage > start_fleeing_below)
+	if (current_health_percentage < stop_fleeing_at)
 		return
-	source.ai_controller.CancelActions()
-	source.ai_controller.set_blackboard_key(BB_BASIC_MOB_FLEEING, TRUE)
+	source.ai_controller.CancelActions() // Stop fleeing go back to whatever you were doing
+	source.ai_controller.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, TRUE)

--- a/code/modules/mob/living/basic/farm_animals/deer.dm
+++ b/code/modules/mob/living/basic/farm_animals/deer.dm
@@ -34,7 +34,6 @@
 
 /datum/ai_controller/basic_controller/deer
 	blackboard = list(
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_STATIONARY_MOVE_TO_TARGET = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction,
 	)

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -49,7 +49,6 @@
 
 /datum/ai_controller/basic_controller/rabbit
 	blackboard = list(
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 	)
 	ai_traits = STOP_MOVING_WHEN_PULLED

--- a/code/modules/mob/living/basic/farm_animals/sheep.dm
+++ b/code/modules/mob/living/basic/farm_animals/sheep.dm
@@ -81,7 +81,6 @@
 
 /datum/ai_controller/basic_controller/sheep
 	blackboard = list(
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 	)
 	ai_traits = STOP_MOVING_WHEN_PULLED

--- a/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid_ai.dm
+++ b/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid_ai.dm
@@ -1,7 +1,6 @@
 /datum/ai_controller/basic_controller/mega_arachnid
 	blackboard = list(
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic,
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_BASIC_MOB_FLEE_DISTANCE = 5,
 	)
 
@@ -37,7 +36,7 @@
 	flee_behaviour = /datum/ai_behavior/run_away_from_target/mega_arachnid
 
 /datum/ai_planning_subtree/flee_target/mega_arachnid/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
-	if(!controller.blackboard[BB_BASIC_MOB_FLEEING])
+	if(controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		return
 	var/datum/action/cooldown/slip_acid = controller.blackboard[BB_ARACHNID_SLIP]
 

--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub_ai.dm
@@ -3,7 +3,6 @@
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic,
 		BB_PET_TARGETTING_DATUM = new /datum/targetting_datum/not_friends,
 		BB_ORE_IGNORE_TYPES = list(/obj/item/stack/ore/iron, /obj/item/stack/ore/glass),
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_STORM_APPROACHING = FALSE,
 	)
 
@@ -25,7 +24,6 @@
 		BB_ORE_IGNORE_TYPES = list(/obj/item/stack/ore/glass),
 		BB_FIND_MOM_TYPES = list(/mob/living/basic/mining/goldgrub),
 		BB_IGNORE_MOM_TYPES = list(/mob/living/basic/mining/goldgrub/baby),
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_STORM_APPROACHING = FALSE,
 	)
 

--- a/code/modules/mob/living/basic/lavaland/legion/legion_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_ai.dm
@@ -2,7 +2,6 @@
 /datum/ai_controller/basic_controller/legion
 	blackboard = list(
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/attack_until_dead/legion,
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_AGGRO_RANGE = 5, // Unobservant
 		BB_BASIC_MOB_FLEE_DISTANCE = 6,
 	)

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -74,7 +74,7 @@
 	var/mob/living/basic/basic_source = source
 	var/mob/living/living_target = target
 	basic_source.melee_attack(living_target, ignore_cooldown = TRUE)
-	basic_source.ai_controller?.set_blackboard_key(BB_BASIC_MOB_FLEEING, FALSE)
+	basic_source.ai_controller?.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, TRUE)
 	basic_source.start_pulling(living_target)
 
 /datum/action/cooldown/mob_cooldown/charge/basic_charge/lobster/do_charge(atom/movable/charger, atom/target_atom, delay, past)

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
@@ -57,6 +57,12 @@
 /datum/ai_planning_subtree/flee_target/lobster
 	flee_behaviour = /datum/ai_behavior/run_away_from_target/lobster
 
+/datum/ai_planning_subtree/flee_target/lobster/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
+	var/datum/action/cooldown/using_action = controller.blackboard[BB_TARGETTED_ACTION]
+	if (using_action?.IsAvailable())
+		return
+	return ..()
+
 /datum/ai_behavior/run_away_from_target/lobster
 	clear_failed_targets = FALSE
 
@@ -64,6 +70,7 @@
 	var/atom/target = controller.blackboard[target_key]
 	if(isnull(target))
 		return ..()
+
 	for (var/trait in controller.blackboard[BB_LOBSTROSITY_EXPLOIT_TRAITS])
 		if (!HAS_TRAIT(target, trait))
 			continue

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
@@ -2,7 +2,6 @@
 	blackboard = list(
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/lobster,
 		BB_LOBSTROSITY_EXPLOIT_TRAITS = list(TRAIT_INCAPACITATED, TRAIT_FLOORED, TRAIT_IMMOBILIZED, TRAIT_KNOCKEDOUT),
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_LOBSTROSITY_FINGER_LUST = 0
 	)
 
@@ -26,7 +25,7 @@
 	melee_attack_behavior = /datum/ai_behavior/basic_melee_attack/lobster
 
 /datum/ai_planning_subtree/basic_melee_attack_subtree/lobster/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
-	if (controller.blackboard[BB_BASIC_MOB_FLEEING])
+	if (!controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		return
 	if (!isnull(controller.blackboard[BB_LOBSTROSITY_TARGET_LIMB]))
 		return
@@ -48,8 +47,8 @@
 		is_vulnerable = TRUE
 		break
 	if (!is_vulnerable)
-		controller.set_blackboard_key(BB_BASIC_MOB_FLEEING, TRUE)
-	if (controller.blackboard[BB_BASIC_MOB_FLEEING])
+		controller.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, FALSE)
+	if (!controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		finish_action(controller = controller, succeeded = TRUE, target_key = target_key) // We don't want to clear our target
 		return
 	return ..()
@@ -74,7 +73,7 @@
 	for (var/trait in controller.blackboard[BB_LOBSTROSITY_EXPLOIT_TRAITS])
 		if (!HAS_TRAIT(target, trait))
 			continue
-		controller.set_blackboard_key(BB_BASIC_MOB_FLEEING, FALSE)
+		controller.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, TRUE)
 		finish_action(controller, succeeded = FALSE)
 		return
 

--- a/code/modules/mob/living/basic/pets/fox.dm
+++ b/code/modules/mob/living/basic/pets/fox.dm
@@ -38,7 +38,6 @@
 
 /datum/ai_controller/basic_controller/fox
 	blackboard = list(
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/of_size/ours_or_smaller/ignore_faction,
 		BB_FLEE_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction
 	)

--- a/code/modules/mob/living/basic/space_fauna/carp/carp_ai_rift_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp_ai_rift_actions.dm
@@ -31,7 +31,7 @@
 	finish_planning = TRUE
 
 /datum/ai_planning_subtree/make_carp_rift/panic_teleport/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
-	if (!controller.blackboard[BB_BASIC_MOB_FLEEING])
+	if (controller.blackboard[BB_BASIC_MOB_STOP_FLEEING])
 		return
 	return ..()
 

--- a/code/modules/mob/living/basic/space_fauna/carp/carp_controllers.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp_controllers.dm
@@ -59,7 +59,6 @@
  */
 /datum/ai_controller/basic_controller/carp/ranged
 	planning_subtrees = list(
-		BB_BASIC_MOB_STOP_FLEEING = TRUE,
 		/datum/ai_planning_subtree/pet_planning,
 		/datum/ai_planning_subtree/simple_find_nearest_target_to_flee,
 		/datum/ai_planning_subtree/make_carp_rift/panic_teleport,

--- a/code/modules/mob/living/basic/space_fauna/carp/carp_controllers.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp_controllers.dm
@@ -9,6 +9,7 @@
  */
 /datum/ai_controller/basic_controller/carp
 	blackboard = list(
+		BB_BASIC_MOB_STOP_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/allow_items(),
 		BB_PET_TARGETTING_DATUM = new /datum/targetting_datum/not_friends()
 	)
@@ -35,6 +36,7 @@
  */
 /datum/ai_controller/basic_controller/carp/pet
 	blackboard = list(
+		BB_BASIC_MOB_STOP_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 		BB_PET_TARGETTING_DATUM = new /datum/targetting_datum/not_friends()
 	)
@@ -57,6 +59,7 @@
  */
 /datum/ai_controller/basic_controller/carp/ranged
 	planning_subtrees = list(
+		BB_BASIC_MOB_STOP_FLEEING = TRUE,
 		/datum/ai_planning_subtree/pet_planning,
 		/datum/ai_planning_subtree/simple_find_nearest_target_to_flee,
 		/datum/ai_planning_subtree/make_carp_rift/panic_teleport,
@@ -78,6 +81,7 @@
  */
 /datum/ai_controller/basic_controller/carp/passive
 	blackboard = list(
+		BB_BASIC_MOB_STOP_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 		BB_PET_TARGETTING_DATUM = new /datum/targetting_datum/not_friends()
 	)

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_ai.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_ai.dm
@@ -1,7 +1,6 @@
 /datum/ai_controller/basic_controller/regal_rat
 	blackboard = list(
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic,
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_FLEE_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction,
 	)
 

--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spider_ai.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spider_ai.dm
@@ -45,7 +45,6 @@
 	blackboard = list(
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/of_size/ours_or_smaller(), // Hunt mobs our size
 		BB_FLEE_TARGETTING_DATUM = new /datum/targetting_datum/basic/of_size/larger(), // Run away from mobs bigger than we are
-		BB_BASIC_MOB_FLEEING = TRUE,
 	)
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 

--- a/code/modules/mob/living/basic/space_fauna/spider/spiderlings/spiderling.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spiderlings/spiderling.dm
@@ -61,7 +61,6 @@
 /datum/ai_controller/basic_controller/spiderling
 	blackboard = list(
 		BB_FLEE_TARGETTING_DATUM = new /datum/targetting_datum/basic/of_size/larger, // Run away from mobs bigger than we are
-		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_VENTCRAWL_COOLDOWN = 20 SECONDS, // enough time to get splatted while we're out in the open.
 		BB_TIME_TO_GIVE_UP_ON_VENT_PATHING = 30 SECONDS,
 	)

--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
@@ -65,7 +65,7 @@
 	fugu.melee_damage_upper = 20
 	fugu.status_flags |= GODMODE
 	fugu.obj_damage = 60
-	fugu.ai_controller.set_blackboard_key(BB_BASIC_MOB_FLEEING, FALSE)
+	fugu.ai_controller.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, TRUE)
 	fugu.ai_controller.CancelActions()
 
 /datum/status_effect/inflated/on_remove()
@@ -84,7 +84,7 @@
 	if (fugu.stat != DEAD)
 		fugu.icon_state = "Fugu0"
 	fugu.obj_damage = 0
-	fugu.ai_controller.set_blackboard_key(BB_BASIC_MOB_FLEEING, TRUE)
+	fugu.ai_controller.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, FALSE)
 	fugu.ai_controller.CancelActions()
 
 /// Remove status effect if we die

--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/wumborian_ai.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/wumborian_ai.dm
@@ -2,7 +2,6 @@
 /datum/ai_controller/basic_controller/wumborian_fugu
 	blackboard = list(
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(),
-		BB_BASIC_MOB_FLEEING = TRUE,
 	)
 
 	ai_movement = /datum/ai_movement/basic_avoidance

--- a/code/modules/mob/living/basic/vermin/crab.dm
+++ b/code/modules/mob/living/basic/vermin/crab.dm
@@ -77,7 +77,7 @@
 ///The basic ai controller for crabs
 /datum/ai_controller/basic_controller/crab
 	blackboard = list(
-		BB_BASIC_MOB_FLEEING = FALSE,
+		BB_BASIC_MOB_STOP_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/of_size/ours_or_smaller,
 		BB_FLEE_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction,
 	)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -376,8 +376,7 @@
 
 /// The mouse AI controller
 /datum/ai_controller/basic_controller/mouse
-	blackboard = list(
-		BB_BASIC_MOB_FLEEING = TRUE, // Always cowardly
+	blackboard = list( // Always cowardly
 		BB_CURRENT_HUNTING_TARGET = null, // cheese
 		BB_LOW_PRIORITY_HUNTING_TARGET = null, // cable
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(), // Use this to find people to run away from


### PR DESCRIPTION
## About The Pull Request

This PR does three things:
- Fixes fleeing, I broke it in a recent PR so mobs would walk to a location then sort of stand there doing nothing. This is due to using `>=` instead of `>`. 
- Makes lobstrosities stop running and charge at you more responsively (when they detect they can charge).
- Inverts the `BB_BASIC_MOB_FLEEING` blackboard key to `BB_BASIC_MOB_STOP_FLEEING` so that the default behaviour is "to perform the behaviour that you put on the mob" instead of to not do that.

## Why It's Good For The Game

Makes commonly used behaviour work properly.
Removes footgun we hand to ai developers.

## Changelog

:cl:
fix: Cowardly mobs will consistently run away from you instead of getting tired and just sort of standing there after an initial burst of movement.
/:cl:
