### PR TITLE
Camera consoles no longer constantly check camera list

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -82,17 +82,18 @@
 
 /obj/machinery/computer/security/ui_data()
 	var/list/data = list()
-	data["network"] = network
 	data["activeCamera"] = null
 	if(active_camera)
 		data["activeCamera"] = list(
 			name = active_camera.c_tag,
+			ref = REF(active_camera),
 			status = active_camera.status,
 		)
 	return data
 
 /obj/machinery/computer/security/ui_static_data()
 	var/list/data = list()
+	data["network"] = network
 	data["mapRef"] = cam_screen.assigned_map
 	var/list/cameras = get_camera_list(network)
 	data["cameras"] = list()
@@ -100,6 +101,7 @@
 		var/obj/machinery/camera/C = cameras[i]
 		data["cameras"] += list(list(
 			name = C.c_tag,
+			ref = REF(C),
 		))
 
 	return data
@@ -110,13 +112,11 @@
 		return
 
 	if(action == "switch_camera")
-		var/c_tag = params["name"]
-		var/list/cameras = get_camera_list(network)
-		var/obj/machinery/camera/selected_camera = cameras[c_tag]
+		var/obj/machinery/camera/selected_camera = locate(params["camera"]) in GLOB.cameranet.cameras
 		active_camera = selected_camera
 		playsound(src, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
 
-		if(!selected_camera)
+		if(isnull(active_camera))
 			return TRUE
 
 		update_active_camera_screen()

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -100,18 +100,19 @@
 
 /datum/computer_file/program/secureye/ui_data()
 	var/list/data = list()
-	data["network"] = network
 	data["activeCamera"] = null
 	var/obj/machinery/camera/active_camera = camera_ref?.resolve()
 	if(active_camera)
 		data["activeCamera"] = list(
 			name = active_camera.c_tag,
+			ref = REF(active_camera),
 			status = active_camera.status,
 		)
 	return data
 
 /datum/computer_file/program/secureye/ui_static_data(mob/user)
 	var/list/data = list()
+	data["network"] = network
 	data["mapRef"] = cam_screen.assigned_map
 	data["can_spy"] = !!spying
 	var/list/cameras = get_camera_list(network)
@@ -120,6 +121,7 @@
 		var/obj/machinery/camera/C = cameras[i]
 		data["cameras"] += list(list(
 			name = C.c_tag,
+			ref = REF(C),
 		))
 
 	return data
@@ -130,13 +132,14 @@
 		return
 	switch(action)
 		if("switch_camera")
-			var/c_tag = format_text(params["name"])
-			var/list/cameras = get_camera_list(network)
-			var/obj/machinery/camera/selected_camera = cameras[c_tag]
-			camera_ref = WEAKREF(selected_camera)
+			var/obj/machinery/camera/selected_camera = locate(params["camera"]) in GLOB.cameranet.cameras
+			if(selected_camera)
+				camera_ref = WEAKREF(selected_camera)
+			else
+				camera_ref = null
 			if(!spying)
 				playsound(computer, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
-			if(!selected_camera)
+			if(isnull(camera_ref))
 				return TRUE
 			if(internal_tracker && internal_tracker.tracking)
 				internal_tracker.set_tracking(FALSE)

--- a/tgui/packages/tgui/interfaces/CameraConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CameraConsole.tsx
@@ -16,6 +16,7 @@ type Data = {
 
 type Camera = {
   name: string;
+  ref: string;
 };
 
 /**
@@ -29,10 +30,8 @@ const prevNextCamera = (
   if (!activeCamera) {
     return [];
   }
-  const index = cameras.findIndex(
-    (camera) => camera?.name === activeCamera.name
-  );
-  return [cameras[index - 1]?.name, cameras[index + 1]?.name];
+  const index = cameras.findIndex((camera) => camera?.ref === activeCamera.ref);
+  return [cameras[index - 1]?.ref, cameras[index + 1]?.ref];
 };
 
 /**
@@ -41,15 +40,15 @@ const prevNextCamera = (
  * Filters cameras, applies search terms and sorts the alphabetically.
  */
 const selectCameras = (cameras: Camera[], searchText = ''): Camera[] => {
-  const testSearch = createSearch(searchText, (camera: Camera) => camera.name);
+  const testSearch = createSearch(searchText, (camera: Camera) => camera.ref);
 
   return flow([
     // Null camera filter
-    filter((camera: Camera) => !!camera?.name),
+    filter((camera: Camera) => !!camera?.ref),
     // Optional search term
     searchText && filter(testSearch),
     // Slightly expensive, but way better than sorting in BYOND
-    sortBy((camera: Camera) => camera.name),
+    sortBy((camera: Camera) => camera),
   ])(cameras);
 };
 
@@ -99,7 +98,7 @@ const CameraSelector = (props, context) => {
             // We're not using the component here because performance
             // would be absolutely abysmal (50+ ms for each re-render).
             <div
-              key={camera.name}
+              key={camera.ref}
               title={camera.name}
               className={classes([
                 'candystripe',
@@ -108,12 +107,12 @@ const CameraSelector = (props, context) => {
                 'Button--color--transparent',
                 'Button--ellipsis',
                 activeCamera &&
-                  camera.name === activeCamera.name &&
+                  camera.ref === activeCamera.ref &&
                   'Button--selected',
               ])}
               onClick={() =>
                 act('switch_camera', {
-                  name: camera.name,
+                  camera: camera.ref,
                 })
               }>
               {camera.name}
@@ -130,10 +129,7 @@ const CameraControls = (props, context) => {
   const { activeCamera, can_spy, mapRef } = data;
   const cameras = selectCameras(data.cameras);
 
-  const [prevCameraName, nextCameraName] = prevNextCamera(
-    cameras,
-    activeCamera
-  );
+  const [prevCamera, nextCamera] = prevNextCamera(cameras, activeCamera);
 
   return (
     <Section fill>
@@ -161,10 +157,10 @@ const CameraControls = (props, context) => {
             <Stack.Item>
               <Button
                 icon="chevron-left"
-                disabled={!prevCameraName}
+                disabled={!prevCamera}
                 onClick={() =>
                   act('switch_camera', {
-                    name: prevCameraName,
+                    camera: prevCamera,
                   })
                 }
               />
@@ -173,10 +169,10 @@ const CameraControls = (props, context) => {
             <Stack.Item>
               <Button
                 icon="chevron-right"
-                disabled={!nextCameraName}
+                disabled={!nextCamera}
                 onClick={() =>
                   act('switch_camera', {
-                    name: nextCameraName,
+                    camera: nextCamera,
                   })
                 }
               />


### PR DESCRIPTION
## About The Pull Request

I would like camera sorting to be handled without having to constantly get the entire list of cameras and sorting itself, but this occasion it isn't even necessary, and was only added because I wanted to keep it consistent with old behavior. This wasn't the best idea, and this is trying to make amends with that.

Instead of getting the entire list of cameras when swapping cameras, it instead gets that specific camera from the list and sets your active camera to that. To do so, camera consoles now have a ref to the camera, rather than going by name alone.

## Why It's Good For The Game

Explained in the about section mostly, we're no longer checking through and sorting the entire list of cameras every single time you swap from one camera to another.

## Changelog

Nothing player-facing.