### PR TITLE
Demonic-Frost Miner Ruin Aesthetic Refresh

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
@@ -2,7 +2,7 @@
 "ax" = (
 /obj/structure/railing/corner,
 /obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "aT" = (
 /obj/structure/railing/corner/end/flip{
@@ -12,38 +12,38 @@
 /area/icemoon/surface/outdoors/nospawn)
 "bE" = (
 /obj/structure/flora/rock/pile,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "cO" = (
 /obj/structure/fence/door/opened{
 	dir = 1
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "ds" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "eu" = (
 /obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "eB" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 4
 	},
 /obj/structure/flora/rock/pile/icy/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "eE" = (
 /obj/structure/railing{
 	dir = 6
 	},
 /obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "fl" = (
 /turf/template_noop,
@@ -51,14 +51,14 @@
 "fK" = (
 /obj/structure/railing,
 /obj/structure/flora/rock/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gv" = (
 /obj/structure/railing{
 	dir = 5
 	},
 /obj/structure/ladder,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "hM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -74,15 +74,15 @@
 	dir = 4
 	},
 /obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "jQ" = (
 /obj/structure/fence/door,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "kd" = (
 /obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "kq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -97,7 +97,10 @@
 /obj/structure/fence/corner{
 	dir = 9
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"lH" = (
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "lR" = (
 /obj/structure/railing/corner/end/flip{
@@ -106,25 +109,25 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "mP" = (
 /turf/open/openspace/icemoon/ruins,
 /area/icemoon/surface/outdoors/nospawn)
 "nt" = (
 /obj/structure/flora/rock/pile/icy/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "nT" = (
 /obj/structure/flora/tree/pine,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "op" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /obj/structure/sign/warning/secure_area,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "tW" = (
 /obj/structure/fence{
@@ -132,7 +135,7 @@
 	},
 /obj/structure/flora/rock/pile/icy/style_2,
 /obj/structure/sign/warning/secure_area,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "uy" = (
 /obj/effect/mob_spawn/corpse/human/minesite/overseer,
@@ -140,7 +143,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "vx" = (
 /obj/structure/flora/tree/pine/style_3,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "vJ" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -149,7 +152,7 @@
 /obj/structure/fence/cut/medium{
 	dir = 4
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "yy" = (
 /obj/structure/railing/corner/end/flip{
@@ -168,14 +171,14 @@
 /area/icemoon/surface/outdoors/nospawn)
 "Aq" = (
 /obj/structure/flora/rock/icy/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "At" = (
 /obj/structure/flora/grass/brown/style_random,
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Bv" = (
 /turf/open/misc/snow,
@@ -186,14 +189,14 @@
 "DG" = (
 /obj/structure/flora/grass/brown/style_random,
 /obj/structure/flora/tree/pine/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Ep" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
 	},
 /obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Ff" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -205,13 +208,13 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "HU" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 4
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Ia" = (
 /obj/structure/railing/corner/end{
@@ -219,14 +222,14 @@
 	},
 /obj/structure/railing/corner/end/flip,
 /obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "IA" = (
 /obj/item/flashlight/glowstick/red{
 	on = 1
 	},
 /obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "KT" = (
 /obj/structure/railing{
@@ -241,7 +244,7 @@
 	pixel_x = 6;
 	pixel_y = 7
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Mp" = (
 /obj/effect/turf_decal/stripes/line{
@@ -276,7 +279,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Tt" = (
 /obj/structure/flora/rock/pile/icy/style_2,
@@ -287,18 +290,18 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "UY" = (
 /obj/structure/fence/cut/large{
 	dir = 4
 	},
 /obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Wg" = (
 /obj/structure/railing,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Wk" = (
 /obj/item/flashlight/glowstick/red{
@@ -311,7 +314,7 @@
 	dir = 4
 	},
 /obj/structure/sign/nanotrasen,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Wt" = (
 /obj/effect/turf_decal/stripes/line,
@@ -320,7 +323,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "Zn" = (
 /obj/structure/fence/cut/large,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 
 (1,1,1) = {"
@@ -383,7 +386,7 @@ fl
 "}
 (3,1,1) = {"
 IA
-Bv
+lH
 lo
 Zn
 Dd
@@ -415,7 +418,7 @@ Bv
 eu
 jQ
 vJ
-Bv
+lH
 Dd
 mP
 mP
@@ -475,7 +478,7 @@ Dd
 eu
 vJ
 vJ
-Bv
+lH
 eB
 mP
 mP
@@ -755,7 +758,7 @@ mP
 mP
 kd
 kd
-Bv
+lH
 wg
 "}
 (16,1,1) = {"
@@ -763,7 +766,7 @@ Dd
 Dd
 kd
 kd
-Bv
+lH
 mP
 mP
 mP
@@ -784,15 +787,15 @@ mP
 mP
 Wk
 vJ
-Bv
+lH
 At
 "}
 (17,1,1) = {"
 Ep
-Bv
+lH
 kd
 vJ
-Bv
+lH
 HU
 mP
 mP
@@ -818,7 +821,7 @@ UY
 "}
 (18,1,1) = {"
 ds
-Bv
+lH
 vx
 Tt
 vJ
@@ -842,12 +845,12 @@ mP
 mP
 Aq
 vJ
-Bv
+lH
 Sc
 "}
 (19,1,1) = {"
 Uz
-Bv
+lH
 vJ
 vJ
 vJ
@@ -906,7 +909,7 @@ wg
 (21,1,1) = {"
 tW
 kd
-Bv
+lH
 Wt
 mP
 Mp
@@ -934,7 +937,7 @@ Dd
 "}
 (22,1,1) = {"
 hS
-Bv
+lH
 Aq
 Ff
 hM

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
@@ -104,7 +104,7 @@
 "w" = (
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/snow,
-/area/template_noop)
+/area/icemoon/surface/outdoors/nospawn)
 "x" = (
 /obj/structure/flora/tree/pine,
 /turf/open/misc/snow,
@@ -115,9 +115,6 @@
 	},
 /turf/closed/indestructible/rock/snow/ice/ore,
 /area/icemoon/surface/outdoors/nospawn)
-"A" = (
-/turf/open/misc/snow,
-/area/template_noop)
 "C" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -140,10 +137,6 @@
 /obj/structure/railing,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"H" = (
-/obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
-/area/template_noop)
 "J" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 4
@@ -209,6 +202,9 @@
 /area/icemoon/surface/outdoors/nospawn)
 "Y" = (
 /turf/open/openspace/icemoon/ruins,
+/area/icemoon/surface/outdoors/nospawn)
+"Z" = (
+/turf/template_noop,
 /area/icemoon/surface/outdoors/nospawn)
 
 (1,1,1) = {"
@@ -706,7 +702,7 @@ t
 "}
 (18,1,1) = {"
 t
-t
+Z
 E
 i
 g
@@ -735,7 +731,7 @@ t
 "}
 (19,1,1) = {"
 w
-A
+c
 c
 g
 g
@@ -763,8 +759,8 @@ t
 t
 "}
 (20,1,1) = {"
-A
-A
+c
+c
 g
 j
 M
@@ -793,7 +789,7 @@ t
 "}
 (21,1,1) = {"
 t
-H
+T
 c
 O
 Y

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
@@ -1,37 +1,234 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"ax" = (
+/obj/structure/railing/corner,
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"aT" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"bE" = (
+/obj/structure/flora/rock/pile,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"cO" = (
+/obj/structure/fence/door/opened{
+	dir = 1
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"ds" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"eu" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"eB" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"eE" = (
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/structure/flora/rock/pile/icy,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"b" = (
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"c" = (
+"fl" = (
+/turf/template_noop,
+/area/template_noop)
+"fK" = (
+/obj/structure/railing,
+/obj/structure/flora/rock/icy,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"d" = (
-/turf/open/openspace/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"e" = (
+"gv" = (
 /obj/structure/railing{
 	dir = 5
 	},
 /obj/structure/ladder,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"f" = (
-/obj/structure/railing/corner,
+"hM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"g" = (
+"hS" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"jQ" = (
+/obj/structure/fence/door,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"kd" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"kq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"h" = (
+"lo" = (
+/obj/structure/fence/corner{
+	dir = 9
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"lR" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"mP" = (
+/turf/open/openspace/icemoon/ruins,
+/area/icemoon/surface/outdoors/nospawn)
+"nt" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"nT" = (
+/obj/structure/flora/tree/pine,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"op" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/sign/warning/secure_area,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"tW" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/icy/style_2,
+/obj/structure/sign/warning/secure_area,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"uy" = (
+/obj/effect/mob_spawn/corpse/human/minesite/overseer,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"vx" = (
+/obj/structure/flora/tree/pine/style_3,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"vJ" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"wg" = (
+/obj/structure/fence/cut/medium{
+	dir = 4
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"yy" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"yA" = (
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Aq" = (
+/obj/structure/flora/rock/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"At" = (
+/obj/structure/flora/grass/brown/style_random,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"Bv" = (
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"Dd" = (
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"DG" = (
+/obj/structure/flora/grass/brown/style_random,
+/obj/structure/flora/tree/pine/style_2,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"Ep" = (
+/obj/structure/fence/cut/medium{
+	dir = 4
+	},
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"Ff" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Fn" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"HU" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"Ia" = (
+/obj/structure/railing/corner/end{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip,
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"IA" = (
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"KT" = (
 /obj/structure/railing{
 	dir = 6
 	},
@@ -46,1063 +243,982 @@
 	},
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"i" = (
-/obj/structure/flora/rock/pile/icy/style_2,
+"Mp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"j" = (
+"Oe" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Ot" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"PT" = (
+/turf/template_noop,
+/area/icemoon/surface/outdoors/nospawn)
+"Qi" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/flashlight/glowstick/red{
 	on = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"l" = (
-/obj/structure/railing/corner/end/flip{
+"Sc" = (
+/obj/structure/fence{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"Tt" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Uz" = (
+/obj/structure/flora/rock/pile/icy,
+/obj/structure/fence{
+	dir = 4
 	},
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"m" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+"UY" = (
+/obj/structure/fence/cut/large{
+	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"o" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"p" = (
-/obj/structure/railing/corner/end{
-	dir = 1
-	},
-/obj/structure/railing/corner/end/flip,
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"q" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"t" = (
-/turf/template_noop,
-/area/template_noop)
-"v" = (
-/turf/closed/indestructible/rock/snow/ice/ore,
-/area/icemoon/surface/outdoors/nospawn)
-"w" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"x" = (
-/obj/structure/flora/tree/pine,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"z" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 8
-	},
-/turf/closed/indestructible/rock/snow/ice/ore,
-/area/icemoon/surface/outdoors/nospawn)
-"C" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"D" = (
-/obj/structure/railing/corner,
-/obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"E" = (
-/obj/structure/flora/tree/pine/style_3,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"F" = (
+"Wg" = (
 /obj/structure/railing,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"J" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"K" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/obj/structure/flora/rock/pile/icy/style_2,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"M" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
+"Wk" = (
+/obj/item/flashlight/glowstick/red{
+	on = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"N" = (
-/obj/structure/flora/rock/icy/style_2,
+"Wr" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/sign/nanotrasen,
 /turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
-"O" = (
+"Wt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"P" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"Q" = (
-/obj/structure/railing,
-/obj/structure/flora/rock/icy,
+"Zn" = (
+/obj/structure/fence/cut/large,
 /turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"R" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"T" = (
-/obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"W" = (
-/turf/open/openspace/icemoon,
-/area/template_noop)
-"X" = (
-/obj/effect/mob_spawn/corpse/human/minesite/overseer,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"Y" = (
-/turf/open/openspace/icemoon/ruins,
-/area/icemoon/surface/outdoors/nospawn)
-"Z" = (
-/turf/template_noop,
 /area/icemoon/surface/outdoors/nospawn)
 
 (1,1,1) = {"
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (2,1,1) = {"
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
+fl
+kd
+kd
+nt
+DG
+Dd
+Dd
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (3,1,1) = {"
-t
-t
-t
-t
-t
-t
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
-t
-t
-t
-t
-t
+IA
+Bv
+lo
+Zn
+Dd
+Dd
+Dd
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (4,1,1) = {"
-t
-t
-t
-t
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
-t
-t
-t
-t
+Bv
+eu
+jQ
+vJ
+Bv
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (5,1,1) = {"
-t
-t
-t
-t
-g
-T
-T
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
-t
-t
-t
+fl
+kd
+Wr
+vJ
+vJ
+kd
+kd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (6,1,1) = {"
-t
-t
-t
-t
-g
-g
-c
-K
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
-t
-t
+fl
+kd
+Dd
+eu
+vJ
+vJ
+Bv
+eB
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
 "}
 (7,1,1) = {"
-t
-t
-t
-g
-g
-g
-g
-q
-l
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
-t
+fl
+Dd
+Dd
+vJ
+vJ
+vJ
+vJ
+Oe
+lR
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
 "}
 (8,1,1) = {"
-t
-t
-t
-x
-T
-b
-X
-f
-h
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
+Dd
+Dd
+PT
+nT
+kd
+yA
+uy
+Ot
+KT
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
 "}
 (9,1,1) = {"
-t
-t
-Y
-Y
-Y
-e
-p
-a
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
+Dd
+Dd
+mP
+mP
+mP
+gv
+Ia
+Fn
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
 "}
 (10,1,1) = {"
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+fl
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
 "}
 (11,1,1) = {"
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+fl
+fl
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
 "}
 (12,1,1) = {"
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+fl
+fl
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+Dd
+Dd
 "}
 (13,1,1) = {"
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+fl
+fl
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+Dd
+Dd
 "}
 (14,1,1) = {"
-t
-t
-v
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+fl
+fl
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+nt
+Dd
+hS
 "}
 (15,1,1) = {"
-t
-v
-v
-v
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+fl
+Dd
+Dd
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+kd
+kd
+Bv
+wg
 "}
 (16,1,1) = {"
-t
-v
-T
-T
-c
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+Dd
+Dd
+kd
+kd
+Bv
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+Wk
+vJ
+Bv
+At
 "}
 (17,1,1) = {"
-t
-t
-T
-g
-c
-J
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+Ep
+Bv
+kd
+vJ
+Bv
+HU
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+kd
+vJ
+vJ
+UY
 "}
 (18,1,1) = {"
-t
-Z
-E
-i
-g
-Q
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+ds
+Bv
+vx
+Tt
+vJ
+fK
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+Aq
+vJ
+Bv
+Sc
 "}
 (19,1,1) = {"
-w
-c
-c
-g
-g
-F
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+Uz
+Bv
+vJ
+vJ
+vJ
+Wg
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+bE
+nT
+op
 "}
 (20,1,1) = {"
-c
-c
-g
-j
-M
-P
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+cO
+vJ
+vJ
+Qi
+kq
+yy
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+kd
+wg
 "}
 (21,1,1) = {"
-t
-T
-c
-O
-Y
-o
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+tW
+kd
+Bv
+Wt
+mP
+Mp
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+Dd
+Dd
 "}
 (22,1,1) = {"
-t
-t
-N
-m
-C
-J
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+hS
+Bv
+Aq
+Ff
+hM
+HU
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+Dd
+fl
 "}
 (23,1,1) = {"
-t
-t
-v
-T
-D
-R
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
+Dd
+Dd
+Dd
+kd
+ax
+eE
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
 "}
 (24,1,1) = {"
-t
-t
-v
-v
-z
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
+fl
+Dd
+Dd
+Dd
+aT
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
 "}
 (25,1,1) = {"
-t
-t
-v
-v
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-d
-t
-t
-t
+fl
+fl
+Dd
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
 "}
 (26,1,1) = {"
-t
-t
-t
-v
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-d
-t
-t
-t
-t
+fl
+fl
+fl
+Dd
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
 "}
 (27,1,1) = {"
-t
-t
-t
-t
-d
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-d
-d
-t
-t
-t
-t
+fl
+fl
+fl
+fl
+fl
+fl
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (28,1,1) = {"
-t
-t
-t
-t
-t
-d
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-d
-d
-t
-t
-t
-t
-t
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (29,1,1) = {"
-t
-t
-t
-t
-t
-t
-d
-d
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-d
-W
-t
-t
-t
-t
-t
-t
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+mP
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (30,1,1) = {"
-t
-t
-t
-t
-t
-t
-t
-t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-t
-t
-t
-t
-t
-t
-t
-t
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}
 (31,1,1) = {"
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
-t
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
+fl
 "}

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
@@ -1,107 +1,219 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/mineral/random/snow,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
 "b" = (
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/ruin/unpowered)
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "c" = (
-/obj/structure/closet/toolcloset,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/crowbar,
-/obj/item/weldingtool/largetank,
-/obj/item/wirecutters,
-/obj/item/radio/off,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
 "d" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "e" = (
-/obj/item/clothing/suit/hooded/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/backpack/explorer,
-/obj/item/flashlight/lantern,
-/obj/item/storage/bag/ore,
-/obj/structure/closet,
-/obj/item/clothing/shoes/winterboots/ice_boots,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/ladder,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
 "f" = (
-/turf/open/floor/wood,
-/area/ruin/unpowered)
+/obj/structure/railing/corner,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "g" = (
-/obj/structure/fireplace,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "h" = (
-/obj/structure/flora/rock/icy/style_random,
-/turf/closed/mineral/random/snow,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/binoculars{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/flashlight/lantern{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"i" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "j" = (
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"k" = (
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"l" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"n" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"o" = (
-/obj/item/reagent_containers/cup/glass/bottle/beer,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"p" = (
-/obj/machinery/light/broken/directional/east,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"q" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/machinery/light/broken/directional/west,
-/obj/item/paper/crumpled/bloody{
-	default_raw_text = "help...";
-	text = ""
+/obj/effect/turf_decal/stripes/corner,
+/obj/item/flashlight/glowstick/red{
+	on = 1
 	},
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"r" = (
-/obj/item/chair/wood,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/mob_spawn/corpse/human/miner/explorer,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"s" = (
-/obj/effect/decal/cleanable/trail_holder,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"l" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"m" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"o" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"p" = (
+/obj/structure/railing/corner/end{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip,
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"q" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "t" = (
 /turf/template_noop,
 /area/template_noop)
-"K" = (
-/obj/structure/ladder{
-	travel_time = 40
+"v" = (
+/turf/closed/indestructible/rock/snow/ice/ore,
+/area/icemoon/surface/outdoors/nospawn)
+"w" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/template_noop)
+"x" = (
+/obj/structure/flora/tree/pine,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"z" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/ruin/unpowered)
+/turf/closed/indestructible/rock/snow/ice/ore,
+/area/icemoon/surface/outdoors/nospawn)
+"A" = (
+/turf/open/misc/snow,
+/area/template_noop)
+"C" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"D" = (
+/obj/structure/railing/corner,
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"E" = (
+/obj/structure/flora/tree/pine/style_3,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"F" = (
+/obj/structure/railing,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"H" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/template_noop)
+"J" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"K" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"M" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"N" = (
+/obj/structure/flora/rock/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"O" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"P" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Q" = (
+/obj/structure/railing,
+/obj/structure/flora/rock/icy,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"R" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"T" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/surface/outdoors/nospawn)
 "W" = (
 /turf/open/openspace/icemoon,
 /area/template_noop)
+"X" = (
+/obj/effect/mob_spawn/corpse/human/minesite/overseer,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "Y" = (
 /turf/open/openspace/icemoon/ruins,
 /area/icemoon/surface/outdoors/nospawn)
 
 (1,1,1) = {"
+t
+t
 t
 t
 t
@@ -136,17 +248,19 @@ t
 t
 t
 t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
 t
 t
 t
@@ -161,6 +275,9 @@ t
 t
 t
 t
+t
+t
+t
 Y
 Y
 Y
@@ -172,9 +289,8 @@ Y
 Y
 Y
 Y
-Y
-Y
-Y
+t
+t
 t
 t
 t
@@ -186,7 +302,9 @@ t
 t
 t
 t
-d
+t
+t
+t
 Y
 Y
 Y
@@ -201,8 +319,8 @@ Y
 Y
 Y
 Y
-Y
-Y
+t
+t
 t
 t
 t
@@ -213,6 +331,10 @@ t
 t
 t
 t
+t
+g
+T
+T
 Y
 Y
 Y
@@ -227,10 +349,8 @@ Y
 Y
 Y
 Y
-Y
-Y
-Y
-Y
+t
+t
 t
 t
 t
@@ -239,6 +359,12 @@ t
 (6,1,1) = {"
 t
 t
+t
+t
+g
+g
+c
+K
 Y
 Y
 Y
@@ -253,12 +379,8 @@ Y
 Y
 Y
 Y
-Y
-Y
-Y
-Y
-Y
-Y
+t
+t
 t
 t
 t
@@ -266,6 +388,13 @@ t
 (7,1,1) = {"
 t
 t
+t
+g
+g
+g
+g
+q
+l
 Y
 Y
 Y
@@ -280,18 +409,21 @@ Y
 Y
 Y
 Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
+t
+t
 t
 t
 "}
 (8,1,1) = {"
 t
+t
+t
+x
+T
+b
+X
+f
+h
 Y
 Y
 Y
@@ -307,18 +439,19 @@ Y
 Y
 Y
 Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
+t
 t
 t
 "}
 (9,1,1) = {"
 t
+t
+Y
+Y
+Y
+e
+p
+a
 Y
 Y
 Y
@@ -327,13 +460,6 @@ Y
 Y
 Y
 Y
-b
-b
-b
-b
-b
-b
-b
 Y
 Y
 Y
@@ -342,10 +468,13 @@ Y
 Y
 Y
 Y
+t
+t
 t
 "}
 (10,1,1) = {"
 t
+t
 Y
 Y
 Y
@@ -353,15 +482,6 @@ Y
 Y
 Y
 Y
-b
-b
-b
-b
-b
-b
-b
-b
-b
 Y
 Y
 Y
@@ -369,10 +489,21 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (11,1,1) = {"
 t
+t
 Y
 Y
 Y
@@ -380,15 +511,6 @@ Y
 Y
 Y
 Y
-b
-b
-c
-f
-f
-o
-q
-b
-b
 Y
 Y
 Y
@@ -396,10 +518,21 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (12,1,1) = {"
 t
+t
 Y
 Y
 Y
@@ -407,15 +540,6 @@ Y
 Y
 Y
 Y
-b
-b
-e
-f
-f
-f
-r
-b
-b
 Y
 Y
 Y
@@ -423,10 +547,21 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (13,1,1) = {"
 t
+t
 Y
 Y
 Y
@@ -434,15 +569,6 @@ Y
 Y
 Y
 Y
-b
-b
-f
-f
-f
-f
-s
-b
-b
 Y
 Y
 Y
@@ -450,10 +576,22 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (14,1,1) = {"
 t
+t
+v
 Y
 Y
 Y
@@ -461,15 +599,6 @@ Y
 Y
 Y
 Y
-b
-b
-g
-f
-f
-f
-s
-b
-b
 Y
 Y
 Y
@@ -477,10 +606,22 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (15,1,1) = {"
 t
+v
+v
+v
 Y
 Y
 Y
@@ -488,15 +629,6 @@ Y
 Y
 Y
 Y
-b
-b
-f
-f
-f
-f
-s
-b
-b
 Y
 Y
 Y
@@ -504,10 +636,22 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (16,1,1) = {"
 t
+v
+T
+T
+c
 Y
 Y
 Y
@@ -515,15 +659,6 @@ Y
 Y
 Y
 Y
-b
-b
-j
-f
-f
-f
-s
-b
-b
 Y
 Y
 Y
@@ -531,10 +666,22 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (17,1,1) = {"
 t
+t
+T
+g
+c
+J
 Y
 Y
 Y
@@ -542,15 +689,6 @@ Y
 Y
 Y
 Y
-b
-b
-k
-f
-f
-f
-s
-b
-b
 Y
 Y
 Y
@@ -558,10 +696,21 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (18,1,1) = {"
 t
+t
+E
+i
+g
+Q
 Y
 Y
 Y
@@ -569,15 +718,6 @@ Y
 Y
 Y
 Y
-b
-b
-l
-f
-f
-f
-K
-b
-b
 Y
 Y
 Y
@@ -585,64 +725,79 @@ Y
 Y
 Y
 Y
+Y
+Y
+Y
+Y
+Y
+t
 t
 "}
 (19,1,1) = {"
+w
+A
+c
+g
+g
+F
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
 t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-b
-b
-b
-f
-f
-p
-b
-b
-b
-Y
-Y
-Y
-Y
-Y
-Y
-Y
 t
 "}
 (20,1,1) = {"
+A
+A
+g
+j
+M
+P
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
 t
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-b
-b
-b
-f
-b
-b
-b
-Y
-Y
-Y
-Y
-Y
-Y
-Y
-Y
 t
 "}
 (21,1,1) = {"
 t
+H
+c
+O
+Y
+o
 Y
 Y
 Y
@@ -653,9 +808,6 @@ Y
 Y
 Y
 Y
-b
-f
-b
 Y
 Y
 Y
@@ -665,11 +817,16 @@ Y
 Y
 Y
 Y
-Y
+t
 t
 "}
 (22,1,1) = {"
 t
+t
+N
+m
+C
+J
 Y
 Y
 Y
@@ -680,9 +837,6 @@ Y
 Y
 Y
 Y
-b
-f
-b
 Y
 Y
 Y
@@ -692,11 +846,16 @@ Y
 Y
 Y
 Y
-Y
+t
 t
 "}
 (23,1,1) = {"
 t
+t
+v
+T
+D
+R
 Y
 Y
 Y
@@ -707,9 +866,6 @@ Y
 Y
 Y
 Y
-b
-f
-b
 Y
 Y
 Y
@@ -725,6 +881,9 @@ t
 (24,1,1) = {"
 t
 t
+v
+v
+z
 Y
 Y
 Y
@@ -734,9 +893,6 @@ Y
 Y
 Y
 Y
-b
-n
-b
 Y
 Y
 Y
@@ -745,14 +901,17 @@ Y
 Y
 Y
 Y
-d
+Y
+Y
+t
 t
 t
 "}
 (25,1,1) = {"
 t
 t
-t
+v
+v
 Y
 Y
 Y
@@ -760,11 +919,12 @@ Y
 Y
 Y
 Y
-a
-h
-h
-h
-a
+Y
+Y
+Y
+Y
+Y
+Y
 Y
 Y
 Y
@@ -780,25 +940,27 @@ t
 t
 t
 t
+v
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
 d
-Y
-Y
-Y
-Y
-Y
-a
-a
-a
-h
-a
-a
-a
-Y
-Y
-Y
-Y
-d
-d
+t
 t
 t
 t
@@ -812,15 +974,17 @@ d
 Y
 Y
 Y
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
 Y
 Y
 d
@@ -837,20 +1001,22 @@ t
 t
 t
 d
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
 d
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
 d
-W
 t
 t
 t
@@ -864,18 +1030,78 @@ t
 t
 t
 t
+d
+d
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+d
+W
 t
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+t
+t
+t
+t
+t
+"}
+(30,1,1) = {"
+t
+t
+t
+t
+t
+t
+t
+t
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+t
+t
+t
+t
+t
+t
+t
+t
+"}
+(31,1,1) = {"
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
+t
 t
 t
 t

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -361,10 +361,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "VR" = (
-/obj/item/paper/crumpled/bloody{
-	default_raw_text = "STRENGTH... UNPARALLELED. UNNATURAL.";
-	color = COLOR_MAROON
-	},
+/obj/item/paper/crumpled/bloody/ruins/mining_site,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "VT" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -84,13 +84,6 @@
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"nS" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8;
-	color = FFFFFF
-	},
-/turf/open/misc/ice/icemoon,
-/area/icemoon/underground/explored)
 "nX" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
@@ -658,7 +651,7 @@ ah
 ep
 ah
 sj
-nS
+hD
 Ya
 Ya
 iB
@@ -685,7 +678,7 @@ Ya
 iB
 ah
 WY
-nS
+hD
 Ya
 Ya
 GB
@@ -706,13 +699,13 @@ Ya
 Ya
 Ya
 Ya
-nS
+hD
 Ya
 Ya
 Ya
 Ya
 Ya
-nS
+hD
 Ya
 Ya
 Ya

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -1,32 +1,32 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "au" = (
 /obj/structure/flora/rock/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "aW" = (
 /obj/structure/flora/rock/pile/icy/style_3,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "ep" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/mob_spawn/corpse/human/minesite,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "fh" = (
 /obj/structure/frost_miner_prism,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "gk" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "hp" = (
 /obj/structure/flora/rock/pile/icy/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "hD" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -36,11 +36,11 @@
 /area/icemoon/underground/explored)
 "hX" = (
 /obj/effect/mob_spawn/corpse/human/minesite,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "it" = (
 /obj/structure/flora/rock/icy/style_3,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "iy" = (
 /obj/item/pickaxe/rusted,
@@ -52,7 +52,7 @@
 /area/icemoon/underground/explored)
 "jI" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "kz" = (
 /obj/structure/flora/grass/brown/style_random,
@@ -60,11 +60,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "lh" = (
 /obj/effect/spawner/random/exotic/snow_gear,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "lL" = (
 /turf/template_noop,
@@ -78,11 +78,11 @@
 	desc = "It looks like fancy glitter to me.";
 	name = "icy wind"
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "nE" = (
 /obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "nX" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -111,7 +111,7 @@
 /area/icemoon/underground/explored)
 "pJ" = (
 /obj/structure/flora/rock/pile/icy,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "qU" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -125,7 +125,7 @@
 	desc = "It looks like fancy glitter to me.";
 	name = "icy wind"
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "rI" = (
 /obj/effect/decal/cleanable/glass,
@@ -148,7 +148,7 @@
 	pixel_y = 4;
 	icon_state = "legion_core_decayed"
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "uN" = (
 /obj/effect/decal/cleanable/glitter/blue{
@@ -189,7 +189,7 @@
 	pixel_x = -6;
 	pixel_y = 7
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "zk" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -209,7 +209,7 @@
 /obj/item/flashlight/glowstick/red{
 	on = 1
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "CX" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -270,7 +270,7 @@
 /area/icemoon/underground/explored)
 "Ik" = (
 /obj/item/trash/flare,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "JP" = (
 /obj/item/organ/internal/monster_core/regenerative_core/legion{
@@ -279,15 +279,15 @@
 	pixel_y = -4;
 	icon_state = "legion_core_decayed"
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Kb" = (
 /obj/structure/ladder,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "KA" = (
 /obj/structure/flora/rock/icy/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "KQ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -297,7 +297,7 @@
 /area/icemoon/underground/explored)
 "KT" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Lz" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -333,14 +333,14 @@
 	pixel_y = 13;
 	pixel_x = -5
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Tt" = (
 /obj/structure/frost_miner_prism,
 /mob/living/simple_animal/hostile/megafauna/demonic_frost_miner,
 /obj/effect/decal/cleanable/grand_remains,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "UB" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -353,7 +353,7 @@
 /area/icemoon/underground/explored)
 "UV" = (
 /obj/structure/frost_miner_prism,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Vz" = (
 /obj/structure/table,
@@ -371,7 +371,7 @@
 	pixel_y = 3;
 	icon_state = "legion_core_decayed"
 	},
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "WY" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -384,7 +384,7 @@
 /area/icemoon/underground/explored)
 "Yp" = (
 /obj/effect/decal/cleanable/blood/footprints,
-/turf/open/misc/snow,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "YR" = (
 /obj/effect/turf_decal/weather/snow/corner{

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -1,144 +1,154 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/open/misc/ice/icemoon,
-/area/icemoon/underground/explored)
-"c" = (
-/obj/item/paper/crumpled/bloody{
-	default_raw_text = "STRENGTH... UNPARALLELED. UNNATURAL.";
-	color = COLOR_MAROON
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"d" = (
-/turf/template_noop,
-/area/template_noop)
-"e" = (
-/obj/item/organ/internal/monster_core/regenerative_core/legion{
-	time_to_decay = 0;
-	pixel_x = 4;
-	pixel_y = 3;
-	icon_state = "legion_core_decayed"
-	},
+"ah" = (
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"f" = (
-/obj/structure/flora/grass/brown/style_random,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"j" = (
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"k" = (
-/turf/open/misc/ice/smooth,
-/area/icemoon/underground/explored)
-"l" = (
-/turf/closed/indestructible/rock/snow/ice/ore,
-/area/icemoon/underground/explored)
-"m" = (
-/obj/structure/flora/rock/pile/icy/style_2,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"n" = (
-/obj/item/pickaxe/rusted,
-/turf/open/misc/ice/icemoon,
-/area/icemoon/underground/explored)
-"o" = (
-/obj/structure/flora/rock/pile/icy/style_3,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"p" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"q" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/ice/icemoon,
-/area/icemoon/underground/explored)
-"r" = (
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"s" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/turf/open/misc/ice/smooth,
-/area/icemoon/underground/explored)
-"t" = (
-/obj/structure/closet/crate/preopen,
-/obj/item/stack/ore/plasma,
-/obj/item/stack/ore/iron,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"u" = (
-/obj/item/organ/internal/monster_core/regenerative_core/legion{
-	time_to_decay = 0;
-	pixel_x = -12;
-	pixel_y = -4;
-	icon_state = "legion_core_decayed"
-	},
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"v" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
-/turf/open/misc/ice/icemoon,
-/area/icemoon/underground/explored)
-"w" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"y" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"z" = (
-/obj/structure/ladder,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"A" = (
-/obj/item/pickaxe/rusted,
-/turf/open/misc/ice/smooth,
-/area/icemoon/underground/explored)
-"B" = (
-/obj/structure/frost_miner_prism,
-/turf/open/misc/ice/smooth,
-/area/icemoon/underground/explored)
-"C" = (
-/obj/item/pickaxe/rusted,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"D" = (
-/obj/structure/table,
-/obj/item/flashlight/lantern{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"F" = (
-/obj/structure/flora/rock/icy/style_2,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"H" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
-	},
-/turf/open/misc/ice/icemoon,
-/area/icemoon/underground/explored)
-"I" = (
+"au" = (
 /obj/structure/flora/rock/icy,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"J" = (
+"aW" = (
+/obj/structure/flora/rock/pile/icy/style_3,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"ep" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mob_spawn/corpse/human/minesite,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"fh" = (
+/obj/structure/frost_miner_prism,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"gk" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"hp" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"hD" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"hX" = (
+/obj/effect/mob_spawn/corpse/human/minesite,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"it" = (
+/obj/structure/flora/rock/icy/style_3,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"iy" = (
+/obj/item/pickaxe/rusted,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"iB" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"jI" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"kz" = (
+/obj/structure/flora/grass/brown/style_random,
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"lh" = (
+/obj/effect/spawner/random/exotic/snow_gear,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"lL" = (
+/turf/template_noop,
+/area/template_noop)
+"mL" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"mQ" = (
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"nE" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"nS" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8;
+	color = FFFFFF
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"nX" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
 	},
-/turf/open/misc/ice/smooth,
+/turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
-"K" = (
+"oi" = (
+/obj/item/pickaxe/rusted,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"oK" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"pi" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"pJ" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"qU" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"rx" = (
+/obj/structure/flora/rock/pile/icy,
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"rI" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"sj" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"sp" = (
 /obj/item/organ/internal/monster_core/regenerative_core/legion{
 	time_to_decay = 0;
 	pixel_x = 11;
@@ -147,967 +157,1154 @@
 	},
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"L" = (
+"uN" = (
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"vm" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"wm" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"wN" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"wX" = (
+/obj/structure/table,
+/obj/item/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"zk" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/misc/ice/smooth,
+/turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
-"M" = (
-/obj/effect/decal/cleanable/blood/footprints,
+"zC" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"zY" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"BN" = (
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"N" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/misc/snow,
+"CX" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
-"O" = (
+"Du" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Ej" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"EM" = (
+/obj/structure/closet/crate/preopen,
+/obj/item/stack/ore/plasma,
+/obj/item/stack/ore/iron,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"Gd" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"GB" = (
+/obj/structure/frost_miner_prism,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"GU" = (
+/obj/structure/frost_miner_prism,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Hw" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"HZ" = (
+/obj/item/pickaxe/rusted,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Ik" = (
 /obj/item/trash/flare,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"P" = (
-/obj/structure/frost_miner_prism,
+"JP" = (
+/obj/item/organ/internal/monster_core/regenerative_core/legion{
+	time_to_decay = 0;
+	pixel_x = -12;
+	pixel_y = -4;
+	icon_state = "legion_core_decayed"
+	},
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"Q" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/misc/ice/smooth,
-/area/icemoon/underground/explored)
-"R" = (
-/obj/effect/mob_spawn/corpse/human/minesite,
+"Kb" = (
+/obj/structure/ladder,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"S" = (
-/obj/structure/table,
-/obj/effect/spawner/random/bureaucracy/folder,
+"KA" = (
+/obj/structure/flora/rock/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"KQ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"KT" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"Lz" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	desc = "It looks like fancy glitter to me.";
+	name = "icy wind"
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Nq" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Og" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Rt" = (
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"T" = (
-/obj/structure/flora/rock/pile/icy,
+"SY" = (
+/obj/structure/flora/grass/brown/style_random,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/knife/combat/survival{
+	pixel_y = 13;
+	pixel_x = -5
+	},
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"U" = (
-/obj/effect/spawner/random/exotic/snow_gear,
-/turf/open/misc/snow,
-/area/icemoon/underground/explored)
-"V" = (
+"Tt" = (
 /obj/structure/frost_miner_prism,
 /mob/living/simple_animal/hostile/megafauna/demonic_frost_miner,
 /obj/effect/decal/cleanable/grand_remains,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"W" = (
-/obj/effect/decal/cleanable/glass,
+"UB" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
 /turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
-"X" = (
-/obj/structure/flora/rock/icy/style_3,
+"UV" = (
+/obj/structure/frost_miner_prism,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"Y" = (
-/obj/effect/decal/cleanable/blood/drip,
+"Vz" = (
+/obj/structure/table,
+/obj/effect/spawner/random/bureaucracy/folder,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"VR" = (
+/obj/item/paper/crumpled/bloody{
+	default_raw_text = "STRENGTH... UNPARALLELED. UNNATURAL.";
+	color = COLOR_MAROON
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"VT" = (
+/obj/item/organ/internal/monster_core/regenerative_core/legion{
+	time_to_decay = 0;
+	pixel_x = 4;
+	pixel_y = 3;
+	icon_state = "legion_core_decayed"
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"WY" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
 /turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
-"Z" = (
-/obj/structure/frost_miner_prism,
+"Ya" = (
 /turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Yp" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"YR" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"Zd" = (
+/turf/closed/indestructible/rock/snow/ice/ore,
 /area/icemoon/underground/explored)
 
 (1,1,1) = {"
-d
-d
-d
-d
-d
-d
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-d
-d
-d
-d
-d
-d
+lL
+lL
+lL
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
+lL
+lL
+lL
 "}
 (2,1,1) = {"
-d
-d
-d
-d
-d
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-d
-d
-d
-d
-d
+lL
+lL
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
+lL
+lL
 "}
 (3,1,1) = {"
-d
-d
-d
-d
-l
-l
-l
-l
-Z
-a
-a
-a
-a
-Z
-a
-a
-a
-a
-Z
-l
-l
-l
-l
-d
-d
-d
-d
+lL
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+GB
+Ya
+Ya
+Ya
+Ya
+GB
+Ya
+Ya
+Ya
+Ya
+GB
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
+lL
 "}
 (4,1,1) = {"
-d
-d
-d
-l
-l
-l
-l
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-l
-l
-l
-l
-d
-d
-d
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
 "}
 (5,1,1) = {"
-d
-d
-l
-l
-l
-l
-r
-k
-k
-a
-a
-a
-a
-a
-a
-a
-a
-W
-a
-a
-a
-l
-l
-l
-l
-d
-d
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+ah
+Og
+Ya
+Ya
+Ya
+Ya
+Ya
+Gd
+Gd
+uN
+uN
+Du
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
+lL
+lL
 "}
 (6,1,1) = {"
-d
-l
-l
-l
-l
-k
-r
-j
-k
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-l
-l
-l
-l
-d
+lL
+Zd
+Zd
+Zd
+Zd
+qU
+ah
+BN
+Og
+Ya
+Ya
+Ya
+qU
+ah
+ah
+sj
+Lz
+uN
+uN
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
+lL
 "}
 (7,1,1) = {"
-l
-l
-l
-l
-r
-F
-r
-f
-m
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-l
-l
-l
-l
+Zd
+Zd
+Zd
+Zd
+ah
+KA
+ah
+nE
+hp
+sj
+Ya
+iB
+ah
+gk
+ah
+Hw
+ah
+wm
+Ya
+Ya
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
 "}
 (8,1,1) = {"
-l
-l
-l
-k
-k
-r
-r
-l
-l
-k
-a
-a
-a
-Z
-a
-a
-a
-a
-a
-k
-k
-k
-a
-a
-l
-l
-l
+Zd
+Zd
+Zd
+Ya
+wN
+ah
+ah
+Zd
+Zd
+Ya
+Ya
+iB
+ah
+fh
+ah
+Hw
+ah
+sj
+Ya
+Ya
+Gd
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
 "}
 (9,1,1) = {"
-l
-l
-Z
-a
-k
-z
-r
-l
-k
-k
-a
-a
-a
-W
-a
-a
-a
-a
-a
-k
-X
-k
-a
-a
-Z
-l
-l
+Zd
+Zd
+GB
+Ya
+iB
+Kb
+ah
+Zd
+Ya
+Ya
+Ya
+iB
+ah
+ep
+ah
+sj
+nS
+Ya
+Ya
+iB
+it
+sj
+Ya
+Ya
+GB
+Zd
+Zd
 "}
 (10,1,1) = {"
-l
-l
-a
-a
-k
-k
-r
-k
-k
-Z
-a
-a
-a
-a
-a
-a
-a
-Z
-a
-k
-k
-s
-J
-v
-a
-l
-l
+Zd
+Zd
+Ya
+Ya
+Ya
+wN
+ah
+WY
+Ya
+GB
+Ya
+iB
+ah
+WY
+nS
+Ya
+Ya
+GB
+Ya
+Ya
+YR
+UB
+nX
+KQ
+Ya
+Zd
+Zd
 "}
 (11,1,1) = {"
-l
-l
-a
-a
-a
-k
-k
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-k
-k
-r
-R
-k
-H
-q
-l
-l
+Zd
+Zd
+Ya
+Ya
+Ya
+Ya
+nS
+Ya
+Ya
+Ya
+Ya
+Ya
+nS
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+qU
+ah
+hX
+sj
+Ej
+Nq
+Zd
+Zd
 "}
 (12,1,1) = {"
-l
-l
-a
-a
-a
-a
-a
-a
-a
-a
-a
-k
-k
-k
-k
-k
-a
-a
-k
-T
-r
-f
-k
-k
-n
-l
-l
+Zd
+Zd
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Gd
+Gd
+Lz
+Ya
+Ya
+Ya
+iB
+pJ
+ah
+nE
+Og
+Ya
+oi
+Zd
+Zd
 "}
 (13,1,1) = {"
-l
-l
-a
-a
-a
-a
-a
-a
-a
-a
-k
-k
-f
-r
-r
-k
-k
-a
-k
-r
-r
-I
-f
-k
-a
-l
-l
+Zd
+Zd
+Ya
+uN
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+qU
+nE
+ah
+mQ
+vm
+Ya
+Ya
+iB
+ah
+ah
+au
+nE
+sj
+Ya
+Zd
+Zd
 "}
 (14,1,1) = {"
-l
-l
-a
-a
-a
-a
-a
-a
-a
-a
-k
-f
-f
-r
-r
-T
-k
-a
-k
-k
-U
-r
-j
-k
-a
-l
-l
+Zd
+Zd
+Ya
+uN
+uN
+uN
+Ya
+Ya
+Ya
+Ya
+iB
+nE
+nE
+ah
+ah
+rx
+sj
+Ya
+Ya
+wN
+lh
+ah
+BN
+sj
+Ya
+Zd
+Zd
 "}
 (15,1,1) = {"
-l
-l
-a
-a
-a
-a
-a
-a
-a
-a
-k
-f
-e
-r
-r
-r
-k
-a
-a
-k
-k
-k
-r
-k
-a
-l
-l
+Zd
+Zd
+Ya
+uN
+uN
+Ya
+Ya
+Ya
+Ya
+Ya
+iB
+nE
+VT
+ah
+ah
+ah
+wm
+Ya
+Ya
+Ya
+hD
+wN
+ah
+sj
+Ya
+Zd
+Zd
 "}
 (16,1,1) = {"
-l
-l
-B
-k
-k
-a
-a
-Z
-W
-a
-k
-M
-M
-V
-u
-r
-k
-a
-a
-B
-k
-k
-k
-Q
-Z
-l
-l
+Zd
+Zd
+GU
+Gd
+uN
+Ya
+Ya
+GB
+Du
+Ya
+iB
+Yp
+Yp
+Tt
+JP
+ah
+sj
+Ya
+Ya
+GB
+Gd
+Ya
+hD
+Du
+GB
+Zd
+Zd
 "}
 (17,1,1) = {"
-l
-l
-D
-f
-k
-k
-a
-a
-a
-Y
-k
-m
-r
-K
-r
-r
-k
-a
-a
-k
-f
-k
-a
-a
-a
-l
-l
+Zd
+Zd
+wX
+kz
+Og
+Ya
+Ya
+Ya
+Ya
+zk
+iB
+hp
+ah
+sp
+ah
+ah
+sj
+Ya
+Ya
+iB
+nE
+sj
+Ya
+Ya
+Ya
+Zd
+Zd
 "}
 (18,1,1) = {"
-l
-l
-c
-f
-U
-L
-a
-Y
-a
-a
-k
-r
-r
-r
-r
-f
-k
-a
-a
-k
-m
-k
-a
-a
-a
-l
-l
+Zd
+Zd
+VR
+SY
+ah
+zY
+Ya
+zk
+Ya
+Ya
+pi
+mQ
+ah
+ah
+ah
+nE
+sj
+Ya
+Ya
+iB
+hp
+sj
+Ya
+Ya
+Ya
+Zd
+Zd
 "}
 (19,1,1) = {"
-l
-l
-t
-w
-m
-k
-k
-a
-a
-a
-k
-k
-r
-f
-f
-k
-k
-a
-a
-k
-k
-k
-a
-a
-a
-l
-l
+Zd
+Zd
+EM
+Rt
+hp
+Og
+Ya
+Ya
+Ya
+Ya
+Ya
+CX
+mQ
+nE
+nE
+WY
+Ya
+Ya
+Ya
+Ya
+hD
+Ya
+Ya
+Ya
+Ya
+Zd
+Zd
 "}
 (20,1,1) = {"
-l
-l
-C
-w
-w
-r
-k
-a
-a
-a
-a
-k
-k
-k
-k
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-l
-l
+Zd
+Zd
+iy
+zC
+zC
+ah
+sj
+Ya
+Ya
+Ya
+Ya
+Ya
+hD
+hD
+hD
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+uN
+Ya
+Zd
+Zd
 "}
 (21,1,1) = {"
-l
-l
-S
-w
-p
-f
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-l
-l
+Zd
+Zd
+Vz
+zC
+mL
+nE
+sj
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+uN
+uN
+Ya
+Zd
+Zd
 "}
 (22,1,1) = {"
-l
-l
-T
-r
-f
-r
-k
-a
-a
-Z
-a
-a
-a
-a
-a
-a
-a
-Z
-a
-a
-a
-a
-W
-a
-a
-l
-l
+Zd
+Zd
+pJ
+ah
+nE
+ah
+sj
+Ya
+Ya
+GB
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+GB
+Ya
+Ya
+Ya
+Ya
+rI
+uN
+Ya
+Zd
+Zd
 "}
 (23,1,1) = {"
-l
-l
-P
-k
-k
-k
-k
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-Z
-l
-l
+Zd
+Zd
+UV
+WY
+hD
+hD
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+uN
+Ya
+GB
+Zd
+Zd
 "}
 (24,1,1) = {"
-l
-l
-l
-k
-a
-a
-a
-a
-a
-a
-a
-a
-k
-B
-k
-k
-k
-k
-a
-a
-a
-a
-a
-a
-l
-l
-l
+Zd
+Zd
+Zd
+Ya
+Ya
+Ya
+Ya
+uN
+Ya
+Ya
+Ya
+Ya
+Ya
+GU
+Gd
+Ya
+Gd
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
 "}
 (25,1,1) = {"
-l
-l
-l
-l
-a
-a
-a
-a
-a
-a
-k
-k
-k
-f
-f
-k
-o
-k
-k
-a
-a
-a
-a
-l
-l
-l
-l
+Zd
+Zd
+Zd
+Zd
+Ya
+Ya
+uN
+uN
+uN
+Ya
+Ya
+Gd
+qU
+nE
+nE
+oK
+aW
+Og
+Ya
+Ya
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
 "}
 (26,1,1) = {"
-d
-l
-l
-l
-l
-a
-a
-a
-a
-a
-k
-r
-y
-T
-k
-k
-f
-r
-k
-a
-a
-a
-l
-l
-l
-l
-d
+lL
+Zd
+Zd
+Zd
+Ya
+Ya
+uN
+uN
+Ya
+Ya
+iB
+ah
+KT
+pJ
+WY
+iB
+nE
+ah
+sj
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
+lL
 "}
 (27,1,1) = {"
-d
-d
-l
-l
-l
-l
-a
-a
-a
-W
-k
-m
-N
-O
-k
-k
-k
-k
-k
-a
-a
-l
-l
-l
-l
-d
-d
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Ya
+Ya
+Ya
+Du
+iB
+hp
+jI
+Ik
+sj
+Ya
+hD
+hD
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
+lL
+lL
 "}
 (28,1,1) = {"
-d
-d
-d
-l
-l
-l
-l
-a
-a
-a
-k
-A
-R
-k
-k
-a
-a
-a
-a
-a
-l
-l
-l
-l
-d
-d
-d
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Ya
+Ya
+Ya
+Ya
+HZ
+hX
+WY
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
 "}
 (29,1,1) = {"
-d
-d
-d
-d
-l
-l
-l
-l
-Z
-a
-a
-k
-k
-B
-a
-a
-a
-a
-Z
-l
-l
-l
-l
-d
-d
-d
-d
+lL
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+GB
+Ya
+Ya
+Ya
+hD
+GB
+Ya
+Ya
+Ya
+Ya
+GB
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
+lL
 "}
 (30,1,1) = {"
-d
-d
-d
-d
-d
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-d
-d
-d
-d
-d
+lL
+lL
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
+lL
+lL
 "}
 (31,1,1) = {"
-d
-d
-d
-d
-d
-d
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-d
-d
-d
-d
-d
-d
+lL
+lL
+lL
+lL
+lL
+lL
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+lL
+lL
+lL
+lL
+lL
+lL
 "}

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -184,6 +184,10 @@
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/snow,
 /area/icemoon/underground/explored)
+"U" = (
+/obj/effect/spawner/random/exotic/snow_gear,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
 "V" = (
 /obj/structure/frost_miner_prism,
 /mob/living/simple_animal/hostile/megafauna/demonic_frost_miner,
@@ -606,7 +610,7 @@ k
 a
 k
 k
-r
+U
 r
 j
 k
@@ -706,7 +710,7 @@ l
 l
 c
 f
-r
+U
 L
 a
 Y

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -2,34 +2,205 @@
 "a" = (
 /turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
-"b" = (
-/obj/structure/ladder{
-	travel_time = 40
+"c" = (
+/obj/item/paper/crumpled/bloody{
+	default_raw_text = "STRENGTH... UNPARALLELED. UNNATURAL.";
+	color = COLOR_MAROON
 	},
-/turf/open/misc/ice/icemoon,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "d" = (
 /turf/template_noop,
 /area/template_noop)
-"g" = (
-/obj/item/clothing/suit/hooded/explorer,
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/misc/ice/icemoon,
+"e" = (
+/obj/item/organ/internal/monster_core/regenerative_core/legion{
+	time_to_decay = 0;
+	pixel_x = 4;
+	pixel_y = 3;
+	icon_state = "legion_core_decayed"
+	},
+/turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"h" = (
-/obj/item/clothing/shoes/winterboots/ice_boots,
-/turf/open/misc/ice/icemoon,
+"f" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/snow,
 /area/icemoon/underground/explored)
-"i" = (
-/obj/item/knife/combat/survival,
-/turf/open/misc/ice/icemoon,
+"j" = (
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"k" = (
+/turf/open/misc/ice/smooth,
 /area/icemoon/underground/explored)
 "l" = (
 /turf/closed/indestructible/rock/snow/ice/ore,
 /area/icemoon/underground/explored)
+"m" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"n" = (
+/obj/item/pickaxe/rusted,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"o" = (
+/obj/structure/flora/rock/pile/icy/style_3,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"p" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"q" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"r" = (
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"s" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/explored)
+"t" = (
+/obj/structure/closet/crate/preopen,
+/obj/item/stack/ore/plasma,
+/obj/item/stack/ore/iron,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"u" = (
+/obj/item/organ/internal/monster_core/regenerative_core/legion{
+	time_to_decay = 0;
+	pixel_x = -12;
+	pixel_y = -4;
+	icon_state = "legion_core_decayed"
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"v" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"w" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"y" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"z" = (
+/obj/structure/ladder,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"A" = (
+/obj/item/pickaxe/rusted,
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/explored)
+"B" = (
+/obj/structure/frost_miner_prism,
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/explored)
+"C" = (
+/obj/item/pickaxe/rusted,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"D" = (
+/obj/structure/table,
+/obj/item/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"F" = (
+/obj/structure/flora/rock/icy/style_2,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"H" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"I" = (
+/obj/structure/flora/rock/icy,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"J" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/explored)
+"K" = (
+/obj/item/organ/internal/monster_core/regenerative_core/legion{
+	time_to_decay = 0;
+	pixel_x = 11;
+	pixel_y = 4;
+	icon_state = "legion_core_decayed"
+	},
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"L" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/explored)
+"M" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"N" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"O" = (
+/obj/item/trash/flare,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"P" = (
+/obj/structure/frost_miner_prism,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"Q" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/explored)
+"R" = (
+/obj/effect/mob_spawn/corpse/human/minesite,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"S" = (
+/obj/structure/table,
+/obj/effect/spawner/random/bureaucracy/folder,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"T" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
 "V" = (
 /obj/structure/frost_miner_prism,
 /mob/living/simple_animal/hostile/megafauna/demonic_frost_miner,
+/obj/effect/decal/cleanable/grand_remains,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"W" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/misc/ice/icemoon,
+/area/icemoon/underground/explored)
+"X" = (
+/obj/structure/flora/rock/icy/style_3,
+/turf/open/misc/snow,
+/area/icemoon/underground/explored)
+"Y" = (
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/ice/icemoon,
 /area/icemoon/underground/explored)
 "Z" = (
@@ -132,7 +303,7 @@ l
 l
 l
 l
-a
+k
 a
 a
 a
@@ -160,6 +331,9 @@ l
 l
 l
 l
+r
+k
+k
 a
 a
 a
@@ -168,10 +342,7 @@ a
 a
 a
 a
-a
-a
-a
-a
+W
 a
 a
 a
@@ -188,11 +359,11 @@ l
 l
 l
 l
-a
-a
-a
-a
-a
+k
+r
+j
+k
+k
 a
 a
 a
@@ -216,12 +387,12 @@ l
 l
 l
 l
-a
-a
-a
-a
-a
-a
+r
+F
+r
+f
+m
+k
 a
 a
 a
@@ -244,13 +415,13 @@ l
 l
 l
 l
-a
-a
-a
-a
-a
-a
-a
+k
+k
+r
+r
+l
+l
+k
 a
 a
 a
@@ -260,9 +431,9 @@ a
 a
 a
 a
-a
-a
-a
+k
+k
+k
 a
 a
 l
@@ -274,24 +445,24 @@ l
 l
 Z
 a
+k
+z
+r
+l
+k
+k
+a
+a
+a
+W
 a
 a
 a
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+X
+k
 a
 a
 Z
@@ -303,11 +474,11 @@ l
 l
 a
 a
-a
-a
-a
-a
-a
+k
+k
+r
+k
+k
 Z
 a
 a
@@ -318,11 +489,11 @@ a
 a
 Z
 a
-a
-a
-a
-a
-a
+k
+k
+s
+J
+v
 a
 l
 l
@@ -333,6 +504,9 @@ l
 a
 a
 a
+k
+k
+k
 a
 a
 a
@@ -343,16 +517,13 @@ a
 a
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+k
+r
+R
+k
+H
+q
 l
 l
 "}
@@ -368,20 +539,20 @@ a
 a
 a
 a
+k
+k
+k
+k
+k
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+T
+r
+f
+k
+k
+n
 l
 l
 "}
@@ -396,20 +567,20 @@ a
 a
 a
 a
+k
+k
+f
+r
+r
+k
+k
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+r
+r
+I
+f
+k
 a
 l
 l
@@ -425,20 +596,20 @@ a
 a
 a
 a
+k
+f
+f
+r
+r
+T
+k
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+k
+r
+r
+j
+k
 a
 l
 l
@@ -454,20 +625,20 @@ a
 a
 a
 a
+k
+f
+e
+r
+r
+r
+k
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+k
+k
+r
+k
 a
 l
 l
@@ -475,28 +646,28 @@ l
 (16,1,1) = {"
 l
 l
+B
+k
+k
+a
+a
 Z
+W
 a
-a
-a
-a
-Z
-a
-a
-a
-a
-a
+k
+M
+M
 V
+u
+r
+k
 a
 a
-a
-a
-a
-Z
-a
-a
-a
-a
+B
+k
+k
+k
+Q
 Z
 l
 l
@@ -504,26 +675,26 @@ l
 (17,1,1) = {"
 l
 l
+D
+f
+k
+k
 a
 a
 a
+Y
+k
+m
+r
+K
+r
+r
+k
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+f
+k
 a
 a
 a
@@ -533,26 +704,26 @@ l
 (18,1,1) = {"
 l
 l
+c
+f
+r
+L
+a
+Y
 a
 a
+k
+r
+r
+r
+r
+f
+k
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+m
+k
 a
 a
 a
@@ -562,26 +733,26 @@ l
 (19,1,1) = {"
 l
 l
+t
+w
+m
+k
+k
 a
 a
 a
+k
+k
+r
+f
+f
+k
+k
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-b
-a
-a
-a
-a
-a
-a
+k
+k
+k
 a
 a
 a
@@ -591,20 +762,20 @@ l
 (20,1,1) = {"
 l
 l
+C
+w
+w
+r
+k
 a
 a
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+k
+k
+k
+k
 a
 a
 a
@@ -620,11 +791,11 @@ l
 (21,1,1) = {"
 l
 l
-a
-a
-a
-a
-a
+S
+w
+p
+f
+k
 a
 a
 a
@@ -649,6 +820,14 @@ l
 (22,1,1) = {"
 l
 l
+T
+r
+f
+r
+k
+a
+a
+Z
 a
 a
 a
@@ -661,15 +840,7 @@ a
 a
 a
 a
-a
-a
-a
-Z
-a
-a
-a
-a
-a
+W
 a
 a
 l
@@ -678,11 +849,11 @@ l
 (23,1,1) = {"
 l
 l
-Z
-a
-a
-a
-a
+P
+k
+k
+k
+k
 a
 a
 a
@@ -708,6 +879,7 @@ l
 l
 l
 l
+k
 a
 a
 a
@@ -716,13 +888,12 @@ a
 a
 a
 a
-a
-a
-Z
-a
-a
-a
-a
+k
+B
+k
+k
+k
+k
 a
 a
 a
@@ -742,17 +913,17 @@ a
 a
 a
 a
-i
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+k
+k
+f
+f
+k
+o
+k
+k
 a
 a
 a
@@ -771,17 +942,17 @@ l
 a
 a
 a
-g
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
+k
+r
+y
+T
+k
+k
+f
+r
+k
 a
 a
 a
@@ -800,17 +971,17 @@ l
 l
 a
 a
-h
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+W
+k
+m
+N
+O
+k
+k
+k
+k
+k
 a
 a
 l
@@ -831,11 +1002,11 @@ l
 a
 a
 a
-a
-a
-a
-a
-a
+k
+A
+R
+k
+k
 a
 a
 a
@@ -861,9 +1032,9 @@ l
 Z
 a
 a
-a
-a
-Z
+k
+k
+B
 a
 a
 a

--- a/code/modules/mapfluff/ruins/icemoonruin_code/mining_site.dm
+++ b/code/modules/mapfluff/ruins/icemoonruin_code/mining_site.dm
@@ -30,3 +30,7 @@
 	name = "Mining Site Overseer"
 	outfit = /datum/outfit/minesite/overseer
 	icon_state = "corpsecargotech"
+
+/obj/item/paper/crumpled/bloody/ruins/mining_site
+	name = "blood-written note"
+	default_raw_text = "<br><br><font color='red'>STRENGTH... UNPARALLELED. UNNATURAL.</font>"

--- a/code/modules/mapfluff/ruins/icemoonruin_code/mining_site.dm
+++ b/code/modules/mapfluff/ruins/icemoonruin_code/mining_site.dm
@@ -1,0 +1,32 @@
+/datum/outfit/minesite
+	name = "Mining Site Worker"
+
+	uniform = /obj/item/clothing/under/rank/cargo/miner
+	suit = /obj/item/clothing/suit/hooded/wintercoat
+	back = /obj/item/storage/backpack/duffelbag
+	gloves = /obj/item/clothing/gloves/color/black
+	shoes = /obj/item/clothing/shoes/winterboots/ice_boots
+	head = /obj/item/clothing/head/utility/hardhat/orange
+
+/datum/outfit/minesite/overseer
+	name = "Mining Site Overseer"
+
+	uniform = /obj/item/clothing/under/rank/cargo/qm
+	suit = /obj/item/clothing/suit/hooded/wintercoat
+	back = /obj/item/storage/backpack/duffelbag
+	gloves = /obj/item/clothing/gloves/color/black
+	shoes = /obj/item/clothing/shoes/winterboots/ice_boots
+	head = /obj/item/clothing/head/utility/hardhat/white
+	glasses = /obj/item/clothing/glasses/sunglasses
+	r_hand = /obj/item/megaphone
+	l_hand = /obj/item/clipboard
+
+/obj/effect/mob_spawn/corpse/human/minesite
+	name = "Mining Site Worker"
+	outfit = /datum/outfit/minesite
+	icon_state = "corpseminer"
+
+/obj/effect/mob_spawn/corpse/human/minesite/overseer
+	name = "Mining Site Overseer"
+	outfit = /datum/outfit/minesite/overseer
+	icon_state = "corpsecargotech"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4187,6 +4187,7 @@
 #include "code\modules\mapfluff\ruins\icemoonruin_code\hotsprings.dm"
 #include "code\modules\mapfluff\ruins\icemoonruin_code\library.dm"
 #include "code\modules\mapfluff\ruins\icemoonruin_code\mailroom.dm"
+#include "code\modules\mapfluff\ruins\icemoonruin_code\mining_site.dm"
 #include "code\modules\mapfluff\ruins\icemoonruin_code\wrath.dm"
 #include "code\modules\mapfluff\ruins\lavalandruin_code\biodome_clown_planet.dm"
 #include "code\modules\mapfluff\ruins\lavalandruin_code\biodome_winter.dm"


### PR DESCRIPTION

## About The Pull Request

Updates the Demonic-Frost Miner ruin on IceBox, keeps multi-z and general shape, but changes some things to better fit the theme of the "Mining Site" that the ruin is named.
![image](https://github.com/tgstation/tgstation/assets/86125936/0693bc59-1130-445d-ace9-61fa65f4639f)
![image](https://github.com/tgstation/tgstation/assets/86125936/cc056de8-2ee4-4506-a6d8-706594af12c6)
## Why It's Good For The Game

The current ruin doesn't fit well as a "Mining Site", this makes it fit the theme more, while looking better in general. It also makes the arena more interesting, rather than solid ice.
## Changelog
:cl:
add: Demonic-Frost Miner's ruin gets an aesthetic refresh
/:cl:
