### PR TITLE
Prevent a runtime in malf AI's overload machine ability when it runs out of uses

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -455,15 +455,15 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		return FALSE
 
 	caller.playsound_local(caller, 'sound/misc/interference.ogg', 50, FALSE, use_reverb = FALSE)
-	adjust_uses(-1)
-
-	if(uses)
-		desc = "[initial(desc)] It has [uses] use\s remaining."
-		build_all_button_icons()
 
 	clicked_machine.audible_message(span_userdanger("You hear a loud electrical buzzing sound coming from [clicked_machine]!"))
 	addtimer(CALLBACK(src, PROC_REF(animate_machine), caller, clicked_machine), 5 SECONDS) //kabeep!
 	unset_ranged_ability(caller, span_danger("Sending override signal..."))
+	adjust_uses(-1) //adjust after we unset the active ability since we may run out of charges, thus deleting the ability
+
+	if(uses)
+		desc = "[initial(desc)] It has [uses] use\s remaining."
+		build_all_button_icons()
 	return TRUE
 
 /datum/action/innate/ai/ranged/override_machine/proc/animate_machine(mob/living/caller, obj/machinery/to_animate)


### PR DESCRIPTION
shifts the uses adjustment after unsetting the ability from the AI's click to prevent a runtime

here `owner` would be `null` and scream cats because the ability would delete itself when running out of uses, thus deleting the owner and whatnot. i mean i guess we could just replace `owner` with `on_who` maybe but eh
https://github.com/tgstation/tgstation/blob/5e21011aabd978dccf2f98dc7f0638e4c8831f38/code/datums/actions/innate_action.dm#L69-L76

runtime
```
[2023-04-01 08:10:00.141] runtime error: Cannot read null.client
 - proc name: unset ranged ability (/datum/action/innate/proc/unset_ranged_ability)
 -   source file: innate_action.dm,72
 -   usr: W.A.R.D.E.N. (/mob/living/silicon/ai)
 -   src: Overload Machine (/datum/action/innate/ai/ranged/overload_machine)
 -   usr.loc: the floor (33,138,2) (/turf/open/floor/circuit/green)
 -   call stack:
 - Overload Machine (/datum/action/innate/ai/ranged/overload_machine): unset ranged ability(W.A.R.D.E.N. (/mob/living/silicon/ai), "<span class=\'danger\'>Overcha...")
 - Overload Machine (/datum/action/innate/ai/ranged/overload_machine): do ability(W.A.R.D.E.N. (/mob/living/silicon/ai), the chem dispenser (/obj/machinery/chem_dispenser))
 - Overload Machine (/datum/action/innate/ai/ranged/overload_machine): InterceptClickOn(W.A.R.D.E.N. (/mob/living/silicon/ai), "icon-x=17;icon-y=19;left=1;but...", the chem dispenser (/obj/machinery/chem_dispenser))
 - W.A.R.D.E.N. (/mob/living/silicon/ai): check click intercept("icon-x=17;icon-y=19;left=1;but...", the chem dispenser (/obj/machinery/chem_dispenser))
 - W.A.R.D.E.N. (/mob/living/silicon/ai): ClickOn(the chem dispenser (/obj/machinery/chem_dispenser), "icon-x=17;icon-y=19;left=1;but...")
 - the chem dispenser (/obj/machinery/chem_dispenser): Click(the shuttle floor (155,97,2) (/turf/open/floor/mineral/plastitanium), "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
 - the chem dispenser (/obj/machinery/chem_dispenser):  Click(the shuttle floor (155,97,2) (/turf/open/floor/mineral/plastitanium), "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(W.A.R.D.E.N. (/mob/living/silicon/ai), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```