### PR TITLE
changes COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED into a more versatile signal

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -77,8 +77,8 @@
 /// global signal sent when a nuclear device is detonating (/obj/machinery/nuclearbomb/nuke/exploding_nuke)
 #define COMSIG_GLOB_NUKE_DEVICE_DETONATING "!nuclear_device_detonating"
 
-/// Global signal sent when a light mechanism is completed (try_id)
-#define COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED "!light_mechanism_completed"
+/// Global signal sent when a puzzle piece is completed (light mechanism, etc.) (try_id)
+#define COMSIG_GLOB_PUZZLE_COMPLETED "!puzzle_completed"
 
 /// Global signal called after the station changes its name.
 /// (new_name, old_name)

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -61,6 +61,19 @@
 	fire = 100
 	acid = 100
 
+/obj/machinery/door/puzzle/Initialize(mapload)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_PUZZLE_COMPLETED, PROC_REF(try_signal))
+
+/obj/machinery/door/puzzle/Destroy(force)
+	. = ..()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_PUZZLE_COMPLETED)
+
+/obj/machinery/door/puzzle/proc/try_signal(datum/source, try_id)
+	SIGNAL_HANDLER
+
+	INVOKE_ASYNC(src, PROC_REF(try_puzzle_open), try_id)
+
 /obj/machinery/door/puzzle/Bumped(atom/movable/AM)
 	return !density && ..()
 
@@ -110,15 +123,6 @@
 
 /obj/machinery/door/puzzle/light
 	desc = "This door only opens when a linked mechanism is powered. It looks virtually indestructible."
-
-/obj/machinery/door/puzzle/light/Initialize(mapload)
-	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED, PROC_REF(check_mechanism))
-
-/obj/machinery/door/puzzle/light/proc/check_mechanism(datum/source, try_id)
-	SIGNAL_HANDLER
-
-	INVOKE_ASYNC(src, PROC_REF(try_puzzle_open), try_id)
 
 //*************************
 //***Box Pushing Puzzles***
@@ -268,5 +272,5 @@
 			return
 	visible_message(span_boldnotice("[src] becomes fully charged!"))
 	powered = TRUE
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED, puzzle_id)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PUZZLE_COMPLETED, puzzle_id)
 	playsound(src, 'sound/machines/synth_yes.ogg', 100, TRUE)


### PR DESCRIPTION

## About The Pull Request

COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED is now COMSIG_GLOB_PUZZLE_COMPLETED 
the light puzzle thingamajig now uses that
puzzle doors on init register this signal, which means if the signal is sent all doors with the ID passed with the signal would open

## Why It's Good For The Game

this means we can use the signal for more pieces such as cool buttons or pressure plates that open doors or whatever else that registers the signal
or you could like make a component that does puzzle stuff like making a mob send it on death

and mappers can change puzzle_id to link stuff together

## Changelog
:cl:
code: COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED is now COMSIG_GLOB_PUZZLE_COMPLETED 
/:cl:
