### PR TITLE
Add burning sound loop to bonfires and fireplaces

### DIFF
--- a/code/datums/looping_sounds/burning.dm
+++ b/code/datums/looping_sounds/burning.dm
@@ -1,0 +1,9 @@
+/// Soundloop for the fire (bonfires, fireplaces, etc.)
+/datum/looping_sound/burning
+	start_sound = 'sound/items/match_strike.ogg'
+	start_length = 3 SECONDS
+	mid_sounds = 'sound/effects/comfyfire.ogg'
+	mid_length = 5 SECONDS
+	volume = 50
+	vary = TRUE
+	extra_range = MEDIUM_RANGE_SOUND_EXTRARANGE

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -34,7 +34,7 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	burning_loop = new(src)
 
-/obj/structure/fireplace/Destroy()
+/obj/structure/bonfire/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(burning_loop)
 	. = ..()

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -107,6 +107,8 @@
 /obj/structure/bonfire/proc/start_burning()
 	if(burning || !check_oxygen())
 		return
+
+	playsound(src, 'sound/items/match_strike.ogg', 40, TRUE)
 	icon_state = burn_icon
 	burning = TRUE
 	set_light(6)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -17,19 +17,14 @@
 	anchored = TRUE
 	buckle_lying = 0
 	pass_flags_self = PASSTABLE | LETPASSTHROW
-	///is the bonfire lit?
+	/// is the bonfire lit?
 	var/burning = FALSE
-	///icon for the bonfire while on. for a softer more burning embers icon, use "bonfire_warm"
+	/// icon for the bonfire while on. for a softer more burning embers icon, use "bonfire_warm"
 	var/burn_icon = "bonfire_on_fire"
-	///if the bonfire has a grill attached
+	/// if the bonfire has a grill attached
 	var/grill = FALSE
-
-/obj/structure/bonfire/dense
-	density = TRUE
-
-/obj/structure/bonfire/prelit/Initialize(mapload)
-	. = ..()
-	start_burning()
+	/// the looping sound effect that is played while burning
+	var/datum/looping_sound/burning/burning_loop
 
 /obj/structure/bonfire/Initialize(mapload)
 	. = ..()
@@ -37,6 +32,12 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	burning_loop = new(src)
+
+/obj/structure/fireplace/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	QDEL_NULL(burning_loop)
+	. = ..()
 
 /obj/structure/bonfire/attackby(obj/item/used_item, mob/living/user, params)
 	if(istype(used_item, /obj/item/stack/rods) && !can_buckle && !grill)
@@ -77,7 +78,6 @@
 		else
 			return ..()
 
-
 /obj/structure/bonfire/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)
@@ -108,7 +108,7 @@
 	if(burning || !check_oxygen())
 		return
 
-	playsound(src, 'sound/items/match_strike.ogg', 40, TRUE)
+	burning_loop.start()
 	icon_state = burn_icon
 	burning = TRUE
 	set_light(6)
@@ -166,6 +166,8 @@
 	. = ..()
 	if(!burning)
 		return
+
+	burning_loop.stop()
 	icon_state = "bonfire"
 	burning = FALSE
 	set_light(0)
@@ -179,5 +181,12 @@
 /obj/structure/bonfire/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
 	if(..())
 		buckled_mob.pixel_y -= 13
+
+/obj/structure/bonfire/dense
+	density = TRUE
+
+/obj/structure/bonfire/prelit/Initialize(mapload)
+	. = ..()
+	start_burning()
 
 #undef BONFIRE_FIRE_STACK_STRENGTH

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -14,17 +14,22 @@
 	light_color = LIGHT_COLOR_FIRE
 	light_angle = 170
 	light_flags = LIGHT_IGNORE_OFFSET
+	/// is the fireplace lit?
 	var/lit = FALSE
-
+	/// the amount of fuel for the fire
 	var/fuel_added = 0
+	/// how much time is left before fire runs out of fuel
 	var/flame_expiry_timer
+	/// the looping sound effect that is played while burning
+	var/datum/looping_sound/burning/burning_loop
 
 /obj/structure/fireplace/Initialize(mapload)
 	. = ..()
-	START_PROCESSING(SSobj, src)
+	burning_loop = new(src)
 
 /obj/structure/fireplace/Destroy()
 	STOP_PROCESSING(SSobj, src)
+	QDEL_NULL(burning_loop)
 	. = ..()
 
 /obj/structure/fireplace/setDir(newdir)
@@ -126,7 +131,6 @@
 		put_out()
 		return
 
-	playsound(src, 'sound/effects/comfyfire.ogg',50,FALSE, FALSE, TRUE)
 	var/turf/T = get_turf(src)
 	T.hotspot_expose(700, 2.5 * seconds_per_tick)
 	update_appearance()
@@ -155,6 +159,8 @@
 		return max(0, fuel_added)
 
 /obj/structure/fireplace/proc/ignite()
+	START_PROCESSING(SSobj, src)
+	burning_loop.start()
 	lit = TRUE
 	desc = "A large stone brick fireplace, warm and cozy."
 	flame_expiry_timer = world.time + fuel_added
@@ -163,6 +169,8 @@
 	adjust_light()
 
 /obj/structure/fireplace/proc/put_out()
+	STOP_PROCESSING(SSobj, src)
+	burning_loop.stop()
 	lit = FALSE
 	update_appearance()
 	adjust_light()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1436,6 +1436,7 @@
 #include "code\datums\keybinding\robot.dm"
 #include "code\datums\looping_sounds\_looping_sound.dm"
 #include "code\datums\looping_sounds\acid.dm"
+#include "code\datums\looping_sounds\burning.dm"
 #include "code\datums\looping_sounds\choking.dm"
 #include "code\datums\looping_sounds\cyborg.dm"
 #include "code\datums\looping_sounds\item_sounds.dm"


### PR DESCRIPTION

## About The Pull Request
This adds a ignition sound whenever a fireplace or bonfire is initially lit on fire.  Afterwards a continuous burning loop is played.  Also added some documentation and optimized fireplaces to only `process()` when lit. 

## Why It's Good For The Game
Better consistency.

## Changelog
:cl:
sound: Add burning sound loop to bonfires and fireplaces
code: Improved fireplaces to only process when lit
/:cl:
