### PR TITLE
Fixes setting prebuilt shutter ids with multiool

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -49,7 +49,7 @@
 		return
 	if (deconstruction != BLASTDOOR_FINISHED)
 		return
-	var/change_id = tgui_input_number(user, "Set the door controllers ID", "Door Controller ID", id, 100)
+	var/change_id = tgui_input_text(user, "Set the door controllers ID", "Door Controller ID", id, 100)
 	if(!change_id || QDELETED(usr) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
 	id = change_id


### PR DESCRIPTION
Most mapped in ids are text not numbers, which would runtime here.