### PR TITLE
Dels a bad stack trace from stoned effect

### DIFF
--- a/code/datums/status_effects/drug_effects.dm
+++ b/code/datums/status_effects/drug_effects.dm
@@ -84,6 +84,8 @@
 	return TRUE
 
 /datum/status_effect/stoned/on_remove()
+	if(!ishuman(owner))
+		return
 	var/mob/living/carbon/human/human_owner = owner
 	human_owner.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cannabis)
 	human_owner.eye_color_left = original_eye_color_left

--- a/code/datums/status_effects/drug_effects.dm
+++ b/code/datums/status_effects/drug_effects.dm
@@ -70,7 +70,7 @@
 
 /datum/status_effect/stoned/on_apply()
 	if(!ishuman(owner))
-		CRASH("[type] status effect added to non-human owner: [owner ? owner.type : "null owner"]")
+		return FALSE
 	var/mob/living/carbon/human/human_owner = owner
 	original_eye_color_left = human_owner.eye_color_left
 	original_eye_color_right = human_owner.eye_color_right
@@ -84,8 +84,6 @@
 	return TRUE
 
 /datum/status_effect/stoned/on_remove()
-	if(!ishuman(owner))
-		stack_trace("[type] status effect being removed from non-human owner: [owner ? owner.type : "null owner"]")
 	var/mob/living/carbon/human/human_owner = owner
 	human_owner.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cannabis)
 	human_owner.eye_color_left = original_eye_color_left


### PR DESCRIPTION
## About The Pull Request

This is a bad stack trace, the reagent application makes no effort in ensuring non-carbons get the effect applied.

https://github.com/tgstation/tgstation/blob/ce51db06ef9dd10ac4fc68907a5a0319ad22e51e/code/modules/reagents/chemistry/reagents/drug_reagents.dm#L48-L50

So rather than crashing, we'll just `return FALSE` to tell the status effect not to apply. 
