### PR TITLE
Fixes bioscramble picking base wing type

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_INIT(bioscrambler_parts_blacklist, typecacheof(list(
 GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list (
 	/obj/item/organ/external/pod_hair,
 	/obj/item/organ/external/spines,
+	/obj/item/organ/external/wings,
 	/obj/item/organ/external/wings/functional,
 	/obj/item/organ/internal/alien,
 	/obj/item/organ/internal/brain,


### PR DESCRIPTION
Base wing type don't actually implement any visuals so it's both invisible and causing runtimes.