### PR TITLE
Fix bitrunning drinking glass using the wrong subtype

### DIFF
--- a/_maps/virtual_domains/beach_bar.dmm
+++ b/_maps/virtual_domains/beach_bar.dmm
@@ -159,7 +159,7 @@
 	pixel_x = -8;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain{
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain{
 	pixel_y = 8;
 	pixel_x = 5
 	},
@@ -424,8 +424,8 @@
 /area/virtual_domain/powered)
 "uq" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain,
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain{
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain,
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain{
 	pixel_x = -4;
 	pixel_y = 8
 	},
@@ -878,11 +878,11 @@
 /area/virtual_domain/powered)
 "Mp" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain{
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain{
 	pixel_y = 7;
 	pixel_x = 4
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain,
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain,
 /turf/open/floor/wood,
 /area/virtual_domain/powered)
 "Mw" = (

--- a/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
@@ -8,12 +8,12 @@
 	map_name = "beach_bar"
 	safehouse_path = /datum/map_template/safehouse/mine
 
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain
 	name = "pina colada"
 	desc = "Whose drink is this? Not yours, that's for sure. Well, it's not like they're going to miss it."
 	list_reagents = list(/datum/reagent/consumable/ethanol/pina_colada = 30)
 
-/obj/item/reagent_containers/cup/glass/drinkingglass/virtual_domain/Initialize(mapload, vol)
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/virtual_domain/Initialize(mapload, vol)
 	. = ..()
 
 	AddComponent(/datum/component/bitrunning_points, \


### PR DESCRIPTION
## About The Pull Request

This drinking glass subtype was runtiming like crazy because it didn't have `base_container_type` set, meaning it ~failed the vibe check~ couldn't properly update its sprite according to the glass styles. 

![image](https://github.com/tgstation/tgstation/assets/51863163/b9410fa4-e8ec-417f-ac41-e8986c754c34)

Swapped it out for a subtype of `filled`. Because it's a glass that starts filled. 

## Changelog

:cl: Melbert
fix: Virtual Drink Glasses now look correct. 
/:cl:
