### PR TITLE
Fixes some EMP'd cyborg bodypart runtimes

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1276,9 +1276,10 @@
 	else
 		update_icon_dropped()
 
+// Note: Does NOT return EMP protection value from parent call or pass it on to subtypes
 /obj/item/bodypart/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_WIRES || !IS_ROBOTIC_LIMB(src))
+	var/protection = ..()
+	if((protection & EMP_PROTECT_WIRES) || !IS_ROBOTIC_LIMB(src))
 		return FALSE
 
 	// with defines at the time of writing, this is 2 brute and 1.5 burn
@@ -1295,16 +1296,14 @@
 		burn_damage *= 2
 
 	receive_damage(brute_damage, burn_damage)
-	do_sparks(number = 1, cardinal_only = FALSE, source = owner)
-	var/damage_percent_to_max = (get_damage() / max_damage)
-	if (time_needed && (damage_percent_to_max >= robotic_emp_paralyze_damage_percent_threshold))
-		owner.visible_message(span_danger("[owner]'s [src] seems to malfunction!"))
-		ADD_TRAIT(src, TRAIT_PARALYSIS, EMP_TRAIT)
-		addtimer(CALLBACK(src, PROC_REF(un_paralyze)), time_needed)
-	return TRUE
+	do_sparks(number = 1, cardinal_only = FALSE, source = owner || src)
 
-/obj/item/bodypart/proc/un_paralyze()
-	REMOVE_TRAITS_IN(src, EMP_TRAIT)
+	if((get_damage() / max_damage) >= robotic_emp_paralyze_damage_percent_threshold)
+		ADD_TRAIT(src, TRAIT_PARALYSIS, EMP_TRAIT)
+		addtimer(TRAIT_CALLBACK_REMOVE(src, TRAIT_PARALYSIS, EMP_TRAIT), time_needed)
+		owner?.visible_message(span_danger("[owner]'s [src] seems to malfunction!"))
+
+	return TRUE
 
 /// Returns the generic description of our BIO_EXTERNAL feature(s), prioritizing certain ones over others. Returns error on failure.
 /obj/item/bodypart/proc/get_external_description()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1298,10 +1298,10 @@
 	receive_damage(brute_damage, burn_damage)
 	do_sparks(number = 1, cardinal_only = FALSE, source = owner || src)
 
-	if((get_damage() / max_damage) >= robotic_emp_paralyze_damage_percent_threshold)
+	if(can_be_disabled && (get_damage() / max_damage) >= robotic_emp_paralyze_damage_percent_threshold)
 		ADD_TRAIT(src, TRAIT_PARALYSIS, EMP_TRAIT)
 		addtimer(TRAIT_CALLBACK_REMOVE(src, TRAIT_PARALYSIS, EMP_TRAIT), time_needed)
-		owner?.visible_message(span_danger("[owner]'s [src] seems to malfunction!"))
+		owner?.visible_message(span_danger("[owner]'s [plaintext_zone] seems to malfunction!"))
 
 	return TRUE
 

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -120,7 +120,7 @@
 	owner.Knockdown(knockdown_time)
 	if(owner.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
 		return
-	to_chat(owner, span_danger("As your [src] unexpectedly malfunctions, it causes you to fall to the ground!"))
+	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
 
 /obj/item/bodypart/leg/right/robot
 	name = "cyborg right leg"
@@ -166,7 +166,7 @@
 	owner.Knockdown(knockdown_time)
 	if(owner.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
 		return
-	to_chat(owner, span_danger("As your [src] unexpectedly malfunctions, it causes you to fall to the ground!"))
+	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
 
 /obj/item/bodypart/chest/robot
 	name = "cyborg torso"
@@ -221,7 +221,7 @@
 
 	var/damage_percent_to_max = (get_damage() / max_damage)
 	if (stun_time && (damage_percent_to_max >= robotic_emp_paralyze_damage_percent_threshold))
-		to_chat(owner, span_danger("Your [src]'s logic boards temporarily become unresponsive!"))
+		to_chat(owner, span_danger("Your [plaintext_zone]'s logic boards temporarily become unresponsive!"))
 		owner.Stun(stun_time)
 	owner.Shake(pixelshiftx = shift_x, pixelshifty = shift_y, duration = shake_duration)
 
@@ -343,7 +343,7 @@
 	if(!. || isnull(owner))
 		return
 
-	to_chat(owner, span_danger("Your [src]'s optical transponders glitch out and malfunction!"))
+	to_chat(owner, span_danger("Your [plaintext_zone]'s optical transponders glitch out and malfunction!"))
 
 	var/glitch_duration = AUGGED_HEAD_EMP_GLITCH_DURATION
 	if (severity == EMP_HEAVY)

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -111,8 +111,9 @@
 
 /obj/item/bodypart/leg/left/robot/emp_act(severity)
 	. = ..()
-	if(!.)
+	if(!. || isnull(owner))
 		return
+
 	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
 	if (severity == EMP_HEAVY)
 		knockdown_time *= 2
@@ -156,8 +157,9 @@
 
 /obj/item/bodypart/leg/right/robot/emp_act(severity)
 	. = ..()
-	if(!.)
+	if(!. || isnull(owner))
 		return
+
 	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
 	if (severity == EMP_HEAVY)
 		knockdown_time *= 2
@@ -203,7 +205,7 @@
 
 /obj/item/bodypart/chest/robot/emp_act(severity)
 	. = ..()
-	if(!.)
+	if(!. || isnull(owner))
 		return
 
 	var/stun_time = 0
@@ -338,8 +340,9 @@
 
 /obj/item/bodypart/head/robot/emp_act(severity)
 	. = ..()
-	if(!.)
+	if(!. || isnull(owner))
 		return
+
 	to_chat(owner, span_danger("Your [src]'s optical transponders glitch out and malfunction!"))
 
 	var/glitch_duration = AUGGED_HEAD_EMP_GLITCH_DURATION


### PR DESCRIPTION
## About The Pull Request

Remember friends, bodypart don't always have owners. 

Fixes some runtimes that occur if cyborg bodyparts were emp'd without an owner. 

## Changelog

:cl: Melbert
fix: Robotic bodyparts not attached to people are now properly affected by EMPs. 
/:cl:

