### PR TITLE
Fix TTS runtime from wearing bread

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -399,7 +399,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			filter += tts_filter.Join(",")
 		if(ishuman(src))
 			var/mob/living/carbon/human/human_speaker = src
-			if(human_speaker.wear_mask)
+			if(istype(human_speaker.wear_mask, /obj/item/clothing/mask))
 				var/obj/item/clothing/mask/worn_mask = human_speaker.wear_mask
 				if(worn_mask.voice_override)
 					voice_to_use = worn_mask.voice_override


### PR DESCRIPTION
## About The Pull Request

Surprise, this just assumed a mob's mask is, well, a mask. But you can wear many non-mask things in your mask, such as bread or roses. 

## Changelog

:cl: Melber
fix: Wearing bread (or roses, or other non-mask things) no longer prevents you from TTS speaking.
/:cl: