### PR TITLE
Fixes sanitizing chemicals (Miner's Salve, Sterilizine, and Space Cleaner) not sanitizing burn wounds

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -49,7 +49,7 @@
 
 	for(var/datum/reagent/reagent as anything in victim.reagents.reagent_list)
 		if(reagent.chemical_flags & REAGENT_AFFECTS_WOUNDS)
-			reagent.on_burn_wound_processing()
+			reagent.on_burn_wound_processing(src)
 
 	if(HAS_TRAIT(victim, TRAIT_VIRUS_RESISTANCE))
 		sanitization += 0.9


### PR DESCRIPTION
## About The Pull Request

This proc didn't pass itself to the reagents to actually do anything.

## Changelog

:cl: Melbert
fix: Miner's Salve, Sterilizine, and Space Cleaner now all properly affect burn wounds
/:cl:

