### PR TITLE
[NO GBP] you can hit tendrils in melee again

### DIFF
--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -39,10 +39,12 @@
 		. += span_notice("It looks like you could probably scan and tag it with a <b>[scanner_descriptor]</b>.")
 
 /obj/structure/spawner/attackby(obj/item/item, mob/user, params)
+	. = ..()
+	if(.)
+		return TRUE
 	if(scanner_taggable && is_type_in_list(item, scanner_types))
 		gps_tag(user)
-	else
-		. = ..()
+		return TRUE
 
 /// Tag the spawner, prefixing its GPS entry with an identifier - or giving it one, if nonexistent.
 /obj/structure/spawner/proc/gps_tag(mob/user)

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -41,6 +41,8 @@
 /obj/structure/spawner/attackby(obj/item/item, mob/user, params)
 	if(scanner_taggable && is_type_in_list(item, scanner_types))
 		gps_tag(user)
+	else
+		. = ..()
 
 /// Tag the spawner, prefixing its GPS entry with an identifier - or giving it one, if nonexistent.
 /obj/structure/spawner/proc/gps_tag(mob/user)


### PR DESCRIPTION
## About The Pull Request
adds an `else . = ..()` to spawner's attackby check so you can just break them with your crusher in case you need to be rid of it

## Why It's Good For The Game

sometimes you just need to melee a spawner

## Changelog

:cl:
fix: Necropolis tendrils and other mining mob spawners can be hit in melee again.
/:cl: