### PR TITLE
Fixes images getting displayed as an appearance in vv

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -12,7 +12,7 @@
 #define isweakref(D) (istype(D, /datum/weakref))
 
 GLOBAL_VAR_INIT(magic_appearance_detecting_image, new /image) // appearances are awful to detect safely, but this seems to be the best way ~ninjanomnom
-#define isappearance(thing) (!ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
+#define isappearance(thing) (!istype(thing, /image) && !ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
 
 #define isgenerator(A) (istype(A, /generator))
 


### PR DESCRIPTION
I forgot to include this in the check >.>

:cl:
fix: Images are once more displayed as images in vv instead of as an appearance
/:cl: