### PR TITLE
Fixes an issue w/ antiglow.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -66,14 +66,6 @@
 #define COMSIG_MOVABLE_SET_ANCHORED "movable_set_anchored"
 ///from base of atom/movable/setGrabState(): (newstate)
 #define COMSIG_MOVABLE_SET_GRAB_STATE "living_set_grab_state"
-///Called when the movable tries to change its dynamic light color setting, from base atom/movable/lighting_overlay_set_color(): (color)
-#define COMSIG_MOVABLE_LIGHT_OVERLAY_SET_RANGE "movable_light_overlay_set_color"
-///Called when the movable tries to change its dynamic light power setting, from base atom/movable/lighting_overlay_set_power(): (power)
-#define COMSIG_MOVABLE_LIGHT_OVERLAY_SET_POWER "movable_light_overlay_set_power"
-///Called when the movable tries to change its dynamic light range setting, from base atom/movable/lighting_overlay_set_range(): (range)
-#define COMSIG_MOVABLE_LIGHT_OVERLAY_SET_COLOR "movable_light_overlay_set_range"
-///Called when the movable tries to toggle its dynamic light LIGHTING_ON status, from base atom/movable/lighting_overlay_toggle_on(): (new_state)
-#define COMSIG_MOVABLE_LIGHT_OVERLAY_TOGGLE_ON "movable_light_overlay_toggle_on"
 ///called when the movable's glide size is updated: (new_glide_size)
 #define COMSIG_MOVABLE_UPDATE_GLIDE_SIZE "movable_glide_size"
 ///Called when a movable is hit by a plunger in layer mode, from /obj/item/plunger/attack_atom()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -254,9 +254,9 @@
 	name = "Anti-Glow"
 	desc = "Your skin seems to attract and absorb nearby light creating 'darkness' around you."
 	text_gain_indication = "<span class='notice'>The light around you seems to disappear.</span>"
-	glow = -1.5
 	conflicts = list(/datum/mutation/human/glow)
 	locked = TRUE
+	glow_power = -1.5
 
 /datum/mutation/human/glow/anti/get_glow_color()
 	return COLOR_BLACK


### PR DESCRIPTION
## About The Pull Request

Antiglow's ``glow`` var used to be how strong it would glow, but it was renamed to ``glow_power`` when ``/obj/effect/dummy/lighting_obj/moblight`` got added to it, which took its previous name of ``glow``. Antiglow was never updated for this, so they set the moblight as -1.5, which is supposed to be its strength.

I also removed some unused defines dw about that

## Why It's Good For The Game

Fixes an unintentional change that maybe breaks something idk.

## Changelog

:cl:
fix: Antiglow now probably has negative glow power.
/:cl: