### PR TITLE
Borg modules can no longer be sold by pirates

### DIFF
--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -217,9 +217,13 @@
 	var/cargo_hold_id
 	///Interface name for the ui_interact call for different subtypes.
 	var/interface_type = "CargoHoldTerminal"
+	///Typecache of things that shouldn't be sold and shouldn't have their contents sold.
+	var/static/list/nosell_typecache
 
 /obj/machinery/computer/piratepad_control/Initialize(mapload)
 	..()
+	if(isnull(nosell_typecache))
+		nosell_typecache = typecacheof(/mob/living/silicon/robot)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/piratepad_control/multitool_act(mob/living/user, obj/item/multitool/I)
@@ -285,7 +289,7 @@
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue
-		export_item_and_contents(AM, apply_elastic = FALSE, dry_run = TRUE, external_report = report)
+		export_item_and_contents(AM, apply_elastic = FALSE, dry_run = TRUE, external_report = report, ignore_typecache = nosell_typecache)
 
 	for(var/datum/export/exported_datum in report.total_amount)
 		status_report += exported_datum.total_printout(report,notes = FALSE)
@@ -306,7 +310,7 @@
 	for(var/atom/movable/item_on_pad in get_turf(pad))
 		if(item_on_pad == pad)
 			continue
-		export_item_and_contents(item_on_pad, apply_elastic = FALSE, delete_unsold = FALSE, external_report = report)
+		export_item_and_contents(item_on_pad, apply_elastic = FALSE, delete_unsold = FALSE, external_report = report, ignore_typecache = nosell_typecache)
 
 	status_report = "Sold: "
 	var/value = 0

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -35,12 +35,13 @@ Then the player gets the profit from selling his own wasted time.
 	** delete_unsold: if the items that were not sold should be deleted
 	** dry_run: if the item should be actually sold, or if its just a pirce test
 	** external_report: works as "transaction" object, pass same one in if you're doing more than one export in single go
+	** ignore_typecache: typecache containing types that should be completely ignored
 */
-/proc/export_item_and_contents(atom/movable/exported_atom, apply_elastic = TRUE, delete_unsold = TRUE, dry_run = FALSE, datum/export_report/external_report)
+/proc/export_item_and_contents(atom/movable/exported_atom, apply_elastic = TRUE, delete_unsold = TRUE, dry_run = FALSE, datum/export_report/external_report, list/ignore_typecache)
 	if(!GLOB.exports_list.len)
 		setupExports()
 
-	var/list/contents = exported_atom.get_all_contents()
+	var/list/contents = exported_atom.get_all_contents_ignoring(ignore_typecache)
 
 	var/datum/export_report/report = external_report
 


### PR DESCRIPTION

## About The Pull Request

The pirate cargo pad and console worked by recursively getting all the contents of all atoms located on the pad. Incidentally, this resulted in borg modules and radios being sold if the borg happened to be on the pad. This PR just makes the pads ignore cyborgs and anything located in a cyborg (or in a thing in a cyborg, and so on). Fixes #47941.
## Why It's Good For The Game

Borg modules probably shouldn't be sold, since they need a module reset to replace. Borg radios _definitely_ shouldn't be sold, as IIRC not even a reset will replace them.
## Changelog
:cl:
fix: Borg modules can no longer be sold by pirates.
/:cl:
