### PR TITLE
Fix outdated research connections from the Lionhunter's Rifle and Rust Charge

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -13,6 +13,9 @@
  * Mark of the Blade
  * Ritual of Knowledge
  * Realignment
+ * > Sidepaths:
+ *   Lionhunter Rifle
+ *
  * Stance of the Scarred Duelist
  * > Sidepaths:
  *   Carving Knife
@@ -22,7 +25,7 @@
  * Furious Steel
  * > Sidepaths:
  *   Maid in the Mirror
- *   Lionhunter Rifle
+ *   Rust Charge
  *
  * Maelstrom of Silver
  */

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -13,6 +13,9 @@
  * Mark of Rust
  * Ritual of Knowledge
  * Rust Construction
+ * > Sidepaths:
+ *   Lionhunter Rifle
+ *
  * Aggressive Spread
  * > Sidepaths:
  *   Curse of Corrosion
@@ -22,7 +25,7 @@
  * Entropic Plume
  * > Sidepaths:
  *   Rusted Ritual
- *   Blood Cleave
+ *   Rust Charge
  *
  * Rustbringer's Oath
  */

--- a/code/modules/antagonists/heretic/knowledge/side_blade_rust.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_blade_rust.dm
@@ -46,8 +46,8 @@
 	gain_text = "I met an old man in an anique shop who wielded a very unusual weapon. \
 		I could not purchase it at the time, but they showed me how they made it ages ago."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/furious_steel,
-		/datum/heretic_knowledge/spell/entropic_plume,
+		/datum/heretic_knowledge/spell/realignment,
+		/datum/heretic_knowledge/spell/rust_construction,
 		/datum/heretic_knowledge/rifle_ammo,
 	)
 	required_atoms = list(
@@ -100,6 +100,10 @@
 	name = "Rust Charge"
 	desc = "A charge that must be started on a rusted tile and will destroy any rusted objects you come into contact with, will deal high damage to others and rust around you during the charge."
 	gain_text = "The hills sparkled now, as I neared them my mind began to wander. I quickly regained my resolve and pushed forward, this last leg would be the most treacherous."
+	next_knowledge = list(
+		/datum/heretic_knowledge/spell/furious_steel,
+		/datum/heretic_knowledge/spell/entropic_plume,
+	)
 	spell_to_add = /datum/action/cooldown/mob_cooldown/charge/rust
 	cost = 1
 	route = PATH_SIDE


### PR DESCRIPTION

## About The Pull Request

So I've been diving into the code for heretic research tree, and I think that, thematically, my mind was broken a little by the mess I've seen. So here's something I think should not be the way it is: I found out that [this old PR](https://github.com/tgstation/tgstation/pull/76720), while changing correctly what research the lionhunter rifle and rust charge are unlocked by, did _not_ change what knowledge is in turn unlocked by these nodes. So the rifle would still unlock the final tier of knowledge and allow you to skip a bit of the tree if researched after the earlier tier, whereas the charge did not unlock anything and so couldn't be used to transfer paths.
## Why It's Good For The Game

Pretty sure this behavior was not intended. Heretic tree is already a bit convoluted and I think the connections should make sense.
## Changelog
:cl:
fix: fixed some faulty research connections in between heretic's blade and rust paths.
/:cl:
