### PR TITLE
Fixes a runtime in obj/item/organ/on_death()

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -458,7 +458,8 @@
 			return
 		for(var/obj/item/organ/internal/organ in organs)
 			// On-death is where organ decay is handled
-			organ?.on_death(seconds_per_tick, times_fired) // organ can be null due to reagent metabolization causing organ shuffling
+			if(organ?.owner) // organ + owner can be null due to reagent metabolization causing organ shuffling
+				organ.on_death(seconds_per_tick, times_fired)
 			// We need to re-check the stat every organ, as one of our others may have revived us
 			if(stat != DEAD)
 				break

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -57,6 +57,8 @@
 	COOLDOWN_DECLARE(reviver_cooldown)
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_death(seconds_per_tick, times_fired)
+	if(isnull(owner)) // owner can be null, on_death() gets called by /obj/item/organ/internal/process() for decay
+		return
 	try_heal() // Allowes implant to work even on dead people
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_life(seconds_per_tick, times_fired)
@@ -89,7 +91,7 @@
 	// this check goes after revive_dead() to delay revival a bit
 	if(owner.stat == DEAD)
 		can_defib_owner = owner.can_defib()
-		if(can_defib_owner == DEFIB_POSSIBLE) 
+		if(can_defib_owner == DEFIB_POSSIBLE)
 			owner.notify_ghost_cloning("You are being revived by [src]!")
 			owner.grab_ghost()
 	/// boolean that stands for if PHYSICAL damage being patched
@@ -114,7 +116,7 @@
 
 	if(body_damage_patched && prob(35)) // healing is called every few seconds, not every tick
 		owner.visible_message(span_warning("[owner]'s body twitches a bit."), span_notice("You feel like something is patching your injured body."))
-		
+
 
 /obj/item/organ/internal/cyberimp/chest/reviver/proc/revive_dead()
 	owner.grab_ghost()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -59,7 +59,7 @@
 /obj/item/organ/internal/cyberimp/chest/reviver/on_death(seconds_per_tick, times_fired)
 	if(isnull(owner)) // owner can be null, on_death() gets called by /obj/item/organ/internal/process() for decay
 		return
-	try_heal() // Allowes implant to work even on dead people
+	try_heal() // Allows implant to work even on dead people
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_life(seconds_per_tick, times_fired)
 	try_heal()


### PR DESCRIPTION
## About The Pull Request

Fixes the following runtime caught by CI.

![firefox_BCIl7d348X](https://github.com/tgstation/tgstation/assets/13398309/8ee2a657-7d25-4793-a5e5-d1e489107188)

`owner` can be null so we have to check for it just like we do before calling `on_life()`.

https://github.com/tgstation/tgstation/blob/e5385508107f043fb8f646abfd7686509b239cb6/code/modules/mob/living/carbon/life.dm#L472-L473

## Why It's Good For The Game

Less runtimes

## Changelog

:cl:
fix: fixes a runtime in organ on_death()
/:cl:
