### PR TITLE
Adds bitrunner to the crew monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -125,6 +125,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		JOB_QUARTERMASTER = 50,
 		JOB_SHAFT_MINER = 51,
 		JOB_CARGO_TECHNICIAN = 52,
+		JOB_BITRUNNER = 53,
 		// 60+: Civilian/other
 		JOB_HEAD_OF_PERSONNEL = 60,
 		JOB_BARTENDER = 61,


### PR DESCRIPTION
## About The Pull Request

She was missing. Now they'll show up in their correct department (cargo) when looking at sensors instead of being lumped in with the assistants.

## Why It's Good For The Game

Bitrunner will now show up where you'd expect them to on the crew monitor.

## Changelog

:cl:
fix: bitrunners will no longer be lumped in with assistants on the crew monitor console's display
/:cl:
