### PR TITLE
Adds object logs to cremator

### DIFF
--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -8,7 +8,7 @@
  * Arguments:
  * * atom/user - argument is the actor performing the action
  * * atom/target - argument is the target of the action
- * * what_done - is a verb describing the action (e.g. punched, throwed, kicked, etc.)
+ * * what_done - is a verb describing the action (e.g. punched, thrown, kicked, etc.)
  * * atom/object - is a tool with which the action was made (usually an item)
  * * addition - is any additional text, which will be appended to the rest of the log line
  */
@@ -89,14 +89,13 @@
  * Arguments:
  * * atom/user - argument is the actor performing the action
  * * list/targets - argument is the list of targets of the action
- * * what_done - is a verb describing the action (e.g. punched, throwed, kicked, etc.)
+ * * what_done - is a verb describing the action (e.g. punched, thrown, kicked, etc.)
  */
 
 /proc/log_combat_listed(atom/user, list/targets, what_done)
 	var/target_list_message = ""
 	for(var/target in targets)
-		var/starget = key_name(target)
-		target_list_message += "[starget], "
+		target_list_message += "[key_name(target)], "
 
 
 	var/message = "[what_done] [target_list_message]"

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -82,3 +82,22 @@
 
 	if(message_admins)
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")
+
+/**
+ * Log a combat message in the attack log, multiple targets.
+ *
+ * Arguments:
+ * * atom/user - argument is the actor performing the action
+ * * list/targets - argument is the list of targets of the action
+ * * what_done - is a verb describing the action (e.g. punched, throwed, kicked, etc.)
+ */
+
+/proc/log_combat_listed(atom/user, list/targets, what_done)
+	var/target_list_message = ""
+	for(var/target in targets)
+		var/starget = key_name(target)
+		target_list_message += "[starget], "
+
+
+	var/message = "[what_done] [target_list_message]"
+	user.log_message(message, LOG_ATTACK, color="red")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -342,7 +342,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 			else if(user)
 				objects_cremated += O
 			qdel(O)
-		log_combat_listed(user, objects_cremated, "has cremated the following:")
+		log_combat_listed(user, objects_cremated, "has cremated the following: ")
 
 		if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir))//prevent pile-up
 			new/obj/effect/decal/cleanable/ash(src)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -335,10 +335,14 @@ GLOBAL_LIST_EMPTY(crematoriums)
 				M.ghostize()
 				qdel(M)
 
+		var/list/objects_cremated = list()
 		for(var/obj/O in conts) //conts defined above, ignores crematorium and tray
 			if(istype(O, /obj/effect/dummy/phased_mob)) //they're not physical, don't burn em.
 				continue
+			else if(user)
+				objects_cremated += O
 			qdel(O)
+		log_combat_listed(user, objects_cremated, "has cremated the following:")
 
 		if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir))//prevent pile-up
 			new/obj/effect/decal/cleanable/ash(src)


### PR DESCRIPTION
## About The Pull Request

Adds attack.log logging for items being destroyed at crematoriums. Those are found under attack logs and are separate from individual attack logs set for actors.

![24htogoiwannabecremated](https://github.com/tgstation/tgstation/assets/39915556/0adc12a1-bc17-4f7a-bcac-a39203393518)

## Why It's Good For The Game

Inspired by [this ban appeal](https://tgstation13.org/phpBB/viewtopic.php?t=35080).

During the ban's discussions on secret hidden admin channels there was a layer of uncertainty as to what items were cremated. Upon further analysis and discussion, it was ascertained that cremated items are not logged, and should be logged.

## Changelog
:cl: conrad
admin: added attack.log logs for cremated items
/:cl:
