### PR TITLE
fixes polymorphing into a holoparasite

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -6,7 +6,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	desc = "A mysterious being that stands by its charge, ever vigilant."
 	speak_emote = list("hisses")
 	gender = NEUTER
-	mob_biotypes = NONE
+	mob_biotypes = MOB_SPECIAL
+	sentience_type = SENTIENCE_HUMANOID
 	bubble_icon = "guardian"
 	response_help_continuous = "passes through"
 	response_help_simple = "pass through"


### PR DESCRIPTION
makes holoparasites `MOB_SPECIAL` and gives them `SENTIENCE_HUMANOID`
only one is needed for the belt to fail copying it but uhhh i don't think it should just be left hanging with no biotype at all thats just weird

fixes #78578

## Changelog

:cl:
fix: you can no longer polymorph belt into a holoparasite
/:cl: