### PR TITLE
[no gbp] Disable summon AI during summoning

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -530,6 +530,7 @@
 
 /datum/heretic_knowledge/summon/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/mob/living/summoned = new mob_to_summon(loc)
+	summoned.ai_controller?.set_ai_status(AI_STATUS_OFF)
 	// Fade in the summon while the ghost poll is ongoing.
 	// Also don't let them mess with the summon while waiting
 	summoned.alpha = 0


### PR DESCRIPTION
## About The Pull Request

Disables AI on heretic minions while they are being summoned, because they're not supposed to exist yet.
This fixes a bug where flesh stalkers would immediately transform into mice and run away.

## Changelog

:cl:
fix: Heretic mobs will not be summoned with AI enabled, and won't turn into small animals instead of summoning a flesh stalker.
/:cl:
