### PR TITLE
Fixes some issues with mirrors not updating mob appearance after making a selection

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -207,7 +207,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	sexy.dna.update_ui_block(DNA_GENDER_BLOCK)
 	sexy.update_body(is_creating = TRUE) // or else physique won't change properly
 	sexy.update_mutations_overlay() //(hulk male/female)
-	sexy.update_clothing(ITEM_SLOT_ICLOTHING) // update gender variant clothing
+	sexy.update_clothing(ITEM_SLOT_ICLOTHING) // update gender shaped clothing
 
 /obj/structure/mirror/proc/change_eyes(mob/living/carbon/human/user)
 	var/new_eye_color = input(user, "Choose your eye color", "Eye Color", user.eye_color_left) as color|null

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -175,8 +175,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 				to_chat(race_changer, span_notice("Invalid color. Your color is not bright enough."))
 				return TRUE
 
-		race_changer.update_body(is_creating = TRUE)
-		race_changer.update_mutations_overlay() // no hulk lizard
+	race_changer.update_body(is_creating = TRUE)
+	race_changer.update_mutations_overlay() // no hulk lizard
 
 // possible Genders: MALE, FEMALE, PLURAL, NEUTER
 // possible Physique: MALE, FEMALE
@@ -207,6 +207,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	sexy.dna.update_ui_block(DNA_GENDER_BLOCK)
 	sexy.update_body()
 	sexy.update_mutations_overlay() //(hulk male/female)
+	sexy.update_clothing(ALL) // update gender variant clothing
 
 /obj/structure/mirror/proc/change_eyes(mob/living/carbon/human/user)
 	var/new_eye_color = input(user, "Choose your eye color", "Eye Color", user.eye_color_left) as color|null

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -205,9 +205,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 		sexy.physique = (chosen_physique == "Warlock Physique") ? MALE : FEMALE
 
 	sexy.dna.update_ui_block(DNA_GENDER_BLOCK)
-	sexy.update_body()
+	sexy.update_body(is_creating = TRUE) // or else physique won't change properly
 	sexy.update_mutations_overlay() //(hulk male/female)
-	sexy.update_clothing(ALL) // update gender variant clothing
+	sexy.update_clothing(ITEM_SLOT_ICLOTHING) // update gender variant clothing
 
 /obj/structure/mirror/proc/change_eyes(mob/living/carbon/human/user)
 	var/new_eye_color = input(user, "Choose your eye color", "Eye Color", user.eye_color_left) as color|null


### PR DESCRIPTION
## About The Pull Request

Found some bugs while doing a downstream mirror PR that's _about_ mirrors (https://github.com/tgstation/tgstation/pull/77842).

Fixed said mirror bugs so that they can come downstream in a mirror.

We've come full circle...

## Why It's Good For The Game

This PR fixes some things not updating on the mob's sprite when selecting them in the magic mirror. Skintones and jumpsuit gender shaping namely.

## Changelog

:cl:
fix: using a magic mirror to change gender or skintone will now update your icon properly to match your selection
/:cl: