### PR TITLE
[NO GBP] Fixed a few more issues with fishing.

### DIFF
--- a/code/modules/experisci/experiment/types/scanning_fish.dm
+++ b/code/modules/experisci/experiment/types/scanning_fish.dm
@@ -58,7 +58,7 @@ GLOBAL_LIST_EMPTY(scanned_fish_by_techweb)
 	message += "<span class='info ml-1'>"
 	for(var/atom_type in required_atoms)
 		for(var/obj/item/fish/fish_path as anything in scanned[atom_type])
-			message += "[initial(fish_path.name)]"
+			message += "\n[initial(fish_path.name)]"
 	message += "</span>"
 	examine_list += message
 

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -176,7 +176,7 @@
 	difficulty += comp.fish_source.calculate_difficulty(reward_path, rod, user, src)
 	difficulty = clamp(round(difficulty), 1, 100)
 
-	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH) || (user.mind && HAS_TAIT(user.mind, TRAIT_REVEAL_FISH)))
+	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH) || (user.mind && HAS_TRAIT(user.mind, TRAIT_REVEAL_FISH)))
 		fish_icon = GLOB.specific_fish_icons[reward_path] || "fish"
 
 	/**
@@ -312,7 +312,7 @@
 	phase = BITING_PHASE
 	// Trashing animation
 	playsound(lure, 'sound/effects/fish_splash.ogg', 100)
-	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH) || (user.mind && HAS_TAIT(user.mind, TRAIT_REVEAL_FISH))
+	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH) || (user.mind && HAS_TRAIT(user.mind, TRAIT_REVEAL_FISH)))
 		switch(fish_icon)
 			if(FISH_ICON_DEF)
 				send_alert("fish!!!")

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -176,7 +176,7 @@
 	difficulty += comp.fish_source.calculate_difficulty(reward_path, rod, user, src)
 	difficulty = clamp(round(difficulty), 1, 100)
 
-	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH))
+	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH) || (user.mind && HAS_TAIT(user.mind, TRAIT_REVEAL_FISH)))
 		fish_icon = GLOB.specific_fish_icons[reward_path] || "fish"
 
 	/**
@@ -203,6 +203,8 @@
 	if(!completed)
 		complete(win = FALSE)
 	if(fishing_line)
+		//Stops the line snapped message from appearing everytime the minigame is over.
+		UnregisterSignal(fishing_line, COMSIG_QDELETING)
 		QDEL_NULL(fishing_line)
 	if(lure)
 		QDEL_NULL(lure)
@@ -242,7 +244,8 @@
 /datum/fishing_challenge/proc/on_line_deleted(datum/source)
 	SIGNAL_HANDLER
 	fishing_line = null
-	send_alert(user.is_holding(used_rod) ? "line snapped" : "rod dropped")
+	///The lure may be out of sight if the user has moed around a corner, so the message should be displayed over him instead.
+	user.balloon_alert(user.is_holding(used_rod) ? "line snapped" : "rod dropped")
 	interrupt()
 
 /datum/fishing_challenge/proc/handle_click(mob/source, atom/target, modifiers)
@@ -309,7 +312,7 @@
 	phase = BITING_PHASE
 	// Trashing animation
 	playsound(lure, 'sound/effects/fish_splash.ogg', 100)
-	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH))
+	if(HAS_TRAIT(user, TRAIT_REVEAL_FISH) || (user.mind && HAS_TAIT(user.mind, TRAIT_REVEAL_FISH))
 		switch(fish_icon)
 			if(FISH_ICON_DEF)
 				send_alert("fish!!!")


### PR DESCRIPTION
## About The Pull Request
fix: Examining twice experiment handlers with an active fish-related experiment now gives a comprehensible, correctly spaced list of scanned species rather than something like "pufferfishguppyslimefishchasmchrab".
fix: No more "line snapped" balloon messages everytime the fishing minigame is over
fix: Getting to the Master level of the fishing skill now correctly gives you that slight helping hand to identify yet-to-be-caught fishes.

## Why It's Good For The Game
Taking care of some issues I've noticed just yesterday.

## Changelog

:cl:
fix: Examining twice experiment handlers with an active fish-related experiment now gives a comprehensible, correctly spaced list of scanned species rather than something like "pufferfishguppyslimefishchasmchrab".
fix: No more "line snapped" balloon messages everytime the fishing minigame is over
fix: Getting to the Master level of the fishing skill now correctly gives you that slight helping hand to identify yet-to-be-caught fishes.
/:cl:
