### PR TITLE
Revenant Cleanup and Fixes Mistakes

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -730,7 +730,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/generate_ruleset_body(mob/applicant)
 	var/mob/living/basic/revenant/revenant = new(pick(spawn_locs))
-	applicant.mind.transfer_to(revenant)
+	revenant.key = applicant.key
 	message_admins("[ADMIN_LOOKUPFLW(revenant)] has been made into a revenant by the midround ruleset.")
 	log_game("[key_name(revenant)] was spawned as a revenant by the midround ruleset.")
 	return revenant

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_effects.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_effects.dm
@@ -9,11 +9,6 @@
 /datum/status_effect/revenant/revealed
 	id = "revenant_revealed"
 
-/datum/status_effect/revenant/revealed/on_creation(mob/living/new_owner, duration)
-	if(isnum(duration))
-		src.duration = duration
-	return ..()
-
 /datum/status_effect/revenant/revealed/on_apply()
 	. = ..()
 	if(!.)
@@ -37,11 +32,6 @@
 
 /datum/status_effect/revenant/inhibited
 	id = "revenant_inhibited"
-
-/datum/status_effect/revenant/inhibited/on_creation(mob/living/new_owner, duration)
-	if(isnum(duration))
-		src.duration = duration
-	return ..()
 
 /datum/status_effect/revenant/inhibited/on_apply()
 	. = ..()

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_harvest.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_harvest.dm
@@ -107,7 +107,7 @@
 		return FALSE
 
 	var/datum/beam/draining_beam = Beam(target, icon_state = "drain_life")
-	if(!do_after(src, 4.6 SECONDS, target, timed_action_flags = IGNORE_HELD_ITEM)) //As one cannot prove the existance of ghosts, ghosts cannot prove the existance of the target they were draining.
+	if(!do_after(src, 4.6 SECONDS, target, timed_action_flags = (IGNORE_HELD_ITEM | IGNORE_INCAPACITATED))) //As one cannot prove the existance of ghosts, ghosts cannot prove the existance of the target they were draining.
 		to_chat(src, span_revenwarning("[target ? "[target]'s soul has" : "[target_They_have]"] been drawn out of your grasp. The link has been broken."))
 		if(target)
 			target.visible_message(

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_items.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_items.dm
@@ -71,11 +71,7 @@
 	var/user_name = old_ckey
 	if(isnull(revenant.client))
 		var/mob/potential_user = get_new_user()
-		var/datum/mind/potential_mind = potential_user?.mind
-		if(isnull(potential_mind))
-			return
-
-		potential_mind.transfer_to(revenant)
+		revenant.key = potential_user.key
 		user_name = potential_user.ckey
 		qdel(potential_user)
 
@@ -102,7 +98,7 @@
 	var/mob/dead/observer/potential_client = pick(candidates)
 	if(isnull(potential_client))
 		qdel(revenant)
-		message_admins("No ckey was found for the new revenant. Oh well!")
+		message_admins("No candidate was found for the new revenant. Oh well!")
 		inert = TRUE
 		visible_message(span_revenwarning("[src] settles down and seems lifeless."))
 		return null

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -133,7 +133,7 @@
 				deity = "Christ"
 			to_chat(ghostie, span_userdanger("The power of [deity] compels you!"))
 			ghostie.apply_status_effect(/datum/status_effect/incapacitating/paralyzed/revenant, 2 SECONDS)
-			ghostie.apply_status_effect(/datum/status_effect/revenant/revealed, 2 SECONDS)
+			ghostie.apply_status_effect(/datum/status_effect/revenant/revealed, 10 SECONDS)
 			ghostie.adjust_health(50)
 		for(var/mob/living/carbon/C in get_hearers_in_view(effective_size,T))
 			if(IS_CULTIST(C))


### PR DESCRIPTION
## About The Pull Request

In large PRs (#78782 (3415828c6bcf3fcb46291e37c2c6092b33d34de4)), some mistakes tend to be made.

Backend Fixes:
* Removes excess and un-necessary `on_creation()` procs for the status effects. The work is already done in the parent `/datum/status_effect/revenant`, no need to duplicate it.

User Facing Fixes:
* I copy-pasted too hard and accidentally nerfed the holy hand grenade's effect on revenant. It was originally intended to stun for 10 seconds, and I had no interest in changing that to 2 seconds. My bad.
* Revenant midrounds were broken because I thought observers had minds, whoops. I really wish there was a better way to transfer clients into a new mob than key mutations in these instances though.
* Revenant Harvesting is fixed, because I forgot that we would be incapacitating the mob with the paralyze status effect. The proper flags are now passed into the `do_after()` and it should now give you delicious essence.

## Why It's Good For The Game

Mea culpa.
## Changelog
:cl:
fix: The Holy Hand Grenade's effect on revealing a revenant had its duration accidentally nerfed, it is now back to 10 seconds.
fix: Revenant midrounds should now properly run.
fix: Revenant harvesting should now let you actually pass the final do_after so you can harvest that sweet essence.
/:cl:

Fixes #78925