### PR TITLE
Universal Scanners Now Make a Noise When Scanning

### DIFF
--- a/code/modules/cargo/universal_scanner.dm
+++ b/code/modules/cargo/universal_scanner.dm
@@ -175,10 +175,7 @@
 		price += report.total_value[exported_datum]
 	if(price)
 		to_chat(user, span_notice("Scanned [target], value: <b>[price]</b> credits[target.contents.len ? " (contents included)" : ""]."))
-		if(price > 0)
-			playsound(src, 'sound/machines/terminal_select.ogg', 50, vary = TRUE)
-		if(price < 0)
-			playsound(src, 'sound/items/barcodebeep.ogg', 50, vary = TRUE)
+		playsound(src, 'sound/machines/terminal_select.ogg', 50, vary = TRUE)
 	else
 		to_chat(user, span_warning("Scanned [target], no export value."))
 

--- a/code/modules/cargo/universal_scanner.dm
+++ b/code/modules/cargo/universal_scanner.dm
@@ -175,6 +175,10 @@
 		price += report.total_value[exported_datum]
 	if(price)
 		to_chat(user, span_notice("Scanned [target], value: <b>[price]</b> credits[target.contents.len ? " (contents included)" : ""]."))
+		if(price > 0)
+			playsound(src, 'sound/machines/terminal_select.ogg', 50, vary = TRUE)
+		if(price < 0)
+			playsound(src, 'sound/items/barcodebeep.ogg', 50, vary = TRUE)
 	else
 		to_chat(user, span_warning("Scanned [target], no export value."))
 


### PR DESCRIPTION
## About The Pull Request
The universal scanner will now make a sound when scanning any item of value. Items that have no value do not make any noise when scanned. The lack of a sound for no-value items is intentional, as I couldn't find a good middle-ground noise that sounded neutral for items with no value.

## Why It's Good For The Game

More audio feedback for scanning stuff with an export scanner. Nearly all item interactions make a noise of some sort.

## Demonstration

https://github.com/tgstation/tgstation/assets/45489195/f1bf9538-7cf6-44cc-9def-2c7c5af676b9

Here you can see (from left to right of the viewer) the sounds that play for positive, no value, and negative value items scanned with an export scanner. The scanner making the same noise for positive or negative valued items is intentional as https://github.com/tgstation/tgstation/pull/78923 will be fixing that.

## Changelog

:cl:
sound: added sounds for scanning valued items with an export scanner
/:cl: