### PR TITLE
Adds blackbox logging to Dynamic setup_parameters proc.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -431,7 +431,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 		"dynamic_threat",
 		1,
 		list(
-			"server_name" = CONFIG_GET(string/servername),
+			"server_name" = CONFIG_GET(string/serversqlname),
 			"forced_threat_level" = GLOB.dynamic_forced_threat_level,
 			"threat_level" = threat_level,
 			"round_start_budget" = round_start_budget,

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -429,6 +429,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 	SSblackbox.record_feedback(
 		"associative",
 		"dynamic_threat",
+		1,
 		list(
 			"server_name" = CONFIG_GET(string/servername),
 			"forced_threat_level" = GLOB.dynamic_forced_threat_level,

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -434,7 +434,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 			"server_name" = CONFIG_GET(string/servername),
 			"forced_threat_level" = GLOB.dynamic_forced_threat_level,
 			"threat_level" = threat_level,
-			"round_start_budget", round_start_budget,
+			"round_start_budget" = round_start_budget,
 			"parameters" = list(
 				"threat_curve_centre" = threat_curve_centre,
 				"threat_curve_width" = threat_curve_width,

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -430,6 +430,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 		"associative",
 		"dynamic_threat",
 		list(
+			"server_name" = CONFIG_GET(string/servername),
 			"forced_threat_level" = GLOB.dynamic_forced_threat_level,
 			"threat_level" = threat_level,
 			"round_start_budget", round_start_budget,

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -426,6 +426,22 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 	generate_budgets()
 	set_cooldowns()
 	log_dynamic("Dynamic Mode initialized with a Threat Level of... [threat_level]! ([round_start_budget] round start budget)")
+	SSblackbox.record_feedback(
+		"associative",
+		"dynamic_threat",
+		list(
+			"forced_threat_level" = GLOB.dynamic_forced_threat_level,
+			"threat_level" = threat_level,
+			"round_start_budget", round_start_budget,
+			"parameters" = list(
+				"threat_curve_centre" = threat_curve_centre,
+				"threat_curve_width" = threat_curve_width,
+				"forced_extended" = GLOB.dynamic_forced_extended,
+				"no_stacking" = GLOB.dynamic_no_stacking,
+				"stacking_limit" = GLOB.dynamic_stacking_limit,
+			),
+		),
+	)
 	return TRUE
 
 /datum/game_mode/dynamic/proc/setup_shown_threat()


### PR DESCRIPTION

## About The Pull Request

Mirrors logging of various dynamic parameters to the blackbox database.
## Why It's Good For The Game

When people want to gather data about dynamic threat, it's usually wanting this kind of information. And wanting it in quantifies several orders of magnitude greater than is reasonably practicable to download and parse logs.

Chucking some Dynamic logging in the blackbox allows information for an arbitrary number of shifts to be gathered in seconds.

Server name and curve parameters are stored alongside it, allowing data to be filtered onto to specific servers and further filtered/categorised by the curve parameters.

“A codebase grows great when old coders store logs whose data they know they shall never create meaningful statistics from.” -Poes Proverb
## Changelog
No player-facing changes.
