### PR TITLE
Fixes camera console bluescreen

### DIFF
--- a/tgui/packages/tgui/interfaces/CameraConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CameraConsole.tsx
@@ -27,20 +27,30 @@ const prevNextCamera = (
   cameras: Camera[],
   activeCamera: Camera & { status: BooleanLike }
 ) => {
-  if (!activeCamera) {
+  if (!activeCamera || cameras.length < 2) {
     return [];
   }
+
   const index = cameras.findIndex((camera) => camera.ref === activeCamera.ref);
 
-  if (index === 0) {
-    return [cameras[cameras.length - 1].ref, cameras[index + 1].ref];
-  }
+  switch (index) {
+    case -1: // Current camera is not in the list
+      return [cameras[cameras.length - 1].ref, cameras[0].ref];
 
-  if (index === cameras.length - 1) {
-    return [cameras[index - 1].ref, cameras[0].ref];
-  }
+    case 0: // First camera
+      if (cameras.length === 2) return [cameras[1].ref, cameras[1].ref]; // Only two
 
-  return [cameras[index - 1].ref, cameras[index + 1].ref];
+      return [cameras[cameras.length - 1].ref, cameras[index + 1].ref];
+
+    case cameras.length - 1: // Last camera
+      if (cameras.length === 2) return [cameras[0].ref, cameras[0].ref];
+
+      return [cameras[index - 1].ref, cameras[0].ref];
+
+    default:
+      // Middle camera
+      return [cameras[index - 1].ref, cameras[index + 1].ref];
+  }
 };
 
 /**


### PR DESCRIPTION
## About The Pull Request
There was faulty logic in determining what's the next/previous cameras in the list. Didn't account for scenarios with under 3 cameras in the filter.
## Why It's Good For The Game
Bug fixes - search without a bluescreen!
Fixes #78825
## Changelog
:cl:
fix: Fixed the errant bluescreen in the camera console.
/:cl:
