### PR TITLE
Scatter laser shells now use the scatter laser beam, and makes them significantly easier to make. Projectiles can now have damage falloff.

### DIFF
--- a/code/datums/components/crafting/weapon_ammo.dm
+++ b/code/datums/components/crafting/weapon_ammo.dm
@@ -74,11 +74,11 @@
 
 /datum/crafting_recipe/laserslug
 	name = "Scatter Laser Shell"
-	result = /obj/item/ammo_casing/shotgun/laserslug
+	result = /obj/item/ammo_casing/shotgun/scatterlaser
 	reqs = list(
 		/obj/item/ammo_casing/shotgun/techshell = 1,
-		/obj/item/stock_parts/capacitor/adv = 1,
-		/obj/item/stock_parts/micro_laser/high = 1,
+		/obj/item/stock_parts/capacitor = 1,
+		/obj/item/stock_parts/micro_laser = 1,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 0.5 SECONDS

--- a/code/datums/components/crafting/weapon_ammo.dm
+++ b/code/datums/components/crafting/weapon_ammo.dm
@@ -72,18 +72,6 @@
 	time = 1.2 SECONDS
 	category = CAT_WEAPON_AMMO
 
-/datum/crafting_recipe/laserslug
-	name = "Scatter Laser Shell"
-	result = /obj/item/ammo_casing/shotgun/scatterlaser
-	reqs = list(
-		/obj/item/ammo_casing/shotgun/techshell = 1,
-		/obj/item/stock_parts/capacitor = 1,
-		/obj/item/stock_parts/micro_laser = 1,
-	)
-	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 0.5 SECONDS
-	category = CAT_WEAPON_AMMO
-
 /datum/crafting_recipe/trashball
 	name = "Trashball"
 	always_available = FALSE

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -125,7 +125,7 @@
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/projectile/beam/weak
+	projectile_type = /obj/projectile/beam/scatter
 	pellets = 6
 	variance = 35
 

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -129,6 +129,13 @@
 	pellets = 6
 	variance = 35
 
+/obj/item/ammo_casing/shotgun/scatterlaser/emp_act(severity)
+	. = ..()
+	if(prob(40/severity))
+		name = "malfunctioning laser shell"
+		desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. This one appears to be malfunctioning and practically useless."
+		projectile_type = /obj/projectile/beam/scatter/pathetic
+
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -133,10 +133,10 @@
 	. = ..()
 	if(isnull(loaded_projectile) || !prob(40/severity))
 		return
-		name = "malfunctioning laser shell"
-		desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. The capacitor powering this assembly appears to be smoking."
-		projectile_type = /obj/projectile/beam/scatter/pathetic
-		loaded_projectile = new projectile_type(src)
+	name = "malfunctioning laser shell"
+	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. The capacitor powering this assembly appears to be smoking."
+	projectile_type = /obj/projectile/beam/scatter/pathetic
+	loaded_projectile = new projectile_type(src)
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -131,7 +131,8 @@
 
 /obj/item/ammo_casing/shotgun/scatterlaser/emp_act(severity)
 	. = ..()
-	if(prob(40/severity) && loaded_projectile)
+	if(isnull(loaded_projectile) || !prob(40/severity))
+		return
 		name = "malfunctioning laser shell"
 		desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. The capacitor powering this assembly appears to be smoking."
 		projectile_type = /obj/projectile/beam/scatter/pathetic

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -121,7 +121,7 @@
 	pellets = 4
 	variance = 35
 
-/obj/item/ammo_casing/shotgun/laserslug
+/obj/item/ammo_casing/shotgun/scatterlaser
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -131,10 +131,11 @@
 
 /obj/item/ammo_casing/shotgun/scatterlaser/emp_act(severity)
 	. = ..()
-	if(prob(40/severity))
+	if(prob(40/severity) && loaded_projectile)
 		name = "malfunctioning laser shell"
 		desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. The capacitor powering this assembly appears to be smoking."
 		projectile_type = /obj/projectile/beam/scatter/pathetic
+		loaded_projectile = new projectile_type(src)
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
@@ -145,7 +146,7 @@
 /obj/item/ammo_casing/shotgun/techshell/Initialize(mapload)
 	. = ..()
 
-	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/meteorslug, /datum/crafting_recipe/pulseslug, /datum/crafting_recipe/dragonsbreath, /datum/crafting_recipe/ionslug, /datum/crafting_recipe/laserslug)
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/meteorslug, /datum/crafting_recipe/pulseslug, /datum/crafting_recipe/dragonsbreath, /datum/crafting_recipe/ionslug)
 
 	AddComponent(
 		/datum/component/slapcrafting,\

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -133,7 +133,7 @@
 	. = ..()
 	if(prob(40/severity))
 		name = "malfunctioning laser shell"
-		desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. This one appears to be malfunctioning and practically useless."
+		desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. The capacitor powering this assembly appears to be smoking."
 		projectile_type = /obj/projectile/beam/scatter/pathetic
 
 /obj/item/ammo_casing/shotgun/techshell

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -192,6 +192,10 @@
 	var/hit_prone_targets = FALSE
 	///For what kind of brute wounds we're rolling for, if we're doing such a thing. Lasers obviously don't care since they do burn instead.
 	var/sharpness = NONE
+	///How much we want to drop damage per tile as it travels through the air
+	var/damage_falloff_tile
+	///How much we want to drop stamina damage (defined by the stamina variable) per tile as it travels through the air
+	var/stamina_falloff_tile
 	///How much we want to drop both wound_bonus and bare_wound_bonus (to a minimum of 0 for the latter) per tile, for falloff purposes
 	var/wound_falloff_tile
 	///How much we want to drop the embed_chance value, if we can embed, per tile, for falloff purposes
@@ -219,8 +223,16 @@
 		bare_wound_bonus = max(0, bare_wound_bonus + wound_falloff_tile)
 	if(embedding)
 		embedding["embed_chance"] += embed_falloff_tile
+	if(damage_falloff_tile && damage ?= 0)
+		damage += damage_falloff_tile
+	if(stamina_falloff_tile && stamina >= 0)
+		stamina += stamina_falloff_tile
+
 	SEND_SIGNAL(src, COMSIG_PROJECTILE_RANGE)
 	if(range <= 0 && loc)
+		on_range()
+
+	if(damage_falloff_tile && damage <= 0 || stamina_falloff_tile && stamina <= 0)
 		on_range()
 
 /obj/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -223,7 +223,7 @@
 		bare_wound_bonus = max(0, bare_wound_bonus + wound_falloff_tile)
 	if(embedding)
 		embedding["embed_chance"] += embed_falloff_tile
-	if(damage_falloff_tile && damage ?= 0)
+	if(damage_falloff_tile && damage >= 0)
 		damage += damage_falloff_tile
 	if(stamina_falloff_tile && stamina >= 0)
 		stamina += stamina_falloff_tile

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -94,6 +94,10 @@
 	name = "laser pellet"
 	icon_state = "scatterlaser"
 	damage = 5
+	wound_bonus = 5
+	bare_wound_bonus = 5
+	damage_falloff_tile = -0.45
+	wound_falloff_tile = -2.5
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -93,7 +93,7 @@
 /obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	damage = 7
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	damage_falloff_tile = -0.45
@@ -104,6 +104,9 @@
 	damage = 1
 	wound_bonus = 0
 	damage_falloff_tile = -0.1
+	color = "#dbc11d"
+	hitsound = 'sound/items/bikehorn.ogg' //honk
+	hitsound_wall = 'sound/items/bikehorn.ogg'
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -93,7 +93,7 @@
 /obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 7
+	damage = 7.5
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	damage_falloff_tile = -0.45

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -99,6 +99,12 @@
 	damage_falloff_tile = -0.45
 	wound_falloff_tile = -2.5
 
+/obj/projectile/beam/scatter/pathetic
+	name = "extremely weak laser pellet"
+	damage = 1
+	wound_bonus = 0
+	damage_falloff_tile = -0.1
+
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -70,17 +70,8 @@
 
 /obj/projectile/bullet/pellet
 	icon_state = "pellet"
-	var/tile_dropoff = 0.45
-	var/tile_dropoff_s = 0.25
-
-/obj/projectile/bullet/pellet/Range()
-	..()
-	if(damage > 0)
-		damage -= tile_dropoff
-	if(stamina > 0)
-		stamina -= tile_dropoff_s
-	if(damage < 0 && stamina < 0)
-		qdel(src)
+	damage_falloff_tile = -0.45
+	stamina_falloff_tile = -0.25
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -365,6 +365,20 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
+/datum/design/lasershell
+	name = "Scatter Laser Shotgun Shell (Lethal)"
+	desc = "A high-tech shotgun shell which houses an internal capacitor and laser focusing crystal inside of a shell casing. \
+		Able to be fired from conventional ballistic shotguns with minimal rifling degradation. Also leaves most targets covered \
+		in grotesque burns."
+	id = "lasershell"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 2, /datum/material/gold = HALF_SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/ammo_casing/shotgun/scatterlaser
+	category = list(
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
 /datum/design/techshell
 	name = "Unloaded Technological Shotshell"
 	desc = "A high-tech shotgun shell which can be crafted into more advanced shells to produce unique effects. \

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1576,6 +1576,7 @@
 	design_ids = list(
 		"pin_testing",
 		"tele_shield",
+		"lasershell",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
 	discount_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb = 10000)


### PR DESCRIPTION
## About The Pull Request

Allows for damage falloff to apply to more than just shotgun pellets. Now any projectile can have a damage falloff defined.

Scatter Laser shells no longer use the minigun beams to determine their damage. Instead they use the actually defined scatter laser beams.  Those beams do 7.5 damage per pellet, times by 6 pellets.

Scatter laser beams now have damage falloff, a separately defined (positive) wounding power from normal beams, and wound falloff.

Scatter laser shells can be printed from security protolathes once you have weapon tech.

Scatter laser shells _may_ be damaged by EMPs based on severity. The result is that it fires a practically useless volley of laser fire. They cause a honk sound when they hit, so you know when you've shot one of these.

## Why It's Good For The Game

Well, we want shotguns universally to not be defined by their damage output (especially extreme damage output) but by niche.

What does the scatter laser shell currently occupy as a niche?

The single highest damage output of any projectile weapon in direct damage. The thing we don't want of shotguns, and it is reigning champion of all guns. 

Okay, that's a bit misleading, because obviously it is competing with the likes of .50 BMG which does 70 damage outright and dismembers limbs, potentially doing upwards of 90 damage if it does, and also hard stuns people. Obviously _that_ is technically a stronger bullet.

But not for raw damage, because the scatter laser does 90 damage out the gate, barring any potential wounding that might occur which increases the damage multiplicatively. No gimmicks, no extra procs, nothing. It's just 15 force lasers (with no damage dropoff) split between 6 beams.

And the reason for this is because this shell has been nerfed once prior by making it not fire 6 normal laser shots into someone. That was 120 damage at the time, 120 to 90 was...I guess a nerf during the taser era. Depends on how you viewed it. Buckshot was doing like 80 at the time, believe me it was a wild period. But anyway, when we did the whole damage rearrangement over the course of the laser few years, every other shell got touched except this one for some reason. Even pulse slugs lost 10 damage while this was still sitting on 90 force point blank.

So what is the new niche? Well, it's laser buckshot. That's not a niche but crew don't get buckshot, so this is their buckshot. It wounds real good. Real goddamn good. And its is a laser. It fits the aesthetic, obviously.

Okay, thanks.

## Changelog
:cl:
balance: Scatter laser shells actually utilize the _real_ scatter laser beam. This comes with damage changes. And wounding power.
feature: EMPs can potentially damage scatter laser shells.
refactor: All projectiles can now have damage falloff defined. Yay.
balance: Scatter laser shells can be printed when weapons technology is researched.
/:cl:
