### PR TITLE
Fixes blast door controllers not working correctly

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -49,7 +49,7 @@
 		return
 	if (deconstruction != BLASTDOOR_FINISHED)
 		return
-	var/change_id = tgui_input_text(user, "Set the door controllers ID", "Door Controller ID", id, 100)
+	var/change_id = tgui_input_number(user, "Set the door controllers ID (Current: [id])", "Door Controller ID", isnum(id) ? id : null, 100)
 	if(!change_id || QDELETED(usr) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
 	id = change_id


### PR DESCRIPTION
I made a mistake, blast door controllers assume numbers and unfortunately i can't just change that too due to assumption we do not want players to link to premapped ids.

Fixes #78902 