### PR TITLE
basicmobs that qdel on death ghost before qdel

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -148,6 +148,7 @@
 /mob/living/basic/death(gibbed)
 	. = ..()
 	if(basic_mob_flags & DEL_ON_DEATH)
+		ghostize(can_reenter_corpse = FALSE)
 		qdel(src)
 	else
 		health = 0


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/70376633/737577c5-b45c-4dfb-8b6c-7a106cd2156a)


## Why It's Good For The Game

its faster i think

## Changelog
:cl:
code: basicmobs that delete on death, ghost before dying
/:cl:
