### PR TITLE
Completely deprecates reagents in protolathe/circuit imprinter/techfab designs

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -462,7 +462,7 @@
 	req_components = list(
 		/datum/stock_part/matter_bin = 1,
 		/datum/stock_part/servo = 1,
-		/obj/item/reagent_containers/cup/beaker = 2)
+		)
 
 /obj/item/circuitboard/machine/circuit_imprinter/offstation
 	name = "Ancient Circuit Imprinter"
@@ -513,7 +513,7 @@
 	req_components = list(
 		/datum/stock_part/matter_bin = 2,
 		/datum/stock_part/servo = 2,
-		/obj/item/reagent_containers/cup/beaker = 2)
+		)
 
 /obj/item/circuitboard/machine/protolathe/offstation
 	name = "Ancient Protolathe"
@@ -601,7 +601,7 @@
 	req_components = list(
 		/datum/stock_part/matter_bin = 2,
 		/datum/stock_part/servo = 2,
-		/obj/item/reagent_containers/cup/beaker = 2)
+		)
 
 /obj/item/circuitboard/machine/techfab/department
 	name = "\improper Departmental Techfab"

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -60,7 +60,6 @@
 	desc = "A device which causes kinetic accelerators to permanently gain damage against creature types killed with it."
 	id = "bountymod"
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2, /datum/material/silver = SHEET_MATERIAL_AMOUNT*2, /datum/material/gold = SHEET_MATERIAL_AMOUNT*2, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT*2)
-	reagents_list = list(/datum/reagent/blood = 40)
 	build_path = /obj/item/borg/upgrade/modkit/bounty
 
 //Spooky special loot

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -39,7 +39,7 @@ other types of metals and chemistry for reagents).
 	var/make_reagent
 	/// What categories this design falls under. Used for sorting in production machines.
 	var/list/category = list()
-	/// List of reagents required to create one unit of the product.
+	/// List of reagents required to create one unit of the product. Currently only supported by the limb grower.
 	var/list/reagents_list = list()
 	/// The maximum number of units of whatever is produced by this can be produced in one go.
 	var/maxstack = 1

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -588,7 +588,6 @@
 	id = "paint_remover"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT)
-	reagents_list = list(/datum/reagent/acetone = 60)
 	build_path = /obj/item/paint/paint_remover
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_JANITORIAL

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -45,7 +45,6 @@
 		TRUE, \
 	)
 
-	create_reagents(0, OPENCONTAINER)
 	RefreshParts()
 	update_icon(UPDATE_OVERLAYS)
 
@@ -185,13 +184,6 @@
 /obj/machinery/rnd/production/proc/calculate_efficiency()
 	efficiency_coeff = 1
 
-	if(reagents)
-		reagents.maximum_volume = 0
-
-		for(var/obj/item/reagent_containers/cup/beaker in component_parts)
-			reagents.maximum_volume += beaker.volume
-			beaker.reagents.trans_to(src, beaker.reagents.total_volume)
-
 	if(materials)
 		var/total_storage = 0
 
@@ -206,12 +198,6 @@
 		total_rating -= servo.tier * 0.1
 
 	efficiency_coeff = max(total_rating, 0)
-
-/obj/machinery/rnd/production/on_deconstruction()
-	for(var/obj/item/reagent_containers/cup/G in component_parts)
-		reagents.trans_to(G, G.reagents.maximum_volume)
-
-	return ..()
 
 /obj/machinery/rnd/production/proc/do_print(path, amount)
 	for(var/i in 1 to amount)
@@ -263,14 +249,10 @@
 	print_quantity = clamp(print_quantity, 1, 50)
 	var/coefficient = build_efficiency(design.build_path)
 
-	//check if sufficient materials/reagents are available
+	//check if sufficient materials are available
 	if(!materials.mat_container.has_materials(design.materials, coefficient, print_quantity))
 		say("Not enough materials to complete prototype[print_quantity > 1? "s" : ""].")
 		return FALSE
-	for(var/reagent in design.reagents_list)
-		if(!reagents.has_reagent(reagent, design.reagents_list[reagent] * print_quantity * coefficient))
-			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
-			return FALSE
 
 	//use power
 	var/power = active_power_usage
@@ -305,8 +287,6 @@
 
 	//consume materials
 	materials.use_materials(design.materials, coefficient, print_quantity, "built", "[design.name]")
-	for(var/reagent in design.reagents_list)
-		reagents.remove_reagent(reagent, design.reagents_list[reagent] * print_quantity * coefficient)
 	//produce item
 	busy = TRUE
 	if(production_animation)

--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -19,7 +19,7 @@
 		else if (!isnull(current_design.build_path) || !isnull(current_design.build_path)) // //Design requires no materials but creates stuff
 			TEST_FAIL("Design [current_design.type] requires NO materials but has build_path or make_reagent set")
 		if (length(current_design.reagents_list) && !(current_design.build_type & LIMBGROWER))
-			TEST_FAIL("Design [current_design.type] requires reagents but isn't a limb grower design. This is deprecated")
+			TEST_FAIL("Design [current_design.type] requires reagents but isn't a limb grower design. Reagent costs are only supported by limb grower designs")
 
 	for(var/path in subtypesof(/datum/design/surgery))
 		var/datum/design/surgery/current_design = new path //Create an instance of each design

--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -18,6 +18,8 @@
 				TEST_FAIL("Design [current_design.type] requires materials but does not have have any build_path or make_reagent set")
 		else if (!isnull(current_design.build_path) || !isnull(current_design.build_path)) // //Design requires no materials but creates stuff
 			TEST_FAIL("Design [current_design.type] requires NO materials but has build_path or make_reagent set")
+		if (length(current_design.reagents_list) && !(current_design.build_type & LIMBGROWER))
+			TEST_FAIL("Design [current_design.type] requires reagents but isn't a limb grower design. This is deprecated")
 
 	for(var/path in subtypesof(/datum/design/surgery))
 		var/datum/design/surgery/current_design = new path //Create an instance of each design


### PR DESCRIPTION

## About The Pull Request

A long time ago, it was common for designs to cost reagents in addition to normal materials. Every circuit board used to require sulfuric acid, for example. However, these designs have slowly been whittled away, and only two remain: the death syphon PKA modkit, which costs blood, and paint remover in the service lathe, which costs acetone. Although these two designs still use the old system, it is very outdated, and it shows. TGUI doesn't take reagent costs into account at all. Reagent costs aren't displayed on mouse over like material costs, and the design won't be greyed out if there necessary reagents aren't present. If you try and fail to print one of the two designs, the protolathe will tell you that reagents are missing, but it won't say what reagents. In fact, there is not way to find out what reagents are required without code diving.
## Why It's Good For The Game

In light of how outdated and unsupported this system is, I think it makes sense to deprecate it almost entirely.* Now, protolathes, circuit imprinters and techfabs will no longer take reagent costs into account at all, even if a design does define reagent costs. The machines also no longer need beakers to be built, and reagents can't be transferred into them. The two remaining designs that did use reagent costs now don't, and I've updated the designs unit test to fail if any non-limbgrower design does set any reagent costs.

*Limb growers are the exception, as they're fully functional and work fine.
## Changelog
:cl:
del: Protolathe/circuit imprinter/techfab designs costing reagents is now totally deprecated.
/:cl:
