### PR TITLE
[no gbp] Don't give every heretic mob mirror walk

### DIFF
--- a/code/modules/mob/living/basic/heretic/heretic_summon.dm
+++ b/code/modules/mob/living/basic/heretic/heretic_summon.dm
@@ -22,6 +22,10 @@
 	response_harm_simple = "tear"
 	death_message = "implodes into itself."
 
+	unsuitable_atmos_damage = 0
+	unsuitable_cold_damage = 0
+	unsuitable_heat_damage = 0
+
 	combat_mode = TRUE
 	ai_controller = null
 	speak_emote = list("screams")

--- a/code/modules/mob/living/basic/heretic/maid_in_the_mirror.dm
+++ b/code/modules/mob/living/basic/heretic/maid_in_the_mirror.dm
@@ -23,7 +23,7 @@
 	/// A list of REFs to people who recently examined us
 	var/list/recent_examiner_refs = list()
 
-/mob/living/basic/heretic_summon/Initialize(mapload)
+/mob/living/basic/heretic_summon/maid_in_the_mirror/Initialize(mapload)
 	. = ..()
 	var/static/list/loot = list(
 		/obj/effect/decal/cleanable/ash,


### PR DESCRIPTION
## About The Pull Request

Fixes #78942

Don't give every heretic mob mirror walk
Also restores their spaceproofing.

The causes of this were respectively:
- I didn't type out the full typepath.
- I forgot.

## Changelog

:cl:
fix: "Mirror Walk" is once more the domain of the Maid in the Mirror rather than "every heretic summon"
fix: Heretic mobs can once again survive space
/:cl:
