### PR TITLE
sdql readout now displays location of turfs properly

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -730,7 +730,11 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 			var/atom/A = object
 			var/turf/T = A.loc
 			var/area/a
-			if(istype(T))
+			if(isturf(A))
+				a = A.loc
+				T = A //this should prevent the "inside" part
+				text_list += " <font color='gray'>at</font> [ADMIN_COORDJMP(A)]"
+			else if(istype(T))
 				text_list += " <font color='gray'>at</font> [T] [ADMIN_COORDJMP(T)]"
 				a = T.loc
 			else


### PR DESCRIPTION

## About The Pull Request

previously
![image](https://github.com/tgstation/tgstation/assets/70376633/d365430a-7775-417d-893a-1e559601de8f)

now
![image](https://github.com/tgstation/tgstation/assets/70376633/636eac5f-175e-4983-a096-bffa7181bd48)


## Why It's Good For The Game

bug or something bad

## Changelog
:cl:
fix: sqdl2 query readout displays location of turfs properly
/:cl:
