### PR TITLE
Fixes playing card hands displaying the wrong card at the top when there's more than five cards in the hand

### DIFF
--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -110,7 +110,7 @@
 		icon_state = null // we want an error icon to appear if this doesn't get qdel
 		return
 
-	var/starting_card_pos = max(1, cards.len - CARDS_MAX_DISPLAY_LIMIT) // only display the top cards in the cardhand
+	var/starting_card_pos = max(0, cards.len - CARDS_MAX_DISPLAY_LIMIT) + 1 // only display the top cards in the cardhand, +1 because list indexes start at 1
 	var/cards_to_display = min(CARDS_MAX_DISPLAY_LIMIT, cards.len)
 	// 90 degrees from the 1st card to the last, so split the divider by total cards displayed
 	var/angle_divider = round(90/(cards_to_display - 1))


### PR DESCRIPTION
## About The Pull Request
Title says it all, really.

It wasn't working right, because BYOND indexes start at 1 and not 0, so when you had 6 cards, `cards.len - 5 = 1`, which is not what it was meant to do.

## Why It's Good For The Game
Now hands of card can be used much more effectively for stuff like discard piles where the top card is important.

(example of what placing down a full, unshuffled deck looks like. It ends on a King, and as you can see, it displays the King now)
![image](https://github.com/tgstation/tgstation/assets/58045821/37da8d75-708a-48b6-a853-b5053632b4ca)


## Changelog

:cl: GoldenAlpharex
fix: Hands of cards will now properly display the last card added to the hand all the time, even when there's more than five cards in that hand.
/:cl: