### PR TITLE
Makes gas visuals send less assets

### DIFF
--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -17,6 +17,18 @@
 
 	return final_color
 
+/// Given a color in the format of "#RRGGBB" or "#RRGGBBAA", gives back a 4 entry list with the number values of each
+/proc/split_color(color)
+	var/list/output = list()
+	output += hex2num(copytext(color, 2, 4))
+	output += hex2num(copytext(color, 4, 6))
+	output += hex2num(copytext(color, 6, 8))
+	if(length(color) == 9)
+		output += hex2num(copytext(color, 8, 10))
+	else
+		output += 255
+	return output
+
 ///Returns a random color picked from a list, has 2 modes (0 and 1), mode 1 doesn't pick white, black or gray
 /proc/random_colour(mode = 0)
 	switch(mode)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -357,6 +357,7 @@
 /obj/effect/abstract/gas_visual
 	appearance_flags  = RESET_COLOR | KEEP_APART
 	vis_flags = VIS_INHERIT_ICON_STATE | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
+	var/color_matrix
 	var/color_filter
 
 /obj/effect/abstract/gas_visual/Initialize(mapload)
@@ -364,6 +365,8 @@
 	color_filter = filter(type="color", color=matrix())
 	filters += color_filter
 	color_filter = filters[filters.len]
+	if(color_matrix)
+		animate(color_filter, color=new_color_matrix, time=5)
 
 /obj/effect/abstract/gas_visual/proc/ChangeColor(new_color)
 	var/list/split_color = split_color(new_color)
@@ -379,5 +382,11 @@
 		0,0,0,alp_percent,
 		0,0,0,0
 	)
+
+	color_matrix = new_color_matrix
+
+	if(isnull(color_filter))
+		// Called before init
+		return
 
 	animate(color_filter, color=new_color_matrix, time=5)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -366,7 +366,7 @@
 	filters += color_filter
 	color_filter = filters[filters.len]
 	if(color_matrix)
-		animate(color_filter, color=new_color_matrix, time=5)
+		animate(color_filter, color=color_matrix, time=5)
 
 /obj/effect/abstract/gas_visual/proc/ChangeColor(new_color)
 	var/list/split_color = split_color(new_color)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -357,7 +357,7 @@
 /obj/effect/abstract/gas_visual
 	appearance_flags  = RESET_COLOR | KEEP_APART
 	vis_flags = VIS_INHERIT_ICON_STATE | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
-	var/color_matrix
+	var/current_color
 	var/color_filter
 
 /obj/effect/abstract/gas_visual/Initialize(mapload)
@@ -365,28 +365,12 @@
 	color_filter = filter(type="color", color=matrix())
 	filters += color_filter
 	color_filter = filters[filters.len]
-	if(color_matrix)
-		animate(color_filter, color=color_matrix, time=5)
+	if(current_color)
+		animate(color_filter, color=current_color, time=5)
 
 /obj/effect/abstract/gas_visual/proc/ChangeColor(new_color)
-	var/list/split_color = split_color(new_color)
-	var/red_percent = split_color[1] / 255
-	var/grn_percent = split_color[2] / 255
-	var/blu_percent = split_color[3] / 255
-	var/alp_percent = split_color[4] / 255
-
-	var/list/new_color_matrix = list(
-		red_percent,0,0,0,
-		0,grn_percent,0,0,
-		0,0,blu_percent,0,
-		0,0,0,alp_percent,
-		0,0,0,0
-	)
-
-	color_matrix = new_color_matrix
-
+	current_color = new_color
 	if(isnull(color_filter))
 		// Called before init
 		return
-
-	animate(color_filter, color=new_color_matrix, time=5)
+	animate(color_filter, time=5, color=new_color)


### PR DESCRIPTION
![Discord_2023-10-12_13-21-06](https://github.com/tgstation/tgstation/assets/1234602/e13cb015-dd94-48d9-a593-4258609049d1)

~~I'll see how this works out for the downstream, if it improves the situation for them I'll check the profiler to see how much it affects performance.~~

This reduces assets that need to be sent to the client, how much is hard to tell but a downstream that was having issues due to it got reduced issues when testing with this. Server side costs are roughly equivalent now that I switched to using a straight color in the color matrix filter.