### PR TITLE
Manifest Rune/Capture the Flag no longer DNR you. Blocks suicides in CTF areas

### DIFF
--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -217,7 +217,7 @@
 	base_lighting_alpha = 255
 	has_gravity = STANDARD_GRAVITY
 	flags_1 = NONE
-	area_flags = UNIQUE_AREA | NOTELEPORT | NO_DEATH_MESSAGE
+	area_flags = UNIQUE_AREA | NOTELEPORT | NO_DEATH_MESSAGE | BLOCK_SUICIDE
 
 /area/centcom/ctf/control_room
 	name = "Control Room A"

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -893,7 +893,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		to_chat(user, span_cultitalic("Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely..."))
 		var/obj/structure/emergency_shield/cult/weak/N = new(T)
 		if(ghost_to_spawn.mind && ghost_to_spawn.mind.current)
-			ghost_to_spawn.AddComponent( \
+			new_human.AddComponent( \
 				/datum/component/temporary_body, \
 				old_mind = ghost_to_spawn.mind, \
 				old_body = ghost_to_spawn.mind.current, \

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -892,6 +892,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 		visible_message(span_warning("A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo":""]man."))
 		to_chat(user, span_cultitalic("Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely..."))
 		var/obj/structure/emergency_shield/cult/weak/N = new(T)
+		if(ghost_to_spawn.mind && ghost_to_spawn.mind.current)
+			ghost_to_spawn.AddComponent( \
+				/datum/component/temporary_body, \
+				old_mind = ghost_to_spawn.mind, \
+				old_body = ghost_to_spawn.mind.current, \
+			)
 		new_human.key = ghost_to_spawn.key
 		var/datum/antagonist/cult/created_cultist = new_human.mind?.add_antag_datum(/datum/antagonist/cult)
 		created_cultist?.silent = TRUE

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -151,6 +151,13 @@
 	new_team_member.prefs.safe_transfer_prefs_to(player_mob, is_antag = TRUE)
 	if(player_mob.dna.species.outfit_important_for_life)
 		player_mob.set_species(/datum/species/human)
+
+	player_mob.AddComponent( \
+		/datum/component/temporary_body, \
+		old_mind = new_team_member.mob.mind, \
+		old_body = new_team_member.mob.mind.current, \
+	)
+
 	player_mob.ckey = new_team_member.ckey
 	if(isnull(ctf_player_component))
 		var/datum/component/ctf_player/player_component = player_mob.mind.AddComponent(/datum/component/ctf_player, team, ctf_game, ammo_type)


### PR DESCRIPTION
## About The Pull Request

You can return to your old body after playing CTF or being summoned as a manifest rune cult ghost. This is done by slapping the temporary_body component onto cult rune summons and CTF bodies. This also extends to Medisim Shuttle knights.

This also blocks suicides from being performed in CTF areas. Ghosting and "manually" suiciding is, of course, still an option. 
## Why It's Good For The Game

There's no reason these two cases should lock you out of being revived. They both also dust bodies on death or after their job is done, making them a perfect fit for this component.

Blocking suicides ensures that all bodies are properly "cleaned up" by the death dusting process. Gun suicides, for instance, would remove the brain from the body and bypass cleanup. This not only prevents the user from being returned to their old body, but likely has other unforeseen problems that leaving a body behind might cause.
## Changelog
:cl: Rhials
qol: You can now return to your old body after being summoned by a manifest rune.
qol: You can now return to your old body after dying in CTF.
qol: You can now return to your old body after dying in the Medisim Shuttle battle area.
qol: You can no longer suicide in CTF areas, for integrity purposes.
/:cl:
