### PR TITLE
Aquariums now have an internal feed storage. Fish catalogs as 25cr goodies.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -26,8 +26,8 @@
 "aaj" = (
 /obj/structure/bed/dogbed/renault,
 /obj/machinery/newscaster/directional/south,
-/mob/living/basic/pet/fox/renault,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/pet/fox/renault,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "aaz" = (
@@ -21101,8 +21101,8 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "fiu" = (
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "fix" = (
@@ -24409,7 +24409,7 @@
 /obj/effect/spawner/random/structure/table_fancy,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
+	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
 	name = "Delta-Down";
 	pixel_x = 5;
 	pixel_y = 5
@@ -26564,6 +26564,7 @@
 /area/station/maintenance/department/security)
 "gzc" = (
 /obj/structure/table/wood,
+/obj/item/aquarium_kit,
 /turf/open/floor/carpet/red,
 /area/station/hallway/secondary/service)
 "gzj" = (
@@ -42756,10 +42757,10 @@
 "kDv" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/item/radio/intercom/directional/south,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "kDB" = (
@@ -47655,8 +47656,8 @@
 /area/station/commons/vacant_room/office)
 "lNN" = (
 /obj/structure/bed/dogbed/mcgriff,
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "lNZ" = (
@@ -49268,8 +49269,8 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "mmM" = (
@@ -51452,8 +51453,8 @@
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "mOo" = (
@@ -54867,8 +54868,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nJK" = (
@@ -76736,9 +76737,9 @@
 "thZ" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/poly,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/newscaster/directional/north,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "tip" = (
@@ -95416,8 +95417,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/mob/living/basic/sloth/citrus,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/sloth/citrus,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "xPo" = (
@@ -95472,8 +95473,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "xQr" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1889,11 +1889,11 @@
 	location = "QM #2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/east,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #2";
 	suffix = "#2"
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aEU" = (
@@ -3558,7 +3558,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/north{
 	linked_elevator_id = "publicElevator";
-	preset_destination_names = list("3"="Icemoon                                                                                                                                                                                                                                                                Level","4"="Station                                                                                                                                                                                                                                                                Level")
+	preset_destination_names = list("3" = "Icemoon                                                                                                                                                                                                                                                                Level", "4" = "Station                                                                                                                                                                                                                                                                Level")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
@@ -47655,6 +47655,7 @@
 	c_tag = "Service Hallway - Upper West"
 	},
 /obj/structure/table,
+/obj/item/aquarium_kit,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "oBs" = (
@@ -68905,7 +68906,7 @@
 "vhr" = (
 /mob/living/basic/goat/pete{
 	desc = "Not known for their pleasant disposition. This one seems a bit more hardy to the cold.";
-	habitable_atmos = list("min_oxy"=1,"max_oxy"=0,"min_plas"=0,"max_plas"=1,"min_co2"=0,"max_co2"=5,"min_n2"=0,"max_n2"=0);
+	habitable_atmos = list("min_oxy" = 1, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0);
 	minimum_survivable_temperature = 150;
 	name = "Snowy Pete"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9742,11 +9742,11 @@
 "dHe" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
-/mob/living/simple_animal/bot/floorbot,
 /obj/structure/sign/departments/telecomms/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dHg" = (
@@ -25212,10 +25212,10 @@
 "jgs" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/item/toy/cattoy,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "jgt" = (
@@ -26040,6 +26040,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/aquarium_kit,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "juj" = (
@@ -30670,8 +30671,8 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/office)
 "kZf" = (
-/mob/living/carbon/human/species/monkey,
 /obj/structure/window/reinforced/spawner/directional/north,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "kZk" = (
@@ -36254,8 +36255,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/mob/living/simple_animal/bot/cleanbot/autopatrol,
 /obj/effect/turf_decal/tile/neutral,
+/mob/living/simple_animal/bot/cleanbot/autopatrol,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "mZL" = (
@@ -38436,8 +38437,8 @@
 "nMF" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/firealarm/directional/east,
-/mob/living/simple_animal/bot/cleanbot,
 /obj/effect/turf_decal/tile/blue,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "nMK" = (
@@ -39819,12 +39820,12 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "onU" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
 /mob/living/basic/chicken{
 	name = "Kentucky";
 	real_name = "Kentucky"
 	},
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "oog" = (
@@ -47362,8 +47363,8 @@
 /area/station/medical/psychology)
 "qXw" = (
 /obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/poly,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "qXB" = (
@@ -49681,10 +49682,10 @@
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 26
 	},
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 9
 	},
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "rOF" = (
@@ -50446,10 +50447,10 @@
 /turf/open/floor/plating,
 /area/station/science/server)
 "sbL" = (
-/mob/living/simple_animal/bot/medbot/autopatrol,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/medbot/autopatrol,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -52449,8 +52450,8 @@
 /area/station/medical/medbay/central)
 "sOw" = (
 /obj/structure/sink/directional/south,
-/mob/living/basic/mouse/brown/tom,
 /obj/machinery/light/small/dim/directional/west,
+/mob/living/basic/mouse/brown/tom,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "sOF" = (
@@ -59245,8 +59246,8 @@
 /area/station/engineering/supermatter)
 "vfm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "vfv" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -7829,20 +7829,20 @@
 /area/station/engineering/atmos)
 "bVK" = (
 /obj/structure/table,
-/mob/living/basic/mouse/brown/tom,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/mob/living/basic/mouse/brown/tom,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bVQ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/cable,
-/mob/living/simple_animal/parrot/poly,
 /obj/machinery/computer/security/telescreen/engine{
 	name = "Engineering and atmospherics monitor"
 	},
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/command/heads_quarters/ce)
 "bVT" = (
@@ -11135,8 +11135,8 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
 "cOS" = (
-/mob/living/simple_animal/bot/cleanbot,
 /obj/machinery/light/small/directional/north,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cPg" = (
@@ -14705,11 +14705,11 @@
 /area/station/service/library)
 "dNw" = (
 /obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
+/mob/living/basic/pet/fox/renault,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "dNx" = (
@@ -15180,10 +15180,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/paramedic)
 "dUq" = (
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dUr" = (
@@ -16268,7 +16268,7 @@
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "fore_vator";
 	pixel_x = -24;
-	preset_destination_names = list("2"="Supply-Engi        Floor","3"="Med-Sci        Floor","4"="Service        Floor")
+	preset_destination_names = list("2" = "Supply-Engi        Floor", "3" = "Med-Sci        Floor", "4" = "Service        Floor")
 	},
 /obj/machinery/lift_indicator/directional/west{
 	linked_elevator_id = "fore_vator";
@@ -16442,17 +16442,17 @@
 "ejT" = (
 /obj/structure/table/reinforced,
 /obj/item/food/butter{
-	food_reagents = list(/datum/reagent/consumable/nutriment=5,/datum/reagent/drug/space_drugs=10);
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/drug/space_drugs = 10);
 	name = "stick of 'medicated' butter";
 	pixel_y = 8
 	},
 /obj/item/food/butter{
-	food_reagents = list(/datum/reagent/consumable/nutriment=5,/datum/reagent/drug/space_drugs=10);
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/drug/space_drugs = 10);
 	name = "stick of 'medicated' butter";
 	pixel_y = 3
 	},
 /obj/item/food/butter{
-	food_reagents = list(/datum/reagent/consumable/nutriment=5,/datum/reagent/drug/space_drugs=10);
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/drug/space_drugs = 10);
 	name = "stick of 'medicated' butter";
 	pixel_y = -2
 	},
@@ -17821,6 +17821,7 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/aquarium_kit,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "eDe" = (
@@ -23720,7 +23721,7 @@
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "com_vator";
 	pixel_x = 24;
-	preset_destination_names = list("3"="Medsci","4"="Service","5"="Command")
+	preset_destination_names = list("3" = "Medsci", "4" = "Service", "5" = "Command")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/floor2/fore)
@@ -29277,8 +29278,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/structure/chair/sofa/middle/brown,
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/carpet/green,
 /area/station/service/bar/atrium)
 "hJD" = (
@@ -30708,11 +30709,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard/fore)
 "idf" = (
-/mob/living/basic/sloth/paperwork,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/mob/living/basic/sloth/paperwork,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "idn" = (
@@ -33447,11 +33448,11 @@
 "iOy" = (
 /obj/structure/table/reinforced,
 /obj/item/food/cake/chocolate{
-	food_reagents = list(/datum/reagent/consumable/nutriment=20,/datum/reagent/drug/space_drugs=10);
+	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/drug/space_drugs = 10);
 	name = "large pot brownie"
 	},
 /obj/item/food/cake/chocolate{
-	food_reagents = list(/datum/reagent/consumable/nutriment=20,/datum/reagent/drug/space_drugs=10);
+	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/drug/space_drugs = 10);
 	name = "large pot brownie";
 	pixel_y = 6
 	},
@@ -36153,13 +36154,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/mob/living/basic/lizard{
-	name = "Allad Minsa"
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Custodial Closet"
 	},
 /obj/item/radio/intercom/directional/west,
+/mob/living/basic/lizard{
+	name = "Allad Minsa"
+	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "jzN" = (
@@ -43545,7 +43546,6 @@
 /area/station/command/meeting_room)
 "ltD" = (
 /obj/structure/bed/dogbed/lia,
-/mob/living/basic/carp/pet/lia,
 /obj/machinery/requests_console/directional/north{
 	department = "Head of Security's Desk";
 	name = "Head of Security Requests Console"
@@ -43553,6 +43553,7 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/mob/living/basic/carp/pet/lia,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ltH" = (
@@ -52293,31 +52294,31 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/reagent_containers/pill/happinesspsych{
 	desc = "A mysterious unlabelled pill. You're not sure what it is, but it's probably a synthetic drug.";
-	list_reagents = list(/datum/reagent/drug/happiness=5,/datum/reagent/drug/space_drugs=10,/datum/reagent/drug/mushroomhallucinogen=10);
+	list_reagents = list(/datum/reagent/drug/happiness = 5, /datum/reagent/drug/space_drugs = 10, /datum/reagent/drug/mushroomhallucinogen = 10);
 	name = "strange pill";
 	pixel_x = 9
 	},
 /obj/item/reagent_containers/pill/happinesspsych{
 	desc = "A mysterious unlabelled pill. You're not sure what it is, but it's probably a synthetic drug.";
-	list_reagents = list(/datum/reagent/drug/happiness=5,/datum/reagent/drug/space_drugs=10,/datum/reagent/drug/mushroomhallucinogen=10);
+	list_reagents = list(/datum/reagent/drug/happiness = 5, /datum/reagent/drug/space_drugs = 10, /datum/reagent/drug/mushroomhallucinogen = 10);
 	name = "strange pill"
 	},
 /obj/item/reagent_containers/pill/happinesspsych{
 	desc = "A mysterious unlabelled pill. You're not sure what it is, but it's probably a synthetic drug.";
-	list_reagents = list(/datum/reagent/drug/happiness=5,/datum/reagent/drug/space_drugs=10,/datum/reagent/drug/mushroomhallucinogen=10);
+	list_reagents = list(/datum/reagent/drug/happiness = 5, /datum/reagent/drug/space_drugs = 10, /datum/reagent/drug/mushroomhallucinogen = 10);
 	name = "strange pill";
 	pixel_x = -9;
 	pixel_y = -8
 	},
 /obj/item/reagent_containers/pill/happinesspsych{
 	desc = "A mysterious unlabelled pill. You're not sure what it is, but it's probably a synthetic drug.";
-	list_reagents = list(/datum/reagent/drug/happiness=5,/datum/reagent/drug/space_drugs=10,/datum/reagent/drug/mushroomhallucinogen=10);
+	list_reagents = list(/datum/reagent/drug/happiness = 5, /datum/reagent/drug/space_drugs = 10, /datum/reagent/drug/mushroomhallucinogen = 10);
 	name = "strange pill";
 	pixel_y = -8
 	},
 /obj/item/reagent_containers/pill/happinesspsych{
 	desc = "A mysterious unlabelled pill. You're not sure what it is, but it's probably a synthetic drug.";
-	list_reagents = list(/datum/reagent/drug/happiness=5,/datum/reagent/drug/space_drugs=10,/datum/reagent/drug/mushroomhallucinogen=10);
+	list_reagents = list(/datum/reagent/drug/happiness = 5, /datum/reagent/drug/space_drugs = 10, /datum/reagent/drug/mushroomhallucinogen = 10);
 	name = "strange pill";
 	pixel_x = -9
 	},
@@ -53642,7 +53643,7 @@
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "aft_vator";
 	pixel_x = 24;
-	preset_destination_names = list("2"="Supply-Engi        Floor","3"="Med-Sci        Floor","4"="Service        Floor")
+	preset_destination_names = list("2" = "Supply-Engi        Floor", "3" = "Med-Sci        Floor", "4" = "Service        Floor")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/floor1/aft)
@@ -54458,8 +54459,8 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms/apartment2)
 "ofI" = (
-/mob/living/basic/butterfly,
 /obj/machinery/light/small/directional/east,
+/mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "ogc" = (
@@ -55660,11 +55661,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/science/xenobiology/hallway)
 "owC" = (
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "owI" = (
@@ -65176,10 +65177,10 @@
 /turf/open/floor/iron/kitchen,
 /area/station/command/heads_quarters/rd)
 "qXQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/carbon/human/species/monkey{
 	name = "Banana"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "qXW" = (
@@ -76886,8 +76887,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/machinery/light/directional/east,
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "ufI" = (
@@ -78076,10 +78077,10 @@
 "uwI" = (
 /obj/structure/cable,
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "uwP" = (
@@ -78803,9 +78804,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "uGT" = (
-/mob/living/simple_animal/bot/floorbot,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uHa" = (
@@ -91748,10 +91749,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xVl" = (
-/mob/living/basic/crab,
 /obj/structure/railing{
 	dir = 1
 	},
+/mob/living/basic/crab,
 /turf/open/misc/beach/sand,
 /area/station/hallway/floor2/fore)
 "xVn" = (
@@ -92708,13 +92709,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/floor2/aft)
 "yiA" = (
-/mob/living/basic/pig{
-	desc = "The best friend of any cytologist.";
-	name = "Oug"
-	},
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
+	},
+/mob/living/basic/pig{
+	desc = "The best friend of any cytologist.";
+	name = "Oug"
 	},
 /turf/open/floor/grass,
 /area/station/science/cytology)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3339,7 +3339,7 @@
 "asR" = (
 /obj/effect/turf_decal/tile/neutral/tram,
 /obj/effect/spawner/random{
-	loot = list(/obj/effect/decal/cleanable/oil/slippery=10,/obj/effect/decal/cleanable/oil=90);
+	loot = list(/obj/effect/decal/cleanable/oil/slippery = 10, /obj/effect/decal/cleanable/oil = 90);
 	name = "funny slipper :)"
 	},
 /turf/open/floor/tram/plate,
@@ -6456,9 +6456,9 @@
 	pixel_y = -8;
 	req_access = list("engineering")
 	},
-/mob/living/simple_animal/parrot/poly,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "bdT" = (
@@ -6983,7 +6983,7 @@
 	},
 /obj/item/reagent_containers/cup/bottle{
 	desc = "A small bottle of Barber's Aid.";
-	list_reagents = list(/datum/reagent/barbers_aid=30);
+	list_reagents = list(/datum/reagent/barbers_aid = 30);
 	name = "Barber's Aid bottle";
 	pixel_x = 10;
 	pixel_y = 3
@@ -19618,6 +19618,7 @@
 "fWO" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/aquarium_kit,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "fWT" = (
@@ -22863,7 +22864,7 @@
 "hhH" = (
 /obj/effect/turf_decal/tile/neutral/tram,
 /obj/effect/spawner/random{
-	loot = list(/obj/effect/decal/cleanable/oil/slippery=10,/obj/effect/decal/cleanable/oil=90);
+	loot = list(/obj/effect/decal/cleanable/oil/slippery = 10, /obj/effect/decal/cleanable/oil = 90);
 	name = "funny slipper :)"
 	},
 /turf/open/floor/tram/plate,
@@ -24123,8 +24124,8 @@
 "hHn" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/sign/clock/directional/north,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/machinery/light/cold/directional/north,
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "hHB" = (
@@ -26072,7 +26073,7 @@
 	layer = 3.1;
 	linked_elevator_id = "tram_xeno_lift";
 	pixel_y = 2;
-	preset_destination_names = list("2"="Lower                                                                Deck","3"="Upper                                                                Deck")
+	preset_destination_names = list("2" = "Lower                                                                Deck", "3" = "Upper                                                                Deck")
 	},
 /turf/closed/wall,
 /area/station/science/xenobiology)
@@ -30091,7 +30092,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
+	preset_destination_names = list("2" = "Hydroponics", "3" = "Kitchen")
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/dark,
@@ -37242,7 +37243,7 @@
 	},
 /obj/item/reagent_containers/cup/bottle{
 	desc = "A small bottle of Barber's Aid.";
-	list_reagents = list(/datum/reagent/barbers_aid=30);
+	list_reagents = list(/datum/reagent/barbers_aid = 30);
 	name = "Barber's Aid bottle";
 	pixel_x = -2;
 	pixel_y = 10
@@ -41301,7 +41302,7 @@
 /obj/structure/transport/linear/public,
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_perma_lift";
-	preset_destination_names = list("2"="Lower                                Deck","3"="Upper                                Deck")
+	preset_destination_names = list("2" = "Lower                                Deck", "3" = "Upper                                Deck")
 	},
 /obj/effect/turf_decal/caution/stand_clear/red{
 	dir = 1
@@ -41315,7 +41316,7 @@
 /obj/structure/transport/linear/public,
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_sci_lift";
-	preset_destination_names = list("2"="Lower                                Deck","3"="Upper                                Deck")
+	preset_destination_names = list("2" = "Lower                                Deck", "3" = "Upper                                Deck")
 	},
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 9
@@ -43621,7 +43622,7 @@
 /obj/structure/transport/linear/public,
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "tram_lower_center_lift";
-	preset_destination_names = list("2"="Lower                                Deck","3"="Upper                                Deck")
+	preset_destination_names = list("2" = "Lower                                Deck", "3" = "Upper                                Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/maintenance/tram/mid)
@@ -45259,8 +45260,8 @@
 "pjP" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/leavy/style_random,
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/light/directional/east,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "pjQ" = (
@@ -48088,7 +48089,7 @@
 /area/station/maintenance/disposal/incinerator)
 "qhl" = (
 /obj/machinery/computer/atmos_control/oxygen_tank{
-	atmos_chambers = list("o2ordance"="Oxygen                                                                Supply")
+	atmos_chambers = list("o2ordance" = "Oxygen                                                                Supply")
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/north,
@@ -49416,11 +49417,11 @@
 /obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light/small/dim/directional/west,
 /mob/living/basic/mouse/gray{
 	dir = 4;
 	name = "Plaguebearer"
 	},
-/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "qGM" = (
@@ -50317,7 +50318,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/north{
 	linked_elevator_id = "tram_upper_center_lift";
-	preset_destination_names = list("2"="Lower                                Deck","3"="Upper                                Deck")
+	preset_destination_names = list("2" = "Lower                                Deck", "3" = "Upper                                Deck")
 	},
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 1
@@ -51476,7 +51477,7 @@
 	layer = 3.1;
 	linked_elevator_id = "tram_xeno_lift";
 	pixel_y = 2;
-	preset_destination_names = list("2"="Lower                                                                Deck","3"="Upper                                                                Deck")
+	preset_destination_names = list("2" = "Lower                                                                Deck", "3" = "Upper                                                                Deck")
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -58815,7 +58816,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning,
 /obj/machinery/elevator_control_panel/directional/south{
 	linked_elevator_id = "tram_dorm_lift";
-	preset_destination_names = list("2"="Lower                                                                Deck","3"="Upper                                                                Deck")
+	preset_destination_names = list("2" = "Lower                                                                Deck", "3" = "Upper                                                                Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/maintenance/tram/left)
@@ -69116,7 +69117,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
+	preset_destination_names = list("2" = "Hydroponics", "3" = "Kitchen")
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -69170,7 +69171,7 @@
 /obj/structure/transport/linear/public,
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_cargo_lift";
-	preset_destination_names = list("2"="Lower                                Deck","3"="Upper                                Deck");
+	preset_destination_names = list("2" = "Lower                                Deck", "3" = "Upper                                Deck");
 	req_access = list("mining")
 	},
 /obj/effect/abstract/elevator_music_zone{

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -216,7 +216,7 @@
 /area/shuttle/escape)
 "nY" = (
 /obj/structure/table/wood,
-/obj/item/book/fish_catalog{
+/obj/item/book/manual/fish_catalog{
 	pixel_y = 2
 	},
 /turf/open/floor/wood/tile,

--- a/_maps/shuttles/emergency_tranquility.dmm
+++ b/_maps/shuttles/emergency_tranquility.dmm
@@ -1750,7 +1750,7 @@
 "Gs" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
-/obj/item/book/fish_catalog{
+/obj/item/book/manual/fish_catalog{
 	pixel_x = -4
 	},
 /obj/item/food/grown/poppy/lily{

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -414,3 +414,8 @@
 	return (buffer.mode == READY) ? ..() : FALSE
 
 #undef READY
+
+///Lazily demand from any direction. Overlays won't look good, and the aquarium sprite occupies about the entire 32x32 area anyway.
+/datum/component/plumbing/aquarium
+	demand_connects = SOUTH|NORTH|EAST|WEST
+	use_overlays = FALSE

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -248,6 +248,18 @@
 	cost = PAYCHECK_CREW * 8
 	contains = list(/obj/item/fishing_rod/telescopic)
 
+/datum/supply_pack/goody/fish_analyzer
+	name = "Fish Analyzer"
+	desc = "A single analyzer to monitor fish's status and traits with, in case you don't have the technology to print one."
+	cost = PAYCHECK_CREW * 2.5
+	contains = list(/obj/item/fish_analyzer)
+
+/datum/supply_pack/goody/fish_catalog
+	name = "Fishing Catalog"
+	desc = "A catalog containing all the fishy info you'll ever need."
+	cost = PAYCHECK_LOWER
+	contains = list(/obj/item/book/manual/fish_catalog)
+
 /datum/supply_pack/goody/coffee_mug
 	name = "Coffee Mug"
 	desc = "A bog standard coffee mug, for drinking coffee."
@@ -283,9 +295,3 @@
 	desc = "A less cheap imported climbing hook. Absolutely no use outside of planetary stations."
 	cost = PAYCHECK_CREW * 5
 	contains = list(/obj/item/climbing_hook)
-
-/datum/supply_pack/goody/fish_analyzer
-	name = "Fish Analyzer"
-	desc = "A single analyzer to monitor fish's status and traits with, in case you don't have the technology to print one."
-	cost = CARGO_CRATE_VALUE * 2.5
-	contains = list(/obj/item/fish_analyzer)

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -26,48 +26,6 @@
 	crate_name = "tattoo crate"
 	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/misc/aquarium_kit
-	name = "Aquarium Kit"
-	desc = "Everything you need to start your own aquarium. Contains aquarium construction kit, \
-		fish catalog, fish food and three freshwater fish from our collection."
-	cost = CARGO_CRATE_VALUE * 5
-	contains = list(/obj/item/book/fish_catalog,
-					/obj/item/storage/fish_case/random/freshwater = 3,
-					/obj/item/fish_feed,
-					/obj/item/storage/box/aquarium_props,
-					/obj/item/aquarium_kit,
-				)
-	crate_name = "aquarium kit crate"
-	crate_type = /obj/structure/closet/crate/wooden
-
-/datum/supply_pack/misc/aquarium_fish
-	name = "Aquarium Fish Case"
-	desc = "An aquarium fish bundle handpicked by monkeys from our collection. Contains two random fish."
-	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/storage/fish_case/random = 2)
-	crate_name = "aquarium fish crate"
-
-/datum/supply_pack/misc/freshwater_fish
-	name = "Freshwater Fish Case"
-	desc = "Aquarium fish that have had most of their mud cleaned off."
-	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/storage/fish_case/random/freshwater = 2)
-	crate_name = "freshwater fish crate"
-
-/datum/supply_pack/misc/saltwater_fish
-	name = "Saltwater Fish Case"
-	desc = "Aquarium fish that fill the room with the smell of salt."
-	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/storage/fish_case/random/saltwater = 2)
-	crate_name = "saltwater fish crate"
-
-/datum/supply_pack/misc/tiziran_fish
-	name = "Tiziran Fish Case"
-	desc = "Tiziran saltwater fish imported from the Zagos Sea."
-	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/storage/fish_case/tiziran = 2)
-	crate_name = "tiziran fish crate"
-
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"
 	desc = "Nanotrasen reminds all employees to never toy with powers outside their control."

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -223,3 +223,34 @@
 	. = ..()
 	for(var/i in 1 to 2)
 		new /mob/living/basic/garden_gnome(.)
+
+/datum/supply_pack/critter/fish
+	crate_type = /obj/structure/closet/crate
+
+/datum/supply_pack/critter/fish/aquarium_fish
+	name = "Aquarium Fish Case"
+	desc = "An aquarium fish bundle handpicked by monkeys from our collection. Contains two random fish."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/random = 2)
+	crate_name = "aquarium fish crate"
+
+/datum/supply_pack/critter/fish/freshwater_fish
+	name = "Freshwater Fish Case"
+	desc = "Aquarium fish that have had most of their mud cleaned off."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/random/freshwater = 2)
+	crate_name = "freshwater fish crate"
+
+/datum/supply_pack/critter/fish/saltwater_fish
+	name = "Saltwater Fish Case"
+	desc = "Aquarium fish that fill the room with the smell of salt."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/random/saltwater = 2)
+	crate_name = "saltwater fish crate"
+
+/datum/supply_pack/critter/fish/tiziran_fish
+	name = "Tiziran Fish Case"
+	desc = "Tiziran saltwater fish imported from the Zagos Sea."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/tiziran = 2)
+	crate_name = "tiziran fish crate"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -270,3 +270,17 @@
 	contains = list(/obj/machinery/coffeemaker/impressa)
 	crate_name = "coffeemaker crate"
 	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/service/aquarium_kit
+	name = "Aquarium Kit"
+	desc = "Everything you need to start your own aquarium. Contains aquarium construction kit, \
+		fish catalog, fish food and three freshwater fish from our collection."
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/item/book/manual/fish_catalog,
+					/obj/item/storage/fish_case/random/freshwater = 3,
+					/obj/item/fish_feed,
+					/obj/item/storage/box/aquarium_props,
+					/obj/item/aquarium_kit,
+				)
+	crate_name = "aquarium kit crate"
+	crate_type = /obj/structure/closet/crate/wooden

--- a/code/modules/fishing/aquarium/aquarium_kit.dm
+++ b/code/modules/fishing/aquarium/aquarium_kit.dm
@@ -96,9 +96,9 @@
 	icon_state = "construction_kit"
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/aquarium_kit/attack_self(mob/user)
+/obj/item/aquarium_kit/Initialize(mapload)
 	. = ..()
-	to_chat(user,span_notice("There's instruction and tools necessary to build aquarium inside. All you need is to start crafting."))
+	AddComponent(/datum/component/slapcrafting, /datum/crafting_recipe/aquarium)
 
 /obj/item/aquarium_prop
 	name = "generic aquarium prop"

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -314,6 +314,8 @@
 		last_feeding = world.time
 	else
 		var/datum/reagent/wrong_reagent = pick(fed_reagents.reagent_list)
+		if(!wrong_reagent)
+			return
 		fed_reagent_type = wrong_reagent.type
 		fed_reagents.remove_reagent(fed_reagent_type, 0.1)
 	SEND_SIGNAL(src, COMSIG_FISH_FED, fed_reagents, fed_reagent_type)

--- a/code/modules/fishing/fish_catalog.dm
+++ b/code/modules/fishing/fish_catalog.dm
@@ -1,17 +1,17 @@
 ///Book detailing where to get the fish and their properties.
-/obj/item/book/fish_catalog
+/obj/item/book/manual/fish_catalog
 	name = "Fish Encyclopedia"
 	desc = "Indexes all fish known to mankind (and related species)."
 	icon_state = "fishbook"
 	starting_content = "Lot of fish stuff" //book wrappers could use cleaning so this is not necessary
 
-/obj/item/book/fish_catalog/ui_interact(mob/user, datum/tgui/ui)
+/obj/item/book/manual/fish_catalog/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "FishCatalog", name)
 		ui.open()
 
-/obj/item/book/fish_catalog/ui_static_data(mob/user)
+/obj/item/book/manual/fish_catalog/ui_static_data(mob/user)
 	. = ..()
 	var/static/fish_info
 	if(!fish_info)
@@ -43,7 +43,7 @@
 	.["fish_info"] = fish_info
 	.["sponsored_by"] = AQUARIUM_COMPANY
 
-/obj/item/book/proc/bait_description(bait)
+/obj/item/book/manual/fish_catalog/proc/bait_description(bait)
 	if(ispath(bait))
 		var/obj/bait_item = bait
 		return initial(bait_item.name)
@@ -52,6 +52,9 @@
 		switch(special_identifier["Type"])
 			if("Foodtype")
 				return jointext(bitfield_to_list(special_identifier["Value"], FOOD_FLAGS_IC),",")
+			if("Reagent")
+				var/datum/reagent/prototype = special_identifier["Value"]
+				return "[initial(prototype.name)] (at least [special_identifier["Amount"]]u)"
 			else
 				stack_trace("Unknown bait identifier in fish favourite/disliked list")
 				return "SOMETHING VERY WEIRD"
@@ -59,7 +62,7 @@
 		//Here we handle descriptions of traits fish use as qualifiers
 		return "something special"
 
-/obj/item/book/fish_catalog/proc/build_fishing_tips(fish_type)
+/obj/item/book/manual/fish_catalog/proc/build_fishing_tips(fish_type)
 	var/obj/item/fish/fishy = fish_type
 	. = list()
 	//// Where can it be found - iterate fish sources, how should this handle key
@@ -101,7 +104,7 @@
 			.["difficulty"] = "Hard"
 	return .
 
-/obj/item/book/fish_catalog/ui_assets(mob/user)
+/obj/item/book/manual/fish_catalog/ui_assets(mob/user)
 	return list(
 		get_asset_datum(/datum/asset/spritesheet/fish)
 	)

--- a/tgui/packages/tgui/interfaces/Aquarium.tsx
+++ b/tgui/packages/tgui/interfaces/Aquarium.tsx
@@ -1,6 +1,6 @@
 import { BooleanLike } from 'common/react';
 import { useBackend } from '../backend';
-import { Button, Flex, Knob, LabeledControls, Section } from '../components';
+import { Button, Flex, Knob, NumberInput, LabeledControls, Section } from '../components';
 import { Window } from '../layouts';
 
 type Data = {
@@ -11,6 +11,7 @@ type Data = {
   fluidTypes: string[];
   contents: { ref: string; name: string }[];
   allow_breeding: BooleanLike;
+  feeding_interval: number;
 };
 
 export const Aquarium = (props, context) => {
@@ -23,10 +24,11 @@ export const Aquarium = (props, context) => {
     fluidTypes,
     contents,
     allow_breeding,
+    feeding_interval,
   } = data;
 
   return (
-    <Window width={500} height={400}>
+    <Window width={520} height={400}>
       <Window.Content>
         <Section title="Aquarium Controls">
           <LabeledControls>
@@ -61,11 +63,25 @@ export const Aquarium = (props, context) => {
                 ))}
               </Flex>
             </LabeledControls.Item>
-            <LabeledControls.Item label="Reproduction Prevention System">
+            <LabeledControls.Item label="Reproduction Prevention">
               <Button
                 content={allow_breeding ? 'Offline' : 'Online'}
                 selected={!allow_breeding}
                 onClick={() => act('allow_breeding')}
+              />
+            </LabeledControls.Item>
+            <LabeledControls.Item label="Feeding Interval">
+              <NumberInput
+                fluid
+                value={feeding_interval}
+                minValue={1}
+                maxValue={7}
+                unit="minutes"
+                onChange={(e, value) =>
+                  act('feeding_interval', {
+                    feeding_interval: value,
+                  })
+                }
               />
             </LabeledControls.Item>
           </LabeledControls>

--- a/tools/UpdatePaths/Scripts/78958_fishing_catalog_manual.txt
+++ b/tools/UpdatePaths/Scripts/78958_fishing_catalog_manual.txt
@@ -1,0 +1,1 @@
+/obj/item/book/fish_catalog : /obj/item/book/manual/fish_catalog{@OLD}


### PR DESCRIPTION
## About The Pull Request
Added a reagent holder to aquarium tanks and some code to enable the fish to be automatically fed at selectable intervals of 1 minute to 7 (default 3). The holder can be accessed and filled by opening the control panel, and emptied with a plunger if necessary. Simple plumbing compatibility has been added as well, in case you think the 6 units of capacity of the reagent holder (enough to feed a fish 60 times) are not enough. The preset fishing tank starts with enough feed to keep its contents alive for 30 minutes.

Beside that, I've fixed a small oversight with the fish analyzer goodie pack. It should cost 150, not 500.
The fish catalog is now a goodie pack you can get as a goodie for dirt cheap (25 creds) and a subtype of `book/manual`, so there's a slim chance you may find it at the library or somewhere else.
Fixed a small oversight inside the fish catalog.
Mapped in a single aquarium kit for each station map, in the service hallway/storage room where the techfab and cargo consoles are also found.
Aquarium kits are now compatible with slapcrafting.

## Why It's Good For The Game
Aquariums require too much maintainance for a gimmick, and it's quite awful to see the fish inside preset aquariums die 5 minutes into the round. Also, you cannot get fish catalogs anywhere but from the aquarium kit crate, which costs 1k credits, though its pertinence with fishing goes beyond aquarium stuff.
Lastiy, I think it's good to give the crew a free aquarium kit. The price of the supply pack is a bit out of reach for many, service could use a bit of fisciculture too (I may make it a service pack later, so that it can be ordered through the service console).

## Changelog

:cl:
add: Aquariums now have a small internal reagent holder, accessible when the panel is open and used to automatically feed the fishes at selectable intervals, also compatible with plumbing.
add: Fish catalogs can now be bought as a goodie pack, for 25 cr, or rarely found at the library or maints.
fix: Fixed the prices of fish analyzers. It's supposed to be 150 cr, not 500.
map: Added an aquarium kit to each station, found in the room where the service techfab and order console also are.
qol: Aquarium kits are now compatible with slapcrafting (crafted by hitting them with the required material without opening the menu).
balance: Moved the aquarium kit and fish supply packs from the "General" section to "Service" and "Livestock" respectively, meaning they can be ordered for free from the service orders console.
/:cl:
