### PR TITLE
Allows domains to forgo giving bitrunners their disk items and spells if that is desired

### DIFF
--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -302,7 +302,7 @@
 			return
 		current_avatar = server.generate_avatar(wayout, netsuit)
 		avatar_ref = WEAKREF(current_avatar)
-		server.stock_gear(current_avatar, neo)
+		server.stock_gear(current_avatar, neo, generated_domain)
 
 	neo.set_static_vision(3 SECONDS)
 	protect_occupant(occupant)

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -85,7 +85,7 @@
 	if(domain_forbid_spells)
 		import_ban += "imported_abilities"
 		disk_ban += "powers"
-	if(import_ban )
+	if(import_ban)
 		to_chat(neo, span_warning("This domain forbids the use of [english_list(import_ban)], your disk [english_list(disk_ban)] will not be granted!")))
 
 	var/failed = FALSE

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -86,7 +86,7 @@
 		import_ban += "imported_abilities"
 		disk_ban += "powers"
 	if(import_ban)
-		to_chat(neo, span_warning("This domain forbids the use of [english_list(import_ban)], your disk [english_list(disk_ban)] will not be granted!")))
+		to_chat(neo, span_warning("This domain forbids the use of [english_list(import_ban)], your disk [english_list(disk_ban)] will not be granted!"))
 
 	var/failed = FALSE
 

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -73,11 +73,21 @@
 	return wayout
 
 /// Scans over neo's contents for bitrunning tech disks. Loads the items or abilities onto the avatar.
-/obj/machinery/quantum_server/proc/stock_gear(mob/living/carbon/human/avatar, mob/living/carbon/human/neo)
+/obj/machinery/quantum_server/proc/stock_gear(mob/living/carbon/human/avatar, mob/living/carbon/human/neo, datum/lazy_template/virtual_domain/generated_domain)
+	var/domain_forbids_items = generated_domain.forbids_disk_items
+	var/domain_forbids_spells = generated_domain.forbids_disk_spells
 	var/failed = FALSE
 
+	if(domain_forbids_items)
+		to_chat(neo, span_warning("This domain forbids the use of smuggled digital equipment, your disk items will not be granted!"))
+	if(domain_forbids_spells)
+		to_chat(neo, span_warning("This domain forbids the use of imported abilities, your disk powers will not be granted!"))
+
+	// We don't need to bother going over the disks if neither of the types can be used.
+	if(domain_forbids_spells && domain_forbids_items)
+		return
 	for(var/obj/item/bitrunning_disk/disk in neo.get_contents())
-		if(istype(disk, /obj/item/bitrunning_disk/ability))
+		if(istype(disk, /obj/item/bitrunning_disk/ability) && !domain_forbids_spells)
 			var/obj/item/bitrunning_disk/ability/ability_disk = disk
 
 			if(isnull(ability_disk.granted_action))
@@ -88,7 +98,7 @@
 			our_action.Grant(avatar)
 			continue
 
-		if(istype(disk, /obj/item/bitrunning_disk/item))
+		if(istype(disk, /obj/item/bitrunning_disk/item) && !domain_forbids_items)
 			var/obj/item/bitrunning_disk/item/item_disk = disk
 
 			if(isnull(item_disk.granted_item))

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -76,12 +76,19 @@
 /obj/machinery/quantum_server/proc/stock_gear(mob/living/carbon/human/avatar, mob/living/carbon/human/neo, datum/lazy_template/virtual_domain/generated_domain)
 	var/domain_forbids_items = generated_domain.forbids_disk_items
 	var/domain_forbids_spells = generated_domain.forbids_disk_spells
-	var/failed = FALSE
 
+	var/import_ban = list()
+	var/disk_ban = list()
 	if(domain_forbids_items)
-		to_chat(neo, span_warning("This domain forbids the use of smuggled digital equipment, your disk items will not be granted!"))
-	if(domain_forbids_spells)
-		to_chat(neo, span_warning("This domain forbids the use of imported abilities, your disk powers will not be granted!"))
+		import_ban += "smuggled digital equipment"
+		disk_ban += "items"
+	if(domain_forbid_spells)
+		import_ban += "imported_abilities"
+		disk_ban += "powers"
+	if(import_ban )
+		to_chat(neo, span_warning("This domain forbids the use of [english_list(import_ban)], your disk [english_list(disk_ban)] will not be granted!")))
+
+	var/failed = FALSE
 
 	// We don't need to bother going over the disks if neither of the types can be used.
 	if(domain_forbids_spells && domain_forbids_items)

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -82,7 +82,7 @@
 	if(domain_forbids_items)
 		import_ban += "smuggled digital equipment"
 		disk_ban += "items"
-	if(domain_forbid_spells)
+	if(domain_forbids_spells)
 		import_ban += "imported_abilities"
 		disk_ban += "powers"
 	if(import_ban)

--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -20,6 +20,10 @@
 	var/filename = "virtual_domain.dmm"
 	/// Any outfit that you wish to force on avatars. Overrides preferences
 	var/datum/outfit/forced_outfit
+	/// If this domain blocks the use of items from disks, for whatever reason
+	var/forbids_disk_items = FALSE
+	/// If this domain blocks the use of spells from disks, for whatever reason
+	var/forbids_disk_spells = FALSE
 	/// Information given to connected clients via ability
 	var/help_text
 	// Name to show in the UI


### PR DESCRIPTION

## About The Pull Request

Adds two variables to bitrunner domains, one for making them not spawn disk items, and one for making them not grant disk abilities to bitrunner characters on loading into the domain.

Not presently used in any domains, but will be a mystery tool that will help us later.
## Why It's Good For The Game

I've thought of a few pretty good domains but the ideas behind them fall apart a bit of joey bitrunner can bring a desword and fireball into them.
## Changelog
:cl:
code: Bitrunner domains can now have spells or items from disks disabled if the domain maker wants such a thing
/:cl:
