### PR TITLE
Rebalances advanced regenerative mesh recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -359,7 +359,7 @@
 		new /obj/item/stack/medical/suture/medicated(location)
 
 /datum/chemical_reaction/medicine/medmesh
-	required_reagents = list(/datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BURN
 
 /datum/chemical_reaction/medicine/medmesh/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)


### PR DESCRIPTION
## About The Pull Request

Modifies the amount of cellulose fibers needed to create an advanced regenerative mesh from 20u to 10u.
## Why It's Good For The Game

Currently, medicated sutures require 10u of cellulose fiber to create. This means they can be created directly from a (medium complexity) botany crossbreed, as the 5% cellulose fiber gene from tower caps can produce 10u cellulose fibers with the densified chemicals trait.

This change allows botanists to create a similar crossbreed which produces advanced regenerative meshes. Lavaland plants, mutations and crosspollination are still needed to complete this, so it's a similarly tough project to the existing suture plant.


## Changelog
:cl:

balance: reduces cellulose fibers required for advanced regenerative mesh creation from 20u to 10u

/:cl:
