### PR TITLE
Saggy fax

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -6,6 +6,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	icon = 'icons/obj/machines/fax.dmi'
 	icon_state = "fax"
 	density = TRUE
+	anchored_tabletop_offset = 6
 	power_channel = AREA_USAGE_EQUIP
 	max_integrity = 100
 	pass_flags = PASSTABLE


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/a635a4d3-ca3a-442b-8f58-98c60461713f)

## About The Pull Request

Makes faxes display with vertical offset when on a table.

## Why It's Good For The Game

Looks nice

## Changelog

:cl:
fix: The crew is instructed to place fax machines properly in the center of a table without hanging.
/:cl:

