### PR TITLE
Fixes Space Dragon Attacking

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -132,6 +132,7 @@
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(DOING_INTERACTION(src, DOAFTER_SOURCE_SPACE_DRAGON_INTERACTION)) // patience grasshopper
+		target.balloon_alert(src, "finish current action first!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(ismecha(target))

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -1,5 +1,7 @@
 /// The darkness threshold for space dragon when choosing a color
 #define DARKNESS_THRESHOLD 50
+/// Any interactions executed by the space dragon
+#define DOAFTER_SOURCE_SPACE_DRAGON_INTERACTION "space dragon interaction"
 
 /**
  * # Space Dragon
@@ -71,8 +73,6 @@
 	var/gust_tiredness = 30
 	/// Determines whether or not Space Dragon is in the middle of using wing gust.  If set to true, prevents him from moving and doing certain actions.
 	var/using_special = FALSE
-	/// Determines whether or not Space Dragon is currently tearing through a wall.
-	var/tearing_wall = FALSE
 	/// The color of the space dragon.
 	var/chosen_color
 	/// Minimum devastation damage dealt coefficient based on max health
@@ -86,6 +86,8 @@
 	AddElement(/datum/element/simple_flying)
 	add_traits(list(TRAIT_SPACEWALK, TRAIT_FREE_HYPERSPACE_MOVEMENT, TRAIT_NO_FLOATING_ANIM, TRAIT_HEALS_FROM_CARP_RIFTS), INNATE_TRAIT)
 	AddElement(/datum/element/content_barfer)
+	RegisterSignal(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(before_attack))
+	RegisterSignal(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, PROC_REF(after_attack))
 
 /mob/living/simple_animal/hostile/space_dragon/Login()
 	. = ..()
@@ -121,41 +123,65 @@
 	eaten.forceMove(loc)
 	eaten.Paralyze(5 SECONDS)
 
-/mob/living/simple_animal/hostile/space_dragon/AttackingTarget()
+/mob/living/simple_animal/hostile/space_dragon/proc/before_attack(datum/source, atom/target)
+	SIGNAL_HANDLER
 	if(using_special)
-		return
+		return COMPONENT_HOSTILE_NO_ATTACK
+
 	if(target == src)
 		to_chat(src, span_warning("You almost bite yourself, but then decide against it."))
-		return
+		return COMPONENT_HOSTILE_NO_ATTACK
+
+	if(DOING_INTERACTION(src, DOAFTER_SOURCE_SPACE_DRAGON_INTERACTION)) // patience grasshopper
+		return COMPONENT_HOSTILE_NO_ATTACK
+
 	if(iswallturf(target))
-		if(tearing_wall)
-			return
-		tearing_wall = TRUE
-		var/turf/closed/wall/thewall = target
-		to_chat(src, span_warning("You begin tearing through the wall..."))
-		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
-		var/timetotear = 40
-		if(istype(target, /turf/closed/wall/r_wall))
-			timetotear = 120
-		if(do_after(src, timetotear, target = thewall))
-			if(isopenturf(thewall))
-				return
-			thewall.dismantle_wall(1)
-			playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
-		tearing_wall = FALSE
-		return
+		INVOKE_ASYNC(src, PROC_REF(tear_down_wall), target)
+		return COMPONENT_HOSTILE_NO_ATTACK
+
 	if(isliving(target)) //Swallows corpses like a snake to regain health.
-		var/mob/living/L = target
-		if(L.stat == DEAD)
-			to_chat(src, span_warning("You begin to swallow [L] whole..."))
-			if(do_after(src, 30, target = L))
-				if(eat(L))
-					adjustHealth(-L.maxHealth * 0.25)
-			return
-	. = ..()
+		var/mob/living/living_target = target
+		if(living_target.stat != DEAD)
+			return // go ham on slapping the shit out of them buddy
+
+		INVOKE_ASYNC(src, PROC_REF(eat_this_corpse), living_target)
+		return COMPONENT_HOSTILE_NO_ATTACK
+
+/mob/living/simple_animal/hostile/space_dragon/proc/after_attack(datum/source, atom/target)
+	SIGNAL_HANDLER
 	if(ismecha(target))
-		var/obj/vehicle/sealed/mecha/M = target
-		M.take_damage(50, BRUTE, MELEE, 1)
+		target.take_damage(50, BRUTE, MELEE, 1)
+
+/// Handles tearing down a wall. Returns TRUE if successful, FALSE otherwise.
+/mob/living/simple_animal/hostile/space_dragon/proc/tear_down_wall(turf/closed/wall/wall_target)
+	to_chat(src, span_warning("You begin tearing through the wall..."))
+	playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
+
+	var/time_to_tear = 4 SECONDS
+	if(istype(wall_target, /turf/closed/wall/r_wall))
+		time_to_tear = 12 SECONDS
+
+	if(!do_after(src, time_to_tear, target = wall_target, interaction_key = DOAFTER_SOURCE_SPACE_DRAGON_INTERACTION))
+		return FALSE
+
+	if(isopenturf(wall_target))
+		return FALSE // well the thing was destroyed while we were sleeping so that's nice, but we didn't successfully tear it down. whatever
+
+	wall_target.dismantle_wall(devastated = TRUE)
+	playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
+	return TRUE
+
+/// Handles eating a corpse, giving us a bit of health back. Returns TRUE if we were sucessful in eating, FALSE otherwise.
+/mob/living/simple_animal/hostile/space_dragon/proc/eat_this_corpse(mob/living/corpse)
+	to_chat(src, span_warning("You begin to swallow the body of [corpse] whole..."))
+
+	if(!do_after(src, 3 SECONDS, target = corpse, interaction_key = DOAFTER_SOURCE_SPACE_DRAGON_INTERACTION))
+		return FALSE
+	if(!eat(corpse))
+		return FALSE
+
+	adjustHealth(-(corpse.maxHealth * 0.25))
+	return TRUE
 
 /mob/living/simple_animal/hostile/space_dragon/ranged_secondary_attack(atom/target, modifiers)
 	if(using_special)
@@ -416,3 +442,4 @@
 	mind.add_antag_datum(/datum/antagonist/space_dragon)
 
 #undef DARKNESS_THRESHOLD
+#undef DOAFTER_SOURCE_SPACE_DRAGON_INTERACTION


### PR DESCRIPTION
Fixes #78953

## About The Pull Request

Basically the gist is that Space Dragon's special attack code was on `AttackingTarget()` rather than whatever the hell simple animals controlled by clients use (I didn't bother enough to look into the chain to remember this). This was the complete wrong proc to use, and it NEVER got executed. Anyways, we just hook into the signal for whatever the simple animal proc is as well as clean up all the code, make everything pretty, and most importantly:

MAKE THE DAMN CODE WORK
## Why It's Good For The Game

Either someone did not test their code at all, or some weird esoteric change in the attack chain changed this somehow? I'm not sure when or why this happened but it is guaranteed to be fixed now.

The code cleanup and tinkering I did means that it's gonna be about 10% easier to port this over to a basic mob eventually (not doing a full refactor when this shit is this broken, the code added here is modular enough to the point where it's plug-n-play).
## Changelog
:cl:
fix: Space Dragons can now, once again, tear down walls and eat corpses. They also have regained their special damage modifier when attacking mechs.
/:cl:
