### PR TITLE
Simplemob AttackingTarget Fix

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -293,6 +293,7 @@
 
 /mob/living/simple_animal/hostile/resolve_unarmed_attack(atom/attack_target, list/modifiers)
 	GiveTarget(attack_target)
+	INVOKE_ASYNC(src, PROC_REF(AttackingTarget), attack_target)
 	return ..()
 
 #undef LIVING_UNARMED_ATTACK_BLOCKED

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -294,7 +294,6 @@
 /mob/living/simple_animal/hostile/resolve_unarmed_attack(atom/attack_target, list/modifiers)
 	GiveTarget(attack_target)
 	INVOKE_ASYNC(src, PROC_REF(AttackingTarget), attack_target)
-	return ..()
 
 #undef LIVING_UNARMED_ATTACK_BLOCKED
 


### PR DESCRIPTION
## About The Pull Request

Fixes #78953, plus some unreported code issues with lavaland elites, player-controlled megafauna, and a couple other hostile simplemobs.

Basically, the sort of "attack wrapper" use of AttackingTarget seen in some simplemobs, specifically when player-controlled, was accidentally removed in the hands element refactor PR. This PR just re-adds that usage for player simplemobs to preserve previous functionality for our remaining simplemobs until their time to be refactored comes.

## Why It's Good For The Game

While we're more geared towards basic mobs and simplemob conversions currently, we should still aim to preserve simplemob functionality until we don't have them anymore.

## Changelog
:cl:
fix: Space Dragon can break walls, eat corpses and destroy mechs more efficiently again
fix: Player-controlled lavaland elites can once again return to their tumor after winning their fight
/:cl: