### PR TITLE
Adds a single airlock inbetween the holding cells and visitation of perma

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12100,12 +12100,6 @@
 /obj/item/cultivator/rake,
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/aft)
-"dAA" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation"
-	},
-/turf/closed/wall/r_wall,
-/area/station/security/prison/visit)
 "dAB" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Research Director Observation";
@@ -169800,7 +169794,7 @@ eDq
 iXh
 lWb
 hRp
-dAA
+dAZ
 wqI
 xSn
 dUO

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12100,6 +12100,12 @@
 /obj/item/cultivator/rake,
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/aft)
+"dAA" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation"
+	},
+/turf/closed/wall/r_wall,
+/area/station/security/prison/visit)
 "dAB" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Research Director Observation";
@@ -15601,7 +15607,10 @@
 /area/station/commons/dorms)
 "eGz" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "eGA" = (
@@ -169791,7 +169800,7 @@ eDq
 iXh
 lWb
 hRp
-dAZ
+dAA
 wqI
 xSn
 dUO


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/tgstation/assets/62606051/7c60ae0c-3931-40b2-87e5-61e653ef3a96)
## Why It's Good For The Game
It makes no sense that sec have to walk all the way around just to open up the door and / or shutters for any visitors. Now the warden can let people use visitation without leaving the brig.
## Changelog
:cl:
qol: Icebox Visitation now has a door connected to brig
/:cl:
