### PR TITLE
Makes fuel tanks explode again

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -178,7 +178,7 @@
 		// It did not account for how much fuel was actually in the tank at all, just the size of the tank.
 		// I encourage others to better scale these numbers in the future.
 		// As it stands this is a minor nerf in exchange for an easy bombing technique working that has been broken for a while.
-		switch(volatiles.volume)
+		switch(fuel_amt)
 			if(25 to 150)
 				explosion(src, light_impact_range = 1, flame_range = 2)
 			if(150 to 300)


### PR DESCRIPTION
## About The Pull Request

Fixes fuel tanks so they explode again. Very weird bug which I will walk through below using the old code for reference.

```
/obj/structure/reagent_dispensers/proc/boom()
	if(QDELETED(src))
		return // little bit of sanity sauce before we wreck ourselves somehow
	var/datum/reagent/fuel/volatiles = reagents.has_reagent(/datum/reagent/fuel)
	var/fuel_amt = 0
	if(istype(volatiles) && volatiles.volume >= 25)
		fuel_amt = volatiles.volume
		reagents.del_reagent(/datum/reagent/fuel) // not actually used for the explosion
	if(reagents.total_volume)
		if(!fuel_amt)
			visible_message(span_danger("\The [src] ruptures!"))
		// Leave it up to future terrorists to figure out the best way to mix reagents with fuel for a useful boom here
		chem_splash(loc, null, 2 + (reagents.total_volume + fuel_amt) / 1000, list(reagents), extra_heat=(fuel_amt / 50),adminlog=(fuel_amt<25))

	if(fuel_amt) // with that done, actually explode
		visible_message(span_danger("\The [src] explodes!"))
		// old code for reference:
		// standard fuel tank = 1000 units = heavy_impact_range = 1, light_impact_range = 5, flame_range = 5
		// big fuel tank = 5000 units = devastation_range = 1, heavy_impact_range = 2, light_impact_range = 7, flame_range = 12
		// It did not account for how much fuel was actually in the tank at all, just the size of the tank.
		// I encourage others to better scale these numbers in the future.
		// As it stands this is a minor nerf in exchange for an easy bombing technique working that has been broken for a while.
		switch(volatiles.volume)
			if(25 to 150)
				explosion(src, light_impact_range = 1, flame_range = 2)
			if(150 to 300)
				explosion(src, light_impact_range = 2, flame_range = 3)
			if(300 to 750)
				explosion(src, heavy_impact_range = 1, light_impact_range = 3, flame_range = 5)
			if(750 to 1500)
				explosion(src, heavy_impact_range = 1, light_impact_range = 4, flame_range = 6)
			if(1500 to INFINITY)
				explosion(src, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 6, flame_range = 8)
	qdel(src)
```

The fuel in the tank is converted into `volatiles`
```
var/datum/reagent/fuel/volatiles = reagents.has_reagent(/datum/reagent/fuel)
```

The `fuel_amt` var is zeroed out, we will recalculate this below
```
var/fuel_amt = 0
```

If there's enough for the tank to explode, this is converted back into `fuel_amt` and the actual reagent is deleted.
```
if(istype(volatiles) && volatiles.volume >= 25)
		fuel_amt = volatiles.volume
		reagents.del_reagent(/datum/reagent/fuel) // not actually used for the explosion
```

If there was fuel in the tank, select the appropriate explosion size depending on the volume of volatiles. As of recently this `volatiles.volume` became zero by this point due to the deletion of the fuel reagent above. Investigation of why this behaviour changed is still ongoing.
```
	if(fuel_amt) // with that done, actually explode
		visible_message(span_danger("\The [src] explodes!"))
		switch(volatiles.volume)
			if(25 to 150)
				explosion(src, light_impact_range = 1, flame_range = 2)
                        if(...
```

Going forward, replacing the switch statement with one checking `fuel_amt` is safer as it's not relying on something we already tried to delete, and is guaranteed to have the same effect as `fuel_amt = volatiles.volume`

Fixes #78975

## Why It's Good For The Game

Fuel tanks should explode.

## Changelog
:cl:
fix: Fuel tanks are explosive again
/:cl:
