### PR TITLE
[NO GBP]Removes excess call to `update_total()`

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -89,7 +89,6 @@
 	for (var/obj/O in (container.contents-result_obj))
 		if (O.reagents)
 			O.reagents.del_reagent(/datum/reagent/consumable/nutriment)
-			O.reagents.update_total()
 			O.reagents.trans_to(result_obj, O.reagents.total_volume)
 		qdel(O)
 	container.reagents.clear_reagents()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -178,7 +178,7 @@
 		// It did not account for how much fuel was actually in the tank at all, just the size of the tank.
 		// I encourage others to better scale these numbers in the future.
 		// As it stands this is a minor nerf in exchange for an easy bombing technique working that has been broken for a while.
-		switch(volatiles.volume)
+		switch(fuel_amt)
 			if(25 to 150)
 				explosion(src, light_impact_range = 1, flame_range = 2)
 			if(150 to 300)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -178,7 +178,7 @@
 		// It did not account for how much fuel was actually in the tank at all, just the size of the tank.
 		// I encourage others to better scale these numbers in the future.
 		// As it stands this is a minor nerf in exchange for an easy bombing technique working that has been broken for a while.
-		switch(fuel_amt)
+		switch(volatiles.volume)
 			if(25 to 150)
 				explosion(src, light_impact_range = 1, flame_range = 2)
 			if(150 to 300)


### PR DESCRIPTION
## About The Pull Request
This is a relatively hot proc. no need to call `update_total()` after you call `del_reagent()` because it calls it for you

## Changelog
:cl:
code: removed unnecessary calls to `update_total()`
/:cl:
