### PR TITLE
Fixes a bug with the plasma flower core MODsuit that would cause a butterfly murder scene wherever there were turrets

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -399,7 +399,7 @@
 	SIGNAL_HANDLER
 	if(mod.active)
 		particle_effect = new(mod.wearer, /particles/pollen, PARTICLE_ATTACH_MOB)
-		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, spawn_types=list(spawned_mob_type), spawn_time=5 SECONDS, max_spawned=3)
+		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, spawn_types=list(spawned_mob_type), spawn_time=5 SECONDS, max_spawned=3, faction=list(FACTION_NEUTRAL))
 		RegisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED, PROC_REF(new_mob))
 		RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(spread_flowers))
 

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -399,7 +399,7 @@
 	SIGNAL_HANDLER
 	if(mod.active)
 		particle_effect = new(mod.wearer, /particles/pollen, PARTICLE_ATTACH_MOB)
-		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, spawn_types=list(spawned_mob_type), spawn_time=5 SECONDS, max_spawned=3, faction=list(FACTION_NEUTRAL))
+		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, spawn_types=list(spawned_mob_type), spawn_time=5 SECONDS, max_spawned=3, faction=mod.wearer.faction)
 		RegisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED, PROC_REF(new_mob))
 		RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(spread_flowers))
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24306

The butterfly effect. 

The "MOD plasma flower core" spawns temporary butterflies using a `/datum/component/spawner`, which is nice and cute. Until you start getting shot at by turrets because spawners assign the faction of the mob to `MOB_MINING` by default.

Fixes that.

## Why It's Good For The Game

No more being murdered by your butterflies.

![dreamseeker_bxeIGl84sS](https://github.com/tgstation/tgstation/assets/13398309/96690e19-c541-4209-85a0-3f3f667e5f2b)

## Changelog

:cl:
fix: Fixes a bug with the plasma flower core MODsuit that would cause a butterfly murder scene wherever there were turrets
/:cl:
