### PR TITLE
Summoning affix fixes

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -35,10 +35,11 @@ GLOBAL_LIST_INIT(abstract_mob_types, list(
 	/mob/living/simple_animal/hostile/construct,
 	/mob/living/simple_animal/hostile/guardian,
 	/mob/living/simple_animal/hostile/megafauna,
-	/mob/living/simple_animal/hostile/mimic,
+	/mob/living/simple_animal/hostile/mimic, // Cannot exist if spawned without being passed an item reference
 	/mob/living/simple_animal/hostile/retaliate,
 	/mob/living/simple_animal/hostile,
 	/mob/living/simple_animal/pet,
+	/mob/living/simple_animal/soulscythe, // As mimic, can't exist if spawned outside an item
 	/mob/living/simple_animal,
 ))
 

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -12,6 +12,36 @@ GLOBAL_LIST_INIT(dangerous_turfs, typecacheof(list(
 	/turf/open/space,
 	/turf/open/openspace)))
 
+/// List of types of abstract mob which shouldn't usually exist in the world on its own if we're spawning random mobs
+GLOBAL_LIST_INIT(abstract_mob_types, list(
+	/mob/living/basic/blob_minion,
+	/mob/living/basic/construct,
+	/mob/living/basic/heretic_summon,
+	/mob/living/basic/mining,
+	/mob/living/basic/pet,
+	/mob/living/basic,
+	/mob/living/basic/spider,
+	/mob/living/carbon/alien/adult,
+	/mob/living/carbon/alien,
+	/mob/living/carbon/human/consistent,
+	/mob/living/carbon/human/dummy/consistent,
+	/mob/living/carbon/human/dummy,
+	/mob/living/carbon/human/species,
+	/mob/living/carbon,
+	/mob/living/silicon,
+	/mob/living/simple_animal/bot,
+	/mob/living/simple_animal/hostile/asteroid/elite,
+	/mob/living/simple_animal/hostile/asteroid,
+	/mob/living/simple_animal/hostile/construct,
+	/mob/living/simple_animal/hostile/guardian,
+	/mob/living/simple_animal/hostile/megafauna,
+	/mob/living/simple_animal/hostile/mimic,
+	/mob/living/simple_animal/hostile/retaliate,
+	/mob/living/simple_animal/hostile,
+	/mob/living/simple_animal/pet,
+	/mob/living/simple_animal,
+))
+
 
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -116,7 +116,6 @@
 		var/list/mob_subtype_blacklist = list(
 			/mob/living/simple_animal/hostile/asteroid/elite,
 			/mob/living/simple_animal/hostile/megafauna,
-			/mob/living/simple_animal/soulscythe,
 		)
 		for(var/type in mob_subtype_blacklist)
 			possible_mobtypes -= subtypesof(type)

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -103,30 +103,36 @@
 	. = ..()
 	// This is set up to be easy to add to these lists as I expect it will need modifications
 	var/static/list/possible_mobtypes
-	if(!possible_mobtypes)
-		// The base list of allowed mob/species types
-		possible_mobtypes = zebra_typecacheof(list(
-			/mob/living/simple_animal = TRUE,
-			/mob/living/carbon = TRUE,
-			/datum/species = TRUE,
-			// Some types to remove them and their subtypes
-			/mob/living/carbon/human/species = FALSE,
-			/mob/living/simple_animal/hostile/asteroid/elite = FALSE,
-			/mob/living/simple_animal/hostile/megafauna = FALSE,
-		))
-		// Some particular types to disallow if they're too broad/abstract
-		// Not in the above typecache generator because it includes subtypes and this doesn't.
-		possible_mobtypes -= list(
-			/mob/living/simple_animal/hostile,
+	if(isnull(possible_mobtypes))
+		possible_mobtypes = list()
+		var/list/mob_subtype_whitelist = list(
+			/mob/living/basic,
+			/mob/living/carbon,
+			/mob/living/simple_animal,
 		)
+		for(var/type in mob_subtype_whitelist)
+			possible_mobtypes += subtypesof(type)
+
+		var/list/mob_subtype_blacklist = list(
+			/mob/living/simple_animal/hostile/asteroid/elite,
+			/mob/living/simple_animal/hostile/megafauna,
+			/mob/living/simple_animal/soulscythe,
+		)
+		for(var/type in mob_subtype_blacklist)
+			possible_mobtypes -= subtypesof(type)
+
+		possible_mobtypes -= GLOB.abstract_mob_types
 
 	var/mob/picked_mobtype = pick(possible_mobtypes)
-	// This works even with the species picks since we're only accessing the name
-
 	var/obj/item/master = comp.parent
-	var/max_mobs = max(CEILING(comp.quality/2, 1), 1)
-	var/spawn_delay = 300 - 30 * comp.quality
-	comp.appliedComponents += master.AddComponent(/datum/component/summoning, list(picked_mobtype), 100, max_mobs, spawn_delay)
+	var/max_mobs = max(CEILING(comp.quality / 2, 1), 1)
+	var/spawn_delay = 30 SECONDS - (3 SECONDS * comp.quality)
+	comp.appliedComponents += master.AddComponent(\
+		/datum/component/summoning,\
+		mob_types = list(picked_mobtype),\
+		max_mobs = max_mobs,\
+		spawn_delay = spawn_delay,\
+	)
 	return "[newName] of [initial(picked_mobtype.name)] summoning"
 
 /datum/fantasy_affix/shrapnel

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -498,7 +498,6 @@
 			return
 		var/datum/fantasy_affix/affix = affixes[picked_affix_name]
 		affixes.Remove(affix)
-		QDEL_LIST_ASSOC(affixes) //remove the rest, we didn't use them
 		var/fantasy_quality = 0
 		if(affix.alignment & AFFIX_GOOD)
 			fantasy_quality++


### PR DESCRIPTION
## About The Pull Request

The fantasy "summon x" affix blacklist doesn't work, and probably hasn't worked for a significant amount of time.
This is because it generated a typecache with true/false values representing whether we should be able to spawn a mob... and then performed a `pick` on it. Pick doesn't care if the value is true or false, so everything in the blacklist was explicitly whitelisted.

For some reason the list was also containing subtypes of a datum? Then passing this to a component which expected typepaths of mobs it could spawn? That doesn't work either.

We _also_ never added basic mobs to this list, so it would never spawn those and they're an increasing number of our mobs total.

While I was there I also just did some general code tidying. I moved the list of "specific subtypes to remove" to a global list because I suspect something else either will need it in the future or already does.

## Changelog

:cl:
fix: Megafauna, lavaland elites, and abstract mobs now correctly cannot be spawned by a toolbox of ash drake summoning
/:cl:
