### PR TITLE
reload savefile on pref assosciation

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -266,6 +266,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	prefs = GLOB.preferences_datums[ckey]
 	if(prefs)
 		prefs.parent = src
+		prefs.load_savefile() // just to make sure we have the latest data
 		prefs.apply_all_client_preferences()
 	else
 		prefs = new /datum/preferences(src)


### PR DESCRIPTION

## About The Pull Request

Tells the preferences datum to reload the savefile when we associate to an already existing one
## Why It's Good For The Game

This trolled me locally for a good hour wondering "why aren't my prefs updating when I swap out the file"
## Changelog
