### PR TITLE
Advanced Robotics Techweb Tweak and General Techweb QOL

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -365,6 +365,10 @@
 			add_experiments(unlocked_node.discount_experiments)
 		update_node_status(unlocked_node)
 
+	// Gain more new experiments
+	if (node.experiments_to_unlock.len)
+		add_experiments(node.experiments_to_unlock)
+
 	// Unlock what the research actually unlocks
 	for(var/id in node.design_ids)
 		add_design_by_id(id)

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -36,6 +36,8 @@
 	var/list/required_experiments = list()
 	/// If completed, these experiments give a specific point amount discount to the node.area
 	var/list/discount_experiments = list()
+	/// When this node is completed, allows these experiments to be performed.
+	var/list/experiments_to_unlock = list()
 	/// Whether or not this node should show on the wiki
 	var/show_on_wiki = TRUE
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -128,6 +128,14 @@
 		"voice_analyzer",
 		"watering_can",
 	)
+	experiments_to_unlock = list(
+		/datum/experiment/autopsy/nonhuman,
+		/datum/experiment/scanning/random/material/medium/one,
+		/datum/experiment/scanning/random/material/medium/three,
+		/datum/experiment/scanning/random/material/hard/one,
+		/datum/experiment/scanning/random/material/hard/two,
+		/datum/experiment/scanning/people/novel_organs,
+	)
 
 /datum/techweb_node/mmi
 	id = "mmi"
@@ -630,6 +638,7 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/easy = 7500)
+	experiments_to_unlock = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_microlaser)
 
 /datum/techweb_node/adv_engi
 	id = "adv_engi"
@@ -911,7 +920,7 @@
 	id = "adv_robotics"
 	display_name = "Advanced Robotics Research"
 	description = "Machines using actual neural networks to simulate human lives."
-	prereq_ids = list("neural_programming", "robotics")
+	prereq_ids = list("robotics")
 	design_ids = list(
 		"mmi_posi",
 	)


### PR DESCRIPTION
## About The Pull Request

This PR is half a successor to #77399, and half QOL changes. When I made the old PR, I originally wanted to add a scanning experiment to the advanced robotics node, but several people (including at least one maintainer) had reservations with this idea. My plan was to make the experiment be completed automatically, instead of needing someone to wave the scanner around, but as it turns out the experiment system is just fundamentally not designed for experiments like that.

Now I've realized that there doesn't really need to be a new experiment. So now the advanced robotics node is just not dependent on neural programming, and that's it. No cost increase, no experiment needed.

As for the QOL changes, it just allows certain experiments to be completed earlier than they otherwise would be. Normally, for an experiment to even be available for completion, you need to get at least one prerequisite node for one of the nodes the experiment benefits (as in, one of the nodes it is required for or grants a discount too). However, this sometimes means that you can't complete an experiment even if you have the means to do it. Nonhuman autopsy is a good example; you can autopsy a nonhuman corpse right at the start of a round, but the experiment won't actually be completed unless biological technology has been researched. The tier two laser experiment is another example. You get access to tier two lasers necessary for the experiment by researching industrial technology, but the experiment itself is locked behind electromagnetic theory.

Now, the nonhuman autopsy experiment, divergent biology experiment, and all medium and high grade material scanning experiments are unlocked round-start. The tier two lasers experiment is unlocked by industrial engineering.
## Why It's Good For The Game

For the advanced robotics change, I'll just quote myself from the last PR:
> Robotics should not be dependent on an entirely different department to access their core job content. Such dependencies encourage tiding and other toxic interactions between departments. 

For the QOL changes, it makes the whole system a lot more newbie-friendly. For the autopsy especially, its common to see new coroners autopsy the nonhuman bodies first and the human one second. This means that, when the nonhuman autopsy experiment is actually unlocked, there aren't any nonhuman bodies left to autopsy. Now it doesn't matter which order they're autopsied in.
## Changelog
:cl:
qol: Nonhuman autopsy, Tier Two Lasers, and several other experiments can now be completed earlier.
balance: Advanced robotics techweb node no longer requires neural programming node.
/:cl:
