### PR TITLE
Ballistics do more environmental damage

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -294,6 +294,8 @@ GLOBAL_LIST_INIT(arm_zones, list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 
 #define NICE_SHOT_RICOCHET_BONUS 10 //if the shooter has the NICE_SHOT trait and they fire a ricocheting projectile, add this to the ricochet chance and auto aim angle
 
+#define BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY 10 //Minimum damage physical bullets need to do to trigger special effects and/or destroy on some machines
+
 /// If a carbon is thrown at a speed faster than normal and impacts something solid, they take extra damage for every extra speed up to this number (see [/mob/living/carbon/proc/throw_impact])
 #define CARBON_MAX_IMPACT_SPEED_BONUS 5
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -294,7 +294,7 @@ GLOBAL_LIST_INIT(arm_zones, list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 
 #define NICE_SHOT_RICOCHET_BONUS 10 //if the shooter has the NICE_SHOT trait and they fire a ricocheting projectile, add this to the ricochet chance and auto aim angle
 
-#define BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY 10 //Minimum damage physical bullets need to do to trigger special effects and/or destroy on some machines
+#define BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY 8 //Minimum damage physical bullets need to do to trigger special effects and/or destroy on some machines
 
 /// If a carbon is thrown at a speed faster than normal and impacts something solid, they take extra damage for every extra speed up to this number (see [/mob/living/carbon/proc/throw_impact])
 #define CARBON_MAX_IMPACT_SPEED_BONUS 5

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -169,6 +169,19 @@
 /datum/wires/proc/cut_random(source)
 	cut(wires[rand(1, wires.len)], source)
 
+//Randomly cut a wire and but dont try to mend any
+/datum/wires/proc/cut_random_dont_mend(source)
+	//Create a list of all uncut wires
+	var/list/uncut_wires = list()
+	for (var/this_wire in wires)
+		if (this_wire in cut_wires)
+			continue
+		uncut_wires += this_wire
+
+	//If there are any wires we can cut, cut a random one
+	if (uncut_wires.len > 0)
+		cut(uncut_wires[rand(1, uncut_wires.len)], source)
+
 /datum/wires/proc/cut_all(source)
 	for(var/wire in wires)
 		cut(wire, source)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -50,7 +50,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 
 /datum/armor/machinery_camera
 	melee = 50
-	bullet = 20
 	laser = 20
 	energy = 20
 	fire = 90

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -582,10 +582,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 //If hit with a bullet, simply break if it does enough damge
 /obj/machinery/camera/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag in list(ENERGY, LASER))
+	if (bullet.armor_flag != BULLET)
 		return ..()
 
-	if (bullet.damage > 10)
+	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		atom_break()
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -581,10 +581,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 //If hit with a bullet, simply break if it does enough damge
 /obj/machinery/camera/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag != BULLET)
-		return ..()
-
-	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
+	if (bullet.armor_flag == BULLET && bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		atom_break()
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -578,3 +578,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 	else
 		user.clear_sight(SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	return 1
+
+//If hit with a bullet, simply break if it does enough damge
+/obj/machinery/camera/bullet_act(obj/projectile/bullet)
+	// Energy attacks dont do anything special
+	if (bullet.armor_flag in list(ENERGY, LASER))
+		return ..()
+
+	if (bullet.damage > 10)
+		do_sparks(number = 2, cardinal_only = FALSE, source = src)
+		atom_break()
+
+	return ..()

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -21,6 +21,7 @@
 	var/authenticated = FALSE
 
 /datum/armor/machinery_computer
+	bullet = -50
 	fire = 40
 	acid = 20
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1602,8 +1602,8 @@
 		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		//The number of wires a bullet will randomly cut
 		var/number_of_wires_bullet_cuts = 3
-		for (var/wire = 1 to number_of_wires_bullet_cuts)
-			src.wires.cut_random_dont_mend()
+		for (var/i in 1 to number_of_wires_bullet_cuts)
+			wires.cut_random_dont_mend()
 
 	return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1594,11 +1594,11 @@
 //If a bullet does enough damage, it randomly cuts some wires
 /obj/machinery/door/airlock/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag in list(ENERGY, LASER))
+	if (bullet.armor_flag != BULLET)
 		return ..()
 
 	// Dont cut the wires if the airlock has been reinforced with something above iron
-	if (bullet.damage > 10 && security_level <= AIRLOCK_SECURITY_IRON)
+	if (bullet.damage > BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY && security_level <= AIRLOCK_SECURITY_IRON)
 		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		//The number of wires a bullet will randomly cut
 		var/number_of_wires_bullet_cuts = 3

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1603,7 +1603,7 @@
 		//The number of wires a bullet will randomly cut
 		var/number_of_wires_bullet_cuts = 3
 		for (var/wire = 1 to number_of_wires_bullet_cuts)
-			src.wires.cut_random()
+			src.wires.cut_random_dont_mend()
 
 	return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1591,6 +1591,23 @@
 	else if(istype(note, /obj/item/photo))
 		return "photo_[frame_state]"
 
+//If a bullet does enough damage, it randomly cuts some wires
+/obj/machinery/door/airlock/bullet_act(obj/projectile/bullet)
+	// Energy attacks dont do anything special
+	if (bullet.armor_flag in list(ENERGY, LASER))
+		return ..()
+
+	// Dont cut the wires if the airlock has been reinforced with something above iron
+	if (bullet.damage > 10 && security_level <= AIRLOCK_SECURITY_IRON)
+		do_sparks(number = 2, cardinal_only = FALSE, source = src)
+		//The number of wires a bullet will randomly cut
+		var/number_of_wires_bullet_cuts = 3
+		for (var/wire = 1 to number_of_wires_bullet_cuts)
+			src.wires.cut_random()
+
+	return ..()
+
+
 /obj/machinery/door/airlock/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -577,3 +577,19 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
 
 	if(COMPONENT_TRIGGERED_BY(reset_trigger, port))
 		attached_alarm?.reset()
+
+// When a bullet hits us, trigger the fire alarm, if it does enough damage also outright destroy the firealarm
+/obj/machinery/firealarm/bullet_act(obj/projectile/bullet)
+	// Energy attacks dont do anything special
+	if (bullet.armor_flag in list(ENERGY, LASER))
+		return ..()
+
+	// Trigger the alarm
+	if (buildstage == FIRE_ALARM_BUILD_SECURED)
+		alarm()
+
+	if (bullet.damage > 10)
+		do_sparks(number = 5, cardinal_only = FALSE, source = src)
+		atom_break()
+
+	return ..()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -581,14 +581,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
 // When a bullet hits us, trigger the fire alarm, if it does enough damage also outright destroy the firealarm
 /obj/machinery/firealarm/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag in list(ENERGY, LASER))
+	if (bullet.armor_flag != BULLET)
 		return ..()
 
 	// Trigger the alarm
 	if (buildstage == FIRE_ALARM_BUILD_SECURED)
 		alarm()
 
-	if (bullet.damage > 10)
+	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		do_sparks(number = 5, cardinal_only = FALSE, source = src)
 		atom_break()
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -218,7 +218,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	if (bullet.armor_flag != BULLET)
 		return ..()
 
-	//Knock if the bullet does enough damage, knock the intercom down
+	//If the bullet does enough damage, knock the intercom down
 	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		knock_down()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -213,6 +213,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	icon_state = "intercom_command"
 	freerange = TRUE
 
+/obj/item/radio/intercom/bullet_act(obj/projectile/bullet)
+	// Energy attacks dont do anything special
+	if (bullet.armor_flag in list(ENERGY, LASER))
+		return ..()
+
+	//Knock if the bullet does enough damage, knock the intercom down
+	if (bullet.damage > 10)
+		knock_down()
+	else
+		return ..()
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/command, 26)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -220,6 +220,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 
 	//Knock if the bullet does enough damage, knock the intercom down
 	if (bullet.damage > 10)
+		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		knock_down()
 	else
 		return ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -215,11 +215,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 
 /obj/item/radio/intercom/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag in list(ENERGY, LASER))
+	if (bullet.armor_flag != BULLET)
 		return ..()
 
 	//Knock if the bullet does enough damage, knock the intercom down
-	if (bullet.damage > 10)
+	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		do_sparks(number = 2, cardinal_only = FALSE, source = src)
 		knock_down()
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -39,6 +39,7 @@
 
 /datum/armor/structure_window
 	melee = 50
+	bullet = -100
 	fire = 80
 	acid = 100
 
@@ -470,6 +471,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 //2023 ONE YEAR TO GO! -LT3
 /datum/armor/window_reinforced
 	melee = 80
+	bullet = -75
 	bomb = 25
 	fire = 80
 	acid = 100

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -701,9 +701,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 		/datum/air_alarm_mode/siphon,
 		/datum/air_alarm_mode/panic_siphon,
 		/datum/air_alarm_mode/off,
-		/datum/air_alarm_mode/flood,
-		/datum/air_alarm_mode/vent_siphon,
 	)
+
+	if(obj_flags & EMAGGED)
+		possible_random_modes += list(
+			/datum/air_alarm_mode/flood,
+			/datum/air_alarm_mode/vent_siphon,
+		)
 
 	var/datum/air_alarm_mode/chosen_mode = possible_random_modes[rand(1, possible_random_modes.len)]
 

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -690,4 +690,23 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	update_appearance()
 	update_name()
 
+//Select a random mode and switch to it
+/obj/machinery/airalarm/proc/select_random_mode()
+	var/list/possible_random_modes = list(
+		/datum/air_alarm_mode/filtering,
+		/datum/air_alarm_mode/contaminated,
+		/datum/air_alarm_mode/draught,
+		/datum/air_alarm_mode/refill,
+		/datum/air_alarm_mode/cycle,
+		/datum/air_alarm_mode/siphon,
+		/datum/air_alarm_mode/panic_siphon,
+		/datum/air_alarm_mode/off,
+		/datum/air_alarm_mode/flood,
+		/datum/air_alarm_mode/vent_siphon,
+	)
+
+	var/datum/air_alarm_mode/chosen_mode = possible_random_modes[rand(1, possible_random_modes.len)]
+
+	select_mode(source = src, mode_path = chosen_mode, should_apply = TRUE)
+
 #undef AIRALARM_WARNING_COOLDOWN

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
@@ -178,10 +178,10 @@
 //When a bullet hits us, if it does enough damage, choose a random mode and break
 /obj/machinery/airalarm/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag in list(ENERGY, LASER))
+	if (bullet.armor_flag != BULLET)
 		return ..()
 
-	if (bullet.damage > 10)
+	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		//Switch to a random mode
 		select_random_mode()
 

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
@@ -175,6 +175,22 @@
 	else
 		return FALSE
 
+//When a bullet hits us, if it does enough damage, choose a random mode and break
+/obj/machinery/airalarm/bullet_act(obj/projectile/bullet)
+	// Energy attacks dont do anything special
+	if (bullet.armor_flag in list(ENERGY, LASER))
+		return ..()
+
+	if (bullet.damage > 10)
+		//Switch to a random mode
+		select_random_mode()
+
+		do_sparks(number = 5, cardinal_only = FALSE, source = src)
+		atom_break()
+
+	return ..()
+
+
 /obj/item/electronics/airalarm
 	name = "air alarm electronics"
 	icon_state = "airalarm_electronics"

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -8,6 +8,7 @@
 	density = TRUE
 	max_integrity = 300
 	integrity_failure = 0.5
+	armor_type = /datum/armor/machinery_computer
 
 	///The power cell, null by default as we use the APC we're in
 	var/internal_cell = null

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -153,7 +153,7 @@
 			if(do_after(user, 20, target = src)) // replacing cover is quicker than replacing whole frame
 				balloon_alert(user, "cover replaced")
 				qdel(attacking_object)
-				update_integrity(30) //needs to be welded to fully repair but can work without
+				update_integrity(max(30, atom_integrity)) //needs to be welded to fully repair but can work without
 				set_machine_stat(machine_stat & ~(BROKEN|MAINT))
 				opened = APC_COVER_OPENED
 				update_appearance()

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -129,7 +129,6 @@
 
 /datum/armor/power_apc
 	melee = 20
-	bullet = 20
 	laser = 10
 	energy = 100
 	bomb = 30

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -720,10 +720,10 @@
 //If the bullet does enough damage, shock everyone in a 3 tile radius and break
 /obj/machinery/power/apc/bullet_act(obj/projectile/bullet)
 	// Energy attacks dont do anything special
-	if (bullet.armor_flag in list(ENERGY, LASER))
+	if (bullet.armor_flag != BULLET)
 		return ..()
 
-	if (bullet.damage > 12)
+	if (bullet.damage >= BULLET_MINIMUM_DAMAGE_NEEDED_TO_EXECUTE_MACHINERY)
 		//break and spark
 		do_sparks(number = 7, cardinal_only = FALSE, source = src)
 		atom_break()

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -716,3 +716,22 @@
 	name = "power control module"
 	icon_state = "power_mod"
 	desc = "Heavy-duty switching circuits for power control."
+
+//If the bullet does enough damage, shock everyone in a 3 tile radius and break
+/obj/machinery/power/apc/bullet_act(obj/projectile/bullet)
+	// Energy attacks dont do anything special
+	if (bullet.armor_flag in list(ENERGY, LASER))
+		return ..()
+
+	if (bullet.damage > 12)
+		//break and spark
+		do_sparks(number = 7, cardinal_only = FALSE, source = src)
+		atom_break()
+
+		//We zap if we are connected to the powernet and it has at least some power
+		if (main_status != APC_NO_POWER)
+			//I want to avoid energy net shenanigans, so lets just keep the zap damage constant
+			var/zap_joules = 4e6
+			tesla_zap(src, 5, zap_joules)
+
+	return ..()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -209,6 +209,7 @@
 
 /datum/armor/machinery_vending
 	melee = 20
+	bullet = -50
 	fire = 50
 	acid = 70
 

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -224,12 +224,14 @@ If you need to drag multiple people either to safety or to space, bring a locker
 If you're bleeding, you can apply pressure to the limb by grabbing yourself while targeting the bleeding limb. This will slow you down and take up a hand, but it'll slow down how fast you lose blood. Note this won't help the bleeding clot any faster.
 If you're using hotkey mode, you can stop pulling things using H.
 In a pinch, stripping yourself naked will give you a sizeable resistance to being tackled. What do you value more, your freedom or your dignity?
+Is your target getting away? Shoot out an APC to shut local airlocks off!
 Laying down will help slow down bloodloss. Death will halt it entirely.
 Maintenance is full of equipment that is randomized every round. Look around and see if anything is worth using.
 Most job-related exosuit clothing can fit job-related items into it, such as the atmospheric technician's winter coat holding an RPD, or labcoats holding most medicine.
 Most things have special interactions with right, alt, shift, and control click. Experiment!
 On most clothing items that go in the exosuit slot, you can put certain small items into your suit storage, such as a spraycan, your emergency oxygen tank, or a flashlight.
 Remote devices will work when used through cameras. For example: Bluespace RPEDs and door remotes.
+Security on your tail? Shoot out a firealarm to slow their pursuit! Just make sure you have a way to open firelocks.
 Sleeping can be used to recover from minor injuries and organ damage. Sanity, darkness, blindfolds, earmuffs, tables, beds, and bedsheets affect the healing rate.
 Some roles cannot be antagonists by default, but antag selection is decided first. For instance, you can set Security Officer to High without affecting your chances of becoming an antag -- the game will just select a different role.
 Some weapons are better at taking down robots and structures than others. Don't try to break a window with a scalpel, try a toolbox.


### PR DESCRIPTION
## About The Pull Request

Gives ballistics (specifically bullets with the BULLET armor_type, so no lasers) some additional functionality with environmental objects if they do enough damage (above 8)

- Windows, consoles, and vending machines take extra damage from bullets
- Instantly destroys APCs, if the APCs powernet has some charge it will also shock people in a 2 tile radius (extra if the electricity jumps, but that makes it do less damage)
- Bullets will cut random wires if they hit an airlock
- Bullets will trigger and then outright destroy fire alarms
- Bullets will set air alarms to a random mode, then outright destroy them
- Bullets will knock down intercoms
- Bullets will outright destroy security cameras

Also added tips for some of these.

## Why It's Good For The Game

Ive seen a couple people say that ballistics should be syndicate sided because they do more damage to the station, and while I though it was an interesting idea its not really supported by any game mechanics. Now station sided crew have more of a reason to use laser weaponry, while those who have access to ballistics can cause loads of station damage. I also think the it adds a lot of interesting interactions other than just shooting people with a gun till they die. Traitors could shoot an APC out to shut all local airlocks off or shock those near it. Or they could shoot an airlock a couple of times to lock pursuers off, or shoot a fire alarm on their way past it. It gives them a lot more options to create environmental destruction, which is also interesting for all crewmembers.


## Changelog

:cl: Seven
balance: Physical bullets do extra damage to windows, consoles, and vending machines.
add: Physical bullets now have some special interactions with some common machinery, along with outright destroying some!
add: This includes APCs, fire alarms, air alarms, airlocks, intercoms, and security cameras.
/:cl:

