### PR TITLE
Icebox medical bed [NO GBP]

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -69576,7 +69576,9 @@
 /area/station/engineering/atmos)
 "vtk" = (
 /obj/machinery/newscaster/directional/east,
-/obj/structure/bed/pod,
+/obj/structure/bed/medical/anchored{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)


### PR DESCRIPTION
## About The Pull Request

I missed one when replacing survival pod beds with medical beds.

## Changelog

:cl: LT3
fix: The remaining survival pod bed on Icebox is now a medical bed
/:cl: