### PR TITLE
Observers can now play CTF again. 

### DIFF
--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -152,11 +152,12 @@
 	if(player_mob.dna.species.outfit_important_for_life)
 		player_mob.set_species(/datum/species/human)
 
-	if(new_team_member.mob.mind?.current)
+	var/datum/mind/new_member_mind = new_team_member.mob.mind
+	if(new_member_mind?.current)
 		player_mob.AddComponent( \
 			/datum/component/temporary_body, \
-			old_mind = new_team_member.mob.mind, \
-			old_body = new_team_member.mob.mind.current, \
+			old_mind = new_member_mind, \
+			old_body = new_member_mind.current, \
 		)
 
 	player_mob.ckey = new_team_member.ckey

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -152,11 +152,12 @@
 	if(player_mob.dna.species.outfit_important_for_life)
 		player_mob.set_species(/datum/species/human)
 
-	player_mob.AddComponent( \
-		/datum/component/temporary_body, \
-		old_mind = new_team_member.mob.mind, \
-		old_body = new_team_member.mob.mind.current, \
-	)
+	if(new_team_member.mob.mind?.current)
+		player_mob.AddComponent( \
+			/datum/component/temporary_body, \
+			old_mind = new_team_member.mob.mind, \
+			old_body = new_team_member.mob.mind.current, \
+		)
 
 	player_mob.ckey = new_team_member.ckey
 	if(isnull(ctf_player_component))


### PR DESCRIPTION

## About The Pull Request

#78957 accidently made it so CTF could only be played by people with mobs to return to after dying. I've made it so those who don't have mobs to return to (e.g. roundstart observers) can play CTF again.
## Why It's Good For The Game

Everyone should be allowed to play CTF without needing to engage with the space roleplay game we've strapped on.
## Changelog
:cl:
fix: Players without bodies to return to can play CTF again.
/:cl:
