### PR TITLE
Gives broken canisters a description

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -287,6 +287,7 @@
 
 /obj/structure/fluff/broken_canister_frame
 	name = "broken canister frame"
+	desc = "A torn apart canister. It looks like some metal can be salvaged with a wrench."
 	icon_state = "broken_canister"
 	anchored = FALSE
 	density = TRUE


### PR DESCRIPTION

## About The Pull Request

A torn apart canister. It looks like some metal can be salvaged with a wrench.
## Why It's Good For The Game

It fixes a part of #79003, the rest seems like balance or qol changes. 
## Changelog
:cl:
spellcheck: Broken canisters now have a description
/:cl:
