### PR TITLE
Makes the active sonar stop destroying the game

### DIFF
--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -422,8 +422,10 @@
 			UnregisterSignal(creature, COMSIG_MOVABLE_MOVED)
 			return
 
-		if(oldgroup != newgroup)
-			sorted_creatures[oldgroup] -= creature
+		if(oldgroup == newgroup)
+			return
+			
+		sorted_creatures[oldgroup] -= creature
 
 	sorted_creatures[newgroup] += creature
 	keyed_creatures[creature] = newgroup


### PR DESCRIPTION

## About The Pull Request
Hey did you know the active sonar would just repeatedly add mobs to its internal list no matter if they were there already or not?

Yea.

Anyways that's fixed now, overtime is saved
## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/66052067/dea57189-034a-46a4-bee3-5d2a1f9eec61)
![kylo-kylo-ren](https://github.com/tgstation/tgstation/assets/66052067/8cbeca30-fd8b-451e-ab61-a91c7192f873)
## Changelog
:cl: Wallem
fix: The active sonar module won't attempt to create 6000000 new pings per process cycle anymore
/:cl:
