### PR TITLE
Make stoplag wait when starting back up before the MC is done

### DIFF
--- a/code/__HELPERS/stoplag.dm
+++ b/code/__HELPERS/stoplag.dm
@@ -21,6 +21,8 @@
 	do
 		. += CEILING(i * DELTA_CALC, 1)
 		sleep(i * world.tick_lag * DELTA_CALC)
+		if(Master.last_run != world.time)
+			sleep()
 		i *= 2
 	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
 #endif


### PR DESCRIPTION
@LemonInTheDark and I were talking about issues with heavy tick usage events like shuttle movement and we ended up hypothesizing that making it wait with `sleep()` so that it checks the tick after the MC has finished running might result in less tick overrun. Checking this on a local server though is painful so this is to testmerge the change.
