### PR TITLE
fixes advanced virus airborne chances

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -98,7 +98,7 @@
 	if(HAS_TRAIT(src, TRAIT_VIRUS_RESISTANCE) && prob(75))
 		return
 
-	if(((disease.spread_flags & DISEASE_SPREAD_AIRBORNE) || force_spread) && prob((50*disease.spreading_modifier) - 1))
+	if(((disease.spread_flags & DISEASE_SPREAD_AIRBORNE) || force_spread) && prob(min((50*disease.spreading_modifier - 1), 50)))
 		ForceContractDisease(disease)
 
 /mob/living/carbon/AirborneContractDisease(datum/disease/disease, force_spread)


### PR DESCRIPTION
## About The Pull Request

Caps airborne virus transmission chance per tick to 50%.

## Why It's Good For The Game

So, all the classic diseases that use this transmission proc have spreading_modifier values up to 1 or lower.

Advanced viruses get their spreading_modifier from their Transmission stat using the following function:
spreading_modifier = max(CEILING(0.4 * properties["transmittable"], 1), 1)

What this means is that if you have a virus that even has airborne spread (starting at transmission 11,) it will have (on top of being able to spread by contact, fluid, and blood,) a probability of (5*50)-1 of infecting anyone eligible in the area assuming they don't have spaceacillin in their system. 

I don't think this is intended. This just caps it to a 50% chance where the normal spreading_modifier stops. Transmission through touching, coughing, sneezing, etc. remain unaffected.

**Edit for one piece of clarification: all airborne viruses have a 41% chance (infectivity is set to 41 for all diseases except HMS) of spreading to eligible candidates per second. This doesn't change that but rather makes the maximum chance of you catching it after a 'spread' from the carrier 50%.**

```
/mob/living/carbon/handle_diseases(seconds_per_tick, times_fired)
	for(var/thing in diseases)
		var/datum/disease/D = thing
		if(SPT_PROB(D.infectivity, seconds_per_tick))
			D.spread()
```

## Changelog

:cl:
fix: Fixes respiration-transmission advanced viruses to no longer have an always-guaranteed infection chance per tick. 
/:cl:
