### PR TITLE
[NO GBP] RCD & RTD ui updates when switching between root categories

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -336,7 +336,7 @@
 			var/new_root = params["root_category"]
 			if(GLOB.rcd_designs[new_root] != null) //is a valid category
 				root_category = new_root
-				update_static_data(ui.user, ui)
+				update_static_data_for_all_viewers()
 
 		if("design")
 			//read and validate params from UI

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -290,6 +290,7 @@
 	data["root_categories"] = list()
 	for(var/category in GLOB.rcd_designs)
 		data["root_categories"] += category
+	data["selected_root"] = root_category
 
 	data["categories"] = list()
 	for(var/sub_category as anything in GLOB.rcd_designs[root_category])
@@ -318,7 +319,6 @@
 	var/list/data = ..()
 
 	//main categories
-	data["selected_root"] = root_category
 	data["selected_category"] = design_category
 	data["selected_design"] = design_title
 

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -336,6 +336,7 @@
 			var/new_root = params["root_category"]
 			if(GLOB.rcd_designs[new_root] != null) //is a valid category
 				root_category = new_root
+				update_static_data(ui.user, ui)
 
 		if("design")
 			//read and validate params from UI

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -171,6 +171,7 @@
 	data["root_categories"] = list()
 	for(var/category in GLOB.floor_designs)
 		data["root_categories"] += category
+	data["selected_root"] = root_category
 
 	data["categories"] = list()
 	for(var/sub_category as anything in GLOB.floor_designs[root_category])
@@ -188,7 +189,6 @@
 /obj/item/construction/rtd/ui_data(mob/user)
 	var/list/data = ..()
 
-	data["selected_root"] = root_category
 	data["selected_category"] = design_category
 	selected_design.fill_ui_data(data)
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -195,12 +195,14 @@
 	return data
 
 /obj/item/construction/rtd/handle_ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
+
 	var/floor_designs = GLOB.floor_designs
 	switch(action)
 		if("root_category")
 			var/new_root = params["root_category"]
 			if(floor_designs[new_root] != null) //is a valid category
 				root_category = new_root
+				update_static_data_for_all_viewers()
 
 		if("set_dir")
 			var/direction = text2dir(params["dir"])


### PR DESCRIPTION
## About The Pull Request
When switching between "Construction" & "Airlocks" tab the UI would not update unless you closed & reopened the UI. This was annoying so I fixed it & now the UI updates properly. Same applies for RTD when switching between floor types

## Changelog
:cl:
fix: RCD & RTD ui updates when switching between root categories
/:cl: