### PR TITLE
Fixes hole in ventcrawl logic

### DIFF
--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -61,7 +61,10 @@
 			return
 		if(!do_after(src, 1 SECONDS, target = ventcrawl_target))
 			return
-		visible_message(span_notice("[src] scrambles out from the ventilation ducts!"),span_notice("You scramble out from the ventilation ducts."))
+		if(ventcrawl_target.welded) // in case it got welded during our sleep
+			to_chat(src, span_warning("You can't crawl around a welded vent!"))
+			return
+		visible_message(span_notice("[src] scrambles out from the ventilation ducts!"), span_notice("You scramble out from the ventilation ducts."))
 		forceMove(ventcrawl_target.loc)
 		REMOVE_TRAIT(src, TRAIT_MOVE_VENTCRAWLING, VENTCRAWLING_TRAIT)
 		update_pipe_vision()
@@ -76,8 +79,11 @@
 				return
 			if(has_client && isnull(client))
 				return
+			if(ventcrawl_target.welded) // in case it got welded during our sleep
+				to_chat(src, span_warning("You can't crawl around a welded vent!"))
+				return
 			ventcrawl_target.flick_overlay_static(image('icons/effects/vent_indicator.dmi', "insert", ABOVE_MOB_LAYER), 1 SECONDS)
-			visible_message(span_notice("[src] scrambles into the ventilation ducts!"),span_notice("You climb into the ventilation ducts."))
+			visible_message(span_notice("[src] scrambles into the ventilation ducts!"), span_notice("You climb into the ventilation ducts."))
 			move_into_vent(ventcrawl_target)
 		else
 			to_chat(src, span_warning("This ventilation duct is not connected to anything!"))


### PR DESCRIPTION

## About The Pull Request

May or may not close https://github.com/tgstation/tgstation/issues/79018

Basically we slept during the `do_after()` and the vent may have been welded while we were sleeping, meaning we could "phase through a welded vent". Just a silly hole in ventcrawling logic that we should be accounting for.
## Why It's Good For The Game

I think there's a few issues with ventcrawling (i.e. it being traitbased and not something like an element) but we can tackle that later. Let's just fix any potential holes and issues that might come with it.
## Changelog
:cl:
fix: People should be crawling into welded vents a lot less now.
/:cl:

No guarantee on the linked issue disappearing since I couldn't replicate it on my end, just noticed a logic failure.
