### PR TITLE
literally just maps in human spawner wands to runtimestation

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -646,6 +646,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/debug/human_spawner{
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -935,6 +939,7 @@
 "dQ" = (
 /obj/structure/table,
 /obj/machinery/light/directional/south,
+/obj/item/debug/human_spawner,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "dR" = (


### PR DESCRIPTION

## About The Pull Request

adds like two human spawner wands to runtimestation

## Why It's Good For The Game

its more convenient than spawning humans or a wand for it when you need to test with more than 3 dummies

## Changelog

runtimestation is not playerfacing
