### PR TITLE
Makes supermatter charged singularity damage the eyes of viewers

### DIFF
--- a/code/datums/components/vision_hurting.dm
+++ b/code/datums/components/vision_hurting.dm
@@ -13,15 +13,14 @@
 	START_PROCESSING(SSdcs, src)
 
 /datum/component/vision_hurting/process(seconds_per_tick)
-	var/damage = damage_per_second * seconds_per_tick
 	for(var/mob/living/carbon/viewer in viewers(parent))
 		if(viewer.is_blind() || viewer.get_eye_protection() >= damage_per_second)
 			continue
 		var/obj/item/organ/internal/eyes/burning_orbs = locate() in viewer.organs
 		if(!burning_orbs)
 			continue
-		burning_orbs.apply_organ_damage(damage)
-		if(prob(max(5, 100 - (50 / seconds_per_tick)))) // Roughly 50% chance per second
+		burning_orbs.apply_organ_damage(damage_per_second * seconds_per_tick)
+		if(SPT_PROB(50, seconds_per_tick))
 			to_chat(viewer, span_userdanger("[message] [parent]!"))
-		if(prob(max(5, 100 - (80 / seconds_per_tick)))) // Roughly 20% chance per second
+		if(SPT_PROB(20, seconds_per_tick))
 			viewer.emote("scream")

--- a/code/datums/components/vision_hurting.dm
+++ b/code/datums/components/vision_hurting.dm
@@ -1,0 +1,27 @@
+/// A component that damages eyes that look at the owner
+/datum/component/vision_hurting
+	var/damage_per_second
+	var/message
+
+/datum/component/vision_hurting/Initialize(damage_per_second=1, message="Your eyes burn as you look at")
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.damage_per_second = damage_per_second
+	src.message = message
+
+	START_PROCESSING(SSdcs, src)
+
+/datum/component/vision_hurting/process(seconds_per_tick)
+	var/damage = damage_per_second * seconds_per_tick
+	for(var/mob/living/carbon/viewer in viewers(parent))
+		if(viewer.is_blind() || viewer.get_eye_protection() >= damage_per_second)
+			continue
+		var/obj/item/organ/internal/eyes/burning_orbs = locate() in viewer.organs
+		if(!burning_orbs)
+			continue
+		burning_orbs.apply_organ_damage(damage)
+		if(prob(max(5, 100 - (50 / seconds_per_tick)))) // Roughly 50% chance per second
+			to_chat(viewer, span_userdanger("[message] [parent]!"))
+		if(prob(max(5, 100 - (80 / seconds_per_tick)))) // Roughly 20% chance per second
+			viewer.emote("scream")

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -267,6 +267,11 @@
 			new_consume_range = 5
 			dissipate = FALSE
 
+	if(temp_allowed_size == STAGE_SIX)
+		AddComponent(/datum/component/vision_hurting)
+	else
+		qdel(GetComponent(/datum/component/vision_hurting))
+
 	var/datum/component/singularity/resolved_singularity = singularity_component.resolve()
 	if (!isnull(resolved_singularity))
 		resolved_singularity.consume_range = new_consume_range

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1139,6 +1139,7 @@
 #include "code\datums\components\uplink.dm"
 #include "code\datums\components\usb_port.dm"
 #include "code\datums\components\vacuum.dm"
+#include "code\datums\components\vision_hurting.dm"
 #include "code\datums\components\wall_mounted.dm"
 #include "code\datums\components\wearertargeting.dm"
 #include "code\datums\components\weatherannouncer.dm"


### PR DESCRIPTION
## About The Pull Request

Mostly made this for the component for admin abuse but let's put it on supermatter singulo as well. Screaming as your eyes fail you while your station is being consumed seems like it would be !!fun!!

## Changelog

:cl: ninjanomnom
balance: It damages your eyes to look at the supermatter singularity
/:cl:

