### PR TITLE
Distillation fixed

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -114,7 +114,7 @@
 /obj/item/food/grown/proc/ferment()
 	var/reagent_purity = seed.get_reagent_purity()
 	var/purity_above_base = clamp((reagent_purity - 0.5) * 2, 0, 1)
-	var/quality_min = 0
+	var/quality_min = DRINK_NICE
 	var/quality_max = DRINK_FANTASTIC
 	var/quality = round(LERP(quality_min, quality_max, purity_above_base))
 	for(var/datum/reagent/reagent in reagents.reagent_list)


### PR DESCRIPTION
## About The Pull Request

The recent changes to the food defines have broken the quality scaling for the fruit wine. This PR fixes the regression.

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: Distilled drink quality is fixed - can't give a mood debuff anymore
/:cl:
