### PR TITLE
B.O.R.I.S. Module Bugfix

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -352,7 +352,7 @@
 				to_chat(user, span_warning("[M] is stuck to your hand!"))
 				return
 			qdel(M)
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot/shell(get_turf(src), user)
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot/shell(get_turf(src))
 
 			if(!aisync)
 				lawsync = FALSE

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -283,7 +283,7 @@
 			if(!user.temporarilyRemoveItemFromInventory(W))
 				return
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot/nocell(get_turf(loc))
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot/nocell(get_turf(loc), user)
 			if(!O)
 				return
 			if(M.laws && M.laws.id != DEFAULT_AI_LAWID)
@@ -352,7 +352,7 @@
 				to_chat(user, span_warning("[M] is stuck to your hand!"))
 				return
 			qdel(M)
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot/shell(get_turf(src))
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot/shell(get_turf(src), user)
 
 			if(!aisync)
 				lawsync = FALSE

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -522,7 +522,7 @@
 /obj/item/borg/upgrade/ai/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-		if(R.shell)
+		if(locate(/obj/item/borg/upgrade/ai) in R.upgrades)
 			to_chat(user, span_warning("This unit is already an AI shell!"))
 			return FALSE
 		if(R.key) //You cannot replace a player unless the key is completely removed.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -788,6 +788,8 @@
 
 ///Use this to add upgrades to robots. It'll register signals for when the upgrade is moved or deleted, if not single use.
 /mob/living/silicon/robot/proc/add_to_upgrades(obj/item/borg/upgrade/new_upgrade, mob/user)
+	if(!user) // If this gets called with a null user then its going to runtime unless we check for it
+		return FALSE
 	if(new_upgrade in upgrades)
 		return FALSE
 	if(!user.temporarilyRemoveItemFromInventory(new_upgrade)) //calling the upgrade's dropped() proc /before/ we add action buttons

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,4 +1,8 @@
-/mob/living/silicon/robot/Initialize(mapload)
+/**
+ * Arguments:
+ * * creator - the mob who placed the MMI/Boris module into the exoskeleton. Needed to make AI shells work.
+ */
+/mob/living/silicon/robot/Initialize(mapload, mob/creator)
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
@@ -60,7 +64,8 @@
 
 	//If this body is meant to be a borg controlled by the AI player
 	if(shell)
-		make_shell()
+		var/obj/item/borg/upgrade/ai/board = new(src)
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/mob/living/silicon/robot, add_to_upgrades), board, creator)
 	else
 		//MMI stuff. Held togheter by magic. ~Miauw
 		if(!mmi?.brainmob)
@@ -828,7 +833,9 @@
  */
 /mob/living/silicon/robot/proc/make_shell(obj/item/borg/upgrade/ai/board)
 	if(!board)
-		upgrades |= new /obj/item/borg/upgrade/ai(src)
+		stack_trace("make_shell was called without a board argument! This is never supposed to happen!")
+		return FALSE // If there isn't a board than cancelling the whole shell creation process is the best option
+
 	shell = TRUE
 	braintype = "AI Shell"
 	name = "Empty AI Shell-[ident]"

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -232,8 +232,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			return
 		cell.update_appearance()
 		cell.add_fingerprint(user)
-		user.put_in_active_hand(cell)
 		to_chat(user, span_notice("You remove \the [cell]."))
+		user.put_in_active_hand(cell)
 		update_icons()
 		diag_hud_set_borgcell()
 

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			to_chat(user, span_warning("[src] already has a defibrillator!"))
 			return
 		var/obj/item/borg/upgrade/defib/backpack/B = new(null, D)
-		add_to_upgrades(B, user)
+		apply_upgrade(B, user)
 		return
 
 	if(istype(W, /obj/item/ai_module))
@@ -142,7 +142,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(!user.canUnEquip(U))
 			to_chat(user, span_warning("The upgrade is stuck to you and you can't seem to let go of it!"))
 			return
-		add_to_upgrades(U, user)
+		apply_upgrade(U, user)
 		return
 
 	if(istype(W, /obj/item/toner))


### PR DESCRIPTION

## About The Pull Request

The boris module that turns a cyborg into an AI shell is a bit weird. It can be used like an MMI or a positronic brain directly on a completed borg exoskeleton. It can also be used like any other cyborg upgrade on a completed cyborg, if an only if that cyborg is not controlled by a player already. If you reset an AI shell, it is intended to make the cyborg un-player controlled and to drop the boris module onto the ground. From there, you are supposed to be able put it back in like any other upgrade.

However, this behavior was bugged. Due to certain parts of the code not calling procs they should have, the boris module was not being properly removed from the list of upgrades when the shell was reset (in most cases). This meant that the boris module could not be re-applied to the newly empty borg. Furthermore, if the empty borg was deconstructed then the dropped boris module would immediately be deleted.

This PR just fixes all that behavior so it works properly. I also fixed a weird typo with removing cells from borgs because I noticed it while testing.
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: B.O.R.I.S. modules can once again be properly applied to the unformatted borg created when you reset an AI shell.
/:cl:
