### PR TITLE
Clicking a bitrunning pod orbits its avatar

### DIFF
--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -227,6 +227,11 @@
 
 	return FALSE
 
+/obj/machinery/netpod/attack_ghost(mob/dead/observer/our_observer)
+	var/our_target = avatar_ref?.resolve()
+	if(!our_target || our_observer.orbit(our_target))
+		return ..()
+
 /// Disconnects the occupant after a certain time so they aren't just hibernating in netpod stasis. A balance change
 /obj/machinery/netpod/proc/auto_disconnect()
 	if(isnull(occupant) || state_open || connected)

--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -229,7 +229,7 @@
 
 /obj/machinery/netpod/attack_ghost(mob/dead/observer/our_observer)
 	var/our_target = avatar_ref?.resolve()
-	if(!our_target || our_observer.orbit(our_target))
+	if(isnull(our_target) || !our_observer.orbit(our_target))
 		return ..()
 
 /// Disconnects the occupant after a certain time so they aren't just hibernating in netpod stasis. A balance change


### PR DESCRIPTION

## About The Pull Request

Clicking an active bitrunner pod as an observer will allow you to orbit that bitrunning pod's current avatar.
## Why It's Good For The Game

Makes it easier to check up on what those cheeky Bitrunners are up to!
## Changelog
:cl: Rhials
qol: As an observer, clicking on a bitrunning pod will let you orbit it's bitrunning avatar. Cool!
/:cl:
