### PR TITLE
Heretic summon name fixes

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -541,7 +541,7 @@
 	animate(summoned, 10 SECONDS, alpha = 155)
 
 	message_admins("A [summoned.name] is being summoned by [ADMIN_LOOKUPFLW(user)] in [ADMIN_COORDJMP(summoned)].")
-	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as a [summoned.real_name]?", ROLE_HERETIC, FALSE, 10 SECONDS, summoned, poll_ignore_define)
+	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as a [summoned.name]?", ROLE_HERETIC, FALSE, 10 SECONDS, summoned, poll_ignore_define)
 	if(!LAZYLEN(candidates))
 		loc.balloon_alert(user, "ritual failed, no ghosts!")
 		animate(summoned, 0.5 SECONDS, alpha = 0)

--- a/code/modules/mob/living/basic/heretic/ash_spirit.dm
+++ b/code/modules/mob/living/basic/heretic/ash_spirit.dm
@@ -2,7 +2,7 @@
  * Player-only mob which is fast, can jaunt a short distance, and is dangerous at close range
  */
 /mob/living/basic/heretic_summon/ash_spirit
-	name = "Ash Spirit"
+	name = "\improper Ash Spirit"
 	real_name = "Ashy"
 	desc = "A manifestation of ash, trailing a perpetual cloud of short-lived cinders."
 	icon_state = "ash_walker"

--- a/code/modules/mob/living/basic/heretic/fire_shark.dm
+++ b/code/modules/mob/living/basic/heretic/fire_shark.dm
@@ -1,5 +1,5 @@
 /mob/living/basic/heretic_summon/fire_shark
-	name = "Fire Shark"
+	name = "\improper Fire Shark"
 	real_name = "Fire Shark"
 	desc = "It is a eldritch dwarf space shark, also known as a fire shark."
 	icon_state = "fire_shark"

--- a/code/modules/mob/living/basic/heretic/fire_shark.dm
+++ b/code/modules/mob/living/basic/heretic/fire_shark.dm
@@ -1,5 +1,6 @@
 /mob/living/basic/heretic_summon/fire_shark
-	name = "fire shark"
+	name = "Fire Shark"
+	real_name = "Fire Shark"
 	desc = "It is a eldritch dwarf space shark, also known as a fire shark."
 	icon_state = "fire_shark"
 	icon_living = "fire_shark"

--- a/code/modules/mob/living/basic/heretic/flesh_stalker.dm
+++ b/code/modules/mob/living/basic/heretic/flesh_stalker.dm
@@ -1,6 +1,6 @@
 /// Durable ambush mob with an EMP ability
 /mob/living/basic/heretic_summon/stalker
-	name = "Flesh Stalker"
+	name = "\improper Flesh Stalker"
 	real_name = "Flesh Stalker"
 	desc = "An abomination cobbled together from varied remains. Its appearance changes slightly every time you blink."
 	icon_state = "stalker"

--- a/code/modules/mob/living/basic/heretic/maid_in_the_mirror.dm
+++ b/code/modules/mob/living/basic/heretic/maid_in_the_mirror.dm
@@ -1,6 +1,6 @@
 /// Scout and assassin who can appear and disappear from glass surfaces. Damaged by being examined.
 /mob/living/basic/heretic_summon/maid_in_the_mirror
-	name = "Maid in the Mirror"
+	name = "\improper Maid in the Mirror"
 	real_name = "Maid in the Mirror"
 	desc = "A floating and flowing wisp of chilled air. Glancing at it causes it to shimmer slightly."
 	icon = 'icons/mob/simple/mob.dmi'

--- a/code/modules/mob/living/basic/heretic/raw_prophet.dm
+++ b/code/modules/mob/living/basic/heretic/raw_prophet.dm
@@ -4,7 +4,7 @@
  * It can blind people to make a getaway, but also get stronger if it attacks the same target consecutively.
  */
 /mob/living/basic/heretic_summon/raw_prophet
-	name = "Raw Prophet"
+	name = "\improper Raw Prophet"
 	real_name = "Raw Prophet"
 	desc = "An abomination stitched together from a few severed arms and one swollen, orphaned eye."
 	icon_state = "raw_prophet"

--- a/code/modules/mob/living/basic/heretic/rust_walker.dm
+++ b/code/modules/mob/living/basic/heretic/rust_walker.dm
@@ -1,6 +1,6 @@
 /// Pretty simple mob which creates areas of rust and has a rust-creating projectile spell
 /mob/living/basic/heretic_summon/rust_walker
-	name = "Rust Walker"
+	name = "\improper Rust Walker"
 	real_name = "Rusty"
 	desc = "A grinding, clanking construct which leaches life from its surroundings with every armoured step."
 	icon_state = "rust_walker_s"

--- a/code/modules/mob/living/basic/heretic/star_gazer.dm
+++ b/code/modules/mob/living/basic/heretic/star_gazer.dm
@@ -1,5 +1,5 @@
 /mob/living/basic/heretic_summon/star_gazer
-	name = "Star Gazer"
+	name = "\improper Star Gazer"
 	desc = "A creature that has been tasked to watch over the stars."
 	icon = 'icons/mob/nonhuman-player/96x96eldritch_mobs.dmi'
 	icon_state = "star_gazer"


### PR DESCRIPTION
## About The Pull Request

Fixes #79049.

The ghost poll for heretic summons used the `real_name` field to display the mob's name. However, for some reason, a couple of the heretic summons have jokey nicknames as their real names ("Ashy" for ash walkers, "Rusty" for rust walkers). I've opted to take the simple option of making the ghost text just use the `name` field instead - it's used for the admin logs around summoning, so it should be fine for the poll too.

Also, I've capitalized "Fire Shark" and set its real name to also be "Fire Shark". For consistency.

Finally, I've made heretic summon names not proper nouns, so examining them will display "That's a Rust Walker" rather than "That's Rust Walker". The Lord of the Night did not receive this treatment due to being a unique thing.
## Why It's Good For The Game

It's good when ghosts know what they're actually signing up to be.

Most heretic summons aren't unique entities, so it makes sense for them to not be proper nouns.
## Changelog
:cl:
fix: Heretic summons should now display the correct name when polling ghosts to play as them.
/:cl:
