### PR TITLE
Birdshot ordnance QoL

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -34590,10 +34590,6 @@
 "mmf" = (
 /obj/structure/table,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = -2
-	},
 /obj/item/assembly/timer{
 	pixel_x = -3;
 	pixel_y = 9
@@ -34603,6 +34599,11 @@
 	},
 /obj/machinery/light_switch/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "mmi" = (
@@ -45940,7 +45941,10 @@
 "qiH" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/west,
-/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_x = 3;
+	pixel_y = -1
+	},
 /obj/item/assembly/timer{
 	pixel_x = -3;
 	pixel_y = 13
@@ -45956,6 +45960,9 @@
 /obj/item/transfer_valve{
 	pixel_x = 4;
 	pixel_y = 17
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 4
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
@@ -55499,6 +55506,10 @@
 	},
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "tns" = (
@@ -56541,7 +56552,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tDM" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8


### PR DESCRIPTION

## About The Pull Request

Fixes #79003

I've added a couple of useful tools to Birdshot's ordnance lab - a second RPD, and two holofan projectors. 

![image](https://github.com/tgstation/tgstation/assets/105025397/8024799a-39e5-461f-9450-912a758f9673)

I also removed one (1) cable from under the reinforced window by ordnance's front door. I didn't touch the other electrified windows in the science wing.
## Why It's Good For The Game

The extra RPD lets two people comfortably work in ordnance, like they can on most maps, and the holofan projectors allow changes to be made to the burn or freeze chambers without disaster. Most other maps have these things available, so it seems reasonable to add them here.

As pointed out in #79003, a quick toxins moment is all it takes for the modified window to explode, and for the pressure to slam an unfortunate spaceman into an electrified grille until they die. This feels excessive to me, and the other ordnance windows aren't electrified - so I took the cable out.
## Changelog
:cl:
qol: Birdshot ordnance is now equipped with a second RPD and two holofan projectors.
qol: Ordnance mishaps on Birdshot are significantly less likely to slam you into an electrified window until you die.
/:cl:
