### PR TITLE
Medical beds show correct overlay [NO GBP]

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -90,6 +90,7 @@
 /obj/structure/bed/medical/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noisy_movement)
+	update_appearance()
 
 /obj/structure/bed/medical/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -90,7 +90,8 @@
 /obj/structure/bed/medical/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noisy_movement)
-	update_appearance()
+	if(anchored)
+		update_appearance()
 
 /obj/structure/bed/medical/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Update the overlay if the brakes are on at mapload

## Changelog

:cl: LT3
fix: Maploaded medical beds now have correct brake lights
/:cl:
