### PR TITLE
Adds a smidge of information for species hard-dels

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -2348,3 +2348,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/check_head_flags(check_flags = NONE)
 	var/obj/item/bodypart/head/fake_head = bodypart_overrides[BODY_ZONE_HEAD]
 	return (initial(fake_head.head_flags) & check_flags)
+
+/datum/species/dump_harddel_info()
+	if(harddel_deets_dumped)
+		return
+	harddel_deets_dumped = TRUE
+	return "Gained / Owned: [properly_gained ? "Yes" : "No"]"


### PR DESCRIPTION
## About The Pull Request

Species hard deletes are a little difficult to track down without the ref tracker due to having no owner so I figure this might help... just a tiny bit. Maybe. 

This will let us know if the species hard-deleting was applied to a human or not. `properly_gained` is set to `TRUE` in `on_species_gain`. If it is false, it might be a shadow species kept in DNA or some other weird place or something. 

