### PR TITLE
Adds Custom Announcement Dividers

### DIFF
--- a/code/__DEFINES/announcements.dm
+++ b/code/__DEFINES/announcements.dm
@@ -1,0 +1,7 @@
+// Priority-type announcement messages for `priority_announcement()`
+/// Prefix this announcement with "Priority Announcement"
+#define ANNOUNCEMENT_TYPE_PRIORITY "Priority"
+/// Make it sound like it's coming from the Captain
+#define ANNOUNCEMENT_TYPE_CAPTAIN "Captain"
+/// Make it sound like it's coming from the Syndicate
+#define ANNOUNCEMENT_TYPE_SYNDICATE "Syndicate"

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -139,7 +139,7 @@
 	if(!players)
 		players = GLOB.player_list
 
-	var/minor_announcement_strings = list()
+	var/list/minor_announcement_strings = list()
 	minor_announcement_strings += MINOR_ANNOUNCEMENT_TITLE(title)
 	minor_announcement_strings += MINOR_ANNOUNCEMENT_TEXT(message)
 
@@ -162,21 +162,23 @@
 	title = html_encode(title)
 	message = html_encode(message)
 
-	var/level_announcement_strings = list()
+	var/list/level_announcement_strings = list()
 	level_announcement_strings += MINOR_ANNOUNCEMENT_TITLE(title)
 	level_announcement_strings += MINOR_ANNOUNCEMENT_TEXT(message)
 
 	var/joined_strings = level_announcement_strings.Join("<br>")
 	var/finalized_announcement = CHAT_ALERT_COLORED_SPAN(divcolor, joined_strings)
 
-	for(var/mob/target in GLOB.player_list)
+	if(!players)
+		players = GLOB.player_list
+
+	for(var/mob/target in players)
 		if(isnewplayer(target))
 			continue
 		if(!target.can_hear())
 			continue
 
-
-
+		to_chat(target, finalized_announcement)
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
 			var/sound_to_play = sound_override || 'sound/misc/notice2.ogg'
 			SEND_SOUND(target, sound(sound_to_play))

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -136,10 +136,10 @@
 	var/message
 
 	if(current_level_number > previous_level_number)
-		title = "Attention! Security level elevated to [capitalize(current_level_name)]:"
+		title = "Attention! Security level elevated to [current_level_name]:"
 		message = selected_level.elevating_to_announcement
 	else
-		title = "Attention! Security level lowered to [capitalize(current_level_name)]:"
+		title = "Attention! Security level lowered to [current_level_name]:"
 		message = selected_level.lowering_to_announcement
 
 	var/list/level_announcement_strings = list()

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -1,10 +1,12 @@
 // please don't use these defines outside of this file in order to ensure a unified framework. unless you have a really good reason to make them global, then whatever
+
+// these four are just text spans that furnish the TEXT itself with the appropriate CSS classes
 #define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='major_announcement_title'>" + string + "</span>")
 #define MAJOR_ANNOUNCEMENT_TEXT(string) ("<span class='major_announcement_text'>" + string + "</span>")
-
 #define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='minor_announcement_title'>" + string + "</span>")
 #define MINOR_ANNOUNCEMENT_TEXT(string) ("<span class='minor_announcement_text'>" + string + "</span>")
 
+// these two are the ones that actually give the striped background
 #define CHAT_ALERT_DEFAULT_SPAN(string) ("<div class='chat_alert_default'>" + string + "</div>")
 #define CHAT_ALERT_COLORED_SPAN(color, string) ("<div class='chat_alert_" + color + "'>" + string + "</div>")
 

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -150,7 +150,7 @@
 
 	dispatch_announcement_to_players(finalized_announcement, GLOB.player_list, current_level_sound)
 
-/// Proc that just generates a custom header based on variables fed into `priority_announce()`.area
+/// Proc that just generates a custom header based on variables fed into `priority_announce()`
 /// Will return a string.
 /proc/generate_unique_announcement_header(title, sender_override)
 	var/list/returnable_strings = list()

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -38,31 +38,30 @@
 		if(!length(text))
 			return
 
-	var/announcement
+	var/list/announcement_strings = list()
+
 	if(!sound)
 		sound = SSstation.announcer.get_rand_alert_sound()
 	else if(SSstation.announcer.event_sounds[sound])
 		sound = SSstation.announcer.event_sounds[sound]
 
-	announcement += "<br>"
+	announcement += "<div class='chat_alert_default'>"
 
-	if(type == ANNOUNCEMENT_TYPE_PRIORITY)
-		announcement += "[span_priorityannounce("<u>Priority Announcement</u>")]"
-		if (title && length(title) > 0)
-			announcement += "[span_prioritytitle("<br>[title]")]"
-	else if(type == ANNOUNCEMENT_TYPE_CAPTAIN)
-		announcement += "[span_priorityannounce("<u>Captain Announces</u>")]"
-		GLOB.news_network.submit_article(text, "Captain's Announcement", "Station Announcements", null)
-	else if(type == ANNOUNCEMENT_TYPE_SYNDICATE)
-		announcement += "[span_priorityannounce("<u>Syndicate Captain Announces</u>")]"
+	var/header
+	switch(type)
+		if(ANNOUNCEMENT_TYPE_PRIORITY)
+			header = MAJOR_ANNOUNCEMENT_TITLE("Priority Announcement")
+			if(length(title) > 0)
+				header += MINOR_ANNOUNCEMENT_TITLE(title)
+		if(ANNOUNCEMENT_TYPE_CAPTAIN)
+			header = MAJOR_ANNOUNCEMENT_TITLE("Captain's Announcement")
+			GLOB.news_network.submit_article(text, "Captain's Announcement", "Station Announcements", null)
+		if(ANNOUNCEMENT_TYPE_SYNDICATE)
+			header = MAJOR_ANNOUNCEMENT_TITLE("Syndicate Captain's Announcement")
+		else
+			header += generate_unique_announcement_header(title, sender_override)
 
 	else
-		if(!sender_override)
-			announcement += "[span_priorityannounce("<u>[command_name()] Update</u>")]"
-		else
-			announcement += "[span_priorityannounce("<u>[sender_override]</u>")]"
-		if (title && length(title) > 0)
-			announcement += "[span_prioritytitle("<br>[title]")]"
 
 		if(!sender_override)
 			if(title == "")
@@ -100,6 +99,20 @@
 	message.content = text
 
 	SScommunications.send_message(message)
+
+/// Proc that just generates a custom header based on variables fed into `priority_announce()`.area
+/// Will return a string.
+/proc/generate_unique_announcement_header(title, sender_override)
+	var/list/returnable_strings = list()
+	if(isnull(sender_override))
+		returnable_strings += MAJOR_ANNOUNCEMENT_TITLE("[command_name()] Update")
+	else
+		returnable_strings += MAJOR_ANNOUNCEMENT_TITLE(sender_override)
+
+	if(length(title) > 0)
+		returnable_strings += MINOR_ANNOUNCEMENT_TITLE(title)
+
+	return returnable_strings.Join("<br>")
 
 /**
  * Sends a minor annoucement to players.

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -1,9 +1,9 @@
 // please don't use these defines outside of this file in order to ensure a unified framework. unless you have a really good reason to make them global, then whatever
-#define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='efannouncemajtitle'>" + string + "</span>")
-#define MAJOR_ANNOUNCEMENT_TEXT(string) ("<span class='efannouncemajtext'>" + string + "</span>")
+#define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='major_announcement_title'>" + string + "</span>")
+#define MAJOR_ANNOUNCEMENT_TEXT(string) ("<span class='major_announcement_text'>" + string + "</span>")
 
-#define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='efannouncemintitle'>" + string + "</span>")
-#define MINOR_ANNOUNCEMENT_TEXT(string) ("<span class='efannouncemintext'>" + string + "</span>")
+#define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='minor_announcement_text'>" + string + "</span>")
+#define MINOR_ANNOUNCEMENT_TEXT(string) ("<span class='minor_announcement_text'>" + string + "</span>")
 
 /**
  * Make a big red text announcement to

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -70,7 +70,7 @@
 	else
 		announcement_strings += MAJOR_ANNOUNCEMENT_TEXT(text)
 
-	var/finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(announcement_strings.Join("<br>"))
+	var/finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(announcement_strings, "<br>"))
 
 	dispatch_announcement_to_players(finalized_announcement, players, sound)
 
@@ -114,18 +114,14 @@
 		title = html_encode(title)
 		message = html_encode(message)
 
-	if(!players)
-		players = GLOB.player_list
-
 	var/list/minor_announcement_strings = list()
 	minor_announcement_strings += MINOR_ANNOUNCEMENT_TITLE(title)
 	minor_announcement_strings += MINOR_ANNOUNCEMENT_TEXT(message)
 
-	var/finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(minor_announcement_strings.Join("<br>"))
+	var/finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(minor_announcement_strings, "<br>"))
 
 	var/custom_sound = sound_override || (alert ? 'sound/misc/notice1.ogg' : 'sound/misc/notice2.ogg')
 	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound)
-
 
 /// Sends an announcement about the level changing to players. Same args as previous procs here, but divcolor is the color of the div that the announcement is wrapped in.
 /proc/level_announce(message, title, alert, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, divcolor = "default")
@@ -139,8 +135,7 @@
 	level_announcement_strings += MINOR_ANNOUNCEMENT_TITLE(title)
 	level_announcement_strings += MINOR_ANNOUNCEMENT_TEXT(message)
 
-	var/joined_strings = level_announcement_strings.Join("<br>")
-	var/finalized_announcement = CHAT_ALERT_COLORED_SPAN(divcolor, joined_strings)
+	var/finalized_announcement = CHAT_ALERT_COLORED_SPAN(divcolor, jointext(level_announcement_strings, "<br>"))
 
 	dispatch_announcement_to_players(finalized_announcement, players, sound_override, should_play_sound)
 
@@ -156,7 +151,7 @@
 	if(length(title) > 0)
 		returnable_strings += MINOR_ANNOUNCEMENT_TITLE(title)
 
-	return returnable_strings.Join("<br>")
+	return jointext(returnable_strings, "<br>")
 
 /// Proc that just dispatches the announcement to our applicable audience. Only the announcement is a mandatory arg.
 /proc/dispatch_announcement_to_players(announcement, list/players, sound_override = null, should_play_sound = TRUE)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -2,7 +2,7 @@
 #define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='major_announcement_title'>" + string + "</span>")
 #define MAJOR_ANNOUNCEMENT_TEXT(string) ("<span class='major_announcement_text'>" + string + "</span>")
 
-#define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='minor_announcement_text'>" + string + "</span>")
+#define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='minor_announcement_title'>" + string + "</span>")
 #define MINOR_ANNOUNCEMENT_TEXT(string) ("<span class='minor_announcement_text'>" + string + "</span>")
 
 #define CHAT_ALERT_DEFAULT_SPAN(string) ("<div class='chat_alert_default'>" + string + "</div>")

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -1,3 +1,10 @@
+// please don't use these defines outside of this file in order to ensure a unified framework. unless you have a really good reason to make them global, then whatever
+#define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='efannouncemajtitle'>" + string + "</span>")
+#define MAJOR_ANNOUNCEMENT_TEXT(string) ("<span class='efannouncemajtext'>" + string + "</span>")
+
+#define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='efannouncemintitle'>" + string + "</span>")
+#define MINOR_ANNOUNCEMENT_TEXT(string) ("<span class='efannouncemintext'>" + string + "</span>")
+
 /**
  * Make a big red text announcement to
  *
@@ -13,7 +20,7 @@
  * * text - required, the text to announce
  * * title - optional, the title of the announcement.
  * * sound - optional, the sound played accompanying the announcement
- * * type - optional, the type of the announcement, for some "preset" announcement templates. ANNOUNCEMENT_TYPE_PRIORITY, ANNOUNCEMENT_TYPE_CAPTAIN,
+ * * type - optional, the type of the announcement, for some "preset" announcement templates. See __DEFINES/announcements.dm
  * * sender_override - optional, modifies the sender of the announcement
  * * has_important_message - is this message critical to the game (and should not be overridden by station traits), or not
  * * players - a list of all players to send the message to. defaults to all players (not including new players)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -123,21 +123,30 @@
 	var/custom_sound = sound_override || (alert ? 'sound/misc/notice1.ogg' : 'sound/misc/notice2.ogg')
 	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound)
 
-/// Sends an announcement about the level changing to players. Same args as previous procs here, but divcolor is the color of the div that the announcement is wrapped in.
-/proc/level_announce(message, title, alert, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, divcolor = "default")
-	if(!message)
-		return
+/// Sends an announcement about the level changing to players. Uses the passed in datum and the subsystem's previous security level to generate the message.
+/proc/level_announce(datum/security_level/selected_level, previous_level_number)
+	var/current_level_number = selected_level.number_level
+	var/current_level_name = selected_level.name
+	var/current_level_color = selected_level.announcement_color
+	var/current_level_sound = selected_level.sound
 
-	title = html_encode(title)
-	message = html_encode(message)
+	var/title
+	var/message
+
+	if(current_level_number > previous_level_number)
+		title = "Attention! Security level elevated to [capitalize(current_level_name)]:"
+		message = selected_level.elevating_to_announcement
+	else
+		title = "Attention! Security level lowered to [capitalize(current_level_name)]:"
+		message = selected_level.lowering_to_announcement
 
 	var/list/level_announcement_strings = list()
 	level_announcement_strings += MINOR_ANNOUNCEMENT_TITLE(title)
 	level_announcement_strings += MINOR_ANNOUNCEMENT_TEXT(message)
 
-	var/finalized_announcement = CHAT_ALERT_COLORED_SPAN(divcolor, jointext(level_announcement_strings, "<br>"))
+	var/finalized_announcement = CHAT_ALERT_COLORED_SPAN(current_level_color, jointext(level_announcement_strings, "<br>"))
 
-	dispatch_announcement_to_players(finalized_announcement, players, sound_override, should_play_sound)
+	dispatch_announcement_to_players(finalized_announcement, GLOB.player_list, current_level_sound)
 
 /// Proc that just generates a custom header based on variables fed into `priority_announce()`.area
 /// Will return a string.

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -5,6 +5,8 @@
 #define MINOR_ANNOUNCEMENT_TITLE(string) ("<span class='minor_announcement_text'>" + string + "</span>")
 #define MINOR_ANNOUNCEMENT_TEXT(string) ("<span class='minor_announcement_text'>" + string + "</span>")
 
+#define CHAT_ALERT_DEFAULT_SPAN(string) ("<div class='chat_alert_default'>" + string + "</div>")
+
 /**
  * Make a big red text announcement to
  *
@@ -45,8 +47,6 @@
 	else if(SSstation.announcer.event_sounds[sound])
 		sound = SSstation.announcer.event_sounds[sound]
 
-	announcement_strings += "<div class='chat_alert_default'>"
-
 	var/header
 	switch(type)
 		if(ANNOUNCEMENT_TYPE_PRIORITY)
@@ -69,9 +69,7 @@
 	else
 		announcement_strings += MAJOR_ANNOUNCEMENT_TEXT(text)
 
-	announcement_strings += "</div>"
-
-	var/finalized_announcement = announcement_strings.Join("<br>")
+	var/finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(announcement_strings.Join("<br>"))
 	if(!players)
 		players = GLOB.player_list
 
@@ -151,3 +149,8 @@
 		if(should_play_sound && target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
 			var/sound_to_play = sound_override || (alert ? 'sound/misc/notice1.ogg' : 'sound/misc/notice2.ogg')
 			SEND_SOUND(target, sound(sound_to_play))
+
+#undef MAJOR_ANNOUNCEMENT_TITLE
+#undef MAJOR_ANNOUNCEMENT_TEXT
+#undef MINOR_ANNOUNCEMENT_TITLE
+#undef MINOR_ANNOUNCEMENT_TEXT

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -13,7 +13,7 @@
  * * text - required, the text to announce
  * * title - optional, the title of the announcement.
  * * sound - optional, the sound played accompanying the announcement
- * * type - optional, the type of the announcement, for some "preset" announcement templates. "Priority", "Captain", "Syndicate Captain"
+ * * type - optional, the type of the announcement, for some "preset" announcement templates. ANNOUNCEMENT_TYPE_PRIORITY, ANNOUNCEMENT_TYPE_CAPTAIN,
  * * sender_override - optional, modifies the sender of the announcement
  * * has_important_message - is this message critical to the game (and should not be overridden by station traits), or not
  * * players - a list of all players to send the message to. defaults to all players (not including new players)
@@ -39,14 +39,14 @@
 
 	announcement += "<br>"
 
-	if(type == "Priority")
+	if(type == ANNOUNCEMENT_TYPE_PRIORITY)
 		announcement += "[span_priorityannounce("<u>Priority Announcement</u>")]"
 		if (title && length(title) > 0)
 			announcement += "[span_prioritytitle("<br>[title]")]"
-	else if(type == "Captain")
+	else if(type == ANNOUNCEMENT_TYPE_CAPTAIN)
 		announcement += "[span_priorityannounce("<u>Captain Announces</u>")]"
 		GLOB.news_network.submit_article(text, "Captain's Announcement", "Station Announcements", null)
-	else if(type == "Syndicate Captain")
+	else if(type == ANNOUNCEMENT_TYPE_SYNDICATE)
 		announcement += "[span_priorityannounce("<u>Syndicate Captain Announces</u>")]"
 
 	else

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -108,7 +108,7 @@
  * sound_override - optional, use the passed sound file instead of the default notice sounds.
  * should_play_sound - Whether the notice sound should be played or not.
  */
-/proc/minor_announce(message, title = "Attention:", alert, html_encode = TRUE, list/players = null, sound_override = null, should_play_sound = TRUE)
+/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players = null, sound_override = null, should_play_sound = TRUE)
 	if(!message)
 		return
 

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -38,9 +38,9 @@ SUBSYSTEM_DEF(communications)
 	else
 		var/list/message_data = user.treat_message(input)
 		if(syndicate)
-			priority_announce(html_decode(message_data["message"]), null, 'sound/misc/announce_syndi.ogg', "Syndicate Captain", has_important_message = TRUE, players = players)
+			priority_announce(html_decode(message_data["message"]), null, 'sound/misc/announce_syndi.ogg', ANNOUNCEMENT_TYPE_SYNDICATE, has_important_message = TRUE, players = players)
 		else
-			priority_announce(html_decode(message_data["message"]), null, 'sound/misc/announce.ogg', "Captain", has_important_message = TRUE, players = players)
+			priority_announce(html_decode(message_data["message"]), null, 'sound/misc/announce.ogg', ANNOUNCEMENT_TYPE_CAPTAIN, has_important_message = TRUE, players = players)
 		COOLDOWN_START(src, nonsilicon_message_cooldown, COMMUNICATION_COOLDOWN)
 	user.log_talk(input, LOG_SAY, tag="priority announcement")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -64,17 +64,13 @@ SUBSYSTEM_DEF(security_level)
  */
 /datum/controller/subsystem/security_level/proc/announce_security_level(datum/security_level/selected_level)
 	var/security_level_name = selected_level.name
-	var/color_to_use
-
-	if(selected_level.number_level == SEC_LEVEL_DELTA)
-		color_to_use = "purple" // HOLY FUCKING SHIT AAAAAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHH
-	else
-		color_to_use = security_level_name // whatever lol
+	var/color_to_use = selected_level.color
+	var/sound_to_use = selected_level.sound
 
 	if(selected_level.number_level > current_security_level.number_level)
-		level_announce(selected_level.elevating_to_announcement, "Attention! Security level elevated to [selected_level.name]:", sound_override = selected_level.sound, divcolor = color_to_use)
+		level_announce(selected_level.elevating_to_announcement, "Attention! Security level elevated to [security_level_name]:", sound_override = sound_to_use, divcolor = color_to_use)
 	else
-		level_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [selected_level.name]:", sound_override = selected_level.sound, divcolor = color_to_use)
+		level_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [security_level_name]:", sound_override = sound_to_use, divcolor = color_to_use)
 
 /**
  * Returns the current security level as a number

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -63,10 +63,18 @@ SUBSYSTEM_DEF(security_level)
  * * selected_level - The new security level that has been set
  */
 /datum/controller/subsystem/security_level/proc/announce_security_level(datum/security_level/selected_level)
+	var/security_level_name = selected_level.name
+	var/color_to_use
+
+	if(get_current_level_as_number() == SEC_LEVEL_DELTA)
+		color_to_use = "purple" // HOLY FUCKING SHIT AAAAAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHH
+	else
+		color_to_use = security_level_name // whatever lol
+
 	if(selected_level.number_level > current_security_level.number_level) // We are elevating to this level.
-		minor_announce(selected_level.elevating_to_announcemnt, "Attention! Security level elevated to [selected_level.name]:", sound_override = selected_level.sound)
+		level_announce(selected_level.elevating_to_announcement, "Attention! Security level elevated to [selected_level.name]:", sound_override = selected_level.sound, divcolor = color_to_use)
 	else // Going down
-		minor_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [selected_level.name]:", sound_override = selected_level.sound)
+		level_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [selected_level.name]:", sound_override = selected_level.sound, divcolor = color_to_use)
 
 /**
  * Returns the current security level as a number

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -64,7 +64,7 @@ SUBSYSTEM_DEF(security_level)
  */
 /datum/controller/subsystem/security_level/proc/announce_security_level(datum/security_level/selected_level)
 	var/security_level_name = selected_level.name
-	var/color_to_use = selected_level.color
+	var/color_to_use = selected_level.announcement_color
 	var/sound_to_use = selected_level.sound
 
 	if(selected_level.number_level > current_security_level.number_level)

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -66,14 +66,14 @@ SUBSYSTEM_DEF(security_level)
 	var/security_level_name = selected_level.name
 	var/color_to_use
 
-	if(get_current_level_as_number() == SEC_LEVEL_DELTA)
+	if(selected_level.number_level == SEC_LEVEL_DELTA)
 		color_to_use = "purple" // HOLY FUCKING SHIT AAAAAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHH
 	else
 		color_to_use = security_level_name // whatever lol
 
-	if(selected_level.number_level > current_security_level.number_level) // We are elevating to this level.
+	if(selected_level.number_level > current_security_level.number_level)
 		level_announce(selected_level.elevating_to_announcement, "Attention! Security level elevated to [selected_level.name]:", sound_override = selected_level.sound, divcolor = color_to_use)
-	else // Going down
+	else
 		level_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [selected_level.name]:", sound_override = selected_level.sound, divcolor = color_to_use)
 
 /**

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -39,7 +39,7 @@ SUBSYSTEM_DEF(security_level)
 	if(!selected_level)
 		CRASH("set_level was called with an invalid security level([new_level])")
 
-	announce_security_level(selected_level) // We want to announce BEFORE updating to the new level
+	level_announce(selected_level, current_security_level.number_level) // We want to announce BEFORE updating to the new level
 
 	SSsecurity_level.current_security_level = selected_level
 
@@ -55,22 +55,6 @@ SUBSYSTEM_DEF(security_level)
 	SEND_SIGNAL(src, COMSIG_SECURITY_LEVEL_CHANGED, selected_level.number_level)
 	SSnightshift.check_nightshift()
 	SSblackbox.record_feedback("tally", "security_level_changes", 1, selected_level.name)
-
-/**
- * Handles announcements of the newly set security level
- *
- * Arguments:
- * * selected_level - The new security level that has been set
- */
-/datum/controller/subsystem/security_level/proc/announce_security_level(datum/security_level/selected_level)
-	var/security_level_name = selected_level.name
-	var/color_to_use = selected_level.announcement_color
-	var/sound_to_use = selected_level.sound
-
-	if(selected_level.number_level > current_security_level.number_level)
-		level_announce(selected_level.elevating_to_announcement, "Attention! Security level elevated to [security_level_name]:", sound_override = sound_to_use, divcolor = color_to_use)
-	else
-		level_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [security_level_name]:", sound_override = sound_to_use, divcolor = color_to_use)
 
 /**
  * Returns the current security level as a number

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -505,13 +505,13 @@ SUBSYSTEM_DEF(shuttle)
 		emergency.sound_played = FALSE
 		priority_announce("Hostile environment detected. \
 			Departure has been postponed indefinitely pending \
-			conflict resolution.", null, 'sound/misc/notice1.ogg', "Priority")
+			conflict resolution.", null, 'sound/misc/notice1.ogg', ANNOUNCEMENT_TYPE_PRIORITY)
 	if(!emergency_no_escape && (emergency.mode == SHUTTLE_STRANDED))
 		emergency.mode = SHUTTLE_DOCKED
 		emergency.setTimer(emergency_dock_time)
 		priority_announce("Hostile environment resolved. \
 			You have 3 minutes to board the Emergency Shuttle.",
-			null, ANNOUNCER_SHUTTLEDOCK, "Priority")
+			null, ANNOUNCER_SHUTTLEDOCK, ANNOUNCEMENT_TYPE_PRIORITY)
 
 //try to move/request to dock_home if possible, otherwise dock_away. Mainly used for admin buttons
 /datum/controller/subsystem/shuttle/proc/toggleShuttle(shuttle_id, dock_home, dock_away, timed)

--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -22,7 +22,7 @@
 	/// Our announcement when lowering to this level
 	var/lowering_to_announcement
 	/// Our announcement when elevating to this level
-	var/elevating_to_announcemnt
+	var/elevating_to_announcement
 	/// Our configuration key for lowering to text, if set, will override the default lowering to announcement.
 	var/lowering_to_configuration_key
 	/// Our configuration key for elevating to text, if set, will override the default elevating to announcement.
@@ -33,7 +33,7 @@
 	if(lowering_to_configuration_key) // I'm not sure about you, but isn't there an easier way to do this?
 		lowering_to_announcement = global.config.Get(lowering_to_configuration_key)
 	if(elevating_to_configuration_key)
-		elevating_to_announcemnt = global.config.Get(elevating_to_configuration_key)
+		elevating_to_announcement = global.config.Get(elevating_to_configuration_key)
 
 /**
  * GREEN

--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -9,6 +9,8 @@
 /datum/security_level
 	/// The name of this security level.
 	var/name = "not set"
+	/// The color of our announcement divider.
+	var/announcement_color = "default"
 	/// The numerical level of this security level, see defines for more information.
 	var/number_level = -1
 	/// The sound that we will play when this security level is set
@@ -42,6 +44,7 @@
  */
 /datum/security_level/green
 	name = "green"
+	announcement_color = "green"
 	sound = 'sound/misc/notice2.ogg' // Friendly beep
 	number_level = SEC_LEVEL_GREEN
 	lowering_to_configuration_key = /datum/config_entry/string/alert_green
@@ -54,6 +57,7 @@
  */
 /datum/security_level/blue
 	name = "blue"
+	announcement_color = "blue"
 	sound = 'sound/misc/notice1.ogg' // Angry alarm
 	number_level = SEC_LEVEL_BLUE
 	lowering_to_configuration_key = /datum/config_entry/string/alert_blue_downto
@@ -67,6 +71,7 @@
  */
 /datum/security_level/red
 	name = "red"
+	announcement_color = "red"
 	sound = 'sound/misc/notice3.ogg' // More angry alarm
 	number_level = SEC_LEVEL_RED
 	lowering_to_configuration_key = /datum/config_entry/string/alert_red_downto
@@ -80,6 +85,7 @@
  */
 /datum/security_level/delta
 	name = "delta"
+	announcement_color = "purple"
 	sound = 'sound/misc/airraid.ogg' // Air alarm to signify importance
 	number_level = SEC_LEVEL_DELTA
 	elevating_to_configuration_key = /datum/config_entry/string/alert_delta

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -358,7 +358,7 @@
 	else
 		SSshuttle.emergency_last_call_loc = null
 
-	priority_announce("The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]", null, ANNOUNCER_SHUTTLECALLED, "Priority")
+	priority_announce("The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]", null, ANNOUNCER_SHUTTLECALLED, ANNOUNCEMENT_TYPE_PRIORITY)
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)
@@ -373,7 +373,7 @@
 		SSshuttle.emergency_last_call_loc = signalOrigin
 	else
 		SSshuttle.emergency_last_call_loc = null
-	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergency_last_call_loc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLERECALLED, "Priority")
+	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergency_last_call_loc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLERECALLED, ANNOUNCEMENT_TYPE_PRIORITY)
 
 	SSticker.emergency_reason = null
 
@@ -462,7 +462,7 @@
 				mode = SHUTTLE_DOCKED
 				setTimer(SSshuttle.emergency_dock_time)
 				send2adminchat("Server", "The Emergency Shuttle has docked with the station.")
-				priority_announce("[SSshuttle.emergency] has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, ANNOUNCER_SHUTTLEDOCK, "Priority")
+				priority_announce("[SSshuttle.emergency] has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, ANNOUNCER_SHUTTLEDOCK, ANNOUNCEMENT_TYPE_PRIORITY)
 				ShuttleDBStuff()
 				addtimer(CALLBACK(src, PROC_REF(announce_shuttle_events)), 20 SECONDS)
 
@@ -514,7 +514,7 @@
 				mode = SHUTTLE_ESCAPE
 				launch_status = ENDGAME_LAUNCHED
 				setTimer(SSshuttle.emergency_escape_time * engine_coeff)
-				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
+				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, ANNOUNCEMENT_TYPE_PRIORITY)
 				INVOKE_ASYNC(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, poll_hearts))
 				SSmapping.mapvote() //If no map vote has been run yet, start one.
 
@@ -579,7 +579,7 @@
 	mode = SHUTTLE_ESCAPE
 	launch_status = ENDGAME_LAUNCHED
 	setTimer(SSshuttle.emergency_escape_time)
-	priority_announce("The Emergency Shuttle is preparing for direct jump. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
+	priority_announce("The Emergency Shuttle is preparing for direct jump. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, ANNOUNCEMENT_TYPE_PRIORITY)
 
 ///Generate a list of events to run during the departure
 /obj/docking_port/mobile/emergency/proc/setup_shuttle_events()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -35,6 +35,7 @@
 #include "code\__DEFINES\airlock.dm"
 #include "code\__DEFINES\alarm.dm"
 #include "code\__DEFINES\alerts.dm"
+#include "code\__DEFINES\announcements.dm"
 #include "code\__DEFINES\anomaly.dm"
 #include "code\__DEFINES\antagonists.dm"
 #include "code\__DEFINES\apc_defines.dm"

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+@use 'sass:map';
+
 em {
   font-style: normal;
   font-weight: bold;
@@ -966,154 +968,45 @@ em {
   font-size: 125%;
 }
 
-.chat_alert_default {
-  color: #ffffff;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #292929;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #252525;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #292929 10px,
-    #292929 20px
-  );
-}
+$alert-stripe-colors: (
+  'default': #292929,
+  'green': #003d00,
+  'blue': #00283a,
+  'pink': #30001b,
+  'yellow': #574a00,
+  'orange': #593400,
+  'red': #540000,
+  'purple': #2c0030,
+);
 
-.chat_alert_green {
-  color: #ffffff;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #003800;
-  background-color: #003d00;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #003800 10px,
-    #003800 20px
-  );
-}
+$alert-background-colors: (
+  'default': #252525,
+  'green': #003800,
+  'blue': #003045,
+  'pink': #400025,
+  'yellow': #4d4100,
+  'orange': #6b4200,
+  'red': #6b0000,
+  'purple': #3a0040,
+);
 
-.chat_alert_blue {
-  color: #ffffff;
-  padding: 0.33em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #00283a;
-  background-color: #003045;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #00283a 10px,
-    #00283a 20px
-  );
-}
-
-.chat_alert_pink {
-  color: #ffffff;
-  padding: 0.33em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #30001b;
-  background-color: #400025;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #30001b 10px,
-    #30001b 20px
-  );
-}
-
-.chat_alert_yellow {
-  color: #ffffff;
-  padding: 0.33em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #574a00;
-  background-color: #4d4100;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #574a00 10px,
-    #574a00 20px
-  );
-}
-
-.chat_alert_orange {
-  color: #ffffff;
-  padding: 0.33em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #593400;
-  background-color: #6b4200;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #593400 10px,
-    #593400 20px
-  );
-}
-
-.chat_alert_red {
-  color: #ffffff;
-  padding: 0.33em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #540000;
-  background-color: #6b0000;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #540000 10px,
-    #540000 20px
-  );
-}
-
-.chat_alert_purple {
-  color: #ffffff;
-  padding: 0.33em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #2c0030;
-  background-color: #3a0040;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #2c0030 10px,
-    #2c0030 20px
-  );
+@each $color-name, $color-value in $alert-stripe-colors {
+  .chat_alert_#{$color-name} {
+    color: #ffffff;
+    padding: 0.5em 0.5em;
+    margin-bottom: 0.5em;
+    box-shadow: none;
+    font-weight: bold;
+    border: 1px solid $color-value;
+    margin: 0.5em 0 0.5em 0;
+    padding: 0.5em 0.75em;
+    background-color: map.get($alert-background-colors, $color-name);
+    background-image: repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 10px,
+      $color-value 10px,
+      $color-value 20px
+    );
+  }
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -941,3 +941,198 @@ em {
   font-style: italic;
   border-bottom: 1px dashed #fff;
 }
+
+.efannouncemajtitle {
+  color: #ff0066;
+  text-decoration: underline;
+  font-weight: bold;
+  font-size: 175%;
+}
+
+.efannouncemajtext {
+  color: #eaeaea;
+  font-weight: bold;
+  font-size: 125%;
+}
+
+.efannouncemintitle {
+  color: #33d5ff;
+  font-weight: bold;
+  font-size: 150%;
+}
+
+.efannouncemintext {
+  color: #eaeaea;
+  font-size: 125%;
+}
+
+.chat_alert_default {
+  color: #ffffff;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #292929;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #252525;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #292929 10px,
+    #292929 20px
+  );
+}
+
+.chat_alert_green {
+  color: #ffffff;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #003800;
+  background-color: #003d00;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #003800 10px,
+    #003800 20px
+  );
+}
+
+.chat_alert_blue {
+  color: #ffffff;
+  padding: 0.33em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #00283a;
+  background-color: #003045;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #00283a 10px,
+    #00283a 20px
+  );
+}
+
+.chat_alert_pink {
+  color: #ffffff;
+  padding: 0.33em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #30001b;
+  background-color: #400025;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #30001b 10px,
+    #30001b 20px
+  );
+}
+
+.chat_alert_yellow {
+  color: #ffffff;
+  padding: 0.33em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #574a00;
+  background-color: #4d4100;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #574a00 10px,
+    #574a00 20px
+  );
+}
+
+.chat_alert_orange {
+  color: #ffffff;
+  padding: 0.33em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #593400;
+  background-color: #6b4200;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #593400 10px,
+    #593400 20px
+  );
+}
+
+.chat_alert_red {
+  color: #ffffff;
+  padding: 0.33em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #540000;
+  background-color: #6b0000;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #540000 10px,
+    #540000 20px
+  );
+}
+
+.chat_alert_purple {
+  color: #ffffff;
+  padding: 0.33em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #2c0030;
+  background-color: #3a0040;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #2c0030 10px,
+    #2c0030 20px
+  );
+}
+
+.minorannounce {
+  color: #ffffff;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  border: 1px solid #292929;
+  background-color: #252525;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #292929 10px,
+    #292929 20px
+  );
+}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -955,7 +955,7 @@ em {
   font-size: 125%;
 }
 
-.minor_announcement_text {
+.minor_announcement_title {
   color: #33d5ff;
   font-weight: bold;
   font-size: 150%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -942,26 +942,26 @@ em {
   border-bottom: 1px dashed #fff;
 }
 
-.efannouncemajtitle {
+.major_announcement_title {
   color: #ff0066;
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;
 }
 
-.efannouncemajtext {
+.major_announcement_text {
   color: #eaeaea;
   font-weight: bold;
   font-size: 125%;
 }
 
-.efannouncemintitle {
+.minor_announcement_text {
   color: #33d5ff;
   font-weight: bold;
   font-size: 150%;
 }
 
-.efannouncemintext {
+.minor_announcement_text {
   color: #eaeaea;
   font-size: 125%;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1117,22 +1117,3 @@ em {
     #2c0030 20px
   );
 }
-
-.minorannounce {
-  color: #ffffff;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  border: 1px solid #292929;
-  background-color: #252525;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #292929 10px,
-    #292929 20px
-  );
-}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+@use 'sass:map';
+
 html,
 body {
   padding: 0;
@@ -998,154 +1000,45 @@ h2.alert {
   font-size: 125%;
 }
 
-.chat_alert_default {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #dedede;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #d1d1d1;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #dedede 10px,
-    #dedede 20px
-  );
-}
+$alert-stripe-colors: (
+  'default': #dedede,
+  'green': #c2ffcc,
+  'blue': #b8e6ff,
+  'pink': #ffc2f4,
+  'yellow': #ffe880,
+  'orange': #ffbb99,
+  'red': #ff99aa,
+  'purple': #d7c2ff,
+);
 
-.chat_alert_green {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #c2ffcc;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #a8ffb7;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #c2ffcc 10px,
-    #c2ffcc 20px
-  );
-}
+$alert-background-colors: (
+  'default': #d1d1d1,
+  'green': #a8ffb7,
+  'blue': #a8e1ff,
+  'pink': #ffb3f3,
+  'yellow': #fff0ad,
+  'orange': #ffc9ad,
+  'red': #ffadbb,
+  'purple': #ccb3ff,
+);
 
-.chat_alert_blue {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #b8e6ff;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #a8e1ff;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #b8e6ff 10px,
-    #b8e6ff 20px
-  );
-}
-
-.chat_alert_pink {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ffc2f4;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ffb3f3;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ffc2f4 10px,
-    #ffc2f4 20px
-  );
-}
-
-.chat_alert_yellow {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ffe880;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #fff0ad;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ffe880 10px,
-    #ffe880 20px
-  );
-}
-
-.chat_alert_orange {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ffbb99;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ffc9ad;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ffbb99 10px,
-    #ffbb99 20px
-  );
-}
-
-.chat_alert_red {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ff99aa;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ffadbb;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ff99aa 10px,
-    #ff99aa 20px
-  );
-}
-
-.chat_alert_purple {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #d7c2ff;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ccb3ff;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #d7c2ff 10px,
-    #d7c2ff 20px
-  );
+@each $color-name, $color-value in $alert-stripe-colors {
+  .chat_alert_#{$color-name} {
+    color: #ffffff;
+    padding: 0.5em 0.5em;
+    margin-bottom: 0.5em;
+    box-shadow: none;
+    font-weight: bold;
+    border: 1px solid $color-value;
+    margin: 0.5em 0 0.5em 0;
+    padding: 0.5em 0.75em;
+    background-color: map.get($alert-background-colors, $color-name);
+    background-image: repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 10px,
+      $color-value 10px,
+      $color-value 20px
+    );
+  }
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -973,3 +973,198 @@ h2.alert {
   font-style: italic;
   border-bottom: 1px dashed #000;
 }
+
+.efannouncemajtitle {
+  color: #ff0066;
+  text-decoration: underline;
+  font-weight: bold;
+  font-size: 175%;
+}
+
+.efannouncemajtext {
+  color: #202020;
+  font-weight: bold;
+  font-size: 125%;
+}
+
+.efannouncemintitle {
+  color: #007ee6;
+  font-weight: bold;
+  font-size: 150%;
+}
+
+.efannouncemintext {
+  color: #202020;
+  font-size: 125%;
+}
+
+.chat_alert_default {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #dedede;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #d1d1d1;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #dedede 10px,
+    #dedede 20px
+  );
+}
+
+.chat_alert_green {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #c2ffcc;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #a8ffb7;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #c2ffcc 10px,
+    #c2ffcc 20px
+  );
+}
+
+.chat_alert_blue {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #b8e6ff;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #a8e1ff;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #b8e6ff 10px,
+    #b8e6ff 20px
+  );
+}
+
+.chat_alert_pink {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #ffc2f4;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #ffb3f3;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #ffc2f4 10px,
+    #ffc2f4 20px
+  );
+}
+
+.chat_alert_yellow {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #ffe880;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #fff0ad;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #ffe880 10px,
+    #ffe880 20px
+  );
+}
+
+.chat_alert_orange {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #ffbb99;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #ffc9ad;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #ffbb99 10px,
+    #ffbb99 20px
+  );
+}
+
+.chat_alert_red {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #ff99aa;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #ffadbb;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #ff99aa 10px,
+    #ff99aa 20px
+  );
+}
+
+.chat_alert_purple {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #d7c2ff;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #ccb3ff;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #d7c2ff 10px,
+    #d7c2ff 20px
+  );
+}
+
+.minorannounce {
+  color: #202020;
+  padding: 0.5em 0.5em;
+  margin-bottom: 0.5em;
+  box-shadow: none;
+  font-weight: bold;
+  border: 1px solid #dedede;
+  margin: 0.5em 0 0.5em 0;
+  padding: 0.5em 0.75em;
+  background-color: #d1d1d1;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 10px,
+    #dedede 10px,
+    #dedede 20px
+  );
+}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -974,26 +974,26 @@ h2.alert {
   border-bottom: 1px dashed #000;
 }
 
-.efannouncemajtitle {
+.major_announcement_title {
   color: #ff0066;
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;
 }
 
-.efannouncemajtext {
+.major_announcement_text {
   color: #202020;
   font-weight: bold;
   font-size: 125%;
 }
 
-.efannouncemintitle {
+.minor_announcement_text {
   color: #007ee6;
   font-weight: bold;
   font-size: 150%;
 }
 
-.efannouncemintext {
+.minor_announcement_text {
   color: #202020;
   font-size: 125%;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1149,22 +1149,3 @@ h2.alert {
     #d7c2ff 20px
   );
 }
-
-.minorannounce {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #dedede;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #d1d1d1;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #dedede 10px,
-    #dedede 20px
-  );
-}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -987,7 +987,7 @@ h2.alert {
   font-size: 125%;
 }
 
-.minor_announcement_text {
+.minor_announcement_title {
   color: #007ee6;
   font-weight: bold;
   font-size: 150%;


### PR DESCRIPTION
This ports a whole bunch of various PRs and commits from https://github.com/effigy-se/effigy-se , with heavy refactoring to keep it fresh for /tg/'s code standards.

## About The Pull Request

The whole slew of announcement touchups lately (as in #78995 (37db1ecbf8d7ceeaeb134c56b403339555f44cea) / #79052 (12308dbd3dae702a1c7b9f7f80d7859aea085c82)) have made me realize how much this stuff sucks. The author of these new spans was advertising these in coding general, so I sat down and coded it. Look at the spans, they're much nicer than what we had going on:

(ignore the capitalized alert status names, this was removed)

<details>
<summary>Dark Mode</summary>

![image](https://github.com/tgstation/tgstation/assets/34697715/107b8efb-b7a1-41ff-9d16-358c4dc3738d)
![image](https://github.com/tgstation/tgstation/assets/34697715/9e730dfe-7ba3-4edd-96bb-0630fe5e85cf)
</details>

<details>
<summary>Light Mode</summary>

![image](https://github.com/tgstation/tgstation/assets/34697715/57f642f9-ee17-4b16-8027-00a9350e9059)
![image](https://github.com/tgstation/tgstation/assets/34697715/b28b7f49-fd4f-420a-9313-e16b9781c07c)
</details>

This PR also features

* Major announcement code handling cleanup and refactor! There was a lot of copypasta so let's distill it all down into one proc
* Better cacheing! We were doing a shit load of new string generation needlessly! That's fixed now.
* Better string concatenation! Lists are better for string tree reasons. It still works just as well, as you can see from the screenshots above. Best of all, no fucking `<br>` dogshit everywhere!
* We don't use string equivalency in order to figure out the "type" of an announcement. It's all defines now. This was a bonus that I just coded in since it irritated me.
* Minor spellcheck of "announcement".
* All of our HTML string mangling stuff is now all span macros! I love macros.

## Why It's Good For The Game

In the same vein of adding examine blocks (#67937 (b864589522f4f14183270a62dbea3df8028d2eb6)) because old examinations tended to blend in with the chat and everything chat-wise used to suck really hard- I think this is a really nice way to draw attention to announcements in the chat box without needing a shit load of line breaks that just really look ugly and have no real consistency. You can look at the PRs/commits I linked above for an idea of just how ugly it could be getting.

I haven't audited every announcement in this PR, we can tweak this down the line.

## Changelog

:cl: LT3, san7890
add: Announcements have gotten a fresh coat of paint! They should be popping with splendid new colors and should have a lot less ugly linebreaks, while still managing to keep your attention at the screen.
/:cl:

I know we didn't need to port all the CSS themes but I added them anyways in case admins wanna have some fun.
There can probably be more code improvements, just figured I'd crack it out while I had time.
The colors also seem fine, let me know if we need more redness or something. It's okay for stuff to be toned down a bit imo, but that should be done after a hot second.