### PR TITLE
Fixes two improper calls to ADD_TRAIT (magic mirror, robo customer) 

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -358,7 +358,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	to_chat(user, span_alert("You feel quite intelligent."))
 	// Prevents wizards from being soft locked out of everything
 	// If this stays after the species was changed once more, well, the magic mirror did it. It's magic i aint gotta explain shit
-	ADD_TRAIT(user, list(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER), SPECIES_TRAIT)
+	user.add_traits(list(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER), SPECIES_TRAIT)
 	return TRUE
 
 /obj/structure/mirror/magic/lesser/Initialize(mapload)

--- a/code/modules/mob/living/basic/space_fauna/robot_customer.dm
+++ b/code/modules/mob/living/basic/space_fauna/robot_customer.dm
@@ -35,7 +35,7 @@
 
 	. = ..()
 
-	ADD_TRAIT(src, list(TRAIT_NOMOBSWAP, TRAIT_NO_TELEPORT, TRAIT_STRONG_GRABBER), INNATE_TRAIT) // never suffer a bitch to fuck with you
+	add_traits(list(TRAIT_NOMOBSWAP, TRAIT_NO_TELEPORT, TRAIT_STRONG_GRABBER), INNATE_TRAIT) // never suffer a bitch to fuck with you
 	AddElement(/datum/element/footstep, FOOTSTEP_OBJ_ROBOT, 1, -6, sound_vary = TRUE)
 
 	ai_controller.set_blackboard_key(BB_CUSTOMER_CUSTOMERINFO, customer_info)


### PR DESCRIPTION
## About The Pull Request

`ADD_TRAIT` doesn't take a list

## Changelog

:cl: Melbert
fix: Magic Mirrors properly prevent you from being soft locked
fix: Robo customers are as robust as before
/:cl:
