### PR TITLE
Fixes magic mirrors not being able to change your race (?)

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -502,6 +502,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(ispath(mrace))
 		new_race = new mrace
 	else if(istype(mrace))
+		if(QDELING(mrace))
+			CRASH("someone is calling set_species() and is passing it a qdeling species datum, this is VERY bad, stop it")
 		new_race = mrace
 	else
 		CRASH("set_species called with an invalid mrace [mrace]")

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -152,17 +152,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	var/racechoice = tgui_input_list(race_changer, "What are we again?", "Race change", selectable_races)
 	if(isnull(racechoice))
 		return TRUE
-	if(!selectable_races[racechoice])
+
+	var/new_race_path = selectable_races[racechoice]
+	if(!ispath(new_race_path, /datum/species))
 		return TRUE
 
-
-	var/datum/species/newrace = new selectable_races[racechoice]
-
+	var/datum/species/newrace = new new_race_path()
 	var/attributes_desc = newrace.get_physical_attributes()
-	qdel(newrace)
 
 	var/answer = tgui_alert(race_changer, attributes_desc, "Become a [newrace]?", list("Yes", "No"))
 	if(answer != "Yes")
+		qdel(newrace)
 		change_race(race_changer) // try again
 		return
 


### PR DESCRIPTION
## About The Pull Request

Not sure why this exactly was happening but I just changed around some vars and it fixed

![image](https://github.com/tgstation/tgstation/assets/51863163/2d8c3d17-593d-4df2-bb67-b18f70a73add)

Also it was assigning a qdeling datum to a mob. Bad bad bad

## Changelog

:cl: Melbert
fix: Magic Mirrors can change your race again (?)
/:cl:
