### PR TITLE
Fix APC cell removal runtime

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -260,10 +260,6 @@
 			user.visible_message(span_notice("[user] removes \the [cell] from [src]!"))
 			balloon_alert(user, "cell removed")
 			user.put_in_hands(cell)
-			cell.update_appearance()
-			cell = null
-			charging = APC_NOT_CHARGING
-			update_appearance()
 		return
 	if((machine_stat & MAINT) && !opened) //no board; no interface
 		return

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -264,6 +264,7 @@
 /obj/machinery/power/apc/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == cell)
+		cell.update_appearance()
 		cell = null
 		charging = APC_NOT_CHARGING
 		update_appearance()


### PR DESCRIPTION
## About The Pull Request

Someone implemented `Exited` but didn't remove this code, it's not necessary and all it does is runtime now. 

