### PR TITLE
Fixes misrotated cytology structures on Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29457,7 +29457,7 @@
 "kCr" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/plumbing/input{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/cytology)
@@ -52202,9 +52202,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/plumbing/growing_vat{
-	dir = 4
-	},
+/obj/machinery/plumbing/growing_vat,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/cytology)
 "sKs" = (


### PR DESCRIPTION

## About The Pull Request
Fixes #79066 

Fixes the Cytology equipment to be facing the correct way to be connected roundstart,

![image](https://github.com/tgstation/tgstation/assets/86125936/c62a30bf-d697-407d-be70-a45a96bca120)
(This one)
## Why It's Good For The Game

Makes it so anyone trying cytology doesn't have to rotate it or give up not knowing why it isn't working.
## Changelog
:cl:
fix: connected Meta's Cytology equipment properly
/:cl:
