### PR TITLE
[NO GBP] Fix airtank gib not dropping parts or items

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -19,7 +19,7 @@
 		BT.on_death()
 
 /mob/living/carbon/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
-	addtimer(CALLBACK(src, PROC_REF(gib), null, null, TRUE, TRUE), 25)
+	addtimer(CALLBACK(src, PROC_REF(gib), DROP_BRAIN|DROP_ORGANS|DROP_ITEMS), 25)
 	var/matrix/M = matrix()
 	M.Scale(1.8, 1.2)
 	animate(src, time = 40, transform = M, easing = SINE_EASING)


### PR DESCRIPTION

## About The Pull Request
- Fixes #79086

I missed a `PROC_REF` when I refactored gib code.

## Why It's Good For The Game
Keeps the same consistency as before.

## Changelog
:cl:
fix: Airtank suicides will now drop items and organs again.
/:cl:
