### PR TITLE
[NO GBP] Fix husks fire decay to be slower and allow pyre rite to sacrifice husks

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -147,10 +147,8 @@
 	if(!on_fire)
 		return TRUE
 
-	if(HAS_TRAIT(owner, TRAIT_HUSK))
-		adjust_stacks(-2 * seconds_between_ticks)
-	else
-		adjust_stacks(owner.fire_stack_decay_rate * seconds_between_ticks)
+	var/decay_multiplier = HAS_TRAIT(owner, TRAIT_HUSK) ? 2 : 1 // husks decay twice as fast
+	adjust_stacks(owner.fire_stack_decay_rate * decay_multiplier * seconds_between_ticks)
 
 	if(stacks <= 0)
 		qdel(src)

--- a/code/modules/religion/pyre_rites.dm
+++ b/code/modules/religion/pyre_rites.dm
@@ -43,7 +43,7 @@
 
 /datum/religion_rites/burning_sacrifice
 	name = "Burning Offering"
-	desc = "Sacrifice a buckled burning corpse for favor, the more burn damage the corpse has the more favor you will receive."
+	desc = "Sacrifice a buckled burning or husked corpse for favor, the more burn damage the corpse has the more favor you will receive."
 	ritual_length = 15 SECONDS
 	ritual_invocations = list("Burning body ...",
 	"... cleansed by the flame ...",
@@ -71,8 +71,8 @@
 		if(chosen_sacrifice.stat != DEAD)
 			to_chat(user, span_warning("You can only sacrifice dead bodies, this one is still alive!"))
 			return FALSE
-		if(!chosen_sacrifice.on_fire)
-			to_chat(user, span_warning("This corpse needs to be on fire to be sacrificed!"))
+		if(!chosen_sacrifice.on_fire && !HAS_TRAIT_FROM(chosen_sacrifice, TRAIT_HUSK, BURN))
+			to_chat(user, span_warning("This corpse needs to be on fire or husked to be sacrificed!"))
 			return FALSE
 		return ..()
 
@@ -82,8 +82,8 @@
 		to_chat(user, span_warning("The right sacrifice is no longer on the altar!"))
 		chosen_sacrifice = null
 		return FALSE
-	if(!chosen_sacrifice.on_fire)
-		to_chat(user, span_warning("The sacrifice is no longer on fire, it needs to burn until the end of the rite!"))
+	if(!chosen_sacrifice.on_fire && !HAS_TRAIT_FROM(chosen_sacrifice, TRAIT_HUSK, BURN))
+		to_chat(user, span_warning("The sacrifice has to be on fire or husked to finish the end of the rite!"))
 		chosen_sacrifice = null
 		return FALSE
 	if(chosen_sacrifice.stat != DEAD)
@@ -92,7 +92,7 @@
 		return FALSE
 	var/favor_gained = 100 + round(chosen_sacrifice.getFireLoss())
 	GLOB.religious_sect.adjust_favor(favor_gained, user)
-	to_chat(user, span_notice("[GLOB.deity] absorbs the burning corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor."))
+	to_chat(user, span_notice("[GLOB.deity] absorbs the charred corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor."))
 	chosen_sacrifice.dust(force = TRUE)
 	playsound(get_turf(religious_tool), 'sound/effects/supermatter.ogg', 50, TRUE)
 	chosen_sacrifice = null


### PR DESCRIPTION
## About The Pull Request

- Fixes #78881

Husks were having their firestacks decay too rapidly to allow chaplains to perform their burning sacrifice rite.  The decay rate is lowered and you can now sacrifice husked bodies (caused only by burns) for the pyre rite sacrifice.

## Why It's Good For The Game

Pyre sacrifice now is functional.

## Changelog

:cl:
fix: Fix husks fire decay rate to be slower. Pyre chaplains can now use husked bodies (only caused by burns) to complete their burning sacrifice rite.
/:cl:

