### PR TITLE
Overclock safety setting for Gygax

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -873,5 +873,5 @@
 			act.button_icon_state = "mech_lights_on"
 		else
 			act.button_icon_state = "mech_lights_off"
-		balloon_alert(occupant, "toggled lights [mecha_flags & LIGHTS_ON ? "on":"off"]")
+		balloon_alert(occupant, "lights [mecha_flags & LIGHTS_ON ? "on":"off"]")
 		act.build_all_button_icons()

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -173,6 +173,10 @@
 	var/overclock_temp = 0
 	///Temperature threshold at which actuators may start causing internal damage
 	var/overclock_temp_danger = 15
+	///Whether the mech has an option to enable safe overclocking
+	var/overclock_safety_available = FALSE
+	///Whether the overclocking turns off automatically when overheated
+	var/overclock_safety = FALSE
 
 	//Bool for zoom on/off
 	var/zoom_mode = FALSE
@@ -520,6 +524,9 @@
 	overclock_temp = min(overclock_temp + seconds_per_tick, overclock_temp_danger * 2)
 	if(overclock_temp < overclock_temp_danger)
 		return
+	if(overclock_temp >= overclock_temp_danger && overclock_safety)
+		toggle_overclock(FALSE)
+		return
 	var/damage_chance = 100 * ((overclock_temp - overclock_temp_danger) / (overclock_temp_danger * 2))
 	if(SPT_PROB(damage_chance, seconds_per_tick))
 		do_sparks(5, TRUE, src)
@@ -811,6 +818,15 @@
 	else
 		overclock_mode = !overclock_mode
 	log_message("Toggled overclocking.", LOG_MECHA)
+
+	for(var/mob/occupant as anything in occupants)
+		var/datum/action/act = locate(/datum/action/vehicle/sealed/mecha/mech_overclock) in occupant.actions
+		if(!act)
+			continue
+		act.button_icon_state = "mech_overload_[overclock_mode ? "on" : "off"]"
+		balloon_alert(occupant, "toggled overclock [overclock_mode ? "on":"off"]")
+		act.build_all_button_icons()
+
 	if(overclock_mode)
 		movedelay = movedelay / overclock_coeff
 		visible_message(span_notice("[src] starts heating up, making humming sounds."))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -824,7 +824,7 @@
 		if(!act)
 			continue
 		act.button_icon_state = "mech_overload_[overclock_mode ? "on" : "off"]"
-		balloon_alert(occupant, "toggled overclock [overclock_mode ? "on":"off"]")
+		balloon_alert(occupant, "overclock [overclock_mode ? "on":"off"]")
 		act.build_all_button_icons()
 
 	if(overclock_mode)

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -22,6 +22,8 @@
 	)
 	step_energy_drain = 4
 	can_use_overclock = TRUE
+	overclock_safety_available = TRUE
+	overclock_safety = TRUE
 
 /datum/armor/mecha_gygax
 	melee = 25

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -152,6 +152,5 @@
 	if(!owner || !chassis || !(owner in chassis.occupants))
 		return
 	chassis.toggle_overclock(forced_state)
-	chassis.balloon_alert(owner, chassis.overclock_mode ? "started overclocking" : "stopped overclocking")
 	button_icon_state = "mech_overload_[chassis.overclock_mode ? "on" : "off"]"
 	build_all_button_icons()

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -82,6 +82,8 @@
 	data["internal_damage"] = internal_damage
 
 	data["can_use_overclock"] = can_use_overclock
+	data["overclock_safety_available"] = overclock_safety_available
+	data["overclock_safety"] = overclock_safety
 	data["overclock_mode"] = overclock_mode
 	data["overclock_temp_percentage"] = overclock_temp / overclock_temp_danger
 
@@ -210,9 +212,8 @@
 			toggle_lights(user = usr)
 		if("toggle_overclock")
 			toggle_overclock()
-			var/datum/action/act = locate(/datum/action/vehicle/sealed/mecha/mech_overclock) in usr.actions
-			act.button_icon_state = "mech_overload_[overclock_mode ? "on" : "off"]"
-			act.build_all_button_icons()
+		if("toggle_overclock_safety")
+			overclock_safety = !overclock_safety
 		if("repair_int_damage")
 			try_repair_int_damage(usr, params["flag"])
 			return FALSE

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -266,11 +266,11 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	var/turf/T = get_turf(loc)
 
 	if(lavaland_equipment_pressure_check(T))
-		movedelay = fast_pressure_step_in
+		movedelay = !overclock_mode ? fast_pressure_step_in : fast_pressure_step_in / overclock_coeff
 		for(var/obj/item/mecha_parts/mecha_equipment/drill/drill in flat_equipment)
 			drill.equip_cooldown = initial(drill.equip_cooldown) * 0.5
 
 	else
-		movedelay = slow_pressure_step_in
+		movedelay = !overclock_mode ? slow_pressure_step_in : slow_pressure_step_in / overclock_coeff
 		for(var/obj/item/mecha_parts/mecha_equipment/drill/drill in flat_equipment)
 			drill.equip_cooldown = initial(drill.equip_cooldown)

--- a/tgui/packages/tgui/interfaces/Mecha/AlertPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/AlertPane.tsx
@@ -27,6 +27,8 @@ export const AlertPane = (props, context) => {
     scanmod_rating,
     capacitor_rating,
     can_use_overclock,
+    overclock_safety_available,
+    overclock_safety,
     overclock_mode,
     overclock_temp_percentage,
   } = data;
@@ -35,21 +37,41 @@ export const AlertPane = (props, context) => {
       title="Status"
       buttons={
         (!!overclock_mode || !!can_use_overclock) && (
-          <Button
-            icon="forward"
-            onClick={() => !!can_use_overclock && act('toggle_overclock')}
-            color={
-              overclock_mode &&
-              (overclock_temp_percentage > 1
-                ? 'bad'
-                : overclock_temp_percentage > 0.5
-                  ? 'average'
-                  : 'good')
-            }>
-            {overclock_mode
-              ? `Overclocking (${Math.round(overclock_temp_percentage * 100)}%)`
-              : 'Overclock'}
-          </Button>
+          <>
+            <Button
+              icon="forward"
+              onClick={() => !!can_use_overclock && act('toggle_overclock')}
+              color={
+                overclock_mode &&
+                (overclock_temp_percentage > 1
+                  ? 'bad'
+                  : overclock_temp_percentage > 0.5
+                    ? 'average'
+                    : 'good')
+              }>
+              {overclock_mode
+                ? `Overclocking (${Math.round(
+                  overclock_temp_percentage * 100
+                )}%)`
+                : 'Overclock'}
+            </Button>
+            {!!overclock_safety_available && (
+              <Button
+                icon={
+                  overclock_safety
+                    ? 'temperature-arrow-down'
+                    : 'temperature-arrow-up'
+                }
+                onClick={() => act('toggle_overclock_safety')}
+                color={overclock_safety ? 'good' : 'bad'}
+                tooltip={
+                  overclock_safety
+                    ? 'OC safety prevents overheat.'
+                    : 'OC safety disabled.'
+                }
+              />
+            )}
+          </>
         )
       }>
       <Stack vertical>

--- a/tgui/packages/tgui/interfaces/Mecha/data.ts
+++ b/tgui/packages/tgui/interfaces/Mecha/data.ts
@@ -1,10 +1,12 @@
+import { BooleanLike } from 'common/react';
+
 export type AccessData = {
   name: string;
   number: number;
 };
 
 export type MainData = {
-  isoperator: boolean;
+  isoperator: BooleanLike;
   ui_theme: string;
   name: string;
   integrity: number;
@@ -16,13 +18,13 @@ export type MainData = {
   internal_damage_keys: string[];
   mechflag_keys: string[];
 
-  can_use_overclock: boolean;
-  overclock_safety_available: boolean;
-  overclock_safety: boolean;
-  overclock_mode: boolean;
+  can_use_overclock: BooleanLike;
+  overclock_safety_available: BooleanLike;
+  overclock_safety: BooleanLike;
+  overclock_mode: BooleanLike;
   overclock_temp_percentage: number;
 
-  one_access: boolean;
+  one_access: BooleanLike;
   regions: string[];
   accesses: string[];
 
@@ -42,10 +44,10 @@ export type MainData = {
   one_atmosphere: number;
   cabin_pressure: number;
   cabin_temp: number;
-  enclosed: boolean;
-  cabin_sealed: boolean;
+  enclosed: BooleanLike;
+  cabin_sealed: BooleanLike;
   dna_lock: string | null;
-  weapons_safety: boolean;
+  weapons_safety: BooleanLike;
   mech_view: string;
   modules: MechModule[];
   selected_module_index: number;
@@ -53,14 +55,14 @@ export type MainData = {
 };
 
 export type MechModule = {
-  selected: boolean;
+  selected: BooleanLike;
   slot: string;
   icon: string;
   name: string;
-  detachable: boolean;
-  can_be_toggled: boolean;
-  can_be_triggered: boolean;
-  active: boolean;
+  detachable: BooleanLike;
+  can_be_toggled: BooleanLike;
+  can_be_triggered: BooleanLike;
+  active: BooleanLike;
   active_label: string;
   equip_cooldown: string;
   energy_per_use: number;

--- a/tgui/packages/tgui/interfaces/Mecha/data.ts
+++ b/tgui/packages/tgui/interfaces/Mecha/data.ts
@@ -17,6 +17,8 @@ export type MainData = {
   mechflag_keys: string[];
 
   can_use_overclock: boolean;
+  overclock_safety_available: boolean;
+  overclock_safety: boolean;
   overclock_mode: boolean;
   overclock_temp_percentage: number;
 


### PR DESCRIPTION
![SVYgXCYIFN](https://github.com/tgstation/tgstation/assets/3625094/fffe3763-fae5-4449-a47e-7fc564e96853)

## About The Pull Request

Since people started using OC on all mechs by attaching a signaller to the wire, I figured that Gygax should have at least something special, except the 2x overclock modifier for dark gygax and the UI button for overclock.

Now Gygax type mechs have an option to automatically disable overclock when the mech is overheated. As Gygax was designed to use overclock, other mechs lack this component and there is no wire for this.

## Why It's Good For The Game

Special overclock behavior for Gygax.

## Changelog

:cl:
add: Gygax type mechs now have an option to disable overclock when overheated.
fix: Fixed overclocking having no effect on Ripley.
/:cl:
