### PR TITLE
Adds missing default biotypes to some damage procs

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -246,7 +246,7 @@
 /mob/living/proc/getToxLoss()
 	return toxloss
 
-/mob/living/proc/can_adjust_tox_loss(amount, forced, required_biotype)
+/mob/living/proc/can_adjust_tox_loss(amount, forced, required_biotype = ALL)
 	if(!forced && ((status_flags & GODMODE) || !(mob_biotypes & required_biotype)))
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_TOX_DAMAGE, TOX, amount, forced) & COMPONENT_IGNORE_CHANGE)
@@ -312,7 +312,7 @@
 /mob/living/proc/getCloneLoss()
 	return cloneloss
 
-/mob/living/proc/can_adjust_clone_loss(amount, forced, required_biotype)
+/mob/living/proc/can_adjust_clone_loss(amount, forced, required_biotype = ALL)
 	if(!forced && (!(mob_biotypes & required_biotype) || status_flags & GODMODE || HAS_TRAIT(src, TRAIT_NOCLONELOSS)))
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_CLONE_DAMAGE, CLONE, amount, forced) & COMPONENT_IGNORE_CHANGE)
@@ -355,7 +355,7 @@
 /mob/living/proc/getStaminaLoss()
 	return staminaloss
 
-/mob/living/proc/can_adjust_stamina_loss(amount, forced, required_biotype)
+/mob/living/proc/can_adjust_stamina_loss(amount, forced, required_biotype = ALL)
 	if(!forced && (!(mob_biotypes & required_biotype) || status_flags & GODMODE))
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_STAMINA_DAMAGE, STAMINA, amount, forced) & COMPONENT_IGNORE_CHANGE)


### PR DESCRIPTION
## About The Pull Request

I noticed by complete coincidence because I happened to glance at the channel a bunch of people complaining about blobbernauts not taking any damage when leaving the blob in manuel round end chat.
Did anyone report this bug, even after prompting? No. Not even the game admin who was playing as the blob.

Makes you wonder how many other bugs people are perfectly willing to spend 15 minutes posting "i fucking hate coders" about without actually telling anyone they exist. Sucks to be them I guess.

Anyone the cause is that some of these procs didn't have a default biotype, so they would never take the toxin damage they were being assigned. Now they will.

## Changelog

:cl:
fix: Blobbernauts will once again take damage when not on blob tiles.
/:cl:
