### PR TITLE
Hairless felinids v2: Now with Approval

### DIFF
--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -112,7 +112,9 @@
 			var/mob/living/carbon/human/human_owner = ownerlimb.owner
 			var/obj/item/bodypart/head/my_head = human_owner.get_bodypart(BODY_ZONE_HEAD) //not always the same as ownerlimb
 			//head hair color takes priority, owner hair color is a backup if we lack a head or something
-			if(my_head)
+			if ((human_owner) && (human_owner.hairstyle == "Bald"))
+				draw_color = skintone2hex(human_owner.skin_tone)
+			else if(my_head)
 				draw_color = my_head.hair_color
 			else
 				draw_color = human_owner.hair_color

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -112,7 +112,7 @@
 			var/mob/living/carbon/human/human_owner = ownerlimb.owner
 			var/obj/item/bodypart/head/my_head = human_owner.get_bodypart(BODY_ZONE_HEAD) //not always the same as ownerlimb
 			//head hair color takes priority, owner hair color is a backup if we lack a head or something
-			if ((human_owner) && (human_owner.hairstyle == "Bald"))
+			if (human_owner.hairstyle == "Bald")
 				draw_color = skintone2hex(human_owner.skin_tone)
 			else if(my_head)
 				draw_color = my_head.hair_color

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -782,12 +782,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 							else
 								accessory_overlay.color = source.dna.features["mcolor"]
 						if(HAIR_COLOR)
-							if (source.hairstyle == "Bald" && istype(accessory, /datum/sprite_accessory/ears/cat))
-								accessory_overlay.color = skintone2hex(source.skin_tone)
-							else if(hair_color == "mutcolor")
+							if(hair_color == "mutcolor")
 								accessory_overlay.color = source.dna.features["mcolor"]
 							else if(hair_color == "fixedmutcolor")
 								accessory_overlay.color = fixed_hair_color
+							else if(source.hairstyle == "Bald")
+								accessory_overlay.color = skintone2hex(source.skin_tone)
 							else
 								accessory_overlay.color = source.hair_color
 						if(FACIAL_HAIR_COLOR)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -782,7 +782,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 							else
 								accessory_overlay.color = source.dna.features["mcolor"]
 						if(HAIR_COLOR)
-							if(hair_color == "mutcolor")
+							if (source.hairstyle == "Bald" && istype(accessory, /datum/sprite_accessory/ears/cat))
+								accessory_overlay.color = skintone2hex(source.skin_tone)
+							else if(hair_color == "mutcolor")
 								accessory_overlay.color = source.dna.features["mcolor"]
 							else if(hair_color == "fixedmutcolor")
 								accessory_overlay.color = fixed_hair_color


### PR DESCRIPTION
![approval](https://github.com/tgstation/tgstation/assets/32695675/be8654fa-66d5-4fa5-8134-e9f5ca5ba2a9)
## About The Pull Request

Copy of: https://github.com/tgstation/tgstation/pull/74539

Allows hairless felinids.
Simply choose the "bald" hair type, and felinid hair/ears will match your skintype.

![image](https://github.com/tgstation/tgstation/assets/32695675/4a5cca4b-2037-4380-b284-7fb94314c097)

![image](https://github.com/tgstation/tgstation/assets/32695675/413377f4-d4e8-4d1a-b316-302625a19d83)


## Why It's Good For The Game

Something something allows more roleplay options.
Mostly I thought it would be funny

## Changelog

:cl: Epoc
add: Hairless felinid option (select "Bald" hairstyle)
/:cl:
