### PR TITLE
Halloween tile decals

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -553,7 +553,7 @@
 	begin_month = OCTOBER
 	end_day = 2
 	end_month = NOVEMBER
-	holiday_colors = list(COLOR_MOSTLY_PURE_ORANGE, COLOR_DARK)
+	holiday_colors = list(COLOR_MOSTLY_PURE_ORANGE, COLOR_PRISONER_BLACK)
 
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -553,10 +553,7 @@
 	begin_month = OCTOBER
 	end_day = 2
 	end_month = NOVEMBER
-	holiday_colors = list(
-	COLOR_ENGINEERING_ORANGE,
-	COLOR_DARK,
-	)
+	holiday_colors = list(COLOR_MOSTLY_PURE_ORANGE, COLOR_DARK)
 
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -553,6 +553,10 @@
 	begin_month = OCTOBER
 	end_day = 2
 	end_month = NOVEMBER
+	holiday_colors = list(
+	COLOR_ENGINEERING_ORANGE,
+	COLOR_DARK,
+	)
 
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"


### PR DESCRIPTION
## About The Pull Request

Adds orange and black tile decals for the Halloween holiday.

<details>
<summary>Screenshot</summary>
  
![image](https://github.com/tgstation/tgstation/assets/83487515/36ac0d48-fe89-4f15-b9f7-bc55cb0f0de1)

![image](https://github.com/tgstation/tgstation/assets/83487515/fa409d3e-004e-45e3-97b3-05f9244fbf13)

</details>

## Why It's Good For The Game

It's Halloween, compliment the visual filter recently added to the holiday.

## Changelog

:cl: LT3
image: Added Halloween themed floor/tram tiles
/:cl: