### PR TITLE
Adds Oxyloss KO unit test

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -197,6 +197,7 @@
 #include "organ_set_bonus.dm"
 #include "organs.dm"
 #include "outfit_sanity.dm"
+#include "oxyloss_suffocation.dm"
 #include "paintings.dm"
 #include "pills.dm"
 #include "plane_double_transform.dm"

--- a/code/modules/unit_tests/oxyloss_suffocation.dm
+++ b/code/modules/unit_tests/oxyloss_suffocation.dm
@@ -1,0 +1,10 @@
+/// Test getting over a certain threshold of oxy damage results in KO
+/datum/unit_test/oxyloss_suffocation
+
+/datum/unit_test/oxyloss_suffocation/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+
+	dummy.setOxyLoss(75)
+	TEST_ASSERT(HAS_TRAIT_FROM(dummy, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT), "Dummy should have been knocked out from taking oxy damage.")
+	dummy.setOxyLoss(0)
+	TEST_ASSERT(!HAS_TRAIT_FROM(dummy, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT), "Dummy should have woken up from KO when healing to 0 oxy damage.")


### PR DESCRIPTION

## About The Pull Request

Adds a unit test ensuring mobs over 50 oxyloss pass out correctly (and likewise, mobs below 50 wake up). 

See #79034