### PR TITLE
Fixes some items produced by using plants not inheriting reagent purity

### DIFF
--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -52,8 +52,8 @@
 
 	if(istype(source, /obj/item/food/grown) && ispath(trash, /obj/item/food))
 		var/obj/item/food/grown/plant = source
-		var/reagent_purity = plant.seed.get_reagent_purity()
-		trash_item = new trash(edible_object.drop_location(), reagent_purity)
+		trash_item = new trash(edible_object.drop_location())
+		trash.reagents?.set_all_reagents_purity(plant.seed.get_reagent_purity())
 	else
 		trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())
 

--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -53,7 +53,7 @@
 	if(istype(source, /obj/item/food/grown) && ispath(trash, /obj/item/food))
 		var/obj/item/food/grown/plant = source
 		trash_item = new trash(edible_object.drop_location())
-		trash.reagents?.set_all_reagents_purity(plant.seed.get_reagent_purity())
+		trash_item.reagents?.set_all_reagents_purity(plant.seed.get_reagent_purity())
 	else
 		trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())
 

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -83,7 +83,7 @@
 	)
 	tastes = list("caramel" = 2, "popcorn" = 1)
 	foodtypes = JUNKFOOD | SUGAR
-	trash_type = /obj/item/trash/popcorn/
+	trash_type = /obj/item/trash/popcorn
 	crafting_complexity = FOOD_COMPLEXITY_1
 
 /obj/item/food/soydope

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -97,8 +97,8 @@
 /obj/item/food/grown/meatwheat/attack_self(mob/living/user)
 	user.visible_message(span_notice("[user] crushes [src] into meat."), span_notice("You crush [src] into something that resembles meat."))
 	playsound(user, 'sound/effects/blobattack.ogg', 50, TRUE)
-	var/reagent_purity = seed.get_reagent_purity()
-	var/obj/item/food/meat/slab/meatwheat/M = new(null, reagent_purity)
+	var/obj/item/food/meat/slab/meatwheat/meaties = new(null)
+	meaties.reagents.set_all_reagents_purity(seed.get_reagent_purity())
 	qdel(src)
-	user.put_in_hands(M)
-	return 1
+	user.put_in_hands(meaties)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

In #78322 I removed the reagent purity initialize argument from grown items, thinking it was only used by butter. It was actually used in two other places which I missed, in which I have implemented the same functionality.
Rather than passing the desired purity on creation we instead just set the purity of contents reagents after initialising the atom. This broadly replicates what the edible component was doing, as these items only get reagents from being edible.

## Changelog

:cl:
fix: Meatwheat Clumps, Bungo Pits, and Eggplant Eggs should once again inherit reagent purity from the grown item which produces them.
/:cl:
