### PR TITLE
Cooked meat no longer spreads blood around.

### DIFF
--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -19,13 +19,12 @@
 		max_blood = custom_materials[custom_materials[1]],\
 	)
 
-	if(foodtypes & RAW)
-		AddComponent(
-			/datum/component/bloody_spreader,\
-			blood_left = custom_materials[custom_materials[1]],\
-			blood_dna = list("meaty DNA" = "MT-"),\
-			diseases = null,\
-		)
+	AddComponent(
+		/datum/component/bloody_spreader,\
+		blood_left = custom_materials[custom_materials[1]],\
+		blood_dna = list("meaty DNA" = "MT-"),\
+		diseases = null,\
+	)
 
 /obj/item/food/meat/slab
 	name = "meat"
@@ -380,6 +379,7 @@
 	tastes = list("bacon" = 1)
 	foodtypes = MEAT | BREAKFAST
 	crafting_complexity = FOOD_COMPLEXITY_1
+	blood_decal_type = null
 
 /obj/item/food/meat/slab/gondola
 	name = "gondola meat"
@@ -442,6 +442,7 @@
 	tastes = list("crab" = 1)
 	foodtypes = SEAFOOD
 	crafting_complexity = FOOD_COMPLEXITY_1
+	blood_decal_type = null
 
 /obj/item/food/meat/slab/chicken
 	name = "chicken meat"
@@ -500,6 +501,7 @@
 	foodtypes = MEAT
 	tastes = list("meat" = 1)
 	crafting_complexity = FOOD_COMPLEXITY_1
+	blood_decal_type = null
 
 /obj/item/food/meat/steak/Initialize(mapload)
 	. = ..()
@@ -544,12 +546,10 @@
 /obj/item/food/meat/steak/xeno
 	name = "xeno steak"
 	tastes = list("meat" = 1, "acid" = 1)
-	blood_decal_type = /obj/effect/decal/cleanable/xenoblood
 
 /obj/item/food/meat/steak/spider
 	name = "spider steak"
 	tastes = list("cobwebs" = 1)
-	blood_decal_type = /obj/effect/decal/cleanable/insectguts
 
 /obj/item/food/meat/steak/goliath
 	name = "goliath steak"
@@ -720,6 +720,7 @@
 	tastes = list("meat" = 1)
 	foodtypes = MEAT
 	crafting_complexity = FOOD_COMPLEXITY_1
+	blood_decal_type = null
 
 /obj/item/food/meat/cutlet/Initialize(mapload)
 	. = ..()
@@ -756,7 +757,6 @@
 	name = "killer tomato cutlet"
 	tastes = list("tomato" = 1)
 	foodtypes = FRUIT
-	blood_decal_type = /obj/effect/decal/cleanable/food/tomato_smudge
 
 /obj/item/food/meat/cutlet/bear
 	name = "bear cutlet"
@@ -765,12 +765,10 @@
 /obj/item/food/meat/cutlet/xeno
 	name = "xeno cutlet"
 	tastes = list("meat" = 1, "acid" = 1)
-	blood_decal_type = /obj/effect/decal/cleanable/xenoblood
 
 /obj/item/food/meat/cutlet/spider
 	name = "spider cutlet"
 	tastes = list("cobwebs" = 1)
-	blood_decal_type = /obj/effect/decal/cleanable/insectguts
 
 /obj/item/food/meat/cutlet/gondola
 	name = "gondola cutlet"

--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -19,13 +19,13 @@
 		max_blood = custom_materials[custom_materials[1]],\
 	)
 
-	AddComponent(
-		/datum/component/bloody_spreader,\
-		blood_left = custom_materials[custom_materials[1]],\
-		blood_dna = list("meaty DNA" = "MT-"),\
-		diseases = null,\
-	)
-
+	if(foodtypes & RAW)
+		AddComponent(
+			/datum/component/bloody_spreader,\
+			blood_left = custom_materials[custom_materials[1]],\
+			blood_dna = list("meaty DNA" = "MT-"),\
+			diseases = null,\
+		)
 
 /obj/item/food/meat/slab
 	name = "meat"


### PR DESCRIPTION
## About The Pull Request
See the title.

## Why It's Good For The Game
Someone pointed it out on #78743. I'd like to consider this a fix, even though carlarc has actually set blood decals for cooked xeno and killer tomato meat toos, because meat generally loses blood as it gets griddled, and doneness really isn't a feature yet.

## Changelog

:cl:
fix: Cooked meat no longer spreads blood around as if it weren't cooked.
/:cl:
