### PR TITLE
Add pocket crowbar to all survival boxes

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -48,6 +48,8 @@
 	if(SSmapping.is_planetary() && LAZYLEN(SSmapping.multiz_levels))
 		new /obj/item/climbing_hook/emergency(src)
 
+	new /obj/item/crowbar(src)
+
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.
 	new /obj/item/radio/off(src)


### PR DESCRIPTION

## About The Pull Request
A pocket crowbar is added to every survival box.
## Why It's Good For The Game
If a room gets spaced and the power is out (for example due to an explosion) one can not open the firedoors. This change is to prevent this from happening. It also prevents that everyone is stealing some crowbar from the fire lockers in the hallway or breaking into a department to print a pocket crowbar.
## Changelog
add: Added pocked crowbar to survival box
