### PR TITLE
It is now possible to survive the Mansus 

### DIFF
--- a/_maps/templates/lazy_templates/heretic_sacrifice.dmm
+++ b/_maps/templates/lazy_templates/heretic_sacrifice.dmm
@@ -761,13 +761,9 @@ ab
 ab
 ab
 ab
-ab
-ab
 "}
 (2,1,1) = {"
 ab
-ab
-Fd
 Fd
 Fd
 Fd
@@ -811,7 +807,6 @@ ab
 "}
 (3,1,1) = {"
 ab
-ab
 Fd
 jt
 jt
@@ -851,11 +846,9 @@ La
 La
 La
 La
-Fd
 ab
 "}
 (4,1,1) = {"
-ab
 ab
 Fd
 jt
@@ -896,11 +889,9 @@ AO
 wY
 Wb
 La
-Fd
 ab
 "}
 (5,1,1) = {"
-ab
 ab
 Fd
 wo
@@ -941,11 +932,9 @@ AO
 AO
 wY
 La
-Fd
 ab
 "}
 (6,1,1) = {"
-ab
 ab
 Fd
 wo
@@ -986,11 +975,9 @@ AO
 AO
 AO
 La
-Fd
 ab
 "}
 (7,1,1) = {"
-ab
 ab
 Fd
 jt
@@ -1031,11 +1018,9 @@ AO
 AO
 wY
 La
-Fd
 ab
 "}
 (8,1,1) = {"
-ab
 ab
 Fd
 En
@@ -1076,11 +1061,9 @@ AO
 wY
 jB
 La
-Fd
 ab
 "}
 (9,1,1) = {"
-ab
 ab
 Fd
 En
@@ -1121,11 +1104,9 @@ AO
 wY
 Wb
 La
-Fd
 ab
 "}
 (10,1,1) = {"
-ab
 ab
 Fd
 jt
@@ -1166,11 +1147,9 @@ AO
 wY
 Wb
 La
-Fd
 ab
 "}
 (11,1,1) = {"
-ab
 ab
 Fd
 wo
@@ -1211,11 +1190,9 @@ AO
 AO
 wY
 La
-Fd
 ab
 "}
 (12,1,1) = {"
-ab
 ab
 Fd
 wo
@@ -1256,11 +1233,9 @@ wY
 AO
 AO
 La
-Fd
 ab
 "}
 (13,1,1) = {"
-ab
 ab
 Fd
 jt
@@ -1301,12 +1276,10 @@ qn
 wY
 AO
 La
-Fd
 ab
 "}
 (14,1,1) = {"
 ab
-ab
 Fd
 jt
 jt
@@ -1346,13 +1319,10 @@ La
 La
 La
 La
-Fd
 ab
 "}
 (15,1,1) = {"
 ab
-ab
-Fd
 Fd
 Fd
 Fd
@@ -1396,7 +1366,6 @@ ab
 "}
 (16,1,1) = {"
 ab
-ab
 Fd
 fO
 fO
@@ -1436,11 +1405,9 @@ HQ
 HQ
 HQ
 HQ
-Fd
 ab
 "}
 (17,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1481,11 +1448,9 @@ St
 ui
 St
 HQ
-Fd
 ab
 "}
 (18,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1526,11 +1491,9 @@ Xt
 Vd
 ui
 HQ
-Fd
 ab
 "}
 (19,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1571,11 +1534,9 @@ hZ
 ui
 St
 HQ
-Fd
 ab
 "}
 (20,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1616,11 +1577,9 @@ RW
 RW
 St
 HQ
-Fd
 ab
 "}
 (21,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1661,11 +1620,9 @@ St
 RW
 St
 HQ
-Fd
 ab
 "}
 (22,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1706,11 +1663,9 @@ JJ
 ui
 St
 HQ
-Fd
 ab
 "}
 (23,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1751,11 +1706,9 @@ ui
 ui
 St
 HQ
-Fd
 ab
 "}
 (24,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1796,11 +1749,9 @@ rP
 ui
 St
 HQ
-Fd
 ab
 "}
 (25,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1841,11 +1792,9 @@ RW
 cS
 ui
 HQ
-Fd
 ab
 "}
 (26,1,1) = {"
-ab
 ab
 Fd
 fO
@@ -1886,12 +1835,10 @@ Yp
 Xt
 St
 HQ
-Fd
 ab
 "}
 (27,1,1) = {"
 ab
-ab
 Fd
 fO
 fO
@@ -1931,13 +1878,10 @@ HQ
 HQ
 HQ
 HQ
-Fd
 ab
 "}
 (28,1,1) = {"
 ab
-ab
-Fd
 Fd
 Fd
 Fd
@@ -2017,9 +1961,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+Fd
 ab
 ab
 ab

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -187,6 +187,11 @@
 
 /obj/structure/bonfire/prelit/Initialize(mapload)
 	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+// Late init so that we can wait for air to exist in lazyloaded templates
+/obj/structure/bonfire/prelit/LateInitialize()
+	. = ..()
 	start_burning()
 
 #undef BONFIRE_FIRE_STACK_STRENGTH

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -13,7 +13,7 @@
 	tick_interval = 1 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/unholy_determination
 	/// How much to heal every second
-	var/heal_per_second = 1
+	var/heal_per_second = 0.25
 
 /datum/status_effect/unholy_determination/on_creation(mob/living/new_owner, set_duration)
 	if(isnum(set_duration))

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -12,6 +12,8 @@
 	duration = 3 MINUTES // Given a default duration so no one gets to hold onto this buff forever by accident.
 	tick_interval = 1 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/unholy_determination
+	/// How much to heal every second
+	var/heal_per_second = 1
 
 /datum/status_effect/unholy_determination/on_creation(mob/living/new_owner, set_duration)
 	if(isnum(set_duration))
@@ -27,7 +29,7 @@
 
 /datum/status_effect/unholy_determination/tick(seconds_between_ticks)
 	// The amount we heal of each damage type per tick. If we're missing legs we heal better because we can't dodge.
-	var/healing_amount = (0.4 + (0.8 - owner.usable_legs))
+	var/healing_amount = (heal_per_second * seconds_between_ticks) + (heal_per_second * (2 - owner.usable_legs))
 
 	// In softcrit you're, strong enough to stay up.
 	if(owner.health <= owner.crit_threshold && owner.health >= owner.hardcrit_threshold)
@@ -49,8 +51,8 @@
 		playsound(owner, pick(GLOB.creepy_ambience), 50, TRUE)
 
 	adjust_all_damages(healing_amount, seconds_between_ticks)
-	adjust_temperature()
-	adjust_bleed_wounds()
+	adjust_temperature(seconds_between_ticks)
+	adjust_bleed_wounds(seconds_between_ticks)
 
 /*
  * Heals up all the owner a bit, fire stacks and losebreath included.
@@ -58,42 +60,42 @@
 /datum/status_effect/unholy_determination/proc/adjust_all_damages(amount, seconds_between_ticks)
 
 	owner.adjust_fire_stacks(-1)
-	owner.losebreath = max(owner.losebreath - 0.5, 0)
+	owner.losebreath = max(owner.losebreath - (0.5 * seconds_between_ticks), 0)
 
-	var/need_mob_update = FALSE
-	need_mob_update += owner.adjustToxLoss(-amount * seconds_between_ticks, updating_health = FALSE, forced = TRUE)
-	need_mob_update += owner.adjustOxyLoss(-amount * seconds_between_ticks, updating_health = FALSE)
-	need_mob_update += owner.adjustBruteLoss(-amount * seconds_between_ticks, updating_health = FALSE)
-	need_mob_update += owner.adjustFireLoss(-amount * seconds_between_ticks, updating_health = FALSE)
-	if(need_mob_update)
+	var/damage_healed = 0
+	damage_healed += owner.adjustToxLoss(-amount, updating_health = FALSE, forced = TRUE)
+	damage_healed += owner.adjustOxyLoss(-amount, updating_health = FALSE)
+	damage_healed += owner.adjustBruteLoss(-amount, updating_health = FALSE)
+	damage_healed += owner.adjustFireLoss(-amount, updating_health = FALSE)
+	if(damage_healed > 0)
 		owner.updatehealth()
 
 /*
  * Adjust the owner's temperature up or down to standard body temperatures.
  */
-/datum/status_effect/unholy_determination/proc/adjust_temperature()
+/datum/status_effect/unholy_determination/proc/adjust_temperature(seconds_between_ticks)
 	var/target_temp = owner.get_body_temp_normal(apply_change = FALSE)
 	if(owner.bodytemperature > target_temp)
-		owner.adjust_bodytemperature(-50 * TEMPERATURE_DAMAGE_COEFFICIENT, target_temp)
+		owner.adjust_bodytemperature(-50 * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_between_ticks, target_temp)
 	else if(owner.bodytemperature < (target_temp + 1))
-		owner.adjust_bodytemperature(50 * TEMPERATURE_DAMAGE_COEFFICIENT, target_temp)
+		owner.adjust_bodytemperature(50 * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_between_ticks, target_temp)
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.coretemperature > target_temp)
-			human_owner.adjust_coretemperature(-50 * TEMPERATURE_DAMAGE_COEFFICIENT, target_temp)
+			human_owner.adjust_coretemperature(-50 * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_between_ticks, target_temp)
 		else if(human_owner.coretemperature < (target_temp + 1))
-			human_owner.adjust_coretemperature(50 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, target_temp)
+			human_owner.adjust_coretemperature(50 * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_between_ticks, 0, target_temp)
 
 /*
  * Slow and stop any blood loss the owner's experiencing.
  */
-/datum/status_effect/unholy_determination/proc/adjust_bleed_wounds()
+/datum/status_effect/unholy_determination/proc/adjust_bleed_wounds(seconds_between_ticks)
 	if(!iscarbon(owner) || !owner.blood_volume)
 		return
 
 	if(owner.blood_volume < BLOOD_VOLUME_NORMAL)
-		owner.blood_volume = owner.blood_volume + 2
+		owner.blood_volume = owner.blood_volume + (2 * seconds_between_ticks)
 
 	var/mob/living/carbon/carbon_owner = owner
 	var/datum/wound/bloodiest_wound
@@ -104,4 +106,4 @@
 	if(!bloodiest_wound)
 		return
 
-	bloodiest_wound.adjust_blood_flow(-0.5)
+	bloodiest_wound.adjust_blood_flow(-0.5 * seconds_between_ticks)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -834,7 +834,7 @@
 	// If they happen to be dead too, try to revive them - if possible.
 	if(stat == DEAD && can_be_revived())
 		// If the revive is successful, show our revival message (if present).
-		if(revive(FALSE, FALSE, 10) && revive_message)
+		if(revive(excess_healing = 10) && revive_message)
 			visible_message(revive_message)
 
 	// Finally update health again after we're all done

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -18,6 +18,7 @@
 
 /obj/projectile/curse_hand/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_FREE_HYPERSPACE_MOVEMENT, INNATE_TRAIT)
 	handedness = prob(50)
 	icon_state = "[base_icon_state][handedness]"
 


### PR DESCRIPTION
## About The Pull Request

Fixes #79113

There were a handful of bugs with the Mansus realm, this PR fixes them.

Firstly an most importantly, a refactor to damage handling touched the "unholy determination" effect incorrectly (and I'm not even sure why?), causing it to damage you instead of healing you most of the time. This damage was not avoidable, so most people would be crit shortly after entering the area and stay there.

Secondly, some of the heretic realms were unlit. A change to when lazyloaded template atmosphere initialises means that the bonfires were trying to light themselves with no air. Now they do this in late_initialize instead, giving time for air to arrive.

Thirdly, the spooky hands were runtiming when passing through transit tiles outside of the bounds of the heretic map. They shouldn't be effected by shuttle drag anyway, so now they aren't.

Fourthly, I removed a row of empty space at the edge of the heretic map, just because it annoyed me slightly.

Finally, while I was touching the heretic buff I made it heal you 1/4 as much as it originally did. This is a balance change rather than a fix, I'll atomise it out if it is controversial but I don't really expect it to be.
In the future I would like to come back to these and make each realm more specific to the path, because I think we could make these both more exciting and more characterful.

## Why It's Good For The Game

Once it is working properly, the hand dodging minigame is actually extremely forgiving, even if you don't move very much and get frequently hit. This means some of those hits might actually add some tension.

## Changelog

:cl:
fix: You should be revived properly when entering the mansus realm following a heretic sacrifice
fix: The buff which is supposed to heal you in the mansus realm will now do that instead of unavoidably damaging you
balance: The mansus realm's healing buff heals for 25% as much as it did before it was broken
/:cl:
