### PR TITLE
Admin outfit popup wording [NO GBP]

### DIFF
--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -209,7 +209,7 @@
 	else
 		human_target = target
 		if(human_target.l_store || human_target.r_store || human_target.s_store) //saves a lot of time for admins and coders alike
-			if(tgui_alert(usr,"Do you need the items in your pockets?", "Pocket items", list("Delete Them", "Drop Them")) == "Delete Them")
+			if(tgui_alert(usr,"Do you need the items in your pockets?", "Pocket Items", list("Delete Them", "Drop Them")) == "Delete Them")
 				delete_pocket = TRUE
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -209,7 +209,7 @@
 	else
 		human_target = target
 		if(human_target.l_store || human_target.r_store || human_target.s_store) //saves a lot of time for admins and coders alike
-			if(tgui_alert(usr,"Drop Items in Pockets? No will delete them.", "Robust quick dress shop", list("Yes", "No")) == "No")
+			if(tgui_alert(usr,"Do you need the items in your pockets?", "Pocket items", list("Delete Them", "Drop Them")) == "Delete Them")
 				delete_pocket = TRUE
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!


### PR DESCRIPTION
## About The Pull Request

I've read it 100 times, but it still confuses me every time. Annoying.
I don't know why you would need your pocket items as an admin, so maybe I should've remove this popup entirely, but whatever.

Turns this:
<img alt="zVnjGznFWh" src="https://github.com/tgstation/tgstation/assets/3625094/ed842d84-55c8-45da-9dc8-a7df65e28fcc">

Into this:
<img  alt="mLPSl14FsE" src="https://github.com/tgstation/tgstation/assets/3625094/dbf4569b-d2a8-4855-bd81-342c162788dd">

## Why It's Good For The Game

No more confusion

## Changelog

:cl:
qol: changed wording of a popup in the admin dressing menu
/:cl:
