### PR TITLE
Fishing-related bounties.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -924,6 +924,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///Trait needed for the lubefish evolution
 #define TRAIT_FISH_FED_LUBE "fish_fed_lube"
 #define TRAIT_FISH_NO_HUNGER "fish_no_hunger"
+///It comes from a fish case. Relevant for bounties so far.
+#define TRAIT_FISH_FROM_CASE "fish_from_case"
 
 /// Trait given to angelic constructs to let them purge cult runes
 #define TRAIT_ANGELIC "angelic"

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -209,3 +209,74 @@
 	description = "We have a moth infestation, send a flamethrower to help deal with the situation."
 	reward = CARGO_CRATE_VALUE * 4
 	wanted_types = list(/obj/item/flamethrower = TRUE)
+
+/datum/bounty/item/assistant/fish
+	name = "Fish"
+	description = "We need fish to populate our aquariums with. Fishes that are dead or from fish cases will only be paid half as much."
+	reward = CARGO_CRATE_VALUE * 9
+	required_count = 4
+	wanted_types = list(/obj/item/fish = TRUE)
+
+/datum/bounty/item/assistant/fish/ship(obj/shipped)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/fish/fishie = shipped
+	if(fishie.status == FISH_DEAD || HAS_TRAIT(fishie, TRAIT_FISH_FROM_CASE))
+		reward -= initial(reward) * 0.5 / required_count
+
+///A subtype of the fish bounty that requires fish with a specific fluid type
+/datum/bounty/item/assistant/fish/fluid
+	reward = CARGO_CRATE_VALUE * 11
+	///The required fluid type of the fish for it to be shipped
+	var/fluid_type
+
+/datum/bounty/item/assistant/fish/fluid/New()
+	..()
+	// sulph water and air are a bit too rare right now
+	fluid_type = pick(AQUARIUM_FLUID_FRESHWATER, AQUARIUM_FLUID_SALTWATER)
+	name = "[fluid_type] Fish"
+	description = "We need [lowertext(fluid_type)] fish to populate our aquariums with. Fishes that are dead or from fish cases will only be paid half as much."
+
+/datum/bounty/item/assistant/fish/fluid/applies_to(obj/shipped)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/fish/fishie = shipped
+	return compatible_fluid_type(fishie.required_fluid_type, fluid_type)
+
+///A subtype of the fish bounty that requires specific fish types. The higher their rarity, the better the pay.
+/datum/bounty/item/assistant/fish/specific
+	description = "Our prestigious fish collection is currently lacking a few specific species. Fishes that are dead or from fish cases will only be paid half as much."
+	reward = CARGO_CRATE_VALUE * 16
+	required_count = 3
+	wanted_types = list()
+
+/datum/bounty/item/assistant/fish/specific/New()
+	var/static/list/choosable_fishes
+	if(!choosable_fishes)
+		choosable_fishes = list()
+		for(var/obj/item/fish/prototype in subtypesof(/obj/item/fish))
+			if(initial(prototype.experisci_scannable) && initial(prototype.show_in_catalog))
+				choosable_fishes += prototype
+
+	var/list/fishes_copylist = choosable_fishes.Copy()
+	///Used to calculate the extra reward
+	var/total_rarity = 0
+	for(var/i in 1 to rand(2,3))
+		var/obj/item/fish/chosen_path = pick_n_take(fishes_copylist)
+		wanted_types[chosen_path] = TRUE
+		total_rarity += initial(chosen_path.random_case_rarity) / 3
+	name = english_list(wanted_types)
+
+	..()
+
+	switch(total_rarity)
+		if(FISH_RARITY_NOPE to FISH_RARITY_GOOD_LUCK_FINDING_THIS)
+			reward += CARGO_CRATE_VALUE * 14
+		if(FISH_RARITY_GOOD_LUCK_FINDING_THIS to FISH_RARITY_VERY_RARE)
+			reward += CARGO_CRATE_VALUE * 6.5
+		if(FISH_RARITY_VERY_RARE to FISH_RARITY_RARE)
+			reward += CARGO_CRATE_VALUE * 3
+		if(FISH_RARITY_RARE to FISH_RARITY_BASIC-1)
+			reward += CARGO_CRATE_VALUE * 1

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -274,8 +274,6 @@
 		total_rarity += initial(chosen_path.random_case_rarity) / 3
 	name = english_list(wanted_types)
 
-	..()
-
 	switch(total_rarity)
 		if(FISH_RARITY_NOPE to FISH_RARITY_GOOD_LUCK_FINDING_THIS)
 			reward += CARGO_CRATE_VALUE * 14
@@ -285,3 +283,5 @@
 			reward += CARGO_CRATE_VALUE * 3
 		if(FISH_RARITY_RARE to FISH_RARITY_BASIC-1)
 			reward += CARGO_CRATE_VALUE * 1
+
+	..()

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -233,8 +233,7 @@
 
 /datum/bounty/item/assistant/fish/fluid/New()
 	..()
-	// sulph water and air are a bit too rare right now
-	fluid_type = pick(AQUARIUM_FLUID_FRESHWATER, AQUARIUM_FLUID_SALTWATER)
+	fluid_type = pick(AQUARIUM_FLUID_FRESHWATER, AQUARIUM_FLUID_SALTWATER, AQUARIUM_FLUID_SULPHWATEVER)
 	name = "[fluid_type] Fish"
 	description = "We need [lowertext(fluid_type)] fish to populate our aquariums with. Fishes that are dead or from fish cases will only be paid half as much."
 

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -212,11 +212,11 @@
 
 /datum/bounty/item/assistant/fish
 	name = "Fish"
-	description = "We need fish to populate our aquariums with. Fishes that are dead or from fish cases will only be paid half as much."
+	description = "We need fish to populate our aquariums with. Fishes that are dead or bought from cargo will only be paid half as much."
 	reward = CARGO_CRATE_VALUE * 9
 	required_count = 4
 	wanted_types = list(/obj/item/fish = TRUE)
-	///the penalty for shipping dead/bought fish, which can drain up to half reward in total.
+	///the penalty for shipping dead/bought fish, which can subtract up to half the reward in total.
 	var/shipping_penalty
 
 /datum/bounty/item/assistant/fish/New()
@@ -241,7 +241,7 @@
 	..()
 	fluid_type = pick(AQUARIUM_FLUID_FRESHWATER, AQUARIUM_FLUID_SALTWATER, AQUARIUM_FLUID_SULPHWATEVER)
 	name = "[fluid_type] Fish"
-	description = "We need [lowertext(fluid_type)] fish to populate our aquariums with. Fishes that are dead or from fish cases will only be paid half as much."
+	description = "We need [lowertext(fluid_type)] fish to populate our aquariums with. Fishes that are dead or bought from cargo will only be paid half as much."
 
 /datum/bounty/item/assistant/fish/fluid/applies_to(obj/shipped)
 	. = ..()
@@ -252,27 +252,30 @@
 
 ///A subtype of the fish bounty that requires specific fish types. The higher their rarity, the better the pay.
 /datum/bounty/item/assistant/fish/specific
-	description = "Our prestigious fish collection is currently lacking a few specific species. Fishes that are dead or from fish cases will only be paid half as much."
+	description = "Our prestigious fish collection is currently lacking a few specific species. Fishes that are dead or bought from cargo will only be paid half as much."
 	reward = CARGO_CRATE_VALUE * 16
 	required_count = 3
 	wanted_types = list()
 
 /datum/bounty/item/assistant/fish/specific/New()
 	var/static/list/choosable_fishes
-	if(!choosable_fishes)
+	if(isnull(choosable_fishes))
 		choosable_fishes = list()
-		for(var/obj/item/fish/prototype in subtypesof(/obj/item/fish))
+		for(var/obj/item/fish/prototype as anything in subtypesof(/obj/item/fish))
 			if(initial(prototype.experisci_scannable) && initial(prototype.show_in_catalog))
 				choosable_fishes += prototype
 
 	var/list/fishes_copylist = choosable_fishes.Copy()
 	///Used to calculate the extra reward
 	var/total_rarity = 0
-	for(var/i in 1 to rand(2,3))
+	var/list/name_list = list()
+	var/num_paths = rand(2,3)
+	for(var/i in 1 to num_paths)
 		var/obj/item/fish/chosen_path = pick_n_take(fishes_copylist)
 		wanted_types[chosen_path] = TRUE
-		total_rarity += initial(chosen_path.random_case_rarity) / 3
-	name = english_list(wanted_types)
+		name_list += initial(chosen_path.name)
+		total_rarity += initial(chosen_path.random_case_rarity) / num_paths
+	name = english_list(name_list)
 
 	switch(total_rarity)
 		if(FISH_RARITY_NOPE to FISH_RARITY_GOOD_LUCK_FINDING_THIS)

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -216,6 +216,12 @@
 	reward = CARGO_CRATE_VALUE * 9
 	required_count = 4
 	wanted_types = list(/obj/item/fish = TRUE)
+	///the penalty for shipping dead/bought fish, which can drain up to half reward in total.
+	var/shipping_penalty
+
+/datum/bounty/item/assistant/fish/New()
+	..()
+	shipping_penalty = reward * 0.5 / required_count
 
 /datum/bounty/item/assistant/fish/ship(obj/shipped)
 	. = ..()
@@ -223,7 +229,7 @@
 		return
 	var/obj/item/fish/fishie = shipped
 	if(fishie.status == FISH_DEAD || HAS_TRAIT(fishie, TRAIT_FISH_FROM_CASE))
-		reward -= initial(reward) * 0.5 / required_count
+		reward -= shipping_penalty
 
 ///A subtype of the fish bounty that requires fish with a specific fluid type
 /datum/bounty/item/assistant/fish/fluid

--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -15,21 +15,22 @@
 /datum/bounty/item/can_claim()
 	return ..() && shipped_count >= required_count
 
-/datum/bounty/item/applies_to(obj/O)
-	if(!is_type_in_typecache(O, wanted_types))
+/datum/bounty/item/applies_to(obj/shipped)
+	if(!is_type_in_typecache(shipped, wanted_types))
 		return FALSE
-	if(O.flags_1 & HOLOGRAM_1)
+	if(shipped.flags_1 & HOLOGRAM_1)
 		return FALSE
 	return shipped_count < required_count
 
-/datum/bounty/item/ship(obj/O)
-	if(!applies_to(O))
-		return
-	if(istype(O,/obj/item/stack))
-		var/obj/item/stack/O_is_a_stack = O
-		shipped_count += O_is_a_stack.amount
+/datum/bounty/item/ship(obj/shipped)
+	if(!applies_to(shipped))
+		return FALSE
+	if(istype(shipped,/obj/item/stack))
+		var/obj/item/stack/shipped_is_a_stack = shipped
+		shipped_count += shipped_is_a_stack.amount
 	else
 		shipped_count += 1
+	return TRUE
 
 /// If the user can actually get this bounty as a selection.
 /datum/bounty/proc/can_get()

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -2,13 +2,12 @@
 	..()
 	description = "Upper management has requested one [name] mech be sent as soon as possible. Ship it to receive a large payment."
 
-/datum/bounty/item/mech/ship(obj/O)
-	if(!applies_to(O))
+/datum/bounty/item/mech/ship(obj/shipped)
+	. = ..()
+	if(!.)
 		return
-	if(ismecha(O))
-		var/obj/vehicle/sealed/mecha/M = O
-		M.wreckage = null // So the mech doesn't explode.
-	..()
+	var/obj/vehicle/sealed/mecha/mecha = shipped
+	mecha.wreckage = null // So the mech doesn't explode.
 
 /datum/bounty/item/mech/ripleymk2
 	name = "APLU MK-II \"Ripley\""

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -6,21 +6,22 @@
 /datum/bounty/reagent/can_claim()
 	return ..() && shipped_volume >= required_volume
 
-/datum/bounty/reagent/applies_to(obj/O)
-	if(!is_reagent_container(O))
+/datum/bounty/reagent/applies_to(obj/shipped)
+	if(!is_reagent_container(shipped))
 		return FALSE
-	if(!O.reagents || !O.reagents.has_reagent(wanted_reagent.type))
+	if(!shipped.reagents || !shipped.reagents.has_reagent(wanted_reagent.type))
 		return FALSE
-	if(O.flags_1 & HOLOGRAM_1)
+	if(shipped.flags_1 & HOLOGRAM_1)
 		return FALSE
 	return shipped_volume < required_volume
 
-/datum/bounty/reagent/ship(obj/O)
-	if(!applies_to(O))
-		return
-	shipped_volume += O.reagents.get_reagent_amount(wanted_reagent.type)
+/datum/bounty/reagent/ship(obj/shipped)
+	if(!applies_to(shipped))
+		return FALSE
+	shipped_volume += shipped.reagents.get_reagent_amount(wanted_reagent.type)
 	if(shipped_volume > required_volume)
 		shipped_volume = required_volume
+	return TRUE
 
 /datum/bounty/reagent/simple_drink
 	name = "Simple Drink"
@@ -193,19 +194,20 @@
 /datum/bounty/pill/can_claim()
 	return ..() && shipped_ammount >= required_ammount
 
-/datum/bounty/pill/applies_to(obj/O)
-	if(!istype(O, /obj/item/reagent_containers/pill))
+/datum/bounty/pill/applies_to(obj/shipped)
+	if(!istype(shipped, /obj/item/reagent_containers/pill))
 		return FALSE
-	if(O?.reagents.get_reagent_amount(wanted_reagent.type) >= wanted_vol)
+	if(shipped?.reagents.get_reagent_amount(wanted_reagent.type) >= wanted_vol)
 		return TRUE
 	return FALSE
 
-/datum/bounty/pill/ship(obj/O)
-	if(!applies_to(O))
-		return
+/datum/bounty/pill/ship(obj/shipped)
+	if(!applies_to(shipped))
+		return FALSE
 	shipped_ammount += 1
 	if(shipped_ammount > required_ammount)
 		shipped_ammount = required_ammount
+	return TRUE
 
 /datum/bounty/pill/simple_pill
 	name = "Simple Pill"

--- a/code/modules/cargo/bounties/virus.dm
+++ b/code/modules/cargo/bounties/virus.dm
@@ -16,57 +16,51 @@
 /datum/bounty/virus/can_claim()
 	return ..() && shipped
 
-/datum/bounty/virus/applies_to(obj/O)
+/datum/bounty/virus/applies_to(obj/shipped)
 	if(shipped)
 		return FALSE
-	if(O.flags_1 & HOLOGRAM_1)
+	if(shipped.flags_1 & HOLOGRAM_1)
 		return FALSE
-	if(!istype(O, /obj/item/reagent_containers || !O.reagents || !O.reagents.reagent_list))
+	if(!istype(shipped, /obj/item/reagent_containers || !shipped.reagents || !shipped.reagents.reagent_list))
 		return FALSE
-	var/datum/reagent/blood/B = locate() in O.reagents.reagent_list
-	if(!B)
+	var/datum/reagent/blood/blud = locate() in shipped.reagents.reagent_list
+	if(!blud)
 		return FALSE
-	for(var/V in B.get_diseases())
-		if(!istype(V, /datum/disease/advance))
-			continue
-		if(accepts_virus(V))
+	for(var/datum/disease/advance/virus in blud.get_diseases())
+		if(accepts_virus(virus))
 			return TRUE
 	return FALSE
 
-/datum/bounty/virus/ship(obj/O)
-	if(!applies_to(O))
-		return
+/datum/bounty/virus/ship(obj/shipped)
+	if(!applies_to(shipped))
+		return FALSE
 	shipped = TRUE
+	return TRUE
 
-
-/datum/bounty/virus/proc/accepts_virus(V)
+/datum/bounty/virus/proc/accepts_virus(virus)
 	return TRUE
 
 /datum/bounty/virus/resistance
 	stat_name = "resistance"
 
-/datum/bounty/virus/resistance/accepts_virus(V)
-	var/datum/disease/advance/A = V
-	return A.totalResistance() == stat_value
+/datum/bounty/virus/resistance/accepts_virus(datum/disease/advance/virus)
+	return virus.totalResistance() == stat_value
 
 /datum/bounty/virus/stage_speed
 	stat_name = "stage speed"
 
-/datum/bounty/virus/stage_speed/accepts_virus(V)
-	var/datum/disease/advance/A = V
-	return A.totalStageSpeed() == stat_value
+/datum/bounty/virus/stage_speed/accepts_virus(datum/disease/advance/virus)
+	return virus.totalStageSpeed() == stat_value
 
 /datum/bounty/virus/stealth
 	stat_name = "stealth"
 
-/datum/bounty/virus/stealth/accepts_virus(V)
-	var/datum/disease/advance/A = V
-	return A.totalStealth() == stat_value
+/datum/bounty/virus/stealth/accepts_virus(datum/disease/advance/virus)
+	return virus.totalStealth() == stat_value
 
 /datum/bounty/virus/transmit
 	stat_name = "transmissible"
 
-/datum/bounty/virus/transmit/accepts_virus(V)
-	var/datum/disease/advance/A = V
-	return A.totalTransmittable() == stat_value
+/datum/bounty/virus/transmit/accepts_virus(datum/disease/advance/virus)
+	return virus.totalTransmittable() == stat_value
 

--- a/code/modules/fishing/aquarium/aquarium_kit.dm
+++ b/code/modules/fishing/aquarium/aquarium_kit.dm
@@ -35,6 +35,7 @@
 	var/fish_type = get_fish_type()
 	if(fish_type)
 		var/obj/item/fish/spawned_fish = new fish_type(null)
+		ADD_TRAIT(spawned_fish, TRAIT_FISH_FROM_CASE, TRAIT_GENERIC)
 		spawned_fish.forceMove(src) // trigger storage.handle_entered
 
 /obj/item/storage/fish_case/proc/get_fish_type()

--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -527,6 +527,18 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
+/datum/design/fish_case
+	name = "Stasis Fish Case"
+	id = "fish_case"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT, /datum/material/plastic = SMALL_MATERIAL_AMOUNT)
+	build_path = /obj/item/storage/fish_case
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
 /datum/design/ticket_machine
 	name = "Ticket Machine Frame"
 	id = "ticket_machine"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -48,6 +48,7 @@
 		"experimentor",
 		"extinguisher",
 		"fax",
+		"fish_case",
 		"fishing_rod",
 		"fishing_portal_generator",
 		"flashlight",


### PR DESCRIPTION
## About The Pull Request
This PR adds three basic/assistant bounties for shipping fish. The reward is above par when compared to other basic bounties, however, each shipped fish that is either dead or comes from a case (bought from cargo, cause that's lazy) will reduce the payout by a portion of it, also the pool of assistant bounties is quite big you wouldn't roll them too often.

The three bounties are the following: One for any kind of fish, another for fish of matching fluid type (freshwater, saltwater, sulphuric water), and lastly, one for specific types of fish, possibly easy money if RNG is with you.

## Why It's Good For The Game
I wanted to add something diffrent from most grimy assistant/basic bounties where you either just print the stuff from the nearby autolathe or fetch it for little money. Also, this provides another outlet to fishing, I guess.

## Changelog

:cl:
add: Added a few fish related bounties.
add: Fish cases to store and preserve life fish within can be now printed from the service techfab and the autolathe.
/:cl:
