### PR TITLE
Prettifies Adminwho into an Examine Block

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -130,7 +130,7 @@
 		if(admin.is_afk() || !isnull(admin.holder.fakekey))
 			continue //Don't show afk or fakekeyed admins to adminwho
 
-		returnable_list += "[get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
+		returnable_list += "• [get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
 
 	return returnable_list
 
@@ -142,7 +142,7 @@
 	for(var/client/admin in checkable_admins)
 		var/list/admin_strings = list()
 
-		admin_strings += "[get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
+		admin_strings += "• [get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
 
 		if(admin.holder.fakekey)
 			admin_strings += "<i>(as [admin.holder.fakekey])</i>"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -97,6 +97,7 @@
 	var/list/message_strings = list()
 	if(isnull(holder))
 		message_strings += get_general_adminwho_information(list_of_admins)
+		message_strings += NO_ADMINS_ONLINE_MESSAGE
 	else
 		message_strings += get_sensitive_adminwho_information(list_of_admins)
 

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -73,11 +73,11 @@
 	set category = "Admin"
 	set name = "Adminwho"
 
-	span_bold("Current Admins:")
 	var/list/lines = list()
 	var/payload_string = generate_adminwho_string()
 	var/header
-	if(payload_string = NO_ADMINS_ONLINE_MESSAGE)
+
+	if(payload_string == NO_ADMINS_ONLINE_MESSAGE)
 		header = "No Admins Currently Online"
 	else
 		header = "Current Admins:"
@@ -100,7 +100,7 @@
 	else
 		message_strings += get_sensitive_adminwho_information(list_of_admins)
 
-	return jointext(message_strings, "\n\t")
+	return jointext(message_strings, "\n")
 
 /// Proc that returns a list of cliented admins. Remember that this list can contain nulls!
 /// Also, will return null if we don't have any admins.
@@ -117,9 +117,6 @@
 
 /// Proc that will return the applicable display name, linkified or not, based on the input client reference.
 /proc/get_linked_admin_name(client/admin)
-	if(isnull(admin))
-		continue // valid case because client moment
-
 	var/feedback_link = admin.holder.feedback_link()
 	return isnull(feedback_link) ? admin : "<a href=[feedback_link]>[admin]</a>"
 
@@ -132,7 +129,7 @@
 		if(admin.is_afk() || !isnull(admin.holder.fakekey))
 			continue //Don't show afk or fakekeyed admins to adminwho
 
-		returnable_list += "[get_linked_admin_name(admin)] is a [client.holder.rank_names()]"
+		returnable_list += "[get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
 
 	return returnable_list
 
@@ -146,8 +143,8 @@
 
 		admin_strings += "[get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
 
-		if(client.holder.fakekey)
-			admin_strings += "<i>(as [client.holder.fakekey])</i>"
+		if(admin.holder.fakekey)
+			admin_strings += "<i>(as [admin.holder.fakekey])</i>"
 
 		if(isobserver(admin.mob))
 			admin_strings += "- Observing"
@@ -163,7 +160,7 @@
 		else
 			admin_strings += "- Playing"
 
-		if(client.is_afk())
+		if(admin.is_afk())
 			admin_strings += "(AFK)"
 
 		returnable_list += jointext(admin_strings, " ")

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -72,11 +72,19 @@
 	set category = "Admin"
 	set name = "Adminwho"
 
-	var/msg = "<b>Current Admins:</b>\n"
+	var/list/message_strings = list()
+
+	span_bold("Current Admins:")
 	var/display_name
+	var/list/list_of_admins = get_list_of_admins()
+
+	if(isnull(list_of_admins))
+		message_strings += "\tNo admins are currently online. Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to."
+		return
+
 	if(holder)
-		for(var/client/client in GLOB.admins)
-			var/feedback_link = client.holder.feedback_link()
+		for(var/client/client in list_of_admins)
+			var/feedback_link = list_of_admins[client]
 			display_name = feedback_link ? "<a href=[feedback_link]>[client]</a>" : client
 
 			msg += "\t[display_name] is a [client.holder.rank_names()]"
@@ -110,7 +118,74 @@
 				continue //Don't show afk admins to adminwho
 			if(!client.holder.fakekey)
 				msg += "\t[display_name] is a [client.holder.rank_names()]\n"
-		msg += span_info("Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.")
+
 	to_chat(src, msg)
+
+/// Proc that returns a list of cliented admins. Remember that this list can contain nulls!
+/// Also, will return null if we don't have any admins.
+/proc/get_list_of_admins()
+	var/returnable_list = list()
+
+	for(var/client/admin in GLOB.admins)
+		returnable_list += admin
+
+	if(length(returnable_list) == 0)
+		return null
+
+	return returnable_list
+
+/// Proc that will return the applicable display name, linkified or not, based on the input client reference.
+/proc/get_linked_admin_name(client/admin)
+	if(isnull(admin))
+		continue // valid case because client moment
+
+	var/feedback_link = admin.holder.feedback_link()
+	return isnull(feedback_link) ? admin : "<a href=[feedback_link]>[admin]</a>"
+
+/// Proc that gathers adminwho information for a general player, which will only give information if an admin isn't AFK, and handles potential fakekeying.
+/// Will return a list of strings.
+/proc/get_general_adminwho_information(list/checkable_admins)
+	var/returnable_list = list()
+
+	for(var/client/admin in checkable_admins)
+		if(admin.is_afk() || !isnull(admin.holder.fakekey))
+			continue //Don't show afk or fakekeyed admins to adminwho
+
+		var/list/admin_strings = list()
+		var/display_name = get_linked_admin_name(admin)
+
+/// Proc that gathers adminwho information for admins, which will contain information on if the admin is AFK, readied to join, etc. Only arg is a list of clients to use.
+/// Will return a list of strings.
+/proc/get_sensitive_adminwho_information(list/checkable_admins)
+	var/returnable_list = list()
+
+	for(var/client/admin in checkable_admins)
+		var/list/admin_strings = list()
+
+		admin_strings += "\t[get_linked_admin_name(admin)] is a [admin.holder.rank_names()]"
+
+		if(client.holder.fakekey)
+			admin_strings += "<i>(as [client.holder.fakekey])</i>"
+
+		if(isobserver(admin.mob))
+			admin_strings += "- Observing"
+		else if(isnewplayer(admin.mob))
+			if(SSticker.current_state <= GAME_STATE_PREGAME)
+				var/mob/dead/new_player/lobbied_admin = admin.mob
+				if(lobbied_admin.ready == PLAYER_READY_TO_PLAY)
+					admin_strings += "- Lobby (Readied)"
+				else
+					admin_strings += "- Lobby (Not Readied)"
+			else
+				admin_strings += "- Lobby"
+		else
+			admin_strings += "- Playing"
+
+		if(client.is_afk())
+			admin_strings += "(AFK)"
+
+		returnable_list += jointext(admin_strings, " ")
+
+	return returnable_list
 
 #undef DEFAULT_WHO_CELLS_PER_ROW

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -85,7 +85,7 @@
 	lines += span_bold(header)
 	lines += payload_string
 
-	var/finalized_string = examine_block(jointext(lines, "\n\t"))
+	var/finalized_string = examine_block(jointext(lines, "\n"))
 	to_chat(src, finalized_string)
 
 /// Proc that generates the applicable string to dispatch to the client for adminwho.


### PR DESCRIPTION
## About The Pull Request

Same vein of #71170 (2d3e7f2383e40d12bf0bf8dde755b9931aefae3f) / #69845 (61d49cb11aee8acdacda6d7707d3edf1cd0a5a0b) in an attempt to lessen the number of cruddy "system messages" that just print straight text to chat.

This could be improved CSS wise but I think a standard examine block helps a lot while maintaing clarity, see below:

![image](https://github.com/tgstation/tgstation/assets/34697715/7c08fac0-bd10-4297-ac82-c85d02d7d792)

I also heavily refactored adminwho code to not have so much copypasta while using more `jointext()` and keeping everything a bit more readable than what it previously was. User-facing stuff should all be the same (with the addition of an examine block) except in two spots

* Custom header message when no admins are online. I think this is a far clearer message than having `Current Admins:` and then the message about adminhelps being relayed to Discord
* There's no tabs per each entry. This was replaced by a bullet point. I think it's better to read.
## Why It's Good For The Game

As time goes on, I'm more and more peeved by these pretty critical messages constantly blending in with output from the rest of the game. This is why balloon_alerts and whatever became so popular to my eyes, there's just constant junk. I figure that we may as well just keep the systematic stuff that _must_ live in the chat box looking as neat as possible.
## Changelog
:cl:
qol: Adminwho messages are now in an examine block for heightened clarity.
/:cl:
