### PR TITLE
Don't play SM dusting noise for emitter beams

### DIFF
--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -33,8 +33,8 @@
 		var/damage_to_be = damage + external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
 		if(damage_to_be > danger_point)
 			visible_message(span_notice("[src] compresses under stress, resisting further impacts!"))
+		playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
 
-	playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
 	qdel(projectile)
 	return COMPONENT_BULLET_BLOCKED
 


### PR DESCRIPTION

## About The Pull Request
Shifts the dusting sound to not happen for EVERY projectile, to instead only projectiles which would deal damage to the supermatter. Introduced by #79024.
## Why It's Good For The Game
I assume this wasn't intentional in which case bugs bad, I squash bug
## Changelog
:cl:
fix: Kisses and emitters no longer make the SM crystal scream so much.
/:cl:
