### PR TITLE
Fixes crafting menu not detecting ingredients properly

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -123,14 +123,15 @@
 			if(isstack(item))
 				var/obj/item/stack/stack = item
 				.["other"][item.type] += stack.amount
-			else if(is_reagent_container(item) && item.is_drainable() && length(item.reagents.reagent_list)) //some container that has some reagents inside it that can be drained
-				var/obj/item/reagent_containers/container = item
-				for(var/datum/reagent/reagent as anything in container.reagents.reagent_list)
-					.["other"][reagent.type] += reagent.volume
-			else //a reagent container that is empty can also be used as a tool. e.g. glass bottle can be used as a rolling pin
-				if(item.tool_behaviour)
-					.["tool_behaviour"] += item.tool_behaviour
+			else
 				.["other"][item.type] += 1
+				if(is_reagent_container(item) && item.is_drainable() && length(item.reagents.reagent_list)) //some container that has some reagents inside it that can be drained
+					var/obj/item/reagent_containers/container = item
+					for(var/datum/reagent/reagent as anything in container.reagents.reagent_list)
+						.["other"][reagent.type] += reagent.volume
+				else //a reagent container that is empty can also be used as a tool. e.g. glass bottle can be used as a rolling pin
+					if(item.tool_behaviour)
+						.["tool_behaviour"] += item.tool_behaviour
 		else if (ismachinery(object))
 			LAZYADDASSOCLIST(.["machinery"], object.type, object)
 		else if (isstructure(object))


### PR DESCRIPTION
## About The Pull Request
1. Fixes #79089
This fix applies for the above issue and all crafting recipes that require some sort of reagent container containing reagents. It now adds the container & the reagents inside of it to the list of available ingredients & not just the reagents which was previously the case.

2. Fixes #79159
Other crafting ingredients in general were not being detected if it was not a stack type. That's fixed now too


## Changelog
:cl:
fix: items that require reagent containers & the reagents inside it for crafting(e.g. molotov) now crafts properly.
fix: most crafting recipes should work now
/:cl:
