### PR TITLE
Pass reagent purity into food created via chemical reaction

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -45,10 +45,9 @@
 	if(resulting_food_path)
 		var/atom/location = holder.my_atom.drop_location()
 		for(var/i in 1 to created_volume)
+			var/obj/item/food/result = new resulting_food_path(location)
 			if(ispath(resulting_food_path, /obj/item/food) && !isnull(resulting_reagent_purity))
-				new resulting_food_path(location, resulting_reagent_purity)
-			else
-				new resulting_food_path(location)
+				result.reagents?.set_all_reagents_purity(resulting_reagent_purity)
 
 /datum/chemical_reaction/food/tofu
 	required_reagents = list(/datum/reagent/consumable/soymilk = 10)


### PR DESCRIPTION
## About The Pull Request

Another missed argument passage.
Dough created by mixing reagents now has a purity related to the purity of the creating reagents, and so on for other foods created by mixing chemicals.

## Changelog

:cl:
fix: Food created by mixing chemicals once again has a reagent purity based on the component chemicals.
/:cl: