### PR TITLE
Fixed runtimes when cliff turfs are destroyed

### DIFF
--- a/code/game/turfs/open/cliff.dm
+++ b/code/game/turfs/open/cliff.dm
@@ -35,6 +35,10 @@
 	SET_PLANE(underlay, underlay_plane || plane, src)
 	underlays += underlay
 
+/turf/open/cliff/Destroy(force)
+	UnregisterSignal(src, COMSIG_TURF_MOVABLE_THROW_LANDED)
+	return ..()
+
 /turf/open/cliff/CanPass(atom/movable/mover, border_dir)
 	..()
 


### PR DESCRIPTION
## About The Pull Request
A signal wasn't properly being unregistered between turf changes.

## Why It's Good For The Game
This will fix #79076.

## Changelog
N/A