### PR TITLE
polymorphic belt shouldn't work on animated objects because it's buggy and weird.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -104,6 +104,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, list(/obj/structure/table, /obj/structure
 /mob/living/simple_animal/hostile/mimic/copy
 	health = 100
 	maxHealth = 100
+	mob_biotypes = MOB_SPECIAL
 	var/mob/living/creator = null // the creator
 	var/destroy_objects = 0
 	var/knockdown_people = 0


### PR DESCRIPTION
## About The Pull Request
Title. Also animated objects wouldn't logically have a DNA.

## Why It's Good For The Game
This will fix #78706

## Changelog

:cl:
fix: The polymorphic belt shouldn't work on animated objects. Logically wouldn't have DNA.
/:cl:
