### PR TITLE
Minor signals memory optimization

### DIFF
--- a/code/datums/signals.dm
+++ b/code/datums/signals.dm
@@ -33,22 +33,24 @@
 	var/list/target_procs = (procs[target] ||= list())
 	var/list/lookup = (target._listen_lookup ||= list())
 
-	if(!override && target_procs[signal_type])
-		var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]"
-		log_signal(override_message)
-		stack_trace(override_message)
-
+	var/exists = target_procs[signal_type]
 	target_procs[signal_type] = proctype
+
+	if(exists)
+		if(!override)
+			var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]"
+			log_signal(override_message)
+			stack_trace(override_message)
+		return
+
 	var/list/looked_up = lookup[signal_type]
 
 	if(isnull(looked_up)) // Nothing has registered here yet
 		lookup[signal_type] = src
-	else if(looked_up == src) // We already registered here
-		return
-	else if(!length(looked_up)) // One other thing registered here
-		lookup[signal_type] = list((looked_up) = TRUE, (src) = TRUE)
+	else if(!islist(looked_up)) // One other thing registered here
+		lookup[signal_type] = list(looked_up, src)
 	else // Many other things have registered here
-		looked_up[src] = TRUE
+		looked_up += src
 
 /// Registers multiple signals to the same proc.
 /datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)


### PR DESCRIPTION
This replaces the inner list of signals which tracked receivers with a flat list instead of the previous keyed list that was used to prevent duplicates. We have code already checking for duplicates before hand so we can lean on that to assume the sender already has the receiver listed. This should also be minutely more performant equal to about a single if statement but I don't want to bother trying to profile something so small.