### PR TITLE
Precalculates special list var names and avoids incorrect vv targets

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -12,3 +12,19 @@ GLOBAL_VAR(stickbanadminexemptiontimerid) //stores the timerid of the callback t
 GLOBAL_LIST_INIT_TYPED(smites, /datum/smite, init_smites())
 
 GLOBAL_VAR_INIT(admin_notice, "") // Admin notice that all clients see when joining the server
+
+// A list of all the special byond lists that need to be handled different by vv
+GLOBAL_LIST_INIT(vv_special_lists, init_special_list_names())
+
+/proc/init_special_list_names()
+	var/list/output = list()
+	var/obj/sacrifice = new
+	for(var/varname in sacrifice.vars)
+		var/value = sacrifice.vars[varname]
+		if(!islist(value))
+			if(!isdatum(value) && hascall(value, "Cut"))
+				output[varname] = TRUE
+			continue
+		if(isnull(locate(REF(value))))
+			output[varname] = TRUE
+	return output

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -64,9 +64,14 @@
 		var/datum/datum_value = value
 		return datum_value.debug_variable_value(name, level, owner, sanitize, display_flags)
 
-	if(islist(value) || hascall(value, "Cut")) // Some special lists arent detectable as a list through istype, so we check if it has a list proc instead
+	if(islist(value) || GLOB.vv_special_lists[name]) // Some special lists arent detectable as a list through istype
 		var/list/list_value = value
 		var/list/items = list()
+
+		// This is becuse some lists either dont count as lists or a locate on their ref will return null
+		var/link_vars = "Vars=[REF(value)]"
+		if(GLOB.vv_special_lists[name])
+			link_vars = "Vars=[REF(owner)];special_varname=[name]"
 
 		if (!(display_flags & VV_ALWAYS_CONTRACT_LIST) && list_value.len > 0 && list_value.len <= (IS_NORMAL_LIST(list_value) ? VV_NORMAL_LIST_NO_EXPAND_THRESHOLD : VV_SPECIAL_LIST_NO_EXPAND_THRESHOLD))
 			for (var/i in 1 to list_value.len)
@@ -80,9 +85,9 @@
 
 				items += debug_variable(key, val, level + 1, sanitize = sanitize)
 
-			return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(owner)];special_varname=[name]'>/list ([list_value.len])</a><ul>[items.Join()]</ul>"
+			return "<a href='?_src_=vars;[HrefToken()];[link_vars]'>/list ([list_value.len])</a><ul>[items.Join()]</ul>"
 		else
-			return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(owner)];special_varname=[name]'>/list ([list_value.len])</a>"
+			return "<a href='?_src_=vars;[HrefToken()];[link_vars]'>/list ([list_value.len])</a>"
 
 	if(name in GLOB.bitfields)
 		var/list/flags = list()


### PR DESCRIPTION
## About The Pull Request

This adds a global list to precalculate lists that need to be handled special by vv instead of manually updating such a list. @LemonInTheDark brought up a potential issue with handling all lists in the way special lists are handled, that modifying a list in vv can in some cases result in the wrong list being opened for editing. This makes only special lists have the issue instead of blindly accessing all lists the same way.