### PR TITLE
[no gbp] knock heretics refuge shenanigans fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -83,6 +83,7 @@
 #define COMSIG_CARBON_EMBED_REMOVAL "item_embed_remove_safe"
 ///Called when someone attempts to cuff a carbon
 #define COMSIG_CARBON_CUFF_ATTEMPTED "carbon_attempt_cuff"
+	#define COMSIG_CARBON_CUFF_PREVENT (1<<0)
 ///Called when a carbon mutates (source = dna, mutation = mutation added)
 #define COMSIG_CARBON_GAIN_MUTATION "carbon_gain_mutation"
 ///Called when a carbon loses a mutation (source = dna, mutation = mutation lose)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -72,7 +72,8 @@
 	if(!istype(C))
 		return
 
-	SEND_SIGNAL(C, COMSIG_CARBON_CUFF_ATTEMPTED, user)
+	if(SEND_SIGNAL(C, COMSIG_CARBON_CUFF_ATTEMPTED, user) & COMSIG_CARBON_CUFF_PREVENT)
+		return
 
 	if(iscarbon(user) && (HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))) //Clumsy people have a 50% chance to handcuff themselves instead of their target.
 		to_chat(user, span_warning("Uh... how do those things work?!"))

--- a/code/modules/antagonists/heretic/magic/caretaker.dm
+++ b/code/modules/antagonists/heretic/magic/caretaker.dm
@@ -24,12 +24,16 @@
 /datum/action/cooldown/spell/caretaker/is_valid_target(atom/cast_on)
 	return isliving(cast_on)
 
-/datum/action/cooldown/spell/caretaker/cast(atom/cast_on)
+/datum/action/cooldown/spell/caretaker/cast(mob/living/cast_on)
 	. = ..()
 	for(var/mob/living/alive in orange(5, owner))
 		if(alive.stat != DEAD && alive.client)
 			owner.balloon_alert(owner, "other minds nearby!")
 			return FALSE
+	
+	if(locate(/obj/item/disk/nuclear) in cast_on.get_contents())
+		owner.balloon_alert(owner, "may not enter refuge with the nuke disk!")
+		return FALSE
 
 	var/mob/living/carbon/carbon_user = owner
 	if(carbon_user.has_status_effect(/datum/status_effect/caretaker_refuge))

--- a/code/modules/antagonists/heretic/magic/caretaker.dm
+++ b/code/modules/antagonists/heretic/magic/caretaker.dm
@@ -24,16 +24,18 @@
 /datum/action/cooldown/spell/caretaker/is_valid_target(atom/cast_on)
 	return isliving(cast_on)
 
-/datum/action/cooldown/spell/caretaker/cast(mob/living/cast_on)
+/datum/action/cooldown/spell/caretaker/before_cast(atom/cast_on)
 	. = ..()
+	if(. & SPELL_CANCEL_CAST)
+		return
+
 	for(var/mob/living/alive in orange(5, owner))
 		if(alive.stat != DEAD && alive.client)
 			owner.balloon_alert(owner, "other minds nearby!")
-			return FALSE
-	
-	if(locate(/obj/item/disk/nuclear) in cast_on.get_contents())
-		owner.balloon_alert(owner, "may not enter refuge with the nuke disk!")
-		return FALSE
+			return . | SPELL_CANCEL_CAST
+
+/datum/action/cooldown/spell/caretaker/cast(mob/living/cast_on)
+	. = ..()
 
 	var/mob/living/carbon/carbon_user = owner
 	if(carbon_user.has_status_effect(/datum/status_effect/caretaker_refuge))

--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -242,7 +242,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	duration = -1
 	alert_type = null
-	var/static/list/caretaking_traits = list(TRAIT_HANDS_BLOCKED, TRAIT_IGNORESLOWDOWN)
+	var/static/list/caretaking_traits = list(TRAIT_HANDS_BLOCKED, TRAIT_IGNORESLOWDOWN, TRAIT_SECLUDED_LOCATION)
 
 /datum/status_effect/caretaker_refuge/on_apply()
 	owner.add_traits(caretaking_traits, TRAIT_STATUS_EFFECT(id))
@@ -291,4 +291,4 @@
 
 /datum/status_effect/caretaker_refuge/proc/prevent_cuff(datum/source, mob/attemptee)
 	SIGNAL_HANDLER
-	SEND_SIGNAL(owner, COMSIG_HERETIC_MANSUS_GRASP_ATTACK, attemptee) //ok lets just mansus grasp this nerd
+	return COMSIG_CARBON_CUFF_PREVENT

--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -252,6 +252,7 @@
 	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), PROC_REF(on_focus_lost))
 	RegisterSignal(owner, COMSIG_MOB_BEFORE_SPELL_CAST, PROC_REF(prevent_spell_usage))
 	RegisterSignal(owner, COMSIG_ATOM_HOLYATTACK, PROC_REF(nullrod_handler))
+	RegisterSignal(owner, COMSIG_CARBON_CUFF_ATTEMPTED, PROC_REF(prevent_cuff))
 	return TRUE
 
 /datum/status_effect/caretaker_refuge/on_remove()
@@ -262,6 +263,7 @@
 	UnregisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING))
 	UnregisterSignal(owner, COMSIG_MOB_BEFORE_SPELL_CAST)
 	UnregisterSignal(owner, COMSIG_ATOM_HOLYATTACK)
+	UnregisterSignal(owner, COMSIG_CARBON_CUFF_ATTEMPTED)
 	owner.visible_message(
 		span_warning("The haze around [owner] disappears, leaving them materialized!"),
 		span_notice("You exit the refuge."),
@@ -286,3 +288,7 @@
 	if(!istype(spell, /datum/action/cooldown/spell/caretaker))
 		owner.balloon_alert(owner, "may not cast spells in refuge!")
 		return SPELL_CANCEL_CAST
+
+/datum/status_effect/caretaker_refuge/proc/prevent_cuff(datum/source, mob/attemptee)
+	SIGNAL_HANDLER
+	SEND_SIGNAL(owner, COMSIG_HERETIC_MANSUS_GRASP_ATTACK, attemptee) //ok lets just mansus grasp this nerd


### PR DESCRIPTION

## About The Pull Request

may not enter refuge with the nuke disk and may not be cuffed in refuge
cuffing someone in refuge mansus grasps the person cuffing

i havent tested this because i am out of time as of time of writing so i am PRing as draft until i test this
also claiming the issues

## Why It's Good For The Game

fixes #79133
fixes #79126

## Changelog
:cl:
fix: you may not enter knock path caretakers last refuge with the nuke disk
fix: you can no longer cuff knock heretics in refuge
/:cl:
