### PR TITLE
Adds a var to determine if anomaly-locked MOD modules can have cores uninstalled

### DIFF
--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -336,6 +336,8 @@
 	var/list/accepted_anomalies = list(/obj/item/assembly/signaler/anomaly)
 	/// If this one starts with a core in.
 	var/prebuilt = FALSE
+	/// If the core is removable once socketed.
+	var/core_removable = TRUE
 
 /obj/item/mod/module/anomaly_locked/Initialize(mapload)
 	. = ..()
@@ -354,13 +356,15 @@
 	if(!length(accepted_anomalies))
 		return
 	if(core)
-		. += span_notice("There is a [core.name] installed in it. You could remove it with a <b>screwdriver</b>...")
+		. += span_notice("There is a [core.name] installed in it. [core_removable ? "You could remove it with a <b>screwdriver</b>..." : "Unfortunately, due to a design quirk, it's unremovable."]")
 	else
 		var/list/core_list = list()
 		for(var/path in accepted_anomalies)
 			var/atom/core_path = path
 			core_list += initial(core_path.name)
 		. += span_notice("You need to insert \a [english_list(core_list, and_text = " or ")] for this module to function.")
+		if(!core_removable)
+			. += span_notice("Due to some design quirk, once a core is inserted, it won't be removable.")
 
 /obj/item/mod/module/anomaly_locked/on_select()
 	if(!core)
@@ -396,6 +400,9 @@
 	. = ..()
 	if(!core)
 		balloon_alert(user, "no core!")
+		return
+	if(!core_removable)
+		balloon_alert(user, "can't remove core!")
 		return
 	balloon_alert(user, "removing core...")
 	if(!do_after(user, 3 SECONDS, target = src))

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -252,12 +252,16 @@
 /obj/item/mod/module/anomaly_locked/kinesis/prebuilt
 	prebuilt = TRUE
 
+/obj/item/mod/module/anomaly_locked/kinesis/prebuilt/locked
+	core_removable = FALSE
+
 /obj/item/mod/module/anomaly_locked/kinesis/prototype
 	name = "MOD prototype kinesis module"
 	prebuilt = TRUE
 	complexity = 0
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 5
 	removable = FALSE
+	core_removable = FALSE
 
 /obj/item/mod/module/anomaly_locked/kinesis/plus
 	name = "MOD kinesis+ module"

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -90,6 +90,9 @@
 /obj/item/mod/module/anomaly_locked/antigrav/prebuilt
 	prebuilt = TRUE
 
+/obj/item/mod/module/anomaly_locked/antigrav/prebuilt/locked
+	core_removable = FALSE
+
 ///Teleporter - Lets the user teleport to a nearby location.
 /obj/item/mod/module/anomaly_locked/teleporter
 	name = "MOD teleporter module"
@@ -128,3 +131,6 @@
 
 /obj/item/mod/module/anomaly_locked/teleporter/prebuilt
 	prebuilt = TRUE
+
+/obj/item/mod/module/anomaly_locked/teleporter/prebuilt/locked
+	core_removable = FALSE


### PR DESCRIPTION
## About The Pull Request
Title. The `core_removable` var on the `anomaly_locked` MOD module typepath now determines if a core can be removed post-installation. This isn't used anywhere, at the moment, but could be used to, say, prevent a space-loot MOD module's core from being removed for other purposes.

Adds `/prebuilt/locked` subtypes to the currently present and defined anomaly-locked modules, which have this var enabled, and puts them nowhere else.

![image](https://github.com/tgstation/tgstation/assets/31829017/af222175-7668-4e46-abab-5adf08be5d34)
![image](https://github.com/tgstation/tgstation/assets/31829017/4d6f4149-1227-4dd9-b368-7d55696fba92)


## Why It's Good For The Game
Another way to control distribution of anomaly cores - making people commit to having a limited-supply item installed in a thing, or something like that.

For habitual Github-readers, this is *unused*, at the moment, just something that could be used by another coder down the line or something.

## Changelog

:cl:
add: Anomaly-locked MODsuit modules can now be varedited to have unremovable cores, or can be spawned with this functionality by using the /prebuilt/locked subtype.
/:cl: