### PR TITLE
scanning export barcodes now tells you who made them and the profit split

### DIFF
--- a/code/modules/cargo/universal_scanner.dm
+++ b/code/modules/cargo/universal_scanner.dm
@@ -207,12 +207,12 @@
 			return
 		var/obj/item/barcode/our_code = parcel.sticker
 		to_chat(user, span_notice("Export barcode detected! This parcel, upon export, will pay out to [our_code.payments_acc.account_holder], \
-		with a [our_code.cut_multiplier * 100]% split to them (already reflected in above recorded value)."))
+			with a [our_code.cut_multiplier * 100]% split to them (already reflected in above recorded value)."))
 
 	if(istype(target, /obj/item/barcode))
 		var/obj/item/barcode/our_code = target
 		to_chat(user, span_notice("Export barcode detected! This barcode, if attached to a parcel, will pay out to [our_code.payments_acc.account_holder], \
-		with a [our_code.cut_multiplier * 100]% split to them."))
+			with a [our_code.cut_multiplier * 100]% split to them."))
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/scan_human = user

--- a/code/modules/cargo/universal_scanner.dm
+++ b/code/modules/cargo/universal_scanner.dm
@@ -183,7 +183,7 @@
 			warning = TRUE
 		if(!report.all_contents_scannable)
 			message += " (Undeterminable value detected, final value may differ)"
-		message += "."	
+		message += "."
 	else
 		if(!report.all_contents_scannable)
 			message += ", unable to determine value."
@@ -200,6 +200,19 @@
 
 	if(price)
 		playsound(src, 'sound/machines/terminal_select.ogg', 50, vary = TRUE)
+
+	if(istype(target, /obj/item/delivery))
+		var/obj/item/delivery/parcel = target
+		if(!parcel.sticker)
+			return
+		var/obj/item/barcode/our_code = parcel.sticker
+		to_chat(user, span_notice("Export barcode detected! This parcel, upon export, will pay out to [our_code.payments_acc.account_holder], \
+		with a [our_code.cut_multiplier * 100]% split to them (already reflected in above recorded value)."))
+
+	if(istype(target, /obj/item/barcode))
+		var/obj/item/barcode/our_code = target
+		to_chat(user, span_notice("Export barcode detected! This barcode, if attached to a parcel, will pay out to [our_code.payments_acc.account_holder], \
+		with a [our_code.cut_multiplier * 100]% split to them."))
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/scan_human = user

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -83,7 +83,7 @@
 	if(do_after(user, 50, target = object))
 		if(!user || user.stat != CONSCIOUS || user.loc != object || object.loc != src)
 			return
-		to_chat(user, span_notice("You successfully removed [object]'s wrapping !"))
+		to_chat(user, span_notice("You successfully removed [object]'s wrapping!"))
 		object.forceMove(loc)
 		unwrap_contents()
 		post_unwrap_contents(user)


### PR DESCRIPTION
## About The Pull Request
Scanning a parcel with an attached barcode, or the barcode itself, with a universal scanner, now actually tells you the owner of the associated bank account and the assigned profit-split.

## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/31829017/bc5380cc-38ae-4098-aed9-465962b64619)

## Changelog

:cl:
qol: Universal scanners are now capable of recognizing the account owners and assigned profit splits on barcodes. Cargo technicians are asked to do their due diligence when matters call for it.
/:cl: