### PR TITLE
Reverts crafting hologram check

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -67,11 +67,7 @@
 		var/list/instances_list = list()
 		for(var/instance_path in item_instances)
 			if(ispath(instance_path, requirement_path))
-				var/obj/item/item = item_instances[instance_path]
-				if(item.flags_1 & HOLOGRAM_1)
-					continue
-
-				instances_list += item
+				instances_list += item_instances[instance_path]
 
 		requirements_list[requirement_path] = instances_list
 


### PR DESCRIPTION
## About The Pull Request

Reverts crafting check from #79028 

I'm investigating this runtime

![image](https://github.com/tgstation/tgstation/assets/51863163/2920270a-ec2b-483b-93f2-a954a32f7d8a)

and - while the runtime points to a larger issue - this check is not even necessary, as hologram items are already excluded from the list of items. 

https://github.com/tgstation/tgstation/blob/67f263d0c140cfd3efeabc71ef675d76f53e3c6c/code/datums/components/crafting/crafting.dm#L110-L113
