### PR TITLE
Fix crafting granters runtiming for food items

### DIFF
--- a/code/game/objects/items/granters/crafting/_crafting_granter.dm
+++ b/code/game/objects/items/granters/crafting/_crafting_granter.dm
@@ -8,7 +8,7 @@
 		return
 	for(var/crafting_recipe_type in crafting_recipe_types)
 		user.mind.teach_crafting_recipe(crafting_recipe_type)
-		var/datum/crafting_recipe/recipe = locate(crafting_recipe_type) in GLOB.crafting_recipes
+		var/datum/crafting_recipe/recipe = locate(crafting_recipe_type) in GLOB.crafting_recipes + GLOB.cooking_recipes
 		to_chat(user, span_notice("You learned how to make [recipe.name]."))
 
 /obj/item/book/granter/crafting_recipe/dusting


### PR DESCRIPTION
## About The Pull Request

Caused by #77465

Two global lists, food items are only found in one. This locate failed and caused the next line to runtime error. 

## Changelog

:cl: Melbert
fix: Cooking Deserts 101 grants all intended recipes 
/:cl:

