### PR TITLE
surgical trays no longer animate when opened

### DIFF
--- a/code/datums/storage/subtypes/surgery_tray.dm
+++ b/code/datums/storage/subtypes/surgery_tray.dm
@@ -2,6 +2,7 @@
 	max_total_storage = 30
 	max_specific_storage = WEIGHT_CLASS_NORMAL
 	max_slots = 14
+	animated = FALSE
 
 /datum/storage/surgery_tray/New()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
it looks stupid


## Changelog
:cl:
fix: surgical trays no longer animate when opened
/:cl:
