### PR TITLE
Improves the deployable component

### DIFF
--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -55,11 +55,11 @@
 	INVOKE_ASYNC(src, PROC_REF(deploy), source, user, location, direction)
 
 /datum/component/deployable/proc/deploy(obj/source, mob/user, location, direction) //If there's no user, location and direction are used
-	/// The object we are going to create
+	// The object we are going to create
 	var/atom/deployed_object
-	/// The turf our object is going to be deployed to
+	// The turf our object is going to be deployed to
 	var/turf/deploy_location
-	/// What direction will the deployed object be placed facing
+	// What direction will the deployed object be placed facing
 	var/new_direction
 
 	if(user)

--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -13,23 +13,29 @@
 	var/deploy_time
 	/// The object that gets spawned if deployed successfully
 	var/obj/thing_to_be_deployed
-	/// If the item used to deploy gets deleted on use or not
-	var/delete_on_use
+	/// Can the parent be deployed multiple times
+	var/multiple_deployments
+	/// How many times we can deploy the parent, set to -1 for infinite
+	var/deployments
 	/// If the component adds a little bit into the parent's description
 	var/add_description_hint
+	/// If the direction of the thing we place is changed upon placing
+	var/direction_setting
 
 	/// Used in getting the name of the deployed object
 	var/deployed_name
 
-/datum/component/deployable/Initialize(deploy_time = 5 SECONDS, thing_to_be_deployed, delete_on_use = TRUE, add_description_hint = TRUE)
+/datum/component/deployable/Initialize(deploy_time = 5 SECONDS, thing_to_be_deployed, multiple_deployments = FALSE, deployments = 1, add_description_hint = TRUE, direction_setting = TRUE)
 	. = ..()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	src.deploy_time = deploy_time
 	src.thing_to_be_deployed = thing_to_be_deployed
-	src.delete_on_use = delete_on_use
 	src.add_description_hint = add_description_hint
+	src.direction_setting = direction_setting
+	src.deployments = deployments
+	src.multiple_deployments = multiple_deployments
 
 	if(add_description_hint)
 		RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
@@ -41,22 +47,23 @@
 /datum/component/deployable/proc/examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_notice("[source.p_they()] look[source.p_s()] like [source.p_they()] can be deployed into \a [deployed_name].")
+	examine_list += span_notice("It can be used <b>in hand</b> to deploy into \a [deployed_name].")
 
 /datum/component/deployable/proc/on_attack_hand(datum/source, mob/user, location, direction)
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, PROC_REF(deploy), source, user, location, direction)
 
 /datum/component/deployable/proc/deploy(obj/source, mob/user, location, direction) //If there's no user, location and direction are used
-	var/obj/deployed_object //Used for spawning the deployed object
-	var/turf/deploy_location //Where our deployed_object gets put
-	var/new_direction //What direction do we want our deployed object in
-	if(user)
-		if(!ishuman(user))
-			return
+	/// The object we are going to create
+	var/atom/deployed_object
+	/// The turf our object is going to be deployed to
+	var/turf/deploy_location
+	/// What direction will the deployed object be placed facing
+	var/new_direction
 
+	if(user)
 		deploy_location = get_step(user, user.dir) //Gets spawn location for thing_to_be_deployed if there is a user
-		if(deploy_location.is_blocked_turf(TRUE))
+		if(deploy_location.is_blocked_turf(TRUE, parent))
 			source.balloon_alert(user, "insufficient room to deploy here.")
 			return
 		new_direction = user.dir //Gets the direction for thing_to_be_deployed if there is a user
@@ -64,16 +71,18 @@
 		playsound(source, 'sound/items/ratchet.ogg', 50, TRUE)
 		if(!do_after(user, deploy_time))
 			return
-	else //If there is for some reason no user, then the location and direction are set here
+	else // If there is for some reason no user, then the location and direction are set here
 		deploy_location = location
 		new_direction = direction
 
 	deployed_object = new thing_to_be_deployed(deploy_location)
 	deployed_object.setDir(new_direction)
 
-	//Sets the integrity of the new deployed machine to that of the object it came from
-	deployed_object.modify_max_integrity(source.max_integrity)
-	deployed_object.update_icon_state()
+	// Sets the direction of the resulting object if the variable says to
+	if(direction_setting)
+		deployed_object.update_icon_state()
 
-	if(delete_on_use)
+	deployments -= 1
+
+	if(!multiple_deployments || deployments < 1)
 		qdel(source)

--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -5,7 +5,8 @@
  * If attaching this to something:
  * Set deploy_time to a number in seconds for the deploy delay
  * Set thing_to_be_deployed to an obj path for the thing that gets spawned
- * Lastly, set delete_on_use to TRUE or FALSE if you want the object you're deploying with to get deleted when used
+ * Multiple deployments and deployments work together to allow a thing to be placed down several times. If multiple deployments is false then don't worry about deployments
+ * Direction setting true means the object spawned will face the direction of the person who deployed it, false goes to the default direction
  */
 
 /datum/component/deployable
@@ -15,7 +16,7 @@
 	var/obj/thing_to_be_deployed
 	/// Can the parent be deployed multiple times
 	var/multiple_deployments
-	/// How many times we can deploy the parent, set to -1 for infinite
+	/// How many times we can deploy the parent, if multiple deployments is set to true and this gets below zero, the parent will be deleted
 	var/deployments
 	/// If the component adds a little bit into the parent's description
 	var/add_description_hint

--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -47,8 +47,7 @@
 
 /datum/component/deployable/proc/examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
-
-	examine_list += span_notice("It can be used <b>in hand</b> to deploy into [multiple_deployments ? "[deployments] more" : "\a"] [deployed_name].")
+	examine_list += span_notice("It can be used <b>in hand</b> to deploy into [((deployments > 1) && multiple_deployments) ? "[deployments]" : "a"] [deployed_name].")
 
 /datum/component/deployable/proc/on_attack_hand(datum/source, mob/user, location, direction)
 	SIGNAL_HANDLER

--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -48,7 +48,7 @@
 /datum/component/deployable/proc/examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_notice("It can be used <b>in hand</b> to deploy into \a [deployed_name].")
+	examine_list += span_notice("It can be used <b>in hand</b> to deploy into [multiple_deployments ? "[deployments] more" : "\a"] [deployed_name].")
 
 /datum/component/deployable/proc/on_attack_hand(datum/source, mob/user, location, direction)
 	SIGNAL_HANDLER

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -234,7 +234,7 @@
 
 /obj/item/deployable_turret_folded/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable, 5 SECONDS, /obj/machinery/deployable_turret/hmg, delete_on_use = TRUE)
+	AddComponent(/datum/component/deployable, 5 SECONDS, /obj/machinery/deployable_turret/hmg)
 
 #undef SINGLE
 #undef VERTICAL

--- a/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -101,7 +101,7 @@
 
 /obj/item/folded_navigation_gigabeacon/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable, 3 SECONDS, /obj/machinery/spaceship_navigation_beacon, delete_on_use = TRUE)
+	AddComponent(/datum/component/deployable, 3 SECONDS, /obj/machinery/spaceship_navigation_beacon)
 
 /obj/item/folded_navigation_gigabeacon/examine()
 	.=..()


### PR DESCRIPTION

## About The Pull Request

The deployable component had a few random things I noticed when I tried actually using it that kinda sucked so I'm:

Making the examine message more generic, we did NOT need to make it that complicated.
Letting anything with hands deploy stuff, because mobs other than humans can hold things.
Giving the option to let something be deployed more than once.
Letting direction setting be optional.
Tweaking the check for if something can be placed somewhere to be a bit better.
## Why It's Good For The Game

I want to use the deployable component for stuff but I made it awful.
## Changelog
:cl:
code: the deployable component has been tweaked and improved with some new options to it
/:cl:
