### PR TITLE
[NO GBP] Infected Domain atmos fix

### DIFF
--- a/_maps/virtual_domains/psyker_zombies.dmm
+++ b/_maps/virtual_domains/psyker_zombies.dmm
@@ -9,7 +9,7 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "c" = (
 /obj/structure/sign/warning/directional/west,
-/turf/open/chasm/lavaland,
+/turf/open/chasm,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "h" = (
 /obj/structure/rack,
@@ -17,7 +17,7 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "i" = (
 /obj/structure/sign/warning/directional/east,
-/turf/open/chasm/lavaland,
+/turf/open/chasm,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "o" = (
 /turf/template_noop,
@@ -73,7 +73,7 @@
 /turf/template_noop,
 /area/virtual_domain/safehouse)
 "Q" = (
-/turf/open/chasm/lavaland,
+/turf/open/chasm,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "R" = (
 /obj/effect/mine/explosive/light,


### PR DESCRIPTION

## About The Pull Request

Modifies the chasms in the Infected Domain to be of the generic variety, instead of lavaland chasms.

The lavaland chasms followed planetary atmos rules, and would dilute the air in the map over time. Oops!
## Why It's Good For The Game

Closes #79202.
## Changelog
:cl:
fix: The Infected Domain should no longer fill up with smelly, poisonous gas over time.
/:cl:
