### PR TITLE
Prevent space-required station goals from running on planetary maps

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -200,10 +200,10 @@
 /datum/game_mode/proc/generate_station_goals(greenshift)
 	var/goal_budget = greenshift ? INFINITY : CONFIG_GET(number/station_goal_budget)
 	var/list/possible = subtypesof(/datum/station_goal)
+	// Remove all goals that require space if space is not present
 	if(SSmapping.is_planetary())
-		for(var/datum/station_goal/goal in possible)
-			if(goal.requires_space)
-				///Removes all goals that require space if space is not present
+		for(var/datum/station_goal/goal as anything in possible)
+			if(initial(goal.requires_space))
 				possible -= goal
 	var/goal_weights = 0
 	while(possible.len && goal_weights < goal_budget)


### PR DESCRIPTION
## About The Pull Request

Received bug report from tgstation lore general where player decided they would rather sit on an unreported bug for several months in order to use it as ammunition in an attempt to be rude to a retired mapper than try to get it fixed. Maybe one day people will learn where to post bugs if they want them fixed? Or perhaps I will simply need to monitor more conversations in our official bug report discord channel (`#lore-general`).

Anyway someone forgot to put `as anything` on an iteration of an array of typepaths. Easy fix.

## Changelog

:cl:
fix: You will no longer be asked to construct meteor shields on stations which cannot be hit by meteors.
/:cl:
