### PR TITLE
Walls built next to firelocks no longer hold onto their alarms

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -270,6 +270,7 @@
 /obj/machinery/door/firedoor/proc/adjacent_change(turf/changed, path, list/new_baseturfs, flags, list/post_change_callbacks)
 	SIGNAL_HANDLER
 	post_change_callbacks += CALLBACK(src, PROC_REF(CalculateAffectingAreas))
+	post_change_callbacks += CALLBACK(src, PROC_REF(process_results), changed) //check the atmosphere of the changed turf so we don't hold onto alarm if a wall is built
 
 /obj/machinery/door/firedoor/proc/check_atmos(turf/checked_turf)
 	var/datum/gas_mixture/environment = checked_turf.return_air()


### PR DESCRIPTION
## About The Pull Request
Walls can now be built next to a firelock without worrying about 'trapping' the atmosphere inside of it.

## Why It's Good For The Game
Gets rid of weird unintuitive behavior when placing a wall over cold/hot atmos that is next to a firelock. Players can now rebuild walls before the atmosphere is fixed in the area without worrying about 'trapping' the atmosphere and keeping the firealarm active

## Changelog
:cl:
fix: walls built next to firelocks no longer hold onto their alarms
/:cl:
