### PR TITLE
Nukie Update Followup: Returns CQC to the previous price range, Core Gear kit for newbies, hat stabilizers for everyone

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -385,7 +385,6 @@
 /obj/item/storage/toolbox/guncase/sword_and_board/PopulateContents()
 	new weapon_to_spawn (src)
 	new extra_to_spawn (src)
-	new /obj/item/mod/module/hat_stabilizer (src)
 	new /obj/item/clothing/head/costume/knight (src)
 
 /obj/item/storage/toolbox/guncase/cqc
@@ -396,8 +395,8 @@
 /obj/item/storage/toolbox/guncase/cqc/PopulateContents()
 	new weapon_to_spawn (src)
 	new extra_to_spawn (src)
-	new /obj/item/mod/module/hat_stabilizer (src)
 	new /obj/item/clothing/head/costume/snakeeater (src)
+	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate (src)
 
 /obj/item/clothing/head/costume/snakeeater
 	name = "strange bandana"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -610,7 +610,16 @@
 	new /obj/item/storage/belt/grenade/full(src)
 	if(prob(1))
 		new /obj/item/clothing/head/hats/hos/shako(src)
-		new /obj/item/mod/module/hat_stabilizer(src)
+
+/obj/item/storage/box/syndie_kit/core_gear
+	name = "core equipment box"
+	desc = "Contains all the necessary gear for success for any nuclear operative unsure of what is needed for success in the field. Everything here WILL help you."
+
+/obj/item/storage/box/syndie_kit/core_gear/PopulateContents()
+	new /obj/item/implanter/freedom (src)
+	new /obj/item/card/emag/doorjack (src)
+	new /obj/item/reagent_containers/hypospray/medipen/stimulants (src)
+	new /obj/item/grenade/c4 (src)
 
 /// Surplus Ammo Box
 

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -60,8 +60,6 @@
 	..()
 	for (var/i in 1 to 5)
 		new /obj/effect/spawner/random/clothing/funny_hats(src)
-	for (var/i in 1 to 5)
-		new /obj/item/mod/module/hat_stabilizer(src)
 	if(prob(1))
 		var/our_contents = list()
 		for(var/obj/item/clothing/head/any_hat in contents)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -216,6 +216,7 @@
 		/obj/item/mod/module/pathfinder,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/dna_lock,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 	)
 	default_pins = list(
 		/obj/item/mod/module/armor_booster,
@@ -234,6 +235,7 @@
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/dna_lock,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 	)
 	default_pins = list(
 		/obj/item/mod/module/armor_booster,
@@ -253,6 +255,7 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 	)
 	default_pins = list(
 		/obj/item/mod/module/armor_booster,
@@ -287,6 +290,7 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 	)
 	default_pins = list(
 		/obj/item/mod/module/armor_booster,
@@ -303,6 +307,7 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 		/obj/item/mod/module/flamethrower,
 	)
 	default_pins = list(
@@ -321,6 +326,7 @@
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/quick_carry,
 		/obj/item/mod/module/visor/diaghud,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 	)
 
 
@@ -335,7 +341,8 @@
 		/obj/item/mod/module/injector,
 		/obj/item/mod/module/surgical_processor/preloaded,
 		/obj/item/mod/module/storage/syndicate,
-		/obj/item/mod/module/tether
+		/obj/item/mod/module/hat_stabilizer/syndicate,
+		/obj/item/mod/module/tether,
 	)
 
 /obj/item/mod/control/pre_equipped/enchanted

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -751,6 +751,15 @@
 		return
 	mod.core.add_charge(power_per_step)
 
+/obj/item/mod/module/hat_stabilizer/syndicate
+	name = "MOD elite hat stabilizer module"
+	desc = "A simple set of deployable stands, directly atop one's head; \
+		these will deploy under a hat to keep it from falling off, allowing them to be worn atop the sealed helmet. \
+		You still need to take the hat off your head while the helmet deploys, though. This is a must-have for \
+		Syndicate Operatives and Agents alike, enabling them to continue to style on the opposition even while in their MODsuit."
+	complexity = 0
+	removable = FALSE
+
 /// Module that shoves garbage inside its material container when the user crosses it, and eject the recycled material with MMB.
 /obj/item/mod/module/recycler
 	name = "MOD recycler module"

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -42,6 +42,21 @@
 
 // ~~ Weapon Categories ~~
 
+// Core Gear Box: This contains all the 'fundamental' equipment that most nuclear operatives probably should be buying. It isn't cheaper, but it is a quick and convenient method of acquiring all the gear necessary immediately.
+// Only allows one purchase, and doesn't prevent the purchase of the contained items. Focused on newer players to help them understand what items they need to succeed, and to help older players quickly purchase the baseline gear they need.
+
+/datum/uplink_item/weapon_kits/core
+	name = "Core Equipment Box (Essential)"
+	desc = "This box contains an airlock authentification override card, a C-4 explosive charge, a freedom implant and a stimpack injector. \
+		The most important support items for most operatives to succeed in their mission, bundled together. It is highly recommend you buy this kit. \
+		Note: This bundle is not at a discount. You can purchase all of these items separately. You do not NEED these items, but most operatives fail WITHOUT at \
+		least SOME of these items. More experienced operatives can do without."
+	item = /obj/item/storage/box/syndie_kit/core_gear
+	cost = 14 //freedom 5, doormag 3, c-4 1, stimpack 5
+	limited_stock = 1
+	cant_discount = TRUE
+	purchasable_from = UPLINK_NUKE_OPS
+
 //Low-cost firearms: Around 8 TC each. Meant for easy squad weapon purchases
 
 /datum/uplink_item/weapon_kits/low_cost
@@ -153,13 +168,20 @@
 	cost = 4
 	purchasable_from = UPLINK_NUKE_OPS
 
-// ~~ Energy Sword and Shield ~~
+// ~~ Energy Sword and Shield & CQC ~~
 
 /datum/uplink_item/weapon_kits/medium_cost/sword_and_board
 	name = "Energy Shield and Sword Case (Very Hard)"
 	desc = "A case containing an energy sword and energy shield. The shield is capable of deflecting \
 		energy and laser projectiles, and the sword most forms of attack. Perfect for the enterprising nuclear knight. "
 	item = /obj/item/storage/toolbox/guncase/sword_and_board
+
+/datum/uplink_item/weapon_kits/medium_cost/cqc
+	name = "CQC Equipment Case (Very Hard)"
+	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant, a pack of smokes and a snazzy bandana (use it with the hat stabilizers in your MODsuit)."
+	item = /obj/item/storage/toolbox/guncase/cqc
+	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
+	surplus = 0
 
 // ~~ Syndicate Revolver ~~
 // Nuclear operatives get a special deal on their revolver purchase compared to traitors.
@@ -330,13 +352,6 @@
 	desc = "A 6-round magazine of marksman ammo designed for use with .50 sniper rifles. \
 		Blast your enemies with instant shots! Just watch out for the rebound..."
 	item = /obj/item/ammo_box/magazine/sniper_rounds/marksman
-
-/datum/uplink_item/weapon_kits/high_cost/cqc
-	name = "CQC Equipment Case (Very Hard)"
-	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant and a snazzy bandana (and a hat stabilizer to go with it)."
-	item = /obj/item/storage/toolbox/guncase/cqc
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
-	surplus = 0
 
 /datum/uplink_item/weapon_kits/high_cost/doublesword
 	name = "Double-Energy Sword Case (Very Hard)"
@@ -803,7 +818,7 @@
 
 /datum/uplink_item/badass/hats
 	name = "Hat Crate"
-	desc = "Hat crate! Contains hats, along with hat stabilizers to wear your hats while you're in your suit! HATS!!!"
+	desc = "Hat crate! Contains hats! HATS!!!"
 	item = /obj/structure/closet/crate/large/hats
 	cost = 5
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS


### PR DESCRIPTION

## About The Pull Request

Brings the CQC kit back down to the same price range of 14 TC (it's 1 more than before weapon kits). It feels like currently that CQC is overpriced, even with the stealth box coming along with it, and by comparison the energy sword and shield got a huge value increase by combining the two. They're both melee styles and also equally difficult play styles. It isn't really necessary to make one more expensive than the other. Also now comes with syndicate smokes. It's a whatever change, ops get these for free on the base.

Adds a core gear kit in the weapon category. This kit comes with a doormag, a freedom implant, stimpack and c-4 charge. All of these are items almost every nukie buys if they want to succeed, so let's inform newer players by putting it RIGHT on top of the list. This isn't at any discount, this is mostly to help inform players what items help make you successful.

Hat stabilizers are now a part of every syndicate modsuit for FREE. It comes built in, can't be removed, and has no complexity cost. Now everyone can wear their wacky hats as they operate.

## Why It's Good For The Game

CQC felt like it got shafted waaay too hard with the weapon case changes. Definitely don't believe that it is punching at the same weight as many of the other high cost weapons. So we've dropped it down a category. 14 TC is still a large upfront cost, even if it comes bundled with a lot of goods.

Melbert gave me the idea of a core bundle kit to help newer players and I was really taken with that. So I added it as part of this followup.

I want people to wear their hats goddamnit, and I didn't learn my mistake with the tool parcels. So now everyone has hat stands on their suits. WEAR THE SOMBRERO YOU **FUCK**.

### THIS IS NOW A THREAT.

## Changelog
:cl:
balance: Operatives can once again read about the basics of CQC at a reasonable price of 14 TC.
qol: All Syndicate MODsuits come with the potent ability to wear hats on their helmets FOR FREE. No longer does any operative need be shamed by their bald helmet's unhatted state when they spot the captain, in their MODsuit, wearing a hat on their helmet. The embarrassment has resulted in more than a few operatives prematurely detonating their implants! BUT NO LONGER! FASHION IS YOURS!
qol: There is now a Core Gear Box, containing a few essential pieces of gear for success as an operative. This is right at the top of the uplink, you can't miss it! Great for those operatives just starting out, or operatives who need all their baseline equipment NOW.
/:cl:
