### PR TITLE
Your unarmed attacks are once again blocked even when you're not in combat mode

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1250,7 +1250,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return
 	if(owner.mind)
 		attacker_style = owner.mind.martial_art
-	if((owner != target) && owner.combat_mode && target.check_shields(owner, 0, owner.name, attack_type = UNARMED_ATTACK))
+	if((owner != target) && target.check_shields(owner, 0, owner.name, attack_type = UNARMED_ATTACK))
 		log_combat(owner, target, "attempted to touch")
 		target.visible_message(span_warning("[owner] attempts to touch [target]!"), \
 						span_danger("[owner] attempts to touch you!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, owner)


### PR DESCRIPTION
## About The Pull Request

Currently, not being in combat mode when making an unarmed attack allows you to bypass ALL BLOCKING. All of it. Every single kind of shielding.

This is now fixed. 

As a consequence, hugging is now blocked, but that's fine, hugging puts you into click cooldown and _might actually be an attack now_. [Like the Hugs of the Gondola martial art](https://github.com/tgstation/tgstation/blob/ab058330b4449f133b7672565c91d28af8ed7e05/code/datums/martial/hugs_of_the_gondola.dm)

Fixes https://github.com/tgstation/tgstation/issues/72812

## Why It's Good For The Game

This was broken with COMBAT MODE AAAAAAAAAAAH

### AAAAAAAAAAAH

## Changelog
:cl:
fix: Every person on the station now no longer has the Tranquility Evades the Shield Pinky Finger Shovegrab unarmed combat technique, an ancient and forbidden strike that allows anyone (literally anyone) to bypass all forms of blocking defense by simply not being in combat mode when they shove or grab their target. As a direct result, the chakra energy of the Spinward Sector has become severely misaligned. Oh well.
/:cl:
