### PR TITLE
Light-Eaten objects can no longer emit light after being turned off and then back on

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
@@ -226,7 +226,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "IA" = (
 /obj/item/flashlight/glowstick/red{
-	on = 1
+	start_on = 1
 	},
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -271,7 +271,7 @@
 "Qi" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/flashlight/glowstick/red{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -305,7 +305,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "Wk" = (
 /obj/item/flashlight/glowstick/red{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
@@ -250,7 +250,7 @@
 /area/icemoon/underground/explored)
 "ut" = (
 /obj/item/flashlight/lantern{
-	on = 1
+	start_on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm
@@ -279,7 +279,7 @@
 /area/ruin/unpowered/buried_library)
 "bz" = (
 /obj/item/flashlight/lantern/jade{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/buried_library)
@@ -337,7 +337,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/secretrecipe,
 /obj/item/flashlight/lantern/jade{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/cult,
 /area/ruin/unpowered/buried_library)

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
@@ -207,7 +207,7 @@
 /area/icemoon/underground/explored)
 "BN" = (
 /obj/item/flashlight/glowstick/red{
-	on = 1
+	start_on = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_mookvillage.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_mookvillage.dmm
@@ -54,7 +54,7 @@
 /area/lavaland/surface/outdoors)
 "m" = (
 /obj/item/flashlight/lantern{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/holofloor/wood,
 /area/lavaland/surface/outdoors)
@@ -174,7 +174,7 @@
 /area/lavaland/surface/outdoors)
 "S" = (
 /obj/item/flashlight/lantern{
-	on = 1
+	start_on = 1
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -550,7 +550,7 @@
 "Dp" = (
 /obj/structure/table,
 /obj/item/flashlight/lantern/syndicate{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)

--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -29,9 +29,9 @@
 "bg" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
-	on = 0;
 	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = 2;
+	start_on = 0
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/waystation/dorms)
@@ -184,9 +184,9 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/item/flashlight/lamp{
-	on = 0;
 	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = 2;
+	start_on = 0
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/waystation/securestorage)
@@ -1916,9 +1916,9 @@
 	pixel_y = 2
 	},
 /obj/item/flashlight/lamp{
-	on = 0;
 	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = 2;
+	start_on = 0
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/waystation/cargooffice)
@@ -2116,9 +2116,9 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/lamp{
-	on = 0;
 	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = 2;
+	start_on = 0
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/waystation/dorms)

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -2959,7 +2959,7 @@
 "sM" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/item/flashlight/flare{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/iron{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -6170,7 +6170,7 @@
 /area/awaymission/moonoutpost19/mines)
 "Pf" = (
 /obj/item/flashlight/flare{
-	on = 1
+	start_on = 1
 	},
 /turf/open/misc/asteroid/moon{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251"

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16702,9 +16702,9 @@
 	c_tag = "Security - HoS Office"
 	},
 /obj/item/flashlight/lamp/green{
-	on = 0;
 	pixel_x = -6;
-	pixel_y = 16
+	pixel_y = 16;
+	start_on = 0
 	},
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -65011,7 +65011,7 @@
 /area/station/security/brig/upper)
 "tSs" = (
 /obj/item/flashlight/lantern{
-	on = 1
+	start_on = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
@@ -70786,7 +70786,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/flashlight/lamp{
-	on = 0
+	start_on = 0
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/aft/greater)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2921,9 +2921,9 @@
 	pixel_x = 10
 	},
 /obj/item/flashlight/lamp{
-	on = 0;
 	pixel_x = -7;
-	pixel_y = 18
+	pixel_y = 18;
+	start_on = 0
 	},
 /obj/item/kitchen/rollingpin{
 	pixel_x = -4

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -66131,9 +66131,9 @@
 	pixel_y = 7
 	},
 /obj/item/flashlight/lamp/green{
-	on = 0;
 	pixel_x = -3;
-	pixel_y = 8
+	pixel_y = 8;
+	start_on = 0
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)

--- a/_maps/safehouses/dig.dmm
+++ b/_maps/safehouses/dig.dmm
@@ -4,7 +4,7 @@
 /obj/effect/turf_decal/siding/yellow/corner,
 /obj/effect/turf_decal/sand/plating,
 /obj/item/flashlight/glowstick{
-	on = 1
+	start_on = 1
 	},
 /turf/open/floor/plating,
 /area/virtual_domain/safehouse)
@@ -38,7 +38,7 @@
 /obj/item/flashlight/lantern{
 	pixel_y = 8;
 	pixel_x = 4;
-	on = 1
+	start_on = 1
 	},
 /turf/open/misc/asteroid,
 /area/virtual_domain/safehouse)

--- a/_maps/templates/lazy_templates/heretic_sacrifice.dmm
+++ b/_maps/templates/lazy_templates/heretic_sacrifice.dmm
@@ -282,7 +282,7 @@
 	fuel = 1e+031;
 	randomize_fuel = 0;
 	icon_state = "flare-on";
-	on = 1
+	start_on = 1
 	},
 /turf/open/indestructible/plating,
 /area/centcom/heretic_sacrifice/knock)
@@ -540,7 +540,7 @@
 	fuel = 1e+031;
 	randomize_fuel = 0;
 	icon_state = "flare-on";
-	on = 1
+	start_on = 1
 	},
 /turf/open/indestructible/plating,
 /area/centcom/heretic_sacrifice/knock)

--- a/code/datums/components/seclight_attachable.dm
+++ b/code/datums/components/seclight_attachable.dm
@@ -160,7 +160,7 @@
 	var/successful_toggle = light.toggle_light(user)
 	if(!successful_toggle)
 		return TRUE
-	user.balloon_alert(user, "[light.name] toggled [light.on ? "on":"off"]")
+	user.balloon_alert(user, "[light.name] toggled [light.light_on ? "on":"off"]")
 	update_light()
 	return TRUE
 
@@ -270,7 +270,7 @@
 	if(!light)
 		return
 
-	var/overlay_state = "[light_overlay][light.on ? "_on":""]"
+	var/overlay_state = "[light_overlay][light.light_on ? "_on":""]"
 	var/mutable_appearance/flashlight_overlay = mutable_appearance(light_overlay_icon, overlay_state)
 	flashlight_overlay.pixel_x = overlay_x
 	flashlight_overlay.pixel_y = overlay_y
@@ -288,7 +288,7 @@
 	var/base_state = source.base_icon_state || initial(source.icon_state)
 	// Updates our icon state based on our light state.
 	if(light)
-		source.icon_state = "[base_state]-[light_icon_state][light.on ? "-on":""]"
+		source.icon_state = "[base_state]-[light_icon_state][light.light_on ? "-on":""]"
 
 	// Reset their icon state when if we've got no light.
 	else if(source.icon_state != base_state)

--- a/code/datums/elements/light_eaten.dm
+++ b/code/datums/elements/light_eaten.dm
@@ -23,6 +23,7 @@
 			target.set_light_power(0)
 			target.set_light_range(0)
 			target.set_light_on(FALSE)
+			target.update_icon()
 
 /datum/element/light_eaten/Detach(datum/source)
 	UnregisterSignal(source, list(

--- a/code/datums/elements/light_eaten.dm
+++ b/code/datums/elements/light_eaten.dm
@@ -54,11 +54,9 @@
 /// Prevents the light from turning on while the light power is greater than 0.
 /datum/element/light_eaten/proc/block_light_on(atom/eaten_light, new_on)
 	SIGNAL_HANDLER
-	if(!new_on)
-		return NONE
-	if(eaten_light.light_power <= 0)
-		return NONE
-	return COMPONENT_BLOCK_LIGHT_UPDATE
+	if(new_on)
+		return COMPONENT_BLOCK_LIGHT_UPDATE
+	return NONE
 
 /// Signal handler for light eater flavortext
 /datum/element/light_eaten/proc/on_examine(atom/eaten_light, mob/examiner, list/examine_text)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -360,6 +360,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
 	custom_materials = null
+	start_on = TRUE
 
 // green-shaded desk lamp
 /obj/item/flashlight/lamp/green

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -31,13 +31,13 @@
 	var/sound_on = 'sound/weapons/magin.ogg'
 	/// The sound the light makes when it's turned off
 	var/sound_off = 'sound/weapons/magout.ogg'
-	/// Is the light turned on or off currently
-	var/on = FALSE
+	/// Should the flashlight start turned on?
+	var/start_on = FALSE
 
 /obj/item/flashlight/Initialize(mapload)
 	. = ..()
-	if(icon_state == "[initial(icon_state)]-on")
-		on = TRUE
+	if(start_on)
+		set_light_on(TRUE)
 	update_brightness()
 	register_context()
 	if(toggle_context)
@@ -52,18 +52,19 @@
 
 /obj/item/flashlight/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	// single use lights can be toggled on once
-	if(isnull(held_item) && (toggle_context || !on))
+	if(isnull(held_item) && (toggle_context || !light_on))
 		context[SCREENTIP_CONTEXT_RMB] = "Toggle light"
 		return CONTEXTUAL_SCREENTIP_SET
 
-	if(istype(held_item, /obj/item/flashlight) && (toggle_context || !on))
+	if(istype(held_item, /obj/item/flashlight) && (toggle_context || !light_on))
 		context[SCREENTIP_CONTEXT_LMB] = "Toggle light"
 		return CONTEXTUAL_SCREENTIP_SET
 
 	return NONE
 
-/obj/item/flashlight/proc/update_brightness()
-	if(on)
+/obj/item/flashlight/update_icon_state()
+	. = ..()
+	if(light_on)
 		icon_state = "[initial(icon_state)]-on"
 		if(!isnull(inhand_icon_state))
 			inhand_icon_state = "[initial(inhand_icon_state)]-on"
@@ -71,22 +72,26 @@
 		icon_state = initial(icon_state)
 		if(!isnull(inhand_icon_state))
 			inhand_icon_state = initial(inhand_icon_state)
-	set_light_on(on)
+
+/obj/item/flashlight/proc/update_brightness()
+	update_appearance(UPDATE_ICON)
 	if(light_system == STATIC_LIGHT)
 		update_light()
 
 /obj/item/flashlight/proc/toggle_light(mob/user)
-	var/disrupted = FALSE
-	on = !on
-	playsound(src, on ? sound_on : sound_off, 40, TRUE)
+	playsound(src, light_on ? sound_off : sound_on, 40, TRUE)
 	if(!COOLDOWN_FINISHED(src, disabled_time))
 		if(user)
 			balloon_alert(user, "disrupted!")
-			on = FALSE
-			disrupted = TRUE
+		set_light_on(FALSE)
+		update_brightness()
+		update_item_action_buttons()
+		return FALSE
+	var/old_light_on = light_on
+	set_light_on(!light_on)
 	update_brightness()
 	update_item_action_buttons()
-	return !disrupted
+	return light_on != old_light_on // If the value of light_on didn't change, return false. Otherwise true.
 
 /obj/item/flashlight/attack_self(mob/user)
 	toggle_light(user)
@@ -104,7 +109,7 @@
 
 /obj/item/flashlight/attack(mob/living/carbon/M, mob/living/carbon/human/user)
 	add_fingerprint(user)
-	if(istype(M) && on && (user.zone_selected in list(BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)))
+	if(istype(M) && light_on && (user.zone_selected in list(BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)))
 
 		if((HAS_TRAIT(user, TRAIT_CLUMSY) || HAS_TRAIT(user, TRAIT_DUMB)) && prob(50)) //too dumb to use flashlight properly
 			return ..() //just hit them in the head
@@ -274,7 +279,7 @@
 /// when hit by a light disruptor - turns the light off, forces the light to be disabled for a few seconds
 /obj/item/flashlight/proc/on_saboteur(datum/source, disrupt_duration)
 	SIGNAL_HANDLER
-	if(on)
+	if(light_on)
 		toggle_light()
 	COOLDOWN_START(src, disabled_time, disrupt_duration)
 	return COMSIG_SABOTEUR_SUCCESS
@@ -355,7 +360,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
 	custom_materials = null
-	on = TRUE
 
 // green-shaded desk lamp
 /obj/item/flashlight/lamp/green
@@ -403,7 +407,7 @@
 	. = ..()
 	if(randomize_fuel)
 		fuel = rand(25 MINUTES, 35 MINUTES)
-	if(on)
+	if(light_on)
 		attack_verb_continuous = string_list(list("burns", "singes"))
 		attack_verb_simple = string_list(list("burn", "singe"))
 		hitsound = 'sound/items/welder.ogg'
@@ -419,15 +423,16 @@
 	if(!isliving(victim))
 		return ..()
 
-	if(on && victim.ignite_mob())
+	if(light_on && victim.ignite_mob())
 		message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(victim)] on fire with [src] at [AREACOORD(user)]")
 		user.log_message("set [key_name(victim)] on fire with [src]", LOG_ATTACK)
 
 	return ..()
 
 /obj/item/flashlight/flare/toggle_light()
-	if(on || !fuel)
+	if(light_on || !fuel)
 		return FALSE
+	. = ..()
 
 	name = "lit [initial(name)]"
 	attack_verb_continuous = string_list(list("burns", "singes"))
@@ -435,10 +440,10 @@
 	hitsound = 'sound/items/welder.ogg'
 	force = on_damage
 	damtype = BURN
-	. = ..()
+
 
 /obj/item/flashlight/flare/proc/turn_off()
-	on = FALSE
+	set_light_on(FALSE)
 	name = initial(name)
 	attack_verb_continuous = initial(attack_verb_continuous)
 	attack_verb_simple = initial(attack_verb_simple)
@@ -454,14 +459,14 @@
 
 /obj/item/flashlight/flare/update_brightness()
 	..()
-	inhand_icon_state = "[initial(inhand_icon_state)]" + (on ? "-on" : "")
+	inhand_icon_state = "[initial(inhand_icon_state)]" + (light_on ? "-on" : "")
 	update_appearance()
 
 /obj/item/flashlight/flare/process(seconds_per_tick)
 	open_flame(heat)
 	fuel = max(fuel - seconds_per_tick * (1 SECONDS), 0)
 
-	if(!fuel || !on)
+	if(!fuel || !light_on)
 		turn_off()
 		STOP_PROCESSING(SSobj, src)
 
@@ -474,7 +479,7 @@
 		if(user)
 			balloon_alert(user, "out of fuel!")
 		return NO_FUEL
-	if(on)
+	if(light_on)
 		if(user)
 			balloon_alert(user, "already lit!")
 		return ALREADY_LIT
@@ -495,7 +500,7 @@
 		user.visible_message(span_notice("[user] lights \the [src]."), span_notice("You light \the [initial(src.name)]!"))
 
 /obj/item/flashlight/flare/get_temperature()
-	return on * heat
+	return light_on * heat
 
 /obj/item/flashlight/flare/candle
 	name = "red candle"
@@ -543,8 +548,8 @@
 
 /obj/item/flashlight/flare/candle/update_icon_state()
 	. = ..()
-	icon_state = "candle[current_wax_level][on ? "_lit" : ""]"
-	inhand_icon_state = "candle[on ? "_lit" : ""]"
+	icon_state = "candle[current_wax_level][light_on ? "_lit" : ""]"
+	inhand_icon_state = "candle[light_on ? "_lit" : ""]"
 
 /**
  * Try to ignite the candle.
@@ -603,7 +608,7 @@
 	return ..()
 
 /obj/item/flashlight/flare/candle/attack_self(mob/user)
-	if(on && (fuel != INFINITY || !can_be_extinguished)) // can't extinguish eternal candles
+	if(light_on && (fuel != INFINITY || !can_be_extinguished)) // can't extinguish eternal candles
 		turn_off()
 		user.visible_message(span_notice("[user] snuffs [src]."))
 
@@ -614,9 +619,9 @@
 /obj/item/flashlight/flare/candle/infinite
 	name = "eternal candle"
 	fuel = INFINITY
-	on = TRUE
 	randomize_fuel = FALSE
 	can_be_extinguished = FALSE
+	start_on = TRUE
 
 /obj/item/flashlight/flare/torch
 	name = "torch"
@@ -697,7 +702,7 @@
 	return TRUE
 
 /obj/item/flashlight/emp/attack(mob/living/M, mob/living/user)
-	if(on && (user.zone_selected in list(BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH))) // call original attack when examining organs
+	if(light_on && (user.zone_selected in list(BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH))) // call original attack when examining organs
 		..()
 	return
 
@@ -763,7 +768,7 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/flashlight/glowstick/proc/turn_off()
-	on = FALSE
+	set_light_on(FALSE)
 	update_appearance(UPDATE_ICON)
 
 /obj/item/flashlight/glowstick/update_appearance(updates=ALL)
@@ -771,18 +776,18 @@
 	if(fuel <= 0)
 		set_light_on(FALSE)
 		return
-	if(on)
+	if(light_on)
 		set_light_on(TRUE)
 		return
 
 /obj/item/flashlight/glowstick/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state][(fuel <= 0) ? "-empty" : ""]"
-	inhand_icon_state = "[base_icon_state][((fuel > 0) && on) ? "-on" : ""]"
-	return ..()
+	inhand_icon_state = "[base_icon_state][((fuel > 0) && light_on) ? "-on" : ""]"
 
 /obj/item/flashlight/glowstick/update_overlays()
 	. = ..()
-	if(fuel <= 0 && !on)
+	if(fuel <= 0 && !light_on)
 		return
 
 	var/mutable_appearance/glowstick_overlay = mutable_appearance(icon, "glowstick-glow")
@@ -793,7 +798,7 @@
 	if(fuel <= 0)
 		balloon_alert(user, "glowstick is spent!")
 		return
-	if(on)
+	if(light_on)
 		balloon_alert(user, "already lit!")
 		return
 
@@ -847,13 +852,13 @@
 	light_power = 10
 	alpha = 0
 	plane = FLOOR_PLANE
-	on = TRUE
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	///Boolean that switches when a full color flip ends, so the light can appear in all colors.
 	var/even_cycle = FALSE
 	///Base light_range that can be set on Initialize to use in smooth light range expansions and contractions.
 	var/base_light_range = 4
+	start_on = TRUE
 
 /obj/item/flashlight/spotlight/Initialize(mapload, _light_range, _light_power, _light_color)
 	. = ..()
@@ -876,6 +881,7 @@
 	var/dark_light_range = 2.5
 	///Variable to preserve old lighting behavior in flashlights, to handle darkness.
 	var/dark_light_power = -3
+	var/on = FALSE
 
 /obj/item/flashlight/flashdark/update_brightness()
 	. = ..()

--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -192,7 +192,7 @@
 			G.color = color_choice
 			G.set_light_color(G.color)
 			G.throw_at(A, 9, 3, user)
-			G.on = TRUE
+			G.light_on = TRUE
 			G.update_brightness()
 
 			return TRUE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -628,8 +628,8 @@ Striking a noncultist, however, will tear their flesh."}
 	color = "#ff0000"
 	on_damage = 15
 	slot_flags = null
-	on = TRUE
 	var/charges = 5
+	start_on = TRUE
 
 /obj/item/flashlight/flare/culttorch/afterattack(atom/movable/A, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -228,7 +228,7 @@
 /datum/religion_sect/pyre/on_sacrifice(obj/item/flashlight/flare/candle/offering, mob/living/user)
 	if(!istype(offering))
 		return
-	if(!offering.on)
+	if(!offering.light_on)
 		to_chat(user, span_notice("The candle needs to be lit to be offered!"))
 		return
 	to_chat(user, span_notice("[GLOB.deity] is pleased with your sacrifice."))

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -363,14 +363,14 @@
 	. = ..()
 	if(!eye)
 		eye = new /obj/item/flashlight/eyelight()
-	eye.on = TRUE
+	eye.set_light_on(TRUE)
 	eye.forceMove(victim)
 	eye.update_brightness(victim)
 	victim.become_blind(FLASHLIGHT_EYES)
 
 /obj/item/organ/internal/eyes/robotic/flashlight/on_remove(mob/living/carbon/victim)
 	. = ..()
-	eye.on = FALSE
+	eye.set_light_on(FALSE)
 	eye.update_brightness(victim)
 	eye.forceMove(src)
 	victim.cure_blind(FLASHLIGHT_EYES)
@@ -420,7 +420,7 @@
 
 /obj/item/organ/internal/eyes/robotic/glow/emp_act()
 	. = ..()
-	if(!eye.on || . & EMP_PROTECT_SELF)
+	if(!eye.light_on || . & EMP_PROTECT_SELF)
 		return
 	deactivate(close_ui = TRUE)
 
@@ -521,7 +521,7 @@
  * Turns on the attached flashlight object, updates the mob overlay to be added.
  */
 /obj/item/organ/internal/eyes/robotic/glow/proc/activate()
-	eye.on = TRUE
+	eye.light_on = TRUE
 	if(eye.light_range) // at range 0 we are just going to make the eyes glow emissively, no light overlay
 		eye.set_light_on(TRUE)
 	update_mob_eye_color()
@@ -537,7 +537,6 @@
 /obj/item/organ/internal/eyes/robotic/glow/proc/deactivate(mob/living/carbon/eye_owner = owner, close_ui = FALSE)
 	if(close_ui)
 		SStgui.close_uis(src)
-	eye.on = FALSE
 	eye.set_light_on(FALSE)
 	update_mob_eye_color(eye_owner)
 
@@ -564,7 +563,7 @@
  */
 /obj/item/organ/internal/eyes/robotic/glow/proc/set_beam_range(new_range)
 	var/old_light_range = eye.light_range
-	if(old_light_range == 0 && new_range > 0 && eye.on) // turn bring back the light overlay if we were previously at 0 (aka emissive eyes only)
+	if(old_light_range == 0 && new_range > 0 && eye.light_on) // turn bring back the light overlay if we were previously at 0 (aka emissive eyes only)
 		eye.light_on = FALSE // this is stupid, but this has to be FALSE for set_light_on() to work.
 		eye.set_light_on(TRUE)
 	eye.set_light_range(clamp(new_range, 0, max_light_beam_distance))
@@ -599,7 +598,7 @@
  * Toggle the attached flashlight object on or off
  */
 /obj/item/organ/internal/eyes/robotic/glow/proc/toggle_active()
-	if(eye.on)
+	if(eye.light_on)
 		deactivate()
 	else
 		activate()
@@ -632,7 +631,7 @@
 	if(QDELETED(eye_owner) || !ishuman(eye_owner)) //Other carbon mobs don't have eye color.
 		return
 
-	if(!eye.on)
+	if(!eye.light_on)
 		eye_icon_state = initial(eye_icon_state)
 		overlay_ignore_lighting = FALSE
 	else
@@ -727,7 +726,7 @@
 	//add lighting
 	if(!adapt_light)
 		adapt_light = new /obj/item/flashlight/eyelight/adapted()
-	adapt_light.on = TRUE
+	adapt_light.set_light_on(TRUE)
 	adapt_light.forceMove(eye_owner)
 	adapt_light.update_brightness(eye_owner)
 	ADD_TRAIT(eye_owner, TRAIT_UNNATURAL_RED_GLOWY_EYES, ORGAN_TRAIT)
@@ -743,7 +742,7 @@
 
 /obj/item/organ/internal/eyes/night_vision/maintenance_adapted/Remove(mob/living/carbon/unadapted, special = FALSE)
 	//remove lighting
-	adapt_light.on = FALSE
+	adapt_light.set_light_on(FALSE)
 	adapt_light.update_brightness(unadapted)
 	adapt_light.forceMove(src)
 	REMOVE_TRAIT(unadapted, TRAIT_UNNATURAL_RED_GLOWY_EYES, ORGAN_TRAIT)

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -42,7 +42,7 @@
 		G.arm_grenade()
 	else if(istype(I, /obj/item/flashlight))
 		var/obj/item/flashlight/F = I
-		F.on = TRUE
+		F.set_light_on(TRUE)
 		F.update_brightness()
 
 /obj/item/vending_refill/security

--- a/tools/UpdatePaths/Scripts/79240_flashlight_var_rename.txt
+++ b/tools/UpdatePaths/Scripts/79240_flashlight_var_rename.txt
@@ -1,0 +1,1 @@
+/obj/item/flashlight/@SUBTYPES{on=@ANY} : /obj/item/flashlight/@SUBTYPES{@OLD;on=@SKIP;start_on=@OLD:on}


### PR DESCRIPTION
## About The Pull Request

#67676 described a bug where PDAs can apparently emit a small amount of light after being affected by the light eater. As it turns out, the bug is even worse than that. It doesn't work for just PDAs, it works for basically any light source that can be turned off and on. Even flashlights. In the following pictures, a flashlight has been light-eaten and then turned off and on again:

![fine](https://github.com/tgstation/tgstation/assets/21979502/e880c3a8-4ae9-4b6c-8ee9-27dacdbb23ab)

Observe how the nightmare jaunt is available, as it should be. However, one step closer to the flashlight:

![not fine](https://github.com/tgstation/tgstation/assets/21979502/b35014d4-71e8-49cf-b0f6-479cdf2ba3fc)

The nightmare jaunt can no longer be used, because the flashlight is still emitting light.

This PR just fixes that behavior. Light-eaten objects will now be totally dark again, even after being power cycled. Closes #67676.
## Why It's Good For The Game

Bugs bad.
## Changelog
:cl:
fix: Light-Eaten objects can no longer emit light after being turned off and then back on.
code: Flashlights now use light_on instead of defining their own variable. Please report buggy behavior.
/:cl:
