### PR TITLE
Fix dsiabler / laser impact effects

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -305,8 +305,8 @@
 
 	if(blocked != 100) // not completely blocked
 		var/obj/item/bodypart/hit_bodypart = living_target.get_bodypart(hit_limb_zone)
-		if (damage)
-			if (living_target.blood_volume && damage_type == BRUTE && (isnull(hit_bodypart) || hit_bodypart.can_bleed()))
+		if (damage && damage_type == BRUTE)
+			if (living_target.blood_volume && (isnull(hit_bodypart) || hit_bodypart.can_bleed()))
 				var/splatter_dir = dir
 				if(starting)
 					splatter_dir = get_dir(starting, target_turf)
@@ -316,7 +316,7 @@
 					new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_turf, splatter_dir)
 				if(prob(33))
 					living_target.add_splatter_floor(target_turf)
-			else if (!isnull(hit_bodypart) && (hit_bodypart.biological_state & (BIO_METAL|BIO_WIRED)))
+			else if (hit_bodypart?.biological_state & (BIO_METAL|BIO_WIRED))
 				var/random_damage_mult = RANDOM_DECIMAL(0.85, 1.15) // SOMETIMES you can get more or less sparks
 				var/damage_dealt = ((damage / (1 - (blocked / 100))) * random_damage_mult)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #79250 

Simply restores the check for brute damage type up a level before going into blood splatters / sparks. 

Not a perfect fix, as this means brute projectiles are unable to have unique impact effects, but as we have no brute projectiles with impact effects currently (~~outside of a CTF projectile I think?~~ Just kidding all bullets are supposed to have an effect but it uses the blood splatter instead. Project for another day?) it suffices. 

## Changelog

:cl: Melbert
fix: Disablers and Lasers now show their on-impact effects on hit mobs again. 
/:cl:
