### PR TITLE
Virus healing symptoms work on slimepeople

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -154,7 +154,7 @@
 	if(M.getToxLoss() && prob(5))
 		to_chat(M, span_notice("Your skin tingles as the starlight seems to heal you."))
 
-	M.adjustToxLoss(-(4 * heal_amt)) //most effective on toxins
+	M.adjustToxLoss(-(4 * heal_amt), forced = TRUE) //most effective on toxins
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, BODYTYPE_ORGANIC)
 
@@ -585,7 +585,7 @@
 		if(prob(5))
 			to_chat(M, span_notice("You feel warmer."))
 
-	M.adjustToxLoss(-heal_amt)
+	M.adjustToxLoss(-heal_amt, forced = TRUE)
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, BODYTYPE_ORGANIC)
 	if(!parts.len)
@@ -641,7 +641,7 @@
 	if(cellular_damage)
 		need_mob_update += M.adjustCloneLoss(-heal_amt * 0.5, updating_health = FALSE)
 
-	need_mob_update += M.adjustToxLoss(-(2 * heal_amt), updating_health = FALSE)
+	need_mob_update += M.adjustToxLoss(-(2 * heal_amt), updating_health = FALSE, forced = TRUE)
 	if(need_mob_update)
 		M.updatehealth()
 


### PR DESCRIPTION

## About The Pull Request

Virus healing symptoms' tox healing is now forced, so it works on slimepeople.

## Why It's Good For The Game

I think it's unreasonable to damage a player for a virus they most likely did not willingly recieve. I also think it's unhelpful to blame the Virologist, or put any amount of blame on them if they decided to spread a 100% beneficial no-drawbacks virus. I don't think that adds anything to the game.

Also, plasma fixation hurts slimes? Huh? Come on.

## Changelog

:cl:
qol: Virus healing symptoms' tox healing is now forced, so it works on slimepeople.
/:cl:

