### PR TITLE
mag check - examining magazines now tells you what's the next/ready round

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -160,7 +160,7 @@
 
 	if(num_loaded)
 		if(!silent)
-			to_chat(user, span_notice("You load [num_loaded > 1 ? "a" : num_loaded] [casing_phrasing]\s into \the [src]!"))
+			to_chat(user, span_notice("You load [num_loaded > 1 ? "[num_loaded] [casing_phrasing]s" : "a [casing_phrasing]"] into \the [src]!"))
 			playsound(src, 'sound/weapons/gun/general/mag_bullet_insert.ogg', 60, TRUE)
 		update_appearance()
 

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -185,7 +185,7 @@
 		return
 	// this is kind of awkward phrasing, but it's the top/ready ammo in the box
 	// intended for people who have like three mislabeled magazines
-	. += span_notice("\The [top_round] is ready in [src].")
+	. += span_notice("The [top_round] is ready in [src].")
 
 
 /obj/item/ammo_box/update_desc(updates)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -19,6 +19,8 @@
 	var/list/stored_ammo = list()
 	///type that the magazine will be searching for, rejects if not a subtype of
 	var/ammo_type = /obj/item/ammo_casing
+	/// wording used for individual units of ammo, e.g. cartridges (regular ammo), shells (shotgun shells)
+	var/casing_phrasing = "cartridge"
 	///maximum amount of ammo in the magazine
 	var/max_ammo = 7
 	///Controls how sprites are updated for the ammo box; see defines in combat.dm: AMMO_BOX_ONE_SPRITE; AMMO_BOX_PER_BULLET; AMMO_BOX_FULL_EMPTY
@@ -66,7 +68,7 @@
 	var/list/readout = list()
 
 	if(caliber && max_ammo) // Text references a 'magazine' as only magazines generally have the caliber variable initialized
-		readout += "Up to [span_warning("[max_ammo] [caliber] rounds")] can be found within this magazine. \
+		readout += "Up to [span_warning("[max_ammo] [caliber] [casing_phrasing]s")] can be found within this magazine. \
 		\nAccidentally discharging any of these projectiles may void your insurance contract."
 
 	var/obj/item/ammo_casing/mag_ammo = get_round(TRUE)
@@ -158,7 +160,7 @@
 
 	if(num_loaded)
 		if(!silent)
-			to_chat(user, span_notice("You load [num_loaded] shell\s into \the [src]!"))
+			to_chat(user, span_notice("You load [num_loaded > 1 ? "a" : num_loaded] [casing_phrasing]\s into \the [src]!"))
 			playsound(src, 'sound/weapons/gun/general/mag_bullet_insert.ogg', 60, TRUE)
 		update_appearance()
 
@@ -173,13 +175,23 @@
 	if(!user.is_holding(src) || !user.put_in_hands(A)) //incase they're using TK
 		A.bounce_away(FALSE, NONE)
 	playsound(src, 'sound/weapons/gun/general/mag_bullet_insert.ogg', 60, TRUE)
-	to_chat(user, span_notice("You remove a round from [src]!"))
+	to_chat(user, span_notice("You remove a [casing_phrasing] from [src]!"))
 	update_appearance()
+
+/obj/item/ammo_box/examine(mob/user)
+	. = ..()
+	var/top_round = get_round()
+	if(!top_round)
+		return
+	// this is kind of awkward phrasing, but it's the top/ready ammo in the box
+	// intended for people who have like three mislabeled magazines
+	. += span_notice("\The [top_round] is ready in [src].")
+
 
 /obj/item/ammo_box/update_desc(updates)
 	. = ..()
 	var/shells_left = LAZYLEN(stored_ammo)
-	desc = "[initial(desc)] There [(shells_left == 1) ? "is" : "are"] [shells_left] shell\s left!"
+	desc = "[initial(desc)] There [(shells_left == 1) ? "is" : "are"] [shells_left] [casing_phrasing]\s left!"
 
 /obj/item/ammo_box/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -6,6 +6,7 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	caliber = CALIBER_SHOTGUN
 	max_ammo = 8
+	casing_phrasing = "shell"
 
 /obj/item/ammo_box/magazine/m12g/update_icon_state()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
joke pr name: Mag Drills (Elite)

- Examining an ammo box (incl. magazines) now tells you the top-loaded/next round in the magazine, so if you have a bunch of mislabeled/unlabeled magazines you can figure out which one is your regular bullets and your Not So Regular bullets.
- Also, adds a variable `casing_phrasing` which is used instead of just "rounds" or "shells" in little, relevant text bits (e.g. moving bullets in/out of magazines).

## Why It's Good For The Game
- Ammo Box Examines: I think it's probably a good thing to be able to check what bullets are in what box/magazine without having to pull them out.
- The casing phrasing thing was just for something that bugged me. I should probably extend that out to the guns, too, but after a certain point it's just something that only a small subset of people will notice.

## Changelog

:cl:
qol: Examining an ammo box (incl. magazines) now tells you the top loaded round, so if you have different ammo types in different magazines, you can at least try to figure out which one is which.
spellcheck: Ammo boxes (incl. magazines) can now be set to use different phrasing for their ammunition (e.g. cartridges, shells, etc. instead of just mixing "rounds" and "shells").
/:cl:
