### PR TITLE
Nitrium Buff

### DIFF
--- a/code/game/objects/items/nitrium_crystals.dm
+++ b/code/game/objects/items/nitrium_crystals.dm
@@ -10,8 +10,7 @@
 	var/datum/effect_system/fluid_spread/smoke/chem/smoke = new
 	var/turf/location = get_turf(src)
 	create_reagents(5)
-	reagents.add_reagent(/datum/reagent/nitrium_low_metabolization, 3)
-	reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, 2)
+	reagents.add_reagent(/datum/reagent/nitrium, 3)
 	smoke.attach(location)
 	smoke.set_up(cloud_size, holder = src, location = location, carry = reagents, silent = TRUE)
 	smoke.start()

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -94,7 +94,6 @@
 	. = ..()
 	var/need_mob_update
 	need_mob_update = breather.adjustStaminaLoss(-2 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjustToxLoss(0.1 * (current_cycle-1) * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -71,35 +71,9 @@
 	if(isplasmaman(breather))
 		breather.set_timed_status_effect(10 SECONDS * REM * seconds_per_tick, /datum/status_effect/hypernob_protection)
 
-/datum/reagent/nitrium_high_metabolization
-	name = "Nitrosyl plasmide"
-	description = "A highly reactive byproduct that stops you from sleeping, while dealing increasing toxin damage over time."
-	reagent_state = GAS
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
-	color = "E1A116"
-	taste_description = "sourness"
-	ph = 1.8
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
-	addiction_types = list(/datum/addiction/stimulants = 14)
-
-/datum/reagent/nitrium_high_metabolization/on_mob_metabolize(mob/living/breather)
-	. = ..()
-	ADD_TRAIT(breather, TRAIT_SLEEPIMMUNE, type)
-
-/datum/reagent/nitrium_high_metabolization/on_mob_end_metabolize(mob/living/breather)
-	. = ..()
-	REMOVE_TRAIT(breather, TRAIT_SLEEPIMMUNE, type)
-
-/datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/breather, seconds_per_tick, times_fired)
-	. = ..()
-	var/need_mob_update
-	need_mob_update = breather.adjustStaminaLoss(-2 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	if(need_mob_update)
-		return UPDATE_MOB_HEALTH
-
-/datum/reagent/nitrium_low_metabolization
+/datum/reagent/nitrium
 	name = "Nitrium"
-	description = "A highly reactive gas that makes you feel faster."
+	description = "A highly reactive gas that makes you feel faster and prevents sleep."
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
@@ -107,13 +81,22 @@
 	ph = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/nitrium_low_metabolization/on_mob_metabolize(mob/living/breather)
+/datum/reagent/nitrium/on_mob_metabolize(mob/living/breather)
 	. = ..()
 	breather.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
+	ADD_TRAIT(breather, TRAIT_SLEEPIMMUNE, type)
 
-/datum/reagent/nitrium_low_metabolization/on_mob_end_metabolize(mob/living/breather)
+/datum/reagent/nitrium/on_mob_end_metabolize(mob/living/breather)
 	. = ..()
 	breather.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
+	REMOVE_TRAIT(breather, TRAIT_SLEEPIMMUNE, type)
+
+/datum/reagent/nitrium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, times_fired)
+	. = ..()
+	var/need_mob_update
+	need_mob_update = breather.adjustStaminaLoss(-2 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	if(need_mob_update)
+		return UPDATE_MOB_HEALTH
 
 /datum/reagent/pluoxium
 	name = "Pluoxium"

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -546,11 +546,8 @@
 		to_chat(breather, "<span class='notice'>You feel a burning sensation in your chest</span>")
 	// Metabolize to reagents.
 	if (nitrium_pp > 5)
-		var/existing = breather.reagents.get_reagent_amount(/datum/reagent/nitrium_low_metabolization)
-		breather.reagents.add_reagent(/datum/reagent/nitrium_low_metabolization, max(0, 2 - existing))
-	if (nitrium_pp > 10)
-		var/existing = breather.reagents.get_reagent_amount(/datum/reagent/nitrium_high_metabolization)
-		breather.reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, max(0, 1 - existing))
+		var/existing = breather.reagents.get_reagent_amount(/datum/reagent/nitrium)
+		breather.reagents.add_reagent(/datum/reagent/nitrium, max(0, 2 - existing)
 
 /// Radioactive, green gas. Toxin damage, and a radiation chance
 /obj/item/organ/internal/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -547,7 +547,7 @@
 	// Metabolize to reagents.
 	if (nitrium_pp > 5)
 		var/existing = breather.reagents.get_reagent_amount(/datum/reagent/nitrium)
-		breather.reagents.add_reagent(/datum/reagent/nitrium, max(0, 2 - existing)
+		breather.reagents.add_reagent(/datum/reagent/nitrium, max(0, 2 - existing))
 
 /// Radioactive, green gas. Toxin damage, and a radiation chance
 /obj/item/organ/internal/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)


### PR DESCRIPTION
## About The Pull Request

Back in 2019, when nitryl and stimulum were two separate gases, stimulum got nerfed. The nerf (PR #45675) made it cause slowly scaling toxin damage. At the time, stimulum granted full stun immunity, so a nerf like that was pretty warranted. Fast forward to 2022. Nitryl and stimulum had since been merged into nitrium, and the stun-immunity part of nitrium was completely removed (PR #69180). However, the scaling toxin damage was left untouched. This PR just gets rid of the scaling toxin damage too.
## Why It's Good For The Game

The scaling toxin damage was only added to counterbalance the stun immunity that stimulum granted. Now that the stun immunity is gone entirely, the toxin damage isn't really needed anymore.
## Changelog
:cl:
balance: Nitrium no longer deals scaling toxin damage at high doses. All remaining effects of nitrium occur at 5 kPa of partial pressure, rather than being split between 5 and 10.
/:cl:
