### PR TITLE
Fix wigs being offset too far by mob height

### DIFF
--- a/code/modules/clothing/head/wig.dm
+++ b/code/modules/clothing/head/wig.dm
@@ -32,6 +32,17 @@
 	return ..()
 
 
+/obj/item/clothing/head/wig/build_worn_icon(
+	default_layer = 0,
+	default_icon_file = null,
+	isinhands = FALSE,
+	female_uniform = NO_FEMALE_UNIFORM,
+	override_state = null,
+	override_file = null,
+	use_height_offset = TRUE,
+)
+	return ..(default_layer, default_icon_file, isinhands, female_uniform, override_state, override_file, use_height_offset = FALSE)
+
 /obj/item/clothing/head/wig/worn_overlays(mutable_appearance/standing, isinhands = FALSE, file2use)
 	. = ..()
 	if(isinhands)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -644,6 +644,7 @@ generate/load female uniform sprites matching all previously decided variables
 	female_uniform = NO_FEMALE_UNIFORM,
 	override_state = null,
 	override_file = null,
+	use_height_offset = TRUE,
 )
 
 	//Find a valid icon_state from variables+arguments
@@ -672,7 +673,7 @@ generate/load female uniform sprites matching all previously decided variables
 	//eg: ammo counters, primed grenade flashes, etc.
 	var/list/worn_overlays = worn_overlays(standing, isinhands, file2use)
 	if(worn_overlays?.len)
-		if(!isinhands && default_layer && ishuman(loc))
+		if(!isinhands && default_layer && ishuman(loc) && use_height_offset)
 			var/mob/living/carbon/human/human_loc = loc
 			if(human_loc.get_mob_height() != HUMAN_HEIGHT_MEDIUM)
 				var/string_form_layer = num2text(default_layer)


### PR DESCRIPTION

## About The Pull Request
Wigs now properly adjust their height to match your head's height. They've been being offset twice, first by the worn item code for hats, and again for the overlay applied that actually makes the hair. Adds an argument to said worn item code to just skip the offset business.

I'm very open to suggestions on how to do this in a better way, I feel very out of my depth with all this icon code.
Fixes #78215
Fixes #73451
Fixes #73153
## Why It's Good For The Game
Fix bugs!
## Changelog
:cl:
fix: Wigs now properly follow your head when you're any non-standard height
/:cl:
