### PR TITLE
Chameleon projector can be used on storage items.

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -976,6 +976,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/user)
 	SIGNAL_HANDLER
 
+	/*if(istype(weapon, /obj/item/chameleon))
+		var/obj/item/chameleon/C = weapon
+		C.make_copy(source, user)
+	else*/
 	return open_storage_on_signal(source, user)
 
 /// Signal handler to open up the storage when we recieve a signal.

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -976,10 +976,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/user)
 	SIGNAL_HANDLER
 
-	/*if(istype(weapon, /obj/item/chameleon))
+	if(istype(weapon, /obj/item/chameleon))
 		var/obj/item/chameleon/C = weapon
 		C.make_copy(source, user)
-	else*/
+
 	return open_storage_on_signal(source, user)
 
 /// Signal handler to open up the storage when we recieve a signal.

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -977,8 +977,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	SIGNAL_HANDLER
 
 	if(istype(weapon, /obj/item/chameleon))
-		var/obj/item/chameleon/C = weapon
-		C.make_copy(source, user)
+		var/obj/item/chameleon/chameleon_weapon = weapon
+		chameleon_weapon.make_copy(source, user)
 
 	return open_storage_on_signal(source, user)
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -58,16 +58,16 @@
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return
-	/*make_copy(target, user)
+	make_copy(target, user)
 
-/obj/item/chameleon/proc/make_copy(atom/target, mob/user)*/
+/obj/item/chameleon/proc/make_copy(atom/target, mob/user)
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, TRUE, -6)
 	to_chat(user, span_notice("Scanned [target]."))
 	var/obj/temp = new /obj()
 	temp.appearance = target.appearance
 	temp.layer = initial(target.layer) // scanning things in your inventory
 	SET_PLANE_EXPLICIT(temp, initial(plane), src)
-	saved_appearance = initial(temp.appearance)
+	saved_appearance = temp.appearance
 
 /obj/item/chameleon/proc/check_sprite(atom/target)
 	if(target.icon_state in icon_states(target.icon))

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -58,13 +58,16 @@
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return
+	/*make_copy(target, user)
+
+/obj/item/chameleon/proc/make_copy(atom/target, mob/user)*/
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, TRUE, -6)
 	to_chat(user, span_notice("Scanned [target]."))
 	var/obj/temp = new /obj()
 	temp.appearance = target.appearance
 	temp.layer = initial(target.layer) // scanning things in your inventory
 	SET_PLANE_EXPLICIT(temp, initial(plane), src)
-	saved_appearance = temp.appearance
+	saved_appearance = initial(temp.appearance)
 
 /obj/item/chameleon/proc/check_sprite(atom/target)
 	if(target.icon_state in icon_states(target.icon))


### PR DESCRIPTION
## About The Pull Request

Fix bug that you can't use chameleon projector on items with datum/storage(backpacks, box, holsters etc). Now you can right-click on it to copy icon.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/issues/55143#issue-749661132

## Changelog
:cl:
fix: chameleon projector now can copy icon for storage items(backpacks, box, holsters etc) using right-click on it.
/:cl:
