### PR TITLE
Sutures now heal a percentage of basic/animal max health instead of a flat amount

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -93,7 +93,7 @@
 			patient.balloon_alert(user, "not hurt!")
 			return FALSE
 		user.visible_message("<span class='infoplain'><span class='green'>[user] applies [src] on [patient].</span></span>", "<span class='infoplain'><span class='green'>You apply [src] on [patient].</span></span>")
-		patient.heal_bodypart_damage((heal_brute * 0.5))
+		patient.heal_bodypart_damage((heal_brute * patient.maxHealth/100))
 		return TRUE
 	if(iscarbon(patient))
 		return heal_carbon(patient, user, heal_brute, heal_burn)


### PR DESCRIPTION
## About The Pull Request

Changes the amount of HP gained when treating basic and animal mobs. For today mobs receive treatment equal to the half treatment of the selected object like sutures heal 5 hp. 

Because of this, mobs with a large amount of HP, such as gorillas, spend one stack of sutures to heal themselves for 1-3% of HP, while mobs with a small amount of HP, for example 25 HP, will receive treatment equal to 20%.

With this PR, all basic/animal mobs receive the same % of HP equal to the amount of healing for using one healing object. Like if sutures heal 10 brute damage, it will heal 10% of basic/animal mob HP.

## Why It's Good For The Game

Makes treatment for basic and animal mobs more understandable and less resource-intensive, like if you heal basic/animal mob with 100 hp or 220 hp you will need the same number of sutures.

## Changelog

:cl:
balance: Sutures now heal a percentage of basic/animal max health instead of a flat amount.
/:cl: