### PR TITLE
Adds support to the wet_floor component to avoid displaying its overlay, makes ice turfs no longer receive said wet overlay

### DIFF
--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -329,8 +329,8 @@
 			slipper.AddComponent(/datum/component/force_move, target, FALSE)//spinning would be bad for ice, fucks up the next dir
 	return TRUE
 
-/turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0, max_wet_time = MAXIMUM_WET_TIME, permanent)
-	AddComponent(/datum/component/wet_floor, wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)
+/turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0, max_wet_time = MAXIMUM_WET_TIME, permanent = FALSE, should_display_overlay = TRUE)
+	AddComponent(/datum/component/wet_floor, wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent, should_display_overlay)
 
 /turf/open/proc/MakeDry(wet_setting = TURF_WET_WATER, immediate = FALSE, amount = INFINITY)
 	SEND_SIGNAL(src, COMSIG_TURF_MAKE_DRY, wet_setting, immediate, amount)

--- a/code/game/turfs/open/ice.dm
+++ b/code/game/turfs/open/ice.dm
@@ -17,7 +17,7 @@
 
 /turf/open/misc/ice/Initialize(mapload)
 	. = ..()
-	MakeSlippery(TURF_WET_PERMAFROST, INFINITY, 0, INFINITY, TRUE)
+	MakeSlippery(TURF_WET_PERMAFROST, INFINITY, 0, INFINITY, TRUE, FALSE)
 
 /turf/open/misc/ice/break_tile()
 	return


### PR DESCRIPTION
## About The Pull Request
The title says it all, really.

I always thought ice looked a bit silly, and always wondered why. Today, I found out it was because of the `wet_floor` component adding an overlay that suddenly made a turf that should look continuous, tiled, which in turn gave some very ugly visuals. Ice already looks slippery, you can tell that it's ice, and the overlay that was added to it just didn't really help telegraph that any better than the sprite itself already does.

That's why I added support to make it so it would be possible to force the overlay to just not be applied to the turf that's affected by the component, to make it all look a bit better overall.

I added it to the ice turfs as a proof of concept, although I guess it could also be used on other turfs that are always "wet", like the bananium floors, but I didn't really care enough to touch that yet, and I guess the bananium floors can use it a bit better than ice did.

I did notice in this PR that the smoothing of ice seemed to potentially be broken, but that's something to look into at a later time.

## Why It's Good For The Game
Look at this ice and how much smoother it looks like now:
![image](https://github.com/tgstation/tgstation/assets/58045821/6fc85239-e8f1-404b-bc0e-6e1fca7f7753)

## Changelog

:cl: GoldenAlpharex
code: Added support to the wet_floor component to make it so the wet overlay could not be applied to certain turfs if desired.
fix: Ice turfs no longer look tiled, and instead look smooth when placed next to one-another.
/:cl: