### PR TITLE
Monkey Business actually spawns monkeys on the station.

### DIFF
--- a/code/modules/unit_tests/monkey_business.dm
+++ b/code/modules/unit_tests/monkey_business.dm
@@ -14,7 +14,8 @@
 
 /datum/unit_test/monkey_business/Run()
 	for(var/monkey_id in 1 to length(GLOB.the_station_areas))
-		var/mob/living/carbon/human/monkey = allocate(/mob/living/carbon/human/consistent, get_first_open_turf_in_area(GLOB.the_station_areas[monkey_id]))
+		var/area/monkey_zone = GLOB.areas_by_type[GLOB.the_station_areas[monkey_id]]
+		var/mob/living/carbon/human/monkey = allocate(/mob/living/carbon/human/consistent, get_first_open_turf_in_area(monkey_zone))
 		monkey.set_species(/datum/species/monkey)
 		monkey.set_name("Monkey [monkey_id]")
 		if(monkey_id % monkey_angry_nth == 0) // BLOOD FOR THE BLOOD GODS


### PR DESCRIPTION

## About The Pull Request

The monkey business unit test was apparently not actually spawning monkeys on the station like it was supposed to. It was trying to find open turfs inside of area _typepaths_, which obviously do not contain turfs. Functionally, this means it was summoning a number of monkeys into the same turf of the unit test z-level equal to the number of areas on the station map. Now it will actually place one monkey in every area of the station itself.

This was an incidental discovery while trying to diagnose #79147 with Jacquerel. We still don't know what's causing that one, and I doubt this will do anything about it, but nonetheless the unit test wasn't working right.
## Why It's Good For The Game

Makes a unit test do what it was actually intended to do, which is put a bunch of monkeys all over the station and see if they ruin anything. This might actually cause _more_ test failures since they're being put in a less controlled environment, but we'll see.
## Changelog
Nothing player facing.
