### PR TITLE
Mech Diagnostic Hud Fix

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -41,6 +41,7 @@
 	if(damage_taken <= 0 || atom_integrity < 0)
 		return damage_taken
 
+	diag_hud_set_mechhealth()
 	spark_system?.start()
 	try_deal_internal_damage(damage_taken)
 	if(damage_taken >= 5 || prob(33))
@@ -332,6 +333,7 @@
 	. = ..()
 	if(.)
 		try_damage_component(., user.zone_selected)
+		diag_hud_set_mechhealth()
 
 /obj/vehicle/sealed/mecha/examine(mob/user)
 	. = ..()
@@ -428,6 +430,7 @@
 			break
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
+		diag_hud_set_mechhealth()
 	else
 		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 
@@ -436,6 +439,7 @@
 	atom_integrity = max_integrity
 	if(cell && charge_cell)
 		cell.charge = cell.maxcharge
+		diag_hud_set_mechcell()
 	if(internal_damage & MECHA_INT_FIRE)
 		clear_internal_damage(MECHA_INT_FIRE)
 	if(internal_damage & MECHA_INT_TEMP_CONTROL)
@@ -446,6 +450,7 @@
 		clear_internal_damage(MECHA_CABIN_AIR_BREACH)
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		clear_internal_damage(MECHA_INT_CONTROL_LOST)
+	diag_hud_set_mechhealth()
 
 /obj/vehicle/sealed/mecha/narsie_act()
 	emp_act(EMP_HEAVY)

--- a/code/modules/vehicles/mecha/mecha_helpers.dm
+++ b/code/modules/vehicles/mecha/mecha_helpers.dm
@@ -8,7 +8,10 @@
 	return cell?.charge
 
 /obj/vehicle/sealed/mecha/proc/use_power(amount)
-	return (get_charge() && cell.use(amount))
+	var/output = get_charge() && cell.use(amount)
+	if (output)
+		diag_hud_set_mechcell()
+	return output
 
 /obj/vehicle/sealed/mecha/proc/give_power(amount)
 	if(!isnull(get_charge()))


### PR DESCRIPTION

## About The Pull Request

The big mech rework PR caused the diagnostic hud display for mechs to be a little bit buggy, not updating the health bar when it should've. I just added some more logic to it to make sure that the health and charge bars update when they should. Closes #79273.
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: The health bar on the mech diagnostic hud display should update consistently now.
/:cl:
