### PR TITLE
Adds back in corn oil to fix Glycerol's recipe.

### DIFF
--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -14,7 +14,7 @@
 	icon_grow = "corn-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "corn-dead" // Same for the dead icon
 	mutatelist = list(/obj/item/seeds/corn/snapcorn)
-	reagents_add = list(/datum/reagent/consumable/nutriment/fat/oil = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/consumable/nutriment/fat/oil/corn = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/food/grown/corn
 	seed = /obj/item/seeds/corn
@@ -24,7 +24,7 @@
 	trash_type = /obj/item/grown/corncob
 	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
-	grind_results = list(/datum/reagent/consumable/cornmeal = 0)
+	grind_results = list(/datum/reagent/consumable/cornmeal = 0, /datum/reagent/consumable/nutriment/fat/oil/corn = 0)
 	juice_typepath = /datum/reagent/consumable/corn_starch
 	tastes = list("corn" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/whiskey

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -222,6 +222,13 @@
 	nutriment_factor = 10
 	default_container = /obj/item/reagent_containers/condiment/olive_oil
 
+/datum/reagent/consumable/nutriment/fat/oil/corn
+	name = "Corn Oil"
+	description = "An oil derived from various types of corn."
+	color = "#302000" // rgb: 48, 32, 0
+	taste_description = "slime"
+	nutriment_factor = 5 //it's a very cheap oil
+
 /datum/reagent/consumable/nutriment/organ_tissue
 	name = "Organ Tissue"
 	description = "Natural tissues that make up the bulk of organs, providing many vitamins and minerals."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -31,7 +31,7 @@
 
 /datum/chemical_reaction/glycerol
 	results = list(/datum/reagent/glycerol = 1)
-	required_reagents = list(/datum/reagent/consumable/nutriment/fat/oil = 3, /datum/reagent/toxin/acid = 1)
+	required_reagents = list(/datum/reagent/consumable/nutriment/fat/oil/corn = 3, /datum/reagent/toxin/acid = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_EXPLOSIVE
 
 /datum/chemical_reaction/sodiumchloride


### PR DESCRIPTION
## About The Pull Request

fixes #78087

This PR adds back in corn oil and changes the vegetable oil reagent in corn to become corn oil, and glycerol's recipe has been changed back to using corn oil.

Corn also produces corn oil when grinded now, where it previously would only produce cornmeal.

## Why It's Good For The Game

The foodening accidentally changed corn oil to vegetable oil when it was actually a crafting ingredient for a chemical. This PR makes it still a consumable oil so that there's the best of both worlds.

Having glycerol being able to be made by vegetable oil changed a rare chemical into something you could get by just going to the cook's cooking oil vat. Considering this is the chemical used to make the instant death shotgun shell, that's pretty bad.

## Changelog
:cl:
add: Corn oil is now produced from corn instead of regular vegetable oil.
balance: Glycerol now uses corn oil instead of vegetable oil in it's recipe.
fix: Grinding corn now produces oil when it previously only made cornmeal despite having oil in it's reagents.
/:cl:

Maintainers will have to decide if this is an addition + balance and a fix or just a fix.