### PR TITLE
[CI Fix] Fixed a runtime when a monkey attacks a parrot.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -324,7 +324,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 	return
 
 /mob/living/simple_animal/parrot/attack_paw(mob/living/carbon/human/user, list/modifiers)
-	return attack_hand(modifiers)
+	return attack_hand(user, modifiers)
 
 /mob/living/simple_animal/parrot/attack_alien(mob/living/carbon/alien/user, list/modifiers)
 	return attack_hand(user, modifiers)


### PR DESCRIPTION

## About The Pull Request

#79276 has caused the monkey business test to start failing a lot, for a few different reasons.

This was a pretty bad one, where the proc specifically used for a monkey attacking a parrot was broken. It would not actually pass along a reference to the monkey with the attack, causing no less than three runtimes per attack. In unit tests this was causing literally thousands of lines of stack traces as an angry monkey keeps trying to beat the ghost of Poly to death.

That should not happen anymore.
## Why It's Good For The Game

Hopefully lets PRs start passing checks more consistently again. Also lets Pun-Pun fight Poly to the death without breaking everything.
## Changelog
:cl:
fix: Monkeys can now properly attack parrots.
/:cl:
