### PR TITLE
remove toggle on PENLITE holobarrier

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -162,8 +162,6 @@
 
 /obj/structure/holosign/barrier/medical/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(force_allaccess)
-		return TRUE
 	if(istype(mover, /obj/vehicle/ridden))
 		for(var/M in mover.buckled_mobs)
 			if(ishuman(M))
@@ -171,7 +169,7 @@
 					return FALSE
 	if(ishuman(mover))
 		return CheckHuman(mover)
-		return TRUE
+			return TRUE
 
 /obj/structure/holosign/barrier/medical/Bumped(atom/movable/AM)
 	. = ..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -169,7 +169,7 @@
 					return FALSE
 	if(ishuman(mover))
 		return CheckHuman(mover)
-			return TRUE
+	return TRUE
 
 /obj/structure/holosign/barrier/medical/Bumped(atom/movable/AM)
 	. = ..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -171,7 +171,7 @@
 					return FALSE
 	if(ishuman(mover))
 		return CheckHuman(mover)
-	return TRUE
+		return TRUE
 
 /obj/structure/holosign/barrier/medical/Bumped(atom/movable/AM)
 	. = ..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -188,13 +188,6 @@
 		return FALSE
 	return TRUE
 
-/obj/structure/holosign/barrier/medical/attack_hand(mob/living/user, list/modifiers)
-	if(!user.combat_mode && CanPass(user, get_dir(src, user)))
-		force_allaccess = !force_allaccess
-		to_chat(user, span_warning("You [force_allaccess ? "deactivate" : "activate"] the biometric scanners.")) //warning spans because you can make the station sick!
-	else
-		return ..()
-
 /obj/structure/holosign/barrier/cyborg/hacked
 	name = "Charged Energy Field"
 	desc = "A powerful energy field that blocks movement. Energy arcs off it."


### PR DESCRIPTION
## About The Pull Request
this PR removes the PENLITE holobarrier’s biometric scanner toggle function activated by hitting the holobarrier.

## Why It's Good For The Game
This is good for the game as having the toggle is quite useless because the only reason someone would have it up is to keep sick people out.

 There is no point to turning off the biometric scanning because you may as well have nothing put up in the first place.

This also prevents people from unknowingly turning it off allowing sick patients to infect valuable medical staff.
## Changelog
:cl:deathrobotpunch1
del: Removed the biometric scanning toggle from the PENLITE holobarrier
/:cl:
