### PR TITLE
[CI Fix] Monkeys cannot use camera consoles.

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -50,7 +50,7 @@
 
 /obj/machinery/computer/security/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
-	if(isnull(user.client)) //uncliented mobs should not interact (namely, monkeys)
+	if(!user.can_perform_action(src, NEED_DEXTERITY)) //prevents monkeys from using camera consoles
 		return
 	// Update UI
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -50,6 +50,8 @@
 
 /obj/machinery/computer/security/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
+	if(isnull(user.client)) //uncliented mobs should not interact (namely, monkeys)
+		return
 	// Update UI
 	ui = SStgui.try_update_ui(user, src, ui)
 


### PR DESCRIPTION
## About The Pull Request

Another source of runtimes revealed by #79276. Monkeys' AI allows them to interact with random objects. This normally causes no problems, but notably, camera consoles do not require you to be literate to use them. This means that if a monkey randomly slaps one, it attempts to show a UI to a mob with no client, and runtimes. Camera consoles now simply disallow mobs without `TRAIT_ADVANCEDTOOLUSER` from using them, which nicely keeps monkeys out.

I don't know if there's a more broad way to go about not showing UI to clientless mobs, but this is the only case I can think of where it would actually happen.
## Why It's Good For The Game

Kills another source of failures during the monkey business unit test. Also kills a runtime in general, which is nice.
## Changelog
:cl:
fix: Mobs without the "advanced tool user" trait - such as monkeys - are no longer able to interact with camera consoles.
/:cl:
