### PR TITLE
[CI Fix] The Demonic Frost-Miner will not attack corpses.

### DIFF
--- a/code/modules/mapfluff/ruins/icemoonruin_code/mining_site.dm
+++ b/code/modules/mapfluff/ruins/icemoonruin_code/mining_site.dm
@@ -26,6 +26,11 @@
 	outfit = /datum/outfit/minesite
 	icon_state = "corpseminer"
 
+// Gives the minesite corpses the gutted effect so that the boss ignores them
+/obj/effect/mob_spawn/corpse/human/minesite/special(mob/living/spawned_mob)
+	. = ..()
+	spawned_mob.apply_status_effect(/datum/status_effect/gutted)
+
 /obj/effect/mob_spawn/corpse/human/minesite/overseer
 	name = "Mining Site Overseer"
 	outfit = /datum/outfit/minesite/overseer

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -43,6 +43,7 @@ Difficulty: Extremely Hard
 	death_message = "falls to the ground, decaying into plasma particles."
 	death_sound = SFX_BODYFALL
 	footstep_type = FOOTSTEP_MOB_HEAVY
+	stat_attack = HARD_CRIT // so it doesn't attack the corpses in its arena
 	/// If the demonic frost miner is in its enraged state
 	var/enraged = FALSE
 	/// If the demonic frost miner is currently transforming to its enraged state

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -43,7 +43,6 @@ Difficulty: Extremely Hard
 	death_message = "falls to the ground, decaying into plasma particles."
 	death_sound = SFX_BODYFALL
 	footstep_type = FOOTSTEP_MOB_HEAVY
-	stat_attack = HARD_CRIT // so it doesn't attack the corpses in its arena
 	/// If the demonic frost miner is in its enraged state
 	var/enraged = FALSE
 	/// If the demonic frost miner is currently transforming to its enraged state
@@ -94,6 +93,9 @@ Difficulty: Extremely Hard
 
 /mob/living/simple_animal/hostile/megafauna/demonic_frost_miner/OpenFire()
 	if(client)
+		return
+	var/mob/living/living_target = target
+	if(istype(living_target) && living_target.stat == DEAD) //don't go out of our way to fire our disintegrating attacks at corpses
 		return
 
 	var/easy_attack = prob(80 - enraged * 40)


### PR DESCRIPTION
## About The Pull Request

Fixes #79147.

Prevents the Demonic Frost-Miner from shooting at corpses by returning early from `OpenFire()`. Also adds the "gutted" status effect to the corpses in its arena so it won't try to gut them.
## Why It's Good For The Game

#78826 introduced an unfortunate bug by placing corpses in the Frost Miner's arena. There were a combination of three factors at play here: that the Miner attacks corpses, that it happens to use colossus bolts in its attacks, which dust corpses, and that some unfortunate quirk of life code causes runtimes if, as far as I can tell, a life tick goes off when a mob is at the wrong point in the dusting process. The time this process takes happened to perfectly coincide with the Monkey Business unit test (being the first test that takes a significant period of time), causing it to randomly fail.

So, this fixes a flaky test that has been a pain in the ass for the last five days, is the big thing.

Also, it can't possibly have been intended for the Miner to run around obliterating the aesthetic corpses in its arena within the first 15 seconds of any given round. Completely ruining the mood!

I'll point out that this particular boss may have been forgotten in #77731, which set out to make only the colossus still gib/dust you, but even were that not the case I think it would be a bit silly for the Miner to be busy shooting lifeless corpses when a player shows up to challenge it, rather than standing in its scary ritual circle.
## Changelog
:cl:
fix: The Demonic Frost-Miner will no longer run around destroying the corpses in its arena the moment the round begins.
/:cl:
