### PR TITLE
Fixes Obsessed Moodlets Not Going Away When They Lose The Trauma

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -67,6 +67,7 @@
 /datum/brain_trauma/special/obsessed/on_lose()
 	..()
 	owner.mind.remove_antag_datum(/datum/antagonist/obsessed)
+	owner.clear_mood_event("creeping")
 	if(obsession)
 		UnregisterSignal(obsession, COMSIG_MOB_EYECONTACT)
 


### PR DESCRIPTION

## About The Pull Request
Adds a clear_mood_event proc to obsessed's on_lose so that the mood event goes away.
On live:
<img src="https://i.ibb.co/R6yBcfL/Obsessed1.png">
On local with fix:
<img src="https://i.ibb.co/xHm884D/Obsessed2.png">

## Why It's Good For The Game
I got owned by this last round on Manuel and Dexter Grif made fun of me :(
## Changelog
:cl:
fix: Obsessed's moodlets (Both positive and negative) go away when the trauma is cured or the antag status is removed.
/:cl:
