### PR TITLE
Changes the Malf Ability "Robotics Factory" to be purchasable multiple times.

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -622,7 +622,6 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	name = "Robotic Factory (Removes Shunting)"
 	description = "Build a machine anywhere, using expensive nanomachines, that can convert a living human into a loyal cyborg slave when placed inside."
 	cost = 100
-	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/place_transformer
 	unlock_text = span_notice("You make contact with Space Amazon and request a robotics factory for delivery.")
 	unlock_sound = 'sound/machines/ping.ogg'
@@ -655,9 +654,11 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	var/obj/machinery/transformer/conveyor = new(T)
 	conveyor.master_ai = owner
 	playsound(T, 'sound/effects/phasein.ogg', 100, TRUE)
-	owner_AI.can_shunt = FALSE
-	to_chat(owner, span_warning("You are no longer able to shunt your core to APCs."))
+	if(owner_AI.can_shunt) //prevent repeated messages
+		owner_AI.can_shunt = FALSE
+		to_chat(owner, span_warning("You are no longer able to shunt your core to APCs."))
 	adjust_uses(-1)
+	active = FALSE
 
 /mob/living/silicon/ai/proc/remove_transformer_image(client/C, image/I, turf/T)
 	if(C && I.loc == T)


### PR DESCRIPTION

## About The Pull Request
- Removes the line that prevents multiple purchases of the Robotics Factory ability.
- Adds a check to prevent the same message being given to the AI about being unable to shunt after the first use.
- Sets Active to False at the end of the activation proc, to properly handle having multiple charges of the ability.
## Why It's Good For The Game
The robotics factory is powerful, but has some pretty hard drawbacks. The main being a removal of the ability to shunt. But you also inevitably and permanently change the shift into being Crew vs Silicon. The robotics factory itself isn't super tanky, and it's not hard for it to be destroyed through any number of means (not to mention it requires a powered APC). Losing the factory doesn't undo any of the downsides, which can feel terrible if you get blindsighted.

This give the AI a way to recover and continue after a factory loss. You'll still need another 100 points (which is ten APCs, hacked over the course of ten minutes).
## Changelog
:cl:
balance: Malf Ability "Robotics Factory" can now be purchased multiple times.
/:cl:
