### PR TITLE
Extends Halloween

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -549,9 +549,9 @@
 
 /datum/holiday/halloween
 	name = HALLOWEEN
-	begin_day = 29
+	begin_day = 27
 	begin_month = OCTOBER
-	end_day = 2
+	end_day = 3
 	end_month = NOVEMBER
 	holiday_colors = list(COLOR_MOSTLY_PURE_ORANGE, COLOR_PRISONER_BLACK)
 


### PR DESCRIPTION
## About The Pull Request

Makes Halloween one week long instead of five days long

## Why It's Good For The Game

The duration of the Halloween event means that it can fall outside of a weekend such that depending on their schedule people don't actually see it
It's not _quite_ as disruptive as things like April Fool's day to have a handful of extra species available. 
also it was an admin request

plus if the holiday is longer it increases the chances that Dullahans will be playable on at least one of the days

## Changelog

:cl:
balance: Halloween now starts earlier and ends a day later
/:cl:
