### PR TITLE
Telecomms Harddel Fix

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -5,8 +5,6 @@
 	/// The current temporary frequency used to add new filtered frequencies
 	/// options.
 	var/tempfreq = FREQ_COMMON
-	/// The current mob operating the machine.
-	var/datum/weakref/operator
 	/// Illegal frequencies that can't be listened to by telecommunication servers.
 	var/list/banned_frequencies = list(
 		FREQ_SYNDICATE,
@@ -37,7 +35,6 @@
 		return ..()
 
 /obj/machinery/telecomms/ui_interact(mob/user, datum/tgui/ui)
-	operator = WEAKREF(user)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Telecomms")
@@ -90,13 +87,11 @@
 	if(.)
 		return
 
-	if(!issilicon(usr))
-		if(!istype(usr.get_active_held_item(), /obj/item/multitool))
+	var/mob/living/current_user = usr
+	if(!issilicon(current_user))
+		if(!istype(current_user.get_active_held_item(), /obj/item/multitool))
 			return
 
-	var/mob/living/current_user = operator?.resolve()
-	if (isnull(current_user))
-		return
 	var/obj/item/multitool/heldmultitool = get_multitool(current_user)
 
 	switch(action)

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -6,7 +6,7 @@
 	/// options.
 	var/tempfreq = FREQ_COMMON
 	/// The current mob operating the machine.
-	var/mob/living/operator
+	var/datum/weakref/operator
 	/// Illegal frequencies that can't be listened to by telecommunication servers.
 	var/list/banned_frequencies = list(
 		FREQ_SYNDICATE,
@@ -37,7 +37,7 @@
 		return ..()
 
 /obj/machinery/telecomms/ui_interact(mob/user, datum/tgui/ui)
-	operator = user
+	operator = WEAKREF(user)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Telecomms")
@@ -94,29 +94,32 @@
 		if(!istype(usr.get_active_held_item(), /obj/item/multitool))
 			return
 
-	var/obj/item/multitool/heldmultitool = get_multitool(operator)
+	var/mob/living/current_user = operator?.resolve()
+	if (isnull(current_user))
+		return
+	var/obj/item/multitool/heldmultitool = get_multitool(current_user)
 
 	switch(action)
 		if("toggle")
 			toggled = !toggled
 			update_power()
 			update_appearance()
-			operator.log_message("toggled [toggled ? "On" : "Off"] [src].", LOG_GAME)
+			current_user.log_message("toggled [toggled ? "On" : "Off"] [src].", LOG_GAME)
 			. = TRUE
 		if("id")
 			if(params["value"])
 				if(length(params["value"]) > 32)
-					to_chat(operator, span_warning("Error: Machine ID too long!"))
+					to_chat(current_user, span_warning("Error: Machine ID too long!"))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 					return
 				else
 					id = params["value"]
-					operator.log_message("has changed the ID for [src] to [id].", LOG_GAME)
+					current_user.log_message("has changed the ID for [src] to [id].", LOG_GAME)
 					. = TRUE
 		if("network")
 			if(params["value"])
 				if(length(params["value"]) > 15)
-					to_chat(operator, span_warning("Error: Network name too long!"))
+					to_chat(current_user, span_warning("Error: Network name too long!"))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 					return
 				else
@@ -124,32 +127,32 @@
 						remove_link(linked_machine)
 					network = params["value"]
 					links = list()
-					operator.log_message("has changed the network for [src] to [network].", LOG_GAME)
+					current_user.log_message("has changed the network for [src] to [network].", LOG_GAME)
 					. = TRUE
 		if("tempfreq")
 			if(params["value"])
 				tempfreq = text2num(params["value"]) * 10
 		if("freq")
 			if(tempfreq in banned_frequencies)
-				to_chat(operator, span_warning("Error: Interference preventing filtering frequency: \"[tempfreq / 10] kHz\""))
+				to_chat(current_user, span_warning("Error: Interference preventing filtering frequency: \"[tempfreq / 10] kHz\""))
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 			else
 				if(!(tempfreq in freq_listening))
 					freq_listening.Add(tempfreq)
-					operator.log_message("added frequency [tempfreq] for [src].", LOG_GAME)
+					current_user.log_message("added frequency [tempfreq] for [src].", LOG_GAME)
 					. = TRUE
 		if("delete")
 			freq_listening.Remove(params["value"])
-			operator.log_message("removed frequency [params["value"]] for [src].", LOG_GAME)
+			current_user.log_message("removed frequency [params["value"]] for [src].", LOG_GAME)
 			. = TRUE
 		if("unlink")
 			var/obj/machinery/telecomms/machine_to_unlink = links[text2num(params["value"])]
 			if(machine_to_unlink)
-				. = remove_link(machine_to_unlink, operator)
+				. = remove_link(machine_to_unlink, current_user)
 		if("link")
 			if(heldmultitool)
 				var/obj/machinery/telecomms/machine_to_link = heldmultitool.buffer
-				. = add_new_link(machine_to_link, operator)
+				. = add_new_link(machine_to_link, current_user)
 		if("buffer")
 			heldmultitool.set_buffer(src)
 			. = TRUE


### PR DESCRIPTION

## About The Pull Request

Currently, telecomms machines store a hard reference to the last person to open the tgui. This can, in certain circumstances, lead to a hard delete. This PR just changes the reference into a weakref, so there should be no more risk of hard deletes.
## Changelog
:cl:
fix: Removed rare hard delete involving telecomms machines.
/:cl:
