### PR TITLE
Changes how halloween lighting works slightly

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -112,6 +112,8 @@
 	#define COMSIG_BLOCK_EYECONTACT (1<<0)
 ///from base of /mob/update_sight(): ()
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"
+///from base of /mob/update_sight(): ()
+#define COMSIG_HUD_UPDATE_SIGHT "hud_update_sight"
 ////from /mob/living/say(): ()
 #define COMSIG_MOB_SAY "mob_say"
 	#define COMPONENT_UPPERCASE_SPEECH (1<<0)

--- a/code/__DEFINES/filters.dm
+++ b/code/__DEFINES/filters.dm
@@ -1,0 +1,2 @@
+/// Entry in a filter list that holds its priority, for sorting the application order
+#define FILTER_PRIORITY "priority"

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -71,7 +71,7 @@
 	return a.priority - b.priority
 
 /proc/cmp_filter_data_priority(list/A, list/B)
-	return A["priority"] - B["priority"]
+	return A[FILTER_PRIORITY] - B[FILTER_PRIORITY]
 
 /proc/cmp_timer(datum/timedevent/a, datum/timedevent/b)
 	return a.timeToRun - b.timeToRun

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -82,8 +82,36 @@
 	if(check_holidays(HALLOWEEN))
 		// Makes things a tad greyscale (leaning purple) and drops low colors for vibes
 		// We're basically using alpha as better constant here btw
-		add_filter("spook_color_boost", 2, color_matrix_filter(list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0.04,0.07,0.06,1, 0,0,0,0)))
-		add_filter("spook_color_dim", 3, color_matrix_filter(list(0.67,0.13,0.13,0, 0.13,0.58,0.13,0, 0.13,0.13,0.67,0, -0.08,-0.11,-0.1,1, 0,0,0,0)))
+		add_filter("spook_color_boost", 2, color_matrix_filter(list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0.07,0.04,0.06,1, 0,0,0,0)))
+		add_filter("spook_color_dim", 3, color_matrix_filter(list(0.67,0.13,0.13,0, 0.13,0.58,0.13,0, 0.13,0.13,0.67,0, -0.12,-0.08,-0.1,1, 0,0,0,0)))
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/show_to(mob/mymob)
+	. = ..()
+	if(!.)
+		return
+	if(!check_holidays(HALLOWEEN))
+		return
+	var/datum/hud/hud = home.our_hud
+	if(hud)
+		RegisterSignal(hud, COMSIG_HUD_UPDATE_SIGHT, PROC_REF(spooky_sight_updated), override = TRUE)
+	account_for_cutoffs(mymob.lighting_cutoff, mymob.lighting_color_cutoffs)
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/spooky_sight_updated(datum/source)
+	SIGNAL_HANDLER
+	var/mob/our_mob = home.our_hud.mymob
+	account_for_cutoffs(our_mob.lighting_cutoff, our_mob.lighting_color_cutoffs)
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/account_for_cutoffs(cutoff, list/color_cutoff)
+	// Spooky lighting cuts down lights somewhat, if we're using cutoffs we should not, since it'll fuck up their effect
+	if(cutoff > 0 || (color_cutoff && (color_cutoff[1] > 0 || color_cutoff[2] > 0 || color_cutoff[3] > 0)))
+		var/red_offset = min(0, 0.07 - 0.12 + (cutoff + color_cutoff[1]) / 100)
+		var/green_offset = min(0, 0.04 - 0.08 + (cutoff + color_cutoff[1]) / 100)
+		var/blue_offset = min(0, 0.06 - 0.1 + (cutoff + color_cutoff[1]) / 100)
+		// Gonna mess with the multiples here to make the effect better. it's not like, perfect, tends to tint the screen more then I'd like, but it's close enough to the non
+		// Cut colors that I can live with it
+		modify_filter("spook_color_dim", color_matrix_filter(list(0.6,0.13,0.13,0, 0.13,0.42,0.13,0, 0.13,0.13,0.6,0, -0.07+red_offset,-0.04+green_offset,-0.06+blue_offset,1, 0,0,0,0)), overwrite = TRUE)
+	else
+		modify_filter("spook_color_dim", color_matrix_filter(list(0.67,0.13,0.13,0, 0.13,0.58,0.13,0, 0.13,0.13,0.67,0, -0.11,-0.1,-0.1,1, 0,0,0,0)), overwrite = TRUE)
 
 // Blackness renders weird when you view down openspace, because of transforms and borders and such
 // This is a consequence of not using lummy's grouped transparency, but I couldn't get that to work without totally fucking up
@@ -173,6 +201,7 @@
 	// show_to can be called twice successfully with no hide_from call. Ensure no runtimes off the registers from this
 	if(hud)
 		RegisterSignal(hud, COMSIG_HUD_OFFSET_CHANGED, PROC_REF(on_offset_change), override = TRUE)
+		RegisterSignal(hud, COMSIG_HUD_UPDATE_SIGHT, PROC_REF(sight_updated), override = TRUE)
 	offset_change(hud?.current_plane_offset || 0)
 	set_light_cutoff(mymob.lighting_cutoff, mymob.lighting_color_cutoffs)
 
@@ -194,6 +223,12 @@
 		disable_alpha()
 	else
 		enable_alpha()
+
+/atom/movable/screen/plane_master/rendering_plate/lighting/proc/sight_updated(datum/source)
+	SIGNAL_HANDLER
+	// We just updated our color cutoffs, let's apply those
+	var/mob/our_mob = home.our_hud.mymob
+	set_light_cutoff(our_mob.lighting_cutoff, our_mob.lighting_color_cutoffs)
 
 /atom/movable/screen/plane_master/rendering_plate/lighting/proc/set_light_cutoff(light_cutoff, list/color_cutoffs)
 	var/list/new_cutoffs = list(light_cutoff)

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -82,7 +82,8 @@
 	if(check_holidays(HALLOWEEN))
 		// Makes things a tad greyscale (leaning purple) and drops low colors for vibes
 		// We're basically using alpha as better constant here btw
-		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.13,0, 0.13,0.7,0.13,0, 0.13,0.13,0.75,0, -0.06,-0.09,-0.08,1, 0,0,0,0)))
+		add_filter("spook_color_boost", 2, color_matrix_filter(list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0.04,0.07,0.06,1, 0,0,0,0)))
+		add_filter("spook_color_dim", 3, color_matrix_filter(list(0.67,0.13,0.13,0, 0.13,0.58,0.13,0, 0.13,0.13,0.67,0, -0.08,-0.11,-0.1,1, 0,0,0,0)))
 
 // Blackness renders weird when you view down openspace, because of transforms and borders and such
 // This is a consequence of not using lummy's grouped transparency, but I couldn't get that to work without totally fucking up
@@ -174,7 +175,6 @@
 		RegisterSignal(hud, COMSIG_HUD_OFFSET_CHANGED, PROC_REF(on_offset_change), override = TRUE)
 	offset_change(hud?.current_plane_offset || 0)
 	set_light_cutoff(mymob.lighting_cutoff, mymob.lighting_color_cutoffs)
-
 
 /atom/movable/screen/plane_master/rendering_plate/lighting/hide_from(mob/oldmob)
 	. = ..()

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -312,7 +312,7 @@
 /datum/proc/add_filter(name, priority, list/params)
 	LAZYINITLIST(filter_data)
 	var/list/copied_parameters = params.Copy()
-	copied_parameters["priority"] = priority
+	copied_parameters[FILTER_PRIORITY] = priority
 	filter_data[name] = copied_parameters
 	update_filters()
 
@@ -325,7 +325,7 @@
 	for(var/filter_raw in filter_data)
 		var/list/data = filter_data[filter_raw]
 		var/list/arguments = data.Copy()
-		arguments -= "priority"
+		arguments -= FILTER_PRIORITY
 		atom_cast.filters += filter(arglist(arguments))
 	UNSETEMPTY(filter_data)
 
@@ -345,6 +345,7 @@
 	if(!filter)
 		return
 	if(overwrite)
+		new_params[FILTER_PRIORITY] = filter_data[name][FILTER_PRIORITY]
 		filter_data[name] = new_params
 	else
 		for(var/thing in new_params)
@@ -375,7 +376,7 @@
 	if(!filter_data || !filter_data[name])
 		return
 
-	filter_data[name]["priority"] = new_priority
+	filter_data[name][FILTER_PRIORITY] = new_priority
 	update_filters()
 
 /// Returns the filter associated with the passed key

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -626,9 +626,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		set_invis_see(SEE_INVISIBLE_OBSERVER)
 
-
 	updateghostimages()
-	..()
+	lighting_color_cutoffs = list(lighting_cutoff_red, lighting_cutoff_green, lighting_cutoff_blue)
+	return ..()
 
 /proc/updateallghostimages()
 	list_clear_nulls(GLOB.ghost_images_default)

--- a/code/modules/mob/living/basic/minebots/minebot_abilities.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_abilities.dm
@@ -45,7 +45,7 @@
 		owner.lighting_cutoff_green -= 15
 		owner.lighting_cutoff_blue -= 5
 
-	owner.sync_lighting_plane_cutoff()
+	owner.update_sight()
 
 	to_chat(owner, span_notice("You toggle your meson vision [(owner.sight & SEE_TURFS) ? "on" : "off"]."))
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1845,7 +1845,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		if(NAMEOF(src, maxHealth))
 			updatehealth()
 		if(NAMEOF(src, lighting_cutoff))
-			sync_lighting_plane_cutoff()
+			update_sight()
 
 
 /mob/living/vv_get_header()

--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -99,7 +99,7 @@
 			lighting_cutoff_green = 0
 			lighting_cutoff_blue = 0
 			msg = "You deactivate your night vision."
-	sync_lighting_plane_cutoff()
+	update_sight()
 	to_chat(src, span_notice(msg))
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1266,14 +1266,8 @@
 /mob/proc/update_sight()
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
-	sync_lighting_plane_cutoff()
-
-///Set the lighting plane hud filters to the mobs lighting_cutoff var
-/mob/proc/sync_lighting_plane_cutoff()
-	if(!hud_used)
-		return
-	for(var/atom/movable/screen/plane_master/rendering_plate/lighting/light as anything in hud_used.get_true_plane_masters(RENDER_PLANE_LIGHTING))
-		light.set_light_cutoff(lighting_cutoff, lighting_color_cutoffs)
+	if(hud_used)
+		SEND_SIGNAL(hud_used, COMSIG_HUD_UPDATE_SIGHT)
 
 ///Update the mouse pointer of the attached client in this mob
 /mob/proc/update_mouse_pointer()

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -319,7 +319,6 @@
 	user.set_sight(BLIND|SEE_TURFS)
 	// Pale blue, should look nice I think
 	user.lighting_color_cutoffs = list(30, 40, 50)
-	user.sync_lighting_plane_cutoff()
 	return TRUE
 
 /datum/action/innate/shuttledocker_rotate

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -92,6 +92,7 @@
 #include "code\__DEFINES\explosions.dm"
 #include "code\__DEFINES\external_organs.dm"
 #include "code\__DEFINES\fantasy_affixes.dm"
+#include "code\__DEFINES\filters.dm"
 #include "code\__DEFINES\firealarm.dm"
 #include "code\__DEFINES\fish.dm"
 #include "code\__DEFINES\flora.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fully dropping lighting is a nice effect, but it makes dark spaces pitch. So instead, let's bump it, then drop that slightly more. That dumps the brights and only slightly darkens. I've also lowered saturation which helps make the effect more scalar rather then direct offfsets.

My intent is not to make this totally normal/remove it, since I do want it to impact vibes. Tolerable for 5 days but vibey > workable for a year if that makes sense. 

Closes #79325 (mostly, won't work for the quirk but I am willing to pay that cost)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/58055496/0bc71347-772c-4558-a4c3-da412a9ce846)

![image](https://github.com/tgstation/tgstation/assets/58055496/4eb1345f-f6b1-4b28-a9b3-57319c0c41d1)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Halloween lighting should no longer black out lavaland. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
