### PR TITLE
Makes stack trace errors set file and line number to caller

### DIFF
--- a/code/__DEFINES/stack_trace.dm
+++ b/code/__DEFINES/stack_trace.dm
@@ -1,2 +1,4 @@
 /// gives us the stack trace from CRASH() without ending the current proc.
 #define stack_trace(message) _stack_trace(message, __FILE__, __LINE__)
+
+#define WORKAROUND_IDENTIFIER "%//%"

--- a/code/__HELPERS/stack_trace.dm
+++ b/code/__HELPERS/stack_trace.dm
@@ -1,4 +1,4 @@
 /// gives us the stack trace from CRASH() without ending the current proc.
 /// Do not call directly, use the [stack_trace] macro instead.
 /proc/_stack_trace(message, file, line)
-	CRASH("[message] ([file]:[line])")
+	CRASH("[message][WORKAROUND_IDENTIFIER][json_encode(list(file, line))][WORKAROUND_IDENTIFIER]")

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -26,12 +26,19 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		Reboot(reason = 1)
 		return
 
+	var/static/regex/stack_workaround = regex("[WORKAROUND_IDENTIFIER](.+?)[WORKAROUND_IDENTIFIER]")
 	var/static/list/error_last_seen = list()
 	var/static/list/error_cooldown = list() /* Error_cooldown items will either be positive(cooldown time) or negative(silenced error)
 												If negative, starts at -1, and goes down by 1 each time that error gets skipped*/
 
 	if(!error_last_seen) // A runtime is occurring too early in start-up initialization
 		return ..()
+
+	if(stack_workaround.Find(E.name))
+		var/list/data = json_decode(stack_workaround.group[1])
+		E.file = data[1]
+		E.line = data[2]
+		E.name = stack_workaround.Replace(E.name, "")
 
 	var/erroruid = "[E.file][E.line]"
 	var/last_seen = error_last_seen[erroruid]


### PR DESCRIPTION
Somewhat annoying on occasion, errors thrown from stack_trace() get combined all into one entry in the runtime viewer. This is because if we were to create our own exception with properly set information, we would lose the call stack. To workaround this I've formatted the file and line number in the exception.name such that it can be extracted in world.Error and assigned to the correct vars before we handle other parts of exception handling.

![2023-10-28_06-41-47](https://github.com/tgstation/tgstation/assets/1234602/1a50ad7f-bd6a-4470-b2b0-d373807d1dc1)
