### PR TITLE
Adds a few extra params to blackbox dynamic threat logs.

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(blackbox)
 							"round_end_stats" = 2,
 							"testmerged_prs" = 2,
 							"dynamic_threat" = 2,
-							) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
+						) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
 
 /datum/controller/subsystem/blackbox/Initialize()
 	triggertime = world.time

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -14,7 +14,9 @@ SUBSYSTEM_DEF(blackbox)
 							"time_dilation_current" = 3,
 							"science_techweb_unlock" = 2,
 							"round_end_stats" = 2,
-							"testmerged_prs" = 2) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
+							"testmerged_prs" = 2,
+							"dynamic_threat" = 2,
+							) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
 
 /datum/controller/subsystem/blackbox/Initialize()
 	triggertime = world.time

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -434,6 +434,8 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 			"server_name" = CONFIG_GET(string/serversqlname),
 			"forced_threat_level" = GLOB.dynamic_forced_threat_level,
 			"threat_level" = threat_level,
+			"max_threat" = (SSticker.totalPlayersReady < low_pop_player_threshold) ? LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold) : max_threat_level,
+			"player_count" = SSticker.totalPlayersReady,
 			"round_start_budget" = round_start_budget,
 			"parameters" = list(
 				"threat_curve_centre" = threat_curve_centre,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the roundstart pop count and the calculated max threat to blackbox logging of dynamic threat.

This allows for identifying lowpop shifts and more intelligent analysis of dynamic threat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I need this added to better track what's going on when analysing threat distribution, as all threat stats will bias low with the inclusion of lowpop shifts capping max threat.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

No player-facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
