### PR TITLE
Fix list pick not working in remotes

### DIFF
--- a/code/modules/wiremod/components/list/list_pick.dm
+++ b/code/modules/wiremod/components/list/list_pick.dm
@@ -54,25 +54,24 @@
 
 
 /obj/item/circuit_component/list_pick/input_received(datum/port/input/port)
-	if(!parent.Adjacent(user.value))
-		failure.set_output(COMPONENT_SIGNAL)
-		return
-
-	if(ismob(user.value))
+	if(isliving(user.value))
+		var/mob/living/living_user = user.value
+		if(!(living_user.can_perform_action(parent.shell, FORBID_TELEKINESIS_REACH, ALLOW_SILICON_REACH, ALLOW_RESTING)))
+			return
 		trigger_output.set_output(COMPONENT_SIGNAL)
 		INVOKE_ASYNC(src, PROC_REF(show_list), user.value, input_name.value, input_list.value)
 
 /// Show a list of options to the user using standed TGUI input list
-/obj/item/circuit_component/list_pick/proc/show_list(mob/user, message, list/showed_list)
+/obj/item/circuit_component/list_pick/proc/show_list(mob/living/u, message, list/showed_list)
 	if(!showed_list || showed_list.len == 0)
 		failure.set_output(COMPONENT_SIGNAL)
 		return
 	if(!message)
 		message = "circuit input"
-	if(!(user.can_perform_action(src, FORBID_TELEKINESIS_REACH)))
+	if(!(u.can_perform_action(parent.shell, FORBID_TELEKINESIS_REACH, ALLOW_SILICON_REACH, ALLOW_RESTING)))
 		return
-	var/picked = tgui_input_list(user, message = message, items = showed_list)
-	if(!(user.can_perform_action(src, FORBID_TELEKINESIS_REACH)))
+	var/picked = tgui_input_list(u, message = message, items = showed_list)
+	if(!(u.can_perform_action(parent.shell, FORBID_TELEKINESIS_REACH, ALLOW_SILICON_REACH, ALLOW_RESTING)))
 		return
 	choose_item(picked, showed_list)
 

--- a/code/modules/wiremod/components/list/list_pick.dm
+++ b/code/modules/wiremod/components/list/list_pick.dm
@@ -54,7 +54,8 @@
 
 
 /obj/item/circuit_component/list_pick/input_received(datum/port/input/port)
-	if(parent.Adjacent(user.value))
+	if(!parent.Adjacent(user.value))
+		failure.set_output(COMPONENT_SIGNAL)
 		return
 
 	if(ismob(user.value))

--- a/code/modules/wiremod/components/list/list_pick.dm
+++ b/code/modules/wiremod/components/list/list_pick.dm
@@ -62,7 +62,7 @@
 		INVOKE_ASYNC(src, PROC_REF(show_list), user.value, input_name.value, input_list.value)
 
 /// Show a list of options to the user using standed TGUI input list
-/obj/item/circuit_component/list_pick/proc/show_list(mob/living/u, message, list/showed_list)
+/obj/item/circuit_component/list_pick/proc/show_list(mob/living/living_user, message, list/showed_list)
 	if(!showed_list || showed_list.len == 0)
 		failure.set_output(COMPONENT_SIGNAL)
 		return
@@ -70,7 +70,7 @@
 		message = "circuit input"
 	if(!(u.can_perform_action(parent.shell, FORBID_TELEKINESIS_REACH, ALLOW_SILICON_REACH, ALLOW_RESTING)))
 		return
-	var/picked = tgui_input_list(u, message = message, items = showed_list)
+	var/picked = tgui_input_list(living_user, message = message, items = showed_list)
 	if(!(u.can_perform_action(parent.shell, FORBID_TELEKINESIS_REACH, ALLOW_SILICON_REACH, ALLOW_RESTING)))
 		return
 	choose_item(picked, showed_list)


### PR DESCRIPTION

## About The Pull Request

during my original implementation. I made a mistake in adjescent which means it did not work in remotes and BMI's, this should fix it

## Why It's Good For The Game

A bug on my part, it can be used in remotes now(as it should have from the start)

## Changelog
:cl:
fix: list pick works in remotes/BMI's now
/:cl:
