### PR TITLE
Fixes mod reskins not having their icon in radial menu when using different dmi path

### DIFF
--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -144,8 +144,9 @@
 		balloon_alert(user, "no alternate skins!")
 		return
 	var/list/skins = list()
-	for(var/mod_skin in mod.theme.skins)
-		skins[mod_skin] = image(icon = mod.icon, icon_state = "[mod_skin]-control")
+	for(var/mod_skin_name in mod.theme.skins)
+		var/list/skin = mod.theme.skins[mod_skin_name]
+		skins[mod_skin_name] = image(icon = skin[MOD_ICON_OVERRIDE], icon_state = "[mod_skin_name]-control")
 	var/pick = show_radial_menu(user, mod, skins, custom_check = CALLBACK(src, PROC_REF(check_menu), mod, user), require_near = TRUE)
 	if(!pick)
 		balloon_alert(user, "no skin picked!")

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -146,9 +146,7 @@
 	var/list/skins = list()
 	for(var/mod_skin_name in mod.theme.skins)
 		var/list/mod_skin = mod.theme.skins[mod_skin_name]
-		skins[mod_skin_name] = image(icon = mod.icon, icon_state = "[mod_skin_name]-control")
-		if(mod_skin[MOD_ICON_OVERRIDE])
-			skins[mod_skin_name] = image(icon = mod_skin[MOD_ICON_OVERRIDE], icon_state = "[mod_skin_name]-control")
+		skins[mod_skin_name] = image(icon = mod_skin[MOD_ICON_OVERRIDE] || mod.icon, icon_state = "[mod_skin_name]-control")
 	var/pick = show_radial_menu(user, mod, skins, custom_check = CALLBACK(src, PROC_REF(check_menu), mod, user), require_near = TRUE)
 	if(!pick)
 		balloon_alert(user, "no skin picked!")

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -145,8 +145,10 @@
 		return
 	var/list/skins = list()
 	for(var/mod_skin_name in mod.theme.skins)
-		var/list/skin = mod.theme.skins[mod_skin_name]
-		skins[mod_skin_name] = image(icon = skin[MOD_ICON_OVERRIDE], icon_state = "[mod_skin_name]-control")
+		var/list/mod_skin = mod.theme.skins[mod_skin_name]
+		skins[mod_skin_name] = image(icon = mod.icon, icon_state = "[mod_skin_name]-control")
+		if(mod_skin[MOD_ICON_OVERRIDE])
+			skins[mod_skin_name] = image(icon = mod_skin[MOD_ICON_OVERRIDE], icon_state = "[mod_skin_name]-control")
 	var/pick = show_radial_menu(user, mod, skins, custom_check = CALLBACK(src, PROC_REF(check_menu), mod, user), require_near = TRUE)
 	if(!pick)
 		balloon_alert(user, "no skin picked!")


### PR DESCRIPTION
## About The Pull Request
Changes repaint proc a bit so it actually supports `MOD_ICON_OVERRIDE` in reskins and shows their icons correctly
## Why It's Good For The Game
It's good for downstreams that want to make new reskins for modsuits and place them in to different dmi's

in short, fixes this
![278809338-ea90bb56-fc61-4e7e-87e2-5ddb56694bba](https://github.com/tgstation/tgstation/assets/8430839/fb1e3378-cc4b-4c3a-8e5e-1f531fdcfb55)

to this...
![image](https://github.com/tgstation/tgstation/assets/8430839/3db3521f-9992-40be-b428-4f44a9966cbe)
(left one has both skins using `MOD_ICON_OVERRIDE`, but each one has different icon file)
## Changelog
:cl:
code: mod reskins now properly shows their icon when skins loaded from different .dmi
/:cl:
