### PR TITLE
Practice Carbine Dual Wielding Fix

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -40,11 +40,10 @@
 	desc = "A modified laser gun which can shoot far faster, but each shot is far less damaging."
 	icon_state = "laser_carbine"
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/carbine)
-	var/allow_akimbo = FALSE
 
 /obj/item/gun/energy/laser/carbine/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.15 SECONDS, allow_akimbo = allow_akimbo)
+	AddComponent(/datum/component/automatic_fire, 0.15 SECONDS, allow_akimbo = FALSE)
 
 /obj/item/gun/energy/laser/carbine/practice
 	name = "practice laser carbine"
@@ -53,7 +52,6 @@
 	clumsy_check = FALSE
 	item_flags = NONE
 	gun_flags = NOT_A_REAL_GUN
-	allow_akimbo = TRUE
 
 /obj/item/gun/energy/laser/retro/old
 	name ="laser gun"


### PR DESCRIPTION

## About The Pull Request

When I added laser carbines, I made it impossible to dual wield them because it could allow you to shoot normal lasers far faster than intended (#72705). Someone else later added practice laser carbines, and decided to allow dual wielding with them. This predictably led to the exact same problem, so now they can't be dual wielded. Closes #79331.
## Changelog
:cl:
fix: Practice laser carbines can no longer be used to rapidly fire regular laser guns.
/:cl:
