### PR TITLE
Improved nightshift check on security level change

### DIFF
--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -39,6 +39,9 @@ SUBSYSTEM_DEF(security_level)
 	if(!selected_level)
 		CRASH("set_level was called with an invalid security level([new_level])")
 
+	if(SSnightshift.can_fire && (selected_level.number_level >= SEC_LEVEL_RED || current_security_level.number_level >= SEC_LEVEL_RED))
+		SSnightshift.next_fire = world.time + 7 SECONDS // Fire nightshift after the security level announcement is complete
+
 	level_announce(selected_level, current_security_level.number_level) // We want to announce BEFORE updating to the new level
 
 	SSsecurity_level.current_security_level = selected_level
@@ -53,7 +56,6 @@ SUBSYSTEM_DEF(security_level)
 		SSshuttle.emergency.alert_coeff_change(selected_level.shuttle_call_time_mod)
 
 	SEND_SIGNAL(src, COMSIG_SECURITY_LEVEL_CHANGED, selected_level.number_level)
-	SSnightshift.check_nightshift()
 	SSblackbox.record_feedback("tally", "security_level_changes", 1, selected_level.name)
 
 /**


### PR DESCRIPTION
## About The Pull Request

Modifies the security level change proc to only fire the nightshift subsystem if the subsystem is running, and if a lighting change is required. If a lighting change is required, nightshift has its next fire set 7 seconds after, so announcements and sounds don't stack.

## Why It's Good For The Game

Nightshift is only updated when required, eliminating nuisance announcements when levels unrelated to red/delta are selected.

## Changelog

:cl: LT3
code: Changing security levels will only trigger the nightshift subsystem if lighting changes are required
/:cl: