### PR TITLE
Lower silicon lathe tax

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -18,7 +18,7 @@
 //How many credits a player is charged if they print something from a departmental lathe they shouldn't have access to.
 #define LATHE_TAX 10
 //How much POWER a borg's cell is taxed if they print something from a departmental lathe.
-#define SILICON_LATHE_TAX 2000
+#define SILICON_LATHE_TAX 200
 
 #define STATION_TARGET_BUFFER 25
 


### PR DESCRIPTION
## About The Pull Request

Lowers silicon lathe tax.

## Why It's Good For The Game

2000 is a big charge cost in exchange for a crewmember not spending 10 credits.  A regular crew member could print 5 things a minute passively, with the amount they can print building up through the shift.  For borgs, they instead need to go and actively spend roughly the same amount of time in a borg charger whenever they print things, which is not peak gameplay, contrary to popular belief.

Charge cost is also meaningless in the economy at large because power is essentially free - if we're that set on not letting silicon cost be free then I could look at detracting 10 credits from the station instead.

I'm also not convinced ordering silicons to print thing is a bug and not a feature - LAW 2 PRINT THIS TO SAVE ME 10 CREDITS is more fun and player interaction than sitting in a charger.  It's still free for the AI, so crew can bypass it anyway.

## Changelog
:cl:
balance: Lowered silicon lathe tax.  Remember you can order silicons to print things for free!
/:cl:
