### PR TITLE
Plumbing Bottler deals with specific container types

### DIFF
--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -88,7 +88,7 @@
 			/obj/item/ammo_casing/shotgun/dart,
 		)
 		if(is_type_in_list(AM, allowed_containers))
-			var/obj/item/reagent_containers/B = AM
+			var/obj/item/B = AM
 			///see if it would overflow else inject
 			if((B.reagents.total_volume + wanted_amount) <= B.reagents.maximum_volume)
 				reagents.trans_to(B, wanted_amount, transferred_by = src)

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -82,7 +82,7 @@
 	if(reagents.total_volume + 0.01 >= wanted_amount && anchored && length(inputspot.contents))
 		use_power(active_power_usage * seconds_per_tick)
 		var/obj/AM = pick(inputspot.contents)///pick a reagent_container that could be used
-		if((is_reagent_container(AM) && !istype(AM, /obj/item/reagent_containers/hypospray/medipen)) || istype(AM, /obj/item/ammo_casing/shotgun/dart))
+		if(istype(AM, /obj/item/reagent_containers/cup/bottle))
 			var/obj/item/reagent_containers/B = AM
 			///see if it would overflow else inject
 			if((B.reagents.total_volume + wanted_amount) <= B.reagents.maximum_volume)
@@ -91,10 +91,8 @@
 				return
 			///glass was full so we move it away
 			AM.forceMove(badspot)
-		if(istype(AM, /obj/item/slime_extract)) ///slime extracts need inject
+		else if(istype(AM, /obj/item/slime_extract)) ///slime extracts need inject
 			AM.forceMove(goodspot)
 			reagents.trans_to(AM, wanted_amount, transferred_by = src, methods = INJECT)
-			return
-		if(istype(AM, /obj/item/slimecross/industrial)) ///no need to move slimecross industrial things
+		else if(istype(AM, /obj/item/slimecross/industrial)) ///no need to move slimecross industrial things
 			reagents.trans_to(AM, wanted_amount, transferred_by = src, methods = INJECT)
-			return

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -82,7 +82,12 @@
 	if(reagents.total_volume + 0.01 >= wanted_amount && anchored && length(inputspot.contents))
 		use_power(active_power_usage * seconds_per_tick)
 		var/obj/AM = pick(inputspot.contents)///pick a reagent_container that could be used
-		if(istype(AM, /obj/item/reagent_containers/cup/bottle))
+		//allowed containers
+		var/static/list/allowed_containers = list(
+			/obj/item/reagent_containers/cup,
+			/obj/item/ammo_casing/shotgun/dart,
+		)
+		if(is_type_in_list(AM, allowed_containers))
 			var/obj/item/reagent_containers/B = AM
 			///see if it would overflow else inject
 			if((B.reagents.total_volume + wanted_amount) <= B.reagents.maximum_volume)


### PR DESCRIPTION
## About The Pull Request
- Fixes #60264

Based on its name it makes sense it should only deal with bottles (slime extracts as the exception which was already there). We have a specific type for this `obj/item/reagent_containers/cup/bottle` this mean now it won't fill
- Pills(`/obj/item/reagent_containers/pill`)
- Patches(`/obj/item/reagent_containers/pill/patch`)
- Syringes(`/obj/item/reagent_containers/syringe`)
- etc(i don't know basically anything else that is of type `obj/item/reagent_containers`

## Changelog
:cl:
fix: plumbing bottler now only deals with bottles, beakers similar stuff but not pills, patches, syringes or anything than can hold reagents. That & slime extracts, slime industrial extract & shotgun shell
/:cl:
