### PR TITLE
Removes obsolete variable from telecomms machinery

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -5,8 +5,6 @@
 	/// The current temporary frequency used to add new filtered frequencies
 	/// options.
 	var/tempfreq = FREQ_COMMON
-	/// The current mob operating the machine.
-	var/mob/living/operator
 	/// Illegal frequencies that can't be listened to by telecommunication servers.
 	var/list/banned_frequencies = list(
 		FREQ_SYNDICATE,
@@ -37,7 +35,6 @@
 		return ..()
 
 /obj/machinery/telecomms/ui_interact(mob/user, datum/tgui/ui)
-	operator = user
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Telecomms")
@@ -90,33 +87,35 @@
 	if(.)
 		return
 
-	if(!issilicon(usr))
-		if(!istype(usr.get_active_held_item(), /obj/item/multitool))
+	var/mob/user = usr
+
+	if(!issilicon(user))
+		if(!istype(user.get_active_held_item(), /obj/item/multitool))
 			return
 
-	var/obj/item/multitool/heldmultitool = get_multitool(operator)
+	var/obj/item/multitool/heldmultitool = get_multitool(user)
 
 	switch(action)
 		if("toggle")
 			toggled = !toggled
 			update_power()
 			update_appearance()
-			operator.log_message("toggled [toggled ? "On" : "Off"] [src].", LOG_GAME)
+			user.log_message("toggled [toggled ? "On" : "Off"] [src].", LOG_GAME)
 			. = TRUE
 		if("id")
 			if(params["value"])
 				if(length(params["value"]) > 32)
-					to_chat(operator, span_warning("Error: Machine ID too long!"))
+					to_chat(user, span_warning("Error: Machine ID too long!"))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 					return
 				else
 					id = params["value"]
-					operator.log_message("has changed the ID for [src] to [id].", LOG_GAME)
+					user.log_message("has changed the ID for [src] to [id].", LOG_GAME)
 					. = TRUE
 		if("network")
 			if(params["value"])
 				if(length(params["value"]) > 15)
-					to_chat(operator, span_warning("Error: Network name too long!"))
+					to_chat(user, span_warning("Error: Network name too long!"))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 					return
 				else
@@ -124,32 +123,32 @@
 						remove_link(linked_machine)
 					network = params["value"]
 					links = list()
-					operator.log_message("has changed the network for [src] to [network].", LOG_GAME)
+					user.log_message("has changed the network for [src] to [network].", LOG_GAME)
 					. = TRUE
 		if("tempfreq")
 			if(params["value"])
 				tempfreq = text2num(params["value"]) * 10
 		if("freq")
 			if(tempfreq in banned_frequencies)
-				to_chat(operator, span_warning("Error: Interference preventing filtering frequency: \"[tempfreq / 10] kHz\""))
+				to_chat(user, span_warning("Error: Interference preventing filtering frequency: \"[tempfreq / 10] kHz\""))
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 			else
 				if(!(tempfreq in freq_listening))
 					freq_listening.Add(tempfreq)
-					operator.log_message("added frequency [tempfreq] for [src].", LOG_GAME)
+					user.log_message("added frequency [tempfreq] for [src].", LOG_GAME)
 					. = TRUE
 		if("delete")
 			freq_listening.Remove(params["value"])
-			operator.log_message("removed frequency [params["value"]] for [src].", LOG_GAME)
+			user.log_message("removed frequency [params["value"]] for [src].", LOG_GAME)
 			. = TRUE
 		if("unlink")
 			var/obj/machinery/telecomms/machine_to_unlink = links[text2num(params["value"])]
 			if(machine_to_unlink)
-				. = remove_link(machine_to_unlink, operator)
+				. = remove_link(machine_to_unlink, user)
 		if("link")
 			if(heldmultitool)
 				var/obj/machinery/telecomms/machine_to_link = heldmultitool.buffer
-				. = add_new_link(machine_to_link, operator)
+				. = add_new_link(machine_to_link, user)
 		if("buffer")
 			heldmultitool.set_buffer(src)
 			. = TRUE


### PR DESCRIPTION
Direct cause of #79368 though more long term solution here would be checking garbage queue before/after tests (specifically c&d) for hard-deletes so leftovers are detected near the test that caused them (monkey business here)