### PR TITLE
Add's surgical apron to the medidrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -67,6 +67,7 @@
 		/obj/item/clothing/under/rank/medical/scrubs/blue = 4,
 		/obj/item/clothing/under/rank/medical/scrubs/green = 4,
 		/obj/item/clothing/under/rank/medical/scrubs/purple = 4,
+		/obj/item/clothing/suit/apron/surgical = 4,
 		/obj/item/clothing/under/rank/medical/paramedic = 4,
 		/obj/item/clothing/under/rank/medical/paramedic/skirt = 4,
 		/obj/item/clothing/suit/toggle/labcoat = 4,


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game

At the moment, they can only be found in medical on DeltaStation in the surgery theaters, most likely other ways to get them but i have not found them, and doing this is much easier then adding them to every surgery theater on every map 
(might do that a different day though)

## Changelog

:cl:
add: surgical apron's are now available for purchase in the medi-drobe
/:cl:
