### PR TITLE
Removes 3 bitrunner computer  consoles from birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -38221,15 +38221,6 @@
 /obj/machinery/computer/quantum_console{
 	dir = 4
 	},
-/obj/machinery/computer/quantum_console{
-	dir = 4
-	},
-/obj/machinery/computer/quantum_console{
-	dir = 4
-	},
-/obj/machinery/computer/quantum_console{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/bitrunning/den)


### PR DESCRIPTION

## About The Pull Request
deletes 3 consoles stacked ontop of eachother
## Why It's Good For The Game
probably a mistake
![image](https://github.com/tgstation/tgstation/assets/54517726/d591022a-62ec-4bee-ab61-3a10805d02fd)
## Changelog
:cl:

del: Removed extra consoles from birdshot's bitrunners
/:cl:
