### PR TITLE
remove revenant from dynamic.json

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -113,10 +113,6 @@
 			"weight": 0
 		},
 
-		"Revenant": {
-			"weight": 0
-		},
-
 		"Sentient Disease": {
 			"weight": 0
 		},


### PR DESCRIPTION

## About The Pull Request

removes revenant from dynamic.json, which I think controls midround spawning

## Why It's Good For The Game

revenants are hilariously unbalanced and exist to ruin the fun of others, they need either a gigantic nerf or to be removed altogether

## Changelog
:cl:
del: removes revenant from spawning midround
/:cl:
