### PR TITLE
[NO GBP] Buckshot no longer instantly deletes itself except when used pointblank. Oops

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -71,7 +71,6 @@
 /obj/projectile/bullet/pellet
 	icon_state = "pellet"
 	damage_falloff_tile = -0.45
-	stamina_falloff_tile = -0.25
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
@@ -87,6 +86,7 @@
 	sharpness = NONE
 	embedding = null
 	speed = 1.2
+	stamina_falloff_tile = -0.25
 	ricochets_max = 4
 	ricochet_chance = 120
 	ricochet_decay_chance = 0.9


### PR DESCRIPTION

## About The Pull Request

This was causing lethal shotgun shells with no stamina damage to instantly delete. Oops.

## Why It's Good For The Game

I broke it and fucked up MrrFish' op round and definitely not because I OWNED HIM WITH A BEEPSKY STUN

### BITCH

## Changelog
:cl:
fix: Lethal ballistic pellet-based shotgun shells no longer instantly delete.
/:cl:
