### PR TITLE
Fix light eater affecting lava, space, openspace, and transparent turfs

### DIFF
--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -83,8 +83,7 @@
  * - [eater][/datum]: The light eater eating the morsel. This is the datum that the element is attached to that started this chain.
  */
 /datum/element/light_eater/proc/devour(atom/morsel, datum/eater)
-	var/static/list/undevourable = typecacheof(list(/turf/open/space))
-	if(is_type_in_typecache(morsel, undevourable))
+	if(isspaceturf(morsel) || isopenspaceturf(morsel) || islava(morsel) || istransparentturf(morsel))
 		return FALSE
 	if(morsel.light_power <= 0 || morsel.light_range <= 0 || !morsel.light_on)
 		return FALSE

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -4,6 +4,10 @@
  * The temporary equivalent is [/datum/component/light_eater]
  */
 /datum/element/light_eater
+	var/static/list/blacklisted_areas = typecacheof(list(
+		/turf/open/space,
+		/turf/open/lava,
+	))
 
 /datum/element/light_eater/Attach(datum/target)
 	if(isatom(target))
@@ -83,7 +87,9 @@
  * - [eater][/datum]: The light eater eating the morsel. This is the datum that the element is attached to that started this chain.
  */
 /datum/element/light_eater/proc/devour(atom/morsel, datum/eater)
-	if(isspaceturf(morsel) || isopenspaceturf(morsel) || islava(morsel) || istransparentturf(morsel))
+	if(is_type_in_typecache(morsel, blacklisted_areas))
+		return FALSE
+	if(istransparentturf(morsel))
 		return FALSE
 	if(morsel.light_power <= 0 || morsel.light_range <= 0 || !morsel.light_on)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
Fixes #79388

Light eater element can no longer affect lava, space (starlight), openspace, or any turf with transparency.

## Why It's Good For The Game
Better consistency.

## Changelog
:cl:
fix: Fix light eater affecting lava, space, openspace, and transparent turfs
/:cl:
