### PR TITLE
Flightpotion/health analyzer balance tweak

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -325,8 +325,7 @@
 			|| targetspecies.mutanttongue != initial(targetspecies.mutanttongue) \
 			|| targetspecies.mutantliver != initial(targetspecies.mutantliver) \
 			|| targetspecies.mutantstomach != initial(targetspecies.mutantstomach) \
-			|| targetspecies.mutantappendix != initial(targetspecies.mutantappendix) \
-			|| istype(humantarget.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS), /obj/item/organ/external/wings/functional)
+			|| targetspecies.mutantappendix != initial(targetspecies.mutantappendix)
 
 		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span>\n"
 		var/core_temperature_message = "Core temperature: [round(humantarget.coretemperature-T0C, 0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)"

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -314,18 +314,8 @@
 		if(advanced && humantarget.has_dna())
 			render_list += "<span class='info ml-1'>Genetic Stability: [humantarget.dna.stability]%.</span>\n"
 
-		// Species and body temperature
-		var/datum/species/targetspecies = humantarget.dna.species
-		var/mutant = humantarget.dna.check_mutation(/datum/mutation/human/hulk) \
-			|| targetspecies.mutantlungs != initial(targetspecies.mutantlungs) \
-			|| targetspecies.mutantbrain != initial(targetspecies.mutantbrain) \
-			|| targetspecies.mutantheart != initial(targetspecies.mutantheart) \
-			|| targetspecies.mutanteyes != initial(targetspecies.mutanteyes) \
-			|| targetspecies.mutantears != initial(targetspecies.mutantears) \
-			|| targetspecies.mutanttongue != initial(targetspecies.mutanttongue) \
-			|| targetspecies.mutantliver != initial(targetspecies.mutantliver) \
-			|| targetspecies.mutantstomach != initial(targetspecies.mutantstomach) \
-			|| targetspecies.mutantappendix != initial(targetspecies.mutantappendix)
+		// Hulk and body temperature
+		var/mutant = humantarget.dna.check_mutation(/datum/mutation/human/hulk)
 
 		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span>\n"
 		var/core_temperature_message = "Core temperature: [round(humantarget.coretemperature-T0C, 0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)"

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -315,6 +315,7 @@
 			render_list += "<span class='info ml-1'>Genetic Stability: [humantarget.dna.stability]%.</span>\n"
 
 		// Hulk and body temperature
+		var/datum/species/targetspecies = humantarget.dna.species
 		var/mutant = humantarget.dna.check_mutation(/datum/mutation/human/hulk)
 
 		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span>\n"


### PR DESCRIPTION

## About The Pull Request

I was asked by a maintainer to split this off from my other PR (#79360), so here it is. Basically, health analyzers are hard-coded to list you as a mutant if you have wings from a flightpotion. This only applies to flightpotion wings; no other organ, internal or external, not even moth wings, work in the same way. So this PR just removes that check for consistency.

I'd also like to note that I'm not opposed to the flightpotion being made to _actually_ change your species again, as long as someone else does the work. In fact, if someone were to do that this change would still make just as much if not more sense.
## Why It's Good For The Game

As far as I can tell, there is no reason for this check to exist. At one point, the flight potion did actually change your species, and it seems like this check is just an old, unneeded relic of that. I'm not aware for any balance reason for this check, unlike the hulk mutation. Although you can argue that policy lists people with angel wings as being nonhuman, that is specifically because the health analyzer lists them as mutants, so it makes no sense for health analyzers to do so because of policy.
## Changelog
:cl:
balance: Flightpotion wings will no longer make health analyzers list you as nonhuman.
/:cl:
