### PR TITLE
Fix holodeck items from being juiced or grinded with a biogenerator or pestle and mortar

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -313,7 +313,6 @@
 		var/obj/item/food/food_to_convert = locate(/obj/item/food) in contents
 
 		if(food_to_convert.flags_1 & HOLOGRAM_1)
-			visible_message(span_notice("[food_to_convert] fades away!"))
 			qdel(food_to_convert)
 			continue
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -312,12 +312,13 @@
 	for(var/i in 1 to processed_items_per_cycle)
 		var/obj/item/food/food_to_convert = locate(/obj/item/food) in contents
 
-		if(food_to_convert.flags_1 & HOLOGRAM_1)
-			qdel(food_to_convert)
-			continue
-
 		if(!food_to_convert)
 			break
+
+		if(food_to_convert.flags_1 & HOLOGRAM_1)
+			qdel(food_to_convert)
+			current_item_count = max(current_item_count - 1, 0)
+			continue
 
 		convert_to_biomass(food_to_convert)
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -312,6 +312,11 @@
 	for(var/i in 1 to processed_items_per_cycle)
 		var/obj/item/food/food_to_convert = locate(/obj/item/food) in contents
 
+		if(food_to_convert.flags_1 & HOLOGRAM_1)
+			to_chat(user, span_notice("You try to process [food_to_convert], but it fades away!"))
+			qdel(food_to_convert)
+			continue
+
 		if(!food_to_convert)
 			break
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -313,7 +313,7 @@
 		var/obj/item/food/food_to_convert = locate(/obj/item/food) in contents
 
 		if(food_to_convert.flags_1 & HOLOGRAM_1)
-			to_chat(user, span_notice("You try to process [food_to_convert], but it fades away!"))
+			visible_message(span_notice("[food_to_convert] fades away!"))
 			qdel(food_to_convert)
 			continue
 

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -508,6 +508,11 @@
 	to_chat(user, span_warning("You can't grind this!"))
 
 /obj/item/reagent_containers/cup/mortar/proc/grind_item(obj/item/item, mob/living/carbon/human/user)
+	if(item.flags_1 & HOLOGRAM_1)
+		to_chat(user, span_notice("You try to grind [item], but it fades away!"))
+		qdel(item)
+		return
+
 	if(!item.grind(reagents, user))
 		if(isstack(item))
 			to_chat(usr, span_notice("[src] attempts to grind as many pieces of [item] as possible."))
@@ -519,6 +524,11 @@
 	QDEL_NULL(item)
 
 /obj/item/reagent_containers/cup/mortar/proc/juice_item(obj/item/item, mob/living/carbon/human/user)
+	if(item.flags_1 & HOLOGRAM_1)
+		to_chat(user, span_notice("You try to juice [item], but it fades away!"))
+		qdel(item)
+		return
+
 	if(!item.juice(reagents, user))
 		to_chat(user, span_notice("You fail to juice [item]."))
 		return


### PR DESCRIPTION

## About The Pull Request
Hologram food from the holodeck could still be processed into reagents via these methods. This has now been fixed.

## Why It's Good For The Game
Try sleeping to heal yourself instead.

## Changelog
:cl:
fix: Fix holodeck items from being juiced or grinded with a biogenerator or pestle and mortar
/:cl:
