### PR TITLE
Remove duplicate northstar message monitor computer

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -53298,9 +53298,6 @@
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/obj/machinery/computer/message_monitor{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
 	name = "Telecomms - Control";
 	network = list("ss13","engine")


### PR DESCRIPTION
## About The Pull Request
This removes a duplicate message monitor computer that was placed on the same tile.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Removed duplicate northstar message monitor computer
/:cl:
