### PR TITLE
Remove duplicate pipe on pirate ship

### DIFF
--- a/_maps/shuttles/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate_ex_interdyne.dmm
@@ -52,7 +52,6 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)


### PR DESCRIPTION
## About The Pull Request
Removes a duplicate pipe that was placed on the same tile.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate pipe on pirate ship
/:cl:
