### PR TITLE
Remove duplicate power computer on oldstation ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -5155,7 +5155,6 @@
 "By" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/monitor,
-/obj/machinery/computer/monitor,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request
This removes a duplicate power monitor computer that was placed on the same tile for the oldstation ruin.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate power computer on oldstation ruin
/:cl:
