### PR TITLE
Remove duplicate machinery from icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12088,7 +12088,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "dBQ" = (
@@ -26544,18 +26543,6 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"ihr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "pharmacy_shutters2";
-	name = "Pharmacy Shutters"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "pharmacy_shutters2";
-	name = "Pharmacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/medical/pharmacy)
 "ihu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -26609,7 +26596,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Cargo Bay Office - Access"
@@ -245155,7 +245141,7 @@ aMP
 dQo
 oQD
 hHI
-ihr
+tdE
 fBR
 fKi
 tHr


### PR DESCRIPTION

## About The Pull Request
This removes duplicates on Icebox:
- Atmos fire alarm
- Cargo air alarm
- Chemistry shutter

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate atmos fire alarm, cargo air alarm, and chemistry shutter from icebox.
/:cl:
