### PR TITLE
Remove duplicate HoP shutter from birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -94790,7 +94790,7 @@ tgw
 lqt
 ghD
 aZP
-wPf
+xQw
 mvT
 vrn
 kvT


### PR DESCRIPTION

## About The Pull Request
Removes a duplicate HoP shutter from birdshot.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate HoP shutter from birdshot
/:cl:
