### PR TITLE
Remove duplicate light in battlecruiser starfury

### DIFF
--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -119,7 +119,6 @@
 "as" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
Removes duplicate light in battlecruiser starfury.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate light in battlecruiser starfury
/:cl:
