### PR TITLE
Remove duplicate space heater from snowcabin ruin

### DIFF
--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -1381,7 +1381,6 @@
 /obj/machinery/space_heater,
 /obj/effect/decal/remains/robot,
 /obj/structure/sign/warning/fire/directional/north,
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/awaymission/cabin)


### PR DESCRIPTION

## About The Pull Request
Removes a stacked space heater on top of one another for snowcabin ruin.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate space heater from snowcabin ruin
/:cl:
