### PR TITLE
Remove duplicate syndi turret on waystation ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -1388,17 +1388,6 @@
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/template_noop,
 /area/template_noop)
-"xk" = (
-/obj/machinery/porta_turret/syndicate/pod{
-	dir = 1;
-	max_integrity = 80
-	},
-/obj/machinery/porta_turret/syndicate/pod{
-	dir = 1;
-	max_integrity = 80
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/waystation/assaultpod)
 "xq" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -4714,7 +4703,7 @@ Qx
 SL
 jG
 my
-xk
+lM
 tb
 FM
 TW


### PR DESCRIPTION

## About The Pull Request
Remove duplicate syndi turret on waystation ruin

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate syndi turret on waystation ruin
/:cl:
