### PR TITLE
Remove duplicate machinery from russian derelict

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -744,7 +744,6 @@
 "jD" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/dorms)
 "jV" = (
@@ -3633,8 +3632,6 @@
 	pixel_x = -5;
 	pixel_y = 9
 	},
-/obj/item/wallframe/apc,
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/tech_storage)
 "Ce" = (
@@ -4080,7 +4077,6 @@
 /area/ruin/space/ks13/science/rnd)
 "EC" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
-/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/singulo)
 "ED" = (
@@ -4253,7 +4249,6 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/hallway/aft)
 "Fy" = (
-/obj/machinery/light/small/directional/west,
 /obj/machinery/light/small/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
@@ -6070,7 +6065,6 @@
 /obj/machinery/light/small/directional/east,
 /obj/item/circuitboard/machine/smes,
 /obj/structure/table,
-/obj/machinery/light/small/directional/east,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,


### PR DESCRIPTION

## About The Pull Request
This removes duplicate machinery from the russian derelict ruin:
- Multiple lights
- APC wall frame
- Plasma canister

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
del: Remove duplicate machinery from russian derelict
/:cl:
