### PR TITLE
Adds a user type to integrated circuits, refactors the list pick component.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -870,6 +870,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait applied when an integrated circuit/module becomes undupable
 #define TRAIT_CIRCUIT_UNDUPABLE "circuit_undupable"
 
+/// Trait applied when an integrated circuit opens a UI on a player (see list pick component)
+#define TRAIT_CIRCUIT_UI_OPEN "circuit_ui_open"
+
 /// Hearing trait that is from the hearing component
 #define CIRCUIT_HEAR_TRAIT "circuit_hear"
 

--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -45,6 +45,8 @@
 #define PORT_TYPE_ATOM "entity"
 /// Datum datatype
 #define PORT_TYPE_DATUM "datum"
+/// User datatype
+#define PORT_TYPE_USER "user"
 
 
 /// The maximum range between a port and an atom

--- a/code/controllers/subsystem/circuit_component.dm
+++ b/code/controllers/subsystem/circuit_component.dm
@@ -39,7 +39,7 @@ SUBSYSTEM_DEF(circuit_component)
  * Those that registered first will be executed first and those registered last will be executed last.
  */
 /datum/controller/subsystem/circuit_component/proc/add_callback(datum/port/input, datum/callback/to_call)
-	if(instant_run_tick == world.time && (TICK_USAGE - instant_run_start_cpu_usage) < instant_run_max_cpu_usage)
+	if(instant_run_tick == world.time && (TICK_USAGE - instant_run_start_cpu_usage) <= instant_run_max_cpu_usage)
 		instant_run_callbacks_to_run += to_call
 		return
 
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(circuit_component)
 	else
 		instant_run_tick = 0
 
-	if((TICK_USAGE - instant_run_start_cpu_usage) < instant_run_max_cpu_usage)
+	if((TICK_USAGE - instant_run_start_cpu_usage) <= instant_run_max_cpu_usage)
 		return received_inputs
 	else
 		return null

--- a/code/modules/tgui_input/list.dm
+++ b/code/modules/tgui_input/list.dm
@@ -25,6 +25,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		return input(user, message, title, default) as null|anything in items
 	var/datum/tgui_list_input/input = new(user, message, title, items, default, timeout, ui_state)
+	if(input.invalid)
+		qdel(input)
+		return
 	input.ui_interact(user)
 	input.wait()
 	if (input)
@@ -58,6 +61,8 @@
 	var/closed
 	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
 	var/datum/ui_state/state
+	/// Whether the tgui list input is invalid or not (i.e. due to all list entries being null)
+	var/invalid = FALSE
 
 /datum/tgui_list_input/New(mob/user, message, title, list/items, default, timeout, ui_state)
 	src.title = title
@@ -77,6 +82,9 @@
 		string_key = avoid_assoc_duplicate_keys(string_key, repeat_items)
 		src.items += string_key
 		src.items_map[string_key] = i
+
+	if(length(src.items) == 0)
+		invalid = TRUE
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time

--- a/code/modules/wiremod/components/list/assoc_list_pick.dm
+++ b/code/modules/wiremod/components/list/assoc_list_pick.dm
@@ -15,7 +15,6 @@
 /obj/item/circuit_component/list_pick/assoc/make_list_port()
 	input_list = add_input_port("List", PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, PORT_TYPE_ANY))
 
-
 /obj/item/circuit_component/list_pick/assoc/pre_input_received(datum/port/input/port)
 	if(port == list_options)
 		var/new_type = list_options.value

--- a/code/modules/wiremod/components/list/assoc_literal.dm
+++ b/code/modules/wiremod/components/list/assoc_literal.dm
@@ -39,20 +39,20 @@
 
 /obj/item/circuit_component/assoc_literal/populate_ports()
 	AddComponent(/datum/component/circuit_component_add_port, \
-		port_list = entry_ports, \
-		add_action = "add", \
-		remove_action = "remove", \
-		port_type = PORT_TYPE_ANY, \
-		prefix = "Index", \
-		minimum_amount = 1, \
-		maximum_amount = 20 \
-	)
-	AddComponent(/datum/component/circuit_component_add_port, \
 		port_list = key_ports, \
 		add_action = "add", \
 		remove_action = "remove", \
 		port_type = PORT_TYPE_STRING, \
 		prefix = "Key", \
+		minimum_amount = 1, \
+		maximum_amount = 20 \
+	)
+	AddComponent(/datum/component/circuit_component_add_port, \
+		port_list = entry_ports, \
+		add_action = "add", \
+		remove_action = "remove", \
+		port_type = PORT_TYPE_ANY, \
+		prefix = "Value", \
 		minimum_amount = 1, \
 		maximum_amount = 20 \
 	)

--- a/code/modules/wiremod/datatypes/datum.dm
+++ b/code/modules/wiremod/datatypes/datum.dm
@@ -4,6 +4,7 @@
 	datatype_flags = DATATYPE_FLAG_ALLOW_MANUAL_INPUT|DATATYPE_FLAG_ALLOW_ATOM_INPUT
 	can_receive_from = list(
 		PORT_TYPE_ATOM,
+		PORT_TYPE_USER
 	)
 
 /datum/circuit_datatype/datum/convert_value(datum/port/port, value_to_convert)

--- a/code/modules/wiremod/datatypes/entity.dm
+++ b/code/modules/wiremod/datatypes/entity.dm
@@ -2,6 +2,9 @@
 	datatype = PORT_TYPE_ATOM
 	color = "purple"
 	datatype_flags = DATATYPE_FLAG_ALLOW_MANUAL_INPUT|DATATYPE_FLAG_ALLOW_ATOM_INPUT
+	can_receive_from = list(
+		PORT_TYPE_USER,
+	)
 
 /datum/circuit_datatype/entity/convert_value(datum/port/port, value_to_convert)
 	var/atom/object = value_to_convert

--- a/code/modules/wiremod/datatypes/user.dm
+++ b/code/modules/wiremod/datatypes/user.dm
@@ -1,0 +1,9 @@
+/datum/circuit_datatype/user
+	datatype = PORT_TYPE_USER
+	color = "label"
+
+/datum/circuit_datatype/user/convert_value(datum/port/port, value_to_convert)
+	var/datum/object = value_to_convert
+	if(QDELETED(object))
+		return null
+	return object

--- a/code/modules/wiremod/shell/bot.dm
+++ b/code/modules/wiremod/shell/bot.dm
@@ -31,7 +31,7 @@
 	var/datum/port/output/entity
 
 /obj/item/circuit_component/bot/populate_ports()
-	entity = add_output_port("User", PORT_TYPE_ATOM)
+	entity = add_output_port("User", PORT_TYPE_USER)
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/bot/register_shell(atom/movable/shell)
@@ -46,4 +46,3 @@
 	playsound(source, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
 	entity.set_output(user)
 	signal.set_output(COMPONENT_SIGNAL)
-

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -114,7 +114,7 @@
 	send_message_signal = add_input_port("Send Message", PORT_TYPE_SIGNAL)
 	show_charge_meter = add_input_port("Show Charge Meter", PORT_TYPE_NUMBER, trigger = PROC_REF(update_charge_action))
 
-	user_port = add_output_port("User", PORT_TYPE_ATOM)
+	user_port = add_output_port("User", PORT_TYPE_USER)
 
 /obj/item/circuit_component/bci_core/Destroy()
 	QDEL_NULL(charge_action)

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -34,7 +34,7 @@
 	var/datum/port/output/entity
 
 /obj/item/circuit_component/controller/populate_ports()
-	entity = add_output_port("User", PORT_TYPE_ATOM)
+	entity = add_output_port("User", PORT_TYPE_USER)
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 	alt = add_output_port("Alternate Signal", PORT_TYPE_SIGNAL)
 	right = add_output_port("Extra Signal", PORT_TYPE_SIGNAL)
@@ -51,6 +51,12 @@
 		COMSIG_CLICK_ALT,
 	))
 
+/obj/item/circuit_component/controller/proc/handle_trigger(atom/source, user, port_name, datum/port/output/port_signal)
+	source.balloon_alert(user, "clicked [port_name] button")
+	playsound(source, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
+	entity.set_output(user)
+	port_signal.set_output(COMPONENT_SIGNAL)
+
 /**
  * Called when the shell item is used in hand
  */
@@ -58,10 +64,7 @@
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))
 		return
-	source.balloon_alert(user, "clicked primary button")
-	playsound(source, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
-	entity.set_output(user)
-	signal.set_output(COMPONENT_SIGNAL)
+	handle_trigger(source, user, "primary", signal)
 
 /**
  * Called when the shell item is alt-clicked
@@ -70,10 +73,8 @@
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))
 		return
-	source.balloon_alert(user, "clicked alternate button")
-	playsound(source, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
-	entity.set_output(user)
-	alt.set_output(COMPONENT_SIGNAL)
+	handle_trigger(source, user, "alternate", alt)
+
 
 /**
  * Called when the shell item is right-clicked in active hand
@@ -82,7 +83,4 @@
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))
 		return
-	source.balloon_alert(user, "clicked extra button")
-	playsound(source, get_sfx(SFX_TERMINAL_TYPE), 25, FALSE)
-	entity.set_output(user)
-	right.set_output(COMPONENT_SIGNAL)
+	handle_trigger(source, user, "extra", right)

--- a/code/modules/wiremod/shell/keyboard.dm
+++ b/code/modules/wiremod/shell/keyboard.dm
@@ -27,7 +27,7 @@
 	var/datum/port/output/output
 
 /obj/item/circuit_component/keyboard_shell/populate_ports()
-	entity = add_output_port("User", PORT_TYPE_ATOM)
+	entity = add_output_port("User", PORT_TYPE_USER)
 	output = add_output_port("Message", PORT_TYPE_STRING)
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 
@@ -52,5 +52,4 @@
 	entity.set_output(user)
 	output.set_output(message)
 	signal.set_output(COMPONENT_SIGNAL)
-
 

--- a/code/modules/wiremod/shell/module.dm
+++ b/code/modules/wiremod/shell/module.dm
@@ -123,7 +123,7 @@
 	toggle_suit = add_input_port("Toggle Suit", PORT_TYPE_SIGNAL)
 	select_module = add_input_port("Select Module", PORT_TYPE_SIGNAL)
 	// States
-	wearer = add_output_port("Wearer", PORT_TYPE_ATOM)
+	wearer = add_output_port("Wearer", PORT_TYPE_USER)
 	deployed = add_output_port("Deployed", PORT_TYPE_NUMBER)
 	activated = add_output_port("Activated", PORT_TYPE_NUMBER)
 	selected_module = add_output_port("Selected Module", PORT_TYPE_STRING)

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -95,7 +95,7 @@
 /obj/item/circuit_component/money_bot/populate_ports()
 	total_money = add_output_port("Total Money", PORT_TYPE_NUMBER)
 	money_input = add_output_port("Last Input Money", PORT_TYPE_NUMBER)
-	entity = add_output_port("User", PORT_TYPE_ATOM)
+	entity = add_output_port("User", PORT_TYPE_USER)
 	money_trigger = add_output_port("Money Input", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/money_bot/register_shell(atom/movable/shell)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5847,6 +5847,7 @@
 #include "code\modules\wiremod\datatypes\option.dm"
 #include "code\modules\wiremod\datatypes\signal.dm"
 #include "code\modules\wiremod\datatypes\string.dm"
+#include "code\modules\wiremod\datatypes\user.dm"
 #include "code\modules\wiremod\datatypes\composite\assoc_list.dm"
 #include "code\modules\wiremod\datatypes\composite\composite.dm"
 #include "code\modules\wiremod\datatypes\composite\list.dm"


### PR DESCRIPTION

## About The Pull Request
Added a user type to integrated circuits that can't be stored as a user type but can be typecasted to entity. Useful for components that directly ask for an input from the user, like the list pick component.

Refactored the list pick component to use this user port and to also send failure signals whenever a success signal is not sent.
Removed the triggered port for the list pick component.

Also fixes a runtime that occurs with the list pick component if the list passed in only contains null values.

## Why It's Good For The Game
Can't force a prompt onto people who haven't interacted with your circuit.

## Changelog
:cl:
add: Added a user type to integrated circuits
/:cl:
