### PR TITLE
[NO GBP] Fix fireplace smoke particles to work properly with all directions

### DIFF
--- a/code/game/objects/effects/particles/smoke.dm
+++ b/code/game/objects/effects/particles/smoke.dm
@@ -18,9 +18,6 @@
 /particles/smoke/burning
 	position = list(0, 0, 0)
 
-/particles/smoke/burning/fireplace
-	position = list(0, 29, 0)
-
 /particles/smoke/burning/small
 	spawning = 1
 	scale = list(0.8, 0.8)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -167,7 +167,17 @@
 	fuel_added = 0
 	update_appearance()
 	adjust_light()
-	particles = new /particles/smoke/burning/fireplace()
+	particles = new /particles/smoke/burning()
+
+	switch(dir)
+		if(SOUTH)
+			particles.position = list(0, 29, 0)
+		if(EAST)
+			particles.position = list(-20, 9, 0)
+		if(WEST)
+			particles.position = list(20, 9, 0)
+		if(NORTH) // there is no icon state for SOUTH
+			QDEL_NULL(particles)
 
 /obj/structure/fireplace/proc/put_out()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION

## About The Pull Request
I wasn't aware we had different icon dir states for fireplaces. Although it seems that no icon state exists for `NORTH` dir fireplaces.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24626

## Why It's Good For The Game
![dreamseeker_35EfgeAdLH](https://github.com/tgstation/tgstation/assets/5195984/79d5b463-5f45-4067-a586-ccfc85b70146)

## Changelog
:cl:
fix: Fix fireplace smoke particles to work properly with all directions
/:cl:
