### PR TITLE
Emote Panel TGUI

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -14,7 +14,7 @@
 	var/key = ""
 	/// This will also call the emote.
 	var/key_third_person = ""
-	/// Needed for more user-friendly emote names, so emotes with keys like "aflap" will show as "angrily flap". Defaulted to key.
+	/// Needed for more user-friendly emote names, so emotes with keys like "aflap" will show as "flap angry". Defaulted to key.
 	var/name = ""
 	/// Message displayed when emote is used.
 	var/message = ""

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -14,6 +14,8 @@
 	var/key = ""
 	/// This will also call the emote.
 	var/key_third_person = ""
+	/// Needed for more user-friendly emote names, so emotes with keys like "aflap" will show as "angrily flap". Defaulted to key.
+	var/name = ""
 	/// Message displayed when emote is used.
 	var/message = ""
 	/// Message displayed if the user is a mime.
@@ -70,6 +72,9 @@
 
 	mob_type_blacklist_typecache = typecacheof(mob_type_blacklist_typecache)
 	mob_type_ignore_stat_typecache = typecacheof(mob_type_ignore_stat_typecache)
+
+	if(!name)
+		name = key
 
 /**
  * Handles the modifications and execution of emotes.

--- a/code/modules/emote_panel/emote_panel.dm
+++ b/code/modules/emote_panel/emote_panel.dm
@@ -1,0 +1,62 @@
+/datum/emote_panel
+	var/list/blacklisted_emotes = list("me", "help")
+
+/datum/emote_panel/ui_static_data(mob/user)
+	var/list/data = list()
+
+	var/list/emotes = list()
+	var/list/keys = list()
+
+	for(var/key in GLOB.emote_list)
+		for(var/datum/emote/emote in GLOB.emote_list[key])
+			if(emote.key in keys)
+				continue
+			if(emote.key in blacklisted_emotes)
+				continue
+			if(emote.can_run_emote(user, status_check = FALSE, intentional = FALSE))
+				keys += emote.key
+				emotes += list(list(
+					"key" = emote.key,
+					"name" = emote.name,
+					"emote_path" = emote.type,
+					"hands" = emote.hands_use_check,
+					"visible" = emote.emote_type & EMOTE_VISIBLE,
+					"audible" = emote.emote_type & EMOTE_AUDIBLE,
+					"sound" = !isnull(emote.get_sound(user)),
+					"use_params" = emote.message_param,
+				))
+
+	data["emotes"] = emotes
+
+	return data
+
+/datum/emote_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("play_emote")
+			var/emote_path = params["emote_path"]
+			var/use_params = params["use_params"]
+			var/datum/emote/emote = new emote_path()
+			var/emote_act = emote.key
+			var/emote_param
+			if(emote.message_param && use_params == "true")
+				emote_param = input(usr, "Add params to the emote...", emote.message_param)
+			usr.emote(emote_act, message = emote_param, intentional = TRUE)
+
+/datum/emote_panel/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "EmotePanel")
+		ui.open()
+
+/datum/emote_panel/ui_state(mob/user)
+	return GLOB.always_state
+
+/mob/living/verb/emote_panel()
+	set name = "Emote Panel"
+	set category = "IC"
+
+	var/static/datum/emote_panel/emote_panel = new
+	emote_panel.ui_interact(src)

--- a/code/modules/emote_panel/emote_panel.dm
+++ b/code/modules/emote_panel/emote_panel.dm
@@ -41,8 +41,8 @@
 			var/datum/emote/emote = new emote_path()
 			var/emote_act = emote.key
 			var/emote_param
-			if(emote.message_param && use_params == "true")
-				emote_param = input(usr, "Add params to the emote...", emote.message_param)
+			if(emote.message_param && use_params)
+				emote_param = tgui_input_text(usr, "Add params to the emote...", emote.message_param)
 			usr.emote(emote_act, message = emote_param, intentional = TRUE)
 
 /datum/emote_panel/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -13,7 +13,7 @@
 
 /datum/emote/living/carbon/blink_r
 	key = "blink_r"
-	name = "blink rapid"
+	name = "Blink (Rapid)"
 	message = "blinks rapidly."
 
 /datum/emote/living/carbon/clap

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -13,7 +13,7 @@
 
 /datum/emote/living/carbon/blink_r
 	key = "blink_r"
-	name = "Blink (Rapid)"
+	name = "blink (Rapid)"
 	message = "blinks rapidly."
 
 /datum/emote/living/carbon/clap

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -13,6 +13,7 @@
 
 /datum/emote/living/carbon/blink_r
 	key = "blink_r"
+	name = "blink rapid"
 	message = "blinks rapidly."
 
 /datum/emote/living/carbon/clap

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -191,7 +191,7 @@
 /datum/emote/living/gasp_shock
 	key = "gaspshock"
 	key_third_person = "gaspsshock"
-	name = "Gasp (Shocked)"
+	name = "Gasp (Shock)"
 	message = "gasps in shock!"
 	message_mime = "gasps in silent shock!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -163,7 +163,7 @@
 /datum/emote/living/flap/aflap
 	key = "aflap"
 	key_third_person = "aflaps"
-	name = "flap angry"
+	name = "Flap (Angry)"
 	message = "flaps their wings ANGRILY!"
 	hands_use_check = TRUE
 	wing_time = 10
@@ -191,6 +191,7 @@
 /datum/emote/living/gasp_shock
 	key = "gaspshock"
 	key_third_person = "gaspsshock"
+	name = "Gasp (Shocked)"
 	message = "gasps in shock!"
 	message_mime = "gasps in silent shock!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
@@ -507,7 +508,7 @@
 
 /datum/emote/living/twitch_s
 	key = "twitch_s"
-	name = "twitch slightly"
+	name = "Twitch (Slight)"
 	message = "twitches."
 
 /datum/emote/living/twitch_s/run_emote(mob/living/user, params, type_override, intentional)
@@ -532,7 +533,7 @@
 /datum/emote/living/wsmile
 	key = "wsmile"
 	key_third_person = "wsmiles"
-	name = "smile weak"
+	name = "Smile (Weak)"
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -163,6 +163,7 @@
 /datum/emote/living/flap/aflap
 	key = "aflap"
 	key_third_person = "aflaps"
+	name = "flap angry"
 	message = "flaps their wings ANGRILY!"
 	hands_use_check = TRUE
 	wing_time = 10
@@ -506,6 +507,7 @@
 
 /datum/emote/living/twitch_s
 	key = "twitch_s"
+	name = "twitch slightly"
 	message = "twitches."
 
 /datum/emote/living/twitch_s/run_emote(mob/living/user, params, type_override, intentional)
@@ -530,6 +532,7 @@
 /datum/emote/living/wsmile
 	key = "wsmile"
 	key_third_person = "wsmiles"
+	name = "smile weak"
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -163,7 +163,7 @@
 /datum/emote/living/flap/aflap
 	key = "aflap"
 	key_third_person = "aflaps"
-	name = "Flap (Angry)"
+	name = "flap (Angry)"
 	message = "flaps their wings ANGRILY!"
 	hands_use_check = TRUE
 	wing_time = 10
@@ -191,7 +191,7 @@
 /datum/emote/living/gasp_shock
 	key = "gaspshock"
 	key_third_person = "gaspsshock"
-	name = "Gasp (Shock)"
+	name = "gasp (Shock)"
 	message = "gasps in shock!"
 	message_mime = "gasps in silent shock!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
@@ -508,7 +508,7 @@
 
 /datum/emote/living/twitch_s
 	key = "twitch_s"
-	name = "Twitch (Slight)"
+	name = "twitch (Slight)"
 	message = "twitches."
 
 /datum/emote/living/twitch_s/run_emote(mob/living/user, params, type_override, intentional)
@@ -533,7 +533,7 @@
 /datum/emote/living/wsmile
 	key = "wsmile"
 	key_third_person = "wsmiles"
-	name = "Smile (Weak)"
+	name = "smile (Weak)"
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3699,6 +3699,7 @@
 #include "code\modules\economy\account.dm"
 #include "code\modules\economy\holopay.dm"
 #include "code\modules\emoji\emoji_parse.dm"
+#include "code\modules\emote_panel\emote_panel.dm"
 #include "code\modules\error_handler\error_handler.dm"
 #include "code\modules\error_handler\error_viewer.dm"
 #include "code\modules\escape_menu\details.dm"

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -1,8 +1,9 @@
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Button, Section, Flex, Icon } from '../components';
+import { Button, Section, Flex, Icon, Box } from '../components';
 import { BooleanLike } from '../../common/react';
 import { SearchBar } from './Fabrication/SearchBar';
+import { capitalizeFirst } from '../../common/string';
 
 type Emote = {
   key: string;
@@ -178,8 +179,10 @@ export const EmotePanelContent = (props, context) => {
                   (filterHands ? emote.hands : true) &&
                   (filterUseParams ? emote.use_params : true)
               )
+              .sort((a, b) => (a.name > b.name ? 1 : -1))
               .map((emote) => (
                 <Button
+                  width={13}
                   key={emote.name}
                   onClick={() =>
                     act('play_emote', {
@@ -187,14 +190,18 @@ export const EmotePanelContent = (props, context) => {
                       use_params: useParams,
                     })
                   }>
-                  {emote.visible ? <Icon name="eye" /> : ''}
-                  {emote.audible ? <Icon name="comment" /> : ''}
-                  {emote.sound ? <Icon name="volume-up" /> : ''}
-                  {emote.hands ? <Icon name="hand-paper" /> : ''}
-                  {emote.use_params ? <Icon name="crosshairs" /> : ''}
-                  {showNames
-                    ? emote.name.toUpperCase()
-                    : emote.key.toUpperCase()}
+                  <Box align="left" inline width="50%" height="100%">
+                    {showNames
+                      ? capitalizeFirst(emote.name.toLowerCase())
+                      : capitalizeFirst(emote.key.toUpperCase())}
+                  </Box>
+                  <Box align="right" inline width="50%" height="100%">
+                    {emote.visible ? <Icon name="eye" /> : ''}
+                    {emote.audible ? <Icon name="comment" /> : ''}
+                    {emote.sound ? <Icon name="volume-up" /> : ''}
+                    {emote.hands ? <Icon name="hand-paper" /> : ''}
+                    {emote.use_params ? <Icon name="crosshairs" /> : ''}
+                  </Box>
                 </Button>
               ))}
           </Flex.Item>

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -72,6 +72,12 @@ export const EmotePanelContent = (props, context) => {
     true
   );
 
+  const [showIcons, toggleShowIcons] = useLocalState<boolean>(
+    context,
+    'showIcons',
+    false
+  );
+
   return (
     <Section>
       <Section
@@ -140,20 +146,18 @@ export const EmotePanelContent = (props, context) => {
         buttons={
           <Flex>
             <Flex.Item>
-              <Button
-                width="100%"
-                height="100%"
-                align="center"
-                onClick={() => toggleShowNames(!showNames)}>
+              <Button onClick={() => toggleShowNames(!showNames)}>
                 {showNames ? 'Show Names' : 'Show Keys'}
+              </Button>
+              <Button
+                selected={showIcons}
+                onClick={() => toggleShowIcons(!showIcons)}>
+                Show Icons
               </Button>
             </Flex.Item>
             <Flex.Item>
               <Button
                 icon="crosshairs"
-                width="100%"
-                height="100%"
-                align="center"
                 selected={useParams}
                 onClick={() => toggleUseParams(!useParams)}>
                 Use Params
@@ -182,29 +186,45 @@ export const EmotePanelContent = (props, context) => {
               .sort((a, b) => (a.name > b.name ? 1 : -1))
               .map((emote) => (
                 <Button
-                  width={13}
+                  width={showIcons ? 16 : 8}
                   key={emote.name}
+                  tooltip={
+                    showIcons ? (
+                      ''
+                    ) : (
+                      <EmoteIcons
+                        visible={emote.visible}
+                        audible={emote.audible}
+                        sound={emote.sound}
+                        hands={emote.hands}
+                        use_params={emote.use_params}
+                        margin={0.5}
+                      />
+                    )
+                  }
                   onClick={() =>
                     act('play_emote', {
                       emote_path: emote.emote_path,
                       use_params: useParams,
                     })
                   }>
-                  <Box align="left" inline width="50%" height="100%">
+                  <Box inline width="50%">
                     {showNames
                       ? capitalizeFirst(emote.name.toLowerCase())
-                      : capitalizeFirst(emote.key.toUpperCase())}
+                      : emote.key}
                   </Box>
-                  <Box align="right" inline width="50%" height="100%">
-                    <Icon name="eye" color={!emote.visible ? 'red' : ''} />
-                    <Icon name="comment" color={!emote.audible ? 'red' : ''} />
-                    <Icon name="volume-up" color={!emote.sound ? 'red' : ''} />
-                    <Icon name="hand-paper" color={!emote.hands ? 'red' : ''} />
-                    <Icon
-                      name="crosshairs"
-                      color={!emote.use_params ? 'red' : ''}
+                  {showIcons ? (
+                    <EmoteIcons
+                      visible={emote.visible}
+                      audible={emote.audible}
+                      sound={emote.sound}
+                      hands={emote.hands}
+                      use_params={emote.use_params}
+                      margin={0}
                     />
-                  </Box>
+                  ) : (
+                    ''
+                  )}
                 </Button>
               ))}
           </Flex.Item>
@@ -214,9 +234,23 @@ export const EmotePanelContent = (props, context) => {
   );
 };
 
+const EmoteIcons = (props, context) => {
+  const { visible, audible, sound, hands, use_params, margin } = props;
+
+  return (
+    <Box inline align="right">
+      <Icon name="eye" m={margin} color={!visible ? 'red' : ''} />
+      <Icon name="comment" m={margin} color={!audible ? 'red' : ''} />
+      <Icon name="volume-up" m={margin} color={!sound ? 'red' : ''} />
+      <Icon name="hand-paper" m={margin} color={!hands ? 'red' : ''} />
+      <Icon name="crosshairs" m={margin} color={!use_params ? 'red' : ''} />
+    </Box>
+  );
+};
+
 export const EmotePanel = (props, context) => {
   return (
-    <Window width={700} height={450}>
+    <Window width={630} height={500}>
       <Window.Content scrollable>
         <EmotePanelContent />
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -47,13 +47,13 @@ export const EmotePanelContent = (props, context) => {
     false
   );
 
-  const [filterUseParams, toggleUseParams] = useLocalState<boolean>(
+  const [filterUseParams, toggleUseParamsFilter] = useLocalState<boolean>(
     context,
     'filterUseParams',
     false
   );
 
-  const [useParams, toggleuseParams] = useLocalState<boolean>(
+  const [useParams, toggleUseParams] = useLocalState<boolean>(
     context,
     'useParams',
     false
@@ -120,7 +120,7 @@ export const EmotePanelContent = (props, context) => {
               align="center"
               tooltip="Params"
               selected={filterUseParams}
-              onClick={() => toggleUseParams(!filterUseParams)}
+              onClick={() => toggleUseParamsFilter(!filterUseParams)}
             />
           </Flex>
         }>
@@ -154,7 +154,7 @@ export const EmotePanelContent = (props, context) => {
                 height="100%"
                 align="center"
                 selected={useParams}
-                onClick={() => toggleuseParams(!useParams)}>
+                onClick={() => toggleUseParams(!useParams)}>
                 Use Params
               </Button>
             </Flex.Item>

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -184,7 +184,7 @@ export const EmotePanelContent = (props, context) => {
                   onClick={() =>
                     act('play_emote', {
                       emote_path: emote.emote_path,
-                      useParams: useParams,
+                      use_params: useParams,
                     })
                   }>
                   {emote.visible ? <Icon name="eye" /> : ''}
@@ -206,7 +206,7 @@ export const EmotePanelContent = (props, context) => {
 
 export const EmotePanel = (props, context) => {
   return (
-    <Window width={500} height={450}>
+    <Window width={700} height={450}>
       <Window.Content scrollable>
         <EmotePanelContent />
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -196,11 +196,14 @@ export const EmotePanelContent = (props, context) => {
                       : capitalizeFirst(emote.key.toUpperCase())}
                   </Box>
                   <Box align="right" inline width="50%" height="100%">
-                    {emote.visible ? <Icon name="eye" /> : ''}
-                    {emote.audible ? <Icon name="comment" /> : ''}
-                    {emote.sound ? <Icon name="volume-up" /> : ''}
-                    {emote.hands ? <Icon name="hand-paper" /> : ''}
-                    {emote.use_params ? <Icon name="crosshairs" /> : ''}
+                    <Icon name="eye" color={!emote.visible ? 'red' : ''} />
+                    <Icon name="comment" color={!emote.audible ? 'red' : ''} />
+                    <Icon name="volume-up" color={!emote.sound ? 'red' : ''} />
+                    <Icon name="hand-paper" color={!emote.hands ? 'red' : ''} />
+                    <Icon
+                      name="crosshairs"
+                      color={!emote.use_params ? 'red' : ''}
+                    />
                   </Box>
                 </Button>
               ))}

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -1,0 +1,215 @@
+import { useBackend, useLocalState } from '../backend';
+import { Window } from '../layouts';
+import { Button, Section, Flex, Icon } from '../components';
+import { BooleanLike } from '../../common/react';
+import { SearchBar } from './Fabrication/SearchBar';
+
+type Emote = {
+  key: string;
+  name: string;
+  emote_path: string;
+  hands: BooleanLike;
+  visible: BooleanLike;
+  audible: BooleanLike;
+  sound: BooleanLike;
+  use_params: BooleanLike;
+};
+
+type EmotePanelData = {
+  emotes: Emote[];
+};
+
+export const EmotePanelContent = (props, context) => {
+  const { act, data } = useBackend<EmotePanelData>(context);
+  const { emotes } = data;
+
+  const [filterVisible, toggleVisualFilter] = useLocalState<boolean>(
+    context,
+    'filterVisible',
+    false
+  );
+
+  const [filterAudible, toggleAudibleFilter] = useLocalState<boolean>(
+    context,
+    'filterAudible',
+    false
+  );
+
+  const [filterSound, toggleSoundFilter] = useLocalState<boolean>(
+    context,
+    'filterSound',
+    false
+  );
+
+  const [filterHands, toggleHandsFilter] = useLocalState<boolean>(
+    context,
+    'filterHands',
+    false
+  );
+
+  const [filterUseParams, toggleUseParams] = useLocalState<boolean>(
+    context,
+    'filterUseParams',
+    false
+  );
+
+  const [useParams, toggleuseParams] = useLocalState<boolean>(
+    context,
+    'useParams',
+    false
+  );
+
+  const [searchText, setSearchText] = useLocalState<string>(
+    context,
+    'search_text',
+    ''
+  );
+
+  const [showNames, toggleShowNames] = useLocalState<boolean>(
+    context,
+    'showNames',
+    true
+  );
+
+  return (
+    <Section>
+      <Section
+        title="Filters"
+        buttons={
+          <Flex>
+            <Button
+              icon="eye"
+              width="100%"
+              height="100%"
+              align="center"
+              tooltip="Visible"
+              selected={filterVisible}
+              onClick={() => toggleVisualFilter(!filterVisible)}
+            />
+            <Button
+              icon="comment"
+              width="100%"
+              height="100%"
+              align="center"
+              tooltip="Audible"
+              selected={filterAudible}
+              onClick={() => toggleAudibleFilter(!filterAudible)}
+            />
+            <Button
+              icon="volume-up"
+              width="100%"
+              height="100%"
+              align="center"
+              tooltip="Sound"
+              selected={filterSound}
+              onClick={() => toggleSoundFilter(!filterSound)}
+            />
+            <Button
+              icon="hand-paper"
+              width="100%"
+              height="100%"
+              align="center"
+              tooltip="Hands"
+              selected={filterHands}
+              onClick={() => toggleHandsFilter(!filterHands)}
+            />
+            <Button
+              icon="crosshairs"
+              width="100%"
+              height="100%"
+              align="center"
+              tooltip="Params"
+              selected={filterUseParams}
+              onClick={() => toggleUseParams(!filterUseParams)}
+            />
+          </Flex>
+        }>
+        <SearchBar
+          searchText={searchText}
+          onSearchTextChanged={setSearchText}
+          hint={'Search all emotes...'}
+        />
+      </Section>
+      <Section
+        title={
+          searchText.length > 0
+            ? `Search results of "${searchText}"`
+            : `All Emotes`
+        }
+        buttons={
+          <Flex>
+            <Flex.Item>
+              <Button
+                width="100%"
+                height="100%"
+                align="center"
+                onClick={() => toggleShowNames(!showNames)}>
+                {showNames ? 'Show Names' : 'Show Keys'}
+              </Button>
+            </Flex.Item>
+            <Flex.Item>
+              <Button
+                icon="crosshairs"
+                width="100%"
+                height="100%"
+                align="center"
+                selected={useParams}
+                onClick={() => toggleuseParams(!useParams)}>
+                Use Params
+              </Button>
+            </Flex.Item>
+          </Flex>
+        }>
+        <Flex>
+          <Flex.Item>
+            {emotes
+              .filter(
+                (emote) =>
+                  emote.key &&
+                  (searchText.length > 0
+                    ? emote.key
+                      .toLowerCase()
+                      .includes(searchText.toLowerCase()) ||
+                    emote.name.toLowerCase().includes(searchText.toLowerCase())
+                    : true) &&
+                  (filterVisible ? emote.visible : true) &&
+                  (filterAudible ? emote.audible : true) &&
+                  (filterSound ? emote.sound : true) &&
+                  (filterHands ? emote.hands : true) &&
+                  (filterUseParams ? emote.use_params : true)
+              )
+              .map((emote) => (
+                <Button
+                  key={emote.name}
+                  onClick={() =>
+                    act('play_emote', {
+                      emote_path: emote.emote_path,
+                      useParams: useParams,
+                    })
+                  }>
+                  {emote.visible ? <Icon name="eye" /> : ''}
+                  {emote.audible ? <Icon name="comment" /> : ''}
+                  {emote.sound ? <Icon name="volume-up" /> : ''}
+                  {emote.hands ? <Icon name="hand-paper" /> : ''}
+                  {emote.use_params ? <Icon name="crosshairs" /> : ''}
+                  {showNames
+                    ? emote.name.toUpperCase()
+                    : emote.key.toUpperCase()}
+                </Button>
+              ))}
+          </Flex.Item>
+        </Flex>
+      </Section>
+    </Section>
+  );
+};
+
+export const EmotePanel = (props, context) => {
+  return (
+    <Window width={500} height={450}>
+      <Window.Content scrollable>
+        <EmotePanelContent />
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -239,11 +239,36 @@ const EmoteIcons = (props, context) => {
 
   return (
     <Box inline align="right">
-      <Icon name="eye" m={margin} color={!visible ? 'red' : ''} />
-      <Icon name="comment" m={margin} color={!audible ? 'red' : ''} />
-      <Icon name="volume-up" m={margin} color={!sound ? 'red' : ''} />
-      <Icon name="hand-paper" m={margin} color={!hands ? 'red' : ''} />
-      <Icon name="crosshairs" m={margin} color={!use_params ? 'red' : ''} />
+      <Icon
+        name="eye"
+        m={margin}
+        color={!visible ? 'red' : ''}
+        opacity={!visible ? 0.5 : 1}
+      />
+      <Icon
+        name="comment"
+        m={margin}
+        color={!audible ? 'red' : ''}
+        opacity={!audible ? 0.5 : 1}
+      />
+      <Icon
+        name="volume-up"
+        m={margin}
+        color={!sound ? 'red' : ''}
+        opacity={!sound ? 0.5 : 1}
+      />
+      <Icon
+        name="hand-paper"
+        m={margin}
+        color={!hands ? 'red' : ''}
+        opacity={!hands ? 0.5 : 1}
+      />
+      <Icon
+        name="crosshairs"
+        m={margin}
+        color={!use_params ? 'red' : ''}
+        opacity={!use_params ? 0.5 : 1}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## About The Pull Request
Adds Emote Panel TGUI in IC category. It shows all the available emotes for the character on the moment of opening the panel. It also has filters for:
* If the emote is visible;
* If the emote is audible;
* If the emote has sound;
* If the emote requires hands;
* If the emote can have params (such as target);

<details><summary>Images</summary>

![Screenshot_1](https://github.com/tgstation/tgstation/assets/31931237/c6bd549c-de33-44dd-8189-7b92fa2f4ac9)
![Screenshot_8](https://github.com/tgstation/tgstation/assets/31931237/2d444a86-459a-441c-bb88-d12760229d65)
![Screenshot_2](https://github.com/tgstation/tgstation/assets/31931237/59145517-e8bc-4a46-8e82-6b738865eb83)
![Screenshot_3](https://github.com/tgstation/tgstation/assets/31931237/60d52f97-4331-40c7-a925-72019304ebea)
![Screenshot_4](https://github.com/tgstation/tgstation/assets/31931237/0eb49e6d-4046-4f56-bcf9-7bfda7444ee2)
![Screenshot_5](https://github.com/tgstation/tgstation/assets/31931237/58e1f491-532d-4225-9048-b98f8a3caa78)
![Screenshot_6](https://github.com/tgstation/tgstation/assets/31931237/dfe8f436-2954-4f2b-9949-d96b0928cfff)
![Screenshot_7](https://github.com/tgstation/tgstation/assets/31931237/7c543a7e-66dd-4192-a6de-698dc027c258)

</details>

## Why It's Good For The Game
Easier for newer players to use emotes without the use of "*help" and keybindings. Also shows if the emote is visible/audible/etc, so there is less need to spam each of them to see which have sound.

## Changelog
:cl:
add: Emote Panel TGUI added in IC category.
/:cl:
