### PR TITLE
Changelings take much longer to revive when killed by Megafauna

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -26,13 +26,13 @@
 	if(user.has_status_effect(/datum/status_effect/gutted))
 		death_duration_mod *= 8 // Anti-megafauna cheese
 
-	if(enable_fakedeath(user, duration_modifier = death_duration_mod))
-		to_chat(user, span_changeling("We begin our stasis, preparing energy to arise once more."))
-		if(death_duration_mod > 1)
-			to_chat(user, span_changeling("<b>Our body has sustained severe damage, and will take longer to regenerate.</b>"))
-		return TRUE
+	if(!enable_fakedeath(user, duration_modifier = death_duration_mod))
+		CRASH("Changeling revive failed to enter fakedeath when it should have been in a valid state to.")
 
-	stack_trace("Changeling revive failed to enter fakedeath when it should have been in a valid state to.")
+	to_chat(user, span_changeling("We begin our stasis, preparing energy to arise once more."))
+	if(death_duration_mod > 1)
+		to_chat(user, span_changeling(span_bold("Our body has sustained severe damage, and will take [death_duration_mod >= 5 ? "far ":""]longer to regenerate.")))
+	return TRUE
 
 /// Used to enable fakedeath and register relevant signals / start timers
 /datum/action/changeling/fakedeath/proc/enable_fakedeath(mob/living/changeling, duration_modifier = 1)

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -20,22 +20,27 @@
 	if(revive_ready)
 		INVOKE_ASYNC(src, PROC_REF(revive), user)
 		disable_revive(user) // this should be already called via signal, but just incase something wacky happens
+		return TRUE
 
-	else if(enable_fakedeath(user))
+	var/death_duration_mod = 1
+	if(user.has_status_effect(/datum/status_effect/gutted))
+		death_duration_mod *= 8 // Anti-megafauna cheese
+
+	if(enable_fakedeath(user, duration_modifier = death_duration_mod))
 		to_chat(user, span_changeling("We begin our stasis, preparing energy to arise once more."))
+		if(death_duration_mod > 1)
+			to_chat(user, span_changeling("<b>Our body has sustained severe damage, and will take longer to regenerate.</b>"))
+		return TRUE
 
-	else
-		stack_trace("Changeling revive failed to enter fakedeath when it should have been in a valid state to.")
-
-	return TRUE
+	stack_trace("Changeling revive failed to enter fakedeath when it should have been in a valid state to.")
 
 /// Used to enable fakedeath and register relevant signals / start timers
-/datum/action/changeling/fakedeath/proc/enable_fakedeath(mob/living/changeling)
+/datum/action/changeling/fakedeath/proc/enable_fakedeath(mob/living/changeling, duration_modifier = 1)
 	if(revive_ready || HAS_TRAIT_FROM(changeling, TRAIT_DEATHCOMA, CHANGELING_TRAIT))
 		return
 
 	changeling.fakedeath(CHANGELING_TRAIT)
-	addtimer(CALLBACK(src, PROC_REF(ready_to_regenerate), changeling), fakedeath_duration, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, PROC_REF(ready_to_regenerate), changeling), fakedeath_duration * duration_modifier, TIMER_UNIQUE)
 	// Basically, these let the ling exit stasis without giving away their ling-y-ness if revived through other means
 	RegisterSignal(changeling, SIGNAL_REMOVETRAIT(TRAIT_DEATHCOMA), PROC_REF(fakedeath_reset))
 	RegisterSignal(changeling, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))


### PR DESCRIPTION
## About The Pull Request

Changelings take 8x as long to revive when felled by Megafauna. (5 minutes 20 seconds, rather than 40 seconds.)

## Why It's Good For The Game

Prior to #77731 , changeling miners had to be cautious around Megafauna as anyone else. 

This is fair, lings should be afraid of Megafauna. As with any other antagonist, taking on a Megafauna for their loot presents option to become a much stronger antagonist at risk of losing your antag round. 

But now, a ling can just get up again and again until they win the war of attrition. This is rather lame. It completely eliminates the risk part of the risk reward, and makes clearing lavaland brain-dead. 

I wanted to make them gib lings again, but this raises a big metagaming issue that I would rather not tackle. ("Lol someone got gibbed, RIP ling bozo")

I also considered making it so being gutted completely prevents ling revival, so you need to be revived like any other miner, but I am certain people would complain about how it makes no sense why a ling just couldn't Get Up Lol. 

So I thought to approach this with a compromise - making it take much much longer to revive if you are gutted by a megafauna. This makes clearing all of lavaland less of a brain-dead, risk free thing, as dying forces you to sit out for a while, but you still have some ling safety to fallback on. 

## Changelog

:cl: Melbert
balance: Changelings gutted by Megafauna now take 8x as long to finalize revival stasis (~5 minutes).
/:cl:
