### PR TITLE
Changes the description of mothic rations poster (lore pr) (very important)

### DIFF
--- a/code/game/objects/effects/posters/contraband.dm
+++ b/code/game/objects/effects/posters/contraband.dm
@@ -509,7 +509,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/triumphal_arch
 	. = ..()
 	. += span_notice("<i>You browse some of the poster's information...</i>")
 	. += "\t[span_info("Va Lümla Commissary Menu (Spring 335)")]"
-	. += "\t[span_info("Windgrass Cigarettes, Half-Pack (6): 1 Ticket")]"
+	. += "\t[span_info("Sparkweed Cigarettes, Half-Pack (6): 1 Ticket")]"
 	. += "\t[span_info("Töchtaüse Schnapps, Bottle (4 Measures): 2 Tickets")]"
 	. += "\t[span_info("Activin Gum, Pack (4): 1 Ticket")]"
 	. += "\t[span_info("A18 Sustenance Bar, Breakfast, Bar (4): 1 Ticket")]"


### PR DESCRIPTION
## About The Pull Request
Swaps windgrass for sparkweed in the description of the mothing rations poster

## Why It's Good For The Game
EOB asked me to change this since windgrass was meant to be a similar future addition but we have more fleshed out lore for sparkweed now

See here for more information
https://github.com/tgstation/common_core/pull/44

:cl:
spellcheck: The Mothic Rations Chart poster description now mentions Sparkweed Cigarettes rather than Windgrass
/:cl:
