### PR TITLE
You can fish out of hydroponics trays

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -84,3 +84,6 @@
 
 /// A list of possible egg laying descriptions
 #define EGG_LAYING_MESSAGES list("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")
+
+/// Used as a baseline plant rarity for more uncommon plants, usually requiring mutation
+#define PLANT_MODERATELY_RARE 20

--- a/code/datums/components/fishing_spot.dm
+++ b/code/datums/components/fishing_spot.dm
@@ -36,7 +36,7 @@
 	if(HAS_TRAIT(user,TRAIT_GONE_FISHING) || rod.currently_hooked_item)
 		user.balloon_alert(user, "already fishing")
 		return COMPONENT_NO_AFTERATTACK
-	var/denial_reason = fish_source.reason_we_cant_fish(rod, user)
+	var/denial_reason = fish_source.reason_we_cant_fish(rod, user, parent)
 	if(denial_reason)
 		to_chat(user, span_warning(denial_reason))
 		return COMPONENT_NO_AFTERATTACK

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 	return
 
 /// Can we fish in this spot at all. Returns DENIAL_REASON or null if we're good to go
-/datum/fish_source/proc/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman)
+/datum/fish_source/proc/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	return rod.reason_we_cant_fish(src)
 
 /**

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -349,7 +349,7 @@
 		var/atom/movable/created_reward = ..()
 		if(ismob(created_reward))
 			created_reward.name = "small [created_reward.name]"
-			created_reward.transform.Scale(0.5)
+			created_reward.transform = created_reward.transform.Scale(0.75)
 		return created_reward
 
 	var/static/list/seeds_to_draw_from

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -216,7 +216,7 @@
 
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
 
-/datum/fish_source/lavaland/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman)
+/datum/fish_source/lavaland/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	. = ..()
 	var/turf/approx = get_turf(fisherman) //todo pass the parent
 	if(!SSmapping.level_trait(approx.z, ZTRAIT_MINING))
@@ -277,7 +277,7 @@
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY - 5
 
-/datum/fish_source/holographic/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman)
+/datum/fish_source/holographic/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	. = ..()
 	if(!istype(get_area(fisherman), /area/station/holodeck))
 		return "You need to be inside the Holodeck to catch holographic fish."
@@ -310,3 +310,61 @@
 		/obj/item/fish/mastodon = 1,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
+
+#define RANDOM_SEED "Random seed"
+
+/datum/fish_source/hydro_tray
+	catalog_description = "Hydroponics trays"
+	fish_table = list(
+		FISHING_DUD = 25,
+		/obj/item/food/grown/grass = 25,
+		RANDOM_SEED = 16,
+		/obj/item/seeds/grass = 6,
+		/obj/item/seeds/random = 1,
+		/mob/living/basic/frog = 1,
+		/mob/living/basic/axolotl = 1,
+	)
+	fish_counts = list(
+		/obj/item/food/grown/grass = 10,
+		/obj/item/seeds/grass = 4,
+		RANDOM_SEED = 4,
+		/obj/item/seeds/random = 1,
+		/mob/living/basic/frog = 1,
+		/mob/living/basic/axolotl = 1,
+	)
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY - 10
+
+/datum/fish_source/hydro_tray/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	if(istype(parent, /obj/machinery/hydroponics/constructable))
+		var/obj/machinery/hydroponics/constructable/basin = parent
+		if(basin.waterlevel <= 0)
+			return "There's no water in [parent] to fish in."
+		if(basin.myseed)
+			return "There's a plant growing in [parent]."
+
+	return ..()
+
+/datum/fish_source/hydro_tray/spawn_reward(reward_path, mob/fisherman, turf/fishing_spot)
+	if(reward_path != RANDOM_SEED)
+		var/atom/movable/created_reward = ..()
+		if(ismob(created_reward))
+			created_reward.name = "small [created_reward.name]"
+			created_reward.transform.Scale(0.5)
+		return created_reward
+
+	var/static/list/seeds_to_draw_from
+	if(isnull(seeds_to_draw_from))
+		seeds_to_draw_from = subtypesof(/obj/item/seeds)
+		// These two are already covered innately
+		seeds_to_draw_from -= /obj/item/seeds/random
+		seeds_to_draw_from -= /obj/item/seeds/grass
+		// -1 yield are unharvestable plants so we don't care
+		// 20 rarirty is where most of the wacky plants are so let's ignore them
+		for(var/obj/item/seeds/seed_path as anything in seeds_to_draw_from)
+			if(initial(seed_path.yield) == -1 || initial(seed_path.rarity) >= PLANT_MODERATELY_RARE)
+				seeds_to_draw_from -= seed_path
+
+	var/picked_path = pick(seeds_to_draw_from)
+	return new picked_path(get_turf(fishing_spot))
+
+#undef RANDOM_SEED

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -335,21 +335,23 @@
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY - 10
 
 /datum/fish_source/hydro_tray/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
-	if(istype(parent, /obj/machinery/hydroponics/constructable))
-		var/obj/machinery/hydroponics/constructable/basin = parent
-		if(basin.waterlevel <= 0)
-			return "There's no water in [parent] to fish in."
-		if(basin.myseed)
-			return "There's a plant growing in [parent]."
+	if(!istype(parent, /obj/machinery/hydroponics/constructable))
+		return ..()
+
+	var/obj/machinery/hydroponics/constructable/basin = parent
+	if(basin.waterlevel <= 0)
+		return "There's no water in [parent] to fish in."
+	if(basin.myseed)
+		return "There's a plant growing in [parent]."
 
 	return ..()
 
 /datum/fish_source/hydro_tray/spawn_reward(reward_path, mob/fisherman, turf/fishing_spot)
 	if(reward_path != RANDOM_SEED)
-		var/atom/movable/created_reward = ..()
-		if(ismob(created_reward))
+		var/mob/living/created_reward = ..()
+		if(istype(created_reward))
 			created_reward.name = "small [created_reward.name]"
-			created_reward.transform = created_reward.transform.Scale(0.75)
+			created_reward.update_transform(0.75)
 		return created_reward
 
 	var/static/list/seeds_to_draw_from

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -39,7 +39,7 @@
 	potency = 10
 	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/carpotoxin = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/koibeans
 	seed = /obj/item/seeds/soya/koi
@@ -96,7 +96,7 @@
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/ants = 0.1) //IRL jumping beans contain insect larve, hence the ants
 	graft_gene = /datum/plant_gene/trait/stable_stats
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/jumpingbeans
 	seed = /obj/item/seeds/greenbean/jump
@@ -105,4 +105,3 @@
 	icon_state = "jumpingbean"
 	foodtypes = FRUIT | BUGS
 	tastes = list("bugs" = 1)
-

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -92,7 +92,7 @@
 	mutatelist = null
 	genes = list(/datum/plant_gene/trait/glow/white, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/uranium = 0.25, /datum/reagent/iodine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	graft_gene = /datum/plant_gene/trait/glow/white
 
 /obj/item/food/grown/berries/glow

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -39,7 +39,7 @@
 	lifespan = 25
 	maturation = 4
 	production = 4
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	genes = list(/datum/plant_gene/trait/chem_cooling)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/frostoil = 0.25, /datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.02)
@@ -66,7 +66,7 @@
 	maturation = 10
 	production = 10
 	yield = 3
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	genes = list(/datum/plant_gene/trait/chem_heating, /datum/plant_gene/trait/backfire/chili_heat)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.3, /datum/reagent/consumable/capsaicin = 0.55, /datum/reagent/consumable/nutriment = 0.04)
@@ -93,7 +93,7 @@
 	maturation = 10
 	production = 10
 	yield = 3
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.08, /datum/reagent/consumable/nutriment = 0.04)

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -242,7 +242,7 @@
 	genes = list(/datum/plant_gene/trait/backfire/novaflower_heat, /datum/plant_gene/trait/attack/novaflower_attack, /datum/plant_gene/trait/preserved)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0, /datum/reagent/toxin/acid = 0.05)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/grown/novaflower
 	seed = /obj/item/seeds/sunflower/novaflower

--- a/code/modules/hydroponics/grown/korta_nut.dm
+++ b/code/modules/hydroponics/grown/korta_nut.dm
@@ -39,7 +39,7 @@
 	production = 10
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/korta_nectar = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/korta_nut/sweet
 	seed = /obj/item/seeds/korta_nut/sweet

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -50,7 +50,7 @@
 	genes = list(/datum/plant_gene/trait/glow/yellow, /datum/plant_gene/trait/anti_magic)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/water/holywater = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	graft_gene = /datum/plant_gene/trait/glow/yellow
 
 /obj/item/food/grown/holymelon

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -238,7 +238,7 @@
 	potency = 30 //-> brightness
 	instability = 20
 	growthstages = 4
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	genes = list(/datum/plant_gene/trait/glow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
 	growing_icon = 'icons/obj/service/hydroponics/growing_mushrooms.dmi'
 	mutatelist = list(/obj/item/seeds/glowshroom/glowcap, /obj/item/seeds/glowshroom/shadowshroom)

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -48,7 +48,7 @@
 	product = /obj/item/food/grown/pumpkin/blumpkin
 	mutatelist = null
 	reagents_add = list(/datum/reagent/ammonia = 0.2, /datum/reagent/chlorine = 0.1, /datum/reagent/consumable/nutriment = 0.2)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/pumpkin/blumpkin
 	seed = /obj/item/seeds/pumpkin/blumpkin

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -34,7 +34,7 @@
 	product = /obj/item/food/grown/tea/astra
 	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/synaptizine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/teapowder = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/tea/astra
 	seed = /obj/item/seeds/tea/astra
@@ -83,7 +83,7 @@
 	product = /obj/item/food/grown/coffee/robusta
 	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/ephedrine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/coffeepowder = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/coffee/robusta
 	seed = /obj/item/seeds/coffee/robusta

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -32,7 +32,7 @@
 	product = /obj/item/food/grown/tobacco/space
 	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/salbutamol = 0.05, /datum/reagent/drug/nicotine = 0.08, /datum/reagent/consumable/nutriment = 0.03)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/tobacco/space
 	seed = /obj/item/seeds/tobacco/space

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -37,7 +37,7 @@
 	product = /obj/item/food/grown/tomato/blood
 	mutatelist = null
 	reagents_add = list(/datum/reagent/blood = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/food/grown/tomato/blood
 	seed = /obj/item/seeds/tomato/blood
@@ -63,7 +63,7 @@
 	mutatelist = list(/obj/item/seeds/tomato/blue/bluespace)
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/lube = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	graft_gene = /datum/plant_gene/trait/slip
 
 /obj/item/food/grown/tomato/blue

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -28,7 +28,7 @@
 	product = /obj/item/grown/log/steel
 	mutatelist = null
 	reagents_add = list(/datum/reagent/cellulose = 0.05, /datum/reagent/iron = 0.05)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 
 /obj/item/grown/log
 	seed = /obj/item/seeds/tower

--- a/code/modules/hydroponics/grown/weeds/nettle.dm
+++ b/code/modules/hydroponics/grown/weeds/nettle.dm
@@ -29,7 +29,7 @@
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging, /datum/plant_gene/trait/attack/nettle_attack/death, /datum/plant_gene/trait/backfire/nettle_burn/death)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.5, /datum/reagent/toxin/acid = 0.5)
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	graft_gene = /datum/plant_gene/trait/stinging
 
 /obj/item/food/grown/nettle // "snack"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -161,8 +161,7 @@
 	AddComponent(/datum/component/simple_rotation)
 	AddComponent(/datum/component/plumbing/hydroponics)
 	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
-	if(mapload)
-		AddComponent(/datum/component/fishing_spot, /datum/fish_source/hydro_tray)
+	AddComponent(/datum/component/fishing_spot, /datum/fish_source/hydro_tray)
 
 /obj/machinery/hydroponics/constructable/RefreshParts()
 	. = ..()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -60,8 +60,8 @@
 	//SO HERE LIES THE "nutrilevel" VAR. IT'S DEAD AND I PUT IT OUT OF IT'S MISERY. USE "reagents" INSTEAD. ~ArcaneMusic, accept no substitutes.
 	create_reagents(maxnutri, INJECTABLE)
 	if(mapload)
-		reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 10) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
-		waterlevel = 100
+		reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, max(maxnutri / 2, 10)) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
+		waterlevel = maxwater
 	. = ..()
 
 	var/static/list/hovering_item_typechecks = list(
@@ -161,6 +161,8 @@
 	AddComponent(/datum/component/simple_rotation)
 	AddComponent(/datum/component/plumbing/hydroponics)
 	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
+	if(mapload)
+		AddComponent(/datum/component/fishing_spot, /datum/fish_source/hydro_tray)
 
 /obj/machinery/hydroponics/constructable/RefreshParts()
 	. = ..()

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -254,7 +254,7 @@
 	yield = 4
 	potency = 15
 	growthstages = 3
-	rarity = 20
+	rarity = PLANT_MODERATELY_RARE
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 	species = "polypore" // silence unit test
 	genes = list(/datum/plant_gene/trait/fire_resistance)


### PR DESCRIPTION
## About The Pull Request

Adds a fishing spot to hydroponics trays. 

Chances 

- 33% nothing
- 33% grass
- 20% random seed (discludes rarer seeds, such as gatfruit and most mutations) 
- 10% grass seeds
- 1% strange seed
- 1% axolotl
- 1% frog

Lightly inspired by something (I think) is possible on Goon, but obviously entirely new code. 

## Why It's Good For The Game

Mostly just for laughs, they're basins of water so surely you can get something out of it. 

## Changelog

:cl: Melbert
add: Fishers can now try their luck at fishing out of hydroponics basins. 
/:cl:

