### PR TITLE
Fixes heretic bitrunner issue [NO GBP]

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -259,6 +259,9 @@
 
 /datum/antagonist/heretic/on_body_transfer(mob/living/old_body, mob/living/new_body)
 	. = ..()
+	if(old_body == new_body) // if they were using a temporary body
+		return
+
 	for(var/knowledge_index in researched_knowledge)
 		var/datum/heretic_knowledge/knowledge = researched_knowledge[knowledge_index]
 		knowledge.on_lose(old_body, src)


### PR DESCRIPTION

## About The Pull Request
Returning a player to their body counts as a body transfer, thus they lose their living heart
## Why It's Good For The Game
Fixes #78780
## Changelog
:cl:
fix: Heretics won't lose their living heart while bitrunning anymore.
/:cl:
