### PR TITLE
Fixes eavesdropping on sillycons

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -531,6 +531,7 @@
 	subspace_transmission = TRUE
 	subspace_switchable = TRUE
 	dog_fashion = null
+	canhear_range = 0
 
 /obj/item/radio/borg/resetChannels()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Borgs don't whisper into comms whenever they use an encryption key. They broadcast the encrypted channel at full volume to everyone in three tiles distance

before, at three tiles:
![image](https://github.com/tgstation/tgstation/assets/42397676/2bcc7f5a-c40d-44cb-a8c3-9f6eb6b4b676)

after, at two tiles:
![image](https://github.com/tgstation/tgstation/assets/42397676/a394dc76-67f6-47c6-aa3a-0a500e32db82)

## Why It's Good For The Game
Fixes #35774
## Changelog
:cl:
fix: You can no longer eavesdrop on nearby borgs' radio comms if they're using encryption keys
/:cl:
