### PR TITLE
Boot occupants now perform unarmed attacks

### DIFF
--- a/code/modules/clothing/shoes/cowboy.dm
+++ b/code/modules/clothing/shoes/cowboy.dm
@@ -38,11 +38,7 @@
 			occupant.forceMove(user.drop_location())
 			user.visible_message(span_warning("[user] recoils as something slithers out of [src]."), span_userdanger("You feel a sudden stabbing pain in your [pick("foot", "toe", "ankle")]!"))
 			user.Knockdown(20) //Is one second paralyze better here? I feel you would fall on your ass in some fashion.
-			user.apply_damage(5, BRUTE, target_zone)
-			if(istype(occupant, /mob/living/simple_animal/hostile/retaliate))
-				user.reagents.add_reagent(/datum/reagent/toxin, 7)
-
-
+			occupant.UnarmedAttack(user, proximity_flag = TRUE)
 
 /obj/item/clothing/shoes/cowboy/dropped(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

When you put on your cowboy boots, and it had a snake in it, they did not poison you, as the code was checking for a retaliate simple animal subtype, meaning say, if you somehow put a goose in your shoe (the last remaining simple animal), they could poison you. 

I have removed the direct damage apply and the reagent add, and replaced with a call for UnarmedAttack. This way snakes will not inject you with a hardcoded amount of toxins, instead they will respect their venom component.

If you place a headslugs or larvae in the shoe, they will bite you, but headslugs only infect dead people, and the larva will do just a small amount of damage, so that is okay.

The downside is that you can not pass targetting through attacks, so the animals will not bite you in the foot but rather in a random bodypart. At least, if you are missing a leg, you still have a chance to not to disturb the slumbering creature, that has been unchanged.

## Why It's Good For The Game

Removed a check for a soon to be removed subtype, and creatures will use their actual attack behaviour to bite you.

## Changelog

:cl:
code: creatures in cowboy boots will retaliate properly
/:cl:
