### PR TITLE
Removes a coffeepot from birdshots security breakroom

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -14856,10 +14856,6 @@
 /obj/machinery/coffeemaker{
 	pixel_y = 12
 	},
-/obj/item/reagent_containers/cup/coffeepot{
-	pixel_x = 3;
-	pixel_y = -5
-	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/breakroom)
 "fyr" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -38221,15 +38221,6 @@
 /obj/machinery/computer/quantum_console{
 	dir = 4
 	},
-/obj/machinery/computer/quantum_console{
-	dir = 4
-	},
-/obj/machinery/computer/quantum_console{
-	dir = 4
-	},
-/obj/machinery/computer/quantum_console{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/bitrunning/den)


### PR DESCRIPTION

## About The Pull Request
Deletes a extra coffeepot that spawned in birdshots breakroom
## Why It's Good For The Game
Less clutter, coffee machine already had a coffeepot inside it, map maker said its fine
## Changelog
:cl:

del: Removed a extra coffee pot in birdshot's security breakroom
/:cl:
