### PR TITLE
Cult Stun & Blood Rites Changes

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -326,6 +326,7 @@
 	button_icon_state = "manip"
 	charges = 5
 	magic_path = "/obj/item/melee/blood_magic/manipulator"
+	deletes_on_empty = FALSE
 
 // The "magic hand" items
 /obj/item/melee/blood_magic
@@ -686,7 +687,6 @@
 	name = "Blood Rite Aura"
 	desc = "Absorbs blood from anything you touch. Touching cultists and constructs can heal them. Use in-hand to cast an advanced rite."
 	color = "#7D1717"
-	deletes_on_empty = FALSE
 
 /obj/item/melee/blood_magic/manipulator/examine(mob/user)
 	. = ..()

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -686,6 +686,7 @@
 	name = "Blood Rite Aura"
 	desc = "Absorbs blood from anything you touch. Touching cultists and constructs can heal them. Use in-hand to cast an advanced rite."
 	color = "#7D1717"
+	deletes_on_empty = FALSE
 
 /obj/item/melee/blood_magic/manipulator/examine(mob/user)
 	. = ..()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -289,6 +289,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 		convertee.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in. (April Fools)")
 
 	else
+		// Remove other stuns, includes cult hand's secondary effects
+		convertee.AdjustAllImmobility(0 SECONDS)
+		convertee.set_dizzy(0 SECONDS)
+		convertee.set_eye_blur(0 SECONDS)
+		// But we KO them because Nar Nar's touch is not gentle. She is a tomboy
 		convertee.Unconscious(10 SECONDS)
 
 	new /obj/item/melee/cultblade/dagger(get_turf(src))


### PR DESCRIPTION

## About The Pull Request

Cultist Stun Hand's power is reduced by 33% when the cult has Risen (red eyes), and by 66% when it has Ascended (halos).

Stunned non-cultists recieve dizziness and temporary eye damage, the duration increasing the more the cult grows.

Effectively, while stuns are weakened, the stun effect applies dizziness as well now, helping against stun-resistant targets.

Stacking multiple spells of one type is no longer allowed. (Oranges wanted this)

Blood Rites no longer disappear at 0 charges.

## Why It's Good For The Game

> Cultist Stun Hand's power is reduced by 33% when the cult has Risen (red eyes), and by 66% when it has Ascended (halos).

This spell is infamous for being a 2018-era stun. Nerfing it completely, however, would be a large issue for early cult as it'd make it extremely hard for them to convert members. Thus, the power is weakened the more the cult grows.

> Stunned non-cultists recieve dizziness and temporary eye damage, the duration increasing the more the cult grows.

This serves two functions: While the non-cultist manages to get up earlier, they're still stumbling around confused so it's not like they can take advantage of it to bring down cultists too well. Additionally, it makes stun immune targets still suffer some form of negative effect from the spell, making hulks less of a game-over for cultists.

> Stacking multiple spells of one type is no longer allowed. (Oranges wanted this)

Orange man bad0

> Blood Rites no longer disappear at 0 charges.

This was annoying.

## Changelog

:cl:
balance: Cultist Stun Hand's power is reduced by 33% when the cult has Risen (red eyes), and by 66% when it has Ascended (halos).
balance: Stunned non-cultists recieve dizziness and temporary eye damage, the duration increasing the more the cult grows.
balance: Effectively, while stuns are weakened, the stun effect applies dizziness as well now, helping against stun-resistant targets.
balance: Stacking multiple spells of one type is no longer allowed. (Oranges wanted this)
qol: Blood Rites no longer disappear at 0 charges.
/:cl:

