### PR TITLE
Reworks Rolling Table Code

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -292,7 +292,7 @@
 	..()
 	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
-/obj/structure/table/proc/AfterPutItemOnTable(obj/item/I, mob/living/user)
+/obj/structure/table/proc/AfterPutItemOnTable(obj/item/thing, mob/living/user)
 	return
 
 /obj/structure/table/deconstruct(disassembled = TRUE, wrench_disassembly = 0)
@@ -358,34 +358,52 @@
 	canSmoothWith = null
 	icon = 'icons/obj/smooth_structures/rollingtable.dmi'
 	icon_state = "rollingtable"
-	var/list/attached_items = list()
+	/// Lazylist of the items that we have on our surface.
+	var/list/attached_items = null
 
 /obj/structure/table/rolling/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noisy_movement)
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_our_moved))
 
-/obj/structure/table/rolling/AfterPutItemOnTable(obj/item/I, mob/living/user)
+/obj/structure/table/rolling/Destroy()
+	for(var/item in attached_items)
+		clear_item_reference(item)
+	LAZYNULL(attached_items) // safety
+	return ..()
+
+/obj/structure/table/rolling/AfterPutItemOnTable(obj/item/thing, mob/living/user)
 	. = ..()
-	attached_items += I
-	RegisterSignal(I, COMSIG_MOVABLE_MOVED, PROC_REF(RemoveItemFromTable)) //Listen for the pickup event, unregister on pick-up so we aren't moved
+	LAZYADD(attached_items, thing)
+	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(on_item_moved))
 
-/obj/structure/table/rolling/proc/RemoveItemFromTable(datum/source, newloc, dir)
+/// Handles cases where any attached item moves, with or without the table. If we get picked up or anything, unregister the signal so we don't move with the table after removal from the surface.
+/obj/structure/table/rolling/proc/on_item_moved(datum/source, atom/old_loc, dir, forced, list/old_locs, momentum_change)
 	SIGNAL_HANDLER
 
-	if(newloc != loc) //Did we not move with the table? because that shit's ok
-		return FALSE
-	attached_items -= source
-	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
-
-/obj/structure/table/rolling/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
-	. = ..()
-	if(!loc)
+	var/atom/thing = source // let it runtime if it doesn't work because that is mad wack
+	if(thing.loc == loc) // if we move with the table, move on
 		return
+
+	clear_item_reference(thing)
+
+/// Handles movement of the table itself, as well as moving along any atoms we have on our surface.
+/obj/structure/table/rolling/proc/on_our_moved(datum/source, atom/old_loc, dir, forced, list/old_locs, momentum_change)
+	SIGNAL_HANDLER
+	if(isnull(loc)) // aw hell naw
+		return
+
 	for(var/mob/living/living_mob in old_loc.contents)//Kidnap everyone on top
 		living_mob.forceMove(loc)
+
 	for(var/atom/movable/attached_movable as anything in attached_items)
-		if(!attached_movable.Move(loc))
-			RemoveItemFromTable(attached_movable, attached_movable.loc)
+		if(!attached_movable.Move(loc)) // weird
+			clear_item_reference(attached_movable) // we check again in on_item_moved() just in case something's wacky tobaccy
+
+/// Removes the signal and the entrance from the list.
+/obj/structure/table/rolling/proc/clear_item_reference(obj/item/thing)
+	UnregisterSignal(thing, COMSIG_MOVABLE_MOVED)
+	LAZYREMOVE(attached_items, thing)
 
 /*
  * Glass tables


### PR DESCRIPTION
## About The Pull Request

Should be a good first step towards reducing the behavior declared in #79411, but since I couldn't get a good reproduction case, we'll have to live with that.

Basically, our SIGNAL_HANDLER procs were using some way outdated arguments, causing some bits of the code to seem rather... illogical (we thought the old location was the new location??? it's wack). Anyways, I just gutted most of it and kept the same overall behavior that only lives on signals rather than doing weird stuff with proc overrides.
## Why It's Good For The Game

If it doesn't root out the cause of the aforementioned issue, it should be far easier to figure out what the true issue is (when we get a proper reprod. case) beyond having weird arguments on our signals.
## Changelog
I'm not certain if this fixes the issue but if it does, yippie. Worst case scenario it's a good code improvement- neither of those are good enough to show to players.
