### PR TITLE
prevents infinite paper glitch in HFR framework

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -169,10 +169,13 @@
 	desc = "Interface for the HFR to control the flow of the reaction."
 	icon_state = "interface_off"
 	circuit = /obj/item/circuitboard/machine/HFR_interface
-	var/obj/machinery/atmospherics/components/unary/hypertorus/core/connected_core
 	icon_state_off = "interface_off"
 	icon_state_open = "interface_open"
 	icon_state_active = "interface_active"
+	/// Have we been activated at least once?
+	var/activated = FALSE
+	/// Reference to the core of our machine
+	var/obj/machinery/atmospherics/components/unary/hypertorus/core/connected_core
 
 /obj/machinery/hypertorus/interface/Destroy()
 	if(connected_core)
@@ -187,10 +190,13 @@
 	if(!centre || !centre.check_part_connectivity())
 		to_chat(user, span_notice("Check all parts and then try again."))
 		return TRUE
-	new/obj/item/paper/guides/jobs/atmos/hypertorus(loc)
-	connected_core = centre
 
+	connected_core = centre
 	connected_core.activate(user)
+	if(!activated)
+		new /obj/item/paper/guides/jobs/atmos/hypertorus(loc)
+		activated = TRUE
+
 	return TRUE
 
 /obj/machinery/hypertorus/interface/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION

## About The Pull Request

Fixes #79492 . Infinite paper isn't so much an exploit as much as it is annoying to have someone spam the multitool action and just end up having dogshit amounts of stuff.
## Why It's Good For The Game

There's no particular need for more than one guide to the HFR, this is an oversight. 
## Changelog
:cl:
fix: The HFR will not print out a piece of paper every time you multitool it, saving any desired energy to use for more useful processes.
/:cl:
