### PR TITLE
Caches data for paintings we have saved

### DIFF
--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -113,6 +113,11 @@ SUBSYSTEM_DEF(persistent_paintings)
 	/// A list of /datum/paintings saved or ready to be saved this round.
 	var/list/paintings = list()
 
+	/// A list of paintings' data for paintings that are currently stored in the library.
+	var/list/painting_data = list()
+	/// A list of paintings' data for paintings that are currently stored in the library, with admin metadata
+	var/list/admin_painting_data = list()
+
 	///The list of available frame reskins (they are purely cosmetic) and the associated patronage amount required for them.
 	var/list/frame_types_by_patronage_tier = list(
 		"simple" = 0,
@@ -128,7 +133,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 		"diamond" = PATRONAGE_AMAZING_FRAME,
 		"rainbow" = PATRONAGE_SUPERB_FRAME,
 		"supermatter" = PATRONAGE_LEGENDARY_FRAME
-			)
+	)
 
 /datum/controller/subsystem/persistent_paintings/Initialize()
 	var/json_file = file("data/paintings.json")
@@ -142,6 +147,19 @@ SUBSYSTEM_DEF(persistent_paintings)
 	for(var/obj/structure/sign/painting/painting_frame as anything in painting_frames)
 		painting_frame.load_persistent()
 
+	for(var/datum/painting/painting as anything in paintings)
+		painting_data += list(list(
+				"title" = painting.title,
+				"creator" = painting.creator_name,
+				"md5" = painting.md5,
+				"ref" = REF(painting),
+				"ratio" = painting.width/painting.height,
+			))
+
+		var/list/pdata = painting.to_json()
+		pdata["ref"] = REF(painting)
+		admin_painting_data += pdata
+
 	return SS_INIT_SUCCESS
 
 /**
@@ -152,7 +170,6 @@ SUBSYSTEM_DEF(persistent_paintings)
  * * search_text : text to search for if the PAINTINGS_FILTER_SEARCH_TITLE or PAINTINGS_FILTER_SEARCH_CREATOR filters are enabled.
  */
 /datum/controller/subsystem/persistent_paintings/proc/painting_ui_data(filter=NONE, admin=FALSE, search_text)
-	. = list()
 	var/searching = filter & (PAINTINGS_FILTER_SEARCH_TITLE|PAINTINGS_FILTER_SEARCH_CREATOR) && search_text
 	for(var/datum/painting/painting as anything in paintings)
 		if(filter & PAINTINGS_FILTER_AI_PORTRAIT && ((painting.width != 24 && painting.width != 23) || (painting.height != 24 && painting.height != 23)))
@@ -165,18 +182,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 				haystack_text = painting.creator_name
 			if(!findtext(haystack_text, search_text))
 				continue
-		if(admin)
-			var/list/pdata = painting.to_json()
-			pdata["ref"] = REF(painting)
-			. += list(pdata)
-		else
-			. += list(list(
-				"title" = painting.title,
-				"creator" = painting.creator_name,
-				"md5" = painting.md5,
-				"ref" = REF(painting),
-				"ratio" = painting.width/painting.height,
-				))
+	return admin ? admin_painting_data : painting_data
 
 /// Returns paintings with given tag.
 /datum/controller/subsystem/persistent_paintings/proc/get_paintings_with_tag(tag_name)

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 		"gold" = PATRONAGE_EXCELLENT_FRAME,
 		"diamond" = PATRONAGE_AMAZING_FRAME,
 		"rainbow" = PATRONAGE_SUPERB_FRAME,
-		"supermatter" = PATRONAGE_LEGENDARY_FRAME
+		"supermatter" = PATRONAGE_LEGENDARY_FRAME,
 	)
 
 /datum/controller/subsystem/persistent_paintings/Initialize()


### PR DESCRIPTION
## About The Pull Request
We got some reports about a server lagging, the cause was determined to be TGUI. Potato figured out it was the painting manager, and I was able to recreate the lag by just quickly scrolling through the 1200+ paintings on Manuel via a curator console. Please don't do this btw.

## Why It's Good For The Game
Allow people to scrub through the painting gallery without lagging the server.

## Changelog
:cl: Tattle
fix: you should now be able to scrub through the library without lagging the server
/:cl:
