### PR TITLE
Fix incorrect metabolization rates in chem dispenser's reagent lookup

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1810,7 +1810,7 @@
 			to_chat(user, "Could not find reagent!")
 			ui_reagent_id = null
 		else
-			data["reagent_mode_reagent"] = list("name" = reagent.name, "id" = reagent.type, "desc" = reagent.description, "reagentCol" = reagent.color, "pH" = reagent.ph, "pHCol" = convert_ph_to_readable_color(reagent.ph), "metaRate" = (reagent.metabolization_rate/2), "OD" = reagent.overdose_threshold)
+			data["reagent_mode_reagent"] = list("name" = reagent.name, "id" = reagent.type, "desc" = reagent.description, "reagentCol" = reagent.color, "pH" = reagent.ph, "pHCol" = convert_ph_to_readable_color(reagent.ph), "metaRate" = reagent.metabolization_rate, "OD" = reagent.overdose_threshold)
 			data["reagent_mode_reagent"]["addictions"] = list()
 			data["reagent_mode_reagent"]["addictions"] = parse_addictions(reagent)
 


### PR DESCRIPTION

## About The Pull Request
Chem dispenser was dividing the metabolization rate value by 2 despite it already being in units per second, I fixed that. Now the rates match those in chemmaster's reagent lookup
![lookup](https://github.com/tgstation/tgstation/assets/113535457/0ab1a2dc-a836-42b4-99f4-dafde2ed55fa)
## Why It's Good For The Game
Fixes #79482 
## Changelog
:cl:
fix: Reagent lookup in chem dispensers now shows correct reagent metabolization rates
/:cl:
