### PR TITLE
[no gbp] Don't try and have a status effect destroy walls

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
@@ -58,7 +58,7 @@
 	RegisterSignal(fugu, COMSIG_MOB_STATCHANGE, PROC_REF(check_death))
 	fugu.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/inflated)
 	ADD_TRAIT(fugu, TRAIT_FUGU_GLANDED, TRAIT_STATUS_EFFECT(id))
-	AddElement(/datum/element/wall_tearer, allow_reinforced = FALSE)
+	fugu.AddElement(/datum/element/wall_tearer, allow_reinforced = FALSE)
 	fugu.mob_size = MOB_SIZE_LARGE
 	fugu.icon_state = "Fugu1"
 	fugu.melee_damage_lower = 15


### PR DESCRIPTION
## About The Pull Request

Fixes #79497

![280296547-1bd169d0-0ccf-4dfb-91a3-9c51e11d020b](https://github.com/tgstation/tgstation/assets/7483112/9d976cb0-7905-4fe4-962b-a6e5374b40b9)
Missed something important here. I put it back.

## Changelog

:cl:
fix: Fugu can correctly destroy walls when they get big.
/:cl:
