### PR TITLE
Increment icon smoothing MAX_S_TURF define

### DIFF
--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -131,7 +131,7 @@ DEFINE_BITFIELD(smoothing_junction, list(
 #define SMOOTH_GROUP_SURVIVAL_TITANIUM_WALLS S_TURF(59) ///turf/closed/wall/mineral/titanium/survival
 #define SMOOTH_GROUP_TURF_OPEN_CLIFF S_TURF(60) ///turf/open/cliff
 
-#define MAX_S_TURF 59 //Always match this value with the one above it.
+#define MAX_S_TURF 60 //Always match this value with the one above it.
 
 #define S_OBJ(num) ("-" + #num + ",")
 /* /obj included */


### PR DESCRIPTION
## About The Pull Request

Increments MAX_S_TURF to match the highest number S_TURF, because the comment says so.

## Changelog

:cl: LT3
fix: Maximum smoothing turf groups now includes cliffs
/:cl: