### PR TITLE
Initializes on_finish_callbacks in the JPS move loop

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -367,7 +367,7 @@
 	///Bool used to determine if we're already making a path in JPS. this prevents us from re-pathing while we're already busy.
 	var/is_pathing = FALSE
 	///Callbacks to invoke once we make a path
-	var/list/datum/callback/on_finish_callbacks
+	var/list/datum/callback/on_finish_callbacks = list()
 
 /datum/move_loop/has_target/jps/New(datum/movement_packet/owner, datum/controller/subsystem/movement/controller, atom/moving, priority, flags, datum/extra_info)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

The on_finish_callbacks list in `/datum/move_loop/has_target/jps` was not initialized. Usually, when you add something to an uninitialized list, it gets initialized and the item gets added to it. However, the `CALLBACK` wrapper is around `new /datum/callback`, this fails. 

This meant on_finish_callback was not a list, therefore at the end of pathfinding, its contents could not be iterated and invoked. This PR fixes this problem by initializing the list.

## Why It's Good For The Game

Closes #79383
Blob minions rally and punch again. 

## Changelog

:cl:
fix: Basic mobs using JPS can move again
/:cl:
