### PR TITLE
Increases the time it takes for venus human traps to die off vines from 5 to 8 seconds

### DIFF
--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -165,7 +165,7 @@
 	melee_attack_cooldown = 1.2 SECONDS
 	ai_controller = /datum/ai_controller/basic_controller/human_trap
 	///how much damage we take out of weeds
-	var/no_weed_damage = 20
+	var/no_weed_damage = 12.5
 	///how much do we heal in weeds
 	var/weed_heal = 10
 	///if the balloon alert was shown atleast once, reset after healing in weeds


### PR DESCRIPTION

## About The Pull Request

Exactly what it says on the tin, 20 damage -> 12.5 damage.
## Why It's Good For The Game

At first glance, 20 damage per second seems pretty harsh. but reasonable, considering your job is to protect the kudzu. but a 5 second time limit sounds _extremely_ unfairly punishing on multi-z maps where you can fall off your kudzu, especially considering the kudzu can block your view of open spaces.

I figured 12.5 damage per second would work since it adds up to a flat 8 seconds until you reach 100, and it should give the player a few more precious to process how fast they're dying, since its easy to underestimate how fast 5 seconds goes by in the heat of combat.
## Changelog
:cl:
balance: Venus human traps now take 12.5 damage per second instead of 20 while off kudzu.
/:cl:
