### PR TITLE
Locker deconstruction message spellcheck

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -804,13 +804,13 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 					if(!opened)
 						return
 					user.visible_message(span_notice("[user] slices apart \the [src]."),
-									span_notice("You cut \the [src] apart weaponith \the [weapon]."),
-									span_hear("You hear weaponelding."))
+									span_notice("You cut \the [src] apart with \the [weapon]."),
+									span_hear("You hear welding."))
 					deconstruct(TRUE)
 				return
 			else // for example cardboard box is cut with wirecutters
 				user.visible_message(span_notice("[user] cut apart \the [src]."), \
-									span_notice("You cut \the [src] apart weaponith \the [weapon]."))
+									span_notice("You cut \the [src] apart with \the [weapon]."))
 				deconstruct(TRUE)
 				return
 		if (user.combat_mode)


### PR DESCRIPTION

## About The Pull Request

Fixes a couple typos when deconstructing lockers.

## Why It's Good For The Game

Better spelling, better game.

## Changelog
:cl: Bumtickley00
spellcheck: You no longer hear weaponelding when deconstructing a closet.
/:cl:
