### PR TITLE
Makes paraplegic no longer exclusive with spacer/settler

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/mute, /datum/quirk/softspoken),
 	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
 	list(/datum/quirk/bilingual, /datum/quirk/foreigner),
-	list(/datum/quirk/spacer_born, /datum/quirk/paraplegic, /datum/quirk/item_quirk/settler),
+	list(/datum/quirk/spacer_born, /datum/quirk/item_quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
 	list(/datum/quirk/numb, /datum/quirk/selfaware),


### PR DESCRIPTION
## About The Pull Request
Pretty self explanatory, gets rid of the restriction on using paraplegic with these quirks. 

I'm going to very tentatively call this a qol, since I can't fathom this really being much of a mechanical help for anyone. But I wouldn't complain if people disagree
## Why It's Good For The Game
Space-born people would likely be able to function fine without legs in little to no gravity, and both of them, lore wise, could have been paralyzed later in life. It doesn't really make sense for them to be exclusive.

In terms of balance, I don't believe either combination meaningfully negates any of the downsides of the quirks. I can't really think of any potentially abusable mechanics that this restriction is preventing.
## Changelog
:cl:
balance: paraplegic is no longer exclusive with spacer or settler or spacer. Broken legs don't discriminate!
/:cl:
