### PR TITLE
Pipe painting, spraycan preset colors

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -367,7 +367,8 @@
 	.["has_cap"] = has_cap
 	.["is_capped"] = is_capped
 	.["can_change_colour"] = can_change_colour
-	.["current_colour"] = paint_color
+	.["selected_color"] = GLOB.pipe_color_name[paint_color] || paint_color
+	.["paint_colors"] = GLOB.pipe_paint_colors
 
 /obj/item/toy/crayon/ui_act(action, list/params)
 	. = ..()
@@ -390,8 +391,14 @@
 				text_buffer = ""
 			else
 				paint_mode = PAINT_NORMAL
-		if("select_colour")
+		if("custom_color")
 			. = can_change_colour && pick_painting_tool_color(usr, paint_color)
+		if("color")
+			if(!can_change_colour)
+				return
+			paint_color = GLOB.pipe_paint_colors[params["paint_color"]]
+			set_painting_tool_color(paint_color)
+			. = TRUE
 		if("enter_text")
 			var/txt = tgui_input_text(usr, "Choose what to write", "Scribbles", text_buffer)
 			if(isnull(txt))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -848,7 +848,6 @@
 		user.visible_message(span_notice("[user] coats [target] with spray paint!"), span_notice("You coat [target] with spray paint."))
 		return
 
-
 	if(isobj(target) && !(target.flags_1 & UNPAINTABLE_1))
 		var/color_is_dark = FALSE
 		if(actually_paints)
@@ -858,7 +857,6 @@
 				to_chat(user, span_warning("A color that dark on an object like this? Surely not..."))
 				return FALSE
 
-			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 			if(isitem(target) && isliving(target.loc))
 				var/obj/item/target_item = target
 				var/mob/living/holder = target.loc
@@ -866,6 +864,27 @@
 					holder.update_held_items()
 				else
 					holder.update_clothing(target_item.slot_flags)
+
+			if(istype(target, /obj/machinery/atmospherics))
+				var/obj/machinery/atmospherics/target_pipe = target
+				if(GLOB.pipe_color_name.Find(paint_color))
+					target_pipe.paint(paint_color)
+					balloon_alert(user, "painted in  [GLOB.pipe_color_name[paint_color]] color")
+				else
+					balloon_alert(user, "invalid pipe color!")
+					return FALSE
+			else if(istype(target, /obj/item/pipe))
+				var/obj/item/pipe/target_pipe = target
+				if(GLOB.pipe_color_name.Find(paint_color))
+					target_pipe.pipe_color = paint_color
+					target.add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
+					balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
+				else
+					balloon_alert(user, "invalid pipe color!")
+					return FALSE
+			else
+				target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
+
 		if(!(SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, user, src, color_is_dark) & DONT_USE_SPRAYCAN_CHARGES))
 			use_charges(user, 2, requires_full = FALSE)
 		reagents.trans_to(target, ., volume_multiplier, transferred_by = user, methods = VAPOR)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -857,6 +857,18 @@
 				to_chat(user, span_warning("A color that dark on an object like this? Surely not..."))
 				return FALSE
 
+			if(istype(target, /obj/item/pipe))
+				if(GLOB.pipe_color_name.Find(paint_color))
+					var/obj/item/pipe/target_pipe = target
+					target_pipe.pipe_color = paint_color
+					target.add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
+					balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
+				else
+					balloon_alert(user, "invalid pipe color!")
+					return FALSE
+			else
+				target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
+
 			if(isitem(target) && isliving(target.loc))
 				var/obj/item/target_item = target
 				var/mob/living/holder = target.loc
@@ -873,17 +885,6 @@
 				else
 					balloon_alert(user, "invalid pipe color!")
 					return FALSE
-			else if(istype(target, /obj/item/pipe))
-				var/obj/item/pipe/target_pipe = target
-				if(GLOB.pipe_color_name.Find(paint_color))
-					target_pipe.pipe_color = paint_color
-					target.add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
-					balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
-				else
-					balloon_alert(user, "invalid pipe color!")
-					return FALSE
-			else
-				target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 		if(!(SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, user, src, color_is_dark) & DONT_USE_SPRAYCAN_CHARGES))
 			use_charges(user, 2, requires_full = FALSE)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -866,6 +866,14 @@
 				else
 					balloon_alert(user, "invalid pipe color!")
 					return FALSE
+			else if(istype(target, /obj/machinery/atmospherics))
+				if(GLOB.pipe_color_name.Find(paint_color))
+					var/obj/machinery/atmospherics/target_pipe = target
+					target_pipe.paint(paint_color)
+					balloon_alert(user, "painted in  [GLOB.pipe_color_name[paint_color]] color")
+				else
+					balloon_alert(user, "invalid pipe color!")
+					return FALSE
 			else
 				target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
@@ -876,15 +884,6 @@
 					holder.update_held_items()
 				else
 					holder.update_clothing(target_item.slot_flags)
-
-			if(istype(target, /obj/machinery/atmospherics))
-				var/obj/machinery/atmospherics/target_pipe = target
-				if(GLOB.pipe_color_name.Find(paint_color))
-					target_pipe.paint(paint_color)
-					balloon_alert(user, "painted in  [GLOB.pipe_color_name[paint_color]] color")
-				else
-					balloon_alert(user, "invalid pipe color!")
-					return FALSE
 
 		if(!(SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, user, src, color_is_dark) & DONT_USE_SPRAYCAN_CHARGES))
 			use_charges(user, 2, requires_full = FALSE)

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -17,15 +17,16 @@
 
 	if(istype(target, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/target_pipe = target
-		target_pipe.paint(paint_color)
+		target_pipe.paint(GLOB.pipe_paint_colors[paint_color])
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
-		balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
+		balloon_alert(user, "painted in [paint_color] color")
 	else if(istype(target, /obj/item/pipe))
 		var/obj/item/pipe/target_pipe = target
-		target_pipe.pipe_color = paint_color
-		target.add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
+		var/color = GLOB.pipe_paint_colors[paint_color]
+		target_pipe.pipe_color = color
+		target.add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
-		balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
+		balloon_alert(user, "painted in [paint_color] color")
 
 /obj/item/pipe_painter/attack_self(mob/user)
 	paint_color = tgui_input_list(user, "Which colour do you want to use?", "Pipe painter", GLOB.pipe_paint_colors)

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -9,19 +9,23 @@
 
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 
-/obj/item/pipe_painter/afterattack(atom/A, mob/user, proximity_flag)
+/obj/item/pipe_painter/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	//Make sure we only paint adjacent items
 	if(!proximity_flag)
 		return
 
-	if(!istype(A, /obj/machinery/atmospherics/pipe))
-		return
-
-	var/obj/machinery/atmospherics/pipe/P = A
-	if(P.paint(GLOB.pipe_paint_colors[paint_color]))
+	if(istype(target, /obj/machinery/atmospherics))
+		var/obj/machinery/atmospherics/target_pipe = target
+		target_pipe.paint(paint_color)
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
-		user.visible_message(span_notice("[user] paints \the [P] [paint_color]."),span_notice("You paint \the [P] [paint_color]."))
+		balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
+	else if(istype(target, /obj/item/pipe))
+		var/obj/item/pipe/target_pipe = target
+		target_pipe.pipe_color = paint_color
+		target.add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
+		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+		balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
 
 /obj/item/pipe_painter/attack_self(mob/user)
 	paint_color = tgui_input_list(user, "Which colour do you want to use?", "Pipe painter", GLOB.pipe_paint_colors)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -613,12 +613,16 @@
 	return
 
 /**
- * Called by the RPD.dm pre_attack(), overriden by pipes.dm
+ * Called by the RPD.dm pre_attack()
  * Arguments:
  * * paint_color - color that the pipe will be painted in (colors in hex like #4f4f4f)
  */
 /obj/machinery/atmospherics/proc/paint(paint_color)
-	return FALSE
+	if(paintable)
+		add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
+		set_pipe_color(paint_color)
+		update_node_icon()
+	return paintable
 
 /// Setter for pipe color, so we can ensure it's all uniform and save cpu time
 /obj/machinery/atmospherics/proc/set_pipe_color(pipe_colour)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -245,13 +245,6 @@
 /obj/machinery/atmospherics/components/return_analyzable_air()
 	return airs
 
-/obj/machinery/atmospherics/components/paint(paint_color)
-	if(paintable)
-		add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
-		set_pipe_color(paint_color)
-		update_node_icon()
-	return paintable
-
 /**
  * Disconnects all nodes from ourselves, remove us from the node's nodes.
  * Nullify our parent pipenet

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -143,12 +143,5 @@
 		var/obj/machinery/atmospherics/current_node = nodes[i]
 		current_node.update_icon()
 
-/obj/machinery/atmospherics/pipe/paint(paint_color)
-	if(paintable)
-		add_atom_colour(paint_color, FIXED_COLOUR_PRIORITY)
-		set_pipe_color(pipe_color)
-		update_node_icon()
-	return paintable
-
 /obj/machinery/atmospherics/pipe/update_layer()
 	layer = initial(layer) + (piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE + (GLOB.pipe_colors_ordered[pipe_color] * 0.0001)

--- a/tgui/packages/tgui/interfaces/Crayon.tsx
+++ b/tgui/packages/tgui/interfaces/Crayon.tsx
@@ -2,6 +2,7 @@ import { BooleanLike } from 'common/react';
 import { useBackend } from '../backend';
 import { Button, LabeledList, Section } from '../components';
 import { Window } from '../layouts';
+import { ColorItem } from './RapidPipeDispenser';
 
 type Data = {
   has_cap: BooleanLike;
@@ -43,11 +44,11 @@ export const Crayon = (props, context) => {
                   onClick={() => act('toggle_cap')}
                 />
               </LabeledList.Item>
+              <ColorItem />
+              <LabeledList.Item label="Custom color">
+                <Button content="Select" onClick={() => act('custom_color')} />
+              </LabeledList.Item>
             </LabeledList>
-            <Button
-              content="Select New Color"
-              onClick={() => act('select_colour')}
-            />
           </Section>
         )}
         <Section title="Stencil">

--- a/tgui/packages/tgui/interfaces/Crayon.tsx
+++ b/tgui/packages/tgui/interfaces/Crayon.tsx
@@ -45,8 +45,11 @@ export const Crayon = (props, context) => {
                 />
               </LabeledList.Item>
               <ColorItem />
-              <LabeledList.Item label="Custom color">
-                <Button content="Select" onClick={() => act('custom_color')} />
+              <LabeledList.Item>
+                <Button
+                  content="Custom color"
+                  onClick={() => act('custom_color')}
+                />
               </LabeledList.Item>
             </LabeledList>
           </Section>


### PR DESCRIPTION
![dreamseeker_AZs0erdnrs](https://github.com/tgstation/tgstation/assets/3625094/06a12d22-387b-4a33-8b61-59bbe3495c82)

## About The Pull Request

Made pipe painter properly paint pipe colors, work on pipe items, and added the same functionality to regular spraycans.

Spraycans now have the color presets in UI for easier selection of the valid pipe colors.

## Why It's Good For The Game

Bug fixing is good.
It was weird that spraycans couldn't paint pipes, but some other device could.
Also custom spraycan color is too clunky, presets are nice for quick spraycan color selection.

## Changelog

:cl:
fix: fixed pipe painter not applying pipe color properly
qol: made spraycans work also as pipe painters
qol: spraycans now have basic color presets for quick selection
/:cl:
