### PR TITLE
Fixes Shaving Beards + Mirror Code Improvement

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -26,7 +26,6 @@
 	integrity_failure = 0.5
 	max_integrity = 200
 	var/list/mirror_options = INERT_MIRROR_OPTIONS
-	var/magical_mirror = FALSE
 
 	///Flags this race must have to be selectable with this type of mirror.
 	var/race_flags = MIRROR_MAGIC
@@ -83,7 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	if(. || !ishuman(user) || broken)
 		return TRUE
 
-	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH) && !magical_mirror)
+	if(istype(src, /obj/structure/mirror/magic) && !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return TRUE //no tele-grooming (if nonmagical)
 
 	return display_radial_menu(user)
@@ -110,20 +109,26 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	return display_radial_menu(user)
 
 /obj/structure/mirror/proc/change_beard(mob/living/carbon/human/beard_dresser)
-	if(beard_dresser.physique != FEMALE && !magical_mirror)
-		var/new_style = tgui_input_list(beard_dresser, "Select a facial hairstyle", "Grooming", GLOB.facial_hairstyles_list)
-		if(isnull(new_style))
-			return TRUE
-		if(HAS_TRAIT(beard_dresser, TRAIT_SHAVED))
-			to_chat(beard_dresser, span_notice("If only growing back facial hair were that easy for you... The reminder makes you feel terrible."))
-			beard_dresser.add_mood_event("bald_hair_day", /datum/mood_event/bald_reminder)
-			return TRUE
-		beard_dresser.set_facial_hairstyle(new_style, update = TRUE)
-	else
+	if(beard_dresser.physique == FEMALE)
 		if(beard_dresser.facial_hairstyle == "Shaved")
-			to_chat(beard_dresser, span_notice("You realize you don't have any facial hair."))
-			return
-		beard_dresser.set_facial_hairstyle("Shaved", update = TRUE)
+			to_chat(beard_dresser, span_notice("You don't have any hair to shave off!"))
+			return TRUE
+		var/shave_beard = tgui_alert(beard_dresser, "Shave your beard?", "Grooming", list("Yes", "No"))
+		if(shave_beard == "Yes")
+			beard_dresser.set_facial_hairstyle("Shaved", update = TRUE)
+		return TRUE
+
+	var/new_style = tgui_input_list(beard_dresser, "Select a facial hairstyle", "Grooming", GLOB.facial_hairstyles_list)
+
+	if(isnull(new_style))
+		return TRUE
+
+	if(HAS_TRAIT(beard_dresser, TRAIT_SHAVED))
+		to_chat(beard_dresser, span_notice("If only growing back facial hair were that easy for you... The reminder makes you feel terrible."))
+		beard_dresser.add_mood_event("bald_hair_day", /datum/mood_event/bald_reminder)
+		return TRUE
+
+	beard_dresser.set_facial_hairstyle(new_style, update = TRUE)
 
 /obj/structure/mirror/proc/change_hair(mob/living/carbon/human/hairdresser)
 	var/new_style = tgui_input_list(hairdresser, "Select a hairstyle", "Grooming", GLOB.hairstyles_list)
@@ -317,7 +322,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	desc = "Turn and face the strange... face."
 	icon_state = "magic_mirror"
 	mirror_options = MAGIC_MIRROR_OPTIONS
-	magical_mirror = TRUE
 
 /obj/structure/mirror/magic/Initialize(mapload)
 	. = ..()
@@ -328,6 +332,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 		if(initial(species_type.changesource_flags) & race_flags)
 			selectable_races[initial(species_type.name)] = species_type
 	selectable_races = sort_list(selectable_races)
+
+/obj/structure/mirror/magic/change_beard(mob/living/carbon/human/beard_dresser) // magical mirrors do nothing but give you the damn beard
+	var/new_style = tgui_input_list(beard_dresser, "Select a facial hairstyle", "Grooming", GLOB.facial_hairstyles_list)
+	if(isnull(new_style))
+		return TRUE
+	beard_dresser.set_facial_hairstyle(new_style, update = TRUE)
+	return TRUE
 
 //Magic mirrors can change hair color as well
 /obj/structure/mirror/magic/change_hair(mob/living/carbon/human/user)
@@ -349,7 +360,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 
 /obj/structure/mirror/magic/attack_hand(mob/living/carbon/human/user)
 	. = ..()
-	if(!.)
+	if(.)
 		return TRUE
 
 	if(HAS_TRAIT(user, TRAIT_ADVANCEDTOOLUSER) && HAS_TRAIT(user, TRAIT_LITERATE))
@@ -377,11 +388,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 
 /obj/structure/mirror/magic/pride/attack_hand(mob/living/carbon/human/user)
 	. = ..()
-	if(!.)
+	if(.)
 		return TRUE
 
-	user.visible_message(span_danger("<B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B>"), \
-	span_notice("Perfect. Much better! Now <i>nobody</i> will be able to resist yo-"))
+	user.visible_message(
+		span_bolddanger("The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!"),
+		span_notice("Perfect. Much better! Now <i>nobody</i> will be able to resist yo-"),
+	)
 
 	var/turf/user_turf = get_turf(user)
 	var/list/levels = SSmapping.levels_by_trait(ZTRAIT_SPACE_RUINS)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -82,7 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	if(. || !ishuman(user) || broken)
 		return TRUE
 
-	if(istype(src, /obj/structure/mirror/magic) && !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+	!if(istype(src, /obj/structure/mirror/magic) && !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return TRUE //no tele-grooming (if nonmagical)
 
 	return display_radial_menu(user)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -111,7 +111,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 /obj/structure/mirror/proc/change_beard(mob/living/carbon/human/beard_dresser)
 	if(beard_dresser.physique == FEMALE)
 		if(beard_dresser.facial_hairstyle == "Shaved")
-			to_chat(beard_dresser, span_notice("You don't have any hair to shave off!"))
+			balloon_alert(beard_dresser, "nothing to shave!")
 			return TRUE
 		var/shave_beard = tgui_alert(beard_dresser, "Shave your beard?", "Grooming", list("Yes", "No"))
 		if(shave_beard == "Yes")

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -82,7 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	if(. || !ishuman(user) || broken)
 		return TRUE
 
-	!if(istype(src, /obj/structure/mirror/magic) && !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+	if(!istype(src, /obj/structure/mirror/magic) && !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return TRUE //no tele-grooming (if nonmagical)
 
 	return display_radial_menu(user)


### PR DESCRIPTION

## About The Pull Request

Fixes #79519

Basically we did a lot of assumptions that we really shouldn't do in the whole magical mirror framework (like having a boolean value for magical mirrors, what?). Anyways, I just made the UX experience a lot better when it came to bearded persons with feminine physiques to easily shave off their beard with an additional confirmatory prompt + details as well as keeping the nature of the magical mirror (giving you a swagadocious beard due to magic:tm:) intact.
## Why It's Good For The Game

There was a lot of convoluted code that skipped through the quality filter checks (it was me i think) so let's both make the code far easier to grasp as well as ensure that people who legitimately acquire beards and wish to keep them, keep them.

We were also doing some FUCK shit on attack_hand and the like (overriding a FALSE return signal to return TRUE is not what we should be doing there)- so that's also cleaned up.
## Changelog
:cl:
fix: Both magic mirrors and regular mirrors are far better at respecting the choice of the beard you wish to wear (within reason, of course).
/:cl:
