### PR TITLE
Green Beer has an overdose effect now. It will permeate your skin.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -169,7 +169,7 @@
 		if(HAS_TRAIT(affected_human, TRAIT_USES_SKINTONES))
 			affected_human.skin_tone = "green"
 		else if(HAS_TRAIT(affected_human, TRAIT_MUTANT_COLORS) && !HAS_TRAIT(affected_human, TRAIT_FIXED_MUTANT_COLORS)) //Code stolen from spraytan overdose
-			affected_human.dna.features["mcolor"] = "#A8E61D"
+			affected_human.dna.features["mcolor"] = "#a8e61d"
 		affected_human.update_body(is_creating = TRUE)
 
 /datum/reagent/consumable/ethanol/kahlua

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -164,13 +164,15 @@
 	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
-	if(ishuman(affected_mob))
-		var/mob/living/carbon/human/affected_human = affected_mob
-		if(HAS_TRAIT(affected_human, TRAIT_USES_SKINTONES))
-			affected_human.skin_tone = "green"
-		else if(HAS_TRAIT(affected_human, TRAIT_MUTANT_COLORS) && !HAS_TRAIT(affected_human, TRAIT_FIXED_MUTANT_COLORS)) //Code stolen from spraytan overdose
-			affected_human.dna.features["mcolor"] = "#a8e61d"
-		affected_human.update_body(is_creating = TRUE)
+	if(!ishuman(affected_mob))
+		return
+
+	var/mob/living/carbon/human/affected_human = affected_mob
+	if(HAS_TRAIT(affected_human, TRAIT_USES_SKINTONES))
+		affected_human.skin_tone = "green"
+	else if(HAS_TRAIT(affected_human, TRAIT_MUTANT_COLORS) && !HAS_TRAIT(affected_human, TRAIT_FIXED_MUTANT_COLORS)) //Code stolen from spraytan overdose
+		affected_human.dna.features["mcolor"] = "#a8e61d"
+	affected_human.update_body(is_creating = TRUE)
 
 /datum/reagent/consumable/ethanol/kahlua
 	name = "Kahlua"

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -147,6 +147,7 @@
 	name = "Green Beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. This variety is dyed a festive green."
 	color = COLOR_CRAYON_GREEN
+	overdose_threshold = 55 //More than a glass
 	taste_description = "green piss water"
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -158,6 +159,18 @@
 
 /datum/reagent/consumable/ethanol/beer/green/on_mob_end_metabolize(mob/living/drinker)
 	drinker.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, color)
+
+/datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+
+	if(ishuman(affected_mob))
+		var/mob/living/carbon/human/affected_human = affected_mob
+		if(HAS_TRAIT(affected_human, TRAIT_USES_SKINTONES))
+			affected_human.skin_tone = "green"
+		else if(HAS_TRAIT(affected_human, TRAIT_MUTANT_COLORS) && !HAS_TRAIT(affected_human, TRAIT_FIXED_MUTANT_COLORS)) //Code stolen from spraytan overdose
+			affected_human.dna.features["mcolor"] = "#A8E61D"
+		affected_human.update_body(is_creating = TRUE)
 
 /datum/reagent/consumable/ethanol/kahlua
 	name = "Kahlua"

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -216,4 +216,4 @@
 		if("orange")
 			. = "#ffc905"
 		if("green")
-			. = "#A8E61D"
+			. = "#a8e61d"

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -215,3 +215,5 @@
 			. = "#fff4e6"
 		if("orange")
 			. = "#ffc905"
+		if("green")
+			. = "#A8E61D"


### PR DESCRIPTION
Green beer now has an overdose effect, stolen from spraytan.
## About The Pull Request
<details>
<summary>Healthy human specimen</summary>

![obraz](https://github.com/tgstation/tgstation/assets/68878861/3ab271df-f9d4-4ae8-a24e-b395e0766787)
</details>

<details>
<summary>What green beer already does to your body</summary>

![obraz](https://github.com/tgstation/tgstation/assets/68878861/0af4d240-bc33-4467-8a3e-b2ccccb13ee7)
</details>

The **Immediate Effects** are temporary.
As the first green moment stretches into long months, 
however - as years become long, regret-filled decades,
Green Beer reveals it's **True Power**:
<br>
<br>
<br>
<br>
<br>
<br>
<br>
<br>
![obraz](https://github.com/tgstation/tgstation/assets/68878861/3dad666f-2bfc-41d5-ab01-2426991b507f)
## Why It's Good For The Game
Spray tan overdose is one of the most creative in the game.

Consuming green beer currently tints your whole sprite green.

While that is cool 
(because this effect has been moved from crayon powder to a plant from cargo, that doesn't see much use)

I thought it would've looked better and made more sense if it applied to your skin specifically.
So I've turned it into an overdose effect, based on spray tan.
## Changelog

:cl:
add: Green Beer has an overdose effect now. It will permeate your skin.
/:cl:
