### PR TITLE
Bitrunner job config

### DIFF
--- a/config/jobconfig.toml
+++ b/config/jobconfig.toml
@@ -46,6 +46,13 @@
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
+[BITRUNNER]
+"# Playtime Requirements" = 0
+"# Required Account Age" = 0
+"# Required Character Age" = 0
+"# Spawn Positions" = 3
+"# Total Positions" = 3
+
 [BOTANIST]
 "# Playtime Requirements" = 0
 "# Required Account Age" = 0


### PR DESCRIPTION
## About The Pull Request

Adds an entry for bitrunners to `jobconfig.toml`.
## Why It's Good For The Game

It should have one.
## Changelog
:cl:
config: The bitrunner job now has a default config for server owners.
/:cl:
