### PR TITLE
makes shadowpeople available at roundstart

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -32,11 +32,6 @@
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/shadow,
 	)
 
-/datum/species/shadow/check_roundstart_eligible()
-	if(check_holidays(HALLOWEEN))
-		return TRUE
-	return ..()
-
 /datum/species/shadow/get_physical_attributes()
 	return "These cursed creatures heal in the dark, but suffer in the light much more heavily. Their eyes let them see in the dark as though it were day."
 


### PR DESCRIPTION
## About The Pull Request
this PR makes shadowpeople available at roundstart
## Why It's Good For The Game
in my opinion shadowpeople is a very fun race to play and allows different play styles with every role, they don’t have any issues balance wise as they are just humans except they heal in the darkness and burn in the light which makes a catch 22 that makes the positives precisely balance the negatives.

it is kind of boring that this is only available at halloween even when they can be easily integrated to every round (no items or food specific to the race) and allows more unique roleplay and gameplay opportunities.
## Changelog
:cl: deathrobotpunch
config: shadowpeople are now available at roundstart
/:cl:
