### PR TITLE
Adds wibbles to certain anomalous entities

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -107,6 +107,10 @@
 	. = ..()
 	QDEL_IN(src, 30 SECONDS)
 
+/obj/effect/client_image_holder/bluespace_stream/generate_image()
+	. = ..()
+	apply_wibbly_filters(.)
+
 /obj/effect/client_image_holder/bluespace_stream/Destroy()
 	if(!QDELETED(linked_to))
 		qdel(linked_to)

--- a/code/game/objects/effects/anomalies/anomalies_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bluespace.dm
@@ -10,6 +10,10 @@
 	///Distance we can teleport someone passively
 	var/teleport_distance = 4
 
+/obj/effect/anomaly/bluespace/Initialize(mapload, new_lifespan, drops_core)
+	. = ..()
+	apply_wibbly_filters(src)
+
 /obj/effect/anomaly/bluespace/anomalyEffect()
 	..()
 	for(var/mob/living/M in range(teleport_range,src))
@@ -98,4 +102,3 @@
 
 	var/mob/living/living = bumpee
 	living.apply_status_effect(/datum/status_effect/teleport_madness)
-

--- a/code/game/objects/effects/anomalies/anomalies_flux.dm
+++ b/code/game/objects/effects/anomalies/anomalies_flux.dm
@@ -14,6 +14,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	apply_wibbly_filters(src)
 
 /obj/effect/anomaly/flux/anomalyEffect()
 	..()

--- a/code/game/objects/effects/anomalies/anomalies_gravity.dm
+++ b/code/game/objects/effects/anomalies/anomalies_gravity.dm
@@ -23,6 +23,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	apply_wibbly_filters(src)
 
 	warp = new(src)
 	vis_contents += warp

--- a/code/game/objects/effects/anomalies/anomalies_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomalies_hallucination.dm
@@ -15,6 +15,10 @@
 		span_warning("You are going insane!"),
 	)
 
+/obj/effect/anomaly/hallucination/Initialize(mapload, new_lifespan, drops_core)
+	. = ..()
+	apply_wibbly_filters(src)
+
 /obj/effect/anomaly/hallucination/anomalyEffect(seconds_per_tick)
 	. = ..()
 	ticks += seconds_per_tick

--- a/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
+++ b/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
@@ -7,6 +7,10 @@
 	var/releasedelay = 10
 	aSignal = /obj/item/assembly/signaler/anomaly/pyro
 
+/obj/effect/anomaly/pyro/Initialize(mapload, new_lifespan, drops_core)
+	. = ..()
+	apply_wibbly_filters(src)
+
 /obj/effect/anomaly/pyro/anomalyEffect(seconds_per_tick)
 	..()
 	ticks += seconds_per_tick

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -100,6 +100,7 @@
 	hardlinked = automatic_link
 	if(isturf(hard_target_override))
 		hard_target = hard_target_override
+	apply_wibbly_filters(src)
 
 /obj/effect/portal/singularity_pull()
 	return

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -43,6 +43,8 @@
 	var/force_teleport = FALSE
 	/// Does this portal create spark effect when teleporting?
 	var/sparkless = FALSE
+	/// If FALSE, the wibble filter will not be applied to this portal (only a visual effect).
+	var/wibbles = TRUE
 
 /obj/effect/portal/anom
 	name = "wormhole"
@@ -53,6 +55,7 @@
 	mech_sized = TRUE
 	teleport_channel = TELEPORT_CHANNEL_WORMHOLE
 	light_on = FALSE
+	wibbles = FALSE
 
 /obj/effect/portal/Move(newloc)
 	for(var/T in newloc)
@@ -100,7 +103,8 @@
 	hardlinked = automatic_link
 	if(isturf(hard_target_override))
 		hard_target = hard_target_override
-	apply_wibbly_filters(src)
+	if(wibbles)
+		apply_wibbly_filters(src)
 
 /obj/effect/portal/singularity_pull()
 	return

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -287,6 +287,10 @@
 	icon_state = "bluestream_fade"
 	duration = 9
 
+/obj/effect/temp_visual/bluespace_fissure/Initialize(mapload)
+	. = ..()
+	apply_wibbly_filters(src)
+
 /obj/effect/temp_visual/gib_animation
 	icon = 'icons/mob/simple/mob.dmi'
 	duration = 15

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -54,6 +54,7 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 	icon_state = "anom"
 	mech_sized = TRUE
 	light_on = FALSE
+	wibbles = FALSE
 
 /obj/effect/portal/wormhole/Initialize(mapload, _creator, _lifespan = 0, obj/effect/portal/_linked, automatic_link = FALSE, turf/hard_target_override)
 	. = ..()

--- a/code/modules/hallucination/hazard.dm
+++ b/code/modules/hallucination/hazard.dm
@@ -86,6 +86,10 @@
 	image_state = "flux"
 	image_layer = OBJ_LAYER + 0.01
 
+/obj/effect/client_image_holder/hallucination/danger/anomaly/generate_image()
+	. = ..()
+	apply_wibbly_filters(.)
+
 /obj/effect/client_image_holder/hallucination/danger/anomaly/Initialize(mapload, list/mobs_which_see_us, datum/hallucination/parent)
 	. = ..()
 	START_PROCESSING(SSobj, src)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -102,6 +102,7 @@
 	mech_sized = TRUE //save your ripley
 	innate_accuracy_penalty = 6
 	light_on = FALSE
+	wibbles = FALSE
 
 /obj/effect/portal/jaunt_tunnel/teleport(atom/movable/M)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds wibble animation to portals, some anomalies, and bluespace rifts.

https://github.com/tgstation/tgstation/assets/51863163/9355dc53-590e-4558-82a3-15145829ce16

## Why It's Good For The Game

It looks kinda cool.
Helps cement these as anomalous, wacky things that don't necessarily fit in our plane of existence.

## Changelog

:cl: Melbert
add: Anomalies, portals, and bluespace rifts will now wibble a bit. 
/:cl:
