### PR TITLE
Slimes can only reproduce out in the open

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -183,54 +183,62 @@
 
 /mob/living/simple_animal/slime/verb/Reproduce()
 	set category = "Slime"
-	set desc = "This will make you split into four Slimes."
+	set desc = "This will make you split into four slimes."
 
-	if(stat)
-		to_chat(src, "<i>I must be conscious to do this...</i>")
+	if(stat != CONSCIOUS)
+		balloon_alert(src, "need to be conscious to split!")
 		return
 
-	if(is_adult)
-		if(amount_grown >= SLIME_EVOLUTION_THRESHOLD)
-			if(stat)
-				to_chat(src, "<i>I must be conscious to do this...</i>")
-				return
+	if(!isturf(loc))
+		balloon_alert(src, "can't reproduce here!")
 
-			var/list/babies = list()
-			var/new_nutrition = round(nutrition * 0.9)
-			var/new_powerlevel = round(powerlevel / 4)
-			var/turf/drop_loc = drop_location()
+	if(!is_adult)
+		balloon_alert(src, "not old enough to reproduce!")
+		return
 
-			for(var/i in 1 to 4)
-				var/child_colour
-				if(mutation_chance >= 100)
-					child_colour = SLIME_TYPE_RAINBOW
-				else if(prob(mutation_chance))
-					child_colour = slime_mutation[rand(1,4)]
-				else
-					child_colour = colour
-				var/mob/living/simple_animal/slime/M
-				M = new(drop_loc, child_colour)
-				if(ckey)
-					M.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
-				M.powerlevel = new_powerlevel
-				if(i != 1)
-					step_away(M,src)
-				M.set_friends(Friends)
-				babies += M
-				M.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
-				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
+	if(amount_grown < SLIME_EVOLUTION_THRESHOLD)
+		to_chat(src, "<i>I need to grow myself more before I can reproduce...</i>")
+		return
 
-			var/mob/living/simple_animal/slime/new_slime = pick(babies)
-			new_slime.set_combat_mode(TRUE)
-			if(src.mind)
-				src.mind.transfer_to(new_slime)
-			else
-				new_slime.key = src.key
-			qdel(src)
+	var/list/babies = list()
+	var/new_nutrition = round(nutrition * 0.9)
+	var/new_powerlevel = round(powerlevel / 4)
+	var/turf/drop_loc = drop_location()
+
+	for(var/i in 1 to 4)
+		var/child_colour
+
+		if(mutation_chance >= 100)
+			child_colour = SLIME_TYPE_RAINBOW
+		else if(prob(mutation_chance))
+			child_colour = slime_mutation[rand(1,4)]
 		else
-			to_chat(src, "<i>I am not ready to reproduce yet...</i>")
+			child_colour = colour
+
+		var/mob/living/simple_animal/slime/baby
+		baby = new(drop_loc, child_colour)
+
+		if(ckey)
+			baby.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
+
+		baby.powerlevel = new_powerlevel
+		if(i != 1)
+			step_away(baby, src)
+
+		baby.set_friends(Friends)
+		babies += baby
+		baby.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
+		SSblackbox.record_feedback("tally", "slime_babies_born", 1, baby.colour)
+
+	var/mob/living/simple_animal/slime/new_slime = pick(babies) // slime that the OG slime will move into.
+	new_slime.set_combat_mode(TRUE)
+
+	if(isnull(src.mind))
+		new_slime.key = src.key
 	else
-		to_chat(src, "<i>I am not old enough to reproduce yet...</i>")
+		src.mind.transfer_to(new_slime)
+
+	qdel(src)
 
 /datum/action/innate/slime/reproduce
 	name = "Reproduce"
@@ -238,8 +246,8 @@
 	needs_growth = GROWTH_NEEDED
 
 /datum/action/innate/slime/reproduce/Activate()
-	var/mob/living/simple_animal/slime/S = owner
-	S.Reproduce()
+	var/mob/living/simple_animal/slime/slime_owner = owner
+	slime_owner.Reproduce()
 
 #undef SIZE_DOESNT_MATTER
 #undef BABIES_ONLY

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -189,7 +189,7 @@
 		balloon_alert(src, "need to be conscious to split!")
 		return
 
-	if(!isturf(loc))
+	if(!isopenturf(loc))
 		balloon_alert(src, "can't reproduce here!")
 
 	if(!is_adult)


### PR DESCRIPTION

## About The Pull Request

Fixes #79296

This code was a bit wack since we used `drop_location()` instead of checking if we even had a valid turf to jump to, so slimes would spawn directly on a turf above the pipe. This has been changed to see our `loc` is actually a valid turf before we continue on in the verb.

Also this code was really fuckin' old so I just did a bunch of early returns in the area to make it just a little bit easier to bear when some poor sod has to refactor all of this into the basic framework.
## Why It's Good For The Game

Bug: Fixed ✅ 
Code: Improved ✅ 
Issue Tracker: One Less Thing ✅ 
## Changelog
:cl:
fix: Slimes now need to be on an open turf to reproduce and split into more slimy slimes, instead of getting away with using phasing powers in pipes.
/:cl:
