### PR TITLE
All vehicles can no longer cross Force Fields

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -123,7 +123,7 @@
 	if(isliving(mover))
 		shock(mover)
 		return
-	if(ismachinery(mover) || isstructure(mover) || ismecha(mover))
+	if(ismachinery(mover) || isstructure(mover) || isvehicle(mover))
 		bump_field(mover)
 		return
 


### PR DESCRIPTION

## About The Pull Request

Fixes #78625

The check only applied to mecha vehicles, when in reality there shouldn't be any vehicle that can freely transverse containment fields, since that vehicle will have a mob in it, which itself shouldn't be allowed to traverse containment fields.
## Why It's Good For The Game

Makes behavior more consistent and expectable.
## Changelog
:cl:
fix: All vehicles (such as VIMs operated by a mouse or a lizard) will no longer be able to phase through containment fields.
/:cl:
