### PR TITLE
Fix nuclear operative induction implants

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -756,13 +756,13 @@
 			human_target.reagents.add_reagent(/datum/reagent/toxin, 2)
 			return FALSE
 
-	/// If all the antag datums are 'fake', disallow induction! No self-antagging.
+	/// If all the antag datums are 'fake' or none exist, disallow induction! No self-antagging.
 	var/faker
 	for(var/datum/antagonist/antag_datum as anything in human_target.mind.antag_datums)
 		if((antag_datum.antag_flags & FLAG_FAKE_ANTAG))
 			faker = TRUE
 
-	if(faker) // GTFO. Technically not foolproof but making a heartbreaker or a paradox clone a nuke op sounds hilarious
+	if(faker || isnull(human_target.mind.antag_datums)) // GTFO. Technically not foolproof but making a heartbreaker or a paradox clone a nuke op sounds hilarious
 		to_chat(human_target, span_notice("Huh? Nothing happened? But you're starting to feel a little ill..."))
 		human_target.reagents.add_reagent(/datum/reagent/toxin, 15)
 		return FALSE

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	/// The typepath for the outfit to show in the preview for the preferences menu.
 	var/preview_outfit
 	/// Flags for antags to turn on or off and check!
-	var/antag_flags = FLAG_FAKE_ANTAG
+	var/antag_flags = NONE
 	/// If true, this antagonist can assign themself a new objective
 	var/can_assign_self_objectives = FALSE
 	/// Default to fill in when entering a custom objective.


### PR DESCRIPTION

## About The Pull Request
Fixes #79547 

#78597 broke induction implants by replacing the "has antag datum" check with a "does not have a fake antag datum" check which passes on a null case. I added an `isnull()` check to cover this.

The introduced `antag_flags` var was by default set to `FLAG_FAKE_ANTAG`, presumably in error as the only antag datums to override this are ERT and Valentines and they just set it to `FLAG_FAKE_ANTAG` anyways. This also means the induction implants ONLY worked on non-antags and anybody with any antag datum would fail the implant. I changed the default to `NONE`. This may have some knock-on effects as `is_special_character()` was returning `FALSE` with any antag datum (unless allow_fake_antags was passed) but no special role which this also fixes.
## Why It's Good For The Game
Non-antags can no longer self-antag their way onto a nuclear operative team and antags can now antag their way onto a nuclear operative team.
## Changelog
:cl:
fix: Nuclear operative induction implants now work correctly on antagonists and fail on non-antagonists
/:cl:
