### PR TITLE
Fixes mafia achievements desyncing you from the database

### DIFF
--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -391,7 +391,7 @@ GLOBAL_LIST_INIT(mafia_role_by_alignment, setup_mafia_role_by_alignment())
 	if(!rewarded.player_pda)
 		return
 	for(var/datum/tgui/window as anything in rewarded.player_pda.open_uis)
-		window.user?.client?.give_award(award, rewarded.body)
+		window.user?.client?.give_award(award, window.user.client.mob)
 
 /**
  * The end of the game is in two procs, because we want a bit of time for players to see eachothers roles.


### PR DESCRIPTION
I swear to fucking god

PDA mafia has two bodies, the real player body, and the fake mafia stand-in. When an achievement is obtained, it's marked as achieved directly on the players client, but then passes the empty mafia stand-in for any afterwork. This causes achievement notifications to be muted, the code to runtime and for it not to update every appropriatew database table (like the achievement highscore table).

:cl:
Fix: Fixes PDA mafia achievements desyncing you from the database
/:cl:

On a somewhat related note, anyone that has gotten PDA mafia achievements (which includes me) is now desynced from the ACHIEVEMENTS_SCORE table. Looks like the only fix is to reset the score in the ACHIEVEMENTS_SCORE to a non-numerical value and force the game to recount every achievement

@Ghommie you made the scoreboard, is the best solution here to just wipe "Achievements Score" and force the game to recount them?