### PR TITLE
[NO GBP] Fixes tcomms relays being permanent (attempt 2)

### DIFF
--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -20,9 +20,18 @@
 	if(!is_freq_listening(signal))
 		return
 
+
+	var/datum/signal/subspace/signal_copy = signal.copy()
+	/**
+	 * signal has been recieved, so remove receiving levels.
+	 * this list will be used to determine broadcasting levels that are added later on.
+	 * make a copy of the signal so that other recievers can still recieve this signal
+	 */
+	signal_copy.levels = list()
+
 	// send the signal to the hub if possible, or a bus otherwise
-	if(!relay_information(signal, /obj/machinery/telecomms/hub))
-		relay_information(signal, /obj/machinery/telecomms/bus)
+	if(!relay_information(signal_copy, /obj/machinery/telecomms/hub))
+		relay_information(signal_copy, /obj/machinery/telecomms/bus)
 
 	use_power(idle_power_usage)
 

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -20,16 +20,13 @@
 	if(!is_freq_listening(signal))
 		return
 
-
+	// Make a copy of the signal so that other recievers can still recieve this signal
 	var/datum/signal/subspace/signal_copy = signal.copy()
-	/**
-	 * signal has been recieved, so remove receiving levels.
-	 * this list will be used to determine broadcasting levels that are added later on.
-	 * make a copy of the signal so that other recievers can still recieve this signal
-	 */
+
+	// Signal has been recieved, so remove receiving levels. This list will be used later on to determine broadcasting levels.
 	signal_copy.levels = list()
 
-	// send the signal to the hub if possible, or a bus otherwise
+	// Send the signal to a hub if possible, or a bus otherwise.
 	if(!relay_information(signal_copy, /obj/machinery/telecomms/hub))
 		relay_information(signal_copy, /obj/machinery/telecomms/bus)
 


### PR DESCRIPTION

## About The Pull Request

The problem was that the levels var of signals was being used as both a list for the levels the receivers can receive on and the levels broadcasters can broadcast on. 

So basically I caused this problem in #74788 because I removed receivers clearing the levels list after receiving the signal. This solved the problem of one receiver clearing the receiving list, preventing any other receivers from receiving the message. However, this led to the receiving levels sticking around to the point when the list was meant to be used for broadcasting levels. 

I originally tried to solve this problem in #78812 but this fix is much simpler.

Another solution could be to make it so that there's separate vars for receiving levels and broadcasting levels instead of using the same var. idk if thats better or not though
## Why It's Good For The Game

Fixes #78806
## Changelog
:cl:
fix: Fixed tcomms relays being weird, they should be sabotagable again
/:cl:
