### PR TITLE
Renames the icon var in barsign datums to icon_state for sanity

### DIFF
--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -37,8 +37,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 	update_appearance()
 
 /obj/machinery/barsign/update_icon_state()
-	if(!(machine_stat & (NOPOWER|BROKEN)) && chosen_sign && chosen_sign.icon)
-		icon_state = chosen_sign.icon
+	if(!(machine_stat & (NOPOWER|BROKEN)) && chosen_sign && chosen_sign.icon_state)
+		icon_state = chosen_sign.icon_state
 	else
 		icon_state = "empty"
 
@@ -64,7 +64,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 		return
 
 	if(chosen_sign && chosen_sign.light_mask)
-		. += emissive_appearance(icon, "[chosen_sign.icon]-light-mask", src)
+		. += emissive_appearance(icon, "[chosen_sign.icon_state]-light-mask", src)
 
 /obj/machinery/barsign/update_appearance(updates=ALL)
 	. = ..()
@@ -202,7 +202,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 	/// User-visible name of the sign.
 	var/name
 	/// Icon state associated with this sign
-	var/icon
+	var/icon_state
 	/// Description shown in the sign's examine text.
 	var/desc
 	/// Hidden from list of selectable options.
@@ -222,175 +222,175 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 
 /datum/barsign/maltesefalcon
 	name = "Maltese Falcon"
-	icon = "maltesefalcon"
+	icon_state = "maltesefalcon"
 	desc = "The Maltese Falcon, Space Bar and Grill."
 	neon_color = "#5E8EAC"
 
 /datum/barsign/thebark
 	name = "The Bark"
-	icon = "thebark"
+	icon_state = "thebark"
 	desc = "Ian's bar of choice."
 	neon_color = "#f7a604"
 
 /datum/barsign/harmbaton
 	name = "The Harmbaton"
-	icon = "theharmbaton"
+	icon_state = "theharmbaton"
 	desc = "A great dining experience for both security members and assistants."
 	neon_color = "#ff7a4d"
 
 /datum/barsign/thesingulo
 	name = "The Singulo"
-	icon = "thesingulo"
+	icon_state = "thesingulo"
 	desc = "Where people go that'd rather not be called by their name."
 	neon_color = "#E600DB"
 
 /datum/barsign/thedrunkcarp
 	name = "The Drunk Carp"
-	icon = "thedrunkcarp"
+	icon_state = "thedrunkcarp"
 	desc = "Don't drink and swim."
 	neon_color = "#a82196"
 
 /datum/barsign/scotchservinwill
 	name = "Scotch Servin Willy's"
-	icon = "scotchservinwill"
+	icon_state = "scotchservinwill"
 	desc = "Willy sure moved up in the world from clown to bartender."
 	neon_color = "#fee4bf"
 
 /datum/barsign/officerbeersky
 	name = "Officer Beersky's"
-	icon = "officerbeersky"
+	icon_state = "officerbeersky"
 	desc = "Man eat a dong, these drinks are great."
 	neon_color = "#16C76B"
 
 /datum/barsign/thecavern
 	name = "The Cavern"
-	icon = "thecavern"
+	icon_state = "thecavern"
 	desc = "Fine drinks while listening to some fine tunes."
 	neon_color = "#0fe500"
 
 /datum/barsign/theouterspess
 	name = "The Outer Spess"
-	icon = "theouterspess"
+	icon_state = "theouterspess"
 	desc = "This bar isn't actually located in outer space."
 	neon_color = "#30f3cc"
 
 /datum/barsign/slipperyshots
 	name = "Slippery Shots"
-	icon = "slipperyshots"
+	icon_state = "slipperyshots"
 	desc = "Slippery slope to drunkeness with our shots!"
 	neon_color = "#70DF00"
 
 /datum/barsign/thegreytide
 	name = "The Grey Tide"
-	icon = "thegreytide"
+	icon_state = "thegreytide"
 	desc = "Abandon your toolboxing ways and enjoy a lazy beer!"
 	neon_color = "#00F4D6"
 
 /datum/barsign/honkednloaded
 	name = "Honked 'n' Loaded"
-	icon = "honkednloaded"
+	icon_state = "honkednloaded"
 	desc = "Honk."
 	neon_color = "#FF998A"
 
 /datum/barsign/thenest
 	name = "The Nest"
-	icon = "thenest"
+	icon_state = "thenest"
 	desc = "A good place to retire for a drink after a long night of crime fighting."
 	neon_color = "#4d6796"
 
 /datum/barsign/thecoderbus
 	name = "The Coderbus"
-	icon = "thecoderbus"
+	icon_state = "thecoderbus"
 	desc = "A very controversial bar known for its wide variety of constantly-changing drinks."
 	neon_color = "#ffffff"
 
 /datum/barsign/theadminbus
 	name = "The Adminbus"
-	icon = "theadminbus"
+	icon_state = "theadminbus"
 	desc = "An establishment visited mainly by space-judges. It isn't bombed nearly as much as court hearings."
 	neon_color = "#ffffff"
 
 /datum/barsign/oldcockinn
 	name = "The Old Cock Inn"
-	icon = "oldcockinn"
+	icon_state = "oldcockinn"
 	desc = "Something about this sign fills you with despair."
 	neon_color = "#a4352b"
 
 /datum/barsign/thewretchedhive
 	name = "The Wretched Hive"
-	icon = "thewretchedhive"
+	icon_state = "thewretchedhive"
 	desc = "Legally obligated to instruct you to check your drinks for acid before consumption."
 	neon_color = "#26b000"
 
 /datum/barsign/robustacafe
 	name = "The Robusta Cafe"
-	icon = "robustacafe"
+	icon_state = "robustacafe"
 	desc = "Holder of the 'Most Lethal Barfights' record 5 years uncontested."
 	neon_color = "#c45f7a"
 
 /datum/barsign/emergencyrumparty
 	name = "The Emergency Rum Party"
-	icon = "emergencyrumparty"
+	icon_state = "emergencyrumparty"
 	desc = "Recently relicensed after a long closure."
 	neon_color = "#f90011"
 
 /datum/barsign/combocafe
 	name = "The Combo Cafe"
-	icon = "combocafe"
+	icon_state = "combocafe"
 	desc = "Renowned system-wide for their utterly uncreative drink combinations."
 	neon_color = "#33ca40"
 
 /datum/barsign/vladssaladbar
 	name = "Vlad's Salad Bar"
-	icon = "vladssaladbar"
+	icon_state = "vladssaladbar"
 	desc = "Under new management. Vlad was always a bit too trigger happy with that shotgun."
 	neon_color = "#306900"
 
 /datum/barsign/theshaken
 	name = "The Shaken"
-	icon = "theshaken"
+	icon_state = "theshaken"
 	desc = "This establishment does not serve stirred drinks."
 	neon_color = "#dcd884"
 
 /datum/barsign/thealenath
 	name = "The Ale' Nath"
-	icon = "thealenath"
+	icon_state = "thealenath"
 	desc = "All right, buddy. I think you've had EI NATH. Time to get a cab."
 	neon_color = "#ed0000"
 
 /datum/barsign/thealohasnackbar
 	name = "The Aloha Snackbar"
-	icon = "alohasnackbar"
+	icon_state = "alohasnackbar"
 	desc = "A tasteful, inoffensive tiki bar sign."
 	neon_color = ""
 
 /datum/barsign/thenet
 	name = "The Net"
-	icon = "thenet"
+	icon_state = "thenet"
 	desc = "You just seem to get caught up in it for hours."
 	neon_color = "#0e8a00"
 
 /datum/barsign/maidcafe
 	name = "Maid Cafe"
-	icon = "maidcafe"
+	icon_state = "maidcafe"
 	desc = "Welcome back, master!"
 	neon_color = "#ff0051"
 
 /datum/barsign/the_lightbulb
 	name = "The Lightbulb"
-	icon = "the_lightbulb"
+	icon_state = "the_lightbulb"
 	desc = "A cafe popular among moths and moffs. Once shut down for a week after the bartender used mothballs to protect her spare uniforms."
 	neon_color = "#faff82"
 
 /datum/barsign/goose
 	name = "The Loose Goose"
-	icon = "goose"
+	icon_state = "goose"
 	desc = "Drink till you puke and/or break the laws of reality!"
 	neon_color = "#00cc33"
 
 /datum/barsign/maltroach
 	name = "Maltroach"
-	icon = "maltroach"
+	icon_state = "maltroach"
 	desc = "Mothroaches politely greet you into the bar, or are they greeting eachother?"
 	neon_color = "#649e8a"
 
@@ -401,19 +401,19 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 
 /datum/barsign/hiddensigns/empbarsign
 	name = "EMP'd"
-	icon = "empbarsign"
+	icon_state = "empbarsign"
 	desc = "Something has gone very wrong."
 	rename_area = FALSE
 
 /datum/barsign/hiddensigns/syndibarsign
 	name = "Syndi Cat"
-	icon = "syndibarsign"
+	icon_state = "syndibarsign"
 	desc = "Syndicate or die."
 	neon_color = "#ff0000"
 
 /datum/barsign/hiddensigns/signoff
 	name = "Off"
-	icon = "empty"
+	icon_state = "empty"
 	desc = "This sign doesn't seem to be on."
 	rename_area = FALSE
 	light_mask = FALSE

--- a/code/modules/unit_tests/barsigns.dm
+++ b/code/modules/unit_tests/barsigns.dm
@@ -12,7 +12,7 @@
 	for(var/sign_type in (subtypesof(/datum/barsign) - /datum/barsign/hiddensigns))
 		var/datum/barsign/sign = new sign_type()
 
-		if(!(sign.icon in barsign_icon_states))
+		if(!(sign.icon_state in barsign_icon_states))
 			TEST_FAIL("Icon state for [sign_type] does not exist in [barsign_icon].")
 
 /**


### PR DESCRIPTION

## About The Pull Request

See title.

## Why It's Good For The Game

Calling this var `icon` is confusing and illogical. It will be applied to the barsign's `icon_state`, and is not an actual icon itself. Renaming to `icon_state` makes this var consistent with `name` and `desc`, which are also applied the same named vars on the sign.

## Changelog
Not player facing
