### PR TITLE
Mafia panel fixes

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -900,7 +900,7 @@
 
 ///Gets the total amount of everything in the associative list.
 /proc/assoc_value_sum(list/input)
-	var/list/keys = list()
+	var/keys = 0
 	for(var/key in input)
 		keys += input[key]
 	return keys

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -196,6 +196,7 @@ GLOBAL_LIST_INIT(mafia_role_by_alignment, setup_mafia_role_by_alignment())
 	for(var/datum/mafia_role/roles as anything in all_roles)
 		var/obj/item/modular_computer/modpc = roles.player_pda
 		if(!modpc)
+			update_static_data(roles.body)
 			continue
 		modpc.update_static_data_for_all_viewers()
 

--- a/code/modules/mafia/controller_ui.dm
+++ b/code/modules/mafia/controller_ui.dm
@@ -2,7 +2,7 @@
 /datum/mafia_controller/ui_static_data(atom/user)
 	var/list/data = list()
 
-	if(usr.client?.holder)
+	if(usr?.client?.holder)
 		data["admin_controls"] = TRUE //show admin buttons to start/setup/stop
 	data["is_observer"] = isobserver(user)
 	data["all_roles"] = current_setup_text

--- a/code/modules/mafia/controller_ui.dm
+++ b/code/modules/mafia/controller_ui.dm
@@ -59,6 +59,7 @@
 		player_info["possible_actions"] = list()
 
 		if(user_role) //not observer
+			player_info["is_you"] = (role.body.real_name == user_role.body.real_name)
 			for(var/datum/mafia_ability/action as anything in user_role.role_unique_actions)
 				if(action.validate_action_target(src, potential_target = role, silent = TRUE))
 					player_info["possible_actions"] += list(list("name" = action, "ref" = REF(action)))

--- a/code/modules/mafia/roles/neutral/neutral_chaos.dm
+++ b/code/modules/mafia/roles/neutral/neutral_chaos.dm
@@ -15,13 +15,13 @@
 
 /datum/mafia_role/obsessed/New(datum/mafia_controller/game) //note: obsession is always a townie
 	. = ..()
-	desc = initial(desc) + " Obsession assigned on the first night."
+	desc = initial(desc) + " Obsessions are assigned on the first night."
 	RegisterSignal(game, COMSIG_MAFIA_SUNDOWN, PROC_REF(find_obsession))
 
 /datum/mafia_role/obsessed/proc/find_obsession(datum/mafia_controller/game)
 	SIGNAL_HANDLER
 
-	var/list/all_roles_shuffle = shuffle(game.living_roles)
+	var/list/all_roles_shuffle = shuffle(game.living_roles) - src
 	for(var/datum/mafia_role/possible as anything in all_roles_shuffle)
 		if(possible.team == MAFIA_TEAM_TOWN)
 			obsession = possible

--- a/code/modules/mafia/roles/neutral/neutral_chaos.dm
+++ b/code/modules/mafia/roles/neutral/neutral_chaos.dm
@@ -1,6 +1,6 @@
 /datum/mafia_role/obsessed
 	name = "Obsessed"
-	desc = "You're completely lost in your own mind. You win by lynching your obsession before you get killed in this mess. Obsession assigned on the first night!"
+	desc = "Lynch your obsession before you get killed at all costs!"
 	win_condition = "lynch their obsession."
 	revealed_outfit = /datum/outfit/mafia/obsessed
 	team = MAFIA_TEAM_SOLO
@@ -15,6 +15,7 @@
 
 /datum/mafia_role/obsessed/New(datum/mafia_controller/game) //note: obsession is always a townie
 	. = ..()
+	desc = initial(desc) + " Obsession assigned on the first night."
 	RegisterSignal(game, COMSIG_MAFIA_SUNDOWN, PROC_REF(find_obsession))
 
 /datum/mafia_role/obsessed/proc/find_obsession(datum/mafia_controller/game)
@@ -27,8 +28,13 @@
 			break
 	if(!obsession)
 		obsession = pick(all_roles_shuffle) //okay no town just pick anyone here
-	//if you still don't have an obsession you're playing a single player game like i can't help your dumb ass
-	to_chat(body, span_userdanger("Your obsession is [obsession.body.real_name]! Get them lynched to win!"))
+	desc = initial(desc) + " Target: [obsession.body.real_name]"
+	var/obj/item/modular_computer/modpc = player_pda
+	if(modpc)
+		modpc.update_static_data_for_all_viewers()
+	else
+		game.update_static_data(body)
+	send_message_to_player(span_userdanger("Your obsession is [obsession.body.real_name]! Get them lynched to win!"))
 	RegisterSignal(obsession, COMSIG_MAFIA_ON_KILL, PROC_REF(check_victory))
 	UnregisterSignal(game, COMSIG_MAFIA_SUNDOWN)
 

--- a/tgui/packages/tgui/interfaces/MafiaPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MafiaPanel.tsx
@@ -1,4 +1,4 @@
-import { classes } from 'common/react';
+import { BooleanLike, classes } from 'common/react';
 import { decodeHtmlEntities } from 'common/string';
 import { multiline } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
@@ -16,6 +16,7 @@ type RoleInfo = {
 
 type PlayerInfo = {
   name: string;
+  is_you: BooleanLike;
   ref: string;
   alive: string;
   possible_actions: ActionInfo[];
@@ -431,7 +432,8 @@ const MafiaPlayers = (props, context) => {
           <Flex.Item className="Section__title candystripe" key={player.ref}>
             <Stack align="center">
               <Stack.Item grow color={!player.alive && 'red'}>
-                {player.name} {!player.alive && '(DEAD)'}
+                {player.name}
+                {player.is_you && ' (YOU)'} {!player.alive && '(DEAD)'}
               </Stack.Item>
               <Stack.Item>
                 {player.votes !== undefined &&


### PR DESCRIPTION
## About The Pull Request

Players can now tell who they are playing as, as the Mafia panel will have a 'YOU' next to their character's name.
Obsessed players now know who their target is in their chat (for PDAs) and in their role description.
Obsessed players also can no longer roll themselves as a target (which never happened anyways because it requires there to have no townies, but hey whatever).
Admins can now properly set the game up again, too.

## Why It's Good For The Game

small QOL nitpicks, and obsesseds can now play the game through PDA

## Changelog

:cl:
fix: [Mafia] Obsessed now knows who their target is in their role description, and people playing on PDA are told in their chat.
/:cl: