### PR TITLE
[NO GBP] Material market buy buttons greys out correctly

### DIFF
--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -251,9 +251,6 @@
 				return
 
 			var/cost = SSstock_market.materials_prices[material_bought] * quantity
-			if(cost > account_payable.account_balance)
-				say("Not enough money to start purchase!")
-				return
 
 			var/list/things_to_order = list()
 			things_to_order += (sheet_to_buy)
@@ -289,6 +286,7 @@
 				current_order.append_order(things_to_order, cost)
 				return TRUE
 
+
 			//Place a new order
 			var/datum/supply_pack/custom/minerals/mineral_pack = new(
 				purchaser = is_ordering_private ? living_user : "Cargo", \
@@ -304,6 +302,12 @@
 				cost_type = "cr",
 				can_be_cancelled = FALSE
 			)
+			//first time order compute the correct cost and compare
+			if(new_order.get_final_cost() > account_payable.account_balance)
+				say("Not enough money to start purchase!")
+				qdel(new_order)
+				return
+
 			say("Thank you for your purchase! It will arrive on the next cargo shuttle!")
 			SSshuttle.shopping_list += new_order
 			return TRUE

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -105,6 +105,10 @@
 		ui = new(user, src, "MatMarket", name)
 		ui.open()
 
+/obj/machinery/materials_market/ui_static_data(mob/user)
+	. = list()
+	.["CARGO_CRATE_VALUE"] = CARGO_CRATE_VALUE
+
 /obj/machinery/materials_market/ui_data(mob/user)
 	. = list()
 

--- a/tgui/packages/tgui/interfaces/MatMarket.tsx
+++ b/tgui/packages/tgui/interfaces/MatMarket.tsx
@@ -21,10 +21,11 @@ type Data = {
   orderBalance: number;
   materials: Material[];
   catastrophe: BooleanLike;
+  CARGO_CRATE_VALUE: number;
 };
 
 export const MatMarket = (props, context) => {
-  const { act, data } = useBackend<Data>(context); // this will tell your editor that data is the type listed above
+  const { act, data } = useBackend<Data>(context);
 
   const {
     orderingPrive,
@@ -33,7 +34,14 @@ export const MatMarket = (props, context) => {
     orderBalance,
     materials = [],
     catastrophe,
+    CARGO_CRATE_VALUE,
   } = data;
+
+  // offset cost with crate value if there is currently nothing in the order
+  const total_order_cost = orderBalance || CARGO_CRATE_VALUE;
+  // multiplier of 1.1 for private orders
+  const multiplier = orderingPrive ? 1.1 : 1;
+
   return (
     <Window width={980} height={630}>
       <Window.Content scrollable>
@@ -126,7 +134,8 @@ export const MatMarket = (props, context) => {
                   disabled={
                     catastrophe === 1 ||
                     material.price <= 0 ||
-                    creditBalance - orderBalance < material.price ||
+                    creditBalance - total_order_cost <
+                      material.price * multiplier ||
                     material.requested + 1 > material.quantity
                   }
                   tooltip={material.price * 1}
@@ -142,7 +151,8 @@ export const MatMarket = (props, context) => {
                   disabled={
                     catastrophe === 1 ||
                     material.price <= 0 ||
-                    creditBalance - orderBalance < material.price * 5 ||
+                    creditBalance - total_order_cost <
+                      material.price * 5 * multiplier ||
                     material.requested + 5 > material.quantity
                   }
                   tooltip={material.price * 5}
@@ -158,7 +168,8 @@ export const MatMarket = (props, context) => {
                   disabled={
                     catastrophe === 1 ||
                     material.price <= 0 ||
-                    creditBalance - orderBalance < material.price * 10 ||
+                    creditBalance - total_order_cost <
+                      material.price * 10 * multiplier ||
                     material.requested + 10 > material.quantity
                   }
                   tooltip={material.price * 10}
@@ -174,7 +185,8 @@ export const MatMarket = (props, context) => {
                   disabled={
                     catastrophe === 1 ||
                     material.price <= 0 ||
-                    creditBalance - orderBalance < material.price * 25 ||
+                    creditBalance - total_order_cost <
+                      material.price * 25 * multiplier ||
                     material.requested + 25 > material.quantity
                   }
                   tooltip={material.price * 25}
@@ -190,7 +202,8 @@ export const MatMarket = (props, context) => {
                   disabled={
                     catastrophe === 1 ||
                     material.price <= 0 ||
-                    creditBalance - orderBalance < material.price * 50 ||
+                    creditBalance - total_order_cost <
+                      material.price * 50 * multiplier ||
                     material.requested + 50 > material.quantity
                   }
                   tooltip={material.price * 50}


### PR DESCRIPTION
## About The Pull Request
The buy buttons in the material market UI now takes into consideration the value of a crate (200 cr) when computing final price and thus prevents you from placing an order that would exceed the available budget.

Also, since private orders have a multiplier of 1.1x that too is taken into account so overall you should not be able to place an order that exceeds the available budget in the UI.

Additional checks applied in the back end as well.

## Changelog
:cl:
fix: Material market buy buttons greys out correctly and thus prevent you from placing orders that exceeds the available budget.
/:cl:
