### PR TITLE
Suite storage units can be locked again

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -380,6 +380,7 @@
 		choices,
 		custom_check = CALLBACK(src, PROC_REF(check_interactable), user),
 		require_near = !issilicon(user),
+		autopick_single_option = FALSE
 	)
 
 	if (!choice)


### PR DESCRIPTION
## About The Pull Request
- Fixes #79486

The radial menu was modified a while back to include a new feature of auto picking the 1st option if the length of the list of available choices is 1. This did not play well with the suit storage unit so i disabled that feature and now suit storage units can be locked again.

Remember to install a card reader or set the access levels in the airlock electronics inside its stock parts & finally swipe your ID to properly enforce access control.  

## Changelog
:cl:
fix: suite storage units can be locked again. Remember to install a card reader or set the access levels in the airlock electronics inside its stock parts & finally swipe your ID to properly enforce access control.  
/:cl:

