### PR TITLE
Examining circuit boards now displays their detailed names correctly if required

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -108,7 +108,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 	. = ..()
 	if(!LAZYLEN(req_components))
 		. += span_info("It requires no components.")
-		return .
+		return
 
 	var/list/nice_list = list()
 	for(var/component_path in req_components)
@@ -118,27 +118,33 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 		var/component_name
 		var/component_amount = req_components[component_path]
 
+		//e.g. "glass sheet" vs. "glass"
 		if(ispath(component_path, /obj/item/stack))
 			var/obj/item/stack/stack_path = component_path
-			if(initial(stack_path.singular_name))
-				component_name = initial(stack_path.singular_name) //e.g. "glass sheet" vs. "glass"
-		else if(ispath(component_path, /obj/item/stock_parts) && !specific_parts)
-			var/obj/item/stock_parts/stock_part = component_path
-			component_name = initial(stock_part.base_name) || initial(stock_part.name)
-		else if(ispath(component_path, /obj/item/stock_parts))
-			var/obj/item/stock_parts/stock_part = component_path
-			component_name = initial(stock_part.name)
-		else if(ispath(component_path, /datum/stock_part))
-			var/datum/stock_part/stock_part = component_path
-			var/obj/item/stock_parts/physical_object_type = initial(stock_part.physical_object_type)
-			component_name = initial(physical_object_type.base_name) || initial(physical_object_type.name)
+			component_name = initial(stack_path.singular_name)
+
+		//stock parts in datum or obj form
+		else if(ispath(component_path, /obj/item/stock_parts) || ispath(component_path, /datum/stock_part))
+			var/obj/item/stock_parts/stock_part
+			if(ispath(component_path, /obj/item/stock_parts))
+				stock_part = component_path
+			else
+				var/datum/stock_part/datum_part = component_path
+				stock_part = initial(datum_part.physical_object_type)
+
+			if(!specific_parts)
+				component_name = initial(stock_part.base_name)
+			if(!component_name)
+				component_name = initial(stock_part.name)
+
+		//beakers, any non conventional part
 		else if(ispath(component_path, /atom))
 			var/atom/stock_part = component_path
 			component_name = initial(stock_part.name)
 
+		//append decoded name to final result
 		if (isnull(component_name))
 			stack_trace("[component_path] was an invalid component")
-
 		nice_list += list("[component_amount] [component_name]\s")
 
 	. += span_info("It requires [english_list(nice_list)].")


### PR DESCRIPTION
## About The Pull Request
- Fixes #79535

This and every other issue related to examining circuit boards. Just cleaned up a lot of code & everything works. yeah!!

## Changelog
:cl:
fix: Examining circuit boards now displays their detailed names(tier included) correctly if required.
/:cl:
