### PR TITLE
Balances the stormtrooper shotgun mob

### DIFF
--- a/code/modules/mob/living/basic/trooper/trooper_ai.dm
+++ b/code/modules/mob/living/basic/trooper/trooper_ai.dm
@@ -90,7 +90,7 @@
 
 /datum/ai_behavior/basic_ranged_attack/trooper_shotgun
 	action_cooldown = 3 SECONDS
-	required_distance = 1
+	required_distance = 3
 	avoid_friendly_fire = TRUE
 
 /datum/ai_controller/basic_controller/trooper/viscerator


### PR DESCRIPTION

## About The Pull Request

A few months ago during the conversion to a Basic mob the shotgun range was changed to 1 instead of staying at what it was prior, meaning the mob itself would get in your face and unload instantly.

## Why It's Good For The Game

Fighting an npc mob that is as fast or faster than you, with 250 health and basically 1 shots you isnt very fun, this returns their range  some even though they dont really act like they did prior still. I thought about making it match the SMG range as well? But 3 leaves it as below

![image](https://github.com/tgstation/tgstation/assets/22140677/1314975d-bbc3-4791-b77e-1661701cabb7)


## Changelog
:cl:zergspower
balance: NPC Syndicate Shotgunners range requirement returned
/:cl:
