### PR TITLE
Allows preference list features to control the order in which they are sorted

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
@@ -342,7 +342,11 @@ const createSetRandomization =
 
 const sortPreferences = sortBy<[string, unknown]>(([featureId, _]) => {
   const feature = features[featureId];
-  return feature?.name;
+  if (feature?.sortingPrefix) {
+    return feature.sortingPrefix + feature.name;
+  } else {
+    return feature?.name;
+  }
 });
 
 const PreferenceList = (props: {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -18,6 +18,7 @@ export type Feature<
   component: FeatureValue<TReceiving, TSending, TServerData>;
   category?: string;
   description?: string;
+  sortingPrefix?: string;
 };
 
 /**

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/body_type.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/body_type.tsx
@@ -3,4 +3,5 @@ import { FeatureChoiced, FeatureDropdownInput } from '../base';
 export const body_type: FeatureChoiced = {
   name: 'Body type',
   component: FeatureDropdownInput,
+  sortingPrefix: 'A_',
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/body_type.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/body_type.tsx
@@ -3,5 +3,4 @@ import { FeatureChoiced, FeatureDropdownInput } from '../base';
 export const body_type: FeatureChoiced = {
   name: 'Body type',
   component: FeatureDropdownInput,
-  sortingPrefix: 'A_',
 };


### PR DESCRIPTION

## About The Pull Request

Title. Accomplishes this through using a sortingPrefix property that will be appended to the beginning of their name for use in the sort function.

**PLEASE NOTE I DONT ACTUALLY KNOW THE CORRECT WAY TO DO THIS SO PLEASE TELL ME A BETTER WAY TO DO IT IF YOU CAN THINK OF ONE**
## Why It's Good For The Game

It's a real headache to smack things into the correct places for preference lists, and requires manipulation of the name. This fixes that by letting us quietly manipulate their placement.
## Changelog
:cl:
code: TGUI preference lists can now have sorting prefixes to allow for specific placement of items
/:cl:
