### PR TITLE
Changes Cryo cells to use machine direction instead of hardcoded one on startup.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
@@ -13,11 +13,14 @@
 		qdel(src)
 		return
 
-	gas_connector.dir = direction
+	gas_connector.dir = connected_machine.dir
 	gas_connector.airs[1].volume = gas_volume
 
 	SSair.start_processing_machine(connected_machine)
 	register_with_machine()
+	gas_connector.set_init_directions()
+	gas_connector.atmos_init()
+	SSair.add_to_rebuild_queue(gas_connector)
 
 /datum/gas_machine_connector/Destroy()
 	connected_machine = null


### PR DESCRIPTION
## About The Pull Request
Cryo cells on Delta and Tram wouldn't work round start due to the fact their gas input was defaulting to South and not the direction of the cell itself.
This uses the machines direction to setup the initial direction for the internal gas connector instead.
Tram Before: 
![Before Tramstation](https://github.com/tgstation/tgstation/assets/106436013/53d98dbd-41d0-4396-9d60-08821b0453cb)
Tram After:
![TramStation](https://github.com/tgstation/tgstation/assets/106436013/a337ada8-73e6-40ac-880c-26e0083d91cc)
Delta After:
![Delta](https://github.com/tgstation/tgstation/assets/106436013/c8d74bc3-79de-4f42-8ce9-0c8b477af8c3)
Icebox (To prove that normal setups still work):
![Icebox](https://github.com/tgstation/tgstation/assets/106436013/5016a06a-1274-4161-b18c-ddf5c2af70af)

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/78830


## Changelog
:cl:TwistedSilicon
fix: Cryo cells now use their direction to orient their initial connection instead of defaulting to South. 
/:cl:
