### PR TITLE
Renames vars on pdas and removes ntnet_relays glob

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -255,7 +255,8 @@
 	build_path = /obj/machinery/ntnet_relay
 	req_components = list(
 		/obj/item/stack/cable_coil = 2,
-		/datum/stock_part/filter = 1)
+		/datum/stock_part/filter = 1,
+	)
 
 /obj/item/circuitboard/machine/pacman
 	name = "PACMAN-type Generator"

--- a/code/modules/NTNet/relays.dm
+++ b/code/modules/NTNet/relays.dm
@@ -1,9 +1,7 @@
-GLOBAL_LIST_EMPTY(ntnet_relays)
-
 ///Checks whether NTNet is available by ensuring at least one relay exists and is operational.
 /proc/find_functional_ntnet_relay()
 	// Check all relays. If we have at least one working relay, ntos is up.
-	for(var/obj/machinery/ntnet_relay/relays as anything in GLOB.ntnet_relays)
+	for(var/obj/machinery/ntnet_relay/relays as anything in SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay))
 		if(!relays.is_operational)
 			continue
 		return TRUE
@@ -33,6 +31,19 @@ GLOBAL_LIST_EMPTY(ntnet_relays)
 	var/dos_capacity = 500 // Amount of DoS "packets" in buffer required to crash the relay
 	var/dos_dissipate = 0.5 // Amount of DoS "packets" dissipated over time.
 
+/obj/machinery/ntnet_relay/Initialize(mapload)
+	. = ..()
+	uid = gl_uid++
+	var/list/current_machines = SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay)
+	SSmodular_computers.add_log("New quantum relay activated. Current amount of linked relays: [current_machines.len]")
+
+/obj/machinery/ntnet_relay/Destroy()
+	. = ..()
+	var/list/machines_left = SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay)
+	SSmodular_computers.add_log("Quantum relay connection severed. Current amount of linked relays: [machines_left.len]")
+	for(var/datum/computer_file/program/ntnet_dos/D in dos_sources)
+		D.target = null
+		D.error = "Connection to quantum relay severed"
 
 ///Proc called to change the value of the `relay_enabled` variable and append behavior related to its change.
 /obj/machinery/ntnet_relay/proc/set_relay_enabled(new_value)
@@ -118,21 +129,3 @@ GLOBAL_LIST_EMPTY(ntnet_relays)
 			SSmodular_computers.add_log("Quantum relay manually [relay_enabled ? "enabled" : "disabled"].")
 			update_appearance()
 			return TRUE
-
-/obj/machinery/ntnet_relay/Initialize(mapload)
-	uid = gl_uid++
-	component_parts = list()
-
-	GLOB.ntnet_relays += src
-	SSmodular_computers.add_log("New quantum relay activated. Current amount of linked relays: [GLOB.ntnet_relays.len]")
-	return ..()
-
-/obj/machinery/ntnet_relay/Destroy()
-	GLOB.ntnet_relays -= src
-	SSmodular_computers.add_log("Quantum relay connection severed. Current amount of linked relays: [GLOB.ntnet_relays.len]")
-
-	for(var/datum/computer_file/program/ntnet_dos/D in dos_sources)
-		D.target = null
-		D.error = "Connection to quantum relay severed"
-
-	return ..()

--- a/code/modules/modular_computers/documentation.md
+++ b/code/modules/modular_computers/documentation.md
@@ -31,13 +31,12 @@ This is how the base program is setup. the rest is mostly tgui stuff. I'll use t
 	/// programs.
 	requires_ntnet = 1
 
-	/// This is access required to run the program itself. ONLY SET THIS FOR
-	/// SUPER SECURE SHIT. This also acts as transfer_access as well.
-	required_access = access_network
+	/// This is access required to run the program itself.
+	run_access = access_network
 
 	/// This is the access needed to download from ntnet or host on the ptp
 	/// program. This is what you want to use most of the time.
-	transfer_access = access_change_ids
+	download_access = access_change_ids
 
 	/// If it's available to download on ntnet. pretty self explanatory.
 	available_on_ntnet = 1

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -7,7 +7,7 @@
 	size = 12
 	requires_ntnet = FALSE
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
-	transfer_access = list(ACCESS_RD)
+	download_access = list(ACCESS_RD)
 	available_on_ntnet = TRUE
 	tgui_id = "NtosAiRestorer"
 	program_icon = "laptop-code"

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -42,7 +42,7 @@
 /datum/computer_file/program/ntnet_dos/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_target_relay")
-			for(var/obj/machinery/ntnet_relay/relays as anything in GLOB.ntnet_relays)
+			for(var/obj/machinery/ntnet_relay/relays as anything in SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay))
 				if(relays.uid == params["targid"])
 					target = relays
 					break
@@ -76,7 +76,7 @@
 	else
 		data["target"] = FALSE
 		data["relays"] = list()
-		for(var/obj/machinery/ntnet_relay/relays as anything in GLOB.ntnet_relays)
+		for(var/obj/machinery/ntnet_relay/relays as anything in SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay))
 			data["relays"] += list(list("id" = relays.uid))
 		data["focus"] = target ? target.uid : null
 

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -6,7 +6,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows for remote monitoring of station cyborgs."
 	requires_ntnet = TRUE
-	transfer_access = list(ACCESS_ROBOTICS)
+	download_access = list(ACCESS_ROBOTICS)
 	size = 5
 	tgui_id = "NtosCyborgRemoteMonitor"
 	program_icon = "project-diagram"
@@ -155,7 +155,7 @@
 	requires_ntnet = FALSE
 	available_on_ntnet = FALSE
 	available_on_syndinet = TRUE
-	transfer_access = list()
+	download_access = list()
 
 /datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
 	if(!is_valid_z_level(get_turf(computer), get_turf(R)))

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -4,7 +4,7 @@
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for programming employee ID cards to access parts of the station."
-	transfer_access = list(ACCESS_COMMAND)
+	download_access = list(ACCESS_COMMAND)
 	requires_ntnet = 0
 	size = 8
 	tgui_id = "NtosCard"

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -4,7 +4,7 @@
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
-	transfer_access = list(ACCESS_SECURITY, ACCESS_COMMAND)
+	download_access = list(ACCESS_SECURITY, ACCESS_COMMAND)
 	requires_ntnet = TRUE
 	size = 4
 	tgui_id = "NtosCrewManifest"

--- a/code/modules/modular_computers/file_system/programs/frontier.dm
+++ b/code/modules/modular_computers/file_system/programs/frontier.dm
@@ -8,7 +8,7 @@
 	program_icon_state = "research"
 	tgui_id = "NtosScipaper"
 	program_icon = "paper-plane"
-	transfer_access = list(ACCESS_ORDNANCE)
+	download_access = list(ACCESS_ORDNANCE)
 
 	var/datum/techweb/linked_techweb
 	/// Unpublished, temporary paper datum.

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -7,7 +7,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and changing job slot availability."
-	transfer_access = list(ACCESS_COMMAND)
+	download_access = list(ACCESS_COMMAND)
 	requires_ntnet = TRUE
 	size = 4
 	tgui_id = "NtosJobManager"

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/newscaster
 	filename = "newscasterapp"
 	filedesc = "Newscaster"
-	transfer_access = list(ACCESS_LIBRARY)
+	download_access = list(ACCESS_LIBRARY)
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "bountyboard"
 	extended_desc = "This program allows any user to access the Newscaster network from anywhere."

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -143,7 +143,7 @@
 			"installed" = !!computer.find_file_by_name(programs.filename),
 			"compatible" = check_compatibility(programs),
 			"size" = programs.size,
-			"access" = programs.can_run(user, transfer = TRUE, access = access),
+			"access" = programs.can_run(user, downloading = TRUE, access = access),
 			"verifiedsource" = programs.available_on_ntnet,
 		))
 

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -15,7 +15,7 @@
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "dummy"
 	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art."
-	transfer_access = list(ACCESS_LIBRARY)
+	download_access = list(ACCESS_LIBRARY)
 	usage_flags = PROGRAM_CONSOLE
 	requires_ntnet = TRUE
 	size = 9

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -7,7 +7,7 @@
 	program_icon_state = "power_monitor"
 	extended_desc = "This program connects to sensors around the station to provide information about electrical systems"
 	ui_header = "power_norm.gif"
-	transfer_access = list(ACCESS_ENGINEERING)
+	download_access = list(ACCESS_ENGINEERING)
 	usage_flags = PROGRAM_CONSOLE
 	requires_ntnet = FALSE
 	size = 8

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -220,7 +220,7 @@
 	filedesc = "Lifeline"
 	extended_desc = "This program allows for tracking of crew members via their suit sensors."
 	requires_ntnet = TRUE
-	transfer_access = list(ACCESS_MEDICAL)
+	download_access = list(ACCESS_MEDICAL)
 	available_on_ntnet = TRUE
 	program_icon = "heartbeat"
 
@@ -260,7 +260,7 @@
 	filedesc = "Custodial Locator"
 	extended_desc = "This program allows for tracking of custodial equipment."
 	requires_ntnet = TRUE
-	transfer_access = list(ACCESS_JANITOR)
+	download_access = list(ACCESS_JANITOR)
 	available_on_ntnet = TRUE
 	program_icon = "broom"
 	size = 2

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -18,7 +18,7 @@
 	filename = "medrecords"
 	program_icon = "book-medical"
 	extended_desc = "Allows the user to view several basic medical records from the crew."
-	transfer_access = list(ACCESS_MEDICAL, ACCESS_FLAG_COMMAND)
+	download_access = list(ACCESS_MEDICAL, ACCESS_FLAG_COMMAND)
 	available_on_ntnet = TRUE
 	mode = "medical"
 
@@ -26,7 +26,7 @@
 	filedesc = "Security Records"
 	filename = "secrecords"
 	extended_desc = "Allows the user to view several basic security records from the crew."
-	transfer_access = list(ACCESS_SECURITY, ACCESS_FLAG_COMMAND)
+	download_access = list(ACCESS_SECURITY, ACCESS_FLAG_COMMAND)
 	available_on_ntnet = TRUE
 	mode = "security"
 

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -8,7 +8,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
 	requires_ntnet = TRUE
-	transfer_access = list(ACCESS_SECURITY)
+	download_access = list(ACCESS_SECURITY)
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
 	size = 5
 	tgui_id = "NtosSecurEye"
@@ -39,7 +39,7 @@
 	filename = "syndeye"
 	filedesc = "SyndEye"
 	extended_desc = "This program allows for illegal access to security camera networks."
-	transfer_access = list()
+	download_access = list()
 	available_on_ntnet = FALSE
 	available_on_syndinet = TRUE
 	requires_ntnet = FALSE

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -6,7 +6,7 @@
 	program_icon_state = "smmon_0"
 	extended_desc = "Crystal Integrity Monitoring System, connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
 	requires_ntnet = TRUE
-	transfer_access = list(ACCESS_CONSTRUCTION)
+	download_access = list(ACCESS_CONSTRUCTION)
 	size = 5
 	tgui_id = "NtosSupermatter"
 	program_icon = "radiation"

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -8,8 +8,8 @@
 	size = 10
 	tgui_id = "NtosTechweb"
 	program_icon = "atom"
-	required_access = list(ACCESS_COMMAND, ACCESS_RESEARCH)
-	transfer_access = list(ACCESS_RESEARCH)
+	run_access = list(ACCESS_COMMAND, ACCESS_RESEARCH)
+	download_access = list(ACCESS_RESEARCH)
 	/// Reference to global science techweb
 	var/datum/techweb/stored_research
 	/// Access needed to lock/unlock the console

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -6,7 +6,7 @@
 	extended_desc = "This program monitors stationwide NTNet network, provides access to logging systems, and allows for configuration changes"
 	size = 12
 	requires_ntnet = TRUE
-	required_access = list(ACCESS_NETWORK) //NETWORK CONTROL IS A MORE SECURE PROGRAM.
+	run_access = list(ACCESS_NETWORK) //NETWORK CONTROL IS A MORE SECURE PROGRAM.
 	available_on_ntnet = TRUE
 	tgui_id = "NtosNetMonitor"
 	program_icon = "network-wired"
@@ -20,7 +20,7 @@
 			SSmodular_computers.intrusion_detection_enabled = !SSmodular_computers.intrusion_detection_enabled
 			return TRUE
 		if("toggle_relay")
-			var/obj/machinery/ntnet_relay/target_relay = locate(params["ref"]) in GLOB.ntnet_relays
+			var/obj/machinery/ntnet_relay/target_relay = locate(params["ref"]) in SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay)
 			if(!istype(target_relay))
 				return
 			target_relay.set_relay_enabled(!target_relay.relay_enabled)
@@ -39,7 +39,7 @@
 	var/list/data = list()
 
 	data["ntnetrelays"] = list()
-	for(var/obj/machinery/ntnet_relay/relays as anything in GLOB.ntnet_relays)
+	for(var/obj/machinery/ntnet_relay/relays as anything in SSmachines.get_machines_by_type(/obj/machinery/ntnet_relay))
 		var/list/relay_data = list()
 		relay_data["is_operational"] = !!relays.is_operational
 		relay_data["name"] = relays.name


### PR DESCRIPTION
## About The Pull Request

- replaces the ntnet_relays global list with ``get_machines_by_type``
- renames ``transfer_access`` var on PDA to ``download_access`` & ``required_access`` to ``run_access`` to better describe what they do, because on more than one ocassion I've confused myself with the two terms and ended up doing something unintentional (see: https://github.com/tgstation/tgstation/pull/74269)

## Why It's Good For The Game

Kills a useless global list and makes pda code a little less confusing.

## Changelog

Nothing player-facing.