### PR TITLE
Fixes a small runtime due to copied memories

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -649,10 +649,8 @@
 		return FALSE
 	var/list/user_memories = user.mind.memories
 	var/datum/memory/key/account/user_key = user_memories[/datum/memory/key/account]
-	var/user_account = 11111
-	if(!isnull(user_key))
-		user_account = user_key.remembered_id
-	var/new_bank_id = tgui_input_number(user, "Enter the account ID to associate with this card.", "Link Bank Account", user_account, 999999, 111111)
+	var/default_account = (istype(user_key) && user_key.remembered_id) || 11111
+	var/new_bank_id = tgui_input_number(user, "Enter the account ID to associate with this card.", "Link Bank Account", default_account, 999999, 111111)
 	if(!new_bank_id || QDELETED(user) || QDELETED(src) || issilicon(user) || !alt_click_can_use_id(user) || loc != user)
 		return FALSE
 	if(registered_account?.account_id == new_bank_id)


### PR DESCRIPTION
## About The Pull Request

Copied memories (`/datum/memory/copy`) are stored in the same slot as the type they copied it from (in this case, `/datum/memory/key/account`), meaning this would runtime if someone with a copied memory tried to change their bank account ID. 

## Changelog

:cl: Melbert
fix: People with copied memories can modify their bank account ID as normal. 
/:cl:
