### PR TITLE
Fixes Dead Lingering Ghost-Control Mobs

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -158,6 +158,12 @@
 	ADD_TRAIT(src, TRAIT_PACIFISM, INNATE_TRAIT)
 	AddComponent(/datum/component/crate_carrier)
 
+/mob/living/basic/gorilla/cargorilla/death(gibbed)
+	var/datum/component/potential_component = GetComponent(/datum/component/ghost_direct_control)
+	if(!QDELETED(potential_component))
+		qdel(potential_component)
+	return ..()
+
 /**
  * Poll ghosts for control of the gorilla. Not added in init because we only want to poll when the round starts.
  * Preferably in future we can replace this with a popup on the lobby to queue to become a gorilla.

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -71,6 +71,12 @@
 
 	grant_actions_by_list(innate_actions)
 
+/mob/living/basic/regal_rat/death(gibbed)
+	var/datum/component/potential_component = GetComponent(/datum/component/ghost_direct_control)
+	if(!QDELETED(potential_component))
+		qdel(potential_component)
+	return ..()
+
 /mob/living/basic/regal_rat/examine(mob/user)
 	. = ..()
 	if(user == src)


### PR DESCRIPTION

## About The Pull Request

Fixes #79008

This is the same method bots use (though a bit more extravagant)- the component is meant to delete itself when a user assumes control but it had no cases for deleting itself on the user's death. This component already has so many args that I don't particularly feel like adding another one for `qdel_ourselves_on_mob_death` or whatever so let's just repeat the pattern we already have going on for the time being.
## Why It's Good For The Game

Fixes bug.
## Changelog
:cl:
fix: Gorillas and Regal Rats will no longer show up in the ghost-control menu if they died without anyone ever taking control of them.
/:cl:
