### PR TITLE
Improves how ai movement checks for if movement is allowed

### DIFF
--- a/code/datums/ai/movement/_ai_movement.dm
+++ b/code/datums/ai/movement/_ai_movement.dm
@@ -24,11 +24,12 @@
 	if(controller.pathing_attempts >= max_pathing_attempts)
 		controller.CancelActions()
 
-///Should the movement be allowed to happen? As of writing this, MOVELOOP_SKIP_STEP is defined as (1<<0) so be careful on using (return TRUE) or (can_move = TRUE; return can_move)
+///Should the movement be allowed to happen? could_move is if default behavior would allow it to move.
 /datum/ai_movement/proc/allowed_to_move(datum/move_loop/source)
+	SHOULD_BE_PURE(TRUE)
+
 	var/atom/movable/pawn = source.moving
 	var/datum/ai_controller/controller = source.extra_info
-	source.delay = controller.movement_delay
 
 	var/can_move = TRUE
 	if(controller.ai_traits & STOP_MOVING_WHEN_PULLED && pawn.pulledby) //Need to store more state. Annoying.
@@ -37,23 +38,29 @@
 	if(!isturf(pawn.loc)) //No moving if not on a turf
 		can_move = FALSE
 
+	return can_move
+
+///Anything to do before moving; any checks if the pawn should be able to move should be placed in allowed_to_move() and called by this proc
+/datum/ai_movement/proc/pre_move(datum/move_loop/source)
+	SIGNAL_HANDLER
+	SHOULD_NOT_OVERRIDE(TRUE)
+
+	var/datum/ai_controller/controller = source.extra_info
+
 	// Check if this controller can actually run, so we don't chase people with corpses
 	if(!controller.able_to_run())
 		controller.CancelActions()
 		qdel(source) //stop moving
 		return MOVELOOP_SKIP_STEP
 
-	//Why doesn't this return TRUE or can_move?
-	//MOVELOOP_SKIP_STEP is defined as (1<<0) and TRUE are defined as the same "1", returning TRUE would be the equivalent of skipping the move
-	if(can_move)
+	source.delay = controller.movement_delay
+
+	// Why doesn't this return TRUE?
+	// MOVELOOP_SKIP_STEP is defined as (1<<0) and TRUE are defined as the same "1", returning TRUE would be the equivalent of skipping the move
+	if(allowed_to_move(source))
 		return
 	increment_pathing_failures(controller)
 	return MOVELOOP_SKIP_STEP
-
-///Anything to do before moving; any checks if the pawn should be able to move should be placed in allowed_to_move() and called by this proc
-/datum/ai_movement/proc/pre_move(datum/move_loop/source)
-	SIGNAL_HANDLER
-	return allowed_to_move(source)
 
 //Anything to do post movement
 /datum/ai_movement/proc/post_move(datum/move_loop/source, succeeded)

--- a/code/datums/ai/movement/_ai_movement.dm
+++ b/code/datums/ai/movement/_ai_movement.dm
@@ -24,7 +24,7 @@
 	if(controller.pathing_attempts >= max_pathing_attempts)
 		controller.CancelActions()
 
-///Should the movement be allowed to happen? could_move is if default behavior would allow it to move.
+///Should the movement be allowed to happen?
 /datum/ai_movement/proc/allowed_to_move(datum/move_loop/source)
 	SHOULD_BE_PURE(TRUE)
 

--- a/code/datums/ai/movement/ai_movement_basic_avoidance.dm
+++ b/code/datums/ai/movement/ai_movement_basic_avoidance.dm
@@ -16,10 +16,8 @@
 /datum/ai_movement/basic_avoidance/allowed_to_move(datum/move_loop/has_target/dist_bound/source)
 	. = ..()
 	var/turf/target_turf = get_step_towards(source.moving, source.target)
-
 	if(!target_turf?.can_cross_safely(source.moving))
-		. = MOVELOOP_SKIP_STEP
-	return .
+		return FALSE
 
 /// Move immediately and don't update our facing
 /datum/ai_movement/basic_avoidance/backstep

--- a/code/datums/ai/movement/ai_movement_complete_stop.dm
+++ b/code/datums/ai/movement/ai_movement_complete_stop.dm
@@ -12,4 +12,4 @@
 	RegisterSignal(loop, COMSIG_MOVELOOP_PREPROCESS_CHECK, PROC_REF(pre_move))
 
 /datum/ai_movement/complete_stop/allowed_to_move(datum/move_loop/source)
-	return // no movement allowed
+	return FALSE

--- a/code/datums/ai/movement/ai_movement_dumb.dm
+++ b/code/datums/ai/movement/ai_movement_dumb.dm
@@ -14,7 +14,5 @@
 /datum/ai_movement/dumb/allowed_to_move(datum/move_loop/has_target/source)
 	. = ..()
 	var/turf/target_turf = get_step_towards(source.moving, source.target)
-
 	if(!target_turf?.can_cross_safely(source.moving))
-		. = MOVELOOP_SKIP_STEP
-	return .
+		return FALSE


### PR DESCRIPTION
## About The Pull Request

While looking into the moveloop processing issues I found a place where moveloops were being interacted with while qdeleted. This restructures the code a bit to prevent that being possible and also improves the design overall here so implementers of `allowed_to_move` don't need to be careful about their return value, which is just begging for a bug down the line. `increment_pathing_failure` also wasn't getting called when subtypes stopped movement.

The rest of this description is a bit of an informative lecture.

There's a pattern you do on occasion when designing public facing functions where you have a public, but non overridden, function with some default behavior that must always run, calling on an internal function that *is* overridden but never called from any other location. This is a good pattern for making sure some core behavior always runs or for making sanity checks that can't be dodged, as the internal function never even gets called when it has been determined that something needs to cancel the whole thing.

Previously this code had something that looked kinda like this, there was a proc called `pre_move` that was not supposed to be overridden, and a proc it called called `allowed_to_move`. However, contrary to the usual reason for doing this, `pre_move` had no behavior itself and was meaningless. `allowed_to_move` on the other hand had exactly the sort of sanity check that we'd want using this pattern in the form of `if(!controller.able_to_run())`. This was allowing subtypes access to a qdeleted move loop when it had just been deleted in the parent's version of the proc.

This is your yearly reminder to watch out for cargo culting.
