### PR TITLE
Slight overclock nerf [NO GBP]

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -521,7 +521,8 @@
 	if(!overclock_mode && overclock_temp > 0)
 		overclock_temp -= seconds_per_tick
 		return
-	overclock_temp = min(overclock_temp + seconds_per_tick, overclock_temp_danger * 2)
+	var/temp_gain = seconds_per_tick * (1 + 1 / movedelay)
+	overclock_temp = min(overclock_temp + temp_gain, overclock_temp_danger * 2)
 	if(overclock_temp < overclock_temp_danger)
 		return
 	if(overclock_temp >= overclock_temp_danger && overclock_safety)

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -7,6 +7,7 @@
 	max_temperature = 65000
 	max_integrity = 200
 	movedelay = 1.25
+	overclock_coeff = 1.25
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	lights_power = 7
 	step_energy_drain = 12 //slightly higher energy drain since you movin those wheels FAST

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -5,6 +5,7 @@
 	base_icon_state = "ripley"
 	silicon_icon_state = "ripley-empty"
 	movedelay = 1.5 //Move speed, lower is faster.
+	overclock_coeff = 1.25
 	max_temperature = 20000
 	max_integrity = 200
 	lights_power = 7


### PR DESCRIPTION
## About The Pull Request

Thanks to @moocowswag 's gimmick I learned that overclock can be set to cycle without overheating when you use an assembly with timer. So essentially it's a free movespeed buff with no downsides.

Now the mech gains additional heat depending on it's movedelay, the faster - the shorter the overclock duration. And the gain is no longer equal the cooling speed, so you can't set it to cycle and forget.

## Why It's Good For The Game

It was an oversight, Ripley and Clarke too strong, while being low tier mechs.

## Changelog

:cl:
balance: Mech overclock coefficient is down to 1.25 from the default 1.5 for Ripley and Clarke. 
balance: Mech overclock heating now scales with movespeed, higher speed - faster overheat.
/:cl:

