### PR TITLE
Replaces the jetpack in Interdyne pirates' suit storage with an air tank

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -143,7 +143,7 @@
 
 /obj/machinery/suit_storage_unit/interdyne
 	mask_type = /obj/item/clothing/mask/gas/syndicate
-	storage_type = /obj/item/tank/jetpack/oxygen/harness
+	storage_type = /obj/item/tank/internals/oxygen
 	mod_type = /obj/item/mod/control/pre_equipped/interdyne
 
 /obj/machinery/suit_storage_unit/void_old


### PR DESCRIPTION
## About The Pull Request

Turns out, they had a jetpack which they couldn't use due to already wearing a modsuit - but no air. This fixes that.

## Why It's Good For The Game

You know, through gene-modding, Interdyne might be less human than average NT citizen, but I'd wager they'd appreciate breathing none the less.

## Changelog

:cl:
fix: Replaces the jetpack in Interdyne pirates' suit storage with air tanks. They need to breath, and already got the suit for speed.
/:cl:

