### PR TITLE
Add grind reagents for lavaland fauna

### DIFF
--- a/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
+++ b/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
@@ -19,6 +19,7 @@
 	icon_state_inert = "brim_sac_decayed"
 	desc_preserved = "A strange organ from a brimdemon. It is preserved, allowing you to coat yourself in its explosive contents at your leisure."
 	desc_inert = "A decayed brimdemon organ. There's nothing usable left inside it."
+	grind_results = list(/datum/reagent/gunpowder = 5)
 	user_status = /datum/status_effect/stacking/brimdust_coating
 	actions_types = list(/datum/action/cooldown/monster_core_action/exhale_brimdust)
 	/// You will gain a stack of the buff every x seconds

--- a/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
+++ b/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
@@ -19,7 +19,6 @@
 	icon_state_inert = "brim_sac_decayed"
 	desc_preserved = "A strange organ from a brimdemon. It is preserved, allowing you to coat yourself in its explosive contents at your leisure."
 	desc_inert = "A decayed brimdemon organ. There's nothing usable left inside it."
-	grind_results = list(/datum/reagent/gunpowder = 5)
 	user_status = /datum/status_effect/stacking/brimdust_coating
 	actions_types = list(/datum/action/cooldown/monster_core_action/exhale_brimdust)
 	/// You will gain a stack of the buff every x seconds

--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -7,6 +7,7 @@
 	desc = "All that remains of a hivelord. It can be used to help keep your body going, but it will rapidly decay into uselessness."
 	desc_preserved = "All that remains of a hivelord. It is preserved, allowing you to use it to heal completely without danger of decay."
 	desc_inert = "All that remains of a hivelord. It has decayed, and is completely useless."
+	grind_results = list(/datum/reagent/medicine/omnizine = 5)
 	user_status = /datum/status_effect/regenerative_core
 	actions_types = list(/datum/action/cooldown/monster_core_action/regenerative_core)
 	icon_state = "hivelord_core"

--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -13,6 +13,7 @@
 	desc = "A lobstrosity's engorged adrenal gland. You can squeeze it to get a rush of energy on demand."
 	desc_preserved = "A lobstrosity's engorged adrenal gland. It is preserved, allowing you to use it for a burst of speed whenever you need it."
 	desc_inert = "A lobstrosity's adrenal gland. It is all shrivelled up."
+	grind_results = list(/datum/reagent/medicine/muscle_stimulant = 5)
 	user_status = /datum/status_effect/lobster_rush
 	actions_types = list(/datum/action/cooldown/monster_core_action/adrenal_boost)
 

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_loot.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_loot.dm
@@ -9,6 +9,7 @@
 	icon_state = "sheet-bileworm"
 	inhand_icon_state = null
 	merge_type = /obj/item/stack/sheet/animalhide/bileworm
+	grind_results = list(/datum/reagent/toxin/acid/nitracid = 5)
 
 //trophy
 


### PR DESCRIPTION

## About The Pull Request
This gives some chemical reagents when grinding lavaland fauna drops:
- Bileworm hide - 5u Nitric acid
- Brimdust sac - 5u Gunpowder
- Regenerative core - 5u Omnizine
- Rush gland - 5u Muscle stimulants

## Why It's Good For The Game
More ways to interact with chemistry.

## Changelog
:cl:
add: Add grind reagents for lavaland fauna drops. Bileworm hide gives nitric acid, brimdust sac gives gunpowder, regenerative core gives omnizine, and rush glands give muscle stimulants.
/:cl:
