### PR TITLE
Fixes Mock Clients Leaking Into Production

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -66,7 +66,7 @@ SUBSYSTEM_DEF(vote)
 	// Remove AFK or clientless non-voters.
 	for(var/non_voter_ckey in non_voters)
 		var/client/non_voter_client = non_voters[non_voter_ckey]
-		if(!non_voter_client || non_voter_client.is_afk())
+		if(!istype(non_voter_client) || non_voter_client.is_afk())
 			non_voters -= non_voter_ckey
 
 	// Now get the result of the vote.

--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -35,7 +35,9 @@
 	src.key = "[key]_[mock_client_uid]"
 	ckey = ckey(key)
 
+#ifdef UNIT_TESTS // otherwise this shit can leak into production servers which is drather bad
 	GLOB.directory[ckey] = src
+#endif
 
 /datum/client_interface/Destroy(force, ...)
 	GLOB.directory -= ckey


### PR DESCRIPTION
## About The Pull Request

Fixes #79601

Basically, every time we made a new client interface, we would add it to `GLOB.directory` (new behavior introduced in (#79348 (https://github.com/tgstation/tgstation/commit/88bb3afcce622d9fa3f00dcbbd10b8408dd3d13f)). This would mean that we would pass in junk mock clients into the vote processing feature instead of actual legitimate clients, as well as a slew of unintended consequences elsewhere wherever we access `GLOB.directory`.

We would create mock clients in stuff like `randomize_human_appearance()`, which is legitimately used and called in a slew of places where we want random humans, which allows junk to enter in directory per the aforementioned point.

Anyways, let's just... not let's add it to the directory if we aren't running unit tests. I also made the vote processing code a bit more strict juuuuuuuust in case
## Why It's Good For The Game

Less junk polluting what should be very standardized and well-fixed global lists.
## Changelog
Don't matter to players.
