### PR TITLE
More appropriate remembrance day message

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -627,6 +627,9 @@
 	begin_day = 11
 	holiday_hat = /obj/item/food/grown/poppy
 
+/datum/holiday/remembrance_day/greet()
+	return "Lest we forget."
+
 /datum/holiday/remembrance_day/getStationPrefix()
 	return pick("Peace", "Armistice", "Poppy")
 


### PR DESCRIPTION
## About The Pull Request
Changes the greeting message displayed during remembrance day to "Lest we forget." Closes #79649.
## Why It's Good For The Game
The current "Have a happy Remembrance day" does not fit. At all. This makes it a bit more tasteful.
## Changelog
:cl:
spellcheck: Made the remembrance day greeting message more tasteful.
/:cl:
