### PR TITLE
Fire temperature effects on a human is soft capped at 1200 kelvin, from when dimishing returns are applied

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -96,6 +96,9 @@
 /// The temperature the blue icon is displayed.
 #define BODYTEMP_COLD_WARNING_3 (BODYTEMP_COLD_DAMAGE_LIMIT - 150) //120k
 
+/// Beyond this temperature, being on fire will increase body temperature by less and less
+#define BODYTEMP_FIRE_TEMP_SOFTCAP 1200
+
 /// The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT, with the maximum of MAX_PRESSURE_DAMAGE
 #define PRESSURE_DAMAGE_COEFFICIENT 2
 #define MAX_HIGH_PRESSURE_DAMAGE 2

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -201,14 +201,19 @@
 	var/mob/living/carbon/human/victim = owner
 	var/thermal_protection = victim.get_thermal_protection()
 
-	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT && !no_protection)
-		return
+	if(!no_protection)
+		if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
+			return
+		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
+			victim.adjust_bodytemperature(5.5 * seconds_per_tick)
+			return
 
-	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
-		victim.adjust_bodytemperature(5.5 * seconds_per_tick)
-		return
+	var/amount_to_heat = (BODYTEMP_HEATING_MAX + (stacks * 12)) * 0.5 * seconds_per_tick
+	if(owner.bodytemperature > BODYTEMP_FIRE_TEMP_SOFTCAP)
+		// Apply dimishing returns upon temp beyond the soft cap
+		amount_to_heat = amount_to_heat ** (BODYTEMP_FIRE_TEMP_SOFTCAP / owner.bodytemperature)
 
-	victim.adjust_bodytemperature((BODYTEMP_HEATING_MAX + (stacks * 12)) * 0.5 * seconds_per_tick)
+	victim.adjust_bodytemperature(amount_to_heat)
 	victim.add_mood_event("on_fire", /datum/mood_event/on_fire)
 	victim.add_mob_memory(/datum/memory/was_burning)
 


### PR DESCRIPTION
## About The Pull Request

Past 1200 kelvin, fire temperature applied to humans receive diminishing returns

![image](https://github.com/tgstation/tgstation/assets/51863163/40ddbcde-f3fa-4ecc-8c5b-ca27e86b9aed)

At 30 minutes of fire, a human is expected to be at about 6,200 k 

## Why It's Good For The Game

It's not really realistic that a body can manage to get up to the hundreds of thousands of kelvin, the energy just isn't there. 

It doesn't even make sense that a body can get to 6000 kelvin that's like as hot as plasma IRL or something. Humans cremate at 1200 kelvin. Temperature in general should be reigned in to prevent that but that's a much larger project. 

This also helps curb two issues, one being the "very high temperature reagents" exploit and the other being "shaft miners coming into medical being very difficult to revive". 

## Changelog

:cl: Melbert
balance: Body temperature from being lit on fire will soft cap at 1,200 K. It will still increase beyond this, but with diminishing returns. For example, at 5,000 K, fire will heat 67x weaker. 
/:cl:

