### PR TITLE
Sleeping Carp grant scroll no longer says deflect with throw mode

### DIFF
--- a/code/game/objects/items/granters/martial_arts/sleeping_carp.dm
+++ b/code/game/objects/items/granters/martial_arts/sleeping_carp.dm
@@ -4,7 +4,7 @@
 	martial_name = "sleeping carp"
 	desc = "A scroll filled with strange markings. It seems to be drawings of some sort of martial art."
 	greet = "<span class='sciradio'>You have learned the ancient martial art of the Sleeping Carp! Your hand-to-hand combat has become much more effective, and you are now able to deflect any projectiles \
-		directed toward you while in Throw Mode. Your body has also hardened itself, granting extra protection against lasting wounds that would otherwise mount during extended combat. \
+		directed toward you while in Combat Mode. Your body has also hardened itself, granting extra protection against lasting wounds that would otherwise mount during extended combat. \
 		However, you are also unable to use any ranged weaponry. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
 	icon = 'icons/obj/scrolls.dmi'
 	icon_state = "sleepingcarp"


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/79517 changed sleeping carp to use combat mode to deflect instead of throw mode, but didn't change the grant scroll text to reflect. I doubt anyone reads that anyways.
## Why It's Good For The Game
telling players contradicting info on their traitor item probably isn't a good thing.
## Changelog
:cl:
fix: The Sleeping Carp scroll no longer says deflect using throw mode.
/:cl:
