### PR TITLE
Fixes an oversight in the examine message for a carbon with an empty golem stomach.

### DIFF
--- a/code/modules/surgery/organs/internal/stomach/stomach_golem.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_golem.dm
@@ -74,7 +74,7 @@
 	return TRUE
 
 /datum/status_effect/golem_statued/get_examine_text()
-	return span_warning("[owner.p_They()] [owner.p_are] as still as a statue!")
+	return span_warning("[owner.p_They()] [owner.p_are()] as still as a statue!")
 
 /datum/status_effect/golem_statued/on_remove()
 	owner.visible_message(span_notice("[owner] slowly stirs back into motion!"), span_notice("You have gathered enough strength to move your body once more."))

--- a/code/modules/surgery/organs/internal/stomach/stomach_golem.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_golem.dm
@@ -74,7 +74,7 @@
 	return TRUE
 
 /datum/status_effect/golem_statued/get_examine_text()
-	return span_warning("[owner.p_They()] are as still as a statue!")
+	return span_warning("[owner.p_They()] [owner.p_are] as still as a statue!")
 
 /datum/status_effect/golem_statued/on_remove()
 	owner.visible_message(span_notice("[owner] slowly stirs back into motion!"), span_notice("You have gathered enough strength to move your body once more."))


### PR DESCRIPTION
## About The Pull Request

Noticed on a round recently where the warden got the golem stomach that the message read as "He are as still as a statue!"
Turns out that the "are" wasn't setup in our pronoun system properly. I think this wasn't noticed before because golems don't have a gender, maybe?
## Why It's Good For The Game

Grammatical errors? bad!
## Changelog
:cl:DATA_
spellcheck: The examine message for a carbon with an empty golem stomach now properly matches said carbon's gender.
/:cl:
