### PR TITLE
pixel perfect 4x

### DIFF
--- a/code/modules/client/preferences/pixel_size.dm
+++ b/code/modules/client/preferences/pixel_size.dm
@@ -4,7 +4,7 @@
 	savefile_identifier = PREFERENCE_PLAYER
 
 	minimum = 0
-	maximum = 3
+	maximum = 5
 
 	step = 0.5
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
@@ -9,5 +9,6 @@ export const pixel_size: Feature<number> = {
     1.5: 'Pixel Perfect 1.5x',
     2: 'Pixel Perfect 2x',
     3: 'Pixel Perfect 3x',
+    4: 'Pixel Perfect 4x',
   }),
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
@@ -11,5 +11,6 @@ export const pixel_size: Feature<number> = {
     3: 'Pixel Perfect 3x',
     4: 'Pixel Perfect 4x',
     4.5: 'Pixel Perfect 4.5x',
+    5: 'Pixel Perfect 5x',
   }),
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
@@ -10,5 +10,6 @@ export const pixel_size: Feature<number> = {
     2: 'Pixel Perfect 2x',
     3: 'Pixel Perfect 3x',
     4: 'Pixel Perfect 4x',
+    4.5: 'Pixel Perfect 4.5x',
   }),
 };


### PR DESCRIPTION
## About The Pull Request
Adds pixel perfect 4x and 4.5x scaling. I tested it and it seems to work though 4.5 scaling  causes very slightly distorted pixel sizes. There's also a bit of letterboxing but I think that happens with all of the pixel perfect settings.

## Why It's Good For The Game
better fits 4k monitors and isn't stretch to fit 

## Changelog
:cl:
qol: adds pixel perfect 4x, 4.5x, and 5x
/:cl:
