### PR TITLE
Removes machine deconstruct overrides that overrides their deletion

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -7,6 +7,7 @@
 	base_icon_state = "pdapainter"
 	density = TRUE
 	max_integrity = 200
+	integrity_failure = 0.5
 	/// Current ID card inserted into the machine.
 	var/obj/item/card/id/stored_id_card = null
 	/// Current PDA inserted into the machine.
@@ -159,9 +160,6 @@
 	else
 		eject_id_card(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-/obj/machinery/pdapainter/deconstruct(disassembled = TRUE)
-	atom_break()
 
 /**
  * Insert a PDA into the machine.

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -183,11 +183,6 @@
 		if(deployed_shields.len && SPT_PROB(2.5, seconds_per_tick))
 			qdel(pick(deployed_shields))
 
-
-/obj/machinery/shieldgen/deconstruct(disassembled = TRUE)
-	atom_break()
-	locked = pick(0,1)
-
 /obj/machinery/shieldgen/interact(mob/user)
 	. = ..()
 	if(.)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -3,6 +3,7 @@
 	desc = "An energy shield used to contain hull breaches."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield-old"
+	integrity_failure = 0.5
 	density = TRUE
 	move_resist = INFINITY
 	opacity = FALSE


### PR DESCRIPTION
## About The Pull Request

Both the PDA painter and the emergency shield generator override the behaviour of deleting themselves when they are supposed to be destroyed, instead redirecting to `atom_break` for some reason. This seems to be very old behaviour and it does not fit with what `take_damage` expects (it does not allow for damage to be taken past 0 integrity, aka it should not *exist* past 0 integrity)
## Why It's Good For The Game

Fixes #68263 
Annoying runtimes and annoying behaviour, especially during a delamination.
## Changelog
:cl:
fix: The PDA painter and the emergency shield generator can now be destroyed.
/:cl:
