### PR TITLE
Removes duplicate atom break calls on atoms taking damage

### DIFF
--- a/code/game/atom_defense.dm
+++ b/code/game/atom_defense.dm
@@ -19,14 +19,18 @@
 
 	. = damage_amount
 
+	var/previous_atom_integrity = atom_integrity
+
 	update_integrity(atom_integrity - damage_amount)
 
+	var/integrity_failure_amount = integrity_failure * max_integrity
+
 	//BREAKING FIRST
-	if(integrity_failure && atom_integrity <= integrity_failure * max_integrity)
+	if(integrity_failure && previous_atom_integrity > integrity_failure_amount && atom_integrity <= integrity_failure_amount)
 		atom_break(damage_flag)
 
 	//DESTROYING SECOND
-	if(atom_integrity <= 0)
+	if(atom_integrity <= 0 && previous_atom_integrity > 0)
 		atom_destruction(damage_flag)
 
 /// Proc for recovering atom_integrity. Returns the amount repaired by


### PR DESCRIPTION

## About The Pull Request

`take_damage` makes no checks to see if the atom has already passed the integrity failure threshold, and as such calls `atom_break` more than once. This PR fixes that. Should mean that we do not have to check `!(machine_stat & BROKEN)` in `atom_break` and early return anymore.
## Why It's Good For The Game

this does not make sense and is unexpected behaviour
## Changelog
:cl:
code: Atoms no longer break again after they are hit when broken, making them hopefully more stable in the future.
/:cl:
