### PR TITLE
Flips the supermatter filters on Birdshot to have them work like other maps.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2020,7 +2020,7 @@
 /area/station/science/ordnance/bomb)
 "aPG" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -2061,7 +2061,7 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs)
 "aQn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/pink/visible,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/engineering/supermatter)
 "aQr" = (
@@ -2080,7 +2080,7 @@
 /area/station/engineering/engine_smes)
 "aQB" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 9
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -46412,7 +46412,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/theater)
 "qrP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 6
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -487,6 +487,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "ajG" = (
@@ -2305,6 +2308,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "aTG" = (
@@ -2323,10 +2329,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "aTW" = (
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "aUA" = (
@@ -2341,6 +2353,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "aVj" = (
@@ -2349,9 +2364,11 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "aVq" = (
@@ -2668,9 +2685,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 8
-	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "bcv" = (
@@ -2682,10 +2696,10 @@
 /area/station/medical/medbay/lobby)
 "bcK" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "bcR" = (
@@ -3275,8 +3289,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
@@ -4473,8 +4487,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "bJZ" = (
@@ -8479,7 +8495,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
@@ -9169,10 +9185,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
 "dyH" = (
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4
-	},
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8;
+	filter_type = list(/datum/gas/nitrogen)
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "dyO" = (
@@ -9866,6 +9883,13 @@
 	},
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/iron/smooth,
+/area/station/engineering/supermatter/room)
+"dLE" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "dLQ" = (
 /obj/structure/cable,
@@ -18766,6 +18790,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/corner,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "gPN" = (
@@ -29113,7 +29140,9 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "kvh" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "kvl" = (
@@ -30580,6 +30609,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "kYQ" = (
@@ -33143,9 +33175,6 @@
 /area/station/maintenance/hallway/abandoned_command)
 "lOh" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 8
-	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "lOi" = (
@@ -42876,10 +42905,10 @@
 /turf/open/floor/iron/textured_large,
 /area/station/security/checkpoint/escape)
 "poI" = (
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "poM" = (
@@ -43864,10 +43893,12 @@
 /area/station/medical/paramedic)
 "pEu" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/meter,
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "pEy" = (
@@ -82397,8 +82428,8 @@ geQ
 aRR
 pbt
 aPG
-aTW
 bAq
+dLE
 aTW
 bhc
 bng


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/13697285/8ccf96ed-7aec-4985-b2dd-6810c8d3725d)

This PR flips the ~~bird~~ filters on the Birdshot Supermatter engine. Now they work like other maps, where the filtered gas is the one that says in the engine, rather than getting filtered out.

## Why It's Good For The Game

Currently like half the rounds on Birdshot (I actually wonder if I'm even hyperbolic or if its not actually lowballing it) happen to have a supermatter delamination early into the round because the design has a critical part that's so different to other maps.

I didn't make it an inverse filter by default since it makes the maps a bit more consistent, but more importantly, makes bad-faith players intentionally sabotaging the supermatter way, way more obvious.

## Changelog
:cl:
qol: The supermatter filters have been flipped on BirdshotStation to work like the supermatters on every round, meaning the filtered gas goes in, and the non-filtered gas comes out.
/:cl: