### PR TITLE
Add error logging for when `send_fax_to_area` is given a non-existent area

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -537,8 +537,10 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 		target_fax.receive(fax_item, sender)
 
 	else if(force) //no fax machines but we really gotte send? SEND A FAX MACHINE
-		var/obj/machinery/fax/new_fax_machine = new ()
-		send_supply_pod_to_area(new_fax_machine, area_type, force_pod_type)
+		var/obj/machinery/fax/new_fax_machine = new()
+		if(!send_supply_pod_to_area(new_fax_machine, area_type, force_pod_type))
+			log_mapping("Attempted to forcibly send a fax to [area_type], however the area does not exist or has no valid dropoff spot for a fax machine")
+			return FALSE
 		addtimer(CALLBACK(new_fax_machine, TYPE_PROC_REF(/obj/machinery/fax, receive), fax_item, sender), 10 SECONDS)
 
 	else

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -539,7 +539,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	else if(force) //no fax machines but we really gotte send? SEND A FAX MACHINE
 		var/obj/machinery/fax/new_fax_machine = new()
 		if(!send_supply_pod_to_area(new_fax_machine, area_type, force_pod_type))
-			log_mapping("Attempted to forcibly send a fax to [area_type], however the area does not exist or has no valid dropoff spot for a fax machine")
+			stack_trace("Attempted to forcibly send a fax to [area_type], however the area does not exist or has no valid dropoff spot for a fax machine")
 			return FALSE
 		addtimer(CALLBACK(new_fax_machine, TYPE_PROC_REF(/obj/machinery/fax, receive), fax_item, sender), 10 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request

`send_fax_to_area` had no handling for when the currently loaded map does not have the area passed to it, leading to a runtime when the fax item is force moved to nullspace where the fax currently exists. This PR just adds some extra map logging to make mappers aware of the map error and then it early returns, hopefully leaving the fax machine to GC. 

This is intentionally not a ST because mapping logs are much quieter than an ST and there are some realistic cases where the currently loaded map does not have a given area.
## Why It's Good For The Game

Fixes #79668
fastest fingers in the west
## Changelog
:cl:
fix: Fixes a runtime when the radioactive nebula trait runs with a map that has no virology area.
/:cl:
