### PR TITLE
[no gbp] Fixes goat runtime

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -352,6 +352,8 @@ multiple modular subtrees with behaviors
 /// Returns true if we have a blackboard key with the provided key and it is not qdeleting
 /datum/ai_controller/proc/blackboard_key_exists(key)
 	var/datum/key_value = blackboard[key]
+	if (islist(key_value))
+		return length(key_value) > 0
 	return !QDELETED(key_value)
 
 /**

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -352,9 +352,11 @@ multiple modular subtrees with behaviors
 /// Returns true if we have a blackboard key with the provided key and it is not qdeleting
 /datum/ai_controller/proc/blackboard_key_exists(key)
 	var/datum/key_value = blackboard[key]
+	if (isdatum(key_value))
+		return !QDELETED(key_value)
 	if (islist(key_value))
 		return length(key_value) > 0
-	return !QDELETED(key_value)
+	return !!key_value
 
 /**
  * Used to manage references to datum by AI controllers


### PR DESCRIPTION
## About The Pull Request

Fixes #79063
Instead of checking if a list is QDELETED (this doesn't work) we check if it has a length.

## Changelog

:cl:
fix: Goats will now calm down after getting grumpy without causing a runtime error.
/:cl:
