### PR TITLE
The AI upload console board can no longer be printed, and the RD locker starts with one inside

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -70,6 +70,7 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 30
 	},
+/obj/item/circuitboard/computer/aiupload,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "as" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,6 +18,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
+	new /obj/item/circuitboard/computer/aiupload(src)
 
 /obj/structure/closet/secure_closet/research_director/populate_contents_immediate()
 	. = ..()

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -56,17 +56,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/aiupload
-	name = "AI Upload Board"
-	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
-	id = "aiupload"
-	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/circuitboard/computer/aiupload
-	category = list(
-		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
-
 /datum/design/board/borgupload
 	name = "Cyborg Upload Board"
 	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1041,7 +1041,6 @@
 		"intellicard",
 		"mecha_tracking_ai_control",
 		"aifixer",
-		"aiupload",
 		"reset_module",
 		"asimov_module",
 		"default_module",


### PR DESCRIPTION
## About The Pull Request
Draft while I make sure I did this properly
What it says on the tin. The AI upload console can no longer be printed, and the RD's locker now has an AI upload console board in it at round start. It's worth nothing that there is also an upload console board in secure tech storage, so maybe the one in RD locker isn't needed. As for the borg upload console, I've left it alone as I don't think it's as powerful and isn't used as much, but I'm not opposed to making it unprintable as well.
## Why It's Good For The Game
Subverting the AI right now is trivially easy. All it takes is a tech that requires less than 5 minutes from the start of the shift to research, and now you can upload whatever laws to the AI you want, without needing to go through any kind of security. Despite the AI upload room being heavily fortified and reinforced, with turrets and all, you don't even need to go near it in order to subvert an AI. 
For something as powerful as having the AI on your side as an antag, it really should take more than some trivial research in order to do. By making it so that the board can't be printed, someone who wants to subvert the AI actually has to physically break into a restricted area and get the board/use the console. They actually have to do something beyond just printing out a board.
## Changelog
:cl:
balance: The AI upload console board can no longer be researched and printed.
balance: The Research Director's locker not starts with an AI upload console board inside.
/:cl:
