### PR TITLE
You can't hurt yourself with your own brimdemon beam

### DIFF
--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimbeam.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimbeam.dm
@@ -66,9 +66,10 @@
 				break
 		if(blocked)
 			break
-		var/atom/new_brimbeam = new /obj/effect/brimbeam(affected_turf)
+		var/obj/effect/brimbeam/new_brimbeam = new(affected_turf)
 		new_brimbeam.dir = owner.dir
 		beam_parts += new_brimbeam
+		new_brimbeam.assign_creator(owner)
 		for(var/mob/living/hit_mob in affected_turf.contents)
 			hit_mob.apply_damage(damage = 25, damagetype = BURN)
 			to_chat(hit_mob, span_userdanger("You're blasted by [owner]'s brimbeam!"))
@@ -101,6 +102,8 @@
 	light_color = LIGHT_COLOR_BLOOD_MAGIC
 	light_power = 3
 	light_range = 2
+	/// Who made us?
+	var/datum/weakref/creator
 
 /obj/effect/brimbeam/Initialize(mapload)
 	. = ..()
@@ -111,13 +114,20 @@
 	return ..()
 
 /obj/effect/brimbeam/process()
+	var/atom/ignore = creator?.resolve()
 	for(var/mob/living/hit_mob in get_turf(src))
+		if(hit_mob == ignore)
+			continue
 		damage(hit_mob)
 
 /// Hurt the passed mob
 /obj/effect/brimbeam/proc/damage(mob/living/hit_mob)
 	hit_mob.apply_damage(damage = 5, damagetype = BURN)
 	to_chat(hit_mob, span_danger("You're damaged by [src]!"))
+
+/// Ignore damage dealt to this mob
+/obj/effect/brimbeam/proc/assign_creator(mob/living/maker)
+	creator = WEAKREF(maker)
 
 /// Disappear
 /obj/effect/brimbeam/proc/disperse()


### PR DESCRIPTION
## About The Pull Request

Some people were complaining about being able to shoot themselves and while I believe this is a skill issue (don't walk into it then) it's also easily fixable so I fixed it.
This makes it less convenient for admins to change the ability into a beam which creates a line of bananas because now it calls a proc bananas don't have but I don't think anyone ever has done this, thought of doing it, or even knew it was possible.

## Why It's Good For The Game

It doesn't make a whole lot of sense that it worked this way to be honest.

## Changelog

:cl:
balance: Sapient brimdemons can't hurt themselves with their own beams
/:cl:
