### PR TITLE
Blank IDs no longer get stuck in modular computers

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -96,6 +96,7 @@
 	)
 
 	data["proposed_login"] = list(
+		IDInserted = computer_id_slot ? TRUE : FALSE,
 		IDName = computer_id_slot?.registered_name,
 		IDJob = computer_id_slot?.assignment,
 	)

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -83,7 +83,7 @@ export const NtosMain = (props, context) => {
               <Button
                 icon="eject"
                 content="Eject ID"
-                disabled={!proposed_login.IDName}
+                disabled={!proposed_login.IDInserted}
                 onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
               />
               {!!show_imprint && (


### PR DESCRIPTION

## About The Pull Request

See name. The Eject ID button now correctly lights up even with no name on the ID
## Why It's Good For The Game

Fixes a mild annoyance
## Changelog
:cl:
fix: You can now eject blank IDs from modular computers
/:cl:
