### PR TITLE
Fixes roundstart mouse cutting power to virology every round on tram

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -9214,7 +9214,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/medical/virology)
 "cdr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6468,7 +6468,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/medical/virology)
 "bfa" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -59593,7 +59593,7 @@
 	dir = 4;
 	name = "Plaguebearer"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/medical/virology)
 "ukj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{


### PR DESCRIPTION

## About The Pull Request
Adds catwalk floors to tram virology's APC closet so that the roundstart mouse Plaguebearer doesn't immediately chew the cable and cut power to the virology office.
![image](https://github.com/tgstation/tgstation/assets/58376695/7582ccbd-30ce-4527-b749-aee419c97d2f)
## Why It's Good For The Game
Fixes #79472
## Changelog
:cl:
fix: fixes the mouse in tram virology biting 1 cable and depowering all of virology
/:cl:
