### PR TITLE
Fixes a small issue with disposal outlets.

### DIFF
--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -42,7 +42,7 @@
 		if(M.client)
 			M.reset_perspective(src)
 		hasmob = TRUE
-		RegisterSignal(M, COMSIG_LIVING_RESIST, PROC_REF(struggle_prep), M)
+		RegisterSignal(M, COMSIG_LIVING_RESIST, PROC_REF(struggle_prep))
 
 	//Checks 1 contents level deep. This means that players can be sent through disposals mail...
 	//...but it should require a second person to open the package. (i.e. person inside a wrapped locker)
@@ -179,12 +179,13 @@
 
 /// Merge two holder objects, used when a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(obj/structure/disposalholder/other)
-	for(var/A in other)
+	for(var/atom/movable/movable in other)
 		var/atom/movable/AM = A
-		AM.forceMove(src) // move everything in other holder to this one
-		if(ismob(AM))
-			var/mob/M = AM
-			M.reset_perspective(src) // if a client mob, update eye to follow this holder
+		movable.forceMove(src) // move everything in other holder to this one
+		if(ismob(movable))
+			var/mob/mob = movable
+			mob.reset_perspective(src) // if a client mob, update eye to follow this holder
+			RegisterSignal(mob, COMSIG_LIVING_RESIST, PROC_REF(struggle_prep))
 			hasmob = TRUE
 	if(destinationTag == 0 && other.destinationTag != 0)
 		destinationTag = other.destinationTag

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -179,8 +179,7 @@
 
 /// Merge two holder objects, used when a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(obj/structure/disposalholder/other)
-	for(var/atom/movable/movable in other)
-		var/atom/movable/AM = A
+	for(var/atom/movable/movable as anything in other)
 		movable.forceMove(src) // move everything in other holder to this one
 		if(ismob(movable))
 			var/mob/mob = movable

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -73,7 +73,7 @@
 	if(playsound)
 		playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
 
-	if(!H)
+	if(QDELETED(H))
 		return
 
 	pipe_eject(H, dir, TRUE, target, eject_range, eject_speed)

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -47,6 +47,11 @@
 
 /obj/structure/disposaloutlet/Destroy()
 	if(trunk)
+		// preemptively expel the contents from the trunk
+		// in case the outlet is deleted before expel_holder could be called.
+		var/obj/structure/disposalholder/holder = locate() in trunk
+		if(holder)
+			trunk.expel(holder)
 		trunk.linked = null
 		trunk = null
 	QDEL_NULL(stored)


### PR DESCRIPTION
## About The Pull Request
Disposal outlets eject the contents of the holder with a 2 seconds delay. Delete the outlet before the delay is over and the contents will stay stuck inside the holder.

Also merging disposal holders doesn't properly register a signal for mobs transfered to the new holder.

## Why It's Good For The Game
Bugfixing. Disposal code is a mess. Perhaps related to #79629 but I couldn't exactly reproduce it.

## Changelog

:cl:
fix: Fixed a small issue with disposal outlets leaving contents about to be ejected stuck inside the pipe beneath it if deleted.
/:cl:
