### PR TITLE
Emagged PDAs won't log to wirecarp.

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -324,11 +324,14 @@
 		return FALSE
 
 	. = ..()
+	if(!forced)
+		add_log("manual overriding of permissions and modification of device firmware detected. Reboot and reinstall required.")
 	obj_flags |= EMAGGED
 	device_theme = PDA_THEME_SYNDICATE
-	balloon_alert(user, "syndieOS loaded")
-	if (emag_card)
-		to_chat(user, span_notice("You swipe \the [src] with [emag_card]. A console window momentarily fills the screen, with white text rapidly scrolling past."))
+	if(user)
+		balloon_alert(user, "syndieOS loaded")
+		if (emag_card)
+			to_chat(user, span_notice("You swipe \the [src] with [emag_card]. A console window momentarily fills the screen, with white text rapidly scrolling past."))
 	return TRUE
 
 /obj/item/modular_computer/examine(mob/user)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -83,9 +83,9 @@
 
 ///Attempts to generate an Ntnet log, returns the log on success, FALSE otherwise.
 /datum/computer_file/program/proc/generate_network_log(text)
-	if(computer)
-		return computer.add_log(text)
-	return FALSE
+	if(!computer || computer.obj_flags & EMAGGED)
+		return FALSE
+	return computer.add_log(text)
 
 /**
  *Runs when the device is used to attack an atom in non-combat mode using right click (secondary).


### PR DESCRIPTION
## About The Pull Request

Currently, every time you open/close a program, that activity is logged for the RD to see. This includes Nukies opening their disk tracking app.
Now, emagged PDAs will no longer log activities to Wirecarp, but I did replace it with a log when the PDA is first emagged.
Basically, nukies are undetected, but Traitors can still be figured out.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/77201

 I thought this would be better as it makes more sense to stop logging when you're emagged, but as you are being emagged it will report the modification instead.

## Changelog

:cl:
fix: PDAs now log that they've been emagged, but will no longer log any further programs they open beyond that. This means Nukies don't sell themselves out by opening their disk tracking app.
/:cl: