### PR TITLE
Orbit Poll respects Preferences + Asks for Permission to Unghost

### DIFF
--- a/code/datums/components/orbit_poll.dm
+++ b/code/datums/components/orbit_poll.dm
@@ -101,15 +101,27 @@
 
 		candidates += ghost
 
-	if(!length(candidates))
+	pick_and_offer(candidates)
+
+/// Takes a list, picks a candidate, and offers the role to them.
+/datum/component/orbit_poll/proc/pick_and_offer(list/volunteers)
+	if(length(volunteers) <= 0)
 		phone_home()
 		return
 
 	var/mob/dead/observer/chosen = pick(candidates)
 
-	if(chosen)
-		deadchat_broadcast("[key_name(chosen, include_name = FALSE)] was selected for the role ([title]).", "Ghost Poll: ", parent)
+	if(isnull(chosen))
+		phone_home()
+		return
 
+	SEND_SOUND(chosen, 'sound/misc/notice2.ogg')
+	var/response = tgui_alert(chosen, "Do you want to assume the role of [title]?", "Orbit Polling", list("Yes", "No"), 10 SECONDS)
+	if(response != "Yes")
+		var/reusable_list = volunteers - chosen
+		return pick_and_offer(reusable_list)
+
+	deadchat_broadcast("[key_name(chosen, include_name = FALSE)] was selected for the role ([title]).", "Ghost Poll: ", parent)
 	phone_home(chosen)
 
 /// Make sure to call your parents my dude

--- a/code/datums/components/orbit_poll.dm
+++ b/code/datums/components/orbit_poll.dm
@@ -89,6 +89,15 @@
 			continue
 		if(is_banned_from(ghost.ckey, job_bans))
 			continue
+		var/ghost_prefs = ghost.client.prefs
+		if(isnull(ghost_prefs))
+			candidates += ghost // we'll assume they wanted to be picked despite prefs being null for whatever fucked up reason
+			continue
+
+		if(!ghost.client.prefs.read_preference(/datum/preference/toggle/ghost_roles))
+			continue
+		if(!isnull(candidate_mob.client.holder) && !candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin))
+			continue
 
 		candidates += ghost
 

--- a/code/datums/components/orbit_poll.dm
+++ b/code/datums/components/orbit_poll.dm
@@ -85,18 +85,22 @@
 		return
 
 	for(var/mob/dead/observer/ghost as anything in orbiter_comp.orbiter_list)
-		if(QDELETED(ghost) || isnull(ghost.client))
+		var/client/ghost_client = ghost.client
+
+		if(QDELETED(ghost) || isnull(ghost_client))
 			continue
+
 		if(is_banned_from(ghost.ckey, job_bans))
 			continue
-		var/ghost_prefs = ghost.client.prefs
+
+		var/datum/preferences/ghost_prefs = ghost_client.prefs
 		if(isnull(ghost_prefs))
 			candidates += ghost // we'll assume they wanted to be picked despite prefs being null for whatever fucked up reason
 			continue
 
-		if(!ghost.client.prefs.read_preference(/datum/preference/toggle/ghost_roles))
+		if(!ghost_prefs.read_preference(/datum/preference/toggle/ghost_roles))
 			continue
-		if(!isnull(ghost.client.holder) && !ghost.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin))
+		if(!isnull(ghost_client.holder) && !ghost_prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin))
 			continue
 
 		candidates += ghost

--- a/code/datums/components/orbit_poll.dm
+++ b/code/datums/components/orbit_poll.dm
@@ -96,7 +96,7 @@
 
 		if(!ghost.client.prefs.read_preference(/datum/preference/toggle/ghost_roles))
 			continue
-		if(!isnull(candidate_mob.client.holder) && !candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin))
+		if(!isnull(ghost.client.holder) && !ghost.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin))
 			continue
 
 		candidates += ghost
@@ -109,7 +109,7 @@
 		phone_home()
 		return
 
-	var/mob/dead/observer/chosen = pick(candidates)
+	var/mob/dead/observer/chosen = pick(volunteers)
 
 	if(isnull(chosen))
 		phone_home()


### PR DESCRIPTION

## About The Pull Request

Fixes #79676

Ticking either the player or admin "do not consider me for ghost roles" excludes you from the pool of candidates in an orbit ghost poll.

You will now get a `tgui_alert()` asking you if you want to accept being put into the orbit poll role's before you accept it, putting it in line with every other ghost role in the game. If the player doesn't accept, the proc is re-ran with someone else on the list.
## Why It's Good For The Game

We need both of these behaviors present to keep it standard with what players expect with ghost roles, and it is annoying to be an admin/AFK player who gets hotswapped into one of these roles while they're doing stuff. 
## Changelog
:cl:
qol: You will no longer be added to the list for ghost-orbit role polls if you have opted out of getting antag ghost roles in your preferences.
qol: You will get a tgui_alert to accept the ghost role if you were selected via the orbit poll, instead of it just throwing you intot he role.
/:cl:
