### PR TITLE
[NO GBP] Fixes handle_bodyparts running needlessly when stat == DEAD

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -27,11 +27,9 @@
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 	else
-
 		if(getStaminaLoss() > 0 && stam_regen_start_time <= world.time)
 			adjustStaminaLoss(-INFINITY)
-
-	handle_bodyparts(seconds_per_tick, times_fired)
+		handle_bodyparts(seconds_per_tick, times_fired)
 
 	if(. && mind) //. == not dead
 		for(var/key in mind.addiction_points)


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. I just noticed this now by chance: when I was doing my damage refactor and removing some deprecated code I accidentally moved the indentation up for `handle_bodyparts()`. This proc only has to be called on live mobs so this is adding unneeded overhead.

![firefox_p49wTxNf7c](https://github.com/tgstation/tgstation/assets/13398309/49863d25-989e-48dc-af8c-4d47b457583c)
![image](https://github.com/tgstation/tgstation/assets/13398309/4b416515-613d-4a10-9289-dfae54d34b49)

This PR just shifts the indentation of `handle_bodyparts()` back to being under the else block, where it belongs.

## Why It's Good For The Game

Less redundant proc calls.

## Changelog

Nothing player facing.