### PR TITLE
Fixes tram plate electrocution [NO GBP]

### DIFF
--- a/code/datums/components/energized.dm
+++ b/code/datums/components/energized.dm
@@ -1,5 +1,5 @@
 #define NORMAL_TOAST_PROB 3
-#define BROKEN_TOAST_PROB 70
+#define BROKEN_TOAST_PROB 33
 
 /datum/component/energized
 	can_transfer = FALSE

--- a/code/datums/components/energized.dm
+++ b/code/datums/components/energized.dm
@@ -1,3 +1,6 @@
+#define NORMAL_TOAST_PROB 3
+#define BROKEN_TOAST_PROB 70
+
 /datum/component/energized
 	can_transfer = FALSE
 	///what we give to connect_loc by default, makes slippable mobs moving over us slip
@@ -48,24 +51,14 @@
 /datum/component/energized/proc/toast(turf/open/floor/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
-	if(!source.broken && !source.burnt)
-		return
-
 	if(!isliving(arrived))
-		return
-
-	if(prob(85))
-		if(prob(25))
-			do_sparks(1, FALSE, source)
-			playsound(src, SFX_SPARKS, 40, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-			source.audible_message(span_danger("[parent] makes an electric crackle..."))
 		return
 
 	var/mob/living/future_tram_victim = arrived
 	var/datum/transport_controller/linear/tram/tram = transport_ref?.resolve()
 
 	// Check for stopped states.
-	if(isnull(tram) || !tram.controller_operational || !inbound || !outbound)
+	if(isnull(tram) || !tram.controller_operational || !tram.controller_active || !inbound || !outbound)
 		return FALSE
 
 	var/obj/structure/transport/linear/tram/tram_part = tram.return_closest_platform_to(parent)
@@ -74,6 +67,17 @@
 		return FALSE
 
 	if(isnull(source))
+		return FALSE
+
+	var/toast_prob = NORMAL_TOAST_PROB
+	if(source.broken || source.burnt || HAS_TRAIT(future_tram_victim, TRAIT_CURSED))
+		toast_prob = BROKEN_TOAST_PROB
+
+	if(prob(100 - toast_prob))
+		if(prob(25))
+			do_sparks(1, FALSE, source)
+			playsound(src, SFX_SPARKS, 40, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+			source.audible_message(span_danger("[parent] makes an electric crackle..."))
 		return FALSE
 
 	// Everything will be based on position and travel direction
@@ -102,7 +106,7 @@
 		return FALSE
 	if((tram.travel_direction & EAST) && outbound > tram.destination_platform.platform_code)
 		return FALSE
-	if(approach_distance >= AMBER_THRESHOLD_NORMAL)
+	if(approach_distance >= AMBER_THRESHOLD_DEGRADED)
 		return FALSE
 
 	// Finally the interesting part where they ACTUALLY get hit!
@@ -112,8 +116,12 @@
 		action = NOTIFY_ORBIT,
 		header = "Electrifying!",
 	)
+	do_sparks(4, FALSE, source)
 	playsound(src, SFX_SPARKS, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	source.audible_message(span_danger("[parent] makes a loud electric crackle!"))
 	to_chat(future_tram_victim, span_userdanger("You hear a loud electric crackle!"))
 	future_tram_victim.electrocute_act(15, src, 1)
 	return TRUE
+
+#undef NORMAL_TOAST_PROB
+#undef BROKEN_TOAST_PROB

--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -31,6 +31,8 @@
 	if(!isnull(damage_mod))
 		src.damage_mod = damage_mod
 
+	ADD_TRAIT(parent, TRAIT_CURSED, src)
+
 /**
  * This is a omen eat omen world! The stronger omen survives.
  */
@@ -50,6 +52,7 @@
 
 /datum/component/omen/Destroy(force)
 	var/mob/living/person = parent
+	REMOVE_TRAIT(person, TRAIT_CURSED, src)
 	to_chat(person, span_nicegreen("You feel a horrible omen lifted off your shoulders!"))
 
 	if(vessel)

--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -31,7 +31,7 @@
 	if(!isnull(damage_mod))
 		src.damage_mod = damage_mod
 
-	ADD_TRAIT(parent, TRAIT_CURSED, src)
+	ADD_TRAIT(parent, TRAIT_CURSED, SMITE_TRAIT)
 
 /**
  * This is a omen eat omen world! The stronger omen survives.
@@ -52,7 +52,7 @@
 
 /datum/component/omen/Destroy(force)
 	var/mob/living/person = parent
-	REMOVE_TRAIT(person, TRAIT_CURSED, src)
+	REMOVE_TRAIT(person, TRAIT_CURSED, SMITE_TRAIT)
 	to_chat(person, span_nicegreen("You feel a horrible omen lifted off your shoulders!"))
 
 	if(vessel)


### PR DESCRIPTION
## About The Pull Request

When tram electrocution was turned into a component instead of on the turf, the bad luck omen stopped having a chance of electrocuting the mob. Fixes the toast proc to check for the cursed trait, now also applied by the omen.

Splits the toast probability into one value for a normal plate, and one for a broken plate or people with omen. Narrows the window of a potential shock with adjusted probability, no chance of electrocution on green.

Adds a missing early return for when the tram isn't moving.

## Changelog

:cl: LT3
fix: Bad luck omen again raises your chance of getting shocked by the tram plate
fix: Tram plate checks and energizes when the tram is moving
code: Omen component now applies the cursed trait
/:cl: