### PR TITLE
Space ruin - All American Diner soda machine fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
+++ b/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
@@ -332,12 +332,11 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/allamericandiner)
 "qp" = (
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 8;
-	pixel_x = 17;
-	pixel_y = 0
+	pixel_x = -11
 	},
-/turf/open/floor/iron/kitchen/small,
+/turf/closed/wall,
 /area/ruin/space/has_grav/allamericandiner)
 "qB" = (
 /obj/structure/closet/crate/trashcart/filled,
@@ -1981,7 +1980,7 @@ EK
 ej
 jZ
 LR
-qp
+jZ
 Vq
 FB
 rd
@@ -2018,7 +2017,7 @@ EK
 EK
 Lu
 EK
-EK
+qp
 EK
 EK
 eM

--- a/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
+++ b/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
@@ -331,13 +331,6 @@
 /obj/structure/urinal/directional/north,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/allamericandiner)
-"qp" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 8;
-	pixel_x = -11
-	},
-/turf/closed/wall,
-/area/ruin/space/has_grav/allamericandiner)
 "qB" = (
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/misc/asteroid/airless,
@@ -470,6 +463,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/cups,
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/allamericandiner)
 "wC" = (
@@ -1158,8 +1152,11 @@
 /area/ruin/space/has_grav/allamericandiner)
 "Vq" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/cups,
 /obj/machinery/light/dim/directional/east,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 1
+	},
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/allamericandiner)
 "Vy" = (
@@ -1982,7 +1979,7 @@ jZ
 LR
 jZ
 Vq
-FB
+rd
 rd
 lI
 yQ
@@ -2017,7 +2014,7 @@ EK
 EK
 Lu
 EK
-qp
+EK
 EK
 EK
 eM


### PR DESCRIPTION

## About The Pull Request

Super small fix that i think was just an oversight but has bugged me everytime i've gone to that ruin, the ultra important and urgent fix for moving the soda machine!

![image](https://github.com/tgstation/tgstation/assets/22140677/52cbbe15-cfeb-45b1-b934-7451ebd9af11)


## Why It's Good For The Game

You can now actually walk around the kitchen without an invisible wall getting in the way

## Changelog
:cl:
fix: Space Ruin - All American Diner - Soda Machine now is scooted out of the way
/:cl:
