### PR TITLE
Codifies male goats not having an udder

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -110,8 +110,10 @@
 
 	INVOKE_ASYNC(src, PROC_REF(eat_plant), edible_plants)
 
-/// When invoked, adds an udder. Overridden on subtypes
+/// When invoked, adds an udder when applicable. Male goats do not have udders.
 /mob/living/basic/goat/proc/add_udder()
+	if(gender == MALE)
+		return
 	AddComponent(/datum/component/udder)
 
 /// Proc that handles dealing with the various types of plants we might eat. Assumes that a valid list of type(s) will be passed in.

--- a/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
@@ -8,5 +8,3 @@
 	if((bodytemperature < T20C) || istype(goat_area, /area/station/service/kitchen/coldroom))
 		. += span_notice("[p_They()] [p_do()]n't seem to be too bothered about the cold.") // special for pete
 
-/mob/living/basic/goat/pete/add_udder()
-	return //no thank you

--- a/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
@@ -2,9 +2,19 @@
 	name = "Pete"
 	gender = MALE
 
+/mob/living/basic/goat/pete/Initialize(mapload)
+	if(mapload && prob(40))
+		new /mob/living/basic/goat/pete/petricia // woaw time for some udder
+		return INITIALIZE_HINT_QDEL
+
+	return ..()
+
 /mob/living/basic/goat/pete/examine()
 	. = ..()
 	var/area/goat_area = get_area(src)
 	if((bodytemperature < T20C) || istype(goat_area, /area/station/service/kitchen/coldroom))
 		. += span_notice("[p_They()] [p_do()]n't seem to be too bothered about the cold.") // special for pete
 
+/mob/living/basic/goat/pete/petricia // A female Pete!
+	name = "Petricia"
+	gender = FEMALE

--- a/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
@@ -3,8 +3,8 @@
 	gender = MALE
 
 /mob/living/basic/goat/pete/Initialize(mapload)
-	if(mapload && prob(40))
-		new /mob/living/basic/goat/pete/petricia // woaw time for some udder
+	if(mapload && prob(40) && gender == MALE)
+		new /mob/living/basic/goat/pete/petricia(loc) // woaw time for some udder
 		return INITIALIZE_HINT_QDEL
 
 	return ..()

--- a/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
@@ -3,8 +3,8 @@
 	gender = MALE
 
 /mob/living/basic/goat/pete/Initialize(mapload)
-	if(mapload && prob(40) && gender == MALE)
-		new /mob/living/basic/goat/pete/petricia(loc) // woaw time for some udder
+	if(mapload && prob(40))
+		new /mob/living/basic/goat/pete/petricia // woaw time for some udder
 		return INITIALIZE_HINT_QDEL
 
 	return ..()

--- a/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/goat_subtypes.dm
@@ -2,19 +2,9 @@
 	name = "Pete"
 	gender = MALE
 
-/mob/living/basic/goat/pete/Initialize(mapload)
-	if(mapload && prob(40))
-		new /mob/living/basic/goat/pete/petricia // woaw time for some udder
-		return INITIALIZE_HINT_QDEL
-
-	return ..()
-
 /mob/living/basic/goat/pete/examine()
 	. = ..()
 	var/area/goat_area = get_area(src)
 	if((bodytemperature < T20C) || istype(goat_area, /area/station/service/kitchen/coldroom))
 		. += span_notice("[p_They()] [p_do()]n't seem to be too bothered about the cold.") // special for pete
 
-/mob/living/basic/goat/pete/petricia // A female Pete!
-	name = "Petricia"
-	gender = FEMALE


### PR DESCRIPTION
## About The Pull Request

This was addressed in #78759 (1b1fde4908826ef5c54ffc0734e74028270af3fd) and reviewed (and merged even though I didn't respond to it, oh well), but I half-assed it because the whole point was to prevent male goats from having an udder, but I only added it to the subtype of Pete i made in that PR. Let's expand that to all male goats now.
## Why It's Good For The Game

It doesn't make biological nor morphological sense as to why a male goat can provide milk. Ideally this should be like this for all animals (because that's real life) but that's a later issue with further balance implication. 

I think it's still an interesting idea that Nanotrasen will just send you any old goat despite it being "useless" beyond being very good at eating plants. Maybe cargo should have a way to guarantee getting a female goat in the future? It's just like real life where zoos and farms have to constantly dealw ith female animals (such as giraffes or other exotic stuff) tending to be far rarer/cost far more than their male variants due to the potential to generate offspring (there's more nuance to husbandry than this but just play along)... and in space, every animal is "exotic".

It still remains possible to biogenerate milk, which tends to be far faster than feeding/milking goats- which is something that the cook should have access to anyways.
## Changelog
:cl:
balance: Male Goats should no longer spawn with an udder, instead of it just being Pete.
/:cl:
