### PR TITLE
Fixes molotovs not lighting their splashed contents

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -803,10 +803,10 @@
 			if(istype(contained_reagent, accelerant_type))
 				firestarter = 1
 				break
+	..()
 	if(firestarter && active)
 		target.fire_act()
 		new /obj/effect/hotspot(get_turf(target))
-	..()
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/attackby(obj/item/I, mob/user, params)
 	if(I.get_temperature() && !active)


### PR DESCRIPTION

## About The Pull Request
Delays fire effects on target and creating a hotspot until after bottle/smash (and the liquid is splashed), not before.
## Why It's Good For The Game
Makes molotovs work properly
## Changelog
:cl:
fix: Molotovs now splash before burning, not after
/:cl:
