### PR TITLE
grabs no longer trigger krav maga

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -116,12 +116,6 @@
 	log_combat(attacker, defender, "neck chopped")
 	return TRUE
 
-/datum/martial_art/krav_maga/grab_act(mob/living/attacker, mob/living/defender)
-	if(check_streak(attacker, defender))
-		return TRUE
-	log_combat(attacker, defender, "grabbed (Krav Maga)")
-	..()
-
 /datum/martial_art/krav_maga/harm_act(mob/living/attacker, mob/living/defender)
 	if(check_streak(attacker, defender))
 		return TRUE


### PR DESCRIPTION
## About The Pull Request
small thing introduced with combat mode, previously you needed to click with an empty hand to do your moves, now you can just ctrl click while holding anything
so we stop that

## Why It's Good For The Game
holding 2 riot shields and ctrl clicking on people to kill them is funny but stupid
also one time as warden i tried to grab my dog and i neck chopped it

## Changelog
:cl:
fix: grabs no longer trigger krav maga
/:cl:
