### PR TITLE
Makes Telekinesis + Russian Revolver Interaction more fair

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1056,6 +1056,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
  */
 #define TRAIT_UNIQUE_IMMERSE "unique_immerse"
 
+/// This item is currently under the control of telekinesis
+#define TRAIT_TELEKINESIS_CONTROLLED "telekinesis_controlled"
 
 // unique trait sources, still defines
 #define EMP_TRAIT "emp_trait"

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -110,7 +110,8 @@
 
 /obj/item/tk_grab/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
-	REMOVE_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(tk_user))
+	if(!QDELETED(focus))
+		REMOVE_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(tk_user))
 	focus = null
 	tk_user = null
 	return ..()

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -110,7 +110,7 @@
 
 /obj/item/tk_grab/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
-	REMOVE_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(src))
+	REMOVE_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(tk_user))
 	focus = null
 	tk_user = null
 	return ..()
@@ -260,7 +260,7 @@
 	if(!check_if_focusable(target))
 		return
 	focus = target
-	ADD_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(src))
+	ADD_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(tk_user))
 	update_appearance()
 	apply_focus_overlay()
 	return TRUE

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -110,6 +110,7 @@
 
 /obj/item/tk_grab/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
+	REMOVE_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(src))
 	focus = null
 	tk_user = null
 	return ..()
@@ -259,6 +260,7 @@
 	if(!check_if_focusable(target))
 		return
 	focus = target
+	ADD_TRAIT(focus, TRAIT_TELEKINESIS_CONTROLLED, REF(src))
 	update_appearance()
 	apply_focus_overlay()
 	return TRUE

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -60,9 +60,9 @@
 	set category = "Object"
 	set desc = "Click to spin your revolver's chamber."
 
-	var/mob/M = usr
+	var/mob/user = usr
 
-	if(M.stat || !in_range(M,src))
+	if(user.stat || !in_range(user, src))
 		return
 
 	if (recent_spin > world.time)
@@ -71,8 +71,8 @@
 
 	if(do_spin())
 		playsound(usr, SFX_REVOLVER_SPIN, 30, FALSE)
-		usr.visible_message(span_notice("[usr] spins [src]'s chamber."), span_notice("You spin [src]'s chamber."))
-		balloon_alert(M, "chamber spun")
+		visible_message(span_notice("[user] spins [src]'s chamber."), span_notice("You spin [src]'s chamber."))
+		balloon_alert(user, "chamber spun")
 	else
 		verbs -= /obj/item/gun/ballistic/revolver/verb/spin
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -212,10 +212,13 @@
 /obj/item/gun/ballistic/revolver/russian/fire_gun(atom/target, mob/living/user, flag, params)
 	. = ..(null, user, flag, params)
 
+	var/tk_controlled = FALSE
 	if(flag)
 		if(!(target in user.contents) && ismob(target))
 			if(user.combat_mode) // Flogging action
 				return
+	else if (HAS_TRAIT(src, TRAIT_TELEKINESIS_CONTROLLED)) // if we're far away, you can still fire it at yourself if you have TK.
+		tk_controlled = TRUE
 
 	if(isliving(user))
 		if(!can_trigger_gun(user))
@@ -223,8 +226,9 @@
 	if(target != user)
 		playsound(src, dry_fire_sound, 30, TRUE)
 		user.visible_message(
-			span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."), \
-			span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at anyone but yourself!"))
+			span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."),
+			span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at anyone but yourself!"),
+		)
 		return
 
 	if(ishuman(user))
@@ -246,7 +250,8 @@
 				antagonist = src, \
 				rounds_loaded = loaded_rounds, \
 				aimed_at =  affecting.name, \
-				result = (chambered ? "lost" : "won"))
+				result = (chambered ? "lost" : "won"), \
+			)
 
 		if(chambered)
 			if(HAS_TRAIT(user, TRAIT_CURSED)) // I cannot live, I cannot die, trapped in myself, body my holding cell.
@@ -257,6 +262,9 @@
 				playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
 				if(is_target_face)
 					shoot_self(user, affecting)
+				else if(tk_controlled) // the consequence of you doing the telekinesis stuff
+					to_chat(user, span_userdanger("As your mind concentrates on the revolver, you realize that it's pointing towards your head a little too late!"))
+					shoot_self(user, BODY_ZONE_HEAD)
 				else
 					user.visible_message(span_danger("[user.name] cowardly fires [src] at [user.p_their()] [affecting.name]!"), span_userdanger("You cowardly fire [src] at your [affecting.name]!"), span_hear("You hear a gunshot!"))
 				chambered = null

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -72,6 +72,7 @@
 	if(do_spin())
 		playsound(usr, SFX_REVOLVER_SPIN, 30, FALSE)
 		usr.visible_message(span_notice("[usr] spins [src]'s chamber."), span_notice("You spin [src]'s chamber."))
+		balloon_alert(M, "chamber spun")
 	else
 		verbs -= /obj/item/gun/ballistic/revolver/verb/spin
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -218,7 +218,7 @@
 		if(!(target in user.contents) && ismob(target))
 			if(user.combat_mode) // Flogging action
 				return
-	else if (HAS_TRAIT(src, TRAIT_TELEKINESIS_CONTROLLED)) // if we're far away, you can still fire it at yourself if you have TK.
+	else if (HAS_TRAIT_FROM_ONLY(src, TRAIT_TELEKINESIS_CONTROLLED, REF(user))) // if we're far away, you can still fire it at yourself if you have TK.
 		tk_controlled = TRUE
 
 	if(isliving(user))


### PR DESCRIPTION
## About The Pull Request

Fixes #77238

Basically, you were able to just spam kill people with the russian revolver if you had telekinesis, which isn't really fair. Now, after taking a leaflet out of the the discussion in that issue report, you can still pull off the same party trick... once...

Basically, let's just say that when you focus on firing the gun in your mind... you're also pointing it directly at your mind (your brain (your skull (you instantly die))). This occurs even if the projectile doesn't actually touch you (because that would be hellish to account for) but you're the one who's playing russian roulette man

You still get to do some collateral damage because that's still a very funny interaction but you only get to do it once per life. I don't know if people will be happy to revive you after you "shoot" them. Also, the way it's coded means that you can still leave the revolver on the table and fire it at your foot or something, or just use it normally, as a telekinesis user. This _only_ applies to distance-based firings.
## Why It's Good For The Game

The russian revolver is specifically coded to prevent you from damaging other people, and this was a pretty silly way to sidestep that based on the checks. Instead, let's make it so that you can still do this admittedly funny interaction, but with enough reason to not do it (the reason being that you'll always get fucking blatted).
## Changelog
:cl:
balance: After a string of unfortunate incidents, persons with telekinesis have been strongly warned against playing Russian Roulette, as they tend to hyperfixate on the gun a bit too much and end up firing it directly at their head. 
/:cl:
