### PR TITLE
Add prior material amount check to turbine part upgrade

### DIFF
--- a/code/modules/power/turbine/turbine_parts.dm
+++ b/code/modules/power/turbine/turbine_parts.dm
@@ -64,7 +64,8 @@
 			if(!istype(attacking_item, second_tier_material))
 				return
 			var/obj/item/stack/sheet/second_tier = attacking_item
-			if(second_tier.use(second_tier_material_amount) && do_after(user, 1 SECONDS, src))
+			if(second_tier.get_amount() >= second_tier_material_amount && do_after(user, 1 SECONDS, src))
+				second_tier.use(second_tier_material_amount)
 				current_tier = 2
 				part_efficiency += part_efficiency_increase_amount
 				max_rpm *= max_rpm_tier_multiplier
@@ -74,7 +75,8 @@
 			if(!istype(attacking_item, third_tier_material))
 				return
 			var/obj/item/stack/sheet/third_tier = attacking_item
-			if(third_tier.use(third_tier_material_amount) && do_after(user, 2 SECONDS, src))
+			if(third_tier.get_amount() >= third_tier_material_amount && do_after(user, 2 SECONDS, src))
+				third_tier.use(third_tier_material_amount)
 				current_tier = 3
 				part_efficiency += part_efficiency_increase_amount
 				max_rpm *= max_rpm_tier_multiplier
@@ -84,7 +86,8 @@
 			if(!istype(attacking_item, fourth_tier_material))
 				return
 			var/obj/item/stack/sheet/fourth_tier = attacking_item
-			if(fourth_tier.use(fourth_tier_material_amount) && do_after(user, 3 SECONDS, src))
+			if(fourth_tier.get_amount() >= fourth_tier_material_amount && do_after(user, 3 SECONDS, src))
+				fourth_tier.use(fourth_tier_material_amount)
 				current_tier = 4
 				part_efficiency += part_efficiency_increase_amount
 				max_rpm *= max_rpm_tier_multiplier

--- a/code/modules/power/turbine/turbine_parts.dm
+++ b/code/modules/power/turbine/turbine_parts.dm
@@ -64,8 +64,7 @@
 			if(!istype(attacking_item, second_tier_material))
 				return
 			var/obj/item/stack/sheet/second_tier = attacking_item
-			if(second_tier.get_amount() >= second_tier_material_amount && do_after(user, 1 SECONDS, src))
-				second_tier.use(second_tier_material_amount)
+			if(do_after(user, 1 SECONDS, src) && second_tier.use(second_tier_material_amount))
 				current_tier = 2
 				part_efficiency += part_efficiency_increase_amount
 				max_rpm *= max_rpm_tier_multiplier
@@ -75,8 +74,7 @@
 			if(!istype(attacking_item, third_tier_material))
 				return
 			var/obj/item/stack/sheet/third_tier = attacking_item
-			if(third_tier.get_amount() >= third_tier_material_amount && do_after(user, 2 SECONDS, src))
-				third_tier.use(third_tier_material_amount)
+			if(do_after(user, 2 SECONDS, src) && third_tier.use(third_tier_material_amount))
 				current_tier = 3
 				part_efficiency += part_efficiency_increase_amount
 				max_rpm *= max_rpm_tier_multiplier
@@ -86,8 +84,7 @@
 			if(!istype(attacking_item, fourth_tier_material))
 				return
 			var/obj/item/stack/sheet/fourth_tier = attacking_item
-			if(fourth_tier.get_amount() >= fourth_tier_material_amount && do_after(user, 3 SECONDS, src))
-				fourth_tier.use(fourth_tier_material_amount)
+			if(do_after(user, 3 SECONDS, src) && fourth_tier.use(fourth_tier_material_amount))
 				current_tier = 4
 				part_efficiency += part_efficiency_increase_amount
 				max_rpm *= max_rpm_tier_multiplier


### PR DESCRIPTION

## About The Pull Request

Currently, upgrading turbine parts will use materials every time the user clicks on it while the upgrade process is active.
The user will now spend a certain amount of materials regardless of the number of clicks.
## Why It's Good For The Game

It doesn't make sense to spend more materials for the same result.
## Changelog
:cl: mogeoko
fix: Turbine parts will now use an amount of materials no greater than needed for the upgrade
/:cl:
