### PR TITLE
replaces AI sat hallways ID access helpers with the proper helpers on northstar

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -28201,7 +28201,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/robotics,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
@@ -29742,10 +29741,11 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/robotics,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "hQl" = (
@@ -64979,7 +64979,8 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "qVv" = (


### PR DESCRIPTION

## About The Pull Request

this PR replaces the singular any robotics access helper thats put all the way from robotics' AI satellite hallway entrance all the way to AI service, for frame of reference, in order to access the AI satellite from the other point of entry, you are required to have any of minisat or command general, and have to get through the same amount of doors.

## Why It's Good For The Game

roboticists aren't special and there is absolutely nothing in the AI sats service hall for roboticists to need that they can't find in their area or that they would need to even access, plus this area IS supposed to be restricted, so i'm just assuming this was an oversight on the helpers 

## Changelog

fix: roboticists no longer have access to the hallway of the AI satellite on northstar as nanotrasen has remembered that the AIs satellite is a restricted area.

/:cl:


