### PR TITLE
CRAB-17 will round down the credit amount it steals

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -197,7 +197,7 @@
 		if(!(B?.being_dumped))
 			accounts_to_rob -= B
 			continue
-		var/amount = B.account_balance * percentage_lost
+		var/amount = round(B.account_balance * percentage_lost) // We don't want fractions of a credit stolen. That's just agony for everyone.
 		var/datum/bank_account/account = bogdanoff?.get_bank_account()
 		if (account) // get_bank_account() may return FALSE
 			account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")


### PR DESCRIPTION

## About The Pull Request

When stealing credits, the CRAB-17 takes a between 5 and 15 percent of your current credit balance.
Due to how numbers work, this almost always ends up with a fractional amount being taken (ie 10% of 1015 is 101.5)
There is, as far as I'm aware, no way to get rid of this fractional amount, as you can only pull whole credits from your ID.

## Why It's Good For The Game

CRAB-17 will now take between 5 and 15 percent of your current credits, rounded down.
No more 1/3 of a credit to stare at in abject horror.

## Changelog
:cl:
fix: The CRAB-17 will now only take whole credits, as fractional credits were found to be worth less.
:cl:
