### PR TITLE
Fixes an issue with un-hidden (alien, syndie etc.) nodes not being researchable.

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -172,6 +172,7 @@
 		return FALSE
 
 	if(id == DESTRUCTIVE_ANALYZER_DESTROY_POINTS)
+		to_chat(world, "AAAAAAA")
 		if(!destroy_item(gain_research_points = TRUE))
 			return FALSE
 		return TRUE
@@ -179,10 +180,10 @@
 	var/datum/techweb_node/node_to_discover = SSresearch.techweb_node_by_id(id)
 	if(!istype(node_to_discover))
 		return FALSE
-	SSblackbox.record_feedback("nested tally", "item_deconstructed", 1, list("[node_to_discover.id]", "[loaded_item.type]"))
 	if(!destroy_item())
 		return FALSE
-	stored_research.unhide_node(SSresearch.techweb_node_by_id(node_to_discover.id))
+	SSblackbox.record_feedback("nested tally", "item_deconstructed", 1, list("[node_to_discover.id]", "[loaded_item.type]"))
+	stored_research.unhide_node(node_to_discover)
 	return TRUE
 
 #undef DESTRUCTIVE_ANALYZER_DESTROY_POINTS

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -172,7 +172,6 @@
 		return FALSE
 
 	if(id == DESTRUCTIVE_ANALYZER_DESTROY_POINTS)
-		to_chat(world, "AAAAAAA")
 		if(!destroy_item(gain_research_points = TRUE))
 			return FALSE
 		return TRUE

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -409,6 +409,8 @@
 	if(!istype(node))
 		return FALSE
 	hidden_nodes -= node.id
+	///Make it available if the prereq ids are already researched
+	update_node_status(node)
 	return TRUE
 
 /datum/techweb/proc/update_tiers(datum/techweb_node/base)


### PR DESCRIPTION
## About The Pull Request
Recently, I've been trying to unlock the ayy node, but couldn't even after disassembling an alien tool. Looked into the variables viewer and saw the node id wasn't set in the `available_nodes` list. It seems there was no update after it being unhidden.

## Why It's Good For The Game
Fixing an issue with the destructive analyzer, maybe from the new UI refactor, but I couldn't bother to git blame it.

## Changelog

:cl:
fix: Fixed an issue with un-hidden (alien, syndie etc.) nodes not being researchable.
/:cl:
