### PR TITLE
Revert "if you die in a mech you are ejected"

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -35,7 +35,6 @@
 	generic_canpass = FALSE
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD, DIAG_CAMERA_HUD)
 	mouse_pointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'
-	verb_say = "beeps"
 	///How much energy the mech will consume each time it moves. this is the current active energy consumed
 	var/step_energy_drain = 8
 	///How much energy we drain each time we mechpunch someone

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -158,14 +158,12 @@
 /obj/vehicle/sealed/mecha/add_occupant(mob/M, control_flags)
 	RegisterSignal(M, COMSIG_MOB_CLICKON, PROC_REF(on_mouseclick), TRUE)
 	RegisterSignal(M, COMSIG_MOB_SAY, PROC_REF(display_speech_bubble), TRUE)
-	RegisterSignal(M, COMSIG_LIVING_DEATH, PROC_REF(pilot_died), TRUE)
 	. = ..()
 	update_appearance()
 
 /obj/vehicle/sealed/mecha/remove_occupant(mob/M)
 	UnregisterSignal(M, COMSIG_MOB_CLICKON)
 	UnregisterSignal(M, COMSIG_MOB_SAY)
-	UnregisterSignal(M, COMSIG_LIVING_DEATH)
 	M.clear_alert(ALERT_CHARGE)
 	M.clear_alert(ALERT_MECH_DAMAGE)
 	if(M.client)
@@ -191,11 +189,3 @@
 	else
 		to_chat(user, span_notice("You stop exiting the mech. Weapons are enabled again."))
 	is_currently_ejecting = FALSE
-
-/obj/vehicle/sealed/mecha/proc/pilot_died(datum/source)
-	SIGNAL_HANDLER
-	if(issilicon(source) || isbrain(source))
-		return
-	playsound(src, 'sound/machines/synth_no.ogg', 25, TRUE)
-	say("Pilot fatality.")
-	mob_exit(source, randomstep = TRUE)


### PR DESCRIPTION
Reverts tgstation/tgstation#79380
this is literally what the mech removal tool is for. gameplay reasons for that tool missing do not mean that we need to remove its use - if you want a better solution then let people purchase it... or just smash the mech- you saving their life and them being sad about their mech is really funny
the original pr being marked as qol when that was a specific balance change is very stupid

## Changelog
🆑
del: if you die in a mech you again don't automatically eject
/🆑