### PR TITLE
Adds a toggle action to implant HUDs

### DIFF
--- a/code/datums/actions/items/toggles.dm
+++ b/code/datums/actions/items/toggles.dm
@@ -83,6 +83,13 @@
 /datum/action/item_action/toggle_hud
 	name = "Toggle Implant HUD"
 
+/datum/action/item_action/toggle_hud/Trigger(trigger_flags)
+   . = ..()
+   if(!.)
+      return
+   var/obj/item/organ/internal/cyberimp/eyes/hud/hud_implant = target
+   hud_implant.toggle_hud(owner)
+
 /datum/action/item_action/wheelys
 	name = "Toggle Wheels"
 	desc = "Pops out or in your shoes' wheels."

--- a/code/datums/actions/items/toggles.dm
+++ b/code/datums/actions/items/toggles.dm
@@ -80,6 +80,9 @@
 		return FALSE
 	return ..()
 
+/datum/action/item_action/toggle_hud
+	name = "Toggle Implant HUD"
+
 /datum/action/item_action/wheelys
 	name = "Toggle Wheels"
 	desc = "Pops out or in your shoes' wheels."

--- a/code/datums/actions/items/toggles.dm
+++ b/code/datums/actions/items/toggles.dm
@@ -82,6 +82,7 @@
 
 /datum/action/item_action/toggle_hud
 	name = "Toggle Implant HUD"
+	desc = "Disables your HUD implant's visuals. You can still access examine information."
 
 /datum/action/item_action/toggle_hud/Trigger(trigger_flags)
 	. = ..()

--- a/code/datums/actions/items/toggles.dm
+++ b/code/datums/actions/items/toggles.dm
@@ -84,11 +84,11 @@
 	name = "Toggle Implant HUD"
 
 /datum/action/item_action/toggle_hud/Trigger(trigger_flags)
-   . = ..()
-   if(!.)
-      return
-   var/obj/item/organ/internal/cyberimp/eyes/hud/hud_implant = target
-   hud_implant.toggle_hud(owner)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/organ/internal/cyberimp/eyes/hud/hud_implant = target
+	hud_implant.toggle_hud(owner)
 
 /datum/action/item_action/wheelys
 	name = "Toggle Wheels"

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -50,6 +50,7 @@
 		hud.hide_from(eye_owner)
 	if(HUD_trait)
 		REMOVE_TRAIT(eye_owner, HUD_trait, ORGAN_TRAIT)
+	toggledOn = FALSE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/medical
 	name = "Medical HUD implant"

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -15,7 +15,8 @@
 	actions_types = list(/datum/action/item_action/toggle_hud)
 	var/HUD_type = 0
 	var/HUD_trait = null
-	var/toggled_on = TRUE /// Whether the HUD implant is on or off
+	/// Whether the HUD implant is on or off
+	var/toggled_on = TRUE 
 
 
 /obj/item/organ/internal/cyberimp/eyes/hud/proc/toggle_hud(mob/living/carbon/eye_owner)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -41,6 +41,7 @@
 		hud.show_to(eye_owner)
 	if(HUD_trait)
 		ADD_TRAIT(eye_owner, HUD_trait, ORGAN_TRAIT)
+	toggledOn = TRUE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/Remove(mob/living/carbon/eye_owner, special = FALSE)
 	. = ..()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -14,6 +14,23 @@
 	slot = ORGAN_SLOT_HUD
 	var/HUD_type = 0
 	var/HUD_trait = null
+	actions_types = list(/datum/action/item_action/toggle_hud)
+	var/toggledOn = TRUE
+
+/obj/item/organ/internal/cyberimp/eyes/hud/ui_action_click(mob/user)
+	toggle_hud(user)
+
+/obj/item/organ/internal/cyberimp/eyes/hud/proc/toggle_hud(mob/living/carbon/eye_owner)
+	if(toggledOn)
+		if(HUD_type)
+			var/datum/atom_hud/hud = GLOB.huds[HUD_type]
+			hud.hide_from(eye_owner)
+		toggledOn = FALSE
+	else
+		if(HUD_type)
+			var/datum/atom_hud/hud = GLOB.huds[HUD_type]
+			hud.show_to(eye_owner)
+		toggledOn = TRUE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/Insert(mob/living/carbon/eye_owner, special = FALSE, drop_if_replaced = TRUE)
 	. = ..()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -15,7 +15,7 @@
 	actions_types = list(/datum/action/item_action/toggle_hud)
 	var/HUD_type = 0
 	var/HUD_trait = null
-	var/toggled_on = TRUE
+	var/toggled_on = TRUE /// Whether the HUD implant is on or off
 
 /obj/item/organ/internal/cyberimp/eyes/hud/ui_action_click(mob/user)
 	toggle_hud(user)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -17,8 +17,6 @@
 	var/HUD_trait = null
 	var/toggled_on = TRUE /// Whether the HUD implant is on or off
 
-/obj/item/organ/internal/cyberimp/eyes/hud/ui_action_click(mob/user)
-	toggle_hud(user)
 
 /obj/item/organ/internal/cyberimp/eyes/hud/proc/toggle_hud(mob/living/carbon/eye_owner)
 	if(toggled_on)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -12,25 +12,25 @@
 	name = "HUD implant"
 	desc = "These cybernetic eyes will display a HUD over everything you see. Maybe."
 	slot = ORGAN_SLOT_HUD
+	actions_types = list(/datum/action/item_action/toggle_hud)
 	var/HUD_type = 0
 	var/HUD_trait = null
-	actions_types = list(/datum/action/item_action/toggle_hud)
-	var/toggledOn = TRUE
+	var/toggled_on = TRUE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/ui_action_click(mob/user)
 	toggle_hud(user)
 
 /obj/item/organ/internal/cyberimp/eyes/hud/proc/toggle_hud(mob/living/carbon/eye_owner)
-	if(toggledOn)
+	if(toggled_on)
 		if(HUD_type)
 			var/datum/atom_hud/hud = GLOB.huds[HUD_type]
 			hud.hide_from(eye_owner)
-		toggledOn = FALSE
+		toggled_on = FALSE
 	else
 		if(HUD_type)
 			var/datum/atom_hud/hud = GLOB.huds[HUD_type]
 			hud.show_to(eye_owner)
-		toggledOn = TRUE
+		toggled_on = TRUE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/Insert(mob/living/carbon/eye_owner, special = FALSE, drop_if_replaced = TRUE)
 	. = ..()
@@ -41,7 +41,7 @@
 		hud.show_to(eye_owner)
 	if(HUD_trait)
 		ADD_TRAIT(eye_owner, HUD_trait, ORGAN_TRAIT)
-	toggledOn = TRUE
+	toggled_on = TRUE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/Remove(mob/living/carbon/eye_owner, special = FALSE)
 	. = ..()
@@ -50,7 +50,7 @@
 		hud.hide_from(eye_owner)
 	if(HUD_trait)
 		REMOVE_TRAIT(eye_owner, HUD_trait, ORGAN_TRAIT)
-	toggledOn = FALSE
+	toggled_on = FALSE
 
 /obj/item/organ/internal/cyberimp/eyes/hud/medical
 	name = "Medical HUD implant"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an action for all implanted HUDs to toggle them on and off. The default state is on, and the state is toggled appropriately when the implant is added or removed. This is done by using hud.hide_from and hud.show_to.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life change for roleplay situations where the HUD is usless clutter.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Implanted HUDs can now be toggled on and off with an action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
