### PR TITLE
Paint cans actually hold an appreciable amount of paint

### DIFF
--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -14,7 +14,7 @@
 	/// With what color will we paint with
 	var/paint_color = COLOR_WHITE
 	/// How many uses are left
-	var/paintleft = 10
+	var/paintleft = 200
 
 /obj/item/paint/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Paint can total uses 10 => 200

## Why It's Good For The Game

Paint cans used to be infinite until it was discovered that was actually a bug and it was fixed back in May
What wasn't actually changed was how much paint is supposed to be in the can.
Cans only hold 10 charges of paint, and lack an apparent way to refill them (as far as I know), which is enough paint to do almost nothing with.
Given crayons and spraycans hold 30 charges, 200 seems a lot more reasonable for a big old can of paint that can only colour things and is generally a lot bigger than spraycans (much less crayons)

## Changelog
:cl:
balance: Paint cans hold 20x more paint than before, painters rejoice! (Janitors cry more)
/:cl:
