### PR TITLE
Hydrotray consumes nutrients disregarding the mixture contents

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -326,9 +326,9 @@
 			// Nutrients deplete at a constant rate, since new nutrients can boost stats far easier.
 			apply_chemicals(lastuser?.resolve())
 			if(self_sustaining)
-				reagents.remove_any(min(0.5, nutridrain))
+				reagents.remove_all(min(0.5, nutridrain))
 			else
-				reagents.remove_any(nutridrain)
+				reagents.remove_all(nutridrain)
 
 			// Lack of nutrients hurts non-weeds
 			if(reagents.total_volume <= 0 && !myseed.get_gene(/datum/plant_gene/trait/plant_type/weed_hardy))


### PR DESCRIPTION
## About The Pull Request

Hydrotrays were using `remove_any` which led to weird behaviour when you mix fertilizers. 

It could randomly select which reagents to consume from the hydrotray, and which reagents should stay unotuched.

With `remove_all`, the plant now simply consumes a unit of the mixture, disregarding the contents.

## Why It's Good For The Game

This simple fix unlocks an entire new level of gameplay for botany, as you can make mixtures that work consistently.

## Changelog

:cl:
fix: Hydrotrays consume nutrients according to their proportion in the mix, instead of randomly picking reagents to consume every cycle.
/:cl:

