### PR TITLE
Fixes grey ID crate typo

### DIFF
--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -190,7 +190,7 @@
 
 /// Box of 7 grey IDs.
 /datum/supply_pack/service/greyidbox
-	name = "Grey ID Card Multipack Cate"
+	name = "Grey ID Card Multipack Crate"
 	desc = "A convenient crate containing a box of seven cheap ID cards in a handy wallet-sized form factor. \
 		Cards come in every colour you can imagne, as long as it's grey."
 	cost = CARGO_CRATE_VALUE * 3


### PR DESCRIPTION

## About The Pull Request

"Grey ID Card Multipack Cate" -> "Grey ID Card Multipack Crate"

That is not a Cate, that is a Crate!
## Why It's Good For The Game

Fixes a silly typo.
## Changelog
:cl: Rhials
spellcheck: The Grey ID Cargo Crate is now spelled properly.
/:cl:
