### PR TITLE
Updates examine text for Nukie & ERT defibs

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -295,7 +295,7 @@
 
 /obj/item/defibrillator/compact/combat
 	name = "combat defibrillator"
-	desc = "A belt-equipped blood-red defibrillator. Can revive through thick clothing, has an experimental self-recharging battery, and can be utilized in combat via applying the paddles in a disarming or aggressive manner."
+	desc = "A belt-equipped blood-red defibrillator. Can revive through thick clothing, has an experimental self-recharging battery, and can be utilized as a weapon via applying the paddles while in a combat stance."
 	icon_state = "defibcombat" //needs defib inhand sprites
 	inhand_icon_state = null
 	worn_icon_state = "defibcombat"
@@ -322,7 +322,7 @@
 
 /obj/item/defibrillator/compact/combat/loaded/nanotrasen
 	name = "elite Nanotrasen defibrillator"
-	desc = "A belt-equipped state-of-the-art defibrillator. Can revive through thick clothing, has an experimental self-recharging battery, and can be utilized in combat via applying the paddles in a disarming or aggressive manner."
+	desc = "A belt-equipped state-of-the-art defibrillator. Can revive through thick clothing, has an experimental self-recharging battery, and can be utilized as a weapon via applying the paddles while in a combat stance."
 	icon_state = "defibnt" //needs defib inhand sprites
 	inhand_icon_state = null
 	worn_icon_state = "defibnt"


### PR DESCRIPTION

## About The Pull Request
Description of these two items tells you how to attack people with them, but it's outdated and tells you to use disarm or aggressive intent. Since those aren't part of the game any more, I changed it so it tells you to use combat mode instead.
Also a minor rewording both to stop the word 'combat' being used twice in quick succession to mean different things (looks awkward), and to make it technically more correct (old description implies you need combat mode on to revive someone in the middle of a fight)
## Why It's Good For The Game
Intents aren't in the game so mini tutorials like this shouldn't refer to them.
## Changelog
:cl:
spellcheck: Nukie and ERT defibrillators now reference combat mode instead of intents.
/:cl:
