### PR TITLE
Make sign language unaffected by the Social Anxiety quirk's direct speech effects

### DIFF
--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -24,6 +24,8 @@
 
 	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
 		return
+	if(HAS_TRAIT(source, TRAIT_SIGN_LANG)) // No modifiers for signers, so you're less anxious when you go non-verbal
+		return
 
 	var/moodmod
 	if(quirk_holder.mob_mood)


### PR DESCRIPTION

## About The Pull Request

Alternative title: "Make going non-verbal make you less anxious."

This is a two line change to `social_anxiety.dm` to quit out its `handle_speech` method when user has the `TRAIT_SIGN_LANG` trait.
This stops the Social Anxiety quirk from applying its stutters/fillers/blockers for as long as the speaker is using sign language.
This does nothing to any of social anxiety's non-verbal effects, those are still active regardless and entirely unaffected.
## Why It's Good For The Game

Primarily: I think giving people the choice between using anxious talk or sign language, and thus the different hurdles inherent to both, makes for a more interesting gameplay interaction than simply blanket-applying the quirk's speech effects to both.

Secondarily: Social Anxiety's non-verbal penalties are entirely unaffected. One will still get the penalties from making eye contact and occasionally make eye contact with objects. Notably this includes the stuttering making eye contact could get you, which still makes your signing shaky. You're still anxious, after all.
On top of this, it still costs more to pick up Signer than Social Anxiety allows for, and thus the change doesn't simply make the combination free points.

Tertiarily: when one has trouble speaking verbally, non-verbal communication can be helpful in overcoming that hurdle. This is especially so when the trigger for said anxiety is speaking verbally in the first place. This is part of why I was so enamoured by the combination before a broader and, mind you, fairly needed fix to sign language made these interact differently.
## Changelog
:cl:
balance: signers no longer suffer from social anxiety's speech changes when they go non-verbal. Other effects are maintained.
/:cl:
