### PR TITLE
Increases CMO hypospray capacity + adds microdosing

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -61,7 +61,7 @@
 
 
 /obj/item/reagent_containers/hypospray/cmo
-	volume = 90
+	volume = 60
 	possible_transfer_amounts = list(1,2,3,4,5)
 	list_reagents = list(/datum/reagent/medicine/omnizine = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -61,6 +61,8 @@
 
 
 /obj/item/reagent_containers/hypospray/cmo
+	volume = 90
+	possible_transfer_amounts = list(1,2,3,4,5)
 	list_reagents = list(/datum/reagent/medicine/omnizine = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -62,7 +62,7 @@
 
 /obj/item/reagent_containers/hypospray/cmo
 	volume = 60
-	possible_transfer_amounts = list(1,2,3,4,5)
+	possible_transfer_amounts = list(1,3,5)
 	list_reagents = list(/datum/reagent/medicine/omnizine = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 


### PR DESCRIPTION
## About The Pull Request

Increases the reagent capacity of the CMO hypospray to 60u and adds the ability to inject smaller amounts of reagents, like a dropper can.

You still only get 30u of omnizine, sorry.

## Why It's Good For The Game

The hypospray is pretty dogwater as a medical tool. The tiny 30u capacity means you'll be refilling it constantly, making it unattractive compared to medigels or pills for everything but murder. These changes solve that issue by making the capacity less miserable and also give it a unique niche of being able to efficiently administer medicines via microdosing.

## Changelog
:cl: Bumtickley00
balance: The CMO's hypospray now holds 60u, and can be set to inject smaller amounts of reagents
/:cl: