### PR TITLE
Fixes sending stuff to "Old" Chat

### DIFF
--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -43,6 +43,7 @@ SUBSYSTEM_DEF(chat)
 
 /datum/controller/subsystem/chat/proc/send_payload_to_client(client/target, datum/chat_payload/payload)
 	target.tgui_panel.window.send_message("chat/message", payload.into_message())
+	SEND_TEXT(target, payload.get_content_as_html())
 
 /datum/controller/subsystem/chat/fire()
 	for(var/ckey in client_to_payloads)

--- a/code/datums/chat_payload.dm
+++ b/code/datums/chat_payload.dm
@@ -10,3 +10,7 @@
 /// Converts the chat payload into a JSON string
 /datum/chat_payload/proc/into_message()
 	return "{\"sequence\":[sequence],\"content\":[json_encode(content)]}"
+
+/// Returns the content of the chat payload
+/datum/chat_payload/proc/get_content_as_html()
+	return message_to_html(content)

--- a/code/datums/chat_payload.dm
+++ b/code/datums/chat_payload.dm
@@ -11,6 +11,6 @@
 /datum/chat_payload/proc/into_message()
 	return "{\"sequence\":[sequence],\"content\":[json_encode(content)]}"
 
-/// Returns the content of the chat payload
+/// Returns an HTML-encoded message from our contents.
 /datum/chat_payload/proc/get_content_as_html()
 	return message_to_html(content)


### PR DESCRIPTION

## About The Pull Request

This functionality was removed in #79479 (e1c6cfdce89c7dbcd507d0c44803f5407a042a96), and we should still be supporting the old chat anyways because it contains a plethora of useful BYOND information that we still can really leverage (such as the built-in profiler and stuff like that) and it's going to be painful to do that if you have to keep spamming `fix-chat` to see OOC/ASAY while alternating every damn time.
## Why It's Good For The Game

It's ugly but we still need it. There's a reason why we still have it.
## Changelog
:cl:
fix: "Old Chat" (AKA: The old-styled non-TGUI raw-HTMLesque chat that you might see when it prods you with the "Failed to load fancy chat!" issue) should now get all text messages as expected.
/:cl:
