### PR TITLE
Fixes admin spawned bitrunning events [No GBP]

### DIFF
--- a/code/modules/bitrunning/event.dm
+++ b/code/modules/bitrunning/event.dm
@@ -92,4 +92,3 @@
 	spawned_mobs = unlucky_server.setup_glitch(forced_role)
 
 	return SUCCESSFUL_SPAWN
- b n

--- a/code/modules/bitrunning/event.dm
+++ b/code/modules/bitrunning/event.dm
@@ -77,13 +77,19 @@
 
 /datum/round_event/ghost_role/bitrunning_glitch/spawn_role()
 	var/datum/round_event_control/bitrunning_glitch/cyber_control = control
+	if(!length(cyber_control.active_servers))
+		return WAITING_FOR_SOMETHING
 
-	var/obj/machinery/quantum_server/unlucky_server = pick(cyber_control.active_servers)
+	var/datum/weakref/server_ref = pick(cyber_control.active_servers)
+	var/obj/machinery/quantum_server/unlucky_server = server_ref?.resolve()
+	if(isnull(unlucky_server))
+		return WAITING_FOR_SOMETHING
+
 	cyber_control.active_servers.Cut()
-
 	if(!unlucky_server.validate_mutation_candidates())
-		return MAP_ERROR
+		return WAITING_FOR_SOMETHING
 
 	spawned_mobs = unlucky_server.setup_glitch(forced_role)
 
 	return SUCCESSFUL_SPAWN
+ b n


### PR DESCRIPTION
## About The Pull Request
Don't mind that I opened this on the wrong branch the PR is still valid ok
## Why It's Good For The Game
Spawning events was broken 
## Changelog
:cl:
fix: Admins can spawn bitrunning events (again!)
/:cl:
