### PR TITLE
Fixes chat bluescreen

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -87,7 +87,13 @@ export const chatMiddleware = (store) => {
       loadChatFromStorage(store);
     }
     if (type === 'chat/message') {
-      const payload_obj = JSON.parse(payload);
+      let payload_obj;
+      try {
+        payload_obj = JSON.parse(payload);
+      } catch (err) {
+        return;
+      }
+
       const sequence = payload_obj.sequence;
       if (sequences.includes(sequence)) {
         return;


### PR DESCRIPTION
## About The Pull Request
Adds a chat reliability layer reliability layer

<details>
<summary>more info</summary>

json.parse claims another
![d86](https://github.com/tgstation/tgstation/assets/42397676/c7d864f2-b5d6-4c5d-95b4-deece37c808d)

javascript completely opaque about what throws. innocuous function not wrapped in try/catch block

</details>

## Why It's Good For The Game
No bluescreen?
Fixes #79814
## Changelog
:cl:
fix: Chat shouldn't bluescreen at the start of the round
/:cl:
