### PR TITLE
Hardcore random will not assign incompatible quirks.

### DIFF
--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -60,8 +60,9 @@
 			var/list/blacklist = bl
 			if(!(picked_quirk in blacklist))
 				continue
-			for(var/iterator_quirk in all_quirks) //Go through all the quirks we've already selected to see if theres a blacklist match
-				if((iterator_quirk in blacklist) && !(iterator_quirk == picked_quirk)) //two quirks have lined up in the list of the list of quirks that conflict with each other, so return (see quirks.dm for more details)
+			for(var/quirk_name in all_quirks) //Go through all the quirks we've already selected to see if theres a blacklist match
+				var/selected_quirk = SSquirks.quirks[quirk_name]
+				if((selected_quirk in blacklist) && !(selected_quirk == picked_quirk)) //two quirks have lined up in the list of the list of quirks that conflict with each other, so return (see quirks.dm for more details)
 					picked_quirk_blacklisted = TRUE
 					break
 			if(picked_quirk_blacklisted)


### PR DESCRIPTION

## About The Pull Request

Fixes #78114.
Fixes #78505.

Grumble grumble, code rot.

#77727 inadvertently broke hardcore random quirk selection, making it not actually check the compatibility of quirks before adding them. This means that quirks that were never meant to go together could be randomly assigned, which broke all kinds of things. I've simply made it properly check for the typepath rather than checking typepaths against names, making it actually function as intended.
## Why It's Good For The Game

Certain quirks are incompatible for a reason. Prevents unintended combos that break in unexpected ways.
## Changelog
:cl:
fix: Hardcore Random will no longer assign incompatible quirks.
/:cl:
