### PR TITLE
Fixes an incorrect term in roundstart tips.

### DIFF
--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -227,7 +227,7 @@ If you're using hotkey mode, you can stop pulling things using H.
 In a pinch, stripping yourself naked will give you a sizeable resistance to being tackled. What do you value more, your freedom or your dignity?
 Laying down will help slow down bloodloss. Death will halt it entirely.
 Maintenance is full of equipment that is randomized every round. Look around and see if anything is worth using.
-Most job-related suit clothing can fit job-related items into it, such as the atmospheric technician's winter coat holding an RPD, or labcoats holding most medicine.
+Most job-related suit slot clothing can fit job-related items into it, such as the atmospheric technician's winter coat holding an RPD, or labcoats holding most medicine.
 Most things have special interactions with right, alt, shift, and control click. Experiment!
 On most clothing items that go in the suit slot, you can put certain small items into your suit storage, such as a spraycan, your emergency oxygen tank, or a flashlight.
 Remote devices will work when used through cameras. For example: Bluespace RPEDs and door remotes.

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -227,9 +227,9 @@ If you're using hotkey mode, you can stop pulling things using H.
 In a pinch, stripping yourself naked will give you a sizeable resistance to being tackled. What do you value more, your freedom or your dignity?
 Laying down will help slow down bloodloss. Death will halt it entirely.
 Maintenance is full of equipment that is randomized every round. Look around and see if anything is worth using.
-Most job-related exosuit clothing can fit job-related items into it, such as the atmospheric technician's winter coat holding an RPD, or labcoats holding most medicine.
+Most job-related suit clothing can fit job-related items into it, such as the atmospheric technician's winter coat holding an RPD, or labcoats holding most medicine.
 Most things have special interactions with right, alt, shift, and control click. Experiment!
-On most clothing items that go in the exosuit slot, you can put certain small items into your suit storage, such as a spraycan, your emergency oxygen tank, or a flashlight.
+On most clothing items that go in the suit slot, you can put certain small items into your suit storage, such as a spraycan, your emergency oxygen tank, or a flashlight.
 Remote devices will work when used through cameras. For example: Bluespace RPEDs and door remotes.
 Sleeping can be used to recover from minor injuries and organ damage. Sanity, darkness, blindfolds, earmuffs, tables, beds, and bedsheets affect the healing rate.
 Some roles cannot be antagonists by default, but antag selection is decided first. For instance, you can set Security Officer to High without affecting your chances of becoming an antag -- the game will just select a different role.
@@ -257,7 +257,7 @@ You can change the control scheme by pressing tab. One is WASD, the other is the
 You can cheat games by baking dice in microwaves to make them loaded. Cards can be seen with x-ray vision or be marked with either a pen or crayon to gain an edge.
 You can climb onto a table by dragging yourself onto one. This takes time and drops the items in your hands on the table. Clicking on a table that someone else is climbing onto will knock them down.
 You can deconvert Cultists of Nar'Sie by feeding them large amounts of holy water. Unlike revolutionaries, implanting them with mindshield implants won't do it!
-You can drag other players onto yourself to open the strip menu, letting you remove their equipment or force them to wear something. Note that exosuits or helmets will block your access to the clothing beneath them, and that certain items take longer to strip or put on than others.
+You can drag other players onto yourself to open the strip menu, letting you remove their equipment or force them to wear something. Note that suits or helmets will block your access to the clothing beneath them, and that certain items take longer to strip or put on than others.
 You can grab someone by holding Ctrl and clicking on them, then upgrade the grab by Ctrl-clicking on them once more. An aggressive grab will momentarily stun someone, allow you to place them on a table by clicking on it, or throw them by toggling on throwing.
 You can light a cigar on a supermatter crystal.
 You can move an item out of the way by dragging it and then clicking on an adjacent tile with an empty hand.


### PR DESCRIPTION

## About The Pull Request

A few roundstart tips erroneously referred to suit-slot clothing as "exosuits". I've changed the wording to refer to the suits and the suit slot properly.
## Why It's Good For The Game

In-game, "exosuit" refers solely to mechs, i.e. the exosuit fabricator and exosuit equipment. Using this term for suit clothing muddles the actual meaning of these roundstart tips.
## Changelog
:cl:
spellcheck: Some roundstart tips have been made clearer regarding "suits" vs. "exosuits".
/:cl:
