### PR TITLE
Calls Allocate on the spawn humans unit test humans

### DIFF
--- a/code/modules/unit_tests/spawn_humans.dm
+++ b/code/modules/unit_tests/spawn_humans.dm
@@ -2,7 +2,7 @@
 	var/locs = block(run_loc_floor_bottom_left, run_loc_floor_top_right)
 
 	for(var/I in 1 to 5)
-		new /mob/living/carbon/human/consistent(pick(locs))
+		allocate(/mob/living/carbon/human/consistent, pick(locs))
 
 	sleep(5 SECONDS)
 


### PR DESCRIPTION

## About The Pull Request

I have found a unit test that spawn instances of `/mob/living/carbon/human/consistent`, without using `allocate`, so they won't get into the list of things to be deleted when CI finishes running. This PR ensures that they won't stick around after the unit test has finished.

I kept them picking a random tile from the unit test room, instead of going with `allocate`'s default of the test area's bottom left corner. Could have maybe swapped it to pick_n_take so there is no chance of them piling up, but that is not relevant to the CI issue.

## Why It's Good For The Game

Maybe this will stop the random CI failures where `/mob/living/carbon/human/consistent` fails to be deleted.

## Changelog

Nothing player facing

