### PR TITLE
Fixes a race condition in mutations code

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -173,7 +173,7 @@
  * returns an instance of a power if modification was complete
  */
 /datum/mutation/human/proc/modify()
-	if(modified || !power_path || !owner)
+	if(modified || !power_path || QDELETED(owner))
 		return
 	var/datum/action/cooldown/modified_power = locate(power_path) in owner.actions
 	if(!modified_power)

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -75,27 +75,16 @@
 	var/energy_coeff = -1
 	/// List of strings of valid chromosomes this mutation can accept.
 	var/list/valid_chrom_list = list()
-	/// Keep track of remove timer id to prevent hard dels
-	var/remove_timer
-	/// Keep track of modify timer id to prevent hard dels
-	var/modify_timer
 
 /datum/mutation/human/New(class = MUT_OTHER, timer, datum/mutation/human/copymut)
 	. = ..()
 	src.class = class
 	if(timer)
-		remove_timer = addtimer(CALLBACK(src, PROC_REF(remove)), timer)
+		addtimer(CALLBACK(src, PROC_REF(remove)), timer)
 		timeout = timer
 	if(copymut && istype(copymut, /datum/mutation/human))
 		copy_mutation(copymut)
 	update_valid_chromosome_list()
-
-/datum/mutation/human/Destroy()
-	if(remove_timer)
-		deltimer(remove_timer)
-	if(modify_timer)
-		deltimer(modify_timer)
-	return ..()
 
 /datum/mutation/human/proc/on_acquiring(mob/living/carbon/human/acquirer)
 	if(!acquirer || !istype(acquirer) || acquirer.stat == DEAD || (src in acquirer.dna.mutations))
@@ -126,7 +115,7 @@
 		owner.apply_overlay(layer_used)
 	grant_power() //we do checks here so nothing about hulk getting magic
 	if(!modified)
-		modify_timer = addtimer(CALLBACK(src, PROC_REF(modify), 0.5 SECONDS)) //gonna want children calling ..() to run first
+		addtimer(CALLBACK(src, PROC_REF(modify), 0.5 SECONDS)) //gonna want children calling ..() to run first
 
 /datum/mutation/human/proc/get_visual_indicator()
 	return


### PR DESCRIPTION
## About The Pull Request

One of the timers has a callback to the `modify()` proc which also doesn't check whether the mutation owner has been deleted since the timer began, potentially resulting in a runtime.

![image](https://github.com/tgstation/tgstation/assets/13398309/1e41c48b-2620-4473-9278-702d490871cc)

## Why It's Good For The Game

Fixes bugs

## Changelog

:cl:
fix: fixed a race condition with mutations
/:cl: