### PR TITLE
Fixes Trait Validity Messages

### DIFF
--- a/tools/trait_validity/check.py
+++ b/tools/trait_validity/check.py
@@ -67,7 +67,7 @@ if number_of_defines == 0:
 	sys.exit(1)
 
 if number_of_defines <= 450:
-	print(red(f"Only found {number_of_defines} defines! Something has likely gone wrong as the number of local defines should not be this low."))
+	print(red(f"Only found {number_of_defines} defines! Something has likely gone wrong as the number of global traits should not be this low."))
 	sys.exit(1)
 
 with open(globalvars_file, "r") as file:

--- a/tools/trait_validity/check.py
+++ b/tools/trait_validity/check.py
@@ -16,7 +16,7 @@ on_github = os.getenv("GITHUB_ACTIONS") == "true"
 defines_file = "code/__DEFINES/traits/declarations.dm"
 globalvars_file = "code/_globalvars/traits/_traits.dm"
 
-how_to_fix_message = "Please ensure that all traits in the {defines_file} file are added in the {globalvars_file} file."
+how_to_fix_message = f"Please ensure that all traits in the {defines_file} file are added in the {globalvars_file} file."
 
 def post_error(define_name):
 	if on_github:


### PR DESCRIPTION
## About The Pull Request
Stuff I missed in #79642 (71b45e54adfaa4c681babc545db97fa7103289de)

Man forgets one `f`, has disasterous consequences.

![image](https://github.com/tgstation/tgstation/assets/34697715/098f68e8-6c9b-4114-9e07-39d75763a0f4)

Top was it being broken, bottom is it after the fix (the message actually spits out the proper file names).

I also fixed a message that we still had after copypasting too hard.