### PR TITLE
Fixes the recycler's missing dir variable

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -57826,7 +57826,9 @@
 	dir = 4;
 	id = "garbage"
 	},
-/obj/machinery/recycler,
+/obj/machinery/recycler{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "uEO" = (


### PR DESCRIPTION

## About The Pull Request

Yeah so like, for some reason the dir variable on meta's recycler was just gone so it faced directly the wall. What a disaster!

## Why It's Good For The Game

It works again now.
## Changelog
:cl:
fix: Meta's recycler works again
/:cl:
