### PR TITLE
Makes the SC/FISHER a bit better - more range/accessibility/pacifist-usability

### DIFF
--- a/code/modules/cargo/markets/market_items/weapons.dm
+++ b/code/modules/cargo/markets/market_items/weapons.dm
@@ -72,4 +72,4 @@
 	price_min = CARGO_CRATE_VALUE * 2
 	price_max = CARGO_CRATE_VALUE * 4
 	stock_max = 1
-	availability_prob = 50
+	availability_prob = 75

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -81,6 +81,7 @@
 
 /obj/item/ammo_casing/energy/fisher
 	projectile_type = /obj/projectile/energy/fisher
-	select_name = "light-buster"
+	select_name = "light disruptor"
+	harmful = FALSE
 	e_cost = LASER_SHOTS(2, STANDARD_CELL_CHARGE * 0.5)
 	fire_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg' // fwip fwip fwip fwip

--- a/code/modules/projectiles/projectile/special/lightbreaker.dm
+++ b/code/modules/projectiles/projectile/special/lightbreaker.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = BRUTE
 	armor_flag = BOMB
-	range = 14
+	range = 21
 	projectile_phasing = PASSTABLE | PASSMOB | PASSMACHINE | PASSSTRUCTURE
 	hitscan = TRUE
 	var/disrupt_duration = 10 SECONDS


### PR DESCRIPTION
## About The Pull Request
- SC/FISHER is now pacifist-usable.
- SC/FISHER black-market availability prob up to 75, from 50.
- SC/FISHER range bumped from 14 to 21.

## Why It's Good For The Game
The SC/FISHER does no damage (except against ethereals, where it does a grand total of 3 per shot), which I think is negligible but can be removed if it's that bad to allow pacifists a gimmick method of murdering another guy, so I think pacifists should be allowed to use it.

The range buff and black-market availability are just because I felt like it, since I don't think it's available enough, especially for a doohickey whose sole purpose is "break lightbulbs".

## Changelog

:cl:
balance: The SC/FISHER disruptor pistol is now more likely to show up in black market uplinks.
balance: The SC/FISHER now has more range (21 tiles up from 14), and is usable by pacifists.
/:cl:
