### PR TITLE
Removes a duplicate bookcase in icebox permabrig library

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -32064,11 +32064,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"jSc" = (
-/obj/structure/bookcase/random,
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/red,
-/area/station/security/prison/work)
 "jSe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -169146,7 +169141,7 @@ scl
 dck
 scl
 htB
-jSc
+scl
 jty
 cIc
 nUL


### PR DESCRIPTION

## About The Pull Request
Removes a duplicate bookcase that is stacked on top of another bookcase in Icebox's permabrig library.
## Why It's Good For The Game
There probably shouldn't be two bookshelves stacked on top of each other.
## Changelog
:cl:
fix: removes a duplicate bookcase in icebox permabrig library
/:cl:
