### PR TITLE
Fixes the admin painting manager

### DIFF
--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -168,7 +168,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 
 		var/list/pdata = painting.to_json()
 		pdata["ref"] = REF(painting)
-		admin_painting_data += list(pdata)
+		UNTYPED_LIST_ADD(admin_painting_data, pdata)
 
 /**
  * Generates painting data ready to be consumed by ui.

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -168,7 +168,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 
 		var/list/pdata = painting.to_json()
 		pdata["ref"] = REF(painting)
-		admin_painting_data += pdata
+		admin_painting_data += list(pdata)
 
 /**
  * Generates painting data ready to be consumed by ui.


### PR DESCRIPTION

## About The Pull Request
I mucked this up a few weeks ago, wrote the fix, then got busy and forgot about it. This fixes the bluescreen that appears when admins try to look at the painting manager.

## Changelog
:cl: Tattle
fix: admin painting manager works again
/:cl:
