### PR TITLE
Fixes cursed/bad luck initializing with the wrong amount of incidents

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -17,7 +17,7 @@
 	/// Base damage from negative events. Cursed take 25% of this damage.
 	var/damage_mod = 1
 
-/datum/component/omen/Initialize(obj/vessel, incidents_left = 1, luck_mod, damage_mod)
+/datum/component/omen/Initialize(obj/vessel, incidents_left, luck_mod, damage_mod)
 	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
 


### PR DESCRIPTION
## About The Pull Request

Fixes cursed/bad luck always spawning with only 1 incident. incidents_left should not have a default value for the arg, as if it's called with null it will use the incidents_left var.

Fixes https://github.com/tgstation/tgstation/issues/79790

## Changelog

:cl: LT3
fix: Cursed/bad luck omen will now stick with the player for more than 1 incident
/:cl: