### PR TITLE
Examining a human mob as an observer displays "Quirks", not "Traits"

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -411,7 +411,7 @@
 					"<a href='?src=[REF(src)];hud=s;add_crime=1;examine_time=[world.time]'>\[Add crime\]</a>",
 					"<a href='?src=[REF(src)];hud=s;add_note=1;examine_time=[world.time]'>\[Add note\]</a>"), "")
 	else if(isobserver(user))
-		. += span_info("<b>Traits:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]")
+		. += span_info("<b>Quirks:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]")
 	. += "</span>"
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE, user, .)


### PR DESCRIPTION
## About The Pull Request
Replaces a remnant of the years before character traits were renamed to quirks.

## Why It's Good For The Game
Taking care of a long-lasting oversight.

## Changelog

:cl:
spellcheck: Examining a human mob as an observer displays "Quirks", not "Traits"
/:cl:
