### PR TITLE
Fixes fullupgrade chem dispenser not spawning with all their chemicals

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -108,7 +108,7 @@
 	if(emagged_reagents)
 		emagged_reagents = sort_list(emagged_reagents, GLOBAL_PROC_REF(cmp_reagents_asc))
 
-	. = ..()
+	. = ..() // So that we call RefreshParts() after adjusting the lists
 
 	if(is_operational)
 		begin_processing()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -93,7 +93,6 @@
 		/datum/reagent/toxin
 	)
 /obj/machinery/chem_dispenser/Initialize(mapload)
-	. = ..()
 	if(dispensable_reagents != null && !dispensable_reagents.len)
 		dispensable_reagents = default_dispensable_reagents
 	if(dispensable_reagents)
@@ -108,6 +107,8 @@
 		emagged_reagents = default_emagged_reagents
 	if(emagged_reagents)
 		emagged_reagents = sort_list(emagged_reagents, GLOBAL_PROC_REF(cmp_reagents_asc))
+
+	. = ..()
 
 	if(is_operational)
 		begin_processing()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24911

Tin. They were spawning with only the emagged reagents. This was not an issue for the drink dispensers because they call the parent after adjusting the reagent lists. It needs to be done that way so that `RefreshParts()` gets called after adjusting the lists. 

<details>
<summary>Before/after</summary>

![dreamseeker_H0sicTrScp](https://github.com/tgstation/tgstation/assets/13398309/649ab998-8308-4efa-be25-f4942ecab175)

![image](https://github.com/tgstation/tgstation/assets/13398309/9709dfa3-bf64-40f8-ab24-8508255d17ae)

</details>


## Why It's Good For The Game

Fixes a bug

## Changelog

:cl:
fix: fullupgrade chem dispensers will now spawn with all their chems
/:cl: