### PR TITLE
Paraplegics can use the skillchip machine.

### DIFF
--- a/code/modules/library/skill_learning/skill_station.dm
+++ b/code/modules/library/skill_learning/skill_station.dm
@@ -9,7 +9,8 @@
 	icon_state = "implantchair"
 	occupant_typecache = list(/mob/living/carbon) //todo make occupant_typecache per type
 	state_open = TRUE
-	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND //Don't call ui_interac by default - we only want that when inside
+	// Only opens UI when inside; also, you can use the machine while lying down (for paraplegics and the like)
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_IGNORE_MOBILITY
 	circuit = /obj/item/circuitboard/machine/skill_station
 	/// Currently implanting/removing
 	var/working = FALSE


### PR DESCRIPTION

## About The Pull Request

Fixes #64387.

Gives the Skillsoft station `INTERACT_ATOM_IGNORE_MOBILITY`, making it possible to use while lying down. This means that it can actually be used by paraplegics, or anyone else without functional legs.
## Why It's Good For The Game

As this particular machine can only be used from inside, and you cannot bring a wheelchair in, it is currently impossible for paraplegic characters to use skillchips at all. There is no good reason _why_ paraplegics or people without legs should be barred from this system, and it doesn't make much sense that this machine would need legs to function - so it no longer requires them.
## Changelog
:cl:
fix: Skillsoft's skillchip stations are now ADA-compliant (Astronauts with Disabilities Act). Paraplegic characters can now implant themselves with skillchips, the same as anyone else.
/:cl:
