### PR TITLE
Makes heads on pikes render correctly.

### DIFF
--- a/code/game/objects/structures/headpike.dm
+++ b/code/game/objects/structures/headpike.dm
@@ -47,11 +47,11 @@
 	. = ..()
 	if(!victim)
 		return
-	var/mutable_appearance/MA = new()
-	MA.copy_overlays(victim)
-	MA.pixel_y = 12
-	MA.pixel_x = pixel_x
-	. += victim
+	var/mutable_appearance/appearance = new()
+	appearance.copy_overlays(victim)
+	appearance.pixel_y = 12
+	appearance.layer = layer + 0.1
+	. += appearance
 
 /obj/structure/headpike/Exited(atom/movable/gone, direction)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Fixes #59037.

This PR makes heads on pikes actually appear properly offset so that they're impaled on the spike instead of halfway down the shaft. In addition, the heads will actually appear on the correct layer, rather than sometimes being rendered on the _UI layer._ This means they will not inexplicably be visible to blind players.

![image](https://github.com/tgstation/tgstation/assets/105025397/6fc16ef8-21d1-4399-b00d-3a6412b1c038)
## Why It's Good For The Game

Judging from the screenshots in the PR that added these six years ago, this has actually _never_ looked correct. For the first time, this makes heads on pikes actually look like they're meant to, rather than having way too much of the spear shoved out the top of the head.

Also, fixes a fairly egregious rendering error that makes blind people see mysterious heads in the void.
## Changelog
:cl:
fix: Heads impaled on spears now render in the correct place on the tip, instead of halfway down the shaft.
fix: Blind personnel are no longer able to magically see heads impaled on spears from a distance.
/:cl:
