### PR TITLE
[NO GBP]RCD can build directional windows on top of existing grills

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -138,14 +138,14 @@
 			var/list/structures_to_ignore
 			if(istype(target, /obj/structure/grille))
 				if(is_full_tile) //if we are trying to build full-tile windows we ignore the grille
-					structures_to_ignore = list(target)
-				else //no building directional windows on grills
-					return FALSE
+					structures_to_ignore = list(/obj/structure/grille)
+				else //when building directional windows we ignore the grill nd other directional windows
+					structures_to_ignore = list(/obj/structure/grille, /obj/structure/window)
 			else //for directional windows we ignore other directional windows as they can be in diffrent directions on the turf.
 				structures_to_ignore = list(/obj/structure/window)
 
 			//check if we can build our window on the grill
-			if(target_turf.is_blocked_turf(exclude_mobs = !is_full_tile, source_atom = null, ignore_atoms = structures_to_ignore, type_list = !is_full_tile))
+			if(target_turf.is_blocked_turf(exclude_mobs = !is_full_tile, source_atom = null, ignore_atoms = structures_to_ignore, type_list = TRUE))
 				playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 				balloon_alert(user, "something is blocking the turf")
 				return FALSE

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -139,7 +139,7 @@
 			if(istype(target, /obj/structure/grille))
 				if(is_full_tile) //if we are trying to build full-tile windows we ignore the grille
 					structures_to_ignore = list(/obj/structure/grille)
-				else //when building directional windows we ignore the grill nd other directional windows
+				else //when building directional windows we ignore the grill and other directional windows
 					structures_to_ignore = list(/obj/structure/grille, /obj/structure/window)
 			else //for directional windows we ignore other directional windows as they can be in diffrent directions on the turf.
 				structures_to_ignore = list(/obj/structure/window)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -68,7 +68,13 @@
 			var/cost = 0
 			var/delay = 0
 
-			if(the_rcd.rcd_design_path  == /obj/structure/window/fulltile)
+			if(the_rcd.rcd_design_path  == /obj/structure/window)
+				cost = 4
+				delay = 2 SECONDS
+			else if(the_rcd.rcd_design_path  == /obj/structure/window/reinforced)
+				cost = 6
+				delay = 2.5 SECONDS
+			else if(the_rcd.rcd_design_path  == /obj/structure/window/fulltile)
 				cost = 8
 				delay = 3 SECONDS
 			else if(the_rcd.rcd_design_path  == /obj/structure/window/reinforced/fulltile)
@@ -101,8 +107,13 @@
 			var/obj/structure/window/window_path = rcd_data["[RCD_DESIGN_PATH]"]
 			if(!ispath(window_path))
 				CRASH("Invalid window path type in RCD: [window_path]")
-			if(!initial(window_path.fulltile)) //only fulltile windows can be built here
-				return FALSE
+
+			//checks if its a valid build direction
+			if(!initial(window_path.fulltile))
+				if(!valid_build_direction(loc, user.dir, is_fulltile = FALSE))
+					balloon_alert(user, "window already here!")
+					return FALSE
+
 			var/obj/structure/window/WD = new window_path(T, user.dir)
 			WD.set_anchored(TRUE)
 			return TRUE


### PR DESCRIPTION
## About The Pull Request
- Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23788

So after #77858 was merged an unintentional side effect was rcd could no longer build directional windows on grills if they already existed on the turf. Sure rcd won't build a grill and then build a directional window on top of that but if a grill already exists on the turf the rcd should still be able to build directional windows on that grill as it helps in repairing mapped in directional windows and such.

If you want to build a grill first set the mode to full tile window, build the grill and then switch to directional window to build a window on top of that grill. Or just select directional window mode and build the windows directly without a grill, choice is yours

## Changelog
:cl:
fix: RCD can build directional windows on top of existing grills & without them.
/:cl: