### PR TITLE
Add CI map linter for window and structure spawners

### DIFF
--- a/tools/maplint/lints/structure_spawners.yml
+++ b/tools/maplint/lints/structure_spawners.yml
@@ -3,11 +3,5 @@
   - /obj/effect/spawner/structure
   - /obj/structure
   - /turf/closed
-    ignore: [
-      /obj/structure/cable,
-      /obj/structure/transit_tube
-    ]
+    ignore: [/obj/structure/cable, /obj/structure/transit_tube]
 
-  # - /obj/structure/lattice
-  # - /obj/structure/window
-  #- /obj/structure/grille

--- a/tools/maplint/lints/structure_spawners.yml
+++ b/tools/maplint/lints/structure_spawners.yml
@@ -1,0 +1,8 @@
+/obj/effect/spawner/structure:
+  banned_neighbors:
+  - /obj/effect/spawner/structure
+  - /obj/structure
+
+  # - /obj/structure/lattice
+  # - /obj/structure/window
+  #- /obj/structure/grille

--- a/tools/maplint/lints/structure_spawners.yml
+++ b/tools/maplint/lints/structure_spawners.yml
@@ -2,6 +2,11 @@
   banned_neighbors:
   - /obj/effect/spawner/structure
   - /obj/structure
+  - /turf/closed
+    ignore: [
+      /obj/structure/cable,
+      /obj/structure/transit_tube
+    ]
 
   # - /obj/structure/lattice
   # - /obj/structure/window

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -43,7 +43,7 @@ class TypepathExtra:
 
 class BannedNeighbor:
     identical: bool = False
-    ignore: Optional[list[Constant]] = None
+    ignore: Optional[Constant] = None
     typepath: Optional[TypepathExtra] = None
     pattern: Optional[re.Pattern] = None
 

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -43,7 +43,7 @@ class TypepathExtra:
 
 class BannedNeighbor:
     identical: bool = False
-    ignore: Optional[list] = None
+    ignore: Optional[Choices] = None
     typepath: Optional[TypepathExtra] = None
     pattern: Optional[re.Pattern] = None
 

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -43,6 +43,7 @@ class TypepathExtra:
 
 class BannedNeighbor:
     identical: bool = False
+    ignore: Optional[list] = None
     typepath: Optional[TypepathExtra] = None
     pattern: Optional[re.Pattern] = None
 
@@ -59,12 +60,21 @@ class BannedNeighbor:
             self.identical = data.pop("identical")
         expect(isinstance(self.identical, bool), "identical must be a boolean.")
 
+        if "ignore" in data:
+            self.ignore = data.pop("ignore")
+            expect(isinstance(self.ignore, list), "ignore must be a list.")
+
         if "pattern" in data:
             self.pattern = re.compile(data.pop("pattern"))
 
         expect(len(data) == 0, f"Unknown key in banned neighbor: {', '.join(data.keys())}.")
 
     def matches(self, identified: Content, neighbor: Content):
+        if self.ignore:
+            for ignored_path in self.ignore:
+                if ignored_path.matches_path(neighbor.path)
+                    return False
+
         if self.identical:
             if identified.path != neighbor.path:
                 return False

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -43,7 +43,7 @@ class TypepathExtra:
 
 class BannedNeighbor:
     identical: bool = False
-    ignore: Optional[Choices] = None
+    ignore: Optional[list[Constant]] = None
     typepath: Optional[TypepathExtra] = None
     pattern: Optional[re.Pattern] = None
 

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -72,7 +72,7 @@ class BannedNeighbor:
     def matches(self, identified: Content, neighbor: Content):
         if self.ignore:
             for ignored_path in self.ignore:
-                if ignored_path.matches_path(neighbor.path)
+                if ignored_path.matches_path(neighbor.path):
                     return False
 
         if self.identical:


### PR DESCRIPTION
## About The Pull Request

Better CI linters to catch common mapping issues.

## Why It's Good For The Game

Improves mapping QA. You can now ignore subtypes via the python mapping linter.

## Changelog

:cl:
del: Removed duplicate things TBA
/:cl:

