### PR TITLE
Fixes Window Damage Overlays

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -419,7 +419,6 @@
 
 	var/ratio = atom_integrity / max_integrity
 	ratio = CEILING(ratio*4, 1) * 25
-	cut_overlay(crack_overlay)
 	if(ratio > 75)
 		return
 	crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -26,7 +26,6 @@
 	var/fulltile = FALSE
 	var/glass_type = /obj/item/stack/sheet/glass
 	var/glass_amount = 1
-	var/mutable_appearance/crack_overlay
 	var/real_explosion_block //ignore this, just use explosion_block
 	var/break_sound = SFX_SHATTER
 	var/knock_sound = 'sound/effects/glassknock.ogg'
@@ -421,8 +420,7 @@
 	ratio = CEILING(ratio*4, 1) * 25
 	if(ratio > 75)
 		return
-	crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))
-	. += crack_overlay
+	. += mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))
 
 /obj/structure/window/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
 	return exposed_temperature > T0C + heat_resistance


### PR DESCRIPTION

## About The Pull Request

Since https://github.com/tgstation/tgstation/pull/78719, Windows lacked their damage overlays. This PR removes the **_one_** line responsible that broke the overlays.
## Why It's Good For The Game

Fixes: https://github.com/tgstation/tgstation/issues/79082
## Changelog
:cl: TwistedSilicon
fix: Window damage overlays have been fixed. 
/:cl:


<details>
  <summary>Before</summary> 

https://github.com/tgstation/tgstation/assets/106436013/694d2e46-0c76-4695-ad52-72c3cc292646

</details>
<details>
  <summary>After</summary> 

https://github.com/tgstation/tgstation/assets/106436013/d843fe5c-aaab-4784-827e-5132e7acdd5e

</details>

![image](https://github.com/tgstation/tgstation/assets/106436013/77c40048-5e2c-4db7-b5c1-581bf78d6999)
(I swear one day I will make a PR longer than 2 lines... but today is not that day.)


