### PR TITLE
Re-blacklists Romerol from plant RNG and synthesis because someone removed it by accident

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2405,6 +2405,7 @@
 	metabolization_rate = INFINITY
 	taste_description = "brains"
 	ph = 0.5
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 
 /datum/reagent/romerol/expose_mob(mob/living/carbon/human/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Re-blacklists Romerol from plant RNG and synthesis because someone removed it by accident

## Why It's Good For The Game

It's bad when the crew can produce infinite romerol by getting lucky on botanist RNG, actually.

## Changelog

:cl:
balance: Re-blacklists Romerol from plant RNG and synthesis because someone removed it by accident
/:cl:
