### PR TITLE
Gives roundstart prisoners a key memory of what their crime is

### DIFF
--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -191,3 +191,25 @@
 		"[protagonist_name] being implanted by a scientist.",
 		"[protagonist_name] having surgery done on them by a scientist.",
 	)
+
+/datum/memory/key/permabrig_crimes
+	var/crimes
+
+/datum/memory/key/permabrig_crimes/New(
+	datum/mind/memorizer_mind,
+	atom/protagonist,
+	atom/deuteragonist,
+	atom/antagonist,
+	crimes,
+)
+	src.crimes = crimes
+	return ..()
+
+/datum/memory/key/permabrig_crimes/get_names()
+	return list("[protagonist_name]'s crimes of [crimes].")
+
+/datum/memory/key/permabrig_crimes/get_starts()
+	return list(
+		"[protagonist_name] being arrested by security for [crimes].",
+		"[protagonist_name] committing the crimes of [crimes].", // Same as the account code
+	)

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -211,5 +211,5 @@
 /datum/memory/key/permabrig_crimes/get_starts()
 	return list(
 		"[protagonist_name] being arrested by security for [crimes].",
-		"[protagonist_name] committing the crimes of [crimes].", // Same as the account code
+		"[protagonist_name] committing the crimes of [crimes].",
 	)

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -206,7 +206,7 @@
 	return ..()
 
 /datum/memory/key/permabrig_crimes/get_names()
-	return list("[protagonist_name]'s crimes of \"[crimes]\".")
+	return list("[protagonist_name]'s crime of \"[crimes]\".")
 
 /datum/memory/key/permabrig_crimes/get_starts()
 	return list(

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -206,7 +206,7 @@
 	return ..()
 
 /datum/memory/key/permabrig_crimes/get_names()
-	return list("[protagonist_name]'s crimes of [crimes].")
+	return list("[protagonist_name]'s crimes of \"[crimes]\".")
 
 /datum/memory/key/permabrig_crimes/get_starts()
 	return list(

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -45,6 +45,7 @@
 	var/datum/crime/past_crime = new(crime.name, crime.desc, "Central Command", "Indefinite.")
 	target_record.crimes += past_crime
 	to_chat(crewmember, span_warning("You are imprisoned for \"[crime_name]\"."))
+	crewmember.add_mob_memory(/datum/memory/key/permabrig_crimes, crimes = crime_name)
 
 /datum/outfit/job/prisoner
 	name = "Prisoner"
@@ -69,7 +70,6 @@
 	if(!crime_name)
 		return
 	var/datum/prisoner_crime/crime = GLOB.prisoner_crimes[crime_name]
-
 	var/list/limbs_to_tat = new_prisoner.bodyparts.Copy()
 	for(var/i in 1 to crime.tattoos)
 		if(!length(SSpersistence.prison_tattoos_to_use) || visualsOnly)


### PR DESCRIPTION

## About The Pull Request
Says it on the tin, roundstart permabrig prisoners a key memory so they can remember what crime they committed.
![image](https://github.com/tgstation/tgstation/assets/58376695/325dbd36-bc24-43ea-8f64-1fcf5d613e5f)
## Why It's Good For The Game
Prisoners typically remember why they are locked in a jail forever. Also, if you have the "random" crime selected in your preferences, sometimes you can forget what crime you committed if you missed it at the start of the round.
## Changelog
:cl:
qol: gives roundstart prisoners a key memory of what their crime is
/:cl:
