### PR TITLE
Contractor reinforcements refund properly.

### DIFF
--- a/code/modules/uplink/uplink_items/contractor.dm
+++ b/code/modules/uplink/uplink_items/contractor.dm
@@ -98,9 +98,10 @@
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_CONTRACTOR_SUPPORT,
 	)
-	if(!LAZYLEN(candidates))
+	if(!LAZYLEN(candidates)) // Failed; refund spent telecrystals and item stock
 		to_chat(user, span_notice("No available agents at this time, please try again later."))
-		limited_stock++
+		uplink_handler.item_stock[stock_key]++
+		uplink_handler.telecrystals += cost
 		return //bobux no icon
 	var/mob/dead/observer/selected_player = pick(candidates)
 	uplink_handler.contractor_hub.contractor_teammate = spawn_contractor_partner(user, selected_player.key)


### PR DESCRIPTION

## About The Pull Request

Fixes #79883.

Contractor reinforcements are meant to refund their 2 TC _and_ refresh their single use if they don't find anyone to serve as reinforcements. However, neither of these things actually work - the telecrystal refund was entirely forgotten, and the restocking didn't work correctly. This PR fixes both of these problems.
## Why It's Good For The Game

Prevents you from wasting TC due to bad luck, and leaves the option open to try again later.
## Changelog
:cl:
fix: If no reinforcements are available when you buy them as a Contractor, the TC you spent will be refunded and you will be able to try again later.
/:cl:
