### PR TITLE
(NO GBP) Revert "Stops rebar crossbow crashing dreamseeker when fired at point blank. (NO GBP) (#79803)"

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -60,7 +60,7 @@
 
 /obj/item/ammo_casing/rebar/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/caseless)
+	AddElement(/datum/element/caseless, TRUE)
 
 /obj/item/ammo_casing/rebar/update_icon_state()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

#79803 was opened *after* I had opened my own PR (#79587) that more directly fixed the problem the former was opened to address. It got merged before mine did.

## Why It's Good For The Game

It's safe to take off the metaphorical bandaid that the first mentioned PR was.

## Changelog

:cl:
fix: Rebar crossbow bolts are now reuseable again, without risking crashing clients when fired at point-blank range.
/:cl:
