### PR TITLE
[NO GBP] Makes dart insert projectile var modification code slightly better

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -499,19 +499,5 @@
 /// from /datum/component/dart_insert/remove_from_dart() : (obj/ammo_casing/dart, mob/user)
 #define COMSIG_DART_INSERT_REMOVED "dart_insert_removed"
 
-/**
- * from /datum/component/dart_insert/get_dart_var_modifiers() : (list/out_modifiers)
- *
- * valid indices for `out_modifiers` are:
- * - `damage`: number
- * - `speed`: number
- * - `armour_penetration`: number
- * - `wound_bonus`: number
- * - `bare_wound_bonus`: number
- * - `demolition_mod`: number
- * - `embedding`: list with embedding params
- */
-#define COMSIG_DART_INSERT_GET_VAR_MODIFIERS "dart_insert_get_var_modifiers"
-
 /// from /datum/component/dart_insert/on_reskin()
 #define COMSIG_DART_INSERT_PARENT_RESKINNED "dart_insert_parent_reskinned"

--- a/code/datums/components/dart_insert.dm
+++ b/code/datums/components/dart_insert.dm
@@ -20,14 +20,17 @@
 	var/projectile_overlay_icon
 	/// The icon state used for the overlay applied over the containing projectile
 	var/projectile_overlay_icon_state
+	/// Optional callback to invoke when acquiring projectile var modifiers
+	var/datum/callback/modifier_getter
 
-/datum/component/dart_insert/Initialize(_casing_overlay_icon, _casing_overlay_icon_state, _projectile_overlay_icon, _projectile_overlay_icon_state)
+/datum/component/dart_insert/Initialize(_casing_overlay_icon, _casing_overlay_icon_state, _projectile_overlay_icon, _projectile_overlay_icon_state, datum/callback/_modifier_getter)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	casing_overlay_icon = _casing_overlay_icon
 	casing_overlay_icon_state = _casing_overlay_icon_state
 	projectile_overlay_icon = _projectile_overlay_icon
 	projectile_overlay_icon_state = _projectile_overlay_icon_state
+	modifier_getter = _modifier_getter
 
 /datum/component/dart_insert/RegisterWithParent()
 	. = ..()
@@ -130,8 +133,7 @@
 	new_overlays += mutable_appearance(projectile_overlay_icon, projectile_overlay_icon_state)
 
 /datum/component/dart_insert/proc/apply_var_modifiers(obj/projectile/projectile)
-	LAZYINITLIST(var_modifiers)
-	SEND_SIGNAL(parent, COMSIG_DART_INSERT_GET_VAR_MODIFIERS, var_modifiers)
+	var_modifiers = istype(modifier_getter) ? modifier_getter.Invoke() : list()
 	projectile.damage += var_modifiers["damage"]
 	if(var_modifiers["speed"])
 		var_modifiers["speed"] = reciprocal_add(projectile.speed, var_modifiers["speed"]) - projectile.speed

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -37,23 +37,29 @@
 
 /obj/item/pen/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/dart_insert, dart_insert_icon, dart_insert_casing_icon_state, dart_insert_icon, dart_insert_projectile_icon_state)
+	AddComponent(/datum/component/dart_insert, \
+		dart_insert_icon, \
+		dart_insert_casing_icon_state, \
+		dart_insert_icon, \
+		dart_insert_projectile_icon_state, \
+		CALLBACK(src, PROC_REF(get_dart_var_modifiers))\
+	)
 	RegisterSignal(src, COMSIG_DART_INSERT_ADDED, PROC_REF(on_inserted_into_dart))
 	RegisterSignal(src, COMSIG_DART_INSERT_REMOVED, PROC_REF(on_removed_from_dart))
-	RegisterSignal(src, COMSIG_DART_INSERT_GET_VAR_MODIFIERS, PROC_REF(get_dart_var_modifiers))
 
 /obj/item/pen/proc/on_inserted_into_dart(datum/source, obj/projectile/dart, mob/user, embedded = FALSE)
 	SIGNAL_HANDLER
 
-/obj/item/pen/proc/get_dart_var_modifiers(datum/source, list/modifiers)
-	SIGNAL_HANDLER
-	modifiers["damage"] = max(5, throwforce)
-	modifiers["speed"] = max(0, throw_speed - 3)
-	modifiers["embedding"] = embedding
-	modifiers["armour_penetration"] = armour_penetration
-	modifiers["wound_bonus"] = wound_bonus
-	modifiers["bare_wound_bonus"] = bare_wound_bonus
-	modifiers["demolition_mod"] = demolition_mod
+/obj/item/pen/proc/get_dart_var_modifiers()
+	return list(
+		"damage" = max(5, throwforce),
+		"speed" = max(0, throw_speed - 3),
+		"embedding" = embedding,
+		"armour_penetration" = armour_penetration,
+		"wound_bonus" = wound_bonus,
+		"bare_wound_bonus" = bare_wound_bonus,
+		"demolition_mod" = demolition_mod,
+	)
 
 /obj/item/pen/proc/on_removed_from_dart(datum/source, obj/projectile/dart, mob/user)
 	SIGNAL_HANDLER
@@ -366,12 +372,12 @@
 	if(istype(projectile))
 		UnregisterSignal(projectile, list(COMSIG_PROJECTILE_FIRE, COMSIG_PROJECTILE_ON_SPAWN_DROP, COMSIG_PROJECTILE_ON_SPAWN_EMBEDDED))
 
-/obj/item/pen/edagger/get_dart_var_modifiers(datum/source, list/modifiers)
+/obj/item/pen/edagger/get_dart_var_modifiers()
 	. = ..()
 	var/datum/component/transforming/transform_comp = GetComponent(/datum/component/transforming)
-	modifiers["damage"] = max(5, transform_comp.throwforce_on)
-	modifiers["speed"] = max(0, transform_comp.throw_speed_on - 3)
-	var/list/embed_params = modifiers["embedding"]
+	.["damage"] = max(5, transform_comp.throwforce_on)
+	.["speed"] = max(0, transform_comp.throw_speed_on - 3)
+	var/list/embed_params = .["embedding"]
 	embed_params["embed_chance"] = 100
 
 /obj/item/pen/edagger/proc/on_containing_dart_fired(obj/projectile/source)


### PR DESCRIPTION
## About The Pull Request

Ninja told me that I shouldn't use a signal to get the variable modifiers that a dart insert applies to its projectile. When I asked if using a callback passed as an initialization param was okay, Potato told me it was better.

## Why It's Good For The Game

Less code smells.

## Changelog

No player-facing changes.