### PR TITLE
fixes gutlunch udder production & some general changes to the udder

### DIFF
--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -10,7 +10,7 @@
 	var/datum/callback/on_milk_callback
 
 //udder_type and reagent_produced_typepath are typepaths, not reference
-/datum/component/udder/Initialize(udder_type = /obj/item/udder, datum/callback/on_milk_callback, datum/callback/on_generate_callback, reagent_produced_override = /datum/reagent/consumable/milk)
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, datum/callback/on_milk_callback, datum/callback/on_generate_callback, reagent_produced_override)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
 	udder = new udder_type(null)

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -10,11 +10,11 @@
 	var/datum/callback/on_milk_callback
 
 //udder_type and reagent_produced_typepath are typepaths, not reference
-/datum/component/udder/Initialize(udder_type = /obj/item/udder, datum/callback/on_milk_callback, datum/callback/on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, datum/callback/on_milk_callback, datum/callback/on_generate_callback, reagent_produced_override = /datum/reagent/consumable/milk)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
 	udder = new udder_type(null)
-	udder.add_features(parent, on_generate_callback, reagent_produced_typepath)
+	udder.add_features(parent, on_generate_callback, reagent_produced_override)
 	src.on_milk_callback = on_milk_callback
 
 /datum/component/udder/RegisterWithParent()
@@ -67,6 +67,8 @@
 	var/reagent_produced_typepath = /datum/reagent/consumable/milk
 	///how much the udder holds
 	var/size = 50
+	///the probability that the udder will produce the reagent (0 - 100)
+	var/production_probability = 5
 	///mob that has the udder component
 	var/mob/living/udder_mob
 	///optional proc to callback to when the udder generates milk
@@ -78,11 +80,12 @@
 	///hunger key we set to look for food
 	var/hunger_key = BB_CHECK_HUNGRY
 
-/obj/item/udder/proc/add_features(parent, callback, reagent = /datum/reagent/consumable/milk)
+/obj/item/udder/proc/add_features(parent, callback, reagent_override)
 	udder_mob = parent
 	on_generate_callback = callback
 	create_reagents(size, REAGENT_HOLDER_ALIVE)
-	reagent_produced_typepath = reagent
+	if(reagent_override)
+		reagent_produced_typepath = reagent_override
 	initial_conditions()
 	if(isnull(require_consume_type))
 		return
@@ -157,12 +160,13 @@
  */
 /obj/item/udder/proc/generate()
 	if(!isnull(require_consume_type) && !(locate(require_consume_type) in src))
-		return
-	if(prob(95))
-		return
+		return FALSE
+	if(!prob(production_probability))
+		return FALSE
 	reagents.add_reagent(reagent_produced_typepath, rand(5, 10), added_purity = 1)
 	if(on_generate_callback)
 		on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)
+	return TRUE
 
 /**
  * Proc called from attacking the component parent with the correct item, moves reagents into the glass basically.


### PR DESCRIPTION

## About The Pull Request
When the ranching PR came out (we love it downstream), there seemed to be an issue-- the gutlunches would produce milk instead of the miner's salve that the code said it would. I looked into it and realized that some of the code would not take into consideration if the udder already had a preset reagent to create.

I've changed some of the arguments for the procs to be called override instead, which will be empty. If you want something that functions similarly to the udder but want it to produce something else and not care about creating a new udder, you can just use the override when attaching the component; otherwise, leave it blank for milk (or whatever kind of reagent the udder you want will produce).

Additionally, gutlunches not only did not produce miner's salve, but with the special ores, it did not produce any of the additional reagents. This was fixed by just adding a return TRUE at the end of the normal udder.

![image](https://github.com/tgstation/tgstation/assets/55967837/c13676d7-7b05-4007-8786-744bfcb70673)
![image](https://github.com/tgstation/tgstation/assets/55967837/3edf912e-49c5-4931-853f-7fc463b17852)


Perhaps it is out of scope (if it is too extreme, please let me know), but I have changed the probability 95 to not produce milk to a var instead, which means you can have udders that are more prone to producing their milk reagent. 95 is still technically the default, but I have made it 5 in a more readable manner (as in you have a 5 percent chance to get milk every 2 seconds if the udder has it's required food type, if any).
## Why It's Good For The Game
Some of this PR is fixes-- we wanted certain behaviors that were not happening and so I fixed that. Other parts of the PR are for, in the future, if we want udders that have higher/lower chances to produce its milk reagent.
## Changelog
:cl:
fix: gutlunches now produce miner salve instead of milk, as well as the other reagents if fed the correct ore
/:cl:
