### PR TITLE
Touches up Moffuchi's pizzeria 

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
@@ -415,6 +415,11 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/item/reagent_containers/condiment/cornmeal,
+/obj/item/reagent_containers/condiment/cornmeal,
+/obj/item/reagent_containers/condiment/olive_oil,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)
 "rZ" = (
@@ -669,6 +674,11 @@
 /obj/item/food/grown/tomato,
 /obj/item/food/grown/tomato,
 /obj/item/food/grown/tomato,
+/obj/item/food/grown/herbs,
+/obj/item/food/grown/herbs,
+/obj/item/food/grown/herbs,
+/obj/item/food/grown/herbs,
+/obj/item/food/grown/herbs,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)
 "Di" = (
@@ -1127,9 +1137,14 @@
 /obj/structure/table,
 /obj/item/plate/small,
 /obj/structure/sign/poster/official/moth_meth/directional/north,
-/obj/item/reagent_containers/condiment/enzyme,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -7
+	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
+	},
+/obj/item/reagent_containers/condiment/vinegar{
+	pixel_x = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)
@@ -1279,9 +1294,17 @@
 /area/ruin/pizzeria)
 "WT" = (
 /obj/structure/table,
-/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/rollingpin{
+	pixel_x = 6
+	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
+	},
+/obj/item/food/canned/tomatoes{
+	pixel_x = -3
+	},
+/obj/item/food/canned/tomatoes{
+	pixel_x = -4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
@@ -355,10 +355,6 @@
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"nJ" = (
-/obj/effect/mapping_helpers/airalarm/all_access,
-/turf/closed/wall,
-/area/ruin/pizzeria/kitchen)
 "om" = (
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -679,6 +675,11 @@
 /obj/item/food/grown/herbs,
 /obj/item/food/grown/herbs,
 /obj/item/food/grown/herbs,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/garlic,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)
 "Di" = (
@@ -966,7 +967,6 @@
 /obj/machinery/airalarm/directional/south{
 	pixel_y = 4
 	},
-/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/closed/wall,
 /area/ruin/pizzeria)
 "Oy" = (
@@ -1509,7 +1509,7 @@ Ze
 kG
 kG
 KL
-nJ
+iK
 IR
 kG
 kG

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
@@ -41,9 +41,6 @@
 /turf/open/floor/plating,
 /area/ruin/pizzeria)
 "cl" = (
-/obj/item/wallframe/airalarm{
-	pixel_y = 3
-	},
 /turf/open/floor/iron/freezer,
 /area/ruin/pizzeria)
 "cv" = (
@@ -292,7 +289,6 @@
 "jY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/no_charge,
 /obj/effect/decal/cleanable/ash,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -359,6 +355,10 @@
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"nJ" = (
+/obj/effect/mapping_helpers/airalarm/all_access,
+/turf/closed/wall,
+/area/ruin/pizzeria/kitchen)
 "om" = (
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -478,6 +478,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/broken/directional/north,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/ruin/pizzeria)
 "wd" = (
@@ -509,6 +510,7 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/iron/checker,
 /area/ruin/pizzeria)
 "xx" = (
@@ -547,7 +549,6 @@
 "yS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/no_charge,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
@@ -614,6 +615,7 @@
 "AP" = (
 /obj/structure/table,
 /obj/item/clothing/suit/jacket/puffer,
+/obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/plating,
 /area/ruin/pizzeria)
 "AZ" = (
@@ -656,6 +658,17 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/structure/closet/crate/freezer/food,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)
 "Di" = (
@@ -781,11 +794,11 @@
 /turf/open/floor/plating,
 /area/ruin/pizzeria/kitchen)
 "IR" = (
-/obj/item/wallframe/airalarm{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
+	},
+/obj/machinery/airalarm/directional/south{
+	pixel_y = 35
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/pizzeria/kitchen)
@@ -937,6 +950,13 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "NL" = (
+/turf/closed/wall,
+/area/ruin/pizzeria)
+"Op" = (
+/obj/machinery/airalarm/directional/south{
+	pixel_y = 4
+	},
+/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/closed/wall,
 /area/ruin/pizzeria)
 "Oy" = (
@@ -1466,7 +1486,7 @@ Ze
 kG
 kG
 KL
-iK
+nJ
 IR
 kG
 kG
@@ -1630,7 +1650,7 @@ TK
 NL
 JM
 bW
-NL
+Op
 cl
 ji
 uU


### PR DESCRIPTION

## About The Pull Request
I've given the icebox pizzeria ruin a few small improvements:
- Firstly, The kitchen is actually stocked with tomatoes from the get go. Along with a few mothic themed ingredients for those signature mothic pizzas we all know and love (And hate for being such a pain to make)
- The discarded air alarm frames have been replaced with working ones (I'm unsure if this was intentional or not)
- Some drinking glasses have been added to the bar
- And finally a pacman has been placed in the backroom along with some plasma to power the place
## Why It's Good For The Game
This place gets overlooked a lot because its completely powerless, and doesn't actually give you enough from the get go to make even a basic pizza besides the tomato seeds a lot of people are gonna miss. This gives the ruin just a little more life to maybe be worth trekking out for. And having mothic themed ingredients in the **MOFFIC** Pizzeria just makes sense even if they are a bitch to make. 

Not sure if this counts as a balance change or a QOL so feel free to yell at me if I've labelled this wrong, I have been advised that this SHOULD be the latter at least.
## Changelog
:cl:
qol: Mothuchi's pizzeria has been improved slightly! Order yourself a fresh mothic pizza today!
/:cl:
