### PR TITLE
Fixes a footsteps runtime

### DIFF
--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -155,11 +155,11 @@
 			heard_clients = playsound(source.loc, pick(source.dna.species.special_step_sounds), 50, TRUE, falloff_distance = 1, vary = sound_vary)
 		else
 			var/static/list/bare_footstep_sounds = GLOB.barefootstep
-
-			heard_clients = playsound(source.loc, pick(bare_footstep_sounds[barefoot_type][1]),
-				bare_footstep_sounds[barefoot_type][2] * volume * volume_multiplier,
-				TRUE,
-				bare_footstep_sounds[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+			if(!isnull(barefoot_type) && bare_footstep_sounds[barefoot_type]) // barefoot_type can be null
+				heard_clients = playsound(source.loc, pick(bare_footstep_sounds[barefoot_type][1]),
+					bare_footstep_sounds[barefoot_type][2] * volume * volume_multiplier,
+					TRUE,
+					bare_footstep_sounds[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
 
 	if(heard_clients)
 		play_fov_effect(source, 5, "footstep", direction, ignore_self = TRUE, override_list = heard_clients)


### PR DESCRIPTION
## About The Pull Request

Tin. Fixes the following runtime:

![image](https://github.com/tgstation/tgstation/assets/13398309/e4cd087f-3c6e-49f7-aaa4-2a91ca1b9a79)

Which happened because `barefoot_type` can potentially be null if `turf.barefootstep` is null.

![Code_KnExLVOSD4](https://github.com/tgstation/tgstation/assets/13398309/1b3c97d5-500b-4d3d-a104-8dac7071fae0)

This results in trying to access `GLOB.barefootstep[null]`, which results in a runtime, which prevents the `play_fov_effect()` from executing.

## Why It's Good For The Game

Less CI failures, and fixes a bug.

## Changelog

:cl:
fix: fixes a runtime in footstep code that would prevent the fov effect from playing to nearby mobs
/:cl: