### PR TITLE
Babyproofs rad nebula against ADMINS!

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -594,7 +594,7 @@
 
 /datum/station_trait/nebula/hostile/radiation/apply_nebula_effect(effect_strength = 0)
 	//big bombad now
-	if(effect_strength > 0)
+	if(effect_strength > 0 && !SSmapping.is_planetary()) //admins can force this
 		if(!SSweather.get_weather_by_type(/datum/weather/rad_storm/nebula))
 			COOLDOWN_START(src, send_care_package_at, send_care_package_time)
 			SSweather.run_weather(/datum/weather/rad_storm/nebula)


### PR DESCRIPTION
Fixes #79845 

Honestly this whole thing is awkward. I really don't want to block being able to force traits under any conditions, but admins keep forcing it on icebox which just kills everyone. This blocks nebula's storm specificaly from running on planetary maps

:cl:
fix: Fixes nebula killing everyone when forced by an admin on icebox
/:cl: