### PR TITLE
Quick carry modules now give the correct bonus

### DIFF
--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -76,15 +76,21 @@
 	incompatible_modules = list(/obj/item/mod/module/quick_carry, /obj/item/mod/module/constructor)
 
 /obj/item/mod/module/quick_carry/on_suit_activation()
-	ADD_TRAIT(mod.wearer, TRAIT_QUICKER_CARRY, MOD_TRAIT)
+	ADD_TRAIT(mod.wearer, TRAIT_QUICK_CARRY, MOD_TRAIT)
 
 /obj/item/mod/module/quick_carry/on_suit_deactivation(deleting = FALSE)
-	REMOVE_TRAIT(mod.wearer, TRAIT_QUICKER_CARRY, MOD_TRAIT)
+	REMOVE_TRAIT(mod.wearer, TRAIT_QUICK_CARRY, MOD_TRAIT)
 
 /obj/item/mod/module/quick_carry/advanced
 	name = "MOD advanced quick carry module"
 	removable = FALSE
 	complexity = 0
+
+/obj/item/mod/module/quick_carry/advanced/on_suit_activation()
+	ADD_TRAIT(mod.wearer, TRAIT_QUICKER_CARRY, MOD_TRAIT)
+
+/obj/item/mod/module/quick_carry/advanced/on_suit_deactivation(deleting = FALSE)
+	REMOVE_TRAIT(mod.wearer, TRAIT_QUICKER_CARRY, MOD_TRAIT)
 
 /obj/item/mod/module/quick_carry/on_suit_activation()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes #79470
The quick carry module and its advanced version both gave the same buff after a copy/paste error. That ain't right.
## Why It's Good For The Game
Uuuuuhhhh oversight bad
## Changelog
:cl:
fix: MOD quick carry modules now give the correct carry speed bonus
/:cl:
