### PR TITLE
Bitrunning glitches that don't escape their domain don't show up in the roundend report

### DIFF
--- a/code/modules/bitrunning/antagonists/_parent.dm
+++ b/code/modules/bitrunning/antagonists/_parent.dm
@@ -6,6 +6,7 @@
 	antagpanel_category = ANTAG_GROUP_GLITCH
 	job_rank = ROLE_GLITCH
 	preview_outfit = /datum/outfit/cyber_police
+	show_in_roundend = FALSE
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE

--- a/code/modules/bitrunning/server/threats.dm
+++ b/code/modules/bitrunning/server/threats.dm
@@ -147,6 +147,10 @@
 	else
 		radio.talk_into(src, "CRITICAL ALERT: Unregistered mechanical entity deployed.")
 
+	var/datum/antagonist/antag_datum = antag.mind?.has_antag_datum(/datum/antagonist/bitrunning_glitch)
+	if(istype(antag_datum))
+		antag_datum.show_in_roundend = TRUE
+
 	do_teleport(antag, get_turf(chosen_forge), forced = TRUE, asoundin = 'sound/magic/ethereal_enter.ogg', asoundout = 'sound/magic/ethereal_exit.ogg', channel = TELEPORT_CHANNEL_QUANTUM)
 
 /// Removes any invalid candidates from the list


### PR DESCRIPTION
## About The Pull Request

Exactly what the title says. I was planning to fully refactor glitches to function more like lavaland elites, which they operate more similarly to, but I was lazy and also discovered the `show_in_roundend` var on `/datum/antagonist` - setting that to `FALSE` does the thing I cared most about.

Making them still appear in the roundend report if they escape was Fikou's idea.

## Why It's Good For The Game

Does the roundend report really need to list a hostile that will cease to exist soon after killing the only characters it can interact with?

## Changelog

:cl:
qol: Bitrunning glitches will not show up in the roundend report unless they escape the virtual domain.
/:cl:
