### PR TITLE
Gives Cargo its own departmental wires

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2494,7 +2494,7 @@
 	},
 /obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "aUk" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/map/right{
@@ -2503,11 +2503,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "aUm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "aUn" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
@@ -2679,7 +2679,7 @@
 "aXq" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "aXE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Maintenance"
@@ -2975,7 +2975,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "bbd" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -6939,7 +6939,7 @@
 /obj/item/chair,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "cyS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8740,7 +8740,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "dhN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -14135,7 +14135,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "fhD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -18568,12 +18568,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"gOG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/lobby)
 "gOS" = (
 /obj/structure/cable,
 /obj/structure/table/glass,
@@ -24518,7 +24512,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "iRW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -25180,7 +25174,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "jdv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26255,7 +26249,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "jvB" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -33704,7 +33698,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "mgK" = (
 /obj/item/target,
 /obj/effect/turf_decal/stripes/line{
@@ -35368,7 +35362,7 @@
 	name = "Ore Redemtion Window"
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "mJE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44244,7 +44238,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "pQG" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -50204,7 +50198,7 @@
 /area/station/security/prison/garden)
 "rVn" = (
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "rVG" = (
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
@@ -50231,7 +50225,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "rVY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50494,7 +50488,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "sal" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
@@ -51303,7 +51297,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "srP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57391,7 +57385,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "uvP" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/virology/glass{
@@ -58765,7 +58759,7 @@
 "uTI" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "uTN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -62483,7 +62477,7 @@
 "wdM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/cargo/lobby)
+/area/station/construction/storage_wing)
 "wem" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -88708,7 +88702,7 @@ hGv
 mNQ
 vQs
 aUk
-gOG
+uwx
 aXq
 ldC
 qMA
@@ -88965,7 +88959,7 @@ puD
 vQs
 vQs
 pQD
-gOG
+uwx
 aXq
 agQ
 fWU
@@ -89736,7 +89730,7 @@ voS
 vQs
 cyR
 rVn
-gOG
+uwx
 mgJ
 aqG
 iyv

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2494,7 +2494,7 @@
 	},
 /obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aUk" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/map/right{
@@ -2503,11 +2503,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aUm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aUn" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
@@ -2679,7 +2679,7 @@
 "aXq" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aXE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Maintenance"
@@ -2975,7 +2975,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "bbd" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -6939,7 +6939,7 @@
 /obj/item/chair,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "cyS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8740,7 +8740,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "dhN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -14135,7 +14135,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "fhD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -18568,6 +18568,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"gOG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "gOS" = (
 /obj/structure/cable,
 /obj/structure/table/glass,
@@ -24512,7 +24518,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "iRW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -25174,7 +25180,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "jdv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26249,7 +26255,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "jvB" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -33698,7 +33704,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "mgK" = (
 /obj/item/target,
 /obj/effect/turf_decal/stripes/line{
@@ -35362,7 +35368,7 @@
 	name = "Ore Redemtion Window"
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "mJE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44238,7 +44244,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "pQG" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -50198,7 +50204,7 @@
 /area/station/security/prison/garden)
 "rVn" = (
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "rVG" = (
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
@@ -50225,7 +50231,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "rVY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50488,7 +50494,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "sal" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
@@ -51297,7 +51303,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "srP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57385,7 +57391,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "uvP" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/virology/glass{
@@ -58759,7 +58765,7 @@
 "uTI" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "uTN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -62477,7 +62483,7 @@
 "wdM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "wem" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -88702,7 +88708,7 @@ hGv
 mNQ
 vQs
 aUk
-uwx
+gOG
 aXq
 ldC
 qMA
@@ -88959,7 +88965,7 @@ puD
 vQs
 vQs
 pQD
-uwx
+gOG
 aXq
 agQ
 fWU
@@ -89730,7 +89736,7 @@ voS
 vQs
 cyR
 rVn
-uwx
+gOG
 mgJ
 aqG
 iyv

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -38,6 +38,10 @@
 	dictionary_key = /datum/wires/airlock/ai
 	proper_name = "AI Airlock"
 
+/datum/wires/airlock/cargo
+	dictionary_key = /datum/wires/airlock/cargo
+	proper_name = "Cargo Airlock"
+
 /datum/wires/airlock/New(atom/holder)
 	wires = list(
 		WIRE_AI,

--- a/code/game/area/areas/station/cargo.dm
+++ b/code/game/area/areas/station/cargo.dm
@@ -1,7 +1,7 @@
 /area/station/cargo
 	name = "Quartermasters"
 	icon_state = "quart"
-	airlock_wires = /datum/wires/airlock/service
+	airlock_wires = /datum/wires/airlock/cargo
 	sound_environment = SOUND_AREA_STANDARD_STATION
 
 /area/station/cargo/sorting


### PR DESCRIPTION

## About The Pull Request

Gives Cargo its own area wires, instead of having them use the same wire layouts as the Service areas.
## Why It's Good For The Game

Back when the original PR (#52563) was made, cargo was a weird subset of "quartermaster" areas that must have just been swept into service. I looked into it and to my surprise cargo just wasn't ever mentioned in it. When the QM areas were converted to cargo areas, there weren't any cargo wires so they probably just inherited the service wires and were forgotten about?

Now, with the QM being a head and cargo being a more defined department than ever, it shall receive the distinction of being called "its own department" in the worst way possible -- by giving it its own wires.
## Changelog
:cl: Rhials
qol: Gives Cargo areas its own wire layout, instead of having it use the same wires as Service areas.
/:cl:
