### PR TITLE
Changes the antechamber outside of Metastation Cargo to use Cargo Lobby areas

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2494,7 +2494,7 @@
 	},
 /obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aUk" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/map/right{
@@ -2503,11 +2503,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aUm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aUn" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
@@ -2679,7 +2679,7 @@
 "aXq" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "aXE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Maintenance"
@@ -2975,7 +2975,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "bbd" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -6939,7 +6939,7 @@
 /obj/item/chair,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "cyS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8740,7 +8740,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "dhN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -14135,7 +14135,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "fhD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -24512,7 +24512,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "iRW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -25174,7 +25174,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "jdv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26249,7 +26249,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "jvB" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -33698,7 +33698,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "mgK" = (
 /obj/item/target,
 /obj/effect/turf_decal/stripes/line{
@@ -35362,7 +35362,7 @@
 	name = "Ore Redemtion Window"
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "mJE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44238,7 +44238,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "pQG" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -45868,6 +45868,12 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"qxJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "qyb" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -50198,7 +50204,7 @@
 /area/station/security/prison/garden)
 "rVn" = (
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "rVG" = (
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
@@ -50225,7 +50231,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "rVY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50488,7 +50494,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "sal" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
@@ -51297,7 +51303,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "srP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57385,7 +57391,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "uvP" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/virology/glass{
@@ -58759,7 +58765,7 @@
 "uTI" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "uTN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -62477,7 +62483,7 @@
 "wdM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/construction/storage_wing)
+/area/station/cargo/lobby)
 "wem" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -88702,7 +88708,7 @@ hGv
 mNQ
 vQs
 aUk
-uwx
+qxJ
 aXq
 ldC
 qMA
@@ -88959,7 +88965,7 @@ puD
 vQs
 vQs
 pQD
-uwx
+qxJ
 aXq
 agQ
 fWU
@@ -89730,7 +89736,7 @@ voS
 vQs
 cyR
 rVn
-uwx
+qxJ
 mgJ
 aqG
 iyv


### PR DESCRIPTION

## About The Pull Request

Hey so while I was working on #79912, I tested it out on Metastation, to my suprise, the front door of cargo didn't use service wires, OR cargo wires, but instead used generic wires. After looking into the area outside of cargo's front door in SDMM, I decided a small change should probably be made regardless of that PR's success.

![image](https://github.com/tgstation/tgstation/assets/28870487/a3724c13-83b0-45a3-9311-52c677e32cab)

This small area outside of cargo is now "cargo lobby" instead of "storage wing". The rest of the storage wing hallway has been untouched, just the front portion where players typically use the desk/bang on the door.

All other maps use the cargo lobby area in this same manner.
## Why It's Good For The Game

Slightly better area consistency, and proper wire use in the event that #79912 is merged.
## Changelog
:cl: Rhials
qol: The area preceding Metastation Cargo's front door is now denoted as being the "cargo lobby".
/:cl:
