### PR TITLE
GMM can order bluepace crystals again

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -76,6 +76,7 @@
 	grind_results = list(/datum/reagent/bluespace = 20)
 	point_value = 30
 	merge_type = /obj/item/stack/sheet/bluespace_crystal
+	material_type = /datum/material/bluespace
 	var/crystal_type = /obj/item/stack/ore/bluespace_crystal/refined
 
 /obj/item/stack/sheet/bluespace_crystal/attack_self(mob/user)// to prevent the construction menu from ever happening


### PR DESCRIPTION
## About The Pull Request
- Fixes #79906
- Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/25190

Bluespace sheets did not have their `material_type` var initialized. This fixes the issue for GMM and possibly other issues that relies on this var

## Changelog
:cl:
fix: you no longer get an empty crate when ordering bluespace crystals from the galactic material market.
/:cl:
