### PR TITLE
Makes oculine taste slightly better

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -706,7 +706,7 @@
 	reagent_state = LIQUID
 	color = "#404040" //oculine is dark grey, inacusiate is light grey
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-	taste_description = "dull toxin"
+	taste_description = "earthy bitterness"
 	purity = REAGENT_STANDARD_PURITY
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED


### PR DESCRIPTION
## About The Pull Request
Changes oculine's taste from 'dull toxin' to 'earthy bitterness'. Probably deserves the no GBP tag.
## Why It's Good For The Game
Oculine is a benign/helpful chem that naturally occurs in carrots. This means it's in all carrot based food the chef cooks, and if the carrots cross pollinate with another plant it's in those too. This is currently a problem, because it means the chef's carrot sticks taste like poison and this tends to freak out new players who don't know that's just what oculine tastes like.

Oculine has no negative effects besides potentially triggering a medical allergy quirk, it can't even be overdosed. So if you see a worrying "you taste dull toxin" message, there's actually no reason to be concerned. Still, I see players who are *convinced* the chef is poisoning their carrot cakes fairly regularly. This should cut down on wasted multiver and lynched chefs.

I changed it to "earthy bitterness" because that's what some species of carrot taste like, and "bitterness" implies medicine. The paranoid can still assume they're being dosed with morphine or something, but they're not being misled into thinking this. For people chugging medicine bottles from chemistry,  oculine stands out a little less too.
## Changelog
:cl:
qol: Oculine now tastes bitter, and not like toxin.
/:cl:
