### PR TITLE
Fixes Ghostize Runtime

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -304,7 +304,13 @@ Works together with spawning an observer, noted above.
 	ghost.client?.init_verbs()
 	if(!can_reenter_corpse)// Disassociates observer mind from the body mind
 		ghost.mind = null
-	ghost.client?.player_details.time_of_death = ghost.mind?.current ? mind.current.timeofdeath : world.time
+
+	var/recordable_time = world.time
+	var/mob/living/former_mob = ghost.mind?.current
+	if(isliving(former_mob))
+		recordable_time = former_mob.timeofdeath
+
+	ghost.client?.player_details.time_of_death = recordable_time
 	SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZED)
 	return ghost
 


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/34697715/32e0ff55-30c3-4a73-b53b-0c2c610d5137)

I had this runtime sitting around for who-knows-how-long so I decided I would just fix it today. `ghostize()` is expected to work on all subtypes of `/mob` so it's a bad idea to access a variable that only exists on `/mob/living` (and there is no real point to move `timeofdeath` up a level imo, we already have too much clutter there and `/mob/camera/imaginary_friend` would _never_ need it).
## Why It's Good For The Game

We should only access variables like these when when they exist.
## Changelog
No shot a player would ever notice this
