### PR TITLE
Fixes the check for borg limb repainting

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -916,7 +916,7 @@
 					part_image.overlays += image(icon = style_list_icons[skin_option], icon_state = "[limb.limb_id]_[limb.aux_zone]")
 				skins += list("[skin_option]" = part_image)
 			var/choice = show_radial_menu(user, src, skins, require_near = TRUE)
-			if(choice && (use_charges(user, 5, requires_full = FALSE) == 5))
+			if(choice && (use_charges(user, 5, requires_full = FALSE)))
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, TRUE, 5)
 				limb.change_appearance(style_list_icons[choice], greyscale = FALSE)
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION
## About The Pull Request

The check for a successful augmented limb  repainting was using the proc incorrectly. Instead of checking for TRUE or FALSE, it tried to see if the returned value was exactly 5 or not. This PR fixes that.

## Why It's Good For The Game

My augmented arms crave fashion.

Fixes: #77429

## Changelog

:cl:
fix: You can once again repaint robotic limbs to use alternate skins
/:cl:
