### PR TITLE
Adds investigative logging for vent overclocking

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -362,7 +362,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		if("overclock")
 			if(isnull(vent))
 				return TRUE
-			vent.toggle_overclock()
+			vent.toggle_overclock(source = key_name(user))
 			vent.update_appearance(UPDATE_ICON)
 			return TRUE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -222,7 +222,7 @@
 	else // pump_direction == SIPHONING
 		icon_state = "vent_in"
 
-/obj/machinery/atmospherics/components/unary/vent_pump/proc/toggle_overclock(from_break = FALSE)
+/obj/machinery/atmospherics/components/unary/vent_pump/proc/toggle_overclock(source, from_break = FALSE)
 	fan_overclocked = !fan_overclocked
 
 	if(from_break)
@@ -233,6 +233,8 @@
 		sound_loop.start()
 	else
 		sound_loop.stop()
+
+	investigate_log("had its overlock setting [fan_overclocked ? "enabled" : "disabled"] by [source]", INVESTIGATE_ATMOS)
 
 	update_appearance()
 
@@ -247,13 +249,10 @@
 	if(!istype(us))
 		return
 
-	var/current_integrity = get_integrity()
 	if(fan_overclocked)
 		take_damage(fan_damage_rate, sound_effect=FALSE)
-		if(current_integrity == 0)
-			on = FALSE
-			set_is_operational(FALSE)
-			toggle_overclock(from_break = TRUE)
+		if(get_integrity() == 0)
+			investigate_log("was destroyed as a result of overclocking", INVESTIGATE_ATMOS)
 			return
 
 	var/percent_integrity = get_integrity_percentage()


### PR DESCRIPTION
## About The Pull Request

Basically what it says in the title. 
We added a feature which could destroy vents but forgot to log who turned it on and forgot to turn it off.
Now the Investigate log for atmos will record who toggled overclocking, whether they turned it on or off, and whenever a vent was destroyed as a result of overlock damage.

Also this removes a little bit of code which never ran, as a result of that it checked the integrity of the vent _before_ damaging it and does not process after being damaged to destruction.

No changelog because it's not player facing.