### PR TITLE
[NO GBP] Fixes footsteps runtimes, part 2

### DIFF
--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -145,7 +145,7 @@
 		// we are wearing shoes
 
 		var/shoestep_type = prepared_steps[FOOTSTEP_MOB_SHOE]
-		if(!isnull(shoestep_type) && bare_footstep_sounds[shoestep_type]) // shoestep type can be null
+		if(!isnull(shoestep_type) && footstep_sounds[shoestep_type]) // shoestep type can be null
 			heard_clients = playsound(source.loc, pick(footstep_sounds[shoestep_type][1]),
 				footstep_sounds[shoestep_type][2] * volume * volume_multiplier,
 				TRUE,

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -115,7 +115,7 @@
 		return
 
 	var/turf_footstep = prepared_steps[footstep_type]
-	if(!turf_footstep)
+	if(isnull(turf_footstep) || !footstep_sounds[turf_footstep])
 		return
 	playsound(source.loc, pick(footstep_sounds[turf_footstep][1]), footstep_sounds[turf_footstep][2] * volume, TRUE, footstep_sounds[turf_footstep][3] + e_range, falloff_distance = 1, vary = sound_vary)
 
@@ -141,19 +141,22 @@
 	///list returned by playsound() filled by client mobs who heard the footstep. given to play_fov_effect()
 	var/list/heard_clients
 
-	if ((source.wear_suit?.body_parts_covered | source.w_uniform?.body_parts_covered | source.shoes?.body_parts_covered) & FEET)
+	if((source.wear_suit?.body_parts_covered | source.w_uniform?.body_parts_covered | source.shoes?.body_parts_covered) & FEET)
 		// we are wearing shoes
 
 		var/shoestep_type = prepared_steps[FOOTSTEP_MOB_SHOE]
-		heard_clients = playsound(source.loc, pick(footstep_sounds[shoestep_type][1]),
-			footstep_sounds[shoestep_type][2] * volume * volume_multiplier,
-			TRUE,
-			footstep_sounds[shoestep_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+		if(!isnull(shoestep_type) && bare_footstep_sounds[shoestep_type]) // shoestep type can be null
+			heard_clients = playsound(source.loc, pick(footstep_sounds[shoestep_type][1]),
+				footstep_sounds[shoestep_type][2] * volume * volume_multiplier,
+				TRUE,
+				footstep_sounds[shoestep_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
 	else
-		var/barefoot_type = prepared_steps[FOOTSTEP_MOB_BAREFOOT]
+		// we are barefoot
+
 		if(source.dna.species.special_step_sounds)
 			heard_clients = playsound(source.loc, pick(source.dna.species.special_step_sounds), 50, TRUE, falloff_distance = 1, vary = sound_vary)
 		else
+			var/barefoot_type = prepared_steps[FOOTSTEP_MOB_BAREFOOT]
 			var/static/list/bare_footstep_sounds = GLOB.barefootstep
 			if(!isnull(barefoot_type) && bare_footstep_sounds[barefoot_type]) // barefoot_type can be null
 				heard_clients = playsound(source.loc, pick(bare_footstep_sounds[barefoot_type][1]),

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -107,7 +107,7 @@
 		return
 
 	var/list/prepared_steps = prepare_step(source)
-	if(!prepared_steps)
+	if(isnull(prepared_steps))
 		return
 
 	if(isfile(footstep_sounds) || istext(footstep_sounds))
@@ -133,7 +133,7 @@
 		range_adjustment = -2
 
 	var/list/prepared_steps = prepare_step(source)
-	if(!prepared_steps)
+	if(isnull(prepared_steps))
 		return
 
 	//cache for sanic speed (lists are references anyways)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/79903 Fixed the most common one, but there are still more of these runtimes it seems.

![image](https://github.com/tgstation/tgstation/assets/13398309/3574d756-d6d6-4c0a-84fa-8512f610bf8d)

This should take care of all the rest. It turns out that any one of the step types keys in the list returned by `prepare_step()` can have `null` values—not just the barefoot one—so we have to check for that in every instance where we read from it.

(Shown here: the list that gets returned. Note that any one of these turf vars can be `null`, aka these are the values that we need to nullcheck for)

https://github.com/tgstation/tgstation/blob/4a6d2b9297a4919d967f944c6786b801e0034df8/code/datums/elements/footstep.dm#L96

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: fixed remaining footstep runtimes
/:cl: