### PR TITLE
Fixes a runtime in advanced camera console

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -74,7 +74,7 @@
 	CRASH("[type] does not implement ai eye handling")
 
 /obj/machinery/computer/camera_advanced/remove_eye_control(mob/living/user)
-	if(!user)
+	if(isnull(user))
 		return
 	for(var/datum/action/actions_removed as anything in actions)
 		actions_removed.Remove(user)
@@ -82,9 +82,9 @@
 		camerachunks_gone.remove(eyeobj)
 	if(user.client)
 		user.reset_perspective(null)
-		if(eyeobj.visible_icon && user.client)
-			user.client.images -= eyeobj.user_image
-		user.client.view_size.unsupress()
+		if(eyeobj.visible_icon)
+			user.client?.images -= eyeobj.user_image
+		user.client?.view_size.unsupress()
 
 	eyeobj.eye_user = null
 	user.remote_control = null
@@ -165,6 +165,8 @@
 	return //AIs would need to disable their own camera procs to use the console safely. Bugs happen otherwise.
 
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
+	if(isnull(user))
+		return
 	GrantActions(user)
 	current_user = user
 	eyeobj.eye_user = user
@@ -173,7 +175,7 @@
 	user.reset_perspective(eyeobj)
 	eyeobj.setLoc(eyeobj.loc)
 	if(should_supress_view_changes)
-		user.client.view_size.supress()
+		user.client?.view_size.supress()
 
 /mob/camera/ai_eye/remote
 	name = "Inactive Camera Eye"

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -121,7 +121,7 @@
 		return
 	if(!can_use(user))
 		return
-	if(isnull(client))
+	if(isnull(user.client))
 		return
 	if(current_user)
 		to_chat(user, span_warning("The console is already in use!"))
@@ -169,7 +169,7 @@
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
 	if(isnull(user))
 		return
-	if(isnull(client))
+	if(isnull(user.client))
 		return
 	GrantActions(user)
 	current_user = user

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -74,7 +74,7 @@
 	CRASH("[type] does not implement ai eye handling")
 
 /obj/machinery/computer/camera_advanced/remove_eye_control(mob/living/user)
-	if(isnull(user))
+	if(isnull(user?.client))
 		return
 	for(var/datum/action/actions_removed as anything in actions)
 		actions_removed.Remove(user)
@@ -84,7 +84,7 @@
 		user.reset_perspective(null)
 		if(eyeobj.visible_icon && user.client)
 			user.client.images -= eyeobj.user_image
-		user.client?.view_size.unsupress()
+		user.client.view_size.unsupress()
 
 	eyeobj.eye_user = null
 	user.remote_control = null
@@ -167,7 +167,7 @@
 	return //AIs would need to disable their own camera procs to use the console safely. Bugs happen otherwise.
 
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
-	if(isnull(user))
+	if(isnull(user?.client))
 		return
 	if(isnull(user.client))
 		return
@@ -179,7 +179,7 @@
 	user.reset_perspective(eyeobj)
 	eyeobj.setLoc(eyeobj.loc)
 	if(should_supress_view_changes)
-		user.client?.view_size.supress()
+		user.client.view_size.supress()
 
 /mob/camera/ai_eye/remote
 	name = "Inactive Camera Eye"

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -121,6 +121,8 @@
 		return
 	if(!can_use(user))
 		return
+	if(isnull(client))
+		return
 	if(current_user)
 		to_chat(user, span_warning("The console is already in use!"))
 		return

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -83,7 +83,7 @@
 		camerachunks_gone.remove(eyeobj)
 
 	user.reset_perspective(null)
-	if(eyeobj.visible_icon && user.client)
+	if(eyeobj.visible_icon)
 		user.client.images -= eyeobj.user_image
 	user.client.view_size.unsupress()
 

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -76,15 +76,16 @@
 /obj/machinery/computer/camera_advanced/remove_eye_control(mob/living/user)
 	if(isnull(user?.client))
 		return
+
 	for(var/datum/action/actions_removed as anything in actions)
 		actions_removed.Remove(user)
 	for(var/datum/camerachunk/camerachunks_gone as anything in eyeobj.visibleCameraChunks)
 		camerachunks_gone.remove(eyeobj)
-	if(user.client)
-		user.reset_perspective(null)
-		if(eyeobj.visible_icon && user.client)
-			user.client.images -= eyeobj.user_image
-		user.client.view_size.unsupress()
+
+	user.reset_perspective(null)
+	if(eyeobj.visible_icon && user.client)
+		user.client.images -= eyeobj.user_image
+	user.client.view_size.unsupress()
 
 	eyeobj.eye_user = null
 	user.remote_control = null
@@ -168,8 +169,6 @@
 
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
 	if(isnull(user?.client))
-		return
-	if(isnull(user.client))
 		return
 	GrantActions(user)
 	current_user = user

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -82,8 +82,8 @@
 		camerachunks_gone.remove(eyeobj)
 	if(user.client)
 		user.reset_perspective(null)
-		if(eyeobj.visible_icon)
-			user.client?.images -= eyeobj.user_image
+		if(eyeobj.visible_icon && user.client)
+			user.client.images -= eyeobj.user_image
 		user.client?.view_size.unsupress()
 
 	eyeobj.eye_user = null

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -167,6 +167,8 @@
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
 	if(isnull(user))
 		return
+	if(isnull(client))
+		return
 	GrantActions(user)
 	current_user = user
 	eyeobj.eye_user = user


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/25222

One of the procs was lacking a `client` check. Also converted some other `client` var accesses to use the `?` operator as they can become null mid execution if the user logs out.

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: fixed a null client runtime in advanced camera console
/:cl:

