### PR TITLE
Improves Cursed Items Wizard Event

### DIFF
--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -61,7 +61,7 @@
 	var/list/mob/living/carbon/human/victims = list()
 
 	for(var/mob/living/carbon/human/target in GLOB.alive_mob_list)
-		if((ruins_spaceworthiness && !is_station_level(target.z)) || isspaceturf(target.loc) || isplasmaman(target))
+		if(isspaceturf(target.loc) || !isnull(target.dna.species.outfit_important_for_life) || (ruins_spaceworthiness && !is_station_level(target.z)))
 			continue //#savetheminers
 		if(ruins_wizard_loadout && IS_WIZARD(target))
 			continue

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -8,7 +8,7 @@
 #define BOXING "boxing"
 /// Gives them a chameleon mask
 #define VOICE_MODULATORS "voicemodulators"
-/// Gives them kitty ears and also modifiers their gender to FEMALE
+/// Gives them kitty ears and also modifies their gender to FEMALE
 #define CATGIRLS_2015 "catgirls2015"
 
 /datum/round_event_control/wizard/cursed_items //fashion disasters

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -1,3 +1,16 @@
+/// Turns them into a psuedo-wizard costume.
+#define WIZARD_MIMICRY "wizardmimic"
+/// Gives them a cursed sword.
+#define CURSED_SWORDS "swords"
+/// Gives them a blunt that they need to smoke
+#define BIG_FAT_DOOBIE "bigfatdoobie"
+/// Gives them boxing gloves and a luchador mask
+#define BOXING "boxing"
+/// Gives them a chameleon mask
+#define VOICE_MODULATORS "voicemodulators"
+/// Gives them kitty ears and also modifiers their gender to FEMALE
+#define CATGIRLS_2015 "catgirls2015"
+
 /datum/round_event_control/wizard/cursed_items //fashion disasters
 	name = "Cursed Items"
 	weight = 3
@@ -11,51 +24,72 @@
 //item you want to equip to the hand, and set its slots_flags = null. Only items equiped to hands need do this.
 
 /datum/round_event/wizard/cursed_items/start()
-	var/item_set = pick("wizardmimic", "swords", "bigfatdoobie", "boxing", "voicemodulators", "catgirls2015")
+	var/item_set = pick(
+		BIG_FAT_DOOBIE,
+		BOXING,
+		CATGIRLS_2015,
+		CURSED_SWORDS,
+		VOICE_MODULATORS,
+		WIZARD_MIMICRY,
+	)
 	var/list/loadout[SLOTS_AMT]
-	var/ruins_spaceworthiness
-	var/ruins_wizard_loadout
+	var/ruins_spaceworthiness = FALSE
+	var/ruins_wizard_loadout = FALSE
 
 	switch(item_set)
-		if("wizardmimic")
+		if(BIG_FAT_DOOBIE)
+			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/cigarette/rollie/trippy
+			ruins_spaceworthiness = TRUE
+		if(BOXING)
+			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/luchador
+			loadout[ITEM_SLOT_GLOVES] = /obj/item/clothing/gloves/boxing
+			ruins_spaceworthiness = TRUE
+		if(CATGIRLS_2015)
+			loadout[ITEM_SLOT_HEAD] = /obj/item/clothing/head/costume/kitty
+			ruins_spaceworthiness = TRUE
+			ruins_wizard_loadout = TRUE
+		if(CURSED_SWORDS)
+			loadout[ITEM_SLOT_HANDS] = /obj/item/katana/cursed
+		if(VOICE_MODULATORS)
+			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/chameleon
+		if(WIZARD_MIMICRY)
 			loadout[ITEM_SLOT_OCLOTHING] = /obj/item/clothing/suit/wizrobe
 			loadout[ITEM_SLOT_FEET] = /obj/item/clothing/shoes/sandal/magic
 			loadout[ITEM_SLOT_HEAD] = /obj/item/clothing/head/wizard
-			ruins_spaceworthiness = 1
-		if("swords")
-			loadout[ITEM_SLOT_HANDS] = /obj/item/katana/cursed
-		if("bigfatdoobie")
-			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/cigarette/rollie/trippy
-			ruins_spaceworthiness = 1
-		if("boxing")
-			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/luchador
-			loadout[ITEM_SLOT_GLOVES] = /obj/item/clothing/gloves/boxing
-			ruins_spaceworthiness = 1
-		if("voicemodulators")
-			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/chameleon
-		if("catgirls2015")
-			loadout[ITEM_SLOT_HEAD] = /obj/item/clothing/head/costume/kitty
-			ruins_spaceworthiness = 1
-			ruins_wizard_loadout = 1
+			ruins_spaceworthiness = TRUE
 
-	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		if(ruins_spaceworthiness && !is_station_level(H.z) || isspaceturf(H.loc) || isplasmaman(H))
+	var/list/mob/living/carbon/human/victims = list()
+
+	for(var/mob/living/carbon/human/target in GLOB.alive_mob_list)
+		if((ruins_spaceworthiness && !is_station_level(target.z)) || isspaceturf(target.loc) || isplasmaman(target))
 			continue //#savetheminers
-		if(ruins_wizard_loadout && IS_WIZARD(H))
+		if(ruins_wizard_loadout && IS_WIZARD(target))
 			continue
-		if(item_set == "catgirls2015") //Wizard code means never having to say you're sorry
-			H.gender = FEMALE
-		for(var/i in 1 to loadout.len)
-			if(loadout[i])
-				var/obj/item/J = loadout[i]
-				var/obj/item/I = new J //dumb but required because of byond throwing a fit anytime new gets too close to a list
-				H.dropItemToGround(H.get_item_by_slot(i), TRUE)
-				H.equip_to_slot_or_del(I, i, indirect_action = TRUE)
-				ADD_TRAIT(I, TRAIT_NODROP, CURSED_ITEM_TRAIT(I))
-				I.item_flags |= DROPDEL
-				I.name = "cursed " + I.name
+		if(item_set == CATGIRLS_2015) //Wizard code means never having to say you're sorry
+			target.gender = FEMALE
+		for(var/iterable in 1 to loadout.len)
+			if(!loadout[iterable])
+				continue
 
-	for(var/mob/living/carbon/human/victim in GLOB.alive_mob_list)
+			var/obj/item/item_type = loadout[iterable]
+			var/obj/item/thing = new item_type //dumb but required because of byond throwing a fit anytime new gets too close to a list
+
+			target.dropItemToGround(target.get_item_by_slot(iterable), TRUE)
+			target.equip_to_slot_or_del(thing, iterable, indirect_action = TRUE)
+			ADD_TRAIT(thing, TRAIT_NODROP, CURSED_ITEM_TRAIT(thing))
+			thing.item_flags |= DROPDEL
+			thing.name = "cursed " + thing.name
+
+		victims += target
+
+	for(var/mob/living/carbon/human/victim as anything in victims)
 		var/datum/effect_system/fluid_spread/smoke/smoke = new
 		smoke.set_up(0, holder = victim, location = victim.loc)
 		smoke.start()
+
+#undef BIG_FAT_DOOBIE
+#undef BOXING
+#undef CATGIRLS_2015
+#undef CURSED_SWORDS
+#undef VOICE_MODULATORS
+#undef WIZARD_MIMICRY


### PR DESCRIPTION

## About The Pull Request

I was bored and stumbled upon this and I remembered how pissed off I got that smoke would spawn on all humans during this event despite nothing *magical* happening to them. So, I fixed that (as well as saving us from iterating through `alive_mob_list` TWICE) and did some other code improvements while in the area.

* We use define keys instead of raw strings (typo prevention)
* No more single-letter variables (way more readable too)
* Better indentation
* Better list multilining
* Some more documentation
* Use legitimate boolean dichotomy

yep it looks good
## Why It's Good For The Game

you don't get smoke spawning on you for no reason at all when you didn't do anything
## Changelog
:cl:
fix: During the "Cursed Items" wizard event, you should only have smoke spawn on you if you actually had a cursed item equipped to you.
/:cl:
