### PR TITLE
Fix bitrunning triggering claustrophobia

### DIFF
--- a/code/datums/quirks/negative_quirks/claustrophobia.dm
+++ b/code/datums/quirks/negative_quirks/claustrophobia.dm
@@ -12,10 +12,10 @@
 	quirk_holder.clear_mood_event("claustrophobia")
 
 /datum/quirk/claustrophobia/process(seconds_per_tick)
-	if(quirk_holder.stat != CONSCIOUS || quirk_holder.IsSleeping() || quirk_holder.IsUnconscious() || HAS_TRAIT(quirk_holder, TRAIT_MIND_TEMPORARILY_GONE))
+	if(quirk_holder.stat != CONSCIOUS || quirk_holder.IsSleeping() || quirk_holder.IsUnconscious())
 		return
 
-	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
+	if(HAS_TRAIT(quirk_holder, TRAIT_MIND_TEMPORARILY_GONE) || HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
 		return
 
 	var/nick_spotted = FALSE

--- a/code/datums/quirks/negative_quirks/claustrophobia.dm
+++ b/code/datums/quirks/negative_quirks/claustrophobia.dm
@@ -12,7 +12,7 @@
 	quirk_holder.clear_mood_event("claustrophobia")
 
 /datum/quirk/claustrophobia/process(seconds_per_tick)
-	if(quirk_holder.stat != CONSCIOUS || quirk_holder.IsSleeping() || quirk_holder.IsUnconscious())
+	if(quirk_holder.stat != CONSCIOUS || quirk_holder.IsSleeping() || quirk_holder.IsUnconscious() || HAS_TRAIT(quirk_holder, TRAIT_MIND_TEMPORARILY_GONE))
 		return
 
 	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))


### PR DESCRIPTION

## About The Pull Request
Fixes #79226

Bitrunning while having claustrophobia would kill you after you left the VR pod. This is no longer the case since your mind is functionally outside of your body, which is similar to the other checks performed to see if  you are unconscious.  

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix bitrunning triggering claustrophobia
/:cl:
