### PR TITLE
Fixes secrets panel disease outbreak button

### DIFF
--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -90,7 +90,7 @@
 			if(!event)
 				return
 			if(length(event.admin_setup))
-				for(var/datum/event_admin_setup/admin_setup_datum in event.admin_setup)
+				for(var/datum/event_admin_setup/admin_setup_datum as anything in event.admin_setup)
 					if(admin_setup_datum.prompt_admins() == ADMIN_CANCEL_EVENT)
 						return
 			var/always_announce_chance = 100

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -214,7 +214,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			if(isnull(event))
 				return
 			if(length(event.admin_setup))
-				for(var/datum/event_admin_setup/admin_setup_datum in event.admin_setup)
+				for(var/datum/event_admin_setup/admin_setup_datum as anything in event.admin_setup)
 					if(admin_setup_datum.prompt_admins() == ADMIN_CANCEL_EVENT)
 						return
 			event.run_event(admin_forced = TRUE)

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -204,7 +204,8 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Virus Outbreak"))
 			var/datum/round_event_control/event
-			switch(tgui_alert(usr,"What disease system do you want?",,list("Advanced","Simple","Make Your Own")))
+			var/prompt = tgui_alert(usr,"What disease system do you want?", "Disease Setup" ,list("Advanced","Simple","Make Your Own"))
+			switch(prompt)
 				if("Make Your Own")
 					AdminCreateVirus(holder)
 				if("Advanced")

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -203,17 +203,24 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			if(!is_funmin)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Virus Outbreak"))
-			switch(tgui_alert(usr,"Do you want this to be a random disease or do you have something in mind?",,list("Make Your Own","Random","Choose")))
+			var/datum/round_event_control/event
+			switch(tgui_alert(usr,"What disease system do you want?",,list("Advanced","Simple","Make Your Own")))
 				if("Make Your Own")
 					AdminCreateVirus(holder)
-				if("Random")
-					force_event(/datum/round_event_control/disease_outbreak)
-				if("Choose")
-					var/virus = input("Choose the virus to spread", "BIOHAZARD") as null|anything in sort_list(typesof(/datum/disease), GLOBAL_PROC_REF(cmp_typepaths_asc))
-					var/datum/round_event_control/disease_outbreak/DC = locate(/datum/round_event_control/disease_outbreak) in SSevents.control
-					var/datum/round_event/disease_outbreak/DO = DC.run_event()
-					DO.virus_type = virus
-					E = DO
+				if("Advanced")
+					event = locate(/datum/round_event_control/disease_outbreak/advanced) in SSevents.control
+				if("Simple")
+					event = locate(/datum/round_event_control/disease_outbreak) in SSevents.control
+			if(isnull(event))
+				return
+			if(length(event.admin_setup))
+				for(var/datum/event_admin_setup/admin_setup_datum in event.admin_setup)
+					if(admin_setup_datum.prompt_admins() == ADMIN_CANCEL_EVENT)
+						return
+			event.run_event(admin_forced = TRUE)
+			message_admins("[key_name_admin(usr)] has triggered an event. ([event.name])")
+			log_admin("[key_name(usr)] has triggered an event. ([event.name])")
+
 		if("allspecies")
 			if(!is_funmin)
 				return

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -204,7 +204,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Virus Outbreak"))
 			var/datum/round_event_control/event
-			var/prompt = tgui_alert(usr,"What disease system do you want?", "Disease Setup" ,list("Advanced","Simple","Make Your Own"))
+			var/prompt = tgui_alert(usr,"What disease system do you want?", "Disease Setup", list("Advanced","Simple","Make Your Own"))
 			switch(prompt)
 				if("Make Your Own")
 					AdminCreateVirus(holder)

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -204,7 +204,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Virus Outbreak"))
 			var/datum/round_event_control/event
-			var/prompt = tgui_alert(usr,"What disease system do you want?", "Disease Setup", list("Advanced","Simple","Make Your Own"))
+			var/prompt = tgui_alert(usr, "What disease system do you want?", "Disease Setup", list("Advanced", "Simple", "Make Your Own"))
 			switch(prompt)
 				if("Make Your Own")
 					AdminCreateVirus(holder)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -139,7 +139,8 @@
 			return
 		CHECK_TICK //don't lag the server to death
 	if(isnull(victim))
-		log_game("Event Disease Outbreak: Classic attempted to start, but failed.")
+		message_admins("Event Disease Outbreak: Classic attempted to start, but failed to find a candidate target.")
+		log_game("Event Disease Outbreak: Classic attempted to start, but failed to find a candidate target")
 
 /datum/round_event_control/disease_outbreak/advanced
 	name = "Disease Outbreak: Advanced"
@@ -275,7 +276,8 @@
 			return
 		CHECK_TICK //don't lag the server to death
 	if(isnull(victim))
-		log_game("Event Disease Outbreak: Advanced attempted to start, but failed.")
+		message_admins("Event Disease Outbreak: Advanced attempted to start, but failed to find a candidate target.")
+		log_game("Event Disease Outbreak: Advanced attempted to start, but failed to find a candidate target.")
 
 /datum/disease/advance/random/event
 	name = "Event Disease"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/79866

Hadn't been updated to the new system where candidates are found during round event setup. Changes the failure message for clarity on why it fails, and sends a message to admins same as a successful outbreak.

## Changelog

:cl: LT3
fix: Disease outbreak: classic spawned from the admin secrets panel no longer fails to start
fix: Disease outbreak provides a message about why it fails to start
/:cl: