### PR TITLE
Fixes tram counter with head-related injuries

### DIFF
--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -554,8 +554,8 @@
 	SEND_TRANSPORT_SIGNAL(COMSIG_COMMS_STATUS, src, TRUE)
 	log_transport("TC: [specific_transport_id] ending Tram Malfunction event.")
 
-/datum/transport_controller/linear/tram/proc/register_collision()
-	tram_registration.collisions += 1
+/datum/transport_controller/linear/tram/proc/register_collision(points = 1)
+	tram_registration.collisions += points
 	SEND_TRANSPORT_SIGNAL(COMSIG_TRAM_COLLISION, SSpersistence.tram_hits_this_round)
 
 /datum/transport_controller/linear/tram/proc/power_lost()

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -464,6 +464,7 @@
 	SSpersistence.tram_hits_this_round += points
 	SSblackbox.record_feedback("amount", "tram_collision", points)
 	var/datum/transport_controller/linear/tram/tram_controller = transport_controller_datum
+	ASSERT(istype(tram_controller))
 	tram_controller.register_collision(points)
 
 ///move the movers list of movables on our tile to destination if we successfully move there first.

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -424,6 +424,7 @@
 							head.dismember()
 							victim_living.regenerate_icons()
 							add_overlay(mutable_appearance(icon, "blood_overlay"))
+							register_collision(points = 3)
 
 					if(FALSE)
 						log_combat(src, victim_living, "collided with")
@@ -452,16 +453,18 @@
 				victim_living.throw_at(throw_target, 200 * collision_lethality, 4 * collision_lethality, callback = land_slam)
 
 				//increment the hit counters
-				if(ismob(victim_living) && victim_living.client)
-					if(istype(transport_controller_datum, /datum/transport_controller/linear/tram))
-						SSpersistence.tram_hits_this_round++
-						SSblackbox.record_feedback("amount", "tram_collision", 1)
-						var/datum/transport_controller/linear/tram/tram_controller = transport_controller_datum
-						tram_controller.register_collision()
+				if(ismob(victim_living) && victim_living.client && istype(transport_controller_datum, /datum/transport_controller/linear/tram))
+					register_collision(points = 1)
 
 	unset_movement_registrations(exited_locs)
 	group_move(things_to_move, travel_direction)
 	set_movement_registrations(entering_locs)
+
+/obj/structure/transport/linear/proc/register_collision(points = 1)
+	SSpersistence.tram_hits_this_round += points
+	SSblackbox.record_feedback("amount", "tram_collision", points)
+	var/datum/transport_controller/linear/tram/tram_controller = transport_controller_datum
+	tram_controller.register_collision(points)
 
 ///move the movers list of movables on our tile to destination if we successfully move there first.
 ///this is like calling forceMove() on everything in movers and ourselves, except nothing in movers


### PR DESCRIPTION
## About The Pull Request

Fixes counter not incrementing when the tram kills via the head. Beheadings are worth triple points.
Closes https://github.com/tgstation/tgstation/issues/79802

## Changelog

:cl: LT3
fix: Getting beheaded by the tram increments the scoreboard
/:cl: