### PR TITLE
No currency symbol for free products

### DIFF
--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -349,7 +349,7 @@ const ProductButton = (props, context) => {
         })
       }>
       {customPrice}
-      {displayed_currency_name}
+      {!access && displayed_currency_name}
     </Button>
   ) : (
     <Button
@@ -361,7 +361,7 @@ const ProductButton = (props, context) => {
         })
       }>
       {standardPrice}
-      {displayed_currency_name}
+      {!free && displayed_currency_name}
     </Button>
   );
 };


### PR DESCRIPTION
## About The Pull Request

I have removed the currency icon for free products

**Basic vendor menu:**
![BaseVendor](https://github.com/tgstation/tgstation/assets/72273449/046be357-1623-4cf2-91ea-ff6663b20f78)

**Custom vendor:**
Owner's view
![CustomOwnerVendor](https://github.com/tgstation/tgstation/assets/72273449/3e959fcb-e389-40d6-943e-fecc5f6ee560)
Client's view:
![CustomVendor](https://github.com/tgstation/tgstation/assets/72273449/f9d8a60b-2b4c-4263-90f1-3d97a95c1241)


## Why It's Good For The Game

I don't think it's important to know what currency the free product is measured in, since in the end it won't affect anything. The buttons look better without Cr

## Changelog

:cl:
code: Removed currency value for free products
/:cl:

