### PR TITLE
Fixes destructive analyzer being unable to research anything

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -171,6 +171,7 @@
 	if(isnull(id))
 		return FALSE
 
+	var/item_type = loaded_item.type
 	if(id == DESTRUCTIVE_ANALYZER_DESTROY_POINTS)
 		if(!destroy_item(gain_research_points = TRUE))
 			return FALSE

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -182,7 +182,7 @@
 		return FALSE
 	if(!destroy_item())
 		return FALSE
-	SSblackbox.record_feedback("nested tally", "item_deconstructed", 1, list("[node_to_discover.id]", "[loaded_item.type]"))
+	SSblackbox.record_feedback("nested tally", "item_deconstructed", 1, list("[node_to_discover.id]", "[item_type]"))
 	stored_research.unhide_node(node_to_discover)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/blob/62165b992df9e3b969519d6cfd776c6479c40743/code/modules/research/destructive_analyzer.dm#L184 placed after `loaded_item` is nulled, so it runtimes and fails to unhide any nodes. I've just saved item's type to new variable. Hopefully, it doesn't make any harddels or other scary things.

![image](https://github.com/tgstation/tgstation/assets/8430839/7d4994a3-e0eb-47e6-b69c-f18a6b820b4e)
## Why It's Good For The Game
less runtimes, more things that works as they should
## Changelog
:cl:
fix: You can now destructively analyze syndicate and abductor items. It works this time, I promise!
/:cl:
