### PR TITLE
Adds neck-snapping to CQC and Sleeping carp

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -183,17 +183,17 @@
 		log_combat(attacker, defender, "sweeped (CQC)")
 		reset_streak()
 		return TRUE
-	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat)
+	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
 		var/obj/item/bodypart/head = defender.get_bodypart("head")
 		if(head)
-			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
-			defender.death()
 			playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
 			defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
 						span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
 			to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
 			log_combat(attacker, defender, "snapped neck")
-			return
+			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
+			defender.death()
+			return TRUE
 
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -192,7 +192,10 @@
 			to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
 			log_combat(attacker, defender, "snapped neck")
 			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
-			defender.death()
+			if(!HAS_TRAIT(defender, TRAIT_NODEATH))
+				defender.death()
+				defender.investigate_log("has had [defender.p_their()] neck snapped by [attacker].", INVESTIGATE_DEATHS)
+
 			return TRUE
 
 	add_to_streak("H", defender)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -186,9 +186,13 @@
 	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
 		var/obj/item/bodypart/head = defender.get_bodypart("head")
 		if(head)
-			playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
-			defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
-						span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
+			playsound(defender, 'sound/effects/wounds/crack1.ogg', 100)
+			defender.visible_message(
+				span_danger("[attacker] snaps the neck of [defender]!"),
+				span_userdanger("Your neck is snapped by [attacker]!"),
+				span_hear("You hear a sickening snap!"),
+				ignored_mobs = attacker
+			)
 			to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
 			log_combat(attacker, defender, "snapped neck")
 			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -183,6 +183,17 @@
 		log_combat(attacker, defender, "sweeped (CQC)")
 		reset_streak()
 		return TRUE
+	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat)
+		var/obj/item/bodypart/head = defender.get_bodypart("head")
+		if(head)
+			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
+			defender.death()
+			playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
+			defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
+						span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
+			to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
+			log_combat(attacker, defender, "snapped neck")
+			return
 
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -107,6 +107,17 @@
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/attacker, mob/living/defender)
+	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
+	var/obj/item/bodypart/head = defender.get_bodypart("head")
+	if(head)
+		playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
+		defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
+					span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
+		to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
+		log_combat(attacker, defender, "snapped neck")
+		defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
+		defender.death()
+		return TRUE
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))
 		return TRUE

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -110,14 +110,19 @@
 	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
 		var/obj/item/bodypart/head = defender.get_bodypart("head")
 		if(head)
-			playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
-			defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
-						span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
+			playsound(defender, 'sound/effects/wounds/crack1.ogg', 100)
+			defender.visible_message(
+				span_danger("[attacker] snaps the neck of [defender]!"),
+				span_userdanger("Your neck is snapped by [attacker]!"),
+				span_hear("You hear a sickening snap!"),
+				ignored_mobs = attacker
+			)
 			to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
 			log_combat(attacker, defender, "snapped neck")
 			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
-			defender.death()
-			return TRUE
+			if(!HAS_TRAIT(defender, TRAIT_NODEATH))
+				defender.death()
+				defender.investigate_log("has had [defender.p_their()] neck snapped by [attacker].", INVESTIGATE_DEATHS)
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))
 		return TRUE

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -108,16 +108,16 @@
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/attacker, mob/living/defender)
 	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
-	var/obj/item/bodypart/head = defender.get_bodypart("head")
-	if(head)
-		playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
-		defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
-					span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
-		to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
-		log_combat(attacker, defender, "snapped neck")
-		defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
-		defender.death()
-		return TRUE
+		var/obj/item/bodypart/head = defender.get_bodypart("head")
+		if(head)
+			playsound(defender, 'sound/effects/wounds/crack1.ogg', 160)
+			defender.visible_message(span_danger("[attacker] snaps the neck of [defender]!"), \
+						span_userdanger("Your neck is snapped by [attacker]!"), span_hear("You hear a sickening snap!"), null, attacker)
+			to_chat(attacker, span_danger("In a swift motion, you snap the neck of [defender]!"))
+			log_combat(attacker, defender, "snapped neck")
+			defender.apply_damage(100, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND)
+			defender.death()
+			return TRUE
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))
 		return TRUE


### PR DESCRIPTION

## About The Pull Request
If you achieve a kill-grab on your target as a sleeping carp or CQC user, you can use harm on their head to snap their neck, killing them instantly.
## Why It's Good For The Game
Neck snapping is in line with that secret-agent/commando badassery that sleeping carp and CQC emulate. If you are in a kill grab from a carp or CQC user, you were probably dead anyways, so this shouldn't have large balance implications.
## Changelog
:cl: itseasytosee
add: Sleeping carp/cqc users can now snap peoples necks by punching them in the head while they are in a kill grab.
/:cl:
