### PR TITLE
ARDS and AN code cleanup

### DIFF
--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -128,7 +128,7 @@ Bonus
 			to_chat(M, span_userdanger("[pick("Your lungs hurt!", "It hurts to breathe!")]"))
 			Asphyxiate(M, A)
 			M.emote("gasp")
-			if(M.getOxyLoss() >= 120)
+			if(M.getOxyLoss() >= (M.maxHealth / (200/120)))
 				M.visible_message(span_warning("[M] stops breathing, as if their lungs have totally collapsed!"))
 				Asphyxiate_death(M, A)
 	return

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -94,7 +94,6 @@ Bonus
 	symptom_delay_min = 3
 	symptom_delay_max = 6
 	var/chems = FALSE
-	var/zombie = FALSE
 	threshold_descs = list(
 		"Stage Speed 7" = "Synthesizes Heparin and Lipolicide inside the host, causing increased bleeding and hunger.",
 		"Stealth 5" = "The symptom remains hidden until active.",
@@ -128,6 +127,4 @@ Bonus
 	M.take_overall_damage(brute = get_damage, required_bodytype = BODYTYPE_ORGANIC)
 	if(chems)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/heparin = 2, /datum/reagent/toxin/lipolicide = 2))
-	if(zombie)
-		M.reagents.add_reagent(/datum/reagent/romerol, 1)
 	return 1


### PR DESCRIPTION
## About The Pull Request

Just cleans up some unused code in the necrosis symptom (it was supposed to give romerol at some point? what?) and makes it so the threshold for instant killdeath oxyloss on ARDS is a proportion of mob.maxHealth as opposed to a static number.

## Why It's Good For The Game

Gets rid of unused code and makes it so we can adjust maxHealth without unexpected consequences. Should probably do this in other areas like check_passout too.

## Changelog

:cl:
code: Made ARDS death check respect maxHealth.
/:cl:
