### PR TITLE
Add a bounds check to prevent runtimes on the ripple shuttle port

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -820,12 +820,10 @@
 	var/list/L1 = return_ordered_turfs(S1.x, S1.y, S1.z, S1.dir)
 
 	var/list/ripple_turfs = list()
-
-	for(var/i in 1 to L0.len)
+	var/stop = min(L0.len, L1.len)
+	for(var/i in 1 to stop)
 		var/turf/T0 = L0[i]
 		var/turf/T1 = L1[i]
-		if(!T0 || !T1)
-			continue  // out of bounds
 		if(!istype(T0.loc, area_type) || istype(T0.loc, /area/shuttle/transit))
 			continue  // not part of the shuttle
 		ripple_turfs += T1


### PR DESCRIPTION
This appears to sometimes runtime when the target stationary port is somehow a different size to the ripple port. The code had an out of bounds check of a sort, but it doesn't actually work because the array accesses runtime instead of returning a null

As to why the turfs available were not the same? most likely because the bounds overlapped the world edge due to a fuck huge shuttle.

I have a feeling even if this proc completes something would fail later anyway.

edit: oh so it was the lance shuttle which is fuck hueg

#79961 is related but not fixed by this.