### PR TITLE
Gives drones the ablity to using the crafting menu again

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -123,7 +123,7 @@
 
 //Drones
 #define ui_drone_drop "CENTER+1:18,SOUTH:5"
-#define ui_drone_pull "CENTER+2:2,SOUTH:5"
+#define ui_drone_pull "CENTER+1.5:2,SOUTH:5"
 #define ui_drone_storage "CENTER-2:14,SOUTH:5"
 #define ui_drone_head "CENTER-3:14,SOUTH:5"
 

--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -174,6 +174,7 @@
 	AddElement(/datum/element/dextrous, hud_type = hud_type)
 	AddComponent(/datum/component/basic_inhands, y_offset = getItemPixelShiftY())
 	AddComponent(/datum/component/simple_access, SSid_access.get_region_access_list(list(REGION_ALL_GLOBAL)))
+	AddComponent(/datum/component/personal_crafting) // Kind of hard to be a drone and not be able to make tiles
 
 	if(default_storage)
 		var/obj/item/storage = new default_storage(src)
@@ -348,6 +349,7 @@
 
 	var/static/list/not_shy_of = typecacheof(list(/mob/living/basic/drone, /mob/living/simple_animal/bot))
 	if(shy)
+		REMOVE_TRAIT(src, TRAIT_CAN_STRIP, DRONE_SHY_TRAIT) // To shy to touch someone elses hat
 		ADD_TRAIT(src, TRAIT_PACIFISM, DRONE_SHY_TRAIT)
 		LoadComponent(/datum/component/shy, mob_whitelist=not_shy_of, shy_range=3, message="Your laws prevent this action near %TARGET.", keyless_shy=FALSE, clientless_shy=TRUE, dead_shy=FALSE, dead_shy_immediate=TRUE, machine_whitelist=shy_machine_whitelist)
 		LoadComponent(/datum/component/shy_in_room, drone_bad_areas, "Touching anything in %ROOM could break your laws.")
@@ -356,6 +358,7 @@
 		RegisterSignal(src, COMSIG_TRY_USE_MACHINE, PROC_REF(blacklist_on_try_use_machine))
 		RegisterSignal(src, COMSIG_TRY_WIRES_INTERACT, PROC_REF(blacklist_on_try_wires_interact))
 	else
+		ADD_TRAIT(src, TRAIT_CAN_STRIP, DRONE_SHY_TRAIT) // ...I wonder if I can ware pants like a hat
 		REMOVE_TRAIT(src, TRAIT_PACIFISM, DRONE_SHY_TRAIT)
 		qdel(GetComponent(/datum/component/shy))
 		qdel(GetComponent(/datum/component/shy_in_room))


### PR DESCRIPTION
## About The Pull Request

It looks like fix removed the drone's ability to use the crafting menu even if they technically have hands.  I also added the ability for non-shy drones to be able to strip a person.  Mainly because derelict drones need to strip things for parts and syndicate drones need the ability to tie shoelaces.
## Why It's Good For The Game

It's fun being a drone but with all the shy restrictions its very difficult to even fix maintenance without the crafting menu.  As for the ability  to strip, when your a derelict drone you get bodies that have great hats and they want that.
## Changelog
:cl:
fix: All drones now can craft again
add: Non-Shy drones can now strip people of their things
fix: Centered the "pull" button properly over the drop button
/:cl:
