### PR TITLE
makes verb callbacks not execute if the original client disconnected

### DIFF
--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -85,8 +85,7 @@ SUBSYSTEM_DEF(verb_manager)
 		return world.push_usr(incoming_callback.object, new_us)
 #endif
 
-	//debatable whether this is needed, this is just to try and ensure that you dont use this to queue stuff that isnt from player input.
-	if(QDELETED(usr))
+	if(QDELETED(usr) || !usr.client)
 		stack_trace("_queue_verb() returned false because it wasnt called from player input!")
 		return FALSE
 

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -85,7 +85,7 @@ SUBSYSTEM_DEF(verb_manager)
 		return world.push_usr(incoming_callback.object, new_us)
 #endif
 
-	if(QDELETED(usr) || !usr.client)
+	if(QDELETED(usr) || isnull(usr.client))
 		stack_trace("_queue_verb() returned false because it wasnt called from player input!")
 		return FALSE
 

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -83,11 +83,14 @@ SUBSYSTEM_DEF(verb_manager)
 		incoming_callback.user = WEAKREF(incoming_callback.object)
 		var/datum/callback/new_us = CALLBACK(arglist(list(GLOBAL_PROC, GLOBAL_PROC_REF(_queue_verb)) + args.Copy()))
 		return world.push_usr(incoming_callback.object, new_us)
-#endif
+
+#else
 
 	if(QDELETED(usr) || !usr.client)
 		stack_trace("_queue_verb() returned false because it wasnt called from player input!")
 		return FALSE
+
+#endif
 
 	if(!istype(subsystem_to_use))
 		stack_trace("_queue_verb() returned false because it was given an invalid subsystem to queue for!")

--- a/code/datums/verb_callbacks.dm
+++ b/code/datums/verb_callbacks.dm
@@ -1,4 +1,5 @@
 ///like normal callbacks but they also record their creation time for measurement purposes
+///they also require the same usr/user that made the callback to both still exist and to still have a client in order to execute
 /datum/callback/verb_callback
 	///the tick this callback datum was created in. used for testing latency
 	var/creation_time = 0
@@ -6,3 +7,22 @@
 /datum/callback/verb_callback/New(thingtocall, proctocall, ...)
 	creation_time = DS2TICKS(world.time)
 	. = ..()
+
+/datum/callback/verb_callback/Invoke(...)
+	var/mob/our_user = user?.resolve()
+	if(QDELETED(our_user) || !our_user.client)
+		return
+	var/mob/temp = usr
+	. = ..()
+	usr = temp
+
+/datum/callback/verb_callback/InvokeAsync(...)
+	var/mob/our_user = user?.resolve()
+	if(QDELETED(our_user) || !our_user.client)
+		return
+	var/mob/temp = usr
+	. = ..()
+	usr = temp
+
+
+

--- a/code/datums/verb_callbacks.dm
+++ b/code/datums/verb_callbacks.dm
@@ -18,7 +18,7 @@
 
 /datum/callback/verb_callback/InvokeAsync(...)
 	var/mob/our_user = user?.resolve()
-	if(QDELETED(our_user) || !our_user.client)
+	if(QDELETED(our_user) || isnull(our_user.client))
 		return
 	var/mob/temp = usr
 	. = ..()

--- a/code/datums/verb_callbacks.dm
+++ b/code/datums/verb_callbacks.dm
@@ -10,7 +10,7 @@
 
 /datum/callback/verb_callback/Invoke(...)
 	var/mob/our_user = user?.resolve()
-	if(QDELETED(our_user) || !our_user.client)
+	if(QDELETED(our_user) || isnull(our_user.client))
 		return
 	var/mob/temp = usr
 	. = ..()

--- a/code/datums/verb_callbacks.dm
+++ b/code/datums/verb_callbacks.dm
@@ -8,6 +8,7 @@
 	creation_time = DS2TICKS(world.time)
 	. = ..()
 
+#ifndef UNIT_TESTS
 /datum/callback/verb_callback/Invoke(...)
 	var/mob/our_user = user?.resolve()
 	if(QDELETED(our_user) || isnull(our_user.client))
@@ -23,6 +24,6 @@
 	var/mob/temp = usr
 	. = ..()
 	usr = temp
-
+#endif
 
 


### PR DESCRIPTION

## About The Pull Request
currently verb callbacks still execute if the usr at the time of their creation got deleted or had their client disconnected before they got invoked. this can cause issues if the verb being deferred assumes usr exists, now the callback will return instead of calling its proc if its invoked after usr is deleted or disconnected.
## Why It's Good For The Game
less runtimes
## Changelog
:cl:
code: verb callbacks will no longer execute if the original client disconnected
/:cl:
