### PR TITLE
Cleanbots are now always blue

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -101,7 +101,7 @@
 
 /mob/living/simple_animal/bot/cleanbot/Initialize(mapload, obj/item/reagent_containers/cup/bucket/bucket_obj)
 	if(!bucket_obj)
-		bucket_obj = new()
+		bucket_obj = new /obj/item/reagent_containers/cup/bucket/consistent
 	bucket_obj.forceMove(src)
 
 	. = ..()

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -375,15 +375,21 @@
 		ITEM_SLOT_DEX_STORAGE
 	)
 
+	/// Should this bucket randomize its colors?
+	var/randomize_colors = TRUE
+
 /datum/armor/cup_bucket
 	melee = 10
 	fire = 75
 	acid = 50
 
 /obj/item/reagent_containers/cup/bucket/Initialize(mapload, vol)
-	if(greyscale_colors == initial(greyscale_colors))
+	if (randomize_colors && greyscale_colors == initial(greyscale_colors))
 		set_greyscale(pick(list("#0085e5", COLOR_OFF_WHITE, COLOR_ORANGE_BROWN, COLOR_SERVICE_LIME, COLOR_MOSTLY_PURE_ORANGE, COLOR_FADED_PINK, COLOR_RED, COLOR_YELLOW, COLOR_VIOLET, COLOR_WEBSAFE_DARK_GRAY)))
 	return ..()
+
+/obj/item/reagent_containers/cup/bucket/consistent
+	randomize_colors = FALSE
 
 /obj/item/reagent_containers/cup/bucket/wooden
 	name = "wooden bucket"


### PR DESCRIPTION
## About The Pull Request
Makes cleanbots always blue
## Why It's Good For The Game
The randomization looks hideous every time I see one, the artists made these blue for a reason
## Changelog
:cl:
image: Premade cleanbots are now always blue.
/:cl:
