### PR TITLE
Changes shove_slowdown to a status effect, changes to unarmed combat grammer

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -96,7 +96,7 @@
 		to_chat(user, span_warning("You're not ready to tackle!"))
 		return
 
-	if(user.has_movespeed_modifier(/datum/movespeed_modifier/shove)) // can't tackle if you just got shoved
+	if(user.has_status_effect(/datum/status_effect/staggered)) // can't tackle if you just got shoved
 		to_chat(user, span_warning("You're too off balance to tackle!"))
 		return
 
@@ -179,9 +179,8 @@
 			to_chat(target, span_userdanger("[user] lands a weak [tackle_word] on you, briefly knocking you off-balance!"))
 
 			user.Knockdown(30)
-			if(ishuman(target) && !T.has_movespeed_modifier(/datum/movespeed_modifier/shove))
-				T.add_movespeed_modifier(/datum/movespeed_modifier/shove) // maybe define a slightly more severe/longer slowdown for this
-				addtimer(CALLBACK(T, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH * 2)
+			if(ishuman(target))
+				target.apply_status_effect(/datum/status_effect/staggered, SHOVE_SLOWDOWN_LENGTH * 2)
 
 		if(-1 to 0) // decent hit, both parties are about equally inconvenienced
 			user.visible_message(span_warning("[user] lands a passable [tackle_word] on [target], sending them both tumbling!"), span_userdanger("You land a passable [tackle_word] on [target], sending you both tumbling!"), ignored_mobs = target)

--- a/code/datums/status_effects/debuffs/staggered.dm
+++ b/code/datums/status_effects/debuffs/staggered.dm
@@ -1,0 +1,23 @@
+/datum/status_effect/staggered
+	id = "staggered"
+	duration = SHOVE_SLOWDOWN_LENGTH
+	remove_on_fullheal = TRUE
+	status_type = STATUS_EFFECT_REPLACE
+
+/datum/status_effect/staggered/on_creation(mob/living/new_owner, set_duration)
+	if(isnum(set_duration))
+		duration = set_duration
+	..()
+
+/datum/status_effect/staggered/on_apply()
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/staggered)
+	owner.emote("sway")
+	return ..()
+
+/datum/status_effect/staggered/on_remove()
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/staggered)
+
+	var/active_item = owner.get_active_held_item()
+	if(is_type_in_typecache(active_item, GLOB.shove_disarming_types))
+		owner.visible_message(span_warning("[owner.name] regains their grip on \the [active_item]!"), span_warning("You regain your grip on \the [active_item]"), null, COMBAT_MESSAGE_RANGE)
+	return ..()

--- a/code/datums/status_effects/debuffs/staggered.dm
+++ b/code/datums/status_effects/debuffs/staggered.dm
@@ -3,6 +3,7 @@
 	duration = SHOVE_SLOWDOWN_LENGTH
 	remove_on_fullheal = TRUE
 	status_type = STATUS_EFFECT_REPLACE
+	alert_type = null
 
 /datum/status_effect/staggered/on_creation(mob/living/new_owner, set_duration)
 	if(isnum(set_duration))

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -244,9 +244,7 @@
 
 			if(14 to 25) // 1.3ish% chance to stumble and be a bit off balance (like being disarmed)
 				to_chat(our_guy, span_danger("You stumble a bit on your untied shoelaces!"))
-				if(!our_guy.has_movespeed_modifier(/datum/movespeed_modifier/shove))
-					our_guy.add_movespeed_modifier(/datum/movespeed_modifier/shove)
-					addtimer(CALLBACK(our_guy, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH)
+				our_guy.apply_status_effect(/datum/status_effect/staggered)
 
 			if(26 to 1000)
 				wiser = FALSE

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1161,13 +1161,13 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		user.do_attack_animation(target, atk_effect)
 
 		//has our target been shoved recently? If so, they're off-balance and we get an easy hit.
-		var/off_balance = FALSE
+		var/staggered = FALSE
 
 		//Someone in a grapple is much more vulnerable to being harmed by punches.
 		var/grappled = FALSE
 
-		if(target.has_movespeed_modifier(/datum/movespeed_modifier/shove))
-			off_balance = TRUE
+		if(target.has_status_effect(/datum/status_effect/staggered))
+			staggered = TRUE
 
 		if(target.pulledby && target.pulledby.grab_state >= GRAB_AGGRESSIVE)
 			grappled = TRUE
@@ -1179,7 +1179,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 		var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases
 		if(attacking_bodypart.unarmed_damage_low)
-			if((target.body_position == LYING_DOWN) || HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) || off_balance) //kicks and attacks against off-balance targets never miss (provided your species deals more than 0 damage)
+			if((target.body_position == LYING_DOWN) || HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) || staggered) //kicks and attacks against off-balance targets never miss (provided your species deals more than 0 damage)
 				miss_chance = 0
 			else
 				miss_chance = clamp(UNARMED_MISS_CHANCE_BASE - limb_accuracy + user.getStaminaLoss() + (user.getBruteLoss()*0.5), 0, UNARMED_MISS_CHANCE_MAX) //Limb miss chance + various damage. capped at 80 so there is at least a chance to land a hit.
@@ -1195,6 +1195,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		var/armor_block = target.run_armor_check(affecting, MELEE)
 
 		playsound(target.loc, attacking_bodypart.unarmed_attack_sound, 25, TRUE, -1)
+
+		if(grappled)
+			atk_verb = "pummel"
 
 		target.visible_message(span_danger("[user] [atk_verb]ed [target]!"), \
 						span_userdanger("You're [atk_verb]ed by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
@@ -1222,7 +1225,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			log_combat(user, target, "punched")
 
 		//If we rolled a punch high enough to hit our stun threshold, or our target is off-balance and they have at least 40 damage+stamina loss, we knock them down
-		if((target.stat != DEAD) && prob(limb_accuracy) || (target.stat != DEAD) && off_balance && (target.getStaminaLoss() + user.getBruteLoss()) >= 40)
+		if((target.stat != DEAD) && prob(limb_accuracy) || (target.stat != DEAD) && staggered && (target.getStaminaLoss() + user.getBruteLoss()) >= 40)
 			target.visible_message(span_danger("[user] knocks [target] down!"), \
 							span_userdanger("You're knocked down by [user]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
 			to_chat(user, span_danger("You knock [target] down!"))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1114,7 +1114,7 @@
 /mob/living/resist_grab(moving_resist)
 	. = TRUE
 	//If we're in an aggressive grab or higher, we're lying down, we're vulnerable to grabs, or we've been shoved and we have some amount of stamina loss, we must resist
-	if(pulledby.grab_state || body_position == LYING_DOWN || HAS_TRAIT(src, TRAIT_GRABWEAKNESS) || has_movespeed_modifier(/datum/movespeed_modifier/shove) && getStaminaLoss() >= 30)
+	if(pulledby.grab_state || body_position == LYING_DOWN || HAS_TRAIT(src, TRAIT_GRABWEAKNESS) || has_status_effect(/datum/status_effect/staggered) && getStaminaLoss() >= 30)
 		var/altered_grab_state = pulledby.grab_state
 		if((body_position == LYING_DOWN || HAS_TRAIT(src, TRAIT_GRABWEAKNESS)) && pulledby.grab_state < GRAB_KILL) //If prone, resisting out of a grab is equivalent to 1 grab state higher. won't make the grab state exceed the normal max, however
 			altered_grab_state++

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -81,9 +81,6 @@
 	blacklisted_movetypes = FLOATING
 	variable = TRUE
 
-/datum/movespeed_modifier/shove
-	multiplicative_slowdown = SHOVE_SLOWDOWN_STRENGTH
-
 /datum/movespeed_modifier/human_carry
 	multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN
 	blacklisted_movetypes = FLOATING

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -1,3 +1,6 @@
+/datum/movespeed_modifier/status_effect/staggered
+	multiplicative_slowdown = SHOVE_SLOWDOWN_STRENGTH
+
 /datum/movespeed_modifier/status_effect/bloodchill
 	multiplicative_slowdown = 3
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1745,6 +1745,7 @@
 #include "code\datums\status_effects\debuffs\slimed.dm"
 #include "code\datums\status_effects\debuffs\spacer.dm"
 #include "code\datums\status_effects\debuffs\speech_debuffs.dm"
+#include "code\datums\status_effects\debuffs\staggered.dm"
 #include "code\datums\status_effects\debuffs\static_vision.dm"
 #include "code\datums\status_effects\debuffs\strandling.dm"
 #include "code\datums\status_effects\debuffs\terrified.dm"


### PR DESCRIPTION

## About The Pull Request
This was done at the behest of @necromanceranne 
This refractors the shove speed penalty into a status effect. It adds the verbiage "pummeled" to attacks made against a target while grabbing them to illustrate the armor bypass that is being applied, it renames all instances of "off_balance" into "staggered"
## Why It's Good For The Game
Status effects make for cleaner implementation of effects that cause the stagger effect, and effects dependent on the stagger effect. Status effects also allow the effect to refreshed without hacky and broken work-arounds. In general status effects have more utility than the previous framework, which was a speed modifier on a callback to remove it. This is good framework for people like myself an Anne to build upon this feature.
## Changelog
:cl: itseasytosee
spellcheck: Added the verbiage "pummeled" to instances where you are punching a person you have grabbed to represent the armor bypass.
refactor: shove slowdowns have been refactored a bit, report any weirdness on github.
/:cl:
