### PR TITLE
Certain ID trims affect secbot response

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -104,6 +104,8 @@
 #define COMSIG_MOB_ATTACK_ALIEN "mob_attack_alien"
 ///from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_THROW "mob_throw"
+///from base of /mob/verb/examinate(): (atom/target, list/examine_strings)
+#define COMSIG_MOB_EXAMINING "mob_examining"
 ///from base of /mob/verb/examinate(): (atom/target)
 #define COMSIG_MOB_EXAMINATE "mob_examinate"
 ///from /mob/living/handle_eye_contact(): (mob/living/other_mob)

--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -176,6 +176,11 @@
 #define JUDGE_WEAPONCHECK (1<<2)
 #define JUDGE_RECORDCHECK (1<<3)
 
+/// Above this level of assessed threat, Beepsky will attack you
+#define THREAT_ASSESS_DANGEROUS 4
+/// Above this level of assessed threat, you are extremely threatening
+#define THREAT_ASSESS_MAXIMUM 10
+
 //SecBOT defines on arresting
 ///Whether arrests should be broadcasted over the Security radio
 #define SECBOT_DECLARE_ARRESTS (1<<0)

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,7 +2,7 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1609
+#define MIN_COMPILER_BUILD 1606
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,7 +2,7 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1606
+#define MIN_COMPILER_BUILD 1609
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.

--- a/code/datums/components/security_vision.dm
+++ b/code/datums/components/security_vision.dm
@@ -1,0 +1,39 @@
+/// This component allows you to judge someone's level of criminal activity by examining them
+/datum/component/security_vision
+	/// Bitfield containing what things we want to judge based upon
+	var/judgement_criteria
+	/// Optional callback which will modify the value of `judgement_criteria` before we make the check
+	var/datum/callback/update_judgement_criteria
+
+/datum/component/security_vision/Initialize(judgement_criteria, datum/callback/update_judgement_criteria)
+	. = ..()
+	if (!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+	src.judgement_criteria = judgement_criteria
+	src.update_judgement_criteria = update_judgement_criteria
+
+/datum/component/security_vision/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOB_EXAMINING, PROC_REF(on_examining))
+
+/datum/component/security_vision/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_EXAMINING)
+
+/// When we examine something, check if we have any extra data to add
+/datum/component/security_vision/proc/on_examining(mob/source, atom/target, list/examine_strings)
+	SIGNAL_HANDLER
+	if (!isliving(target))
+		return
+	var/mob/living/perp = target
+	judgement_criteria = update_judgement_criteria?.Invoke() || judgement_criteria
+
+	var/threat_level = perp.assess_threat(judgement_criteria)
+	if (threat_level >= THREAT_ASSESS_MAXIMUM)
+		examine_strings += span_boldwarning("Assessed threat level of [threat_level]! Extreme danger of criminal activity!")
+		return
+	if (threat_level >= THREAT_ASSESS_DANGEROUS)
+		examine_strings += span_warning("Assessed threat level of [threat_level]. Criminal scum detected!")
+		return
+	if (threat_level > 0)
+		examine_strings += span_notice("Assessed threat level of [threat_level]. Probably not dangerous... yet.")
+		return
+	examine_strings += span_notice("Seems to be a trustworthy individual.")

--- a/code/datums/components/security_vision.dm
+++ b/code/datums/components/security_vision.dm
@@ -27,13 +27,12 @@
 	judgement_criteria = update_judgement_criteria?.Invoke() || judgement_criteria
 
 	var/threat_level = perp.assess_threat(judgement_criteria)
-	if (threat_level >= THREAT_ASSESS_MAXIMUM)
-		examine_strings += span_boldwarning("Assessed threat level of [threat_level]! Extreme danger of criminal activity!")
-		return
-	if (threat_level >= THREAT_ASSESS_DANGEROUS)
-		examine_strings += span_warning("Assessed threat level of [threat_level]. Criminal scum detected!")
-		return
-	if (threat_level > 0)
-		examine_strings += span_notice("Assessed threat level of [threat_level]. Probably not dangerous... yet.")
-		return
-	examine_strings += span_notice("Seems to be a trustworthy individual.")
+	switch(threat_level)
+		if (THREAT_ASSESS_MAXIMUM to INFINITY)
+			examine_strings += span_boldwarning("Assessed threat level of [threat_level]! Extreme danger of criminal activity!")
+		if (THREAT_ASSESS_DANGEROUS to THREAT_ASSESS_MAXIMUM)
+			examine_strings += span_warning("Assessed threat level of [threat_level]. Criminal scum detected!")
+		if (1 to THREAT_ASSESS_DANGEROUS)
+			examine_strings += span_notice("Assessed threat level of [threat_level]. Probably not dangerous... yet.")
+		else
+			examine_strings += span_notice("Seems to be a trustworthy individual.")

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -16,6 +16,8 @@
 	var/intern_alt_name = null
 	/// The icon_state associated with this trim, as it will show on the security HUD.
 	var/sechud_icon_state = SECHUD_UNKNOWN
+	/// How threatened does a security bot feel when scanning this ID? A negative value may cause them to forgive things which would otherwise cause aggro.
+	var/threat_modifier = 0
 
 	/// Accesses that this trim unlocks on a card it is imprinted on. These accesses never take wildcard slots and can be added and removed at will.
 	var/list/access = list()

--- a/code/datums/id_trim/admin.dm
+++ b/code/datums/id_trim/admin.dm
@@ -4,6 +4,8 @@
 	trim_state = "trim_janitor"
 	department_color = COLOR_CENTCOM_BLUE
 	subdepartment_color = COLOR_SERVICE_LIME
+	threat_modifier = -INFINITY
+
 /datum/id_trim/admin/New()
 	. = ..()
 	// Every single access in the game, all on one handy trim.

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -6,6 +6,7 @@
 	sechud_icon_state = SECHUD_CENTCOM
 	department_color = COLOR_CENTCOM_BLUE
 	subdepartment_color = COLOR_CENTCOM_BLUE
+	threat_modifier = -10 // Centcom are legally allowed to do whatever they want
 
 /// Trim for Centcom VIPs
 /datum/id_trim/centcom/vip

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -775,6 +775,7 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/prisoner
+	threat_modifier = 1 // I'm watching you
 
 /datum/id_trim/job/prisoner/one
 	trim_state = "trim_prisoner_1"

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -69,6 +69,7 @@
 	trim_state = "trim_deathcommando"
 	department_color = COLOR_BLACK
 	subdepartment_color = COLOR_GREEN
+	threat_modifier = -1 // Cops recognise cops
 
 /datum/id_trim/cyber_police/New()
 	. = ..()

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -6,6 +6,7 @@
 	subdepartment_color = COLOR_SYNDIE_RED
 	sechud_icon_state = SECHUD_SYNDICATE
 	access = list(ACCESS_SYNDICATE)
+	threat_modifier = 5 // Bad guy on deck
 
 /// Trim for Syndicate mobs, outfits and corpses.
 /datum/id_trim/syndicom/crew
@@ -53,6 +54,7 @@
 	assignment = "Syndicate Battlecruiser Crew"
 	trim_state = "trim_syndicate"
 	access = list(ACCESS_SYNDICATE)
+	threat_modifier = 10
 
 /// Trim for Syndicate mobs, outfits and corpses.
 /datum/id_trim/battlecruiser/captain
@@ -63,6 +65,7 @@
 /datum/id_trim/chameleon
 	assignment = "Unknown"
 	access = list(ACCESS_SYNDICATE, ACCESS_MAINT_TUNNELS)
+	threat_modifier = -5 // This guy seems legit
 
 /// Trim for Chameleon ID cards. Many outfits, nuke ops and some corpses hold Chameleon ID cards.
 /datum/id_trim/chameleon/operative

--- a/code/modules/mob/living/basic/trooper/nanotrasen.dm
+++ b/code/modules/mob/living/basic/trooper/nanotrasen.dm
@@ -9,6 +9,9 @@
 	loot = list(/obj/effect/mob_spawn/corpse/human/nanotrasensoldier)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/nanotrasensoldier
 
+/mob/living/basic/trooper/nanotrasen/assess_threat(judgement_criteria, lasercolor, datum/callback/weaponcheck)
+	return -10 // Respect our troops
+
 /// A variant that calls for reinforcements on spotting a target
 /mob/living/basic/trooper/nanotrasen/screaming
 	ai_controller = /datum/ai_controller/basic_controller/trooper/calls_reinforcements

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -347,6 +347,8 @@
 		var/obj/item/bodypart/the_part = isbodypart(target_zone) ? target_zone : get_bodypart(check_zone(target_zone)) //keep these synced
 		to_chat(user, span_alert("There is no exposed flesh or thin material on [p_their()] [the_part.name]."))
 
+#define CHECK_PERMIT(item) (item && item.item_flags & NEEDS_PERMIT)
+
 /mob/living/carbon/human/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null)
 	if(judgement_criteria & JUDGE_EMAGGED)
 		return 10 //Everyone is a criminal!
@@ -376,16 +378,16 @@
 	//Check for ID
 	var/obj/item/card/id/idcard = get_idcard(FALSE)
 	threatcount += idcard?.trim.threat_modifier || 0
-	if( (judgement_criteria & JUDGE_IDCHECK) && !idcard && name == "Unknown")
+	if((judgement_criteria & JUDGE_IDCHECK) && isnull(idcard) && name == "Unknown")
 		threatcount += 4
 
 	//Check for weapons
-	if( (judgement_criteria & JUDGE_WEAPONCHECK) && weaponcheck)
-		if(!idcard || !(ACCESS_WEAPONS in idcard.access))
-			for(var/obj/item/I in held_items) //if they're holding a gun
-				if(weaponcheck.Invoke(I))
+	if((judgement_criteria & JUDGE_WEAPONCHECK))
+		if(isnull(idcard) || !(ACCESS_WEAPONS in idcard.access))
+			for(var/obj/item/toy_gun in held_items) //if they're holding a gun
+				if(CHECK_PERMIT(toy_gun))
 					threatcount += 4
-			if(weaponcheck.Invoke(belt) || weaponcheck.Invoke(back)) //if a weapon is present in the belt or back slot
+			if(CHECK_PERMIT(belt) || CHECK_PERMIT(back)) //if a weapon is present in the belt or back slot
 				threatcount += 2 //not enough to trigger look_for_perp() on it's own unless they also have criminal status.
 
 	//Check for arrest warrant
@@ -417,6 +419,7 @@
 
 	return threatcount
 
+#undef CHECK_PERMIT
 
 //Used for new human mobs created by cloning/goleming/podding
 /mob/living/carbon/human/proc/set_cloned_appearance()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -375,6 +375,7 @@
 
 	//Check for ID
 	var/obj/item/card/id/idcard = get_idcard(FALSE)
+	threatcount += idcard?.trim.threat_modifier || 0
 	if( (judgement_criteria & JUDGE_IDCHECK) && !idcard && name == "Unknown")
 		threatcount += 4
 

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -117,25 +117,21 @@
 		if((C.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
-		threatlevel = C.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, PROC_REF(check_for_weapons)))
+		threatlevel = C.assess_threat(judgement_criteria)
 
-		if(!threatlevel)
+		if (threatlevel < THREAT_ASSESS_DANGEROUS)
 			continue
-
-		else if(threatlevel >= 4)
-			target = C
-			oldtarget_name = C.name
-			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/beepsky/criminal.ogg', 'sound/voice/beepsky/justice.ogg', 'sound/voice/beepsky/freeze.ogg'), 50, FALSE)
-			playsound(src,'sound/weapons/saberon.ogg',50,TRUE,-1)
-			visible_message(span_warning("[src] ignites his energy swords!"))
-			icon_state = "grievous-c"
-			visible_message("<b>[src]</b> points at [C.name]!")
-			mode = BOT_HUNT
-			INVOKE_ASYNC(src, PROC_REF(handle_automated_action))
-			break
-		else
-			continue
+		target = C
+		oldtarget_name = C.name
+		speak("Level [threatlevel] infraction alert!")
+		playsound(src, pick('sound/voice/beepsky/criminal.ogg', 'sound/voice/beepsky/justice.ogg', 'sound/voice/beepsky/freeze.ogg'), 50, FALSE)
+		playsound(src,'sound/weapons/saberon.ogg',50,TRUE,-1)
+		visible_message(span_warning("[src] ignites his energy swords!"))
+		icon_state = "grievous-c"
+		visible_message("<b>[src]</b> points at [C.name]!")
+		mode = BOT_HUNT
+		INVOKE_ASYNC(src, PROC_REF(handle_automated_action))
+		break
 
 /mob/living/simple_animal/bot/secbot/grievous/explode()
 	var/atom/Tsec = drop_location()

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -43,8 +43,8 @@
 		var/threatlevel = 0
 		if(nearby_carbon.incapacitated())
 			continue
-		threatlevel = nearby_carbon.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, PROC_REF(check_for_weapons)))
-		if(threatlevel < 4 )
+		threatlevel = nearby_carbon.assess_threat(judgement_criteria)
+		if(threatlevel < THREAT_ASSESS_DANGEROUS)
 			continue
 		var/dst = get_dist(src, nearby_carbon)
 		if(dst <= 1 || dst > 7)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -201,6 +201,9 @@
 	if(threatlevel >= THREAT_ASSESS_DANGEROUS)
 		target = attacking_human
 		mode = BOT_HUNT
+	if(threatlevel < 0 && prob(5))
+		manual_emote("salutes.")
+		speak("Thank you sir.")
 
 /mob/living/simple_animal/bot/secbot/proc/judgement_criteria()
 	var/final = FALSE

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -128,6 +128,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	AddComponent(/datum/component/security_vision, judgement_criteria = NONE, update_judgement_criteria = CALLBACK(src, PROC_REF(judgement_criteria)))
 
 /mob/living/simple_animal/bot/secbot/Destroy()
 	QDEL_NULL(weapon)
@@ -195,9 +196,9 @@
 
 /mob/living/simple_animal/bot/secbot/proc/retaliate(mob/living/carbon/human/attacking_human)
 	var/judgement_criteria = judgement_criteria()
-	threatlevel = attacking_human.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, PROC_REF(check_for_weapons)))
+	threatlevel = attacking_human.assess_threat(judgement_criteria)
 	threatlevel += 6
-	if(threatlevel >= 4)
+	if(threatlevel >= THREAT_ASSESS_DANGEROUS)
 		target = attacking_human
 		mode = BOT_HUNT
 
@@ -329,11 +330,11 @@
 		current_target.set_stutter(10 SECONDS)
 		current_target.Paralyze(100)
 		var/mob/living/carbon/human/human_target = current_target
-		threat = human_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, PROC_REF(check_for_weapons)))
+		threat = human_target.assess_threat(judgement_criteria)
 	else
 		current_target.Paralyze(100)
 		current_target.set_stutter(10 SECONDS)
-		threat = current_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, PROC_REF(check_for_weapons)))
+		threat = current_target.assess_threat(judgement_criteria)
 
 	log_combat(src, current_target, "stunned")
 	if(security_mode_flags & SECBOT_DECLARE_ARRESTS)
@@ -457,29 +458,23 @@
 		if((nearby_carbons.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
-		threatlevel = nearby_carbons.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, PROC_REF(check_for_weapons)))
+		threatlevel = nearby_carbons.assess_threat(judgement_criteria)
 
-		if(!threatlevel)
+		if(threatlevel < THREAT_ASSESS_DANGEROUS)
 			continue
 
-		if(threatlevel >= 4)
-			target = nearby_carbons
-			oldtarget_name = nearby_carbons.name
-			threat_react(threatlevel)
-			visible_message("<b>[src]</b> points at [nearby_carbons.name]!")
-			mode = BOT_HUNT
-			INVOKE_ASYNC(src, PROC_REF(handle_automated_action))
-			break
+		target = nearby_carbons
+		oldtarget_name = nearby_carbons.name
+		threat_react(threatlevel)
+		visible_message("<b>[src]</b> points at [nearby_carbons.name]!")
+		mode = BOT_HUNT
+		INVOKE_ASYNC(src, PROC_REF(handle_automated_action))
+		break
 
 /// React to detecting criminal scum by making some kind of noise
 /mob/living/simple_animal/bot/secbot/proc/threat_react(threatlevel)
 	speak("Level [threatlevel] infraction alert!")
 	playsound(src, pick('sound/voice/beepsky/criminal.ogg', 'sound/voice/beepsky/justice.ogg', 'sound/voice/beepsky/freeze.ogg'), 50, FALSE)
-
-/mob/living/simple_animal/bot/secbot/proc/check_for_weapons(obj/item/slot_item)
-	if(slot_item && (slot_item.item_flags & NEEDS_PERMIT))
-		return TRUE
-	return FALSE
 
 /mob/living/simple_animal/bot/secbot/explode()
 	var/atom/Tsec = drop_location()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -578,6 +578,7 @@
 				result += span_notice("<i>You examine [examinify] closer, but find nothing of interest...</i>")
 		else
 			result = examinify.examine(src)
+			SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result)
 			client.recent_examines[ref_to_atom] = world.time // set to when we last normal examine'd them
 			addtimer(CALLBACK(src, PROC_REF(clear_from_recent_examines), ref_to_atom), RECENT_EXAMINE_MAX_WINDOW)
 			handle_eye_contact(examinify)
@@ -590,7 +591,6 @@
 
 	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)
-
 
 /mob/proc/blind_examine_check(atom/examined_thing)
 	return TRUE //The non-living will always succeed at this check.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1124,6 +1124,7 @@
 #include "code\datums\components\scope.dm"
 #include "code\datums\components\seclight_attachable.dm"
 #include "code\datums\components\sect_nullrod_bonus.dm"
+#include "code\datums\components\security_vision.dm"
 #include "code\datums\components\seethrough.dm"
 #include "code\datums\components\seethrough_mob.dm"
 #include "code\datums\components\shell.dm"


### PR DESCRIPTION
## About The Pull Request

A prior refactor of how ID cards worked removed (without commentary?) the long-previously-existing behaviour that Agent IDs cause a subtraction from the level of suspicion that security bots see from you.
I have not only restored this behaviour, but applied it to a handful of other ID cards (based on trim).

When Beepsky looks at you he will make an assessment based on various factors controlled by his bot settings:

- If Beepsky is set to check ID and your identity is concealed (you appear as "Unknown") add 4 points.
- If Beepsky is set to check Weapons and you are holding a restricted weapon without a permit, add 4 points.
- If Beepsky is set to check Weapons and you are wearing a restricted weapon on your belt or back without a permit, add 2 points.
- If Beepsky is set to check records and you are set to Arrest, add 5 points.
- If Beepsky is set to check records and you have some other non-innocent status, add 2 points.
- If you are wearing a wizard's hat, add 2 points.
- If you are not human, add 1 point (police are racist).
- If you are loyalty implanted, subtract 1 point.

Factors added or restored in this PR based on your ID now are:

- If you are wearing an Agent ID, subtract 5 points.
- If you are wearing a Cybercop ID, subtract 1 point.
- If you are wearing a Centcomm ID, subtract 10 points.
- If you are wearing an Admin ID, subtract infinite points.
- If you are wearing a prisoner ID, add 1 point.
- If you are wearing a Syndicate or Battlecruiser ID, add 5 or 10 points.

If Beepsky is _emagged_ then he will view all targets as having 10 threat, regardless of their ID card.
If you complete this process with >4 points he will attempt to arrest you.

The upshot of my changes are:
Wearing an Agent ID card will cause Beepsky to overlook the fact that you are carrying a gun in your hands without a permit, unless you are also set to arrest.
Wearing an Agent ID card will cause Beepsky to overlook the fact that you are set to arrest, unless you are carrying a gun in your hands.
Wearing a prisoner ID while not human will cause Beepsky to try and arrest you if you have a weapon on your belt or back (if he is set to care about weapons permits or unless you have one).
Wearing a centcomm ID card will cause Beepsky to treat you as above the law in basically all circumstances, up to and including when you try and beat him to death. He will simply sit there and take it. 

In addition to this, this information forwarded to AI is now also available to player secbots upon examine.
Players can't become secbots very easily because you can't upload PAIs into them or enable their sentience in the panel, but it sometimes happens via random event or admin intervention.

## Why It's Good For The Game

I think this was removed by mistake? It wasn't included in the changelog and everyone I talked to thought it was still true.
It's a fun feature which makes agent IDs marginally more useful. 
I think Beepsky and pals judging you based on your job makes sense, even if it is mostly applied to fluff roles.

## Changelog

:cl:
add: Agent IDs once more trick Beepsky into treating you more leniently. 
add: Prisoner IDs make Beepsky treat you somewhat more suspiciously, as do Syndicate IDs. Wearing a Centcomm ID means that Beepsky is aware that you are above the law.
add: Player-controlled security bots can view someone's assessed threat level by examining them.
/:cl:
