### PR TITLE
Fixes the Nebula Station Trait strength scaling to be properly capped at its maximum value

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -473,7 +473,7 @@
 
 ///Calculate how strong we currently are
 /datum/station_trait/nebula/hostile/proc/calculate_nebula_strength()
-	nebula_intensity = min(STATION_TIME_PASSED() / intensity_increment_time, maximum_nebula_intensity)
+	nebula_intensity = min(STATION_TIME_PASSED(), maximum_nebula_intensity) / intensity_increment_time
 
 ///Check how strong the stations shielding is
 /datum/station_trait/nebula/hostile/proc/get_shielding_level()


### PR DESCRIPTION
## About The Pull Request
The maximum value wasn't properly taking into account the intensity steps, meaning that it would simply keep on scaling past the expected maximum of one hour and forty minutes that was set in the original PR. Not really noticeable when your round doesn't really scale past the two hours mark, but if it ends up going past that, it ends up being very noticeable.

`maximum_nebula_intensity` is actually not intensity, but rather the time at which the maximum intensity will have been reached, hence why this fix had to be done in order for it to work.

I could alternatively make it so the intensity is properly representative of the maximum intensity the nebula can reach, if that's what we want, it would technically make the math a bit simpler to calculate the amount of shielding will be needed to protect the station entirely, but I opted not to just to reduce the amount of changes I would have to do, and because it gives a better idea of how long the scaling takes. I don't mind doing it that way if asked to, however.

## Why It's Good For The Game
Makes a maximum properly work like a maximum, so that caps can be properly respected.

## Changelog

:cl: GoldenAlpharex
fix: The Radioactive Nebula station trait will now respect its upper intensity cap set at one hour and forty minutes, no longer scaling past that, as was initially intended.
/:cl: