### PR TITLE
Fixes smartfridges showing overlays when there is nothing inside

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -227,7 +227,7 @@
 /obj/machinery/smartfridge/proc/visible_items()
 	var/component_part_count = 0
 	for(var/datum/stock_part/datum_part in component_parts)
-		component_part_count -= 1
+		component_part_count++
 	return contents.len - component_part_count
 
 /obj/machinery/smartfridge/update_overlays()

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -225,10 +225,7 @@
 
 /// Returns the number of items visible in the fridge. Faster than subtracting 2 lists
 /obj/machinery/smartfridge/proc/visible_items()
-	var/component_part_count = 0
-	for(var/datum/stock_part/datum_part in component_parts)
-		component_part_count++
-	return contents.len - component_part_count
+	return contents.len - 1 // Circuitboard
 
 /obj/machinery/smartfridge/update_overlays()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

It was considering stock parts as contents after the refactor in #79623

## Why It's Good For The Game

Bug fix

## Changelog

:cl: MrMelbert 
fix: smartfridges no longer show false overlays
/:cl:


