### PR TITLE
Renames a bar door on Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53427,11 +53427,11 @@
 /area/station/maintenance/starboard/fore)
 "tbl" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "tbp" = (


### PR DESCRIPTION

## About The Pull Request

Renames one of the bar doors on Metastation.

![image](https://github.com/tgstation/tgstation/assets/28870487/0e24da6e-acbe-4077-8f87-cfe07f0ce76d)

This was named "Kitchen" for some reason. All of the other doors (including the one next to it) were Bar doors, and I'm assuming this was a copy/paste mistake.
## Why It's Good For The Game

I don't think that door should be named that.
## Changelog
:cl: Rhials
fix: Renames a bar door from "Kitchen" to "Bar" on Metastation.
/:cl:
