### PR TITLE
Adds medical record descriptions for quirks without any

### DIFF
--- a/code/datums/quirks/neutral_quirks/heretochromatic.dm
+++ b/code/datums/quirks/neutral_quirks/heretochromatic.dm
@@ -3,6 +3,7 @@
 	desc = "One of your eyes is a different color than the other!"
 	icon = FA_ICON_EYE_LOW_VISION // Ignore the icon name, its actually a fairly good representation of different color eyes
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
+	medical_record_text = "Patient's irises are different colors."
 	value = 0
 	mail_goodies = list(/obj/item/clothing/glasses/eyepatch)
 

--- a/code/datums/quirks/positive_quirks/signer.dm
+++ b/code/datums/quirks/positive_quirks/signer.dm
@@ -4,6 +4,7 @@
 	icon = FA_ICON_HANDS
 	value = 4
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
+	medical_record_text = "Patient can communicate with sign language."
 	mail_goodies = list(/obj/item/clothing/gloves/radio)
 
 /datum/quirk/item_quirk/signer/add_unique(client/client_source)

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -11,6 +11,7 @@
 	icon = FA_ICON_USER_ASTRONAUT
 	value = 7
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
+	medical_record_text = "Patient is well-adapted to non-terrestrial environments."
 	mail_goodies = list(
 		/obj/item/storage/pill_bottle/ondansetron,
 		/obj/item/reagent_containers/pill/gravitum,

--- a/code/datums/quirks/positive_quirks/voracious.dm
+++ b/code/datums/quirks/positive_quirks/voracious.dm
@@ -6,4 +6,5 @@
 	mob_trait = TRAIT_VORACIOUS
 	gain_text = span_notice("You feel HONGRY.")
 	lose_text = span_danger("You no longer feel HONGRY.")
+	medical_record_text = "Patient has an above average appreciation for food and drink."
 	mail_goodies = list(/obj/effect/spawner/random/food_or_drink/dinner)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -24,23 +24,20 @@
 
 /datum/unit_test/quirk_initial_medical_records/Run()
 	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human/consistent)
-	//So anything that needs the mind doesn't fail (theres a few)
-	patient.mind_initialize()
-	//Make hud for quirks that need it (removing junkie)
-	patient.create_mob_hud()
-	//Make mock client for quirks that need it (food allergy)
-	var/datum/client_interface/mock_client = new()
-	patient.mock_client = mock_client
 
 	for(var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
 		if (initial(quirk_type.abstract_parent_type) == quirk_type)
 			continue
-		//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
-		patient.add_quirk(quirk_type)
-		// Get added quirk from patient
-		var/datum/quirk/quirk = patient.get_quirk(quirk_type)
+
+		var/datum/quirk/quirk = initial(quirk_type)
 
 		if(isnull(quirk.medical_record_text))
-			TEST_FAIL("[quirk_type] has no medical record description!")
+			//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
+			patient.add_quirk(quirk_type)
 
-		patient.remove_quirk(quirk)
+			quirk = patient.get_quirk(quirk_type)
+
+			if(isnull(quirk.medical_record_text))
+				TEST_FAIL("[quirk_type] has no medical record description!")
+
+			patient.remove_quirk(quirk)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -1,5 +1,6 @@
 /// Ensure every quirk has a unique icon
 /datum/unit_test/quirk_icons
+// Make sure all quirks start with a description in medical records
 /datum/unit_test/quirk_initial_medical_records
 
 /datum/unit_test/quirk_icons/Run()
@@ -31,13 +32,13 @@
 	for(var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
 		if (initial(quirk_type.abstract_parent_type) == quirk_type)
 			continue
-			//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
-			patient.add_quirk(quirk_type);
+		//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
+		patient.add_quirk(quirk_type);
 
-			// Get added quirk from patient
-			var/datum/quirk/quirk = patient.get_quirk(quirk_type);
+		// Get added quirk from patient
+		var/datum/quirk/quirk = patient.get_quirk(quirk_type);
 
-			if(isnull(quirk.medical_record_text))
-				TEST_FAIL("[quirk_type] has no medical record description!")
+		if(isnull(quirk.medical_record_text))
+			TEST_FAIL("[quirk_type] has no medical record description!")
 
-			patient.remove_quirk(quirk_type);
+		patient.remove_quirk(quirk_type);

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -36,6 +36,6 @@
 
 			var/datum/quirk/quirk = patient.get_quirk(quirk_type)
 
-			TEST_ASSERT(!isnull(quirk.medical_record_text),"[quirk_type] has no medical record description!")
+			TEST_ASSERT_NOTNULL(quirk.medical_record_text,"[quirk_type] has no medical record description!")
 
 			patient.remove_quirk(quirk_type)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -1,7 +1,5 @@
 /// Ensure every quirk has a unique icon
 /datum/unit_test/quirk_icons
-// Make sure all quirks start with a description in medical records
-/datum/unit_test/quirk_initial_medical_records
 
 /datum/unit_test/quirk_icons/Run()
 	var/list/used_icons = list()
@@ -22,6 +20,9 @@
 
 		used_icons[icon] = quirk_type
 
+// Make sure all quirks start with a description in medical records
+/datum/unit_test/quirk_initial_medical_records
+
 /datum/unit_test/quirk_initial_medical_records/Run()
 	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human/consistent)
 
@@ -29,15 +30,12 @@
 		if (initial(quirk_type.abstract_parent_type) == quirk_type)
 			continue
 
-		var/datum/quirk/quirk = initial(quirk_type)
-
-		if(isnull(quirk.medical_record_text))
+		if(isnull(quirk_type.medical_record_text))
 			//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
 			patient.add_quirk(quirk_type)
 
-			quirk = patient.get_quirk(quirk_type)
+			var/datum/quirk/quirk = patient.get_quirk(quirk_type)
 
-			if(isnull(quirk.medical_record_text))
-				TEST_FAIL("[quirk_type] has no medical record description!")
+			TEST_ASSERT(!isnull(quirk.medical_record_text),"[quirk_type] has no medical record description!")
 
-			patient.remove_quirk(quirk)
+			patient.remove_quirk(quirk_type)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -26,19 +26,21 @@
 	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human/consistent)
 	//So anything that needs the mind doesn't fail (theres a few)
 	patient.mind_initialize()
-	//So anything that needs the client doesn't fail (i.e. food allergy)
-	patient.mock_client = new();
+	//Make hud for quirks that need it (removing junkie)
+	patient.create_mob_hud()
+	//Make mock client for quirks that need it (food allergy)
+	var/datum/client_interface/mock_client = new()
+	patient.mock_client = mock_client
 
 	for(var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
 		if (initial(quirk_type.abstract_parent_type) == quirk_type)
 			continue
 		//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
-		patient.add_quirk(quirk_type);
-
+		patient.add_quirk(quirk_type)
 		// Get added quirk from patient
-		var/datum/quirk/quirk = patient.get_quirk(quirk_type);
+		var/datum/quirk/quirk = patient.get_quirk(quirk_type)
 
 		if(isnull(quirk.medical_record_text))
 			TEST_FAIL("[quirk_type] has no medical record description!")
 
-		patient.remove_quirk(quirk_type);
+		patient.remove_quirk(quirk)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -1,5 +1,6 @@
 /// Ensure every quirk has a unique icon
 /datum/unit_test/quirk_icons
+/datum/unit_test/quirk_initial_medical_records
 
 /datum/unit_test/quirk_icons/Run()
 	var/list/used_icons = list()
@@ -19,3 +20,24 @@
 			continue
 
 		used_icons[icon] = quirk_type
+
+/datum/unit_test/quirk_initial_medical_records/Run()
+	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human/consistent)
+	//So anything that needs the mind doesn't fail (theres a few)
+	patient.mind_initialize()
+	//So anything that needs the client doesn't fail (i.e. food allergy)
+	patient.mock_client = new();
+
+	for(var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
+		if (initial(quirk_type.abstract_parent_type) == quirk_type)
+			continue
+			//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
+			patient.add_quirk(quirk_type);
+
+			// Get added quirk from patient
+			var/datum/quirk/quirk = patient.get_quirk(quirk_type);
+
+			if(isnull(quirk.medical_record_text))
+				TEST_FAIL("[quirk_type] has no medical record description!")
+
+			patient.remove_quirk(quirk_type);

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -30,12 +30,14 @@
 		if (initial(quirk_type.abstract_parent_type) == quirk_type)
 			continue
 
-		if(isnull(quirk_type.medical_record_text))
-			//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
-			patient.add_quirk(quirk_type)
+		if(!isnull(quirk_type.medical_record_text))
+			continue
 
-			var/datum/quirk/quirk = patient.get_quirk(quirk_type)
+		//Add quirk to a patient - so we can pass quirks that add a medical record after being assigned someone
+		patient.add_quirk(quirk_type)
 
-			TEST_ASSERT_NOTNULL(quirk.medical_record_text,"[quirk_type] has no medical record description!")
+		var/datum/quirk/quirk = patient.get_quirk(quirk_type)
 
-			patient.remove_quirk(quirk_type)
+		TEST_ASSERT_NOTNULL(quirk.medical_record_text,"[quirk_type] has no medical record description!")
+
+		patient.remove_quirk(quirk_type)


### PR DESCRIPTION

## About The Pull Request

Adds medical record descriptions to the heterochromatic, signer, spacer, and voracious quirks.
## Why It's Good For The Game

More flavor text! And also means they show up on medical records or when using medical HUDs to view quirks.

Right now if you view someone with these quirks the line will be blank in the medical records, so it makes that less confusing.
## Changelog
:cl:
add: Heterochromatic, Signer, Spacer, and Voracious quirks are now properly accounted for in medical records.
/:cl:
