### PR TITLE
Removes `adjusted_flags` variable and slightly reworks `adjust_mask`

### DIFF
--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -9,7 +9,6 @@
 	equip_delay_other = 40
 	var/modifies_speech = FALSE
 	var/mask_adjusted = FALSE
-	var/adjusted_flags = null
 	///Did we install a filtering cloth?
 	var/has_filter = FALSE
 	/// If defined, what voice should we override with if TTS is active?
@@ -67,10 +66,8 @@
 		var/mob/M = loc
 		M.update_worn_mask()
 
-//Proc that moves gas/breath masks out of the way, disabling them and allowing pill/food consumption
-/obj/item/clothing/mask/proc/adjustmask(mob/living/carbon/user)
-	if(user?.incapacitated())
-		return
+/// Proc that moves gas/breath masks out of the way, disabling them and allowing pill/food consumption
+/obj/item/clothing/mask/proc/do_adjustmask(mob/living/carbon/user)
 	mask_adjusted = !mask_adjusted
 	if(!mask_adjusted)
 		icon_state = initial(icon_state)
@@ -85,8 +82,14 @@
 		clothing_flags &= ~visor_flags
 		flags_inv &= ~visor_flags_inv
 		flags_cover &= ~visor_flags_cover
-		if(adjusted_flags)
-			slot_flags = adjusted_flags
+
+//// Verifies that that user can adjust the mask, and updates the mob afterwards
+/obj/item/clothing/mask/proc/try_adjustmask(mob/living/carbon/user)
+	if(user?.incapacitated())
+		return
+
+	do_adjustmask(user)
+
 	if(!istype(user))
 		return
 	// Update the mob if it's wearing the mask.

--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -34,7 +34,7 @@
 	if(slot_flags & ITEM_SLOT_NECK)
 		to_chat(user, span_warning("You must undo [src] in order to push it into a hat!"))
 		return
-	adjustmask(user)
+	try_adjustmask(user)
 
 /obj/item/clothing/mask/bandana/do_adjustmask(mob/living/user)
 	. = ..()

--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -5,7 +5,6 @@
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	visor_flags_cover = MASKCOVERSMOUTH
 	slot_flags = ITEM_SLOT_MASK
-	adjusted_flags = ITEM_SLOT_HEAD
 	species_exception = list(/datum/species/golem)
 	dying_key = DYE_REGISTRY_BANDANA
 	flags_1 = IS_PLAYER_COLORABLE_1
@@ -37,10 +36,11 @@
 		return
 	adjustmask(user)
 
-/obj/item/clothing/mask/bandana/adjustmask(mob/living/user)
+/obj/item/clothing/mask/bandana/do_adjustmask(mob/living/user)
 	. = ..()
 	if(mask_adjusted)
 		undyeable = TRUE
+		slot_flags = ITEM_SLOT_HEAD
 	else
 		inhand_icon_state = initial(inhand_icon_state)
 		worn_icon_state = initial(worn_icon_state)

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -10,7 +10,7 @@
 	actions_types = list(/datum/action/item_action/adjust)
 
 /obj/item/clothing/mask/balaclava/attack_self(mob/user)
-	adjustmask(user)
+	try_adjustmask(user)
 
 /obj/item/clothing/mask/luchador
 	name = "Luchador Mask"

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -21,12 +21,12 @@
 	return OXYLOSS
 
 /obj/item/clothing/mask/breath/attack_self(mob/user)
-	adjustmask(user)
+	try_adjustmask(user)
 
 /obj/item/clothing/mask/breath/AltClick(mob/user)
 	..()
 	if(user.can_perform_action(src, NEED_DEXTERITY))
-		adjustmask(user)
+		try_adjustmask(user)
 
 /obj/item/clothing/mask/breath/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	cig?.equipped(equipee, slot)
 	return ..()
 
-/obj/item/clothing/mask/gas/adjustmask(mob/living/carbon/user)
+/obj/item/clothing/mask/gas/do_adjustmask(mob/living/carbon/user)
 	if(isnull(cig))
 		return ..()
 	balloon_alert(user, "there's a cig in the way!")

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	if(istype(action, /datum/action/item_action/halt))
 		halt()
 	else
-		adjustmask(user)
+		try_adjustmask(user)
 
 /obj/item/clothing/mask/gas/sechailer/attack_self()
 	halt()

--- a/code/modules/clothing/masks/surgical.dm
+++ b/code/modules/clothing/masks/surgical.dm
@@ -15,4 +15,4 @@
 	bio = 100
 
 /obj/item/clothing/mask/surgical/attack_self(mob/user)
-	adjustmask(user)
+	try_adjustmask(user)

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -85,9 +85,9 @@
 	starting_filter_type = /obj/item/gas_filter/plasmaman
 
 /obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
-	adjustmask(user)
+	try_adjustmask(user)
 
-/obj/item/clothing/mask/gas/explorer/adjustmask(mob/user)
+/obj/item/clothing/mask/gas/explorer/do_adjustmask(mob/user)
 	. = ..()
 	// adjusted = out of the way = smaller = can fit in boxes
 	w_class = mask_adjusted ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
@@ -107,7 +107,7 @@
 
 /obj/item/clothing/mask/gas/explorer/folded/Initialize(mapload)
 	. = ..()
-	adjustmask()
+	try_adjustmask()
 
 /obj/item/clothing/suit/hooded/cloak
 	icon = 'icons/obj/clothing/suits/armor.dmi'

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -326,7 +326,7 @@
 	if(isclothing(wear_mask) && ((wear_mask.visor_flags & MASKINTERNALS) || (wear_mask.clothing_flags & MASKINTERNALS)))
 		// Adjust dishevelled breathing mask back onto face.
 		if (wear_mask.mask_adjusted)
-			wear_mask.adjustmask(src)
+			wear_mask.try_adjustmask(src)
 		return toggle_open_internals(tank, is_external)
 	// Use helmet in absence of tube or valid mask.
 	if(can_breathe_helmet())


### PR DESCRIPTION
I split up `adjust_mask` into two procs, one that does checks and updates the mob, and one that updates the sprite and flags. This way I could remove the `adjusted_flags` variable as it was only ever used on the bandana which is stupid and i hate it

