### PR TITLE
Fix typo in spacer negative moodlet

### DIFF
--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -93,7 +93,7 @@
 	description = "Space is long and dark and empty, but it's my home."
 
 /datum/mood_event/spacer/on_planet
-	description = "I'm on a planet. The gravity here makes me uncomfotable."
+	description = "I'm on a planet. The gravity here makes me uncomfortable."
 	mood_change = -2
 
 /datum/mood_event/spacer/on_planet/too_long


### PR DESCRIPTION

## About The Pull Request

Fixes a typo in one of the spacer quirk's negative moodlets.
## Why It's Good For The Game

Typos aren't good.
## Changelog
:cl:
spellcheck: fixed typo in one of spacer's moodlets
/:cl:
