### PR TITLE
Deletes `area` var on clients

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -76,8 +76,6 @@
 	var/move_delay = 0
 	///The visual delay to use for the current client.Move(), mostly used for making a client based move look like it came from some other slower source
 	var/visual_delay = 0
-	///Current area of the controlled mob
-	var/area = null
 
 		///////////////
 		//SOUND STUFF//


### PR DESCRIPTION

## About The Pull Request

Literally nothing wrote to or accessed this variable, in pretty much _every_ case we just use `get_area(mob)` instead of ever looking at the client's area (again, ???)
## Why It's Good For The Game

this variable was added 12 years ago and I don't think anyone has ever novelly used this.
## Changelog
Doesn't matter to players.
