### PR TITLE
Disables mod links from virtual modsuits [NO GBP]

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -811,3 +811,10 @@
 	. = (!locked && panel_open && !(flags_1 & NODECONSTRUCT_1) && crowbar.tool_behaviour == TOOL_CROWBAR)
 	if(.)
 		return ..()
+
+/// If the SSU needs to have any communications wires cut.
+/obj/machinery/suit_storage_unit/proc/disable_modlink()
+	if(isnull(mod))
+		return
+
+	mod.disable_modlink()

--- a/code/modules/bitrunning/antagonists/cyber_police.dm
+++ b/code/modules/bitrunning/antagonists/cyber_police.dm
@@ -17,3 +17,25 @@
 
 /datum/outfit/cyber_police
 	name = ROLE_CYBER_POLICE
+	glasses = /obj/item/clothing/glasses/sunglasses
+	gloves = /obj/item/clothing/gloves/color/black
+	id = /obj/item/card/id/advanced
+	id_trim = /datum/id_trim/cyber_police
+	shoes = /obj/item/clothing/shoes/laceup
+	uniform = /obj/item/clothing/under/suit/black_really
+
+/datum/outfit/cyber_police/pre_equip(mob/living/carbon/human/user, visualsOnly)
+	if(!visualsOnly)
+		return
+
+	user.set_facial_hairstyle("Shaved", update = FALSE)
+	user.set_haircolor("#4B3D28", update = FALSE)
+	user.set_hairstyle("Business Hair")
+
+/datum/outfit/cyber_police/post_equip(mob/living/carbon/human/user, visualsOnly)
+	var/obj/item/clothing/under/officer_uniform = user.w_uniform
+	if(officer_uniform)
+		officer_uniform.has_sensor = NO_SENSORS
+		officer_uniform.sensor_mode = SENSOR_OFF
+		user.update_suit_sensors()
+

--- a/code/modules/bitrunning/antagonists/cyber_tac.dm
+++ b/code/modules/bitrunning/antagonists/cyber_tac.dm
@@ -45,6 +45,7 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/jump_jet,
 	)
+	starting_frequency = null
 
 /datum/armor/mod_theme_glitch
 	melee = 15

--- a/code/modules/bitrunning/outfits.dm
+++ b/code/modules/bitrunning/outfits.dm
@@ -1,27 +1,4 @@
-/datum/outfit/cyber_police
-	name = ROLE_CYBER_POLICE
 
-	glasses = /obj/item/clothing/glasses/sunglasses
-	gloves = /obj/item/clothing/gloves/color/black
-	id = /obj/item/card/id/advanced
-	id_trim = /datum/id_trim/cyber_police
-	shoes = /obj/item/clothing/shoes/laceup
-	uniform = /obj/item/clothing/under/suit/black_really
-
-/datum/outfit/cyber_police/pre_equip(mob/living/carbon/human/user, visualsOnly)
-	if(!visualsOnly)
-		return
-
-	user.set_facial_hairstyle("Shaved", update = FALSE)
-	user.set_haircolor("#4B3D28", update = FALSE)
-	user.set_hairstyle("Business Hair")
-
-/datum/outfit/cyber_police/post_equip(mob/living/carbon/human/user, visualsOnly)
-	var/obj/item/clothing/under/officer_uniform = user.w_uniform
-	if(officer_uniform)
-		officer_uniform.has_sensor = NO_SENSORS
-		officer_uniform.sensor_mode = SENSOR_OFF
-		user.update_suit_sensors()
 
 /datum/outfit/echolocator
 	name = "Bitrunning Echolocator"

--- a/code/modules/bitrunning/server/signal_handlers.dm
+++ b/code/modules/bitrunning/server/signal_handlers.dm
@@ -78,6 +78,16 @@
 			var/obj/effect/mob_spawn/corpse/spawner = thing
 
 			mutation_candidate_refs.Add(spawner.spawned_mob_ref)
+			continue
+
+		if(istype(thing, /obj/machinery/suit_storage_unit))
+			var/obj/machinery/suit_storage_unit/storage = thing
+			storage.disable_modlink()
+			continue
+
+		if(istype(thing, /obj/item/mod/control))
+			var/obj/item/mod/control/modsuit = thing
+			modsuit.disable_modlink()
 
 	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -759,3 +759,11 @@
 	update_speed()
 	qdel(speed_potion)
 	return SPEED_POTION_STOP
+
+/// Disables the mod link frequency attached to this unit.
+/obj/item/mod/control/proc/disable_modlink()
+	if(isnull(mod_link))
+		return
+
+	mod_link.end_call()
+	mod_link.frequency = null


### PR DESCRIPTION

## About The Pull Request
Via discussion in discord:
![image](https://github.com/tgstation/tgstation/assets/42397676/b1990bce-35c3-4266-9ee1-3f6abde846bb)
## Why It's Good For The Game
Virtual entities, however suited up they are, shouldn't be able to communicate station side with crew or with syndicate entities.
## Changelog
:cl:
fix: Mod links are now disabled in the virtual realm.
/:cl:
