### PR TITLE
fixes magnate modsuit from having a pathfinder module

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -190,7 +190,6 @@
 		/obj/item/mod/module/hat_stabilizer,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack/advanced,
-		/obj/item/mod/module/pathfinder,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,


### PR DESCRIPTION
## About The Pull Request
removes the pathfinder module from the magnate (captain’s) modsuit
## Why It's Good For The Game
non functional when inside a modsuit on its own (requires an external implant)
## Changelog
:cl:
fix:removes non functional module from the magnate modsuit
/:cl:
