### PR TITLE
removes pathfinder module from magnate modsuit (updated for clarity)

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -190,7 +190,6 @@
 		/obj/item/mod/module/hat_stabilizer,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack/advanced,
-		/obj/item/mod/module/pathfinder,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,


### PR DESCRIPTION

## About The Pull Request
removes the pathfinder module from the magnate modsuit
## Why It's Good For The Game
the pathfinder module needs to be used outside of the module to give an implant to the user.

since it is inside the modsuit already means that you have to manually remove it and replace it to function.
## Changelog
:cl:
fix: removes the pathfinder module from the magnate modsuit because it requires an implant inside the user for it to function
/:cl:
