### PR TITLE
Fixes crafting menu incorrect use of reagents

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -264,34 +264,23 @@
 			surroundings = get_environment(a, R.blacklist)
 			surroundings -= Deletion
 			if(ispath(path_key, /datum/reagent))
-				var/datum/reagent/RG = new path_key
-				var/datum/reagent/RGNT
 				while(amt > 0)
 					var/obj/item/reagent_containers/RC = locate() in surroundings
-					RG = RC.reagents.has_reagent(path_key)
+					if(QDELETED(RC)) //being deleted or null(i.e. not found)
+						break
+					var/datum/reagent/RG = RC.reagents.has_reagent(path_key)
 					if(RG)
-						if(!locate(RG.type) in Deletion)
-							Deletion += new RG.type()
-						if(RG.volume > amt)
-							RG.volume -= amt
-							data = RG.data
-							RC.update_appearance(UPDATE_ICON)
-							RG = locate(RG.type) in Deletion
-							RG.volume = amt
-							RG.data += data
+						if(RG.volume >= amt)
+							RC.reagents.remove_reagent(path_key, amt)
 							continue main_loop
 						else
 							surroundings -= RC
 							amt -= RG.volume
-							RC.reagents.reagent_list -= RG
-							RC.update_appearance(UPDATE_ICON)
-							RGNT = locate(RG.type) in Deletion
-							RGNT.volume += RG.volume
-							RGNT.data += RG.data
-							qdel(RG)
+							RC.reagents.remove_reagent(path_key, RG.volume)
 						SEND_SIGNAL(RC.reagents, COMSIG_REAGENTS_CRAFTING_PING) // - [] TODO: Make this entire thing less spaghetti
 					else
 						surroundings -= RC
+					RC.update_appearance(UPDATE_ICON)
 			else if(ispath(path_key, /obj/item/stack))
 				var/obj/item/stack/S
 				var/obj/item/stack/SD


### PR DESCRIPTION
## About The Pull Request
- Fixes #79931

The way crafting menu handles reagents is an abomination. It manually updates its volume, rather than calling the correct procs for it and also "clones" reagents like... it does some weird stuff that can leave the beaker in an inconsistent state let's just leave it at that.

Now we properly consume the reagent via `remove_reagent()` proc and don't do stuff manually so it works now. Also added some sanity checks such as `>=` and not simply `>` when checking for reagent volumes and also checks if we actually found a container in our surroundings which could runtime if none was available

Also for my sanity please don't tell me to change any single letter var names here. This whole file is crawling with them so let someone else get their GBP from that

## Changelog
:cl:
fix: crafting food or any other items that require reagents will not leave behind blank reagents. That and properly updates the holder those reagents are stored in
/:cl: