### PR TITLE
Honorbound Sect Improvements: Creatures are not Innocent, and Neither is the Blatantly Evil. Declarations are Cheaper, too

### DIFF
--- a/code/modules/religion/honorbound/honorbound_rites.dm
+++ b/code/modules/religion/honorbound/honorbound_rites.dm
@@ -1,3 +1,6 @@
+/// how much favor is gained when 
+#define DEACONIZE_FAVOR_GAIN 300
+
 ///Makes the person holy, but they now also have to follow the honorbound code (CBT). Actually earns favor, convincing others to uphold the code (tm) is not easy
 /datum/religion_rites/deaconize
 	name = "Join Crusade"
@@ -64,7 +67,7 @@
 	var/datum/brain_trauma/special/honorbound/honor = user.has_trauma_type(/datum/brain_trauma/special/honorbound)
 	if(joining_now in honor.guilty)
 		honor.guilty -= joining_now
-	GLOB.religious_sect.adjust_favor(300, user)
+	GLOB.religious_sect.adjust_favor(DEACONIZE_FAVOR_GAIN, user)
 	to_chat(user, span_notice("[GLOB.deity] has bound [joining_now] to the code! They are now a holy role! (albeit the lowest level of such)"))
 	joining_now.mind.holy_role = HOLY_ROLE_DEACON
 	GLOB.religious_sect.on_conversion(joining_now)

--- a/code/modules/religion/honorbound/honorbound_rites.dm
+++ b/code/modules/religion/honorbound/honorbound_rites.dm
@@ -64,7 +64,7 @@
 	var/datum/brain_trauma/special/honorbound/honor = user.has_trauma_type(/datum/brain_trauma/special/honorbound)
 	if(joining_now in honor.guilty)
 		honor.guilty -= joining_now
-	GLOB.religious_sect.adjust_favor(200, user)
+	GLOB.religious_sect.adjust_favor(300, user)
 	to_chat(user, span_notice("[GLOB.deity] has bound [joining_now] to the code! They are now a holy role! (albeit the lowest level of such)"))
 	joining_now.mind.holy_role = HOLY_ROLE_DEACON
 	GLOB.religious_sect.on_conversion(joining_now)
@@ -151,7 +151,8 @@
 	<br>
 	1.) Thou shalt not attack the unready!<br>
 	Those who are not ready for battle should not be wrought low. The evil of this world must lose
-	in a fair battle if you are to conquer them completely.
+	in a fair battle if you are to conquer them completely. Lesser creatures are given the benefit of
+	being unready, keep that in mind.
 	<br>
 	<br>
 	2.) Thou shalt not attack the just!<br>
@@ -162,7 +163,9 @@
 	<br>
 	3.) Thou shalt not attack the innocent!<br>
 	There is no honor on a pre-emptive strike, unless they are truly evil vermin.
-	Those who are guilty will either lay a hand on you first, or you may declare their evil.
+	Those who are guilty will either lay a hand on you first, or you may declare their evil. Mindless, lesser
+	creatures cannot be considered innocent, nor evil. They are beings of passion and function, and
+	may be dispatched as such if their passions misalign with the pursuits of a better world.
 	<br>
 	<br>
 	4.) Thou shalt not use profane magicks!<br>

--- a/code/modules/religion/honorbound/honorbound_rites.dm
+++ b/code/modules/religion/honorbound/honorbound_rites.dm
@@ -1,4 +1,4 @@
-/// how much favor is gained when 
+/// how much favor is gained when someone joins the crusade and is deaconized
 #define DEACONIZE_FAVOR_GAIN 300
 
 ///Makes the person holy, but they now also have to follow the honorbound code (CBT). Actually earns favor, convincing others to uphold the code (tm) is not easy
@@ -178,3 +178,5 @@
 	been allowed as it is a school focused on the light and mending of this world.
 	"}
 	return ..()
+
+#undef DEACONIZE_FAVOR_GAIN

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -62,7 +62,7 @@
 		return (COMSIG_MOB_CANCEL_CLICKON)
 
 /// Checks a mob for any obvious signs of evil, and applies a guilty reason for each.
-/datum/brain_trauma/special/honorbound/proc/check_visible_guilt(var/mob/living/attacked_mob)
+/datum/brain_trauma/special/honorbound/proc/check_visible_guilt(mob/living/attacked_mob)
 	if(ROLE_SYNDICATE in attacked_mob.faction)
 		// as a reminder, ROLE_SYNDICATE is given to obvious and outward syndicates like nuke ops and mobs,
 		// NOT given to traitors. this should be just fine

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -123,10 +123,10 @@
 		if(job?.departments_bitflags & DEPARTMENT_BITFLAG_MEDICAL && !is_guilty)
 			to_chat(honorbound_human, span_warning("If you truly think this healer is not <b>innocent</b>, declare them guilty."))
 			return FALSE
-		//THE INNOCENT (human exclusive)
-		if(!is_guilty)
-			to_chat(honorbound_human, span_warning("There is nothing righteous in attacking the <b>innocent</b>."))
-			return FALSE
+	//THE INNOCENT (human and borg exclusive)
+	if(!is_guilty && (is_human || issilicon(target_creature)))
+		to_chat(target_creature, span_warning("There is nothing righteous in attacking the <b>innocent</b>."))
+		return FALSE
 	return TRUE
 
 //spell checking

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -57,18 +57,32 @@
 		return
 	if(!honorbound.combat_mode && (HAS_TRAIT(clicked_mob, TRAIT_ALLOWED_HONORBOUND_ATTACK) || ((!weapon || !weapon.force) && !LAZYACCESS(modifiers, RIGHT_CLICK))))
 		return
-	check_visible_guilt(clicked_mob)
+	if(!(clicked_mob in guilty))
+		check_visible_guilt(clicked_mob)
 	if(!is_honorable(honorbound, clicked_mob))
 		return (COMSIG_MOB_CANCEL_CLICKON)
 
 /// Checks a mob for any obvious signs of evil, and applies a guilty reason for each.
 /datum/brain_trauma/special/honorbound/proc/check_visible_guilt(mob/living/attacked_mob)
+	//will most likely just hit nuke ops but good catch-all. WON'T hit traitors
 	if(ROLE_SYNDICATE in attacked_mob.faction)
-		// as a reminder, ROLE_SYNDICATE is given to obvious and outward syndicates like nuke ops and mobs,
-		// NOT given to traitors. this should be just fine
 		guilty(attacked_mob, "for their misaligned association with the Syndicate!")
+	//not an antag datum check so it applies to wizard minions as well
+	if(ROLE_WIZARD in attacked_mob.faction)
+		guilty(attacked_mob, "for blasphemous magicks!")
 	if(HAS_TRAIT(attacked_mob, TRAIT_CULT_HALO))
 		guilty(attacked_mob, "for blasphemous worship!")
+	if(attacked_mob.mind)
+		var/datum/mind/guilty_conscience = attacked_mob.mind
+		if(guilty_conscience.has_antag_datum(/datum/antagonist/abductor))
+			guilty(attacked_mob, "for their blatant surgical malice...")
+		if(guilty_conscience.has_antag_datum(/datum/antagonist/nightmare))
+			guilty(attacked_mob, "for being a light-consuming nightmare!")
+		if(guilty_conscience.has_antag_datum(/datum/antagonist/ninja))
+			guilty(attacked_mob, "for their misaligned association with the Spider Clan!")
+		var/datum/antagonist/heretic/heretic_datum = guilty_conscience.has_antag_datum(/datum/antagonist/heretic)
+		if(heretic_datum?.ascended)
+			guilty(attacked_mob, "for blasphemous, heretical, out of control worship!")
 
 /**
  * Called by hooked signals whenever someone attacks the person with this trauma

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -48,26 +48,27 @@
 	if(!isliving(clickingon))
 		return
 
-	var/mob/living/clickedmob = clickingon
+	var/mob/living/clicked_mob = clickingon
 	var/obj/item/weapon = honorbound.get_active_held_item()
 
-	if(!honorbound.DirectAccess(clickedmob) && !isgun(weapon))
+	if(!honorbound.DirectAccess(clicked_mob) && !isgun(weapon))
 		return
 	if(weapon?.item_flags & NOBLUDGEON)
 		return
-	if(!honorbound.combat_mode && (HAS_TRAIT(clickedmob, TRAIT_ALLOWED_HONORBOUND_ATTACK) || ((!weapon || !weapon.force) && !LAZYACCESS(modifiers, RIGHT_CLICK))))
+	if(!honorbound.combat_mode && (HAS_TRAIT(clicked_mob, TRAIT_ALLOWED_HONORBOUND_ATTACK) || ((!weapon || !weapon.force) && !LAZYACCESS(modifiers, RIGHT_CLICK))))
 		return
-	check_visible_guilt(clickedmob)
-	if(!is_honorable(honorbound, clickedmob))
+	check_visible_guilt(clicked_mob)
+	if(!is_honorable(honorbound, clicked_mob))
 		return (COMSIG_MOB_CANCEL_CLICKON)
 
-/datum/brain_trauma/special/honorbound/proc/check_visible_guilt(var/mob/living/clickedmob)
-	if(ROLE_SYNDICATE in clickedmob.faction)
+/// Checks a mob for any obvious signs of evil, and applies a guilty reason for each.
+/datum/brain_trauma/special/honorbound/proc/check_visible_guilt(var/mob/living/attacked_mob)
+	if(ROLE_SYNDICATE in attacked_mob.faction)
 		// as a reminder, ROLE_SYNDICATE is given to obvious and outward syndicates like nuke ops and mobs,
 		// NOT given to traitors. this should be just fine
-		guilty(clickedmob, "for their misaligned association with the Syndicate!")
-	if(HAS_TRAIT(clickedmob, TRAIT_CULT_HALO))
-		guilty(clickedmob, "for blasphemous worship!")
+		guilty(attacked_mob, "for their misaligned association with the Syndicate!")
+	if(HAS_TRAIT(attacked_mob, TRAIT_CULT_HALO))
+		guilty(attacked_mob, "for blasphemous worship!")
 
 /**
  * Called by hooked signals whenever someone attacks the person with this trauma

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -1,3 +1,6 @@
+/// one reason for declaring guilty is specifically checked for, keeping it as a define to avoid future mistakes
+#define GUILT_REASON_DECLARATION "from your declaration."
+
 ///Honorbound prevents you from attacking the unready, the just, or the innocent
 /datum/brain_trauma/special/honorbound
 	name = "Dogmatic Compulsions"
@@ -78,13 +81,11 @@
 	if(user in guilty)
 		return
 	var/datum/mind/guilty_conscience = user.mind
-	if(guilty_conscience && !declaration) //sec and medical are immune to becoming guilty through attack (we don't check holy because holy shouldn't be able to attack eachother anyways)
+	if(guilty_conscience && reason != GUILT_REASON_DECLARATION) //sec and medical are immune to becoming guilty through attack (we don't check holy because holy shouldn't be able to attack eachother anyways)
 		var/datum/job/job = guilty_conscience.assigned_role
 		if(job.departments_bitflags & (DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY))
 			return
 	to_chat(owner, span_notice("[user] is now considered guilty by [GLOB.deity] [reason]"))
-	if(declaration)
-		to_chat(owner, span_notice("[user] is now considered guilty by [GLOB.deity] "))
 	to_chat(user, span_danger("[GLOB.deity] no longer considers you innocent!"))
 	guilty += user
 
@@ -271,4 +272,6 @@
 /datum/action/cooldown/spell/pointed/declare_evil/cast(mob/living/cast_on)
 	. = ..()
 	GLOB.religious_sect.adjust_favor(-required_favor, owner)
-	honor_trauma.guilty(cast_on, "from your declaration.")
+	honor_trauma.guilty(cast_on, GUILT_REASON_DECLARATION)
+
+#undef GUILT_REASON_DECLARATION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Innocence is no longer considered when an honorbound attacks a nonhuman (as in mob, not like, lizardpeople, lol).
Attacking a cultist with a halo, or a blatant syndicate operative will now immediately make THEM guilty.
Converting a new follower now gives 300 favor, enough for 2 declarations (costing 150 each)

## Why It's Good For The Game

Feedback and stats taken from https://tgstation13.org/phpBB/viewtopic.php?p=713399#p713399
This is really the first half of fixing Honorbound Sect. It's the least picked sect, because it gives a strange conditional pacifism and while that's fun for roleplay, the pacifism is painfully difficult to work with and there are just so many cases you have to ask out loud "HOW IS THIS INNOCENT" when a xenomorph is running at you and you can't swing. I still need to add rewards, but just for now let's make honorbound more playable by putting aside lesser creatures as at least not innocent or guilty (well they can be guilty, but it doesn't matter)

Once it's better to play with the honorbound rules, we can talk more rewards like banners for fellow honorbound deacons and other stuff.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Honorbound no longer cares about innocence when it comes to lesser creatures. They can still be considered unready in some cases.
balance: Attacking a cultist with a halo or a nuclear operative first instantly makes THEM guilty, allowing further attacks.
balance: More favor for converting someone to the honorbound rules
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
