### PR TITLE
Instant Delete Pipes with RPD

### DIFF
--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -197,9 +197,9 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	///Speed of building transit devices
 	var/transit_build_speed = 0.5 SECONDS
 	///Speed of removal of unwrenched devices
-	var/destroy_speed = 0.2 SECONDS
+	var/destroy_speed = 0 SECONDS
 	///Speed of reprogramming connectable directions of smart pipes
-	var/reprogram_speed = 0.2 SECONDS
+	var/reprogram_speed = 0 SECONDS
 	///Category currently active (Atmos, disposal, transit)
 	var/category = ATMOS_CATEGORY
 	///Piping layer we are going to spawn the atmos device in

--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -196,10 +196,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/disposal_build_speed = 0.5 SECONDS
 	///Speed of building transit devices
 	var/transit_build_speed = 0.5 SECONDS
-	///Speed of removal of unwrenched devices
-	var/destroy_speed = 0 SECONDS
-	///Speed of reprogramming connectable directions of smart pipes
-	var/reprogram_speed = 0 SECONDS
 	///Category currently active (Atmos, disposal, transit)
 	var/category = ATMOS_CATEGORY
 	///Piping layer we are going to spawn the atmos device in
@@ -436,9 +432,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 	if((mode & DESTROY_MODE) && istype(attack_target, /obj/item/pipe) || istype(attack_target, /obj/structure/disposalconstruct) || istype(attack_target, /obj/structure/c_transit_tube) || istype(attack_target, /obj/structure/c_transit_tube_pod) || istype(attack_target, /obj/item/pipe_meter) || istype(attack_target, /obj/structure/disposalpipe/broken))
 		playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
-		if(do_after(user, destroy_speed, target = attack_target))
-			playsound(get_turf(src), RPD_USE_SOUND, 50, TRUE)
-			qdel(attack_target)
+		playsound(get_turf(src), RPD_USE_SOUND, 50, TRUE)
+		qdel(attack_target)
 		return
 
 	if(mode & REPROGRAM_MODE)
@@ -459,8 +454,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 				return
 
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
-			if(!do_after(user, reprogram_speed, target = target_smart_pipe))
-				return
 
 			// Something else could have changed the target's state while we were waiting in do_after
 			// Most of the edge cases don't matter, but atmos components being able to have live connections not described by initializable directions sounds like a headache at best and an exploit at worst


### PR DESCRIPTION
## About The Pull Request
Lets you instantly delete pipes/atmos devices with the RPD rather than wait 0.2s
## Why It's Good For The Game
Playing atmos is a pain because of how time consuming it is, 0.2s adds up. It's especially annoying if a bomb goes off and you have to click on every single little loose pipe/heatpipe/device and wait to get rid of them
## Changelog
:cl:
balance: Deleting and reprogramming pipes/devices with RPD is now INSTANT!
/:cl:
