### PR TITLE
Sign Language action now properly updates its background when toggled

### DIFF
--- a/code/datums/actions/mobs/sign_language.dm
+++ b/code/datums/actions/mobs/sign_language.dm
@@ -48,11 +48,13 @@
 	active = TRUE
 	ADD_TRAIT(owner, TRAIT_SIGN_LANG, TRAIT_GENERIC)
 	to_chat(owner, span_green("You are now communicating with sign language."))
+	build_all_button_icons(UPDATE_BUTTON_BACKGROUND)
 
 /datum/action/innate/sign_language/Deactivate()
 	active = FALSE
 	REMOVE_TRAIT(owner, TRAIT_SIGN_LANG, TRAIT_GENERIC)
 	to_chat(owner, span_green("You have stopped using sign language."))
+	build_all_button_icons(UPDATE_BUTTON_BACKGROUND)
 
 /// Shows the linked action to the owner Carbon.
 /datum/action/innate/sign_language/proc/show_action()


### PR DESCRIPTION

## About The Pull Request

Changes two lines in `sign_language.dm` such that it actually updates its background when toggled, rather than only when forced to update by some other signal.
## Why It's Good For The Game

The Sign Language action has a visual distinction for whether it's active or not, but it did not update this properly when toggled. This fixes that problem.
## Changelog
:cl:
fix: Sign Language action properly toggles between an active/inactive background again.
/:cl:
