### PR TITLE
Typescript refactor for tgui components

### DIFF
--- a/tgui/packages/tgui/components/Box.tsx
+++ b/tgui/packages/tgui/components/Box.tsx
@@ -19,7 +19,9 @@ export type BoxProps = Partial<CommonProps & MappedProps & AsType> & {
 type CommonProps = {
   className: string | boolean;
   key: string | number;
+  id: string;
   onClick: (event?) => void;
+  onmouseover: (event?) => void;
 };
 
 type MappedProps = {

--- a/tgui/packages/tgui/components/Box.tsx
+++ b/tgui/packages/tgui/components/Box.tsx
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { classes, pureComponentHooks } from 'common/react';
+import { BooleanLike, classes, pureComponentHooks } from 'common/react';
 import { createVNode } from 'inferno';
 import { ChildFlags, VNodeFlags } from 'inferno-vnode-flags';
 import { CSS_COLORS } from '../constants';
@@ -25,7 +25,7 @@ type CommonProps = {
 type MappedProps = {
   [key in StringMap]: string | number;
 } &
-  { [key in BooleanMap]: boolean };
+  { [key in BooleanMap]: BooleanLike };
 
 type AsType =
   | {
@@ -188,11 +188,12 @@ const stringStyleMap = {
 
 // Boolean props
 const booleanStyleMap = {
-  inline: mapBooleanPropTo('display', 'inline-block'),
   bold: mapBooleanPropTo('font-weight', 'bold'),
+  inline: mapBooleanPropTo('display', 'inline-block'),
   italic: mapBooleanPropTo('font-style', 'italic'),
   nowrap: mapBooleanPropTo('white-space', 'nowrap'),
   preserveWhitespace: mapBooleanPropTo('white-space', 'pre-wrap'),
+  wrap: mapBooleanPropTo('white-space', 'normal'),
 } as const;
 
 export const computeBoxProps = (props) => {

--- a/tgui/packages/tgui/components/ByondUi.jsx
+++ b/tgui/packages/tgui/components/ByondUi.jsx
@@ -59,12 +59,9 @@ window.addEventListener('beforeunload', () => {
 const getBoundingBox = (element) => {
   const pixelRatio = window.devicePixelRatio ?? 1;
   const rect = element.getBoundingClientRect();
-  // prettier-ignore
+
   return {
-    pos: [
-      rect.left * pixelRatio,
-      rect.top * pixelRatio,
-    ],
+    pos: [rect.left * pixelRatio, rect.top * pixelRatio],
     size: [
       (rect.right - rect.left) * pixelRatio,
       (rect.bottom - rect.top) * pixelRatio,
@@ -92,20 +89,12 @@ export class ByondUi extends Component {
   }
 
   componentDidMount() {
-    // IE8: It probably works, but fuck you anyway.
-    if (Byond.IS_LTE_IE10) {
-      return;
-    }
     window.addEventListener('resize', this.handleResize);
     this.componentDidUpdate();
     this.handleResize();
   }
 
   componentDidUpdate() {
-    // IE8: It probably works, but fuck you anyway.
-    if (Byond.IS_LTE_IE10) {
-      return;
-    }
     const { params = {} } = this.props;
     const box = getBoundingBox(this.containerRef.current);
     logger.debug('bounding box', box);
@@ -118,10 +107,6 @@ export class ByondUi extends Component {
   }
 
   componentWillUnmount() {
-    // IE8: It probably works, but fuck you anyway.
-    if (Byond.IS_LTE_IE10) {
-      return;
-    }
     window.removeEventListener('resize', this.handleResize);
     this.byondUiElement.unmount();
   }

--- a/tgui/packages/tgui/components/Chart.jsx
+++ b/tgui/packages/tgui/components/Chart.jsx
@@ -40,7 +40,7 @@ const dataToPolylinePoints = (data) => {
   return points;
 };
 
-class Chart extends Component {
+export class Chart extends Component {
   constructor(props) {
     super(props);
     this.ref = createRef();

--- a/tgui/packages/tgui/components/Chart.jsx
+++ b/tgui/packages/tgui/components/Chart.jsx
@@ -40,7 +40,7 @@ const dataToPolylinePoints = (data) => {
   return points;
 };
 
-class LineChart extends Component {
+class Chart extends Component {
   constructor(props) {
     super(props);
     this.ref = createRef();
@@ -117,11 +117,4 @@ class LineChart extends Component {
   }
 }
 
-LineChart.defaultHooks = pureComponentHooks;
-
-const Stub = (props) => null;
-
-// IE8: No inline svg support
-export const Chart = {
-  Line: Byond.IS_LTE_IE8 ? Stub : LineChart,
-};
+Chart.defaultHooks = pureComponentHooks;

--- a/tgui/packages/tgui/components/Dropdown.tsx
+++ b/tgui/packages/tgui/components/Dropdown.tsx
@@ -11,25 +11,26 @@ export interface DropdownEntry {
   value: string | number | Enumerator;
 }
 
-type DropdownUniqueProps = {
-  options: string[] | DropdownEntry[];
-  icon?: string;
-  iconRotation?: number;
-  clipSelectedText?: boolean;
-  width?: string;
-  menuWidth?: string;
-  over?: boolean;
-  color?: string;
-  nochevron?: boolean;
-  displayText?: string | number | InfernoNode;
-  onClick?: (event) => void;
+type Props = { options: string[] | DropdownEntry[] } & Partial<{
+  buttons: boolean;
+  clipSelectedText: boolean;
+  color: string;
+  disabled: boolean;
+  displayText: string | number | InfernoNode;
+  dropdownStyle: any;
+  icon: string;
+  iconRotation: number;
+  iconSpin: boolean;
+  menuWidth: string;
+  nochevron: boolean;
+  onClick: (event) => void;
+  onSelected: (selected: any) => void;
+  over: boolean;
   // you freaks really are just doing anything with this shit
-  selected?: any;
-  onSelected?: (selected: any) => void;
-  buttons?: boolean;
-};
-
-export type DropdownProps = BoxProps & DropdownUniqueProps;
+  selected: any;
+  width: string;
+}> &
+  BoxProps;
 
 const DEFAULT_OPTIONS = {
   placement: 'left-start',
@@ -52,7 +53,7 @@ const NULL_RECT: DOMRect = {
   toJSON: () => null,
 } as const;
 
-type DropdownState = {
+type State = {
   selected?: string;
   open: boolean;
 };
@@ -60,7 +61,7 @@ type DropdownState = {
 const DROPDOWN_DEFAULT_CLASSNAMES = 'Layout Dropdown__menu';
 const DROPDOWN_SCROLL_CLASSNAMES = 'Layout Dropdown__menu-scroll';
 
-export class Dropdown extends Component<DropdownProps, DropdownState> {
+export class Dropdown extends Component<Props, State> {
   static renderedMenu: HTMLDivElement | undefined;
   static singletonPopper: ReturnType<typeof createPopper> | undefined;
   static currentOpenMenu: Element | undefined;
@@ -69,7 +70,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       Dropdown.currentOpenMenu?.getBoundingClientRect() ?? NULL_RECT,
   };
   menuContents: any;
-  state: DropdownState = {
+  state: State = {
     open: false,
     selected: this.props.selected,
   };

--- a/tgui/packages/tgui/components/FitText.tsx
+++ b/tgui/packages/tgui/components/FitText.tsx
@@ -4,6 +4,7 @@ const DEFAULT_ACCEPTABLE_DIFFERENCE = 5;
 
 type Props = {
   acceptableDifference?: number;
+  children?: any;
   maxWidth: number;
   maxFontSize: number;
   native?: HTMLAttributes<HTMLDivElement>;

--- a/tgui/packages/tgui/components/Flex.tsx
+++ b/tgui/packages/tgui/components/Flex.tsx
@@ -4,23 +4,24 @@
  * @license MIT
  */
 
-import { BooleanLike, classes, pureComponentHooks } from 'common/react';
+import { classes, pureComponentHooks } from 'common/react';
 import { BoxProps, computeBoxClassName, computeBoxProps, unit } from './Box';
 
-export type FlexProps = BoxProps & {
-  direction?: string | BooleanLike;
-  wrap?: string | BooleanLike;
-  align?: string | BooleanLike;
-  justify?: string | BooleanLike;
-  inline?: BooleanLike;
-};
+export type FlexProps = BoxProps &
+  Partial<{
+    direction: string | boolean;
+    wrap: string | boolean;
+    align: string | boolean;
+    justify: string | boolean;
+    inline: boolean;
+    scrollable: boolean;
+    style: Partial<HTMLDivElement['style']>;
+  }>;
 
 export const computeFlexClassName = (props: FlexProps) => {
   return classes([
     'Flex',
     props.inline && 'Flex--inline',
-    Byond.IS_LTE_IE10 && 'Flex--iefix',
-    Byond.IS_LTE_IE10 && props.direction === 'column' && 'Flex--iefix--column',
     computeBoxClassName(props),
   ]);
 };
@@ -51,42 +52,32 @@ export const Flex = (props) => {
 
 Flex.defaultHooks = pureComponentHooks;
 
-export type FlexItemProps = BoxProps & {
-  grow?: number;
-  order?: number;
-  shrink?: number;
-  basis?: string | BooleanLike;
-  align?: string | BooleanLike;
-};
+export type FlexItemProps = BoxProps &
+  Partial<{
+    grow: number | boolean;
+    order: number;
+    shrink: number | boolean;
+    basis: string | number;
+    align: string | boolean;
+    style: Partial<HTMLDivElement['style']>;
+  }>;
 
 export const computeFlexItemClassName = (props: FlexItemProps) => {
-  return classes([
-    'Flex__item',
-    Byond.IS_LTE_IE10 && 'Flex__item--iefix',
-    computeBoxClassName(props),
-  ]);
+  return classes(['Flex__item', computeBoxClassName(props)]);
 };
 
 export const computeFlexItemProps = (props: FlexItemProps) => {
-  // prettier-ignore
-  const {
-    className,
-    style,
-    grow,
-    order,
-    shrink,
-    basis,
-    align,
-    ...rest
-  } = props;
-  // prettier-ignore
-  const computedBasis = basis
+  const { className, style, grow, order, shrink, basis, align, ...rest } =
+    props;
+
+  const computedBasis =
+    basis ??
     // IE11: Set basis to specified width if it's known, which fixes certain
     // bugs when rendering tables inside the flex.
-    ?? props.width
+    props.width ??
     // If grow is used, basis should be set to 0 to be consistent with
     // flex css shorthand `flex: 1`.
-    ?? (grow !== undefined ? 0 : undefined);
+    (grow !== undefined ? 0 : undefined);
   return computeBoxProps({
     style: {
       ...style,

--- a/tgui/packages/tgui/components/Icon.tsx
+++ b/tgui/packages/tgui/components/Icon.tsx
@@ -38,6 +38,7 @@ export const Icon = (props: IconProps) => {
     }
     style['transform'] = `rotate(${rotation}deg)`;
   }
+  
   rest.style = style;
 
   const boxProps = computeBoxProps(rest);

--- a/tgui/packages/tgui/components/Icon.tsx
+++ b/tgui/packages/tgui/components/Icon.tsx
@@ -12,14 +12,13 @@ import { BoxProps, computeBoxClassName, computeBoxProps } from './Box';
 
 const FA_OUTLINE_REGEX = /-o$/;
 
-type IconPropsUnique = {
-  name: string;
-  size?: number;
-  spin?: boolean;
-  className?: string;
-  rotation?: number;
-  style?: string | CSSProperties;
-};
+type IconPropsUnique = { name: string } & Partial<{
+  size: number;
+  spin: boolean;
+  className: string;
+  rotation: number;
+  style: Partial<HTMLDivElement['style']>;
+}>;
 
 export type IconProps = IconPropsUnique & BoxProps;
 

--- a/tgui/packages/tgui/components/Knob.tsx
+++ b/tgui/packages/tgui/components/Knob.tsx
@@ -8,14 +8,31 @@ import { keyOfMatchingRange, scale } from 'common/math';
 import { classes } from 'common/react';
 import { computeBoxClassName, computeBoxProps } from './Box';
 import { DraggableControl } from './DraggableControl';
-import { NumberInput } from './NumberInput';
 
-export const Knob = (props) => {
-  // IE8: I don't want to support a yet another component on IE8.
-  // IE8: It also can't handle SVG.
-  if (Byond.IS_LTE_IE8) {
-    return <NumberInput {...props} />;
-  }
+type Props = Partial<{
+  animated: boolean;
+  bipolar: boolean;
+  children: any;
+  className: string;
+  color: string;
+  fillValue: number;
+  format: string;
+  maxValue: number;
+  minValue: number;
+  onChange: (value: number) => void;
+  onDrag: (value: number) => void;
+  ranges: Record<string, number[]>;
+  size: number;
+  step: number;
+  stepPixelSize: number;
+  style: Partial<HTMLDivElement['style']>;
+  suppressFlicker: boolean;
+  unclamped: boolean;
+  unit: string;
+  value: number;
+}>;
+
+export const Knob = (props: Props) => {
   const {
     // Draggable props (passthrough)
     animated,
@@ -41,6 +58,7 @@ export const Knob = (props) => {
     children,
     ...rest
   } = props;
+
   return (
     <DraggableControl
       dragMatrix={[0, -1]}

--- a/tgui/packages/tgui/components/Knob.tsx
+++ b/tgui/packages/tgui/components/Knob.tsx
@@ -6,7 +6,7 @@
 
 import { keyOfMatchingRange, scale } from 'common/math';
 import { classes } from 'common/react';
-import { computeBoxClassName, computeBoxProps } from './Box';
+import { BoxProps, computeBoxClassName, computeBoxProps } from './Box';
 import { DraggableControl } from './DraggableControl';
 
 type Props = Partial<{
@@ -19,8 +19,8 @@ type Props = Partial<{
   format: string;
   maxValue: number;
   minValue: number;
-  onChange: (value: number) => void;
-  onDrag: (value: number) => void;
+  onChange: (event: Event, value: number) => void;
+  onDrag: (event: Event, value: number) => void;
   ranges: Record<string, number[]>;
   size: number;
   step: number;
@@ -30,7 +30,8 @@ type Props = Partial<{
   unclamped: boolean;
   unit: string;
   value: number;
-}>;
+}> &
+  BoxProps;
 
 export const Knob = (props: Props) => {
   const {

--- a/tgui/packages/tgui/components/LabeledList.tsx
+++ b/tgui/packages/tgui/components/LabeledList.tsx
@@ -21,7 +21,7 @@ type LabeledListItemProps = Partial<{
   buttons: InfernoNode;
   children: InfernoNode;
   className: string | BooleanLike;
-  color: string;
+  color: string | BooleanLike;
   key: string | number;
   label: string | InfernoNode | BooleanLike;
   labelColor: string;

--- a/tgui/packages/tgui/components/LabeledList.tsx
+++ b/tgui/packages/tgui/components/LabeledList.tsx
@@ -10,11 +10,7 @@ import { Box, unit } from './Box';
 import { Divider } from './Divider';
 import { Tooltip } from './Tooltip';
 
-type LabeledListProps = {
-  children?: any;
-};
-
-export const LabeledList = (props: LabeledListProps) => {
+export const LabeledList = (props: { children?: any }) => {
   const { children } = props;
   return <table className="LabeledList">{children}</table>;
 };
@@ -22,33 +18,31 @@ export const LabeledList = (props: LabeledListProps) => {
 LabeledList.defaultHooks = pureComponentHooks;
 
 type LabeledListItemProps = Partial<{
-  className: string | BooleanLike;
-  label: string | InfernoNode | BooleanLike;
-  labelColor: string | BooleanLike;
-  labelWrap: boolean;
-  color: string | BooleanLike;
-  textAlign: string | BooleanLike;
   buttons: InfernoNode;
-  /** @deprecated */
-  content: any;
   children: InfernoNode;
-  verticalAlign: string;
+  className: string | BooleanLike;
+  color: string;
+  key: string | number;
+  label: string | InfernoNode | BooleanLike;
+  labelColor: string;
+  labelWrap: boolean;
+  textAlign: string;
   tooltip: string;
+  verticalAlign: string;
 }>;
 
 const LabeledListItem = (props: LabeledListItemProps) => {
   const {
+    buttons,
+    children,
     className,
+    color,
     label,
     labelColor = 'label',
     labelWrap,
-    color,
     textAlign,
-    buttons,
-    content,
-    children,
-    verticalAlign = 'baseline',
     tooltip,
+    verticalAlign = 'baseline',
   } = props;
 
   let innerLabel;
@@ -95,7 +89,6 @@ const LabeledListItem = (props: LabeledListItemProps) => {
         className={classes(['LabeledList__cell', 'LabeledList__content'])}
         colSpan={buttons ? undefined : 2}
         verticalAlign={verticalAlign}>
-        {content}
         {children}
       </Box>
       {buttons && (

--- a/tgui/packages/tgui/components/NoticeBox.tsx
+++ b/tgui/packages/tgui/components/NoticeBox.tsx
@@ -5,7 +5,7 @@
  */
 
 import { classes, pureComponentHooks } from 'common/react';
-import { Box } from './Box';
+import { Box, BoxProps } from './Box';
 
 type Props = Partial<{
   className: string;
@@ -14,7 +14,8 @@ type Props = Partial<{
   warning: boolean;
   success: boolean;
   danger: boolean;
-}>;
+}> &
+  BoxProps;
 
 export const NoticeBox = (props: Props) => {
   const { className, color, info, warning, success, danger, ...rest } = props;

--- a/tgui/packages/tgui/components/NoticeBox.tsx
+++ b/tgui/packages/tgui/components/NoticeBox.tsx
@@ -7,8 +7,18 @@
 import { classes, pureComponentHooks } from 'common/react';
 import { Box } from './Box';
 
-export const NoticeBox = (props) => {
+type Props = Partial<{
+  className: string;
+  color: string;
+  info: boolean;
+  warning: boolean;
+  success: boolean;
+  danger: boolean;
+}>;
+
+export const NoticeBox = (props: Props) => {
   const { className, color, info, warning, success, danger, ...rest } = props;
+
   return (
     <Box
       className={classes([

--- a/tgui/packages/tgui/components/NumberInput.jsx
+++ b/tgui/packages/tgui/components/NumberInput.jsx
@@ -165,14 +165,15 @@ export class NumberInput extends Component {
       displayValue = intermediateValue;
     }
 
-    // prettier-ignore
     const contentElement = (
       <div className="NumberInput__content" unselectable={Byond.IS_LTE_IE8}>
-        {
-          (animated && !dragging && !suppressingFlicker) ?
-            (<AnimatedNumber value={displayValue} format={format} />) :
-            (format ? format(displayValue) : displayValue)
-        }
+        {animated && !dragging && !suppressingFlicker ? (
+          <AnimatedNumber value={displayValue} format={format} />
+        ) : format ? (
+          format(displayValue)
+        ) : (
+          displayValue
+        )}
 
         {unit ? ' ' + unit : ''}
       </div>
@@ -194,10 +195,12 @@ export class NumberInput extends Component {
           <div
             className="NumberInput__bar"
             style={{
-              // prettier-ignore
-              height: clamp(
-                (displayValue - minValue) / (maxValue - minValue) * 100,
-                0, 100) + '%',
+              height:
+                clamp(
+                  ((displayValue - minValue) / (maxValue - minValue)) * 100,
+                  0,
+                  100
+                ) + '%',
             }}
           />
         </div>
@@ -236,7 +239,6 @@ export class NumberInput extends Component {
           }}
           onKeyDown={(e) => {
             if (e.keyCode === 13) {
-              // prettier-ignore
               const value = clamp(
                 parseFloat(e.target.value),
                 minValue,

--- a/tgui/packages/tgui/components/Popper.tsx
+++ b/tgui/packages/tgui/components/Popper.tsx
@@ -2,13 +2,14 @@ import { createPopper } from '@popperjs/core';
 import { ArgumentsOf } from 'common/types';
 import { Component, findDOMfromVNode, InfernoNode, render } from 'inferno';
 
-type PopperProps = {
+type Props = {
   popperContent: InfernoNode;
   options?: ArgumentsOf<typeof createPopper>[2];
   additionalStyles?: CSSProperties;
+  children?: any;
 };
 
-export class Popper extends Component<PopperProps> {
+export class Popper extends Component<Props> {
   static id: number = 0;
 
   renderedContent: HTMLDivElement;

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -9,25 +9,21 @@ import { Component, InfernoNode, RefObject, createRef } from 'inferno';
 import { addScrollableNode, removeScrollableNode } from '../events';
 import { canRender, classes } from 'common/react';
 
-export type SectionProps = BoxProps & {
-  className?: string;
-  title?: InfernoNode;
-  buttons?: InfernoNode;
-  fill?: boolean;
-  fitted?: boolean;
-  scrollable?: boolean;
-  scrollableHorizontal?: boolean;
-  /** @deprecated This property no longer works, please remove it. */
-  level?: never;
-  /** @deprecated Please use `scrollable` property */
-  overflowY?: never;
+type Props = Partial<{
+  buttons: InfernoNode;
+  fill: boolean;
+  fitted: boolean;
+  scrollable: boolean;
+  scrollableHorizontal: boolean;
+  title: InfernoNode;
   /** @member Allows external control of scrolling. */
-  scrollableRef?: RefObject<HTMLDivElement>;
+  scrollableRef: RefObject<HTMLDivElement>;
   /** @member Callback function for the `scroll` event */
-  onScroll?: (this: GlobalEventHandlers, ev: Event) => any;
-};
+  onScroll: (this: GlobalEventHandlers, ev: Event) => any;
+}> &
+  BoxProps;
 
-export class Section extends Component<SectionProps> {
+export class Section extends Component<Props> {
   scrollableRef: RefObject<HTMLDivElement>;
   scrollable: boolean;
   onScroll?: (this: GlobalEventHandlers, ev: Event) => any;
@@ -74,7 +70,6 @@ export class Section extends Component<SectionProps> {
       <div
         className={classes([
           'Section',
-          Byond.IS_LTE_IE8 && 'Section--iefix',
           fill && 'Section--fill',
           fitted && 'Section--fitted',
           scrollable && 'Section--scrollable',

--- a/tgui/packages/tgui/components/Stack.tsx
+++ b/tgui/packages/tgui/components/Stack.tsx
@@ -8,13 +8,15 @@ import { classes } from 'common/react';
 import { RefObject } from 'inferno';
 import { computeFlexClassName, computeFlexItemClassName, computeFlexItemProps, computeFlexProps, FlexItemProps, FlexProps } from './Flex';
 
-type StackProps = FlexProps & {
-  vertical?: boolean;
-  fill?: boolean;
-};
+type StackProps = Partial<{
+  vertical: boolean;
+  fill: boolean;
+}> &
+  FlexProps;
 
 export const Stack = (props: StackProps) => {
   const { className, vertical, fill, ...rest } = props;
+
   return (
     <div
       className={classes([
@@ -32,12 +34,14 @@ export const Stack = (props: StackProps) => {
   );
 };
 
-type StackItemProps = FlexProps & {
+type StackItemProps = Partial<{
   innerRef?: RefObject<HTMLDivElement>;
-};
+}> &
+  FlexItemProps;
 
 const StackItem = (props: StackItemProps) => {
   const { className, innerRef, ...rest } = props;
+
   return (
     <div
       className={classes([
@@ -53,12 +57,14 @@ const StackItem = (props: StackItemProps) => {
 
 Stack.Item = StackItem;
 
-type StackDividerProps = FlexItemProps & {
-  hidden?: boolean;
-};
+type StackDividerProps = Partial<{
+  hidden: boolean;
+}> &
+  FlexItemProps;
 
 const StackDivider = (props: StackDividerProps) => {
   const { className, hidden, ...rest } = props;
+
   return (
     <div
       className={classes([

--- a/tgui/packages/tgui/components/StyleableSection.tsx
+++ b/tgui/packages/tgui/components/StyleableSection.tsx
@@ -1,25 +1,28 @@
-import { SFC } from 'inferno';
+import { InfernoNode } from 'inferno';
 import { Box } from './Box';
 
+type Props = Partial<{
+  children?: InfernoNode;
+  style: Record<string, any>;
+  titleStyle: Record<string, any>;
+  textStyle: Record<string, any>;
+  title: InfernoNode;
+  titleSubtext: string;
+}>;
+
 // The cost of flexibility and prettiness.
-export const StyleableSection: SFC<{
-  style?;
-  titleStyle?;
-  textStyle?;
-  title?;
-  titleSubtext?;
-}> = (props) => {
+export const StyleableSection = (props: Props) => {
   return (
     <Box style={props.style}>
       {/* Yes, this box (line above) is missing the "Section" class. This is very intentional, as the layout looks *ugly* with it.*/}
-      <Box class="Section__title" style={props.titleStyle}>
-        <Box class="Section__titleText" style={props.textStyle}>
+      <Box className="Section__title" style={props.titleStyle}>
+        <Box className="Section__titleText" style={props.textStyle}>
           {props.title}
         </Box>
         <div className="Section__buttons">{props.titleSubtext}</div>
       </Box>
-      <Box class="Section__rest">
-        <Box class="Section__content">{props.children}</Box>
+      <Box className="Section__rest">
+        <Box className="Section__content">{props.children}</Box>
       </Box>
     </Box>
   );

--- a/tgui/packages/tgui/components/Tabs.tsx
+++ b/tgui/packages/tgui/components/Tabs.tsx
@@ -6,7 +6,7 @@
 
 import { canRender, classes } from 'common/react';
 import { InfernoNode } from 'inferno';
-import { computeBoxClassName, computeBoxProps } from './Box';
+import { BoxProps, computeBoxClassName, computeBoxProps } from './Box';
 import { Icon } from './Icon';
 
 type Props = Partial<{
@@ -15,18 +15,21 @@ type Props = Partial<{
   fill: boolean;
   fluid: boolean;
   vertical: boolean;
-}>;
+}> &
+  BoxProps;
 
 type TabProps = Partial<{
   children: InfernoNode;
   className: string;
   color: string;
+  fluid: boolean;
   icon: string;
   leftSlot: InfernoNode;
   onClick: () => void;
   rightSlot: InfernoNode;
   selected: boolean;
-}>;
+}> &
+  BoxProps;
 
 export const Tabs = (props: Props) => {
   const { className, vertical, fill, fluid, children, ...rest } = props;

--- a/tgui/packages/tgui/components/Tabs.tsx
+++ b/tgui/packages/tgui/components/Tabs.tsx
@@ -5,11 +5,32 @@
  */
 
 import { canRender, classes } from 'common/react';
+import { InfernoNode } from 'inferno';
 import { computeBoxClassName, computeBoxProps } from './Box';
 import { Icon } from './Icon';
 
-export const Tabs = (props) => {
+type Props = Partial<{
+  children: InfernoNode;
+  className: string;
+  fill: boolean;
+  fluid: boolean;
+  vertical: boolean;
+}>;
+
+type TabProps = Partial<{
+  children: InfernoNode;
+  className: string;
+  color: string;
+  icon: string;
+  leftSlot: InfernoNode;
+  onClick: () => void;
+  rightSlot: InfernoNode;
+  selected: boolean;
+}>;
+
+export const Tabs = (props: Props) => {
   const { className, vertical, fill, fluid, children, ...rest } = props;
+
   return (
     <div
       className={classes([
@@ -26,7 +47,7 @@ export const Tabs = (props) => {
   );
 };
 
-const Tab = (props) => {
+const Tab = (props: TabProps) => {
   const {
     className,
     selected,
@@ -37,6 +58,7 @@ const Tab = (props) => {
     children,
     ...rest
   } = props;
+
   return (
     <div
       className={classes([
@@ -45,7 +67,7 @@ const Tab = (props) => {
         'Tab--color--' + color,
         selected && 'Tab--selected',
         className,
-        ...computeBoxClassName(rest),
+        computeBoxClassName(rest),
       ])}
       {...computeBoxProps(rest)}>
       {(canRender(leftSlot) && <div className="Tab__left">{leftSlot}</div>) ||

--- a/tgui/packages/tgui/interfaces/AntagInfoMalf.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoMalf.tsx
@@ -120,7 +120,7 @@ const CodewordsSection = (props) => {
   const { data } = useBackend<Info>();
   const { has_codewords, phrases, responses } = data;
   return (
-    <Section title="Codewords" mb={!has_codewords && -1}>
+    <Section title="Codewords" mb={!has_codewords ? -1 : 0}>
       <Stack fill>
         {(!has_codewords && (
           <BlockQuote>

--- a/tgui/packages/tgui/interfaces/DepartmentOrders.tsx
+++ b/tgui/packages/tgui/interfaces/DepartmentOrders.tsx
@@ -116,7 +116,7 @@ const DepartmentCatalog = (props) => {
         <Tabs textAlign="center" fluid>
           {supplies.map((cat) => (
             <Tabs.Tab
-              key={cat}
+              key={cat.name}
               selected={tabCategory === cat}
               onClick={() => setTabCategory(cat)}>
               {cat.name}

--- a/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
@@ -419,7 +419,7 @@ const EquipmentGrid = (props: { drone: ActiveDrone & DroneData }) => {
               )}
             </Stack.Item>
             <Stack.Item>
-              <Stack wrap="wrap" width={10}>
+              <Stack wrap width={10}>
                 {cargo.map((cargo_element) => (
                   <EquipmentBox
                     drone={props.drone}

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
@@ -96,7 +96,7 @@ const MaterialCounter = (props: MaterialCounterProps) => {
         hovering && 'MaterialDock--active',
         sheets < 1 && 'MaterialDock--disabled',
       ])}>
-      <Stack vertial direction={'column-reverse'}>
+      <Stack vertical direction={'column-reverse'}>
         <Flex
           direction="column"
           textAlign="center"

--- a/tgui/packages/tgui/interfaces/LightController.tsx
+++ b/tgui/packages/tgui/interfaces/LightController.tsx
@@ -67,7 +67,7 @@ export const LightController = (props) => {
         <Stack fill>
           <Stack.Item>
             <Section fitted fill scrollable width="170px">
-              <Tabs fluid centered>
+              <Tabs fluid align="center">
                 {category_keys.map((category, index) => (
                   <Tabs.Tab
                     key={category}

--- a/tgui/packages/tgui/interfaces/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputModal.tsx
@@ -186,7 +186,7 @@ const ListDisplay = (props) => {
     props;
 
   return (
-    <Section fill scrollable tabIndex={0}>
+    <Section fill scrollable>
       {filteredItems.map((item, index) => {
         return (
           <Button

--- a/tgui/packages/tgui/interfaces/LogViewer.tsx
+++ b/tgui/packages/tgui/interfaces/LogViewer.tsx
@@ -100,7 +100,7 @@ const CategoryBar = (props: CategoryBarProps) => {
           onChange={(_: any, value: string) => setCategorySearch(value)}
         />
       }>
-      <Stack scrollableHorizontal>
+      <Stack style={{ 'overflow-x': 'auto' }}>
         {/** these are not in stack items to have them directly next to eachother */}
         <Button
           textAlign="left"

--- a/tgui/packages/tgui/interfaces/MafiaPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MafiaPanel.tsx
@@ -64,11 +64,14 @@ export const MafiaPanelData = (props) => {
       <Stack fill>
         <Stack.Item grow={1}>
           <Stack fill vertical>
-            <MafiaLobby />
-
-            <Stack grow>
-              <Stack.Item>{!!admin_controls && <MafiaAdmin />}</Stack.Item>
-            </Stack>
+            <Stack.Item>
+              <MafiaLobby />
+            </Stack.Item>
+            <Stack.Item grow>
+              <Stack>
+                <Stack.Item>{!!admin_controls && <MafiaAdmin />}</Stack.Item>
+              </Stack>
+            </Stack.Item>
           </Stack>
         </Stack.Item>
       </Stack>
@@ -96,16 +99,16 @@ export const MafiaPanelData = (props) => {
               )}
             </>
           )}
-          <Stack grow>
+          <Stack>
             <Stack.Item>{!!admin_controls && <MafiaAdmin />}</Stack.Item>
           </Stack>
           {phase !== 'No Game' && (
-            <Stack grow fill>
+            <Stack fill>
               <>
                 <Stack.Item grow>
                   <MafiaPlayers />
                 </Stack.Item>
-                <Stack.Item fluid grow>
+                <Stack.Item grow>
                   <Stack.Item>
                     <Tabs fluid>
                       <Tabs.Tab
@@ -191,8 +194,8 @@ const MafiaChat = (props) => {
             placeholder={'Type to chat'}
             value={message_to_send}
           />
-          <Stack grow>
-            <Stack.Item grow fill>
+          <Stack>
+            <Stack.Item grow>
               <Button
                 color="bad"
                 fluid
@@ -359,7 +362,7 @@ const MafiaNotesTab = (props) => {
   const { user_notes } = data;
   const [note_message, setNotesMessage] = useLocalState('Notes', user_notes);
   return (
-    <Section grow fill>
+    <Section fill>
       <TextArea
         height="80%"
         maxLength={600}
@@ -368,8 +371,8 @@ const MafiaNotesTab = (props) => {
         placeholder={'Insert Notes...'}
         value={note_message}
       />
-      <Stack grow>
-        <Stack.Item grow fill>
+      <Stack fill>
+        <Stack.Item grow>
           <Button
             color="good"
             fluid
@@ -431,9 +434,9 @@ const MafiaPlayers = (props) => {
             <Stack align="center">
               <Stack.Item
                 grow
-                color={!player.alive && 'red'}
+                color={!player.alive ? 'red' : ''}
                 backgroundColor={
-                  player.ref === person_voted_up_ref ? 'yellow' : null
+                  player.ref === person_voted_up_ref ? 'yellow' : ''
                 }>
                 {player.name}
                 {(!!player.is_you && ' (YOU)') ||

--- a/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
@@ -101,7 +101,6 @@ const NoteTabs = (props) => {
       {notes.map((note, index) => (
         <Tabs.Tab
           key={index}
-          label={index + 1}
           onClick={() => setNote(note)}
           selected={selectedNote?.note_ref === note.note_ref}>
           {index + 1}

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
@@ -93,7 +93,6 @@ const CrewTab = (props: { record: MedicalRecord }) => {
   return (
     <Tabs.Tab
       className="candystripe"
-      label={name}
       onClick={() => selectRecord(record)}
       selected={selectedRecord?.crew_ref === crew_ref}>
       <Box wrap>

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
@@ -96,7 +96,6 @@ const CrewTab = (props: { record: SecurityRecord }) => {
   return (
     <Tabs.Tab
       className="candystripe"
-      label={record.name}
       onClick={() => selectRecord(record)}
       selected={isSelected}>
       <Box bold={isSelected} color={CRIMESTATUS2COLOR[wanted_status]} wrap>

--- a/tgui/packages/tgui/interfaces/SparringContract.tsx
+++ b/tgui/packages/tgui/interfaces/SparringContract.tsx
@@ -141,8 +141,8 @@ export const SparringContract = (props) => {
               </Stack>
             </Stack.Item>
             <Stack.Item grow>
-              <Stack grow textAlign="center">
-                <Stack.Item fontSize={left_sign !== 'none' && '14px'} grow>
+              <Stack fill textAlign="center">
+                <Stack.Item fontSize={left_sign !== 'none' ? '14px' : ''} grow>
                   {(left_sign === 'none' && (
                     <Button
                       icon="pen"
@@ -160,7 +160,7 @@ export const SparringContract = (props) => {
                     left_sign}
                 </Stack.Item>
                 <Stack.Item fontSize="16px">VS</Stack.Item>
-                <Stack.Item fontSize={right_sign !== 'none' && '14px'} grow>
+                <Stack.Item fontSize={right_sign !== 'none' ? '14px' : ''} grow>
                   {(right_sign === 'none' && (
                     <Button
                       icon="pen"

--- a/tgui/packages/tgui/interfaces/TrainingMachine.tsx
+++ b/tgui/packages/tgui/interfaces/TrainingMachine.tsx
@@ -55,7 +55,7 @@ const TrainingControls = (props) => {
       <Stack.Item>
         <Divider vertical />
       </Stack.Item>
-      <Stack.Item label="Simulation">
+      <Stack.Item>
         <Button
           fluid
           selected={moving}

--- a/tgui/packages/tgui/interfaces/TraitorObjectiveDebug.tsx
+++ b/tgui/packages/tgui/interfaces/TraitorObjectiveDebug.tsx
@@ -206,9 +206,9 @@ export const TraitorObjectiveDebug = (props) => {
           <Stack vertical>
             <Stack.Item>
               <Tabs width="100%" fluid textAlign="center">
-                {sortingOptions.map((value) => (
+                {sortingOptions.map((value, index) => (
                   <Tabs.Tab
-                    key={value.sort}
+                    key={index}
                     selected={value.name === sortingFunc}
                     onClick={() => setSortingFunc(value.name)}>
                     {value.name}

--- a/tgui/packages/tgui/interfaces/TramPlaque.tsx
+++ b/tgui/packages/tgui/interfaces/TramPlaque.tsx
@@ -45,7 +45,7 @@ export const TramPlaque = (props) => {
           </LabeledList>
         </Section>
         <Section title="Tram History">
-          <Stack horizontal fill>
+          <Stack fill>
             <Stack.Item m={1} grow>
               <b>Serial</b>
             </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Vendatray.tsx
+++ b/tgui/packages/tgui/interfaces/Vendatray.tsx
@@ -26,7 +26,7 @@ export const Vendatray = (props) => {
           </Stack.Item>
         </Stack>
         {registered ? (
-          <Section italics>Pays to the account of {owner_name}.</Section>
+          <Section>Pays to the account of {owner_name}.</Section>
         ) : (
           <>
             <Section>Tray is unregistered.</Section>

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -376,7 +376,7 @@ const CategorySelector = (props: {
 
   return (
     <Section>
-      <Stack grow>
+      <Stack fill>
         <Stack.Item>
           {Object.entries(categories).map(([name, category]) => (
             <Button


### PR DESCRIPTION
## About The Pull Request
Further atomization of #80044.

This includes some aggressive TypeScript refactors - primarily Box, for instance, which I was troubleshooting in #80044. This refactor links type to the actual style map used, rather than maintaining the list of both. It's a much more intuitive way of doing it. `typeof` is a powerful keyword.

Other components (where it was simple) I wrote out a type and converted from jsx -> tsx. Tabs for instance. It's important to understand that TypeScript types can even be wrong - it has no functional affect on a UI. It will just give a compiler error if so, and can be corrected. This is outweighed by the fact it offers suggestions /at all/ compared to vanilla js.

In other places, I removed prettier-ignore and IE8 components, just because I wanted it standardized, out of sight out of mind.
## Why It's Good For The Game
Easier conversion to react with #80044. Also, a more robust type system will guide future contributors to just what they can and can't do with components. TypeScript is a no-brainer at this point.
## Changelog
N/A nothing player facing.
