### PR TITLE
Adds the message server key to the Chief Engineer's memories.

### DIFF
--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -217,7 +217,7 @@
 /datum/memory/key/message_server_key
 	var/decrypt_key
 
-/datum/memory/key/message_server_code/New(
+/datum/memory/key/message_server_key/New(
 	datum/mind/memorizer_mind,
 	atom/protagonist,
 	atom/deuteragonist,

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -213,3 +213,26 @@
 		"[protagonist_name] being arrested by security for [crimes].",
 		"[protagonist_name] committing the crimes of [crimes].",
 	)
+
+/datum/memory/key/message_server_key
+	var/decrypt_key
+
+/datum/memory/key/message_server_code/New(
+	datum/mind/memorizer_mind,
+	atom/protagonist,
+	atom/deuteragonist,
+	atom/antagonist,
+	decrypt_key,
+)
+	src.decrypt_key = decrypt_key
+	return ..()
+
+/datum/memory/key/message_server_key/get_names()
+	return list("The message monitor key should be [decrypt_key]. Keep it a secret from the clown.")
+
+/datum/memory/key/message_server_key/get_starts()
+	return list(
+		"A sticky note attached to a monitor with [decrypt_key] written on it.",
+		"Poly the parrot screaming \"[decrypt_key]!\" over and over again.",
+		"[protagonist_name] spilling coffee over the message monitor while typing [decrypt_key].",
+	)

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -228,7 +228,7 @@
 	return ..()
 
 /datum/memory/key/message_server_key/get_names()
-	return list("The message monitor key should be [decrypt_key]. Keep it a secret from the clown.")
+	return list("The daily message server key is [decrypt_key]. Keep it a secret from the clown.")
 
 /datum/memory/key/message_server_key/get_starts()
 	return list(

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -178,7 +178,7 @@ GLOBAL_VAR(preset_station_message_server_key)
 		return
 	decryptkey = pick("the", "if", "of", "as", "in", "a", "you", "from", "to", "an", "too", "little", "snow", "dead", "drunk", "rosebud", "duck", "al", "le")
 	decryptkey += pick("diamond", "beer", "mushroom", "assistant", "clown", "captain", "twinkie", "security", "nuke", "small", "big", "escape", "yellow", "gloves", "monkey", "engine", "nuclear", "ai")
-	decryptkey += rand(0, 9)
+	decryptkey += "[rand(0, 9)]"
 	if(is_on_station)
 		GLOB.preset_station_message_server_key = decryptkey
 

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -119,12 +119,6 @@
 	if(calibrating)
 		. += span_warning("It's still calibrating.")
 
-/**
- * Handles generating a key for the message server, returning it. Doesn't assign
- * it in this proc, you have to do so yourself.
- */
-/obj/machinery/telecomms/message_server/proc/generate_key()
-
 /obj/machinery/telecomms/message_server/process()
 	. = ..()
 	if(calibrating && calibrating <= world.time)
@@ -176,6 +170,7 @@ GLOBAL_VAR(preset_station_message_server_key)
 	if(is_on_station && GLOB.preset_station_message_server_key)
 		decryptkey = GLOB.preset_station_message_server_key
 		return
+	//Generate a random password for the message server
 	decryptkey = pick("the", "if", "of", "as", "in", "a", "you", "from", "to", "an", "too", "little", "snow", "dead", "drunk", "rosebud", "duck", "al", "le")
 	decryptkey += pick("diamond", "beer", "mushroom", "assistant", "clown", "captain", "twinkie", "security", "nuke", "small", "big", "escape", "yellow", "gloves", "monkey", "engine", "nuclear", "ai")
 	decryptkey += "[rand(0, 9)]"

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -173,7 +173,7 @@ GLOBAL_VAR(preset_station_message_server_key)
 	// Just in case there are multiple preset messageservers somehow once the CE arrives,
 	// we want those on the station to share the same preset default decrypt key shown in his memories.
 	var/is_on_station = is_station_level(z)
-	if(is_station_level(z) && GLOB.preset_station_message_server_key)
+	if(is_on_station && GLOB.preset_station_message_server_key)
 		decryptkey = GLOB.preset_station_message_server_key
 		return
 	decryptkey = pick("the", "if", "of", "as", "in", "a", "you", "from", "to", "an", "too", "little", "snow", "dead", "drunk", "rosebud", "duck", "al", "le")

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -101,9 +101,6 @@
 
 /obj/machinery/telecomms/message_server/Initialize(mapload)
 	. = ..()
-	if (!decryptkey)
-		decryptkey = generate_key()
-
 	if (calibrating)
 		calibrating += world.time
 		say("Calibrating... Estimated wait time: [rand(3, 9)] minutes.")
@@ -127,11 +124,6 @@
  * it in this proc, you have to do so yourself.
  */
 /obj/machinery/telecomms/message_server/proc/generate_key()
-	var/generated_key
-	generated_key += pick("the", "if", "of", "as", "in", "a", "you", "from", "to", "an", "too", "little", "snow", "dead", "drunk", "rosebud", "duck", "al", "le")
-	generated_key += pick("diamond", "beer", "mushroom", "assistant", "clown", "captain", "twinkie", "security", "nuke", "small", "big", "escape", "yellow", "gloves", "monkey", "engine", "nuclear", "ai")
-	generated_key += pick("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
-	return generated_key
 
 /obj/machinery/telecomms/message_server/process()
 	. = ..()
@@ -172,9 +164,23 @@
 	id = "Messaging Server"
 	network = "tcommsat"
 	autolinkers = list("messaging")
-	decryptkey = null //random
 	calibrating = 0
 
+GLOBAL_VAR(preset_station_message_server_key)
+
+/obj/machinery/telecomms/message_server/preset/Initialize(mapload)
+	. = ..()
+	// Just in case there are multiple preset messageservers somehow once the CE arrives,
+	// we want those on the station to share the same preset default decrypt key shown in his memories.
+	var/is_on_station = is_station_level(z)
+	if(is_station_level(z) && GLOB.preset_station_message_server_key)
+		decryptkey = GLOB.preset_station_message_server_key
+		return
+	decryptkey = pick("the", "if", "of", "as", "in", "a", "you", "from", "to", "an", "too", "little", "snow", "dead", "drunk", "rosebud", "duck", "al", "le")
+	decryptkey += pick("diamond", "beer", "mushroom", "assistant", "clown", "captain", "twinkie", "security", "nuke", "small", "big", "escape", "yellow", "gloves", "monkey", "engine", "nuclear", "ai")
+	decryptkey += rand(0, 9)
+	if(is_on_station)
+		GLOB.preset_station_message_server_key = decryptkey
 
 // Root messaging signal datum
 /datum/signal/subspace/messaging

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -50,10 +50,7 @@
 
 /datum/job/chief_engineer/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()
-	for(var/obj/machinery/telecomms/message_server/preset/server in GLOB.telecomms_list)
-		if(server.decryptkey)
-			spawned.add_mob_memory(/datum/memory/key/message_server_code, decrypt_key = server.decryptkey)
-			break
+	spawned.add_mob_memory(/datum/memory/key/message_server_key, decrypt_key = GLOB.preset_station_message_server_key)
 
 /datum/job/chief_engineer/get_captaincy_announcement(mob/living/captain)
 	return "Due to staffing shortages, newly promoted Acting Captain [captain.real_name] on deck!"

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -48,6 +48,13 @@
 	voice_of_god_power = 1.4 //Command staff has authority
 
 
+/datum/job/chief_engineer/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	for(var/obj/machinery/telecomms/message_server/preset/server in GLOB.telecomms_list)
+		if(server.decryptkey)
+			spawned.add_mob_memory(/datum/memory/key/message_server_code, decrypt_key = server.decryptkey)
+			break
+
 /datum/job/chief_engineer/get_captaincy_announcement(mob/living/captain)
 	return "Due to staffing shortages, newly promoted Acting Captain [captain.real_name] on deck!"
 


### PR DESCRIPTION
## About The Pull Request
Like the captain has innate knowledge of the golden safe code, the Chief Engineer should know the daily key of the message server.

## Why It's Good For The Game
It's a perk of the job.

## Changelog

:cl:
add: Added the daily (roundstart) message server key to the Chief Engineer's memories.
/:cl:
