### PR TITLE
Makes the QM Skirt Work For Digi Legs

### DIFF
--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -15,6 +15,7 @@
 	inhand_icon_state = "lb_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	dying_key = DYE_REGISTRY_JUMPSKIRT
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/under/rank/cargo/tech
 	name = "cargo technician's uniform"


### PR DESCRIPTION

## About The Pull Request
Makes digi legs use the QM skirt properly.
<img src="https://i.ibb.co/9qKDkr3/Digi-Lizard-Skirt.png">
(Difference illustrated with VV)
## Why It's Good For The Game
Realistically lizards shouldn't be allowed in this role, as such inferior beings have no business being a head of staff on a cutting-edge Nanotrasen research station. But if a human decides to get a leg transplant or something this is good for them.
Clearly an oversight in the code. Fixes good oversights bad for the project.
## Changelog
:cl:
fix: Digi legs work with the QM's jumpskirt
/:cl:
