### PR TITLE
PDA update (Messenger works while dead, Microwave works, etc).

### DIFF
--- a/code/__DEFINES/modular_computer.dm
+++ b/code/__DEFINES/modular_computer.dm
@@ -1,13 +1,33 @@
 /**
- * Program bitflags
+ * can_run_on_flags bitflags
  * Used by programs to tell what type of ModPC it can run on.
  * Everything a program can run on needs valid icons for each individual one.
  */
-
+///Runs on everything.
 #define PROGRAM_ALL ALL
+///Can run on Modular PC Consoles
 #define PROGRAM_CONSOLE (1<<0)
+///Can run on Laptops.
 #define PROGRAM_LAPTOP (1<<1)
+///Can run on PDAs.
 #define PROGRAM_PDA (1<<2)
+
+/**
+ * program_flags
+ * Used by programs to tell the ModPC any special functions it has.
+ */
+///If the program requires NTNet to be online for it to work.
+#define PROGRAM_REQUIRES_NTNET (1<<0)
+///The program can be downloaded from the default NTNet downloader store.
+#define PROGRAM_ON_NTNET_STORE (1<<1)
+///The program can only be downloaded from the Syndinet store, usually nukie/emagged pda.
+#define PROGRAM_ON_SYNDINET_STORE (1<<2)
+///The program is unique and will delete itself upon being transferred to ensure only one copy exists.
+#define PROGRAM_UNIQUE_COPY (1<<3)
+///The program is a header and will show up at the top of the ModPC's UI.
+#define PROGRAM_HEADER (1<<4)
+///The program will run despite the ModPC not having any power in it.
+#define PROGRAM_RUNS_WITHOUT_POWER (1<<5)
 
 //Program categories
 #define PROGRAM_CATEGORY_DEVICE "Device Tools"

--- a/code/controllers/subsystem/modular_computers.dm
+++ b/code/controllers/subsystem/modular_computers.dm
@@ -35,9 +35,9 @@ SUBSYSTEM_DEF(modular_computers)
 			continue
 		prog = new prog
 
-		if(prog.available_on_ntnet)
+		if(prog.program_flags & PROGRAM_ON_NTNET_STORE)
 			available_station_software.Add(prog)
-		if(prog.available_on_syndinet)
+		if(prog.program_flags & PROGRAM_ON_SYNDINET_STORE)
 			available_antag_software.Add(prog)
 
 ///Attempts to find a new file through searching the available stores with its name.

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -59,7 +59,7 @@
 		RegisterSignal(parent, COMSIG_IMPLANT_IMPLANTING, PROC_REF(implanting))
 		RegisterSignal(parent, COMSIG_IMPLANT_OTHER, PROC_REF(old_implant))
 		RegisterSignal(parent, COMSIG_IMPLANT_EXISTING_UPLINK, PROC_REF(new_implant))
-	else if(istype(parent, /obj/item/modular_computer/pda))
+	else if(istype(parent, /obj/item/modular_computer))
 		RegisterSignal(parent, COMSIG_TABLET_CHANGE_ID, PROC_REF(new_ringtone))
 		RegisterSignal(parent, COMSIG_TABLET_CHECK_DETONATE, PROC_REF(check_detonate))
 	else if(istype(parent, /obj/item/radio))
@@ -455,7 +455,7 @@
 /datum/component/uplink/proc/setup_unlock_code()
 	unlock_code = generate_code()
 	var/obj/item/P = parent
-	if(istype(parent,/obj/item/modular_computer/pda))
+	if(istype(parent,/obj/item/modular_computer))
 		unlock_note = "<B>Uplink Passcode:</B> [unlock_code] ([P.name])."
 	else if(istype(parent,/obj/item/radio))
 		unlock_note = "<B>Radio Passcode:</B> [unlock_code] ([P.name], [RADIO_TOKEN_UPLINK] channel)."
@@ -465,7 +465,7 @@
 /datum/component/uplink/proc/generate_code()
 	var/returnable_code = ""
 
-	if(istype(parent, /obj/item/modular_computer/pda))
+	if(istype(parent, /obj/item/modular_computer))
 		returnable_code = "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
 
 	else if(istype(parent, /obj/item/radio))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -342,7 +342,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 			return
 
 	// OTHER
-	if(istype(attacking_item, /obj/item/modular_computer/pda))
+	if(istype(attacking_item, /obj/item/modular_computer))
 		var/itemname = ""
 		var/info = ""
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1000,7 +1000,7 @@
 	if(istype(old_loc, /obj/item/storage/wallet))
 		UnregisterSignal(old_loc, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 
-	if(istype(old_loc, /obj/item/modular_computer/pda))
+	if(istype(old_loc, /obj/item/modular_computer))
 		UnregisterSignal(old_loc, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 
 	//New loc
@@ -1008,7 +1008,7 @@
 		RegisterSignal(loc, COMSIG_ITEM_EQUIPPED, PROC_REF(update_intern_status))
 		RegisterSignal(loc, COMSIG_ITEM_DROPPED, PROC_REF(remove_intern_status))
 
-	if(istype(loc, /obj/item/modular_computer/pda))
+	if(istype(loc, /obj/item/modular_computer))
 		RegisterSignal(loc, COMSIG_ITEM_EQUIPPED, PROC_REF(update_intern_status))
 		RegisterSignal(loc, COMSIG_ITEM_DROPPED, PROC_REF(remove_intern_status))
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -167,9 +167,9 @@
 		id.update_icon()
 
 		if(worn)
-			if(istype(worn, /obj/item/modular_computer/pda))
-				var/obj/item/modular_computer/pda/PDA = worn
-				PDA.InsertID(id, H)
+			if(istype(worn, /obj/item/modular_computer))
+				var/obj/item/modular_computer/worn_computer = worn
+				worn_computer.InsertID(id, H)
 
 			else if(istype(worn, /obj/item/storage/wallet))
 				var/obj/item/storage/wallet/W = worn

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -575,7 +575,7 @@
 
 	if(cell_powered && cell?.charge < TIER_1_CELL_CHARGE_RATE * efficiency)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
-		balloon_alert(cooker, "no cell!")
+		balloon_alert(cooker, "no power draw!")
 		return
 
 	if(cooker && HAS_TRAIT(cooker, TRAIT_CURSED) && prob(7))

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -417,7 +417,7 @@
 		return ..()
 
 	if(vampire_charging_capable && istype(item, /obj/item/modular_computer) && ingredients.len > 0)
-		balloon_alert(user, "max 1 pda!")
+		balloon_alert(user, "max 1 device!")
 		return FALSE
 
 	if(istype(item, /obj/item/storage))

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -416,7 +416,7 @@
 			return TRUE
 		return ..()
 
-	if(vampire_charging_capable && istype(item, /obj/item/modular_computer/pda) && ingredients.len > 0)
+	if(vampire_charging_capable && istype(item, /obj/item/modular_computer) && ingredients.len > 0)
 		balloon_alert(user, "max 1 pda!")
 		return FALSE
 
@@ -575,7 +575,7 @@
 
 	if(cell_powered && cell?.charge < TIER_1_CELL_CHARGE_RATE * efficiency)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
-		balloon_alert(cooker, "replace cell!")
+		balloon_alert(cooker, "no cell!")
 		return
 
 	if(cooker && HAS_TRAIT(cooker, TRAIT_CURSED) && prob(7))
@@ -591,7 +591,7 @@
 	for(var/atom/movable/potential_fooditem as anything in ingredients)
 		if(IS_EDIBLE(potential_fooditem))
 			non_food_ingedients--
-		if(istype(potential_fooditem, /obj/item/modular_computer/pda) && prob(75))
+		if(istype(potential_fooditem, /obj/item/modular_computer) && prob(75))
 			pda_failure = TRUE
 			notify_ghosts(
 				"[cooker] has overheated their PDA!",
@@ -608,11 +608,13 @@
 	start(cooker)
 
 /obj/machinery/microwave/proc/wzhzhzh()
+	if(cell_powered && !isnull(cell))
+		if(!cell.use(TIER_1_CELL_CHARGE_RATE * efficiency))
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+			return
+
 	visible_message(span_notice("\The [src] turns on."), null, span_hear("You hear a microwave humming."))
 	operating = TRUE
-	if(cell_powered && !isnull(cell))
-		cell.use(TIER_1_CELL_CHARGE_RATE * efficiency)
-
 	set_light(l_range = 1.5, l_power = 1.2, l_on = TRUE)
 	soundloop.start()
 	update_appearance()
@@ -762,7 +764,7 @@
  * * cooker - The mob that initiated the cook cycle, can be null if no apparent mob triggered it (such as via emp)
  */
 /obj/machinery/microwave/proc/vampire(mob/cooker)
-	var/obj/item/modular_computer/pda/vampire_pda = LAZYACCESS(ingredients, 1)
+	var/obj/item/modular_computer/vampire_pda = LAZYACCESS(ingredients, 1)
 	if(isnull(vampire_pda))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 		after_finish_loop()
@@ -794,7 +796,7 @@
 
 	// We should only be charging PDAs
 	for(var/atom/movable/potential_item as anything in ingredients)
-		if(!istype(potential_item, /obj/item/modular_computer/pda))
+		if(!istype(potential_item, /obj/item/modular_computer))
 			balloon_alert(cooker, "pda only!")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			eject()
@@ -815,7 +817,7 @@
 		pre_fail()
 		return
 
-	if(!vampire_charge_amount || !length(ingredients) || (!isnull(cell) && !cell.charge) || vampire_charge_amount < 25)
+	if(!vampire_charge_amount || !length(ingredients) || isnull(cell) || !cell.charge || vampire_charge_amount < 25)
 		vampire_cell = null
 		charge_loop_finish(cooker)
 		return

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -91,7 +91,7 @@
 //Useful when player is being seen by other mobs
 /mob/living/carbon/human/proc/get_id_name(if_no_id = "Unknown")
 	var/obj/item/storage/wallet/wallet = wear_id
-	var/obj/item/modular_computer/pda/pda = wear_id
+	var/obj/item/modular_computer/pda = wear_id
 	var/obj/item/card/id/id = wear_id
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
 		. = if_no_id //You get NOTHING, no id name, good day sir

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -47,7 +47,7 @@
 	var/max_idle_programs = 2
 
 	///Flag of the type of device the modular computer is, deciding what types of apps it can run.
-	var/hardware_flag = NONE
+	var/hardware_flag = PROGRAM_ALL
 //	Options: PROGRAM_ALL | PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_PDA
 
 	///The theme, used for the main menu and file browser apps.
@@ -582,7 +582,7 @@
 		active_program = program
 		program.alert_pending = FALSE
 		idle_threads.Remove(program)
-		if(user && open_ui)
+		if(open_ui)
 			update_tablet_open_uis(user)
 		update_appearance(UPDATE_ICON)
 		return TRUE
@@ -605,7 +605,7 @@
 
 	active_program = program
 	program.alert_pending = FALSE
-	if(open_ui && user)
+	if(open_ui)
 		update_tablet_open_uis(user)
 	update_appearance(UPDATE_ICON)
 	return TRUE
@@ -905,3 +905,14 @@
 	inserted_pai = null
 	update_appearance(UPDATE_ICON)
 	return TRUE
+
+/**
+ * Debug ModPC
+ * Used to spawn all programs for Create and Destroy unit test.
+ */
+/obj/item/modular_computer/debug
+	max_capacity = INFINITY
+
+/obj/item/modular_computer/debug/Initialize(mapload)
+	starting_programs += subtypesof(/datum/computer_file/program)
+	return ..()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -472,13 +472,13 @@
 		shutdown_computer()
 		return
 
-	if(active_program && active_program.requires_ntnet && !get_ntnet_status())
+	if(active_program && (active_program.program_flags & PROGRAM_REQUIRES_NTNET) && !get_ntnet_status())
 		active_program.event_networkfailure(FALSE) // Active program requires NTNet to run but we've just lost connection. Crash.
 
 	for(var/datum/computer_file/program/idle_programs as anything in idle_threads)
 		idle_programs.process_tick(seconds_per_tick)
 		idle_programs.ntnet_status = get_ntnet_status()
-		if(idle_programs.requires_ntnet && !idle_programs.ntnet_status)
+		if((idle_programs.program_flags & PROGRAM_REQUIRES_NTNET) && !idle_programs.ntnet_status)
 			idle_programs.event_networkfailure(TRUE)
 
 	if(active_program)
@@ -506,6 +506,8 @@
 	physical.loc.visible_message(span_notice("[icon2html(physical, viewers(physical.loc))] \The [src] displays a [caller.filedesc] notification: [alerttext]"))
 
 /obj/item/modular_computer/proc/ring(ringtone) // bring bring
+	if(!use_power())
+		return
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PDA_GLITCHED))
 		playsound(src, pick('sound/machines/twobeep_voice1.ogg', 'sound/machines/twobeep_voice2.ogg'), 50, TRUE)
 	else
@@ -589,7 +591,7 @@
 		to_chat(user, span_danger("\The [src] displays a \"Maximal CPU load reached. Unable to run another program.\" error."))
 		return FALSE
 
-	if(program.requires_ntnet && !get_ntnet_status()) // The program requires NTNet connection, but we are not connected to NTNet.
+	if(program.program_flags & PROGRAM_REQUIRES_NTNET && !get_ntnet_status()) // The program requires NTNet connection, but we are not connected to NTNet.
 		to_chat(user, span_danger("\The [src]'s screen shows \"Unable to connect to NTNet. Please retry. If problem persists contact your system administrator.\" warning."))
 		return FALSE
 

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -7,12 +7,6 @@
 	if(check_power_override())
 		return TRUE
 
-	if(ismachinery(physical))
-		var/obj/machinery/machine_holder = physical
-		if(machine_holder.powered())
-			machine_holder.use_power(amount)
-			return TRUE
-
 	if(!internal_cell)
 		return FALSE
 	if(!internal_cell.charge && (isnull(active_program) || !(active_program.program_flags & PROGRAM_RUNS_WITHOUT_POWER)))
@@ -26,6 +20,13 @@
 		internal_cell.use(min(amount JOULES, internal_cell.charge)) //drain it anyways.
 		return FALSE
 	return TRUE
+
+/obj/item/modular_computer/processor/use_power(amount = 0)
+	var/obj/machinery/machine_holder = physical
+	if(machine_holder.powered())
+		machine_holder.use_power(amount)
+		return TRUE
+	return FALSE
 
 /obj/item/modular_computer/proc/give_power(amount)
 	if(internal_cell)

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -10,7 +10,7 @@
 	if(!internal_cell)
 		return FALSE
 	if(!internal_cell.charge && (isnull(active_program) || !(active_program.program_flags & PROGRAM_RUNS_WITHOUT_POWER)))
-		power_failure()
+		active_program.event_powerfailure()
 		for(var/datum/computer_file/program/programs as anything in stored_files)
 			if((programs.program_flags & PROGRAM_RUNS_WITHOUT_POWER) && open_program(program = programs, open_ui = FALSE))
 				return TRUE
@@ -54,6 +54,7 @@
 
 	if(use_power(power_usage * seconds_per_tick))
 		return TRUE
+	power_failure()
 	return FALSE
 
 ///Returns TRUE if the PC should not be using any power, FALSE otherwise.

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -10,9 +10,9 @@
 	if(!internal_cell)
 		return FALSE
 	if(!internal_cell.charge && (isnull(active_program) || !(active_program.program_flags & PROGRAM_RUNS_WITHOUT_POWER)))
-		active_program.event_powerfailure()
+		close_all_programs()
 		for(var/datum/computer_file/program/programs as anything in stored_files)
-			if((programs.program_flags & PROGRAM_RUNS_WITHOUT_POWER) && open_program(program = programs, open_ui = FALSE))
+			if((programs.program_flags & PROGRAM_RUNS_WITHOUT_POWER) && open_program(program = programs))
 				return TRUE
 		return FALSE
 
@@ -60,7 +60,7 @@
 ///Returns TRUE if the PC should not be using any power, FALSE otherwise.
 ///Checks to see if the current app allows to be ran without power, if so we'll run with it.
 /obj/item/modular_computer/proc/check_power_override()
-	return (internal_cell && !internal_cell.charge && (active_program.program_flags & PROGRAM_RUNS_WITHOUT_POWER))
+	return (!internal_cell?.charge && (active_program?.program_flags & PROGRAM_RUNS_WITHOUT_POWER))
 
 //Integrated (Silicon) tablets don't drain power, because the tablet is required to state laws, so it being disabled WILL cause problems.
 /obj/item/modular_computer/pda/silicon/check_power_override()

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -21,13 +21,6 @@
 		return FALSE
 	return TRUE
 
-/obj/item/modular_computer/processor/use_power(amount = 0)
-	var/obj/machinery/machine_holder = physical
-	if(machine_holder.powered())
-		machine_holder.use_power(amount)
-		return TRUE
-	return FALSE
-
 /obj/item/modular_computer/proc/give_power(amount)
 	if(internal_cell)
 		return internal_cell.give(amount)

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -135,13 +135,15 @@
 
 	switch(action)
 		if("PC_exit")
-			active_program.kill_program(usr)
+			//you can't close apps in emergency mode.
+			if(internal_cell.charge)
+				active_program.kill_program(usr)
 			return TRUE
 		if("PC_shutdown")
 			shutdown_computer()
 			return TRUE
 		if("PC_minimize")
-			if(!active_program)
+			if(!active_program || !internal_cell.charge)
 				return
 			active_program.background_program()
 			return TRUE

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -113,7 +113,7 @@
 		data["programs"] += list(list(
 			"name" = program.filename,
 			"desc" = program.filedesc,
-			"header_program" = program.header_program,
+			"header_program" = !!(program.program_flags & PROGRAM_HEADER),
 			"running" = !!(program in idle_threads),
 			"icon" = program.program_icon,
 			"alert" = program.alert_pending,

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -8,23 +8,24 @@
  * This is best called when you're actually changing the app, as we don't check
  * if we're swapping to the current UI repeatedly.
  * Args:
- * user - The person whose UI we're updating.
+ * user - The person whose UI we're updating. Only necessary if we're opening the UI for the first time.
  */
 /obj/item/modular_computer/proc/update_tablet_open_uis(mob/user)
-	var/datum/tgui/active_ui = SStgui.get_open_ui(user, src)
-	if(!active_ui)
-		if(active_program)
-			active_ui = new(user, src, active_program.tgui_id, active_program.filedesc)
-			active_program.ui_interact(user, active_ui)
-		else
-			active_ui = new(user, src, "NtosMain")
-		return active_ui.open()
+	if(user)
+		var/datum/tgui/active_ui = SStgui.get_open_ui(user, src)
+		if(!active_ui)
+			if(active_program)
+				active_ui = new(user, src, active_program.tgui_id, active_program.filedesc)
+				active_program.ui_interact(user, active_ui)
+			else
+				active_ui = new(user, src, "NtosMain")
+			return active_ui.open()
 
 	for (var/datum/tgui/window as anything in open_uis)
 		if(active_program)
 			window.interface = active_program.tgui_id
 			window.title = active_program.filedesc
-			active_program.ui_interact(user, window)
+			active_program.ui_interact(window.user, window)
 		else
 			window.interface = "NtosMain"
 		window.send_assets()

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -44,6 +44,13 @@
 	machinery_computer = null
 	return ..()
 
+/obj/item/modular_computer/processor/use_power(amount = 0)
+	var/obj/machinery/machine_holder = physical
+	if(machine_holder.powered())
+		machine_holder.use_power(amount)
+		return TRUE
+	return FALSE
+
 /obj/item/modular_computer/processor/relay_qdel()
 	qdel(machinery_computer)
 

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -86,6 +86,8 @@
  * * background - Whether the app is running in the background.
  */
 /datum/computer_file/program/proc/event_powerfailure()
+	if(program_flags & PROGRAM_RUNS_WITHOUT_POWER)
+		return
 	kill_program()
 
 /**

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -191,7 +191,7 @@
 	if(src == computer.active_program)
 		computer.active_program = null
 		if(computer.enabled)
-			computer.update_tablet_open_uis(usr)
+			computer.update_tablet_open_uis(user)
 	if(src in computer.idle_threads)
 		computer.idle_threads.Remove(src)
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -7,6 +7,12 @@
 	/// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NTNET!
 	filename = "UnknownProgram"
 
+	/// Program-specific bitflags that tell the app what it runs on.
+	/// (PROGRAM_ALL | PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_PDA)
+	var/can_run_on_flags = PROGRAM_ALL
+	/// Program-specific bitflags that tells the ModPC what the app is able to do special.
+	/// (PROGRAM_REQUIRES_NTNET|PROGRAM_ON_NTNET_STORE|PROGRAM_ON_SYNDINET_STORE|PROGRAM_UNIQUE_COPY|PROGRAM_HEADER|PROGRAM_RUNS_WITHOUT_POWER)
+	var/program_flags = PROGRAM_ON_NTNET_STORE
 	///How much power running this program costs.
 	var/power_cell_use = PROGRAM_BASIC_CELL_USE
 	///List of required accesses to *run* the program. Any match will do.
@@ -19,23 +25,14 @@
 	/// Short description of this program's function.
 	var/extended_desc = "N/A"
 	///What category this program can be found in within NTNetDownloader.
+	///This is required if PROGRAM_ON_NTNET_STORE or PROGRAM_ON_SYNDINET_STORE is on.
 	var/downloader_category = PROGRAM_CATEGORY_DEVICE
 	///The overlay to add ontop of the ModPC running the app while it's open.
-	///This is taken from the same file as the ModPC, so you can use usage_flags to prevent
+	///This is taken from the same file as the ModPC, so you can use can_run_on_flags to prevent
 	///the program from being used on devices that don't have sprites for it.
 	var/program_open_overlay = null
-	///Boolean on whether the program will appear at the top on PDA menus, or in the app list with everything else.
-	var/header_program = FALSE
-	/// Set to 1 for program to require nonstop NTNet connection to run. If NTNet connection is lost program crashes.
-	var/requires_ntnet = FALSE
 	/// NTNet status, updated every tick by computer running this program. Don't use this for checks if NTNet works, computers do that. Use this for calculations, etc.
 	var/ntnet_status = 1
-	/// Bitflags (PROGRAM_CONSOLE, PROGRAM_LAPTOP, PROGRAM_PDA combination) or PROGRAM_ALL
-	var/usage_flags = PROGRAM_ALL
-	/// Whether the program can be downloaded from NTNet. Set to FALSE to disable.
-	var/available_on_ntnet = TRUE
-	/// Whether the program can be downloaded from SyndiNet (accessible via emagging the computer). Set to TRUE to enable.
-	var/available_on_syndinet = FALSE
 	/// Name of the tgui interface. If this is not defined, this will not be available in NTNet.
 	var/tgui_id
 	/// Example: "something.gif" - a header image that will be rendered in computer's UI when this program is running at background. Images must also be inserted into /datum/asset/simple/headers.
@@ -50,17 +47,15 @@
 	var/alert_pending = FALSE
 	/// How well this program will help combat detomatix viruses.
 	var/detomatix_resistance = NONE
-	///Boolean on whether or not only one copy of the app can exist. This means it deletes itself when cloned elsewhere.
-	var/unique_copy = FALSE
 
 /datum/computer_file/program/clone()
 	var/datum/computer_file/program/temp = ..()
 	temp.run_access = run_access
 	temp.filedesc = filedesc
 	temp.program_open_overlay = program_open_overlay
-	temp.requires_ntnet = requires_ntnet
-	temp.usage_flags = usage_flags
-	if(unique_copy)
+	temp.program_flags = program_flags
+	temp.can_run_on_flags = can_run_on_flags
+	if(program_flags & PROGRAM_UNIQUE_COPY)
 		if(computer)
 			computer.remove_file(src)
 		if(disk_host)
@@ -107,7 +102,7 @@
 
 ///Makes sure a program can run on this hardware (for apps limited to tablets/computers/laptops)
 /datum/computer_file/program/proc/is_supported_by_hardware(hardware_flag = NONE, loud = FALSE, mob/user)
-	if(!(hardware_flag & usage_flags))
+	if(!(hardware_flag & can_run_on_flags))
 		if(loud && computer && user)
 			to_chat(user, span_danger("\The [computer] flashes a \"Hardware Error - Incompatible software\" warning."))
 		return FALSE
@@ -135,7 +130,7 @@
 	if(isAdminGhostAI(user))
 		return TRUE
 
-	if(computer && (computer.obj_flags & EMAGGED) && (available_on_syndinet || !downloading)) //emagged can run anything on syndinet, and can bypass execution locks, but not download.
+	if(computer && (computer.obj_flags & EMAGGED) && (program_flags & PROGRAM_ON_SYNDINET_STORE || !downloading)) //emagged can run anything on syndinet, and can bypass execution locks, but not download.
 		return TRUE
 
 	if(!access_to_check)
@@ -176,7 +171,7 @@
 /datum/computer_file/program/proc/on_start(mob/living/user)
 	SHOULD_CALL_PARENT(TRUE)
 	if(can_run(user, loud = TRUE))
-		if(requires_ntnet)
+		if(program_flags & PROGRAM_REQUIRES_NTNET)
 			var/obj/item/card/id/ID = computer.computer_id_slot?.GetID()
 			generate_network_log("Connection opened -- Program ID:[filename] User:[ID?"[ID.registered_name]":"None"]")
 		return TRUE
@@ -200,7 +195,7 @@
 	if(src in computer.idle_threads)
 		computer.idle_threads.Remove(src)
 
-	if(requires_ntnet)
+	if(program_flags & PROGRAM_REQUIRES_NTNET)
 		var/obj/item/card/id/ID = computer.computer_id_slot?.GetID()
 		generate_network_log("Connection closed -- Program ID: [filename] User:[ID ? "[ID.registered_name]" : "None"]")
 
@@ -210,7 +205,7 @@
 ///Sends the running program to the background/idle threads. Header programs can't be minimized and will kill instead.
 /datum/computer_file/program/proc/background_program()
 	SHOULD_CALL_PARENT(TRUE)
-	if(header_program)
+	if(program_flags & PROGRAM_HEADER)
 		return kill_program()
 
 	computer.idle_threads.Add(src)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -124,11 +124,11 @@
  * access can contain a list of access numbers to check against. If access is not empty, it will be used istead of checking any inserted ID.
  */
 /datum/computer_file/program/proc/can_run(mob/user, loud = FALSE, access_to_check, downloading = FALSE, list/access)
-	if(issilicon(user) && !ispAI(user))
-		return TRUE
-
-	if(isAdminGhostAI(user))
-		return TRUE
+	if(user)
+		if(issilicon(user) && !ispAI(user))
+			return TRUE
+		if(isAdminGhostAI(user))
+			return TRUE
 
 	if(computer && (computer.obj_flags & EMAGGED) && (program_flags & PROGRAM_ON_SYNDINET_STORE || !downloading)) //emagged can run anything on syndinet, and can bypass execution locks, but not download.
 		return TRUE
@@ -147,7 +147,7 @@
 			accesscard = computer.computer_id_slot?.GetID()
 
 		if(!accesscard)
-			if(loud)
+			if(loud && user)
 				to_chat(user, span_danger("\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning."))
 			return FALSE
 		access = accesscard.GetAccess()
@@ -156,7 +156,7 @@
 		if(singular_access in access) //For loop checks every individual access entry in the access list. If the user's ID has access to any entry, then we're good.
 			return TRUE
 
-	if(loud)
+	if(loud && user)
 		to_chat(user, span_danger("\The [computer] flashes an \"Access Denied\" warning."))
 	return FALSE
 

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -5,10 +5,8 @@
 	program_open_overlay = "generic"
 	extended_desc = "Firmware Restoration Kit, capable of reconstructing damaged AI systems. Requires direct AI connection via intellicard slot."
 	size = 12
-	requires_ntnet = FALSE
-	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
+	can_run_on_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
 	download_access = list(ACCESS_RD)
-	available_on_ntnet = TRUE
 	tgui_id = "NtosAiRestorer"
 	program_icon = "laptop-code"
 

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -5,7 +5,7 @@
 	ui_header = "alarm_green.gif"
 	program_open_overlay = "alert-green"
 	extended_desc = "This program provides visual interface for a station's alarm system."
-	requires_ntnet = 1
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 4
 	tgui_id = "NtosStationAlertConsole"
 	program_icon = "bell"

--- a/code/modules/modular_computers/file_system/programs/antagonist/contractor_program.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contractor_program.dm
@@ -6,11 +6,8 @@
 	program_icon = "tasks"
 	size = 10
 
-	requires_ntnet = FALSE
-	available_on_ntnet = FALSE
-	available_on_syndinet = FALSE
-	usage_flags = PROGRAM_PDA //this is all we've got sprites for :sob:
-	unique_copy = TRUE
+	program_flags = PROGRAM_ON_SYNDINET_STORE | PROGRAM_UNIQUE_COPY
+	can_run_on_flags = PROGRAM_PDA //this is all we've got sprites for :sob:
 	undeletable = TRUE
 	tgui_id = "SyndicateContractor"
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -5,9 +5,7 @@
 	program_open_overlay = "hostile"
 	extended_desc = "This advanced script can perform denial of service attacks against NTNet quantum relays. The system administrator will probably notice this. Multiple devices can run this program together against same relay for increased effect"
 	size = 20
-	requires_ntnet = TRUE
-	available_on_ntnet = FALSE
-	available_on_syndinet = TRUE
+	program_flags = PROGRAM_ON_SYNDINET_STORE | PROGRAM_REQUIRES_NTNET
 	tgui_id = "NtosNetDos"
 	program_icon = "satellite-dish"
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -5,9 +5,7 @@
 	program_open_overlay = "hostile"
 	extended_desc = "This virus can destroy hard drive of system it is executed on. It may be obfuscated to look like another non-malicious program. Once armed, it will destroy the system upon next execution."
 	size = 13
-	requires_ntnet = FALSE
-	available_on_ntnet = FALSE
-	available_on_syndinet = TRUE
+	program_flags = PROGRAM_ON_SYNDINET_STORE
 	tgui_id = "NtosRevelation"
 	program_icon = "magnet"
 	var/armed = 0

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -3,7 +3,6 @@
 	filedesc = "Donksoft Micro Arcade"
 	program_open_overlay = "arcade"
 	extended_desc = "This port of the classic game 'Outbomb Cuban Pete', redesigned to run on tablets, with thrilling graphics and chilling storytelling."
-	requires_ntnet = FALSE
 	downloader_category = PROGRAM_CATEGORY_GAMES
 	size = 6
 	tgui_id = "NtosArcade"

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -5,7 +5,7 @@
 	ui_header = "borg_mon.gif"
 	program_open_overlay = "generic"
 	extended_desc = "This program allows for remote monitoring of station cyborgs."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	download_access = list(ACCESS_ROBOTICS)
 	size = 5
 	tgui_id = "NtosCyborgRemoteMonitor"
@@ -152,9 +152,7 @@
 	ui_header = "borg_mon.gif"
 	program_open_overlay = "generic"
 	extended_desc = "This program allows for remote monitoring of mission-assigned cyborgs."
-	requires_ntnet = FALSE
-	available_on_ntnet = FALSE
-	available_on_syndinet = TRUE
+	program_flags = PROGRAM_ON_SYNDINET_STORE
 	download_access = list()
 
 /datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)

--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -4,7 +4,7 @@
 	downloader_category = PROGRAM_CATEGORY_SUPPLY
 	program_open_overlay = "bountyboard"
 	extended_desc = "A multi-platform network for placing requests across the station, with payment across the network being possible.."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 10
 	tgui_id = "NtosBountyBoard"
 	///Reference to the currently logged in user.

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -4,8 +4,8 @@
 	downloader_category = PROGRAM_CATEGORY_SUPPLY
 	program_open_overlay = "request"
 	extended_desc = "Nanotrasen Internal Requisition Network interface for supply purchasing using a department budget account."
-	requires_ntnet = TRUE
-	usage_flags = PROGRAM_LAPTOP | PROGRAM_PDA
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
+	can_run_on_flags = PROGRAM_LAPTOP | PROGRAM_PDA
 	size = 10
 	tgui_id = "NtosCargo"
 	///Are you actually placing orders with it?

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -5,7 +5,6 @@
 	program_open_overlay = "id"
 	extended_desc = "Program for programming employee ID cards to access parts of the station."
 	download_access = list(ACCESS_COMMAND)
-	requires_ntnet = 0
 	size = 8
 	tgui_id = "NtosCard"
 	program_icon = "id-card"

--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -11,9 +11,8 @@
 	program_open_overlay = "command"
 	extended_desc = "This program allows communication over NTNRC network"
 	size = 8
-	requires_ntnet = TRUE
 	ui_header = "ntnrc_idle.gif"
-	available_on_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	tgui_id = "NtosNetChat"
 	program_icon = "comment-alt"
 	alert_able = TRUE

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -5,7 +5,7 @@
 	program_open_overlay = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
 	download_access = list(ACCESS_SECURITY, ACCESS_COMMAND)
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 4
 	tgui_id = "NtosCrewManifest"
 	program_icon = "clipboard-list"

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -4,8 +4,7 @@
 	extended_desc = "This program allows management of files."
 	program_open_overlay = "generic"
 	size = 8
-	requires_ntnet = FALSE
-	available_on_ntnet = FALSE
+	program_flags = NONE
 	undeletable = TRUE
 	tgui_id = "NtosFileManager"
 	program_icon = "folder"

--- a/code/modules/modular_computers/file_system/programs/frontier.dm
+++ b/code/modules/modular_computers/file_system/programs/frontier.dm
@@ -3,7 +3,7 @@
 	filedesc = "NT Frontier"
 	downloader_category = PROGRAM_CATEGORY_SCIENCE
 	extended_desc = "Scientific paper publication and navigation software."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 12
 	program_open_overlay = "research"
 	tgui_id = "NtosScipaper"

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -8,7 +8,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	program_open_overlay = "id"
 	extended_desc = "Program for viewing and changing job slot availability."
 	download_access = list(ACCESS_COMMAND)
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 4
 	tgui_id = "NtosJobManager"
 	program_icon = "address-book"

--- a/code/modules/modular_computers/file_system/programs/mafia_ntos.dm
+++ b/code/modules/modular_computers/file_system/programs/mafia_ntos.dm
@@ -3,7 +3,6 @@
 	filedesc = "Mafia"
 	program_open_overlay = "mafia"
 	extended_desc = "A program that allows you to play the infamous Mafia game, straight from your Modular PC."
-	requires_ntnet = FALSE
 	downloader_category = PROGRAM_CATEGORY_GAMES
 	size = 6
 	tgui_id = "NtosMafiaPanel"

--- a/code/modules/modular_computers/file_system/programs/maintenance/_maintenance_program.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/_maintenance_program.dm
@@ -6,5 +6,4 @@
  */
 /datum/computer_file/program/maintenance
 	filetype = "MNT"
-	available_on_ntnet = FALSE
-	unique_copy = TRUE
+	program_flags = PROGRAM_UNIQUE_COPY

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -5,7 +5,7 @@
 	downloader_category = PROGRAM_CATEGORY_EQUIPMENT
 	extended_desc = "This program allows the taking of pictures."
 	size = 4
-	usage_flags = PROGRAM_PDA
+	can_run_on_flags = PROGRAM_PDA
 	tgui_id = "NtosCamera"
 	program_icon = "camera"
 

--- a/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
@@ -4,7 +4,7 @@
 	downloader_category = PROGRAM_CATEGORY_EQUIPMENT
 	extended_desc = "This program allows the tablet to scan physical objects and display a data output."
 	size = 2
-	usage_flags = PROGRAM_PDA
+	can_run_on_flags = PROGRAM_PDA
 	tgui_id = "NtosPhysScanner"
 	program_icon = "barcode"
 	/// Information from the last scanned person, to display on the app.

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -13,9 +13,8 @@
 	extended_desc = "This program allows old-school communication with other modular devices."
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
-	header_program = TRUE
-	available_on_ntnet = FALSE
-	usage_flags = PROGRAM_PDA
+	program_flags = PROGRAM_HEADER
+	can_run_on_flags = PROGRAM_PDA
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"
 	program_icon = "comment-alt"

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -13,7 +13,8 @@
 	extended_desc = "This program allows old-school communication with other modular devices."
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
-	program_flags = PROGRAM_HEADER
+	power_cell_use = NONE
+	program_flags = PROGRAM_HEADER | PROGRAM_RUNS_WITHOUT_POWER
 	can_run_on_flags = PROGRAM_PDA
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -6,8 +6,7 @@
 	program_open_overlay = "bountyboard"
 	extended_desc = "This program allows any user to access the Newscaster network from anywhere."
 	size = 2
-	requires_ntnet = TRUE
-	available_on_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	tgui_id = "NtosNewscaster"
 	program_icon = "newspaper"
 	///The UI we use for the newscaster

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -7,7 +7,7 @@
 	size = 2
 	tgui_id = "NtosNotepad"
 	program_icon = "book"
-	usage_flags = PROGRAM_ALL
+	can_run_on_flags = PROGRAM_ALL
 
 	var/written_note = "Congratulations on your station upgrading to the new NtOS and Thinktronic based collaboration effort, \
 		bringing you the best in electronics and software since 2467!\n\

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -7,7 +7,7 @@
 	size = 2
 	tgui_id = "NtosPay"
 	program_icon = "money-bill-wave"
-	usage_flags = PROGRAM_ALL
+	can_run_on_flags = PROGRAM_ALL
 	///Reference to the currently logged in user.
 	var/datum/bank_account/current_user
 	///Pay token, by which we can send credits

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -135,15 +135,8 @@
 	data["emagged"] = (computer.obj_flags & EMAGGED)
 
 	var/list/repo = SSmodular_computers.available_antag_software | SSmodular_computers.available_station_software
-	var/static/list/program_categories = list()
-	var/should_build_categories = FALSE
-	if(!length(program_categories))
-		should_build_categories = TRUE
 
 	for(var/datum/computer_file/program/programs as anything in repo)
-		if(should_build_categories)
-			if(!(programs.downloader_category in program_categories))
-				program_categories.Add(programs.downloader_category)
 		data["programs"] += list(list(
 			"icon" = programs.program_icon,
 			"filename" = programs.filename,
@@ -157,7 +150,7 @@
 			"verifiedsource" = !!(programs.program_flags & PROGRAM_ON_NTNET_STORE),
 		))
 
-	data["categories"] = show_categories & program_categories
+	data["categories"] = show_categories
 
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -5,8 +5,7 @@
 	extended_desc = "This program allows downloads of software from official NT repositories"
 	undeletable = TRUE
 	size = 4
-	requires_ntnet = TRUE
-	available_on_ntnet = FALSE
+	program_flags = PROGRAM_REQUIRES_NTNET
 	tgui_id = "NtosNetDownloader"
 	program_icon = "download"
 
@@ -46,7 +45,7 @@
 		return FALSE
 
 	// Attempting to download antag only program, but without having emagged/syndicate computer. No.
-	if(PRG.available_on_syndinet && !(computer.obj_flags & EMAGGED))
+	if((PRG.program_flags & PROGRAM_ON_SYNDINET_STORE) && !(computer.obj_flags & EMAGGED))
 		return FALSE
 
 	if(!computer || !computer.can_store_file(PRG))
@@ -136,11 +135,15 @@
 	data["emagged"] = (computer.obj_flags & EMAGGED)
 
 	var/list/repo = SSmodular_computers.available_antag_software | SSmodular_computers.available_station_software
-	var/list/program_categories = list()
+	var/static/list/program_categories = list()
+	var/should_build_categories = FALSE
+	if(!length(program_categories))
+		should_build_categories = TRUE
 
 	for(var/datum/computer_file/program/programs as anything in repo)
-		if(!(programs.downloader_category in program_categories))
-			program_categories.Add(programs.downloader_category)
+		if(should_build_categories)
+			if(!(programs.downloader_category in program_categories))
+				program_categories.Add(programs.downloader_category)
 		data["programs"] += list(list(
 			"icon" = programs.program_icon,
 			"filename" = programs.filename,
@@ -151,7 +154,7 @@
 			"compatible" = check_compatibility(programs),
 			"size" = programs.size,
 			"access" = programs.can_run(user, downloading = TRUE, access = access),
-			"verifiedsource" = programs.available_on_ntnet,
+			"verifiedsource" = !!(programs.program_flags & PROGRAM_ON_NTNET_STORE),
 		))
 
 	data["categories"] = show_categories & program_categories

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -16,8 +16,8 @@
 	program_open_overlay = "dummy"
 	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art."
 	download_access = list(ACCESS_LIBRARY)
-	usage_flags = PROGRAM_CONSOLE
-	requires_ntnet = TRUE
+	can_run_on_flags = PROGRAM_CONSOLE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 9
 	tgui_id = "NtosPortraitPrinter"
 	program_icon = "paint-brush"

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -8,8 +8,8 @@
 	extended_desc = "This program connects to sensors around the station to provide information about electrical systems"
 	ui_header = "power_norm.gif"
 	download_access = list(ACCESS_ENGINEERING)
-	usage_flags = PROGRAM_CONSOLE
-	requires_ntnet = FALSE
+	can_run_on_flags = PROGRAM_CONSOLE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 8
 	tgui_id = "NtosPowerMonitor"
 	program_icon = "plug"

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -4,9 +4,8 @@
 	downloader_category = PROGRAM_CATEGORY_EQUIPMENT
 	ui_header = "borg_mon.gif" //DEBUG -- new icon before PR
 	program_open_overlay = "radarntos"
-	requires_ntnet = TRUE
-	available_on_ntnet = FALSE
-	usage_flags = PROGRAM_LAPTOP | PROGRAM_PDA
+	program_flags = PROGRAM_REQUIRES_NTNET
+	can_run_on_flags = PROGRAM_LAPTOP | PROGRAM_PDA
 	size = 5
 	tgui_id = "NtosRadar"
 	///List of trackable entities. Updated by the scan() proc.
@@ -219,9 +218,8 @@
 	filename = "lifeline"
 	filedesc = "Lifeline"
 	extended_desc = "This program allows for tracking of crew members via their suit sensors."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	download_access = list(ACCESS_MEDICAL)
-	available_on_ntnet = TRUE
 	program_icon = "heartbeat"
 
 /datum/computer_file/program/radar/lifeline/find_atom()
@@ -259,9 +257,8 @@
 	filename = "custodiallocator"
 	filedesc = "Custodial Locator"
 	extended_desc = "This program allows for tracking of custodial equipment."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	download_access = list(ACCESS_JANITOR)
-	available_on_ntnet = TRUE
 	program_icon = "broom"
 	size = 2
 	detomatix_resistance = DETOMATIX_RESIST_MINOR
@@ -304,9 +301,7 @@
 	filedesc = "Fission360"
 	program_open_overlay = "radarsyndicate"
 	extended_desc = "This program allows for tracking of nuclear authorization disks and warheads."
-	requires_ntnet = FALSE
-	available_on_ntnet = FALSE
-	available_on_syndinet = TRUE
+	program_flags = PROGRAM_ON_SYNDINET_STORE
 	tgui_id = "NtosRadarSyndicate"
 	program_icon = "bomb"
 	arrowstyle = "ntosradarpointerS.png"

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -7,8 +7,8 @@
 	program_open_overlay = "crew"
 	tgui_id = "NtosRecords"
 	size = 4
-	usage_flags = PROGRAM_PDA | PROGRAM_LAPTOP
-	available_on_ntnet = FALSE
+	can_run_on_flags = PROGRAM_PDA | PROGRAM_LAPTOP
+	program_flags = NONE
 	detomatix_resistance = DETOMATIX_RESIST_MINOR
 
 	var/mode
@@ -19,7 +19,7 @@
 	program_icon = "book-medical"
 	extended_desc = "Allows the user to view several basic medical records from the crew."
 	download_access = list(ACCESS_MEDICAL, ACCESS_FLAG_COMMAND)
-	available_on_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE
 	mode = "medical"
 
 /datum/computer_file/program/records/security
@@ -27,7 +27,7 @@
 	filename = "secrecords"
 	extended_desc = "Allows the user to view several basic security records from the crew."
 	download_access = list(ACCESS_SECURITY, ACCESS_FLAG_COMMAND)
-	available_on_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE
 	mode = "security"
 
 /datum/computer_file/program/records/proc/GetRecordsReadable()

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -5,7 +5,7 @@
 	downloader_category = PROGRAM_CATEGORY_SCIENCE
 	program_open_overlay = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 6
 	tgui_id = "NtosRoboControl"
 	program_icon = "robot"

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -5,10 +5,9 @@
 	extended_desc = "A built-in app for cyborg self-management and diagnostics."
 	ui_header = "robotact.gif" //DEBUG -- new icon before PR
 	program_open_overlay = "command"
-	requires_ntnet = FALSE
-	available_on_ntnet = FALSE
+	program_flags = NONE
 	undeletable = TRUE
-	usage_flags = PROGRAM_PDA
+	can_run_on_flags = PROGRAM_PDA
 	size = 5
 	tgui_id = "NtosRobotact"
 	program_icon = "terminal"

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -7,9 +7,9 @@
 	ui_header = "borg_mon.gif"
 	program_open_overlay = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	download_access = list(ACCESS_SECURITY)
-	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
+	can_run_on_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
 	size = 5
 	tgui_id = "NtosSecurEye"
 	program_icon = "eye"
@@ -40,11 +40,8 @@
 	filedesc = "SyndEye"
 	extended_desc = "This program allows for illegal access to security camera networks."
 	download_access = list()
-	available_on_ntnet = FALSE
-	available_on_syndinet = TRUE
-	requires_ntnet = FALSE
-	usage_flags = PROGRAM_ALL
-	unique_copy = TRUE
+	can_run_on_flags = PROGRAM_ALL
+	program_flags = PROGRAM_ON_SYNDINET_STORE | PROGRAM_UNIQUE_COPY
 
 	network = list("ss13", "mine", "rd", "labor", "ordnance", "minisat")
 	spying = TRUE

--- a/code/modules/modular_computers/file_system/programs/signalcommander.dm
+++ b/code/modules/modular_computers/file_system/programs/signalcommander.dm
@@ -7,7 +7,7 @@
 	size = 2
 	tgui_id = "NtosSignaler"
 	program_icon = "satellite-dish"
-	usage_flags = PROGRAM_PDA | PROGRAM_LAPTOP
+	can_run_on_flags = PROGRAM_PDA | PROGRAM_LAPTOP
 	///What is the saved signal frequency?
 	var/signal_frequency = FREQ_SIGNALER
 	/// What is the saved signal code?

--- a/code/modules/modular_computers/file_system/programs/skill_tracker.dm
+++ b/code/modules/modular_computers/file_system/programs/skill_tracker.dm
@@ -7,7 +7,7 @@
 	size = 2
 	tgui_id = "NtosSkillTracker"
 	program_icon = "medal"
-	usage_flags = PROGRAM_PDA // Must be a handheld device to read read your chakras or whatever
+	can_run_on_flags = PROGRAM_PDA // Must be a handheld device to read read your chakras or whatever
 
 /datum/computer_file/program/skill_tracker/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -5,7 +5,7 @@
 	ui_header = "smmon_0.gif"
 	program_open_overlay = "smmon_0"
 	extended_desc = "Crystal Integrity Monitoring System, connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	download_access = list(ACCESS_CONSTRUCTION)
 	size = 5
 	tgui_id = "NtosSupermatter"

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -3,14 +3,13 @@
 	filedesc = "Status Display"
 	program_icon = "signal"
 	program_open_overlay = "generic"
-	requires_ntnet = TRUE
 	size = 1
 
 	extended_desc = "An app used to change the message on the station status displays."
 	tgui_id = "NtosStatus"
 
-	usage_flags = PROGRAM_ALL
-	available_on_ntnet = FALSE
+	can_run_on_flags = PROGRAM_ALL
+	program_flags = PROGRAM_REQUIRES_NTNET
 
 	var/upper_text = ""
 	var/lower_text = ""

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -4,7 +4,7 @@
 	downloader_category = PROGRAM_CATEGORY_SCIENCE
 	program_open_overlay = "research"
 	extended_desc = "Connect to the internal science server in order to assist in station research efforts."
-	requires_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 10
 	tgui_id = "NtosTechweb"
 	program_icon = "atom"

--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -5,9 +5,7 @@
 	program_open_overlay = "generic"
 	undeletable = TRUE
 	size = 0
-	header_program = TRUE
-	available_on_ntnet = TRUE
-	requires_ntnet = FALSE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_HEADER
 	tgui_id = "NtosThemeConfigure"
 	program_icon = "paint-roller"
 

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -5,9 +5,8 @@
 	program_open_overlay = "comm_monitor"
 	extended_desc = "This program monitors stationwide NTNet network, provides access to logging systems, and allows for configuration changes"
 	size = 12
-	requires_ntnet = TRUE
 	run_access = list(ACCESS_NETWORK) //NETWORK CONTROL IS A MORE SECURE PROGRAM.
-	available_on_ntnet = TRUE
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	tgui_id = "NtosNetMonitor"
 	program_icon = "network-wired"
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -20,12 +20,12 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*7, /datum/material/glass=SMALL_MATERIAL_AMOUNT*0.5)
+	grind_results = list(/datum/reagent/lithium = 15, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 	///Current charge in cell units
 	var/charge = 0
 	///Maximum charge in cell units
 	var/maxcharge = STANDARD_CELL_CHARGE
-	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*7, /datum/material/glass=SMALL_MATERIAL_AMOUNT*0.5)
-	grind_results = list(/datum/reagent/lithium = 15, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 	///If the cell has been booby-trapped by injecting it with plasma. Chance on use() to explode.
 	var/rigged = FALSE
 	///If the power cell was damaged by an explosion, chance for it to become corrupted and function the same as rigged.

--- a/tgui/packages/tgui/layouts/NtosWindow.jsx
+++ b/tgui/packages/tgui/layouts/NtosWindow.jsx
@@ -42,7 +42,7 @@ export const NtosWindow = (props, context) => {
             </Box>
             <Box inline italic mr={2} opacity={0.33}>
               {(PC_device_theme === 'syndicate' && 'Syndix') || 'NtOS'}
-              {!!PC_lowpower_mode && '- RUNNING ON LOW POWER MODE'}
+              {!!PC_lowpower_mode && ' - RUNNING ON LOW POWER MODE'}
             </Box>
           </div>
           <div className="NtosHeader__right">

--- a/tgui/packages/tgui/layouts/NtosWindow.jsx
+++ b/tgui/packages/tgui/layouts/NtosWindow.jsx
@@ -21,6 +21,7 @@ export const NtosWindow = (props, context) => {
     PC_stationtime,
     PC_programheaders = [],
     PC_showexitprogram,
+    PC_lowpower_mode,
   } = data;
   return (
     <Window title={title} width={width} height={height} theme={PC_device_theme}>
@@ -41,6 +42,7 @@ export const NtosWindow = (props, context) => {
             </Box>
             <Box inline italic mr={2} opacity={0.33}>
               {(PC_device_theme === 'syndicate' && 'Syndix') || 'NtOS'}
+              {PC_lowpower_mode && '- RUNNING ON LOW POWER MODE'}
             </Box>
           </div>
           <div className="NtosHeader__right">

--- a/tgui/packages/tgui/layouts/NtosWindow.jsx
+++ b/tgui/packages/tgui/layouts/NtosWindow.jsx
@@ -42,7 +42,7 @@ export const NtosWindow = (props, context) => {
             </Box>
             <Box inline italic mr={2} opacity={0.33}>
               {(PC_device_theme === 'syndicate' && 'Syndix') || 'NtOS'}
-              {PC_lowpower_mode && '- RUNNING ON LOW POWER MODE'}
+              {!!PC_lowpower_mode && '- RUNNING ON LOW POWER MODE'}
             </Box>
           </div>
           <div className="NtosHeader__right">


### PR DESCRIPTION
## About The Pull Request

This is an update that touches many more things all at once (compared to my other PRs) meant to make PDAs in general feel more consistent and not take away from one of the experiences we want to encourage: interaction between players.

1. Replaced all checks of a 'pda' with a 'modular pc'. This means technically (though not done in-game currently) other modpcs can hold an uplink, and microwaves can charge laptops.
2. Speaking of microwave, they now don't break and require deconstruction if the cell is removed mid-charge.
3. When a Mod PC is out of power, it will now allow the Messenger to work (which now also doesn't consume any additional power), if the app exists on the PC. Here's a video demonstration

https://github.com/tgstation/tgstation/assets/53777086/7ae12f81-a271-49b8-95fa-2ba54d2e2d1f

4. Flashlights can't be turned on while the cell is dead
5. I replaced a bunch of program vars with ``program_flags`` and renamed ``usage_flags`` to ``can_run_on_flags``.
6. Added a debug modPC that has every app installed by default. Mafia had some issues in the past that were unknown because Mafia wasn't preinstalled with any tablet so was never in create & destroy nor in any other unit test. This was just an easy solution I had, but PDAs should get more in-depth unit tests in the future for running apps n stuff- I just wanted to make sure no other apps were broken/harddeling.

## Why It's Good For The Game

Currently when a PDA dies, its only use is to reply to PDA messages sent to you, since you can still reply to them. Instead of just fixing it and telling players to cope, I thought it would be nice to allow PDA Messenger to still work, as it is a vital app.
You can call it some emergency power mode or whatever, I don't really mind the reason behind why it is this way.

When I made cells used more on PDAs, my main goal was to encourage upgrading your PDA and/or limiting how many apps you use at once, I did not want this to hit on players who use it as a form of interaction. This is the best of both worlds, I think.

The rest of the changes is just for modularity, if some downstream wants to add tablets, phone computers, or whatever the hell else, they can still get just as far as PDAs should be able to get to, hopefully.

## Changelog

:cl:
add: PDAs with a dead power cell are now limited to using their Messenger app.
fix: Microwaves now stop charging PDAs if the cell was removed mid-charge.
fix: Microwaves can now charge laptops.
fix: PDA Flashlights can't be turned on while the PDA is dead.
fix: You can now hold a laptop up to a camera (if it has a notekeeper app installed) like PDAs already could.
/:cl: