### PR TITLE
[NO GBP] Cargo-ordered bar signs don't come with access restrictions

### DIFF
--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -12,6 +12,8 @@
 	var/datum/barsign/chosen_sign
 	/// Do we attempt to rename the area we occupy when the chosen sign is changed?
 	var/change_area_name = FALSE
+	/// What kind of sign do we drop upon being disassembled?
+	var/disassemble_result = /obj/item/wallframe/barsign
 
 /datum/armor/sign_barsign
 	melee = 20
@@ -92,7 +94,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 /obj/machinery/barsign/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/wallframe/barsign(loc)
+			new disassemble_result(drop_location())
 		else
 			new /obj/item/stack/sheet/iron(drop_location(), 2)
 			new /obj/item/stack/cable_coil(drop_location(), 2)
@@ -487,6 +489,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 // For other locations that aren't in the main bar
 /obj/machinery/barsign/all_access
 	req_access = null
+	disassemble_result = /obj/item/wallframe/barsign/all_access
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign/all_access, 32)
 
@@ -513,3 +516,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign/all_access, 32)
 	if(isopenturf(get_step(on_wall, EAST))) //This takes up 2 tiles so we want to make sure we have two tiles to hang it from.
 		balloon_alert(user, "needs more support!")
 		return FALSE
+
+/obj/item/wallframe/barsign/all_access
+	desc = "Used to help draw the rabble into your bar. Some assembly required. This one doesn't have an access lock."
+	result_path = /obj/machinery/barsign/all_access

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -293,5 +293,5 @@
 	name = "Bar Sign Replacement Kit"
 	desc = "A replacement bar sign, perfect for drawing in customers to your bar, tavern, inn, nightclub, or even coffeehouse!"
 	cost = CARGO_CRATE_VALUE * 14
-	contains = list(/obj/item/wallframe/barsign)
-	crate_name = "bar sign replacement crate"
+	contains = list(/obj/item/wallframe/barsign/all_access)
+	crate_name = "bar sign crate"


### PR DESCRIPTION

## About The Pull Request

Bar signs ordered from cargo will not have an access restriction attached to them.

The barsign disassembly code has been slightly modified to accommodate this.
## Why It's Good For The Game

It didn't even occur to me that bar signs had access locks on them.

Now you can establish Bargonia without begging the bartender/captain for their ID.
## Changelog
:cl: Rhials
qol: Bar signs ordered from cargo will no longer be access-restricted.
/:cl:
