### PR TITLE
[NO GBP] Fixes blocking tackles forcing people to be stunned when they shouldn't be (both tackler and potentially blocker)

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -154,15 +154,17 @@
 	var/mob/living/carbon/target = hit
 	var/tackle_word = isfelinid(user) ? "pounce" : "tackle" //If cat, "pounce" instead of "tackle".
 
+	var/roll = rollTackle(target)
+	tackling = FALSE
+	tackle.gentle = TRUE
+
 	if(target.check_block(user, 0, user.name, attack_type = LEAP_ATTACK))
 		user.visible_message(span_danger("[user]'s tackle is blocked by [target], softening the effect!"), span_userdanger("Your tackle is blocked by [target], softening the effect!"), ignored_mobs = target)
 		to_chat(target, span_userdanger("[target] blocks [user]'s tackle attempt, softening the effect!"))
 		neutral_outcome(user, target, tackle_word) //Forces a neutral outcome so you're not screwed too much from being blocked while tackling
-		return
+		return COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH
 
-	var/roll = rollTackle(target)
-	tackling = FALSE
-	tackle.gentle = TRUE
+
 
 	switch(roll)
 		if(-INFINITY to -1)


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/80047 

## Why It's Good For The Game

This shouldn't be happen and it's my fault, oops.

## Changelog
:cl:
fix: Blocking a tackler no longer causes things to go haywire and stun the tackler/the tackle victim.
/:cl:
