### PR TITLE
Fixes an outfit typo

### DIFF
--- a/code/modules/bitrunning/virtual_domain/domains/pipedream.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/pipedream.dm
@@ -75,7 +75,7 @@
 	r_pocket = /obj/item/assembly/flash/handheld
 
 /datum/outfit/factory/qm
-	name = "Factory Quatermaster"
+	name = "Factory Quartermaster"
 
 	id_trim = /datum/id_trim/factory/qm
 	id = /obj/item/card/id/advanced/silver


### PR DESCRIPTION

## About The Pull Request

Fixes a typo in one of the outfits used in the Pipe Dream domain.

Factory Quatermaster -> Factory Quartermaster
## Why It's Good For The Game

Quatermaster...
## Changelog
:cl: Rhials
spellcheck: Fixes a typo in the Factory Quartermaster outfit name.
/:cl:
