### PR TITLE
Fixes misapplication of `CAN_BE_DIRTY_1` (floors should now spawn dirty)

### DIFF
--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -232,7 +232,8 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 
 /// Exact subtype as parent, just used in ruins to prevent other ruins/chasms from spawning on top of it.
 /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
-	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST | NO_RUINS
+	flags_1 = CAN_BE_DIRTY_1
+	turf_flags = IS_SOLID | NO_RUST | NO_RUINS
 
 /turf/open/misc/asteroid/snow/icemoon/do_not_scrape
 	flags_1 = CAN_BE_DIRTY_1

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -9,8 +9,8 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	flags_1 = NO_SCREENTIPS_1
-	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID
+	flags_1 = NO_SCREENTIPS_1 | CAN_BE_DIRTY_1
+	turf_flags = IS_SOLID
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_OPEN_FLOOR
 	canSmoothWith = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_OPEN_FLOOR
 

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -5,8 +5,8 @@
 	name = "coder/mapper fucked up"
 	desc = "report on github please"
 
-	flags_1 = NO_SCREENTIPS_1
-	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST
+	flags_1 = NO_SCREENTIPS_1 | CAN_BE_DIRTY_1
+	turf_flags = IS_SOLID | NO_RUST
 
 	footstep = FOOTSTEP_FLOOR
 	barefootstep = FOOTSTEP_HARD_BAREFOOT


### PR DESCRIPTION
## About The Pull Request

For some reason, people were adding `CAN_BE_DIRTY_1` to `turf_flags` when we literally only ever check for this flag on `flags_1` (and it's a bitfield that only exists on `flags_1` too!). Anyways, this didn't cause any issues with bitflag confusion since there wasn't any overlap HOWEVER- it's very likely that a lot of floors that should have been spawning dirty were not spawning dirty.
## Why It's Good For The Game

If the floor should spawn dirty, it should spawn dirty. We were missing out on a lot of dirty floors.
## Changelog

:cl:
fix: Janitors rejoice (or lament): Floors should now be dirty shift-start.
/ \:cl:
