### PR TITLE
Fixes a major heretic exploit.

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -48,7 +48,7 @@
 	button_icon_state = "spell_default"
 	overlay_icon_state = "bg_spell_border"
 	active_overlay_icon_state = "bg_spell_border_active_red"
-	check_flags = AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_PHASED
 	panel = "Spells"
 	melee_cooldown_time = 0 SECONDS
 


### PR DESCRIPTION

## About The Pull Request
As it turns out, doing a refactor without testing to see if the thing you refactored works is bad.
Heretics should probably not be able to hover around someone and cast cleave on them until they loose all their blood.

Fixes:
- https://github.com/tgstation/tgstation/issues/79648

## Why It's Good For The Game
Exploit bad

## Changelog
:cl:
fix: Heretics can no longer cast all of their spells while in jaunt
/:cl:
