### PR TITLE
Minor say code refactor, fixes signers sometimes using the wrong verbs over radio

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -5,6 +5,7 @@
 #define RADIO_EXTENSION "department specific"
 #define RADIO_KEY "department specific key"
 #define LANGUAGE_EXTENSION "language specific"
+#define SAY_MOD_VERB "say_mod_verb"
 
 //Message modes. Each one defines a radio channel, more or less.
 //if you use ! as a mode key for some ungodly reason, change the first character for ion_num() so get_message_mode() doesn't freak out with state law prompts - shiz.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -21,6 +21,7 @@
 	/// The list of factions this atom belongs to
 	var/list/faction
 
+	/// Use get_default_say_verb() in say.dm to get the correct say verb
 	var/verb_say = "says"
 	var/verb_ask = "asks"
 	var/verb_exclaim = "exclaims"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -21,7 +21,7 @@
 	/// The list of factions this atom belongs to
 	var/list/faction
 
-	/// Use get_default_say_verb() in say.dm to get the correct say verb
+	/// Use get_default_say_verb() in say.dm instead of reading verb_say.
 	var/verb_say = "says"
 	var/verb_ask = "asks"
 	var/verb_exclaim = "exclaims"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -354,6 +354,8 @@
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
 	var/filtered_mods = list()
+	if (message_mods[SAY_MOD_VERB])
+		filtered_mods[SAY_MOD_VERB] = message_mods[SAY_MOD_VERB]
 	if (message_mods[MODE_CUSTOM_SAY_EMOTE])
 		filtered_mods[MODE_CUSTOM_SAY_EMOTE] = message_mods[MODE_CUSTOM_SAY_EMOTE]
 		filtered_mods[MODE_CUSTOM_SAY_ERASE_INPUT] = message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -285,6 +285,12 @@
 	if(use_command)
 		spans |= SPAN_COMMAND
 
+	var/radio_message = message
+	if(message_mods[WHISPER_MODE])
+		// Radios don't pick up whispers very well
+		radio_message = stars(radio_message)
+		spans |= SPAN_ITALICS
+
 	flick_overlay_view(overlay_mic_active, 5 SECONDS)
 
 	/*
@@ -317,7 +323,7 @@
 	var/atom/movable/virtualspeaker/speaker = new(null, talking_movable, src)
 
 	// Construct the signal
-	var/datum/signal/subspace/vocal/signal = new(src, freq, speaker, language, message, spans, message_mods)
+	var/datum/signal/subspace/vocal/signal = new(src, freq, speaker, language, radio_message, spans, message_mods)
 
 	// Independent radios, on the CentCom frequency, reach all independent radios
 	if (independent && (freq == FREQ_CENTCOM || freq == FREQ_CTF_RED || freq == FREQ_CTF_BLUE || freq == FREQ_CTF_GREEN || freq == FREQ_CTF_YELLOW))
@@ -355,12 +361,6 @@
 		return
 	var/filtered_mods = list()
 
-	var/radio_message = raw_message
-	if(message_mods[WHISPER_MODE])
-		// radios don't pick up whispers very well
-		radio_message = stars(radio_message)
-		spans |= SPAN_ITALICS
-
 	if (message_mods[MODE_SING])
 		filtered_mods[MODE_SING] = message_mods[MODE_SING]
 	if (message_mods[WHISPER_MODE])
@@ -379,7 +379,7 @@
 			if (idx && (idx % 2) == (message_mods[RADIO_EXTENSION] == MODE_L_HAND))
 				return
 
-	talk_into(speaker, radio_message, , spans, language=message_language, message_mods=filtered_mods)
+	talk_into(speaker, raw_message, , spans, language=message_language, message_mods=filtered_mods)
 
 /// Checks if this radio can receive on the given frequency.
 /obj/item/radio/proc/can_receive(input_frequency, list/levels)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -354,6 +354,13 @@
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
 	var/filtered_mods = list()
+
+	var/radio_message = raw_message
+	if(message_mods[WHISPER_MODE])
+		// radios don't pick up whispers very well
+		radio_message = stars(radio_message)
+		spans |= SPAN_ITALICS
+
 	if (message_mods[SAY_MOD_VERB])
 		filtered_mods[SAY_MOD_VERB] = message_mods[SAY_MOD_VERB]
 	if (message_mods[MODE_CUSTOM_SAY_EMOTE])
@@ -368,7 +375,7 @@
 			if (idx && (idx % 2) == (message_mods[RADIO_EXTENSION] == MODE_L_HAND))
 				return
 
-	talk_into(speaker, raw_message, , spans, language=message_language, message_mods=filtered_mods)
+	talk_into(speaker, radio_message, , spans, language=message_language, message_mods=filtered_mods)
 
 /// Checks if this radio can receive on the given frequency.
 /obj/item/radio/proc/can_receive(input_frequency, list/levels)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -361,6 +361,10 @@
 		radio_message = stars(radio_message)
 		spans |= SPAN_ITALICS
 
+	if (message_mods[MODE_SING])
+		filtered_mods[MODE_SING] = message_mods[MODE_SING]
+	if (message_mods[WHISPER_MODE])
+		filtered_mods[WHISPER_MODE] = message_mods[WHISPER_MODE]
 	if (message_mods[SAY_MOD_VERB])
 		filtered_mods[SAY_MOD_VERB] = message_mods[SAY_MOD_VERB]
 	if (message_mods[MODE_CUSTOM_SAY_EMOTE])

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -143,6 +143,12 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
+/**
+ * Works out and returns which prefix verb the passed message should use.
+ *
+ * input - The message for which we want the verb.
+ * message_mods - A list of message modifiers, i.e. whispering/singing.
+ */
 /atom/movable/proc/say_mod(input, list/message_mods = list())
 	var/ending = copytext_char(input, -1)
 	if(copytext_char(input, -2) == "!!")
@@ -156,7 +162,15 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	else if(ending == "!")
 		return verb_exclaim
 	else
-		return verb_say
+		return get_default_say_verb()
+
+/**
+ * Gets the say verb we default to if no special verb is chosen.
+ * This is primarily a hook for inheritors,
+ * like human_say.dm's tongue-based verb_say changes.
+ */
+/atom/movable/proc/get_default_say_verb()
+	return verb_say
 
 /atom/movable/proc/say_quote(input, list/spans=list(speech_span), list/message_mods = list())
 	if(!input)
@@ -256,7 +270,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 	source = M
 	if(istype(M))
 		name = radio.anonymize ? "Unknown" : M.GetVoice()
-		verb_say = M.verb_say
+		verb_say = M.get_default_say_verb()
 		verb_ask = M.verb_ask
 		verb_exclaim = M.verb_exclaim
 		verb_yell = M.verb_yell

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -31,7 +31,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	spans |= speech_span
 	if(!language)
 		language = get_selected_language()
-	send_speech(message, message_range, src, bubble_type, spans, message_language = language, forced = forced)
+	var/list/message_mods = list()
+	message_mods[SAY_MOD_VERB] = say_mod(message, message_mods)
+	send_speech(message, message_range, src, bubble_type, spans, language, message_mods, forced = forced)
 
 /// Called when this movable hears a message from a source.
 /// Returns TRUE if the message was received and understood.

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -176,9 +176,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if(!input)
 		input = "..."
 
-	var/say_mod = message_mods[MODE_CUSTOM_SAY_EMOTE]
-	if (!say_mod)
-		say_mod = say_mod(input, message_mods)
+	var/say_mod = message_mods[MODE_CUSTOM_SAY_EMOTE] || message_mods[SAY_MOD_VERB] || say_mod(input, message_mods)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_SAY_QUOTE, args)
 

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -138,7 +138,7 @@
 	if(staminaloss > 0)
 		adjustStaminaLoss(-stamina_recovery * seconds_per_tick, forced = TRUE)
 
-/mob/living/basic/say_mod(input, list/message_mods = list())
+/mob/living/basic/update_verbs(input, list/message_mods = list())
 	if(length(speak_emote))
 		verb_say = pick(speak_emote)
 	return ..()

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -138,10 +138,8 @@
 	if(staminaloss > 0)
 		adjustStaminaLoss(-stamina_recovery * seconds_per_tick, forced = TRUE)
 
-/mob/living/basic/update_verbs(input, list/message_mods = list())
-	if(length(speak_emote))
-		verb_say = pick(speak_emote)
-	return ..()
+/mob/living/basic/get_default_say_verb()
+	return length(speak_emote) ? pick(speak_emote) : ..()
 
 /mob/living/basic/death(gibbed)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -9,16 +9,13 @@
 			message = tongueless_upper.Replace(message, pick("AA","OO","'"))
 	return ..()
 
-/mob/living/carbon/human/update_verbs(input, list/message_mods = list())
+/mob/living/carbon/human/get_default_say_verb()
 	var/obj/item/organ/internal/tongue/tongue = get_organ_slot(ORGAN_SLOT_TONGUE)
-	if(!tongue)
+	if(isnull(tongue))
 		if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
-			verb_say = "signs"
-		else
-			verb_say = "gurgles"
-	else
-		verb_say = tongue.temp_say_mod || tongue.say_mod
-	return ..()
+			return "signs"
+		return "gurgles"
+	return  tongue.temp_say_mod || tongue.say_mod || ..()
 
 /mob/living/carbon/human/GetVoice()
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -9,7 +9,7 @@
 			message = tongueless_upper.Replace(message, pick("AA","OO","'"))
 	return ..()
 
-/mob/living/carbon/human/say_mod(input, list/message_mods = list())
+/mob/living/carbon/human/update_verbs(input, list/message_mods = list())
 	var/obj/item/organ/internal/tongue/tongue = get_organ_slot(ORGAN_SLOT_TONGUE)
 	if(!tongue)
 		if(HAS_TRAIT(src, TRAIT_SIGN_LANG))

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -211,10 +211,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		if(succumbed)
 			succumb()
 		return
-	
-	//Updates the verb variables of this living before sending any messages
-	//This avoids copying the wrong verbs to the radio's virtualspeaker
-	update_verbs(message, message_mods)
 
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something
 	if(saymode && !saymode.handle_message(src, message, language))
@@ -316,7 +312,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	if(speaker != src)
 		if(!radio_freq) //These checks have to be separate, else people talking on the radio will make "You can't hear yourself!" appear when hearing people over the radio while deaf.
-			deaf_message = "[span_name("[speaker]")] [speaker.verb_say] something but you cannot hear [speaker.p_them()]."
+			deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something but you cannot hear [speaker.p_them()]."
 			deaf_type = MSG_VISUAL
 	else
 		deaf_message = span_notice("You can't hear yourself!")
@@ -531,14 +527,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			return ITALICS | REDUCE_RANGE
 
 	return NONE
-
-/**
- * Updates the verb variables on the living.
- * This is primarily a hook for inheritors,
- * like human_say.dm's tongue-based verb updates.
- */
-/mob/living/proc/update_verbs(input, list/message_mods = list())
-	return
 
 /mob/living/say_mod(input, list/message_mods = list())
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -211,6 +211,10 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		if(succumbed)
 			succumb()
 		return
+	
+	//Updates the verb variables of this living before sending any messages
+	//This avoids copying the wrong verbs to the radio's virtualspeaker
+	update_verbs(message, message_mods)
 
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something
 	if(saymode && !saymode.handle_message(src, message, language))
@@ -527,6 +531,14 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			return ITALICS | REDUCE_RANGE
 
 	return NONE
+
+/**
+ * Updates the verb variables on the living.
+ * This is primarily a hook for inheritors,
+ * like human_say.dm's tongue-based verb updates.
+ */
+/mob/living/proc/update_verbs(input, list/message_mods = list())
+	return
 
 /mob/living/say_mod(input, list/message_mods = list())
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -212,6 +212,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			succumb()
 		return
 
+	//Get which verb is prefixed to the message before radio but after most modifications
+	message_mods[SAY_MOD_VERB] = say_mod(message, message_mods)
+
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something
 	if(saymode && !saymode.handle_message(src, message, language))
 		return
@@ -228,6 +231,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		message_range = 1
 		if(!message_mods[WHISPER_MODE])
 			message_mods[WHISPER_MODE] = MODE_WHISPER
+			message_mods[SAY_MOD_VERB] = say_mod(message, message_mods)
 	if(radio_return & NOPASS)
 		return TRUE
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -219,10 +219,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(saymode && !saymode.handle_message(src, message, language))
 		return
 	var/radio_message = message
-	if(message_mods[WHISPER_MODE])
-		// radios don't pick up whispers very well
-		radio_message = stars(radio_message)
-		spans |= SPAN_ITALICS
 
 	var/radio_return = radio(radio_message, message_mods, spans, language)//roughly 27% of living/say()'s total cost
 	if(radio_return & ITALICS)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -218,9 +218,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something
 	if(saymode && !saymode.handle_message(src, message, language))
 		return
-	var/radio_message = message
 
-	var/radio_return = radio(radio_message, message_mods, spans, language)//roughly 27% of living/say()'s total cost
+	var/radio_return = radio(message, message_mods, spans, language)//roughly 27% of living/say()'s total cost
 	if(radio_return & ITALICS)
 		spans |= SPAN_ITALICS
 	if(radio_return & REDUCE_RANGE)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -413,10 +413,8 @@
 		new /obj/effect/temp_visual/gib_animation/animal(loc, icon_gib)
 
 
-/mob/living/simple_animal/update_verbs(input, list/message_mods = list())
-	if(length(speak_emote))
-		verb_say = pick(speak_emote)
-	return ..()
+/mob/living/simple_animal/get_default_say_verb()
+	return length(speak_emote) ? pick(speak_emote) : ..()
 
 /mob/living/simple_animal/proc/set_varspeed(var_value)
 	speed = var_value

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -413,7 +413,7 @@
 		new /obj/effect/temp_visual/gib_animation/animal(loc, icon_gib)
 
 
-/mob/living/simple_animal/say_mod(input, list/message_mods = list())
+/mob/living/simple_animal/update_verbs(input, list/message_mods = list())
 	if(length(speak_emote))
 		verb_say = pick(speak_emote)
 	return ..()


### PR DESCRIPTION

## About The Pull Request

Alternative title: "Baby's third pr: surprise say code refactor"

While testing sign language I worked out that if the first message sent after toggling sign language involves speaking directly into a radio, it proceeds to use the wrong verb. After several hours of digging through say and telecomms code, I worked out the cause:
the `verb_say` on humans is primarily updated to match tongue data during the verb _selection_ method `say_mod()` in `human_say.dm`, and as a consequence this meant the verb wasn't updated to the correct one until far after it had been copied to a virtualspeaker, leading to the incorrect verb being used for the radio message.

This pr fixes this by refactoring this verb updating behaviour to be in a new method `update_verbs()`, which we then call _before_ attempting to call `radio()` to avoid wrongful copying and thus fixing the bug.

There's theoretically also cases where the previous behaviour would use the wrong verb if one lost or gained a tongue between radio messages, or the wrong verb from those picked from a list for some simple/basic animals, but those are significantly less common.

To note, I gave the new `update_verbs()` method the same arguments as the `say_mod()` method it got split out of, but having gone through all instances of it being used for this I don't feel it actually *needs* those arguments. So I'm unsure whether it should keep them or not. Opened as a draft for now for sanity's sake, and also cause, y'know, it touches say code.
## Why It's Good For The Game

It was _really_ annoying.
## Changelog
:cl:
fix: Signers no longer use the wrong verb when speaking directly into a radio for the first message after toggling sign language.
refactor: Moved the updating of verb variables into a new method which is called earlier in living's say, which should avoid this happening for other things which updated their verbs the same way.
/:cl:
