### PR TITLE
Blood brother gives chat log for conversions, fix blood brothers getting more antags (maybe?), better admin logging

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -128,6 +128,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 
 		assigned += candidate.mind
 		candidate.mind.restricted_roles = restricted_roles
+		candidate.mind.special_role = ROLE_BROTHER
 		GLOB.pre_setup_antags += candidate.mind
 
 	return TRUE

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -59,9 +59,9 @@
 		flashed.balloon_alert(source, "unconscious!")
 		return
 
-	if (isnull(flashed.mind) || !GET_CLIENT(flashed))
-		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
-		return
+	// if (isnull(flashed.mind) || !GET_CLIENT(flashed))
+	// 	flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
+	// 	return
 
 	if (flashed.mind.has_antag_datum(/datum/antagonist/brother))
 		flashed.balloon_alert(source, "[flashed.p_theyre()] loyal to someone else!")
@@ -72,8 +72,15 @@
 		return
 
 	flashed.mind.add_antag_datum(/datum/antagonist/brother, team)
+	source.log_message("converted [key_name(flashed)] to blood brother", LOG_ATTACK)
+	flashed.log_message("was converted by [key_name(source)] to blood brother", LOG_ATTACK)
+	log_game("[key_name(flashed)] converted [key_name(source)] to blood brother", list(
+		"flashed" = flashed,
+		"victim" = source,
+	))
 
 	flashed.balloon_alert(source, "converted")
+	to_chat(source, span_notice("[span_bold("[flashed]")] has been converted to aide you as your Brother!"))
 	flash.burn_out()
 	flashed.mind.add_memory( \
 		/datum/memory/recruited_by_blood_brother, \

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -59,9 +59,9 @@
 		flashed.balloon_alert(source, "unconscious!")
 		return
 
-	// if (isnull(flashed.mind) || !GET_CLIENT(flashed))
-	// 	flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
-	// 	return
+	if (isnull(flashed.mind) || !GET_CLIENT(flashed))
+		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
+		return
 
 	if (flashed.mind.has_antag_datum(/datum/antagonist/brother))
 		flashed.balloon_alert(source, "[flashed.p_theyre()] loyal to someone else!")


### PR DESCRIPTION
## About
Closes #80094.

I think I fixed the issue of blood brothers getting more antags by setting special_role. Dynamic rulesets are too complicated and this shouldn't even be possible as a bug. I intend to completely rewrite how rulesets work.

## Changelog
:cl:
qol: Converting someone will now give a chat message.
fix: Blood brothers can no longer get other antagonists, I hope.
/:cl:
