### PR TITLE
Moves the new "Turn Target into MMI" verb into a VV dropdown option and rewrites the code around it.

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -153,6 +153,7 @@
 #define VV_HK_SET_SPECIES "setspecies"
 #define VV_HK_PURRBATION "purrbation"
 #define VV_HK_APPLY_DNA_INFUSION "apply_dna_infusion"
+#define VV_HK_TURN_INTO_MMI "turn_into_mmi"
 
 // misc
 #define VV_HK_SPACEVINE_PURGE "spacevine_purge"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -221,7 +221,6 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/run_empty_query,
 	/client/proc/SDQL2_query,
 	/client/proc/set_dynex_scale,
-	/client/proc/spawn_as_mmi,
 	/client/proc/spawn_debug_full_crew,
 	/client/proc/test_cardpack_distribution,
 	/client/proc/test_movable_UI,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1189,17 +1189,3 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		segment.AddComponent(/datum/component/mob_chain, front = previous)
 		previous = segment
 
-/client/proc/spawn_as_mmi(mob/living/carbon/human/target in GLOB.human_list)
-	set category = "Debug"
-	set name = "Turn target into MMI"
-	set desc = "Turns something into an MMI, must be used on humans"
-	if(!check_rights(R_DEBUG))
-		return
-	if(!ishuman(target))
-		return
-
-	var/obj/item/mmi/new_mmi = new(target.loc)
-	var/obj/item/organ/internal/brain/target_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	target_brain.Remove(target)
-	new_mmi.attackby(target_brain,target)
-	qdel(target)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -111,18 +111,30 @@
 	else
 		return ..()
 
-/// Forces target brain into the MMI. Mainly intended for admin purposes, as this allows transfer without a mob or user.
+/**
+ * Forces target brain into the MMI. Mainly intended for admin purposes, as this allows transfer without a mob or user.
+ *
+ * Returns FALSE on failure, TRUE on success.
+ *
+ * Arguments:
+ * * new_brain - Brain to be force-inserted into the MMI. Any calling code should handle proper removal of the brain from the mob, as this proc only forceMoves.
+ */
 /obj/item/mmi/proc/force_brain_into(obj/item/organ/internal/brain/new_brain)
-	if(!new_brain)
-		return
+	if(isnull(new_brain))
+		stack_trace("Proc called with null brain.")
+		return FALSE
 
-	if(!new_brain.brainmob)
+	if(!istype(new_brain))
+		stack_trace("Proc called with invalid type: [new_brain] ([new_brain.type])")
+		return FALSE
+
+	if(isnull(new_brain.brainmob))
 		new_brain.forceMove(src)
 		brain = new_brain
 		brain.organ_flags |= ORGAN_FROZEN
 		name = "[initial(name)]: [copytext(new_brain.name, 1, -8)]"
 		update_appearance()
-		return
+		return TRUE
 
 	new_brain.forceMove(src)
 
@@ -152,6 +164,8 @@
 		braintype = "Cyborg"
 
 	SSblackbox.record_feedback("amount", "mmis_filled", 1)
+
+	return TRUE
 
 /obj/item/mmi/attack_self(mob/user)
 	if(!brain)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -859,13 +859,19 @@
 
 		if(!target_brain)
 			to_chat(usr, "This mob has no brain to insert into an MMI.")
+			return
 
 		var/obj/item/mmi/new_mmi = new(src.loc)
 
 		target_brain.Remove(src)
-		new_mmi.attackby(target_brain, null)
+		new_mmi.force_brain_into(target_brain)
+
+		to_chat(usr, "Turned [src] into an MMI.")
+		log_admin("[key_name(usr)] turned [key_name(src)] into an MMI.")
 
 		qdel(src)
+
+
 
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -850,7 +850,7 @@
 		if(result != "Yes")
 			return
 
-		if(!ishuman(target))
+		if(!ishuman(src))
 			to_chat(usr, "This can only be done to humanoid mobs.")
 			return
 
@@ -862,10 +862,10 @@
 
 		var/obj/item/mmi/new_mmi = new(src.loc)
 
-		target_brain.Remove(target)
-		new_mmi.attackby(target_brain, target)
+		target_brain.Remove(src)
+		new_mmi.attackby(target_brain, null)
 
-		qdel(target)
+		qdel(src)
 
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -745,6 +745,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_SET_SPECIES, "Set Species")
 	VV_DROPDOWN_OPTION(VV_HK_PURRBATION, "Toggle Purrbation")
 	VV_DROPDOWN_OPTION(VV_HK_APPLY_DNA_INFUSION, "Apply DNA Infusion")
+	VV_DROPDOWN_OPTION(VV_HK_TURN_INTO_MMI, "Turn into MMI")
 
 /mob/living/carbon/human/vv_do_topic(list/href_list)
 	. = ..()
@@ -840,6 +841,31 @@
 		else
 			to_chat(usr, "Failed to apply DNA Infusion to [src].")
 			log_admin("[key_name(usr)] failed to apply a DNA Infusion to [key_name(src)].")
+
+	if(href_list[VV_HK_TURN_INTO_MMI])
+		if(!check_rights(R_DEBUG))
+			return
+
+		var/result = input(usr, "This will delete the mob, are you sure?", "Turn into MMI") in list("Yes", "No")
+		if(result != "Yes")
+			return
+
+		if(!ishuman(target))
+			to_chat(usr, "This can only be done to humanoid mobs.")
+			return
+
+
+		var/obj/item/organ/internal/brain/target_brain = src.get_organ_slot(ORGAN_SLOT_BRAIN)
+
+		if(!target_brain)
+			to_chat(usr, "This mob has no brain to insert into an MMI.")
+
+		var/obj/item/mmi/new_mmi = new(src.loc)
+
+		target_brain.Remove(target)
+		new_mmi.attackby(target_brain, target)
+
+		qdel(target)
 
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -850,24 +850,19 @@
 		if(result != "Yes")
 			return
 
-		if(!ishuman(src))
-			to_chat(usr, "This can only be done to humanoid mobs.")
-			return
+		var/obj/item/organ/internal/brain/target_brain = get_organ_slot(ORGAN_SLOT_BRAIN)
 
-
-		var/obj/item/organ/internal/brain/target_brain = src.get_organ_slot(ORGAN_SLOT_BRAIN)
-
-		if(!target_brain)
+		if(isnull(target_brain))
 			to_chat(usr, "This mob has no brain to insert into an MMI.")
 			return
 
-		var/obj/item/mmi/new_mmi = new(src.loc)
+		var/obj/item/mmi/new_mmi = new(get_turf(src))
 
 		target_brain.Remove(src)
 		new_mmi.force_brain_into(target_brain)
 
 		to_chat(usr, "Turned [src] into an MMI.")
-		log_admin("[key_name(usr)] turned [key_name(src)] into an MMI.")
+		log_admin("[key_name(usr)] turned [key_name_and_tag(src)] into an MMI.")
 
 		qdel(src)
 


### PR DESCRIPTION

## About The Pull Request

Removes the Turn Target into MMI verb and re-adds it as a VV dropdown option.

Rewrites the code around this to support what is effectively an admin-forced action, which MMI code previously didn't support cleanly.
## Why It's Good For The Game

#79896 added a new debug verb, unfortunately because of how that debug verb was defined (it has args for a target mob in the proc params) it automatically gets added to the right click context menu instead...

![image](https://github.com/tgstation/tgstation/assets/24975989/26529f7c-4393-45cc-a8e2-7aa2405384a2)

Which is not ideal for admins as they're one misclick away from just deleting a mob.

This moves it to the VV dropdown menu for humans and rewrites the code behind it, which previously relied on the MMI attackby proc which expects a user and thus has side effects as a result.

This new code is more suited to an admin force-insertion than the old code which removed the brain and forced the now brainless mob to insert its former brain into the MMI (with the potential to fail on user input for the now brainless mob).

![dreamseeker_VUBPYXOmEJ](https://github.com/tgstation/tgstation/assets/24975989/89e8b1ab-15f7-4187-a5db-b064b0861014)
## Changelog
:cl:
admin: Removed the "Turn Target into MMI" right click context menu verb entirely, and instead added the same command as a VV dropdown on human mobs.
/:cl:
