### PR TITLE
gives sectech restockers a name

### DIFF
--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -46,4 +46,5 @@
 		F.update_brightness()
 
 /obj/item/vending_refill/security
+	name = "SecTech"
 	icon_state = "refill_sec"

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -46,5 +46,5 @@
 		F.update_brightness()
 
 /obj/item/vending_refill/security
-	name = "SecTech"
+	machine_name = "SecTech"
 	icon_state = "refill_sec"


### PR DESCRIPTION
## About The Pull Request
uh. title? gives sectech restock units a `machine_name` so they actually tell you what they restock

## Why It's Good For The Game
sectech restockers are no longer just named "generic restocking units"

## Changelog

:cl:
fix: SecTech restocking units are now actually named SecTech restocking units, and not Generic restocking units.
/:cl:
