### PR TITLE
Chasms prevent teleportation

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -20,6 +20,7 @@
 		/obj/effect/light_emitter/tendril,
 		/obj/effect/mapping_helpers,
 		/obj/effect/particle_effect/ion_trails,
+		/obj/effect/particle_effect/sparks,
 		/obj/effect/portal,
 		/obj/effect/projectile,
 		/obj/effect/spectre_of_resurrection,
@@ -42,6 +43,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_ABSTRACT_ENTERED, PROC_REF(entered))
 	RegisterSignal(parent, COMSIG_ATOM_ABSTRACT_EXITED, PROC_REF(exited))
 	RegisterSignal(parent, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, PROC_REF(initialized_on))
+	RegisterSignal(parent, COMSIG_ATOM_INTERCEPT_TELEPORTING, PROC_REF(block_teleport))
 	//allow catwalks to give the turf the CHASM_STOPPED trait before dropping stuff when the turf is changed.
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
@@ -62,6 +64,9 @@
 /datum/component/chasm/proc/initialized_on(datum/source, atom/movable/movable, mapload)
 	SIGNAL_HANDLER
 	drop_stuff(movable)
+
+/datum/component/chasm/proc/block_teleport()
+	return COMPONENT_BLOCK_TELEPORT
 
 /datum/component/chasm/proc/on_chasm_stopped(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -66,6 +66,7 @@
 
 	if(!forced)
 		if(!check_teleport_valid(teleatom, destination, channel))
+			teleatom.balloon_alert(teleatom, "something holds you back!")
 			return FALSE
 
 	if(isobserver(teleatom))

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -15,6 +15,7 @@
 		GLOB.teleportbeacons += src
 	else
 		icon_state = "beacon-off"
+	ADD_TRAIT(src, TRAIT_CHASM_DESTROYED, INNATE_TRAIT)
 
 /obj/item/beacon/Destroy()
 	GLOB.teleportbeacons -= src

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -15,7 +15,6 @@
 		GLOB.teleportbeacons += src
 	else
 		icon_state = "beacon-off"
-	ADD_TRAIT(src, TRAIT_CHASM_DESTROYED, INNATE_TRAIT)
 
 /obj/item/beacon/Destroy()
 	GLOB.teleportbeacons -= src


### PR DESCRIPTION
## About The Pull Request
Chasms prevent teleportation

Fixes #80101

## Why It's Good For The Game
Being able to teleport people into chasms using beacons as an anchor is bad. It has very little counterplay besides fishing out the beacon, changing the teleport target (assuming it's not hidden), or killing someone holding a handtele.

The alternate idea for this PR was to see if the chasm added some sort of trait to the things falling in it and make it so the teleporter would ignore things with that trait, but it seems like chasms don't do that.

## Changelog
:cl: Tattle
balance: you can no longer teleport into chasms
/:cl:
