### PR TITLE
Fix void adaptation not reapplying when born from a headslug

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -350,12 +350,12 @@
 /datum/antagonist/changeling/proc/regain_powers()
 	emporium_action.Grant(owner.current)
 	for(var/datum/action/changeling/power as anything in innate_powers)
-		power.Grant(owner.current)
+		power.on_purchase(owner.current)
 
 	for(var/power_path in purchased_powers)
 		var/datum/action/changeling/power = purchased_powers[power_path]
 		if(istype(power))
-			power.Grant(owner.current)
+			power.on_purchase(owner.current)
 
 /*
  * The act of purchasing a certain power for a changeling.


### PR DESCRIPTION

## About The Pull Request

This bug happend because of 2 things, 
1. the traits where applied to the current mob on *purchase*
2. When head slug calls regain_powers, it uses the grant proc

There are 2 solutions for this. Either make void adapatation apply its effects on grant or change regain powers to be on purchase.

This would break admin bussing non ling events into a lings innate_powers. but saves having to rewrite all ling thingies from on_purchase to on_grant

## Why It's Good For The Game

Permantly losing void adaptation  because of last resort is meh

## Changelog
:cl:
fix: Rebirthing from headslug properly reapplys void adaptation
/:cl:
