### PR TITLE
No longer stuck inside legion when you revive

### DIFF
--- a/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -88,7 +88,7 @@
 
 /mob/living/basic/mining/legion/proc/on_consumed_revive(full_heal_flags)
 	SIGNAL_HANDLER
-	death(TRUE)
+	death()
 
 /mob/living/basic/mining/legion/spawner_made
 	corpse_type = /obj/effect/mob_spawn/corpse/human/legioninfested/skeleton/charred

--- a/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -52,6 +52,7 @@
 	. = ..()
 	if (gone != stored_mob)
 		return
+	UnregisterSignal(stored_mob, COMSIG_LIVING_REVIVE)
 	ai_controller.clear_blackboard_key(BB_LEGION_CORPSE)
 	stored_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_LEGION_EATEN)
 	stored_mob.add_mood_event(MOOD_CATEGORY_LEGION_CORE, /datum/mood_event/healsbadman/long_term) // This will still probably mostly be gone before you are alive

--- a/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -88,7 +88,7 @@
 
 /mob/living/basic/mining/legion/proc/on_consumed_revive(full_heal_flags)
 	SIGNAL_HANDLER
-	death()
+	gib()
 
 /mob/living/basic/mining/legion/spawner_made
 	corpse_type = /obj/effect/mob_spawn/corpse/human/legioninfested/skeleton/charred

--- a/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -72,6 +72,7 @@
 	consumed.extinguish_mob()
 	consumed.fully_heal(HEAL_DAMAGE)
 	consumed.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_LEGION_EATEN)
+	RegisterSignal(consumed, COMSIG_LIVING_REVIVE, PROC_REF(on_consumed_revive))
 	consumed.forceMove(src)
 	ai_controller?.set_blackboard_key(BB_LEGION_CORPSE, consumed)
 	ai_controller?.set_blackboard_key(BB_LEGION_RECENT_LINES, consumed.copy_recent_speech(line_chance = 80))
@@ -84,6 +85,11 @@
 	cancer.Insert(consumed, special = TRUE, drop_if_replaced = FALSE)
 
 /// A Legion which only drops skeletons instead of corpses which might have fun loot, so it cannot be farmed
+
+/mob/living/basic/mining/legion/proc/on_consumed_revive(full_heal_flags)
+	SIGNAL_HANDLER
+	death(TRUE)
+
 /mob/living/basic/mining/legion/spawner_made
 	corpse_type = /obj/effect/mob_spawn/corpse/human/legioninfested/skeleton/charred
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -12,11 +12,11 @@
 	var/prev_lying = lying_angle
 	spawn_gibs(drop_bitflags)
 
-	if(stat != DEAD)
-		death(TRUE)
-
 	if(!prev_lying)
 		gib_animation()
+
+	if(stat != DEAD)
+		death(TRUE)
 
 	ghostize()
 	spill_organs(drop_bitflags)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -10,6 +10,8 @@
 **/
 /mob/living/proc/gib(drop_bitflags=NONE)
 	var/prev_lying = lying_angle
+	spawn_gibs(drop_bitflags)
+
 	if(stat != DEAD)
 		death(TRUE)
 
@@ -22,7 +24,6 @@
 	if(drop_bitflags & DROP_BODYPARTS)
 		spread_bodyparts(drop_bitflags)
 
-	spawn_gibs(drop_bitflags)
 	SEND_SIGNAL(src, COMSIG_LIVING_GIBBED, drop_bitflags)
 	qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

Since legions applied stasis, upon reviving you could not escape without last resort. This fixes that.

side fix of calling gib ensuring the gibs get spawned

## Why It's Good For The Game
fixes #80111
being permantly imprissoned inside a legion is not that fun

## Changelog
:cl:
fix: Being revived inside a legion now sets you free
fix: in some rare cases gib() did infact not spawn gib
/🆑
