### PR TITLE
[NOGBP] Adds a confirmation alert for turn target into MMI

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1197,6 +1197,9 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		return
 	if(!ishuman(target))
 		return
+	var/confirm = tgui_alert(usr, "Are you sure you wish to turn [target.real_name] into a MMI", "Are you sure?", list("No", "Yes"))
+	if(confirm != "Yes")
+		return
 
 	var/obj/item/mmi/new_mmi = new(target.loc)
 	var/obj/item/organ/internal/brain/target_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)


### PR DESCRIPTION
## About The Pull Request

Simply put, this adds a confirmation alert for when a admin with `R_DEBUG` clicks on the `Turn target into MMI` button on the right click menu.

## Why It's Good For The Game

No accidentally turning someone into a MMI when in reality you just wanted to check their variables and your mouse was just slightly off target.

<details>
<summary>Screenshots/Videos</summary>
  
![LAL65m16gI](https://github.com/tgstation/tgstation/assets/2568378/9d613430-f0a2-46bf-9799-687f57177ae0)

</details>

## Changelog

:cl:
qol: Admins can no longer ACCIDENTALLY turn someone into a MMI, They sadly now have to put a conscious effort towards it.
/:cl:
