### PR TITLE
Fix build mode preview spawning atoms needlessly

### DIFF
--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -135,7 +135,7 @@
 	preview.name = initial(typepath.name)
 
 	// Scale the preview if it's bigger than one tile
-	var/mutable_appearance/preview_overlay = get_small_overlay(new typepath)
+	var/mutable_appearance/preview_overlay = get_small_overlay(new /mutable_appearance(typepath))
 	preview_overlay.appearance_flags |= TILE_BOUND
 	preview_overlay.layer = FLOAT_LAYER
 	preview_overlay.plane = FLOAT_PLANE


### PR DESCRIPTION
Before the large icon fix, it would use a mutable_appearance, get_small_overlay wants atoms but it only does appearance things with them so images and mutable appearances should work. There is no need to spawn the atom itself.

We will at some point need a way to specify interfaces as argument types, many such cases of atom or image or mutable_appearance in icon related procs.

closes #80125