### PR TITLE
Expands issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Create a report to help reproduce and fix the issue
 
 ## Issue Summary
 
-<!-- Briefly explain your issue in a few plain sentences. "X has Y issue" "When I do X, Y happens instead of Z" "X on Y map has Z issue" You may copy and paste the issue title here if it is suitable -->
+<!-- Briefly explain your issue in a few plain sentences, e.g. "X has Y issue" "When I do X, Y happens instead of Z" "X on Y map has Z issue". You may copy and paste the issue title here if it is suitable. -->
 
 ## Round ID:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,11 @@ name: Bug report
 about: Create a report to help reproduce and fix the issue
 ---
 <!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable -->
+
+## Issue Summary
+
+<!-- Briefly explain your issue in a few plain sentences. "X has Y issue" "When I do X, Y happens instead of Z" "X on Y map has Z issue" You may copy and paste the issue title here if it is suitable -->
+
 ## Round ID:
 
 <!--- **INCLUDE THE ROUND ID**


### PR DESCRIPTION
Too many issues don't actually plainly state the actual bug being reported, requiring you read thru replication steps to figure out what is being reported.

As we try to add new issue report embeds to the discord having a plain summary at the top will make that more useful.

@tgstation/commit-access 