### PR TITLE
Fix medibots

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -259,7 +259,7 @@
 	icon_state = "medkit_advanced"
 	inhand_icon_state = "medkit-rad"
 	custom_premium_price = PAYCHECK_COMMAND * 6
-	damagetype_healed = "all"
+	damagetype_healed = HEAL_ALL_DAMAGE
 
 /obj/item/storage/medkit/advanced/PopulateContents()
 	if(empty)
@@ -276,7 +276,7 @@
 	desc = "I hope you've got insurance."
 	icon_state = "medkit_tactical"
 	inhand_icon_state = "medkit-tactical"
-	damagetype_healed = "all"
+	damagetype_healed = HEAL_ALL_DAMAGE
 
 /obj/item/storage/medkit/tactical/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -255,7 +255,7 @@
 		"It is tipped over and requesting help.",
 		"They are tipped over and appear visibly distressed.",
 		span_warning("They are tipped over and visibly panicking!"),
-		span_warning("<b>They are freaking out from being tipped over!</b>")
+		span_warning(span_bold("They are freaking out from being tipped over!"))
 	)
 	. += pick(panic_state)
 /*

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -320,7 +320,7 @@
 		return
 	var/modified_heal_amount = heal_amount
 	var/done_healing = FALSE
-	if(damage_type_healer == BRUTE && medkit_type == /obj/item/storage/medkit/brute) //Re-add specialized brute bonus for brute medkits
+	if(damage_type_healer == BRUTE && medkit_type == /obj/item/storage/medkit/brute) 
 		modified_heal_amount *= 1.1
 	if(bot_access_flags & BOT_COVER_EMAGGED)
 		patient.reagents?.add_reagent(/datum/reagent/toxin/chloralhydrate, 5)

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -298,12 +298,15 @@
 	if(!do_after(src, delay = 0.5 SECONDS, target = patient, interaction_key = TEND_DAMAGE_INTERACTION))
 		update_bot_mode(new_mode = BOT_IDLE)
 		return
+	var/modified_heal_amount = heal_amount
+	if(damage_type_healer == BRUTE && medkit_type == /obj/item/storage/medkit/brute) //Re-add specialized brute bonus for brute medkits
+		modified_heal_amount *= 1.1
 	if(bot_access_flags & BOT_COVER_EMAGGED)
 		patient.reagents?.add_reagent(/datum/reagent/toxin/chloralhydrate, 5)
 	else if(damage_type_healer == HEAL_ALL_DAMAGE)
-		patient.heal_overall_damage(heal_amount)
+		patient.heal_ordered_damage(amount = modified_heal_amount, damagetype = list(BRUTE, BURN, TOX, OXY))
 	else
-		patient.heal_damage_type(heal_amount = heal_amount, damagetype = damage_type_healer)
+		patient.heal_damage_type(heal_amount = modified_heal_amount, damagetype = damage_type_healer)
 	update_bot_mode(new_mode = BOT_IDLE)
 
 /mob/living/basic/bot/medbot/autopatrol

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -304,7 +304,7 @@
 	if(bot_access_flags & BOT_COVER_EMAGGED)
 		patient.reagents?.add_reagent(/datum/reagent/toxin/chloralhydrate, 5)
 	else if(damage_type_healer == HEAL_ALL_DAMAGE)
-		patient.heal_ordered_damage(amount = modified_heal_amount, damagetype = list(BRUTE, BURN, TOX, OXY))
+		patient.heal_ordered_damage(amount = modified_heal_amount, damage_types = list(BRUTE, BURN, TOX, OXY))
 	else
 		patient.heal_damage_type(heal_amount = modified_heal_amount, damagetype = damage_type_healer)
 	update_bot_mode(new_mode = BOT_IDLE)

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -324,7 +324,7 @@
 		update_bot_mode(new_mode = BOT_IDLE)
 	//If player-controlled, call them to heal again here for continous player healing
 	else if(!isnull(client))
-		addtimer(CALLBACK(src, PROC_REF(melee_attack), patient), 0.25 SECONDS)
+		melee_attack(patient)
 
 
 /mob/living/basic/bot/medbot/autopatrol

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -293,6 +293,11 @@
 /mob/living/basic/bot/medbot/proc/medicate_patient(mob/living/carbon/human/patient)
 	if(DOING_INTERACTION(src, TEND_DAMAGE_INTERACTION))
 		return
+
+	if(!isnull(client))
+		if((damage_type_healer == HEAL_ALL_DAMAGE && patient.get_total_damage() <= heal_threshold) || (!(damage_type_healer == HEAL_ALL_DAMAGE) && patient.get_current_damage_of_type(damage_type_healer) <= heal_threshold))
+			to_chat(src, "[patient] is healthy! Your programming prevents you from tending the wounds of anyone with less than [heal_threshold + 1] [damage_type_healer == HEAL_ALL_DAMAGE ? "total" : damage_type_healer] damage.")
+			return
 	update_bot_mode(new_mode = BOT_HEALING, update_hud = FALSE)
 
 	if(!do_after(src, delay = 0.5 SECONDS, target = patient, interaction_key = TEND_DAMAGE_INTERACTION))
@@ -319,8 +324,7 @@
 	//Go into idle only when we're done
 	if(done_healing)
 		visible_message("<span class='infoplain'>[src] places its tools back into itself.</span>")
-	//Player bots can heal more than their threshold but not automatically
-		to_chat(src, "[patient] is below your healing threshold of [heal_threshold].")
+		to_chat(src, "[patient] is now healthy!")
 		update_bot_mode(new_mode = BOT_IDLE)
 	//If player-controlled, call them to heal again here for continous player healing
 	else if(!isnull(client))

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -248,15 +248,16 @@
 
 /mob/living/basic/bot/medbot/examine()
 	. = ..()
-	if(medical_mode_flags & MEDBOT_TIPPED_MODE)
-		var/list/panic_state = list(
+	if(!(medical_mode_flags & MEDBOT_TIPPED_MODE))
+		return
+	var/static/list/panic_state = list(
 		"It appears to be tipped over, and is quietly waiting for someone to set it right.",
 		"It is tipped over and requesting help.",
 		"They are tipped over and appear visibly distressed.",
 		span_warning("They are tipped over and visibly panicking!"),
 		span_warning("<b>They are freaking out from being tipped over!</b>")
-		)
-		. += pick(panic_state)
+	)
+	. += pick(panic_state)
 /*
  * Proc used in a callback for before this medibot is tipped by the tippable component.
  *

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -319,7 +319,13 @@
 	//Go into idle only when we're done
 	if(done_healing)
 		visible_message("<span class='infoplain'>[src] places its tools back into itself.</span>")
+	//Player bots can heal more than their threshold but not automatically
+		to_chat(src, "[patient] is above your healing threshold of [heal_threshold].")
 		update_bot_mode(new_mode = BOT_IDLE)
+	//If player-controlled, call them to heal again here for continous player healing
+	else if(!isnull(client))
+		addtimer(CALLBACK(src, PROC_REF(melee_attack), patient), 0.5 SECONDS)
+
 
 /mob/living/basic/bot/medbot/autopatrol
 	bot_mode_flags = BOT_MODE_ON | BOT_MODE_AUTOPATROL | BOT_MODE_REMOTE_ENABLED | BOT_MODE_CAN_BE_SAPIENT | BOT_MODE_ROUNDSTART_POSSESSION

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -10,6 +10,7 @@
 	anchored = FALSE
 	health = 20
 	maxHealth = 20
+	speed = 2
 	pass_flags = PASSMOB | PASSFLAPS
 	status_flags = (CANPUSH | CANSTUN)
 	ai_controller = /datum/ai_controller/basic_controller/bot/medbot

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -324,7 +324,7 @@
 		update_bot_mode(new_mode = BOT_IDLE)
 	//If player-controlled, call them to heal again here for continous player healing
 	else if(!isnull(client))
-		addtimer(CALLBACK(src, PROC_REF(melee_attack), patient), 0.5 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(melee_attack), patient), 0.25 SECONDS)
 
 
 /mob/living/basic/bot/medbot/autopatrol

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -299,6 +299,7 @@
 		update_bot_mode(new_mode = BOT_IDLE)
 		return
 	var/modified_heal_amount = heal_amount
+	var/done_healing = FALSE
 	if(damage_type_healer == BRUTE && medkit_type == /obj/item/storage/medkit/brute) //Re-add specialized brute bonus for brute medkits
 		modified_heal_amount *= 1.1
 	if(bot_access_flags & BOT_COVER_EMAGGED)
@@ -307,17 +308,16 @@
 	else if(damage_type_healer == HEAL_ALL_DAMAGE)
 		patient.heal_ordered_damage(amount = modified_heal_amount, damage_types = list(BRUTE, BURN, TOX, OXY))
 		log_combat(src, patient, "tended the wounds of", "internal tools")
+		if(patient.get_total_damage() <= heal_threshold)
+			done_healing = TRUE
 	else
 		patient.heal_damage_type(heal_amount = modified_heal_amount, damagetype = damage_type_healer)
 		log_combat(src, patient, "tended the wounds of", "internal tools")
+		if(patient.get_current_damage_of_type(damage_type_healer) <= heal_threshold)
+			done_healing = TRUE
 	patient.visible_message(span_notice("[src] tends the wounds of [patient]!"), "<span class='infoplain'>[span_green("[src] tends your wounds!")]</span>")
 	//Go into idle only when we're done
-	if(bot_access_flags & BOT_COVER_EMAGGED)
-		return
-	else if(damage_type_healer == HEAL_ALL_DAMAGE && patient.get_total_damage() <= heal_threshold)
-		visible_message("<span class='infoplain'>[src] places its tools back into itself.</span>")
-		update_bot_mode(new_mode = BOT_IDLE)
-	else if(patient.get_current_damage_of_type(damage_type_healer) <= heal_threshold)
+	if(done_healing)
 		visible_message("<span class='infoplain'>[src] places its tools back into itself.</span>")
 		update_bot_mode(new_mode = BOT_IDLE)
 

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -274,10 +274,9 @@
 /mob/living/basic/bot/medbot/proc/after_tip_over(mob/user)
 	medical_mode_flags |= MEDBOT_TIPPED_MODE
 	tipper = WEAKREF(user)
-	var/tipper_name = user.name
 	playsound(src, 'sound/machines/warning-buzzer.ogg', 50)
 	if(prob(10))
-		speak("PSYCH ALERT: Crewmember [tipper_name] recorded displaying antisocial tendencies torturing bots in [get_area(src)]. Please schedule psych evaluation.", radio_channel)
+		speak("PSYCH ALERT: Crewmember [user.name] recorded displaying antisocial tendencies torturing bots in [get_area(src)]. Please schedule psych evaluation.", radio_channel)
 
 /*
  * Proc used in a callback for after this medibot is righted, either by themselves or by a mob, by the tippable component.

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -320,7 +320,7 @@
 	if(done_healing)
 		visible_message("<span class='infoplain'>[src] places its tools back into itself.</span>")
 	//Player bots can heal more than their threshold but not automatically
-		to_chat(src, "[patient] is above your healing threshold of [heal_threshold].")
+		to_chat(src, "[patient] is below your healing threshold of [heal_threshold].")
 		update_bot_mode(new_mode = BOT_IDLE)
 	//If player-controlled, call them to heal again here for continous player healing
 	else if(!isnull(client))

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -1,5 +1,5 @@
 /datum/emote/silicon
-	mob_type_allowed_typecache = list(/mob/living/silicon, /mob/living/simple_animal/bot)
+	mob_type_allowed_typecache = list(/mob/living/silicon, /mob/living/simple_animal/bot, /mob/living/basic/bot)
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/silicon/boop


### PR DESCRIPTION
## About The Pull Request

Should fix advanced medkit medibots healing and also give back the healing bonus to brute medkit medibots. Medibots should no longer leave their healing pose in the middle of healing either. Player medibots can't overheal.

It also readds any removed lines. And they can use robot emotes again.
Fixes #80135
## Why It's Good For The Game

Fixes!
## Changelog
:cl:
fix: Medibots made from advanced medkits works again
fix: Medibots made from brute medkits have their bonus healing again
fix: Medibots can use robotic emotes again
/:cl:
