### PR TITLE
Add hotkey and screentip to tracking beacons

### DIFF
--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -15,10 +15,18 @@
 		GLOB.teleportbeacons += src
 	else
 		icon_state = "beacon-off"
+	register_context()
 
 /obj/item/beacon/Destroy()
 	GLOB.teleportbeacons -= src
 	return ..()
+
+/obj/item/beacon/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_RMB] = "Toggle beacon"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
 
 /obj/item/beacon/proc/turn_off()
 	icon_state = "beacon-off"
@@ -34,6 +42,10 @@
 		turn_off()
 	to_chat(user, span_notice("You [enabled ? "enable" : "disable"] the beacon."))
 	return
+
+/obj/item/beacon/attack_hand_secondary(mob/user, list/modifiers)
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/beacon/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/pen)) // needed for things that use custom names like the locator


### PR DESCRIPTION

## About The Pull Request

Adds RMB to toggle a tracking beacon on/off. Also adds this as a screentip UI indicator.

## Why It's Good For The Game

Adds a simple interaction so people don't have to pick up things.

## Changelog

:cl:
qol: Add RMB hotkey and screentip UI to tracking beacons to toggle them on/off.
/:cl:

