### PR TITLE
Adds wound armor to heretic robes and gives heretic blades knife level wounding

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -91,6 +91,7 @@
 	laser = 30
 	energy = 30
 	bomb = 15
+	wound = 10
 
 /obj/item/clothing/suit/hooded/cultrobes/void/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -34,6 +34,7 @@
 	bio = 20
 	fire = 20
 	acid = 20
+	wound = 20
 
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/examine(mob/user)
 	. = ..()
@@ -64,6 +65,7 @@
 	laser = 30
 	energy = 30
 	bomb = 15
+	wound = 10
 
 /obj/item/clothing/head/hooded/cult_hoodie/void/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -14,6 +14,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 20
 	throwforce = 10
+	wound_bonus = 5
+	bare_wound_bonus = 15
 	toolspeed = 0.375
 	demolition_mod = 0.8
 	hitsound = 'sound/weapons/bladeslice.ogg'


### PR DESCRIPTION
## About The Pull Request
Adds 20 points of wound armor to ominous robes
Adds 10 points to void robes

Adds 5 wound bonus(15 bare) to heretic blades.

## Why It's Good For The Game
Literally every other armor piece has these, I don’t know why heretic robes were included and honestly it seems like an oversight

Heretic blades are made from knives, knives have 5 wound bonus, it makes no sense for heretic blades to be worse than 20 force knives.

## Changelog
:cl:
balance: heretic robes now have wound armor
balance: heretic blades now have knife-level wound bonuses
/:cl:
