### PR TITLE
Ash drake armor and explorer suit slot now fits crusher

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -193,6 +193,7 @@
 		/obj/item/spear,
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/tank/internals,
+		/obj/item/kinetic_crusher
 		)
 	armor_type = /datum/armor/cloak_drake
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -22,6 +22,7 @@
 		/obj/item/storage/bag/ore,
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/tank/internals,
+		/obj/item/kinetic_crusher
 		)
 	resistance_flags = FIRE_PROOF
 


### PR DESCRIPTION
## About The Pull Request

you can now put your crusher inside drake armor and explorer suit

![afbeelding](https://github.com/tgstation/tgstation/assets/36102060/d40a73fd-7b5b-45e0-8c86-cec04ac83717)


## Why It's Good For The Game

Why not? modsuit fits it and the pka fits so why not the axe?

## Changelog
:cl:
balance: crusher fits inside suit slot of ash drake armor now
balance: crusher fits inside suit slot of explorer suit now
/:cl:
