### PR TITLE
Fix cult halo and eyes affecting deconverted cultists

### DIFF
--- a/code/datums/elements/cult_eyes.dm
+++ b/code/datums/elements/cult_eyes.dm
@@ -22,6 +22,10 @@
 /datum/element/cult_eyes/proc/set_eyes(mob/living/target)
 	SIGNAL_HANDLER
 
+	if(!IS_CULTIST(target))
+		target.RemoveElement(/datum/element/cult_eyes)
+		return
+
 	ADD_TRAIT(target, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
 	if (ishuman(target))
 		var/mob/living/carbon/human/human_parent = target

--- a/code/datums/elements/cult_halo.dm
+++ b/code/datums/elements/cult_halo.dm
@@ -22,6 +22,10 @@
 /datum/element/cult_halo/proc/set_halo(mob/living/target)
 	SIGNAL_HANDLER
 
+	if(!IS_CULTIST(target))
+		target.RemoveElement(/datum/element/cult_halo)
+		return
+
 	ADD_TRAIT(target, TRAIT_CULT_HALO, CULT_TRAIT)
 	var/mutable_appearance/new_halo_overlay = mutable_appearance('icons/effects/cult/halo.dmi', "halo[rand(1, 6)]", -HALO_LAYER)
 	if (ishuman(target))


### PR DESCRIPTION

## About The Pull Request

Fixes #69423

Cult halo and eyes were appearing on deconverted cultists due to a delay when the element gets attatched. This lead to a small window of oppurtunity where someone could get converted, then deconverted, and still  have the cult icons appear on them later.

## Why It's Good For The Game

The Antichrist is dead.

## Changelog

:cl:
fix: Fix cult halo and eyes affecting deconverted cultists
/:cl:

