### PR TITLE
Turns the "Admin Permission Elevation Notification" into a macro

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -174,3 +174,10 @@ GLOBAL_VAR_INIT(ghost_role_flags, ALL)
 /// Used in logging uses of admin verbs (and sometimes some non-admin or debug verbs) to the blackbox
 /// Only pass it a string key, the verb being used.
 #define BLACKBOX_LOG_ADMIN_VERB(the_verb) SSblackbox.record_feedback("tally", "admin_verb", 1, the_verb)
+
+/// String used in the message to notify admins if a permissions elevation attempt is detected
+#define PERMISSIONS_ELEVATION_DETECTED_MESSAGE(user_string) "[##user_string] has tried to elevate permissions!"
+/// Macro used to notify admins if someone attempts to elevate permissions by invoking a proc that allows them to do so.
+#define PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(user) \
+	message_admins(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name_admin(##user))); \
+	log_admin(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name(##user)))

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -175,9 +175,3 @@ GLOBAL_VAR_INIT(ghost_role_flags, ALL)
 /// Only pass it a string key, the verb being used.
 #define BLACKBOX_LOG_ADMIN_VERB(the_verb) SSblackbox.record_feedback("tally", "admin_verb", 1, the_verb)
 
-/// String used in the message to notify admins if a permissions elevation attempt is detected
-#define PERMISSIONS_ELEVATION_DETECTED_MESSAGE(user_string) "[##user_string] has tried to elevate permissions!"
-/// Macro used to notify admins if someone attempts to elevate permissions by invoking a proc that allows them to do so.
-#define PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(user) \
-	message_admins(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name_admin(##user))); \
-	log_admin(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name(##user)))

--- a/code/__HELPERS/admin.dm
+++ b/code/__HELPERS/admin.dm
@@ -1,3 +1,13 @@
+/// String used in the message to notify admins if a permissions elevation attempt is detected
+#define PERMISSIONS_ELEVATION_DETECTED_MESSAGE(user_string) "[##user_string] has tried to elevate permissions!"
+
 /// Returns if the given client is an admin, REGARDLESS of if they're deadminned or not.
 /proc/is_admin(client/client)
 	return !isnull(GLOB.admin_datums[client.ckey]) || !isnull(GLOB.deadmins[client.ckey])
+
+/// Sends a message in the event that someone attempts to elevate their permissions through invoking a certain proc.
+/proc/alert_to_permissions_elevation_attempt(mob/user)
+	message_admins(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name_admin(user)))
+	log_admin(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name(user)))
+
+#undef PERMISSIONS_ELEVATION_DETECTED_MESSAGE

--- a/code/__HELPERS/admin.dm
+++ b/code/__HELPERS/admin.dm
@@ -1,13 +1,10 @@
-/// String used in the message to notify admins if a permissions elevation attempt is detected
-#define PERMISSIONS_ELEVATION_DETECTED_MESSAGE(user_string) "[##user_string] has tried to elevate permissions!"
-
 /// Returns if the given client is an admin, REGARDLESS of if they're deadminned or not.
 /proc/is_admin(client/client)
 	return !isnull(GLOB.admin_datums[client.ckey]) || !isnull(GLOB.deadmins[client.ckey])
 
 /// Sends a message in the event that someone attempts to elevate their permissions through invoking a certain proc.
 /proc/alert_to_permissions_elevation_attempt(mob/user)
-	message_admins(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name_admin(user)))
-	log_admin(PERMISSIONS_ELEVATION_DETECTED_MESSAGE(key_name(user)))
+	var/message = " has tried to elevate permissions!"
+	message_admins(key_name_admin(user) + message)
+	log_admin(key_name(user) + message)
 
-#undef PERMISSIONS_ELEVATION_DETECTED_MESSAGE

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -13,9 +13,7 @@ GLOBAL_PROTECT(protected_ranks)
 
 /datum/admin_rank/New(init_name, init_rights, init_exclude_rights, init_edit_rights)
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		if (name == "NoRank") //only del if this is a true creation (and not just a New() proc call), other wise trialmins/coders could abuse this to deadmin other admins
 			QDEL_IN(src, 0)
 			CRASH("Admin proc call creation of admin datum")
@@ -35,9 +33,7 @@ GLOBAL_PROTECT(protected_ranks)
 
 /datum/admin_rank/Destroy()
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return QDEL_HINT_LETMELIVE
 	. = ..()
 
@@ -47,9 +43,7 @@ GLOBAL_PROTECT(protected_ranks)
 // Adds/removes rights to this admin_rank
 /datum/admin_rank/proc/process_keyword(group, group_count, datum/admin_rank/previous_rank)
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return
 	var/list/keywords = splittext(group, " ")
 	var/flag = 0

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -13,7 +13,7 @@ GLOBAL_PROTECT(protected_ranks)
 
 /datum/admin_rank/New(init_name, init_rights, init_exclude_rights, init_edit_rights)
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		if (name == "NoRank") //only del if this is a true creation (and not just a New() proc call), other wise trialmins/coders could abuse this to deadmin other admins
 			QDEL_IN(src, 0)
 			CRASH("Admin proc call creation of admin datum")
@@ -33,7 +33,7 @@ GLOBAL_PROTECT(protected_ranks)
 
 /datum/admin_rank/Destroy()
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return QDEL_HINT_LETMELIVE
 	. = ..()
 
@@ -43,7 +43,7 @@ GLOBAL_PROTECT(protected_ranks)
 // Adds/removes rights to this admin_rank
 /datum/admin_rank/proc/process_keyword(group, group_count, datum/admin_rank/previous_rank)
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return
 	var/list/keywords = splittext(group, " ")
 	var/flag = 0

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -50,9 +50,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/New(list/datum/admin_rank/ranks, ckey, force_active = FALSE, protected)
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		if (!target) //only del if this is a true creation (and not just a New() proc call), other wise trialmins/coders could abuse this to deadmin other admins
 			QDEL_IN(src, 0)
 			CRASH("Admin proc call creation of admin datum")
@@ -79,17 +77,13 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/Destroy()
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return QDEL_HINT_LETMELIVE
 	. = ..()
 
 /datum/admins/proc/activate()
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return
 	GLOB.deadmins -= target
 	GLOB.admin_datums[target] = src
@@ -101,9 +95,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/proc/deactivate()
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return
 	GLOB.deadmins[target] = src
 	GLOB.admin_datums -= target
@@ -119,9 +111,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/proc/associate(client/client)
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return
 
 	if(!istype(client))
@@ -163,9 +153,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/proc/disassociate()
 	if(IsAdminAdvancedProcCall())
-		var/msg = " has tried to elevate permissions!"
-		message_admins("[key_name_admin(usr)][msg]")
-		log_admin("[key_name(usr)][msg]")
+		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
 		return
 	if(owner)
 		GLOB.admins -= owner

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -50,7 +50,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/New(list/datum/admin_rank/ranks, ckey, force_active = FALSE, protected)
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		if (!target) //only del if this is a true creation (and not just a New() proc call), other wise trialmins/coders could abuse this to deadmin other admins
 			QDEL_IN(src, 0)
 			CRASH("Admin proc call creation of admin datum")
@@ -77,13 +77,13 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/Destroy()
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return QDEL_HINT_LETMELIVE
 	. = ..()
 
 /datum/admins/proc/activate()
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return
 	GLOB.deadmins -= target
 	GLOB.admin_datums[target] = src
@@ -95,7 +95,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/proc/deactivate()
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return
 	GLOB.deadmins[target] = src
 	GLOB.admin_datums -= target
@@ -111,7 +111,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/proc/associate(client/client)
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return
 
 	if(!istype(client))
@@ -153,7 +153,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins/proc/disassociate()
 	if(IsAdminAdvancedProcCall())
-		PERMISSIONS_ELEVATION_DETECTED_NOTIFICATION(usr)
+		alert_to_permissions_elevation_attempt(usr)
 		return
 	if(owner)
 		GLOB.admins -= owner


### PR DESCRIPTION
## About The Pull Request
Turns this boilerplate message into a centralized macro because this code is important, but not so important that every coder know the nitty gritty details of it. In case someone wants to add more logging/handling (or update the message), there's now a central macro to update for all nine events in which we check.

This shouldn't break anything because it's the exact same thing we were doing previously and the early return checks are still all there, but it does work on my machine regardless ✔️ 

![image](https://github.com/tgstation/tgstation/assets/34697715/db4405d3-e57d-4c29-8a01-b32ba185041b)
