### PR TITLE
Fixes the typing indicator

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -408,13 +408,13 @@
 	add_image_to_clients(active_typing_indicator, group_clients())
 
 /mob/camera/imaginary_friend/remove_typing_indicator()
-	REMOVE_TRAIT(src, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
 	if(!active_typing_indicator)
 		return FALSE
 	remove_image_from_clients(active_typing_indicator, group_clients())
 	active_typing_indicator = null
 
 /mob/camera/imaginary_friend/remove_all_indicators()
+	REMOVE_TRAIT(src, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
 	remove_thinking_indicator()
 	remove_typing_indicator()
 

--- a/code/modules/tgui_input/say_modal/typing.dm
+++ b/code/modules/tgui_input/say_modal/typing.dm
@@ -84,7 +84,6 @@
 	play_fov_effect(src, 6, "talk", ignore_self = TRUE)
 
 /mob/living/remove_thinking_indicator()
-	REMOVE_TRAIT(src, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
 	if(!active_thinking_indicator)
 		return FALSE
 	cut_overlay(active_thinking_indicator)
@@ -104,6 +103,7 @@
 	active_typing_indicator = null
 
 /mob/living/remove_all_indicators()
+	REMOVE_TRAIT(src, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
 	remove_thinking_indicator()
 	remove_typing_indicator()
 


### PR DESCRIPTION
## About The Pull Request
It was very specifically broken by [this commit](https://github.com/tgstation/tgstation/pull/80122/commits/94d00aa526f31ed0bc8357f060d2c190d2ad87c7), because it wrongfully changed the logic. Now the typing indicator is back, it's no longer just the thinking indicator.

## Why It's Good For The Game
Typing indicator is meant to be there, now it's back! No more awkward flickering!

## Changelog

:cl: GoldenAlpharex
fix: The typing indicator has overcome its shyness and is now back to its usual form.
/:cl: