### PR TITLE
Fixes issues on guns with BOLT_TYPE_LOCKING

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -270,7 +270,8 @@
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
 	..()
-	return fire_gun(target, user, flag, params) | AFTERATTACK_PROCESSED_ITEM
+	. = fire_gun(target, user, flag, params) | AFTERATTACK_PROCESSED_ITEM
+	return AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/gun/proc/fire_gun(atom/target, mob/living/user, flag, params)
 	if(QDELETED(target))
@@ -402,6 +403,7 @@
 	update_appearance()
 	return TRUE
 
+///returns true if the gun successfully fires
 /obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	var/base_bonus_spread = 0
 	if(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -270,7 +270,7 @@
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
 	..()
-	. = fire_gun(target, user, flag, params) | AFTERATTACK_PROCESSED_ITEM
+	fire_gun(target, user, flag, params)
 	return AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/gun/proc/fire_gun(atom/target, mob/living/user, flag, params)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -484,11 +484,11 @@
 		if (empty_alarm && last_shot_succeeded)
 			playsound(src, empty_alarm_sound, empty_alarm_volume, empty_alarm_vary)
 			update_appearance()
-		if (last_shot_succeeded && bolt_type == BOLT_TYPE_LOCKING)
+		if (last_shot_succeeded && bolt_type == BOLT_TYPE_LOCKING && semi_auto == TRUE)
 			bolt_locked = TRUE
 			update_appearance()
 
-/obj/item/gun/ballistic/afterattack()
+/obj/item/gun/ballistic/fire_gun(atom/target, mob/living/user, flag, params)
 	prefire_empty_checks()
 	. = ..() //The gun actually firing
 	postfire_empty_checks(.)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -484,7 +484,7 @@
 		if (empty_alarm && last_shot_succeeded)
 			playsound(src, empty_alarm_sound, empty_alarm_volume, empty_alarm_vary)
 			update_appearance()
-		if (last_shot_succeeded && bolt_type == BOLT_TYPE_LOCKING && semi_auto == TRUE)
+		if (last_shot_succeeded && bolt_type == BOLT_TYPE_LOCKING && semi_auto)
 			bolt_locked = TRUE
 			update_appearance()
 


### PR DESCRIPTION

## About The Pull Request
Bolt-actions no longer open their bolt aftering firing their last shot.
All BOLT_TYPE_LOCKING weapons, including semi automatics, no longer open their bolt after dryfiring
Fixes #75452 
Fixes #79128
## Why It's Good For The Game
Fixes unintended and confusing gun behavior
## Changelog
:cl:
fix: Bolt action rifles no longer open their bolt when firing their last bullet.
/:cl:
