### PR TITLE
Removes an exploit that can farm Russian revolver moodlets, adds Russian revolvers to the contraband section of games vendors

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -245,6 +245,10 @@
 		var/is_target_face = zone == BODY_ZONE_HEAD || zone == BODY_ZONE_PRECISE_EYES || zone == BODY_ZONE_PRECISE_MOUTH
 		var/loaded_rounds = get_ammo(FALSE, FALSE) // check before it is fired
 
+		if(HAS_TRAIT(user, TRAIT_CURSED)) // I cannot live, I cannot die, trapped in myself, body my holding cell.
+			to_chat(user, span_warning("What a horrible night... To have a curse!"))
+			return
+
 		if(loaded_rounds && is_target_face)
 			add_memory_in_range(user, 7, /datum/memory/witnessed_russian_roulette, \
 				protagonist = user, \
@@ -255,9 +259,6 @@
 			)
 
 		if(chambered)
-			if(HAS_TRAIT(user, TRAIT_CURSED)) // I cannot live, I cannot die, trapped in myself, body my holding cell.
-				to_chat(user, span_warning("What a horrible night... To have a curse!"))
-				return
 			var/obj/item/ammo_casing/AC = chambered
 			if(AC.fire_casing(user, user, params, distro = 0, quiet = 0, zone_override = null, spread = 0, fired_from = src))
 				playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -81,6 +81,7 @@
 		/obj/item/dice/fudge = 9,
 		/obj/item/clothing/shoes/wheelys/skishoes = 4,
 		/obj/item/instrument/musicalmoth = 1,
+		/obj/item/gun/ballistic/revolver/russian, //the most dangerous game
 	)
 	premium = list(
 		/obj/item/disk/holodisk = 5,

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -81,7 +81,7 @@
 		/obj/item/dice/fudge = 9,
 		/obj/item/clothing/shoes/wheelys/skishoes = 4,
 		/obj/item/instrument/musicalmoth = 1,
-		/obj/item/gun/ballistic/revolver/russian, //the most dangerous game
+		/obj/item/gun/ballistic/revolver/russian = 1, //the most dangerous game
 	)
 	premium = list(
 		/obj/item/disk/holodisk = 5,


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/80158 by making curses block you from playing Russian roulette regardless of whether or not there's a live bullet in your Russian revolver's chamber.

A Russian revolver has been added to the contraband section of each Good Clean Fun vendor.

## Why It's Good For The Game

The bug is incredibly funny, but ~~I want GBP~~ probably should be fixed.

There's no actual way to get (more) Russian revolvers outside of the mapstart ones, and that can be a bit stifling to gimmicks that involve them. And Russian roulette IS a game.

Like the roundstart ones, you could unload these vendor revolvers for .357 bullets, but you can already just print .357 bullets from a hacked autolathe directly, so I don't think that's an issue.

## Changelog

:cl: ATHATH
fix: Spacemen can no longer use curses to cheat at Russian roulette by selectively blocking attempts to shoot themselves.
add: A Russian revolver has been added to the contraband section of each Good Clean Fun vendor.
/:cl: