### PR TITLE
Air Alarm Circuit fix 2: It works this time

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -141,10 +141,13 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	GLOB.air_alarms -= src
 	return ..()
 
-/obj/machinery/airalarm/power_change()
+/obj/machinery/airalarm/proc/get_enviroment()
 	var/turf/our_turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
-	var/datum/gas_mixture/environment = our_turf.return_air()
-	check_danger(our_turf, environment, environment.temperature)
+	return our_turf.return_air()
+
+/obj/machinery/airalarm/power_change()
+	var/datum/gas_mixture/environment = get_enviroment()
+	check_danger(environment, environment.temperature)
 	return ..()
 
 /obj/machinery/airalarm/on_enter_area(datum/source, area/area_to_register)
@@ -228,8 +231,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	data["sensor"] = !!connected_sensor
 	data["allowLinkChange"] = allow_link_change
 
-	var/turf/turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
-	var/datum/gas_mixture/environment = turf.return_air()
+	var/datum/gas_mixture/environment = get_enviroment()
 	var/total_moles = environment.total_moles()
 	var/temp = environment.temperature
 	var/pressure = environment.return_pressure()
@@ -457,9 +459,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 			tlv.set_value(threshold_type, value)
 			investigate_log("threshold value for [threshold]:[threshold_type] was set to [value] by [key_name(usr)]", INVESTIGATE_ATMOS)
 
-			var/turf/our_turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
-			var/datum/gas_mixture/environment = our_turf.return_air()
-			check_danger(our_turf, environment, environment.temperature)
+			var/datum/gas_mixture/environment = get_enviroment()
+			check_danger(environment, environment.temperature)
 
 		if("reset_threshold")
 			var/threshold = text2path(params["threshold"]) || params["threshold"]
@@ -470,9 +471,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 			tlv.reset_value(threshold_type)
 			investigate_log("threshold value for [threshold]:[threshold_type] was reset by [key_name(usr)]", INVESTIGATE_ATMOS)
 
-			var/turf/our_turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
-			var/datum/gas_mixture/environment = our_turf.return_air()
-			check_danger(our_turf, environment, environment.temperature)
+			var/datum/gas_mixture/environment = get_enviroment()
+			check_danger(environment, environment.temperature)
 
 		if ("alarm")
 			if (alarm_manager.send_alarm(ALARM_ATMOS))
@@ -540,7 +540,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 /// Check the current air and update our danger level.
 /// [/obj/machinery/airalarm/var/danger_level]
-/obj/machinery/airalarm/proc/check_danger(turf/location, datum/gas_mixture/environment, exposed_temperature)
+/obj/machinery/airalarm/proc/check_danger(datum/gas_mixture/environment, exposed_temperature)
 	SIGNAL_HANDLER
 	if((machine_stat & (NOPOWER|BROKEN)) || shorted)
 		return
@@ -680,9 +680,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	RegisterSignal(connected_sensor, COMSIG_QDELETING, PROC_REF(disconnect_sensor))
 	my_area = get_area(connected_sensor)
 
-	var/turf/our_turf = get_turf(connected_sensor)
-	var/datum/gas_mixture/environment = our_turf.return_air()
-	check_danger(our_turf, environment, environment.temperature)
+	var/datum/gas_mixture/environment = get_enviroment()
+	check_danger(environment, environment.temperature)
 
 	update_appearance()
 	update_name()
@@ -693,9 +692,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	connected_sensor = null
 	my_area = get_area(src)
 
-	var/turf/our_turf = get_turf(src)
-	var/datum/gas_mixture/environment = our_turf.return_air()
-	check_danger(our_turf, environment, environment.temperature)
+	var/datum/gas_mixture/environment = get_enviroment()
+	check_danger(environment, environment.temperature)
 
 	update_appearance()
 	update_name()

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -141,13 +141,17 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	GLOB.air_alarms -= src
 	return ..()
 
+/obj/machinery/airalarm/proc/check_enviroment()
+	var/turf/our_turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
+	var/datum/gas_mixture/environment = our_turf.return_air()
+	check_danger(our_turf, environment, environment.temperature)
+
 /obj/machinery/airalarm/proc/get_enviroment()
 	var/turf/our_turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
 	return our_turf.return_air()
 
 /obj/machinery/airalarm/power_change()
-	var/datum/gas_mixture/environment = get_enviroment()
-	check_danger(environment, environment.temperature)
+	check_enviroment()
 	return ..()
 
 /obj/machinery/airalarm/on_enter_area(datum/source, area/area_to_register)
@@ -459,8 +463,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 			tlv.set_value(threshold_type, value)
 			investigate_log("threshold value for [threshold]:[threshold_type] was set to [value] by [key_name(usr)]", INVESTIGATE_ATMOS)
 
-			var/datum/gas_mixture/environment = get_enviroment()
-			check_danger(environment, environment.temperature)
+			check_enviroment()
 
 		if("reset_threshold")
 			var/threshold = text2path(params["threshold"]) || params["threshold"]
@@ -471,8 +474,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 			tlv.reset_value(threshold_type)
 			investigate_log("threshold value for [threshold]:[threshold_type] was reset by [key_name(usr)]", INVESTIGATE_ATMOS)
 
-			var/datum/gas_mixture/environment = get_enviroment()
-			check_danger(environment, environment.temperature)
+			check_enviroment()
 
 		if ("alarm")
 			if (alarm_manager.send_alarm(ALARM_ATMOS))
@@ -540,7 +542,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 /// Check the current air and update our danger level.
 /// [/obj/machinery/airalarm/var/danger_level]
-/obj/machinery/airalarm/proc/check_danger(datum/gas_mixture/environment, exposed_temperature)
+/obj/machinery/airalarm/proc/check_danger(turf/location, datum/gas_mixture/environment, exposed_temperature)
 	SIGNAL_HANDLER
 	if((machine_stat & (NOPOWER|BROKEN)) || shorted)
 		return
@@ -680,8 +682,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	RegisterSignal(connected_sensor, COMSIG_QDELETING, PROC_REF(disconnect_sensor))
 	my_area = get_area(connected_sensor)
 
-	var/datum/gas_mixture/environment = get_enviroment()
-	check_danger(environment, environment.temperature)
+	check_enviroment()
 
 	update_appearance()
 	update_name()
@@ -692,8 +693,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	connected_sensor = null
 	my_area = get_area(src)
 
-	var/datum/gas_mixture/environment = get_enviroment()
-	check_danger(environment, environment.temperature)
+	check_enviroment()
 
 	update_appearance()
 	update_name()

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_circuit.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_circuit.dm
@@ -226,8 +226,7 @@
 
 	var/current_option = air_alarm_options.value
 
-	var/turf/alarm_turf = get_turf(connected_alarm.my_area)
-	var/datum/gas_mixture/environment = alarm_turf.return_air()
+	var/datum/gas_mixture/environment = connected_alarm.get_enviroment()
 	pressure.set_output(round(environment.return_pressure()))
 	temperature.set_output(round(environment.temperature))
 	if(ispath(options_map[current_option]))


### PR DESCRIPTION
Also removed the (turf/location check in "check danger" as its not being used.
## About The Pull Request

I made a mistake in the last fix as I thought my_area was a turf.  I am not sure why as its in the freaking name.  I went though the air alarm and noticed it was using the same code to get the turf from either the air_alarm turf itself or the connected sensor so I just created a function get_enviroment() so any future device can just get the environment pointed by the air alarm.

I also removed the turf/location from the check_danger function as it had no purpose in the function itself.  Then I started 3 separate games and tested to make 100% sure the air alarm AND a simple circuit works.
## Why It's Good For The Game

Fixing bugs is good.
## Changelog
:cl:
fix: The air_alarm_circuit to gets the environment from the proper turf.
:cl:
