### PR TITLE
Addresses Icon Smoothing Runtimes

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -166,6 +166,8 @@ xxx xxx xxx
 
 ///do not use, use QUEUE_SMOOTH(atom)
 /atom/proc/smooth_icon()
+	if(QDELETED(src))
+		return
 	smoothing_flags &= ~SMOOTH_QUEUED
 	flags_1 |= HTML_USE_INITAL_ICON_1
 	if (!z)


### PR DESCRIPTION

## About The Pull Request

Noticed this in the runtime logs on Terry:

```txt
[2023-12-07 02:30:12.334] RUNTIME: runtime error: /obj/structure/table/glass called smooth_icon() without being on a z-level
 - proc name: smooth icon (/atom/proc/smooth_icon)
 -   source file: code/__HELPERS/icon_smoothing.dm,172
 -   usr: null
 -   src: the glass table (/obj/structure/table/glass)
 -   src.loc: null
 -   call stack:
 - the glass table (/obj/structure/table/glass): smooth icon()
 - the glass table (/obj/structure/table/glass): smooth icon()
 - Icon Smoothing (/datum/controller/subsystem/icon_smooth): fire(0)
 - Icon Smoothing (/datum/controller/subsystem/icon_smooth): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```

Glass tables, on their qdeletion (which occurs when someone breaks one by standing on it), call `QUEUE_SMOOTH_NEIGHBORS()`, which invokes the smooth on potentially all other glass tables it's merged to. However, since this is a queueing process that we halt if the MC is choked out or we're overtiming elsewhere, it's possible that the queued object `qdel()`s (like if someone is spamming throwing people on 2x1 glass tables) between fires of `SSicon_smooth`.

Instead of doing a crash on a null z-level, let's check if we're qdeleted first. It is not unreasonable to just simply early-return because it is always possible that things just get qdeleted while `SSicon_smooth` sleeps/postpones work when the server is crunching and munching cpu time.
## Changelog
No affect to players.
