### PR TITLE
Pocket keybinds!

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -40,6 +40,8 @@
 #define COMSIG_KB_HUMAN_QUICKEQUIPBELT_DOWN "keybinding_human_quickequipbelt_down"
 #define COMSIG_KB_HUMAN_BAGEQUIP_DOWN "keybinding_human_bagequip_down"
 #define COMSIG_KB_HUMAN_SUITEQUIP_DOWN "keybinding_human_suitequip_down"
+#define COMSIG_KB_HUMAN_LPOCKETEQUIP_DOWN "keybinding_human_lpocketequip_down"
+#define COMSIG_KB_HUMAN_RPOCKETEQUIP_DOWN "keybinding_human_rpocketequip_down"
 
 //Living
 #define COMSIG_KB_LIVING_RESIST_DOWN "keybinding_living_resist_down"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -58,7 +58,7 @@
 	keybind_signal = COMSIG_KB_HUMAN_SUITEQUIP_DOWN
 
 /datum/keybinding/human/quick_equip_belt/quick_equip_lpocket
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list("Ctrl1")
 	name = "quick_equip_lpocket"
 	full_name = "Quick equip left pocket"
 	description = "Put in or take out an item in left pocket"
@@ -67,7 +67,7 @@
 	keybind_signal = COMSIG_KB_HUMAN_LPOCKETEQUIP_DOWN
 
 /datum/keybinding/human/quick_equip_belt/quick_equip_rpocket
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list("Ctrl2")
 	name = "quick_equip_rpocket"
 	full_name = "Quick equip right pocket"
 	description = "Put in or take out an item in right pocket"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -56,3 +56,21 @@
 	slot_type = ITEM_SLOT_SUITSTORE
 	slot_item_name = "suit storage slot item"
 	keybind_signal = COMSIG_KB_HUMAN_SUITEQUIP_DOWN
+
+/datum/keybinding/human/quick_equip_belt/quick_equip_lpocket
+	hotkey_keys = list("Unbound")
+	name = "quick_equip_lpocket"
+	full_name = "Quick equip left pocket"
+	description = "Put in or take out an item in left pocket"
+	slot_type = ITEM_SLOT_LPOCKET
+	slot_item_name = "left pocket"
+	keybind_signal = COMSIG_KB_HUMAN_LPOCKETEQUIP_DOWN
+
+/datum/keybinding/human/quick_equip_belt/quick_equip_rpocket
+	hotkey_keys = list("Unbound")
+	name = "quick_equip_rpocket"
+	full_name = "Quick equip right pocket"
+	description = "Put in or take out an item in right pocket"
+	slot_type = ITEM_SLOT_RPOCKET
+	slot_item_name = "right pocket"
+	keybind_signal = COMSIG_KB_HUMAN_RPOCKETEQUIP_DOWN


### PR DESCRIPTION
## About The Pull Request

adds 2 (defaulted to ctrl 1 and ctrl 2) keybinds for quick equipping pockets (left and right)
visual aid

![image](https://github.com/tgstation/tgstation/assets/114047053/595861f0-9a7b-4f86-8ad9-dd6bb197843c)

https://github.com/tgstation/tgstation/assets/114047053/72596cf8-374d-40ac-9de1-20137dc959d4

## Why It's Good For The Game

There are already keybinds for suit storage, belt and bag. Having some keybinds for pockets should let you take things from your inventory with more ease.

## Changelog
:cl:
add: Added 2 pocket quick equip keybinds
/:cl:
