### PR TITLE
Reactions correctly respect the `REACTION_HEAT_ARBITARY` flag

### DIFF
--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -359,11 +359,11 @@
 	#endif
 
 	//Apply thermal output of reaction to beaker
-	if(reaction.reaction_flags & REACTION_HEAT_ARBITARY)
-		holder.chem_temp += clamp((reaction.thermic_constant * total_step_added * thermic_mod), 0, CHEMICAL_MAXIMUM_TEMPERATURE) //old method - for every bit added, the whole temperature is adjusted
-	else //Standard mechanics
-		var/heat_energy = reaction.thermic_constant * total_step_added * thermic_mod * SPECIFIC_HEAT_DEFAULT
-		holder.adjust_thermal_energy(heat_energy, 0, CHEMICAL_MAXIMUM_TEMPERATURE) //heat is relative to the beaker conditions
+	var/heat_energy = reaction.thermic_constant * total_step_added * thermic_mod
+	if(reaction.reaction_flags & REACTION_HEAT_ARBITARY) //old method - for every bit added, the whole temperature is adjusted
+		holder.set_temperature(clamp(holder.chem_temp + heat_energy, 0, CHEMICAL_MAXIMUM_TEMPERATURE))
+	else //Standard mechanics - heat is relative to the beaker conditions
+		holder.adjust_thermal_energy(heat_energy * SPECIFIC_HEAT_DEFAULT, 0, CHEMICAL_MAXIMUM_TEMPERATURE)
 
 	//Give a chance of sounds
 	if(prob(5))

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -46,7 +46,7 @@
 	var/temp_exponent_factor = 2
 	/// How sharp the pH exponential curve is (to the power of value)
 	var/ph_exponent_factor = 2
-	/// How much the temperature will change (with no intervention) (i.e. for 30u made the temperature will increase by 100, same with 300u. The final temp will always be start + this value, with the exception con beakers with different specific heats)
+	/// How much the temperature changes per unit of chem used. without REACTION_HEAT_ARBITARY flag the rate of change depends on the holder heat capacity else results are more accurate
 	var/thermic_constant = 50
 	/// pH change per 1u reaction
 	var/H_ion_release = 0.01

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -488,7 +488,7 @@
 	determin_ph_range = 0
 	temp_exponent_factor = 1
 	ph_exponent_factor = 1
-	thermic_constant = -50 //This is the part that cools things down now
+	thermic_constant = -5 //This is the part that cools things down now
 	H_ion_release = 0
 	rate_up_lim = 4
 	purity_min = 0.15


### PR DESCRIPTION
## About The Pull Request
1. This flag basically adjusts the temperature of the whole holder without taking into consideration its heat capacity. If the reactions `thermic_constant` was negative this flag would not function correctly as it would clamp the rate of change between 0 and `CHEMICAL_MAX_TEMPERATURE` and then apply it to the final temperature.
Now it clamps the final result(current temperature + rate of change) therefore reactions that uses this flag to cool down temps now works correctly.

2. Fixes #74667
The above point explains how the fix works. basically `thermic_constant` determines how much the holder temps cool down per unit of chem consumed. Cryostylane + oxygen reaction had this value at -50 which is way to low (cause it means per unit of oxygen consumed it would cool down the holder by 50 kelvin). It has been adjusted to -5 instead more reasonable. 

## Changelog
:cl:
fix: Cryostylane and oxygen reaction now cools down temps. Other reactions with the `REACTION_HEAT_ARBITARY` flag also cools down temps correctly
/:cl: