### PR TITLE
Fixes coffin cookie being invisible

### DIFF
--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -186,9 +186,9 @@
 	foodtypes = GRAIN | JUNKFOOD | SUGAR
 	crafting_complexity = FOOD_COMPLEXITY_2
 
-/obj/item/food/cookie/sugar/Initialize(mapload)
+/obj/item/food/cookie/sugar/Initialize(mapload, seasonal_changes = TRUE)
 	. = ..()
-	if(check_holidays(FESTIVE_SEASON))
+	if(seasonal_changes && check_holidays(FESTIVE_SEASON))
 		var/shape = pick("tree", "bear", "santa", "stocking", "present", "cane")
 		desc = "A sugar cookie in the shape of a [shape]. I hope Santa likes it!"
 		icon_state = "sugarcookie_[shape]"

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -42,7 +42,7 @@
 
 /obj/item/food/cookie/sugar/spookycoffin/Initialize(mapload, seasonal_changes = FALSE)
 	// Changes default parameter of seasonal_changes to FALSE, pass to parent
-	return ..()
+	return ..(mapload, seasonal_changes)
 
 //spooky items
 

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -40,6 +40,9 @@
 	icon_state = "coffincookie"
 	crafting_complexity = FOOD_COMPLEXITY_2
 
+/obj/item/food/cookie/sugar/spookycoffin/Initialize(mapload, seasonal_changes = FALSE)
+	return ..()
+
 //spooky items
 
 /obj/item/storage/spooky

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -41,6 +41,7 @@
 	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/cookie/sugar/spookycoffin/Initialize(mapload, seasonal_changes = FALSE)
+	// Changes default parameter of seasonal_changes to FALSE, pass to parent
 	return ..()
 
 //spooky items


### PR DESCRIPTION
## About The Pull Request
- Fixes #80161

It's a seasonal bug i.e. occurs only during the holiday seasons. Yeah so its caused by this code
https://github.com/tgstation/tgstation/blob/2a359b817874c4bb52be814551780af304cc9e07/code/game/objects/items/food/pastries.dm#L191-L194

So like it changes the icon state based on the season. Unfortunately none of the icon states it picks are located in the icon file `'icons/obj/holiday/halloween_items.dmi` i.e. it causes an invalid icon state causing it to go invisible(not spooky just a bug).

We now make sure this cookie type does not change based on the season. It will stay unique throughout the year 

## Changelog
:cl:
fix: coffin cookies are no longer invisible during the holiday seasons
/:cl:
