### PR TITLE
Adds basic mobs to "fancy types" (spawn atom window type-shortener)

### DIFF
--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -28,8 +28,9 @@
 			/turf = "T",
 			/mob/living/carbon = "CARBON",
 			/mob/living/simple_animal = "SIMPLE",
+			/mob/living/basic = "BASIC",
 			/mob/living = "LIVING",
-			/mob = "M"
+			/mob = "M",
 		)
 		for (var/tn in TYPES_SHORTCUTS)
 			if(copytext(typename, 1, length("[tn]/") + 1) == "[tn]/" /*findtextEx(typename,"[tn]/",1,2)*/ )


### PR DESCRIPTION

## About The Pull Request

Basically in the spawn window instead of writing out something like `/mob/living/basic/heretic/thingamcdohicker/lesser` it will now prepend to `BASIC/heretic/thingamcdochiker/lesser` which is quite a bit better imo.

Here's a screenshot that should summarize it a bit better:

![image](https://github.com/tgstation/tgstation/assets/34697715/fcb4cadb-1e90-49fb-8bd7-c187a4d454fa)
## Why It's Good For The Game

we do the same thing for simple animals since those can also have pretty long typepaths/subtype trees so it's probably a good idea to add this case in as well while we're converting everything over.
## Changelog
:cl:
qol: For admins, in the "Spawn Atom" window where you pick atoms to spawn-by-type, anything that is a subtype of `/mob/living/basic` should now be replaced with the `BASIC` tag instead (like with carbons, reagent containers, turfs, etc.). So, instead of having to scroll through and try and figure out what that weird subtype of Poly is, it should now be easier to read in that smaller screen.
/:cl:
