### PR TITLE
[No GBP] Allows away lathes to build nav beacons

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -1120,7 +1120,6 @@
 	name = "Machine Design (Bot Navigational Beacon)"
 	desc = "The circuit board for a beacon that aids bot navigation."
 	id = "botnavbeacon"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/navbeacon
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ROBOTICS


### PR DESCRIPTION


## About The Pull Request

I accidentally made bot navigational beacons not be buildable by away lathes, for no real reason. This PR fixes that.

## Why It's Good For The Game

Now folks at Charlie station can make medbots patrol around, should they desire to do so.

## Changelog

:cl:
fix: Away lathes can now print robot navigational beacons
/:cl:

