### PR TITLE
Fixes genetics console right click [NO GBP]

### DIFF
--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
@@ -61,7 +61,7 @@ const GeneCycler = (props) => {
 
         return;
       }}
-      oncontextmenu={(e) => {
+      onContextMenu={(e) => {
         e.preventDefault();
 
         act('pulse_gene', {


### PR DESCRIPTION
## About The Pull Request
oncontextmenu -> onContextMenu

![MgwIp62uoi](https://github.com/tgstation/tgstation/assets/42397676/ced30fd3-2c1f-4344-8929-c842e51509f0)

## Why It's Good For The Game
Bug fix
Closes #80200

## Changelog
:cl:
fix: DNA Sequencer UI: You should be able to cycle in reverse with RMB again.
/:cl:
