### PR TITLE
Modular room hole patching

### DIFF
--- a/_maps/modular_generic/station_l_crates.dmm
+++ b/_maps/modular_generic/station_l_crates.dmm
@@ -174,6 +174,12 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark/textured_large,
 /area/template_noop)
+"x" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/plating/rust,
+/area/template_noop)
 "y" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/box,
@@ -195,6 +201,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
 /area/template_noop)
+"A" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/template_noop)
 "B" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -207,6 +218,14 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
+/area/template_noop)
+"C" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
 /area/template_noop)
 "D" = (
 /obj/effect/decal/cleanable/dirt,
@@ -422,7 +441,7 @@ j
 "}
 (2,1,1) = {"
 e
-e
+T
 T
 T
 T
@@ -430,12 +449,12 @@ s
 s
 s
 T
-e
+T
 e
 "}
 (3,1,1) = {"
 e
-e
+A
 T
 l
 X
@@ -443,7 +462,7 @@ H
 W
 k
 T
-e
+C
 e
 "}
 (4,1,1) = {"
@@ -513,7 +532,7 @@ e
 "}
 (9,1,1) = {"
 e
-e
+A
 T
 c
 F
@@ -521,12 +540,12 @@ P
 S
 r
 T
-e
+x
 e
 "}
 (10,1,1) = {"
 e
-e
+T
 T
 s
 o
@@ -534,7 +553,7 @@ T
 s
 s
 T
-e
+T
 e
 "}
 (11,1,1) = {"


### PR DESCRIPTION
## About The Pull Request

This patches some holes in the station_l_crates modular mapping piece

The highlighted areas would render as open space, ventilating the Sunset Saloon virtual domain in the process.

![image](https://github.com/tgstation/tgstation/assets/28870487/ea48ebe9-e0dc-4f02-a8a3-fdbca72d0fc8)

These open areas have been replaced with:

![image](https://github.com/tgstation/tgstation/assets/28870487/a7543b9a-d9cf-4130-bb3f-d94a74bf683b)
## Why It's Good For The Game

Fixes a problem that can ruin your bitrunner gamer sesh.

Closes #80163 
## Changelog
:cl: Rhials
fix: Sunset Saloon virtual domain should no longer sometimes spawn with holes in the floor.
/:cl:
