### PR TITLE
Blackout drunkard warning adjustment

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -293,8 +293,8 @@
 	if(duration_in_seconds <= 0)
 		qdel(src)
 		return
-	else if(duration_in_seconds <= 50)
-		to_chat(owner, span_warning("You have 50 seconds left before sobering up!"))
+	else if(duration_in_seconds <= 60 && !(duration_in_seconds % 20))
+		to_chat(owner, span_warning("You have [duration_in_seconds] seconds left before sobering up!"))
 	if(prob(10) && !HAS_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER))
 		ADD_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
 		owner.balloon_alert(owner, "dexterity reduced temporarily!")


### PR DESCRIPTION

## About The Pull Request

This adjusts the "you have 50 seconds before sobering up!" warning for the blackout-drunkard split personality.

Originally, this message would always send when 50 seconds are left, meaning you'd get a "50 seconds left" warning every second, for the last 50 seconds. 

Now, instead of that, you get a warning starting at the 60 second mark, that updates you every 20 seconds.

So basically, you get a warning at 60, 40, and 20 seconds left instead of every second for the last 50 seconds of drunkenness

Also, I think this is my 200th PR to tgstation. Neat!
## Why It's Good For The Game

Less chat spam while you're trying to make bad choices.
## Changelog
:cl: Rhials
qol: Blackout drunkard personalities will now recieve a "you are about to sober up" warning at the 60/40/20 second mark, instead of repeatedly at the 50 second mark.
/:cl:
