### PR TITLE
Goldgrubs no longer block death bolts, even while alive.

### DIFF
--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -75,7 +75,7 @@
 
 	///high penetration bullets should still go through. No goldgrub can save you from the colossus' death bolts.
 	if(prob(hitting_projectile.armour_penetration))
-		return
+		return NONE
 
 	visible_message(span_danger("[hitting_projectile] is repelled by [source]'s girth!"))
 	return COMPONENT_BULLET_BLOCKED

--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -73,6 +73,10 @@
 	if(stat != CONSCIOUS)
 		return COMPONENT_BULLET_PIERCED
 
+	///high penetration bullets should still go through. No goldgrub can save you from the colossus' death bolts.
+	if(prob(hitting_projectile.armour_penetration))
+		return
+
 	visible_message(span_danger("[hitting_projectile] is repelled by [source]'s girth!"))
 	return COMPONENT_BULLET_BLOCKED
 


### PR DESCRIPTION
## About The Pull Request
Projectiles have a chance to not get blocked by goldgrubs' hide based on their armor penetration, and it so happens that the colossus' death bolts have 100 armor penetration.

## Why It's Good For The Game
This will fix #80181.

## Changelog

:cl:
fix: Goldgrubs no longer block death bolts, even while alive.
/:cl:
