### PR TITLE
medborgs get autopsy scanners

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -664,6 +664,7 @@
 		/obj/item/circular_saw,
 		/obj/item/bonesetter,
 		/obj/item/blood_filter,
+		/obj/item/autopsy_scanner,
 		/obj/item/extinguisher/mini,
 		/obj/item/emergency_bed/silicon,
 		/obj/item/borg/cyborghug/medical,


### PR DESCRIPTION

## About The Pull Request

medborgs get autopsy scanners

## Why It's Good For The Game

them being able to do autopsy is good incase of no coroner and crew being too lazy to just walk and buy an autopsy scanner
and also like investigative medbay shenanigans and stuff

## Changelog
:cl:
add: medical cyborgs have autopsy scanners
/:cl:
