### PR TITLE
SDQL2 Query doesn't automatically bake in `span_admin()`

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -207,7 +207,7 @@
 	var/list/results = world.SDQL2_query(query_text, key_name_admin(usr), "[key_name(usr)]")
 	if(length(results) == 3)
 		for(var/I in 1 to 3)
-			to_chat(usr, results[I], confidential = TRUE)
+			to_chat(usr, span_admin(results[I]), confidential = TRUE)
 	SSblackbox.record_feedback("nested tally", "SDQL query", 1, list(ckey, query_text))
 
 /world/proc/SDQL2_query(query_text, log_entry1, log_entry2, silent = FALSE)
@@ -303,9 +303,11 @@
 	while(!finished)
 
 	var/end_time_total = REALTIMEOFDAY - start_time_total
-	return list(span_admin("SDQL query combined results: [query_text]"),\
-		span_admin("SDQL query completed: [objs_all] objects selected by path, and [selectors_used ? objs_eligible : objs_all] objects executed on after WHERE filtering/MAPping if applicable."),\
-		span_admin("SDQL combined querys took [DisplayTimeText(end_time_total)] to complete.")) + combined_refs
+	return list(
+		"SDQL query combined results: [query_text]",
+		"SDQL query completed: [objs_all] objects selected by path, and [selectors_used ? objs_eligible : objs_all] objects executed on after WHERE filtering/MAPping if applicable.",
+		"SDQL combined querys took [DisplayTimeText(end_time_total)] to complete.",
+	) + combined_refs
 
 GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null, "VIEW VARIABLES (all)", null))


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/34697715/81d1b517-6b69-4303-b389-5c41f0b806c6)

this shit is UGLY to see in Discord, let's not automatically bake in `span_admin()` every time we send this stuff out and only use it in the context where it matters (sending the message results `to_chat()` to an admin who is actually in the game)

## Changelog

irrelevant