### PR TITLE
Fixes `cliented mob with no .loc` spamming HTML junk into TGS Relay

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -23,7 +23,7 @@
 			move_to_error_room()
 			var/msg = " was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
 			message_admins(ADMIN_LOOKUPFLW(src) + msg)
-			send2tgs_adminless_only("Mob", key_name(src) + msg, R_ADMIN)
+			send2tgs_adminless_only("Mob", key_name_and_tag(src) + msg, R_ADMIN)
 			src.log_message("was found to have no .loc with an attached client.", LOG_GAME)
 
 		// This is a temporary error tracker to make sure we've caught everything

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -21,9 +21,9 @@
 		var/turf/T = get_turf(src)
 		if(!T)
 			move_to_error_room()
-			var/msg = "[ADMIN_LOOKUPFLW(src)] was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
-			message_admins(msg)
-			send2tgs_adminless_only("Mob", msg, R_ADMIN)
+			var/msg = " was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
+			message_admins(ADMIN_LOOKUPFLW(src) + msg)
+			send2tgs_adminless_only("Mob", key_name(src) + msg, R_ADMIN)
 			src.log_message("was found to have no .loc with an attached client.", LOG_GAME)
 
 		// This is a temporary error tracker to make sure we've caught everything


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/34697715/a4c67f5c-1682-45c9-b561-8c34bdf21e3c)

this is garbage, let's just send the `key_name_and_tag()` with a descriptive message rather than always flooding in all of our HREF binding span embed stuff

## Changelog

:cl:
server: The TGS -> Discord Relay Warning that detects if a cliented mob has a null loc should now be plaintext instead of being fully screwed up with useless codestuffs.
/:cl:
