### PR TITLE
Experiments done AFTER their tech is researched give full points

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -47,11 +47,6 @@
 	/// Completing these experiments will have a refund.
 	var/list/datum/experiment/skipped_experiment_types = list()
 
-	/// If science researches something without completing its discount experiments,
-	/// they have the option to complete them later for a refund
-	/// This ratio determines how much of the original discount is refunded
-	var/skipped_experiment_refund_ratio = 0.66
-
 	///All RD consoles connected to this individual techweb.
 	var/list/obj/machinery/computer/rdconsole/consoles_accessing = list()
 	///All research servers connected to this individual techweb.
@@ -353,7 +348,7 @@
 	for(var/missed_experiment in node.discount_experiments)
 		if(completed_experiments[missed_experiment] || skipped_experiment_types[missed_experiment])
 			continue
-		skipped_experiment_types[missed_experiment] = node.discount_experiments[missed_experiment] * skipped_experiment_refund_ratio
+		skipped_experiment_types[missed_experiment] = node.discount_experiments[missed_experiment]
 
 	// Gain the experiments from the new node
 	for(var/id in node.unlock_ids)


### PR DESCRIPTION

## About The Pull Request
Doing experisci experiments after their tech is researched gives the full 100% point amount, up from 66%
## Why It's Good For The Game
This encourages actually doing the tedious helpful experiments (like upgrading the chem dispensers, cryo cells, SMES, etc.) that give a low point bonus (1.5K pts, etc.) which helps other players. Also, the scientist doing experiments has zero control over who is researching, they might be just about to finish the 10K pts HyperNob gas shells experiment and a random dude walks in and buys T4 lasers for 15K pts anyway. So now the experiment is worth 3400 pts less for no reason
## Changelog
:cl:
balance: Doing experiments AFTER their tech is researched now gives full 100% points instead of 66%.
/:cl:
