### PR TITLE
[NO GBP] Fixes a mistake with mutation cleanup

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -366,20 +366,22 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 			set_uni_feature_block(blocknumber, construct_block(GLOB.pod_hair_list.Find(features["pod_hair"]), GLOB.pod_hair_list.len))
 
 //Please use add_mutation or activate_mutation instead
-/datum/dna/proc/force_give(datum/mutation/human/HM)
-	if(holder && HM)
-		if(HM.class == MUT_NORMAL)
-			set_se(1, HM)
-		. = HM.on_acquiring(holder)
+/datum/dna/proc/force_give(datum/mutation/human/human_mutation)
+	if(holder && human_mutation)
+		if(human_mutation.class == MUT_NORMAL)
+			set_se(1, human_mutation)
+		. = human_mutation.on_acquiring(holder)
 		if(.)
-			qdel(HM)
+			qdel(human_mutation)
 		update_instability()
 
 //Use remove_mutation instead
-/datum/dna/proc/force_lose(datum/mutation/human/HM)
-	if(holder && (HM in mutations))
-		set_se(0, HM)
-		. = HM.on_losing(holder)
+/datum/dna/proc/force_lose(datum/mutation/human/human_mutation)
+	if(holder && (human_mutation in mutations))
+		set_se(0, human_mutation)
+		. = human_mutation.on_losing(holder)
+		if(!.)
+			qdel(human_mutation) // qdel mutations on removal
 		update_instability(FALSE)
 		return
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -380,8 +380,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(holder && (human_mutation in mutations))
 		set_se(0, human_mutation)
 		. = human_mutation.on_losing(holder)
-		if(!.)
-			qdel(human_mutation) // qdel mutations on removal
+		qdel(human_mutation) // qdel mutations on removal
 		update_instability(FALSE)
 		return
 

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -143,7 +143,6 @@
 		mut_overlay.Remove(get_visual_indicator())
 		owner.overlays_standing[layer_used] = mut_overlay
 		owner.apply_overlay(layer_used)
-	qdel(src)
 
 /mob/living/carbon/proc/update_mutations_overlay()
 	return

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -82,6 +82,7 @@
 	if(owner.health < owner.crit_threshold)
 		on_losing(owner)
 		to_chat(owner, span_danger("You suddenly feel very weak."))
+		qdel(src)
 
 /datum/mutation/human/hulk/on_losing(mob/living/carbon/human/owner)
 	if(..())


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/80199

`on_lose()` tends to call the parent first, where the `qdel(src)` was happening. The issue with that: it returns from the parent call, and now due to being qdeled the `owner` is set to `null`. Certain mutations try to access owner to do various things post-removal, cue the runtimes...

---

I just moved the mutation qdeletion out of the proc and into `force_lose()` instead. There are only two other places where `on_lose()` gets called, one of which is for unstable mutations and it already immediately qdels the mutation afterwards. 

The other is when hulks get put into crit. I added a qdel to the latter. This should ensure that mutations always get deleted after removal (but without breaking anything this time).

Also renamed some abbreviated vars.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/25543

## Why It's Good For The Game

Fixes a bug that I accidentally introduced.

## Changelog

:cl:
fix: fixes a bug which was causing certain mutations to only get partially removed
/:cl: