### PR TITLE
Atmos wrench act & small typo fix

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -28,7 +28,7 @@
 /// Return when an item interaction is successful.
 /// This cancels the rest of the chain entirely and indicates success.
 #define ITEM_INTERACT_SUCCESS (1<<0) // Same as TRUE, as most tool (legacy) tool acts return TRUE on success
-/// Return to prevent the rest of the attacck chain from being executed / preventing the item user from thwacking the target.
+/// Return to prevent the rest of the attack chain from being executed / preventing the item user from thwacking the target.
 /// Similar to [ITEM_INTERACT_SUCCESS], but does not necessarily indicate success.
 #define ITEM_INTERACT_BLOCKING (1<<1)
 /// Return to skip the rest of the interaction chain, going straight to attack.

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -382,7 +382,7 @@
 
 /obj/machinery/atmospherics/wrench_act(mob/living/user, obj/item/I)
 	if(!can_unwrench(user))
-		return ..()
+		return ITEM_INTERACT_BLOCKING
 
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
@@ -396,11 +396,11 @@
 		var/empty_mixes = 0
 		for(var/gas_mix_number in 1 to device_type)
 			var/datum/gas_mixture/gas_mix = all_gas_mixes[gas_mix_number]
-			if(!(gas_mix.total_moles() > 0))
+			if(!gas_mix.total_moles())
 				empty_mixes++
 		if(empty_mixes == device_type)
 			empty_pipe = TRUE
-	if(!(int_air.total_moles() > 0))
+	if(!int_air.total_moles())
 		empty_pipe = TRUE
 
 	if(!empty_pipe)
@@ -410,8 +410,7 @@
 		to_chat(user, span_warning("As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?"))
 		unsafe_wrenching = TRUE //Oh dear oh dear
 
-	var/time_taken = empty_pipe ? 0 : 20
-	if(I.use_tool(src, user, time_taken, volume = 50))
+	if(I.use_tool(src, user, empty_pipe ? 0 : 20, volume = 50))
 		user.visible_message( \
 			"[user] unfastens \the [src].", \
 			span_notice("You unfasten \the [src]."), \
@@ -421,9 +420,10 @@
 		//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
 		if(unsafe_wrenching)
 			unsafe_pressure_release(user, internal_pressure)
-		return deconstruct(TRUE)
+		deconstruct(TRUE)
+		return ITEM_INTERACT_SUCCESS
 
-	return ..()
+	return ITEM_INTERACT_BLOCKING
 
 /**
  * Getter for can_unwrench

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -410,7 +410,7 @@
 		to_chat(user, span_warning("As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?"))
 		unsafe_wrenching = TRUE //Oh dear oh dear
 
-	if(I.use_tool(src, user, empty_pipe ? 0 : 20, volume = 50))
+	if(I.use_tool(src, user, empty_pipe ? 0 : 2 SECONDS, volume = 50))
 		user.visible_message( \
 			"[user] unfastens \the [src].", \
 			span_notice("You unfasten \the [src]."), \


### PR DESCRIPTION
## About The Pull Request
Fixes this, when you unwrench any atmos component
![Screenshot (366)](https://github.com/tgstation/tgstation/assets/110812394/63436280-78ce-4c3d-8ef8-4aeb2feec775)

Because `deconstruct()` returns the component that was unwrenched which is not a valid attack result. We have to explicitly state what our result is. The parent proc wrench act does nothing so no point calling it

Also fixes small typo in attack define comment

## Changelog
:cl:
fix: no runtime when unwrenching Atmos components
spellcheck: fixed typo in attack chain define comment
/:cl: