### PR TITLE
Adds a smaller size targeting strategy, makes crabs use them

### DIFF
--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -126,6 +126,10 @@
 	find_smaller = FALSE
 	inclusive = FALSE
 
+
+/datum/targeting_strategy/basic/of_size/smaller
+	inclusive = FALSE
+
 /// Makes the mob only attack their own faction. Useful mostly if their attacks do something helpful (e.g. healing touch).
 /datum/targeting_strategy/basic/same_faction
 

--- a/code/modules/mob/living/basic/vermin/crab.dm
+++ b/code/modules/mob/living/basic/vermin/crab.dm
@@ -78,7 +78,7 @@
 /datum/ai_controller/basic_controller/crab
 	blackboard = list(
 		BB_ALWAYS_IGNORE_FACTION = TRUE,
-		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/of_size/ours_or_smaller,
+		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/of_size/smaller,
 		BB_FLEE_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 	)
 


### PR DESCRIPTION
## About The Pull Request

The PR that added crabs said crabs are now small creatures, and will hunt tiny creatures. However, their targeting strategy was `our_our_smaller`, so a group of crabs ended up eating each other. This PR creates a new targeting strategy, and applies it to the crab AI.

## Why It's Good For The Game

Puts an end to crabbibalism.

## Changelog

:cl:
fix: Crabs will properly only target Tiny creatures
/:cl:

