### PR TITLE
Allows creating new areas on the tram asteroid and surrounding mini-asteroids

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -86,6 +86,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 	// Ignore these areas and dont let people expand them. They can expand into them though
 	var/static/list/blacklisted_areas = typecacheof(list(
 		/area/space,
+		/area/station/asteroid,
 		))
 
 	var/error = ""

--- a/code/game/area/areas/station/misc.dm
+++ b/code/game/area/areas/station/misc.dm
@@ -31,3 +31,4 @@
 	requires_power = TRUE
 	ambience_index = AMBIENCE_MINING
 	area_flags = UNIQUE_AREA
+	outdoors = TRUE


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin.

## Why It's Good For The Game

Allows people to expand rooms into the asteroid, or create new rooms within it.

## Changelog

:cl:
qol: The asteroid on Tramstation can now have areas expanded into or created within.
/:cl:
