### PR TITLE
Mimes get a positive mood instead for having a vow active

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -2,10 +2,6 @@
 	description = "I guess my antics have finally caught up with me."
 	mood_change = -1
 
-/datum/mood_event/broken_vow //Used for when mimes break their vow of silence
-	description = "I have brought shame upon my name, and betrayed my fellow mimes by breaking our sacred vow..."
-	mood_change = -8
-
 /datum/mood_event/on_fire
 	description = "I'M ON FIRE!!!"
 	mood_change = -12

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -134,6 +134,10 @@
 	description = "I love showing off my mime pin!"
 	mood_change = 1
 
+/datum/mood_event/mime_vow //has an active vow of silence
+	description = "I've mastered the arts of speaking without language."
+	mood_change = 2
+
 /datum/mood_event/goodmusic
 	description = "There is something soothing about this music."
 	mood_change = 3

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -13,7 +13,7 @@
 
 	spell_max_level = 1
 
-/datum/action/cooldown/spell/vow_of_silence/Grant(mob/grant_to)
+/datum/action/cooldown/spell/vow_of_silence/Grant(mob/living/grant_to)
 	. = ..()
 	ADD_TRAIT(grant_to, TRAIT_MIMING, "[type]")
 	grant_to.add_mood_event("vow", /datum/mood_event/mime_vow)

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -27,11 +27,9 @@
 	if(HAS_TRAIT_FROM(cast_on, TRAIT_MIMING, "[type]"))
 		to_chat(cast_on, span_notice("You break your vow of silence."))
 		cast_on.log_message("broke [cast_on.p_their()] vow of silence.", LOG_GAME)
-		cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
 		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
 	else
 		to_chat(cast_on, span_notice("You make a vow of silence."))
 		cast_on.log_message("made a vow of silence.", LOG_GAME)
-		cast_on.clear_mood_event("vow")
 		ADD_TRAIT(cast_on, TRAIT_MIMING, "[type]")
 	cast_on.update_mob_action_buttons()

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -16,6 +16,7 @@
 /datum/action/cooldown/spell/vow_of_silence/Grant(mob/grant_to)
 	. = ..()
 	ADD_TRAIT(grant_to, TRAIT_MIMING, "[type]")
+	grant_to.add_mood_event("vow", /datum/mood_event/mime_vow)
 
 /datum/action/cooldown/spell/vow_of_silence/Remove(mob/living/remove_from)
 	. = ..()
@@ -28,8 +29,10 @@
 		to_chat(cast_on, span_notice("You break your vow of silence."))
 		cast_on.log_message("broke [cast_on.p_their()] vow of silence.", LOG_GAME)
 		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
+		cast_on.clear_mood_event("vow")
 	else
 		to_chat(cast_on, span_notice("You make a vow of silence."))
 		cast_on.log_message("made a vow of silence.", LOG_GAME)
 		ADD_TRAIT(cast_on, TRAIT_MIMING, "[type]")
+		cast_on.add_mood_event("vow", /datum/mood_event/mime_vow)
 	cast_on.update_mob_action_buttons()


### PR DESCRIPTION
## About The Pull Request

Removes the -8 mood penalty given to mimes for breaking their vow.

This mood penalty was actually a common talking point against my previous Mime PR https://github.com/tgstation/tgstation/pull/74674 and my response was to just remove the mood effect, but no one ended up doing it.
I did get a kneejerk revert PR within 48 hours though, that was cool i guess.

## Why It's Good For The Game

Mimes are a job like every other one on the station, and they should not be punished for taking breaks from it.
It is fine for mimes to break their vow when they need to use text/writing/spells?, it's a sandbox and this is such a weird way to try to limit players. They should want to keep their vow because it's their job not to, not because they will be slow as mods until they can remake it.

Comments argued it should give a positive moodlet so I added that. It's a +2 instead of Clown's +5 because they get spells out of it which is way better than turning yourself into a crawling soap I think.

## Changelog

:cl:
balance: Mimes get a positive moodlet for having an active vow of silence instead of a negative mood effect for breaking it.
/:cl: