### PR TITLE
[NO GBP] fixes oversight on chemical cure chances for advanced viruses

### DIFF
--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -105,6 +105,10 @@ DEFINE_BITFIELD(spread_flags, list(
 //// Set to maximum # of cycles you want to be able to offset symptoms. Scales down linearly over time.
 #define DISEASE_SYMPTOM_OFFSET_DURATION 100
 
-///Symptom Frequency Modifier
+/// Symptom Frequency Modifier
 //// Raise to make symptoms fire less frequently, lower to make them fire more frequently. Keep at 0 or above.
 #define DISEASE_SYMPTOM_FREQUENCY_MODIFIER 1
+
+/// Minimum Chemical Cure Chance
+//// Minimum per-cycle chance we want of being able to cure an advanced disease with the chemicals present.
+#define DISEASE_MINIMUM_CHEMICAL_CURE_CHANCE 5

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -78,6 +78,7 @@
 /datum/disease/proc/stage_act(seconds_per_tick, times_fired)
 	var/slowdown = HAS_TRAIT(affected_mob, TRAIT_VIRUS_RESISTANCE) ? 0.5 : 1 // spaceacillin slows stage speed by 50%
 	var/recovery_prob = 0
+	var/cure_mod
 
 	if(required_organ)
 		if(!has_required_infectious_organ(affected_mob, required_organ))
@@ -85,13 +86,16 @@
 			return FALSE
 
 	if(has_cure())
-		if(disease_flags & CHRONIC && SPT_PROB(cure_chance, seconds_per_tick))
+		cure_mod = cure_chance
+		if(istype(src, /datum/disease/advance))
+			cure_mod = max(cure_chance, DISEASE_MINIMUM_CHEMICAL_CURE_CHANCE)
+		if(disease_flags & CHRONIC && SPT_PROB(cure_mod, seconds_per_tick))
 			update_stage(1)
 			to_chat(affected_mob, span_notice("Your chronic illness is alleviated a little, though it can't be cured!"))
 			return
-		if(SPT_PROB(cure_chance, seconds_per_tick))
+		if(SPT_PROB(cure_mod, seconds_per_tick))
 			update_stage(max(stage - 1, 1))
-		if(disease_flags & CURABLE && SPT_PROB(cure_chance, seconds_per_tick))
+		if(disease_flags & CURABLE && SPT_PROB(cure_mod, seconds_per_tick))
 			cure()
 			return FALSE
 


### PR DESCRIPTION
## About The Pull Request

fixes an oversight from when I lowered the floor on cure_chance to work with the #79854 changes - unintentionally made chemical cures on high-resistance viruses less effective than they used to be.

This just adds a define and reintroduces the old floor of 5% per cycle with the chemical cure present.

## Why It's Good For The Game

fix good - I'd considered just multiplying cure chances up for advanced diseases, but that would arguably be a balance change. this just restores the old behavior 

demonstration of what it was before (desired behavior)
![image](https://github.com/tgstation/tgstation/assets/3894717/7d7eb79d-fca9-4480-b756-9b322583456f)

and what it is now (thing we are trying to fix)
![image](https://github.com/tgstation/tgstation/assets/3894717/7fc1be36-3593-4e66-93fb-143513ebebe0)

chems should be fast

## Changelog

:cl:
fix: Chemicals are now no longer less effective at curing advanced viruses than they used to be.
/:cl: