### PR TITLE
Irish Car Bomb Kills Everyone In The Clown Car Again

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -72,8 +72,9 @@
 				addtimer(CALLBACK(src, PROC_REF(irish_car_bomb)), 5 SECONDS)
 
 /obj/vehicle/sealed/car/clowncar/proc/irish_car_bomb()
-	dump_mobs()
-	explosion(src, light_impact_range = 1)
+	dump_mobs(randomstep = FALSE)
+	//Die
+	explosion(src, devastation_range = 1)
 
 /obj/vehicle/sealed/car/clowncar/after_add_occupant(mob/M, control_flags)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

As it currently stands, having 30 units of Irish Car Bomb in your system and getting caught by a clown car frees everyone in the clown car and does a small light explosion. This makes it very safe for non-antags to make and drink in order to stop a clown car, as the driver will also get ejected and this usually results the clown being easily killed before he can get back into the car, making Irish Car Bomb an extremely easy counter for a 20 TC traitor item. This PR makes the Irish Car Bomb eject everyone onto the tile of the clown car. and then causes a devastating explosion on just that tile which gibs everyone and destroys their items. This results in a single destroyed floor tile and a bunch of organs, which does include brains if you're inclined to try and save the victims.

## Why It's Good For The Game

The Irish Car Bomb isn't hard to make and shouldn't be a hard counter to the 20 TC clown car, as its current effect is a very boring shutdown to a fun traitor item. Now, this interaction is essentially for other antagonists to capitalize on the clown's chaos and ideally kill as many people as possible. The extremely small range of the explosion ensures little structural damage is done when this is performed as well.

## Changelog
🆑
balance: Irish Car Bomb's effects when getting caught inside a clown car now kills everyone inside the car with a deadly explosion which does very little collateral damage.
/:cl: