### PR TITLE
Removes The Irish Car Bomb Clown Car Reaction

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -60,20 +60,6 @@
 /obj/vehicle/sealed/car/clowncar/mob_forced_enter(mob/M, silent = FALSE)
 	. = ..()
 	playsound(src, pick('sound/vehicles/clowncar_load1.ogg', 'sound/vehicles/clowncar_load2.ogg'), 75)
-	if(iscarbon(M))
-		var/mob/living/carbon/forced_mob = M
-		if(forced_mob.has_reagent(/datum/reagent/consumable/ethanol/irishcarbomb))
-			var/reagent_amount = forced_mob.reagents.get_reagent_amount(/datum/reagent/consumable/ethanol/irishcarbomb)
-			forced_mob.reagents.del_reagent(/datum/reagent/consumable/ethanol/irishcarbomb)
-			if(reagent_amount >= 30)
-				message_admins("[ADMIN_LOOKUPFLW(forced_mob)] was forced into a clown car with [reagent_amount] unit(s) of Irish Car Bomb, causing an explosion.")
-				forced_mob.log_message("was forced into a clown car with [reagent_amount] unit(s) of Irish Car Bomb, causing an explosion.", LOG_GAME)
-				audible_message(span_userdanger("You hear a rattling sound coming from the engine. That can't be good..."), null, 1)
-				addtimer(CALLBACK(src, PROC_REF(irish_car_bomb)), 5 SECONDS)
-
-/obj/vehicle/sealed/car/clowncar/proc/irish_car_bomb()
-	dump_mobs()
-	explosion(src, light_impact_range = 1)
 
 /obj/vehicle/sealed/car/clowncar/after_add_occupant(mob/M, control_flags)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

 it currently stands, having 30 units of Irish Car Bomb in your system and getting caught by a clown car frees everyone in the clown car and does a small light explosion. This makes it very safe for non-antags to make and drink in order to stop a clown car, as the driver will also get ejected and this usually results the clown being easily killed before he can get back into the car, making Irish Car Bomb an extremely easy counter for a 20 TC traitor item. This PR removes that.

## Why It's Good For The Game

The Irish Car Bomb isn't hard to make and shouldn't be a hard counter to the 20 TC clown car, as its current effect is a very boring shutdown to a fun traitor item. 

## Changelog

:cl:
del: The Irish Car Bomb's reaction when kidnapped by a clown car has been removed.
/:cl:
