### PR TITLE
Fixes text inputs[NO GBP]

### DIFF
--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -35,7 +35,8 @@ export const TextInputModal = (props) => {
     timeout,
     title,
   } = data;
-  const [input, setInput] = useState(placeholder);
+
+  const [input, setInput] = useState(placeholder || '');
   const onType = (value: string) => {
     if (value === input) {
       return;
@@ -92,7 +93,10 @@ export const TextInputModal = (props) => {
 };
 
 /** Gets the user input and invalidates if there's a constraint. */
-const InputArea = (props) => {
+const InputArea = (props: {
+  input: string;
+  onType: (value: string) => void;
+}) => {
   const { act, data } = useBackend<TextInputData>();
   const { max_length, multiline } = data;
   const { input, onType } = props;


### PR DESCRIPTION
## About The Pull Request
Cult chat was bluescreening. Seems we can't set a default for `placeholder` then use it as the initial state. I added a safety net for it.
## Why It's Good For The Game
Fixes cult chat & possibly an issue not opened yet.
## Changelog
:cl:
fix: Cult chat, PDAs, succumbing, etc shouldn't blue screen anymore.
/:cl:
