### PR TITLE
Fixes newscasters

### DIFF
--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -603,10 +603,9 @@ const NewscasterChannelMessages = (props) => {
                   the station and therefore marked with a <b>D-Notice</b>.
                 </Section>
               ) : (
-                <Section
-                  dangerouslySetInnerHTML={processedText(message.body)}
-                  pl={1}
-                />
+                <Section pl={1}>
+                  <Box dangerouslySetInnerHTML={processedText(message.body)} />
+                </Section>
               )}
               {message.photo !== null && !message.censored_message && (
                 <Box as="img" src={message.photo} />
@@ -618,10 +617,11 @@ const NewscasterChannelMessages = (props) => {
                       <Box italic textColor="white">
                         By: {comment.auth} at {comment.time}
                       </Box>
-                      <Section
-                        dangerouslySetInnerHTML={processedText(comment.body)}
-                        ml={2.5}
-                      />
+                      <Section ml={2.5}>
+                        <Box
+                          dangerouslySetInnerHTML={processedText(comment.body)}
+                        />
+                      </Section>
                     </BlockQuote>
                   ))}
                 </Box>


### PR DESCRIPTION

## About The Pull Request
Box hierarchy is pretty complex, so when setting `dangerouslysetInnerHTML` on things like Section, React will throw the error:

> `Can only set one of 'children' or 'props.dangerouslySetInnerHTML'.`

We need to ensure it's just called on `Box`.
## Why It's Good For The Game
Bug fix
Fixes #80209
## Changelog
:cl:
fix: Newscaster shouldn't bluescreen anymore.
/:cl:
