### PR TITLE
Fixes zombie tumor

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -25,8 +25,7 @@
 
 /obj/item/organ/internal/zombie_infection/on_mob_insert(mob/living/carbon/M, special = FALSE, movement_flags)
 	. = ..()
-	if(!.)
-		return .
+
 	START_PROCESSING(SSobj, src)
 
 /obj/item/organ/internal/zombie_infection/on_mob_remove(mob/living/carbon/M, special = FALSE)


### PR DESCRIPTION
There is no return value, this always breaks

fixes #80248

:cl:
fix: fixes zombie tumor not reviving
/:cl: