### PR TITLE
Increase TGUI connection lost threshold

### DIFF
--- a/tgui/packages/tgui-panel/game/constants.ts
+++ b/tgui/packages/tgui-panel/game/constants.ts
@@ -4,4 +4,4 @@
  * @license MIT
  */
 
-export const CONNECTION_LOST_AFTER = 35000;
+export const CONNECTION_LOST_AFTER = 45000;

--- a/tgui/packages/tgui-panel/game/constants.ts
+++ b/tgui/packages/tgui-panel/game/constants.ts
@@ -4,4 +4,4 @@
  * @license MIT
  */
 
-export const CONNECTION_LOST_AFTER = 20000;
+export const CONNECTION_LOST_AFTER = 35000;


### PR DESCRIPTION
## About The Pull Request

Increases the TGUI connection lost timeout before the manual reconnect button is required.

## Why It's Good For The Game

The server takes more than 20 seconds to reboot and start allowing connections for a new round. By increasing the duration TGUI will try to automatically reconnect, players will more consistently actually reconnect to the new round without intervention.

More
![image](https://github.com/tgstation/tgstation/assets/83487515/a9a8bebb-812c-4774-ac06-d5344994f630)

Less
![image](https://github.com/tgstation/tgstation/assets/83487515/f9df84c8-1608-4533-98de-5f8e5c390ad0)


## Changelog

:cl: LT3
qol: TGUI will now wait longer trying to reconnect to a new round
/:cl: