### PR TITLE
Gives bitrunners access to the Northstar Cargo ORM

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -86652,11 +86652,10 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mail Sorting"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/storage)
 "wEQ" = (


### PR DESCRIPTION

## About The Pull Request
Changes the access to the shipping room that contains the ORM to general so bitrunners can access it
## Why It's Good For The Game
Fixes a problem that prevents bitrunners from getting to the ORM
## Changelog
:cl:
fix: Bitrunners can now access the Northstar ORM
:cl: 
