### PR TITLE
Scarves and Wallets station traits are now neutral.

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -361,7 +361,7 @@
 	for(var/obj/item/item as anything in living_mob.get_equipped_items(include_accessories = TRUE))
 		if(living_mob.is_holding(item)) //We don't care of held items.
 			continue
-		item.add_atom_colour(get_new_color(), WASHABLE_COLOUR_PRIORITY)
+		item.add_atom_colour(get_new_color(), FIXED_COLOUR_PRIORITY)
 		slot_flags_to_update |= item.slot_flags
 	living_mob.update_clothing(slot_flags_to_update)
 
@@ -369,23 +369,23 @@
 	SHOULD_CALL_PARENT(FALSE)
 
 /datum/station_trait/outfit_color/rotated
-	weight = 1
+	weight = 2
 	report_message = "So ugh, before the shift we tried a new experimental slime jelly and plasma-infused laundry capsule, and..."
-	var/rotation = 120
+	var/rotation = 70
+
+/datum/station_trait/outfit_color/rotated/New()
+	. = ..()
+	rotation = pick(70, 290)
 
 /datum/station_trait/outfit_color/rotated/get_new_color()
 	return color_matrix_rotate_hue(rotation)
 
 /datum/station_trait/outfit_color/random
-	weight = 1
-	report_message = "So ugh, a clown pulled a prank on us and dyed your outfits of random colors at the last minute..."
+	weight = 2
+	report_message = "So ugh, before the shift some clown dumped a bunch of dyes into the laundry, and..."
 
 /datum/station_trait/outfit_color/random/get_new_color()
 	return RANDOM_COLOUR
-
-/datum/station_trait/outfit_color/rotated/New()
-	. = ..()
-	rotation = pick(120, 240)
 
 /// Tells the area map generator to ADD MORE TREEEES
 /datum/station_trait/forested

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -361,12 +361,19 @@
 	for(var/obj/item/item as anything in living_mob.get_equipped_items(include_accessories = TRUE))
 		if(living_mob.is_holding(item)) //We don't care of held items.
 			continue
-		item.add_atom_colour(get_new_color(), FIXED_COLOUR_PRIORITY)
+		get_new_color(item)
 		slot_flags_to_update |= item.slot_flags
 	living_mob.update_clothing(slot_flags_to_update)
 
-/datum/station_trait/outfit_color/proc/get_new_color()
+/datum/station_trait/outfit_color/proc/get_new_color(obj/item/item)
 	SHOULD_CALL_PARENT(FALSE)
+
+/datum/station_trait/outfit_color/random
+	weight = 3
+	report_message = "So ugh, before the shift we had a security breach in the laundry. It was a clown carrying lots of spraycans..."
+
+/datum/station_trait/outfit_color/random/get_new_color(obj/item/item)
+	item.add_atom_colour(RANDOM_COLOUR, WASHABLE_COLOUR_PRIORITY)
 
 /datum/station_trait/outfit_color/rotated
 	weight = 2
@@ -375,17 +382,10 @@
 
 /datum/station_trait/outfit_color/rotated/New()
 	. = ..()
-	rotation = pick(70, 290)
+	rotation = pick(75, 285)
 
-/datum/station_trait/outfit_color/rotated/get_new_color()
-	return color_matrix_rotate_hue(rotation)
-
-/datum/station_trait/outfit_color/random
-	weight = 2
-	report_message = "So ugh, before the shift some clown dumped a bunch of dyes into the laundry, and..."
-
-/datum/station_trait/outfit_color/random/get_new_color()
-	return RANDOM_COLOUR
+/datum/station_trait/outfit_color/rotated/get_new_color(obj/item/item)
+	item.add_atom_colour(color_matrix_rotate_hue(rotation), FIXED_COLOUR_PRIORITY)
 
 /// Tells the area map generator to ADD MORE TREEEES
 /datum/station_trait/forested

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -272,6 +272,121 @@
 	greyscale_config = /datum/greyscale_config/festive_hat
 	greyscale_config_worn = /datum/greyscale_config/festive_hat/worn
 
+/datum/station_trait/scarves
+	name = "Scarves"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 10
+	show_in_report = TRUE
+	var/list/scarves
+
+/datum/station_trait/scarves/New()
+	. = ..()
+	report_message = pick(
+		"Nanotrasen is experimenting with seeing if neck warmth improves employee morale.",
+		"After Space Fashion Week, scarves are the hot new accessory.",
+		"Everyone was simultaneously a little bit cold when they packed to go to the station.",
+		"The station is definitely not under attack by neck grappling aliens masquerading as wool. Definitely not.",
+		"You all get free scarves. Don't ask why.",
+		"A shipment of scarves was delivered to the station.",
+	)
+	scarves = typesof(/obj/item/clothing/neck/scarf) + list(
+		/obj/item/clothing/neck/large_scarf/red,
+		/obj/item/clothing/neck/large_scarf/green,
+		/obj/item/clothing/neck/large_scarf/blue,
+	)
+
+	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
+
+
+/datum/station_trait/scarves/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
+	SIGNAL_HANDLER
+	var/scarf_type = pick(scarves)
+
+	spawned.equip_to_slot_or_del(new scarf_type(spawned), ITEM_SLOT_NECK, initial = FALSE)
+
+/datum/station_trait/wallets
+	name = "Wallets!"
+	trait_type = STATION_TRAIT_NEUTRAL
+	show_in_report = TRUE
+	weight = 10
+	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
+
+/datum/station_trait/wallets/New()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
+
+/datum/station_trait/wallets/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/M, joined_late)
+	SIGNAL_HANDLER
+
+	var/obj/item/card/id/advanced/id_card = living_mob.get_item_by_slot(ITEM_SLOT_ID)
+	if(!istype(id_card))
+		return
+
+	living_mob.temporarilyRemoveItemFromInventory(id_card, force=TRUE)
+
+	// "Doc, what's wrong with me?"
+	var/obj/item/storage/wallet/wallet = new(src)
+	// "You've got a wallet embedded in your chest."
+	wallet.add_fingerprint(living_mob, ignoregloves = TRUE)
+
+	living_mob.equip_to_slot_if_possible(wallet, ITEM_SLOT_ID, initial=TRUE)
+
+	id_card.forceMove(wallet)
+
+	var/holochip_amount = id_card.registered_account.account_balance
+	new /obj/item/holochip(wallet, holochip_amount)
+	id_card.registered_account.adjust_money(-holochip_amount, "System: Withdrawal")
+
+	new /obj/effect/spawner/random/entertainment/wallet_storage(wallet)
+
+	// Put our filthy fingerprints all over the contents
+	for(var/obj/item/item in wallet)
+		item.add_fingerprint(living_mob, ignoregloves = TRUE)
+
+/datum/station_trait/outfit_color
+	name = "Laundry Disaster"
+	trait_type = STATION_TRAIT_NEUTRAL
+	abstract_type = /datum/station_trait/outfit_color
+	show_in_report = TRUE
+	report_message = "So, we ended up doing something astract and unspecified with the corporate laundry."
+
+/datum/station_trait/outfit_color/New()
+	. = ..()
+	blacklist = typesof(/datum/station_trait/outfit_color) - type
+	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
+
+/datum/station_trait/outfit_color/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/M, joined_late)
+	SIGNAL_HANDLER
+	var/slot_flags_to_update = NONE
+	for(var/obj/item/item as anything in living_mob.get_equipped_items(include_accessories = TRUE))
+		if(living_mob.is_holding(item)) //We don't care of held items.
+			continue
+		item.add_atom_colour(get_new_color(), WASHABLE_COLOUR_PRIORITY)
+		slot_flags_to_update |= item.slot_flags
+	living_mob.update_clothing(slot_flags_to_update)
+
+/datum/station_trait/outfit_color/proc/get_new_color()
+	SHOULD_CALL_PARENT(FALSE)
+
+/datum/station_trait/outfit_color/rotated
+	weight = 1
+	report_message = "So ugh, before the shift we tried a new experimental slime jelly and plasma-infused laundry capsule, and..."
+	var/rotation = 120
+
+/datum/station_trait/outfit_color/rotated/get_new_color()
+	return color_matrix_rotate_hue(rotation)
+
+/datum/station_trait/outfit_color/random
+	weight = 1
+	report_message = "So ugh, a clown pulled a prank on us and dyed your outfits of random colors at the last minute..."
+
+/datum/station_trait/outfit_color/random/get_new_color()
+	return RANDOM_COLOUR
+
+/datum/station_trait/outfit_color/rotated/New()
+	. = ..()
+	rotation = pick(120, 240)
+
 /// Tells the area map generator to ADD MORE TREEEES
 /datum/station_trait/forested
 	name = "Forested"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -343,50 +343,6 @@
 	for(var/obj/item/item in wallet)
 		item.add_fingerprint(living_mob, ignoregloves = TRUE)
 
-/datum/station_trait/outfit_color
-	name = "Laundry Disaster"
-	trait_type = STATION_TRAIT_NEUTRAL
-	abstract_type = /datum/station_trait/outfit_color
-	show_in_report = TRUE
-	report_message = "So, we ended up doing something astract and unspecified with the corporate laundry."
-
-/datum/station_trait/outfit_color/New()
-	. = ..()
-	blacklist = typesof(/datum/station_trait/outfit_color) - type
-	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-
-/datum/station_trait/outfit_color/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/M, joined_late)
-	SIGNAL_HANDLER
-	var/slot_flags_to_update = NONE
-	for(var/obj/item/item as anything in living_mob.get_equipped_items(include_accessories = TRUE))
-		if(living_mob.is_holding(item)) //We don't care of held items.
-			continue
-		get_new_color(item)
-		slot_flags_to_update |= item.slot_flags
-	living_mob.update_clothing(slot_flags_to_update)
-
-/datum/station_trait/outfit_color/proc/get_new_color(obj/item/item)
-	SHOULD_CALL_PARENT(FALSE)
-
-/datum/station_trait/outfit_color/random
-	weight = 3
-	report_message = "So ugh, before the shift we had a security breach in the laundry. It was a clown carrying lots of spraycans..."
-
-/datum/station_trait/outfit_color/random/get_new_color(obj/item/item)
-	item.add_atom_colour(RANDOM_COLOUR, WASHABLE_COLOUR_PRIORITY)
-
-/datum/station_trait/outfit_color/rotated
-	weight = 2
-	report_message = "So ugh, before the shift we tried a new experimental slime jelly and plasma-infused laundry capsule, and..."
-	var/rotation = 70
-
-/datum/station_trait/outfit_color/rotated/New()
-	. = ..()
-	rotation = pick(75, 285)
-
-/datum/station_trait/outfit_color/rotated/get_new_color(obj/item/item)
-	item.add_atom_colour(color_matrix_rotate_hue(rotation), FIXED_COLOUR_PRIORITY)
-
 /// Tells the area map generator to ADD MORE TREEEES
 /datum/station_trait/forested
 	name = "Forested"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -382,6 +382,7 @@
 
 /datum/station_trait/outfit_color/rotated/New()
 	. = ..()
+	// A full 120/240 rotation would look bad in terms of contrast, since the RGB colorspace is kinda flawed.
 	rotation = pick(75, 285)
 
 /datum/station_trait/outfit_color/rotated/get_new_color(obj/item/item)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -72,39 +72,6 @@
 /datum/station_trait/strong_supply_lines/on_round_start()
 	SSeconomy.pack_price_modifier *= 0.8
 
-/datum/station_trait/scarves
-	name = "Scarves"
-	trait_type = STATION_TRAIT_POSITIVE
-	weight = 5
-	show_in_report = TRUE
-	var/list/scarves
-
-/datum/station_trait/scarves/New()
-	. = ..()
-	report_message = pick(
-		"Nanotrasen is experimenting with seeing if neck warmth improves employee morale.",
-		"After Space Fashion Week, scarves are the hot new accessory.",
-		"Everyone was simultaneously a little bit cold when they packed to go to the station.",
-		"The station is definitely not under attack by neck grappling aliens masquerading as wool. Definitely not.",
-		"You all get free scarves. Don't ask why.",
-		"A shipment of scarves was delivered to the station.",
-	)
-	scarves = typesof(/obj/item/clothing/neck/scarf) + list(
-		/obj/item/clothing/neck/large_scarf/red,
-		/obj/item/clothing/neck/large_scarf/green,
-		/obj/item/clothing/neck/large_scarf/blue,
-	)
-
-	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-
-
-/datum/station_trait/scarves/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
-	SIGNAL_HANDLER
-	var/scarf_type = pick(scarves)
-
-	spawned.equip_to_slot_or_del(new scarf_type(spawned), ITEM_SLOT_NECK, initial = FALSE)
-
-
 /datum/station_trait/filled_maint
 	name = "Filled up maintenance"
 	trait_type = STATION_TRAIT_POSITIVE
@@ -223,46 +190,6 @@
 	var/obj/item/implant/deathrattle/implant_to_give = new()
 	deathrattle_group.register(implant_to_give)
 	implant_to_give.implant(spawned, spawned, TRUE, TRUE)
-
-
-/datum/station_trait/wallets
-	name = "Wallets!"
-	trait_type = STATION_TRAIT_POSITIVE
-	show_in_report = TRUE
-	weight = 10
-	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
-
-/datum/station_trait/wallets/New()
-	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-
-/datum/station_trait/wallets/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/M, joined_late)
-	SIGNAL_HANDLER
-
-	var/obj/item/card/id/advanced/id_card = living_mob.get_item_by_slot(ITEM_SLOT_ID)
-	if(!istype(id_card))
-		return
-
-	living_mob.temporarilyRemoveItemFromInventory(id_card, force=TRUE)
-
-	// "Doc, what's wrong with me?"
-	var/obj/item/storage/wallet/wallet = new(src)
-	// "You've got a wallet embedded in your chest."
-	wallet.add_fingerprint(living_mob, ignoregloves = TRUE)
-
-	living_mob.equip_to_slot_if_possible(wallet, ITEM_SLOT_ID, initial=TRUE)
-
-	id_card.forceMove(wallet)
-
-	var/holochip_amount = id_card.registered_account.account_balance
-	new /obj/item/holochip(wallet, holochip_amount)
-	id_card.registered_account.adjust_money(-holochip_amount, "System: Withdrawal")
-
-	new /obj/effect/spawner/random/entertainment/wallet_storage(wallet)
-
-	// Put our filthy fingerprints all over the contents
-	for(var/obj/item/item in wallet)
-		item.add_fingerprint(living_mob, ignoregloves = TRUE)
 
 /datum/station_trait/cybernetic_revolution
 	name = "Cybernetic Revolution"


### PR DESCRIPTION
## About The Pull Request
"Scarves" and "Wallets!" are now neutral traits. They never felt that positive tbh.

This PR also adds two station traits of similar types. EDIT: That's no longer the case, Oranges has told me they take away the importance of color identity of different departments and that they may confuse new players a tad much.

## Why It's Good For The Game
As I said before, "Scarves" and "Wallets!" ain't really that positive.

## Changelog

:cl:
balance: "Scarves" and "Wallets!" are now neutral traits.
/:cl:
