### PR TITLE
Delamination variants are now locked in after the countdown is reached

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -318,7 +318,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	damage_factors = calculate_damage()
 	if(damage == 0) // Clear any in game forced delams if on full health.
 		set_delam(SM_DELAM_PRIO_IN_GAME, SM_DELAM_STRATEGY_PURGE)
-	else
+	else if(damage <= explosion_point)
 		set_delam(SM_DELAM_PRIO_NONE, SM_DELAM_STRATEGY_PURGE) // This one cant clear any forced delams.
 	delamination_strategy.delam_progress(src)
 	if(damage > explosion_point && !final_countdown)


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.
## Why It's Good For The Game

This effectively changes one and only one thing: 

The "All Within Theoretical Limits" achievement is easier/fairer to get with this. Previously, if you edged a crystal with the gas composition method to get a resonance cascade, you had to make sure that your gas composition stayed until it left the explosion point, which made the achievement extremely finnicky and unfun to get this way. Regular delaminations won't really be affected, because yeah. It's at the explosion point. What are you going to do about it?

This makes the achievement easier to cheese, but honestly, in my opinion as person who added the achievement, meh. If people feel like this isn't good for the achievement, say something in the comments.

Closes #79528

## Changelog
:cl:
balance: Delamination variants no longer change once the explosion point has been reached.
/:cl:
