### PR TITLE
Addresses broken emojis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Space Station 13 is a paranoia-laden round-based roleplaying game set against th
 
 **The long way**. Find `bin/build.cmd` in this folder, and double click it to initiate the build. It consists of multiple steps and might take around 1-5 minutes to compile. If it closes, it means it has finished its job. You can then [setup the server](.github/guides/RUNNING_A_SERVER.md) normally by opening `tgstation.dmb` in DreamDaemon.
 
-**Building tgstation in DreamMaker directly is now deprecated and might produce errors**, such as `'tgui.bundle.js': cannot find file`.
+**Building tgstation in DreamMaker directly is deprecated and might produce errors**, such as `'tgui.bundle.js': cannot find file`.
 
 **[How to compile in VSCode and other build options](tools/build/README.md).**
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ Space Station 13 is a paranoia-laden round-based roleplaying game set against th
 
 [Maps and Away Missions](.github/guides/MAPS_AND_AWAY_MISSIONS.md)
 
-## :exclamation: How to compile :exclamation:
-
-On **2021-01-04** we have changed the way to compile the codebase.
+## Compilation
 
 **The quick way**. Find `bin/server.cmd` in this folder and double click it to automatically build and host the server on port 1337.
 


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/34697715/b61554a9-3928-45c4-bc23-ed6e4c4b5f24)

the whole `:exclamation:` thing appears to be broken and instead of just pasting in the emoji itself, i think now is probably the time to just reformat it so it looks in line with the rest of the readme (single-word headers).

I also removed the historical comment about the build system being changed (it'll soon be the three year anniversary and it's not really relevant information to have the date there any more, we still have the warning about compiling on dreammaker being potentially busted a few lines down)