### PR TITLE
A Mime's Vow to Silence Cannot be Repaired Once Broken. (Mimes can Write Under the Vow Again.)

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -4,7 +4,8 @@
 
 /datum/mood_event/broken_vow //Used for when mimes break their vow of silence
 	description = "I have brought shame upon my name, and betrayed my fellow mimes by breaking our sacred vow..."
-	mood_change = -8
+	mood_change = -4
+	timeout = 3 MINUTES
 
 /datum/mood_event/on_fire
 	description = "I'M ON FIRE!!!"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1338,10 +1338,6 @@
 			to_chat(src, span_warning("You can't write with the [writing_instrument]!"))
 		return FALSE
 
-	if(HAS_MIND_TRAIT(src, TRAIT_MIMING) && !istype(writing_instrument, /obj/item/toy/crayon/mime))
-		to_chat(src, span_warning("Your vow of silence is preventing you from talking with text."))
-		return FALSE
-
 	if(!is_literate())
 		to_chat(src, span_warning("You try to write, but don't know how to spell anything!"))
 		return FALSE

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -31,4 +31,6 @@
 	cast_on.log_message("broke [cast_on.p_their()] vow of silence.", LOG_GAME)
 	cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
 	REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
+	var/datum/job/mime/mime_job = SSjob.GetJob(JOB_MIME)
+	mime_job.total_positions += 1
 	qdel(src)

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -8,7 +8,6 @@
 	panel = "Mime"
 
 	school = SCHOOL_MIME
-	cooldown_time = 5 MINUTES
 	spell_requirements = NONE
 
 	spell_max_level = 1

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/vow_of_silence
-	name = "Speech"
-	desc = "Make (or break) a vow of silence."
+	name = "Break Vow"
+	desc = "Break your vow of silence. Permanently."
 	background_icon_state = "bg_mime"
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
@@ -20,18 +20,16 @@
 /datum/action/cooldown/spell/vow_of_silence/Remove(mob/living/remove_from)
 	. = ..()
 	REMOVE_TRAIT(remove_from, TRAIT_MIMING, "[type]")
-	remove_from.clear_mood_event("vow")
+
+/datum/action/cooldown/spell/vow_of_silence/before_cast(atom/cast_on)
+	if(tgui_alert(usr, "Are you sure? There's no going back.", "Break Vow", list("I'm Sure", "Abort")) == "Abort")
+		return SPELL_CANCEL_CAST
+	return ..()
 
 /datum/action/cooldown/spell/vow_of_silence/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	if(HAS_TRAIT_FROM(cast_on, TRAIT_MIMING, "[type]"))
-		to_chat(cast_on, span_notice("You break your vow of silence."))
-		cast_on.log_message("broke [cast_on.p_their()] vow of silence.", LOG_GAME)
-		cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
-		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
-	else
-		to_chat(cast_on, span_notice("You make a vow of silence."))
-		cast_on.log_message("made a vow of silence.", LOG_GAME)
-		cast_on.clear_mood_event("vow")
-		ADD_TRAIT(cast_on, TRAIT_MIMING, "[type]")
-	cast_on.update_mob_action_buttons()
+	to_chat(cast_on, span_notice("You break your vow of silence."))
+	cast_on.log_message("broke [cast_on.p_their()] vow of silence.", LOG_GAME)
+	cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
+	REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
+	qdel(src)

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -21,7 +21,7 @@
 	REMOVE_TRAIT(remove_from, TRAIT_MIMING, "[type]")
 
 /datum/action/cooldown/spell/vow_of_silence/before_cast(atom/cast_on)
-	if(tgui_alert(usr, "Are you sure? There's no going back.", "Break Vow", list("I'm Sure", "Abort")) == "Abort")
+	if(tgui_alert(usr, "Are you sure? There's no going back.", "Break Vow", list("I'm Sure", "Abort")) != "I'm Sure")
 		return SPELL_CANCEL_CAST
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Breaking your Vow is now a permanent action. Here's the changes that come with that:

- Renamed "Speech" to "Break Vow" and changed description to match.
- You no longer get a permanent bad moodlet, just a temporary, lighter one. I calculated that breaking your vow of silence provides roughly the same emotional damage as getting your eyes stabbed out.
- Breaking vow now comes with a confirm alert.
- Mimes can once again write while under the vow.

## Why It's Good For The Game

After all this recent hullabaloo about mimes breaking and repairing their vow, and what the moodlets for that action should be, it was decided by a headcoder majority that mime vow breaking should be a permanent action.

![image](https://github.com/tgstation/tgstation/assets/40974010/8e945095-7244-4071-8fdd-8a1529b5a4fb)

But beyond headcoder decisions, I myself agree with it being permanent. Making vow breaking a temporary action that can be repaired after only 5 minutes makes ignoring the main gimmick of mime not only viable but essentially expected. When silence can usually cause moments where you NEED to explain yourself or else risk possibly dying, we're essentially pushing players to break a vow. Now, it will be seen as less of a potential option, because you can't undo it after 5 minutes.

## Changelog
:cl:
qol: Added a confirmation prompt to breaking your vow of silence.
balance: Mimes can no longer repair the vow of silence once broken.
balance: The negative moodlet from breaking your vow of silence is now lighter, and no longer permanent.
balance: Mimes are back to being able to write while under a vow of silence.
/:cl:
