### PR TITLE
Fixes keybindings page & Button margins [NO GBP]

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -14,6 +14,7 @@ import { range, sortBy } from 'common/collections';
 import { KeyEvent } from '../../events';
 import { TabbedMenu } from './TabbedMenu';
 import { fetchRetry } from '../../http';
+import { KEY } from 'common/keys';
 
 type Keybinding = {
   name: string;
@@ -37,10 +38,10 @@ type KeybindingsPageState = {
 
 const isStandardKey = (event: KeyboardEvent): boolean => {
   return (
-    event.key !== 'Alt' &&
-    event.key !== 'Control' &&
-    event.key !== 'Shift' &&
-    event.key !== 'Esc'
+    event.key !== KEY.Alt &&
+    event.key !== KEY.Control &&
+    event.key !== KEY.Shift &&
+    event.key !== KEY.Escape
   );
 };
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -133,7 +133,10 @@ class KeybindingButton extends Component<{
         fluid
         textAlign="center"
         captureKeys={typingHotkey === undefined}
-        onClick={onClick}
+        onClick={(event) => {
+          event.stopPropagation();
+          onClick?.();
+        }}
         selected={typingHotkey !== undefined}
       >
         {typingHotkey || currentHotkey || 'Unbound'}

--- a/tgui/packages/tgui/styles/components/Button.scss
+++ b/tgui/packages/tgui/styles/components/Button.scss
@@ -95,6 +95,7 @@ $bg-map: colors.$bg-map !default;
 
 .Button--ellipsis {
   text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .Button--fluid {
@@ -168,7 +169,6 @@ $bg-map: colors.$bg-map !default;
 .Button__content {
   display: block;
   align-self: stretch;
-  overflow: hidden;
 }
 
 .Button__textMargin {


### PR DESCRIPTION
## About The Pull Request
Keybindings page needed to use stopPropagation() just like the rest. There should be no more instances of TrackOutsideClicks which doesn't use this. 

As a bonus- fixed the css caused by the recent button pr #80194
## Why It's Good For The Game
Bug fixes
Fixes #80319
Fixes #80339
## Changelog
:cl:
fix: Keybindings in prefs are able to be set again.
fix: Fixed the weird spacing on buttons.
/:cl:
