### PR TITLE
Coffee Cartridge Racks now start with a spare Coffee Cartridge

### DIFF
--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -484,6 +484,7 @@
 	contents_tag = "coffee cartridge"
 	open_status = FANCY_CONTAINER_ALWAYS_OPEN
 	spawn_type = /obj/item/coffee_cartridge
+	spawn_count = 2
 
 /obj/item/storage/fancy/coffee_cart_rack/Initialize(mapload)
 	. = ..()

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -484,7 +484,7 @@
 	contents_tag = "coffee cartridge"
 	open_status = FANCY_CONTAINER_ALWAYS_OPEN
 	spawn_type = /obj/item/coffee_cartridge
-	spawn_count = 2
+	spawn_count = 1
 
 /obj/item/storage/fancy/coffee_cart_rack/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes #80131

Fix to make coffee cart racks start with a coffee cart in them, as (I assume) intended.
Racks didn't have a set spawn_count, which defaults to 0. Meaning that the cartridges set to spawn, didn't actually spawn.
## Why It's Good For The Game
Coffee cart racks were assumingly meant to start with cartridges in them, but didn't. This fixes the spawn count so they can spawn as intended, giving any caffeicionados an extra cartridge for their coffee making endeavors.
## Changelog
:cl:
fix: coffee cartridge racks start with a coffee cartridge in them
/:cl:
