### PR TITLE
Fixes Runtime When Thanking Non-Existent Clown

### DIFF
--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -301,9 +301,11 @@
 		return
 	COOLDOWN_START(src, thank_time_cooldown, 6 SECONDS)
 	var/obj/vehicle/sealed/car/clowncar/clown_car = vehicle_entered_target
-	var/mob/living/carbon/human/clown = pick(clown_car.return_drivers())
-	if(!clown)
+	var/list/mob/drivers = clown_car.return_drivers()
+	if(!length(drivers))
+		to_chat(owner, span_danger("You prepare to thank the driver, only to realize that they don't exist."))
 		return
+	var/mob/clown = pick(drivers)
 	owner.say("Thank you for the fun ride, [clown.name]!")
 	clown_car.increment_thanks_counter()
 


### PR DESCRIPTION
## About The Pull Request

Currently, attempting to thank the driver of a clown car when none exists causes a runtime. This is because while there is logic to ensure we don't attempt to thank a driver if there is none, said logic only checks the result of a pick() called on the list of drivers, which will runtime if the list is empty. This PR fixes the error by checking if the the driver list is empty first, then using pick() solely for choosing a driver to thank.

## Why It's Good For The Game

While this isn't a very common runtime in normal gameplay, it is a bug and should be fixed regardless.

## Changelog

:cl:
fix: Fixed runtime regarding thanking non-existent clown car drivers
/:cl: