### PR TITLE
Fix false positive morgue alarms

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -953,7 +953,7 @@
 	return DEFIB_POSSIBLE
 
 /mob/living/carbon/proc/can_defib_client()
-	return (key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES)
+	return (client || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES)
 
 /mob/living/carbon/harvest(mob/living/user)
 	if(QDELETED(src))


### PR DESCRIPTION

## About The Pull Request
Currently, putting a player who died and disconnected without moving their ghost out of their body will set off the alarm on morgue trays. Following #79730, lets make sure people can differentiate between corpses that would have an active player when revived or not.
## Why It's Good For The Game
Fix bugs, a tray blaring an alarm for a body whose "soul has departed" is inconsistent
## Changelog
:cl:
fix: Fixed a rare false positive with morgue tray alarms.
/:cl:
