### PR TITLE
fixes confirm buttons [No gbp]

### DIFF
--- a/tgui/packages/tgui/components/Button.tsx
+++ b/tgui/packages/tgui/components/Button.tsx
@@ -208,40 +208,32 @@ type ConfirmProps = Partial<{
 const ButtonConfirm = (props: ConfirmProps) => {
   const {
     color,
-    confirmColor,
-    confirmContent,
+    confirmColor = 'bad',
+    confirmContent = 'Confirm?',
     confirmIcon,
     content,
     children,
     icon,
-    onClick = () => null,
+    onClick,
     ...rest
   } = props;
   const [clickedOnce, setClickedOnce] = useState(false);
 
   const handleClick = () => {
-    if (clickedOnce) {
-      setClickedOnce(false);
+    if (!clickedOnce) {
+      setClickedOnce(true);
+      return;
     }
+
+    onClick?.();
+    setClickedOnce(false);
   };
-
-  useEffect(() => {
-    if (clickedOnce) {
-      window.addEventListener('click', handleClick);
-    } else {
-      window.removeEventListener('click', handleClick);
-    }
-
-    return () => {
-      window.removeEventListener('click', handleClick);
-    };
-  }, [clickedOnce]);
 
   return (
     <Button
       icon={clickedOnce ? confirmIcon : icon}
       color={clickedOnce ? confirmColor : color}
-      onClick={() => (clickedOnce ? onClick() : setClickedOnce(true))}
+      onClick={handleClick}
       {...rest}
     >
       {clickedOnce ? confirmContent : content}


### PR DESCRIPTION
## About The Pull Request
Confirm-type buttons were missing default color/content messages for the confirming state

I also cleaned up the logic some
## Why It's Good For The Game
Bug fix
Fixes #80345
Fixes #80343
Fixes #80331
## Changelog
:cl:
fix: Confirmation buttons should be usable again. Bitrunning domains, command reports, etc.
/:cl:
