### PR TITLE
Last Resort can be used while dead

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -6,10 +6,12 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = TRUE
+	req_stat = DEAD
+	ignores_fakedeath = TRUE
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE
-	var/confirm = tgui_alert(user, "Are we sure we wish to kill ourself and create a headslug?", "Last Resort", list("Yes", "No"))
+	var/confirm = tgui_alert(user, "Are we sure we wish to destroy our body and create a headslug?", "Last Resort", list("Yes", "No"))
 	if(confirm != "Yes")
 		return
 
@@ -23,9 +25,9 @@
 		if(!eyes || blinded_human.is_blind())
 			continue
 		to_chat(blinded_human, span_userdanger("You are blinded by a shower of blood!"))
-		blinded_human.Stun(2 SECONDS)
+		blinded_human.Stun(4 SECONDS)
 		blinded_human.set_eye_blur_if_lower(40 SECONDS)
-		blinded_human.adjust_confusion(3 SECONDS)
+		blinded_human.adjust_confusion(12 SECONDS)
 
 	for(var/mob/living/silicon/blinded_silicon in range(2,user))
 		to_chat(blinded_silicon, span_userdanger("Your sensors are disabled by a shower of blood!"))
@@ -39,6 +41,7 @@
 	. = TRUE
 	addtimer(CALLBACK(src, PROC_REF(spawn_headcrab), stored_mind, user_turf, organs), 1 SECONDS)
 
+/// Creates the headrab to occupy
 /datum/action/changeling/headcrab/proc/spawn_headcrab(datum/mind/stored_mind, turf/spawn_location, list/organs)
 	var/mob/living/basic/headslug/crab = new(spawn_location)
 	for(var/obj/item/organ/I in organs)

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -30,7 +30,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	mob_remove(organ_owner, special, movement_flags)
-	bodypart_remove(null, organ_owner, movement_flags)
+	bodypart_remove(limb_owner = organ_owner, movement_flags = movement_flags)
 
 /*
  * Insert the organ into the select mob.
@@ -185,7 +185,7 @@
 /obj/item/organ/proc/bodypart_remove(obj/item/bodypart/limb, mob/living/carbon/limb_owner, movement_flags)
 	SHOULD_CALL_PARENT(TRUE)
 
-	if(limb_owner)
+	if(!isnull(limb_owner))
 		limb = limb_owner.get_bodypart(deprecise_zone(zone))
 
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED) //DONT MOVE THIS!!!! we moves the organ right after, so we unregister before we move them physically
@@ -216,7 +216,7 @@
 	if(owner)
 		Remove(owner)
 	else if(bodypart_owner)
-		bodypart_remove(limb_owner = owner)
+		bodypart_remove(bodypart_owner)
 	else
 		stack_trace("Force removed an already removed organ!")
 


### PR DESCRIPTION
## About The Pull Request

This PR allows Last Resort to be used while dead, in crit, or during your reviving stasis.
Additionally it increases the stun duration applied to bystanders from 2 to 4 seconds.
The confusion applied to bystanders has been increased from 3 to 12 seconds.

Additionally it fixes a runtime which was being triggered by Last Resort where a body part was being passed into the argument for `bodypart_remove` which expected to be passed a human, not a limb.

## Why It's Good For The Game

Last Resort is a rarely-used ability which makes you very vulnerable and requires you to find (or create) a corpse as a fairly fragile mob in order to return to the round (it's a last resort in other words). It also costs 20 chemicals, which means you need to have saved those to do this instead of Regenerative Coma or Fleshmend.

Because it was only usable while _alive_ (not even when in crit) it was also actually quite difficult to trigger because it requires two inputs (there's a confirmation box about whether you are sure you want to gib yourself) during a narrow window (where you know you are going to lose a fight, but haven't been knocked unconscious yet). Being usable while in crit or dead means it can now be activated during the relatively common scenario where you are dead, handcuffed, and being dragged towards a machine which will destroy your body without first needing to wait for regenerative coma to complete _and_ to regenerate an additional 20 chemicals.
This likely makes changelings potentially stickier and harder to permanently remove, to which I think: good, they're too _easy_ to deal with at the moment and seeing them get reborn due to careless corpse disposal is fun.

Additionally I have _slightly_ increased the duration of the stun and disorient applied to onlookers. Previously it applied a two second stun (and a 3 second confusion, 2 seconds of which was spent stunned), however the headslug only spawns after a one second delay. This makes its chance of escaping essentially nil, even if the corpse bursts directly on top of an air vent.
With a slightly longer stun there is some chance that it will escape, though there is still a reasonable chance that if there's more than one person around, they will manage to catch you before you crawl into a vent.

## Changelog

:cl:
balance: Last Resort can now be used while unconscious or dead.
balance: Last Resort stuns bystanders for slightly longer.
/:cl: