### PR TITLE
Martian food complexity fix

### DIFF
--- a/code/game/objects/items/food/martian.dm
+++ b/code/game/objects/items/food/martian.dm
@@ -409,7 +409,7 @@
 	tastes = list("bun" = 1, "burger" = 2, "teriyaki onions" = 1, "cheese" = 1, "bacon" = 1, "pineapple" = 1)
 	foodtypes = MEAT | GRAIN | DAIRY | VEGETABLES | FRUIT | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
-	crafting_complexity = FOOD_COMPLEXITY_3
+	crafting_complexity = FOOD_COMPLEXITY_4 //It's THE big blue, Baby!
 
 /obj/item/food/burger/chappy
 	name = "\improper Chappy patty"

--- a/code/game/objects/items/food/martian.dm
+++ b/code/game/objects/items/food/martian.dm
@@ -11,6 +11,7 @@
 	tastes = list("spicy cabbage" = 1)
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/inferno_kimchi
 	name = "inferno kimchi"
@@ -24,6 +25,7 @@
 	tastes = list("very spicy cabbage" = 1)
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/garlic_kimchi
 	name = "garlic kimchi"
@@ -38,6 +40,7 @@
 	tastes = list("spicy cabbage" = 1, "garlic" = 1)
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/surimi
 	name = "surimi"
@@ -51,6 +54,7 @@
 	tastes = list("fish" = 1)
 	foodtypes = SEAFOOD
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/surimi/Initialize(mapload)
 	. = ..()
@@ -68,6 +72,7 @@
 	tastes = list("fish" = 1)
 	foodtypes = SEAFOOD
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/kamaboko/Initialize(mapload)
 	. = ..()
@@ -90,6 +95,7 @@
 	tastes = list("fish" = 1)
 	foodtypes = SEAFOOD
 	w_class = WEIGHT_CLASS_TINY
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/sambal
 	name = "sambal"
@@ -103,6 +109,7 @@
 	tastes = list("chilli heat" = 1, "umami" = 1)
 	foodtypes = SEAFOOD | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/katsu_fillet
 	name = "katsu fillet"
@@ -117,6 +124,7 @@
 	tastes = list("meat" = 1, "breadcrumbs" = 1)
 	foodtypes = MEAT | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/rice_dough
 	name = "rice dough"
@@ -128,6 +136,7 @@
 	)
 	tastes = list("rice" = 1)
 	foodtypes = GRAIN
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/rice_dough/make_bakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/food/bread/reispan, rand(30 SECONDS, 45 SECONDS), TRUE, TRUE)
@@ -146,6 +155,7 @@
 	)
 	tastes = list("rice" = 1)
 	foodtypes = GRAIN
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/spaghetti/boilednoodles
 	name = "cooked noodles"
@@ -157,6 +167,7 @@
 	)
 	tastes = list("rice" = 1)
 	foodtypes = GRAIN
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/bread/reispan
 	name = "reispan"
@@ -167,8 +178,9 @@
 		/datum/reagent/consumable/nutriment = 15
 	)
 	tastes = list("bread" = 10)
-	foodtypes = GRAIN 
+	foodtypes = GRAIN
 	venue_value = FOOD_PRICE_TRASH
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/bread/reispan/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/reispan, 5, 3 SECONDS, table_required = TRUE)
@@ -182,6 +194,7 @@
 		/datum/reagent/consumable/nutriment = 3
 	)
 	foodtypes = GRAIN | VEGETABLES
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Fried Rice
 
@@ -198,6 +211,7 @@
 	tastes = list("rice" = 1, "meat" = 1, "pineapple" = 1, "veggies" = 1)
 	foodtypes = MEAT | GRAIN | PINEAPPLE | FRUIT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/ikareis
 	name = "ikareis"
@@ -213,6 +227,7 @@
 	tastes = list("rice" = 1, "squid ink" = 1, "veggies" = 1, "sausage" = 1, "chilli heat" = 1)
 	foodtypes = MEAT | GRAIN | SEAFOOD | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4
 
 /obj/item/food/salad/hawaiian_fried_rice
 	name = "\improper Hawaiian fried rice"
@@ -227,6 +242,7 @@
 	tastes = list("rice" = 1, "pork" = 1, "pineapple" = 1, "soy sauce" = 1, "veggies" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES | FRUIT | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/ketchup_fried_rice
 	name = "ketchup fried rice"
@@ -242,6 +258,7 @@
 	tastes = list("rice" = 1, "sausage" = 1, "ketchup" = 1, "veggies" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/mediterranean_fried_rice
 	name = "mediterranean fried rice"
@@ -256,6 +273,7 @@
 	tastes = list("rice" = 1, "cheese" = 1, "meatball" = 1, "olives" = 1, "herbs" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES | DAIRY
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/egg_fried_rice
 	name = "egg fried rice"
@@ -269,6 +287,7 @@
 	tastes = list("rice" = 1, "egg" = 1, "soy sauce" = 1)
 	foodtypes = MEAT | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/salad/egg_fried_rice/Initialize(mapload)
 	. = ..()
@@ -288,6 +307,7 @@
 	tastes = list("rice" = 1, "spicy cabbage" = 1, "chilli heat" = 1, "egg" = 1, "meat" = 1)
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/bibimbap/Initialize(mapload)
 	. = ..()
@@ -307,6 +327,7 @@
 	tastes = list("barbecue meat" = 1, "noodles" = 1, "chilli heat" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES | FRUIT
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/yakisoba_katsu
 	name = "yakisoba katsu"
@@ -321,6 +342,7 @@
 	tastes = list("fried noodles" = 1, "meat" = 1, "breadcrumbs" = 1, "veggies" = 1)
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/martian_fried_noodles
 	name = "\improper Martian fried noodles"
@@ -335,6 +357,7 @@
 	tastes = list("noodles" = 1, "meat" = 1, "nuts" = 1, "onion" = 1, "egg" = 1)
 	foodtypes = GRAIN | NUTS | MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/simple_fried_noodles
 	name = "simple fried noodles"
@@ -349,6 +372,7 @@
 	tastes = list("noodles" = 1, "soy sauce" = 1)
 	foodtypes = GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/salad/simple_fried_noodles/Initialize(mapload)
 	. = ..()
@@ -369,6 +393,7 @@
 	tastes = list("masterful curry" = 1, "rice" = 1)
 	foodtypes = GRAIN | MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_5 //Extensive and secretly guarded. Was previously 2 and I thought it was pathetic.
 
 // Burgers and Sandwiches
 /obj/item/food/burger/big_blue
@@ -384,6 +409,7 @@
 	tastes = list("bun" = 1, "burger" = 2, "teriyaki onions" = 1, "cheese" = 1, "bacon" = 1, "pineapple" = 1)
 	foodtypes = MEAT | GRAIN | DAIRY | VEGETABLES | FRUIT | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/burger/chappy
 	name = "\improper Chappy patty"
@@ -397,6 +423,7 @@
 	tastes = list("bun" = 1, "fried pork" = 2, "egg" = 1, "cheese" = 1, "ketchup" = 1)
 	foodtypes = MEAT | GRAIN | DAIRY | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/king_katsu_sandwich
 	name = "\improper King Katsu sandwich"
@@ -412,6 +439,7 @@
 	tastes = list("meat" = 1, "bacon" = 1, "kimchi" = 1, "salad" = 1, "rice bread" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/marte_cubano_sandwich
 	name = "\improper Marte Cubano sandwich"
@@ -426,6 +454,7 @@
 	tastes = list("bacon" = 1, "pickles" = 1, "cheese" = 1, "rice bread" = 1)
 	foodtypes = MEAT | DAIRY | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/little_shiro_sandwich
 	name = "\improper Little Shiro sandwich"
@@ -441,6 +470,7 @@
 	tastes = list("egg" = 1, "meat" = 1, "kimchi" = 1, "mozzarella" = 1)
 	foodtypes = MEAT | DAIRY | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/croque_martienne
 	name = "croque-martienne"
@@ -455,6 +485,7 @@
 	tastes = list("egg" = 1, "toast" = 1, "pork" = 1, "pineapple" = 1, "cheese" = 1)
 	foodtypes = MEAT | DAIRY | VEGETABLES | GRAIN | PINEAPPLE | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/prospect_sunrise
 	name = "\improper Prospect Sunrise"
@@ -469,6 +500,7 @@
 	tastes = list("egg" = 1, "toast" = 1, "bacon" = 1, "pickles" = 1, "cheese" = 1)
 	foodtypes = MEAT | DAIRY | VEGETABLES | GRAIN | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Snacks
 /obj/item/food/takoyaki
@@ -484,6 +516,7 @@
 	tastes = list("octopus" = 1, "batter" = 1, "onion" = 1, "worcestershire sauce" = 1)
 	foodtypes = SEAFOOD | GRAIN | FRIED | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/takoyaki/russian
 	name = "russian takoyaki"
@@ -498,6 +531,7 @@
 	tastes = list("octopus" = 1, "batter" = 1, "onion" = 1, "chilli heat" = 1)
 	foodtypes = SEAFOOD | GRAIN | FRIED | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/takoyaki/taco
 	name = "tacoyaki"
@@ -512,6 +546,7 @@
 	tastes = list("taco meat" = 1, "batter" = 1, "corn" = 1, "cheese" = 1)
 	foodtypes = MEAT | GRAIN | FRIED | VEGETABLES | DAIRY
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4 //Batter AND Cargo ingredients.
 
 /obj/item/food/okonomiyaki
 	name = "okonomiyaki"
@@ -525,6 +560,7 @@
 	tastes = list("batter" = 1, "cabbage" = 1, "onion" = 1, "worcestershire sauce" = 1)
 	foodtypes = SEAFOOD | GRAIN | FRIED | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4 //Cargo stuff and batter.
 
 //hey, the name literally means "grilled how you like it", it'd be crazy to not make it customisable
 /obj/item/food/okonomiyaki/Initialize(mapload)
@@ -545,6 +581,7 @@
 	tastes = list("spicy cabbage" = 1, "sausage" = 1)
 	foodtypes = MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/tonkatsuwurst
 	name = "tonkatsuwurst"
@@ -559,6 +596,7 @@
 	tastes = list("sausage" = 1, "spicy sauce" = 1, "fries" = 1)
 	foodtypes = MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4 //Cargo ingredients and a few steps.
 
 /obj/item/food/kebab/ti_hoeh_koe
 	name = "ti hoeh koe skewer"
@@ -573,6 +611,7 @@
 	tastes = list("blood" = 1, "nuts" = 1, "herbs" = 1)
 	foodtypes = MEAT | NUTS | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/kitzushi
 	name = "kitzushi"
@@ -587,6 +626,7 @@
 	tastes = list("rice" = 1, "tofu" = 1, "chilli cheese" = 1)
 	foodtypes = GRAIN | FRIED | VEGETABLES | DAIRY
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/epok_epok
 	name = "epok-epok"
@@ -600,6 +640,7 @@
 	tastes = list("curry" = 1, "egg" = 1, "pastry" = 1)
 	foodtypes = GRAIN | MEAT | VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/roti_john
 	name = "roti john"
@@ -614,6 +655,7 @@
 	tastes = list("bread" = 1, "egg" = 1, "meat" = 1, "onion" = 1)
 	foodtypes = GRAIN | MEAT | VEGETABLES | FRIED | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4
 
 /obj/item/food/izakaya_fries
 	name = "izakaya fries"
@@ -629,6 +671,7 @@
 	tastes = list("fries" = 1, "mars" = 1)
 	foodtypes = VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3 //Extra complexity due to cargo ingredient.
 
 /obj/item/food/kurry_ok_subsando
 	name = "kurry-ok subsando"
@@ -643,6 +686,7 @@
 	tastes = list("bread" = 1, "spicy fries" = 1, "mayonnaise" = 1, "curry" = 1, "meat" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4
 
 /obj/item/food/loco_moco
 	name = "loco moco"
@@ -656,6 +700,7 @@
 	tastes = list("rice" = 1, "burger" = 1, "gravy" = 1, "egg" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/wild_duck_fries
 	name = "wild duck fries"
@@ -671,6 +716,7 @@
 	tastes = list("fries" = 1, "duck" = 1, "ketchup" = 1, "mayo" = 1, "spicy seasoning" = 1)
 	foodtypes = MEAT | VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4 //Requires a complex 3 as an ingredient.
 
 /obj/item/food/little_hawaii_hotdog
 	name = "\improper Little Hawaii hotdog"
@@ -685,6 +731,7 @@
 	tastes = list("sausage" = 1, "pineapple" = 1, "onion" = 1, "teriyaki" = 1)
 	foodtypes = MEAT | VEGETABLES | FRUIT | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4
 
 /obj/item/food/salt_chilli_fries
 	name = "salt n' chilli fries"
@@ -700,6 +747,7 @@
 	tastes = list("fries" = 1, "garlic" = 1, "ginger" = 1, "numbing heat" = 1, "salt" = 1)
 	foodtypes = VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/grilled_octopus
 	name = "grilled octopus tentacle"
@@ -713,6 +761,7 @@
 	tastes = list("octopus" = 1)
 	foodtypes = SEAFOOD | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/steak_croquette
 	name = "steak croquette"
@@ -726,6 +775,7 @@
 	tastes = list("steak" = 1, "potato" = 1)
 	foodtypes = MEAT | VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/chapsilog
 	name = "chapsilog"
@@ -741,6 +791,7 @@
 	tastes = list("ham" = 1, "garlic rice" = 1, "egg" = 1)
 	foodtypes = MEAT | GRAIN | VEGETABLES | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/chap_hash
 	name = "chap hash"
@@ -755,6 +806,7 @@
 	tastes = list("ham" = 1, "onion" = 1, "pepper" = 1, "potato" = 1)
 	foodtypes = MEAT | VEGETABLES | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/agedashi_tofu
 	name = "agedashi tofu"
@@ -769,6 +821,7 @@
 	tastes = list("umami broth" = 1, "tofu" = 1)
 	foodtypes = SEAFOOD | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 // Curries and Stews
 /obj/item/food/salad/po_kok_gai
@@ -784,6 +837,7 @@
 	tastes = list("chicken" = 1, "coconut" = 1, "curry" = 1)
 	foodtypes = MEAT | VEGETABLES | FRUIT
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/huoxing_tofu
 	name = "\improper Huoxing tofu"
@@ -799,6 +853,7 @@
 	tastes = list("meat" = 1, "chilli heat" = 1, "tofu" = 1)
 	foodtypes = MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/feizhou_ji
 	name = "fēizhōu jī"
@@ -813,6 +868,8 @@
 	tastes = list("chicken" = 1, "chilli heat" = 1, "vinegar" = 1)
 	foodtypes = MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
+
 
 /obj/item/food/salad/galinha_de_cabidela
 	name = "galinha de cabidela"
@@ -826,6 +883,7 @@
 	tastes = list("chicken" = 1, "iron" = 1, "vinegar" = 1, "rice" = 1)
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/katsu_curry
 	name = "katsu curry"
@@ -839,6 +897,7 @@
 	tastes = list("curry" = 1, "meat" = 1, "breadcrumbs" = 1, "rice" = 1)
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/beef_bowl
 	name = "beef bowl"
@@ -853,6 +912,7 @@
 	tastes = list("beef" = 25, "onion" = 25, "chili heat" = 15, "rice" = 34, "soul" = 1) //I pour my soul into this bowl
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/salt_chilli_bowl
 	name = "salt n' chilli octopus bowl"
@@ -869,6 +929,7 @@
 	tastes = list("seafood" = 1, "rice" = 1, "garlic" = 1, "ginger" = 1, "numbing heat" = 1, "salt" = 1)
 	foodtypes = SEAFOOD | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4 //A few Cargo ingredients
 
 /obj/item/food/salad/kansai_bowl
 	name = "\improper Kansai bowl"
@@ -883,6 +944,7 @@
 	tastes = list("seafood" = 1, "rice" = 1, "egg" = 1, "onion" = 1)
 	foodtypes = SEAFOOD | MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/eigamudo_curry //curry is meant to be really spicy or kinda mild, this just stinks!
 	name = "\improper Eigamudo curry"
@@ -897,6 +959,7 @@
 	tastes = list("grit" = 1, "slime" = 1, "gristle" = 1, "rice" = 1, "Mystery Food X" = 1)
 	foodtypes = GROSS | GRAIN | TOXIC
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Entrees
 /obj/item/food/cilbir
@@ -914,6 +977,7 @@
 	tastes = list("yoghurt" = 1, "garlic" = 1, "lemon" = 1, "egg" = 1, "chilli heat" = 1)
 	foodtypes = DAIRY | VEGETABLES | FRUIT | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/peking_duck_crepes
 	name = "\improper Peking duck crepes a l'orange"
@@ -929,6 +993,7 @@
 	tastes = list("meat" = 1, "crepes" = 1, "orange" = 1)
 	foodtypes = MEAT | DAIRY | VEGETABLES | FRUIT
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Desserts
 /obj/item/food/cake/spekkoek
@@ -942,6 +1007,7 @@
 	)
 	tastes = list("winter spices" = 2, "ambrosia vulgaris" = 2, "cake" = 5)
 	foodtypes = GRAIN | SUGAR | DAIRY
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/cake/spekkoek/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/spekkoek, 5, 3 SECONDS, table_required = TRUE)
@@ -953,6 +1019,7 @@
 	icon_state = "spekkoek_slice"
 	tastes = list("winter spices" = 2, "ambrosia vulgaris" = 2, "cake" = 5)
 	foodtypes = GRAIN | SUGAR | DAIRY
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/salad/pineapple_foster
 	name = "pineapple foster"
@@ -969,6 +1036,7 @@
 	tastes = list("pineapple" = 1, "vanilla" = 1, "caramel" = 1, "ice cream" = 1)
 	foodtypes = FRUIT | DAIRY | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/pastel_de_nata
 	name = "pastel de nata"
@@ -983,6 +1051,7 @@
 	tastes = list("custard" = 1, "vanilla" = 1, "sweet pastry" = 1)
 	foodtypes = DAIRY | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/boh_loh_yah
 	name = "boh loh yah"
@@ -996,6 +1065,7 @@
 	tastes = list("cookie" = 1, "butter" = 1)
 	foodtypes = DAIRY | GRAIN | PINEAPPLE //it's funny
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/banana_fritter
 	name = "banana fritter"
@@ -1010,6 +1080,7 @@
 	tastes = list("banana" = 1, "batter" = 1)
 	foodtypes = GRAIN | FRUIT | FRIED
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3 //Fried goodness, oil scawy.
 
 /obj/item/food/pineapple_fritter
 	name = "pineapple fritter"
@@ -1024,6 +1095,7 @@
 	tastes = list("pineapple" = 1, "batter" = 1)
 	foodtypes = GRAIN | FRUIT | FRIED | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/kebab/kasei_dango
 	name = "kasei dango"
@@ -1039,6 +1111,7 @@
 	tastes = list("pomegranate" = 1, "orange" = 1)
 	foodtypes = FRUIT | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Frozen
 /obj/item/food/pb_ice_cream_mochi
@@ -1055,6 +1128,7 @@
 	tastes = list("peanut butter" = 1, "mochi" = 1)
 	foodtypes = NUTS | GRAIN | DAIRY | SUGAR
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/popsicle/pineapple_pop
 	name = "frozen pineapple pop"
@@ -1068,6 +1142,7 @@
 	)
 	tastes = list("cold pineapple" = 1, "chocolate" = 1)
 	foodtypes = SUGAR | PINEAPPLE
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/popsicle/sea_salt
 	name = "sea salt ice-cream bar"
@@ -1082,6 +1157,7 @@
 	)
 	tastes = list("salt" = 1, "sweet" = 1)
 	foodtypes = SUGAR | DAIRY
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // topsicles, also known as tofu popsicles
 /obj/item/food/popsicle/topsicle
@@ -1095,6 +1171,7 @@
 	)
 	tastes = list("berry" = 1, "tofu" = 1)
 	foodtypes = FRUIT | VEGETABLES
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/popsicle/topsicle/banana
 	name = "banana topsicle"
@@ -1132,6 +1209,7 @@
 	tastes = list("sausage" = 1, "relish" = 1, "onion" = 1, "fruity salsa" = 1)
 	foodtypes = FRUIT | MEAT | PINEAPPLE | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_4 //Uses Sambal
 
 /obj/item/food/frickles
 	name = "frickles"
@@ -1146,6 +1224,7 @@
 	tastes = list("frickles" = 1)
 	foodtypes = VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3 //batter and cargo stuff.
 
 /obj/item/food/raw_ballpark_pretzel
 	name = "raw pretzel"
@@ -1159,6 +1238,7 @@
 	tastes = list("bread" = 1, "salt" = 1)
 	foodtypes = GRAIN | RAW
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/raw_ballpark_pretzel/make_bakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/food/ballpark_pretzel, rand(15 SECONDS, 25 SECONDS), TRUE, TRUE)
@@ -1178,6 +1258,7 @@
 	tastes = list("bread" = 1, "salt" = 1)
 	foodtypes = GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 /obj/item/food/kebab/raw_ballpark_tsukune
 	name = "raw tsukune"
@@ -1191,6 +1272,7 @@
 	tastes = list("raw chicken" = 7, "salmonella" = 1)
 	foodtypes = MEAT | RAW
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2
 
 /obj/item/food/kebab/raw_ballpark_tsukune/make_grillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/kebab/ballpark_tsukune, rand(15 SECONDS, 25 SECONDS), TRUE, TRUE)
@@ -1207,6 +1289,7 @@
 	tastes = list("chicken" = 1, "umami sauce" = 1)
 	foodtypes = MEAT
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Ethereal-suitable cross-culture food
 /*	Ethereals are, as part of the uplifting process, considered as citizens of the Terran Federation.
@@ -1228,6 +1311,7 @@
 	tastes = list("sour radish" = 1)
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_2 //If it comes straight from cargo, should be worth paying for.
 
 // 24-Volt Energy
 /obj/item/food/volt_fish
@@ -1242,6 +1326,7 @@
 	tastes = list("fish" = 1, "sour pear" = 1)
 	foodtypes = SEAFOOD
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3
 
 // Sprout Bowl
 /obj/item/food/salad/sprout_bowl
@@ -1257,3 +1342,4 @@
 	tastes = list("fish" = 1, "sour radish" = 1, "rice" = 1)
 	foodtypes = SEAFOOD | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
+	crafting_complexity = FOOD_COMPLEXITY_3


### PR DESCRIPTION

## About The Pull Request
I noticed a lot of the martian food had no quality or very low quality, so I just set out to fix that quickly.
General rule of thumb, if it takes prep-work (batters, broths and such) +1 complexity, if it takes cargo ingredients +1 complexity, if it requires a food item as an ingredient, it should always be above that.
![image](https://github.com/tgstation/tgstation/assets/53197594/90be096a-eacb-480c-97ea-49b47e75e0d5)

P.S. Shout out to whoever made the martian food, this stuff's pretty dope.
## Why It's Good For The Game
Chefs who want to make nice, interesting variety shouldn't lose their good food buffs because the game says a curry that requires 14 ingredients should be quality 2 and makes haemorrhaging money through cargo actually seem worth it. (Like, so much redbay and such)
## Changelog
:cl:
fix: fixed the oversight with martian food complexity.
/:cl:
