### PR TITLE
Allows ai's to eject from mech domination

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -891,7 +891,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/ai_module/upgrade/mecha_domination
 	name = "Unlock Mech Domination"
 	description = "Allows you to hack into a mech's onboard computer, shunting all processes into it and ejecting any occupants. \
-		Once uploaded to the mech, it is impossible to leave. Do not allow the mech to leave the station's vicinity or allow it to be destroyed. \
+		Do not allow the mech to leave the station's vicinity or allow it to be destroyed. \
 		Upgrade is done immediately upon purchase."
 	cost = 30
 	upgrade = TRUE

--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -72,7 +72,6 @@
 				to_chat(occupants, span_danger("You have been forcibly ejected!"))
 				for(var/ejectee in occupants)
 					mob_exit(ejectee, silent = TRUE, randomstep = TRUE, forced = TRUE) //IT IS MINE, NOW. SUCK IT, RD!
-				AI.can_shunt = FALSE //ONE AI ENTERS. NO AI LEAVES.
 
 		if(AI_TRANS_FROM_CARD) //Using an AI card to upload to a mech.
 			AI = card.AI


### PR DESCRIPTION
## About The Pull Request
Lets ais eject from dominated mechs

If this is too strong at 30 I'd be happy to bump it or apply some other restrictions
## Why It's Good For The Game
They have a big eject button which is essentially bait at the moment, it does nothing. 

I think its fine to let combat upgraded ai's and malfunctional ai's to use this mech domination ability more freely, because how it usually goes is malf ai dominates mech, everyone sees occupants of mech get tossed out and the ai is promptly killed. I don't think this is fun or healthy for an ability which is pretty expensive and the only other way I see it used is an ai just trying to live for a few moments more by shunting into a cargo mech, from which they can't do a whole lot and simply exist until the crew figure them out.

TLDR: For a very expensive ability it does not provide a lot of benefit and is easily dispatched by the crew. 
## Changelog
:cl:
balance: Ai's using the mech domination ability can now eject from the mech
/:cl:
