### PR TITLE
Shuttle event "Turbulence"

### DIFF
--- a/code/modules/shuttle/shuttle_events/turbulence.dm
+++ b/code/modules/shuttle/shuttle_events/turbulence.dm
@@ -1,0 +1,48 @@
+/// Repeat the "buckle in or fall over" event a couple times
+/datum/shuttle_event/turbulence
+	name = "Turbulence"
+	event_probability = 5
+	activation_fraction = 0.1
+	/// Minimum time to wait between periods of turbulence
+	var/minimum_interval = 20 SECONDS
+	/// Maximum time to wait between periods of turbulence
+	var/maximum_interval = 50 SECONDS
+	/// Time until we should shake again
+	COOLDOWN_DECLARE(turbulence_cooldown)
+	/// How long do we give people to get buckled?
+	var/warning_interval = 2 SECONDS
+
+/datum/shuttle_event/turbulence/activate()
+	. = ..()
+	minor_announce("Please note, we are entering an area of subspace turbulence. For your own safety, \
+		please fasten your belts and remain seated until the vehicle comes to a complete stop.",
+		title = "Emergency Shuttle", alert = TRUE)
+	COOLDOWN_START(src, turbulence_cooldown, rand(5 SECONDS, 20 SECONDS)) // Reduced interval after the announcement
+
+/datum/shuttle_event/turbulence/event_process()
+	. = ..()
+	if (!.)
+		return
+	if (!COOLDOWN_FINISHED(src, turbulence_cooldown))
+		return
+	COOLDOWN_START(src, turbulence_cooldown, rand(minimum_interval, maximum_interval))
+	shake()
+	addtimer(CALLBACK(src, PROC_REF(knock_down)), warning_interval, TIMER_DELETE_ME)
+
+/// Warn players to get buckled
+/datum/shuttle_event/turbulence/proc/shake()
+	var/list/mobs = mobs_in_area_type(list(/area/shuttle/escape))
+	for(var/mob/living/mob as anything in mobs)
+		var/shake_intensity = mob.buckled ? 0.25 : 1
+		if(mob.client)
+			shake_camera(mob, 3 SECONDS, shake_intensity)
+
+/// Knock them down
+/datum/shuttle_event/turbulence/proc/knock_down()
+	if (SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
+		return // They docked
+	var/list/mobs = mobs_in_area_type(list(/area/shuttle/escape)) // Not very efficient but check again in case someone was outdoors
+	for(var/mob/living/mob as anything in mobs)
+		if(mob.buckled)
+			continue
+		mob.Paralyze(3 SECONDS, ignore_canstun = TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5519,6 +5519,7 @@
 #include "code\modules\shuttle\shuttle_events\meteors.dm"
 #include "code\modules\shuttle\shuttle_events\misc.dm"
 #include "code\modules\shuttle\shuttle_events\player_controlled.dm"
+#include "code\modules\shuttle\shuttle_events\turbulence.dm"
 #include "code\modules\spatial_grid\cell_tracker.dm"
 #include "code\modules\spells\spell.dm"
 #include "code\modules\spells\spell_types\madness_curse.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a new shuttle event: turbulence.
The escape shuttle is experiencing subspace turbulence, effectively causing the takeoff/landing buckle check to repeat a couple of times during the duration of the flight.
Players will get a two second warning when the screen starts shaking, after which if they are not buckled (or... outside of the shuttle I guess) they will fall over for a few seconds.

The presence of turbulence in the shuttle's path will be announced shortly after takeoff, so strap yourself in.

## Why It's Good For The Game

I think it adds a bit of flavour and influences what is going on in the shuttle (falling over at the wrong moment can turn a scrum over bridge access on its head) without being quite as disruptive as "there's 13 carp in here now".

## Changelog

:cl:
add: Adds a new shuttle event, where space shuttles can experience minor turbulance. Keep your belt on while the appropriate cabin light is lit.
/:cl:
