### PR TITLE
Fix NtosCard merge skew

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -164,9 +164,10 @@ const IdCardPage = (props) => {
             fluid
             ellipsis
             icon="eject"
-            content={authIDName}
             onClick={() => act('PRG_eject_id')}
-          />
+          >
+            {authIDName}
+          </Button>
         </Stack.Item>
         <Stack.Item width="100%" mt={1} ml={0}>
           Login: {authenticatedUser || '-----'}


### PR DESCRIPTION
Haven't tested but if TypeScript passes then it works

Can't mix ellipsis and content