### PR TITLE
Fixes an inconsistency with ED-209's crafting recipe

### DIFF
--- a/code/datums/components/crafting/robot.dm
+++ b/code/datums/components/crafting/robot.dm
@@ -3,7 +3,7 @@
 	result = /mob/living/simple_animal/bot/secbot/ed209
 	reqs = list(
 		/obj/item/robot_suit = 1,
-		/obj/item/clothing/head/helmet = 1,
+		/obj/item/clothing/head/helmet/sec = 1,
 		/obj/item/clothing/suit/armor/vest = 1,
 		/obj/item/bodypart/leg/left/robot = 1,
 		/obj/item/bodypart/leg/right/robot = 1,

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -135,7 +135,7 @@
 					build_step++
 
 		if(ASSEMBLY_FIFTH_STEP)
-			if(istype(W, /obj/item/clothing/head/helmet))
+			if(istype(W, /obj/item/clothing/head/helmet/sec))
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
 				to_chat(user, span_notice("You add [W] to [src]."))


### PR DESCRIPTION

## About The Pull Request
Makes the ED-209 crafting recipe only take security helmets, just as the Beepsky one does.

## Why It's Good For The Game

As it stands right now, any helmet can be used to assemble an ED-209. This includes anything from your standard security helmet, to a hardhat, an envirohelm, or even a cheap toy roman helmet. This makes it so you need an actual security helmet, just like the Beepsky recipe does.
## Changelog
:cl:
fix: ED-209s can no longer be crafted with most instances of helmet, you need security ones just like Beepsky.
/:cl: