### PR TITLE
Fix PAI health scanning

### DIFF
--- a/code/modules/pai/hud.dm
+++ b/code/modules/pai/hud.dm
@@ -94,6 +94,7 @@
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		pAI.host_scan(PAI_SCAN_MASTER)
 		return TRUE
+
 /atom/movable/screen/pai/crew_manifest
 	name = "Crew Manifest"
 	icon_state = "manifest"

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -71,8 +71,6 @@
 	// Onboard Items
 	/// Atmospheric analyzer
 	var/obj/item/analyzer/atmos_analyzer
-	/// Health analyzer
-	var/obj/item/healthanalyzer/host_scan
 	/// GPS
 	var/obj/item/gps/pai/internal_gps
 	/// Music Synthesizer
@@ -153,7 +151,6 @@
 /mob/living/silicon/pai/Destroy()
 	QDEL_NULL(atmos_analyzer)
 	QDEL_NULL(hacking_cable)
-	QDEL_NULL(host_scan)
 	QDEL_NULL(instrument)
 	QDEL_NULL(internal_gps)
 	QDEL_NULL(newscaster)
@@ -193,8 +190,6 @@
 		atmos_analyzer = null
 	else if(gone == aicamera)
 		aicamera = null
-	else if(gone == host_scan)
-		host_scan = null
 	else if(gone == internal_gps)
 		internal_gps = null
 	else if(gone == instrument)

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -38,7 +38,7 @@
 		return TRUE
 	// Software related ui actions
 	if(available_software[action] && !installed_software.Find(action))
-		balloon_alert(usr, "software unavailable!")
+		balloon_alert(ui.user, "software unavailable!")
 		return FALSE
 	switch(action)
 		if("Atmospheric Sensor")

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -208,7 +208,7 @@
 			if(!is_valid_z_level(get_turf(src), get_turf(resolved_master)))
 				balloon_alert(src, "master out of range!")
 				return FALSE
-			healthscan(src, target)
+			healthscan(src, resolved_master)
 			return TRUE
 
 	stack_trace("Invalid mode passed to host scan: [mode || "null"]")

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -38,7 +38,7 @@
 		return TRUE
 	// Software related ui actions
 	if(available_software[action] && !installed_software.Find(action))
-		balloon_alert(usr, "software unavailable")
+		balloon_alert(usr, "software unavailable!")
 		return FALSE
 	switch(action)
 		if("Atmospheric Sensor")
@@ -116,8 +116,6 @@
 			atmos_analyzer = new(src)
 		if("Digital Messenger")
 			create_modularInterface()
-		if("Host Scan")
-			host_scan = new(src)
 		if("Internal GPS")
 			internal_gps = new(src)
 		if("Music Synthesizer")
@@ -193,28 +191,27 @@
  * @returns {boolean} - TRUE if the scan was successful, FALSE otherwise.
  */
 /mob/living/silicon/pai/proc/host_scan(mode)
-	if(isnull(mode))
-		return FALSE
-	if(mode == PAI_SCAN_TARGET)
-		var/mob/living/target = get_holder()
-		if(!target || !isliving(target))
-			balloon_alert(src, "not being carried")
-			return FALSE
-		host_scan.attack(target, src)
-		return TRUE
-	if(mode == PAI_SCAN_MASTER)
-		if(!master_ref)
-			balloon_alert(src, "no master detected")
-			return FALSE
-		var/mob/living/resolved_master = find_master()
-		if(!resolved_master)
-			balloon_alert(src, "cannot locate master")
-			return FALSE
-		if(!is_valid_z_level(get_turf(src), get_turf(resolved_master)))
-			balloon_alert(src, "master out of range")
-			return FALSE
-		host_scan.attack(resolved_master, src)
-		return TRUE
+	switch(mode)
+		if(PAI_SCAN_TARGET)
+			var/mob/living/target = get_holder()
+			if(!isliving(target))
+				balloon_alert(src, "not being carried!")
+				return FALSE
+			healthscan(src, target)
+			return TRUE
+
+		if(PAI_SCAN_MASTER)
+			var/mob/living/resolved_master = find_master()
+			if(isnull(resolved_master))
+				balloon_alert(src, "no master detected!")
+				return FALSE
+			if(!is_valid_z_level(get_turf(src), get_turf(resolved_master)))
+				balloon_alert(src, "master out of range!")
+				return FALSE
+			healthscan(src, target)
+			return TRUE
+
+	stack_trace("Invalid mode passed to host scan: [mode || "null"]")
 	return FALSE
 
 /**


### PR DESCRIPTION
## About The Pull Request

Fixes #80370 

Rather than just using the global `healthscan` proc, PAIs created a health analyzer in their contents and called `attack` directly,

despite the fact that all health analyzer `attack` does is call the global proc

- [ ] I tested this pr

## Changelog

:cl: Melbert
fix: Fixes PAI health scan software
/:cl:
