### PR TITLE
Fixes ghost role descriptions on NTTS Independence

### DIFF
--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -1394,7 +1394,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/fun_balloon/sentience/emergency_shuttle,
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	group_name = "bar staff on the NTTS Independence"
+	},
 /turf/open/floor/wood/parquet,
 /area/shuttle/escape)
 "DF" = (

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -925,9 +925,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "tT" = (
-/obj/structure/railing{
-	dir = 2
-	},
+/obj/structure/railing,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "tZ" = (
@@ -1224,9 +1222,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "Av" = (
-/obj/structure/railing{
-	dir = 2
-	},
+/obj/structure/railing,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/stairs{
 	dir = 8
@@ -1754,9 +1750,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
 	},
-/obj/structure/railing{
-	dir = 2
-	},
+/obj/structure/railing,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "LD" = (
@@ -2818,7 +2812,7 @@ WX
 hB
 AF
 Mv
-DA
+Tz
 il
 YY
 tG
@@ -2864,7 +2858,7 @@ at
 AL
 AF
 AF
-Tz
+DA
 il
 IO
 Ew


### PR DESCRIPTION

## About The Pull Request
Fixes #80251

Fixes the group descriptions for the barmaid ghost roles on the NTTS Independence from the default to "bar staff on the NTTS Independence"
## Why It's Good For The Game
Causes less confusion for ghosts attempting to spawn as the barmaids or as the spiders that it was previously labled.
## Changelog
:cl:
fix: fixed ghost role descriptions on NTTS Independence
/:cl:
