### PR TITLE
Fire Alarm Lights (Lit version) (Also lumin cleanup)

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -24,8 +24,6 @@
 
 	COOLDOWN_DECLARE(activation_cooldown)
 
-	///Trick to get the glowing overlay visible from a distance
-	luminosity = 1
 	///X offset for the overlay lights, so that they line up with the thin border firelocks
 	var/light_xoffset = 0
 	///Y offset for the overlay lights, so that they line up with the thin border firelocks

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -145,9 +145,9 @@
 /obj/machinery/firealarm/update_appearance(updates)
 	. = ..()
 	if((my_area?.fire || LAZYLEN(my_area?.active_firelocks)) && !(obj_flags & EMAGGED) && !(machine_stat & (BROKEN|NOPOWER)))
-		set_light(l_power = 3)
+		set_light(l_range = 2.5, l_power = 1.5)
 	else
-		set_light(l_power = 1)
+		set_light(l_range = 1.6, l_power = 1)
 
 /obj/machinery/firealarm/update_icon_state()
 	if(panel_open)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -27,8 +27,6 @@
 	light_range = 1.6
 	light_color = LIGHT_COLOR_ELECTRIC_CYAN
 
-	//Trick to get the glowing overlay visible from a distance
-	luminosity = 1
 	//We want to use area sensitivity, let us
 	always_area_sensitive = TRUE
 	///Buildstate for contruction steps

--- a/code/game/machinery/mining_weather_monitor.dm
+++ b/code/game/machinery/mining_weather_monitor.dm
@@ -4,7 +4,6 @@
 	desc = "A machine monitoring atmospheric data from mining environments. Provides warnings about incoming weather fronts."
 	icon = 'icons/obj/miningradio.dmi'
 	icon_state = "wallmount"
-	luminosity = 1
 	light_power = 1
 	light_range = 1.6
 

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -180,13 +180,6 @@
 		if(batong.cell)
 			batong.cell.charge = 0
 
-/obj/machinery/recharger/update_appearance(updates)
-	. = ..()
-	if((machine_stat & (NOPOWER|BROKEN)) || panel_open || !anchored)
-		luminosity = 0
-		return
-	luminosity = 1
-
 /obj/machinery/recharger/update_overlays()
 	. = ..()
 	if(machine_stat & (NOPOWER|BROKEN) || !anchored)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_EMPTY(heretic_sacrifice_landmarks)
 	nightshift_allowed = FALSE
 	bulb_colour = "#d6b6a6ff"
 	brightness = 3
-	fire_brightness = 2
+	fire_brightness = 3.5
 	bulb_power = 0.5
 
 /obj/machinery/light/very_dim/directional/north

--- a/code/modules/mining/equipment/miningradio.dm
+++ b/code/modules/mining/equipment/miningradio.dm
@@ -5,7 +5,6 @@
 	icon_state = "miningradio"
 	desc = "A weather radio designed for use in inhospitable environments. Gives audible warnings when storms approach. Has access to cargo channel."
 	freqlock = RADIO_FREQENCY_LOCKED
-	luminosity = 1
 	light_power = 1
 	light_range = 1.6
 

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -72,7 +72,7 @@
 	///The minimum value for the light's power in low power mode
 	var/bulb_low_power_pow_min = 0.5
 	///The Light range to use when working in fire alarm status
-	var/fire_brightness = 7
+	var/fire_brightness = 9
 	///The Light power to use when working in fire alarm status
 	var/fire_power = 0.5
 	///The Light colour to use when working in fire alarm status
@@ -718,7 +718,7 @@
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
 	nightshift_brightness = 3
-	fire_brightness = 2
+	fire_brightness = 4.5
 
 /obj/machinery/light/floor/get_light_offset()
 	return list(0, 0)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -72,7 +72,9 @@
 	///The minimum value for the light's power in low power mode
 	var/bulb_low_power_pow_min = 0.5
 	///The Light range to use when working in fire alarm status
-	var/fire_brightness = 4
+	var/fire_brightness = 7
+	///The Light power to use when working in fire alarm status
+	var/fire_power = 0.5
 	///The Light colour to use when working in fire alarm status
 	var/fire_colour = COLOR_FIRE_LIGHT_RED
 
@@ -222,6 +224,7 @@
 		var/area/local_area = get_room_area()
 		if (local_area?.fire)
 			color_set = fire_colour
+			power_set = fire_power
 			brightness_set = fire_brightness
 		else if (nightshift_enabled)
 			brightness_set = nightshift_brightness

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -39,7 +39,7 @@
 /obj/machinery/light/red/dim
 	brightness = 4
 	bulb_power = 0.7
-	fire_brightness = 3
+	fire_brightness = 4.5
 
 /obj/machinery/light/blacklight
 	bulb_colour = "#A700FF"
@@ -58,7 +58,7 @@
 	fitting = "bulb"
 	brightness = 4
 	nightshift_brightness = 4
-	fire_brightness = 3
+	fire_brightness = 4.5
 	bulb_colour = "#FFD6AA"
 	fire_colour = "#bd3f46"
 	desc = "A small lighting fixture."
@@ -85,13 +85,13 @@
 /obj/machinery/light/small/red/dim
 	brightness = 2
 	bulb_power = 0.8
-	fire_brightness = 2
+	fire_brightness = 2.5
 
 /obj/machinery/light/small/blacklight
 	bulb_colour = "#A700FF"
 	nightshift_allowed = FALSE
 	brightness = 4
-	fire_brightness = 3
+	fire_brightness = 4.5
 	fire_colour = "#d400ff"
 
 // -------- Directional presets

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -39,7 +39,7 @@
 /obj/machinery/light/red/dim
 	brightness = 4
 	bulb_power = 0.7
-	fire_brightness = 2
+	fire_brightness = 3
 
 /obj/machinery/light/blacklight
 	bulb_colour = "#A700FF"

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -402,13 +402,6 @@
 	pressure_charging = TRUE
 	update_appearance()
 
-/obj/machinery/disposal/bin/update_appearance(updates)
-	. = ..()
-	if((machine_stat & (BROKEN|NOPOWER)) || panel_open)
-		luminosity = 0
-		return
-	luminosity = 1
-
 /obj/machinery/disposal/bin/update_overlays()
 	. = ..()
 	if(machine_stat & BROKEN)

--- a/code/modules/transport/elevator/elev_indicator.dm
+++ b/code/modules/transport/elevator/elev_indicator.dm
@@ -17,7 +17,6 @@
 	light_range = 1
 	light_power = 1
 	light_color = COLOR_DISPLAY_BLUE
-	luminosity = 1
 
 	maptext_x = 18
 	maptext_y = 20

--- a/code/modules/transport/tram/tram_signals.dm
+++ b/code/modules/transport/tram/tram_signals.dm
@@ -18,7 +18,6 @@
 	// pointless if it only takes 2 seconds to cross but updates every 2 seconds
 	subsystem_type = /datum/controller/subsystem/processing/transport
 	light_color = LIGHT_COLOR_BABY_BLUE
-	luminosity = 1
 	/// green, amber, or red for tram, blue if it's emag, tram missing, etc.
 	var/signal_state = XING_STATE_MALF
 	/// the sensor we use
@@ -82,7 +81,6 @@
 	light_range = 1.5
 	light_power = 3
 	light_color = COLOR_VIBRANT_LIME
-	luminosity = 1
 	var/sign_dir = INBOUND
 
 /obj/machinery/static_signal/northwest


### PR DESCRIPTION

## About The Pull Request
[Removes redundant uses of luminosity](https://github.com/tgstation/tgstation/commit/dd4ec1fc73a090ac778459c0b58087299daab692)

I had a bunch of these left over from an old pr, sweep sweep (Made redundant because mobs can see through all byond darkness now)

[Starts working on the fire alarm lighting](https://github.com/tgstation/tgstation/commit/b555ba00c6dbb8ebfdcc5fe0c3dbb3a08f9e48e2)

Dimmer but wider fire alarms, dimmer but MUCH wider lights. The idea is to highlight fire alarms while providing a not pitchblack but vibey space.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/assets/58055496/5058bab4-0b04-4891-82d7-e3130711e5d0

Looks nice

## Changelog
:cl:
fix: Fire alarms no longer cause pitch blackness, instead creating a dark but not black red light.
/:cl:
