### PR TITLE
Refactors reviver code

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -71,8 +71,6 @@
 			to_chat(owner, span_notice("Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)]."))
 		else
 			addtimer(CALLBACK(src, PROC_REF(heal)), 3 SECONDS)
-			if(COOLDOWN_FINISHED(src, defib_cooldown))
-				revive_dead()
 		return
 
 	if(!COOLDOWN_FINISHED(src, reviver_cooldown) || HAS_TRAIT(owner, TRAIT_SUICIDED))
@@ -86,6 +84,8 @@
 
 
 /obj/item/organ/internal/cyberimp/chest/reviver/proc/heal()
+	if(COOLDOWN_FINISHED(src, defib_cooldown))
+		revive_dead()
 
 	/// boolean that stands for if PHYSICAL damage being patched
 	var/body_damage_patched = FALSE

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -112,21 +112,22 @@
 
 
 /obj/item/organ/internal/cyberimp/chest/reviver/proc/revive_dead()
-	if(COOLDOWN_FINISHED(src, defib_cooldown) && owner.stat == DEAD && owner.can_defib() == DEFIB_POSSIBLE)
-		owner.notify_revival("You are being revived by [src]!")
-		revive_cost += 10 MINUTES // Additional 10 minutes cooldown after revival.
-		owner.grab_ghost()
+	if(!COOLDOWN_FINISHED(src, defib_cooldown) || owner.stat != DEAD || owner.can_defib() != DEFIB_POSSIBLE)
+		return
+	owner.notify_revival("You are being revived by [src]!")
+	revive_cost += 10 MINUTES // Additional 10 minutes cooldown after revival.
+	owner.grab_ghost()
 
-		defib_cooldown += 16 SECONDS // delay so it doesn't spam
+	defib_cooldown += 16 SECONDS // delay so it doesn't spam
 
-		owner.visible_message(span_warning("[owner]'s body convulses a bit."))
-		playsound(owner, SFX_BODYFALL, 50, TRUE)
-		playsound(owner, 'sound/machines/defib_zap.ogg', 75, TRUE, -1)
-		owner.revive()
-		owner.emote("gasp")
-		owner.set_jitter_if_lower(200 SECONDS)
-		SEND_SIGNAL(owner, COMSIG_LIVING_MINOR_SHOCK)
-		log_game("[owner] been revived by [src]")
+	owner.visible_message(span_warning("[owner]'s body convulses a bit."))
+	playsound(owner, SFX_BODYFALL, 50, TRUE)
+	playsound(owner, 'sound/machines/defib_zap.ogg', 75, TRUE, -1)
+	owner.revive()
+	owner.emote("gasp")
+	owner.set_jitter_if_lower(200 SECONDS)
+	SEND_SIGNAL(owner, COMSIG_LIVING_MINOR_SHOCK)
+	log_game("[owner] been revived by [src]")
 
 
 /obj/item/organ/internal/cyberimp/chest/reviver/emp_act(severity)


### PR DESCRIPTION
## About The Pull Request

Cleans up reviver code to overall make it simpler and properly implement the cooldown that it said it had in the code but never really had. Additionally, stops the reviver trying to revive someone that isn't in a revivable state, which fixes https://github.com/tgstation/tgstation/issues/80371. Wasn't sure how long to make the delay but I figured just a 5 second delay after the first heal proc should be fine. About the same as what the original cooldown was from being paired to the heal proc's second iteration.
## Why It's Good For The Game

Changes variables and checks used by the reviver to make sure it functions properly with the cooldown that seemed to be intended in the code. Additionally, prevents the reviver from infinitely defibbing a non-revivable corpse.
## Changelog
:cl:
fix: Reviver no longer attempts to revive impossible to defib mobs.
refactor: Cleaned up unnecessary variables and re-arraigned code to have it perform altogether in one tick. Additionally added a proper cooldown to revivers.
/:cl:
