### PR TITLE
Fixed a runtime error with lobstrosity charge (also rust charge).

### DIFF
--- a/code/modules/antagonists/heretic/magic/rust_charge.dm
+++ b/code/modules/antagonists/heretic/magic/rust_charge.dm
@@ -46,4 +46,4 @@
 			SSexplosions.med_mov_atom += target
 
 	INVOKE_ASYNC(src, PROC_REF(DestroySurroundings), source)
-	hit_target(source, target, charge_damage)
+	try_hit_target(source, target, charge_damage)

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -68,7 +68,7 @@
 
 /datum/action/cooldown/mob_cooldown/charge/basic_charge/lobster/hit_target(atom/movable/source, atom/target, damage_dealt)
 	. = ..()
-	if(!isbasicmob(source))
+	if(!isbasicmob(source) || !isliving(target))
 		return
 	var/mob/living/basic/basic_source = source
 	var/mob/living/living_target = target


### PR DESCRIPTION
## About The Pull Request
Small premise: `basic_charge` can call `hit_target` for objects and not just mobs, unlike the parent type, also you usually call `try_hit_target` and not `hit_target` directly. That said, this PR fixes two small issues with a couple subtypes of the charge action.

## Why It's Good For The Game
Runtimes bad.

## Changelog
N/A