### PR TITLE
Disallows siphoning credits outside of station

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,7 +67,7 @@
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
-	if (!is_station_level(src.z) && !is_centcom_level(src.z))
+	if (!(is_station_level(src.z) || is_centcom_level(src.z)))
 		say("Error: Console not in reach of station. Siphon halted.")
 		end_siphon()
 		return

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,6 +67,10 @@
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
+	if (is_station_level(src.z) || is_centcom_level(src.z))
+		say("Error: Console not in reach of station. Siphon halted.")
+		end_siphon()
+		return
 	var/siphon_am = 100 * seconds_per_tick
 	if(!synced_bank_account.has_money(siphon_am))
 		say("[synced_bank_account.account_holder] depleted. Halting siphon.")
@@ -105,11 +109,8 @@
 
 	switch(action)
 		if("siphon")
-			if(is_station_level(src.z) || is_centcom_level(src.z))
-				say("Siphon of station credits has begun!")
-				start_siphon(ui.user)
-			else
-				say("Error: Console not in reach of station, withdrawal cannot begin.")
+			say("Siphon of station credits has begun!")
+			start_siphon(ui.user)
 			. = TRUE
 		if("halt")
 			say("Station credit withdrawal halted.")

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,10 +67,6 @@
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
-	if (!(is_station_level(src.z) || is_centcom_level(src.z)))
-		say("Error: Console not in reach of station. Siphon halted.")
-		end_siphon()
-		return
 	var/siphon_am = 100 * seconds_per_tick
 	if(!synced_bank_account.has_money(siphon_am))
 		say("[synced_bank_account.account_holder] depleted. Halting siphon.")
@@ -109,13 +105,22 @@
 
 	switch(action)
 		if("siphon")
-			say("Siphon of station credits has begun!")
-			start_siphon(ui.user)
+			if(is_station_level(src.z) || is_centcom_level(src.z))
+				say("Siphon of station credits has begun!")
+				start_siphon(ui.user)
+			else
+				say("Error: Console not in reach of station, withdrawal cannot begin.")
 			. = TRUE
 		if("halt")
 			say("Station credit withdrawal halted.")
 			end_siphon()
 			. = TRUE
+
+/obj/machinery/computer/bank_machine/on_changed_z_level()
+	. = ..()
+	if(siphoning && !(is_station_level(src.z) || is_centcom_level(src.z)))
+		say("Error: Console not in reach of station. Siphon halted.")
+		end_siphon()
 
 /obj/machinery/computer/bank_machine/proc/end_siphon()
 	siphoning = FALSE

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,7 +67,7 @@
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
-	if (!is_station_level(src.z) || !is_centcom_level(src.z))
+	if (!is_station_level(src.z) && !is_centcom_level(src.z))
 		say("Error: Console not in reach of station. Siphon halted.")
 		end_siphon()
 		return

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,7 +67,7 @@
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
-	if (is_station_level(src.z) || is_centcom_level(src.z))
+	if (!is_station_level(src.z) || !is_centcom_level(src.z))
 		say("Error: Console not in reach of station. Siphon halted.")
 		end_siphon()
 		return

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -105,8 +105,11 @@
 
 	switch(action)
 		if("siphon")
-			say("Siphon of station credits has begun!")
-			start_siphon(ui.user)
+			if(is_station_level(src.z) || is_centcom_level(src.z))
+				say("Siphon of station credits has begun!")
+				start_siphon(ui.user)
+			else
+				say("Error: Console not in reach of station, withdrawal cannot begin.")
 			. = TRUE
 		if("halt")
 			say("Station credit withdrawal halted.")


### PR DESCRIPTION

## About The Pull Request

See name
## Why It's Good For The Game

Imagine a funny little antagonist going to deep space with one of these. You'll never find them, and even if it were to have a gps signal by the time you were out to the location they could (And most like will) be long gone, or in a different ruin entirely.

Basically this is easy to abuse and not fun to play against.
## Changelog
:cl:
balance: Disallows siphoning credits outside of station
/:cl:
