### PR TITLE
Fixes interview panel [NO GBP]

### DIFF
--- a/tgui/packages/tgui/interfaces/Interview.tsx
+++ b/tgui/packages/tgui/interfaces/Interview.tsx
@@ -65,6 +65,7 @@ export const Interview = (props) => {
   } = data;
 
   const allAnswered = questions.every((q) => q.response);
+  const numAnswered = questions.filter((q) => q.response)?.length;
 
   return (
     <Window
@@ -84,9 +85,13 @@ export const Interview = (props) => {
             <span>
               <Button
                 onClick={() => act('submit')}
-                disabled={read_only || !allAnswered}
+                disabled={read_only || !allAnswered || !questions.length}
                 icon="envelope"
-                tooltip={!allAnswered && 'Please answer all questions.'}
+                tooltip={
+                  !allAnswered &&
+                  `Please answer all questions.
+                     ${numAnswered} / ${questions.length}`
+                }
               >
                 {read_only ? 'Submitted' : 'Submit'}
               </Button>
@@ -167,22 +172,22 @@ const QuestionArea = (props: Question) => {
     });
   };
 
-  // Determine if the response has changed
   const changedResponse = userInput !== response;
+
+  const saveAvailable = !read_only && !!userInput && changedResponse;
+
+  const isSaved = !!response && !changedResponse;
 
   return (
     <Section
       title={`Question ${qidx}`}
       buttons={
         <Button
-          // Set color to null if userInput is empty or matches the response
-          color={!userInput || !changedResponse ? null : 'good'}
-          // Disable the button if read_only is true or if userInput is not changed and not empty
-          disabled={read_only || (!changedResponse && !!userInput)}
+          disabled={!saveAvailable}
           onClick={saveResponse}
-          icon={!changedResponse ? 'check' : 'save'}
+          icon={isSaved ? 'check' : 'save'}
         >
-          {!changedResponse ? 'Saved' : 'Save'}
+          {isSaved ? 'Saved' : 'Save'}
         </Button>
       }
     >

--- a/tgui/packages/tgui/interfaces/Interview.tsx
+++ b/tgui/packages/tgui/interfaces/Interview.tsx
@@ -4,10 +4,11 @@ import {
   Section,
   BlockQuote,
   NoticeBox,
+  Box,
 } from '../components';
 import { Window } from '../layouts';
 import { useBackend } from '../backend';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 type Data = {
   connected: boolean;
@@ -22,7 +23,7 @@ type Data = {
 type Question = {
   qidx: number;
   question: string;
-  response: string;
+  response: string | null;
 };
 
 enum STATUS {
@@ -56,12 +57,14 @@ export const Interview = (props) => {
   const {
     connected,
     is_admin,
-    questions = [], // TODO: Remove default
+    questions = [],
     queue_pos,
     read_only,
     status,
     welcome_message = '',
   } = data;
+
+  const allAnswered = questions.every((q) => q.response);
 
   return (
     <Window
@@ -80,62 +83,51 @@ export const Interview = (props) => {
           buttons={
             <span>
               <Button
-                content={read_only ? 'Submitted' : 'Submit'}
                 onClick={() => act('submit')}
-                disabled={read_only}
-              />
+                disabled={read_only || !allAnswered}
+                icon="envelope"
+                tooltip={!allAnswered && 'Please answer all questions.'}
+              >
+                {read_only ? 'Submitted' : 'Submit'}
+              </Button>
               {!!is_admin && status === 'interview_pending' && (
                 <span>
-                  <Button
-                    content="Admin PM"
-                    enabled={connected}
-                    onClick={() => act('adminpm')}
-                  />
-                  <Button
-                    content="Approve"
-                    color="good"
-                    onClick={() => act('approve')}
-                  />
-                  <Button
-                    content="Deny"
-                    color="bad"
-                    onClick={() => act('deny')}
-                  />
+                  <Button disabled={!connected} onClick={() => act('adminpm')}>
+                    Admin PM
+                  </Button>
+                  <Button color="good" onClick={() => act('approve')}>
+                    Approve
+                  </Button>
+                  <Button color="bad" onClick={() => act('deny')}>
+                    Deny
+                  </Button>
                 </span>
               )}
             </span>
           }
         >
           {!read_only && (
-            <p>
-              Please answer the following questions, and press submit when you
-              are satisfied with your answers.
-              <br />
-              <br />
-              <b>You will not be able to edit your answers after submitting.</b>
-            </p>
+            <>
+              <Box as="p" color="label">
+                Please answer the following questions.
+                <ul>
+                  <li>
+                    You can press enter key or the save button to save an
+                    answer.
+                  </li>
+                  <li>
+                    You can edit your answers until you press the submit button.
+                  </li>
+                  <li>Press SUBMIT when you are done.</li>
+                </ul>
+              </Box>
+              <NoticeBox info align="center">
+                You will not be able to edit your answers after submitting.
+              </NoticeBox>
+            </>
           )}
-          {questions.map(({ qidx, question, response }) => (
-            <Section key={qidx} title={`Question ${qidx}`}>
-              <p>{linkifyText(question)}</p>
-              {((read_only || is_admin) && (
-                <BlockQuote>{response || 'No response.'}</BlockQuote>
-              )) || (
-                <TextArea
-                  value={response}
-                  fluid
-                  height={10}
-                  maxLength={500}
-                  placeholder="Write your response here, max of 500 characters. Press enter to submit."
-                  onEnter={(e, input) =>
-                    act('update_answer', {
-                      qidx,
-                      answer: input,
-                    })
-                  }
-                />
-              )}
-            </Section>
+          {questions.map((question) => (
+            <QuestionArea key={question.qidx} {...question} />
           ))}
         </Section>
       </Window.Content>
@@ -159,4 +151,52 @@ const RenderedStatus = (props: { status: string; queue_pos: number }) => {
         </NoticeBox>
       );
   }
+};
+
+const QuestionArea = (props: Question) => {
+  const { qidx, question, response } = props;
+  const { act, data } = useBackend<Data>();
+  const { is_admin, read_only } = data;
+
+  const [userInput, setUserInput] = useState(response);
+
+  const saveResponse = () => {
+    act('update_answer', {
+      qidx,
+      answer: userInput,
+    });
+  };
+
+  const changedResponse = !!response && userInput !== response;
+
+  return (
+    <Section
+      title={`Question ${qidx}`}
+      buttons={
+        <Button
+          color={!changedResponse && 'good'}
+          disabled={!changedResponse || read_only}
+          onClick={saveResponse}
+          icon={!changedResponse ? 'check' : 'save'}
+        >
+          {!changedResponse ? 'Saved' : 'Save'}
+        </Button>
+      }
+    >
+      <p>{linkifyText(question)}</p>
+      {((read_only || is_admin) && (
+        <BlockQuote>{response || 'No response.'}</BlockQuote>
+      )) || (
+        <TextArea
+          fluid
+          height={10}
+          maxLength={500}
+          onChange={(e, input) => setUserInput(input)}
+          onEnter={saveResponse}
+          placeholder="Write your response here, max of 500 characters. Press enter to submit."
+          value={response}
+        />
+      )}
+    </Section>
+  );
 };

--- a/tgui/packages/tgui/interfaces/Interview.tsx
+++ b/tgui/packages/tgui/interfaces/Interview.tsx
@@ -167,15 +167,18 @@ const QuestionArea = (props: Question) => {
     });
   };
 
-  const changedResponse = !!response && userInput !== response;
+  // Determine if the response has changed
+  const changedResponse = userInput !== response;
 
   return (
     <Section
       title={`Question ${qidx}`}
       buttons={
         <Button
-          color={!changedResponse && 'good'}
-          disabled={!changedResponse || read_only}
+          // Set color to null if userInput is empty or matches the response
+          color={!userInput || !changedResponse ? null : 'good'}
+          // Disable the button if read_only is true or if userInput is not changed and not empty
+          disabled={read_only || (!changedResponse && !!userInput)}
           onClick={saveResponse}
           icon={!changedResponse ? 'check' : 'save'}
         >


### PR DESCRIPTION
## About The Pull Request
This was a problematic UI based on how React handles onChange compared to Inferno, our previous. It was extra laggy after the switch, sending data on every key. When I had changed it to not send on keystroke, it wasn't super obvious that you must press "enter". I've tried to make this more obvious, and it now also safeguards against incomplete forms. This should resolve the issue, but not a screen I can test locally 100%.

<details>
<summary>Pictures</summary>

![image](https://github.com/tgstation/tgstation/assets/42397676/3f06e0ab-3a58-4d03-b3c4-fdd809937bfc)

</details>

## Why It's Good For The Game
Bug fix
fixes #80378
## Changelog
:cl:
fix: Interview UI should now be more obvious how it works: You must press "enter" or save the answer.
/:cl:
