### PR TITLE
Adds energy drinks to all nighter quirk stimulants list

### DIFF
--- a/code/datums/quirks/negative_quirks/all_nighter.dm
+++ b/code/datums/quirks/negative_quirks/all_nighter.dm
@@ -31,7 +31,9 @@
 		/datum/reagent/drug/pumpup,
 		/datum/reagent/drug/blastoff,
 		/datum/reagent/consumable/coffee,
-		/datum/reagent/consumable/tea
+		/datum/reagent/consumable/tea,
+		/datum/reagent/consumable/volt_energy,
+		/datum/reagent/consumable/monkey_energy
 	)
 	///essentially our "sleep bank". sleeping charges it up and its drained while awake
 	var/five_more_minutes = 0


### PR DESCRIPTION
## About The Pull Request

Adds monkey energy and volt drinks to all nighter stimulants quirks

## Why It's Good For The Game
Energy drinks contain caffeine and taurine, so they are stimulants

## Changelog

:cl:
code: All nighters can now drink energy drinks to cope with their lack of sleep.
/:cl:

