### PR TITLE
Mecha cell, Medipen & related reagent holder refactors

### DIFF
--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -76,7 +76,7 @@
 			return
 		add_overlay("active")
 		if(do_after(user, 2 SECONDS, src))
-			medipen.reagents.maximum_volume = initial(medipen.reagents.maximum_volume)
+			medipen.used_up = FALSE
 			medipen.add_initial_reagents()
 			reagents.remove_reagent(allowed_pens[medipen.type], 10)
 			balloon_alert(user, "refilled")

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -633,7 +633,7 @@
 	var/num_reagents = length(cached_reagents)
 	var/total_ph = 0
 	var/reagent_volume = 0
-	var/running_volume = 0
+	. = 0
 
 	//responsible for removing reagents and computing total ph & volume
 	//all it's code was taken out of del_reagent() initially for efficiency purposes
@@ -662,17 +662,17 @@
 			continue
 
 		//compute volume & ph like we would normally
-		running_volume += reagent_volume
+		. += reagent_volume
 		total_ph += (reagent.ph * reagent_volume)
 
 		//reasign rounded value
 		reagent.volume = reagent_volume
 
 	//assign the final values, rounding up can sometimes cause overflow so bring it down
-	total_volume = min(round(running_volume, CHEMICAL_VOLUME_ROUNDING), maximum_volume)
-	if(!running_volume)
+	total_volume = min(round(., CHEMICAL_VOLUME_ROUNDING), maximum_volume)
+	if(!total_volume)
 		ph = CHEMICAL_NORMAL_PH
-	else if(total_volume)
+	else
 		ph = clamp(total_ph / total_volume, CHEMICAL_MIN_PH, CHEMICAL_MAX_PH)
 
 	//now send the signals after the volume & ph has been computed

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -633,7 +633,7 @@
 	var/num_reagents = length(cached_reagents)
 	var/total_ph = 0
 	var/reagent_volume = 0
-	. = 0
+	var/running_volume = 0
 
 	//responsible for removing reagents and computing total ph & volume
 	//all it's code was taken out of del_reagent() initially for efficiency purposes
@@ -662,17 +662,17 @@
 			continue
 
 		//compute volume & ph like we would normally
-		. += reagent_volume
+		running_volume += reagent_volume
 		total_ph += (reagent.ph * reagent_volume)
 
 		//reasign rounded value
 		reagent.volume = reagent_volume
 
 	//assign the final values, rounding up can sometimes cause overflow so bring it down
-	total_volume = min(round(., CHEMICAL_VOLUME_ROUNDING), maximum_volume)
-	if(!.)
+	total_volume = min(round(running_volume, CHEMICAL_VOLUME_ROUNDING), maximum_volume)
+	if(!running_volume)
 		ph = CHEMICAL_NORMAL_PH
-	else
+	else if(total_volume != 0)
 		ph = clamp(total_ph / total_volume, CHEMICAL_MIN_PH, CHEMICAL_MAX_PH)
 
 	//now send the signals after the volume & ph has been computed

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -672,7 +672,7 @@
 	total_volume = min(round(running_volume, CHEMICAL_VOLUME_ROUNDING), maximum_volume)
 	if(!running_volume)
 		ph = CHEMICAL_NORMAL_PH
-	else if(total_volume != 0)
+	else if(total_volume)
 		ph = clamp(total_ph / total_volume, CHEMICAL_MIN_PH, CHEMICAL_MAX_PH)
 
 	//now send the signals after the volume & ph has been computed

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -28,7 +28,7 @@
 ///Handles all injection checks, injection and logging.
 /obj/item/reagent_containers/hypospray/proc/inject(mob/living/affected_mob, mob/user)
 	if(used_up)
-		to_chat(user, span_warning("[src] is empty!"))
+		to_chat(user, span_warning("[src] tip is broken and is now unusable!"))
 		return FALSE
 	if(!iscarbon(affected_mob))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -17,6 +17,7 @@
 	var/infinite = FALSE
 	/// If TRUE, won't play a noise when injecting.
 	var/stealthy = FALSE
+	var/used_up = FALSE
 
 /obj/item/reagent_containers/hypospray/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
@@ -26,7 +27,7 @@
 
 ///Handles all injection checks, injection and logging.
 /obj/item/reagent_containers/hypospray/proc/inject(mob/living/affected_mob, mob/user)
-	if(!reagents.total_volume)
+	if(used_up)
 		to_chat(user, span_warning("[src] is empty!"))
 		return FALSE
 	if(!iscarbon(affected_mob))
@@ -39,7 +40,7 @@
 	var/contained = english_list(injected)
 	log_combat(user, affected_mob, "attempted to inject", src, "([contained])")
 
-	if(reagents.total_volume && (ignore_flags || affected_mob.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
+	if(!used_up && (ignore_flags || affected_mob.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
 		to_chat(affected_mob, span_warning("You feel a tiny prick!"))
 		to_chat(user, span_notice("You inject [affected_mob] with [src]."))
 		if(!stealthy)
@@ -134,8 +135,8 @@
 
 /obj/item/reagent_containers/hypospray/medipen/inject(mob/living/affected_mob, mob/user)
 	. = ..()
-	if(.)
-		reagents.maximum_volume = 0 //Makes them useless afterwards
+	if(. && !reagents.total_volume)
+		used_up = TRUE //Makes them useless afterwards
 		reagents.flags = NONE
 		update_appearance()
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -17,6 +17,7 @@
 	var/infinite = FALSE
 	/// If TRUE, won't play a noise when injecting.
 	var/stealthy = FALSE
+	/// If TRUE, the hypospray will be permanently unusable.
 	var/used_up = FALSE
 
 /obj/item/reagent_containers/hypospray/attack_paw(mob/user, list/modifiers)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -576,7 +576,7 @@
 		if(!enclosed && occupant?.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
 			mob_exit(occupant, randomstep = TRUE) //bye bye
 			continue
-		if(cell && cell.maxcharge != 0)
+		if(cell && cell.maxcharge)
 			var/cellcharge = cell.charge/cell.maxcharge
 			switch(cellcharge)
 				if(0.75 to INFINITY)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -576,7 +576,7 @@
 		if(!enclosed && occupant?.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
 			mob_exit(occupant, randomstep = TRUE) //bye bye
 			continue
-		if(cell)
+		if(cell && cell.maxcharge != 0)
 			var/cellcharge = cell.charge/cell.maxcharge
 			switch(cellcharge)
 				if(0.75 to INFINITY)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -589,6 +589,8 @@
 					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell/mech, 3)
 				else
 					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/emptycell/mech)
+		else
+			occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/nocell)
 		var/integrity = atom_integrity/max_integrity*100
 		switch(integrity)
 			if(30 to 45)


### PR DESCRIPTION
## About The Pull Request

Changed the reagent volume check to a total reagent volume check as sometimes the total volume can be set to 0 and can pass through the check if it was only looking for the sum total of all the reagents' volume. Additionally added a check to mechs for if it's cell has a max charge of 0 so that it won't divide by zero. Refactoring hyposprays to utilize a new var to check  if they're fully used up rather than forcefully setting the total volume to 0 should prevent any potential future errors.
## Why It's Good For The Game

Removes division by zero runtimes and doesn't force total volume to equal 0.

## Changelog
:cl:
fix: Injecting yourself twice with a luxury medipen in pressure doesn't runtime and mechs with a cell with no max charge won't runtime.
refactor: Gives hyposprays a var to check if they're fully used up rather than setting total_volume to 0.
/:cl:

## Runtime Logs
To show that they exist and were ignored because they're extremely specific weird ones.

![image](https://github.com/tgstation/tgstation/assets/26240645/c38c04f0-3e39-41b3-94e4-433eda4f2930)

Mech runtime from somehow having a cell with no charge. No idea how they managed to do that at all.

<img width="967" alt="image" src="https://github.com/tgstation/tgstation/assets/26240645/a66401a7-e52b-42f9-85c8-b5715c45848b">

Using the luxury medipen twice causes a runtime by somehow causing the total_volume to believe it's 0.
