### PR TITLE
Adds hazard vests, orange hard hats, and pocket protectors to the Cargodrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -170,6 +170,9 @@
 		/obj/item/storage/backpack/messenger = 3,
 		/obj/item/storage/bag/mail = 3,
 		/obj/item/radio/headset/headset_cargo = 3,
+		/obj/item/clothing/accessory/pocketprotector = 3,
+		/obj/item/clothing/head/utility/hardhat/orange = 3,
+		/obj/item/clothing/suit/hazardvest = 3,
 	)
 	premium = list(
 		/obj/item/clothing/head/costume/mailman = 1,


### PR DESCRIPTION

## About The Pull Request
Adds orange hardhats, hazard vests, and pocket protectors to the cargo drobe. It follows the current cargo supply vendor's stock (which means there are three hard hats, three hazard vests, and three pocket protectors)

## Why It's Good For The Game
I always thought it'd make sense for cargo to have these things as pseudo-dockworkers and mailmen. Plus, it allows for a bit of uniform customization that doesn't stray from the overall 'theme' of the department, similar to how medical has several outfit combinations and accessory options in their clothes vendor that still fit the medical department theme.

Hazard vests: I thought it'd make sense for cargo workers to be able to wear high visibility vests since you have freight moving around and cargo shuttles docking and undocking throughout the shift.

(Orange) Hard Hats: additional safety that goes nicely with the hazard vests.

Pocket Protectors: Cargo has a lot of pens and papers, as well as paper cutters, in its delivery office.

## Photo examples:

Cargo Tech (Default uniform)
![vest6](https://github.com/tgstation/tgstation/assets/45489195/1077d3c5-e04a-44e0-91e4-51caade99418)

Cargo Tech (Shorts)
![vest5](https://github.com/tgstation/tgstation/assets/45489195/8cd0d8f9-2af0-4ad4-b4dc-152739694ca6)

## Changelog

Adds orange hardhats, hazard (high-vis) vests, and pocket protectors to the cargo drobe

:cl:
add: Added orange hardhats, hazard vests, and pocket protectors to the cargo drobe
/:cl:
