### PR TITLE
Fixes ashwalker respawn + more

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -50,12 +50,12 @@
 		if(offeredmob.loc == src)
 			continue //Ashwalker Revive in Progress...
 		if(offeredmob.stat)
-			for(var/obj/item/W in offeredmob)
-				if(!offeredmob.dropItemToGround(W))
-					qdel(W)
+			offeredmob.unequip_everything()
+
 			if(issilicon(offeredmob)) //no advantage to sacrificing borgs...
 				offeredmob.investigate_log("has been gibbed by the necropolis tendril.", INVESTIGATE_DEATHS)
 				visible_message(span_notice("Serrated tendrils eagerly pull [offeredmob] apart, but find nothing of interest."))
+				offeredmob.gib(DROP_BRAIN)
 				return
 
 			if(offeredmob.mind?.has_antag_datum(/datum/antagonist/ashwalker) && (offeredmob.ckey || offeredmob.get_ghost(FALSE, TRUE))) //special interactions for dead lava lizards with ghosts attached

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -55,7 +55,7 @@
 			if(issilicon(offeredmob)) //no advantage to sacrificing borgs...
 				offeredmob.investigate_log("has been gibbed by the necropolis tendril.", INVESTIGATE_DEATHS)
 				visible_message(span_notice("Serrated tendrils eagerly pull [offeredmob] apart, but find nothing of interest."))
-				offeredmob.gib(DROP_BRAIN)
+				offeredmob.gib()
 				return
 
 			if(offeredmob.mind?.has_antag_datum(/datum/antagonist/ashwalker) && (offeredmob.ckey || offeredmob.get_ghost(FALSE, TRUE))) //special interactions for dead lava lizards with ghosts attached


### PR DESCRIPTION
## About The Pull Request

Fixes #79678 
Fixes #71965
Fixes silicons not being gibbed when sacrificed, instead they would just sit there while the tendril spewed text after dropping its parts.

The tendril was trying to drop every item on the body, including the chest, which would gib the ashwalker.

## Why It's Good For The Game

Fixes bugs

## Changelog

:cl: Seven
fix: Ashwalkers can respawn fellow ashwalkers by bringing them back to their tendril again.
fix: Ashwalker tendrils no longer break hooded suits and modsuits.
fix: Ashwalkers can sacrifice silicons, it wont give anything though.
/:cl:
