### PR TITLE
Fixes observers spamming admin logs when observing themselves

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -970,7 +970,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(is_secret_level(mob_eye.z) && !client?.holder)
 			set_sight(null) //we dont want ghosts to see through walls in secret areas
 		RegisterSignal(mob_eye, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_observing_z_changed))
-		if(mob_eye.hud_used)
+		if(mob_eye.hud_used && src != usr) // can't view your own inventory and hud but you're either A: permanently ghosted out. Or B: dead and it barely matters.
 			client.clear_screen()
 			LAZYOR(mob_eye.observers, src)
 			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)


### PR DESCRIPTION

## About The Pull Request

Fixes #77034 by adding in a check to do_observe to prevent observers from observing themselves. It does prevent them from observing their own bodies and seeing their hud and entire inventory as a ghost, but that's not a major problem because they probably either remember what they had if it's so important to constantly see what's on their mob or it doesn't matter. Additionally they can just use re-enter corpse so whatever.
## Why It's Good For The Game

Observers can no longer intentionally or even completely accidentally flood admin logs from their observetarget not resetting due to them observing themselves.
## Changelog
:cl:
fix: Observers observing themselves no longer floods admins' logs.
/:cl:
