### PR TITLE
Fixes circuit variable UI

### DIFF
--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/VariableMenu.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/VariableMenu.jsx
@@ -14,6 +14,7 @@ import {
   VARIABLE_LIST,
   VARIABLE_NOT_A_LIST,
 } from './constants';
+import { multiline } from 'common/string';
 
 export class VariableMenu extends Component {
   constructor(props) {


### PR DESCRIPTION

## About The Pull Request
Circuit UI bluescreens when inputting a global var.
I was curious stepping into this, the recent trend would suggest my recent UI changes did it, but why would it lose an import statement? I looked through the history, and this file's just [never had one](https://github.com/tgstation/tgstation/commit/a4be13ac625f8bf669e2c7b4cd83fffab4759b07#diff-4250b9fec9c0c9ff00917c2e75c6ebd937a364531b9b743b15edd9dfe177be28). It's been calling an undefined tag for two years. Fascinating.
## Why It's Good For The Game
Fixes #80387
## Changelog
:cl:
fix: Fixed a bluescreen while inputting a global variable in the circuit UI.
/:cl:
