### PR TITLE
Fix Escape not unbinding keys

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -293,7 +293,7 @@ export class KeybindingsPage extends Component<{}, KeybindingsPageState> {
     if (isStandardKey(event)) {
       this.setRebindingHotkey(formatKeyboardEvent(event));
       return;
-    } else if (event.key === 'Esc') {
+    } else if (event.key === KEY.Escape) {
       this.setRebindingHotkey(undefined);
       return;
     }


### PR DESCRIPTION
Broke as part of React migration--this used to be 'Esc' but is now 'Escape'.

## Changelog
:cl:
fix: Fixed pressing Esc not unbinding keys in preferences.
/:cl:
