### PR TITLE
Intern assistants are Interns

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -79,6 +79,7 @@
 /datum/id_trim/job/assistant
 	assignment = "Assistant"
 	trim_state = "trim_assistant"
+	intern_alt_name = "Intern"
 	sechud_icon_state = SECHUD_ASSISTANT
 	minimal_access = list()
 	extra_access = list(


### PR DESCRIPTION
Revive of #78498 
This is what I tried to explain in the PR, it was trying to add code that already existed
@optimumtact 

## Why it's good for the game
It's just flavor, it changes the "Intern Assistant" to "Intern" on the job ID for SOUL. 

:cl:
qol: Assistants with <10h of playtime are now "Interns"
/:cl: