### PR TITLE
Alien nests and some other stuf can be hit again.

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -40,7 +40,7 @@
 	req_access = null
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 /datum/track
 	var/song_name = "generic"

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -123,7 +123,7 @@ Possible to do for anyone motivated enough:
 
 /obj/machinery/holopad/tutorial
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	on_network = FALSE
 	///Proximity monitor associated with this atom, needed for proximity checks.
 	var/datum/proximity_monitor/proximity_monitor

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -283,7 +283,7 @@
 
 /obj/machinery/limbgrower/fullupgrade //Inherently cheaper organ production. This is to NEVER be inherently emagged, no valids.
 	desc = "It grows new limbs using Synthflesh. This alien model seems more efficient."
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	circuit = /obj/item/circuitboard/machine/limbgrower/fullupgrade
 
 /obj/machinery/limbgrower/fullupgrade/Initialize(mapload)

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -20,7 +20,7 @@
 
 /obj/machinery/telecomms/allinone/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 /obj/machinery/telecomms/allinone/receive_signal(datum/signal/subspace/signal)
 	if(!istype(signal) || signal.transmission_method != TRANSMISSION_SUBSPACE)  // receives on subspace only

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -12,7 +12,7 @@
 	smoothing_groups = SMOOTH_GROUP_ALIEN_NEST
 	canSmoothWith = SMOOTH_GROUP_ALIEN_NEST
 	build_stack_type = null
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	elevation = 0
 	var/static/mutable_appearance/nest_overlay = mutable_appearance('icons/mob/nonhuman-player/alien.dmi', "nestoverlay", LYING_MOB_LAYER)
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -487,7 +487,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	icon_state = null
 	buildstacktype = null
 	item_chair = null
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	alpha = 0
 
 /obj/structure/chair/mime/post_buckle_mob(mob/living/M)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -446,11 +446,12 @@
 	name = "xmas tree"
 	desc = "A wondrous decorated Christmas tree."
 	icon_state = "pine_c"
-	obj_flags = NO_DECONSTRUCTION //protected by the christmas spirit
 
 /obj/structure/flora/tree/pine/xmas/presents
 	icon_state = "pinepresents"
 	desc = "A wondrous decorated Christmas tree. It has presents!"
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF //protected by the christmas spirit
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	var/gift_type = /obj/item/gift/anything
 	var/unlimited = FALSE
 	var/static/list/took_presents //shared between all xmas trees

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -803,7 +803,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 
 /obj/structure/window/reinforced/shuttle/indestructible
 	name = "hardened shuttle window"
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	flags_1 = PREVENT_CLICK_UNDER_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 

--- a/code/modules/awaymissions/mission_code/murderdome.dm
+++ b/code/modules/awaymissions/mission_code/murderdome.dm
@@ -1,7 +1,7 @@
 
 /obj/structure/window/reinforced/fulltile/indestructible
 	name = "robust window"
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	flags_1 = PREVENT_CLICK_UNDER_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -464,7 +464,7 @@
 
 /obj/structure/table/reinforced/ctf
 	resistance_flags = INDESTRUCTIBLE
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 #define CTF_LOADING_UNLOADED 0
 #define CTF_LOADING_LOADING 1

--- a/code/modules/food_and_drinks/machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/machinery/food_cart.dm
@@ -8,7 +8,7 @@
 	anchored = FALSE
 	use_power = NO_POWER_USE
 	req_access = list(ACCESS_KITCHEN)
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	var/unpacked = FALSE
 	var/obj/machinery/griddle/stand/cart_griddle
 	var/obj/machinery/smartfridge/food/cart_smartfridge

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1159,7 +1159,7 @@
 	circuit = null
 	density = FALSE
 	use_power = NO_POWER_USE
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	unwrenchable = FALSE
 	self_sustaining_overlay_icon_state = null
 	maxnutri = 15

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -201,7 +201,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/survival_pod/spawne
 	light_color = COLOR_VERY_PALE_LIME_GREEN
 	max_n_of_items = 10
 	pixel_y = -4
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 /obj/machinery/smartfridge/survival_pod/Initialize(mapload)
 	AddElement(/datum/element/update_icon_blocker)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -664,7 +664,7 @@
 /obj/machinery/chem_dispenser/mutagensaltpeter
 	name = "botanical chemical dispenser"
 	desc = "Creates and dispenses chemicals useful for botany."
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	circuit = /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
 
 	/// The default list of dispensable reagents available in the mutagensaltpeter chem dispenser

--- a/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
@@ -6,7 +6,7 @@
 	base_icon_state = "dispenser"
 	amount = 10
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	use_power = NO_POWER_USE
 	var/static/list/shortcuts = list(
 		"meth" = /datum/reagent/drug/methamphetamine

--- a/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -5,7 +5,7 @@
 	icon_state = "beacon_active"
 	base_icon_state = "beacon"
 	density = TRUE
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 	/// Locked beacons cannot be jumped to by ships.
 	var/locked = FALSE

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -79,7 +79,7 @@
 	var/obj/machinery/power/emitter/energycannon/magical/our_statue
 	var/list/mob/living/sleepers = list()
 	var/never_spoken = TRUE
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 /obj/structure/table/abductor/wabbajack/Initialize(mapload)
 	. = ..()
@@ -201,7 +201,7 @@
 
 /obj/structure/table/wood/shuttle_bar
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = NO_DECONSTRUCTION|CAN_BE_HIT
 	max_integrity = 1000
 	var/boot_dir = 1
 

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -201,7 +201,7 @@
 
 /obj/structure/table/wood/shuttle_bar
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	obj_flags = NO_DECONSTRUCTION|CAN_BE_HIT
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 	max_integrity = 1000
 	var/boot_dir = 1
 

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -11,7 +11,7 @@
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 /obj/machinery/computer/shuttle/syndicate/launch_check(mob/user)
 	. = ..()

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -697,7 +697,7 @@
 
 /obj/machinery/transport/tram_controller/hilbert
 	configured_transport_id = HILBERT_LINE_1
-	obj_flags = NO_DECONSTRUCTION
+	obj_flags = /obj::obj_flags | NO_DECONSTRUCTION
 
 /obj/machinery/transport/tram_controller/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Another small issue fixed. Thanks Melbert for telling us what's wrong with it.

EDIT: other objects were rendered unhittable by that flags refactor PR.

## Why It's Good For The Game
Fixes #80311. I made the xmas tree indestructible because the comment to the `NO_DECONSTRUCTION` flag didn't make a load of sense since that doesn't stop it from getting destroyed anyway.

## Changelog

:cl: MrMelbert, Ghommie
fix: Alien nests, and some other stuff, can be physically attacked again.
balance: x-mas trees (the ones with presents), are indestructibles. Truly protected by a yuletide spirit.
/:cl:
