### PR TITLE
Fixes a morgue trays causing burn damage to corpses because it's TOO cold, also organ decay

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	/// The rate at which the internal air mixture cools
 	var/cooling_rate_per_second = 4
 	/// Minimum temperature of the internal air mixture
-	var/minimum_temperature = T0C - 20
+	var/minimum_temperature = BODYTEMP_COLD_DAMAGE_LIMIT + 1
 
 
 /obj/structure/bodycontainer/morgue/Initialize(mapload)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	/// The rate at which the internal air mixture cools
 	var/cooling_rate_per_second = 4
 	/// Minimum temperature of the internal air mixture
-	var/minimum_temperature = T0C - 60
+	var/minimum_temperature = T0C - 20
 
 
 /obj/structure/bodycontainer/morgue/Initialize(mapload)

--- a/code/modules/surgery/organs/internal/_internal_organ.dm
+++ b/code/modules/surgery/organs/internal/_internal_organ.dm
@@ -33,12 +33,12 @@
 
 	if(owner)
 		if(owner.bodytemperature > T0C)
-			var/air_temperature_factor = min((owner.bodytemperature - T0C) / T20C, 1)
+			var/air_temperature_factor = min((owner.bodytemperature - T0C) / (T20C - T0C), 1)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 	else
 		var/datum/gas_mixture/exposed_air = return_air()
 		if(exposed_air && exposed_air.temperature > T0C)
-			var/air_temperature_factor = min((exposed_air.temperature - T0C) / T20C, 1)
+			var/air_temperature_factor = min((exposed_air.temperature - T0C) / (T20C - T0C), 1)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 
 /// Called once every life tick on every organ in a carbon's body


### PR DESCRIPTION
## About The Pull Request
This will fix #80302 for everything except ethereals, but ethereals take damage at above 0° C temp anyway so their organs cannot be preserved within the body.

Also fixing some wrong logic also from #80219, which lead to organs decay being but a fraction of what it should be.
## Why It's Good For The Game
Fixing issues.

## Changelog

:cl:
fix: Fixed organ decay being too low.
fix: Fixed morgue trays having excessively low temperatures that damage corpses.
/:cl:
