### PR TITLE
Fixes invisible delete button in admin painting manager.

### DIFF
--- a/tgui/packages/tgui/interfaces/PaintingAdminPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PaintingAdminPanel.tsx
@@ -133,9 +133,8 @@ export const PaintingAdminPanel = (props) => {
                   setChosenPaintingRef(undefined);
                   act('delete', { ref: chosenPainting.ref });
                 }}
-              >
-                Delete
-              </Button.Confirm>
+                content="Delete"
+              />
               <Button
                 onClick={() => act('dumpit', { ref: chosenPainting.ref })}
               >


### PR DESCRIPTION
Fixes #80422

This is the only Button.Confirm in the codebase that tries to wrap content tags around the component content instead of setting content="stuff" in the component's props.

![image](https://github.com/tgstation/tgstation/assets/24975989/14746233-31de-46a4-975e-87c0ce4d08b3)
![image](https://github.com/tgstation/tgstation/assets/24975989/e9361562-4e99-477b-a823-06c66f6de870)

I'm not sure what broke this, since it supposedly worked in the past. We've had recent PRs touching button code and confirm buttons.

But at the very least this fixes the issue and brings this unique Button.Confirm into the same standard all other Button.Confirms use for their inner content.

This hasn't been tested on a local server with DB/saved persistent paintings, however when I took other interfaces (such as the air alarm) and had their Button.Confirms wrap around their content instead of putting it in the props the content wasn't rendered (although icons were). So I'm positive this will see the button return to life.

## Why It's Good For The Game

Admins can delete paintings again.
## Changelog
:cl:
admin: Delete painting button is once again visible.
/:cl:
