### PR TITLE
The bitrunning domain completion screen alert works again

### DIFF
--- a/code/modules/bitrunning/alerts.dm
+++ b/code/modules/bitrunning/alerts.dm
@@ -9,7 +9,8 @@
 	timeout = 20 SECONDS
 
 /atom/movable/screen/alert/bitrunning/qserver_domain_complete/Click(location, control, params)
-	if(..())
+	. = ..()
+	if(!.)
 		return
 
 	var/mob/living/living_owner = owner


### PR DESCRIPTION

## About The Pull Request

When a domain is cleared via delivering the crate, all bitrunners get an alert that lets them disconnect safely when clicked. However, it was not working due to an inverted check. This PR fixes that, and also passes along the return value properly.

## Why It's Good For The Game

I want to get off Mr Bone's Wild VR safely if I am trapped in a corner but my friends manage to deliver the loot back to base.

## Changelog

:cl:
fix: The bitrunner domain completion screen alert is once again properly clickable
/:cl:

