### PR TITLE
Changes the 'red pill' signal into a more generic 'living pill consumed'

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_bitrunning.dm
+++ b/code/__DEFINES/dcs/signals/signals_bitrunning.dm
@@ -4,9 +4,6 @@
 /// from /obj/effect/bitrunning/loot_signal: (points)
 #define COMSIG_BITRUNNER_GOAL_POINT "bitrunner_goal_point"
 
-/// from /obj/item/reagent_containers/pill
-#define COMSIG_BITRUNNER_RED_PILL_SEVER "bitrunner_red_pill_sever"
-
 // Netpods
 
 /// from /obj/machinery/netpod/sever_connection()

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -235,6 +235,9 @@
 /// Sent from a 'contract chain' button on a mob chain
 #define COMSIG_MOB_CHAIN_CONTRACT "living_chain_contracted"
 
+/// Sent from `obj/item/reagent_containers/pill/on_consumption`: (obj/item/reagent_containers/pill/pill, mob/feeder)
+#define COMSIG_LIVING_PILL_CONSUMED "living_pill_consumed"
+
 /// Sent from a mob to their loc when starting to remove cuffs on itself
 #define COMSIG_MOB_REMOVING_CUFFS "living_removing_cuffs"
 /// Sent as a reply to above from any atom that wishs to stop self-cuff removal

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -82,18 +82,21 @@
 	 * - Mailed in a cache
 	 * - Click / Stand on the ladder
 	 */
-	RegisterSignals(parent, list(COMSIG_BITRUNNER_ALERT_SEVER, COMSIG_BITRUNNER_CACHE_SEVER, COMSIG_BITRUNNER_LADDER_SEVER, COMSIG_BITRUNNER_RED_PILL_SEVER), PROC_REF(on_safe_disconnect))
+	RegisterSignals(parent, list(COMSIG_BITRUNNER_ALERT_SEVER, COMSIG_BITRUNNER_CACHE_SEVER, COMSIG_BITRUNNER_LADDER_SEVER), PROC_REF(on_safe_disconnect))
+	RegisterSignal(parent, COMSIG_LIVING_PILL_CONSUMED, PROC_REF(disconnect_if_red_pill))
 	RegisterSignal(parent, COMSIG_LIVING_DEATH, PROC_REF(on_sever_connection))
 	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_linked_damage))
 
 /datum/component/avatar_connection/UnregisterFromParent()
 	REMOVE_TRAIT(parent, TRAIT_TEMPORARY_BODY, REF(src))
-	UnregisterSignal(parent, COMSIG_BITRUNNER_ALERT_SEVER)
-	UnregisterSignal(parent, COMSIG_BITRUNNER_CACHE_SEVER)
-	UnregisterSignal(parent, COMSIG_BITRUNNER_LADDER_SEVER)
-	UnregisterSignal(parent, COMSIG_BITRUNNER_RED_PILL_SEVER)
-	UnregisterSignal(parent, COMSIG_LIVING_DEATH)
-	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE)
+	UnregisterSignal(parent, list(
+		COMSIG_BITRUNNER_ALERT_SEVER,
+		COMSIG_BITRUNNER_CACHE_SEVER,
+		COMSIG_BITRUNNER_LADDER_SEVER,
+		COMSIG_LIVING_DEATH,
+		COMSIG_LIVING_PILL_CONSUMED,
+		COMSIG_MOB_APPLY_DAMAGE
+	))
 
 /// Disconnects the avatar and returns the mind to the old_body.
 /datum/component/avatar_connection/proc/full_avatar_disconnect(cause_damage = FALSE, datum/source)
@@ -180,6 +183,12 @@
 	)
 	alert.name = "Integrity Compromised"
 	alert.desc = "The netpod is damaged. Find an exit."
+
+//if your bitrunning avatar somehow manages to acquire and consume a red pill, they will be ejected from the Matrix
+/datum/component/avatar_connection/proc/disconnect_if_red_pill(datum/source, obj/item/reagent_containers/pill/pill, mob/feeder)
+	SIGNAL_HANDLER
+	if(pill.icon_state == "pill4")
+		full_avatar_disconnect()
 
 /// Triggers when a safe disconnect is called
 /datum/component/avatar_connection/proc/on_safe_disconnect(datum/source)

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -95,7 +95,7 @@
 		COMSIG_BITRUNNER_LADDER_SEVER,
 		COMSIG_LIVING_DEATH,
 		COMSIG_LIVING_PILL_CONSUMED,
-		COMSIG_MOB_APPLY_DAMAGE
+		COMSIG_MOB_APPLY_DAMAGE,
 	))
 
 /// Disconnects the avatar and returns the mind to the old_body.

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -48,11 +48,10 @@
 
 ///Runs the consumption code, can be overriden for special effects
 /obj/item/reagent_containers/pill/proc/on_consumption(mob/consumer, mob/giver)
-	if(icon_state == "pill4") //you take the red pill - you stay in Wonderland, and I show you how deep the rabbit hole goes
-		SEND_SIGNAL(consumer, COMSIG_BITRUNNER_RED_PILL_SEVER) //if your bitrunning avatar somehow manages to acquire and consume a red pill, they will be ejected from the Matrix
-		if(prob(5)) //the other kind of red pill
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), consumer, span_notice("[pick(strings(REDPILL_FILE, "redpill_questions"))]")), 50)
+	if(icon_state == "pill4" && prob(5)) //you take the red pill - you stay in Wonderland, and I show you how deep the rabbit hole goes
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), consumer, span_notice("[pick(strings(REDPILL_FILE, "redpill_questions"))]")), 50)
 	if(apply_type == INGEST)
+		SEND_SIGNAL(consumer, COMSIG_LIVING_PILL_CONSUMED, src, giver)
 		SEND_SIGNAL(src, COMSIG_PILL_CONSUMED, eater = consumer, feeder = giver)
 	if(reagents.total_volume)
 		reagents.trans_to(consumer, reagents.total_volume, transferred_by = giver, methods = apply_type)


### PR DESCRIPTION
## About The Pull Request
I've been reminded to do that by Mothblocks.

## Why It's Good For The Game
Who would have thought that an oddly specific signal that is only sent when the pill is red was bad design.

## Changelog
N/A