### PR TITLE
[TM ONLY] Remove 'natural' beheading

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -386,7 +386,7 @@
 /datum/heretic_knowledge/ultimate/blade_final
 	name = "Maelstrom of Silver"
 	desc = "The ascension ritual of the Path of Blades. \
-		Bring 3 headless corpses to a transmutation rune to complete the ritual. \
+		Bring 3 LEGLESS (NOT HEADLESS) corpses to a transmutation rune to complete the ritual. \
 		When completed, you will be surrounded in a constant, regenerating orbit of blades. \
 		These blades will protect you from all attacks, but are consumed on use. \
 		Your Furious Steel spell will also have a shorter cooldown. \
@@ -401,7 +401,7 @@
 	if(!.)
 		return FALSE
 
-	return !sacrifice.get_bodypart(BODY_ZONE_HEAD)
+	return !sacrifice.get_bodypart(BODY_ZONE_L_LEG) && !sacrifice.get_bodypart(BODY_ZONE_R_LEG)
 
 /datum/heretic_knowledge/ultimate/blade_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	desc = "Allows you to transmute a sheet of glass and a pair of eyes to create an Amber Focus. \
 		A focus must be worn in order to cast more advanced spells."
 	required_atoms = list(
-		/obj/item/organ/internal/eyes = 1,
+		/obj/item/bodypart/leg/left = 1,
 		/obj/item/stack/sheet/glass = 1,
 	)
 	result_atoms = list(/obj/item/clothing/neck/heretic_focus)

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -4,11 +4,11 @@
 		list(
 			list(
 				/datum/traitor_objective/target_player/assassinate/calling_card = 1,
-				/datum/traitor_objective/target_player/assassinate/behead = 1,
+				// /datum/traitor_objective/target_player/assassinate/behead = 1,
 			) = 1,
 			list(
 				/datum/traitor_objective/target_player/assassinate/calling_card/heads_of_staff = 1,
-				/datum/traitor_objective/target_player/assassinate/behead/heads_of_staff = 1,
+				// /datum/traitor_objective/target_player/assassinate/behead/heads_of_staff = 1,
 			) = 1,
 		) = 1,
 		list(
@@ -58,6 +58,7 @@
 
 	heads_of_staff = TRUE
 
+/*
 /datum/traitor_objective/target_player/assassinate/behead
 	name = "Behead %TARGET%, the %JOB TITLE%"
 	description = "Behead and hold %TARGET%'s head to succeed this objective. If the head gets destroyed before you can do this, you will fail this objective."
@@ -74,7 +75,7 @@
 	telecrystal_reward = list(2, 3)
 
 	heads_of_staff = TRUE
-
+*/
 
 /datum/traitor_objective/target_player/assassinate/calling_card/generate_ui_buttons(mob/user)
 	var/list/buttons = list()
@@ -117,6 +118,7 @@
 	//you cannot plant anything on someone who is gone gone, so even if this happens after you're still liable to fail
 	fail_objective(penalty_cost = telecrystal_penalty)
 
+/*
 /datum/traitor_objective/target_player/assassinate/behead/special_target_filter(list/possible_targets)
 	for(var/datum/mind/possible_target as anything in possible_targets)
 		var/mob/living/carbon/possible_current = possible_target.current
@@ -157,6 +159,7 @@
 	else
 		behead_goal = lost_head
 		RegisterSignal(behead_goal, COMSIG_ITEM_PICKUP, PROC_REF(on_head_pickup))
+*/
 
 /datum/traitor_objective/target_player/assassinate/New(datum/uplink_handler/handler)
 	. = ..()

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -141,9 +141,7 @@
 			. += span_info("[real_name]'s tongue has been removed.")
 
 /obj/item/bodypart/head/can_dismember(obj/item/item)
-	if(owner.stat < HARD_CRIT)
-		return FALSE
-	return ..()
+	return FALSE
 
 /obj/item/bodypart/head/drop_organs(mob/user, violent_removal)
 	if(user)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -184,6 +184,9 @@
 	should_draw_greyscale = FALSE
 	head_flags = HEAD_EYESPRITES|HEAD_DEBRAIN
 
+/obj/item/bodypart/head/zombie/can_dismember(obj/item/item)
+	return owner.stat >= HARD_CRIT
+
 /obj/item/bodypart/chest/zombie
 	limb_id = SPECIES_ZOMBIE
 	is_dimorphic = FALSE


### PR DESCRIPTION
Removes:
- The ability for heads to get the dismemberment wound
- The beheading traitor objective

Keeps:
- Amputation on head
- Amputation shears on head
- Really anything that isn't the round
- Zombies can be beheaded

Changes:
- Amber focus now uses a left leg instead of eyes because beheading is harder (just roll with it it's whatever)
- Maelstrom of silver needs a body with no legs

Test merging this after some talks with admins about heavy near-RR murderboning to see the impact it makes on what people do and if this is a direction we should move further in. Beheading is a favorite because it's extremely easy to do, both in terms of effort and availability.

It is also extremely common. [The Superset dashboard on Wounds](https://superset.moth.fans/superset/dashboard/19/) reports nearly ~~200~~ **947** beheadings this week alone.

![image](https://github.com/tgstation/tgstation/assets/35135081/f1b15291-59e8-4ee6-948a-3b90cb941be4)
