### PR TITLE
Adds unique vendor description to the bitrunning disks

### DIFF
--- a/code/modules/bitrunning/orders/disks.dm
+++ b/code/modules/bitrunning/orders/disks.dm
@@ -4,23 +4,29 @@
 /datum/orderable_item/bitrunning_tech/item_tier1
 	cost_per_order = 1000
 	item_path = /obj/item/bitrunning_disk/item/tier1
+	desc = "This disk contains a program that lets you equip a medical beamgun, a C4 explosive, or a box of infinite pizza."
 
 /datum/orderable_item/bitrunning_tech/item_tier2
 	cost_per_order = 1500
 	item_path = /obj/item/bitrunning_disk/item/tier2
+	desc = "This disk contains a program that lets you equip a luxury medipen, a pistol, or an armour vest."
 
 /datum/orderable_item/bitrunning_tech/item_tier3
 	cost_per_order = 2500
 	item_path = /obj/item/bitrunning_disk/item/tier3
+	desc = "This disk contains a program that lets you equip an advanced energy gun, a dual bladed energy sword, or a minibomb."
 
 /datum/orderable_item/bitrunning_tech/ability_tier1
 	cost_per_order = 1000
 	item_path = /obj/item/bitrunning_disk/ability/tier1
+	desc = "This disk contains a program that lets you cast Summon Cheese or Lesser Heal."
 
 /datum/orderable_item/bitrunning_tech/ability_tier2
 	cost_per_order = 1800
 	item_path = /obj/item/bitrunning_disk/ability/tier2
+	desc = "This disk contains a program that lets you cast Fireball, Lightning Bolt, or Forcewall."
 
 /datum/orderable_item/bitrunning_tech/ability_tier3
 	cost_per_order = 3200
 	item_path = /obj/item/bitrunning_disk/ability/tier3
+	desc = "This disk contains a program that lets you shapeshift into a lesser ashdrake, or a polar bear."


### PR DESCRIPTION


## About The Pull Request

This PR adds a unique description to the six bitrunning disk vendor orders.

![image](https://github.com/tgstation/tgstation/assets/2676196/70b8c998-c32d-442c-94be-cb92922728c1)


## Why It's Good For The Game

This lets you know in advance what the disks contain, so you can plan out if you want to save up your heard earned bitpoints for being able to turn into a dragon, or perhaps if you want to double up on complex spells.

## Changelog

:cl:
qol: The bitrunning equipment vending machine now has a unique description for each of the bitrunning disks 
/:cl:
