### PR TITLE
Adds a mint condition clear PDA to the Goodies menu for 100,000 credits.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -4,6 +4,12 @@
 	group = "Goodies"
 	goody = TRUE
 
+/datum/supply_pack/goody/clear_pda
+	name = "Mint Condition Nanotrasen Clear PDA"
+	desc = "Mint condition, freshly repackaged! A valuable collector's item normally valued at over 2.5 million credits, now available for a steal!"
+	cost = 100000
+	contains = list(/obj/item/modular_computer/pda/clear)
+
 /datum/supply_pack/goody/dumdum38
 	name = ".38 DumDum Speedloader"
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."


### PR DESCRIPTION
## About The Pull Request

Adds a mint condition clear PDA to the Goodies menu for 100,000 credits.

## Why It's Good For The Game

Encourages crewmembers to hustle for that sweet, sweet mint condition in box clear PDA.

## Changelog

:cl:
add: Adds a mint condition clear PDA to the Goodies menu for 100,000 credits.
/:cl: