### PR TITLE
Fake Virus doesn't affect virus immune mobs

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -738,6 +738,13 @@
 	alert_type = null
 	var/msg_stage = 0//so you dont get the most intense messages immediately
 
+/datum/status_effect/fake_virus/on_apply()
+	if(HAS_TRAIT(owner, TRAIT_VIRUSIMMUNE))
+		return FALSE
+	if(owner.stat != CONSCIOUS)
+		return FALSE
+	return TRUE
+
 /datum/status_effect/fake_virus/tick(seconds_between_ticks)
 	var/fake_msg = ""
 	var/fake_emote = ""

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -7,27 +7,29 @@
 
 /datum/round_event/fake_virus/start()
 	var/list/fake_virus_victims = list()
-	for(var/mob/living/carbon/human/victim in shuffle(GLOB.player_list))
-		if(victim.stat == DEAD || HAS_TRAIT(victim, TRAIT_CRITICAL_CONDITION) || !(victim.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
+	for(var/mob/living/carbon/human/victim in GLOB.player_list)
+		if(victim.stat != CONSCIOUS || HAS_TRAIT(victim, TRAIT_VIRUSIMMUNE))
+			continue
+		if(!(victim.mind?.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
 		fake_virus_victims += victim
 
 	//first we do hard status effect victims
-	var/defacto_min = min(3, LAZYLEN(fake_virus_victims))
-	if(defacto_min)// event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
-		for(var/i in 1 to rand(1,defacto_min))
-			var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
-			hypochondriac.apply_status_effect(/datum/status_effect/fake_virus)
-			fake_virus_victims -= hypochondriac
-			announce_to_ghosts(hypochondriac)
+	var/defacto_min = min(3, length(fake_virus_victims))
+	if(defacto_min <= 0)// event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
+		return
+	for(var/i in 1 to rand(1, defacto_min))
+		var/mob/living/carbon/human/hypochondriac = pick_n_take(fake_virus_victims)
+		hypochondriac.apply_status_effect(/datum/status_effect/fake_virus)
+		announce_to_ghosts(hypochondriac)
 
 	//then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
-	defacto_min = min(5, LAZYLEN(fake_virus_victims))
-	if(defacto_min)
-		for(var/i in 1 to rand(1,defacto_min))
-			var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
-			if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
-				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), onecoughman, span_warning("[pick("Your head hurts.", "Your head pounds.")]")), rand(30,150))
-			else
-				addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob, emote), pick("cough", "sniff", "sneeze")), rand(30,150))//deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
-			fake_virus_victims -= onecoughman
+	defacto_min = min(5, length(fake_virus_victims))
+	if(defacto_min <= 0)
+		return
+	for(var/i in 1 to rand(1, defacto_min))
+		var/mob/living/carbon/human/onecoughman = pick_n_take(fake_virus_victims)
+		if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), onecoughman, span_warning("[pick("Your head hurts.", "Your head pounds.")]")), rand(3 SECONDS, 15 SECONDS))
+		else
+			addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob, emote), pick("cough", "sniff", "sneeze")), rand(3 SECONDS, 15 SECONDS))//deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time


### PR DESCRIPTION
## About The Pull Request

Fake Virus random event won't pick Virus Immune mobs. 

Plus some code cleanup.

## Why It's Good For The Game

Feeling a virus when you can't feel a virus makes it pretty obvious what's going on.

## Changelog

:cl: Melbert
fix: Crewmembers immune to viruses won't be picked by the fake virus event. 
/:cl:
