### PR TITLE
Add a missing deadsay span for DC examination

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -325,7 +325,7 @@
 			if(!key)
 				msg += "[span_deadsay("[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.")]\n"
 			else if(!client)
-				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
+				msg += "[span_deadsay("[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.")]\n"
 
 	var/scar_severity = 0
 	for(var/i in all_scars)


### PR DESCRIPTION
## Why It's Good For The Game

Keeps parity between the two messages and their appearance.
Closes https://github.com/tgstation/tgstation/issues/80448

## Changelog

:cl:
fix: Examine text on disconnected players is no longer accidentally subtle
/:cl:
