### PR TITLE
Deviant Crew antag panel category, Obsessed crew now shown in orbit menu, Paradox Clone orbit tab is now white

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -333,6 +333,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define ANTAG_GROUP_FUGITIVES "Escaped Fugitives"
 #define ANTAG_GROUP_HUNTERS "Bounty Hunters"
 #define ANTAG_GROUP_PARADOX "Spacetime Aberrations"
+#define ANTAG_GROUP_CREW "Deviant Crew"
 
 
 // This flag disables certain checks that presume antagonist datums mean 'baddie'.

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -33,7 +33,7 @@
 	roundend_category = "brainwashed victims"
 	show_in_antagpanel = TRUE
 	antag_hud_name = "brainwashed"
-	antagpanel_category = "Other"
+	antagpanel_category = ANTAG_GROUP_CREW
 	show_name_in_check_antagonists = TRUE
 	count_against_dynamic_roll_chance = FALSE
 	ui_name = "AntagInfoBrainwashed"

--- a/code/modules/antagonists/hypnotized/hypnotized.dm
+++ b/code/modules/antagonists/hypnotized/hypnotized.dm
@@ -6,7 +6,7 @@
 	antag_hud_name = "brainwashed"
 	ui_name = "AntagInfoBrainwashed"
 	show_in_antagpanel = TRUE
-	antagpanel_category = "Other"
+	antagpanel_category = ANTAG_GROUP_CREW
 	show_name_in_check_antagonists = TRUE
 	count_against_dynamic_roll_chance = FALSE
 

--- a/code/modules/antagonists/obsessed/obsessed.dm
+++ b/code/modules/antagonists/obsessed/obsessed.dm
@@ -1,8 +1,9 @@
 /datum/antagonist/obsessed
 	name = "Obsessed"
 	show_in_antagpanel = TRUE
-	antagpanel_category = "Other"
+	antagpanel_category = ANTAG_GROUP_CREW
 	job_rank = ROLE_OBSESSED
+	show_to_ghosts = TRUE
 	antag_hud_name = "obsessed"
 	show_name_in_check_antagonists = TRUE
 	roundend_category = "obsessed"

--- a/code/modules/antagonists/wizard/grand_ritual/finales/grand_ritual_finale.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/finales/grand_ritual_finale.dm
@@ -71,7 +71,7 @@
 	name = "\improper Wizard Prank Victim"
 	roundend_category = "wizard prank victims"
 	show_in_antagpanel = FALSE
-	antagpanel_category = "Other"
+	antagpanel_category = ANTAG_GROUP_CREW
 	show_name_in_check_antagonists = TRUE
 	count_against_dynamic_roll_chance = FALSE
 	silent = TRUE

--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -8,6 +8,7 @@ export const ANTAG2COLOR = {
   'Emergency Response Team': 'teal',
   'Escaped Fugitives': 'orange',
   'Xenomorph Infestation': 'violet',
+  'Spacetime Aberrations': 'white',
   'Deviant Crew': 'white',
 } as const;
 

--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -8,6 +8,7 @@ export const ANTAG2COLOR = {
   'Emergency Response Team': 'teal',
   'Escaped Fugitives': 'orange',
   'Xenomorph Infestation': 'violet',
+  'Deviant Crew': 'white',
 } as const;
 
 export const THREAT = {


### PR DESCRIPTION

## About The Pull Request

This rounds up the "Other" (Brainwashed, Hypnotised, Wizard Revenge, and Obsession) antagonist category into the new "Deviant Crew" category. This tab is white!

Obsessed crew are now displayed in the orbit panel (no other antagonists in this group are though).

The Spacetime Aberrations (Paradox Clone) group has also been changed to be white.

Here's how that looks:

![image](https://github.com/tgstation/tgstation/assets/28870487/415b8cbb-7ac3-4e24-9f74-466480c2aab0)
## Why It's Good For The Game

As was the case with paradox clones, observers can already discern when a player is obsessed. It shouldn't be a pain to observe these guys, especially when they're a more RP oriented antag that are (usually) deserving of the audience.

I made paradox clones and obsessed the same color because they're both in the broader spectrum of "fucked up crew".

Also converts common text entries to a single define. That is good coding practice I think.
## Changelog
:cl: Rhials
qol: Obsessed crewmembers are now displayed in the orbit panel.
qol: The Paradox Clone orbit menu tab is now white. Neat!
/:cl:
