### PR TITLE
Icebox escape pods now properly target the Icemoon surface

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -736,7 +736,7 @@
 	return INITIALIZE_HINT_QDEL
 
 /obj/docking_port/stationary/random/icemoon
-	target_area = /area/icemoon/surface/outdoors
+	target_area = /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters
 
 //Pod suits/pickaxes
 


### PR DESCRIPTION

## About The Pull Request

This fixes Icebox escape pods only landing in certain ruins when launched early.

`/area/icemoon/surface/outdoors` only shows up in a few select ruins. The new area value used to decide a landing point, `/area/icemoon/surface/outdoors/unexplored/rivers/no_monsters`, covers the majority of the Icemoon surface.
## Why It's Good For The Game

Closes #78735.

Escape pods might not very useful on Icebox, but this makes using them less hazardous. You're guaranteed to at least land somewhere safe and away from the station.
## Changelog
:cl: Rhials
fix: Icebox escape pods will now land randomly on the surface, instead of only in certain ruins.
/:cl:
