### PR TITLE
Fixes dropdowns not rendering the selection's displayText post-selection

### DIFF
--- a/tgui/packages/tgui/components/Dropdown.tsx
+++ b/tgui/packages/tgui/components/Dropdown.tsx
@@ -342,7 +342,7 @@ export class Dropdown extends Component<Props, State> {
                 overflow: clipSelectedText ? 'hidden' : 'visible',
               }}
             >
-              {this.state.selected || displayText}
+              {displayText || this.state.selected}
             </span>
             {nochevron || (
               <span className="Dropdown__arrow-button">


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Dropdowns were displaying the `selection` instead of `displayText` after clicking an option. 

Note: this bug was only _noticeably_ affecting dropdowns whose `selection` differed from `displayText`. In the below example, the dropdown uses numeric indices for `selection` and a string for `displayText`. In those cases the `displayText` should take precedence, not the other way around.

<details><summary>From this</summary>

![XCsUpfbezj](https://github.com/tgstation/tgstation/assets/13398309/3fac640d-a4ac-488c-94de-5413a74b0836)

</details>

<details><summary>To this</summary>

![CvjsD6TmtW](https://github.com/tgstation/tgstation/assets/13398309/ec30cb11-11db-4a64-87ad-cef6add86f5b)

</details>

## Why It's Good For The Game

Fixes a minor bug

## Changelog

:cl:
fix: fixes some dropdowns not displaying the right text after selecting something
/:cl:

