### PR TITLE
Wizard Apprentices now spawn at their summoning contract, instead of the Wizard Den

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -257,6 +257,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	name = "Wizard Apprentice"
 	antag_hud_name = "apprentice"
 	can_assign_self_objectives = FALSE
+	move_to_lair = FALSE
 	var/datum/mind/master
 	var/school = APPRENTICE_DESTRUCTION
 	outfit_type = /datum/outfit/wizard/apprentice


### PR DESCRIPTION

## About The Pull Request

Wizard apprentices will now spawn on the summoning contract's turf, instead of in the wizard den.

Originally, apprentices would be spawned on the contract with a puff of smoke, and then sent to their spawn point by the wizard antag datum. It makes more sense for them to spawn in with the smoke, and whoever summoned them.
## Why It's Good For The Game

More consistency with how most other antag spawners work.

I watched a wizard get confused by this last night which was kind of funny and prompted me to make this change.
## Changelog
:cl: Rhials
qol: Wizard apprentices now spawn on the same tile as the contract that summoned them.
/:cl:
