### PR TITLE
Combine roundstart intercept and security level announcements

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -361,11 +361,11 @@ SUBSYSTEM_DEF(dynamic)
 
 	print_command_report(., "[command_name()] Status Summary", announce=FALSE)
 	if(greenshift)
-		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", SSstation.announcer.get_rand_report_sound())
+		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", SSstation.announcer.get_rand_report_sound(), color_override = "green")
 	else
-		priority_announce("A summary has been copied and printed to all communications consoles.", "Security level elevated.", ANNOUNCER_INTERCEPT)
 		if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_BLUE)
-			SSsecurity_level.set_level(SEC_LEVEL_BLUE)
+			SSsecurity_level.set_level(SEC_LEVEL_BLUE, announce = FALSE)
+		priority_announce("[SSsecurity_level.current_security_level.elevating_to_announcement]\n\nA summary has been copied and printed to all communications consoles.", "Security level elevated.", ANNOUNCER_INTERCEPT, color_override = SSsecurity_level.current_security_level.announcement_color)
 
 	return .
 

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -28,8 +28,9 @@ SUBSYSTEM_DEF(security_level)
  *
  * Arguments:
  * * new_level - The new security level that will become our current level
+ * * announce - Play the announcement, set FALSE if you're doing your own custom announcement to prevent duplicates
  */
-/datum/controller/subsystem/security_level/proc/set_level(new_level)
+/datum/controller/subsystem/security_level/proc/set_level(new_level, announce = TRUE)
 	new_level = istext(new_level) ? new_level : number_level_to_text(new_level)
 	if(new_level == current_security_level.name) // If we are already at the desired level, do nothing
 		return
@@ -42,7 +43,8 @@ SUBSYSTEM_DEF(security_level)
 	if(SSnightshift.can_fire && (selected_level.number_level >= SEC_LEVEL_RED || current_security_level.number_level >= SEC_LEVEL_RED))
 		SSnightshift.next_fire = world.time + 7 SECONDS // Fire nightshift after the security level announcement is complete
 
-	level_announce(selected_level, current_security_level.number_level) // We want to announce BEFORE updating to the new level
+	if(announce)
+		level_announce(selected_level, current_security_level.number_level) // We want to announce BEFORE updating to the new level
 
 	SSsecurity_level.current_security_level = selected_level
 


### PR DESCRIPTION
## About The Pull Request

At roundstart when the intercept report is sent, two announcements are created at the same time. It's loud and overlaps. This combines them into a single announcement.

Before:

![image](https://github.com/tgstation/tgstation/assets/83487515/024e783a-65d9-4c28-8850-f114b1f020ad)

After:

![image](https://github.com/tgstation/tgstation/assets/83487515/7272f82f-23b4-4e90-99a2-1b590c7d56cf)

## Why It's Good For The Game

Two Centcom or any other announcements playing at the same time (especially with two different sound files) can be annoying and the sounds distort each other.

## Changelog

:cl: LT3
qol: Roundstart intercept report and security level announcements are combined into a single announcement
/:cl:
