### PR TITLE
Makes traitor guns cheaper

### DIFF
--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -20,7 +20,7 @@
 	desc = "A small, easily concealable handgun that uses 9mm auto rounds in 8-round magazines and is compatible \
 			with suppressors."
 	item = /obj/item/gun/ballistic/automatic/pistol
-	cost = 7
+	cost = 4
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/dangerous/throwingweapons
@@ -93,7 +93,7 @@
 	name = "Syndicate Revolver"
 	desc = "Waffle Co.'s modernized Syndicate revolver. Fires 7 brutal rounds of .357 Magnum."
 	item = /obj/item/gun/ballistic/revolver/syndicate
-	cost = 13
+	cost = 7
 	surplus = 50
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS) //nukies get their own version
 


### PR DESCRIPTION

## About The Pull Request

This makes the traitor guns significantly cheaper. The makarov is reduced from 7 TC to 4 TC, and the revolver is reduced from 13 TC to 7 TC.
**These are not final values**. We can adjust them up or down as needed to fine-tune the price.
## Why It's Good For The Game

Traitors should be generally capable of defeating any crew member in 1v1 combat consistently, for a few reasons:
- In order for traitors to be a real threat, they need to be a cut above other crew members. No one will have any real fear of, or reason to play around, traitors if they can't even consistently kill you.
- Similarly, traitors won't try to kill people if they aren't confident they can actually, well, kill them, since a failed kill most often means that the traitor's run is over.
- It's generally more interesting if the traitor succeeds in the actual killing but then has to struggle to not get caught, than if the traitor gets shovestunned and toolboxed to death as soon as they begin attacking.

In addition, unlike with normal crew, it's important that traitors be able to complete their act of murder quickly. The longer it takes to finish killing the victim, the more likely the victim is to call for help, or for someone to just randomly happen upon them.

Making the guns cheaper makes traitors more consistently threatening at these things, since they can use the guns to ensure their lethality at 1v1 combat and their ability to quickly silence victims without sacrificing most of their TC, ensuring that they still have plenty to spend on utility and sabotage tools and don't have to choose between the ability to sabotage, disguise, and other such utility and the ability to not have murdering people be a coin flip.

This will not make gun murderbones more likely, because the limiting factor for those is the ammo, not the guns. Buying two revolvers won't help bone much more than buying one revolver and an ammo reload will.
The revolver is already not good at killing groups of people, because it only has 7 shots and its speed at murdering people is more or less nullified when fighting groups, since you can only shoot one person at a time.
## Changelog

:cl:
balance: Syndicate revolver TC cost changed from 13 to 7 TC.
balance: Makarov TC cost changed from 7 to 4 TC.
/:cl:
