### PR TITLE
makes a very important change to `strings/names/death_commando.txt` so that my immersion isn't broken by passage of time

### DIFF
--- a/strings/names/death_commando.txt
+++ b/strings/names/death_commando.txt
@@ -1,4 +1,4 @@
-A whole bunch of spiders in a SWAT suit
+A whole bunch of spiders in a MOD suit
 Al "Otta" Gore
 AMERICA
 Beat Punchbeef

--- a/strings/names/death_commando.txt
+++ b/strings/names/death_commando.txt
@@ -1,4 +1,4 @@
-A whole bunch of spiders in a MOD suit
+A whole bunch of spiders in a MODsuit
 Al "Otta" Gore
 AMERICA
 Beat Punchbeef


### PR DESCRIPTION
## About The Pull Request

For an undisclosed period of time since the addition of MOD suits, the death commando name 'A whole bunch of spiders in a SWAT suit' located in `strings/names/death_commando.txt` has been factually incorrect. I am fixing the discrepancy that has breached my immersion so many times.
## Why It's Good For The Game

Fixes the codebase.
## Changelog
:cl:
fix: 'A whole bunch of spiders in a SWAT suit' to 'A whole bunch of spiders in a MODsuit'
/:cl:
