### PR TITLE
Add weapon rechargers to sec designs

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -661,7 +661,7 @@
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_SECURITY
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/board/vendor
 	name = "Vendor Board"


### PR DESCRIPTION
## About The Pull Request

This PR makes weapon rechargers boards available at sec techfab.

## Why It's Good For The Game

I think it is obvious that sec should have this at their techfabs, becuase it is literally designed for them.

## Changelog

:cl:
add: Added weapon recharger boards to designs available to print on sec techfab.
/:cl:
