### PR TITLE
Ventcrawling mobs now get a warning when crawling into hazardous pipenets

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -583,9 +583,13 @@
 	animate(our_client, pixel_x = 0, pixel_y = 0, time = 0.05 SECONDS)
 	our_client.move_delay = world.time + 0.05 SECONDS
 
-/obj/machinery/atmospherics/AltClick(mob/living/L)
-	if(vent_movement & VENTCRAWL_ALLOWED && istype(L))
-		L.handle_ventcrawl(src)
+/obj/machinery/atmospherics/AltClick(mob/living/living_mob)
+	if(vent_movement & VENTCRAWL_ALLOWED && istype(living_mob))
+		var/datum/gas_mixture/internal_air = return_air()
+		if(internal_air.temperature > living_mob.get_body_temp_heat_damage_limit() || internal_air.temperature < living_mob.get_body_temp_cold_damage_limit())
+			if(!tgui_alert(living_mob, "The air in this machine is [internal_air.temperature]. Are you sure you want to enter?", "This WILL kill you!", list("Yes")) == "Yes")
+				return
+		living_mob.handle_ventcrawl(src)
 		return
 	return ..()
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -585,10 +585,6 @@
 
 /obj/machinery/atmospherics/AltClick(mob/living/living_mob)
 	if(vent_movement & VENTCRAWL_ALLOWED && istype(living_mob))
-		var/datum/gas_mixture/internal_air = return_air()
-		if(internal_air.temperature > living_mob.get_body_temp_heat_damage_limit() || internal_air.temperature < living_mob.get_body_temp_cold_damage_limit())
-			if(!tgui_alert(living_mob, "The air in this machine is [internal_air.temperature]. Are you sure you want to enter?", "This WILL kill you!", list("Yes")) == "Yes")
-				return
 		living_mob.handle_ventcrawl(src)
 		return
 	return ..()

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -73,6 +73,10 @@
 	else
 		var/datum/pipeline/vent_parent = ventcrawl_target.parents[1]
 		if(vent_parent && (vent_parent.members.len || vent_parent.other_atmos_machines))
+			var/datum/gas_mixture/internal_air = vent_parent.air
+			if(internal_air.temperature > get_body_temp_heat_damage_limit() || internal_air.temperature < get_body_temp_cold_damage_limit())
+				if(tgui_alert(src, "The air in this machine is hazardous to your health! (Temperature: [internal_air.temperature]). Are you sure you want to enter?", "This will PROBABLY kill you!", list("Yes", "No")) != "Yes")
+					return
 			ventcrawl_target.flick_overlay_static(image('icons/effects/vent_indicator.dmi', "arrow", ABOVE_MOB_LAYER, dir = get_dir(src.loc, ventcrawl_target.loc)), 2 SECONDS)
 			visible_message(span_notice("[src] begins climbing into the ventilation system...") ,span_notice("You begin climbing into the ventilation system..."))
 			if(!do_after(src, 2.5 SECONDS, target = ventcrawl_target, extra_checks = CALLBACK(src, PROC_REF(can_enter_vent), ventcrawl_target)))

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -75,7 +75,7 @@
 		if(vent_parent && (vent_parent.members.len || vent_parent.other_atmos_machines))
 			var/datum/gas_mixture/internal_air = vent_parent.air
 			if(internal_air.temperature > get_body_temp_heat_damage_limit() || internal_air.temperature < get_body_temp_cold_damage_limit())
-				if(tgui_alert(src, "The air in this machine is hazardous to your health! (Temperature: [internal_air.temperature]). Are you sure you want to enter?", "This will PROBABLY kill you!", list("Yes", "No")) != "Yes")
+				if(tgui_alert(src, "The air in this machine is hazardous to your health! (Temperature: [internal_air.temperature]!). Are you sure you want to enter?", "This will PROBABLY kill you!", list("Yes", "No")) != "Yes")
 					return
 			ventcrawl_target.flick_overlay_static(image('icons/effects/vent_indicator.dmi', "arrow", ABOVE_MOB_LAYER, dir = get_dir(src.loc, ventcrawl_target.loc)), 2 SECONDS)
 			visible_message(span_notice("[src] begins climbing into the ventilation system...") ,span_notice("You begin climbing into the ventilation system..."))


### PR DESCRIPTION

## About The Pull Request

Attempting to ventcrawl into a pipenet full of harmful air (above/below the heat/cold temp thresholds of your mob) will give a pop-up warning.

![image](https://github.com/tgstation/tgstation/assets/28870487/062fb219-7c1f-4d59-afb8-355f6d48f4d8)

It's a bit blunt, but it works. Maybe giving the exact temperature is a bit much, idk. I might change it.
## Why It's Good For The Game

Handles yet another way that xenos (and other ventcrawlers) can accidentally throw their roll while ventcrawling.

Dying without warning sucks, doubly so when your body then gets stuck in a pipe! Lame!
## Changelog
:cl: Rhials
qol: Attempting to ventcrawl into a pipe with hazardous air will give a pop-up warning and the option to confirm entry.
/:cl:
