### PR TITLE
Gibbing bots no longer spawn bloody gibs

### DIFF
--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -809,3 +809,6 @@ GLOBAL_LIST_INIT(command_strings, list(
 /mob/living/basic/bot/proc/after_attacked(datum/source, atom/attacker, attack_flags)
 	if(attack_flags & ATTACKER_DAMAGING_ATTACK)
 		do_sparks(number = 5, cardinal_only = TRUE, source = src)
+
+/mob/living/basic/bot/spawn_gibs(drop_bitflags = NONE)
+	new /obj/effect/gibspawner/robot(drop_location(), src)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1230,3 +1230,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/rust_heretic_act()
 	adjustBruteLoss(400)
+
+/mob/living/simple_animal/bot/spawn_gibs(drop_bitflags = NONE)
+	new /obj/effect/gibspawner/robot(drop_location(), src)


### PR DESCRIPTION
## About The Pull Request

It spawns robot gibs instead. 

## Changelog

:cl: Melbert
fix: Gibbing a bot will no longer spawn bloody gibs.
/:cl:
