### PR TITLE
Miasma is now filtered through gas mask filters, at medium strength.

### DIFF
--- a/code/modules/clothing/masks/gas_filter.dm
+++ b/code/modules/clothing/masks/gas_filter.dm
@@ -40,7 +40,7 @@
 		/datum/gas/freon,
 		/datum/gas/hypernoblium,
 		/datum/gas/bz,
-		/datum/gas/miasma
+		/datum/gas/miasma,
 		)
 	///List of gases with low filter priority
 	var/list/low_filtering_gases = list(

--- a/code/modules/clothing/masks/gas_filter.dm
+++ b/code/modules/clothing/masks/gas_filter.dm
@@ -39,7 +39,8 @@
 		/datum/gas/nitrium,
 		/datum/gas/freon,
 		/datum/gas/hypernoblium,
-		/datum/gas/bz
+		/datum/gas/bz.
+		/datum/gas/miasma
 		)
 	///List of gases with low filter priority
 	var/list/low_filtering_gases = list(

--- a/code/modules/clothing/masks/gas_filter.dm
+++ b/code/modules/clothing/masks/gas_filter.dm
@@ -39,7 +39,7 @@
 		/datum/gas/nitrium,
 		/datum/gas/freon,
 		/datum/gas/hypernoblium,
-		/datum/gas/bz.
+		/datum/gas/bz,
 		/datum/gas/miasma
 		)
 	///List of gases with low filter priority


### PR DESCRIPTION
## About The Pull Request

Miasma is now filtered through gas mask, at medium strength.

## Why It's Good For The Game

A little weird that miasma isn't filtered through gas masks despite that being something that'd make sense for gas masks to filter.

## Changelog

:cl: BurgerBB
balance: Miasma is now filtered through gas mask filters, at medium strength.
/:cl:
