### PR TITLE
Adds Head of Security beret and bowman to their locker

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -89,6 +89,7 @@
 	new /obj/item/clothing/suit/armor/vest/leather(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/gars/giga(src)
+	new /obj/item/clothing/head/hats/hos/beret(src)
 	new /obj/item/clothing/head/hats/hos/cap(src)
 	new /obj/item/clothing/mask/gas/sechailer/swat(src)
 	new /obj/item/clothing/neck/cloak/hos(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -55,6 +55,7 @@
 
 	new /obj/item/computer_disk/command/hos(src)
 	new /obj/item/radio/headset/heads/hos(src)
+	new /obj/item/radio/headset/heads/hos/alt(src)
 	new /obj/item/storage/bag/garment/hos(src)
 	new /obj/item/storage/lockbox/medal/sec(src)
 	new /obj/item/megaphone/sec(src)


### PR DESCRIPTION
## About The Pull Request

adds Head of Security beret to their garmet bag and adds Head of Security bowman to their locker

## Why It's Good For The Game
Other departments start with their round start drip in their lockers, Head of Security should too, for consistency!
Promoted Head of Security should get their fancy beret and headset

## Changelog
:cl:
qol: Head of Security beret added to their garmet bag
qol: Head of Security bowman added to their locker
/:cl:
