### PR TITLE
Fixes fishing rods being able to hook and pull anchored objects

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -234,6 +234,8 @@
 /// Called by hook projectile when hitting things
 /obj/item/fishing_rod/proc/hook_hit(atom/atom_hit_by_hook_projectile)
 	var/mob/user = loc
+	if(!anchored)
+		return
 	if(!istype(user))
 		return
 	if(SEND_SIGNAL(atom_hit_by_hook_projectile, COMSIG_FISHING_ROD_CAST, src, user) & FISHING_ROD_CAST_HANDLED)


### PR DESCRIPTION

## About The Pull Request
Fixes hooking and pulling anchored items such as intercoms

## Why It's Good For The Game
Fixes an oversight

## Changelog
:cl:
fix: fixes tearing intercoms off the walls with a fishing rod
/:cl: