### PR TITLE
Change datum.vars warning to use MIN_COMPILER_VERSION

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -19,7 +19,7 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	controller_vars["vars"] = null
 	gvars_datum_in_built_vars = controller_vars + list(NAMEOF(src, gvars_datum_protected_varlist), NAMEOF(src, gvars_datum_in_built_vars), NAMEOF(src, gvars_datum_init_order))
 
-#if DM_VERSION >= 515 && DM_BUILD > 1620
+#if MIN_COMPILER_VERSION >= 515 && MIN_COMPILER_BUILD > 1620
 	#warn datum.vars hanging a ref should now be fixed, there should be no reason to remove the vars list from our controller's vars list anymore
 #endif
 	QDEL_IN(exclude_these, 0) //signal logging isn't ready


### PR DESCRIPTION
We can't change this line of code until we require 515.1620, so it shouldn't warn.