### PR TITLE
Make spritesheets cacheable by default, killing a lot of overtime in the round start spike

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -327,7 +327,6 @@
 
 /datum/asset/spritesheet/decals
 	name = "floor_decals"
-	cross_round_cachable = TRUE
 
 	/// The floor icon used for blend_preview_floor()
 	var/preview_floor_icon = 'icons/turf/floors.dmi'

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	/// Whether or not this asset can be cached across rounds of the same commit under the `CACHE_ASSETS` config.
 	/// This is not a *guarantee* the asset will be cached. Not all asset subtypes respect this field, and the
 	/// config can, of course, be disabled.
+	/// Disable this if your asset can change between rounds on the same exact version of the code.
 	var/cross_round_cachable = FALSE
 
 /datum/asset/New()
@@ -133,6 +134,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /datum/asset/spritesheet
 	_abstract = /datum/asset/spritesheet
+	cross_round_cachable = TRUE
 	var/name
 	/// List of arguments to pass into queuedInsert
 	/// Exists so we can queue icon insertion, mostly for stuff like preferences
@@ -145,6 +147,9 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	/// If this asset should be fully loaded on new
 	/// Defaults to false so we can process this stuff nicely
 	var/load_immediately = FALSE
+	VAR_PRIVATE
+		// Kept in state so that the result is the same, even when the files are created, for this run
+		should_refresh = null
 
 /datum/asset/spritesheet/proc/should_load_immediately()
 #ifdef DO_NOT_DEFER_ASSETS
@@ -157,9 +162,6 @@ GLOBAL_LIST_EMPTY(asset_datums)
 /datum/asset/spritesheet/should_refresh()
 	if (..())
 		return TRUE
-
-	// Static so that the result is the same, even when the files are created, for this run
-	var/static/should_refresh = null
 
 	if (isnull(should_refresh))
 		// `fexists` seems to always fail on static-time

--- a/code/modules/asset_cache/assets/emojipedia.dm
+++ b/code/modules/asset_cache/assets/emojipedia.dm
@@ -1,7 +1,5 @@
 /datum/asset/spritesheet/emojipedia
 	name = "emojipedia"
-	cross_round_cachable = TRUE // The Emoji DMI is static and doesn't change without a commit mis-match.
 
 /datum/asset/spritesheet/emojipedia/create_spritesheets()
 	InsertAll("", EMOJI_SET)
-

--- a/code/modules/asset_cache/assets/portraits.dm
+++ b/code/modules/asset_cache/assets/portraits.dm
@@ -1,5 +1,6 @@
 /datum/asset/simple/portraits
 	assets = list()
+	cross_round_cachable = FALSE
 
 /datum/asset/simple/portraits/New()
 	if(!length(SSpersistent_paintings.paintings))

--- a/code/modules/asset_cache/assets/portraits.dm
+++ b/code/modules/asset_cache/assets/portraits.dm
@@ -1,6 +1,5 @@
 /datum/asset/simple/portraits
 	assets = list()
-	cross_round_cachable = FALSE
 
 /datum/asset/simple/portraits/New()
 	if(!length(SSpersistent_paintings.paintings))

--- a/code/modules/client/preferences/assets.dm
+++ b/code/modules/client/preferences/assets.dm
@@ -2,7 +2,6 @@
 /datum/asset/spritesheet/preferences
 	name = "preferences"
 	early = TRUE
-	cross_round_cachable = TRUE
 
 /datum/asset/spritesheet/preferences/create_spritesheets()
 	var/list/to_insert = list()

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -108,7 +108,6 @@
 /datum/asset/spritesheet/antagonists
 	name = "antagonists"
 	early = TRUE
-	cross_round_cachable = TRUE
 
 	/// Mapping of spritesheet keys -> icons
 	var/list/antag_icons = list()

--- a/code/modules/client/preferences/middleware/species.dm
+++ b/code/modules/client/preferences/middleware/species.dm
@@ -9,7 +9,6 @@
 /datum/asset/spritesheet/species
 	name = "species"
 	early = TRUE
-	cross_round_cachable = TRUE
 
 /datum/asset/spritesheet/species/create_spritesheets()
 	var/list/to_insert = list()


### PR DESCRIPTION

## About The Pull Request
Makes all spritesheets cache by default. This wasn't the case originally because some spritesheets like vending machines relied on in world state, but none of them do anymore because that's whack.

Also fixes a bug that would cause half completed caches to break other stuff. This didn't happen in real gameplay, but would've happened if you tried to change cachable on anything while you already had a tmp folder.

## Changelog
:cl:
fix: Cut down a significant amount of time that caused the start of rounds to lag.
/:cl:
