### PR TITLE
Making the camera circuit actually work again, and letting it work while held.

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -121,7 +121,7 @@
 			return FALSE
 		else if(!(get_turf(target) in get_hear(world.view, user)))
 			return FALSE
-	else if(istype(loc, /mob/living/carbon))
+	else if(isliving(loc))
 		if(!(get_turf(target) in view(world.view, loc)))
 			return FALSE
 	else //user is an atom or null
@@ -264,8 +264,8 @@
 					picture.caption = caption
 			else if(default_picture_name)
 				picture.picture_name = default_picture_name
-	else if(istype(loc, /mob/living/carbon))
-		var/mob/living/carbon/holder = loc
+	else if(isliving(loc))
+		var/mob/living/holder = loc
 		if(holder.put_in_hands(new_photo))
 			to_chat(holder, span_notice("[pictures_left] photos left."))
 

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -241,27 +241,26 @@
 		printpicture(user, picture)
 
 /obj/item/camera/proc/printpicture(mob/user, datum/picture/picture) //Normal camera proc for creating photos
-	if(!user)
-		return
 	pictures_left--
 	var/obj/item/photo/new_photo = new(get_turf(src), picture)
-	if(in_range(new_photo, user) && user.put_in_hands(new_photo)) //needed because of TK
-		to_chat(user, span_notice("[pictures_left] photos left."))
+	if(user)
+		if(in_range(new_photo, user) && user.put_in_hands(new_photo)) //needed because of TK
+			to_chat(user, span_notice("[pictures_left] photos left."))
 
-	if(can_customise)
-		var/customise = tgui_alert(user, "Do you want to customize the photo?", "Customization", list("Yes", "No"))
-		if(customise == "Yes")
-			var/name1 = tgui_input_text(user, "Set a name for this photo, or leave blank.", "Name", max_length = 32)
-			var/desc1 = tgui_input_text(user, "Set a description to add to photo, or leave blank.", "Description", max_length = 128)
-			var/caption = tgui_input_text(user, "Set a caption for this photo, or leave blank.", "Caption", max_length = 256)
-			if(name1)
-				picture.picture_name = name1
-			if(desc1)
-				picture.picture_desc = "[desc1] - [picture.picture_desc]"
-			if(caption)
-				picture.caption = caption
-		else if(default_picture_name)
-			picture.picture_name = default_picture_name
+		if(can_customise)
+			var/customise = tgui_alert(user, "Do you want to customize the photo?", "Customization", list("Yes", "No"))
+			if(customise == "Yes")
+				var/name1 = tgui_input_text(user, "Set a name for this photo, or leave blank.", "Name", max_length = 32)
+				var/desc1 = tgui_input_text(user, "Set a description to add to photo, or leave blank.", "Description", max_length = 128)
+				var/caption = tgui_input_text(user, "Set a caption for this photo, or leave blank.", "Caption", max_length = 256)
+				if(name1)
+					picture.picture_name = name1
+				if(desc1)
+					picture.picture_desc = "[desc1] - [picture.picture_desc]"
+				if(caption)
+					picture.caption = caption
+			else if(default_picture_name)
+				picture.picture_name = default_picture_name
 
 	new_photo.set_picture(picture, TRUE, TRUE)
 	if(CONFIG_GET(flag/picture_logging_camera))

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -334,6 +334,6 @@
 			return
 	if(!camera.can_target(target))
 		return
-	INVOKE_ASYNC(camera, TYPE_PROC_REF(/obj/item/camera, captureimage), target, null, camera.picture_size_y  - 1, camera.picture_size_y - 1)
+	INVOKE_ASYNC(camera, TYPE_PROC_REF(/obj/item/camera, captureimage), target, null, camera.picture_size_x  - 1, camera.picture_size_y - 1)
 
 #undef CAMERA_PICTURE_SIZE_HARD_LIMIT

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -268,7 +268,6 @@
 		var/mob/living/carbon/holder = loc
 		if(holder.put_in_hands(new_photo))
 			to_chat(holder, span_notice("[pictures_left] photos left."))
-		
 
 	new_photo.set_picture(picture, TRUE, TRUE)
 	if(CONFIG_GET(flag/picture_logging_camera))

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -121,6 +121,9 @@
 			return FALSE
 		else if(!(get_turf(target) in get_hear(world.view, user)))
 			return FALSE
+	else if(istype(loc, /mob/living/carbon))
+		if(!(get_turf(target) in view(world.view, loc)))
+			return FALSE
 	else //user is an atom or null
 		if(!(get_turf(target) in view(world.view, user || src)))
 			return FALSE
@@ -261,6 +264,11 @@
 					picture.caption = caption
 			else if(default_picture_name)
 				picture.picture_name = default_picture_name
+	else if(istype(loc, /mob/living/carbon))
+		var/mob/living/carbon/holder = loc
+		if(holder.put_in_hands(new_photo))
+			to_chat(holder, span_notice("[pictures_left] photos left."))
+		
 
 	new_photo.set_picture(picture, TRUE, TRUE)
 	if(CONFIG_GET(flag/picture_logging_camera))


### PR DESCRIPTION

## About The Pull Request

Alternative title: Hidden Pocket Camera Circuits! _(That Actually Work)_.

So camera circuits have been broken for a while, and looking deeper into it this seems to be because at some point someone moved the user check for customization to before actually creating the picture item. Because camera circuits rely on calling the `captureimage()` proc with a null user, this made it so no image was ever printed nor were the photos left decremented.

Similarly, multiple times I've encountered people being confused about why their camera circuit isn't even trying to proc while held or hung around their neck. So I decided to add a check to the `can_target()` proc for whether it's on a carbon and what it could see from the given carbon. This allows it to work while held, while hung around one's neck, and while hidden sneakily in one's pockets. Well, insofar a bright flash and camera snap are sneaky.
Notably it doesn't work when put in a bag in your inventory. While having it work from a briefcase would be _incredibly_ funny, that's outside of the scope of this pr.
Additionally, it felt weird for it to just drop the picture while procced in your inventory, so I made it first try to put the printed picture in the carbon's hands if at all possible.

While looking through the code, I also found that there was a typo in where the circuit calls `captureimage()`, where `camera.picture_size_y` was used in place of where `camera.picture_size_x` should be.
## Why It's Good For The Game

It makes camera circuits actually work again.

As for having them work while on a carbon, I've encountered multiple people who were confused about their camera circuits not even _trying_ to proc while held or hung around their neck, when logically they should- it's visible, after all. Hell, when held it works manually, but not with a circuit!
Then, camera circuits working in one's pockets were a side-effect of my first naive fix, and I thought it'd be neat to keep in; the ability to make hidden pocket cameras just sounds cool to have. They're also only hidden insofar you can still see the flash and hear the snap.
## Changelog
:cl:
fix: Camera circuits actually print pictures again!
qol: Camera circuits can now take pictures while on a carbon, whether held, hung around the neck, or sneakily hidden in either pocket. When held they try to deposit their pictures into the holder's hands if possible.
fix: Camera circuits should now actually use the camera's x axis picture size, rather than using the camera's y axis picture size setting for both axis.
/:cl:
