### PR TITLE
Fixes runtime which prevents Sentience Fun Balloons working.

### DIFF
--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -147,8 +147,8 @@ SUBSYSTEM_DEF(polling)
 
 	return possible_candidates
 
-/datum/controller/subsystem/polling/proc/poll_ghost_candidates_for_mobs(question, role, check_jobban, poll_time = 30 SECONDS, list/mobs, ignore_category = null, pic_source, role_name_text)
-	var/list/candidate_list = poll_ghost_candidates(question, role, check_jobban, poll_time, ignore_category, pic_source, role_name_text)
+/datum/controller/subsystem/polling/proc/poll_ghost_candidates_for_mobs(question, role, check_jobban, poll_time = 30 SECONDS, list/mobs, ignore_category = null, flashwindow = TRUE, pic_source, role_name_text)
+	var/list/candidate_list = poll_ghost_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, pic_source, role_name_text)
 
 	for(var/mob/potential_mob as anything in mobs)
 		if(QDELETED(potential_mob) || !potential_mob.loc)

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -87,8 +87,17 @@
 		if (!possessable.ckey && possessable.stat == CONSCIOUS) // Only assign ghosts to living, non-occupied mobs!
 			bodies += possessable
 
-	var/question = "Would you like to be [group_name]?"
-	var/list/candidates = SSpolling.poll_ghost_candidates_for_mobs(question, check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, poll_time = 10 SECONDS, mobs = bodies, ignore_category = POLL_IGNORE_SHUTTLE_DENIZENS, pic_source = src, role_name_text = "sentience fun balloon")
+	var/list/candidates = SSpolling.poll_ghost_candidates_for_mobs(
+		question = "Would you like to be [group_name]?",
+		role = ROLE_SENTIENCE,
+		check_jobban = ROLE_SENTIENCE,
+		poll_time = 10 SECONDS,
+		mobs = bodies,
+		ignore_category = POLL_IGNORE_SHUTTLE_DENIZENS,
+		pic_source = src,
+		role_name_text = "sentience fun balloon",
+	)
+
 	while(LAZYLEN(candidates) && LAZYLEN(bodies))
 		var/mob/dead/observer/C = pick_n_take(candidates)
 		var/mob/living/body = pick_n_take(bodies)


### PR DESCRIPTION

## About The Pull Request

Fixes #80534

```
[2023-12-23 19:23:03.446] RUNTIME: runtime error: Cannot read "sentience fun balloon".layer
 - proc name: poll candidates (/datum/controller/subsystem/polling/proc/poll_candidates)
 -   source file: code/controllers/subsystem/polling.dm,90
 -   usr: Bob Stange (/mob/dead/observer)
 -   src: Polling (/datum/controller/subsystem/polling)
 -   usr.loc: the floor (166,47,1) (/turf/open/floor/iron)
 -   call stack:
 - Polling (/datum/controller/subsystem/polling): poll candidates("Would you like to be test?", "Sentience Potion Spawn", "Sentience Potion Spawn", 100, "shuttle_denizens", the sentience fun balloon (/obj/effect/fun_balloon/sentience), /list (/list), "sentience fun balloon", "Sentience Potion Spawn")
...
```

Classic off-by-one error, except instead of a mathematical error it was a logical error.

`/datum/controller/subsystem/polling/proc/poll_ghost_candidates_for_mobs(...)` called `poll_ghost_candidates` with an incorrect number of args, omitting the `flashwindow` arg and causing `pic_source` to be passed as `flashwindow` and `role_name_text` to be passed as `pic_source`.

Since `role_name_text` is a string, this causes the above runtime as the code tries to access the `.layer` member of the string. Which strings don't have. Because they're strings.

I added the missing `flashwindow` arg and tidied up the base proc call a touch back at the sentience balloon layer, since I noticed it was using named args out of order which - while valid - could cause issues in any future refactor or copypasted code.
## Why It's Good For The Game

Sentience Fun Balloons work again!
## Changelog
:cl:
fix: Fixed an issue with polling ghost roles to control multiple mobs that prevented Sentience Fun Balloons from working as intended.
/:cl:
