### PR TITLE
Fix: Allow PAI to wake up

### DIFF
--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -267,6 +267,15 @@
 	held_state = "[chassis]"
 	return ..()
 
+/mob/living/silicon/pai/set_stat(new_stat)
+	. = ..()
+	update_stat()
+
+/mob/living/silicon/pai/on_knockedout_trait_loss(datum/source)
+	. = ..()
+	set_stat(CONSCIOUS)
+	update_stat()
+
 /**
  * Resolves the weakref of the pai's master.
  * If the master has been deleted, calls reset_software().


### PR DESCRIPTION
## About The Pull Request

Fixes #66760
Fixes Skyrat-SS13/Skyrat-tg#25745

This PR fixes a bug which causes Personal AI cards to be unable to wake up from sleep.

Currently, emotes such as "collapse" effectively cause PAI to go into a coma, which I tested on both TG and Skyrat.

We noticed a similar issue was fixed in PR #77857 in a very direct way, so I copied that fix.

## Why It's Good For The Game

- Allows PAI to safely get knocked-out and wake up.
- Allows PAI to safely emote knockout-applying emotes such as "collapse" and "faint" without going into a coma.
- Successfully tested!

## Changelog

:cl: A.C.M.O.
fix: Fixed Personal AI cards, allowing them to wake up from sleep.
/:cl:
