### PR TITLE
Fix heartbeat continuing for a while on revival

### DIFF
--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -119,7 +119,7 @@
 			SEND_SOUND(owner, sound('sound/health/fastbeat.ogg', repeat = TRUE, channel = CHANNEL_HEARTBEAT, volume = 40))
 			beat = BEAT_FAST
 
-	else if(beat == BEAT_SLOW)
+	else if(beat != BEAT_NONE)
 		owner.stop_sound_channel(CHANNEL_HEARTBEAT)
 		beat = BEAT_NONE
 


### PR DESCRIPTION
## About The Pull Request

- If you are defibbed (into hard crit), your heartbeat will be `BEAT_FAST`
- If you are healed fast enough from hard crit, such that you do not life tick while in soft crit, you skip `BEAT_SLOW`
- If you skip `BEAT_SLOW`, it never stops the heartbeat

This PR fixes this issue by checking `if not in crit, and heartbeat sound is playing -> stop sound`. 

## Changelog

:cl: Melbert
fix: Fixed some occasions in which heartbeat SFX will continue on revival for longer than expected
/:cl:

