### PR TITLE
Reduces Yawn prop chances

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -537,9 +537,9 @@
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you
-#define YAWN_PROPAGATE_CHANCE_BASE 40
-/// The base chance for your yawn to propagate to someone else if they're on the same tile as you
-#define YAWN_PROPAGATE_CHANCE_DECAY 8
+#define YAWN_PROPAGATE_CHANCE_BASE 20
+/// The amount the base chance to propagate yawns falls for each tile of distance
+#define YAWN_PROPAGATE_CHANCE_DECAY 4
 
 /datum/emote/living/yawn
 	key = "yawn"


### PR DESCRIPTION
## About The Pull Request
Cuts down on the rate of yawn propagation between different mobs
## Why It's Good For The Game
Yawn propagation rates were near guaranteed if you did it in a group of people, this lowers the incidence of it considerably

## Changelog
:cl: Ryll/Shaps
balance: Yawns are less likely to propagate
/:cl:
