### PR TITLE
Add UI screentips to spraycans

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -762,6 +762,30 @@
 		/datum/component/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+	register_context()
+	register_item_context()
+
+/obj/item/toy/crayon/spraycan/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+
+	if(!user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
+		return NONE
+
+	if(has_cap)
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Toggle cap"
+
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/item/toy/crayon/spraycan/add_item_context(datum/source, list/context, atom/target, mob/living/user)
+	. = ..()
+
+	if(!user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
+		return NONE
+
+	context[SCREENTIP_CONTEXT_LMB] = "Paint"
+	context[SCREENTIP_CONTEXT_RMB] = "Copy color"
+
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/toy/crayon/spraycan/isValidSurface(surface)
 	return (isfloorturf(surface) || iswallturf(surface))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -769,7 +769,7 @@
 	. = ..()
 
 	if(!user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
-		return NONE
+		return .
 
 	if(has_cap)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Toggle cap"
@@ -780,7 +780,7 @@
 	. = ..()
 
 	if(!user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
-		return NONE
+		return .
 
 	context[SCREENTIP_CONTEXT_LMB] = "Paint"
 	context[SCREENTIP_CONTEXT_RMB] = "Copy color"


### PR DESCRIPTION

## About The Pull Request

This adds screentips to spraycans for:

- AltClick - toggle cap
- RMB - copy
- LMB - paint

## Why It's Good For The Game

Better UI/UX.

## Changelog

:cl:
qol: Add UI screentips to spraycans
/:cl:

