### PR TITLE
Remove eye surgery fluff line

### DIFF
--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -22,10 +22,7 @@
 
 /datum/surgery/eye_surgery/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/internal/eyes/target_eyes = target.get_organ_slot(ORGAN_SLOT_EYES)
-	if(!target_eyes)
-		to_chat(user, span_warning("It's hard to do surgery on someone's eyes when [target.p_they()] [target.p_do()]n't have any."))
-		return FALSE
-	return TRUE
+	return !isnull(target_eyes)
 
 /datum/surgery_step/fix_eyes/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(


### PR DESCRIPTION

## About The Pull Request
Removes a side effect in can_start which MUST be pure. This causes the surgery tgui to spam this message. It's pointless because you can't do the surgery to begin with if this returns false, so you only ever see this where you shouldn't.

## Changelog

:cl:
fix: Fixed the surgery menu spamming chat messages when on the eyes section of a player with no eyes.
/:cl:
