### PR TITLE
Add 50% graffiti speed boost to tagger quirk

### DIFF
--- a/code/datums/quirks/positive_quirks/tagger.dm
+++ b/code/datums/quirks/positive_quirks/tagger.dm
@@ -1,10 +1,10 @@
 /datum/quirk/item_quirk/tagger
 	name = "Tagger"
-	desc = "You're an experienced artist. People will actually be impressed by your graffiti, and you can get twice as many uses out of drawing supplies."
+	desc = "You're an experienced artist. People will actually be impressed by your graffiti, and you can get twice as many uses out of drawing supplies in half the time."
 	icon = FA_ICON_SPRAY_CAN
 	value = 4
 	mob_trait = TRAIT_TAGGER
-	gain_text = span_notice("You know how to tag walls efficiently.")
+	gain_text = span_notice("You know how to tag walls efficiently and quickly.")
 	lose_text = span_danger("You forget how to tag walls properly.")
 	medical_record_text = "Patient was recently seen for possible paint huffing incident."
 	mail_goodies = list(

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -14,6 +14,7 @@
 
 #define AVAILABLE_SPRAYCAN_SPACE 8 // enough to fill one radial menu page
 
+#define DRAW_TIME 5 SECONDS
 #define INFINITE_CHARGES -1
 
 /*
@@ -504,11 +505,13 @@
 		audible_message(span_notice("You hear spraying."))
 		playsound(user.loc, 'sound/effects/spray.ogg', 5, TRUE, 5)
 
-	var/wait_time = 50
+	var/wait_time = DRAW_TIME
 	if(paint_mode == PAINT_LARGE_HORIZONTAL)
 		wait_time *= 3
+	if(istagger)
+		wait_time *= 0.5
 
-	if(!instant && !do_after(user, 50, target = target))
+	if(!instant && !do_after(user, wait_time, target = target))
 		return
 
 	if(!use_charges(user, cost))
@@ -1040,3 +1043,4 @@
 #undef PAINT_LARGE_HORIZONTAL_ICON
 
 #undef INFINITE_CHARGES
+#undef DRAW_TIME

--- a/code/game/objects/items/syndie_spraycan.dm
+++ b/code/game/objects/items/syndie_spraycan.dm
@@ -1,3 +1,5 @@
+#define SYNDIE_DRAW_TIME 3 SECONDS
+
 // Extending the existing spraycan item was more trouble than it was worth, I don't want or need this to be able to draw arbitrary shapes.
 /obj/item/traitor_spraycan
 	name = "seditious spraycan"
@@ -79,7 +81,12 @@
 /obj/item/traitor_spraycan/proc/try_draw_step(start_output, mob/living/user, atom/target)
 	drawing_rune = TRUE
 	user.balloon_alert(user, "[start_output]")
-	if (!do_after(user, 3 SECONDS, target))
+	var/wait_time = SYNDIE_DRAW_TIME
+
+	if(HAS_TRAIT(user, TRAIT_TAGGER))
+		wait_time *= 0.5
+
+	if(!do_after(user, wait_time, target))
 		user.balloon_alert(user, "interrupted!")
 		drawing_rune = FALSE
 		return FALSE
@@ -220,6 +227,7 @@
 
 	return ..()
 
+#undef SYNDIE_DRAW_TIME
 #undef RUNE_STAGE_COLOURED
 #undef RUNE_STAGE_COMPLETE
 #undef RUNE_STAGE_OUTLINE


### PR DESCRIPTION

## About The Pull Request

This gives the tagger quirk a 50% speed boost when drawing graffiti. There was also some unused variable intended to make large graffiti more time consuming that is now fixed.

## Why It's Good For The Game

It'd be nice to be able to spraypaint messages on the floor quicker. Especially if you are doing a gimmick that requires making a shop sign using letters.

## Changelog

:cl:
add: Add 50% graffiti speed boost to tagger quirk
fix: Fix time duration of large graffiti not applying properly
/:cl:

