### PR TITLE
[NO GBP] Poll Alerts cleanup

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -844,6 +844,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	QDEL_NULL(stacks_overlay)
 	QDEL_NULL(candidates_num_overlay)
 	QDEL_NULL(signed_up_overlay)
+	if(poll)
+		poll.alert_buttons -= src
+	poll = null
 	return ..()
 
 /atom/movable/screen/alert/poll_alert/add_context(atom/source, list/context, obj/item/held_item, mob/user)
@@ -889,23 +892,19 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(LAZYACCESS(modifiers, CTRL_CLICK) && poll.jump_to_me)
 		jump_to_pic_source()
 		return
-	if(handle_sign_up())
-		update_candidates_number_overlay()
-		update_signed_up_overlay()
+	handle_sign_up()
 
 /atom/movable/screen/alert/poll_alert/proc/handle_sign_up()
 	if(owner in poll.signed_up)
-		return poll.remove_candidate(owner, src)
-	if(owner.ckey in GLOB.poll_ignore[poll.ignoring_category])
-		return FALSE
-	if(poll.sign_up(owner))
-		return poll.sign_up(owner)
+		poll.remove_candidate(owner)
+	else if(!(owner.ckey in GLOB.poll_ignore[poll.ignoring_category]))
+		poll.sign_up(owner)
+	update_signed_up_overlay()
 
 /atom/movable/screen/alert/poll_alert/proc/set_never_round()
 	if(!(owner.ckey in GLOB.poll_ignore[poll.ignoring_category]))
 		poll.do_never_for_this_round(owner)
 		color = "red"
-		update_candidates_number_overlay()
 		update_signed_up_overlay()
 		return
 	poll.undo_never_for_this_round(owner)

--- a/code/datums/candidate_poll.dm
+++ b/code/datums/candidate_poll.dm
@@ -64,6 +64,8 @@
 		for(var/datum/candidate_poll/existing_poll as anything in SSpolling.currently_polling)
 			if(src != existing_poll && poll_key == existing_poll.poll_key && !(candidate in existing_poll.signed_up))
 				existing_poll.sign_up(candidate, TRUE)
+	for(var/atom/movable/screen/alert/poll_alert/linked_button as anything in alert_buttons)
+		linked_button.update_candidates_number_overlay()
 	return TRUE
 
 /datum/candidate_poll/proc/remove_candidate(mob/candidate, silent = FALSE)
@@ -86,6 +88,8 @@
 		for(var/datum/candidate_poll/existing_poll as anything in SSpolling.currently_polling)
 			if(src != existing_poll && poll_key == existing_poll.poll_key && (candidate in existing_poll.signed_up))
 				existing_poll.remove_candidate(candidate, TRUE)
+	for(var/atom/movable/screen/alert/poll_alert/linked_button as anything in alert_buttons)
+		linked_button.update_candidates_number_overlay()
 	return TRUE
 
 /datum/candidate_poll/proc/do_never_for_this_round(mob/candidate)


### PR DESCRIPTION
~Hopefully the candidates number and signed up overlay should show up for everyone now and be more responsive~

Ghommie tackled most of it in https://github.com/tgstation/tgstation/pull/80610

I think the candidate number overlay updating is done incorrectly in his PR though.
Candidate number overlay should be updated for ALL candidates' poll alert buttons, whenever ANY candidate enters/leaves the poll

:cl:
fix: Poll alert buttons candidate number should be more responsive
/:cl:
