### PR TITLE
Fixes for mat container & ORM

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_material_container.dm
+++ b/code/__DEFINES/dcs/signals/signals_material_container.dm
@@ -2,10 +2,14 @@
 /// Called from datum/component/material_container/proc/can_hold_material() : (mat)
 #define COMSIG_MATCONTAINER_MAT_CHECK "matcontainer_mat_check"
 	#define MATCONTAINER_ALLOW_MAT (1<<0)
-/// Called from datum/component/material_container/proc/user_insert() : (held_item, user)
+/// Called from datum/component/material_container/proc/user_insert() : (target_item, user)
 #define COMSIG_MATCONTAINER_PRE_USER_INSERT "matcontainer_pre_user_insert"
 	#define MATCONTAINER_BLOCK_INSERT (1<<1)
-/// Called from datum/component/material_container/proc/insert_item() : (target, last_inserted_id, mats_consumed, material_amount, context)
+/// Called from datum/component/material_container/proc/insert_item() : (item, primary_mat, mats_consumed, material_amount, context)
 #define COMSIG_MATCONTAINER_ITEM_CONSUMED "matcontainer_item_consumed"
-/// Called from datum/component/material_container/proc/retrieve_sheets() : (sheets, context)
+/// Called from datum/component/material_container/proc/retrieve_sheets() : (new_sheets, context)
 #define COMSIG_MATCONTAINER_SHEETS_RETRIEVED "matcontainer_sheets_retrieved"
+
+//mat container signals but from the ore silo's perspective
+/// Called from /obj/machinery/ore_silo/on_item_consumed() : (container, item_inserted, last_inserted_id, mats_consumed, amount_inserted)
+#define COMSIG_SILO_ITEM_CONSUMED "silo_item_consumed"

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -52,9 +52,21 @@
 	if(!GLOB.autounlock_techwebs[/datum/techweb/autounlocking/smelter])
 		GLOB.autounlock_techwebs[/datum/techweb/autounlocking/smelter] = new /datum/techweb/autounlocking/smelter
 	stored_research = GLOB.autounlock_techwebs[/datum/techweb/autounlocking/smelter]
-	materials = AddComponent(/datum/component/remote_materials, mapload)
 
-	RegisterSignal(src, COMSIG_MATCONTAINER_ITEM_CONSUMED, TYPE_PROC_REF(/obj/machinery/mineral/ore_redemption, redeem_points))
+	//mat_container_signals is for reedeming points from local storage if silo is not required
+	var/list/local_signals = null
+	if(!requires_silo)
+		local_signals = list(
+			COMSIG_MATCONTAINER_ITEM_CONSUMED = TYPE_PROC_REF(/obj/machinery/mineral/ore_redemption, local_redeem_points)
+		)
+	materials = AddComponent( \
+		/datum/component/remote_materials, \
+		mapload, \
+		mat_container_signals = local_signals \
+	)
+
+	//for reedeming points from items inserted into ore silo
+	RegisterSignal(src, COMSIG_SILO_ITEM_CONSUMED, TYPE_PROC_REF(/obj/machinery/mineral/ore_redemption, silo_redeem_points))
 
 /obj/machinery/mineral/ore_redemption/Destroy()
 	stored_research = null
@@ -67,7 +79,12 @@
 		. += span_notice("Alt-click to rotate the input and output direction.")
 
 
-/obj/machinery/mineral/ore_redemption/proc/redeem_points(obj/machinery/mineral/ore_redemption/machine, container, obj/item/stack/ore/gathered_ore)
+/obj/machinery/mineral/ore_redemption/proc/silo_redeem_points(obj/machinery/mineral/ore_redemption/machine, container, obj/item/stack/ore/gathered_ore)
+	SIGNAL_HANDLER
+
+	local_redeem_points(container, gathered_ore)
+
+/obj/machinery/mineral/ore_redemption/proc/local_redeem_points(container, obj/item/stack/ore/gathered_ore)
 	SIGNAL_HANDLER
 
 	if(istype(gathered_ore) && gathered_ore.refined_type)
@@ -156,7 +173,7 @@
 		if(isnull(gathered_ore.refined_type))
 			continue
 
-		if(materials.mat_container.insert_item(gathered_ore, ore_multiplier, context = src) <= 0)
+		if(materials.insert_item(gathered_ore, ore_multiplier) <= 0)
 			unload_mineral(gathered_ore) //if rejected unload
 
 		SEND_SIGNAL(src, COMSIG_ORM_COLLECTED_ORE)
@@ -289,21 +306,26 @@
 	var/datum/component/material_container/mat_container = materials.mat_container
 	switch(action)
 		if("Claim")
+			//requires silo but silo not in range
+			if(requires_silo && !materials.check_z_level())
+				return FALSE
+
+			//no ID
 			var/obj/item/card/id/user_id_card
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
-			if(!materials.check_z_level() && (requires_silo || !user_id_card.registered_account.replaceable))
-				return TRUE
+			if(isnull(user_id_card))
+				to_chat(usr, span_warning("No valid ID detected."))
+				return FALSE
+
+			//we have points
 			if(points)
-				if(user_id_card)
-					user_id_card.registered_account.mining_points += points
-					points = 0
-				else
-					to_chat(usr, span_warning("No valid ID detected."))
-			else
-				to_chat(usr, span_warning("No points to claim."))
-			return TRUE
+				user_id_card.registered_account.mining_points += points
+				points = 0
+				return TRUE
+
+			return FALSE
 		if("Release")
 			if(!mat_container)
 				return

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 
 	silo_log(context, "deposited", amount_inserted, item_inserted.name, mats_consumed)
 
-	SEND_SIGNAL(context, COMSIG_MATCONTAINER_ITEM_CONSUMED, container, item_inserted, last_inserted_id, mats_consumed, amount_inserted)
+	SEND_SIGNAL(context, COMSIG_SILO_ITEM_CONSUMED, container, item_inserted, last_inserted_id, mats_consumed, amount_inserted)
 
 /obj/machinery/ore_silo/proc/log_sheets_ejected(datum/component/material_container/container, obj/item/stack/sheet/sheets, atom/context)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
- Fixes #80559

1) The ORM now hooks onto the local container only if off station. The ui act if statement was also messed up but that's fixed now too.

2) Creates a dedicated signal for items inserted into the silo for clarity & uses the helper proc defined inside remote materials for inserting items so we don't have to specify the `context` manually.

3) Properly updates the auto Doc for the container signal defines

## Changelog
:cl:
fix: Off station ORM's can redeem points again.
/:cl: