### PR TITLE
Spelling Error fix and death knell logging for the Vorpal Scythe

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -149,7 +149,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 	if(ispodperson(potential_reaping) || ismonkey(potential_reaping)) //And if they're a podperson or monkey, they can just die.
 		death_knell_speed_mod *= 0.5
 
-	log_combat(attacker, defender, "prepared to use [src] to decapitate")
+	log_combat(user, potential_reaping, "prepared to use [src] to decapitate")
 
 	if(do_after(user,  15 SECONDS * death_knell_speed_mod, target = potential_reaping))
 		playsound(get_turf(potential_reaping), 'sound/weapons/bladeslice.ogg', 250, TRUE)
@@ -167,7 +167,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 			)
 
 		scythe_empowerment(potential_empowerment)
-		log_combat(attacker, defender, "used [src] to decapitate")
+		log_combat(user, potential_reaping, "used [src] to decapitate")
 
 		if(HAS_MIND_TRAIT(user, TRAIT_MORBID)) //You feel good about yourself, pal?
 			user.add_mood_event("morbid_dismemberment", /datum/mood_event/morbid_dismemberment)

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -139,7 +139,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 
 	var/death_knell_speed_mod = 1
 
-	potential_reaping.visible_message(span_danger("[user] begins to raise [src] arove [potential_reaping]'s [head_name]."), span_userdanger("[user] begins to raise [src], aiming to slice off your [head_name]!"))
+	potential_reaping.visible_message(span_danger("[user] begins to raise [src] above [potential_reaping]'s [head_name]."), span_userdanger("[user] begins to raise [src], aiming to slice off your [head_name]!"))
 	if(potential_reaping.stat >= UNCONSCIOUS || HAS_TRAIT(potential_reaping, TRAIT_INCAPACITATED)) //if the victim is incapacitated (due to paralysis, a stun, being in staminacrit, etc.), critted, unconscious, or dead, it's much easier to properly behead
 		death_knell_speed_mod *= 0.5
 	if(potential_reaping.stat != DEAD && potential_reaping.has_status_effect(/datum/status_effect/jitter)) //jittering will make it harder to perform the death knell, even if they're still
@@ -148,6 +148,8 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 		death_knell_speed_mod *= 0.5
 	if(ispodperson(potential_reaping) || ismonkey(potential_reaping)) //And if they're a podperson or monkey, they can just die.
 		death_knell_speed_mod *= 0.5
+
+	log_combat(attacker, defender, "prepared to use [src] to decapitate")
 
 	if(do_after(user,  15 SECONDS * death_knell_speed_mod, target = potential_reaping))
 		playsound(get_turf(potential_reaping), 'sound/weapons/bladeslice.ogg', 250, TRUE)
@@ -165,6 +167,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 			)
 
 		scythe_empowerment(potential_empowerment)
+		log_combat(attacker, defender, "used [src] to decapitate")
 
 		if(HAS_MIND_TRAIT(user, TRAIT_MORBID)) //You feel good about yourself, pal?
 			user.add_mood_event("morbid_dismemberment", /datum/mood_event/morbid_dismemberment)


### PR DESCRIPTION

## About The Pull Request

Fixes a spelling error in the death knell windup chat message for the Vorpal Scythe.

Adds logging for starting the windup of a death knell, and on a successful death knell for the Vorpal Scythe.

## Why It's Good For The Game

Oops, this was unlogged. Fixes https://github.com/tgstation/tgstation/issues/80458

## Changelog
:cl:
spellcheck: Fixes a typo in chat message when starting a Death Knell with the Vorpal Scythe
admin: Adds logging for the death knell, both when starts and when it is completed successfully.
/:cl:
