### PR TITLE
Makes the turbine core part remove references on deactivation

### DIFF
--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -231,8 +231,6 @@
 	off_overlay = "inlet_off"
 	open_overlay = "inlet_open"
 
-	/// The rotor this inlet is linked to
-	var/obj/machinery/power/turbine/core_rotor/rotor
 	/// The turf from which it absorbs gases from
 	var/turf/open/input_turf
 	/// Work acheived during compression
@@ -244,9 +242,6 @@
 
 /obj/machinery/power/turbine/inlet_compressor/deactivate_parts(mob/user)
 	. = ..()
-	if(!QDELETED(rotor))
-		rotor.deactivate_parts()
-	rotor = null
 	input_turf = null
 
 /**
@@ -293,16 +288,11 @@
 	off_overlay = "outlet_off"
 	open_overlay = "outlet_open"
 
-	/// The rotor this outlet is linked to
-	var/obj/machinery/power/turbine/core_rotor/rotor
 	/// The turf to puch the gases out into
 	var/turf/open/output_turf
 
 /obj/machinery/power/turbine/turbine_outlet/deactivate_parts(mob/user)
 	. = ..()
-	if(!QDELETED(rotor))
-		rotor.deactivate_parts()
-	rotor = null
 	output_turf = null
 
 /// push gases from its gas mix to output turf
@@ -498,8 +488,6 @@
 	if(check_only)
 		return TRUE
 
-	compressor.rotor = src
-	turbine.rotor = src
 	max_allowed_rpm = (compressor.installed_part.max_rpm + turbine.installed_part.max_rpm + installed_part.max_rpm) / 3
 	max_allowed_temperature = (compressor.installed_part.max_temperature + turbine.installed_part.max_temperature + installed_part.max_temperature) / 3
 	connect_to_network()

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -232,7 +232,7 @@
 	open_overlay = "inlet_open"
 
 	/// The rotor this inlet is linked to
-	var/datum/weakref/rotor_ref
+	var/obj/machinery/power/turbine/core_rotor/rotor
 
 	/// The turf from which it absorbs gases from
 	var/turf/open/input_turf
@@ -245,7 +245,6 @@
 
 /obj/machinery/power/turbine/inlet_compressor/deactivate_parts(mob/user)
 	. = ..()
-	var/obj/machinery/power/turbine/core_rotor/rotor = rotor_ref.resolve()
 	if(!QDELETED(rotor))
 		rotor.deactivate_parts()
 	rotor = null
@@ -296,7 +295,7 @@
 	open_overlay = "outlet_open"
 
 	/// The rotor this outlet is linked to
-	var/datum/weakref/rotor_ref
+	var/obj/machinery/power/turbine/core_rotor/rotor
 	/// The turf to puch the gases out into
 	var/turf/open/output_turf
 
@@ -501,8 +500,8 @@
 	if(check_only)
 		return TRUE
 
-	compressor.rotor_ref = WEAKREF(src)
-	turbine.rotor_ref = WEAKREF(src)
+	compressor.rotor = src
+	turbine.rotor = src
 	max_allowed_rpm = (compressor.installed_part.max_rpm + turbine.installed_part.max_rpm + installed_part.max_rpm) / 3
 	max_allowed_temperature = (compressor.installed_part.max_temperature + turbine.installed_part.max_temperature + installed_part.max_temperature) / 3
 	connect_to_network()
@@ -515,7 +514,9 @@
 /obj/machinery/power/turbine/core_rotor/deactivate_parts()
 	if(all_parts_connected)
 		power_off()
+	compressor.rotor = null
 	compressor = null
+	turbine.rotor = null
 	turbine = null
 	all_parts_connected = FALSE
 	disconnect_from_network()

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -233,7 +233,6 @@
 
 	/// The rotor this inlet is linked to
 	var/obj/machinery/power/turbine/core_rotor/rotor
-
 	/// The turf from which it absorbs gases from
 	var/turf/open/input_turf
 	/// Work acheived during compression
@@ -301,7 +300,6 @@
 
 /obj/machinery/power/turbine/turbine_outlet/deactivate_parts(mob/user)
 	. = ..()
-	var/obj/machinery/power/turbine/core_rotor/rotor
 	if(!QDELETED(rotor))
 		rotor.deactivate_parts()
 	rotor = null

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -231,6 +231,9 @@
 	off_overlay = "inlet_off"
 	open_overlay = "inlet_open"
 
+	/// The rotor this inlet is linked to
+	var/datum/weakref/rotor_ref
+
 	/// The turf from which it absorbs gases from
 	var/turf/open/input_turf
 	/// Work acheived during compression
@@ -242,6 +245,10 @@
 
 /obj/machinery/power/turbine/inlet_compressor/deactivate_parts(mob/user)
 	. = ..()
+	var/obj/machinery/power/turbine/core_rotor/rotor = rotor_ref.resolve()
+	if(!QDELETED(rotor))
+		rotor.deactivate_parts()
+	rotor = null
 	input_turf = null
 
 /**
@@ -288,11 +295,17 @@
 	off_overlay = "outlet_off"
 	open_overlay = "outlet_open"
 
+	/// The rotor this outlet is linked to
+	var/datum/weakref/rotor_ref
 	/// The turf to puch the gases out into
 	var/turf/open/output_turf
 
 /obj/machinery/power/turbine/turbine_outlet/deactivate_parts(mob/user)
 	. = ..()
+	var/obj/machinery/power/turbine/core_rotor/rotor
+	if(!QDELETED(rotor))
+		rotor.deactivate_parts()
+	rotor = null
 	output_turf = null
 
 /// push gases from its gas mix to output turf
@@ -488,6 +501,8 @@
 	if(check_only)
 		return TRUE
 
+	compressor.rotor_ref = WEAKREF(src)
+	turbine.rotor_ref = WEAKREF(src)
 	max_allowed_rpm = (compressor.installed_part.max_rpm + turbine.installed_part.max_rpm + installed_part.max_rpm) / 3
 	max_allowed_temperature = (compressor.installed_part.max_temperature + turbine.installed_part.max_temperature + installed_part.max_temperature) / 3
 	connect_to_network()

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -512,9 +512,9 @@
 /obj/machinery/power/turbine/core_rotor/deactivate_parts()
 	if(all_parts_connected)
 		power_off()
-	compressor.rotor = null
+	compressor?.rotor = null
 	compressor = null
-	turbine.rotor = null
+	turbine?.rotor = null
 	turbine = null
 	all_parts_connected = FALSE
 	disconnect_from_network()


### PR DESCRIPTION
## About The Pull Request
The delete the world test was showing that the turbine's non-core parts, the compressor and outlet were causing runtimes, so I made the deactivation of the core remove the references from the secondary turbine parts
## Why It's Good For The Game
Less harddels means less lag, hopefully

No changelog since nothing player facing

