### PR TITLE
Makes immerse use weakrefs

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -170,7 +170,7 @@
 
 	movable.vis_contents |= vis_overlay
 
-	LAZYSET(immersed_movables, WEAKREF(movable), vis_overlay)
+	LAZYSET(immersed_movables, WEAKREF(movable), WEAKREF(vis_overlay))
 
 ///Initializes and caches a new visual overlay given parameters such as width, height and whether it should appear fully underwater.
 /datum/element/immerse/proc/generate_vis_overlay(width, height, is_below_water)
@@ -216,7 +216,7 @@
 	if(!vis_overlay)
 		return
 	movable.vis_contents -= vis_overlay
-	LAZYREMOVE(immersed_movables, movable)
+	LAZYREMOVE(immersed_movables, WEAKREF(movable))
 	if(HAS_TRAIT(movable, TRAIT_UNIQUE_IMMERSE))
 		UnregisterSignal(movable, list(COMSIG_ATOM_SPIN_ANIMATION, COMSIG_LIVING_POST_UPDATE_TRANSFORM))
 		qdel(vis_overlay)

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -170,7 +170,7 @@
 
 	movable.vis_contents |= vis_overlay
 
-	LAZYSET(immersed_movables, WEAKREF(movable), WEAKREF(vis_overlay))
+	LAZYSET(immersed_movables, WEAKREF(movable), vis_overlay)
 
 ///Initializes and caches a new visual overlay given parameters such as width, height and whether it should appear fully underwater.
 /datum/element/immerse/proc/generate_vis_overlay(width, height, is_below_water)

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -96,8 +96,8 @@
 /datum/element/immerse/proc/stop_immersion(turf/source)
 	SIGNAL_HANDLER
 	UnregisterSignal(source, list(COMSIG_ATOM_ABSTRACT_ENTERED, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, COMSIG_ATOM_ABSTRACT_EXITED))
-	for(var/atom/movable/movable as anything in attached_turfs_and_movables[source])
-		remove_from_element(source, movable)
+	for(var/datum/weakref/movable as anything in attached_turfs_and_movables[source])
+		remove_from_element(source, movable.resolve())
 	attached_turfs_and_movables -= source
 
 /**
@@ -122,7 +122,7 @@
 
 	try_immerse(movable, buckled)
 	RegisterSignal(movable, COMSIG_QDELETING, PROC_REF(on_movable_qdel))
-	LAZYADD(attached_turfs_and_movables[source], movable)
+	LAZYADD(attached_turfs_and_movables[source], WEAKREF(movable))
 	ADD_TRAIT(movable, TRAIT_IMMERSED, ELEMENT_TRAIT(src))
 
 /datum/element/immerse/proc/on_movable_qdel(atom/movable/source)
@@ -170,7 +170,7 @@
 
 	movable.vis_contents |= vis_overlay
 
-	LAZYSET(immersed_movables, movable, vis_overlay)
+	LAZYSET(immersed_movables, WEAKREF(movable), vis_overlay)
 
 ///Initializes and caches a new visual overlay given parameters such as width, height and whether it should appear fully underwater.
 /datum/element/immerse/proc/generate_vis_overlay(width, height, is_below_water)
@@ -212,7 +212,7 @@
 
 ///This proc removes the vis_overlay, the keep together trait and some signals from the movable.
 /datum/element/immerse/proc/remove_immerse_overlay(atom/movable/movable)
-	var/atom/movable/immerse_overlay/vis_overlay = LAZYACCESS(immersed_movables, movable)
+	var/atom/movable/immerse_overlay/vis_overlay = LAZYACCESS(immersed_movables, WEAKREF(movable))
 	if(!vis_overlay)
 		return
 	movable.vis_contents -= vis_overlay
@@ -298,8 +298,8 @@
 	if(!(exited.loc in attached_turfs_and_movables))
 		remove_from_element(source, exited)
 	else
-		LAZYREMOVE(attached_turfs_and_movables[source], exited)
-		LAZYADD(attached_turfs_and_movables[exited.loc], exited)
+		LAZYREMOVE(attached_turfs_and_movables[source], WEAKREF(exited))
+		LAZYADD(attached_turfs_and_movables[exited.loc], WEAKREF(exited))
 
 ///Remove any signal, overlay, trait given to the movable and reference to it within the element.
 /datum/element/immerse/proc/remove_from_element(turf/source, atom/movable/movable)
@@ -311,7 +311,7 @@
 
 	UnregisterSignal(movable, list(COMSIG_LIVING_SET_BUCKLED, COMSIG_QDELETING))
 	REMOVE_TRAIT(movable, TRAIT_IMMERSED, ELEMENT_TRAIT(src))
-	LAZYREMOVE(attached_turfs_and_movables[source], movable)
+	LAZYREMOVE(attached_turfs_and_movables[source], WEAKREF(movable))
 
 /// A band-aid to keep the (unique) visual overlay from scaling and rotating along with its owner. I'm sorry.
 /datum/element/immerse/proc/on_update_transform(mob/living/source, resize, new_lying_angle, is_opposite_angle)
@@ -320,7 +320,7 @@
 	new_transform.Scale(1/source.current_size)
 	new_transform.Turn(-new_lying_angle)
 
-	var/atom/movable/immerse_overlay/vis_overlay = immersed_movables[source]
+	var/atom/movable/immerse_overlay/vis_overlay = immersed_movables[WEAKREF(source)]
 	if(is_opposite_angle)
 		vis_overlay.transform = new_transform
 		vis_overlay.adjust_living_overlay_offset(source)
@@ -361,7 +361,7 @@
 ///Spin the overlay in the opposite direction so it doesn't look like it's spinning at all.
 /datum/element/immerse/proc/on_spin_animation(atom/source, speed, loops, segments, segment)
 	SIGNAL_HANDLER
-	var/atom/movable/immerse_overlay/vis_overlay = immersed_movables[source]
+	var/atom/movable/immerse_overlay/vis_overlay = immersed_movables[WEAKREF(source)]
 	vis_overlay.do_spin_animation(speed, loops, segments, -segment)
 
 ///We need to make sure to remove hard refs from the element when deleted.


### PR DESCRIPTION

## About The Pull Request
Immerse was causing harddels due to it having references to mobs. Makes it use weakrefs for mobs instead. 

## Why It's Good For The Game
Immerse would cause harddels if a mob was deleted while it was in it's list. It could probably also happen if a turf was deleted too, but doing that here would be much harder.

no CL since nothing playerfacing

