### PR TITLE
[NO GBP] Some reaction & chamber fixes

### DIFF
--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -341,7 +341,7 @@
 	var/total_step_added = 0
 	for(var/datum/reagent/product as anything in reaction.results)
 		//create the products
-		step_add = holder.add_reagent(product, delta_chem_factor * reaction.results[product], null, cached_temp, purity, override_base_ph = TRUE, no_react = TRUE)
+		step_add = holder.add_reagent(product, delta_chem_factor * reaction.results[product], null, cached_temp, purity, override_base_ph = TRUE)
 		if(!step_add)
 			to_delete = TRUE
 			return

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -194,7 +194,7 @@
 			set_temperature(reagtemp)
 
 	SEND_SIGNAL(src, COMSIG_REAGENTS_NEW_REAGENT, new_reagent, amount, reagtemp, data, no_react)
-	if(!no_react && !is_reacting)
+	if(!no_react)
 		handle_reactions()
 	return amount
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -146,11 +146,13 @@
 
 		//keep constant with the chemical acclimator please
 		beaker.reagents.adjust_thermal_energy((target_temperature - beaker.reagents.chem_temp) * heater_coefficient * seconds_per_tick * SPECIFIC_HEAT_DEFAULT * beaker.reagents.total_volume * randomness)
-		if(!beaker.reagents.is_reacting)
-			beaker.reagents.handle_reactions()
+		beaker.reagents.handle_reactions()
 
 		//use power
 		use_power(active_power_usage * seconds_per_tick)
+
+		//show changes to ui immediatly for responsivenes
+		SStgui.update_uis(src)
 
 /obj/machinery/chem_heater/wrench_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_BLOCKING
@@ -176,8 +178,10 @@
 			var/obj/item/reagent_containers/injector = held_item
 			injector.afterattack(beaker, user, proximity_flag = TRUE)
 			return TRUE
+
 	if(is_reagent_container(held_item)  && held_item.is_open_container())
-		replace_beaker(user, held_item)
+		if(replace_beaker(user, held_item))
+			ui_interact(user)
 		balloon_alert(user, "beaker added!")
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #80596
The UI opens when you remove/add a beaker to it

- Fixes #80597
Calls `handle_reactions()` per step and updates UI thus reporting changes more often

- Fixes https://github.com/tgstation/tgstation/issues/80597#issuecomment-1869693182. For instant reactions such as plastic we want to call `handle_reactions()` wherever possible (in this case whenever new reagent is added per equilibrium step) so that we can maximise product formed and start new reactions whenever possible

- Fixes #80632 
Same explanation as above since it now triggers all reactions more often

## Changelog
:cl:
fix: reaction chamber open its UI when inserting/removing beakers from it
fix: reaction chamber triggers new reactions & updates UI more often during heating
fix: instant and  normal reactions now get triggered more often so for e.g. more plastic sheets from polymer reactions or more reactions occur when there are multiple reagents present
/:cl: