### PR TITLE
Optimize find_potential_targets self cost

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/targeting.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/targeting.dm
@@ -1,11 +1,12 @@
+/// List of objects that AIs will treat as targets
+GLOBAL_LIST_EMPTY_TYPED(hostile_machines, /atom)
+
 /datum/ai_behavior/find_potential_targets
 	action_cooldown = 2 SECONDS
 	/// How far can we see stuff?
 	var/vision_range = 9
 	/// Blackboard key for aggro range, uses vision range if not specified
 	var/aggro_range_key = BB_AGGRO_RANGE
-	/// Static typecache list of potentially dangerous objs
-	var/static/list/hostile_machines = typecacheof(list(/obj/machinery/porta_turret, /obj/vehicle/sealed/mecha))
 
 /datum/ai_behavior/find_potential_targets/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	. = ..()
@@ -26,9 +27,9 @@
 
 	var/list/potential_targets = hearers(aggro_range, get_turf(controller.pawn)) - living_mob //Remove self, so we don't suicide
 
-	for(var/HM in typecache_filter_list(range(aggro_range, living_mob), hostile_machines)) //Can we see any hostile machines?
-		if(can_see(living_mob, HM, aggro_range))
-			potential_targets += HM
+	for (var/atom/hostile_machine as anything in GLOB.hostile_machines)
+		if (can_see(living_mob, hostile_machine, aggro_range))
+			potential_targets += hostile_machine
 
 	if(!potential_targets.len)
 		finish_action(controller, succeeded = FALSE)

--- a/code/datums/elements/hostile_machine.dm
+++ b/code/datums/elements/hostile_machine.dm
@@ -1,0 +1,15 @@
+/// AIs will attack this as a potential target if they see it
+/datum/element/hostile_machine
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+
+/datum/element/hostile_machine/Attach(datum/target)
+	. = ..()
+
+	if (!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+
+	GLOB.hostile_machines += target
+
+/datum/element/hostile_machine/Detach(datum/source)
+	GLOB.hostile_machines -= source
+	return ..()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -133,6 +133,8 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(!has_cover)
 		INVOKE_ASYNC(src, PROC_REF(popUp))
 
+	AddElement(/datum/element/hostile_machine)
+
 /obj/machinery/porta_turret/proc/toggle_on(set_to)
 	var/current = on
 	if (!isnull(set_to))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -267,6 +267,7 @@
 			equip_by_category[key] -= path
 
 	AddElement(/datum/element/falling_hazard, damage = 80, wound_bonus = 10, hardhat_safety = FALSE, crushes = TRUE)
+	AddElement(/datum/element/hostile_machine)
 
 /obj/vehicle/sealed/mecha/Destroy()
 	for(var/ejectee in occupants)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1403,6 +1403,7 @@
 #include "code\datums\elements\haunted.dm"
 #include "code\datums\elements\high_fiver.dm"
 #include "code\datums\elements\honkspam.dm"
+#include "code\datums\elements\hostile_machine.dm"
 #include "code\datums\elements\human_biter.dm"
 #include "code\datums\elements\immerse.dm"
 #include "code\datums\elements\item_fov.dm"


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/35135081/84ae20b6-5f44-4a69-bda3-0df1435dea5c)

`find_potential_targets/perform` currently has a pretty bad self cost in part due to it running a second "loop over everything in range" check to find turrets and mechs. This doesn't drop it down by as much as I'd like because it still needs `hearers`, it still shows up pretty high, but this at least cuts out some unnecessary work.

Best case is likely to minimize work AIs need to do when there are no players on their z-level, as there are a lot of calls from Lavaland.