### PR TITLE
Fixing the transhumanist quirk.

### DIFF
--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -130,21 +130,18 @@
 		if(!isturf(target.loc) || target == quirk_holder || target.alpha <= 128 || target.invisibility > quirk_holder.see_invisible)
 			continue
 
-		if(target.mob_biotypes & MOB_ORGANIC)
-			if(!iscarbon(target))
+		if(iscarbon(target))
+			var/list/score = get_bodypart_score(target, limbs_only = TRUE)
+			// For an average human, they'll need 2 augmented limbs to not get counted as an organic nor a silicon.
+			// If some monstrosity has 20-30 organic limbs, they'll likely need more.
+			if(score[BODYPART_SCORE_OVERALL] < 1)
 				organics_nearby += 1
-			else
-				var/list/score = get_bodypart_score(target, limbs_only = TRUE)
-				// For an average human, they'll need 2 augmented limbs to not get counted as an organic nor a silicon.
-				// If some monstrosity has 20-30 organic limbs, they'll likely need more.
-				if(score[BODYPART_SCORE_OVERALL] < 1)
-					organics_nearby += 1
-				else if(score[BODYPART_SCORE_ORGANIC] == 0)
-					silicons_nearby += 1
-		else if(target.mob_biotypes & MOB_ROBOTIC)
-			// Dead silicons don't count, they're basically just machinery
-			if(target.stat != DEAD)
+			else if(score[BODYPART_SCORE_ORGANIC] == 0)
 				silicons_nearby += 1
+		else if(target.mob_biotypes & MOB_ORGANIC)
+			organics_nearby += 1
+		else if(target.mob_biotypes & MOB_ROBOTIC && target.stat != DEAD) // Dead silicons don't count, they're basically just machinery
+			silicons_nearby += 1
 
 	var/mood_result = silicons_nearby - organics_nearby
 

--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -41,7 +41,7 @@
 /datum/quirk/transhumanist/remove()
 	UnregisterSignal(quirk_holder, list(COMSIG_CARBON_REMOVE_LIMB, COMSIG_CARBON_ATTACH_LIMB))
 
-/datum/quirk/transhumanist/proc/get_bodypart_score(mob/living/target, limbs_only = FALSE)
+/datum/quirk/transhumanist/proc/get_bodypart_score(mob/living/carbon/target, limbs_only = FALSE)
 	var/organic_bodytypes = 0
 	var/silicon_bodytypes = 0
 	var/other_bodytypes = FALSE

--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -41,7 +41,7 @@
 /datum/quirk/transhumanist/remove()
 	UnregisterSignal(quirk_holder, list(COMSIG_CARBON_REMOVE_LIMB, COMSIG_CARBON_ATTACH_LIMB))
 
-/datum/quirk/transhumanist/proc/get_bodypart_score(mob/living/carbon/target, limbs_only = FALSE)
+/datum/quirk/transhumanist/proc/get_bodypart_score(mob/living/target, limbs_only = FALSE)
 	var/organic_bodytypes = 0
 	var/silicon_bodytypes = 0
 	var/other_bodytypes = FALSE
@@ -131,13 +131,16 @@
 			continue
 
 		if(target.mob_biotypes & MOB_ORGANIC)
-			var/list/score = get_bodypart_score(target, limbs_only = TRUE)
-			// For an average human, they'll need 2 augmented limbs to not get counted as an organic nor a silicon.
-			// If some monstrosity has 20-30 organic limbs, they'll likely need more.
-			if(score[BODYPART_SCORE_OVERALL] < 1)
+			if(!iscarbon(target))
 				organics_nearby += 1
-			else if(score[BODYPART_SCORE_ORGANIC] == 0)
-				silicons_nearby += 1
+			else
+				var/list/score = get_bodypart_score(target, limbs_only = TRUE)
+				// For an average human, they'll need 2 augmented limbs to not get counted as an organic nor a silicon.
+				// If some monstrosity has 20-30 organic limbs, they'll likely need more.
+				if(score[BODYPART_SCORE_OVERALL] < 1)
+					organics_nearby += 1
+				else if(score[BODYPART_SCORE_ORGANIC] == 0)
+					silicons_nearby += 1
 		else if(target.mob_biotypes & MOB_ROBOTIC)
 			// Dead silicons don't count, they're basically just machinery
 			if(target.stat != DEAD)


### PR DESCRIPTION
## About The Pull Request
Apparently `get_bodypart_score` was being called on simple/basic mobs too.

## Why It's Good For The Game
I've seen a few runtimes about it on Terry.

## Changelog

:cl:
fix: The transhumanist quirk now should work as intended.
/:cl:
