### PR TITLE
Healium doesn't kill toxinlovers

### DIFF
--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -52,7 +52,7 @@
 	breather.SetSleeping(30 SECONDS)
 	var/need_mob_update
 	need_mob_update = breather.adjustFireLoss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjustToxLoss(-5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjustToxLoss(-5 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 	need_mob_update += breather.adjustBruteLoss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH


### PR DESCRIPTION

## About The Pull Request

Not sure if it's an oversight, or intended, but here is a PR that changes it nonetheless.

## Why It's Good For The Game

Atmospheric technicians no longer risk accidentally murdering weird alien races with their magical healing gas.

## Changelog
:cl:
balance: healium no longer kills toxinlovers
/:cl:
