### PR TITLE
Fixes wallmounted lights falling on drag

### DIFF
--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -19,7 +19,7 @@
 	ADD_TRAIT(parent, TRAIT_WALLMOUNTED, REF(src))
 	RegisterSignal(hanging_wall_turf, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(hanging_wall_turf, COMSIG_TURF_CHANGE, PROC_REF(on_turf_changing))
-	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(drop_wallmount))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_linked_destroyed))
 
 /datum/component/wall_mounted/UnregisterFromParent()
@@ -51,6 +51,18 @@
 	if (ispath(path, /turf/open))
 		drop_wallmount()
 
+
+/**
+ * If we get dragged from our wall (by a singulo for instance) we should deconstruct
+ */
+/datum/component/wall_mounted/proc/on_move(datum/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	// If we're having our lighting messed with we're likely to get dragged about
+	// That shouldn't lead to a decon
+	if(HAS_TRAIT(parent, TRAIT_LIGHTING_DEBUGGED))
+		return
+	drop_wallmount()
+
 /**
  * Handles the dropping of the linked object. This is done via deconstruction, as that should be the most sane way to handle it for most objects.
  * Except for intercoms, which are handled by creating a new wallframe intercom, as they're apparently items.
@@ -68,6 +80,7 @@
 
 	if(!QDELING(src))
 		qdel(src) //Well, we fell off the wall, so we're done here.
+
 /**
  *	Checks object direction and then verifies if there's a wall in that direction. Finally, applies a wall_mounted component to the object.
  *


### PR DESCRIPTION
## About The Pull Request

Being able to move around lights when using the light debugger is important
Can't just be qdeling em whenever you try

Closes https://github.com/tgstation/tgstation/issues/78662
## Changelog
:cl:
fix: Dear mappers, the light debugger tool no longer deletes dragged wall lights
/:cl:
