### PR TITLE
Fixing the constant poll alert runtimes, and the selector outline not being updated.

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -888,18 +888,24 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(LAZYACCESS(modifiers, CTRL_CLICK) && poll.jump_to_me)
 		jump_to_pic_source()
 		return
-	handle_sign_up()
+	if(handle_sign_up())
+		update_candidates_number_overlay()
+		update_signed_up_overlay()
 
 /atom/movable/screen/alert/poll_alert/proc/handle_sign_up()
 	if(owner in poll.signed_up)
-		poll.remove_candidate(owner)
-	else if(!(owner.ckey in GLOB.poll_ignore[poll.ignoring_category]))
-		poll.sign_up(owner)
+		return poll.remove_candidate(owner, src)
+	if(owner.ckey in GLOB.poll_ignore[poll.ignoring_category])
+		return FALSE
+	if(poll.sign_up(owner))
+		return poll.sign_up(owner)
 
 /atom/movable/screen/alert/poll_alert/proc/set_never_round()
 	if(!(owner.ckey in GLOB.poll_ignore[poll.ignoring_category]))
 		poll.do_never_for_this_round(owner)
 		color = "red"
+		update_candidates_number_overlay()
+		update_signed_up_overlay()
 		return
 	poll.undo_never_for_this_round(owner)
 	color = initial(color)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -826,6 +826,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/poll_alert/Initialize(mapload)
 	. = ..()
+	signed_up_overlay = mutable_appearance('icons/hud/screen_gen.dmi', icon_state = "selector")
 	register_context()
 
 /atom/movable/screen/alert/poll_alert/proc/set_role_overlay()
@@ -928,7 +929,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return
 
 /atom/movable/screen/alert/poll_alert/proc/update_signed_up_overlay()
-	signed_up_overlay = mutable_appearance('icons/hud/screen_gen.dmi', icon_state = "selector")
 	if(owner in poll.signed_up)
 		add_overlay(signed_up_overlay)
 	else

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -38,6 +38,8 @@ SUBSYSTEM_DEF(polling)
 	var/category = "[new_poll.poll_key]_poll_alert"
 
 	for(var/mob/candidate_mob as anything in group)
+		if(!candidate_mob.client)
+			continue
 		// Universal opt-out for all players.
 		if((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles)))
 			continue
@@ -55,7 +57,7 @@ SUBSYSTEM_DEF(polling)
 		// we need to keep the first one's timeout rather than use the shorter one
 		var/atom/movable/screen/alert/poll_alert/current_alert = LAZYACCESS(candidate_mob.alerts, category)
 		var/alert_time = poll_time
-		var/alert_poll = new_poll
+		var/datum/candidate_poll/alert_poll = new_poll
 		if(current_alert && current_alert.timeout > (world.time + poll_time - world.tick_lag))
 			alert_time = current_alert.timeout - world.time + world.tick_lag
 			alert_poll = current_alert.poll

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -190,14 +190,13 @@ SUBSYSTEM_DEF(polling)
 
 	// Take care of updating the remaining screen alerts if a similar poll is found, or deleting them.
 	if(length(finishing_poll.alert_buttons))
-		var/datum/candidate_poll/poll_of_same_type
+		var/polls_of_same_type_left = FALSE
 		for(var/datum/candidate_poll/running_poll as anything in currently_polling)
 			if(running_poll.poll_key == finishing_poll.poll_key && running_poll.time_left() > 0)
-				poll_of_same_type = running_poll
+				polls_of_same_type_left = TRUE
 				break
 		for(var/atom/movable/screen/alert/poll_alert/alert as anything in finishing_poll.alert_buttons)
-			if(poll_of_same_type)
-				alert.poll = poll_of_same_type
+			if(polls_of_same_type_left)
 				alert.update_stacks_overlay()
 			else
 				alert.owner.clear_alert("[finishing_poll.poll_key]_poll_alert")


### PR DESCRIPTION
## About The Pull Request
The new ghost polling looks and works creamy, though it isn't without its couple issues. For once, the `candidate_poll` datum has an `alert_button` variable that stores a single alert button, used to update the alert icon, whereas there're multiple candidates and therefore screen alerts associated to the datum, which means it doesn't update the outline that denotes whether you've signed up for it or not correctly.

The second issue is finished polls not being removed from the `currently_running` list, since the `polling_finished` proc will error right before the the operation. Turns out screen alerts are cleared/deleted before the proc is called, so you're ending up with a `null.update_stacks_overlay()` situation. But again, the way alert buttons are handled is garbage.

Possibly fixes a couple hard dels too because the reference to them weren't being correctly cleared from the `candidate_poll` datum.

This PR aims to tackle down these issues.

EDIT: Borrowing a couple elements that #80572 has while mine doesn't. The author told me they hadn't taken into consideration that polls of same category can stack up (shown as a counter in the alert button) while making their PR, though mine does. Credits in the CL.

## Why It's Good For The Game
Reducing the runtimes counter by the thousands.

## Changelog

:cl: Ghommie, 13spacemen
fix: Signing or removing your candidature from ghost roles now properly updates the screen button for it.
/:cl: