### PR TITLE
Fixes input value not clearing on NTOS app [no gbp]

### DIFF
--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -77,21 +77,32 @@ export const Input = (props: Props) => {
     }
   };
 
+  /** Focuses the input on mount */
+  useEffect(() => {
+    if (!autoFocus && !autoSelect) return;
+
+    const input = inputRef.current;
+    if (!input) return;
+
+    setTimeout(() => {
+      input.focus();
+
+      if (autoSelect) {
+        input.select();
+      }
+    }, 1);
+  }, []);
+
+  /** Updates the initial value on props change */
   useEffect(() => {
     const input = inputRef.current;
     if (!input) return;
 
-    input.value = toInputValue(value);
-    if (autoFocus || autoSelect) {
-      setTimeout(() => {
-        input.focus();
+    const newValue = toInputValue(value);
+    if (input.value === newValue) return;
 
-        if (autoSelect) {
-          input.select();
-        }
-      }, 1);
-    }
-  }, []);
+    input.value = newValue;
+  }, [value]);
 
   return (
     <Box


### PR DESCRIPTION

## About The Pull Request
Problem goes a little deeper than simply adding "selfClear" prop - ntos messenger is looking for more of a controlled component. Whenever messages are sent, it attempts to update the value in the input box
## Why It's Good For The Game
Fixes #80611
## Changelog
:cl:
fix: NTOS Messenger should clear on enter now
/:cl:
