### PR TITLE
A/B test qdel micro-optimization by expecting only force parameter

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -338,10 +338,10 @@ SUBSYSTEM_DEF(garbage)
 	var/static/call_count = 0
 
 	if (args.len > 2)
-		stack_trace("[to_delete] ([to_delete.path]) was deleted with more than just itself and force")
-		qdel_OLD(to_delete, force, arglist(args))
+		stack_trace("[to_delete] ([to_delete.type]) was deleted with more than just itself and force")
+		qdel_OLD(arglist(args))
 	else if (++call_count % 2 == 0)
-		qdel_OLD(to_delete, force, arglist(args))
+		qdel_OLD(arglist(args))
 	else
 		qdel_NEW(to_delete, force)
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -74,13 +74,12 @@
  * * force - makes it not check for and remove the component from the parent
  * * silent - deletes the component without sending a [COMSIG_COMPONENT_REMOVING] signal
  */
-/datum/component/Destroy(force=FALSE, silent=FALSE)
+/datum/component/Destroy(force=FALSE)
 	if(!parent)
 		return ..()
 	if(!force)
 		_RemoveFromParent()
-	if(!silent)
-		SEND_SIGNAL(parent, COMSIG_COMPONENT_REMOVING, src)
+	SEND_SIGNAL(parent, COMSIG_COMPONENT_REMOVING, src)
 	parent = null
 	return ..()
 

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -72,7 +72,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		particle_effect = new(atom_parent, acid_particles, isitem(atom_parent) ? NONE : PARTICLE_ATTACH_MOB)
 	START_PROCESSING(SSacid, src)
 
-/datum/component/acid/Destroy(force, silent)
+/datum/component/acid/Destroy(force)
 	STOP_PROCESSING(SSacid, src)
 	if(sizzle)
 		QDEL_NULL(sizzle)

--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -24,7 +24,7 @@
 	src.item_ref = WEAKREF(item)
 	src.item_callback = item_callback
 
-/datum/component/action_item_overlay/Destroy(force, silent)
+/datum/component/action_item_overlay/Destroy(force)
 	item_ref = null
 	item_callback = null
 	item_appearance = null

--- a/code/datums/components/admin_popup.dm
+++ b/code/datums/components/admin_popup.dm
@@ -26,7 +26,7 @@
 		PROC_REF(delete_self),
 	)
 
-/datum/component/admin_popup/Destroy(force, silent)
+/datum/component/admin_popup/Destroy(force)
 	var/client/parent_client = parent
 
 	parent_client?.screen -= admin_popup

--- a/code/datums/components/ai_has_target_timer.dm
+++ b/code/datums/components/ai_has_target_timer.dm
@@ -33,7 +33,7 @@
 	REMOVE_TRAIT(parent, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM, type)
 	return ..()
 
-/datum/component/ai_target_timer/Destroy(force, silent)
+/datum/component/ai_target_timer/Destroy(force)
 	finalise_losing_target()
 	return ..()
 

--- a/code/datums/components/ai_retaliate_advanced.dm
+++ b/code/datums/components/ai_retaliate_advanced.dm
@@ -16,7 +16,7 @@
 
 	ADD_TRAIT(parent, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM, type)
 
-/datum/component/ai_retaliate_advanced/Destroy(force, silent)
+/datum/component/ai_retaliate_advanced/Destroy(force)
 	post_retaliate_callback = null
 	return ..()
 

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -56,7 +56,7 @@
 	src.drain_antimagic = drain_antimagic
 	src.expiration = expiration
 
-/datum/component/anti_magic/Destroy(force, silent)
+/datum/component/anti_magic/Destroy(force)
 	drain_antimagic = null
 	expiration = null
 	return ..()

--- a/code/datums/components/aquarium_content.dm
+++ b/code/datums/components/aquarium_content.dm
@@ -138,7 +138,7 @@
 	. = ..()
 	REMOVE_TRAIT(parent, TRAIT_FISH_CASE_COMPATIBILE, REF(src))
 
-/datum/component/aquarium_content/Destroy(force, silent)
+/datum/component/aquarium_content/Destroy(force)
 	if(current_aquarium)
 		remove_from_aquarium()
 	QDEL_NULL(vc_obj)

--- a/code/datums/components/area_sound_manager.dm
+++ b/code/datums/components/area_sound_manager.dm
@@ -29,7 +29,7 @@
 	else if(!isnull(remove_on))
 		RegisterSignal(parent, remove_on, PROC_REF(handle_removal))
 
-/datum/component/area_sound_manager/Destroy(force, silent)
+/datum/component/area_sound_manager/Destroy(force)
 	QDEL_NULL(our_loop)
 	. = ..()
 

--- a/code/datums/components/areabound.dm
+++ b/code/datums/components/areabound.dm
@@ -26,6 +26,6 @@
 		AM.forceMove(reset_turf)
 		moving = FALSE
 
-/datum/component/areabound/Destroy(force, silent)
+/datum/component/areabound/Destroy(force)
 	QDEL_NULL(move_tracker)
 	. = ..()

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -78,7 +78,7 @@
 	src.limit_to_trait = limit_to_trait
 	src.healing_color = healing_color
 
-/datum/component/aura_healing/Destroy(force, silent)
+/datum/component/aura_healing/Destroy(force)
 	STOP_PROCESSING(SSaura_healing, src)
 	var/alert_category = "aura_healing_[REF(src)]"
 

--- a/code/datums/components/basic_mob_attack_telegraph.dm
+++ b/code/datums/components/basic_mob_attack_telegraph.dm
@@ -25,7 +25,7 @@
 	src.telegraph_duration = telegraph_duration
 	src.on_began_forecast = on_began_forecast
 
-/datum/component/basic_mob_attack_telegraph/Destroy(force, silent)
+/datum/component/basic_mob_attack_telegraph/Destroy(force)
 	if(current_target)
 		forget_target(current_target)
 	target_overlay = null

--- a/code/datums/components/basic_ranged_ready_overlay.dm
+++ b/code/datums/components/basic_ranged_ready_overlay.dm
@@ -29,7 +29,7 @@
 	UnregisterSignal(parent, list(COMSIG_BASICMOB_POST_ATTACK_RANGED, COMSIG_LIVING_REVIVE))
 	return ..()
 
-/datum/component/basic_ranged_ready_overlay/Destroy(force, silent)
+/datum/component/basic_ranged_ready_overlay/Destroy(force)
 	deltimer(waiting_timer)
 	return ..()
 

--- a/code/datums/components/boss_music.dm
+++ b/code/datums/components/boss_music.dm
@@ -22,7 +22,7 @@
 	src.boss_track = boss_track
 	src.track_duration = track_duration
 
-/datum/component/boss_music/Destroy(force, silent)
+/datum/component/boss_music/Destroy(force)
 	. = ..()
 	for(var/callback in music_callbacks)
 		deltimer(callback)

--- a/code/datums/components/bullet_intercepting.dm
+++ b/code/datums/components/bullet_intercepting.dm
@@ -25,7 +25,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_parent_equipped))
 	RegisterSignal(parent, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(on_unequipped))
 
-/datum/component/bullet_intercepting/Destroy(force, silent)
+/datum/component/bullet_intercepting/Destroy(force)
 	wearer = null
 	on_intercepted = null
 	return ..()

--- a/code/datums/components/burning.dm
+++ b/code/datums/components/burning.dm
@@ -30,7 +30,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 		particle_effect = new(atom_parent, fire_particles, isitem(atom_parent) ? NONE : PARTICLE_ATTACH_MOB)
 	START_PROCESSING(SSburning, src)
 
-/datum/component/burning/Destroy(force, silent)
+/datum/component/burning/Destroy(force)
 	STOP_PROCESSING(SSburning, src)
 	fire_overlay = null
 	if(particle_effect)

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -34,7 +34,7 @@
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(onItemAttack))
 
-/datum/component/butchering/Destroy(force, silent)
+/datum/component/butchering/Destroy(force)
 	butcher_callback = null
 	return ..()
 

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -29,7 +29,7 @@
 	src.pre_clean_callback = pre_clean_callback
 	src.on_cleaned_callback = on_cleaned_callback
 
-/datum/component/cleaner/Destroy(force, silent)
+/datum/component/cleaner/Destroy(force)
 	pre_clean_callback = null
 	on_cleaned_callback = null
 	return ..()

--- a/code/datums/components/combo_attacks.dm
+++ b/code/datums/components/combo_attacks.dm
@@ -32,7 +32,7 @@
 	src.leniency_time = leniency_time
 	src.can_attack_callback = can_attack_callback
 
-/datum/component/combo_attacks/Destroy(force, silent)
+/datum/component/combo_attacks/Destroy(force)
 	can_attack_callback = null
 	return ..()
 

--- a/code/datums/components/cracked.dm
+++ b/code/datums/components/cracked.dm
@@ -12,7 +12,7 @@
 	src.crack_appearances = crack_appearances
 	src.crack_integrity = crack_integrity
 
-/datum/component/cracked/Destroy(force, silent)
+/datum/component/cracked/Destroy(force)
 	RemoveCracks(parent, length(applied_cracks))
 	return ..()
 

--- a/code/datums/components/crafting/slapcrafting.dm
+++ b/code/datums/components/crafting/slapcrafting.dm
@@ -38,7 +38,7 @@
 		return
 	src.slapcraft_recipes += slapcraft_recipes
 
-/datum/component/slapcrafting/Destroy(force, silent)
+/datum/component/slapcrafting/Destroy(force)
 	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE, COMSIG_ATOM_EXAMINE_MORE))
 	return ..()
 

--- a/code/datums/components/crate_carrier.dm
+++ b/code/datums/components/crate_carrier.dm
@@ -23,7 +23,7 @@
 		var/static/default_cache = typecacheof(list(/obj/structure/closet/crate))
 		src.carriable_cache = default_cache
 
-/datum/component/crate_carrier/Destroy(force, silent)
+/datum/component/crate_carrier/Destroy(force)
 	LAZYCLEARLIST(crates_in_hand)
 	return ..()
 

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -39,7 +39,7 @@
 		var/datum/action/added_action = item_parent.add_item_action(action)
 		linked_action_ref = WEAKREF(added_action)
 
-/datum/component/cult_ritual_item/Destroy(force, silent)
+/datum/component/cult_ritual_item/Destroy(force)
 	cleanup_shields()
 	QDEL_NULL(linked_action_ref)
 	return ..()

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -55,7 +55,7 @@
 			handle_fill(ingredient)
 
 
-/datum/component/customizable_reagent_holder/Destroy(force, silent)
+/datum/component/customizable_reagent_holder/Destroy(force)
 	QDEL_NULL(top_overlay)
 	return ..()
 

--- a/code/datums/components/damage_aura.dm
+++ b/code/datums/components/damage_aura.dm
@@ -74,7 +74,7 @@
 	src.immune_factions = immune_factions
 	src.current_owner = WEAKREF(current_owner)
 
-/datum/component/damage_aura/Destroy(force, silent)
+/datum/component/damage_aura/Destroy(force)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/datums/components/damage_chain.dm
+++ b/code/datums/components/damage_chain.dm
@@ -61,7 +61,7 @@
 /datum/component/damage_chain/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_LIVING_DEATH)
 
-/datum/component/damage_chain/Destroy(force, silent)
+/datum/component/damage_chain/Destroy(force)
 	if (!QDELETED(chain))
 		UnregisterSignal(chain, COMSIG_QDELETING)
 		QDEL_NULL(chain)

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -48,7 +48,7 @@
 		SSpoints_of_interest.make_point_of_interest(parent)
 		generated_point_of_interest = TRUE
 
-/datum/component/deadchat_control/Destroy(force, silent)
+/datum/component/deadchat_control/Destroy(force)
 	on_removal?.Invoke()
 	inputs = null
 	orbiters = null

--- a/code/datums/components/direct_explosive_trap.dm
+++ b/code/datums/components/direct_explosive_trap.dm
@@ -46,7 +46,7 @@
 	if (!isnull(saboteur))
 		UnregisterSignal(saboteur, COMSIG_QDELETING)
 
-/datum/component/direct_explosive_trap/Destroy(force, silent)
+/datum/component/direct_explosive_trap/Destroy(force)
 	if (isnull(saboteur))
 		return ..()
 	UnregisterSignal(saboteur, COMSIG_QDELETING)

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -63,7 +63,7 @@
 	echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
 	START_PROCESSING(SSfastprocess, src)
 
-/datum/component/echolocation/Destroy(force, silent)
+/datum/component/echolocation/Destroy(force)
 	STOP_PROCESSING(SSfastprocess, src)
 	var/mob/living/echolocator = parent
 	QDEL_NULL(client_color)

--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -41,7 +41,7 @@
 	src.effects_we_clear = typecacheof(effects_we_clear)
 	src.time_to_remove = time_to_remove
 
-/datum/component/effect_remover/Destroy(force, silent)
+/datum/component/effect_remover/Destroy(force)
 	on_clear_callback = null
 	return ..()
 

--- a/code/datums/components/egg_layer.dm
+++ b/code/datums/components/egg_layer.dm
@@ -47,7 +47,7 @@
 	. = ..()
 	UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
 
-/datum/component/egg_layer/Destroy(force, silent)
+/datum/component/egg_layer/Destroy(force)
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 	egg_laid_callback = null

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -52,7 +52,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
 	engraved_wall.update_appearance()
 
-/datum/component/engraved/Destroy(force, silent)
+/datum/component/engraved/Destroy(force)
 	if(!parent)
 		return ..()
 	parent.RemoveElement(/datum/element/art)

--- a/code/datums/components/evolutionary_leap.dm
+++ b/code/datums/components/evolutionary_leap.dm
@@ -30,7 +30,7 @@
 
 	setup_timer()
 
-/datum/component/evolutionary_leap/Destroy(force, silent)
+/datum/component/evolutionary_leap/Destroy(force)
 	. = ..()
 	deltimer(timer_id)
 

--- a/code/datums/components/focused_attacker.dm
+++ b/code/datums/components/focused_attacker.dm
@@ -17,7 +17,7 @@
 	src.maximum_gain = maximum_gain
 	src.gain_per_attack = gain_per_attack
 
-/datum/component/focused_attacker/Destroy(force, silent)
+/datum/component/focused_attacker/Destroy(force)
 	if (!isnull(last_target))
 		UnregisterSignal(last_target, COMSIG_QDELETING)
 	return ..()

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -187,7 +187,7 @@ Behavior that's still missing from this component that original food items had t
 	// add newly passed in reagents
 	setup_initial_reagents(initial_reagents)
 
-/datum/component/edible/Destroy(force, silent)
+/datum/component/edible/Destroy(force)
 	after_eat = null
 	on_consume = null
 	check_liked = null

--- a/code/datums/components/food/ghost_edible.dm
+++ b/code/datums/components/food/ghost_edible.dm
@@ -36,7 +36,7 @@
 /datum/component/ghost_edible/UnregisterFromParent()
 	STOP_PROCESSING(SSdcs, src)
 
-/datum/component/ghost_edible/Destroy(force, silent)
+/datum/component/ghost_edible/Destroy(force)
 	STOP_PROCESSING(SSdcs, src)
 	return ..()
 

--- a/code/datums/components/food/golem_food.dm
+++ b/code/datums/components/food/golem_food.dm
@@ -29,7 +29,7 @@
 	UnregisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ATOM_EXAMINE))
 	return ..()
 
-/datum/component/golem_food/Destroy(force, silent)
+/datum/component/golem_food/Destroy(force)
 	QDEL_NULL(golem_snack)
 	snack_type = null
 	extra_validation = null

--- a/code/datums/components/food_storage.dm
+++ b/code/datums/components/food_storage.dm
@@ -33,7 +33,7 @@
 
 	food.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 
-/datum/component/food_storage/Destroy(force, silent)
+/datum/component/food_storage/Destroy(force)
 	if(stored_item)
 		stored_item.forceMove(stored_item.drop_location())
 		stored_item.dropped()

--- a/code/datums/components/gas_leaker.dm
+++ b/code/datums/components/gas_leaker.dm
@@ -30,7 +30,7 @@
 	src.integrity_leak_percent = integrity_leak_percent
 	src.leak_rate = leak_rate
 
-/datum/component/gas_leaker/Destroy(force, silent)
+/datum/component/gas_leaker/Destroy(force)
 	SSair.stop_processing_machine(src)
 	return ..()
 

--- a/code/datums/components/geiger_sound.dm
+++ b/code/datums/components/geiger_sound.dm
@@ -8,7 +8,7 @@
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
-/datum/component/geiger_sound/Destroy(force, silent)
+/datum/component/geiger_sound/Destroy(force)
 	QDEL_NULL(sound)
 
 	if (!isnull(last_parent))

--- a/code/datums/components/ghost_direct_control.dm
+++ b/code/datums/components/ghost_direct_control.dm
@@ -48,7 +48,7 @@
 	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_EXAMINE, COMSIG_MOB_LOGIN))
 	return ..()
 
-/datum/component/ghost_direct_control/Destroy(force, silent)
+/datum/component/ghost_direct_control/Destroy(force)
 	extra_control_checks = null
 	after_assumed_control = null
 

--- a/code/datums/components/ground_sinking.dm
+++ b/code/datums/components/ground_sinking.dm
@@ -59,7 +59,7 @@
 		deltimer(ground_sinking_start_timer)
 	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
 
-/datum/component/ground_sinking/Destroy(force, silent)
+/datum/component/ground_sinking/Destroy(force)
 	if(sinked || is_sinking)
 		unsink()
 	. = ..()

--- a/code/datums/components/growth_and_differentiation.dm
+++ b/code/datums/components/growth_and_differentiation.dm
@@ -63,7 +63,7 @@
 
 	return setup_growth_tracking()
 
-/datum/component/growth_and_differentiation/Destroy(force, silent)
+/datum/component/growth_and_differentiation/Destroy(force)
 	STOP_PROCESSING(SSdcs, src)
 	deltimer(timer_id)
 	optional_checks = null

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -73,7 +73,7 @@
 
 	addtimer(CALLBACK(src, PROC_REF(update_stage), 2), GUNPOINT_DELAY_STAGE_2)
 
-/datum/component/gunpoint/Destroy(force, silent)
+/datum/component/gunpoint/Destroy(force)
 	var/mob/living/shooter = parent
 	shooter.remove_status_effect(/datum/status_effect/holdup)
 	target.remove_status_effect(/datum/status_effect/grouped/heldup, REF(shooter))

--- a/code/datums/components/hazard_area.dm
+++ b/code/datums/components/hazard_area.dm
@@ -39,7 +39,7 @@
 	UnregisterSignal(SSdcs, COMSIG_AREA_CREATED)
 	parent_mob.lose_area_sensitivity(type)
 
-/datum/component/hazard_area/Destroy(force, silent)
+/datum/component/hazard_area/Destroy(force)
 	. = ..()
 	area_created = null
 

--- a/code/datums/components/healing_touch.dm
+++ b/code/datums/components/healing_touch.dm
@@ -103,7 +103,7 @@
 	UnregisterSignal(parent, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_HOSTILE_PRE_ATTACKINGTARGET))
 	return ..()
 
-/datum/component/healing_touch/Destroy(force, silent)
+/datum/component/healing_touch/Destroy(force)
 	extra_checks = null
 	return ..()
 

--- a/code/datums/components/health_scaling_effects.dm
+++ b/code/datums/components/health_scaling_effects.dm
@@ -53,7 +53,7 @@
 	UnregisterSignal(parent, COMSIG_LIVING_HEALTH_UPDATE)
 	return ..()
 
-/datum/component/health_scaling_effects/Destroy(force, silent)
+/datum/component/health_scaling_effects/Destroy(force)
 	additional_status_callback = null
 	return ..()
 

--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -14,7 +14,7 @@
 
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
-/datum/component/heirloom/Destroy(force, silent)
+/datum/component/heirloom/Destroy(force)
 	owner = null
 	return ..()
 

--- a/code/datums/components/interaction_booby_trap.dm
+++ b/code/datums/components/interaction_booby_trap.dm
@@ -56,7 +56,7 @@
 	if (length(additional_triggers))
 		RegisterSignals(parent, additional_triggers, PROC_REF(trigger_explosive))
 
-/datum/component/interaction_booby_trap/Destroy(force, silent)
+/datum/component/interaction_booby_trap/Destroy(force)
 	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_TOOL_ACT(defuse_tool), COMSIG_ATOM_EXAMINE_MORE) + additional_triggers)
 	QDEL_NULL(active_sound_loop)
 	on_triggered_callback = null

--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -58,7 +58,7 @@
 		COMSIG_GEIGER_COUNTER_SCAN,
 	))
 
-/datum/component/irradiated/Destroy(force, silent)
+/datum/component/irradiated/Destroy(force)
 	var/atom/movable/parent_movable = parent
 	if (istype(parent_movable))
 		parent_movable.remove_filter("rad_glow")

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -40,7 +40,7 @@
 		return
 	qdel(src)
 
-/datum/component/itembound/Destroy(force, silent)
+/datum/component/itembound/Destroy(force)
 	var/atom/movable/container = containerref?.resolve()
 	if (!QDELETED(container))
 		UnregisterSignal(container, COMSIG_ATOM_EXAMINE_MORE)

--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -63,7 +63,7 @@
 	if(trail && trail.effect_type != effect_type)
 		setup_trail(trail.holder)
 
-/datum/component/jetpack/Destroy(force, silent)
+/datum/component/jetpack/Destroy(force)
 	if(trail)
 		QDEL_NULL(trail)
 	check_on_move = null

--- a/code/datums/components/keep_me_secure.dm
+++ b/code/datums/components/keep_me_secure.dm
@@ -22,7 +22,7 @@
 	src.secured_callback = secured_callback
 	src.unsecured_callback = unsecured_callback
 
-/datum/component/keep_me_secure/Destroy(force, silent)
+/datum/component/keep_me_secure/Destroy(force)
 	secured_callback = null
 	unsecured_callback = null
 	return ..()

--- a/code/datums/components/light_eater.dm
+++ b/code/datums/components/light_eater.dm
@@ -22,7 +22,7 @@
 		LAZYSET(cached_eaten_lights, morsel, TRUE)
 		RegisterSignal(morsel, COMSIG_QDELETING, PROC_REF(deref_eaten_light))
 
-/datum/component/light_eater/Destroy(force, silent)
+/datum/component/light_eater/Destroy(force)
 	for(var/light in eaten_lights)
 		var/atom/eaten_light = light
 		eaten_light.RemoveElement(/datum/element/light_eaten)

--- a/code/datums/components/listen_and_repeat.dm
+++ b/code/datums/components/listen_and_repeat.dm
@@ -33,7 +33,7 @@
 
 	ADD_TRAIT(parent, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM, type)
 
-/datum/component/listen_and_repeat/Destroy(force, silent)
+/datum/component/listen_and_repeat/Destroy(force)
 	REMOVE_TRAIT(parent, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM, type)
 	return ..()
 

--- a/code/datums/components/lock_on_cursor.dm
+++ b/code/datums/components/lock_on_cursor.dm
@@ -62,7 +62,7 @@
 	mouse_tracker.assign_to_mob(owner)
 	START_PROCESSING(SSfastprocess, src)
 
-/datum/component/lock_on_cursor/Destroy(force, silent)
+/datum/component/lock_on_cursor/Destroy(force)
 	clear_visuals()
 	STOP_PROCESSING(SSfastprocess, src)
 	mouse_tracker = null

--- a/code/datums/components/magnet.dm
+++ b/code/datums/components/magnet.dm
@@ -40,7 +40,7 @@
 	STOP_PROCESSING(SSdcs, src)
 	UnregisterSignal(parent, COMSIG_MOB_STATCHANGE)
 
-/datum/component/magnet/Destroy(force, silent)
+/datum/component/magnet/Destroy(force)
 	STOP_PROCESSING(SSdcs, src)
 	on_pulled = null
 	on_contact = null

--- a/code/datums/components/manual_blinking.dm
+++ b/code/datums/components/manual_blinking.dm
@@ -22,7 +22,7 @@
 		last_blink = world.time
 		to_chat(C, span_notice("You suddenly realize you're blinking manually."))
 
-/datum/component/manual_blinking/Destroy(force, silent)
+/datum/component/manual_blinking/Destroy(force)
 	E = null
 	STOP_PROCESSING(SSdcs, src)
 	to_chat(parent, span_notice("You revert back to automatic blinking."))

--- a/code/datums/components/manual_breathing.dm
+++ b/code/datums/components/manual_breathing.dm
@@ -22,7 +22,7 @@
 		last_breath = world.time
 		to_chat(C, span_notice("You suddenly realize you're breathing manually."))
 
-/datum/component/manual_breathing/Destroy(force, silent)
+/datum/component/manual_breathing/Destroy(force)
 	L = null
 	STOP_PROCESSING(SSdcs, src)
 	to_chat(parent, span_notice("You revert back to automatic breathing."))

--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -74,7 +74,7 @@
 
 	RegisterSignal(atom_target, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
 
-/datum/component/material_container/Destroy(force, silent)
+/datum/component/material_container/Destroy(force)
 	retrieve_all()
 	materials = null
 	allowed_materials = null

--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -59,7 +59,7 @@
 	master_speech = new(src)
 	master_speech.Grant(owner)
 
-/datum/component/mind_linker/Destroy(force, silent)
+/datum/component/mind_linker/Destroy(force)
 	for(var/mob/living/remaining_mob as anything in linked_mobs)
 		unlink_mob(remaining_mob)
 	linked_mobs.Cut()

--- a/code/datums/components/mob_chain.dm
+++ b/code/datums/components/mob_chain.dm
@@ -28,7 +28,7 @@
 		var/mob/living/living_parent = parent
 		living_parent.set_glide_size(front.glide_size)
 
-/datum/component/mob_chain/Destroy(force, silent)
+/datum/component/mob_chain/Destroy(force)
 	if (!isnull(front))
 		SEND_SIGNAL(front, COMSIG_MOB_LOST_CHAIN_TAIL, parent)
 	front = null

--- a/code/datums/components/mob_harvest.dm
+++ b/code/datums/components/mob_harvest.dm
@@ -42,7 +42,7 @@
 	item_generation_time = item_generation_wait
 	START_PROCESSING(SSobj, src)
 
-/datum/component/mob_harvest/Destroy(force, silent)
+/datum/component/mob_harvest/Destroy(force)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/datums/components/nuclear_bomb_operator.dm
+++ b/code/datums/components/nuclear_bomb_operator.dm
@@ -48,7 +48,7 @@
 	))
 	parent.remove_traits(list(TRAIT_DISK_VERIFIER, TRAIT_CAN_STRIP, TRAIT_CAN_USE_NUKE), NUKE_OP_MINION_TRAIT)
 
-/datum/component/nuclear_bomb_operator/Destroy(force, silent)
+/datum/component/nuclear_bomb_operator/Destroy(force)
 	QDEL_NULL(disky)
 	on_disk_collected = null
 	add_disk_overlays = null

--- a/code/datums/components/on_hit_effect.dm
+++ b/code/datums/components/on_hit_effect.dm
@@ -21,7 +21,7 @@
 		return ELEMENT_INCOMPATIBLE
 	src.thrown_effect = thrown_effect
 
-/datum/component/on_hit_effect/Destroy(force, silent)
+/datum/component/on_hit_effect/Destroy(force)
 	on_hit_callback = null
 	extra_check_callback = null
 	return ..()

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -69,7 +69,7 @@
 	else if(isgrenade(parent) || islandmine(parent) || issupplypod(parent))
 		radius = magnitude
 
-/datum/component/pellet_cloud/Destroy(force, silent)
+/datum/component/pellet_cloud/Destroy(force)
 	purple_hearts = null
 	pellets = null
 	targets_hit = null

--- a/code/datums/components/pet_commands/obeys_commands.dm
+++ b/code/datums/components/pet_commands/obeys_commands.dm
@@ -22,7 +22,7 @@
 		var/datum/pet_command/new_command = new command_path(parent)
 		available_commands[new_command.command_name] = new_command
 
-/datum/component/obeys_commands/Destroy(force, silent)
+/datum/component/obeys_commands/Destroy(force)
 	. = ..()
 	QDEL_NULL(available_commands)
 

--- a/code/datums/components/pinata.dm
+++ b/code/datums/components/pinata.dm
@@ -52,7 +52,7 @@
 		new dropped_item(get_turf(parent))
 	qdel(src)
 
-/datum/component/pinata/Destroy(force, silent)
+/datum/component/pinata/Destroy(force)
 	UnregisterSignal(parent, list(
 		COMSIG_MOB_APPLY_DAMAGE,
 		COMSIG_LIVING_DEATH,

--- a/code/datums/components/plumbing/chemical_acclimator.dm
+++ b/code/datums/components/plumbing/chemical_acclimator.dm
@@ -9,7 +9,7 @@
 		return COMPONENT_INCOMPATIBLE
 	myacclimator = parent
 
-/datum/component/plumbing/acclimator/Destroy(force, silent)
+/datum/component/plumbing/acclimator/Destroy(force)
 	myacclimator = null
 	return ..()
 

--- a/code/datums/components/puzzgrid.dm
+++ b/code/datums/components/puzzgrid.dm
@@ -55,7 +55,7 @@
 		addtimer(CALLBACK(src, PROC_REF(out_of_time)), timer)
 		time_to_finish = world.time + timer
 
-/datum/component/puzzgrid/Destroy(force, silent)
+/datum/component/puzzgrid/Destroy(force)
 	puzzgrid = null
 	on_victory_callback = null
 	on_fail_callback = null

--- a/code/datums/components/radioactive_emitter.dm
+++ b/code/datums/components/radioactive_emitter.dm
@@ -41,7 +41,7 @@
 	// Easier to handle edits to the cooldown duration, prevents timer spam for short cooldown emitters
 	START_PROCESSING(SSfastprocess, src)
 
-/datum/component/radioactive_emitter/Destroy(force, silent)
+/datum/component/radioactive_emitter/Destroy(force)
 	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 

--- a/code/datums/components/radioactive_exposure.dm
+++ b/code/datums/components/radioactive_exposure.dm
@@ -66,7 +66,7 @@
 
 	qdel(src)
 
-/datum/component/radioactive_exposure/Destroy(force, silent)
+/datum/component/radioactive_exposure/Destroy(force)
 	var/mob/living/carbon/human/human_parent = parent
 	human_parent.clear_alert(ALERT_RADIOACTIVE_AREA)
 

--- a/code/datums/components/reagent_refiller.dm
+++ b/code/datums/components/reagent_refiller.dm
@@ -28,7 +28,7 @@
 
 	return ..()
 
-/datum/component/reagent_refiller/Destroy(force, silent)
+/datum/component/reagent_refiller/Destroy(force)
 	power_draw_callback = null
 	return ..()
 

--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -25,7 +25,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	connect_to_new_turf()
 
-/datum/component/redirect_attack_hand_from_turf/Destroy(force, silent)
+/datum/component/redirect_attack_hand_from_turf/Destroy(force)
 	disconnect_from_old_turf()
 	return ..()
 

--- a/code/datums/components/reflection.dm
+++ b/code/datums/components/reflection.dm
@@ -55,7 +55,7 @@
 	var/list/reflect_update_signals = list(COMSIG_MOVABLE_MOVED) + update_signals
 	RegisterSignals(parent, reflect_update_signals, PROC_REF(get_reflection_targets))
 
-/datum/component/reflection/Destroy(force, silent)
+/datum/component/reflection/Destroy(force)
 	QDEL_LIST_ASSOC_VAL(reflected_movables)
 	QDEL_NULL(reflection_holder)
 	can_reflect = null

--- a/code/datums/components/regenerator.dm
+++ b/code/datums/components/regenerator.dm
@@ -59,7 +59,7 @@
 	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE)
 	stop_regenerating()
 
-/datum/component/regenerator/Destroy(force, silent)
+/datum/component/regenerator/Destroy(force)
 	stop_regenerating()
 	. = ..()
 	if(regeneration_start_timer)

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -43,7 +43,7 @@
 	RegisterSignal(SSdcs, COMSIG_RELIGIOUS_SECT_CHANGED, PROC_REF(SetGlobalToLocal))
 	RegisterSignal(SSdcs, COMSIG_RELIGIOUS_SECT_RESET, PROC_REF(on_sect_reset))
 
-/datum/component/religious_tool/Destroy(force, silent)
+/datum/component/religious_tool/Destroy(force)
 	easy_access_sect = null
 	performing_rite = null
 	catalyst_type = null

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -26,7 +26,7 @@
 		var/mob/living/simple_animal/simple_parent = parent
 		simple_parent.stop_automated_movement = TRUE
 
-/datum/component/riding/creature/Destroy(force, silent)
+/datum/component/riding/creature/Destroy(force)
 	unequip_buckle_inhands(parent)
 	if(isanimal(parent))
 		var/mob/living/simple_animal/simple_parent = parent
@@ -437,7 +437,7 @@
 	var/mob/living/basic/mining/goliath/goliath = parent
 	goliath.add_movespeed_modifier(/datum/movespeed_modifier/goliath_mount)
 
-/datum/component/riding/creature/goliath/Destroy(force, silent)
+/datum/component/riding/creature/goliath/Destroy(force)
 	var/mob/living/basic/mining/goliath/goliath = parent
 	goliath.remove_movespeed_modifier(/datum/movespeed_modifier/goliath_mount)
 	return ..()

--- a/code/datums/components/scope.dm
+++ b/code/datums/components/scope.dm
@@ -13,7 +13,7 @@
 		return COMPONENT_INCOMPATIBLE
 	src.range_modifier = range_modifier
 
-/datum/component/scope/Destroy(force, silent)
+/datum/component/scope/Destroy(force)
 	if(tracker)
 		stop_zooming(tracker.owner)
 	return ..()

--- a/code/datums/components/seclight_attachable.dm
+++ b/code/datums/components/seclight_attachable.dm
@@ -50,7 +50,7 @@
 	if(istype(starting_light))
 		add_light(starting_light)
 
-/datum/component/seclite_attachable/Destroy(force, silent)
+/datum/component/seclite_attachable/Destroy(force)
 	if(light)
 		remove_light()
 	return ..()

--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -42,7 +42,7 @@
 	var/datum/action/cooldown/toggle_seethrough/action = new(src)
 	action.Grant(parent)
 
-/datum/component/seethrough_mob/Destroy(force, silent)
+/datum/component/seethrough_mob/Destroy(force)
 	QDEL_NULL(render_source_atom)
 	return ..()
 

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -101,7 +101,7 @@
 
 	QDEL_NULL(attached_circuit)
 
-/datum/component/shell/Destroy(force, silent)
+/datum/component/shell/Destroy(force)
 	QDEL_LIST(unremovable_circuit_components)
 	return ..()
 

--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -57,7 +57,7 @@
 	if(recharge_start_delay)
 		START_PROCESSING(SSdcs, src)
 
-/datum/component/shielded/Destroy(force, silent)
+/datum/component/shielded/Destroy(force)
 	if(wearer)
 		shield_icon = "broken"
 		UnregisterSignal(wearer, COMSIG_ATOM_UPDATE_OVERLAYS)

--- a/code/datums/components/shovel_hands.dm
+++ b/code/datums/components/shovel_hands.dm
@@ -20,7 +20,7 @@
 	UnregisterSignal(parent, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_HOSTILE_PRE_ATTACKINGTARGET))
 	return ..()
 
-/datum/component/shovel_hands/Destroy(force, silent)
+/datum/component/shovel_hands/Destroy(force)
 	if (internal_shovel)
 		UnregisterSignal(internal_shovel, COMSIG_QDELETING)
 	QDEL_NULL(internal_shovel)

--- a/code/datums/components/shuttle_cling.dm
+++ b/code/datums/components/shuttle_cling.dm
@@ -177,7 +177,7 @@
 
 	qdel(src)
 
-/datum/component/shuttle_cling/Destroy(force, silent)
+/datum/component/shuttle_cling/Destroy(force)
 	REMOVE_TRAIT(parent, TRAIT_HYPERSPACED, REF(src))
 	QDEL_NULL(hyperloop)
 

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -108,7 +108,7 @@
 
 	GLOB.singularities |= src
 
-/datum/component/singularity/Destroy(force, silent)
+/datum/component/singularity/Destroy(force)
 	GLOB.singularities -= src
 	consume_callback = null
 	target = null

--- a/code/datums/components/sitcomlaughter.dm
+++ b/code/datums/components/sitcomlaughter.dm
@@ -22,7 +22,7 @@
 	if(laugh_delay)
 		src.laugh_delay = laugh_delay
 
-/datum/component/wearertargeting/sitcomlaughter/Destroy(force, silent)
+/datum/component/wearertargeting/sitcomlaughter/Destroy(force)
 	post_comedy_callback = null
 	return ..()
 

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -88,7 +88,7 @@
 	else
 		RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(Slip))
 
-/datum/component/slippery/Destroy(force, silent)
+/datum/component/slippery/Destroy(force)
 	can_slip_callback = null
 	on_slip_callback = null
 	holder = null

--- a/code/datums/components/smooth_tunes.dm
+++ b/code/datums/components/smooth_tunes.dm
@@ -24,7 +24,7 @@
 	src.particles_path = particles_path
 	src.glow_color = glow_color
 
-/datum/component/smooth_tunes/Destroy(force, silent)
+/datum/component/smooth_tunes/Destroy(force)
 	if(particle_holder)
 		QDEL_NULL(particle_holder)
 	qdel(linked_songtuner_rite)

--- a/code/datums/components/spin2win.dm
+++ b/code/datums/components/spin2win.dm
@@ -38,7 +38,7 @@
 	src.start_spin_message = start_spin_message
 	src.end_spin_message = end_spin_message
 
-/datum/component/spin2win/Destroy(force, silent)
+/datum/component/spin2win/Destroy(force)
 	on_spin_callback = null
 	on_unspin_callback = null
 	return ..()

--- a/code/datums/components/spinny.dm
+++ b/code/datums/components/spinny.dm
@@ -18,7 +18,7 @@
 	turn_degrees = (reverse ? -90 : 90)
 	START_PROCESSING(SSfastprocess, src)
 
-/datum/component/spinny/Destroy(force, silent)
+/datum/component/spinny/Destroy(force)
 	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -13,7 +13,7 @@
 	if(!ismovable(parent)) //you may apply this to mobs, i take no responsibility for how that works out
 		return COMPONENT_INCOMPATIBLE
 
-/datum/component/spirit_holding/Destroy(force, silent)
+/datum/component/spirit_holding/Destroy(force)
 	. = ..()
 	if(bound_spirit)
 		QDEL_NULL(bound_spirit)

--- a/code/datums/components/squashable.dm
+++ b/code/datums/components/squashable.dm
@@ -29,7 +29,7 @@
 
 	AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)
 
-/datum/component/squashable/Destroy(force, silent)
+/datum/component/squashable/Destroy(force)
 	on_squash_callback = null
 	return ..()
 

--- a/code/datums/components/strong_pull.dm
+++ b/code/datums/components/strong_pull.dm
@@ -10,7 +10,7 @@ Basically, the items they pull cannot be pulled (except by the puller)
 	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
 
-/datum/component/strong_pull/Destroy(force, silent)
+/datum/component/strong_pull/Destroy(force)
 	if(strongpulling)
 		lose_strong_grip()
 	return ..()

--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -144,7 +144,7 @@
 		qdel(projectile_parry.resolve())
 
 
-/datum/component/style/Destroy(force, silent)
+/datum/component/style/Destroy(force)
 	STOP_PROCESSING(SSdcs, src)
 	var/mob/mob_parent = parent
 	if(mob_parent.hud_used)

--- a/code/datums/components/subtype_picker.dm
+++ b/code/datums/components/subtype_picker.dm
@@ -22,7 +22,7 @@
 	src.on_picked_callback = on_picked_callback
 	build_radial_list()
 
-/datum/component/subtype_picker/Destroy(force, silent)
+/datum/component/subtype_picker/Destroy(force)
 	on_picked_callback = null
 	return ..()
 

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -28,7 +28,7 @@
 	src.tool_act_callback = tool_act_callback
 	src.consume_callback = consume_callback
 
-/datum/component/supermatter_crystal/Destroy(force, silent)
+/datum/component/supermatter_crystal/Destroy(force)
 	tool_act_callback = null
 	consume_callback = null
 	return ..()

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -14,7 +14,7 @@
 	var/obj/item/surgery_tool = parent
 	surgery_tool.item_flags |= ITEM_HAS_CONTEXTUAL_SCREENTIPS
 
-/datum/component/surgery_initiator/Destroy(force, silent)
+/datum/component/surgery_initiator/Destroy(force)
 	last_user_ref = null
 	surgery_target_ref = null
 

--- a/code/datums/components/swabbing.dm
+++ b/code/datums/components/swabbing.dm
@@ -32,7 +32,7 @@ This component is used in vat growing to swab for microbiological samples which 
 	src.update_icons = update_icons
 	src.update_overlays = update_overlays
 
-/datum/component/swabbing/Destroy(force, silent)
+/datum/component/swabbing/Destroy(force)
 	for(var/swabbed in swabbed_items)
 		qdel(swabbed)
 	update_icons = null

--- a/code/datums/components/takes_reagent_appearance.dm
+++ b/code/datums/components/takes_reagent_appearance.dm
@@ -43,7 +43,7 @@
 
 	src.base_container_type = base_container_type || parent.type
 
-/datum/component/takes_reagent_appearance/Destroy(force, silent)
+/datum/component/takes_reagent_appearance/Destroy(force)
 	on_icon_changed = null
 	on_icon_reset = null
 	return ..()

--- a/code/datums/components/tameable.dm
+++ b/code/datums/components/tameable.dm
@@ -32,7 +32,7 @@
 	RegisterSignal(parent, COMSIG_SIMPLEMOB_SENTIENCEPOTION, PROC_REF(on_tame)) //Instantly succeeds
 	RegisterSignal(parent, COMSIG_SIMPLEMOB_TRANSFERPOTION, PROC_REF(on_tame)) //Instantly succeeds
 
-/datum/component/tameable/Destroy(force, silent)
+/datum/component/tameable/Destroy(force)
 	after_tame = null
 	return ..()
 

--- a/code/datums/components/tattoo.dm
+++ b/code/datums/components/tattoo.dm
@@ -25,7 +25,7 @@
 	if(tatted_limb.owner)
 		setup_tatted_owner(tatted_limb.owner)
 
-/datum/component/tattoo/Destroy(force, silent)
+/datum/component/tattoo/Destroy(force)
 	if(!parent)
 		return ..()
 	var/obj/item/bodypart/tatted_limb = parent

--- a/code/datums/components/toggle_attached_clothing.dm
+++ b/code/datums/components/toggle_attached_clothing.dm
@@ -78,7 +78,7 @@
 	if (!destroy_on_removal)
 		create_deployable()
 
-/datum/component/toggle_attached_clothing/Destroy(force, silent)
+/datum/component/toggle_attached_clothing/Destroy(force)
 	unequip_deployable()
 	QDEL_NULL(deployable)
 	QDEL_NULL(toggle_action)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -56,7 +56,7 @@
 	if(require_twohands)
 		ADD_TRAIT(parent, TRAIT_NEEDS_TWO_HANDS, ABSTRACT_ITEM_TRAIT)
 
-/datum/component/two_handed/Destroy(force, silent)
+/datum/component/two_handed/Destroy(force)
 	offhand_item = null
 	wield_callback = null
 	unwield_callback = null

--- a/code/datums/components/unbreakable.dm
+++ b/code/datums/components/unbreakable.dm
@@ -6,7 +6,7 @@
 		return COMPONENT_INCOMPATIBLE
 	ADD_TRAIT(parent, TRAIT_UNBREAKABLE, INNATE_TRAIT)
 
-/datum/component/unbreakable/Destroy(force, silent)
+/datum/component/unbreakable/Destroy(force)
 	REMOVE_TRAIT(parent, TRAIT_UNBREAKABLE, INNATE_TRAIT)
 	return ..()
 

--- a/code/datums/components/unusual_effect.dm
+++ b/code/datums/components/unusual_effect.dm
@@ -39,7 +39,7 @@
 		special_effects = new(parent_movable, /particles/unusual_effect)
 	START_PROCESSING(SSobj, src)
 
-/datum/component/unusual_effect/Destroy(force, silent)
+/datum/component/unusual_effect/Destroy(force)
 	var/atom/movable/parent_movable = parent
 	if (istype(parent_movable))
 		parent_movable.remove_filter("unusual_effect")

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -38,7 +38,7 @@
 	speaker.update_appearance(UPDATE_ICON)
 	update_light_color()
 
-/datum/component/weather_announcer/Destroy(force, silent)
+/datum/component/weather_announcer/Destroy(force)
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -129,10 +129,10 @@
 			var/component_or_list = dc[component_key]
 			if(islist(component_or_list))
 				for(var/datum/component/component as anything in component_or_list)
-					qdel(component, FALSE, TRUE)
+					qdel(component, FALSE)
 			else
 				var/datum/component/C = component_or_list
-				qdel(C, FALSE, TRUE)
+				qdel(C, FALSE)
 		dc.Cut()
 
 	_clear_signal_refs()

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -36,7 +36,7 @@
  */
 /obj/item/implant/uplink/proc/_component_removal(datum/source, datum/component/component)
 	SIGNAL_HANDLER
-	if(istype(component, /datum/component/uplink))
+	if(istype(component, /datum/component/uplink) && !QDELING(src))
 		qdel(src)
 
 /obj/item/implanter/uplink

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -19,7 +19,7 @@
 	action = new(src)
 	action.Grant(organ_parent.owner)
 
-/datum/component/living_heart/Destroy(force, silent)
+/datum/component/living_heart/Destroy(force)
 	QDEL_NULL(action)
 	return ..()
 

--- a/code/modules/antagonists/revenant/haunted_item.dm
+++ b/code/modules/antagonists/revenant/haunted_item.dm
@@ -65,7 +65,7 @@
 	src.types_which_dispell_us = types_which_dispell_us || default_dispell_types
 	src.despawn_message = despawn_message
 
-/datum/component/haunted_item/Destroy(force, silent)
+/datum/component/haunted_item/Destroy(force)
 	var/obj/item/haunted_item = parent
 	// Handle these two specifically in Destroy() instead of clear_haunting(),
 	// because we want to make sure they always get dealt with no matter how the component is removed

--- a/code/modules/bitrunning/components/netpod_healing.dm
+++ b/code/modules/bitrunning/components/netpod_healing.dm
@@ -13,7 +13,7 @@
 
 	START_PROCESSING(SSmachines, src)
 
-/datum/component/netpod_healing/Destroy(force, silent)
+/datum/component/netpod_healing/Destroy(force)
 	STOP_PROCESSING(SSmachines, src)
 
 	var/mob/living/carbon/player = parent

--- a/code/modules/bitrunning/components/npc_friendly.dm
+++ b/code/modules/bitrunning/components/npc_friendly.dm
@@ -28,7 +28,7 @@
 	previous_factions.Add(player.faction)
 	player.faction |= npc_factions
 
-/datum/component/npc_friendly/Destroy(force, silent)
+/datum/component/npc_friendly/Destroy(force)
 	. = ..()
 
 	var/mob/living/player = parent

--- a/code/modules/capture_the_flag/ctf_player_component.dm
+++ b/code/modules/capture_the_flag/ctf_player_component.dm
@@ -74,7 +74,7 @@
 		player_mob.dust()
 	qdel(src)
 
-/datum/component/ctf_player/Destroy(force, silent)
+/datum/component/ctf_player/Destroy(force)
 	if(player_mob)
 		UnregisterSignal(player_mob, list(COMSIG_MOB_AFTER_APPLY_DAMAGE, COMSIG_MOB_GHOSTIZED))
 	return ..()

--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -72,7 +72,7 @@
 
 	GLOB.experiment_handlers += src
 
-/datum/component/experiment_handler/Destroy(force, silent)
+/datum/component/experiment_handler/Destroy(force)
 	. = ..()
 	GLOB.experiment_handlers -= src
 


### PR DESCRIPTION
Alternates between current qdel and a qdel with this change:

```patch
-	var/hint = to_delete.Destroy(arglist(args.Copy(2))) // Let our friend know they're about to get fucked up.
+	var/hint = to_delete.Destroy(force) // Let our friend know they're about to get fucked up.
```

This is 30% faster in a rudimentary MoMMI test, so I'm interested to see how it performs on prod where qdel is called tens of millions of times.

The only other qdel parameter is `silent` on components, which appears to be unused and is vestigial according to ninja.