### PR TITLE
Some micro optimizations for `qdel()`

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -338,6 +338,9 @@ SUBSYSTEM_DEF(garbage)
 ///
 /// Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
 /proc/qdel(datum/to_delete, force = FALSE, ...)
+	if(isnull(to_delete))
+		return
+
 	if(!istype(to_delete))
 		del(to_delete)
 		return
@@ -365,9 +368,6 @@ SUBSYSTEM_DEF(garbage)
 		trash.slept_destroy++
 	else
 		trash.destroy_time += TICK_USAGE_TO_MS(start_tick)
-
-	if(isnull(to_delete))
-		return
 
 	switch(hint)
 		if (QDEL_HINT_QUEUE) //qdel should queue the object for deletion.

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -345,18 +345,18 @@ SUBSYSTEM_DEF(garbage)
 		del(to_delete)
 		return
 
-	var/datum/qdel_item/trash = SSgarbage.items[to_delete.type]
-	if (isnull(trash))
-		trash = SSgarbage.items[to_delete.type] = new /datum/qdel_item(to_delete.type)
-	trash.qdels++
-
 	if(!isnull(to_delete.gc_destroyed))
 		if(to_delete.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
 			CRASH("[to_delete.type] destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic")
 		return
 
-	if (SEND_SIGNAL(to_delete, COMSIG_PREQDELETED, force)) // Give the components a chance to prevent their parent from being deleted
+	if(SEND_SIGNAL(to_delete, COMSIG_PREQDELETED, force)) // Give the components a chance to prevent their parent from being deleted
 		return
+
+	var/datum/qdel_item/trash = SSgarbage.items[to_delete.type]
+	if (isnull(trash))
+		trash = SSgarbage.items[to_delete.type] = new /datum/qdel_item(to_delete.type)
+	trash.qdels++
 
 	to_delete.gc_destroyed = GC_CURRENTLY_BEING_QDELETED
 	var/start_time = world.time


### PR DESCRIPTION
## About The Pull Request
How did this not runtime 1 decade ago or something? And if it hasn't then do we even need this null check? (maybe remove it save some micro ticks or something?), cause if we do then we need to move it up to the top of the proc so we can early return and save processing. Or something like that idk this makes sense right?

The `istype()` check below will pass if `to_delete` is null and pass `null` to `del()` which also doesn't seem ideal so this should work better?

I also moved up some other checks before we start creating instances of `datum/qdel_item` so you know early return & save time if the object is already getting deleted? Again i don't know someone please advice.

Also stored the type for `to_delete` inside a var so you save some memory access time for datum variables

## Changelog
N/A
