### PR TITLE
Sec Biosuit craft, more bio-emergency supplies

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -378,3 +378,23 @@
 		/obj/item/paper = 1,
 	)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/biohood_sec
+	name = "security biohood"
+	result = /obj/item/clothing/head/bio_hood/security
+	time = 2 SECONDS
+	reqs = list(
+		/obj/item/clothing/head/bio_hood/general = 1,
+		/obj/item/clothing/head/helmet/sec = 1,
+	)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/biosuit_sec
+	name = "security biosuit"
+	result = /obj/item/clothing/suit/bio_suit/security
+	time = 2 SECONDS
+	reqs = list(
+		/obj/item/clothing/suit/bio_suit/general = 1,
+		/obj/item/clothing/suit/armor/vest = 1,
+	)
+	category = CAT_CLOTHING

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -4,13 +4,15 @@
 
 /datum/supply_pack/emergency/bio
 	name = "Biological Emergency Crate"
-	desc = "This crate holds 2 full bio suits which will protect you from viruses."
+	desc = "This crate includes 2 complete bio suits, along with a box containing sterile masks and latex gloves, providing effective protection against viruses."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/bio_hood = 2,
 					/obj/item/clothing/suit/bio_suit = 2,
 					/obj/item/storage/bag/bio,
 					/obj/item/reagent_containers/syringe/antiviral = 2,
 					/obj/item/clothing/gloves/latex/nitrile = 2,
+					/obj/item/storage/box/masks,
+					/obj/item/storage/box/gloves,
 				)
 	crate_name = "bio suit crate"
 


### PR DESCRIPTION

## About The Pull Request
Makes Security bio suit and bio hood craftable using a normal bio suit/hood and helmet/armour vest.

Adds a box of sterile masks and latex gloves to the bio-emergency crate from Cargo.
## Why It's Good For The Game
Security bio suit is the only one with different armour values, yet there is only one for the entire Security department.
By giving them the ability to craft them we give more Security Officers protection from disease without losing their red colour and armour (which is worse in bio suits than on their armour vests). This makes Security more likely to care about roleplaying during outbreaks, like enforcing quarantines.
This isn't creating any new bio-suits, as to craft a Security bio-suit you need to acquire a normal bio-suit and some spare armour.

Adding a box of sterile masks and latex gloves to the emergency bio-emergency crate makes it more useful. There is only 1 box of sterile gloves and 1 box of latex gloves on all of the stations at medbay at the moment. This way they can get more sterile masks and latex gloves to protect themselves from diseases, which is cool to see players caring about not getting infected and being in fear.
## Changelog
:cl:
qol: It is now possible to craft more Security bio suits
qol: Bio-emergency crate from Cargo now contains a box of latex gloves and sterile masks
/:cl:
