### PR TITLE
Bot launchpads also accept basic/bot

### DIFF
--- a/code/game/machinery/botlaunchpad.dm
+++ b/code/game/machinery/botlaunchpad.dm
@@ -56,7 +56,7 @@
 /obj/machinery/botpad/proc/recall(mob/living/user)
 	var/atom/our_bot = launched_bot?.resolve()
 	if(isnull(our_bot))
-		user.balloon_alert(user, "no bots detected on the pad!")
+		user.balloon_alert(user, "no bots sent from the pad!")
 		return
 	user.balloon_alert(user, "bot sent back to pad")
 	if(isbasicbot(our_bot))

--- a/code/game/machinery/botlaunchpad.dm
+++ b/code/game/machinery/botlaunchpad.dm
@@ -36,7 +36,7 @@
 /obj/machinery/botpad/proc/launch(mob/living/user)
 	var/turf/reverse_turf = get_turf(user)
 	var/atom/possible_bot
-	for(var/mob/living/robot in get_turf(src))
+	for(var/mob/living/robot in get_turf(src)) //May need to edit this condition
 		if(!isbot(robot))
 			user.balloon_alert(user, "unidentified life form on the pad!")
 			return

--- a/code/game/machinery/botlaunchpad.dm
+++ b/code/game/machinery/botlaunchpad.dm
@@ -36,7 +36,7 @@
 /obj/machinery/botpad/proc/launch(mob/living/user)
 	var/turf/reverse_turf = get_turf(user)
 	var/atom/possible_bot
-	for(var/mob/living/robot in get_turf(src)) //May need to edit this condition
+	for(var/mob/living/robot in get_turf(src))
 		if(!isbot(robot))
 			user.balloon_alert(user, "unidentified life form on the pad!")
 			return

--- a/code/game/objects/items/botpad_remote.dm
+++ b/code/game/objects/items/botpad_remote.dm
@@ -52,7 +52,7 @@
 	if(connected_botpad.panel_open)
 		user?.balloon_alert(user, "close the panel!")
 		return
-	if(!(locate(/mob/living/simple_animal/bot) in get_turf(connected_botpad)))
+	if(!(locate(/mob/living) in get_turf(connected_botpad)))
 		user?.balloon_alert(user, "no bots detected on the pad!")
 		return
 	connected_botpad.launch(user)


### PR DESCRIPTION

## About The Pull Request
During a round, someone has made a row of bot launchpads with different bots. Altough they had issues to send a cleanbot and a medibot.
I have figured that there was some PR that converted them into basic mobs and that may have been the issue. And I have found out that the remote was checking only for a simple_animal/bot when you pressed the button to launch. This was redundant to be specific as the machine already checks if the mob is a bot or not.

I also clarified the message when failling to recall a bot to be different from when there is nothing on the pad.
https://streamable.com/nzivs9?src=player-page-share
## Why It's Good For The Game
Cleanbots and Medibots could be sent before from the bot launchpad. And they are still acting like bots in terms of functionnality. 

Also it makes it clearer that if we fail to recall a bot, it's likely because we didn't send any bot at first. not because the bot is absent from the pad.
## Changelog
:cl:
fix: Bot launchpads can deploy cleanbots and medibots again.
spellcheck: Clarified the message when failling to recall a bot.
/:cl:
