### PR TITLE
Fixes .jsx missing from TguiTarget in build.js

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -327,7 +327,7 @@ export const TguiTarget = new Juke.Target({
     'tgui/.yarn/install-target',
     'tgui/webpack.config.js',
     'tgui/**/package.json',
-    'tgui/packages/**/*.+(js|cjs|ts|tsx|scss)',
+    'tgui/packages/**/*.+(js|cjs|ts|tsx|jsx|scss)',
   ],
   outputs: [
     'tgui/public/tgui.bundle.css',


### PR DESCRIPTION
## About The Pull Request
.jsx files were recently switched to by TGstation, but because they were not in TGUITarget, when you make changes to a .jsx file, it doesn't recompile TGUI! Yippee!

I SPENT HALF AN HOUR RECOMPILING MY TGUI AND HAVING IT JUST NOT SHOW UP. IT'S THE WORST. PLEASE FREE ME.
This PR fixes that

## Why It's Good For The Game
This has no game impact, it just fixes something that infuriates me. It will save coders from the pain I had to go through before I realized what was wrong.

## Changelog

:cl: ReturnToZender
fix: JSX files, when edited, cause TGUI to recompile on build
/:cl:

