### PR TITLE
Unholy water double parent call fix

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -488,7 +488,7 @@
 
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	. = ..()
+
 	var/need_mob_update = FALSE
 	if(IS_CULTIST(affected_mob))
 		affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)


### PR DESCRIPTION

## About The Pull Request

Unholy water now only calls parent in on_mob_life() once, instead of twice.

The parent call would give you a small shot of toxin damage. Now you'll only get hit by it once, instead of twice. Neat!

The linked issue mentions the double parent call on holy water too, but that seems to have been removed at some point.
## Why It's Good For The Game

Closes #80511.
## Changelog
:cl: Rhials
code: Unholy water no longer calls parent twice in on_mob_life().
/:cl:
