### PR TITLE
Fixes being able to fish up qdeleted spawners

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -39,9 +39,8 @@
 	return QDEL_HINT_QUEUE
 
 /obj/effect/spawner/forceMove(atom/destination)
-	if(destination) // throw a warning if we try to forceMove a spawner to somewhere other than nullspace
-		stack_trace("Warning: something tried to forceMove() [src]([type]) to a non-null destination [destination]([destination.type])!")
-		return
+	if(destination && QDELETED(src)) // throw a warning if we try to forceMove a qdeleted spawner to somewhere other than nullspace
+		stack_trace("Warning: something tried to forceMove() a qdeleted [src]([type]) to a non-null destination [destination]([destination.type])!")
 	return ..()
 
 /obj/effect/list_container

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -38,6 +38,12 @@
 	moveToNullspace()
 	return QDEL_HINT_QUEUE
 
+/obj/effect/spawner/forceMove(atom/destination)
+	if(destination) // throw a warning if we try to forceMove a spawner to somewhere other than nullspace
+		stack_trace("Warning: something tried to forceMove() [src]([type]) to a non-null destination [destination]([destination.type])!")
+		return
+	return ..()
+
 /obj/effect/list_container
 	name = "list container"
 

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -40,7 +40,7 @@
 
 /obj/effect/spawner/forceMove(atom/destination)
 	if(destination && QDELETED(src)) // throw a warning if we try to forceMove a qdeleted spawner to somewhere other than nullspace
-		stack_trace("Warning: something tried to forceMove() a qdeleted [src]([type]) to a non-null destination [destination]([destination.type])!")
+		stack_trace("Warning: something tried to forceMove() a qdeleted [src]([type]) to non-null destination [destination]([destination.type])!")
 	return ..()
 
 /obj/effect/list_container

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -170,12 +170,12 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 
 	var/atom/movable/reward = spawn_reward(reward_path, fisherman, fishing_spot)
 	if(!reward) //balloon alert instead
-		fisherman.balloon_alert(fisherman,pick(duds))
+		fisherman.balloon_alert(fisherman, pick(duds))
 		return
 	if(isitem(reward)) //Try to put it in hand
 		INVOKE_ASYNC(fisherman, TYPE_PROC_REF(/mob, put_in_hands), reward)
 	else if(istype(reward, /obj/effect/spawner)) // Do not attempt to forceMove() a spawner. It will break things, and the spawned item should already be at the mob's turf by now.
-		fisherman.balloon_alert("Caught something!")
+		fisherman.balloon_alert(fisherman, "Caught something!")
 		return
 	else // for fishing things like corpses, move them to the turf of the fisherman
 		INVOKE_ASYNC(reward, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(fisherman))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 	if(isitem(reward)) //Try to put it in hand
 		INVOKE_ASYNC(fisherman, TYPE_PROC_REF(/mob, put_in_hands), reward)
 	else if(istype(reward, /obj/effect/spawner)) // Do not attempt to forceMove() a spawner. It will break things, and the spawned item should already be at the mob's turf by now.
-		fisherman.balloon_alert(fisherman, "Caught something!")
+		fisherman.balloon_alert(fisherman, "caught something!")
 		return
 	else // for fishing things like corpses, move them to the turf of the fisherman
 		INVOKE_ASYNC(reward, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(fisherman))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -174,7 +174,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 		return
 	if(isitem(reward)) //Try to put it in hand
 		INVOKE_ASYNC(fisherman, TYPE_PROC_REF(/mob, put_in_hands), reward)
-	else if(!istype(reward, /obj/effect/spawner)) // for fishing things like corpses, move them to the turf of the fisherman. Do not do this for spawners.
+	else if(istype(reward, /obj/effect/spawner)) // Do not attempt to forceMove() a spawner. It will break things, and the spawned item should already be at the mob's turf by now.
+		fisherman.balloon_alert("Caught something!")
+		return
+	else // for fishing things like corpses, move them to the turf of the fisherman
 		INVOKE_ASYNC(reward, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(fisherman))
 	fisherman.balloon_alert(fisherman, "caught [reward]!")
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 		return
 	if(isitem(reward)) //Try to put it in hand
 		INVOKE_ASYNC(fisherman, TYPE_PROC_REF(/mob, put_in_hands), reward)
-	else // for fishing things like corpses, move them to the turf of the fisherman
+	else if(!istype(reward, /obj/effect/spawner)) // for fishing things like corpses, move them to the turf of the fisherman. Do not do this for spawners.
 		INVOKE_ASYNC(reward, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(fisherman))
 	fisherman.balloon_alert(fisherman, "caught [reward]!")
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/152

This is mostly a downstream issue, I think, but should a spawner ever get added to the fish tables here this bug will be present.
Basically spawners, when created, do their item spawning behavior on the src loc and then immediately qdel themselves.

If you try to forceMove() the spawners out of nullspace, like what was happening with fishing, you'd end up with an unmovable broken item that cannot be easily admin deleted.

This PR also adds a stack_trace when you forceMove() a qdeleted spawner, because this is not the first time I've seen this issue come up. It doesn't stop it from happening, though, because it's easier to visually see the bug that way. This just provides some useful feedback as to why the bug is happening should you check the debug logs.

## Why It's Good For The Game

Fixes a bug

## Changelog

:cl:
fix: fishing up a spawner will now give you the spawned item instead of a broken, undeletable spawner object
code: adds a warning to the stack trace when something tries to forceMove() a qdeleted spawner
/:cl:
