### PR TITLE
Makes ListInputModal autofocus

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputModal.tsx
@@ -7,7 +7,7 @@ import {
   KEY_Z,
 } from '../../common/keycodes';
 import { useBackend, useLocalState } from '../backend';
-import { Button, Input, Section, Stack } from '../components';
+import { Autofocus, Button, Input, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { InputButtons } from './common/InputButtons';
 import { Loader } from './common/Loader';
@@ -196,6 +196,7 @@ const ListDisplay = (props) => {
 
   return (
     <Section fill scrollable>
+      <Autofocus />
       {filteredItems.map((item, index) => {
         return (
           <Button


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. You would have to click on the window and press enter or make your selections, this just lets you skip the clicking step.

## Why It's Good For The Game

Just makes it a bit nicer to use these.

<details><summary>No clicking involved</summary>

![oPuiZ3rl3x](https://github.com/tgstation/tgstation/assets/13398309/c5aa70d2-d6a1-4ba8-a64e-805259b0d345)

</details>

## Changelog

:cl:
qol: makes modal list uis autofocus
/:cl:
