### PR TITLE
[NO GBP] Fixes return values of some chem UI actions.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -332,7 +332,7 @@
 				return FALSE
 
 			dispense_volume = target
-			return FALSE
+			return TRUE
 
 /**
  * Injects either acid/base buffer into the beaker

--- a/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
@@ -45,16 +45,28 @@
 			return TRUE
 
 		if("amount")
-			var/input = text2num(params["amount"])
-			if(input)
-				amount = input
-			return FALSE
+			var/input = params["amount"]
+			if(isnull(input))
+				return FALSE
+
+			input = text2num(input)
+			if(isnull(input))
+				return FALSE
+
+			amount = input
+			return TRUE
 
 		if("purity")
-			var/input = text2num(params["amount"])
-			if(input)
-				purity = input
-			return FALSE
+			var/input = params["amount"]
+			if(isnull(input))
+				return FALSE
+
+			input = text2num(input)
+			if(isnull(input))
+				return FALSE
+
+			purity = input
+			return TRUE
 
 	update_appearance()
 


### PR DESCRIPTION
## About The Pull Request
- The chem heater now returns `TRUE` when its buffer dispense volume is changed thus showing the new value immediately without a 1 second delay
- The debug chem synthesizer also now returns `TRUE` when its amount & purity values are changed thus showing their new values immediately without a 1 second delay

## Changelog
:cl:
fix: chem heater now shows the new value of its buffer dispense volume immediately when it gets changed.
fix: debug chem synthesizer now shows the new values of amount & purity immediately when it gets changed.
/:cl: