### PR TITLE
Felinids play the sound effect when using *gaspshock

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -201,7 +201,7 @@
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/human_user = user
-	if(human_user.dna.species.id == SPECIES_HUMAN && !HAS_MIND_TRAIT(human_user, TRAIT_MIMING))
+	if(ishumanbasic(human_user) || isfelinid(human_user) && !HAS_MIND_TRAIT(human_user, TRAIT_MIMING))
 		if(human_user.physique == FEMALE)
 			return pick('sound/voice/human/gasp_female1.ogg', 'sound/voice/human/gasp_female2.ogg', 'sound/voice/human/gasp_female3.ogg')
 		else


### PR DESCRIPTION

## About The Pull Request
Felinids play the sound effect that humans do when using the *gaspshock emote
## Why It's Good For The Game
Seems like an obvious oversight and I was told on discord it was fine to PR
## Changelog
:cl: PapaMichael
sound: added *gaspshock emote sound effect to felinids
/:cl:
