### PR TITLE
Emergency DMAPI fix for downstreams still on TGS5

### DIFF
--- a/code/modules/tgs/v5/bridge.dm
+++ b/code/modules/tgs/v5/bridge.dm
@@ -48,7 +48,7 @@
 	var/json = CreateBridgeData(command, data, TRUE)
 	var/encoded_json = url_encode(json)
 
-	var/api_prefix = interop_version.minor >= 7 ? "api/" : ""
+	var/api_prefix = interop_version.minor >= 8 ? "api/" : ""
 
 	var/url = "http://127.0.0.1:[server_port]/[api_prefix]Bridge?[DMAPI5_BRIDGE_DATA]=[encoded_json]"
 	return url


### PR DESCRIPTION
There was a double version bump on two branches that got merged, this feature flag should be in 8