### PR TITLE
Dimensional anomaly converting airlocks preserves old name

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -117,6 +117,8 @@
 		return
 	var/obj/new_object = new replace_path(object.loc)
 	new_object.setDir(object.dir)
+	if(istype(object, /obj/machinery/door/airlock))
+		new_object.name = object.name
 	qdel(object)
 
 /**


### PR DESCRIPTION
## Why It's Good For The Game
the name of an airlock indicates what area it is, also generic names like "gold airlock" look dull

Fixes https://github.com/tgstation/tgstation/issues/80655

## Changelog
:cl:
fix: Dimensional anomlies converting airlocks preserves the old name
/:cl:
