### PR TITLE
Fixes holodeck monkeys gibbing

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -325,6 +325,8 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	UnregisterSignal(holo_atom, COMSIG_QDELETING)
 	var/turf/target_turf = get_turf(holo_atom)
 	for(var/atom/movable/atom_contents as anything in holo_atom) //make sure that things inside of a holoitem are moved outside before destroying it
+		if(atom_contents.flags_1 & HOLOGRAM_1) //hologram in hologram is fine
+			continue
 		atom_contents.forceMove(target_turf)
 
 	if(istype(holo_atom, /obj/item/clothing/under))

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -286,6 +286,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 			RegisterSignal(holo_effect_product, COMSIG_QDELETING, PROC_REF(remove_from_holo_lists))
 		if(islist(holo_effect_product))
 			for(var/atom/atom_product as anything in holo_effect_product)
+				spawned += atom_product
 				RegisterSignal(atom_product, COMSIG_QDELETING, PROC_REF(remove_from_holo_lists))
 		return
 

--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -105,6 +105,13 @@
 /obj/effect/holodeck_effect/mobspawner/monkey
 	mobtype = /mob/living/carbon/human/species/monkey/holodeck
 
+/obj/effect/holodeck_effect/mobspawner/monkey/activate(obj/machinery/computer/holodeck/computer)
+	var/mob/living/carbon/human/monkey = ..()
+	. = list() + monkey
+
+	for(var/atom/atom as anything in monkey.contents + monkey.organs)
+		. += atom
+
 /obj/effect/holodeck_effect/mobspawner/penguin
 	mobtype = /mob/living/basic/pet/penguin/emperor/neuter
 

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -45,7 +45,7 @@
 	. = ..()
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
 		limb.bodypart_flags |= BODYPART_UNREMOVABLE // no farming organs or limbs from these fellers. get a monkey cube
-		limb.flags_1 = HOLOGRAM_1
+		limb.flags_1 |= HOLOGRAM_1
 
 GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/punpun)
 

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -45,6 +45,7 @@
 	. = ..()
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
 		limb.bodypart_flags |= BODYPART_UNREMOVABLE // no farming organs or limbs from these fellers. get a monkey cube
+		limb.flags_1 = HOLOGRAM_1
 
 GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/punpun)
 

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -38,15 +38,6 @@
 /mob/living/carbon/human/species/monkey/holodeck/spawn_gibs() // no blood and no gibs
 	return
 
-/mob/living/carbon/human/species/monkey/holodeck/has_dna()
-	return null
-
-/mob/living/carbon/human/species/monkey/holodeck/create_bodyparts(list/overrides) // done like this in case people add more limbs to monkeys or something
-	. = ..()
-	for(var/obj/item/bodypart/limb as anything in bodyparts)
-		limb.bodypart_flags |= BODYPART_UNREMOVABLE // no farming organs or limbs from these fellers. get a monkey cube
-		limb.flags_1 |= HOLOGRAM_1
-
 GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/punpun)
 
 /mob/living/carbon/human/species/monkey/punpun

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -209,13 +209,5 @@
 		TRAIT_NOHUNGER,
 		TRAIT_VENTCRAWLER_NUDE,
 	)
-	bodypart_overrides = list(
-		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/monkey,
-		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/monkey,
-		BODY_ZONE_HEAD = /obj/item/bodypart/head/monkey,
-		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/monkey,
-		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/monkey,
-		BODY_ZONE_CHEST = /obj/item/bodypart/chest/monkey,
-	)
 
 #undef MONKEY_SPEC_ATTACK_BITE_MISS_CHANCE


### PR DESCRIPTION
Holodeck takes apart all hologram atoms, blindly. This breaks a lot, but most notably people.
I've also went and given monkeys organs again, which were removed in #79068. This broke incredibly hard, because monkeys can't live without DNA or organs (who would've thought)

Fixes #80369, #79184

:cl:
fix: Holodeck monkeys are properly cleaned up now
fix: Holodeck monkeys have organs now
/:cl:

Look they're so happy and wont gib on deload
![image](https://github.com/tgstation/tgstation/assets/7501474/7e1f5a12-143c-4906-9d1e-79559dcb49dc)
