### PR TITLE
Atmos Holofan Clearview

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -111,6 +111,20 @@
 	rad_insulation = RAD_LIGHT_INSULATION
 	resistance_flags = FIRE_PROOF | FREEZE_PROOF
 
+/obj/structure/holosign/barrier/atmos/proc/clearview_transparency()
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 25
+	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
+	var/turf/our_turf = get_turf(src)
+	SSvis_overlays.add_vis_overlay(src, icon, icon_state, ABOVE_MOB_LAYER, MUTATE_PLANE(GAME_PLANE, our_turf), dir)
+
+/obj/structure/holosign/barrier/atmos/proc/reset_transparency()
+	mouse_opacity = initial(mouse_opacity)
+	alpha = initial(alpha)
+	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
+	var/turf/our_turf = get_turf(src)
+	SSvis_overlays.add_vis_overlay(src, icon, icon_state, ABOVE_MOB_LAYER, MUTATE_PLANE(GAME_PLANE, our_turf), dir, add_appearance_flags = RESET_ALPHA)
+
 /obj/structure/holosign/barrier/atmos/sturdy
 	name = "sturdy holofirelock"
 	max_integrity = 150


### PR DESCRIPTION
## Vid

https://github.com/tgstation/tgstation/assets/46101244/b322aac7-519f-4a55-8180-eb9a38b3abc7
## About The Pull Request
You can right-click the Atmos Holofan projector in-hand to make the holograms more transparent and unclickable

Only lasts for 40 seconds if you don't toggle it off yourself
## Why It's Good For The Game
Sometimes you want to pipe under the holofan or put a machine there, and it's frustrating having to alt-click the tile for every action since you can't see anything under the holofan
## Changelog
:cl:
add: Atmos Holofan projectors can be right-clicked inhand to make their holograms more transparent
/:cl:
