### PR TITLE
Fixes vendors displaying wrong amounts and wrong options for color customization availability

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1206,11 +1206,12 @@
 	for (var/datum/data/vending_product/product_record as anything in product_records + coin_records + hidden_records)
 		var/list/product_data = list(
 			name = product_record.name,
+			path = replacetext(replacetext("[product_record.product_path]", "/obj/item/", ""), "/", "-"),
 			amount = product_record.amount,
 			colorable = product_record.colorable,
 		)
 
-		.["stock"] += list(product_data)
+		.["stock"][product_data["path"]] = product_data
 
 	.["extended_inventory"] = extended_inventory
 

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -60,6 +60,7 @@ type UserData = {
 
 type StockItem = {
   name: string;
+  path: string;
   amount: number;
   colorable: boolean;
 };
@@ -84,7 +85,7 @@ export const Vending = (props) => {
 
   const [selectedCategory, setSelectedCategory] = useLocalState<string>(
     'selectedCategory',
-    Object.keys(data.categories)[0],
+    Object.keys(data.categories)[0]
   );
 
   let inventory: (ProductRecord | CustomInput)[];
@@ -112,7 +113,7 @@ export const Vending = (props) => {
           return false;
         }
       });
-    }),
+    })
   );
 
   return (
@@ -218,12 +219,12 @@ const ProductDisplay = (props: {
               return true;
             }
           })
-          .map((product, index) => (
+          .map((product) => (
             <VendingRow
               key={product.path}
               custom={custom}
               product={product}
-              productStock={stock[index]}
+              productStock={stock[product.path]}
             />
           ))}
       </Table>

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -85,7 +85,7 @@ export const Vending = (props) => {
 
   const [selectedCategory, setSelectedCategory] = useLocalState<string>(
     'selectedCategory',
-    Object.keys(data.categories)[0]
+    Object.keys(data.categories)[0],
   );
 
   let inventory: (ProductRecord | CustomInput)[];
@@ -113,7 +113,7 @@ export const Vending = (props) => {
           return false;
         }
       });
-    })
+    }),
   );
 
   return (


### PR DESCRIPTION
## About The Pull Request
It was broken since https://github.com/tgstation/tgstation/pull/80500, displaying both wrong amounts and wrong options of color customization availability, due to using the wrong index in a filtered list. I've gone around the issue by making it an associative list (dictionary in TSX), so we don't need to rely on indexes anymore.

## Why It's Good For The Game
You can once again customize the colors of the stuff in the vendor properly, which is nice.
![image](https://github.com/tgstation/tgstation/assets/58045821/68c6e128-20ef-480a-b472-55e14644ecfc)


## Changelog

:cl: GoldenAlpharex
fix: Vending machines now display the proper color customization options and item quantities again!
/:cl: