### PR TITLE
adds screentips to the janicart (pimpin' ride)

### DIFF
--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -89,11 +89,16 @@
 /obj/vehicle/ridden/janicart/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	//has occupant && hands empty
-		//lmb dismount
-		//rmb remove trash bag
-		//if key inserted && you are the driver
-			//context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
+	if(occupant_amount() > 0)
+		if(!held_item)
+			context[SCREENTIP_CONTEXT_LMB] = "Dismount"
+			context[SCREENTIP_CONTEXT_RMB] = "Dismount"
+			if(trash_bag)
+				context[SCREENTIP_CONTEXT_RMB] = "Remove trash bag"
+			if(is_key(inserted_key))
+				if(occupants.Find(user))
+					context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
+			return CONTEXTUAL_SCREENTIP_SET
 
 	if(!held_item) //&& not driving it
 		if(trash_bag)

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -89,38 +89,32 @@
 /obj/vehicle/ridden/janicart/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	if(occupant_amount() > 0)
-		if(!held_item)
+	if(!held_item)
+		if(occupant_amount() > 0)
 			context[SCREENTIP_CONTEXT_LMB] = "Dismount"
 			context[SCREENTIP_CONTEXT_RMB] = "Dismount"
 			if(trash_bag)
 				context[SCREENTIP_CONTEXT_RMB] = "Remove trash bag"
-			if(is_key(inserted_key))
-				if(occupants.Find(user))
-					context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
+			if(is_key(inserted_key) && occupants.Find(user))
+				context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
 			return CONTEXTUAL_SCREENTIP_SET
-
-	if(!held_item) //&& not driving it
-		if(trash_bag)
+		else if(trash_bag)
 			context[SCREENTIP_CONTEXT_LMB] = "Remove trash bag"
 			context[SCREENTIP_CONTEXT_RMB] = "Remove trash bag"
 			return CONTEXTUAL_SCREENTIP_SET
 
-	if(istype(held_item, /obj/item/storage/bag/trash))
-		if(!trash_bag)
-			context[SCREENTIP_CONTEXT_LMB] = "Add trash bag"
-			context[SCREENTIP_CONTEXT_RMB] = "Add trash bag"
-			return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/storage/bag/trash) && !trash_bag)
+		context[SCREENTIP_CONTEXT_LMB] = "Add trash bag"
+		context[SCREENTIP_CONTEXT_RMB] = "Add trash bag"
+		return CONTEXTUAL_SCREENTIP_SET
 
-	if(istype(held_item, /obj/item/janicart_upgrade))
-		if(!installed_upgrade)
-			context[SCREENTIP_CONTEXT_LMB] = "Install upgrade"
-			return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/janicart_upgrade) && !installed_upgrade)
+		context[SCREENTIP_CONTEXT_LMB] = "Install upgrade"
+		return CONTEXTUAL_SCREENTIP_SET
 
-	if(istype(held_item, /obj/item/screwdriver))
-		if(installed_upgrade)
-			context[SCREENTIP_CONTEXT_LMB] = "Remove upgrade"
-			return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/screwdriver) && installed_upgrade)
+		context[SCREENTIP_CONTEXT_LMB] = "Remove upgrade"
+		return CONTEXTUAL_SCREENTIP_SET
 
 	if(is_key(held_item) && !is_key(inserted_key))
 		context[SCREENTIP_CONTEXT_LMB] = "Insert key"
@@ -128,10 +122,8 @@
 		return CONTEXTUAL_SCREENTIP_SET
 	else if (trash_bag)
 		context[SCREENTIP_CONTEXT_LMB] = "Insert into trash bag"
-		context[SCREENTIP_CONTEXT_RMB] = "Insert key"
+		context[SCREENTIP_CONTEXT_RMB] = "Insert into trash bag"
 		return CONTEXTUAL_SCREENTIP_SET
-
-//TODO move key insertion and dismount to basetype?
 
 
 /**

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -125,7 +125,6 @@
 		context[SCREENTIP_CONTEXT_RMB] = "Insert into trash bag"
 		return CONTEXTUAL_SCREENTIP_SET
 
-
 /**
  * Called if the attached bag is being qdeleted, ensures appearance is maintained properly
  */

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -14,6 +14,7 @@
 
 /obj/vehicle/ridden/janicart/Initialize(mapload)
 	. = ..()
+	register_context()
 	update_appearance()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/janicart)
 	GLOB.janitor_devices += src
@@ -84,6 +85,45 @@
 	. = (LAZYACCESS(modifiers, RIGHT_CLICK) && try_remove_bag(user)) || ..()
 	if (!.)
 		try_remove_bag(user)
+
+/obj/vehicle/ridden/janicart/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	//has occupant && hands empty
+		//lmb dismount
+		//rmb remove bag
+
+	if(!held_item)
+		if(trash_bag)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove bag"
+			context[SCREENTIP_CONTEXT_RMB] = "Remove bag"
+			//if key inserted
+				//context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/storage/bag/trash))
+		if(!trash_bag)
+			context[SCREENTIP_CONTEXT_LMB] = "Add bag"
+			context[SCREENTIP_CONTEXT_RMB] = "Add bag"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/janicart_upgrade))
+		if(!installed_upgrade)
+			context[SCREENTIP_CONTEXT_LMB] = "Install upgrade"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/screwdriver))
+		if(installed_upgrade)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove upgrade"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	//holding key
+		//lmb insert key
+
+	//holding something that isn't the key (and probably also tiny/small)
+		//LMB = insert into bag
+
+//TODO move key insertion and dismount to basetype?
 
 
 /**

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -91,20 +91,20 @@
 
 	//has occupant && hands empty
 		//lmb dismount
-		//rmb remove bag
+		//rmb remove trash bag
+		//if key inserted && you are the driver
+			//context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
 
-	if(!held_item)
+	if(!held_item) //&& not driving it
 		if(trash_bag)
-			context[SCREENTIP_CONTEXT_LMB] = "Remove bag"
-			context[SCREENTIP_CONTEXT_RMB] = "Remove bag"
-			//if key inserted
-				//context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove key"
+			context[SCREENTIP_CONTEXT_LMB] = "Remove trash bag"
+			context[SCREENTIP_CONTEXT_RMB] = "Remove trash bag"
 			return CONTEXTUAL_SCREENTIP_SET
 
 	if(istype(held_item, /obj/item/storage/bag/trash))
 		if(!trash_bag)
-			context[SCREENTIP_CONTEXT_LMB] = "Add bag"
-			context[SCREENTIP_CONTEXT_RMB] = "Add bag"
+			context[SCREENTIP_CONTEXT_LMB] = "Add trash bag"
+			context[SCREENTIP_CONTEXT_RMB] = "Add trash bag"
 			return CONTEXTUAL_SCREENTIP_SET
 
 	if(istype(held_item, /obj/item/janicart_upgrade))
@@ -117,11 +117,14 @@
 			context[SCREENTIP_CONTEXT_LMB] = "Remove upgrade"
 			return CONTEXTUAL_SCREENTIP_SET
 
-	//holding key
-		//lmb insert key
-
-	//holding something that isn't the key (and probably also tiny/small)
-		//LMB = insert into bag
+	if(is_key(held_item) && !is_key(inserted_key))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert key"
+		context[SCREENTIP_CONTEXT_RMB] = "Insert key"
+		return CONTEXTUAL_SCREENTIP_SET
+	else if (trash_bag)
+		context[SCREENTIP_CONTEXT_LMB] = "Insert into trash bag"
+		context[SCREENTIP_CONTEXT_RMB] = "Insert key"
+		return CONTEXTUAL_SCREENTIP_SET
 
 //TODO move key insertion and dismount to basetype?
 


### PR DESCRIPTION

## About The Pull Request
Adds screentips the janicart (pimpin' ride) for dismounting, adding and removing trash bags/upgrades/keys and inserting into the connected trash bag.

The dismounting and key insertion/removal screentips could maybe be used in the base vehicle. But right now I can't figure out how to move those there without needing to do the same checks on the janicart (pimpin' ride) again.
## Why It's Good For The Game
The janicart (pimpin' ride) has a lot of things you can do with it that are not immediately obvious. It took me a while to figure out that you can grab the trash bag from it without having to get off of it first.
## Changelog
:cl:
qol: added screentips to the janicart (pimpin' ride)
/:cl:
