### PR TITLE
Adds bananium metalgen & another way to get super lube

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -244,7 +244,7 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	singular_name = "bananium sheet"
 	sheettype = "bananium"
 	mats_per_unit = list(/datum/material/bananium=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/consumable/banana = 20)
+	grind_results = list(/datum/reagent/consumable/banana = 20, /datum/reagent/lube/superlube = 10)
 	point_value = 50
 	merge_type = /obj/item/stack/sheet/mineral/bananium
 	material_type = /datum/material/bananium

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -570,6 +570,7 @@
 /datum/reagent/lube/superlube
 	name = "Super Duper Lube"
 	description = "This \[REDACTED\] has been outlawed after the incident on \[DATA EXPUNGED\]."
+	material = /datum/material/bananium
 	lube_kind = TURF_WET_SUPERLUBE
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -970,3 +970,14 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/hauntium(location)
+
+/datum/chemical_reaction/bananium_solidification
+	required_reagents = list(/datum/reagent/consumable/laughter = 5, /datum/reagent/lube/superlube = 10, /datum/reagent/iron = 1)
+	mob_react = FALSE
+	reaction_flags = REACTION_INSTANT
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/bananium_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i in 1 to created_volume)
+		new /obj/item/stack/sheet/mineral/bananium(location)


### PR DESCRIPTION

## About The Pull Request
Makes it so you can grind bananium for a little bit of super duper lube, as well as being able to use that super duper lube to make bananium metalgen.

https://github.com/tgstation/tgstation/assets/58376695/21b58aac-b08f-4a71-813e-27523cc40205
## Why It's Good For The Game
Bananium is one of the few main materials that isn't able to be used in metalgen, although probably being one of most fun things that metalgen could be used for. 
This changes that as well as allowing the access of super duper lube, which was a very niche, unused chemical that was only accessible in a spray flower from the clown lavaland ruin, or by things like botany RNG. Allowing slightly easier access to it lets it have some use and fun outside of a very small RNG chance, since the 30 units that are in the spray flower won't do much at all.
## Changelog
:cl:
add: lets you use super duper lube to make bananium metalgen and lets you grind bananium to get a small amount of super duper lube
/:cl:
