### PR TITLE
Fixes extinguisher cabinet not updating its icon

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -105,6 +105,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 29)
 		if(!opened)
 			opened = 1
 			playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
+			update_appearance(UPDATE_ICON)
 	else
 		toggle_cabinet(user)
 


### PR DESCRIPTION
## About The Pull Request

Just makes the extinguisher cabinet actually look opened after removing the extinguisher like it's supposed to.

## Why It's Good For The Game

<details><summary>Looks like it's supposed to again</summary>

![dreamseeker_NlHRontRpD](https://github.com/tgstation/tgstation/assets/13398309/c485c612-30d0-480a-9525-1962aa050587)

</details>

## Changelog

:cl:
fix: fixed fire extinguisher cabinets not appearing opened after removing the fire extinguisher from them
/:cl: