### PR TITLE
Optimize Github Actions CI workflow with `paths-ignore`

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -6,10 +6,24 @@ on:
     - 'project/**'
     - 'gh-readonly-queue/master/**'
     - 'gh-readonly-queue/project/**'
+    # Do not run if the only files changed cannot affect the build
+    paths-ignore:
+      - "**.md"
+      - "**.json"
+      - ".github/CODEOWNERS"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".editorconfig"
   pull_request:
     branches:
     - master
     - 'project/**'
+    # Do not run if the only files changed cannot affect the build
+    paths-ignore:
+      - "**.md"
+      - "**.json"
+      - ".github/CODEOWNERS"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".editorconfig"
   merge_group:
     branches:
     - master

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -9,7 +9,7 @@ on:
     # Do not run if the only files changed cannot affect the build
     paths-ignore:
       - "**.md"
-      - "**.json"
+      - "**.txt"
       - ".github/CODEOWNERS"
       - ".github/PULL_REQUEST_TEMPLATE.md"
       - ".editorconfig"
@@ -20,7 +20,7 @@ on:
     # Do not run if the only files changed cannot affect the build
     paths-ignore:
       - "**.md"
-      - "**.json"
+      - "**.txt"
       - ".github/CODEOWNERS"
       - ".github/PULL_REQUEST_TEMPLATE.md"
       - ".editorconfig"


### PR DESCRIPTION

## About The Pull Request
There is no need to be running a full CI workflow when no code has changed.  See relevant [GitHub Docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) related to how `paths-ignore` works.

Two caveats:
- It doesn't work with `merge_groups`
- It still might be a good idea to require JSON files use a linter

## Why It's Good For The Game
Faster CI is good.

## Changelog
N/A
