### PR TITLE
borgs dont dgasp twice when dying

### DIFF
--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -5,8 +5,6 @@
 	new /obj/effect/decal/remains/robot(loc)
 
 /mob/living/silicon/death(gibbed)
-	if(!gibbed)
-		INVOKE_ASYNC(src, PROC_REF(emote), "deathgasp")
 	diag_hud_set_status()
 	diag_hud_set_health()
 	update_health_hud()


### PR DESCRIPTION
## About The Pull Request
fixes #80552 
removes a single if statement that makes borgs dgasp when dying to _not_ gibbing, which they already did
from what i checked mob/living/silicon/death(gibbed) didnt do much, but idk if its something important

## Why It's Good For The Game

Cyborgs couldnt play dead since a single dgasp meant the cyborg wasnt dead

## Changelog
:cl:
fix: Cyborgs do not deathgasp twice when dying anymore
/:cl:
