### PR TITLE
RPD Speedpipe Upgrade

### DIFF
--- a/code/__DEFINES/construction/rcd.dm
+++ b/code/__DEFINES/construction/rcd.dm
@@ -36,7 +36,8 @@
 #define RCD_ALL_UPGRADES (RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_SILO_LINK | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN)
 /// Upgrades for the Rapid Pipe Dispenser to unwrench pipes
 #define RPD_UPGRADE_UNWRENCH (1 << 0)
-
+/// Upgrade for RPD to autolay pipes on marked turfs
+#define RPD_UPGRADE_SPEEDPIPE (1 << 1)
 //Memory constants for faster construction speeds
 /// The memory constant for a wall
 #define RCD_MEMORY_WALL 1

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -202,6 +202,18 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/rpd_upgrade/speedpipe
+	name = "Advanced RPD speedpipe upgrade"
+	desc = "Upgrades the RPD to be able to mark locations to build on by simply moving."
+	id = "rpd_upgrade_speedpipe"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT*1.25, /datum/material/glass =SHEET_MATERIAL_AMOUNT*1.25, /datum/material/silver =SHEET_MATERIAL_AMOUNT*1.25, /datum/material/titanium =SHEET_MATERIAL_AMOUNT*1.25, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT*1.25)
+	build_path = /obj/item/rpd_upgrade/speedpipe
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
 /datum/design/rld_mini
 	name = "Mini Rapid Light Device (MRLD)"
 	desc = "A tool that can deploy portable and standing lighting orbs and glowsticks."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1586,12 +1586,13 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/datum/techweb_node/adv_rcd_upgrade
-	id = "adv_rcd_upgrade"
-	display_name = "Advanced RCD Designs Upgrade"
-	description = "Unlocks new RCD designs."
+/datum/techweb_node/adv_rapid_upgrade
+	id = "adv_rapid_upgrade"
+	display_name = "Advanced Rapid Tool Upgrades"
+	description = "Unlocks designs for advanced rapid tool upgrades."
 	design_ids = list(
 		"rcd_upgrade_silo_link",
+		"rpd_upgrade_speedpipe",
 	)
 	prereq_ids = list(
 		"bluespace_travel",


### PR DESCRIPTION

## About The Pull Request

- Adds a new RPD upgrade, called speedpipe. It lets you mark tiles and then automatically builds on them (with the same delay as normal RPD use)
- Alt-click to start/stop marking tiles, right-click a marked tile to unmark it, ctrl-click to unmark all tiles
- Alt-right-click to start/stop building on marked tiles. It builds whatever is set in the RPD TGUI
- As counterplay, changing the turf of the tile will prevent speedpipe building on it.

## Vid


https://github.com/tgstation/tgstation/assets/46101244/9d1a4e89-d62c-44aa-aa78-fbc0a35ec0ca
## Why It's Good For The Game

The only RPD upgrade that exists is an upgrade that gives it unwrenching functionality

This is a nice upgrade, in RND it's in the same category as the RCD silo link upgrade, so it requires an extra 10k points after researching the tier 1 'Rapid' Upgrades.

Makes it much less painful to pipe up from atmos to the HFR, from atmos to SM, SM to atmos, or atmos to a room on the other side of the station.

It has the same delay as the regular RPD and very obviously marks tiles. You can counterplay by changing the turf [crowbarring it, etc.]
## Changelog
:cl:
add: The RPD now has a new "Speedpipe" upgrade. Pipe across the station in seconds, just by walking!
/:cl:
