### PR TITLE
emagged cyborgs may now selfdestruct if locked, but require a charged cell

### DIFF
--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -132,7 +132,7 @@
 			cyborg.toggle_headlamp(FALSE, TRUE)
 
 		if("selfDestruct")
-			if(cyborg.stat || isnull(cyborg.cell)) //No detonation while stunned or no cell
+			if(cyborg.stat || isnull(cyborg.cell) || cyborg.cell.charge) //No detonation while stunned or no cell
 				return
 			if(cyborg.emagged || istype(cyborg, /mob/living/silicon/robot/model/syndicate)) //This option shouldn't even be showing otherwise
 				cyborg.self_destruct(cyborg)

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -132,7 +132,7 @@
 			cyborg.toggle_headlamp(FALSE, TRUE)
 
 		if("selfDestruct")
-			if(cyborg.stat || cyborg.lockcharge) //No detonation while stunned or locked down
+			if(cyborg.stat || isnull(cyborg.cell)) //No detonation while stunned or no cell
 				return
 			if(cyborg.emagged || istype(cyborg, /mob/living/silicon/robot/model/syndicate)) //This option shouldn't even be showing otherwise
 				cyborg.self_destruct(cyborg)


### PR DESCRIPTION
## About The Pull Request
you need a charged cell instead of being unlocked and to be unstunned to selfdestruct as an emagged cyborg

## Why It's Good For The Game

allows emagged cyborgs an easy way to make sure their secrecy law is fulfilled by blowing up if captured

## Changelog
:cl:
balance: to self-destruct as an emagged cyborg, you need a cell with charge and to be not stunned
/:cl:
