### PR TITLE
saves 90 seconds of cpu time in every 60 hour round.

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -115,7 +115,6 @@ Then the player gets the profit from selling his own wasted time.
 	return ..()
 
 /datum/export/process()
-	..()
 	cost *= NUM_E**(k_elasticity * (1/30))
 	if(cost > init_cost)
 		cost = init_cost


### PR DESCRIPTION
/datum/proc/process() does nothing and having it in the top 100 called because of this one line is silly.
