### PR TITLE
"Explosive Planted" C4 ghost notification actually shows the C4

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -119,9 +119,12 @@
 
 		message_admins("[ADMIN_LOOKUPFLW(user)] planted [name] on [target.name] at [ADMIN_VERBOSEJMP(target)] with [det_time] second fuse")
 		user.log_message("planted [name] on [target.name] with a [det_time] second fuse.", LOG_ATTACK)
+		var/icon/target_icon = icon(bomb_target.icon, bomb_target.icon_state)
+		target_icon.Blend(icon(icon, icon_state), ICON_OVERLAY)
+		var/image/bomb_target_image = image(target_icon)
 		notify_ghosts(
 			"[user] has planted \a [src] on [target] with a [det_time] second fuse!",
-			source = bomb_target,
+			source = bomb_target_image,
 			header = "Explosive Planted",
 			notify_flags = NOTIFY_CATEGORY_NOFLASH,
 		)


### PR DESCRIPTION
## About The Pull Request
"Explosive Planted" C4 ghost notification actually shows the C4 on the icon
## Why It's Good For The Game
It looks very strange seeing an image of just a wall, or just a firelock, this give you info at a glance that "oh it's C4" rather than having to read chat or hover over the alert
![Screenshot 2023-12-31 192717](https://github.com/tgstation/tgstation/assets/46101244/eef8c51c-1f86-48d4-8425-1622e9c1123b)


## Changelog
:cl:
qol: The "Explosive Planted" alert for C4 actually shows the C4
/:cl:
