### PR TITLE
Fixes crashing through tables from a table giving you a negative offset

### DIFF
--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -152,12 +152,13 @@
 /datum/element/elevation_core/proc/on_exited(turf/source, atom/movable/gone)
 	SIGNAL_HANDLER
 	if((isnull(gone.loc) || !HAS_TRAIT_FROM(gone.loc, TRAIT_ELEVATED_TURF, REF(src))) && isliving(gone))
+		// Always unregister the signal, we're still leaving even if already shifted down.
+		UnregisterSignal(gone, COMSIG_LIVING_SET_BUCKLED)
 		if(!HAS_TRAIT_FROM(gone, TRAIT_ON_ELEVATED_SURFACE, REF(src)))
 			return
 		REMOVE_TRAIT(gone, TRAIT_ON_ELEVATED_SURFACE, REF(src))
 		var/elevate_time = isturf(gone.loc) && source.Adjacent(gone.loc) ? ELEVATE_TIME : 0
 		elevate_mob(gone, -pixel_shift, elevate_time)
-		UnregisterSignal(gone, COMSIG_LIVING_SET_BUCKLED)
 
 /datum/element/elevation_core/proc/elevate_mob(mob/living/target, z_shift = pixel_shift, elevate_time = ELEVATE_TIME)
 	var/buckled_to_vehicle = FALSE

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -152,6 +152,8 @@
 /datum/element/elevation_core/proc/on_exited(turf/source, atom/movable/gone)
 	SIGNAL_HANDLER
 	if((isnull(gone.loc) || !HAS_TRAIT_FROM(gone.loc, TRAIT_ELEVATED_TURF, REF(src))) && isliving(gone))
+		if(!HAS_TRAIT_FROM(gone, TRAIT_ON_ELEVATED_SURFACE, REF(src)))
+			return
 		REMOVE_TRAIT(gone, TRAIT_ON_ELEVATED_SURFACE, REF(src))
 		var/elevate_time = isturf(gone.loc) && source.Adjacent(gone.loc) ? ELEVATE_TIME : 0
 		elevate_mob(gone, -pixel_shift, elevate_time)


### PR DESCRIPTION

## About The Pull Request

While failing to reproduce #80675, given no amount of slamming this poor little moth creature through glass tables in any order and then rebuilding it under them seemed to be doing anything, I found that it _does_ cause a negative offset if the moth-to-be-slammed in question was already on a table before being slammed into a glass table. (Don't worry they have health insurance.)

After some debugging, this seemed to be because `Detach()` is called for the new turf with the smashed table _before_ `on_exited()` is called for the previous turf, causing it to first reduce one's offset by 12, and then reduce it by 12 _again_ upon calling `on_exited()`. This seemed to be true for whichever method was used, whether walking, dragging, or being smashed.
![image](https://github.com/tgstation/tgstation/assets/42909981/3782776f-7153-4235-b377-8f8bd8904110)
So I introduced the same check for `TRAIT_ON_ELEVATED_SURFACE` that `Detach()` has to `on_exited()`, making it only attempt to shift down the movable if it still has the trait, and this seems to fix it fine!
It doesn't seem to cause issues with moving from beds onto tables or tables onto beds, or smashing through glass tables from tables or beds. So this should fix #80675, or at least I can't find what they would've meant if not this.

And yes I did test this on Tramstation just in case.
![image](https://github.com/tgstation/tgstation/assets/42909981/e3d8e755-c288-4ed7-93cb-8948c6012c56)
## Why It's Good For The Game

Fixes #80675.
## Changelog
:cl:
fix: slamming through a glass table while previously on a table no longer gives you a negative offset.
/:cl:
