### PR TITLE
Hub Entry shows Next Map and Shuttle Time, removes Alert

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -381,15 +381,12 @@ GLOBAL_VAR(restart_counter)
 		new_status += ": [jointext(features, ", ")]"
 
 	new_status += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
+	if(SSshuttle.emergency)
+		new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
 	if(SSmapping.config)
 		new_status += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"
-		if(SSmapping.next_map_config)
-			new_status += " | Next: <b>[SSmapping.next_map_config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.next_map_config.map_name]</b>"
-	var/alert_text = SSsecurity_level.get_current_level_as_text()
-	if(alert_text)
-		new_status += "<br>Alert: <b>[capitalize(alert_text)]</b>"
-		if(SSshuttle.emergency)
-			new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
+	if(SSmapping.next_map_config)
+		new_status += "[SSmapping.config ? " | " : "<br>"]Next: <b>[SSmapping.next_map_config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.next_map_config.map_name]</b>"
 
 	status = new_status
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -383,9 +383,13 @@ GLOBAL_VAR(restart_counter)
 	new_status += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
 	if(SSmapping.config)
 		new_status += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"
+		if(SSmapping.next_map_config)
+			new_status += " | Next: <b>[SSmapping.next_map_config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.next_map_config.map_name]</b>"
 	var/alert_text = SSsecurity_level.get_current_level_as_text()
 	if(alert_text)
 		new_status += "<br>Alert: <b>[capitalize(alert_text)]</b>"
+		if(SSshuttle.emergency)
+			new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
 
 	status = new_status
 


### PR DESCRIPTION
## About The Pull Request
If there is a next map and if shuttle is called, show them in the hub entry

Removes the alert from the hub entry cuz it's useless, 99% of the time it's blue, generally not useful to those in the hub
## Why It's Good For The Game
More info is good, so players know "ok round's about to end i'll join up"
Or if players dislike a certain map like Birdshot/Northstar, they may join up and play anyway since they can see "alright Meta's coming up soon so i might as well jump in"
## Changelog
:cl:
qol: The hub entry shows the next map and shuttle time, and no longer shows the alert
/:cl:
