### PR TITLE
Fixes integrated circuit speech logging

### DIFF
--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -31,5 +31,5 @@
 
 	if(message.value)
 		var/atom/movable/shell = parent.shell
-		shell.say(message.value, forced = "circuit speech | [key_name(parent.get_creator())]")
+		shell.say(message.value, forced = "circuit speech | [parent.get_creator()]")
 		TIMER_COOLDOWN_START(shell, COOLDOWN_CIRCUIT_SPEECH, speech_cooldown)


### PR DESCRIPTION

## About The Pull Request
get_creator() returns a printable string rather than a mob, so it doesn't need key_name() here

## Why It's Good For The Game
Bugfixes

## Changelog
:cl:
fix: Fixed integrated circuit speech logging
/:cl:
