### PR TITLE
Lawyer badge now points instead of giving a message in chat

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -8,7 +8,7 @@
 	. = ..()
 	if(prob(1))
 		user.say("The testimony contradicts the evidence!", forced = "[src]")
-	user.visible_message(span_notice("[user] shows [user.p_their()] attorney's badge."), span_notice("You show your attorney's badge."))
+	user.point_at(src)
 
 /obj/item/clothing/accessory/lawyers_badge/accessory_equipped(obj/item/clothing/under/clothes, mob/living/user)
 	RegisterSignal(user, COMSIG_LIVING_SLAM_TABLE, PROC_REF(table_slam))


### PR DESCRIPTION
## About The Pull Request

Using a Lawyer badge in hand will now point to it, giving the thought bubble over your head, rather than sending a message to your chat.

I thought the lawyer badge would show its icon in chat when using it, but it doesn't seem like that was the case. I thought this would be a better change though, since it doesn't rely on chat.

## Why It's Good For The Game

Moves the lawyer badge away from a thing that spams your chat and makes it more visible as an action being done by a player.

## Changelog

:cl:
qol: Using a Lawyer badge in your hand now shows a thought bubble with the badge, rather than giving a lousy message in your chat.
/:cl: