### PR TITLE
Changes some cargo windoor stuff on Delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6773,8 +6773,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/west{
 	dir = 4;
-	name = "Mining Desk";
-	req_access = list("mining")
+	name = "Delivery Desk";
+	req_access = list("cargo")
 	},
 /obj/effect/turf_decal/delivery,
 /obj/item/paper_bin,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -77596,7 +77596,8 @@
 	},
 /obj/machinery/door/window/left/directional/south{
 	dir = 1;
-	req_access = list("cargo")
+	req_access = list("cargo");
+	name = "Office Desk"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/desk_bell{


### PR DESCRIPTION
## About The Pull Request

Renames and re-accesses the "Mining Desk" windoor in the delivery office on Delta to be accessible to cargo techs and named "Delivery Desk". Renames the cargo office windoor to "Office Desk" aswell for consistency.

## Why It's Good For The Game

I honestly can't tell if it's a bug or intended, but having it be a "mining desk" and restricting cargo techs access to it makes no sense. It is my DREAM to put assistant's mail there.

## Changelog

:cl:fIoppie
qol: Cargo techs can now access the windoor in the delivery office on Delta.
/:cl:
