### PR TITLE
Fixes netpod healing exploit

### DIFF
--- a/code/modules/bitrunning/components/netpod_healing.dm
+++ b/code/modules/bitrunning/components/netpod_healing.dm
@@ -6,7 +6,13 @@
 	if (!iscarbon(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	RegisterSignal(pod, COMSIG_BITRUNNER_NETPOD_OPENED, PROC_REF(on_opened))
+	RegisterSignals(
+		pod,
+		list(COMSIG_MACHINERY_BROKEN, COMSIG_QDELETING, COMSIG_BITRUNNER_NETPOD_OPENED),
+		PROC_REF(on_remove),
+	)
+
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_remove))
 
 	var/mob/living/carbon/player = parent
 	player.apply_status_effect(/datum/status_effect/embryonic, STASIS_NETPOD_EFFECT)
@@ -39,7 +45,7 @@
 		owner.updatehealth()
 
 /// Deletes itself when the machine was opened
-/datum/component/netpod_healing/proc/on_opened()
+/datum/component/netpod_healing/proc/on_remove()
 	SIGNAL_HANDLER
 
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
This PR addresses an issue where netpod healing effects persisted under certain conditions (Issue #80715). Specifically, when a netpod is destroyed with a player inside, the embryonic stasis effect improperly continued. This adds another cases where the user is teleported out by other means (not currently a known issue).
## Why It's Good For The Game
Fixes an in game exploit / bug
Fixes #80715
## Changelog
:cl:
fix: Having a netpod destroyed will no longer grant you permanent healing.
/:cl:
