### PR TITLE
Adds logging to door remote bolting

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -73,8 +73,10 @@
 
 			if (airlock.locked)
 				airlock.unbolt()
+				log_combat(user, airlock, "unbolted", src)
 			else
 				airlock.bolt()
+				log_combat(user, airlock, "bolted", src)
 		if (WAND_EMERGENCY)
 			if (!istype(airlock))
 				target.balloon_alert(user, "only airlocks!")


### PR DESCRIPTION

## About The Pull Request

Adds log entries when a player bolts or unbolts a door using a remote.

## Why It's Good For The Game

Letting people mess with door bolts completely unlogged is potentially inconvenient.

## Changelog

Not player facing
