### PR TITLE
Healing and surgery requirements

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -446,7 +446,7 @@
 	forceMove(defib)
 	defib.update_power()
 
-/obj/item/shockpaddles/attack(mob/M, mob/living/user, params)
+/obj/item/shockpaddles/attack(mob/living/carbon/patient, mob/living/user, params)
 	if(busy)
 		return
 	defib?.update_power()
@@ -469,30 +469,32 @@
 
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		do_disarm(M, user)
+		do_disarm(patient, user)
 		return
 
-	if(!iscarbon(M))
+	if(!iscarbon(patient))
 		if(req_defib)
 			to_chat(user, span_warning("The instructions on [defib] don't mention how to revive that..."))
 		else
 			to_chat(user, span_warning("You aren't sure how to revive that..."))
 		return
-	var/mob/living/carbon/H = M
 
 	if(user.zone_selected != BODY_ZONE_CHEST)
 		to_chat(user, span_warning("You need to target your patient's chest with [src]!"))
 		return
 
 	if(user.combat_mode)
-		do_harm(H, user)
+		do_harm(patient, user)
 		return
 
-	if(H.can_defib() == DEFIB_POSSIBLE)
-		H.notify_revival("Your heart is being defibrillated!")
-		H.grab_ghost() // Shove them back in their body.
+	if(!user.can_perform_action(patient, NEED_LIGHT|NEED_DEXTERITY))
+		return
 
-	do_help(H, user)
+	if(patient.can_defib() == DEFIB_POSSIBLE)
+		patient.notify_revival("Your heart is being defibrillated!")
+		patient.grab_ghost() // Shove them back in their body.
+
+	do_help(patient, user)
 
 /// Called whenever the paddles successfuly shock something
 /obj/item/shockpaddles/proc/do_success()

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -72,6 +72,9 @@
 
 /// Checks if the passed patient can be healed by the passed user
 /obj/item/stack/medical/proc/can_heal(mob/living/patient, mob/user)
+	if(!user.can_perform_action(patient, NEED_LIGHT|NEED_DEXTERITY))
+		return
+
 	return patient.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE)
 
 /// In which we print the message that we're starting to heal someone, then we try healing them. Does the do_after whether or not it can actually succeed on a targeted mob

--- a/code/modules/surgery/experimental_dissection.dm
+++ b/code/modules/surgery/experimental_dissection.dm
@@ -30,7 +30,6 @@
 		/obj/item/shard = 10,
 	)
 	time = 12 SECONDS
-	silicons_obey_prob = TRUE
 
 /datum/surgery_step/experimental_dissection/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='notice'>[user] starts dissecting [target].</span>", "<span class='notice'>You start dissecting [target].</span>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -110,6 +110,8 @@
 		return FALSE
 	if(step_in_progress)
 		return TRUE
+	if(!user.can_perform_action(target, NEED_LIGHT|NEED_DEXTERITY))
+		return TRUE
 
 	var/try_to_fail = FALSE
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))


### PR DESCRIPTION

## About The Pull Request
- Healing and surgery require nearby light
- Healing and surgery require monkeys to have the clever mutation
- Mobs affected by clumsy (clowns) have a 25% chance of failure
- Mobs affected by nearsight have a 35% chance of failure
- Mobs affected by blindness have a 50% chance of failure and get surgery feedback messages
- Remove cyborgs 100% success for dissection surgery (snowflake code)
- Fix surgery success chance to be static values instead of based on time (ghetto surgery was completely broken due to this)

Performing medical operations in the dark is dumb. The light requirement can be met with a simple PDA light so it is a small burden to overcome.

Monkeys performing surgery and healing is also dumb. Unless they are _clever_! Then they should be able to perform the same actions as the humanoid mobs.

Clumsy, nearsight, and blind drawbacks make surgery more difficult but not impossible. They will fail more often and it will make patients nervous but it could lead to some quality RP moments. 

There was a cyborg surgery override check in the code that was only used in one place that was redundant and ugly. #78132 had added this but it wasn't included anywhere in the changelog or PR so I removed it to cleanup the code.

Ghetto surgery was broken. Most things either gave a 1% success rate or it was 100% guaranteed. This was because the probability chance was tied to the surgery duration for tool speed. The intent was so that if surgery took longer, it should be more likely to succeed, but if it was faster than it was more likely to fail.  It was very inconsistent and needlessly complicated so I scrapped the old system. This means that better surgery tools only perform the surgery faster and don't affect success chance. This is more simple and easy to understand.


## Why It's Good For The Game
Silly realism.

![9fafd78d813aa5ecb97a2f56809beea6](https://github.com/tgstation/tgstation/assets/5195984/1112d623-3ecb-41a1-84cf-f7b224de8c34)

## Changelog
:cl:
add: Healing and surgery require a nearby light source
add: Healing and surgery require monkeys to have the clever mutation
balance: Surgery for mobs affected by clumsy (clowns) have a 25% chance of failure, nearsighted mobs have a 35% chance of failure, and blind mobs have a 50% chance of failure.
balance: Remove cyborgs 100% success for dissection surgery (snowflake code)
fix: Fix surgery success chance to be static values instead of based on time (ghetto surgery was completely broken due to this)
fix: Blind mobs now get feedback messages when performing surgery
/:cl:
