### PR TITLE
[NO GBP] Fixes path of moon and path of lock sidepaths, replaces brains with other organs

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -71,9 +71,9 @@
 	gain_text = "The distant stars crept into my dreams, roaring and screaming without reason. \
 		I spoke, and heard my own words echoed back."
 	next_knowledge = list(
+		/datum/heretic_knowledge/summon/fire_shark,
 		/datum/heretic_knowledge/mark/cosmic_mark,
 		/datum/heretic_knowledge/essence,
-		/datum/heretic_knowledge/summon/fire_shark,
 	)
 	spell_to_add = /datum/action/cooldown/spell/cosmic_rune
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -20,13 +20,13 @@
  * Raw Ritual
  * > Sidepaths:
  *   Blood Siphon
- *   Aptera Vulnera
+ *   Opening Blast
  *
  * Bleeding Steel
  * Lonely Ritual
  * > Sidepaths:
  *   Cleave
- *   Opening Blast
+ *   Aptera Vulnera
  *
  * Priest's Final Hymn
  */
@@ -240,7 +240,7 @@
 		/datum/heretic_knowledge/blade_upgrade/flesh,
 		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/spell/blood_siphon,
-		/datum/heretic_knowledge/spell/apetra_vulnera,
+		/datum/heretic_knowledge/spell/opening_blast,
 	)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
@@ -279,7 +279,7 @@
 		An ever shapeshifting mass of flesh, it knew well my goals. The Marshal approved."
 	next_knowledge = list(
 		/datum/heretic_knowledge/ultimate/flesh_final,
-		/datum/heretic_knowledge/spell/opening_blast,
+		/datum/heretic_knowledge/spell/apetra_vulnera,
 		/datum/heretic_knowledge/spell/cleave,
 	)
 	required_atoms = list(

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -13,7 +13,6 @@
  * Imperfect Ritual
  * > Sidepaths:
  *   Void Cloak
- *   Ashen Eyes
  *
  * Mark of Flesh
  * Ritual of Knowledge
@@ -21,13 +20,13 @@
  * Raw Ritual
  * > Sidepaths:
  *   Blood Siphon
- *   Curse of Paralysis
+ *   Aptera Vulnera
  *
  * Bleeding Steel
  * Lonely Ritual
  * > Sidepaths:
- *   Ashen Ritual
  *   Cleave
+ *   Opening Blast
  *
  * Priest's Final Hymn
  */
@@ -129,7 +128,6 @@
 	next_knowledge = list(
 		/datum/heretic_knowledge/mark/flesh_mark,
 		/datum/heretic_knowledge/void_cloak,
-		/datum/heretic_knowledge/medallion,
 	)
 	required_atoms = list(
 		/mob/living/carbon/human = 1,
@@ -242,7 +240,7 @@
 		/datum/heretic_knowledge/blade_upgrade/flesh,
 		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/spell/blood_siphon,
-		/datum/heretic_knowledge/curse/paralysis,
+		/datum/heretic_knowledge/spell/apetra_vulnera,
 	)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
@@ -281,7 +279,7 @@
 		An ever shapeshifting mass of flesh, it knew well my goals. The Marshal approved."
 	next_knowledge = list(
 		/datum/heretic_knowledge/ultimate/flesh_final,
-		/datum/heretic_knowledge/summon/ashy,
+		/datum/heretic_knowledge/spell/opening_blast,
 		/datum/heretic_knowledge/spell/cleave,
 	)
 	required_atoms = list(

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -13,14 +13,14 @@
  * Ritual of Knowledge
  * Burglar's Finesse
  * > Sidepaths:
- *   Apetra Vulnera
+ *   Opening Blast
  *   Unfathomable Curio
  * 	 Unsealed arts
  *
  * Opening Blade
  * Caretaker’s Last Refuge
  * > Sidepaths:
- * 	 Opening Blast
+ * 	 Apetra Vulnera
  *
  * Unlock the Labyrinth
  */
@@ -144,7 +144,7 @@
 		that puts a random item from the victims backpack into your hand."
 	gain_text = "Consorting with Burglar spirits is frowned upon, but a Steward will always want to learn about new doors."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/apetra_vulnera,
+		/datum/heretic_knowledge/spell/opening_blast,
 		/datum/heretic_knowledge/blade_upgrade/flesh/lock,
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/painting,
@@ -174,7 +174,7 @@
 	gain_text = "Jealously, the Guard and the Hound hunted me. But I unlocked my form, and was but a haze, untouchable."
 	next_knowledge = list(
 		/datum/heretic_knowledge/ultimate/lock_final,
-		/datum/heretic_knowledge/spell/opening_blast,
+		/datum/heretic_knowledge/spell/apetra_vulnera,
 	)
 	route = PATH_LOCK
 	spell_to_add = /datum/action/cooldown/spell/caretaker

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -5,22 +5,22 @@
  *
  * A Steward's Secret
  * Grasp of Lock
+ * Key Keeper’s Burden
  * > Sidepaths:
  *   Mindgate
- * Key Keeper’s Burden
- *
  * Concierge's Rite
  * Mark Of Lock
  * Ritual of Knowledge
  * Burglar's Finesse
  * > Sidepaths:
- * 	 Opening Blast
  *   Apetra Vulnera
  *   Unfathomable Curio
  * 	 Unsealed arts
  *
  * Opening Blade
  * Caretaker’s Last Refuge
+ * > Sidepaths:
+ * 	 Opening Blast
  *
  * Unlock the Labyrinth
  */
@@ -46,10 +46,7 @@
 		DNA locks on mechs will be removed, and any pilot will be ejected. Works on consoles. \
 		Makes a distinctive knocking sound on use."
 	gain_text = "Nothing may remain closed from my touch."
-	next_knowledge = list(
-		/datum/heretic_knowledge/key_ring,
-		/datum/heretic_knowledge/medallion,
-	)
+	next_knowledge = list(/datum/heretic_knowledge/key_ring)
 	cost = 1
 	route = PATH_LOCK
 
@@ -105,7 +102,10 @@
 		/obj/item/card/id = 1,
 	)
 	result_atoms = list(/obj/item/card/id/advanced/heretic)
-	next_knowledge = list(/datum/heretic_knowledge/limited_amount/concierge_rite)
+	next_knowledge = list(
+		/datum/heretic_knowledge/limited_amount/concierge_rite,
+		/datum/heretic_knowledge/spell/mind_gate,
+	)
 	cost = 1
 	route = PATH_LOCK
 
@@ -145,10 +145,8 @@
 	gain_text = "Consorting with Burglar spirits is frowned upon, but a Steward will always want to learn about new doors."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/apetra_vulnera,
-		/datum/heretic_knowledge/spell/opening_blast,
 		/datum/heretic_knowledge/blade_upgrade/flesh/lock,
 		/datum/heretic_knowledge/unfathomable_curio,
-		/datum/heretic_knowledge/curse/paralysis,
 		/datum/heretic_knowledge/painting,
 	)
 	spell_to_add = /datum/action/cooldown/spell/pointed/burglar_finesse
@@ -174,7 +172,10 @@
 		While in refuge, you cannot use your hands or spells, and you are immune to slowdown. \
 		You are invincible but unable to harm anything. Cancelled by being hit with an anti-magic item."
 	gain_text = "Jealously, the Guard and the Hound hunted me. But I unlocked my form, and was but a haze, untouchable."
-	next_knowledge = list(/datum/heretic_knowledge/ultimate/lock_final)
+	next_knowledge = list(
+		/datum/heretic_knowledge/ultimate/lock_final,
+		/datum/heretic_knowledge/spell/opening_blast,
+	)
 	route = PATH_LOCK
 	spell_to_add = /datum/action/cooldown/spell/caretaker
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -136,7 +136,7 @@
 	next_knowledge = list(/datum/heretic_knowledge/blade_upgrade/moon)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
-		/obj/item/organ/internal/brain = 1,
+		/obj/item/organ/internal/heart = 1,
 		/obj/item/stack/sheet/glass = 2,
 		/obj/item/clothing/neck/tie = 1,
 	)

--- a/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
@@ -6,7 +6,7 @@
 	gain_text = "Piercing eyes guided them through the mundane. Neither darkness nor terror could stop them."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/ash_passage,
-		/datum/heretic_knowledge/limited_amount/flesh_ghoul,
+		/datum/heretic_knowledge/spell/moon_smile,
 	)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
@@ -25,7 +25,7 @@
 	gain_text = "The flesh of humanity is weak. Make them bleed. Show them their fragility."
 	next_knowledge = list(
 		/datum/heretic_knowledge/mad_mask,
-		/datum/heretic_knowledge/summon/raw_prophet,
+		/datum/heretic_knowledge/moon_amulette,
 	)
 	required_atoms = list(
 		/obj/item/bodypart/leg/left = 1,
@@ -64,7 +64,7 @@
 	gain_text = "I combined my principle of hunger with my desire for destruction. The Marshal knew my name, and the Nightwatcher gazed on."
 	next_knowledge = list(
 		/datum/heretic_knowledge/summon/stalker,
-		/datum/heretic_knowledge/spell/flame_birth,
+		/datum/heretic_knowledge/spell/moon_ringleader,
 	)
 	required_atoms = list(
 		/obj/effect/decal/cleanable/ash = 1,

--- a/code/modules/antagonists/heretic/knowledge/side_lock_flesh.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_flesh.dm
@@ -1,4 +1,16 @@
 // Sidepaths for knowledge between Knock and Flesh.
+/datum/heretic_knowledge/spell/opening_blast
+	name = "Wave Of Desperation"
+	desc = "Grants you Wave Of Desparation, a spell which can only be cast while restrained. \
+		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby."
+	gain_text = "My shackles undone in dark fury, their feeble bindings crumble before my power."
+	next_knowledge = list(
+		/datum/heretic_knowledge/summon/raw_prophet,
+		/datum/heretic_knowledge/spell/burglar_finesse,
+	)
+	spell_to_add = /datum/action/cooldown/spell/aoe/wave_of_desperation
+	cost = 1
+	route = PATH_SIDE
 
 /datum/heretic_knowledge/spell/apetra_vulnera
 	name = "Apetra Vulnera"
@@ -7,22 +19,9 @@
 		Wounds a random limb if no limb is sufficiently damaged."
 	gain_text = "Flesh opens, and blood spills. My master seeks sacrifice, and I shall appease."
 	next_knowledge = list(
-		/datum/heretic_knowledge/summon/raw_prophet,
-		/datum/heretic_knowledge/spell/burglar_finesse,
-	)
-	spell_to_add = /datum/action/cooldown/spell/pointed/apetra_vulnera
-	cost = 1
-	route = PATH_SIDE
-
-/datum/heretic_knowledge/spell/opening_blast
-	name = "Wave Of Desperation"
-	desc = "Grants you Wave Of Desparation, a spell which can only be cast while restrained. \
-		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby."
-	gain_text = "My shackles undone in dark fury, their feeble bindings crumble before my power."
-	next_knowledge = list(
 		/datum/heretic_knowledge/summon/stalker,
 		/datum/heretic_knowledge/spell/caretaker_refuge,
 	)
-	spell_to_add = /datum/action/cooldown/spell/aoe/wave_of_desperation
+	spell_to_add = /datum/action/cooldown/spell/pointed/apetra_vulnera
 	cost = 1
 	route = PATH_SIDE

--- a/code/modules/antagonists/heretic/knowledge/side_lock_flesh.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_flesh.dm
@@ -7,8 +7,8 @@
 		Wounds a random limb if no limb is sufficiently damaged."
 	gain_text = "Flesh opens, and blood spills. My master seeks sacrifice, and I shall appease."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/blood_siphon,
-		/datum/heretic_knowledge/void_cloak,
+		/datum/heretic_knowledge/summon/raw_prophet,
+		/datum/heretic_knowledge/spell/burglar_finesse,
 	)
 	spell_to_add = /datum/action/cooldown/spell/pointed/apetra_vulnera
 	cost = 1
@@ -20,8 +20,8 @@
 		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby."
 	gain_text = "My shackles undone in dark fury, their feeble bindings crumble before my power."
 	next_knowledge = list(
-		/datum/heretic_knowledge/summon/ashy,
-		/datum/heretic_knowledge/void_cloak,
+		/datum/heretic_knowledge/summon/stalker,
+		/datum/heretic_knowledge/spell/caretaker_refuge,
 	)
 	spell_to_add = /datum/action/cooldown/spell/aoe/wave_of_desperation
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
@@ -26,7 +26,7 @@
 		/datum/heretic_knowledge/spell/moon_parade,
 	)
 	required_atoms = list(
-		/obj/item/organ/internal/brain = 1,
+		/obj/item/organ/internal/lungs = 1,
 		/obj/item/stack/rods = 3,
 		/obj/item/storage/belt = 1,
 	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3011,7 +3011,7 @@
 #include "code\modules\antagonists\heretic\knowledge\lock_lore.dm"
 #include "code\modules\antagonists\heretic\knowledge\moon_lore.dm"
 #include "code\modules\antagonists\heretic\knowledge\rust_lore.dm"
-#include "code\modules\antagonists\heretic\knowledge\side_ash_flesh.dm"
+#include "code\modules\antagonists\heretic\knowledge\side_ash_moon.dm"
 #include "code\modules\antagonists\heretic\knowledge\side_blade_rust.dm"
 #include "code\modules\antagonists\heretic\knowledge\side_cosmos_ash.dm"
 #include "code\modules\antagonists\heretic\knowledge\side_flesh_void.dm"


### PR DESCRIPTION

## About The Pull Request

This pull request makes the paths as follows:
Rust<>Cosmic<>Ash<>Moon<>Lock<>Flesh
This means flesh and ash are no longer adjacent and their old sidepaths is now between moon and ash
Apetra Vulnera has been moved up one tier and is now unlocked at caretakers refuge/stalker for lock/flesh.
## Why It's Good For The Game
Heretic paths should actually fit with each other and this ensures that it does. As for the removal of brains from certain rituals it is a very difficult organ to obtain as opposed to the rest of the bunch and we are moving towards a direction of making brains even harder to obtain so this ensures those rituals still stay relevant.
## Changelog
:cl:
qol: Path of moon and lock now actually fit in the heretic tree
balance: Certain path of moon rituals that needed brains now use easier to obtain organs
/:cl:
