### PR TITLE
Stops qdeleting progressbar /images

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -82,7 +82,7 @@
 	bar_loc = null
 
 	if(bar)
-		QDEL_NULL(bar)
+		bar = null
 
 	return ..()
 

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -80,9 +80,7 @@
 		clean_user_client()
 
 	bar_loc = null
-
-	if(bar)
-		bar = null
+	bar = null
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. These are getting qdeleted A LOT...
LemonInTheDark we don't need to be doing this I don't think?

## Why It's Good For The Game

Saves a bit on overhead of a very commonly qdeleted item that doesn't need to be.

## Changelog

:cl:
code: progressbars no longer qdel their /image
/:cl: