### PR TITLE
Fixes some runtimes in pathfinding (and bonus)

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -101,6 +101,10 @@
 	controller.queue_loop(src)
 
 /datum/move_loop/process()
+	if(isnull(controller))
+		qdel(src)
+		return
+
 	var/old_delay = delay //The signal can sometimes change delay
 
 	if(SEND_SIGNAL(src, COMSIG_MOVELOOP_PREPROCESS_CHECK) & MOVELOOP_SKIP_STEP) //Chance for the object to react
@@ -441,7 +445,8 @@
 	// this check if we're on exactly the next tile may be overly brittle for dense objects who may get bumped slightly
 	// to the side while moving but could maybe still follow their path without needing a whole new path
 	if(get_turf(moving) == next_step)
-		movement_path.Cut(1,2)
+		if(length(movement_path))
+			movement_path.Cut(1,2)
 	else
 		INVOKE_ASYNC(src, PROC_REF(recalculate_path))
 		return MOVELOOP_FAILURE

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -217,6 +217,8 @@
 		if(tgui_alert(usr,"This mob is being controlled by [M.key]. Are you sure you wish to give someone else control of it? [M.key] will be made a ghost.",,list("Yes","No")) != "Yes")
 			return
 	var/client/newkey = input(src, "Pick the player to put in control.", "New player") as null|anything in sort_list(GLOB.clients)
+	if(isnull(newkey))
+		return
 	var/mob/oldmob = newkey.mob
 	var/delmob = FALSE
 	if((isobserver(oldmob) || tgui_alert(usr,"Do you want to delete [newkey]'s old mob?","Delete?",list("Yes","No")) != "No"))


### PR DESCRIPTION
## About The Pull Request

Found these while running a test server all night. I am not sure if the second one really causes issues because `.` is being set to something but it is is certainly polluting the runtime logs.

Also fixes an unrelated runtime with one of the admin verbs, where it would runtime if you canceled out of the input prompt.

## Why It's Good For The Game

Less runtime spam.

![IklvTShHJB](https://github.com/tgstation/tgstation/assets/13398309/2441ad6b-67b7-4d65-83a3-eabba4516fe9)

![veGkt0Eyul](https://github.com/tgstation/tgstation/assets/13398309/e99eced9-89e6-4065-93d9-578795ddbd8d)

## Changelog

:cl:
fix: fixes some runtimes in pathfinding code, as well as one in the give direct control admin verb
/:cl: