### PR TITLE
Fixes some image hard dels, and adds context to qdeleting images.

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -412,5 +412,5 @@
 	if(harddel_deets_dumped)
 		return
 	harddel_deets_dumped = TRUE
-	return "Image icon: [icon] - icon_state: [icon_state] loc: [loc] ([loc?.x],[loc?.y],[loc?.z])"
+	return "Image icon: [icon] - icon_state: [icon_state] [loc ? "loc: [loc] ([loc.x],[loc.y],[loc.z]) : ""]"
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -412,5 +412,5 @@
 	if(harddel_deets_dumped)
 		return
 	harddel_deets_dumped = TRUE
-	return "Image icon: [icon] - icon_state: [icon_state] [loc ? "loc: [loc] ([loc.x],[loc.y],[loc.z]) : ""]"
+	return "Image icon: [icon] - icon_state: [icon_state] [loc ? ("loc: [loc] ([loc.x],[loc.y],[loc.z])) : ""]"
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -406,3 +406,11 @@
 /// Can be called more then once per object, use harddel_deets_dumped to avoid duplicate calls (I am so sorry)
 /datum/proc/dump_harddel_info()
 	return
+
+///images are pretty generic, this should help a bit with tracking harddels related to them
+/image/dump_harddel_info()
+	if(harddel_deets_dumped)
+		return
+	harddel_deets_dumped = TRUE
+	return "Image icon: [icon] - icon_state: [icon_state] loc: [loc] ([loc?.x][loc?.y][loc?.z])"
+

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -412,5 +412,5 @@
 	if(harddel_deets_dumped)
 		return
 	harddel_deets_dumped = TRUE
-	return "Image icon: [icon] - icon_state: [icon_state] [(loc ? "loc: [loc] ([loc.x],[loc.y],[loc.z]) : "")]"
+	return "Image icon: [icon] - icon_state: [icon_state] [loc ? "loc: [loc] ([loc.x],[loc.y],[loc.z])" : ""]"
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -412,5 +412,5 @@
 	if(harddel_deets_dumped)
 		return
 	harddel_deets_dumped = TRUE
-	return "Image icon: [icon] - icon_state: [icon_state] [loc ? ("loc: [loc] ([loc.x],[loc.y],[loc.z])) : ""]"
+	return "Image icon: [icon] - icon_state: [icon_state] [(loc ? "loc: [loc] ([loc.x],[loc.y],[loc.z]) : "")]"
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -412,5 +412,5 @@
 	if(harddel_deets_dumped)
 		return
 	harddel_deets_dumped = TRUE
-	return "Image icon: [icon] - icon_state: [icon_state] loc: [loc] ([loc?.x][loc?.y][loc?.z])"
+	return "Image icon: [icon] - icon_state: [icon_state] loc: [loc] ([loc?.x],[loc?.y],[loc?.z])"
 

--- a/code/modules/mob/living/basic/bots/bot_hud.dm
+++ b/code/modules/mob/living/basic/bots/bot_hud.dm
@@ -50,7 +50,7 @@
 	clear_path_hud()
 
 	var/list/path_images = active_hud_list[DIAG_PATH_HUD]
-	path_images?.Cut()
+	LAZYCLEARLIST(path_images)
 
 	var/list/path_huds_watching_me = list(GLOB.huds[DATA_HUD_DIAGNOSTIC_ADVANCED])
 

--- a/code/modules/mob/living/basic/bots/bot_hud.dm
+++ b/code/modules/mob/living/basic/bots/bot_hud.dm
@@ -50,7 +50,7 @@
 	clear_path_hud()
 
 	var/list/path_images = active_hud_list[DIAG_PATH_HUD]
-	QDEL_LIST(path_images)
+	path_images?.Cut()
 
 	var/list/path_huds_watching_me = list(GLOB.huds[DATA_HUD_DIAGNOSTIC_ADVANCED])
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1175,7 +1175,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		hud.remove_atom_from_hud(src)
 
 	var/list/path_images = active_hud_list[DIAG_PATH_HUD]
-	QDEL_LIST(path_images)
+	path_images?.Cut()
 	if(length(newpath))
 		var/mutable_appearance/path_image = new /mutable_appearance()
 		path_image.icon = path_image_icon

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1175,7 +1175,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		hud.remove_atom_from_hud(src)
 
 	var/list/path_images = active_hud_list[DIAG_PATH_HUD]
-	path_images?.Cut()
+	LAZYCLEARLIST(path_images)
 	if(length(newpath))
 		var/mutable_appearance/path_image = new /mutable_appearance()
 		path_image.icon = path_image_icon


### PR DESCRIPTION
## About The Pull Request

(see https://github.com/NovaSector/NovaSector/pull/250 , credit to capsaicinz for tracking these!).

Upstreaming the fixes for some bot hard dels likely brought up by a recent PR.

There are a lot of them because it is qdeleting a whole list of them at a time.

Example log:

![image](https://github.com/tgstation/tgstation/assets/13398309/defe698c-7526-4b95-b49a-5cfee32a97c2)

[link to log](https://tgstation13.org/parsed-logs/sybil/data/logs/2024/01/01/round-221465/qdel.txt)

---

I have also included some context that I have been using to help track image qdels locally, it might be something you want here. If not I can just revert that part.

## Why It's Good For The Game

Should help a ton with lag spikes.

## Changelog

:cl:
fix: fixes an image hard del
code: adds context to image hard dels to make them easier to track
/:cl: