### PR TITLE
Fix Fugu applying wall tearer element to the wrong thing

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/fugu_gland.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/fugu_gland.dm
@@ -38,6 +38,6 @@
 	animal.melee_damage_lower = max((animal.melee_damage_lower * 2), 10)
 	animal.melee_damage_upper = max((animal.melee_damage_upper * 2), 10)
 	animal.transform *= 2
-	AddElement(/datum/element/wall_tearer)
+	animal.AddElement(/datum/element/wall_tearer)
 	to_chat(user, span_info("You increase the size of [animal], giving [animal.p_them()] a surge of strength!"))
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Don't put the element on the item itself, put it on the thing it's being applied to

## Changelog

:cl: Melbert
fix: Fixed Fugu Gland applying to mobs incorrectly
/:cl:

