### PR TITLE
Fix blobbernaut attack runtime on non-living mobs

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
+++ b/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
@@ -145,7 +145,8 @@ GLOBAL_LIST_INIT(valid_blobstrains, subtypesof(/datum/blobstrain) - list(/datum/
 /datum/blobstrain/proc/attack_living(mob/living/L, list/nearby_blobs) // When the blob attacks people
 	send_message(L)
 
-/datum/blobstrain/proc/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut) // When this blob's blobbernaut attacks people
+/// When this blob's blobbernaut attacks any atom
+/datum/blobstrain/proc/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut)
 	return
 
 /datum/blobstrain/proc/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag, coefficient = 1) //when the blob takes damage, do this

--- a/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
+++ b/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
@@ -145,7 +145,8 @@ GLOBAL_LIST_INIT(valid_blobstrains, subtypesof(/datum/blobstrain) - list(/datum/
 /datum/blobstrain/proc/attack_living(mob/living/L, list/nearby_blobs) // When the blob attacks people
 	send_message(L)
 
-/datum/blobstrain/proc/blobbernaut_attack(mob/living/L, blobbernaut) // When this blob's blobbernaut attacks people
+/datum/blobstrain/proc/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut) // When this blob's blobbernaut attacks people
+	return
 
 /datum/blobstrain/proc/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag, coefficient = 1) //when the blob takes damage, do this
 	return coefficient*damage

--- a/code/modules/antagonists/blob/blobstrains/_reagent.dm
+++ b/code/modules/antagonists/blob/blobstrains/_reagent.dm
@@ -11,9 +11,13 @@
 	reagent.expose_mob(L, VAPOR, BLOB_REAGENTATK_VOL, TRUE, mob_protection, overmind)
 	send_message(L)
 
-/datum/blobstrain/reagent/blobbernaut_attack(mob/living/L)
-	var/mob_protection = L.getarmor(null, BIO) * 0.01
-	reagent.expose_mob(L, VAPOR, BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL+blobbernaut_reagentatk_bonus, FALSE, mob_protection, overmind)//this will do between 10 and 20 damage(reduced by mob protection), depending on chemical, plus 4 from base brute damage.
+/datum/blobstrain/reagent/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut)
+	if(!isliving(attacking))
+		return
+
+	var/mob/living/living_attacking = attacking
+	var/mob_protection = living_attacking.getarmor(null, BIO) * 0.01
+	reagent.expose_mob(living_attacking, VAPOR, BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL+blobbernaut_reagentatk_bonus, FALSE, mob_protection, overmind)//this will do between 10 and 20 damage(reduced by mob protection), depending on chemical, plus 4 from base brute damage.
 
 /datum/blobstrain/reagent/on_sporedeath(mob/living/basic/spore)
 	var/burst_range = (spore.type == /mob/living/basic/blob_minion/spore) ? 1 : 0

--- a/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
+++ b/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
@@ -29,7 +29,7 @@
 	for (var/obj/item/I in T)
 		I.forceMove(overmind.blob_core)
 
-/datum/blobstrain/debris_devourer/proc/debris_attack(atom/attacking, source)
+/datum/blobstrain/debris_devourer/proc/debris_attack(atom/attacking, atom/source)
 	var/obj/structure/blob/special/core/core = overmind.blob_core
 	if (prob(40 * DEBRIS_DENSITY)) // Pretend the items are spread through the blob and its mobs and not in the core.
 		var/obj/item/I = length(core.contents) ? pick(core.contents) : null
@@ -37,7 +37,7 @@
 			I.forceMove(get_turf(source))
 			I.throw_at(attacking, 6, 5, overmind, TRUE, FALSE, null, 3)
 
-/datum/blobstrain/debris_devourer/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut) // When this blob's blobbernaut attacks people
+/datum/blobstrain/debris_devourer/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut)
 	debris_attack(attacking, blobbernaut)
 
 /datum/blobstrain/debris_devourer/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag, coefficient = 1) //when the blob takes damage, do this

--- a/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
+++ b/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
@@ -29,16 +29,16 @@
 	for (var/obj/item/I in T)
 		I.forceMove(overmind.blob_core)
 
-/datum/blobstrain/debris_devourer/proc/debris_attack(mob/living/L, source)
+/datum/blobstrain/debris_devourer/proc/debris_attack(atom/attacking, source)
 	var/obj/structure/blob/special/core/core = overmind.blob_core
 	if (prob(40 * DEBRIS_DENSITY)) // Pretend the items are spread through the blob and its mobs and not in the core.
-		var/obj/item/I = pick(core.contents)
-		if (I && !QDELETED(I))
+		var/obj/item/I = length(core.contents) ? pick(core.contents) : null
+		if (!QDELETED(I))
 			I.forceMove(get_turf(source))
-			I.throw_at(L, 6, 5, overmind, TRUE, FALSE, null, 3)
+			I.throw_at(attacking, 6, 5, overmind, TRUE, FALSE, null, 3)
 
-/datum/blobstrain/debris_devourer/blobbernaut_attack(mob/living/L, mob/living/blobbernaut) // When this blob's blobbernaut attacks people
-	debris_attack(L,blobbernaut)
+/datum/blobstrain/debris_devourer/blobbernaut_attack(atom/attacking, mob/living/basic/blobbernaut) // When this blob's blobbernaut attacks people
+	debris_attack(attacking, blobbernaut)
 
 /datum/blobstrain/debris_devourer/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag, coefficient = 1) //when the blob takes damage, do this
 	var/obj/structure/blob/special/core/core = overmind.blob_core


### PR DESCRIPTION
## About The Pull Request

Despite being cast to a living, this argument had no guarantee of being one.

## Changelog

:cl: Melbert
fix: Fixed runtime from blobbernauts attacking non-living things
/:cl:

