### PR TITLE
Fixes redundant "integrity"

### DIFF
--- a/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
@@ -89,7 +89,7 @@ export const Vent = (props: VentProps) => {
               'Overclocking will allow the vent to overpower extreme pressure conditions. However, it will also cause the vent to become damaged over time and eventually fail. The lower the integrity, the less effective the vent will be when in normal operation.'
             }
           >
-            Integrity: {(integrity * 100).toFixed(2)}%
+            {(integrity * 100).toFixed(2)}%
           </p>
         </LabeledList.Item>
         <LabeledList.Item label="Mode">


### PR DESCRIPTION

## About The Pull Request
Air alarms stated Integrity: Integrity: (number)
## Why It's Good For The Game
Bug fix
## Changelog
:cl:
fix: Fixed redundant "Integrity:" in air alarms
/:cl:
