### PR TITLE
Icebox: Adds a fire alarm to the upstairs fore hallway.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -39584,6 +39584,13 @@
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"mdX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "mdZ" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -238581,7 +238588,7 @@ jQU
 psN
 pfe
 aeQ
-gYp
+mdX
 pfe
 duq
 pyW


### PR DESCRIPTION

## About The Pull Request

See title, this hallway had zero fire alarms.

## Why It's Good For The Game

A main hallway should have at least one fire alarm somewhere in it.

## Changelog
:cl:
fix: Icebox: Added a fire alarm to the upstairs fore primary hallway.
/:cl:
