### PR TITLE
Birdshot: Prisoners can leave the gulag again

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -33423,6 +33423,18 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"lTq" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/processing)
 "lTt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40327,6 +40339,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth_half,
 /area/station/engineering/atmos)
 "osY" = (
@@ -46158,6 +46171,9 @@
 	shuttledocked = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/processing)
 "qnj" = (
@@ -62956,6 +62972,16 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
+"vHc" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/processing)
 "vHj" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -70323,8 +70349,10 @@
 	name = "Labor Camp Shuttle Airlock";
 	shuttledocked = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/processing)
 "xLm" = (
@@ -90254,7 +90282,7 @@ xLl
 xur
 bCf
 xur
-xLl
+lTq
 xur
 xpg
 xzE
@@ -91021,7 +91049,7 @@ nCH
 blb
 blb
 wpO
-qnc
+vHc
 xKv
 blb
 xKv

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -33423,18 +33423,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"lTq" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/processing)
 "lTt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40339,7 +40327,6 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/autoname/directional/north,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth_half,
 /area/station/engineering/atmos)
 "osY" = (
@@ -40790,6 +40777,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"oBv" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/processing)
 "oBA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -44945,6 +44942,17 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/station/service/hydroponics/garden)
+"pUS" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/processing)
 "pVa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -62972,16 +62980,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
-"vHc" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/processing)
 "vHj" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -70349,6 +70347,7 @@
 	name = "Labor Camp Shuttle Airlock";
 	shuttledocked = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -90278,11 +90277,11 @@ xur
 nGi
 yaU
 xsF
-xLl
+pUS
 xur
 bCf
 xur
-lTq
+xLl
 xur
 xpg
 xzE
@@ -91049,7 +91048,7 @@ nCH
 blb
 blb
 wpO
-vHc
+oBv
 xKv
 blb
 xKv


### PR DESCRIPTION
## About The Pull Request

Removes the access restrictions from the airlock leading to the prisoner side of birdshot's gulag shuttle. This allows freed gulag prisoners to leave the shuttle without having to wait with no access to a radio until security notices them. Incidentally adds missing cyclelink helpers to the airlocks.

Fixes #80752

## Why It's Good For The Game

They've already done their sentence and shouldn't be kept in purgatory.

## Changelog
:cl:
fix: Birdshot: Released gulag prisoners can now get off the gulag shuttle.
fix: Birdshot: The gulag shuttle airlocks will now cycle like other airlocks.
/:cl:
