### PR TITLE
Fixes a runtime in throwthings

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -233,7 +233,8 @@ SUBSYSTEM_DEF(throwing)
 	if(thrownthing)
 		SEND_SIGNAL(thrownthing, COMSIG_MOVABLE_THROW_LANDED, src)
 		var/turf/landed_turf = get_turf(thrownthing)
-		SEND_SIGNAL(landed_turf, COMSIG_TURF_MOVABLE_THROW_LANDED, thrownthing)
+		if(landed_turf)
+			SEND_SIGNAL(landed_turf, COMSIG_TURF_MOVABLE_THROW_LANDED, thrownthing)
 
 	qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

![tJlDYvPfAy](https://github.com/tgstation/tgstation/assets/13398309/7631077e-8889-4a08-a91c-40007b44b8cc)

This is kinda not great because it causes them to not reach the part of the code where they're supposed to clean up after themselves. Added a safety for it.

![image](https://github.com/tgstation/tgstation/assets/13398309/48b9a791-b9b6-4ce7-8428-ff0184ea5512)

## Why It's Good For The Game

## Changelog

:cl:
fix: fixed a runtime in datum/thrownthing
/:cl:

