### PR TITLE
Fix incorrect carpet reskin options

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -254,6 +254,7 @@
 	turf_type = /turf/open/floor/carpet/black
 	tableVariant = /obj/structure/table/wood/fancy/black
 	merge_type = /obj/item/stack/tile/carpet/black
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/blue
 	name = "blue carpet"
@@ -262,6 +263,7 @@
 	turf_type = /turf/open/floor/carpet/blue
 	tableVariant = /obj/structure/table/wood/fancy/blue
 	merge_type = /obj/item/stack/tile/carpet/blue
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/cyan
 	name = "cyan carpet"
@@ -270,6 +272,7 @@
 	turf_type = /turf/open/floor/carpet/cyan
 	tableVariant = /obj/structure/table/wood/fancy/cyan
 	merge_type = /obj/item/stack/tile/carpet/cyan
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/green
 	name = "green carpet"
@@ -278,6 +281,7 @@
 	turf_type = /turf/open/floor/carpet/green
 	tableVariant = /obj/structure/table/wood/fancy/green
 	merge_type = /obj/item/stack/tile/carpet/green
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/orange
 	name = "orange carpet"
@@ -286,6 +290,7 @@
 	turf_type = /turf/open/floor/carpet/orange
 	tableVariant = /obj/structure/table/wood/fancy/orange
 	merge_type = /obj/item/stack/tile/carpet/orange
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/purple
 	name = "purple carpet"
@@ -294,6 +299,7 @@
 	turf_type = /turf/open/floor/carpet/purple
 	tableVariant = /obj/structure/table/wood/fancy/purple
 	merge_type = /obj/item/stack/tile/carpet/purple
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/red
 	name = "red carpet"
@@ -302,6 +308,7 @@
 	turf_type = /turf/open/floor/carpet/red
 	tableVariant = /obj/structure/table/wood/fancy/red
 	merge_type = /obj/item/stack/tile/carpet/red
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/royalblack
 	name = "royal black carpet"
@@ -310,6 +317,7 @@
 	turf_type = /turf/open/floor/carpet/royalblack
 	tableVariant = /obj/structure/table/wood/fancy/royalblack
 	merge_type = /obj/item/stack/tile/carpet/royalblack
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/royalblue
 	name = "royal blue carpet"
@@ -318,6 +326,7 @@
 	turf_type = /turf/open/floor/carpet/royalblue
 	tableVariant = /obj/structure/table/wood/fancy/royalblue
 	merge_type = /obj/item/stack/tile/carpet/royalblue
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/executive
 	name = "executive carpet"
@@ -325,6 +334,7 @@
 	inhand_icon_state = "tile-carpet-royalblue"
 	turf_type = /turf/open/floor/carpet/executive
 	merge_type = /obj/item/stack/tile/carpet/executive
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/stellar
 	name = "stellar carpet"
@@ -332,6 +342,7 @@
 	inhand_icon_state = "tile-carpet-royalblue"
 	turf_type = /turf/open/floor/carpet/stellar
 	merge_type = /obj/item/stack/tile/carpet/stellar
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/donk
 	name = "\improper Donk Co. promotional carpet"
@@ -339,6 +350,7 @@
 	inhand_icon_state = "tile-carpet-orange"
 	turf_type = /turf/open/floor/carpet/donk
 	merge_type = /obj/item/stack/tile/carpet/donk
+	tile_reskin_types = null
 
 /obj/item/stack/tile/carpet/fifty
 	amount = 50
@@ -386,6 +398,8 @@
 	inhand_icon_state = "tile-neon"
 	turf_type = /turf/open/floor/carpet/neon
 	merge_type = /obj/item/stack/tile/carpet/neon
+	tile_reskin_types = null
+
 
 	// Neon overlay
 	/// The icon used for the neon overlay and emissive overlay.


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/80737 where carpet types with no reskinnable variants showing the default carpet variant.

## Changelog

:cl: LT3
fix: Alternate carpet colors will no longer reskin to normal carpet
/:cl: