### PR TITLE
Fixes some observer hard dels

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -171,10 +171,10 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		mind.current.med_hud_set_status()
 
 	GLOB.ghost_images_default -= ghostimage_default
-	QDEL_NULL(ghostimage_default)
+	ghostimage_default = null
 
 	GLOB.ghost_images_simple -= ghostimage_simple
-	QDEL_NULL(ghostimage_simple)
+	ghostimage_simple = null
 
 	updateallghostimages()
 


### PR DESCRIPTION
## About The Pull Request

Tin. This was another /image hard del that I came across within a given round. AFAIK this was occurring because `updateallghostimages()` removes refs of these images from GLOB.ghost_images_default and GLOB.ghost_images_simple, and this proc was being called after `QDEL_NULL()`. So they were still in the lists at the time of the qdeletion. We don't need to be qdeleting them at all though so let's just set them to null.

![image](https://github.com/tgstation/tgstation/assets/13398309/2397de8c-dbec-4453-8714-eb5ee0c01329)

## Why It's Good For The Game

Reduces the lag.

## Changelog

:cl:
fix: fixed an /image hard del in ghost code
/:cl:
