### PR TITLE
[NO GBP] Fixes a minor bug in buildmode map export

### DIFF
--- a/code/modules/buildmode/submodes/map_export.dm
+++ b/code/modules/buildmode/submodes/map_export.dm
@@ -18,6 +18,8 @@
 		"Object Property Saving" = SAVE_OBJECT_PROPERTIES,
 	)
 	var/what_to_change = tgui_input_list(builder, "What export setting would you like to toggle?", "Map Exporter", options)
+	if (!what_to_change)
+		return
 	save_flag ^= options[what_to_change]
 	to_chat(builder, "<span class='notice'>[what_to_change] is now [save_flag & options[what_to_change] ? "ENABLED" : "DISABLED"].</span>")
 


### PR DESCRIPTION
## About The Pull Request

Simply put, if the value is null, respect the null value and return.

## Why It's Good For The Game

Fixes the game from saying "[blank] is disabled" if you hit cancel or the x on the window

![firefox_SkuH31JBg9](https://github.com/tgstation/tgstation/assets/2568378/86ea5fbf-ac2e-4c2c-b33c-147ea2ae4585)

## Changelog

:cl: SomeRandomOwl
fix: Build Mode Export's options menu now knows when you want to cancel and not change the options
/:cl:
