### PR TITLE
lets traitors buy 3 of the same discounted item, instead of 1

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -104,7 +104,7 @@
 				if((uplink_handler.assigned_role in item.restricted_roles) || (uplink_handler.assigned_species in item.restricted_species))
 					uplink_items += item
 					continue
-		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, 1, uplink_items)
+		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, 3, uplink_items)
 
 	if(give_objectives)
 		forge_traitor_objectives()


### PR DESCRIPTION

## About The Pull Request

traitors can now purchase 3 of the same item if they so desire

## Why It's Good For The Game

i miss seeing mass syndie  bomb bombings, mass hypno flashbangings, and several funny traitors with syndie suits. i think this change will give traitors some more fun gear to play with and make rounds intresting

## Changelog

:cl:
balance: traitors can now purchase 3 of the same discounted item
/:cl:
