### PR TITLE
Remove blind mobs reading ability

### DIFF
--- a/code/game/machinery/dna_infuser/infuser_book.dm
+++ b/code/game/machinery/dna_infuser/infuser_book.dm
@@ -11,7 +11,7 @@
 	drop_sound = 'sound/items/handling/book_drop.ogg'
 	pickup_sound = 'sound/items/handling/book_pickup.ogg'
 
-/obj/item/infuser_book/ui_status(mob/user, /datum/ui_state/state)
+/obj/item/infuser_book/ui_status(mob/user)
 	if(user.is_blind())
 		to_chat(user, span_warning("You are blind and can't read anything!"))
 		return UI_CLOSE

--- a/code/game/machinery/dna_infuser/infuser_book.dm
+++ b/code/game/machinery/dna_infuser/infuser_book.dm
@@ -11,6 +11,14 @@
 	drop_sound = 'sound/items/handling/book_drop.ogg'
 	pickup_sound = 'sound/items/handling/book_pickup.ogg'
 
+/obj/item/infuser_book/ui_status(mob/user, /datum/ui_state/state)
+	if(user.is_blind())
+		to_chat(user, span_warning("You are blind and can't read anything!"))
+		return UI_CLOSE
+	if(!user.can_read(src))
+		return UI_CLOSE
+	return ..()
+
 /obj/item/infuser_book/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -33,8 +33,15 @@
 	return TOXLOSS
 
 /obj/item/newspaper/attack_self(mob/user)
-	if(!istype(user) || !user.can_read(src))
+	if(!istype(user))
 		return
+
+	if(!user.can_read(src))
+		return
+
+	if(user.is_blind())
+		to_chat(user, span_warning("You are blind and can't read anything!"))
+
 	var/dat
 	pages = 0
 	switch(screen)

--- a/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
@@ -136,6 +136,14 @@
 		possible_entry.set_spell_info() //loads up things for the entry that require checking spell instance.
 		entries |= possible_entry
 
+/obj/item/spellbook/ui_status(mob/user, /datum/ui_state/state)
+	if(user.is_blind())
+		to_chat(user, span_warning("You are blind and can't read anything!"))
+		return UI_CLOSE
+	if(!user.can_read(src))
+		return UI_CLOSE
+	return ..()
+
 /obj/item/spellbook/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
@@ -136,7 +136,7 @@
 		possible_entry.set_spell_info() //loads up things for the entry that require checking spell instance.
 		entries |= possible_entry
 
-/obj/item/spellbook/ui_status(mob/user, /datum/ui_state/state)
+/obj/item/spellbook/ui_status(mob/user)
 	if(user.is_blind())
 		to_chat(user, span_warning("You are blind and can't read anything!"))
 		return UI_CLOSE


### PR DESCRIPTION
## About The Pull Request
Blind people can no longer read.

## Why It's Good For The Game
Braille not included.

![stream_free_preview](https://github.com/tgstation/tgstation/assets/5195984/c1bd1133-ffb4-48b3-be01-b944d8fefe84)

## Changelog
:cl:
fix: Remove blind mobs reading ability
/:cl:
