### PR TITLE
Fixing a runtime with H.A.R.S.

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -186,36 +186,44 @@
 		return dismembering.apply_dismember(src, wounding_type)
 
 /obj/item/organ/internal/eyes/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.eyes = src
-	..()
+	if(istype(head))
+		head.eyes = src
+	return ..()
 
 /obj/item/organ/internal/ears/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.ears = src
-	..()
+	if(istype(head))
+		head.ears = src
+	return ..()
 
 /obj/item/organ/internal/tongue/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.tongue = src
-	..()
+	if(istype(head))
+		head.tongue = src
+	return ..()
 
 /obj/item/organ/internal/brain/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.brain = src
-	..()
+	if(istype(head))
+		head.brain = src
+	return ..()
 
 /obj/item/organ/internal/eyes/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.eyes = null
-	..()
+	if(istype(head))
+		head.eyes = null
+	return ..()
 
 /obj/item/organ/internal/ears/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.ears = null
-	..()
+	if(istype(head))
+		head.ears = null
+	return ..()
 
 /obj/item/organ/internal/tongue/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.tongue = null
-	..()
+	if(istype(head))
+		head.tongue = null
+	return ..()
 
 /obj/item/organ/internal/brain/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.brain = null
-	..()
+	if(istype(head))
+		head.brain = null
+	return ..()
 
 /obj/item/bodypart/chest/drop_limb(special, dismembered, move_to_floor = TRUE)
 	if(special)


### PR DESCRIPTION
## About The Pull Request
The brain gets moved into the chest with H.A.R.S. now, but the bodypart insertion and removal procs for it still asume it can only be found in the head. This should fix it. For the sake of preventing similar issues in the future, I've also updated the pretty-much-identical versions for ears, eyes and tongue.

I've checked, and the brain var is only used by the head for visuals and examine strings.

## Why It's Good For The Game
Bugfixing.

## Changelog

:cl:
fix: Fixed H.A.R.S. fucking up the brains a little.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
