### PR TITLE
tgui now disables topics on world reboot, should fix reconnects randomly failing

### DIFF
--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -33,6 +33,7 @@ SUBSYSTEM_DEF(tgui)
 	basehtml = replacetextEx(basehtml, "<!-- tgui:nt-copyright -->", "Nanotrasen (c) 2525-[CURRENT_STATION_YEAR]")
 
 /datum/controller/subsystem/tgui/Shutdown()
+	lock_all_windows()
 	close_all_uis()
 
 /datum/controller/subsystem/tgui/stat_entry(msg)
@@ -236,6 +237,19 @@ SUBSYSTEM_DEF(tgui)
 			ui.close()
 			count++
 	return count
+
+/**
+ * private
+ *
+ * Lock all windows so they will no longer send messages to the server.
+ * This is only to fix a byond bug with reconnects.
+ *
+ * return void
+ */
+/datum/controller/subsystem/tgui/proc/lock_all_windows()
+	for (var/client/client as anything in GLOB.clients)
+		for (var/datum/tgui_window/tgui_window as anything in client?.tgui_windows)
+			tgui_window?.lock_communication()
 
 /**
  * public

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -25,6 +25,7 @@
 	var/initial_inline_js
 	var/initial_inline_css
 	var/mouse_event_macro_set = FALSE
+	var/communication_locked = FALSE
 
 	/**
 	 * Static list used to map in macros that will then emit execute events to the tgui window
@@ -86,6 +87,7 @@
 	src.initial_inline_js = inline_js
 	src.initial_inline_css = inline_css
 	status = TGUI_WINDOW_LOADING
+	communication_locked = FALSE
 	fatally_errored = FALSE
 	// Build window options
 	var/options = "file=[id].html;can_minimize=0;auto_format=0;"
@@ -386,6 +388,20 @@
 			reinitialize()
 		if("chat/resend")
 			SSchat.handle_resend(client, payload)
+
+/**
+ * public
+ *
+ * Blocks all communication with the server until the window is closed or reloaded by browse()
+ */
+/datum/tgui_window/proc/lock_communication()
+	if(!client || isnull(id))
+		return
+	communication_locked = TRUE
+	client << output("", is_browser \
+		? "[id]:lock_communication" \
+		: "[id].browser:lock_communication")
+
 
 /datum/tgui_window/vv_edit_var(var_name, var_value)
 	return var_name != NAMEOF(src, id) && ..()

--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -84,6 +84,14 @@ type ByondType = {
   strictMode: boolean;
 
   /**
+   * If `true`, all byond.topic and byond.send_message calls will silently fail.
+   * This is to deal with a byond bug where sending messages to the server while
+   * a client is reconnecting or the world is rebooting can cause the connection
+   * to die. Set on world reboot.
+   */
+  communicationLocked: boolean;
+
+  /**
    * Makes a BYOND call.
    *
    * If path is empty, this will trigger a Topic call.

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -69,6 +69,9 @@
   // Strict mode flag
   Byond.strictMode = Boolean(Number(parseMetaTag('tgui:strictMode')));
 
+  // communication locked flag
+  Byond.communicationLocked = false;
+
   // Callbacks for asynchronous calls
   Byond.__callbacks__ = [];
 
@@ -144,6 +147,9 @@
   };
 
   Byond.topic = function (params) {
+    if (Byond.communicationLocked) {
+      return;
+    }
     return Byond.call('', params);
   };
 
@@ -467,6 +473,11 @@ window.update = function (rawMessage) {
   for (var i = 0; i < listeners.length; i++) {
     listeners[i](message.type, message.payload);
   }
+};
+
+// locking message handler
+window.lock_communication = function () {
+  Byond.communicationLocked = true;
 };
 
 // Properties and variables of this specific handler


### PR DESCRIPTION
## About The Pull Request
So the main bug that breaks reconnects seems to stem from clients sending messages/topics/commands to the server during a reconnect. my guess is the client is actually sending this down the socket before the connection is ready and the server is aborting the connection for a protocol error because of this. (edit, this guess was correct)

This sets a flag on **__all__** tgui windows (including tgui panels like stat output and the chat panel) on world/reboot that blocks all topics and tgui messages from the client to the server during reconnects, but not raw commands or raw Byond.call(), as those are needed for client side commands like `.reconnect` that the reconnect button uses.

## Why It's Good For The Game

When a player loses connection during round end there is a small likelihood they end their play session there instead of playing one or two more rounds. This causes sharper population drops at night.

## Changelog



:cl:
fix: Improves round end reconnects
/:cl:


(Note, this doesn't solve the same thing happening when the client naturally tries a reconnect. I'll need to play with figuring out ways to know if a client is mid connection attempt using winget or the like which will open the flood gates on things like auto-reconnects. for now an easy target for somebody who understands how the middleware works would be to make the reconnect button in tgui lock communication too)