### PR TITLE
conveyors stop conveying whatever exits their z level

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -248,7 +248,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /obj/machinery/conveyor/proc/conveyable_exit(datum/source, atom/convayable, direction)
 	SIGNAL_HANDLER
 	var/has_conveyor = neighbors["[direction]"]
-	if(!has_conveyor || !isturf(convayable.loc)) //If you've entered something on us, stop moving
+	if(convayable.z != z || !has_conveyor || !isturf(convayable.loc)) //If you've entered something on us, stop moving
 		SSmove_manager.stop_looping(convayable, SSconveyors)
 
 /obj/machinery/conveyor/proc/start_conveying(atom/movable/moving)


### PR DESCRIPTION

## About The Pull Request

not fixed

https://github.com/tgstation/tgstation/assets/70376633/a6269a2f-abaf-48af-98de-561f7b1db8e6


fixed

https://github.com/tgstation/tgstation/assets/70376633/f77fe38d-aa3f-468a-a4fd-95a2dfca0a1f



## Why It's Good For The Game
fixes #80575

## Changelog
:cl:
fix: conveyor belts no longer maintain movement if whatever is on them suddenly leaves their z level
/:cl:
