### PR TITLE
Fixes spasm_animation not resetting to initial values when finishing, slowly moving you downward.

### DIFF
--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -54,17 +54,18 @@
 
 /// Similar to shake but more spasm-y and jerk-y
 /atom/proc/spasm_animation(loops = -1)
+	var/initial_transform = transform
+
 	var/list/transforms = list(
 		matrix(transform).Translate(-1, 0),
 		matrix(transform).Translate(0, 1),
 		matrix(transform).Translate(1, 0),
-		matrix(transform).Translate(0, -1),
 	)
 
 	animate(src, transform = transforms[1], time = 0.2, loop = loops)
 	animate(transform = transforms[2], time = 0.1)
 	animate(transform = transforms[3], time = 0.2)
-	animate(transform = transforms[4], time = 0.3)
+	animate(transform = initial_transform, time = 0.3)
 
 /**
  * Proc called when you want the atom to spin around the center of its icon (or where it would be if its transform var is translated)

--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -60,12 +60,14 @@
 		matrix(transform).Translate(-1, 0),
 		matrix(transform).Translate(0, 1),
 		matrix(transform).Translate(1, 0),
+		matrix(transform).Translate(0, -1),
 	)
 
-	animate(src, transform = transforms[1], time = 0.2, loop = loops)
+	animate(src, transform = transforms[1], time = 0.1, loop = loops)
 	animate(transform = transforms[2], time = 0.1)
 	animate(transform = transforms[3], time = 0.2)
-	animate(transform = initial_transform, time = 0.3)
+	animate(transform = transforms[4], time = 0.3)
+	animate(transform = initial_transform, time = 0.1)
 
 /**
  * Proc called when you want the atom to spin around the center of its icon (or where it would be if its transform var is translated)

--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -54,20 +54,19 @@
 
 /// Similar to shake but more spasm-y and jerk-y
 /atom/proc/spasm_animation(loops = -1)
-	var/initial_transform = transform
-
 	var/list/transforms = list(
 		matrix(transform).Translate(-1, 0),
 		matrix(transform).Translate(0, 1),
 		matrix(transform).Translate(1, 0),
 		matrix(transform).Translate(0, -1),
+		matrix(transform),
 	)
 
 	animate(src, transform = transforms[1], time = 0.1, loop = loops)
 	animate(transform = transforms[2], time = 0.1)
 	animate(transform = transforms[3], time = 0.2)
 	animate(transform = transforms[4], time = 0.3)
-	animate(transform = initial_transform, time = 0.1)
+	animate(transform = transforms[5], time = 0.1)
 
 /**
  * Proc called when you want the atom to spin around the center of its icon (or where it would be if its transform var is translated)


### PR DESCRIPTION
## About The Pull Request
Calling `spasm_animation` repeatedly would slowly make the object move off the screen, moving southward for the winter.

Example of chairs (One had `spasm_animation(10)` called twice, the other wasn't touched:

![image](https://github.com/tgstation/tgstation/assets/49160555/1c20131e-8203-446f-bbb0-d34190f3b470)
Yes this is because it ends with a Translate(0,-1), leaving it a single pixel lower on the y axis than before

Anyhow yes this should be fixed now.

I can't actually confirm they look the same I've been staring at two instances of the game side to side with shaking chairs for so long I might get an actual spasm. They feel the same to me but I suggest you run this yourself and see (I suck at screen recording). 

## Why It's Good For The Game

My OCD cannot allow this to continue, and now that you saw this you will be forever cursed until this is merged

## Changelog
:cl:
fix: spasm_animation now correctly resets the transform, as it should
/:cl:
