### PR TITLE
Restricts cargorilla from antag roles

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
@@ -66,6 +66,7 @@
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 1
 	weight = 11
@@ -197,6 +198,7 @@
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 1
 	weight = 8
@@ -239,6 +241,7 @@
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 1
 	weight = 2

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -237,6 +237,7 @@
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 		ROLE_POSITRONIC_BRAIN,
 	)
 	required_candidates = 1
@@ -441,6 +442,7 @@
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 		ROLE_POSITRONIC_BRAIN,
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
@@ -812,6 +814,7 @@
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 		ROLE_POSITRONIC_BRAIN,
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -22,6 +22,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 1
 	weight = 5
@@ -111,6 +112,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	weight = 5
 	cost = 8
@@ -164,6 +166,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 1
 	weight = 3
@@ -213,6 +216,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 1
 	weight = 3
@@ -333,6 +337,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 		JOB_PRISONER,
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 2
 	weight = 3
@@ -508,6 +513,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 		JOB_RESEARCH_DIRECTOR,
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
+		JOB_CARGO_GORILLA,
 	)
 	required_candidates = 3
 	weight = 3


### PR DESCRIPTION

## About The Pull Request

Adds cargorilla to the `restricted_roles` list for any antag type that could result in an antagonist cargorilla.

Fixes #80776

## Why It's Good For The Game

As per https://github.com/tgstation/tgstation/issues/80776#issuecomment-1877238614 cargorillas rolling antag is unintended and unsupported behaviour (they are pacifist gorillas and can't receive or interact with antag gear properly). They can be removed from the list on a per-antag basis if support is added down the line.

## Changelog
:cl:
fix: Cargo Gorillas can no longer be selected as antagonists.
/:cl:
