### PR TITLE
Stop misfiring from re-iterating and looping through every munition in the mag like that doesn't make much sense.

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -427,10 +427,9 @@
 	return TRUE
 
 /obj/item/gun/ballistic/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	if(magazine && chambered.loaded_projectile && can_misfire && misfire_probability > 0)
-		if(prob(misfire_probability))
-			if(blow_up(user))
-				to_chat(user, span_userdanger("[src] misfires!"))
+	if(target != user && chambered.loaded_projectile && can_misfire && prob(misfire_probability) && blow_up(user))
+		to_chat(user, span_userdanger("[src] misfires!"))
+		return
 
 	if (sawn_off)
 		bonus_spread += SAWN_OFF_ACC_PENALTY
@@ -697,11 +696,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 
 ///used for sawing guns, causes the gun to fire without the input of the user
 /obj/item/gun/ballistic/proc/blow_up(mob/user)
-	. = FALSE
-	for(var/obj/item/ammo_casing/AC in magazine.stored_ammo)
-		if(AC.loaded_projectile)
-			process_fire(user, user, FALSE)
-			. = TRUE
+	return chambered && process_fire(user, user, FALSE)
 
 /obj/item/gun/ballistic/proc/instant_reload()
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
So, the misfiring proc (`blow_up`) can trigger even when the shot is aimed at oneself, which is what the proc does. It also tries  to loop through every loaded projetile in the magazine when you only need the chambered round, which is the one we're going to fire anyway. It's... just plain dumb and can freeze your game for a fair bit.

## Why It's Good For The Game
![immagine](https://github.com/tgstation/tgstation/assets/42542238/f449e6ac-6fc5-4677-b409-c0e67ad3c137)

## Changelog

:cl:
fix: Fixed misfiring for firearms like tinkered detective revolvers.
/:cl:
