### PR TITLE
fixes a bunch of moodlets potentially lasting forever (less band-aidy)

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -49,7 +49,7 @@
 	else
 		viewing = FALSE
 	if(viewing)
-		owner.add_mood_event("creeping", /datum/mood_event/creeping, obsession.name)
+		owner.add_mood_event("creeping", /datum/mood_event/creeping, 1, obsession.name)
 		total_time_creeping += seconds_per_tick SECONDS
 		time_spent_away = 0
 		if(attachedobsessedobj)//if an objective needs to tick down, we can do that since traumas coexist with the antagonist datum
@@ -60,9 +60,9 @@
 /datum/brain_trauma/special/obsessed/proc/out_of_view()
 	time_spent_away += 20
 	if(time_spent_away > 1800) //3 minutes
-		owner.add_mood_event("creeping", /datum/mood_event/notcreepingsevere, obsession.name)
+		owner.add_mood_event("creeping", /datum/mood_event/notcreepingsevere, 1, obsession.name)
 	else
-		owner.add_mood_event("creeping", /datum/mood_event/notcreeping, obsession.name)
+		owner.add_mood_event("creeping", /datum/mood_event/notcreeping, 1, obsession.name)
 
 /datum/brain_trauma/special/obsessed/on_lose()
 	..()

--- a/code/datums/elements/pet_bonus.dm
+++ b/code/datums/elements/pet_bonus.dm
@@ -36,4 +36,4 @@
 	SEND_SIGNAL(pet, COMSIG_ANIMAL_PET, petter, modifiers)
 	if(emote_message && prob(33))
 		pet.manual_emote(emote_message)
-	petter.add_mood_event("petting_bonus", moodlet, pet)
+	petter.add_mood_event("petting_bonus", moodlet, 1, pet)

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -154,18 +154,20 @@
 			clear_mood_event(category)
 		else
 			if (the_event.timeout)
-				if(isnum(timeout_mod))
-					the_event.timeout = initial(the_event.timeout) * timeout_mod
+				if(!isnum(timeout_mod))
+					CRASH("An invalid (non-numeric) timeout_mod was passed to [the_event]. Ask a coder to look at the variables passed through.")
+				the_event.timeout = initial(the_event.timeout) * timeout_mod
 				addtimer(CALLBACK(src, PROC_REF(clear_mood_event), category), the_event.timeout, (TIMER_UNIQUE|TIMER_OVERRIDE))
 			return // Don't need to update the event.
-	var/list/params = args.Copy(3)
+	var/list/params = args.Copy(4)
 
 	params.Insert(1, mob_parent)
 	the_event = new type(arglist(params))
 	if (QDELETED(the_event)) // the mood event has been deleted for whatever reason (requires a job, etc)
 		return
-	if(isnum(timeout_mod))
-		the_event.timeout *= timeout_mod
+	if(!isnum(timeout_mod))
+		CRASH("An invalid (non-numeric) timeout_mod was passed to [the_event]. Ask a coder to look at the variables passed through.")
+	the_event.timeout *= timeout_mod
 	the_event.category = category
 	mood_events[category] = the_event
 	update_mood()
@@ -372,7 +374,7 @@
 
 	update_beauty(new_area)
 	if (new_area.mood_bonus && (!new_area.mood_trait || HAS_TRAIT(source, new_area.mood_trait)))
-		add_mood_event("area", /datum/mood_event/area, new_area.mood_bonus, new_area.mood_message)
+		add_mood_event("area", /datum/mood_event/area, new_area.mood_bonus, 1, new_area.mood_message)
 	else
 		clear_mood_event("area")
 

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -154,7 +154,8 @@
 			clear_mood_event(category)
 		else
 			if (the_event.timeout)
-				the_event.timeout = initial(the_event.timeout) * timeout_mod
+				if(isnum(timeout_mod))
+					the_event.timeout = initial(the_event.timeout) * timeout_mod
 				addtimer(CALLBACK(src, PROC_REF(clear_mood_event), category), the_event.timeout, (TIMER_UNIQUE|TIMER_OVERRIDE))
 			return // Don't need to update the event.
 	var/list/params = args.Copy(3)
@@ -163,8 +164,8 @@
 	the_event = new type(arglist(params))
 	if (QDELETED(the_event)) // the mood event has been deleted for whatever reason (requires a job, etc)
 		return
-
-	the_event.timeout *= timeout_mod
+	if(isnum(timeout_mod))
+		the_event.timeout *= timeout_mod
 	the_event.category = category
 	mood_events[category] = the_event
 	update_mood()

--- a/code/datums/quirks/negative_quirks/body_purist.dm
+++ b/code/datums/quirks/negative_quirks/body_purist.dm
@@ -42,7 +42,7 @@
 /datum/quirk/body_purist/proc/update_mood()
 	quirk_holder.clear_mood_event("body_purist")
 	if(cybernetics_level)
-		quirk_holder.add_mood_event("body_purist", /datum/mood_event/body_purist, -cybernetics_level * 10)
+		quirk_holder.add_mood_event("body_purist", /datum/mood_event/body_purist, 1, -cybernetics_level * 10)
 
 /datum/quirk/body_purist/proc/on_organ_gain(datum/source, obj/item/organ/new_organ, special)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -407,8 +407,8 @@
 		offerer.add_mob_memory(/datum/memory/helped_up, protagonist = offerer, deuteragonist = taker)
 		taker.add_mob_memory(/datum/memory/helped_up, protagonist = offerer, deuteragonist = taker)
 
-		offerer.add_mood_event("helping_up", /datum/mood_event/helped_up, taker, TRUE) // Different IDs because you could be helped up and then help someone else up.
-		taker.add_mood_event("helped_up", /datum/mood_event/helped_up, offerer, FALSE)
+		offerer.add_mood_event("helping_up", /datum/mood_event/helped_up, 1, taker, TRUE) // Different IDs because you could be helped up and then help someone else up.
+		taker.add_mood_event("helped_up", /datum/mood_event/helped_up, 1, offerer, FALSE)
 
 		qdel(src)
 		return
@@ -566,7 +566,7 @@
 		living_target.visible_message(span_danger("[living_target] is hit by \a [src]."), span_userdanger("You're hit by \a [src]!"), vision_distance=COMBAT_MESSAGE_RANGE)
 
 	living_target.add_mob_memory(/datum/memory/kissed, deuteragonist = firer)
-	living_target.add_mood_event("kiss", /datum/mood_event/kiss, firer, suppressed)
+	living_target.add_mood_event("kiss", /datum/mood_event/kiss, 1, firer, suppressed)
 	if(isliving(firer))
 		var/mob/living/kisser = firer
 		kisser.add_mob_memory(/datum/memory/kissed, protagonist = living_target, deuteragonist = firer)
@@ -605,7 +605,7 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/living_target = target
-		living_target.add_mood_event("kiss", /datum/mood_event/kiss, firer, suppressed)
+		living_target.add_mood_event("kiss", /datum/mood_event/kiss, 1, firer, suppressed)
 		try_fluster(living_target)
 
 /obj/projectile/kiss/death

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -204,7 +204,7 @@
 	pushed_mob.visible_message(span_danger("[user] smashes [pushed_mob]'s [banged_limb.plaintext_zone] against \the [src]!"),
 								span_userdanger("[user] smashes your [banged_limb.plaintext_zone] against \the [src]"))
 	log_combat(user, pushed_mob, "head slammed", null, "against [src]")
-	pushed_mob.add_mood_event("table", /datum/mood_event/table_limbsmash, banged_limb)
+	pushed_mob.add_mood_event("table", /datum/mood_event/table_limbsmash, 1, banged_limb)
 
 /obj/structure/table/screwdriver_act_secondary(mob/living/user, obj/item/tool)
 	if(obj_flags & NO_DECONSTRUCTION || !deconstruction_ready)

--- a/code/modules/mob/living/basic/pets/dog/corgi.dm
+++ b/code/modules/mob/living/basic/pets/dog/corgi.dm
@@ -213,7 +213,7 @@
 			user.visible_message(span_notice("[user] pets [src]."), span_notice("You rest your hand on [src]'s head for a moment."))
 			if(flags_1 & HOLOGRAM_1)
 				return
-			user.add_mood_event(REF(src), /datum/mood_event/pet_animal, src)
+			user.add_mood_event(REF(src), /datum/mood_event/pet_animal, 1, src)
 		return FALSE
 
 	if(user && !user.temporarilyRemoveItemFromInventory(item_to_add))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -460,10 +460,10 @@
 			else
 				if(bodytemperature > helper.bodytemperature)
 					if(!HAS_TRAIT(helper, TRAIT_BADTOUCH))
-						helper.add_mood_event("hug", /datum/mood_event/warmhug, src) // Hugger got a warm hug (Unless they hate hugs)
+						helper.add_mood_event("hug", /datum/mood_event/warmhug, 1, src) // Hugger got a warm hug (Unless they hate hugs)
 					add_mood_event("hug", /datum/mood_event/hug) // Receiver always gets a mood for being hugged
 				else
-					add_mood_event("hug", /datum/mood_event/warmhug, helper) // You got a warm hug
+					add_mood_event("hug", /datum/mood_event/warmhug, 1, helper) // You got a warm hug
 		else
 			if (helper.grab_state >= GRAB_AGGRESSIVE)
 				add_mood_event("hug", /datum/mood_event/bad_touch_bear_hug)
@@ -482,9 +482,9 @@
 		if(HAS_TRAIT(helper, TRAIT_FRIENDLY))
 			if (helper.mob_mood.sanity >= SANITY_GREAT)
 				new /obj/effect/temp_visual/heart(loc)
-				add_mood_event("friendly_hug", /datum/mood_event/besthug, helper)
+				add_mood_event("friendly_hug", /datum/mood_event/besthug, 1, helper)
 			else if (helper.mob_mood.sanity >= SANITY_DISTURBED)
-				add_mood_event("friendly_hug", /datum/mood_event/betterhug, helper)
+				add_mood_event("friendly_hug", /datum/mood_event/betterhug, 1, helper)
 
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(helper, span_warning("[src] looks visibly upset as you hug [p_them()]."))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -297,7 +297,7 @@
 					msg += "[t_He] seem[p_s()] sickly.\n"
 				if(mob_mood.sanity <= SANITY_DISTURBED)
 					msg += "[t_He] seem[p_s()] distressed.\n"
-					living_user.add_mood_event("empath", /datum/mood_event/sad_empath, src)
+					living_user.add_mood_event("empath", /datum/mood_event/sad_empath, 1, src)
 				if(is_blind())
 					msg += "[t_He] appear[p_s()] to be staring off into space.\n"
 				if (HAS_TRAIT(src, TRAIT_DEAF))

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -274,7 +274,7 @@
 				return
 
 		if(loaded_rounds && is_target_face)
-			user.add_mood_event("russian_roulette_win", /datum/mood_event/russian_roulette_win, loaded_rounds)
+			user.add_mood_event("russian_roulette_win", /datum/mood_event/russian_roulette_win, 1, loaded_rounds)
 
 		user.visible_message(span_danger("*click*"))
 		playsound(src, dry_fire_sound, 30, TRUE)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -229,7 +229,7 @@ Primarily used in reagents/reaction_agents
 /// Called when an overdose starts. Returning UPDATE_MOB_HEALTH will cause updatehealth() to be called on the holder mob by /datum/reagents/proc/metabolize.
 /datum/reagent/proc/overdose_start(mob/living/affected_mob)
 	to_chat(affected_mob, span_userdanger("You feel like you took too much of [name]!"))
-	affected_mob.add_mood_event("[type]_overdose", /datum/mood_event/overdose, name)
+	affected_mob.add_mood_event("[type]_overdose", /datum/mood_event/overdose, 1, name)
 	return
 
 /**

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -2361,7 +2361,7 @@
 
 /datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
-	drinker.add_mood_event("numb", /datum/mood_event/narcotic_medium, name) //comfortably numb
+	drinker.add_mood_event("numb", /datum/mood_event/narcotic_medium, 1, name) //comfortably numb
 
 /datum/reagent/consumable/ethanol/drunken_espatier/on_mob_metabolize(mob/living/drinker)
 	. = ..()
@@ -2410,7 +2410,7 @@
 /datum/reagent/consumable/ethanol/triumphal_arch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
 	if(islizard(drinker))
-		drinker.add_mood_event("triumph", /datum/mood_event/memories_of_home, name)
+		drinker.add_mood_event("triumph", /datum/mood_event/memories_of_home, 1, name)
 
 /datum/reagent/consumable/ethanol/the_juice
 	name = "The Juice"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -1139,7 +1139,7 @@
 /datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired) //ET loves peanut butter
 	. = ..()
 	if(isabductor(affected_mob))
-		affected_mob.add_mood_event("ET_pieces", /datum/mood_event/et_pieces, name)
+		affected_mob.add_mood_event("ET_pieces", /datum/mood_event/et_pieces, 1, name)
 		affected_mob.set_drugginess(30 SECONDS * REM * seconds_per_tick)
 
 /datum/reagent/consumable/vinegar

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -680,7 +680,7 @@
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(current_cycle > 5)
-		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
+		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, 1, name)
 	switch(current_cycle)
 		if(12)
 			to_chat(affected_mob, span_warning("You start to feel tired...") )

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3019,7 +3019,7 @@
 	// When we exit the system we'll leave the moodlet based on the amount we had
 	var/duration_of_moodlet = current_cycle * 20 SECONDS
 	affected_mob.clear_mood_event(name)
-	affected_mob.add_mood_event(name, /datum/mood_event/love_reagent, duration_of_moodlet)
+	affected_mob.add_mood_event(name, /datum/mood_event/love_reagent, 1, duration_of_moodlet)
 
 /datum/reagent/love/overdose_process(mob/living/metabolizer, seconds_per_tick, times_fired)
 	. = ..()
@@ -3051,9 +3051,9 @@
 /datum/reagent/hauntium/on_mob_metabolize(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	to_chat(affected_mob, span_userdanger("You feel an evil presence inside you!"))
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID))
-		affected_mob.add_mood_event("morbid_hauntium", /datum/mood_event/morbid_hauntium, name) //8 minutes of slight mood buff if undead or morbid
+		affected_mob.add_mood_event("morbid_hauntium", /datum/mood_event/morbid_hauntium, 1, name) //8 minutes of slight mood buff if undead or morbid
 	else
-		affected_mob.add_mood_event("hauntium_spirits", /datum/mood_event/hauntium_spirits, name) //8 minutes of mood debuff
+		affected_mob.add_mood_event("hauntium_spirits", /datum/mood_event/hauntium_spirits, 1, name) //8 minutes of mood debuff
 
 /datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -709,7 +709,7 @@
 	if(affected_mob.toxloss <= 60)
 		need_mob_update += affected_mob.adjustToxLoss(1 * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(current_cycle > 4)
-		affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, name)
+		affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, 1, name)
 	if(current_cycle > 18)
 		affected_mob.Sleeping(40 * REM * normalise_creation_purity() * seconds_per_tick)
 	if(need_mob_update)

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -115,10 +115,10 @@
 
 	if(ismob(target))
 		var/mob/living/target_mob = target
-		target_mob.add_mood_event("soda_spill", /datum/mood_event/soda_spill, src)
+		target_mob.add_mood_event("soda_spill", /datum/mood_event/soda_spill, 1, src)
 		for(var/mob/living/iter_mob in view(src, 7))
 			if(iter_mob != target)
-				iter_mob.add_mood_event("observed_soda_spill", /datum/mood_event/observed_soda_spill, target, src)
+				iter_mob.add_mood_event("observed_soda_spill", /datum/mood_event/observed_soda_spill, 1, target, src)
 
 	playsound(src, 'sound/effects/can_pop.ogg', 80, TRUE)
 	if(!hide_message)

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -106,15 +106,15 @@
 
 /// Called when addiction enters stage 1
 /datum/addiction/proc/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
-	affected_carbon.add_mood_event("[type]_addiction", light_withdrawal_moodlet, name)
+	affected_carbon.add_mood_event("[type]_addiction", light_withdrawal_moodlet, 1, name)
 
 /// Called when addiction enters stage 2
 /datum/addiction/proc/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
-	affected_carbon.add_mood_event("[type]_addiction", medium_withdrawal_moodlet, name)
+	affected_carbon.add_mood_event("[type]_addiction", medium_withdrawal_moodlet, 1, name)
 
 /// Called when addiction enters stage 3
 /datum/addiction/proc/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
-	affected_carbon.add_mood_event("[type]_addiction", severe_withdrawal_moodlet, name)
+	affected_carbon.add_mood_event("[type]_addiction", severe_withdrawal_moodlet, 1, name)
 
 /datum/addiction/proc/end_withdrawal(mob/living/carbon/affected_carbon)
 	LAZYSET(affected_carbon.mind.active_addictions, type, 1) //Keeps withdrawal at first cycle.

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -20,7 +20,7 @@
 		limb_owner.visible_message(span_danger("<B>[limb_owner]'s [name] is violently dismembered!</B>"))
 	INVOKE_ASYNC(limb_owner, TYPE_PROC_REF(/mob, emote), "scream")
 	playsound(get_turf(limb_owner), 'sound/effects/dismember.ogg', 80, TRUE)
-	limb_owner.add_mood_event("dismembered_[body_zone]", /datum/mood_event/dismembered, src)
+	limb_owner.add_mood_event("dismembered_[body_zone]", /datum/mood_event/dismembered, 1, src)
 	limb_owner.add_mob_memory(/datum/memory/was_dismembered, lost_limb = src)
 
 	if (wounding_type)
@@ -344,7 +344,7 @@
 
 	if(new_limb_owner.mob_mood?.has_mood_of_category("dismembered_[body_zone]"))
 		new_limb_owner.clear_mood_event("dismembered_[body_zone]")
-		new_limb_owner.add_mood_event("phantom_pain_[body_zone]", /datum/mood_event/reattachment, src)
+		new_limb_owner.add_mood_event("phantom_pain_[body_zone]", /datum/mood_event/reattachment, 1, src)
 
 	update_bodypart_damage_state()
 	if(can_be_disabled)


### PR DESCRIPTION
## About The Pull Request
In a previous PR (https://github.com/tgstation/tgstation/pull/79661), I noted that a lot of moodlets tended to have their timeouts break because it was passing their names and whatnot as a parameter, that gets fed into the timeout modifier parameter, causing the timeout multiplier to break, because BYOND type-agnosticism means that it can multiply a number (timeout_mod) by text (a name or some other object), resulting in 0 - which makes a moodlet permanent. This is probably not intended.

This fixes that in two ways:
- Adding a `1` to potentially applicable moodlets (searched for with a regex of `.add_mood_event(.*, .*,)`) just to make sure the timeout doesn't get multiplied out weirdly.
- Making the add_mood_event thing CRASH() if the timeout_mod is bad.

If someone else wants to come up with a solution better than this, please do.

## Why It's Good For The Game
Maybe having your arm permanently fall asleep after getting it reattached sucks, moodlet-wise. (Being stuck with permanent positive/negative moodlets is probably not intended.)

## Changelog

:cl:
fix: Moodlets with parameters/effects e.g. limb reattachment moodlets should probably disappear more appropriately.
/:cl: