### PR TITLE
Spamming the weld on a robotic part no longer drains the fuel with no benefit

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -145,14 +145,15 @@
 	if(isnull(affecting) || !IS_ROBOTIC_LIMB(affecting))
 		return NONE
 
-	if(!use_tool(attacked_humanoid, user, 0, volume=50, amount=1))
-		return ITEM_INTERACT_BLOCKING
+	var/use_delay = 0
 
 	if(user == attacked_humanoid)
 		user.visible_message(span_notice("[user] starts to fix some of the dents on [attacked_humanoid]'s [affecting.name]."),
 			span_notice("You start fixing some of the dents on [attacked_humanoid == user ? "your" : "[attacked_humanoid]'s"] [affecting.name]."))
-		if(!do_after(user, 5 SECONDS, attacked_humanoid))
-			return ITEM_INTERACT_BLOCKING
+		use_delay = 5 SECONDS
+
+	if(!use_tool(attacked_humanoid, user, use_delay, volume=50, amount=1))
+		return ITEM_INTERACT_BLOCKING
 
 	item_heal_robotic(attacked_humanoid, user, 15, 0)
 	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION

## About The Pull Request

See name, spamming the self repair will no longer empty your welding tool faster than a clown emptying the captain's office.

## Why It's Good For The Game

It's a bug, annoying one at that

## Changelog

:cl:
fix: Spamming the weld on a robotic part no longer drains the fuel
/:cl:
