### PR TITLE
Makes the clown biodome completable without cheese

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -333,7 +333,7 @@
 /area/ruin/powered/clownplanet)
 "bZ" = (
 /obj/machinery/door/airlock/bananium,
-/turf/open/indestructible/honk,
+/turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "ca" = (
 /obj/item/bikehorn,

--- a/_maps/virtual_domains/clown_planet.dmm
+++ b/_maps/virtual_domains/clown_planet.dmm
@@ -761,7 +761,7 @@
 /area/virtual_domain)
 "WT" = (
 /obj/machinery/door/airlock/bananium,
-/turf/open/indestructible/honk,
+/turf/open/floor/carpet,
 /area/virtual_domain)
 "WX" = (
 /turf/open/indestructible/white,


### PR DESCRIPTION
## About The Pull Request

Removes the last slippery tile of the clown biodome and virtual domain under the treasure room airlock. This makes it possible to complete without either cheesing or having a buddy to throw you in exactly the right way.

Fixes #78784

## Why It's Good For The Game

As per https://github.com/tgstation/tgstation/issues/78784#issuecomment-1749859479 this kind of content should be theoretically possible to complete solo without having to resort to cheesing.

## Changelog
:cl:
fix: The clown planet biodome and virtual domain can now be completed without slipping directly into the exit.
/:cl:
