### PR TITLE
Changes hotkey for head targeting to only target head.

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -65,7 +65,7 @@
 #define COMSIG_KB_MOB_SWAPHANDS_DOWN "keybinding_mob_swaphands_down"
 #define COMSIG_KB_MOB_ACTIVATEINHAND_DOWN "keybinding_mob_activateinhand_down"
 #define COMSIG_KB_MOB_DROPITEM_DOWN "keybinding_mob_dropitem_down"
-#define COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN "keybinding_mob_targetcyclehead_down"
+#define COMSIG_KB_MOB_TARGETHEAD_DOWN "keybinding_mob_targethead_down"
 #define COMSIG_KB_MOB_TARGETEYES_DOWN "keybinding_mob_targeteyes_down"
 #define COMSIG_KB_MOB_TARGETMOUTH_DOWN "keybinding_mob_targetmouth_down"
 #define COMSIG_KB_MOB_TARGETRIGHTARM_DOWN "keybinding_mob_targetrightarm_down"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -78,8 +78,8 @@
 
 	var/original = user.mob.zone_selected
 	switch(keybind_signal)
-		if(COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN)
-			user.body_toggle_head()
+		if(COMSIG_KB_MOB_TARGETHEAD_DOWN)
+			user.body_head()
 		if(COMSIG_KB_MOB_TARGETEYES_DOWN)
 			user.body_eyes()
 		if(COMSIG_KB_MOB_TARGETMOUTH_DOWN)
@@ -101,12 +101,12 @@
 			return FALSE
 	user.mob.log_manual_zone_selected_update("keybind", old_target = original)
 
-/datum/keybinding/mob/target/head_cycle
+/datum/keybinding/mob/target/head
 	hotkey_keys = list("Numpad8")
-	name = "target_head_cycle"
-	full_name = "Target: Cycle Head"
-	description = "Pressing this key targets the head, and continued presses will cycle to the eyes and mouth. This will impact where you hit people, and can be used for surgery."
-	keybind_signal = COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN
+	name = "target_head"
+	full_name = "Target: Head"
+	description = "Pressing this key targets the head. This will impact where you hit people, and can be used for surgery."
+	keybind_signal = COMSIG_KB_MOB_TARGETHEAD_DOWN
 
 /datum/keybinding/mob/target/eyes
 	hotkey_keys = list("Numpad7")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -349,8 +349,7 @@
 	add_mob_memory(/datum/memory/was_slipped, antagonist = slipped_on)
 
 //bodypart selection verbs - Cyberboss
-//8: repeated presses toggles through head - eyes - mouth
-//9: eyes 8: head 7: mouth
+//7: mouth 8: head  9: eyes
 //4: r-arm 5: chest 6: l-arm
 //1: r-leg 2: groin 3: l-leg
 
@@ -359,30 +358,21 @@
 	return mob && mob.hud_used && mob.hud_used.zone_select && istype(mob.hud_used.zone_select, /atom/movable/screen/zone_sel)
 
 /**
- * Hidden verb to set the target zone of a mob to the head
+ * Hidden verbs to set desired body target zone
  *
- * (bound to 8) - repeated presses toggles through head - eyes - mouth
+ * Uses numpad keys 1-9
  */
 
 ///Hidden verb to target the head, bound to 8
-/client/verb/body_toggle_head()
-	set name = "body-toggle-head"
+/client/verb/body_head()
+	set name = "body-head"
 	set hidden = TRUE
 
 	if(!check_has_body_select())
 		return
 
-	var/next_in_line
-	switch(mob.zone_selected)
-		if(BODY_ZONE_HEAD)
-			next_in_line = BODY_ZONE_PRECISE_EYES
-		if(BODY_ZONE_PRECISE_EYES)
-			next_in_line = BODY_ZONE_PRECISE_MOUTH
-		else
-			next_in_line = BODY_ZONE_HEAD
-
 	var/atom/movable/screen/zone_sel/selector = mob.hud_used.zone_select
-	selector.set_selected_zone(next_in_line, mob)
+	selector.set_selected_zone(BODY_ZONE_HEAD, mob)
 
 ///Hidden verb to target the eyes, bound to 7
 /client/verb/body_eyes()


### PR DESCRIPTION
## About The Pull Request

Currently the way the numpad hotkeys work on /tg/ is every key targets one body part... except 8. Numpad 8 Currently cycles through head-eyes-mouth, despite _**numpad 7 already handling mouth and numpad 9 already handling eyes**_. There's no head-only key.

I've changed this to make Numpad 8 exclusively target the head, and adjusted the terminology and comments accordingly in the code.


## Why It's Good For The Game

-It is currently easy to make the mistake of pressing numpad 8 when you mean to target the head, but you may have already been targeting it or the eyes/mouth and now you're not targeting the head and instead of continuing your surgery you stab someone. 

-Also pressing the same key to cycle through multiple settings like that is tedious and a poor design choice.

-This will bring the numpad targeting hotkeys into conformity with each other. They will now only target one body part each.

## Changelog
:cl:
qol: Numpad 8 now ONLY targets head, instead of cycling between head-eyes-mouth.
/:cl:
