### PR TITLE
Correctly offsets bayonets on pipeguns

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -274,6 +274,7 @@
 	alternative_fire_sound = 'sound/weapons/gun/shotgun/shot.ogg'
 	can_modify_ammo = TRUE
 	can_bayonet = TRUE
+	knife_x_offset = 25
 	knife_y_offset = 11
 	can_be_sawn_off = FALSE
 	projectile_damage_multiplier = 0.75


### PR DESCRIPTION

## About The Pull Request

Changes the offset for pipegun bayonets to align with the gun properly.

Fixes #79607

## Why It's Good For The Game

Floating bayonets are ugly

## Changelog
:cl:
fix: Pipeguns no longer have floating bayonets
/:cl:
