### PR TITLE
Less giggles for trace nitrous

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -503,12 +503,12 @@
 /obj/item/organ/internal/lungs/proc/too_much_n2o(mob/living/carbon/breather, datum/gas_mixture/breath, n2o_pp, old_n2o_pp)
 	if(n2o_pp < n2o_para_min)
 		// Small amount of N2O, small side-effects.
-		if(n2o_pp <= 0.01)
-			if(old_n2o_pp > 0.01)
+		if(n2o_pp <= 0.1)
+			if(old_n2o_pp > 0.1)
 				return BREATH_LOST
 			return
 		// No alert for small amounts, but the mob randomly feels euphoric.
-		if(old_n2o_pp >= n2o_para_min || old_n2o_pp <= 0.01)
+		if(old_n2o_pp >= n2o_para_min || old_n2o_pp <= 0.1)
 			breather.clear_alert(ALERT_TOO_MUCH_N2O)
 
 		if(prob(20))


### PR DESCRIPTION

## About The Pull Request

I've increased the minimum amount of n2o required in the air to cause giggling. Threshold is still well below the para and sleep values. 

This should stop people randomly getting drugged and giggly from trace amounts of gas.

I'm not gonna lie I've got no idea how to fully dial this in, so the numbers are an arbitrary 10x increase from .01 mol to .1 mol. I have no idea how breathcode works because irl one breath should only have like  .1 mol in it


## Why It's Good For The Game

After "extensive" real life testing I've determined that giggling and euphoria from trace amounts of the gas is unrealistic.

Also it would be a lot less annoying. @Cheshify also called it qol so I'm sticking with that. 

<img alt="220f1c0470cef181192facef1374bf5c" src="https://github.com/tgstation/tgstation/assets/26744576/1f42cc27-24d0-42c1-a233-f0bae9f1aa77">


## Changelog
:cl:
qol: Increased threshold of trace n2o required to make euphoria and giggles happen.
/:cl:
