### PR TITLE
Runechat color now goes by voice rather than name

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -125,13 +125,6 @@
 	if (length_char(text) > maxlen)
 		text = copytext_char(text, 1, maxlen + 1) + "..." // BYOND index moment
 
-	// Calculate target color if not already present
-	var/voice_name = target.GetVoice()
-	if (!target.chat_color || target.chat_color_name != voice_name)
-		target.chat_color = colorize_string(voice_name)
-		target.chat_color_darkened = colorize_string(voice_name, 0.85, 0.85)
-		target.chat_color_name = voice_name
-
 	// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
 	var/static/regex/url_scheme = new(@"[A-Za-z][A-Za-z0-9+-\.]*:\/\/", "g")
 	text = replacetext(text, url_scheme, "")
@@ -151,6 +144,7 @@
 		extra_classes |= SPAN_YELL
 
 	var/list/prefixes
+	var/chat_color_name_to_use
 
 	// Append radio icon if from a virtual speaker
 	if (extra_classes.Find("virtual-speaker"))
@@ -159,6 +153,19 @@
 	else if (extra_classes.Find("emote"))
 		var/image/r_icon = image('icons/ui_icons/chat/chat_icons.dmi', icon_state = "emote")
 		LAZYADD(prefixes, "\icon[r_icon]")
+		chat_color_name_to_use = target.get_visible_name() // use visible name for nonverbal messages
+
+	if(isnull(chat_color_name_to_use))
+		if(HAS_TRAIT(target, TRAIT_SIGN_LANG))
+			chat_color_name_to_use = target.get_visible_name() // use visible name for signers
+		else
+			chat_color_name_to_use = target.GetVoice() // for everything else, use the target's voice
+
+	// Calculate target color if not already present
+	if (!target.chat_color || target.chat_color_name != chat_color_name_to_use)
+		target.chat_color = colorize_string(chat_color_name_to_use)
+		target.chat_color_darkened = colorize_string(chat_color_name_to_use, 0.85, 0.85)
+		target.chat_color_name = chat_color_name_to_use
 
 	// Append language icon if the language uses one
 	var/datum/language/language_instance = GLOB.language_datum_instances[language]

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -149,13 +149,13 @@
 	else if (extra_classes.Find("emote"))
 		var/image/r_icon = image('icons/ui_icons/chat/chat_icons.dmi', icon_state = "emote")
 		LAZYADD(prefixes, "\icon[r_icon]")
-		chat_color_name_to_use = target.get_visible_name() // use visible name for nonverbal messages
+		chat_color_name_to_use = target.get_face_name() // use face name for nonverbal messages
 
 	if(isnull(chat_color_name_to_use))
 		if(HAS_TRAIT(target, TRAIT_SIGN_LANG))
-			chat_color_name_to_use = target.get_visible_name() // use visible name for signers
+			chat_color_name_to_use = target.get_face_name() // use face name for signers too
 		else
-			chat_color_name_to_use = target.GetVoice() // for everything else, use the target's voice
+			chat_color_name_to_use = target.GetVoice() // for everything else, use the target's voice name
 
 	// Calculate target color if not already present
 	if (!target.chat_color || target.chat_color_name != chat_color_name_to_use)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -126,10 +126,11 @@
 		text = copytext_char(text, 1, maxlen + 1) + "..." // BYOND index moment
 
 	// Calculate target color if not already present
-	if (!target.chat_color || target.chat_color_name != target.name)
-		target.chat_color = colorize_string(target.name)
-		target.chat_color_darkened = colorize_string(target.name, 0.85, 0.85)
-		target.chat_color_name = target.name
+	var/voice_name = target.GetVoice()
+	if (!target.chat_color || target.chat_color_name != voice_name)
+		target.chat_color = colorize_string(voice_name)
+		target.chat_color_darkened = colorize_string(voice_name, 0.85, 0.85)
+		target.chat_color_name = voice_name
 
 	// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
 	var/static/regex/url_scheme = new(@"[A-Za-z][A-Za-z0-9+-\.]*:\/\/", "g")

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -44,10 +44,6 @@
 	var/eol_complete
 	/// Contains the approximate amount of lines for height decay
 	var/approx_lines
-	/// Contains the reference to the next chatmessage in the bucket, used by runechat subsystem
-	var/datum/chatmessage/next
-	/// Contains the reference to the previous chatmessage in the bucket, used by runechat subsystem
-	var/datum/chatmessage/prev
 	/// The current index used for adjusting the layer of each sequential chat message such that recent messages will overlay older ones
 	var/static/current_z_idx = 0
 	/// When we started animating the message

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -149,11 +149,11 @@
 	else if (extra_classes.Find("emote"))
 		var/image/r_icon = image('icons/ui_icons/chat/chat_icons.dmi', icon_state = "emote")
 		LAZYADD(prefixes, "\icon[r_icon]")
-		chat_color_name_to_use = target.get_face_name() // use face name for nonverbal messages
+		chat_color_name_to_use = target.get_visible_name(add_id_name = FALSE) // use face name for nonverbal messages
 
 	if(isnull(chat_color_name_to_use))
 		if(HAS_TRAIT(target, TRAIT_SIGN_LANG))
-			chat_color_name_to_use = target.get_face_name() // use face name for signers too
+			chat_color_name_to_use = target.get_visible_name(add_id_name = FALSE) // use face name for signers too
 		else
 			chat_color_name_to_use = target.GetVoice() // for everything else, use the target's voice name
 

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -101,6 +101,6 @@
 /atom/proc/get_name_chaser(mob/user, list/name_chaser = list())
 	return name_chaser
 
-/// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name.
+/// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name. add_id_name will control whether or not we append "(as [id_name])".
 /atom/proc/get_visible_name(add_id_name = FALSE)
 	return name

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -102,5 +102,5 @@
 	return name_chaser
 
 /// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name.
-/atom/proc/get_face_name(if_no_face="Unknown")
+/atom/proc/get_visible_name(add_id_name = FALSE)
 	return name

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -102,5 +102,5 @@
 	return name_chaser
 
 /// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name. add_id_name will control whether or not we append "(as [id_name])".
-/atom/proc/get_visible_name(add_id_name = FALSE)
+/atom/proc/get_visible_name(add_id_name)
 	return name

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -100,3 +100,7 @@
 ///Used to insert text after the name but before the description in examine()
 /atom/proc/get_name_chaser(mob/user, list/name_chaser = list())
 	return name_chaser
+
+/// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name.
+/atom/proc/get_face_name(if_no_face="Unknown")
+	return name

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -231,7 +231,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return "2"
 	return "0"
 
-/atom/movable/proc/GetVoice()
+/atom/proc/GetVoice()
 	return "[src]" //Returns the atom's name, prepended with 'The' if it's not a proper noun
 
 //HACKY VIRTUALSPEAKER STUFF BEYOND THIS POINT

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -57,7 +57,7 @@
 	return if_no_id
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere
-/mob/living/carbon/human/get_visible_name()
+/mob/living/carbon/human/get_visible_name(add_id_name = TRUE)
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
 		return "Unknown"
 	var/list/identity = list(null, null)
@@ -67,7 +67,7 @@
 	var/face_name = !isnull(signal_face) ? signal_face : get_face_name("")
 	var/id_name = !isnull(signal_id) ? signal_id : get_id_name("")
 	if(face_name)
-		if(id_name && (id_name != face_name))
+		if(add_id_name && id_name && (id_name != face_name))
 			return "[face_name] (as [id_name])"
 		return face_name
 	if(id_name)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -75,7 +75,7 @@
 	return "Unknown"
 
 //Returns "Unknown" if facially disfigured and real_name if not. Useful for setting name when Fluacided or when updating a human's name variable
-/mob/living/carbon/human/get_face_name(if_no_face="Unknown")
+/mob/living/carbon/human/proc/get_face_name(if_no_face="Unknown")
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
 		return if_no_face //We're Unknown, no face information for you
 	if( wear_mask && (wear_mask.flags_inv&HIDEFACE) ) //Wearing a mask which hides our face, use id-name if possible

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -75,7 +75,7 @@
 	return "Unknown"
 
 //Returns "Unknown" if facially disfigured and real_name if not. Useful for setting name when Fluacided or when updating a human's name variable
-/mob/living/carbon/human/proc/get_face_name(if_no_face="Unknown")
+/mob/living/carbon/human/get_face_name(if_no_face="Unknown")
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
 		return if_no_face //We're Unknown, no face information for you
 	if( wear_mask && (wear_mask.flags_inv&HIDEFACE) ) //Wearing a mask which hides our face, use id-name if possible

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1186,9 +1186,6 @@
 /mob/living/proc/resist_restraints()
 	return
 
-/mob/living/proc/get_visible_name()
-	return name
-
 /mob/living/proc/update_gravity(gravity)
 	// Handle movespeed stuff
 	var/speed_change = max(0, gravity - STANDARD_GRAVITY)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1186,7 +1186,7 @@
 /mob/living/proc/resist_restraints()
 	return
 
-/mob/living/proc/get_visible_name()
+/atom/proc/get_visible_name()
 	return name
 
 /mob/living/proc/update_gravity(gravity)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1186,7 +1186,7 @@
 /mob/living/proc/resist_restraints()
 	return
 
-/atom/proc/get_visible_name()
+/mob/living/proc/get_visible_name()
 	return name
 
 /mob/living/proc/update_gravity(gravity)


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. The color you get from runechat is currently tied to your `name`, which doesn't accurately reflect how your character is speaking in all cases.

What this change means: now things like voice changer masks, changeling mimicry, and voice change disease will now actually change the color of your voice to match the mob you are speaking in the voice of.

As a result it should now be impossible to figure out whether someone is voice changing from looking at their runechat color and knowing what the real mob's color was.

## Why It's Good For The Game

Just feels like an oversight that it didn't do this in the first place.

## Changelog
:cl:
fix: if your voice changes (e.g. through a voice changer or changeling mimicry) your runechat will now appear as the mob you are speaking in the voice of
fix: when doing emotes with your face obscured, your runechat color will now appear as either that of Unknown or the mob you are wearing the id of (if you are wearing a mask with someone else's id)
/:cl: