### PR TITLE
Deduplicate hard delete and timer fail flaky tests better

### DIFF
--- a/tools/pull_request_hooks/rerunFlakyTests.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.js
@@ -4,139 +4,139 @@ const TITLE_BOT_HEADER = "title: ";
 // Only check jobs that start with these.
 // Helps make sure we don't restart something like screenshot tests or linters, which are not known to be flaky.
 const CONSIDERED_JOBS = [
-  "Integration Tests",
+	"Integration Tests",
 ];
 
 async function getFailedJobsForRun(github, context, workflowRunId, runAttempt) {
-  const {
-    data: { jobs },
-  } = await github.rest.actions.listJobsForWorkflowRunAttempt({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    run_id: workflowRunId,
-    attempt_number: runAttempt,
-  });
+	const {
+		data: { jobs },
+	} = await github.rest.actions.listJobsForWorkflowRunAttempt({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		run_id: workflowRunId,
+		attempt_number: runAttempt,
+	});
 
-  return jobs
-    .filter((job) => job.conclusion === "failure")
-    .filter((job) =>
-      CONSIDERED_JOBS.some((title) => job.name.startsWith(title))
-    );
+	return jobs
+		.filter((job) => job.conclusion === "failure")
+		.filter((job) =>
+			CONSIDERED_JOBS.some((title) => job.name.startsWith(title))
+		);
 }
 
 export async function rerunFlakyTests({ github, context }) {
-  const failingJobs = await getFailedJobsForRun(
-    github,
-    context,
-    context.payload.workflow_run.id,
-    context.payload.workflow_run.run_attempt
-  );
+	const failingJobs = await getFailedJobsForRun(
+		github,
+		context,
+		context.payload.workflow_run.id,
+		context.payload.workflow_run.run_attempt
+	);
 
-  if (failingJobs.length > 1) {
-    console.log("Multiple jobs failing. PROBABLY not flaky, not rerunning.");
-    return;
-  }
+	if (failingJobs.length > 1) {
+		console.log("Multiple jobs failing. PROBABLY not flaky, not rerunning.");
+		return;
+	}
 
-  if (failingJobs.length === 0) {
-    throw new Error(
-      "rerunFlakyTests should not have run on a run with no failing jobs"
-    );
-  }
+	if (failingJobs.length === 0) {
+		throw new Error(
+			"rerunFlakyTests should not have run on a run with no failing jobs"
+		);
+	}
 
-  github.rest.actions.reRunWorkflowFailedJobs({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    run_id: context.payload.workflow_run.id,
-  });
+	github.rest.actions.reRunWorkflowFailedJobs({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		run_id: context.payload.workflow_run.id,
+	});
 }
 
 // Tries its best to extract a useful error title and message for the given log
 export function extractDetails(log) {
-  // Strip off timestamp
-  const lines = log.split(/^[0-9.:T\-]*?Z /gm);
+	// Strip off timestamp
+	const lines = log.split(/^[0-9.:T\-]*?Z /gm);
 
-  const failureRegex = /^\t?FAILURE #(?<number>[0-9]+): (?<headline>.+)/;
-  const groupRegex = /^##\[group\](?<group>.+)/;
+	const failureRegex = /^\t?FAILURE #(?<number>[0-9]+): (?<headline>.+)/;
+	const groupRegex = /^##\[group\](?<group>.+)/;
 
-  const failures = [];
-  let lastGroup = "root";
-  let loggingFailure;
+	const failures = [];
+	let lastGroup = "root";
+	let loggingFailure;
 
-  const newFailure = (failureMatch) => {
-    const { headline } = failureMatch.groups;
+	const newFailure = (failureMatch) => {
+		const { headline } = failureMatch.groups;
 
-    loggingFailure = {
-      headline,
-      group: lastGroup.replace("/datum/unit_test/", ""),
-      details: [],
-    };
-  };
+		loggingFailure = {
+			headline,
+			group: lastGroup.replace("/datum/unit_test/", ""),
+			details: [],
+		};
+	};
 
-  for (const line of lines) {
-    const groupMatch = line.match(groupRegex);
-    if (groupMatch) {
-      lastGroup = groupMatch.groups.group.trim();
-      continue;
-    }
+	for (const line of lines) {
+		const groupMatch = line.match(groupRegex);
+		if (groupMatch) {
+			lastGroup = groupMatch.groups.group.trim();
+			continue;
+		}
 
-    const failureMatch = line.match(failureRegex);
+		const failureMatch = line.match(failureRegex);
 
-    if (loggingFailure === undefined) {
-      if (!failureMatch) {
-        continue;
-      }
+		if (loggingFailure === undefined) {
+			if (!failureMatch) {
+				continue;
+			}
 
-      newFailure(failureMatch);
-    } else if (failureMatch || line.startsWith("##")) {
-      failures.push(loggingFailure);
-      loggingFailure = undefined;
+			newFailure(failureMatch);
+		} else if (failureMatch || line.startsWith("##")) {
+			failures.push(loggingFailure);
+			loggingFailure = undefined;
 
-      if (failureMatch) {
-        newFailure(failureMatch);
-      }
-    } else {
-      loggingFailure.details.push(line.trim());
-    }
-  }
+			if (failureMatch) {
+				newFailure(failureMatch);
+			}
+		} else {
+			loggingFailure.details.push(line.trim());
+		}
+	}
 
-  // We had no logged failures, there's not really anything we can do here
-  if (failures.length === 0) {
-    return {
-      title: "Flaky test failure with no obvious source",
-      failures,
-    };
-  }
+	// We had no logged failures, there's not really anything we can do here
+	if (failures.length === 0) {
+		return {
+			title: "Flaky test failure with no obvious source",
+			failures,
+		};
+	}
 
-  // We *could* create multiple failures for multiple groups.
-  // This would be important if we had multiple flaky tests at the same time.
-  // I'm choosing not to because it complicates this logic a bit, has the ability to go terribly wrong,
-  // and also because there's something funny to me about that increasing the urgency of fixing
-  // flaky tests. If it becomes a serious issue though, I would not mind this being fixed.
-  const uniqueGroups = new Set(failures.map((failure) => failure.group));
+	// We *could* create multiple failures for multiple groups.
+	// This would be important if we had multiple flaky tests at the same time.
+	// I'm choosing not to because it complicates this logic a bit, has the ability to go terribly wrong,
+	// and also because there's something funny to me about that increasing the urgency of fixing
+	// flaky tests. If it becomes a serious issue though, I would not mind this being fixed.
+	const uniqueGroups = new Set(failures.map((failure) => failure.group));
 
-  if (uniqueGroups.size > 1) {
-    return {
-      title: `Multiple flaky test failures in ${Array.from(uniqueGroups)
-        .sort()
-        .join(", ")}`,
-      failures,
-    };
-  }
+	if (uniqueGroups.size > 1) {
+		return {
+			title: `Multiple flaky test failures in ${Array.from(uniqueGroups)
+				.sort()
+				.join(", ")}`,
+			failures,
+		};
+	}
 
-  const failGroup = failures[0].group;
+	const failGroup = failures[0].group;
 
-  if (failures.length > 1) {
-    return {
-      title: `Multiple errors in flaky test ${failGroup}`,
-      failures,
-    };
-  }
+	if (failures.length > 1) {
+		return {
+			title: `Multiple errors in flaky test ${failGroup}`,
+			failures,
+		};
+	}
 
-  const failure = failures[0];
+	const failure = failures[0];
 
-  // Common patterns where we can always get a detailed title
-  const runtimeMatch = failure.headline.match(/Runtime in .+?: (?<error>.+)/);
-  if (runtimeMatch) {
+	// Common patterns where we can always get a detailed title
+	const runtimeMatch = failure.headline.match(/Runtime in .+?: (?<error>.+)/);
+	if (runtimeMatch) {
 		const runtime = runtimeMatch.groups.error.trim();
 
 		const invalidTimerMatch = runtime.match(/^Invalid timer:.+object:(?<object>[^[]+).*delegate:(?<proc>.+?), source:/);
@@ -147,11 +147,11 @@ export function extractDetails(log) {
 			};
 		}
 
-    return {
-      title: `Flaky test ${failGroup}: ${runtime}`,
-      failures,
-    };
-  }
+		return {
+			title: `Flaky test ${failGroup}: ${runtime}`,
+			failures,
+		};
+	}
 
 	const hardDelMatch = failure.headline.match(/^(?<object>\/[\w/]+) hard deleted .* times out of a total del count of/);
 	if (hardDelMatch) {
@@ -161,64 +161,64 @@ export function extractDetails(log) {
 		};
 	}
 
-  // Try to normalize the title and remove anything that might be variable
-  const normalizedError = failure.headline.replace(/\s*at .+?:[0-9]+.*/g, ""); // "<message> at code.dm:123"
+	// Try to normalize the title and remove anything that might be variable
+	const normalizedError = failure.headline.replace(/\s*at .+?:[0-9]+.*/g, ""); // "<message> at code.dm:123"
 
-  return {
-    title: `Flaky test ${failGroup}: ${normalizedError}`,
-    failures,
-  };
+	return {
+		title: `Flaky test ${failGroup}: ${normalizedError}`,
+		failures,
+	};
 }
 
 async function getExistingIssueId(graphql, context, title) {
-  // Hope you never have more than 100 of these open!
-  const {
-    repository: {
-      issues: { nodes: openFlakyTestIssues },
-    },
-  } = await graphql(
-    `
-      query ($owner: String!, $repo: String!, $label: String!) {
-        repository(owner: $owner, name: $repo) {
-          issues(
-            labels: [$label]
-            first: 100
-            orderBy: { field: CREATED_AT, direction: DESC }
-            states: [OPEN]
-          ) {
-            nodes {
-              number
-              title
-              body
-            }
-          }
-        }
-      }
-    `,
-    {
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      label: LABEL,
-    }
-  );
+	// Hope you never have more than 100 of these open!
+	const {
+		repository: {
+			issues: { nodes: openFlakyTestIssues },
+		},
+	} = await graphql(
+		`
+			query ($owner: String!, $repo: String!, $label: String!) {
+				repository(owner: $owner, name: $repo) {
+					issues(
+						labels: [$label]
+						first: 100
+						orderBy: { field: CREATED_AT, direction: DESC }
+						states: [OPEN]
+					) {
+						nodes {
+							number
+							title
+							body
+						}
+					}
+				}
+			}
+		`,
+		{
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			label: LABEL,
+		}
+	);
 
-  const exactTitle = openFlakyTestIssues.find((issue) => issue.title === title);
-  if (exactTitle !== undefined) {
-    return exactTitle.number;
-  }
+	const exactTitle = openFlakyTestIssues.find((issue) => issue.title === title);
+	if (exactTitle !== undefined) {
+		return exactTitle.number;
+	}
 
-  const foundInBody = openFlakyTestIssues.find((issue) =>
-    issue.body.includes(`<!-- ${TITLE_BOT_HEADER}${exactTitle} -->`)
-  );
-  if (foundInBody !== undefined) {
-    return foundInBody.number;
-  }
+	const foundInBody = openFlakyTestIssues.find((issue) =>
+		issue.body.includes(`<!-- ${TITLE_BOT_HEADER}${exactTitle} -->`)
+	);
+	if (foundInBody !== undefined) {
+		return foundInBody.number;
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function createBody({ title, failures }, runUrl) {
-  return `
+	return `
 	<!-- This issue can be renamed, but do not change the next comment! -->
 	<!-- title: ${title} -->
 
@@ -227,67 +227,67 @@ function createBody({ title, failures }, runUrl) {
 	Failures:
 	\`\`\`
 	${failures
-    .map(
-      (failure) =>
-        `${failure.group}: ${failure.headline}\n\t${failure.details.join("\n")}`
-    )
-    .join("\n")}
+		.map(
+			(failure) =>
+				`${failure.group}: ${failure.headline}\n\t${failure.details.join("\n")}`
+		)
+		.join("\n")}
 	\`\`\`
 	`.replace(/^\s*/gm, "");
 }
 
 export async function reportFlakyTests({ github, context }) {
-  const failedJobsFromLastRun = await getFailedJobsForRun(
-    github,
-    context,
-    context.payload.workflow_run.id,
-    context.payload.workflow_run.run_attempt - 1
-  );
+	const failedJobsFromLastRun = await getFailedJobsForRun(
+		github,
+		context,
+		context.payload.workflow_run.id,
+		context.payload.workflow_run.run_attempt - 1
+	);
 
-  // This could one day be relaxed if we face serious enough flaky test problems, so we're going to loop anyway
-  if (failedJobsFromLastRun.length !== 1) {
-    console.log(
-      "Multiple jobs failing after retry, assuming maintainer rerun."
-    );
+	// This could one day be relaxed if we face serious enough flaky test problems, so we're going to loop anyway
+	if (failedJobsFromLastRun.length !== 1) {
+		console.log(
+			"Multiple jobs failing after retry, assuming maintainer rerun."
+		);
 
-    return;
-  }
+		return;
+	}
 
-  for (const job of failedJobsFromLastRun) {
-    const { data: log } =
-      await github.rest.actions.downloadJobLogsForWorkflowRun({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        job_id: job.id,
-      });
+	for (const job of failedJobsFromLastRun) {
+		const { data: log } =
+			await github.rest.actions.downloadJobLogsForWorkflowRun({
+				owner: context.repo.owner,
+				repo: context.repo.repo,
+				job_id: job.id,
+			});
 
-    const details = extractDetails(log);
+		const details = extractDetails(log);
 
-    const existingIssueId = await getExistingIssueId(
-      github.graphql,
-      context,
-      details.title
-    );
+		const existingIssueId = await getExistingIssueId(
+			github.graphql,
+			context,
+			details.title
+		);
 
-    if (existingIssueId !== undefined) {
-      // Maybe in the future, if it's helpful, update the existing issue with new links
-      console.log(`Existing issue found: #${existingIssueId}`);
-      return;
-    }
+		if (existingIssueId !== undefined) {
+			// Maybe in the future, if it's helpful, update the existing issue with new links
+			console.log(`Existing issue found: #${existingIssueId}`);
+			return;
+		}
 
-    await github.rest.issues.create({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      title: details.title,
-      labels: [LABEL],
-      body: createBody(
-        details,
-        `https://github.com/${context.repo.owner}/${
-          context.repo.repo
-        }/actions/runs/${context.payload.workflow_run.id}/attempts/${
-          context.payload.workflow_run.run_attempt - 1
-        }`
-      ),
-    });
-  }
+		await github.rest.issues.create({
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			title: details.title,
+			labels: [LABEL],
+			body: createBody(
+				details,
+				`https://github.com/${context.repo.owner}/${
+					context.repo.repo
+				}/actions/runs/${context.payload.workflow_run.id}/attempts/${
+					context.payload.workflow_run.run_attempt - 1
+				}`
+			),
+		});
+	}
 }

--- a/tools/pull_request_hooks/rerunFlakyTests.test.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.test.js
@@ -3,38 +3,38 @@ import fs from "node:fs";
 import { extractDetails } from "./rerunFlakyTests.js";
 
 function extractDetailsFromPayload(filename) {
-  return extractDetails(
-    fs.readFileSync(`tests/flakyTestPayloads/${filename}.txt`, {
-      encoding: "utf8",
-    })
-  );
+	return extractDetails(
+		fs.readFileSync(`tests/flakyTestPayloads/${filename}.txt`, {
+			encoding: "utf8",
+		})
+	);
 }
 
 const chatClient = extractDetailsFromPayload("chat_client");
 assert.equal(
-  chatClient.title,
-  "Flaky hard delete: /datum/computer_file/program/chatclient"
+	chatClient.title,
+	"Flaky hard delete: /datum/computer_file/program/chatclient"
 );
 assert.equal(chatClient.failures.length, 1);
 
 const monkeyBusiness = extractDetailsFromPayload("monkey_business");
 assert.equal(
-  monkeyBusiness.title,
-  "Flaky test monkey_business: Cannot execute null.resolve()."
+	monkeyBusiness.title,
+	"Flaky test monkey_business: Cannot execute null.resolve()."
 );
 assert.equal(monkeyBusiness.failures.length, 1);
 
 const shapeshift = extractDetailsFromPayload("shapeshift");
 assert.equal(
-  shapeshift.title,
-  "Multiple errors in flaky test shapeshift_spell"
+	shapeshift.title,
+	"Multiple errors in flaky test shapeshift_spell"
 );
 assert.equal(shapeshift.failures.length, 16);
 
 const multipleFailures = extractDetailsFromPayload("multiple_failures");
 assert.equal(
-  multipleFailures.title,
-  "Multiple flaky test failures in more_shapeshift_spell, shapeshift_spell"
+	multipleFailures.title,
+	"Multiple flaky test failures in more_shapeshift_spell, shapeshift_spell"
 );
 assert.equal(multipleFailures.failures.length, 2);
 

--- a/tools/pull_request_hooks/rerunFlakyTests.test.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.test.js
@@ -13,7 +13,7 @@ function extractDetailsFromPayload(filename) {
 const chatClient = extractDetailsFromPayload("chat_client");
 assert.equal(
   chatClient.title,
-  "Flaky test create_and_destroy: /datum/computer_file/program/chatclient hard deleted 1 times out of a total del count of 13"
+  "Flaky hard delete: /datum/computer_file/program/chatclient"
 );
 assert.equal(chatClient.failures.length, 1);
 
@@ -37,3 +37,9 @@ assert.equal(
   "Multiple flaky test failures in more_shapeshift_spell, shapeshift_spell"
 );
 assert.equal(multipleFailures.failures.length, 2);
+
+const invalidTimer = extractDetailsFromPayload("invalid_timer");
+assert.equal(
+	invalidTimer.title,
+	"Flaky test monkey_business: Invalid timer: /datum/looping_sound/proc/start_sound_loop() on /datum/looping_sound/showering"
+);

--- a/tools/pull_request_hooks/tests/flakyTestPayloads/invalid_timer.txt
+++ b/tools/pull_request_hooks/tests/flakyTestPayloads/invalid_timer.txt
@@ -1,0 +1,2389 @@
+2023-11-12T08:57:50.1971985Z Requested labels: ubuntu-latest
+2023-11-12T08:57:50.1972288Z Job defined at: tgstation/tgstation/.github/workflows/run_integration_tests.yml@refs/pull/79384/merge
+2023-11-12T08:57:50.1972523Z Reusable workflow chain:
+2023-11-12T08:57:50.1972632Z tgstation/tgstation/.github/workflows/ci_suite.yml@refs/pull/79384/merge (0f52a54577af8e336ee4407c83bc6d3bfedd1d11)
+2023-11-12T08:57:50.1972727Z -> tgstation/tgstation/.github/workflows/run_integration_tests.yml@refs/pull/79384/merge (0f52a54577af8e336ee4407c83bc6d3bfedd1d11)
+2023-11-12T08:57:50.1972819Z Waiting for a runner to pick up this job...
+2023-11-12T08:59:41.2590058Z Job is waiting for a hosted runner to come online.
+2023-11-12T08:59:44.1017042Z Job is about to start running on the hosted runner: GitHub Actions 11 (hosted)
+2023-11-12T08:59:46.1455792Z Current runner version: '2.311.0'
+2023-11-12T08:59:46.1479790Z ##[group]Operating System
+2023-11-12T08:59:46.1480441Z Ubuntu
+2023-11-12T08:59:46.1480899Z 22.04.3
+2023-11-12T08:59:46.1481734Z LTS
+2023-11-12T08:59:46.1482077Z ##[endgroup]
+2023-11-12T08:59:46.1482560Z ##[group]Runner Image
+2023-11-12T08:59:46.1482961Z Image: ubuntu-22.04
+2023-11-12T08:59:46.1483353Z Version: 20231030.2.0
+2023-11-12T08:59:46.1484421Z Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20231030.2/images/linux/Ubuntu2204-Readme.md
+2023-11-12T08:59:46.1485799Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20231030.2
+2023-11-12T08:59:46.1486650Z ##[endgroup]
+2023-11-12T08:59:46.1487161Z ##[group]Runner Image Provisioner
+2023-11-12T08:59:46.1487606Z 2.0.312.1
+2023-11-12T08:59:46.1487945Z ##[endgroup]
+2023-11-12T08:59:46.1490099Z ##[group]GITHUB_TOKEN Permissions
+2023-11-12T08:59:46.1491698Z Actions: read
+2023-11-12T08:59:46.1492248Z Checks: read
+2023-11-12T08:59:46.1492761Z Contents: read
+2023-11-12T08:59:46.1493311Z Deployments: read
+2023-11-12T08:59:46.1493676Z Discussions: read
+2023-11-12T08:59:46.1494123Z Issues: read
+2023-11-12T08:59:46.1494582Z Metadata: read
+2023-11-12T08:59:46.1494935Z Packages: read
+2023-11-12T08:59:46.1495330Z Pages: read
+2023-11-12T08:59:46.1495763Z PullRequests: read
+2023-11-12T08:59:46.1496142Z RepositoryProjects: read
+2023-11-12T08:59:46.1496603Z SecurityEvents: read
+2023-11-12T08:59:46.1497060Z Statuses: read
+2023-11-12T08:59:46.1497394Z ##[endgroup]
+2023-11-12T08:59:46.1500314Z Secret source: None
+2023-11-12T08:59:46.1501009Z Prepare workflow directory
+2023-11-12T08:59:46.2366322Z Prepare all required actions
+2023-11-12T08:59:46.2521312Z Getting action download info
+2023-11-12T08:59:46.4989409Z Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e18286ca9a3d1956744)
+2023-11-12T08:59:46.6372596Z Download action repository 'actions/cache@v3' (SHA:704facf57e6136b1bc63b828d79edcd491f0ee84)
+2023-11-12T08:59:46.7365405Z Download action repository 'actions/upload-artifact@v3' (SHA:a8a3f3ad30e3422c9c7b888a15615d19a852ae32)
+2023-11-12T08:59:46.7793243Z Download action repository 'tgstation/byond-client-compatibility-check@v3' (SHA:d9fac1c9713569fa6681906325ddce115bb53365)
+2023-11-12T08:59:47.0659791Z Uses: tgstation/tgstation/.github/workflows/run_integration_tests.yml@refs/pull/79384/merge (0f52a54577af8e336ee4407c83bc6d3bfedd1d11)
+2023-11-12T08:59:47.0662504Z ##[group] Inputs
+2023-11-12T08:59:47.0663016Z   map: tramstation
+2023-11-12T08:59:47.0663530Z   major:
+2023-11-12T08:59:47.0663853Z   minor:
+2023-11-12T08:59:47.0664217Z   max_required_byond_client: 514
+2023-11-12T08:59:47.0664786Z ##[endgroup]
+2023-11-12T08:59:47.0665727Z Complete job name: Integration Tests (tramstation) / run_integration_tests
+2023-11-12T08:59:47.1316890Z ##[group]Checking docker version
+2023-11-12T08:59:47.1331488Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2023-11-12T08:59:47.2035568Z '1.43'
+2023-11-12T08:59:47.2048856Z Docker daemon API version: '1.43'
+2023-11-12T08:59:47.2049704Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2023-11-12T08:59:47.2209793Z '1.43'
+2023-11-12T08:59:47.2229627Z Docker client API version: '1.43'
+2023-11-12T08:59:47.2235325Z ##[endgroup]
+2023-11-12T08:59:47.2239282Z ##[group]Clean up resources from previous jobs
+2023-11-12T08:59:47.2245596Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=bae3f2"
+2023-11-12T08:59:47.2382764Z ##[command]/usr/bin/docker network prune --force --filter "label=bae3f2"
+2023-11-12T08:59:47.2513406Z ##[endgroup]
+2023-11-12T08:59:47.2513906Z ##[group]Create local container network
+2023-11-12T08:59:47.2524774Z ##[command]/usr/bin/docker network create --label bae3f2 github_network_bc2270e2d9644957ba98982ec5cf35f2
+2023-11-12T08:59:47.3421425Z 7e144ec3bd040fce7400908b83369d64424efaa98e355fff9ec0d703a41602b1
+2023-11-12T08:59:47.3441937Z ##[endgroup]
+2023-11-12T08:59:47.3517647Z ##[group]Starting mysql service container
+2023-11-12T08:59:47.3536963Z ##[command]/usr/bin/docker pull mysql:latest
+2023-11-12T08:59:47.5471538Z latest: Pulling from library/mysql
+2023-11-12T08:59:47.5925068Z 8e0176adc18c: Pulling fs layer
+2023-11-12T08:59:47.5926146Z 2d2c52718f65: Pulling fs layer
+2023-11-12T08:59:47.5926867Z d88d03ce139b: Pulling fs layer
+2023-11-12T08:59:47.5927652Z 4a7d7f11aa1e: Pulling fs layer
+2023-11-12T08:59:47.5928644Z ce5949193e4c: Pulling fs layer
+2023-11-12T08:59:47.5929143Z f7f024dfb329: Pulling fs layer
+2023-11-12T08:59:47.5929598Z 5fc3c840facc: Pulling fs layer
+2023-11-12T08:59:47.5930195Z 509068e49488: Pulling fs layer
+2023-11-12T08:59:47.5930586Z cbc847bab598: Pulling fs layer
+2023-11-12T08:59:47.5930994Z 942bef62a146: Pulling fs layer
+2023-11-12T08:59:47.5931450Z f7f024dfb329: Waiting
+2023-11-12T08:59:47.5931833Z 5fc3c840facc: Waiting
+2023-11-12T08:59:47.5932180Z 509068e49488: Waiting
+2023-11-12T08:59:47.5932601Z cbc847bab598: Waiting
+2023-11-12T08:59:47.5932952Z 942bef62a146: Waiting
+2023-11-12T08:59:47.5933295Z 4a7d7f11aa1e: Waiting
+2023-11-12T08:59:47.5933717Z ce5949193e4c: Waiting
+2023-11-12T08:59:47.6370843Z 2d2c52718f65: Verifying Checksum
+2023-11-12T08:59:47.6371886Z 2d2c52718f65: Download complete
+2023-11-12T08:59:47.6628390Z d88d03ce139b: Verifying Checksum
+2023-11-12T08:59:47.6630340Z d88d03ce139b: Download complete
+2023-11-12T08:59:47.7021669Z ce5949193e4c: Verifying Checksum
+2023-11-12T08:59:47.7022614Z ce5949193e4c: Download complete
+2023-11-12T08:59:47.7184829Z 4a7d7f11aa1e: Verifying Checksum
+2023-11-12T08:59:47.7185700Z 4a7d7f11aa1e: Download complete
+2023-11-12T08:59:47.7547210Z f7f024dfb329: Download complete
+2023-11-12T08:59:47.8055625Z 509068e49488: Verifying Checksum
+2023-11-12T08:59:47.8057291Z 509068e49488: Download complete
+2023-11-12T08:59:48.0054531Z 8e0176adc18c: Verifying Checksum
+2023-11-12T08:59:48.0055844Z 8e0176adc18c: Download complete
+2023-11-12T08:59:48.0721310Z 942bef62a146: Verifying Checksum
+2023-11-12T08:59:48.0723241Z 942bef62a146: Download complete
+2023-11-12T08:59:48.2055324Z 5fc3c840facc: Verifying Checksum
+2023-11-12T08:59:48.2056029Z 5fc3c840facc: Download complete
+2023-11-12T08:59:48.2822740Z cbc847bab598: Verifying Checksum
+2023-11-12T08:59:48.2824083Z cbc847bab598: Download complete
+2023-11-12T08:59:49.3079176Z 8e0176adc18c: Pull complete
+2023-11-12T08:59:49.6617199Z 2d2c52718f65: Pull complete
+2023-11-12T08:59:49.6872468Z d88d03ce139b: Pull complete
+2023-11-12T08:59:49.8872416Z 4a7d7f11aa1e: Pull complete
+2023-11-12T08:59:49.9014484Z ce5949193e4c: Pull complete
+2023-11-12T08:59:49.9174666Z f7f024dfb329: Pull complete
+2023-11-12T08:59:51.3130074Z 5fc3c840facc: Pull complete
+2023-11-12T08:59:51.3233267Z 509068e49488: Pull complete
+2023-11-12T08:59:56.1487617Z cbc847bab598: Pull complete
+2023-11-12T08:59:56.6779169Z 942bef62a146: Pull complete
+2023-11-12T08:59:56.6823169Z Digest: sha256:1773f3c7aa9522f0014d0ad2bbdaf597ea3b1643c64c8ccc2123c64afd8b82b1
+2023-11-12T08:59:56.6835281Z Status: Downloaded newer image for mysql:latest
+2023-11-12T08:59:56.6843575Z docker.io/library/mysql:latest
+2023-11-12T08:59:56.6952276Z ##[command]/usr/bin/docker create --name c43e2a4f7a0044eda3c3640d7583be1f_mysqllatest_210664 --label bae3f2 --network github_network_bc2270e2d9644957ba98982ec5cf35f2 --network-alias mysql -p 3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ROOT_PASSWORD=root" -e GITHUB_ACTIONS=true -e CI=true mysql:latest
+2023-11-12T08:59:56.7205373Z 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T08:59:56.7226574Z ##[command]/usr/bin/docker start 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T08:59:57.0122389Z 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T08:59:57.0147762Z ##[command]/usr/bin/docker ps --all --filter id=37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2023-11-12T08:59:57.0270403Z 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded Up Less than a second (health: starting)
+2023-11-12T08:59:57.0292510Z ##[command]/usr/bin/docker port 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T08:59:57.0413612Z 3306/tcp -> 0.0.0.0:32768
+2023-11-12T08:59:57.0414454Z 3306/tcp -> [::]:32768
+2023-11-12T08:59:57.0511341Z ##[endgroup]
+2023-11-12T08:59:57.0545971Z ##[group]Waiting for all services to be ready
+2023-11-12T08:59:57.0594766Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T08:59:57.0736995Z starting
+2023-11-12T08:59:57.0767183Z mysql service is starting, waiting 2 seconds before checking again.
+2023-11-12T08:59:59.0767458Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T08:59:59.0896661Z starting
+2023-11-12T08:59:59.0908862Z mysql service is starting, waiting 4 seconds before checking again.
+2023-11-12T09:00:03.1488036Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T09:00:03.1606151Z starting
+2023-11-12T09:00:03.1617891Z mysql service is starting, waiting 8 seconds before checking again.
+2023-11-12T09:00:11.5749953Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T09:00:11.5876640Z healthy
+2023-11-12T09:00:11.5893980Z mysql service is healthy.
+2023-11-12T09:00:11.5894520Z ##[endgroup]
+2023-11-12T09:00:11.6253438Z ##[group]Run actions/checkout@v3
+2023-11-12T09:00:11.6253862Z with:
+2023-11-12T09:00:11.6254192Z   repository: tgstation/tgstation
+2023-11-12T09:00:11.6254857Z   token: ***
+2023-11-12T09:00:11.6255173Z   ssh-strict: true
+2023-11-12T09:00:11.6255558Z   persist-credentials: true
+2023-11-12T09:00:11.6256022Z   clean: true
+2023-11-12T09:00:11.6256343Z   sparse-checkout-cone-mode: true
+2023-11-12T09:00:11.6256740Z   fetch-depth: 1
+2023-11-12T09:00:11.6257139Z   fetch-tags: false
+2023-11-12T09:00:11.6257424Z   lfs: false
+2023-11-12T09:00:11.6257739Z   submodules: false
+2023-11-12T09:00:11.6258160Z   set-safe-directory: true
+2023-11-12T09:00:11.6258498Z ##[endgroup]
+2023-11-12T09:00:11.7905131Z Syncing repository: tgstation/tgstation
+2023-11-12T09:00:11.7906924Z ##[group]Getting Git version info
+2023-11-12T09:00:11.7907608Z Working directory is '/home/runner/work/tgstation/tgstation'
+2023-11-12T09:00:11.7908545Z [command]/usr/bin/git version
+2023-11-12T09:00:11.7926430Z git version 2.42.0
+2023-11-12T09:00:11.7950009Z ##[endgroup]
+2023-11-12T09:00:11.7969428Z Temporarily overriding HOME='/home/runner/work/_temp/36501371-137a-461b-978e-be8cc4242865' before making global git config changes
+2023-11-12T09:00:11.7971339Z Adding repository directory to the temporary git global config as a safe directory
+2023-11-12T09:00:11.7973813Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2023-11-12T09:00:11.8018133Z Deleting the contents of '/home/runner/work/tgstation/tgstation'
+2023-11-12T09:00:11.8021715Z ##[group]Initializing the repository
+2023-11-12T09:00:11.8024938Z [command]/usr/bin/git init /home/runner/work/tgstation/tgstation
+2023-11-12T09:00:11.8167504Z hint: Using 'master' as the name for the initial branch. This default branch name
+2023-11-12T09:00:11.8168867Z hint: is subject to change. To configure the initial branch name to use in all
+2023-11-12T09:00:11.8170077Z hint: of your new repositories, which will suppress this warning, call:
+2023-11-12T09:00:11.8170644Z hint:
+2023-11-12T09:00:11.8171097Z hint: 	git config --global init.defaultBranch <name>
+2023-11-12T09:00:11.8171661Z hint:
+2023-11-12T09:00:11.8172234Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2023-11-12T09:00:11.8173070Z hint: 'development'. The just-created branch can be renamed via this command:
+2023-11-12T09:00:11.8173978Z hint:
+2023-11-12T09:00:11.8174325Z hint: 	git branch -m <name>
+2023-11-12T09:00:11.8177381Z Initialized empty Git repository in /home/runner/work/tgstation/tgstation/.git/
+2023-11-12T09:00:11.8185891Z [command]/usr/bin/git remote add origin https://github.com/tgstation/tgstation
+2023-11-12T09:00:11.8237650Z ##[endgroup]
+2023-11-12T09:00:11.8238368Z ##[group]Disabling automatic garbage collection
+2023-11-12T09:00:11.8241714Z [command]/usr/bin/git config --local gc.auto 0
+2023-11-12T09:00:11.8277184Z ##[endgroup]
+2023-11-12T09:00:11.8277752Z ##[group]Setting up auth
+2023-11-12T09:00:11.8283624Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2023-11-12T09:00:11.8319856Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2023-11-12T09:00:11.8657173Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2023-11-12T09:00:11.8696672Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2023-11-12T09:00:11.8934506Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2023-11-12T09:00:11.8975797Z ##[endgroup]
+2023-11-12T09:00:11.8976409Z ##[group]Fetching the repository
+2023-11-12T09:00:11.8984535Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +0f52a54577af8e336ee4407c83bc6d3bfedd1d11:refs/remotes/pull/79384/merge
+2023-11-12T09:00:12.3422502Z remote: Enumerating objects: 14728, done.
+2023-11-12T09:00:12.3435399Z remote: Counting objects:   0% (1/14728)
+2023-11-12T09:00:12.3437322Z remote: Counting objects:   1% (148/14728)
+2023-11-12T09:00:12.3438041Z remote: Counting objects:   2% (295/14728)
+2023-11-12T09:00:12.3438941Z remote: Counting objects:   3% (442/14728)
+2023-11-12T09:00:12.3440148Z remote: Counting objects:   4% (590/14728)
+2023-11-12T09:00:12.3442925Z remote: Counting objects:   5% (737/14728)
+2023-11-12T09:00:12.3445483Z remote: Counting objects:   6% (884/14728)
+2023-11-12T09:00:12.3447273Z remote: Counting objects:   7% (1031/14728)
+2023-11-12T09:00:12.3460133Z remote: Counting objects:   8% (1179/14728)
+2023-11-12T09:00:12.3461187Z remote: Counting objects:   9% (1326/14728)
+2023-11-12T09:00:12.3461949Z remote: Counting objects:  10% (1473/14728)
+2023-11-12T09:00:12.3462472Z remote: Counting objects:  11% (1621/14728)
+2023-11-12T09:00:12.3463038Z remote: Counting objects:  12% (1768/14728)
+2023-11-12T09:00:12.3463556Z remote: Counting objects:  13% (1915/14728)
+2023-11-12T09:00:12.3467828Z remote: Counting objects:  14% (2062/14728)
+2023-11-12T09:00:12.3483848Z remote: Counting objects:  15% (2210/14728)
+2023-11-12T09:00:12.3489421Z remote: Counting objects:  16% (2357/14728)
+2023-11-12T09:00:12.3489959Z remote: Counting objects:  17% (2504/14728)
+2023-11-12T09:00:12.3490601Z remote: Counting objects:  18% (2652/14728)
+2023-11-12T09:00:12.3491065Z remote: Counting objects:  19% (2799/14728)
+2023-11-12T09:00:12.3491549Z remote: Counting objects:  20% (2946/14728)
+2023-11-12T09:00:12.3492150Z remote: Counting objects:  21% (3093/14728)
+2023-11-12T09:00:12.3492599Z remote: Counting objects:  22% (3241/14728)
+2023-11-12T09:00:12.3497394Z remote: Counting objects:  23% (3388/14728)
+2023-11-12T09:00:12.3498533Z remote: Counting objects:  24% (3535/14728)
+2023-11-12T09:00:12.3499302Z remote: Counting objects:  25% (3682/14728)
+2023-11-12T09:00:12.3500231Z remote: Counting objects:  26% (3830/14728)
+2023-11-12T09:00:12.3500908Z remote: Counting objects:  27% (3977/14728)
+2023-11-12T09:00:12.3501885Z remote: Counting objects:  28% (4124/14728)
+2023-11-12T09:00:12.3502758Z remote: Counting objects:  29% (4272/14728)
+2023-11-12T09:00:12.3504000Z remote: Counting objects:  30% (4419/14728)
+2023-11-12T09:00:12.3508426Z remote: Counting objects:  31% (4566/14728)
+2023-11-12T09:00:12.3510860Z remote: Counting objects:  32% (4713/14728)
+2023-11-12T09:00:12.3513541Z remote: Counting objects:  33% (4861/14728)
+2023-11-12T09:00:12.3517241Z remote: Counting objects:  34% (5008/14728)
+2023-11-12T09:00:12.3518978Z remote: Counting objects:  35% (5155/14728)
+2023-11-12T09:00:12.3522056Z remote: Counting objects:  36% (5303/14728)
+2023-11-12T09:00:12.3522867Z remote: Counting objects:  37% (5450/14728)
+2023-11-12T09:00:12.3524352Z remote: Counting objects:  38% (5597/14728)
+2023-11-12T09:00:12.3525521Z remote: Counting objects:  39% (5744/14728)
+2023-11-12T09:00:12.3526808Z remote: Counting objects:  40% (5892/14728)
+2023-11-12T09:00:12.3528838Z remote: Counting objects:  41% (6039/14728)
+2023-11-12T09:00:12.3529652Z remote: Counting objects:  42% (6186/14728)
+2023-11-12T09:00:12.3531108Z remote: Counting objects:  43% (6334/14728)
+2023-11-12T09:00:12.3531942Z remote: Counting objects:  44% (6481/14728)
+2023-11-12T09:00:12.3535178Z remote: Counting objects:  45% (6628/14728)
+2023-11-12T09:00:12.3536185Z remote: Counting objects:  46% (6775/14728)
+2023-11-12T09:00:12.3537509Z remote: Counting objects:  47% (6923/14728)
+2023-11-12T09:00:12.3538838Z remote: Counting objects:  48% (7070/14728)
+2023-11-12T09:00:12.3539490Z remote: Counting objects:  49% (7217/14728)
+2023-11-12T09:00:12.3540416Z remote: Counting objects:  50% (7364/14728)
+2023-11-12T09:00:12.3542997Z remote: Counting objects:  51% (7512/14728)
+2023-11-12T09:00:12.3546735Z remote: Counting objects:  52% (7659/14728)
+2023-11-12T09:00:12.3547627Z remote: Counting objects:  53% (7806/14728)
+2023-11-12T09:00:12.3549945Z remote: Counting objects:  54% (7954/14728)
+2023-11-12T09:00:12.3551486Z remote: Counting objects:  55% (8101/14728)
+2023-11-12T09:00:12.3554841Z remote: Counting objects:  56% (8248/14728)
+2023-11-12T09:00:12.3558919Z remote: Counting objects:  57% (8395/14728)
+2023-11-12T09:00:12.3559895Z remote: Counting objects:  58% (8543/14728)
+2023-11-12T09:00:12.3561635Z remote: Counting objects:  59% (8690/14728)
+2023-11-12T09:00:12.3562509Z remote: Counting objects:  60% (8837/14728)
+2023-11-12T09:00:12.3565221Z remote: Counting objects:  61% (8985/14728)
+2023-11-12T09:00:12.3566377Z remote: Counting objects:  62% (9132/14728)
+2023-11-12T09:00:12.3567330Z remote: Counting objects:  63% (9279/14728)
+2023-11-12T09:00:12.3568404Z remote: Counting objects:  64% (9426/14728)
+2023-11-12T09:00:12.3569399Z remote: Counting objects:  65% (9574/14728)
+2023-11-12T09:00:12.3570508Z remote: Counting objects:  66% (9721/14728)
+2023-11-12T09:00:12.3573805Z remote: Counting objects:  67% (9868/14728)
+2023-11-12T09:00:12.3574713Z remote: Counting objects:  68% (10016/14728)
+2023-11-12T09:00:12.3575852Z remote: Counting objects:  69% (10163/14728)
+2023-11-12T09:00:12.3576870Z remote: Counting objects:  70% (10310/14728)
+2023-11-12T09:00:12.3577724Z remote: Counting objects:  71% (10457/14728)
+2023-11-12T09:00:12.3578357Z remote: Counting objects:  72% (10605/14728)
+2023-11-12T09:00:12.3578886Z remote: Counting objects:  73% (10752/14728)
+2023-11-12T09:00:12.3579497Z remote: Counting objects:  74% (10899/14728)
+2023-11-12T09:00:12.3580417Z remote: Counting objects:  75% (11046/14728)
+2023-11-12T09:00:12.3581097Z remote: Counting objects:  76% (11194/14728)
+2023-11-12T09:00:12.3581574Z remote: Counting objects:  77% (11341/14728)
+2023-11-12T09:00:12.3582409Z remote: Counting objects:  78% (11488/14728)
+2023-11-12T09:00:12.3582915Z remote: Counting objects:  79% (11636/14728)
+2023-11-12T09:00:12.3583405Z remote: Counting objects:  80% (11783/14728)
+2023-11-12T09:00:12.3583954Z remote: Counting objects:  81% (11930/14728)
+2023-11-12T09:00:12.3586461Z remote: Counting objects:  82% (12077/14728)
+2023-11-12T09:00:12.3587052Z remote: Counting objects:  83% (12225/14728)
+2023-11-12T09:00:12.3587941Z remote: Counting objects:  84% (12372/14728)
+2023-11-12T09:00:12.3588988Z remote: Counting objects:  85% (12519/14728)
+2023-11-12T09:00:12.3591543Z remote: Counting objects:  86% (12667/14728)
+2023-11-12T09:00:12.3594301Z remote: Counting objects:  87% (12814/14728)
+2023-11-12T09:00:12.3597908Z remote: Counting objects:  88% (12961/14728)
+2023-11-12T09:00:12.3601958Z remote: Counting objects:  89% (13108/14728)
+2023-11-12T09:00:12.3605574Z remote: Counting objects:  90% (13256/14728)
+2023-11-12T09:00:12.3610280Z remote: Counting objects:  91% (13403/14728)
+2023-11-12T09:00:12.3612894Z remote: Counting objects:  92% (13550/14728)
+2023-11-12T09:00:12.3615660Z remote: Counting objects:  93% (13698/14728)
+2023-11-12T09:00:12.3619462Z remote: Counting objects:  94% (13845/14728)
+2023-11-12T09:00:12.3623758Z remote: Counting objects:  95% (13992/14728)
+2023-11-12T09:00:12.3628748Z remote: Counting objects:  96% (14139/14728)
+2023-11-12T09:00:12.3636487Z remote: Counting objects:  97% (14287/14728)
+2023-11-12T09:00:12.3641426Z remote: Counting objects:  98% (14434/14728)
+2023-11-12T09:00:12.3646422Z remote: Counting objects:  99% (14581/14728)
+2023-11-12T09:00:12.3649144Z remote: Counting objects: 100% (14728/14728)
+2023-11-12T09:00:12.3649919Z remote: Counting objects: 100% (14728/14728), done.
+2023-11-12T09:00:12.3825128Z remote: Compressing objects:   0% (1/13137)
+2023-11-12T09:00:12.3961841Z remote: Compressing objects:   1% (132/13137)
+2023-11-12T09:00:12.4112502Z remote: Compressing objects:   2% (263/13137)
+2023-11-12T09:00:12.4227069Z remote: Compressing objects:   3% (395/13137)
+2023-11-12T09:00:12.4228313Z remote: Compressing objects:   4% (526/13137)
+2023-11-12T09:00:12.4228983Z remote: Compressing objects:   5% (657/13137)
+2023-11-12T09:00:12.4229643Z remote: Compressing objects:   6% (789/13137)
+2023-11-12T09:00:12.4271804Z remote: Compressing objects:   7% (920/13137)
+2023-11-12T09:00:12.4360389Z remote: Compressing objects:   8% (1051/13137)
+2023-11-12T09:00:12.4466461Z remote: Compressing objects:   9% (1183/13137)
+2023-11-12T09:00:12.4646998Z remote: Compressing objects:  10% (1314/13137)
+2023-11-12T09:00:12.5428669Z remote: Compressing objects:  11% (1446/13137)
+2023-11-12T09:00:12.8296153Z remote: Compressing objects:  12% (1577/13137)
+2023-11-12T09:00:12.9213149Z remote: Compressing objects:  13% (1708/13137)
+2023-11-12T09:00:13.0041408Z remote: Compressing objects:  14% (1840/13137)
+2023-11-12T09:00:13.1340856Z remote: Compressing objects:  15% (1971/13137)
+2023-11-12T09:00:13.1645036Z remote: Compressing objects:  16% (2102/13137)
+2023-11-12T09:00:13.1904768Z remote: Compressing objects:  17% (2234/13137)
+2023-11-12T09:00:13.2018494Z remote: Compressing objects:  18% (2365/13137)
+2023-11-12T09:00:13.2019779Z remote: Compressing objects:  19% (2497/13137)
+2023-11-12T09:00:13.2134073Z remote: Compressing objects:  20% (2628/13137)
+2023-11-12T09:00:13.2199911Z remote: Compressing objects:  21% (2759/13137)
+2023-11-12T09:00:13.2260920Z remote: Compressing objects:  22% (2891/13137)
+2023-11-12T09:00:13.2343043Z remote: Compressing objects:  23% (3022/13137)
+2023-11-12T09:00:13.2821833Z remote: Compressing objects:  24% (3153/13137)
+2023-11-12T09:00:13.3039708Z remote: Compressing objects:  25% (3285/13137)
+2023-11-12T09:00:13.3255129Z remote: Compressing objects:  26% (3416/13137)
+2023-11-12T09:00:13.3405305Z remote: Compressing objects:  27% (3547/13137)
+2023-11-12T09:00:13.3571381Z remote: Compressing objects:  28% (3679/13137)
+2023-11-12T09:00:13.3670018Z remote: Compressing objects:  29% (3810/13137)
+2023-11-12T09:00:13.4040877Z remote: Compressing objects:  29% (3868/13137)
+2023-11-12T09:00:13.4251871Z remote: Compressing objects:  30% (3942/13137)
+2023-11-12T09:00:13.4457155Z remote: Compressing objects:  31% (4073/13137)
+2023-11-12T09:00:13.4780533Z remote: Compressing objects:  32% (4204/13137)
+2023-11-12T09:00:13.4983464Z remote: Compressing objects:  33% (4336/13137)
+2023-11-12T09:00:13.5295246Z remote: Compressing objects:  34% (4467/13137)
+2023-11-12T09:00:13.5719629Z remote: Compressing objects:  35% (4598/13137)
+2023-11-12T09:00:13.6054442Z remote: Compressing objects:  36% (4730/13137)
+2023-11-12T09:00:13.6350098Z remote: Compressing objects:  37% (4861/13137)
+2023-11-12T09:00:13.6626461Z remote: Compressing objects:  38% (4993/13137)
+2023-11-12T09:00:13.6916464Z remote: Compressing objects:  39% (5124/13137)
+2023-11-12T09:00:13.7302124Z remote: Compressing objects:  40% (5255/13137)
+2023-11-12T09:00:13.7576240Z remote: Compressing objects:  41% (5387/13137)
+2023-11-12T09:00:13.7850663Z remote: Compressing objects:  42% (5518/13137)
+2023-11-12T09:00:13.8125191Z remote: Compressing objects:  43% (5649/13137)
+2023-11-12T09:00:13.8344430Z remote: Compressing objects:  44% (5781/13137)
+2023-11-12T09:00:13.8648361Z remote: Compressing objects:  45% (5912/13137)
+2023-11-12T09:00:13.8890504Z remote: Compressing objects:  46% (6044/13137)
+2023-11-12T09:00:13.9134975Z remote: Compressing objects:  47% (6175/13137)
+2023-11-12T09:00:13.9382739Z remote: Compressing objects:  48% (6306/13137)
+2023-11-12T09:00:13.9574317Z remote: Compressing objects:  49% (6438/13137)
+2023-11-12T09:00:13.9764171Z remote: Compressing objects:  50% (6569/13137)
+2023-11-12T09:00:13.9965671Z remote: Compressing objects:  51% (6700/13137)
+2023-11-12T09:00:14.0240257Z remote: Compressing objects:  52% (6832/13137)
+2023-11-12T09:00:14.0468725Z remote: Compressing objects:  53% (6963/13137)
+2023-11-12T09:00:14.0669881Z remote: Compressing objects:  54% (7094/13137)
+2023-11-12T09:00:14.0895124Z remote: Compressing objects:  55% (7226/13137)
+2023-11-12T09:00:14.1141069Z remote: Compressing objects:  56% (7357/13137)
+2023-11-12T09:00:14.1354395Z remote: Compressing objects:  57% (7489/13137)
+2023-11-12T09:00:14.1570266Z remote: Compressing objects:  58% (7620/13137)
+2023-11-12T09:00:14.1754980Z remote: Compressing objects:  59% (7751/13137)
+2023-11-12T09:00:14.2084676Z remote: Compressing objects:  60% (7883/13137)
+2023-11-12T09:00:14.2310657Z remote: Compressing objects:  61% (8014/13137)
+2023-11-12T09:00:14.2625166Z remote: Compressing objects:  62% (8145/13137)
+2023-11-12T09:00:14.2909864Z remote: Compressing objects:  63% (8277/13137)
+2023-11-12T09:00:14.3192565Z remote: Compressing objects:  64% (8408/13137)
+2023-11-12T09:00:14.3424597Z remote: Compressing objects:  65% (8540/13137)
+2023-11-12T09:00:14.3648230Z remote: Compressing objects:  66% (8671/13137)
+2023-11-12T09:00:14.3654208Z remote: Compressing objects:  67% (8802/13137)
+2023-11-12T09:00:14.3852572Z remote: Compressing objects:  67% (8803/13137)
+2023-11-12T09:00:14.4083890Z remote: Compressing objects:  68% (8934/13137)
+2023-11-12T09:00:14.4346236Z remote: Compressing objects:  69% (9065/13137)
+2023-11-12T09:00:14.4412610Z remote: Compressing objects:  70% (9196/13137)
+2023-11-12T09:00:14.4438826Z remote: Compressing objects:  71% (9328/13137)
+2023-11-12T09:00:14.4557338Z remote: Compressing objects:  72% (9459/13137)
+2023-11-12T09:00:14.4560053Z remote: Compressing objects:  73% (9591/13137)
+2023-11-12T09:00:14.4561406Z remote: Compressing objects:  74% (9722/13137)
+2023-11-12T09:00:14.4562102Z remote: Compressing objects:  75% (9853/13137)
+2023-11-12T09:00:14.4598003Z remote: Compressing objects:  76% (9985/13137)
+2023-11-12T09:00:14.4599196Z remote: Compressing objects:  77% (10116/13137)
+2023-11-12T09:00:14.4600027Z remote: Compressing objects:  78% (10247/13137)
+2023-11-12T09:00:14.4610318Z remote: Compressing objects:  79% (10379/13137)
+2023-11-12T09:00:14.4610882Z remote: Compressing objects:  80% (10510/13137)
+2023-11-12T09:00:14.4625739Z remote: Compressing objects:  81% (10641/13137)
+2023-11-12T09:00:14.4627218Z remote: Compressing objects:  82% (10773/13137)
+2023-11-12T09:00:14.4628087Z remote: Compressing objects:  83% (10904/13137)
+2023-11-12T09:00:14.4628755Z remote: Compressing objects:  84% (11036/13137)
+2023-11-12T09:00:14.4641964Z remote: Compressing objects:  85% (11167/13137)
+2023-11-12T09:00:14.4643000Z remote: Compressing objects:  86% (11298/13137)
+2023-11-12T09:00:14.4643588Z remote: Compressing objects:  87% (11430/13137)
+2023-11-12T09:00:14.4644263Z remote: Compressing objects:  88% (11561/13137)
+2023-11-12T09:00:14.4644780Z remote: Compressing objects:  89% (11692/13137)
+2023-11-12T09:00:14.4667702Z remote: Compressing objects:  90% (11824/13137)
+2023-11-12T09:00:14.4763174Z remote: Compressing objects:  91% (11955/13137)
+2023-11-12T09:00:14.4790967Z remote: Compressing objects:  92% (12087/13137)
+2023-11-12T09:00:14.4805225Z remote: Compressing objects:  93% (12218/13137)
+2023-11-12T09:00:14.4826093Z remote: Compressing objects:  94% (12349/13137)
+2023-11-12T09:00:14.4845748Z remote: Compressing objects:  95% (12481/13137)
+2023-11-12T09:00:14.4852480Z remote: Compressing objects:  96% (12612/13137)
+2023-11-12T09:00:14.4863608Z remote: Compressing objects:  97% (12743/13137)
+2023-11-12T09:00:14.4890566Z remote: Compressing objects:  98% (12875/13137)
+2023-11-12T09:00:14.4901499Z remote: Compressing objects:  99% (13006/13137)
+2023-11-12T09:00:14.4905499Z remote: Compressing objects: 100% (13137/13137)
+2023-11-12T09:00:14.4906263Z remote: Compressing objects: 100% (13137/13137), done.
+2023-11-12T09:00:14.5298519Z Receiving objects:   0% (1/14728)
+2023-11-12T09:00:14.7511556Z Receiving objects:   1% (148/14728)
+2023-11-12T09:00:15.0383718Z Receiving objects:   2% (295/14728)
+2023-11-12T09:00:15.0790920Z Receiving objects:   3% (442/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.1841924Z Receiving objects:   4% (590/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.1886539Z Receiving objects:   5% (737/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.1946135Z Receiving objects:   6% (884/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2129478Z Receiving objects:   7% (1031/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2298890Z Receiving objects:   8% (1179/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2441190Z Receiving objects:   9% (1326/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2535883Z Receiving objects:  10% (1473/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2682741Z Receiving objects:  11% (1621/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2854458Z Receiving objects:  12% (1768/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2953047Z Receiving objects:  13% (1915/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.2998284Z Receiving objects:  14% (2062/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.3017511Z Receiving objects:  15% (2210/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.3161978Z Receiving objects:  16% (2357/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.3233106Z Receiving objects:  17% (2504/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.3483968Z Receiving objects:  18% (2652/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.3784019Z Receiving objects:  19% (2799/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.3954481Z Receiving objects:  20% (2946/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.4245221Z Receiving objects:  21% (3093/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.4470709Z Receiving objects:  22% (3241/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.4723098Z Receiving objects:  23% (3388/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.4937347Z Receiving objects:  24% (3535/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.4944940Z Receiving objects:  24% (3669/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.5175139Z Receiving objects:  25% (3682/14728), 2.91 MiB | 5.72 MiB/s
+2023-11-12T09:00:15.5292638Z Receiving objects:  26% (3830/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.5497254Z Receiving objects:  27% (3977/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.5672343Z Receiving objects:  28% (4124/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.5843576Z Receiving objects:  29% (4272/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.5937090Z Receiving objects:  30% (4419/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6094771Z Receiving objects:  31% (4566/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6238194Z Receiving objects:  32% (4713/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6342923Z Receiving objects:  33% (4861/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6565056Z Receiving objects:  34% (5008/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6729745Z Receiving objects:  35% (5155/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6807225Z Receiving objects:  36% (5303/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.6932642Z Receiving objects:  37% (5450/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.7116778Z Receiving objects:  38% (5597/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.7226855Z Receiving objects:  39% (5744/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.7368698Z Receiving objects:  40% (5892/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.7722704Z Receiving objects:  41% (6039/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.8013149Z Receiving objects:  42% (6186/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.8245559Z Receiving objects:  43% (6334/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.8412984Z Receiving objects:  44% (6481/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.8809019Z Receiving objects:  45% (6628/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9077444Z Receiving objects:  46% (6775/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9198076Z Receiving objects:  47% (6923/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9335440Z Receiving objects:  48% (7070/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9409235Z Receiving objects:  49% (7217/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9475966Z Receiving objects:  50% (7364/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9632751Z Receiving objects:  51% (7512/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9710761Z Receiving objects:  52% (7659/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:15.9997665Z Receiving objects:  53% (7806/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:16.1754062Z Receiving objects:  54% (7954/14728), 8.94 MiB | 8.86 MiB/s
+2023-11-12T09:00:16.4937069Z Receiving objects:  55% (8101/14728), 16.55 MiB | 10.97 MiB/s
+2023-11-12T09:00:16.4977595Z Receiving objects:  55% (8228/14728), 16.55 MiB | 10.97 MiB/s
+2023-11-12T09:00:16.5335682Z Receiving objects:  56% (8248/14728), 16.55 MiB | 10.97 MiB/s
+2023-11-12T09:00:16.5529510Z Receiving objects:  57% (8395/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.6298834Z Receiving objects:  58% (8543/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.6477417Z Receiving objects:  59% (8690/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.6877035Z Receiving objects:  60% (8837/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.7190945Z Receiving objects:  61% (8985/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.7421126Z Receiving objects:  62% (9132/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.7678021Z Receiving objects:  63% (9279/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:16.8523998Z Receiving objects:  64% (9426/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:17.1043001Z Receiving objects:  65% (9574/14728), 40.02 MiB | 19.93 MiB/s
+2023-11-12T09:00:17.3854775Z Receiving objects:  66% (9721/14728), 71.27 MiB | 28.42 MiB/s
+2023-11-12T09:00:17.4325550Z Receiving objects:  67% (9868/14728), 71.27 MiB | 28.42 MiB/s
+2023-11-12T09:00:17.4843860Z Receiving objects:  68% (10016/14728), 71.27 MiB | 28.42 MiB/s
+2023-11-12T09:00:17.4974216Z Receiving objects:  69% (10163/14728), 71.27 MiB | 28.42 MiB/s
+2023-11-12T09:00:17.5355293Z Receiving objects:  69% (10174/14728), 71.27 MiB | 28.42 MiB/s
+2023-11-12T09:00:17.6035052Z Receiving objects:  70% (10310/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.6662170Z Receiving objects:  71% (10457/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.7426342Z Receiving objects:  72% (10605/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.7732421Z Receiving objects:  73% (10752/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.7890371Z Receiving objects:  74% (10899/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.8003342Z Receiving objects:  75% (11046/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.8123812Z Receiving objects:  76% (11194/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.8868154Z Receiving objects:  77% (11341/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.9248750Z Receiving objects:  78% (11488/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.9430493Z Receiving objects:  79% (11636/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.9815619Z Receiving objects:  80% (11783/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:17.9897797Z Receiving objects:  81% (11930/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:18.0004021Z Receiving objects:  82% (12077/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:18.0065635Z Receiving objects:  83% (12225/14728), 104.98 MiB | 34.90 MiB/s
+2023-11-12T09:00:18.0133099Z Receiving objects:  84% (12372/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.0212448Z Receiving objects:  85% (12519/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.0292270Z Receiving objects:  86% (12667/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.0477194Z Receiving objects:  87% (12814/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1050651Z Receiving objects:  88% (12961/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1401134Z Receiving objects:  89% (13108/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1440829Z Receiving objects:  90% (13256/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1503769Z Receiving objects:  91% (13403/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1562677Z Receiving objects:  92% (13550/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1618314Z Receiving objects:  93% (13698/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1655496Z Receiving objects:  94% (13845/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1708799Z Receiving objects:  95% (13992/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1779590Z Receiving objects:  96% (14139/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1850924Z Receiving objects:  97% (14287/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1887710Z Receiving objects:  98% (14434/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1982209Z Receiving objects:  99% (14581/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1983900Z remote: Total 14728 (delta 1648), reused 9457 (delta 1437), pack-reused 0
+2023-11-12T09:00:18.1993200Z Receiving objects: 100% (14728/14728), 137.62 MiB | 39.23 MiB/s
+2023-11-12T09:00:18.1994500Z Receiving objects: 100% (14728/14728), 147.84 MiB | 39.90 MiB/s, done.
+2023-11-12T09:00:18.2019068Z Resolving deltas:   0% (0/1648)
+2023-11-12T09:00:18.2023348Z Resolving deltas:   1% (17/1648)
+2023-11-12T09:00:18.2032679Z Resolving deltas:   2% (33/1648)
+2023-11-12T09:00:18.2057515Z Resolving deltas:   3% (50/1648)
+2023-11-12T09:00:18.2067595Z Resolving deltas:   4% (66/1648)
+2023-11-12T09:00:18.2311083Z Resolving deltas:   5% (83/1648)
+2023-11-12T09:00:18.2318508Z Resolving deltas:   6% (99/1648)
+2023-11-12T09:00:18.2326847Z Resolving deltas:   7% (116/1648)
+2023-11-12T09:00:18.2335304Z Resolving deltas:   8% (132/1648)
+2023-11-12T09:00:18.2348077Z Resolving deltas:   9% (149/1648)
+2023-11-12T09:00:18.2360740Z Resolving deltas:  10% (165/1648)
+2023-11-12T09:00:18.2369574Z Resolving deltas:  11% (182/1648)
+2023-11-12T09:00:18.2383691Z Resolving deltas:  12% (198/1648)
+2023-11-12T09:00:18.2394926Z Resolving deltas:  13% (215/1648)
+2023-11-12T09:00:18.2398748Z Resolving deltas:  14% (231/1648)
+2023-11-12T09:00:18.2404491Z Resolving deltas:  15% (248/1648)
+2023-11-12T09:00:18.2406714Z Resolving deltas:  16% (264/1648)
+2023-11-12T09:00:18.2407998Z Resolving deltas:  17% (281/1648)
+2023-11-12T09:00:18.2409292Z Resolving deltas:  18% (297/1648)
+2023-11-12T09:00:18.2411513Z Resolving deltas:  19% (315/1648)
+2023-11-12T09:00:18.2413614Z Resolving deltas:  20% (330/1648)
+2023-11-12T09:00:18.2414462Z Resolving deltas:  21% (347/1648)
+2023-11-12T09:00:18.2418247Z Resolving deltas:  22% (363/1648)
+2023-11-12T09:00:18.2418936Z Resolving deltas:  23% (380/1648)
+2023-11-12T09:00:18.2419539Z Resolving deltas:  24% (396/1648)
+2023-11-12T09:00:18.2427604Z Resolving deltas:  25% (412/1648)
+2023-11-12T09:00:18.2432866Z Resolving deltas:  26% (429/1648)
+2023-11-12T09:00:18.2441981Z Resolving deltas:  27% (445/1648)
+2023-11-12T09:00:18.2447582Z Resolving deltas:  28% (462/1648)
+2023-11-12T09:00:18.2466027Z Resolving deltas:  29% (478/1648)
+2023-11-12T09:00:18.2471796Z Resolving deltas:  30% (495/1648)
+2023-11-12T09:00:18.2480036Z Resolving deltas:  31% (511/1648)
+2023-11-12T09:00:18.2490887Z Resolving deltas:  32% (528/1648)
+2023-11-12T09:00:18.2494739Z Resolving deltas:  33% (544/1648)
+2023-11-12T09:00:18.2502376Z Resolving deltas:  34% (561/1648)
+2023-11-12T09:00:18.2508410Z Resolving deltas:  35% (577/1648)
+2023-11-12T09:00:18.2513823Z Resolving deltas:  36% (594/1648)
+2023-11-12T09:00:18.2527222Z Resolving deltas:  37% (610/1648)
+2023-11-12T09:00:18.2537398Z Resolving deltas:  38% (627/1648)
+2023-11-12T09:00:18.2549132Z Resolving deltas:  39% (643/1648)
+2023-11-12T09:00:18.2554784Z Resolving deltas:  40% (660/1648)
+2023-11-12T09:00:18.2556656Z Resolving deltas:  41% (676/1648)
+2023-11-12T09:00:18.2557507Z Resolving deltas:  42% (693/1648)
+2023-11-12T09:00:18.2558588Z Resolving deltas:  43% (709/1648)
+2023-11-12T09:00:18.2559455Z Resolving deltas:  44% (727/1648)
+2023-11-12T09:00:18.2561210Z Resolving deltas:  45% (742/1648)
+2023-11-12T09:00:18.2562565Z Resolving deltas:  46% (760/1648)
+2023-11-12T09:00:18.2563347Z Resolving deltas:  47% (775/1648)
+2023-11-12T09:00:18.2564389Z Resolving deltas:  48% (792/1648)
+2023-11-12T09:00:18.2565291Z Resolving deltas:  49% (808/1648)
+2023-11-12T09:00:18.2566382Z Resolving deltas:  50% (824/1648)
+2023-11-12T09:00:18.2567240Z Resolving deltas:  51% (841/1648)
+2023-11-12T09:00:18.2568283Z Resolving deltas:  52% (857/1648)
+2023-11-12T09:00:18.2573986Z Resolving deltas:  53% (874/1648)
+2023-11-12T09:00:18.2578038Z Resolving deltas:  54% (890/1648)
+2023-11-12T09:00:18.2579766Z Resolving deltas:  55% (907/1648)
+2023-11-12T09:00:18.2583389Z Resolving deltas:  56% (923/1648)
+2023-11-12T09:00:18.2587856Z Resolving deltas:  57% (940/1648)
+2023-11-12T09:00:18.2589664Z Resolving deltas:  58% (956/1648)
+2023-11-12T09:00:18.2591411Z Resolving deltas:  59% (973/1648)
+2023-11-12T09:00:18.2594574Z Resolving deltas:  60% (989/1648)
+2023-11-12T09:00:18.2597339Z Resolving deltas:  61% (1006/1648)
+2023-11-12T09:00:18.2599661Z Resolving deltas:  62% (1022/1648)
+2023-11-12T09:00:18.2605805Z Resolving deltas:  63% (1039/1648)
+2023-11-12T09:00:18.2606445Z Resolving deltas:  64% (1055/1648)
+2023-11-12T09:00:18.2608833Z Resolving deltas:  65% (1072/1648)
+2023-11-12T09:00:18.2612033Z Resolving deltas:  66% (1088/1648)
+2023-11-12T09:00:18.2614253Z Resolving deltas:  67% (1105/1648)
+2023-11-12T09:00:18.2618118Z Resolving deltas:  68% (1121/1648)
+2023-11-12T09:00:18.2619827Z Resolving deltas:  69% (1138/1648)
+2023-11-12T09:00:18.2621203Z Resolving deltas:  70% (1154/1648)
+2023-11-12T09:00:18.2624401Z Resolving deltas:  71% (1171/1648)
+2023-11-12T09:00:18.2627592Z Resolving deltas:  72% (1187/1648)
+2023-11-12T09:00:18.2630703Z Resolving deltas:  73% (1204/1648)
+2023-11-12T09:00:18.2633542Z Resolving deltas:  74% (1220/1648)
+2023-11-12T09:00:18.2636165Z Resolving deltas:  75% (1236/1648)
+2023-11-12T09:00:18.2638056Z Resolving deltas:  76% (1253/1648)
+2023-11-12T09:00:18.2642611Z Resolving deltas:  77% (1269/1648)
+2023-11-12T09:00:18.2645574Z Resolving deltas:  78% (1286/1648)
+2023-11-12T09:00:18.2650111Z Resolving deltas:  79% (1302/1648)
+2023-11-12T09:00:18.2653615Z Resolving deltas:  80% (1319/1648)
+2023-11-12T09:00:18.2657080Z Resolving deltas:  81% (1335/1648)
+2023-11-12T09:00:18.2661192Z Resolving deltas:  82% (1352/1648)
+2023-11-12T09:00:18.2666443Z Resolving deltas:  83% (1368/1648)
+2023-11-12T09:00:18.2671066Z Resolving deltas:  84% (1385/1648)
+2023-11-12T09:00:18.2675875Z Resolving deltas:  85% (1401/1648)
+2023-11-12T09:00:18.2680749Z Resolving deltas:  86% (1418/1648)
+2023-11-12T09:00:18.2685418Z Resolving deltas:  87% (1434/1648)
+2023-11-12T09:00:18.2691672Z Resolving deltas:  88% (1451/1648)
+2023-11-12T09:00:18.2696947Z Resolving deltas:  89% (1467/1648)
+2023-11-12T09:00:18.2704268Z Resolving deltas:  90% (1484/1648)
+2023-11-12T09:00:18.2714966Z Resolving deltas:  91% (1500/1648)
+2023-11-12T09:00:18.2724238Z Resolving deltas:  92% (1518/1648)
+2023-11-12T09:00:18.2727054Z Resolving deltas:  93% (1533/1648)
+2023-11-12T09:00:18.2732989Z Resolving deltas:  94% (1550/1648)
+2023-11-12T09:00:18.2738406Z Resolving deltas:  95% (1567/1648)
+2023-11-12T09:00:18.2743401Z Resolving deltas:  96% (1583/1648)
+2023-11-12T09:00:18.2748306Z Resolving deltas:  97% (1599/1648)
+2023-11-12T09:00:18.2752079Z Resolving deltas:  98% (1616/1648)
+2023-11-12T09:00:18.2774732Z Resolving deltas:  99% (1632/1648)
+2023-11-12T09:00:18.2776965Z Resolving deltas: 100% (1648/1648)
+2023-11-12T09:00:18.2777617Z Resolving deltas: 100% (1648/1648), done.
+2023-11-12T09:00:18.4151233Z From https://github.com/tgstation/tgstation
+2023-11-12T09:00:18.4152324Z  * [new ref]         0f52a54577af8e336ee4407c83bc6d3bfedd1d11 -> pull/79384/merge
+2023-11-12T09:00:18.4174692Z ##[endgroup]
+2023-11-12T09:00:18.4175546Z ##[group]Determining the checkout info
+2023-11-12T09:00:18.4177292Z ##[endgroup]
+2023-11-12T09:00:18.4178077Z ##[group]Checking out the ref
+2023-11-12T09:00:18.4182006Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/79384/merge
+2023-11-12T09:00:19.4499153Z Updating files:  65% (8853/13535)
+2023-11-12T09:00:19.4677754Z Updating files:  66% (8934/13535)
+2023-11-12T09:00:19.4881367Z Updating files:  67% (9069/13535)
+2023-11-12T09:00:19.5117589Z Updating files:  68% (9204/13535)
+2023-11-12T09:00:19.5393100Z Updating files:  69% (9340/13535)
+2023-11-12T09:00:19.5649915Z Updating files:  70% (9475/13535)
+2023-11-12T09:00:19.5885545Z Updating files:  71% (9610/13535)
+2023-11-12T09:00:19.6092470Z Updating files:  72% (9746/13535)
+2023-11-12T09:00:19.6193070Z Updating files:  73% (9881/13535)
+2023-11-12T09:00:19.6275200Z Updating files:  74% (10016/13535)
+2023-11-12T09:00:19.6366161Z Updating files:  75% (10152/13535)
+2023-11-12T09:00:19.6497650Z Updating files:  76% (10287/13535)
+2023-11-12T09:00:19.6864064Z Updating files:  77% (10422/13535)
+2023-11-12T09:00:19.6905958Z Updating files:  78% (10558/13535)
+2023-11-12T09:00:19.7095469Z Updating files:  79% (10693/13535)
+2023-11-12T09:00:19.7217904Z Updating files:  80% (10828/13535)
+2023-11-12T09:00:19.7299066Z Updating files:  81% (10964/13535)
+2023-11-12T09:00:19.7371348Z Updating files:  82% (11099/13535)
+2023-11-12T09:00:19.7439098Z Updating files:  83% (11235/13535)
+2023-11-12T09:00:19.7509681Z Updating files:  84% (11370/13535)
+2023-11-12T09:00:19.7583669Z Updating files:  85% (11505/13535)
+2023-11-12T09:00:19.7654399Z Updating files:  86% (11641/13535)
+2023-11-12T09:00:19.7761508Z Updating files:  87% (11776/13535)
+2023-11-12T09:00:19.7996111Z Updating files:  88% (11911/13535)
+2023-11-12T09:00:19.8212241Z Updating files:  89% (12047/13535)
+2023-11-12T09:00:19.8280038Z Updating files:  90% (12182/13535)
+2023-11-12T09:00:19.8351398Z Updating files:  91% (12317/13535)
+2023-11-12T09:00:19.8428752Z Updating files:  92% (12453/13535)
+2023-11-12T09:00:19.8508292Z Updating files:  93% (12588/13535)
+2023-11-12T09:00:19.8572225Z Updating files:  94% (12723/13535)
+2023-11-12T09:00:19.8650650Z Updating files:  95% (12859/13535)
+2023-11-12T09:00:19.8729362Z Updating files:  96% (12994/13535)
+2023-11-12T09:00:19.8829435Z Updating files:  97% (13129/13535)
+2023-11-12T09:00:19.8894699Z Updating files:  98% (13265/13535)
+2023-11-12T09:00:19.8994866Z Updating files:  99% (13400/13535)
+2023-11-12T09:00:19.8995690Z Updating files: 100% (13535/13535)
+2023-11-12T09:00:19.8996705Z Updating files: 100% (13535/13535), done.
+2023-11-12T09:00:19.9124545Z Note: switching to 'refs/remotes/pull/79384/merge'.
+2023-11-12T09:00:19.9125161Z
+2023-11-12T09:00:19.9125767Z You are in 'detached HEAD' state. You can look around, make experimental
+2023-11-12T09:00:19.9127145Z changes and commit them, and you can discard any commits you make in this
+2023-11-12T09:00:19.9128712Z state without impacting any branches by switching back to a branch.
+2023-11-12T09:00:19.9129440Z
+2023-11-12T09:00:19.9129888Z If you want to create a new branch to retain commits you create, you may
+2023-11-12T09:00:19.9131250Z do so (now or later) by using -c with the switch command. Example:
+2023-11-12T09:00:19.9131887Z
+2023-11-12T09:00:19.9132223Z   git switch -c <new-branch-name>
+2023-11-12T09:00:19.9132633Z
+2023-11-12T09:00:19.9133095Z Or undo this operation with:
+2023-11-12T09:00:19.9133655Z
+2023-11-12T09:00:19.9133848Z   git switch -
+2023-11-12T09:00:19.9134127Z
+2023-11-12T09:00:19.9134677Z Turn off this advice by setting config variable advice.detachedHead to false
+2023-11-12T09:00:19.9135426Z
+2023-11-12T09:00:19.9136195Z HEAD is now at 0f52a54 Merge 2104248ba951649225e5c5cb8168346f0220bdb7 into 1eb94ba2286812853f5c65b2557bf2f8f5e46d4f
+2023-11-12T09:00:19.9215939Z ##[endgroup]
+2023-11-12T09:00:19.9261644Z [command]/usr/bin/git log -1 --format='%H'
+2023-11-12T09:00:19.9293509Z '0f52a54577af8e336ee4407c83bc6d3bfedd1d11'
+2023-11-12T09:00:19.9616124Z ##[group]Run actions/cache@v3
+2023-11-12T09:00:19.9616601Z with:
+2023-11-12T09:00:19.9616946Z   path: ~/BYOND
+2023-11-12T09:00:19.9617286Z   key: Linux-byond-
+2023-11-12T09:00:19.9617686Z   enableCrossOsArchive: false
+2023-11-12T09:00:19.9618092Z   fail-on-cache-miss: false
+2023-11-12T09:00:19.9618460Z   lookup-only: false
+2023-11-12T09:00:19.9618822Z ##[endgroup]
+2023-11-12T09:00:20.2859595Z Cache Size: ~4 MB (4090426 B)
+2023-11-12T09:00:20.2888527Z [command]/usr/bin/tar -xf /home/runner/work/_temp/edb2b23d-361f-4c19-b676-33998159e0b8/cache.tzst -P -C /home/runner/work/tgstation/tgstation --use-compress-program unzstd
+2023-11-12T09:00:20.3193378Z Cache restored successfully
+2023-11-12T09:00:20.3317264Z Cache restored from key: Linux-byond-
+2023-11-12T09:00:20.3451434Z ##[group]Run sudo systemctl start mysql
+2023-11-12T09:00:20.3452154Z [36;1msudo systemctl start mysql[0m
+2023-11-12T09:00:20.3452715Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci;'[0m
+2023-11-12T09:00:20.3453355Z [36;1mmysql -u root -proot tg_ci < SQL/tgstation_schema.sql[0m
+2023-11-12T09:00:20.3454118Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'[0m
+2023-11-12T09:00:20.3454828Z [36;1mmysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql[0m
+2023-11-12T09:00:20.3513329Z shell: /usr/bin/bash -e {0}
+2023-11-12T09:00:20.3513775Z ##[endgroup]
+2023-11-12T09:00:23.5982676Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2023-11-12T09:00:23.6362129Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2023-11-12T09:00:24.0220158Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2023-11-12T09:00:24.0302175Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2023-11-12T09:00:24.3266576Z ##[group]Run bash tools/ci/install_rust_g.sh
+2023-11-12T09:00:24.3267216Z [36;1mbash tools/ci/install_rust_g.sh[0m
+2023-11-12T09:00:24.3311615Z shell: /usr/bin/bash -e {0}
+2023-11-12T09:00:24.3311996Z ##[endgroup]
+2023-11-12T09:00:24.6018389Z 2023-11-12 09:00:24 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/127494547/aea9a209-14bc-4b8b-b98c-1ba32c0aaf86?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231112T085850Z&X-Amz-Expires=300&X-Amz-Signature=c3e69a55ec6f839925bb9729c6b2e6b4d5b76b4855bfd64b96933c73f95a6734&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=127494547&response-content-disposition=attachment%3B%20filename%3Dlibrust_g.so&response-content-type=application%2Foctet-stream [66491316/66491316] -> "/home/runner/.byond/bin/librust_g.so" [1]
+2023-11-12T09:00:24.6320307Z 	linux-gate.so.1 (0xf7f74000)
+2023-11-12T09:00:24.6321993Z 	libz.so.1 => /lib32/libz.so.1 (0xf7f45000)
+2023-11-12T09:00:24.6322879Z 	libgcc_s.so.1 => /lib32/libgcc_s.so.1 (0xf7f1e000)
+2023-11-12T09:00:24.6323651Z 	libm.so.6 => /lib32/libm.so.6 (0xf7e16000)
+2023-11-12T09:00:24.6324533Z 	libc.so.6 => /lib32/libc.so.6 (0xf7400000)
+2023-11-12T09:00:24.6326012Z 	/lib/ld-linux.so.2 (0xf7f76000)
+2023-11-12T09:00:24.6368501Z ##[group]Run bash tools/ci/install_auxlua.sh
+2023-11-12T09:00:24.6369036Z [36;1mbash tools/ci/install_auxlua.sh[0m
+2023-11-12T09:00:24.6417060Z shell: /usr/bin/bash -e {0}
+2023-11-12T09:00:24.6417480Z ##[endgroup]
+2023-11-12T09:00:24.7086755Z 2023-11-12 09:00:24 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/473295481/ec517e6d-2695-477e-ae92-7645fee5b7ce?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231112T085916Z&X-Amz-Expires=300&X-Amz-Signature=e13d49b79e73a573dc4a351e5e9575d601b7f51fc16f9d3f03f959884cdf8941&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=473295481&response-content-disposition=attachment%3B%20filename%3Dlibauxlua.so&response-content-type=application%2Foctet-stream [6045340/6045340] -> "/home/runner/.byond/bin/libauxlua.so" [1]
+2023-11-12T09:00:24.7172511Z 	linux-gate.so.1 (0xf7f77000)
+2023-11-12T09:00:24.7173643Z 	libstdc++.so.6 => /lib32/libstdc++.so.6 (0xf7800000)
+2023-11-12T09:00:24.7174378Z 	libgcc_s.so.1 => /lib32/libgcc_s.so.1 (0xf7f3e000)
+2023-11-12T09:00:24.7175045Z 	libpthread.so.0 => /lib32/libpthread.so.0 (0xf7f39000)
+2023-11-12T09:00:24.7176413Z 	libm.so.6 => /lib32/libm.so.6 (0xf7e31000)
+2023-11-12T09:00:24.7177209Z 	libdl.so.2 => /lib32/libdl.so.2 (0xf7e2c000)
+2023-11-12T09:00:24.7177918Z 	libc.so.6 => /lib32/libc.so.6 (0xf7400000)
+2023-11-12T09:00:24.7178575Z 	/lib/ld-linux.so.2 (0xf7f79000)
+2023-11-12T09:00:24.7231003Z ##[group]Run bash tools/ci/install_byond.sh
+2023-11-12T09:00:24.7231555Z [36;1mbash tools/ci/install_byond.sh[0m
+2023-11-12T09:00:24.7232077Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2023-11-12T09:00:24.7232805Z [36;1mtools/build/build --ci dm -DCIBUILDING -DANSICOLORS -WError -NWTG0001[0m
+2023-11-12T09:00:24.7274898Z shell: /usr/bin/bash -e {0}
+2023-11-12T09:00:24.7275297Z ##[endgroup]
+2023-11-12T09:00:24.7365575Z Setting up BYOND.
+2023-11-12T09:00:24.7497243Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+2023-11-12T09:00:24.7498339Z                                  Dload  Upload   Total   Spent    Left  Speed
+2023-11-12T09:00:24.7499103Z
+2023-11-12T09:00:24.7733411Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+2023-11-12T09:00:24.7884475Z   0 4021k    0  4979    0     0   203k      0  0:00:19 --:--:--  0:00:19  202k
+2023-11-12T09:00:24.7885997Z 100 4021k  100 4021k    0     0   100M      0 --:--:-- --:--:-- --:--:--  100M
+2023-11-12T09:00:24.8068033Z Archive:  byond.zip
+2023-11-12T09:00:24.8069055Z    creating: byond/
+2023-11-12T09:00:24.8069884Z    creating: byond/key/
+2023-11-12T09:00:24.8071025Z    creating: byond/web/
+2023-11-12T09:00:24.8073333Z   inflating: byond/web/child.dms
+2023-11-12T09:00:24.8074283Z   inflating: byond/web/button.dms
+2023-11-12T09:00:24.8076478Z   inflating: byond/web/input.dms
+2023-11-12T09:00:24.8077391Z   inflating: byond/web/text.dms
+2023-11-12T09:00:24.8176215Z   inflating: byond/web/webclient.dart.js
+2023-11-12T09:00:24.8177154Z   inflating: byond/web/verbmenu.dms
+2023-11-12T09:00:24.8178296Z   inflating: byond/web/defaultSkin.dms
+2023-11-12T09:00:24.8179798Z   inflating: byond/web/hotbar.dms
+2023-11-12T09:00:24.8180913Z   inflating: byond/web/label.dms
+2023-11-12T09:00:24.8181973Z   inflating: byond/web/alert.dms
+2023-11-12T09:00:24.8182843Z   inflating: byond/web/message.dms
+2023-11-12T09:00:24.8183665Z   inflating: byond/web/drag.png
+2023-11-12T09:00:24.8185004Z   inflating: byond/web/map.dms
+2023-11-12T09:00:24.8186150Z   inflating: byond/web/splashlogo.png
+2023-11-12T09:00:24.8186893Z   inflating: byond/web/drop.png
+2023-11-12T09:00:24.8282279Z   inflating: byond/web/ext.js
+2023-11-12T09:00:24.8283075Z   inflating: byond/web/file.dms
+2023-11-12T09:00:24.8284575Z   inflating: byond/web/grid.dms
+2023-11-12T09:00:24.8286207Z   inflating: byond/web/bar.dms
+2023-11-12T09:00:24.8288946Z   inflating: byond/web/dpad.dms
+2023-11-12T09:00:24.8289936Z   inflating: byond/web/output.dms
+2023-11-12T09:00:24.8291365Z   inflating: byond/web/tab.dms
+2023-11-12T09:00:24.8293155Z   inflating: byond/web/info.dms
+2023-11-12T09:00:24.8294881Z   inflating: byond/web/color.dms
+2023-11-12T09:00:24.8296103Z   inflating: byond/web/gamepad.dms
+2023-11-12T09:00:24.8297532Z   inflating: byond/web/browser.dms
+2023-11-12T09:00:24.8298158Z   inflating: byond/web/status.dms
+2023-11-12T09:00:24.8299313Z   inflating: byond/web/any.dms
+2023-11-12T09:00:24.8300438Z   inflating: byond/web/pane.dms
+2023-11-12T09:00:24.8302172Z   inflating: byond/web/pop.dms
+2023-11-12T09:00:24.8303255Z   inflating: byond/license.txt
+2023-11-12T09:00:24.8303882Z   inflating: byond/legal.txt
+2023-11-12T09:00:24.8305048Z   inflating: byond/Makefile
+2023-11-12T09:00:24.8305748Z    creating: byond/man/
+2023-11-12T09:00:24.8306319Z    creating: byond/man/man6/
+2023-11-12T09:00:24.8307604Z   inflating: byond/man/man6/DreamDaemon.6
+2023-11-12T09:00:24.8308434Z   inflating: byond/man/man6/DreamMaker.6
+2023-11-12T09:00:24.8309437Z    creating: byond/lib/
+2023-11-12T09:00:24.8310004Z    creating: byond/host/
+2023-11-12T09:00:24.8311286Z   inflating: byond/host/readme.html
+2023-11-12T09:00:24.8312492Z   inflating: byond/host/readme-unix.txt
+2023-11-12T09:00:24.8313289Z    creating: byond/host/home/
+2023-11-12T09:00:24.8314244Z    creating: byond/host/home/root/
+2023-11-12T09:00:24.8315083Z    creating: byond/host/home/root/byond/
+2023-11-12T09:00:24.8315883Z    creating: byond/host/home/root/byond/tools/
+2023-11-12T09:00:24.8316724Z    creating: byond/host/home/root/byond/tools/root/
+2023-11-12T09:00:24.8321401Z   inflating: byond/host/home/root/byond/tools/root/root.dmb
+2023-11-12T09:00:24.8322363Z    creating: byond/host/shared/
+2023-11-12T09:00:24.8323118Z    creating: byond/host/shared/byond/
+2023-11-12T09:00:24.8323939Z    creating: byond/host/shared/byond/tools/
+2023-11-12T09:00:24.8324697Z    creating: byond/host/shared/byond/tools/ftp/
+2023-11-12T09:00:24.8326100Z   inflating: byond/host/shared/byond/tools/ftp/ftp.dmb
+2023-11-12T09:00:24.8327214Z    creating: byond/host/shared/byond/tools/admin/
+2023-11-12T09:00:24.8332506Z   inflating: byond/host/shared/byond/tools/admin/admin.dmb
+2023-11-12T09:00:24.8333692Z    creating: byond/host/shared-web/
+2023-11-12T09:00:24.8334536Z    creating: byond/host/shared-web/web/
+2023-11-12T09:00:24.8335395Z    creating: byond/host/shared-web/web/tools/
+2023-11-12T09:00:24.8336389Z    creating: byond/host/shared-web/web/tools/admin/
+2023-11-12T09:00:24.8340610Z   inflating: byond/host/shared-web/web/tools/admin/index.dmb
+2023-11-12T09:00:24.8347816Z   inflating: byond/host/host.dmb
+2023-11-12T09:00:24.8348686Z   inflating: byond/host/host.start
+2023-11-12T09:00:24.8349570Z   inflating: byond/host/hostconf.orig
+2023-11-12T09:00:24.8350612Z   inflating: byond/host/hostconf.txt
+2023-11-12T09:00:24.8351646Z   inflating: byond/readme.txt
+2023-11-12T09:00:24.8352393Z    creating: byond/bin/
+2023-11-12T09:00:24.8353203Z   inflating: byond/bin/byondexec
+2023-11-12T09:00:24.8355525Z   inflating: byond/bin/DreamDownload
+2023-11-12T09:00:24.8915164Z   inflating: byond/bin/libbyond.so
+2023-11-12T09:00:24.9052390Z   inflating: byond/bin/libext.so
+2023-11-12T09:00:24.9056691Z   inflating: byond/bin/DreamDaemon
+2023-11-12T09:00:24.9060064Z   inflating: byond/bin/DreamMaker
+2023-11-12T09:00:24.9060916Z    creating: byond/cfg/
+2023-11-12T09:00:24.9061543Z   inflating: byond/cfg/release.txt
+2023-11-12T09:00:24.9218525Z ***************************
+2023-11-12T09:00:24.9225188Z Now run the following command:
+2023-11-12T09:00:24.9233824Z
+2023-11-12T09:00:24.9243155Z source /home/runner/BYOND/byond/bin/byondsetup
+2023-11-12T09:00:24.9251769Z
+2023-11-12T09:00:24.9259232Z If it generates errors, your shell is not compatible with 'sh', so you will
+2023-11-12T09:00:24.9265751Z have to edit byondsetup and make it work with your shell.  If the script works, you should be able to run DreamDaemon.
+2023-11-12T09:00:24.9273703Z
+2023-11-12T09:00:24.9280708Z IMPORTANT: once you have the script working, you must add the above line
+2023-11-12T09:00:24.9287739Z to your startup script.  The name of your startup script depends on the
+2023-11-12T09:00:24.9294443Z shell you use.  Typical ones are .profile or .bash_profile.
+2023-11-12T09:00:24.9302682Z
+2023-11-12T09:00:24.9309851Z Once everything is working, you can find out more about the software
+2023-11-12T09:00:24.9316763Z by doing 'man DreamDaemon'.  A host server has also been included
+2023-11-12T09:00:24.9323620Z so edit host/hostconf.txt and boot up your world server!
+2023-11-12T09:00:24.9330177Z ***************************
+2023-11-12T09:00:24.9736645Z Using system-wide Node v18.18.2
+2023-11-12T09:00:25.1112864Z :: Juke Build version 0.8.1
+2023-11-12T09:00:25.3377241Z => Starting 'dm'
+2023-11-12T09:00:25.3385788Z :: Using defines: CBT, CIBUILDING, ANSICOLORS
+2023-11-12T09:00:25.6662719Z DM compiler version 514.1588
+2023-11-12T09:00:25.6663169Z loading tgstation.m.dme
+2023-11-12T09:00:25.9197564Z code/__DEFINES/qdel.dm:22:warning: #warn TG0001 qdel REFERENCE_TRACKING enabled
+2023-11-12T09:00:36.5749452Z loading interface/skin.dmf
+2023-11-12T09:01:29.5751892Z loading map_files/generic/CentCom.dmm
+2023-11-12T09:01:29.9653644Z saving tgstation.m.dmb (DEBUG mode)
+2023-11-12T09:01:30.6467137Z tgstation.m.dmb - 0 errors, 1 warning (11/12/23 9:01 am)
+2023-11-12T09:01:30.6468251Z Total time: 1:05
+2023-11-12T09:01:31.6898602Z => Finished 'dm' in 66.352s
+2023-11-12T09:01:31.6901009Z => Done in 66.578s
+2023-11-12T09:01:31.7007243Z ##[group]Run source $HOME/BYOND/byond/bin/byondsetup
+2023-11-12T09:01:31.7007981Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2023-11-12T09:01:31.7008503Z [36;1mbash tools/ci/run_server.sh tramstation[0m
+2023-11-12T09:01:31.7058146Z shell: /usr/bin/bash -e {0}
+2023-11-12T09:01:31.7058547Z ##[endgroup]
+2023-11-12T09:01:31.7139001Z Testing tramstation
+2023-11-12T09:01:32.0865721Z cp: cannot stat 'tgui/packages/tgfont/dist/*': No such file or directory
+2023-11-12T09:01:32.1025274Z Sun Nov 12 09:01:32 2023
+2023-11-12T09:01:32.1026062Z World opened on network port 34125.
+2023-11-12T09:01:32.1026759Z Welcome BYOND! (5.0 Public Version 514.1588)
+2023-11-12T09:01:54.2375415Z World loaded at 09:01:54!
+2023-11-12T09:01:54.2376123Z Running /tg/ revision:
+2023-11-12T09:01:54.2376721Z No commit information
+2023-11-12T09:01:54.2377340Z Running rust-g version 3.0.0
+2023-11-12T09:01:54.2445249Z Loading config file config.txt...
+2023-11-12T09:01:54.2449139Z Loading config file maps.txt...
+2023-11-12T09:01:54.2703464Z Unable to locate admins backup file.
+2023-11-12T09:01:55.2792475Z Initialized Title Screen subsystem within 0 seconds!
+2023-11-12T09:01:55.2793681Z Initialized Server Tasks subsystem within 0 seconds!
+2023-11-12T09:01:55.2795047Z Initialized Input subsystem within 0 seconds!
+2023-11-12T09:01:55.2858203Z Initialized Profiler subsystem within 0 seconds!
+2023-11-12T09:01:55.2859689Z Initialized Database subsystem within 0 seconds!
+2023-11-12T09:01:55.2862218Z Initialized Blackbox subsystem within 0 seconds!
+2023-11-12T09:01:55.2938165Z Initialized Sounds subsystem within 0.01 seconds!
+2023-11-12T09:01:55.3061210Z Initialized Instruments subsystem within 0.01 seconds!
+2023-11-12T09:01:55.8390630Z Initialized Greyscale subsystem within 0.53 seconds!
+2023-11-12T09:01:55.8391416Z Initialized Vis contents overlays subsystem within 0 seconds!
+2023-11-12T09:01:55.8392841Z Initialized Security Level subsystem within 0 seconds!
+2023-11-12T09:01:55.8412303Z Initialized Station subsystem within 0 seconds!
+2023-11-12T09:01:55.8426733Z Initialized Quirks subsystem within 0 seconds!
+2023-11-12T09:01:55.8553936Z Initialized Reagents subsystem within 0.01 seconds!
+2023-11-12T09:01:55.8563912Z Initialized Events subsystem within 0 seconds!
+2023-11-12T09:01:55.8612984Z Initialized IDs and Access subsystem within 0 seconds!
+2023-11-12T09:01:55.8616522Z Initialized Jobs subsystem within 0 seconds!
+2023-11-12T09:01:55.8618600Z Initialized AI movement subsystem within 0 seconds!
+2023-11-12T09:01:55.8637284Z Initialized Ticker subsystem within 0 seconds!
+2023-11-12T09:01:55.8693586Z Initialized AI Controller Ticker subsystem within 0.01 seconds!
+2023-11-12T09:01:55.8697702Z Initialized AI Behavior Ticker subsystem within 0 seconds!
+2023-11-12T09:01:55.8821358Z Initialized Trading Card Game subsystem within 0.01 seconds!
+2023-11-12T09:01:55.8968123Z Loading Tramstation...
+2023-11-12T09:01:57.4366548Z Loaded Station in 1.6s!
+2023-11-12T09:01:58.7018385Z Loaded Lavaland in 1.3s!
+2023-11-12T09:01:59.6958478Z All ruins being loaded for map testing.
+2023-11-12T09:01:59.6960551Z Ruin loader finished with 0 left to spend.
+2023-11-12T09:01:59.6963383Z All ruins being loaded for map testing.
+2023-11-12T09:01:59.6966951Z Ruin loader finished with 0 left to spend.
+2023-11-12T09:01:59.8030218Z Cave Generator terrain generation finished in 0.1s!
+2023-11-12T09:01:59.8242156Z Cave Generator terrain generation finished in 0s!
+2023-11-12T09:02:00.0123579Z Cave Generator terrain population finished in 0.1s!
+2023-11-12T09:02:00.0174657Z Cave Generator terrain population finished in 0s!
+2023-11-12T09:02:00.4204586Z Initialized Mapping subsystem within 4.54 seconds!
+2023-11-12T09:02:18.7137331Z Initialized Early Assets subsystem within 18.29 seconds!
+2023-11-12T09:02:18.7960177Z Initialized Research subsystem within 0.08 seconds!
+2023-11-12T09:02:18.7964943Z Initialized Time Tracking subsystem within 0 seconds!
+2023-11-12T09:02:18.8516125Z Initialized Spatial Grid subsystem within 0.05 seconds!
+2023-11-12T09:02:18.8519915Z Initialized Economy subsystem within 0 seconds!
+2023-11-12T09:02:18.8529046Z Initialized Restaurant subsystem within 0 seconds!
+2023-11-12T09:02:24.3564078Z The BYOND hub reports that port 34125 is not reachable.
+2023-11-12T09:03:00.5242715Z ## NOTICE: morgue_cadaver_disable_nonhumans. There are no valid roundstart nonhuman races enabled. Defaulting to humans only!
+2023-11-12T09:03:08.8938364Z Initialized Atoms subsystem within 50.04 seconds!
+2023-11-12T09:03:08.9459509Z Initialized Language subsystem within 0.01 seconds!
+2023-11-12T09:03:09.0602930Z Initialized Machines subsystem within 0.11 seconds!
+2023-11-12T09:03:09.0612163Z Initialized Skills subsystem within 0 seconds!
+2023-11-12T09:03:09.0615253Z Initialized Queue Links subsystem within 0 seconds!
+2023-11-12T09:03:09.0619204Z Initialized Addiction subsystem within 0 seconds!
+2023-11-12T09:03:09.0639408Z Initialized Blackmarket subsystem within 0 seconds!
+2023-11-12T09:03:09.0647224Z Initialized Disease subsystem within 0 seconds!
+2023-11-12T09:03:09.0650704Z Initialized Fluid subsystem within 0 seconds!
+2023-11-12T09:03:09.0654199Z Initialized Smoke subsystem within 0 seconds!
+2023-11-12T09:03:09.0657541Z Initialized Foam subsystem within 0 seconds!
+2023-11-12T09:03:09.0660882Z Initialized Lag Switch subsystem within 0 seconds!
+2023-11-12T09:03:09.0888582Z Initialized Library Loading subsystem within 0.02 seconds!
+2023-11-12T09:03:09.2645071Z Initialized Lua Scripting subsystem within 0.18 seconds!
+2023-11-12T09:03:09.2735036Z Initialized Modular Computers subsystem within 0.01 seconds!
+2023-11-12T09:03:09.2737635Z Initialized Night Shift subsystem within 0 seconds!
+2023-11-12T09:03:09.2741231Z Initialized Stock Market subsystem within 0 seconds!
+2023-11-12T09:03:09.2743761Z Initialized Sun subsystem within 0 seconds!
+2023-11-12T09:03:09.2792256Z Initialized Traitor subsystem within 0 seconds!
+2023-11-12T09:03:09.2795417Z Initialized Tutorials subsystem within 0 seconds!
+2023-11-12T09:03:09.3133961Z Initialized Wardrobe subsystem within 0.03 seconds!
+2023-11-12T09:03:09.3136967Z Initialized Weather subsystem within 0 seconds!
+2023-11-12T09:03:09.3140470Z Initialized Wiremod Composite Templates subsystem within 0 seconds!
+2023-11-12T09:03:14.7053894Z Initialized Atmospherics subsystem within 5.39 seconds!
+2023-11-12T09:03:14.7127034Z Initialized Persistence subsystem within 0.01 seconds!
+2023-11-12T09:03:14.7131026Z Initialized Persistent Paintings subsystem within 0 seconds!
+2023-11-12T09:03:14.7134716Z Initialized Vote subsystem within 0 seconds!
+2023-11-12T09:03:25.6600909Z Initialized Assets subsystem within 10.95 seconds!
+2023-11-12T09:03:29.1318017Z Initialized Icon Smoothing subsystem within 3.42 seconds!
+2023-11-12T09:03:29.1329352Z Initialized XKeyScore subsystem within 0 seconds!
+2023-11-12T09:03:29.1349808Z Initialized PRISM subsystem within 0 seconds!
+2023-11-12T09:03:39.5066635Z Initialized Lighting subsystem within 10.37 seconds!
+2023-11-12T09:03:42.0097538Z Initialized Shuttle subsystem within 2.5 seconds!
+2023-11-12T09:03:42.0100528Z Initialized Pathfinder subsystem within 0 seconds!
+2023-11-12T09:03:42.0112119Z Initialized Ban Cache subsystem within 0 seconds!
+2023-11-12T09:03:42.0114877Z Initialized Init Profiler subsystem within 0 seconds!
+2023-11-12T09:03:42.0117470Z Initialized Chat subsystem within 0 seconds!
+2023-11-12T09:03:42.0119918Z Initializations complete within 106.8 seconds!
+2023-11-12T09:03:42.0699329Z Game start took 0s
+2023-11-12T09:03:53.5395990Z ##[group]/datum/unit_test/log_mapping
+2023-11-12T09:03:53.5399338Z [1;32mPASS[0m /datum/unit_test/log_mapping 0s
+2023-11-12T09:03:53.5400530Z ##[endgroup]
+2023-11-12T09:03:53.5529741Z ##[group]/datum/unit_test/abductor_baton_spell
+2023-11-12T09:03:53.6248315Z [1;32mPASS[0m /datum/unit_test/abductor_baton_spell 0.1s
+2023-11-12T09:03:53.6250017Z ##[endgroup]
+2023-11-12T09:03:53.7293652Z ##[group]/datum/unit_test/ablative_hood_hud
+2023-11-12T09:03:53.7538980Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud 0s
+2023-11-12T09:03:53.7540945Z ##[endgroup]
+2023-11-12T09:03:53.8177940Z ##[group]/datum/unit_test/ablative_hood_hud_with_helmet
+2023-11-12T09:03:53.8373528Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud_with_helmet 0s
+2023-11-12T09:03:53.8375040Z ##[endgroup]
+2023-11-12T09:03:53.9037089Z ##[group]/datum/unit_test/achievements
+2023-11-12T09:03:53.9146939Z [1;32mPASS[0m /datum/unit_test/achievements 0s
+2023-11-12T09:03:53.9148600Z ##[endgroup]
+2023-11-12T09:03:53.9709749Z ##[group]/datum/unit_test/anchored_mobs
+2023-11-12T09:03:53.9714871Z [1;32mPASS[0m /datum/unit_test/anchored_mobs 0s
+2023-11-12T09:03:53.9717149Z ##[endgroup]
+2023-11-12T09:03:54.0290915Z ##[group]/datum/unit_test/anonymous_themes
+2023-11-12T09:03:54.1282674Z [1;32mPASS[0m /datum/unit_test/anonymous_themes 0.1s
+2023-11-12T09:03:54.1284602Z ##[endgroup]
+2023-11-12T09:03:54.2369870Z ##[group]/datum/unit_test/revolution_conversion
+2023-11-12T09:03:54.2811074Z [1;32mPASS[0m /datum/unit_test/revolution_conversion 0s
+2023-11-12T09:03:54.2812989Z ##[endgroup]
+2023-11-12T09:03:54.3619950Z ##[group]/datum/unit_test/cult_conversion
+2023-11-12T09:03:54.4185381Z [1;32mPASS[0m /datum/unit_test/cult_conversion 0.1s
+2023-11-12T09:03:54.4187014Z ##[endgroup]
+2023-11-12T09:03:54.5109339Z ##[group]/datum/unit_test/antag_moodlets
+2023-11-12T09:03:54.5391588Z [1;32mPASS[0m /datum/unit_test/antag_moodlets 0s
+2023-11-12T09:03:54.5393248Z ##[endgroup]
+2023-11-12T09:03:54.6099817Z ##[group]/datum/unit_test/armor_verification
+2023-11-12T09:03:54.6105398Z [1;32mPASS[0m /datum/unit_test/armor_verification 0s
+2023-11-12T09:03:54.6107086Z ##[endgroup]
+2023-11-12T09:03:54.6711998Z ##[group]/datum/unit_test/autowiki
+2023-11-12T09:03:56.4795605Z [1;32mPASS[0m /datum/unit_test/autowiki 1.8s
+2023-11-12T09:03:56.4797118Z ##[endgroup]
+2023-11-12T09:03:56.5376207Z ##[group]/datum/unit_test/autowiki_include_template
+2023-11-12T09:03:56.5378371Z [1;32mPASS[0m /datum/unit_test/autowiki_include_template 0s
+2023-11-12T09:03:56.5380504Z ##[endgroup]
+2023-11-12T09:03:56.6003986Z ##[group]/datum/unit_test/barsigns_icon
+2023-11-12T09:03:56.6303581Z [1;32mPASS[0m /datum/unit_test/barsigns_icon 0.1s
+2023-11-12T09:03:56.6305267Z ##[endgroup]
+2023-11-12T09:03:56.6912219Z ##[group]/datum/unit_test/barsigns_name
+2023-11-12T09:03:56.6914950Z [1;32mPASS[0m /datum/unit_test/barsigns_name 0s
+2023-11-12T09:03:56.6917244Z ##[endgroup]
+2023-11-12T09:03:56.7530053Z ##[group]/datum/unit_test/baseturfs_unmodified_scrape
+2023-11-12T09:03:56.7541656Z [1;32mPASS[0m /datum/unit_test/baseturfs_unmodified_scrape 0s
+2023-11-12T09:03:56.7543322Z ##[endgroup]
+2023-11-12T09:03:56.8163460Z ##[group]/datum/unit_test/baseturfs_placed_on_top
+2023-11-12T09:03:56.8173471Z [1;32mPASS[0m /datum/unit_test/baseturfs_placed_on_top 0s
+2023-11-12T09:03:56.8175579Z ##[endgroup]
+2023-11-12T09:03:56.8789484Z ##[group]/datum/unit_test/baseturfs_placed_on_bottom
+2023-11-12T09:03:56.8806366Z [1;32mPASS[0m /datum/unit_test/baseturfs_placed_on_bottom 0s
+2023-11-12T09:03:56.8808190Z ##[endgroup]
+2023-11-12T09:03:56.9420497Z ##[group]/datum/unit_test/bespoke_id
+2023-11-12T09:03:56.9422999Z [1;32mPASS[0m /datum/unit_test/bespoke_id 0s
+2023-11-12T09:03:56.9425227Z ##[endgroup]
+2023-11-12T09:03:57.1727331Z ##[group]/datum/unit_test/binary_insert
+2023-11-12T09:03:57.1728436Z [1;32mPASS[0m /datum/unit_test/binary_insert 0s
+2023-11-12T09:03:57.1730597Z ##[endgroup]
+2023-11-12T09:03:57.2270246Z ##[group]/datum/unit_test/bitrunner_vdom_settings
+2023-11-12T09:03:57.2368664Z [1;32mPASS[0m /datum/unit_test/bitrunner_vdom_settings 0s
+2023-11-12T09:03:57.2370507Z ##[endgroup]
+2023-11-12T09:03:57.2860471Z ##[group]/datum/unit_test/blindness
+2023-11-12T09:03:57.3060031Z [1;32mPASS[0m /datum/unit_test/blindness 0.1s
+2023-11-12T09:03:57.3061453Z ##[endgroup]
+2023-11-12T09:03:57.3685247Z ##[group]/datum/unit_test/nearsightedness
+2023-11-12T09:03:57.3856666Z [1;32mPASS[0m /datum/unit_test/nearsightedness 0s
+2023-11-12T09:03:57.3857831Z ##[endgroup]
+2023-11-12T09:03:57.4094606Z ##[group]/datum/unit_test/eye_damage
+2023-11-12T09:03:57.4266705Z [1;32mPASS[0m /datum/unit_test/eye_damage 0s
+2023-11-12T09:03:57.4268768Z ##[endgroup]
+2023-11-12T09:03:57.4514012Z ##[group]/datum/unit_test/bloody_footprints
+2023-11-12T09:03:57.4771474Z [1;32mPASS[0m /datum/unit_test/bloody_footprints 0s
+2023-11-12T09:03:57.4773523Z ##[endgroup]
+2023-11-12T09:03:57.5095312Z ##[group]/datum/unit_test/breath/breath_sanity
+2023-11-12T09:03:57.5793797Z [1;32mPASS[0m /datum/unit_test/breath/breath_sanity 0s
+2023-11-12T09:03:57.5795766Z ##[endgroup]
+2023-11-12T09:03:57.6356372Z ##[group]/datum/unit_test/breath/breath_sanity_plasmamen
+2023-11-12T09:03:57.6920259Z [1;32mPASS[0m /datum/unit_test/breath/breath_sanity_plasmamen 0s
+2023-11-12T09:03:57.6922126Z ##[endgroup]
+2023-11-12T09:03:57.7478880Z ##[group]/datum/unit_test/breath/breath_sanity_ashwalker
+2023-11-12T09:03:57.7793279Z [1;32mPASS[0m /datum/unit_test/breath/breath_sanity_ashwalker 0s
+2023-11-12T09:03:57.7794768Z ##[endgroup]
+2023-11-12T09:03:57.8063286Z ##[group]/datum/unit_test/burning
+2023-11-12T09:03:57.8235820Z [1;32mPASS[0m /datum/unit_test/burning 0s
+2023-11-12T09:03:57.8237580Z ##[endgroup]
+2023-11-12T09:03:57.8463809Z ##[group]/datum/unit_test/cable_powernets
+2023-11-12T09:03:57.8467369Z [1;32mPASS[0m /datum/unit_test/cable_powernets 0s
+2023-11-12T09:03:57.8468842Z ##[endgroup]
+2023-11-12T09:03:57.8681387Z ##[group]/datum/unit_test/card_mismatch
+2023-11-12T09:03:57.8715332Z [1;32mPASS[0m /datum/unit_test/card_mismatch 0s
+2023-11-12T09:03:57.8717822Z ##[endgroup]
+2023-11-12T09:03:57.8839316Z ##[group]/datum/unit_test/cardboard_cutouts
+2023-11-12T09:03:57.8847499Z 	cardboard_cutouts_normal_cutout was put in data/screenshots_new
+2023-11-12T09:03:58.1374772Z 	cardboard_cutouts_nukie_cutout was put in data/screenshots_new
+2023-11-12T09:03:58.1378574Z 	cardboard_cutouts_nukie_cutout_pushed was put in data/screenshots_new
+2023-11-12T09:03:58.1547388Z 	cardboard_cutouts_xenomorph_cutout was put in data/screenshots_new
+2023-11-12T09:03:58.1550933Z [1;32mPASS[0m /datum/unit_test/cardboard_cutouts 0.3s
+2023-11-12T09:03:58.1553499Z ##[endgroup]
+2023-11-12T09:03:58.2402466Z ##[group]/datum/unit_test/chain_pull_through_space
+2023-11-12T09:03:58.2453035Z [1;32mPASS[0m /datum/unit_test/chain_pull_through_space 0s
+2023-11-12T09:03:58.2454853Z ##[endgroup]
+2023-11-12T09:03:58.3033483Z ##[group]/datum/unit_test/transformation_sting
+2023-11-12T09:03:59.7549687Z 	transformation_sting_appearances was put in data/screenshots_new
+2023-11-12T09:03:59.7551965Z [1;32mPASS[0m /datum/unit_test/transformation_sting 1.4s
+2023-11-12T09:03:59.7553272Z ##[endgroup]
+2023-11-12T09:03:59.7969350Z ##[group]/datum/unit_test/chat_filter_sanity
+2023-11-12T09:03:59.7976589Z [1;32mPASS[0m /datum/unit_test/chat_filter_sanity 0s
+2023-11-12T09:03:59.7978237Z ##[endgroup]
+2023-11-12T09:03:59.8105892Z ##[group]/datum/unit_test/circuit_component_category
+2023-11-12T09:03:59.8107746Z [1;32mPASS[0m /datum/unit_test/circuit_component_category 0s
+2023-11-12T09:03:59.8109947Z ##[endgroup]
+2023-11-12T09:03:59.8879728Z ##[group]/datum/unit_test/client_colours
+2023-11-12T09:03:59.8889068Z [1;32mPASS[0m /datum/unit_test/client_colours 0s
+2023-11-12T09:03:59.8891665Z ##[endgroup]
+2023-11-12T09:03:59.9525316Z ##[group]/datum/unit_test/closets
+2023-11-12T09:04:01.8031965Z [1;32mPASS[0m /datum/unit_test/closets 1.9s
+2023-11-12T09:04:01.8033340Z ##[endgroup]
+2023-11-12T09:04:02.6399153Z ##[group]/datum/unit_test/clothing_under_armor_subtype_check
+2023-11-12T09:04:02.6403381Z [1;32mPASS[0m /datum/unit_test/clothing_under_armor_subtype_check 0s
+2023-11-12T09:04:02.6405014Z ##[endgroup]
+2023-11-12T09:04:02.7020573Z ##[group]/datum/unit_test/harm_punch
+2023-11-12T09:04:02.7364226Z [1;32mPASS[0m /datum/unit_test/harm_punch 0s
+2023-11-12T09:04:02.7366615Z ##[endgroup]
+2023-11-12T09:04:02.7919290Z ##[group]/datum/unit_test/harm_melee
+2023-11-12T09:04:02.8266028Z [1;32mPASS[0m /datum/unit_test/harm_melee 0.1s
+2023-11-12T09:04:02.8268574Z ##[endgroup]
+2023-11-12T09:04:02.8738136Z ##[group]/datum/unit_test/harm_different_damage
+2023-11-12T09:04:02.9125671Z [1;32mPASS[0m /datum/unit_test/harm_different_damage 0.1s
+2023-11-12T09:04:02.9127697Z ##[endgroup]
+2023-11-12T09:04:02.9510991Z ##[group]/datum/unit_test/attack_chain
+2023-11-12T09:04:02.9859497Z [1;32mPASS[0m /datum/unit_test/attack_chain 0s
+2023-11-12T09:04:02.9861383Z ##[endgroup]
+2023-11-12T09:04:03.0312671Z ##[group]/datum/unit_test/disarm
+2023-11-12T09:04:03.0675162Z [1;32mPASS[0m /datum/unit_test/disarm 0s
+2023-11-12T09:04:03.0677029Z ##[endgroup]
+2023-11-12T09:04:03.1122424Z ##[group]/datum/unit_test/self_punch
+2023-11-12T09:04:03.1297149Z [1;32mPASS[0m /datum/unit_test/self_punch 0s
+2023-11-12T09:04:03.1299012Z ##[endgroup]
+2023-11-12T09:04:03.1617839Z ##[group]/datum/unit_test/handcuff_punch
+2023-11-12T09:04:03.1949728Z [1;32mPASS[0m /datum/unit_test/handcuff_punch 0s
+2023-11-12T09:04:03.1950695Z ##[endgroup]
+2023-11-12T09:04:03.2665996Z ##[group]/datum/unit_test/handcuff_bite
+2023-11-12T09:04:03.3310134Z [1;32mPASS[0m /datum/unit_test/handcuff_bite 0.1s
+2023-11-12T09:04:03.3311967Z ##[endgroup]
+2023-11-12T09:04:03.3720567Z ##[group]/datum/unit_test/component_duping
+2023-11-12T09:04:03.3725700Z [1;32mPASS[0m /datum/unit_test/component_duping 0s
+2023-11-12T09:04:03.3728116Z ##[endgroup]
+2023-11-12T09:04:03.3854948Z ##[group]/datum/unit_test/confusion_symptom
+2023-11-12T09:04:03.4020935Z [1;32mPASS[0m /datum/unit_test/confusion_symptom 0.1s
+2023-11-12T09:04:03.4023437Z ##[endgroup]
+2023-11-12T09:04:03.4660129Z ##[group]/datum/unit_test/connect_loc_basic
+2023-11-12T09:04:03.4667486Z [1;32mPASS[0m /datum/unit_test/connect_loc_basic 0s
+2023-11-12T09:04:03.4669665Z ##[endgroup]
+2023-11-12T09:04:03.5206421Z ##[group]/datum/unit_test/connect_loc_change_turf
+2023-11-12T09:04:03.5219191Z [1;32mPASS[0m /datum/unit_test/connect_loc_change_turf 0s
+2023-11-12T09:04:03.5221198Z ##[endgroup]
+2023-11-12T09:04:03.5413589Z ##[group]/datum/unit_test/connect_loc_multiple_on_turf
+2023-11-12T09:04:03.5422679Z [1;32mPASS[0m /datum/unit_test/connect_loc_multiple_on_turf 0s
+2023-11-12T09:04:03.5424576Z ##[endgroup]
+2023-11-12T09:04:03.5552785Z ##[group]/datum/unit_test/reagent_container_sanity
+2023-11-12T09:04:03.8101359Z [1;32mPASS[0m /datum/unit_test/reagent_container_sanity 0.3s
+2023-11-12T09:04:03.8102486Z ##[endgroup]
+2023-11-12T09:04:03.9680842Z ##[group]/datum/unit_test/crayon_naming
+2023-11-12T09:04:03.9683784Z [1;32mPASS[0m /datum/unit_test/crayon_naming 0s
+2023-11-12T09:04:03.9686430Z ##[endgroup]
+2023-11-12T09:04:03.9815420Z ##[group]/datum/unit_test/dcs_get_id_from_arguments
+2023-11-12T09:04:03.9822614Z [1;32mPASS[0m /datum/unit_test/dcs_get_id_from_arguments 0s
+2023-11-12T09:04:03.9825219Z ##[endgroup]
+2023-11-12T09:04:03.9952914Z ##[group]/datum/unit_test/designs
+2023-11-12T09:04:04.0032294Z [1;32mPASS[0m /datum/unit_test/designs 0.1s
+2023-11-12T09:04:04.0034986Z ##[endgroup]
+2023-11-12T09:04:04.0184498Z ##[group]/datum/unit_test/dismemberment
+2023-11-12T09:04:04.0687805Z [1;32mPASS[0m /datum/unit_test/dismemberment 0s
+2023-11-12T09:04:04.0690374Z ##[endgroup]
+2023-11-12T09:04:04.1062552Z ##[group]/datum/unit_test/door_access_check
+2023-11-12T09:04:04.1315486Z [1;32mPASS[0m /datum/unit_test/door_access_check 0s
+2023-11-12T09:04:04.1318637Z ##[endgroup]
+2023-11-12T09:04:04.1659906Z ##[group]/datum/unit_test/contents_barfer
+2023-11-12T09:04:04.1881762Z [1;32mPASS[0m /datum/unit_test/contents_barfer 0s
+2023-11-12T09:04:04.1884275Z ##[endgroup]
+2023-11-12T09:04:04.2328534Z ##[group]/datum/unit_test/space_dragon_expiration
+2023-11-12T09:04:04.2672064Z [1;32mPASS[0m /datum/unit_test/space_dragon_expiration 0s
+2023-11-12T09:04:04.2674522Z ##[endgroup]
+2023-11-12T09:04:04.3282341Z ##[group]/datum/unit_test/glass_style_icons
+2023-11-12T09:04:04.3517947Z [1;32mPASS[0m /datum/unit_test/glass_style_icons 0s
+2023-11-12T09:04:04.3520368Z ##[endgroup]
+2023-11-12T09:04:04.3761901Z ##[group]/datum/unit_test/glass_style_functionality
+2023-11-12T09:04:04.3773186Z [1;32mPASS[0m /datum/unit_test/glass_style_functionality 0s
+2023-11-12T09:04:04.3775791Z ##[endgroup]
+2023-11-12T09:04:04.3908269Z ##[group]/datum/unit_test/drink_icons
+2023-11-12T09:04:04.4155215Z [1;32mPASS[0m /datum/unit_test/drink_icons 0.1s
+2023-11-12T09:04:04.4157609Z ##[endgroup]
+2023-11-12T09:04:04.4303228Z ##[group]/datum/unit_test/dummy_spawn_species
+2023-11-12T09:04:05.4828810Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_species 1s
+2023-11-12T09:04:05.4829704Z ##[endgroup]
+2023-11-12T09:04:05.5166735Z ##[group]/datum/unit_test/dummy_spawn_outfit
+2023-11-12T09:04:05.5400845Z 	Job type /datum/job/ai could not be retrieved from SSjob
+2023-11-12T09:04:06.0232636Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_outfit 0.5s
+2023-11-12T09:04:06.0234589Z ##[endgroup]
+2023-11-12T09:04:06.0505202Z ##[group]/datum/unit_test/dynamic_roundstart_ruleset_sanity
+2023-11-12T09:04:06.0508804Z [1;32mPASS[0m /datum/unit_test/dynamic_roundstart_ruleset_sanity 0s
+2023-11-12T09:04:06.0511050Z ##[endgroup]
+2023-11-12T09:04:06.0637233Z ##[group]/datum/unit_test/dynamic_unique_antag_flags
+2023-11-12T09:04:06.0640294Z [1;32mPASS[0m /datum/unit_test/dynamic_unique_antag_flags 0s
+2023-11-12T09:04:06.0642513Z ##[endgroup]
+2023-11-12T09:04:06.0770713Z ##[group]/datum/unit_test/egg_glands
+2023-11-12T09:04:06.1407083Z [1;32mPASS[0m /datum/unit_test/egg_glands 0.1s
+2023-11-12T09:04:06.1408405Z ##[endgroup]
+2023-11-12T09:04:06.1628261Z ##[group]/datum/unit_test/emoting
+2023-11-12T09:04:06.1818671Z [1;32mPASS[0m /datum/unit_test/emoting 0s
+2023-11-12T09:04:06.1821362Z ##[endgroup]
+2023-11-12T09:04:06.2077157Z ##[group]/datum/unit_test/ensure_subtree_operational_datum
+2023-11-12T09:04:08.1731821Z [1;32mPASS[0m /datum/unit_test/ensure_subtree_operational_datum 1.9s
+2023-11-12T09:04:08.1733285Z ##[endgroup]
+2023-11-12T09:04:08.7539706Z ##[group]/datum/unit_test/explosion_action
+2023-11-12T09:04:08.8465799Z [1;32mPASS[0m /datum/unit_test/explosion_action 0.1s
+2023-11-12T09:04:08.8468184Z ##[endgroup]
+2023-11-12T09:04:08.9010946Z ##[group]/datum/unit_test/fish_size_weight
+2023-11-12T09:04:08.9019514Z [1;32mPASS[0m /datum/unit_test/fish_size_weight 0s
+2023-11-12T09:04:08.9022220Z ##[endgroup]
+2023-11-12T09:04:08.9154882Z ##[group]/datum/unit_test/fish_breeding
+2023-11-12T09:04:08.9227664Z [1;32mPASS[0m /datum/unit_test/fish_breeding 0s
+2023-11-12T09:04:08.9230704Z ##[endgroup]
+2023-11-12T09:04:08.9389958Z ##[group]/datum/unit_test/fish_evolution
+2023-11-12T09:04:08.9418165Z [1;32mPASS[0m /datum/unit_test/fish_evolution 0s
+2023-11-12T09:04:08.9421366Z ##[endgroup]
+2023-11-12T09:04:08.9631338Z ##[group]/datum/unit_test/fish_scanning
+2023-11-12T09:04:08.9635076Z [1;32mPASS[0m /datum/unit_test/fish_scanning 0s
+2023-11-12T09:04:08.9638063Z ##[endgroup]
+2023-11-12T09:04:08.9772162Z ##[group]/datum/unit_test/font_awesome_icons
+2023-11-12T09:04:08.9779113Z CSS Actual: 96991
+2023-11-12T09:04:09.3976724Z [1;32mPASS[0m /datum/unit_test/font_awesome_icons 0.4s
+2023-11-12T09:04:09.3978084Z ##[endgroup]
+2023-11-12T09:04:09.4388919Z ##[group]/datum/unit_test/food_edibility_check
+2023-11-12T09:04:11.4659822Z [1;32mPASS[0m /datum/unit_test/food_edibility_check 2s
+2023-11-12T09:04:11.4661512Z ##[endgroup]
+2023-11-12T09:04:11.4957968Z ##[group]/datum/unit_test/full_heal_heals_organs
+2023-11-12T09:04:11.5147883Z [1;32mPASS[0m /datum/unit_test/full_heal_heals_organs 0.1s
+2023-11-12T09:04:11.5149360Z ##[endgroup]
+2023-11-12T09:04:11.5413116Z ##[group]/datum/unit_test/full_heal_regenerates_organs
+2023-11-12T09:04:11.5651258Z [1;32mPASS[0m /datum/unit_test/full_heal_regenerates_organs 0s
+2023-11-12T09:04:11.5653018Z ##[endgroup]
+2023-11-12T09:04:11.6325061Z ##[group]/datum/unit_test/full_heal_damage_types
+2023-11-12T09:04:11.6518216Z [1;32mPASS[0m /datum/unit_test/full_heal_damage_types 0s
+2023-11-12T09:04:11.6519698Z ##[endgroup]
+2023-11-12T09:04:11.7209709Z ##[group]/datum/unit_test/atmospheric_gas_transfer
+2023-11-12T09:04:11.7227226Z [1;32mPASS[0m /datum/unit_test/atmospheric_gas_transfer 0s
+2023-11-12T09:04:11.7228891Z ##[endgroup]
+2023-11-12T09:04:11.7822095Z ##[group]/datum/unit_test/get_turf_pixel
+2023-11-12T09:04:11.7849880Z [1;32mPASS[0m /datum/unit_test/get_turf_pixel 0s
+2023-11-12T09:04:11.7851756Z ##[endgroup]
+2023-11-12T09:04:11.8495917Z ##[group]/datum/unit_test/geyser
+2023-11-12T09:04:11.8516781Z [1;32mPASS[0m /datum/unit_test/geyser 0s
+2023-11-12T09:04:11.8518776Z ##[endgroup]
+2023-11-12T09:04:11.9115770Z ##[group]/datum/unit_test/greyscale_item_icon_states
+2023-11-12T09:04:11.9172841Z [1;32mPASS[0m /datum/unit_test/greyscale_item_icon_states 0s
+2023-11-12T09:04:11.9174524Z ##[endgroup]
+2023-11-12T09:04:11.9770664Z ##[group]/datum/unit_test/greyscale_color_count
+2023-11-12T09:04:11.9908294Z [1;32mPASS[0m /datum/unit_test/greyscale_color_count 0s
+2023-11-12T09:04:11.9910694Z ##[endgroup]
+2023-11-12T09:04:12.0513128Z ##[group]/datum/unit_test/hallucination_icons
+2023-11-12T09:04:12.2294786Z [1;32mPASS[0m /datum/unit_test/hallucination_icons 0.2s
+2023-11-12T09:04:12.2296061Z ##[endgroup]
+2023-11-12T09:04:12.2752905Z ##[group]/datum/unit_test/heretic_knowledge
+2023-11-12T09:04:12.2797900Z [1;32mPASS[0m /datum/unit_test/heretic_knowledge 0s
+2023-11-12T09:04:12.2800226Z ##[endgroup]
+2023-11-12T09:04:12.3526741Z ##[group]/datum/unit_test/heretic_main_paths
+2023-11-12T09:04:12.3530666Z [1;32mPASS[0m /datum/unit_test/heretic_main_paths 0s
+2023-11-12T09:04:12.3532858Z ##[endgroup]
+2023-11-12T09:04:12.3985035Z ##[group]/datum/unit_test/heretic_rituals
+2023-11-12T09:04:12.4878733Z [1;32mPASS[0m /datum/unit_test/heretic_rituals 0.1s
+2023-11-12T09:04:12.4880607Z ##[endgroup]
+2023-11-12T09:04:12.5120786Z ##[group]/datum/unit_test/high_five
+2023-11-12T09:04:12.5591361Z [1;32mPASS[0m /datum/unit_test/high_five 0s
+2023-11-12T09:04:12.5593593Z ##[endgroup]
+2023-11-12T09:04:12.6154998Z ##[group]/datum/unit_test/high_five_too_slow
+2023-11-12T09:04:12.6462178Z [1;32mPASS[0m /datum/unit_test/high_five_too_slow 0s
+2023-11-12T09:04:12.6464631Z ##[endgroup]
+2023-11-12T09:04:12.6825675Z ##[group]/datum/unit_test/high_five_walk_away
+2023-11-12T09:04:12.7302468Z [1;32mPASS[0m /datum/unit_test/high_five_walk_away 0.1s
+2023-11-12T09:04:12.7304078Z ##[endgroup]
+2023-11-12T09:04:12.7849321Z ##[group]/datum/unit_test/hanukkah_2123
+2023-11-12T09:04:12.7857129Z [1;32mPASS[0m /datum/unit_test/hanukkah_2123 0s
+2023-11-12T09:04:12.7859467Z ##[endgroup]
+2023-11-12T09:04:12.7985283Z ##[group]/datum/unit_test/ramadan_2165
+2023-11-12T09:04:12.7988232Z [1;32mPASS[0m /datum/unit_test/ramadan_2165 0s
+2023-11-12T09:04:12.7990308Z ##[endgroup]
+2023-11-12T09:04:12.8115461Z ##[group]/datum/unit_test/thanksgiving_2020
+2023-11-12T09:04:12.8118309Z [1;32mPASS[0m /datum/unit_test/thanksgiving_2020 0s
+2023-11-12T09:04:12.8120732Z ##[endgroup]
+2023-11-12T09:04:12.8276159Z ##[group]/datum/unit_test/mother_3683
+2023-11-12T09:04:12.8278795Z [1;32mPASS[0m /datum/unit_test/mother_3683 0s
+2023-11-12T09:04:12.8281149Z ##[endgroup]
+2023-11-12T09:04:12.8402992Z ##[group]/datum/unit_test/hello_2020
+2023-11-12T09:04:12.8405520Z [1;32mPASS[0m /datum/unit_test/hello_2020 0s
+2023-11-12T09:04:12.8408004Z ##[endgroup]
+2023-11-12T09:04:12.8529607Z ##[group]/datum/unit_test/new_year_1983
+2023-11-12T09:04:12.8531956Z [1;32mPASS[0m /datum/unit_test/new_year_1983 0s
+2023-11-12T09:04:12.8534286Z ##[endgroup]
+2023-11-12T09:04:12.8655830Z ##[group]/datum/unit_test/moth_week_2020
+2023-11-12T09:04:12.8735184Z [1;32mPASS[0m /datum/unit_test/moth_week_2020 0s
+2023-11-12T09:04:12.8737646Z ##[endgroup]
+2023-11-12T09:04:12.8963722Z ##[group]/datum/unit_test/hulk_attack
+2023-11-12T09:04:12.9298282Z [1;32mPASS[0m /datum/unit_test/hulk_attack 0.1s
+2023-11-12T09:04:12.9300378Z ##[endgroup]
+2023-11-12T09:04:12.9631065Z ##[group]/datum/unit_test/hulk_north_star
+2023-11-12T09:04:12.9971964Z [1;32mPASS[0m /datum/unit_test/hulk_north_star 0s
+2023-11-12T09:04:12.9974198Z ##[endgroup]
+2023-11-12T09:04:13.0684879Z ##[group]/datum/unit_test/human_through_recycler
+2023-11-12T09:04:13.1042839Z [1;32mPASS[0m /datum/unit_test/human_through_recycler 0.1s
+2023-11-12T09:04:13.1045346Z ##[endgroup]
+2023-11-12T09:04:13.1302366Z ##[group]/datum/unit_test/hunger_curse
+2023-11-12T09:04:13.1487751Z [1;32mPASS[0m /datum/unit_test/hunger_curse 0s
+2023-11-12T09:04:13.1490362Z ##[endgroup]
+2023-11-12T09:04:13.1724484Z ##[group]/datum/unit_test/hydroponics_extractor_storage
+2023-11-12T09:04:13.2045321Z [1;32mPASS[0m /datum/unit_test/hydroponics_extractor_storage 0.1s
+2023-11-12T09:04:13.2047744Z ##[endgroup]
+2023-11-12T09:04:13.2424994Z ##[group]/datum/unit_test/hydroponics_harvest
+2023-11-12T09:04:13.3172098Z [1;32mPASS[0m /datum/unit_test/hydroponics_harvest 0.1s
+2023-11-12T09:04:13.3173538Z ##[endgroup]
+2023-11-12T09:04:13.3896863Z ##[group]/datum/unit_test/hydroponics_self_mutation
+2023-11-12T09:04:13.4546321Z [1;32mPASS[0m /datum/unit_test/hydroponics_self_mutation 0.1s
+2023-11-12T09:04:13.4548349Z ##[endgroup]
+2023-11-12T09:04:13.5127280Z ##[group]/datum/unit_test/hydroponics_validate_genes
+2023-11-12T09:04:13.5761114Z [1;32mPASS[0m /datum/unit_test/hydroponics_validate_genes 0s
+2023-11-12T09:04:13.5765353Z ##[endgroup]
+2023-11-12T09:04:13.5897676Z ##[group]/datum/unit_test/defined_inhand_icon_states
+2023-11-12T09:04:14.5257265Z 	Notice - Possible inhand icon matches found. It is best to be explicit with inhand sprite values.
+2023-11-12T09:04:14.5260490Z 	/obj/item/clothing/head/costume/lizard does not have an inhand_icon_state value - Possible matching sprites for "lizard" found in: 'icons/mob/inhands/animal_item_lefthand.dmi' & 'icons/mob/inhands/animal_item_righthand.dmi'
+2023-11-12T09:04:14.5265334Z 	/obj/item/clothing/head/costume/paper_hat does not have an inhand_icon_state value - Possible matching sprites for "paper" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2023-11-12T09:04:14.5269130Z 	/obj/item/clothing/head/collectable/paper does not have an inhand_icon_state value - Possible matching sprites for "paper" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2023-11-12T09:04:14.5272911Z 	/obj/item/clothing/head/cowboy does not have an inhand_icon_state value - Possible matching sprites for "cowboy_hat_brown" found in: 'icons/mob/inhands/clothing/hats_lefthand.dmi' & 'icons/mob/inhands/clothing/hats_righthand.dmi'
+2023-11-12T09:04:14.5276899Z 	/obj/item/clothing/head/chaplain/habit_veil does not have an inhand_icon_state value - Possible matching sprites for "nun_hood_alt" found in: 'icons/mob/inhands/clothing/hats_lefthand.dmi' & 'icons/mob/inhands/clothing/hats_righthand.dmi'
+2023-11-12T09:04:14.5280655Z 	/obj/item/clothing/mask/animal/small/fox does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2023-11-12T09:04:14.5284605Z 	/obj/item/clothing/mask/animal/small/fox/cursed does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2023-11-12T09:04:14.5288384Z 	/obj/item/clothing/accessory/pride does not have an inhand_icon_state value - Possible matching sprites for "pride" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2023-11-12T09:04:14.5292328Z 	/obj/item/clothing/suit/apron/overalls does not have an inhand_icon_state value - Possible matching sprites for "overalls" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2023-11-12T09:04:14.5296324Z 	/obj/item/clothing/suit/caution does not have an inhand_icon_state value - Possible matching sprites for "caution" found in: 'icons/mob/inhands/equipment/custodial_righthand.dmi' & 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
+2023-11-12T09:04:14.5300339Z 	/obj/item/clothing/suit/chaplainsuit/habit does not have an inhand_icon_state value - Possible matching sprites for "habit" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2023-11-12T09:04:14.5305034Z 	/obj/item/clothing/glasses/hud/health/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudmed" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2023-11-12T09:04:14.5309450Z 	/obj/item/clothing/glasses/hud/security/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudsec" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2023-11-12T09:04:14.5313568Z 	/obj/item/mecha_parts/mecha_equipment/generator does not have an inhand_icon_state value - Possible matching sprites for "tesla" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2023-11-12T09:04:14.5317158Z 	/obj/item/food/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5320529Z 	/obj/item/food/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5324489Z 	/obj/item/storage/bag/ore does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_righthand.dmi' & 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
+2023-11-12T09:04:14.5328382Z 	/obj/item/storage/bag/ore/cyborg does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_righthand.dmi' & 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
+2023-11-12T09:04:14.5332211Z 	/obj/item/melee/energy/blade does not have an inhand_icon_state value - Possible matching sprites for "blade" found in: 'icons/mob/inhands/weapons/swords_righthand.dmi' & 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+2023-11-12T09:04:14.5335835Z 	/obj/item/fireaxe does not have an inhand_icon_state value - Possible matching sprites for "fireaxe0" found in: 'icons/mob/inhands/weapons/axes_lefthand.dmi' & 'icons/mob/inhands/weapons/axes_righthand.dmi'
+2023-11-12T09:04:14.5339617Z 	/obj/item/fireaxe/boneaxe does not have an inhand_icon_state value - Possible matching sprites for "bone_axe0" found in: 'icons/mob/inhands/weapons/axes_lefthand.dmi' & 'icons/mob/inhands/weapons/axes_righthand.dmi'
+2023-11-12T09:04:14.5343300Z 	/obj/item/fireaxe/metal_h2_axe does not have an inhand_icon_state value - Possible matching sprites for "metalh2_axe0" found in: 'icons/mob/inhands/weapons/axes_lefthand.dmi' & 'icons/mob/inhands/weapons/axes_righthand.dmi'
+2023-11-12T09:04:14.5347106Z 	/obj/item/crowbar/mechremoval does not have an inhand_icon_state value - Possible matching sprites for "mechremoval0" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5350901Z 	/obj/item/mod/module/medbeam does not have an inhand_icon_state value - Possible matching sprites for "chronogun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2023-11-12T09:04:14.5354609Z 	/obj/item/mod/module/welding does not have an inhand_icon_state value - Possible matching sprites for "welding" found in: 'icons/mob/inhands/clothing/masks_righthand.dmi' & 'icons/mob/inhands/clothing/masks_lefthand.dmi'
+2023-11-12T09:04:14.5358402Z 	/obj/item/mod/module/mister does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2023-11-12T09:04:14.5362405Z 	/obj/item/mod/module/mister/atmos does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2023-11-12T09:04:14.5366326Z 	/obj/item/mod/module/jetpack does not have an inhand_icon_state value - Possible matching sprites for "jetpack" found in: 'icons/mob/inhands/equipment/jetpacks_righthand.dmi' & 'icons/mob/inhands/equipment/jetpacks_lefthand.dmi'
+2023-11-12T09:04:14.5370513Z 	/obj/item/mod/module/flashlight does not have an inhand_icon_state value - Possible matching sprites for "flashlight" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5374077Z 	/obj/item/mod/module/stamp does not have an inhand_icon_state value - Possible matching sprites for "stamp" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2023-11-12T09:04:14.5377613Z 	/obj/item/mod/module/holster does not have an inhand_icon_state value - Possible matching sprites for "holster" found in: 'icons/mob/inhands/equipment/belt_lefthand.dmi' & 'icons/mob/inhands/equipment/belt_righthand.dmi'
+2023-11-12T09:04:14.5381427Z 	/obj/item/mod/module/megaphone does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_righthand.dmi' & 'icons/mob/inhands/items/megaphone_lefthand.dmi'
+2023-11-12T09:04:14.5386246Z 	/obj/item/mod/module/drill does not have an inhand_icon_state value - Possible matching sprites for "drill" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5390973Z 	/obj/item/mod/module/tem does not have an inhand_icon_state value - Possible matching sprites for "chronogun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2023-11-12T09:04:14.5394601Z 	/obj/item/reagent_containers/cup/soda_cans does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5396934Z 	/obj/item/reagent_containers/cup/soda_cans/random does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5399759Z 	/obj/item/reagent_containers/cup/soda_cans/cola does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5402114Z 	/obj/item/reagent_containers/cup/soda_cans/tonic does not have an inhand_icon_state value - Possible matching sprites for "tonic" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5404446Z 	/obj/item/reagent_containers/cup/soda_cans/sodawater does not have an inhand_icon_state value - Possible matching sprites for "sodawater" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5406584Z 	/obj/item/reagent_containers/cup/soda_cans/lemon_lime does not have an inhand_icon_state value - Possible matching sprites for "lemon-lime" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5408970Z 	/obj/item/reagent_containers/cup/soda_cans/space_up does not have an inhand_icon_state value - Possible matching sprites for "space-up" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5411153Z 	/obj/item/reagent_containers/cup/soda_cans/starkist does not have an inhand_icon_state value - Possible matching sprites for "starkist" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5413351Z 	/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind does not have an inhand_icon_state value - Possible matching sprites for "space_mountain_wind" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5415775Z 	/obj/item/reagent_containers/cup/soda_cans/thirteenloko does not have an inhand_icon_state value - Possible matching sprites for "thirteen_loko" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5417918Z 	/obj/item/reagent_containers/cup/soda_cans/dr_gibb does not have an inhand_icon_state value - Possible matching sprites for "dr_gibb" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5420047Z 	/obj/item/reagent_containers/cup/soda_cans/pwr_game does not have an inhand_icon_state value - Possible matching sprites for "purple_can" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5422176Z 	/obj/item/reagent_containers/cup/soda_cans/wellcheers does not have an inhand_icon_state value - Possible matching sprites for "wellcheers" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5424331Z 	/obj/item/reagent_containers/cup/soda_cans/volt_energy does not have an inhand_icon_state value - Possible matching sprites for "volt_energy" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5426605Z 	/obj/item/reagent_containers/cup/soda_cans/melon_soda does not have an inhand_icon_state value - Possible matching sprites for "melon_soda" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5428700Z 	/obj/item/reagent_containers/cup/soda_cans/beer does not have an inhand_icon_state value - Possible matching sprites for "space_beer" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5430842Z 	/obj/item/reagent_containers/cup/soda_cans/beer/rice does not have an inhand_icon_state value - Possible matching sprites for "ebisu" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5432971Z 	/obj/item/reagent_containers/cup/glass/coffee does not have an inhand_icon_state value - Possible matching sprites for "coffee" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5435080Z 	/obj/item/reagent_containers/chem_pack does not have an inhand_icon_state value - Possible matching sprites for "chempack" found in: 'icons/mob/inhands/equipment/backpack_righthand.dmi' & 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
+2023-11-12T09:04:14.5437143Z 	/obj/item/toy/talking/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2023-11-12T09:04:14.5439342Z 	/obj/item/toy/figure/chef does not have an inhand_icon_state value - Possible matching sprites for "chef" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2023-11-12T09:04:14.5441474Z 	/obj/item/toy/figure/clown does not have an inhand_icon_state value - Possible matching sprites for "clown" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2023-11-12T09:04:14.5443437Z 	/obj/item/toy/figure/janitor does not have an inhand_icon_state value - Possible matching sprites for "janitor" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2023-11-12T09:04:14.5445333Z 	/obj/item/toy/cards/cardhand does not have an inhand_icon_state value - Possible matching sprites for "nothing" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2023-11-12T09:04:14.5447188Z 	/obj/item/book/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2023-11-12T09:04:14.5449271Z 	/obj/item/pipe_dispenser does not have an inhand_icon_state value - Possible matching sprites for "rpd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5451184Z 	/obj/item/sbeacondrop does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5453081Z 	/obj/item/sbeacondrop/bomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5454974Z 	/obj/item/sbeacondrop/emp does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5456921Z 	/obj/item/sbeacondrop/powersink does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5459034Z 	/obj/item/sbeacondrop/clownbomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5460981Z 	/obj/item/sbeacondrop/horse does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5463020Z 	/obj/item/stack/medical/bruise_pack does not have an inhand_icon_state value - Possible matching sprites for "brutepack" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2023-11-12T09:04:14.5465143Z 	/obj/item/stack/medical/ointment does not have an inhand_icon_state value - Possible matching sprites for "ointment" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2023-11-12T09:04:14.5467227Z 	/obj/item/stack/tile/fairygrass does not have an inhand_icon_state value - Possible matching sprites for "tile_fairygrass" found in: 'icons/mob/inhands/items/tiles_righthand.dmi' & 'icons/mob/inhands/items/tiles_lefthand.dmi'
+2023-11-12T09:04:14.5469256Z 	/obj/item/organ/internal/heart/gland/blood does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5471272Z 	/obj/item/organ/internal/heart/gland/egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5473406Z 	/obj/item/organ/internal/heart/gland/quantum does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_lefthand.dmi' & 'icons/mob/inhands/equipment/security_righthand.dmi'
+2023-11-12T09:04:14.5475638Z 	/obj/item/organ/internal/heart/gland/trauma does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_lefthand.dmi' & 'icons/mob/inhands/equipment/security_righthand.dmi'
+2023-11-12T09:04:14.5477679Z 	/obj/item/minespawner does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5479615Z 	/obj/item/boxcutter does not have an inhand_icon_state value - Possible matching sprites for "boxcutter" found in: 'icons/mob/inhands/equipment/boxcutter_righthand.dmi' & 'icons/mob/inhands/equipment/boxcutter_lefthand.dmi'
+2023-11-12T09:04:14.5482091Z 	/obj/item/boxcutter/extended does not have an inhand_icon_state value - Possible matching sprites for "boxcutter" found in: 'icons/mob/inhands/equipment/boxcutter_righthand.dmi' & 'icons/mob/inhands/equipment/boxcutter_lefthand.dmi'
+2023-11-12T09:04:14.5484159Z 	/obj/item/pushbroom does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_righthand.dmi' & 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
+2023-11-12T09:04:14.5486168Z 	/obj/item/pushbroom/cyborg does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_righthand.dmi' & 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
+2023-11-12T09:04:14.5488176Z 	/obj/item/chainsaw does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_righthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
+2023-11-12T09:04:14.5490187Z 	/obj/item/chainsaw/doomslayer does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_righthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
+2023-11-12T09:04:14.5492367Z 	/obj/item/kitchen/fork does not have an inhand_icon_state value - Possible matching sprites for "fork" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2023-11-12T09:04:14.5494352Z 	/obj/item/kitchen/spoon does not have an inhand_icon_state value - Possible matching sprites for "spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2023-11-12T09:04:14.5496447Z 	/obj/item/kitchen/spoon/plastic does not have an inhand_icon_state value - Possible matching sprites for "plastic_spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2023-11-12T09:04:14.5498538Z 	/obj/item/pitchfork does not have an inhand_icon_state value - Possible matching sprites for "pitchfork0" found in: 'icons/mob/inhands/weapons/polearms_lefthand.dmi' & 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+2023-11-12T09:04:14.5500478Z 	/obj/item/godstaff does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2023-11-12T09:04:14.5502414Z 	/obj/item/godstaff/red does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2023-11-12T09:04:14.5504543Z 	/obj/item/godstaff/blue does not have an inhand_icon_state value - Possible matching sprites for "godstaff-blue" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2023-11-12T09:04:14.5506586Z 	/obj/item/singularityhammer does not have an inhand_icon_state value - Possible matching sprites for "singularity_hammer0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2023-11-12T09:04:14.5508606Z 	/obj/item/mjollnir does not have an inhand_icon_state value - Possible matching sprites for "mjollnir0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2023-11-12T09:04:14.5510522Z 	/obj/item/spear does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_lefthand.dmi' & 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+2023-11-12T09:04:14.5512535Z 	/obj/item/spear/explosive does not have an inhand_icon_state value - Possible matching sprites for "spearbomb0" found in: 'icons/mob/inhands/weapons/polearms_lefthand.dmi' & 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+2023-11-12T09:04:14.5514725Z 	/obj/item/spear/grey_tide does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_lefthand.dmi' & 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+2023-11-12T09:04:14.5516757Z 	/obj/item/spear/bonespear does not have an inhand_icon_state value - Possible matching sprites for "bone_spear0" found in: 'icons/mob/inhands/weapons/polearms_lefthand.dmi' & 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+2023-11-12T09:04:14.5518804Z 	/obj/item/spear/bamboospear does not have an inhand_icon_state value - Possible matching sprites for "bamboo_spear0" found in: 'icons/mob/inhands/weapons/polearms_lefthand.dmi' & 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+2023-11-12T09:04:14.5520748Z 	/obj/item/sticker/robot does not have an inhand_icon_state value - Possible matching sprites for "tile" found in: 'icons/mob/inhands/items/tiles_righthand.dmi' & 'icons/mob/inhands/items/tiles_lefthand.dmi'
+2023-11-12T09:04:14.5522828Z 	/obj/item/trash/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5524800Z 	/obj/item/trash/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5526598Z 	/obj/item/trash/can does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2023-11-12T09:04:14.5528508Z 	/obj/item/highfrequencyblade does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_righthand.dmi' & 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+2023-11-12T09:04:14.5530557Z 	/obj/item/highfrequencyblade/wizard does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_righthand.dmi' & 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+2023-11-12T09:04:14.5532581Z 	/obj/item/construction/rcd does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5534544Z 	/obj/item/construction/rcd/borg does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5536539Z 	/obj/item/construction/rcd/loaded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5538610Z 	/obj/item/construction/rcd/loaded/upgraded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5540806Z 	/obj/item/construction/rcd/ce does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5542811Z 	/obj/item/construction/rcd/internal does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5544792Z 	/obj/item/construction/rld does not have an inhand_icon_state value - Possible matching sprites for "rld" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5546898Z 	/obj/item/construction/rld/mini does not have an inhand_icon_state value - Possible matching sprites for "rld" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5548856Z 	/obj/item/construction/rtd does not have an inhand_icon_state value - Possible matching sprites for "rtd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5551347Z 	/obj/item/construction/rtd/loaded does not have an inhand_icon_state value - Possible matching sprites for "rtd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5553359Z 	/obj/item/construction/rtd/admin does not have an inhand_icon_state value - Possible matching sprites for "rtd" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5555307Z 	/obj/item/rcd_ammo does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5557368Z 	/obj/item/rcd_ammo/large does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_lefthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi'
+2023-11-12T09:04:14.5559329Z 	/obj/item/borg/sight/meson does not have an inhand_icon_state value - Possible matching sprites for "meson" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2023-11-12T09:04:14.5561639Z 	/obj/item/harmalarm does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_righthand.dmi' & 'icons/mob/inhands/items/megaphone_lefthand.dmi'
+2023-11-12T09:04:14.5564165Z 	/obj/item/abductor_machine_beacon does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5566370Z 	/obj/item/abductor_machine_beacon/chem_dispenser does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5568963Z 	/obj/item/grown/carbon_rose does not have an inhand_icon_state value - Possible matching sprites for "carbonrose" found in: 'icons/mob/inhands/weapons/plants_lefthand.dmi' & 'icons/mob/inhands/weapons/plants_righthand.dmi'
+2023-11-12T09:04:14.5571469Z 	/obj/item/paint_palette does not have an inhand_icon_state value - Possible matching sprites for "palette" found in: 'icons/mob/inhands/equipment/palette_lefthand.dmi' & 'icons/mob/inhands/equipment/palette_righthand.dmi'
+2023-11-12T09:04:14.5573366Z 	/obj/item/surprise_egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_righthand.dmi' & 'icons/mob/inhands/items/food_lefthand.dmi'
+2023-11-12T09:04:14.5575235Z 	/obj/item/experi_scanner does not have an inhand_icon_state value - Possible matching sprites for "experiscanner" found in: 'icons/mob/inhands/items/devices_righthand.dmi' & 'icons/mob/inhands/items/devices_lefthand.dmi'
+2023-11-12T09:04:14.5577115Z 	/obj/item/fishing_hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2023-11-12T09:04:14.5578938Z 	/obj/item/shovel/giant_wrench does not have an inhand_icon_state value - Possible matching sprites for "giant_wrench" found in: 'icons/mob/inhands/64x64_righthand.dmi' & 'icons/mob/inhands/64x64_lefthand.dmi'
+2023-11-12T09:04:14.5580822Z 	/obj/item/cursed_katana does not have an inhand_icon_state value - Possible matching sprites for "cursed_katana" found in: 'icons/mob/inhands/weapons/swords_righthand.dmi' & 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+2023-11-12T09:04:14.5583032Z 	/obj/item/guardian_creator/tech does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2023-11-12T09:04:14.5584953Z 	/obj/item/research_notes does not have an inhand_icon_state value - Possible matching sprites for "paper" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2023-11-12T09:04:14.5586814Z 	/obj/item/bonesetter does not have an inhand_icon_state value - Possible matching sprites for "bonesetter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2023-11-12T09:04:14.5588821Z 	/obj/item/blood_filter does not have an inhand_icon_state value - Possible matching sprites for "bloodfilter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2023-11-12T09:04:14.5590945Z 	/obj/item/mecha_ammo/flashbang does not have an inhand_icon_state value - Possible matching sprites for "flashbang" found in: 'icons/mob/inhands/equipment/security_lefthand.dmi' & 'icons/mob/inhands/equipment/security_righthand.dmi'
+2023-11-12T09:04:14.5592385Z [1;32mPASS[0m /datum/unit_test/defined_inhand_icon_states 1s
+2023-11-12T09:04:14.5593067Z ##[endgroup]
+2023-11-12T09:04:14.5593503Z ##[group]/datum/unit_test/json_savefiles
+2023-11-12T09:04:14.5593927Z [1;32mPASS[0m /datum/unit_test/json_savefiles 0s
+2023-11-12T09:04:14.5594439Z ##[endgroup]
+2023-11-12T09:04:14.5697545Z ##[group]/datum/unit_test/keybinding_init
+2023-11-12T09:04:14.5700044Z [1;32mPASS[0m /datum/unit_test/keybinding_init 0s
+2023-11-12T09:04:14.5702215Z ##[endgroup]
+2023-11-12T09:04:14.5828294Z ##[group]/datum/unit_test/knockoff_component
+2023-11-12T09:04:14.6242363Z [1;32mPASS[0m /datum/unit_test/knockoff_component 0.1s
+2023-11-12T09:04:14.6244697Z ##[endgroup]
+2023-11-12T09:04:14.6630391Z ##[group]/datum/unit_test/language_species_swap_simple
+2023-11-12T09:04:14.7587413Z [1;32mPASS[0m /datum/unit_test/language_species_swap_simple 0.1s
+2023-11-12T09:04:14.7588791Z ##[endgroup]
+2023-11-12T09:04:14.7909664Z ##[group]/datum/unit_test/language_species_swap_complex
+2023-11-12T09:04:14.8535770Z [1;32mPASS[0m /datum/unit_test/language_species_swap_complex 0.1s
+2023-11-12T09:04:14.8537437Z ##[endgroup]
+2023-11-12T09:04:14.8839470Z ##[group]/datum/unit_test/language_species_change_other_known
+2023-11-12T09:04:14.9795952Z [1;32mPASS[0m /datum/unit_test/language_species_change_other_known 0.1s
+2023-11-12T09:04:14.9797030Z ##[endgroup]
+2023-11-12T09:04:15.0435933Z ##[group]/datum/unit_test/language_mind_transfer
+2023-11-12T09:04:15.1107127Z [1;32mPASS[0m /datum/unit_test/language_mind_transfer 0.1s
+2023-11-12T09:04:15.1109587Z ##[endgroup]
+2023-11-12T09:04:15.2112030Z ##[group]/datum/unit_test/language_mind_swap
+2023-11-12T09:04:15.2925264Z [1;32mPASS[0m /datum/unit_test/language_mind_swap 0s
+2023-11-12T09:04:15.2927698Z ##[endgroup]
+2023-11-12T09:04:15.3795431Z ##[group]/datum/unit_test/book_of_babel
+2023-11-12T09:04:15.4462613Z [1;32mPASS[0m /datum/unit_test/book_of_babel 0.1s
+2023-11-12T09:04:15.4464636Z ##[endgroup]
+2023-11-12T09:04:15.4773421Z ##[group]/datum/unit_test/lesserform
+2023-11-12T09:04:15.6945571Z [1;32mPASS[0m /datum/unit_test/lesserform 0.2s
+2023-11-12T09:04:15.6948228Z ##[endgroup]
+2023-11-12T09:04:15.7353723Z ##[group]/datum/unit_test/limbsanity
+2023-11-12T09:04:15.7943636Z [1;32mPASS[0m /datum/unit_test/limbsanity 0s
+2023-11-12T09:04:15.7944637Z ##[endgroup]
+2023-11-12T09:04:15.8094514Z ##[group]/datum/unit_test/limb_height_adjustment
+2023-11-12T09:04:15.8922884Z [1;32mPASS[0m /datum/unit_test/limb_height_adjustment 0s
+2023-11-12T09:04:15.8924726Z ##[endgroup]
+2023-11-12T09:04:15.9430586Z ##[group]/datum/unit_test/ling_decap
+2023-11-12T09:04:15.9835506Z [1;32mPASS[0m /datum/unit_test/ling_decap 0s
+2023-11-12T09:04:15.9839509Z ##[endgroup]
+2023-11-12T09:04:16.0140352Z ##[group]/datum/unit_test/normal_decap
+2023-11-12T09:04:16.0424498Z [1;32mPASS[0m /datum/unit_test/normal_decap 0s
+2023-11-12T09:04:16.0426983Z ##[endgroup]
+2023-11-12T09:04:16.0805164Z ##[group]/datum/unit_test/liver/skeleton
+2023-11-12T09:04:16.1038545Z [1;32mPASS[0m /datum/unit_test/liver/skeleton 0.1s
+2023-11-12T09:04:16.1041112Z ##[endgroup]
+2023-11-12T09:04:16.1284821Z ##[group]/datum/unit_test/liver/plasmaman
+2023-11-12T09:04:16.1580562Z [1;32mPASS[0m /datum/unit_test/liver/plasmaman 0s
+2023-11-12T09:04:16.1583210Z ##[endgroup]
+2023-11-12T09:04:16.2153103Z ##[group]/datum/unit_test/load_map_security
+2023-11-12T09:04:16.2161683Z map directory not in whitelist: data/load_map_security_temp for map runtimestation
+2023-11-12T09:04:16.2164604Z [1;32mPASS[0m /datum/unit_test/load_map_security 0s
+2023-11-12T09:04:16.2167411Z ##[endgroup]
+2023-11-12T09:04:16.2305620Z ##[group]/datum/unit_test/lungs/lungs_sanity
+2023-11-12T09:04:16.2992950Z [1;32mPASS[0m /datum/unit_test/lungs/lungs_sanity 0s
+2023-11-12T09:04:16.2993961Z ##[endgroup]
+2023-11-12T09:04:16.3555743Z ##[group]/datum/unit_test/lungs/lungs_sanity_plasmaman
+2023-11-12T09:04:16.3893402Z [1;32mPASS[0m /datum/unit_test/lungs/lungs_sanity_plasmaman 0s
+2023-11-12T09:04:16.3896070Z ##[endgroup]
+2023-11-12T09:04:16.4363609Z ##[group]/datum/unit_test/lungs/lungs_sanity_ashwalker
+2023-11-12T09:04:16.4534765Z [1;32mPASS[0m /datum/unit_test/lungs/lungs_sanity_ashwalker 0s
+2023-11-12T09:04:16.4537484Z ##[endgroup]
+2023-11-12T09:04:16.5268598Z ##[group]/datum/unit_test/machine_disassembly
+2023-11-12T09:04:16.5331398Z [1;32mPASS[0m /datum/unit_test/machine_disassembly 0s
+2023-11-12T09:04:16.5334165Z ##[endgroup]
+2023-11-12T09:04:16.5965192Z ##[group]/datum/unit_test/mafia
+2023-11-12T09:04:16.9361333Z [1;32mPASS[0m /datum/unit_test/mafia 0.4s
+2023-11-12T09:04:16.9362885Z ##[endgroup]
+2023-11-12T09:04:17.0130362Z ##[group]/datum/unit_test/job_roundstart_spawnpoints
+2023-11-12T09:04:17.0143039Z [1;32mPASS[0m /datum/unit_test/job_roundstart_spawnpoints 0s
+2023-11-12T09:04:17.0145274Z ##[endgroup]
+2023-11-12T09:04:17.0659056Z ##[group]/datum/unit_test/mecha_damage
+2023-11-12T09:04:17.1110027Z [1;32mPASS[0m /datum/unit_test/mecha_damage 0.1s
+2023-11-12T09:04:17.1112178Z ##[endgroup]
+2023-11-12T09:04:17.2054159Z ##[group]/datum/unit_test/test_human_base
+2023-11-12T09:04:17.2287354Z [1;32mPASS[0m /datum/unit_test/test_human_base 0s
+2023-11-12T09:04:17.2289454Z ##[endgroup]
+2023-11-12T09:04:17.2929615Z ##[group]/datum/unit_test/test_human_bone
+2023-11-12T09:04:17.3157404Z [1;32mPASS[0m /datum/unit_test/test_human_bone 0.1s
+2023-11-12T09:04:17.3160356Z ##[endgroup]
+2023-11-12T09:04:17.3434694Z ##[group]/datum/unit_test/merge_type
+2023-11-12T09:04:17.3440046Z [1;32mPASS[0m /datum/unit_test/merge_type 0s
+2023-11-12T09:04:17.3442753Z ##[endgroup]
+2023-11-12T09:04:17.3573048Z ##[group]/datum/unit_test/metabolization
+2023-11-12T09:04:17.6960389Z [1;32mPASS[0m /datum/unit_test/metabolization 0.3s
+2023-11-12T09:04:17.6963225Z ##[endgroup]
+2023-11-12T09:04:17.7388896Z ##[group]/datum/unit_test/on_mob_end_metabolize
+2023-11-12T09:04:17.7590192Z [1;32mPASS[0m /datum/unit_test/on_mob_end_metabolize 0s
+2023-11-12T09:04:17.7592863Z ##[endgroup]
+2023-11-12T09:04:17.7841810Z ##[group]/datum/unit_test/addictions
+2023-11-12T09:04:17.8425631Z [1;32mPASS[0m /datum/unit_test/addictions 0.1s
+2023-11-12T09:04:17.8428724Z ##[endgroup]
+2023-11-12T09:04:17.9023556Z ##[group]/datum/unit_test/actions_moved_on_mind_transfer
+2023-11-12T09:04:17.9228877Z [1;32mPASS[0m /datum/unit_test/actions_moved_on_mind_transfer 0s
+2023-11-12T09:04:17.9231703Z ##[endgroup]
+2023-11-12T09:04:17.9679832Z ##[group]/datum/unit_test/missing_icons
+2023-11-12T09:04:24.5752532Z [1;32mPASS[0m /datum/unit_test/missing_icons 6.6s
+2023-11-12T09:04:24.5754181Z ##[endgroup]
+2023-11-12T09:04:24.6466600Z ##[group]/datum/unit_test/mob_chains
+2023-11-12T09:04:24.6632928Z [1;32mPASS[0m /datum/unit_test/mob_chains 0s
+2023-11-12T09:04:24.6635968Z ##[endgroup]
+2023-11-12T09:04:24.7913005Z ##[group]/datum/unit_test/mob_faction
+2023-11-12T09:04:28.5066463Z [1;32mPASS[0m /datum/unit_test/mob_faction 3.8s
+2023-11-12T09:04:28.5069188Z ##[endgroup]
+2023-11-12T09:04:31.6163193Z ##[group]/datum/unit_test/mob_spawn
+2023-11-12T09:04:31.6427245Z [1;32mPASS[0m /datum/unit_test/mob_spawn 0s
+2023-11-12T09:04:31.6431419Z ##[endgroup]
+2023-11-12T09:04:32.0058055Z ##[group]/datum/unit_test/modsuit_checks
+2023-11-12T09:04:32.2811166Z [1;32mPASS[0m /datum/unit_test/modsuit_checks 0.2s
+2023-11-12T09:04:32.2812528Z ##[endgroup]
+2023-11-12T09:04:32.3511926Z ##[group]/datum/unit_test/modular_map_loader
+2023-11-12T09:04:32.3521874Z [1;32mPASS[0m /datum/unit_test/modular_map_loader 0s
+2023-11-12T09:04:32.3523808Z ##[endgroup]
+2023-11-12T09:04:32.4142704Z ##[group]/datum/unit_test/mouse_bite_cable
+2023-11-12T09:04:32.4246879Z [1;32mPASS[0m /datum/unit_test/mouse_bite_cable 0s
+2023-11-12T09:04:32.4248567Z ##[endgroup]
+2023-11-12T09:04:32.4874261Z ##[group]/datum/unit_test/mutant_hands
+2023-11-12T09:04:32.5112259Z [1;32mPASS[0m /datum/unit_test/mutant_hands 0.1s
+2023-11-12T09:04:32.5113850Z ##[endgroup]
+2023-11-12T09:04:32.5849921Z ##[group]/datum/unit_test/mutant_hands_with_nodrop
+2023-11-12T09:04:32.6040138Z [1;32mPASS[0m /datum/unit_test/mutant_hands_with_nodrop 0.1s
+2023-11-12T09:04:32.6041689Z ##[endgroup]
+2023-11-12T09:04:32.6773675Z ##[group]/datum/unit_test/mutant_hands_carry
+2023-11-12T09:04:32.7131388Z [1;32mPASS[0m /datum/unit_test/mutant_hands_carry 0.1s
+2023-11-12T09:04:32.7133185Z ##[endgroup]
+2023-11-12T09:04:32.7786446Z ##[group]/datum/unit_test/mutant_organs
+2023-11-12T09:04:34.2934214Z [1;32mPASS[0m /datum/unit_test/mutant_organs 1.5s
+2023-11-12T09:04:34.2935313Z ##[endgroup]
+2023-11-12T09:04:34.6462244Z ##[group]/datum/unit_test/novaflower_burn
+2023-11-12T09:04:34.6850680Z [1;32mPASS[0m /datum/unit_test/novaflower_burn 0s
+2023-11-12T09:04:34.6852577Z ##[endgroup]
+2023-11-12T09:04:34.7556767Z ##[group]/datum/unit_test/nuke_cinematic
+2023-11-12T09:04:39.0321508Z [1;32mPASS[0m /datum/unit_test/nuke_cinematic 4.3s
+2023-11-12T09:04:39.0323281Z ##[endgroup]
+2023-11-12T09:04:39.0458593Z ##[group]/datum/unit_test/objectives_category
+2023-11-12T09:04:39.0479702Z [1;32mPASS[0m /datum/unit_test/objectives_category 0s
+2023-11-12T09:04:39.0482187Z ##[endgroup]
+2023-11-12T09:04:39.0633771Z ##[group]/datum/unit_test/operating_table
+2023-11-12T09:04:39.0971239Z [1;32mPASS[0m /datum/unit_test/operating_table 0s
+2023-11-12T09:04:39.0973601Z ##[endgroup]
+2023-11-12T09:04:39.1707308Z ##[group]/datum/unit_test/orderable_items
+2023-11-12T09:04:39.3304868Z [1;32mPASS[0m /datum/unit_test/orderable_items 0.2s
+2023-11-12T09:04:39.3307041Z ##[endgroup]
+2023-11-12T09:04:39.4628600Z ##[group]/datum/unit_test/organ_set_bonus_id
+2023-11-12T09:04:39.4631127Z [1;32mPASS[0m /datum/unit_test/organ_set_bonus_id 0s
+2023-11-12T09:04:39.4632993Z ##[endgroup]
+2023-11-12T09:04:39.4763602Z ##[group]/datum/unit_test/organ_set_bonus_sanity
+2023-11-12T09:04:39.7566200Z [1;32mPASS[0m /datum/unit_test/organ_set_bonus_sanity 0.3s
+2023-11-12T09:04:39.7567687Z ##[endgroup]
+2023-11-12T09:04:39.8948309Z ##[group]/datum/unit_test/organ_sanity
+2023-11-12T09:04:39.8957864Z [1;32mPASS[0m /datum/unit_test/organ_sanity 0s
+2023-11-12T09:04:39.8960612Z ##[endgroup]
+2023-11-12T09:04:39.9099785Z ##[group]/datum/unit_test/organ_damage
+2023-11-12T09:04:39.9663107Z [1;32mPASS[0m /datum/unit_test/organ_damage 0s
+2023-11-12T09:04:39.9665107Z ##[endgroup]
+2023-11-12T09:04:40.0023907Z ##[group]/datum/unit_test/outfit_sanity
+2023-11-12T09:04:52.5011539Z [1;32mPASS[0m /datum/unit_test/outfit_sanity 12.5s
+2023-11-12T09:04:52.5013136Z ##[endgroup]
+2023-11-12T09:04:52.5847995Z ##[group]/datum/unit_test/oxyloss_suffocation
+2023-11-12T09:04:52.6033624Z [1;32mPASS[0m /datum/unit_test/oxyloss_suffocation 0.1s
+2023-11-12T09:04:52.6035713Z ##[endgroup]
+2023-11-12T09:04:52.6523199Z ##[group]/datum/unit_test/paintings
+2023-11-12T09:04:52.6718185Z [1;32mPASS[0m /datum/unit_test/paintings 0s
+2023-11-12T09:04:52.6720334Z ##[endgroup]
+2023-11-12T09:04:52.6860350Z ##[group]/datum/unit_test/pills
+2023-11-12T09:04:52.7049829Z [1;32mPASS[0m /datum/unit_test/pills 0.1s
+2023-11-12T09:04:52.7051614Z ##[endgroup]
+2023-11-12T09:04:52.7284869Z ##[group]/datum/unit_test/plane_double_transform
+2023-11-12T09:04:52.7568954Z [1;32mPASS[0m /datum/unit_test/plane_double_transform 0s
+2023-11-12T09:04:52.7570947Z ##[endgroup]
+2023-11-12T09:04:52.8088783Z ##[group]/datum/unit_test/plane_dupe_detector
+2023-11-12T09:04:52.8092292Z [1;32mPASS[0m /datum/unit_test/plane_dupe_detector 0s
+2023-11-12T09:04:52.8094235Z ##[endgroup]
+2023-11-12T09:04:52.8223651Z ##[group]/datum/unit_test/plantgrowth
+2023-11-12T09:04:52.9104725Z [1;32mPASS[0m /datum/unit_test/plantgrowth 0.1s
+2023-11-12T09:04:52.9106537Z ##[endgroup]
+2023-11-12T09:04:52.9238426Z ##[group]/datum/unit_test/preference_species
+2023-11-12T09:04:52.9241982Z [1;32mPASS[0m /datum/unit_test/preference_species 0s
+2023-11-12T09:04:52.9243985Z ##[endgroup]
+2023-11-12T09:04:52.9366837Z ##[group]/datum/unit_test/preferences_implement_everything
+2023-11-12T09:04:52.9767879Z [1;32mPASS[0m /datum/unit_test/preferences_implement_everything 0s
+2023-11-12T09:04:52.9769887Z ##[endgroup]
+2023-11-12T09:04:53.0386005Z ##[group]/datum/unit_test/preferences_valid_savefile_key
+2023-11-12T09:04:53.0390164Z [1;32mPASS[0m /datum/unit_test/preferences_valid_savefile_key 0s
+2023-11-12T09:04:53.0392300Z ##[endgroup]
+2023-11-12T09:04:53.0533180Z ##[group]/datum/unit_test/preferences_valid_main_feature_name
+2023-11-12T09:04:53.0536519Z [1;32mPASS[0m /datum/unit_test/preferences_valid_main_feature_name 0s
+2023-11-12T09:04:53.0538733Z ##[endgroup]
+2023-11-12T09:04:53.0666858Z ##[group]/datum/unit_test/preferences_should_generate_icons_sanity
+2023-11-12T09:04:53.5932797Z [1;32mPASS[0m /datum/unit_test/preferences_should_generate_icons_sanity 0.5s
+2023-11-12T09:04:53.5934463Z ##[endgroup]
+2023-11-12T09:04:53.6200764Z ##[group]/datum/unit_test/projectile_movetypes
+2023-11-12T09:04:53.6204485Z [1;32mPASS[0m /datum/unit_test/projectile_movetypes 0s
+2023-11-12T09:04:53.6206834Z ##[endgroup]
+2023-11-12T09:04:53.6336940Z ##[group]/datum/unit_test/gun_go_bang
+2023-11-12T09:04:53.6829687Z [1;32mPASS[0m /datum/unit_test/gun_go_bang 0s
+2023-11-12T09:04:53.6830843Z ##[endgroup]
+2023-11-12T09:04:53.7230698Z ##[group]/datum/unit_test/quirk_icons
+2023-11-12T09:04:53.7234275Z [1;32mPASS[0m /datum/unit_test/quirk_icons 0s
+2023-11-12T09:04:53.7236777Z ##[endgroup]
+2023-11-12T09:04:53.7365585Z ##[group]/datum/unit_test/range_return
+2023-11-12T09:04:53.7369094Z [1;32mPASS[0m /datum/unit_test/range_return 0s
+2023-11-12T09:04:53.7371240Z ##[endgroup]
+2023-11-12T09:04:53.7500465Z ##[group]/datum/unit_test/frame_stacking
+2023-11-12T09:04:53.7979971Z [1;32mPASS[0m /datum/unit_test/frame_stacking 0s
+2023-11-12T09:04:53.7981883Z ##[endgroup]
+2023-11-12T09:04:53.8318167Z ##[group]/datum/unit_test/reagent_container_defaults
+2023-11-12T09:04:54.0941417Z [1;32mPASS[0m /datum/unit_test/reagent_container_defaults 0.2s
+2023-11-12T09:04:54.0943278Z ##[endgroup]
+2023-11-12T09:04:54.2270413Z ##[group]/datum/unit_test/reagent_id_typos
+2023-11-12T09:04:54.2286982Z [1;32mPASS[0m /datum/unit_test/reagent_id_typos 0s
+2023-11-12T09:04:54.2289435Z ##[endgroup]
+2023-11-12T09:04:54.2420053Z ##[group]/datum/unit_test/reagent_mob_expose
+2023-11-12T09:04:54.2723656Z [1;32mPASS[0m /datum/unit_test/reagent_mob_expose 0s
+2023-11-12T09:04:54.2726334Z ##[endgroup]
+2023-11-12T09:04:54.3099472Z ##[group]/datum/unit_test/reagent_mob_procs
+2023-11-12T09:04:54.3289033Z [1;32mPASS[0m /datum/unit_test/reagent_mob_procs 0s
+2023-11-12T09:04:54.3291717Z ##[endgroup]
+2023-11-12T09:04:54.3541628Z ##[group]/datum/unit_test/reagent_names
+2023-11-12T09:04:55.1766396Z [1;32mPASS[0m /datum/unit_test/reagent_names 0.8s
+2023-11-12T09:04:55.1768837Z ##[endgroup]
+2023-11-12T09:04:55.2029840Z ##[group]/datum/unit_test/reagent_recipe_collisions
+2023-11-12T09:04:56.8716958Z [1;32mPASS[0m /datum/unit_test/reagent_recipe_collisions 1.6s
+2023-11-12T09:04:56.8718508Z ##[endgroup]
+2023-11-12T09:04:56.8869144Z ##[group]/datum/unit_test/reagent_transfer
+2023-11-12T09:04:56.8878975Z [1;32mPASS[0m /datum/unit_test/reagent_transfer 0s
+2023-11-12T09:04:56.8880828Z ##[endgroup]
+2023-11-12T09:04:56.9011226Z ##[group]/datum/unit_test/required_map_items
+2023-11-12T09:04:56.9014244Z [1;32mPASS[0m /datum/unit_test/required_map_items 0s
+2023-11-12T09:04:56.9016215Z ##[endgroup]
+2023-11-12T09:04:56.9145903Z ##[group]/datum/unit_test/stop_drop_and_roll
+2023-11-12T09:04:56.9332587Z [1;32mPASS[0m /datum/unit_test/stop_drop_and_roll 0s
+2023-11-12T09:04:56.9334766Z ##[endgroup]
+2023-11-12T09:04:56.9894372Z ##[group]/datum/unit_test/container_resist
+2023-11-12T09:04:57.0133852Z [1;32mPASS[0m /datum/unit_test/container_resist 0.1s
+2023-11-12T09:04:57.0136482Z ##[endgroup]
+2023-11-12T09:04:57.0869981Z ##[group]/datum/unit_test/get_message_mods
+2023-11-12T09:04:57.1036296Z [1;32mPASS[0m /datum/unit_test/get_message_mods 0.1s
+2023-11-12T09:04:57.1038377Z ##[endgroup]
+2023-11-12T09:04:57.1761766Z ##[group]/datum/unit_test/say_signal
+2023-11-12T09:04:57.1785738Z [1;32mPASS[0m /datum/unit_test/say_signal 0s
+2023-11-12T09:04:57.1787867Z ##[endgroup]
+2023-11-12T09:04:57.2275108Z ##[group]/datum/unit_test/translate_language
+2023-11-12T09:04:57.2445118Z [1;32mPASS[0m /datum/unit_test/translate_language 0s
+2023-11-12T09:04:57.2447197Z ##[endgroup]
+2023-11-12T09:04:57.2776300Z ##[group]/datum/unit_test/speech
+2023-11-12T09:04:57.3273922Z [1;32mPASS[0m /datum/unit_test/speech 0.1s
+2023-11-12T09:04:57.3276048Z ##[endgroup]
+2023-11-12T09:04:57.3648311Z ##[group]/datum/unit_test/screenshot_antag_icons
+2023-11-12T09:04:57.3655596Z 	screenshot_antag_icons_cyberpolice was put in data/screenshots_new
+2023-11-12T09:04:57.3668195Z 	screenshot_antag_icons_fugitive was put in data/screenshots_new
+2023-11-12T09:04:57.3673743Z 	screenshot_antag_icons_loneoperative was put in data/screenshots_new
+2023-11-12T09:04:57.3918428Z 	screenshot_antag_icons_sentiencepotionspawn was put in data/screenshots_new
+2023-11-12T09:04:57.3925180Z 	screenshot_antag_icons_traitor was put in data/screenshots_new
+2023-11-12T09:04:57.4212360Z 	screenshot_antag_icons_malfai was put in data/screenshots_new
+2023-11-12T09:04:57.4244403Z 	screenshot_antag_icons_bloodbrother was put in data/screenshots_new
+2023-11-12T09:04:57.4250630Z 	screenshot_antag_icons_changeling was put in data/screenshots_new
+2023-11-12T09:04:57.4282149Z 	screenshot_antag_icons_heretic was put in data/screenshots_new
+2023-11-12T09:04:57.4292701Z 	screenshot_antag_icons_wizard was put in data/screenshots_new
+2023-11-12T09:04:57.4322992Z 	screenshot_antag_icons_cultist was put in data/screenshots_new
+2023-11-12T09:04:57.4335181Z 	screenshot_antag_icons_operative was put in data/screenshots_new
+2023-11-12T09:04:57.4347253Z 	screenshot_antag_icons_clownoperative was put in data/screenshots_new
+2023-11-12T09:04:57.4360316Z 	screenshot_antag_icons_headrevolutionary was put in data/screenshots_new
+2023-11-12T09:04:57.4362553Z 	screenshot_antag_icons_syndicateinfiltrator was put in data/screenshots_new
+2023-11-12T09:04:57.4364249Z 	screenshot_antag_icons_provocateur was put in data/screenshots_new
+2023-11-12T09:04:57.4365976Z 	screenshot_antag_icons_hereticsmuggler was put in data/screenshots_new
+2023-11-12T09:04:57.4367872Z 	screenshot_antag_icons_stowawaychangeling was put in data/screenshots_new
+2023-11-12T09:04:57.4369724Z 	screenshot_antag_icons_wizardmidround was put in data/screenshots_new
+2023-11-12T09:04:57.4371538Z 	screenshot_antag_icons_operativemidround was put in data/screenshots_new
+2023-11-12T09:04:57.4836255Z 	screenshot_antag_icons_blob was put in data/screenshots_new
+2023-11-12T09:04:57.4913104Z 	screenshot_antag_icons_xenomorph was put in data/screenshots_new
+2023-11-12T09:04:57.4918547Z 	screenshot_antag_icons_nightmare was put in data/screenshots_new
+2023-11-12T09:04:57.4972641Z 	screenshot_antag_icons_spacedragon was put in data/screenshots_new
+2023-11-12T09:04:57.4978863Z 	screenshot_antag_icons_abductor was put in data/screenshots_new
+2023-11-12T09:04:57.4984390Z 	screenshot_antag_icons_spaceninja was put in data/screenshots_new
+2023-11-12T09:04:57.5142179Z 	screenshot_antag_icons_revenant was put in data/screenshots_new
+2023-11-12T09:04:57.5158225Z 	screenshot_antag_icons_sentientdisease was put in data/screenshots_new
+2023-11-12T09:04:57.5164048Z 	screenshot_antag_icons_changelingmidround was put in data/screenshots_new
+2023-11-12T09:04:57.5175747Z 	screenshot_antag_icons_paradoxclone was put in data/screenshots_new
+2023-11-12T09:04:57.5177675Z 	screenshot_antag_icons_syndicatesleeperagent was put in data/screenshots_new
+2023-11-12T09:04:57.5295585Z 	screenshot_antag_icons_blobinfection was put in data/screenshots_new
+2023-11-12T09:04:57.5313285Z 	screenshot_antag_icons_obsessed was put in data/screenshots_new
+2023-11-12T09:04:57.5315517Z 	screenshot_antag_icons_malfaimidround was put in data/screenshots_new
+2023-11-12T09:04:57.5319787Z [1;32mPASS[0m /datum/unit_test/screenshot_antag_icons 0.2s
+2023-11-12T09:04:57.5322595Z ##[endgroup]
+2023-11-12T09:04:57.5541756Z ##[group]/datum/unit_test/screenshot_basic
+2023-11-12T09:04:57.5545037Z 	screenshot_basic_red was put in data/screenshots_new
+2023-11-12T09:04:57.5548126Z [1;32mPASS[0m /datum/unit_test/screenshot_basic 0s
+2023-11-12T09:04:57.5550758Z ##[endgroup]
+2023-11-12T09:04:57.5683479Z ##[group]/datum/unit_test/screenshot_dynamic_human_icons
+2023-11-12T09:04:57.8350756Z 	screenshot_dynamic_human_icons_syndicate_commando was put in data/screenshots_new
+2023-11-12T09:04:57.8354817Z [1;32mPASS[0m /datum/unit_test/screenshot_dynamic_human_icons 0.3s
+2023-11-12T09:04:57.8357024Z ##[endgroup]
+2023-11-12T09:04:57.8497778Z ##[group]/datum/unit_test/screenshot_humanoids
+2023-11-12T09:04:58.2541589Z 	screenshot_humanoids__datum_species_lizard was put in data/screenshots_new
+2023-11-12T09:04:58.8071729Z 	screenshot_humanoids__datum_species_moth was put in data/screenshots_new
+2023-11-12T09:04:59.0481483Z 	screenshot_humanoids__datum_species_shadow was put in data/screenshots_new
+2023-11-12T09:04:59.2204964Z 	screenshot_humanoids__datum_species_shadow_nightmare was put in data/screenshots_new
+2023-11-12T09:04:59.4446438Z 	screenshot_humanoids__datum_species_abductor was put in data/screenshots_new
+2023-11-12T09:04:59.9025529Z 	screenshot_humanoids__datum_species_human was put in data/screenshots_new
+2023-11-12T09:05:00.3720324Z 	screenshot_humanoids__datum_species_human_tallboy was put in data/screenshots_new
+2023-11-12T09:05:00.8410192Z 	screenshot_humanoids__datum_species_human_felinid was put in data/screenshots_new
+2023-11-12T09:05:01.3919326Z 	screenshot_humanoids__datum_species_human_krokodil_addict was put in data/screenshots_new
+2023-11-12T09:05:01.5050044Z 	screenshot_humanoids__datum_species_monkey was put in data/screenshots_new
+2023-11-12T09:05:01.6332131Z 	screenshot_humanoids__datum_species_monkey_human_legged was put in data/screenshots_new
+2023-11-12T09:05:01.8078163Z 	screenshot_humanoids__datum_species_monkey_monkey_freak was put in data/screenshots_new
+2023-11-12T09:05:01.9204604Z 	screenshot_humanoids__datum_species_monkey_holodeck was put in data/screenshots_new
+2023-11-12T09:05:02.2703729Z 	screenshot_humanoids__datum_species_android was put in data/screenshots_new
+2023-11-12T09:05:02.5066397Z 	screenshot_humanoids__datum_species_dullahan was put in data/screenshots_new
+2023-11-12T09:05:02.8821597Z 	screenshot_humanoids__datum_species_ethereal was put in data/screenshots_new
+2023-11-12T09:05:03.0618503Z 	screenshot_humanoids__datum_species_ethereal_lustrous was put in data/screenshots_new
+2023-11-12T09:05:03.6054858Z 	screenshot_humanoids__datum_species_fly was put in data/screenshots_new
+2023-11-12T09:05:03.7723456Z 	screenshot_humanoids__datum_species_golem was put in data/screenshots_new
+2023-11-12T09:05:04.2399263Z 	screenshot_humanoids__datum_species_jelly was put in data/screenshots_new
+2023-11-12T09:05:04.7039511Z 	screenshot_humanoids__datum_species_jelly_slime was put in data/screenshots_new
+2023-11-12T09:05:05.1607461Z 	screenshot_humanoids__datum_species_jelly_luminescent was put in data/screenshots_new
+2023-11-12T09:05:05.6194475Z 	screenshot_humanoids__datum_species_jelly_stargazer was put in data/screenshots_new
+2023-11-12T09:05:05.9809404Z 	screenshot_humanoids__datum_species_lizard_ashwalker was put in data/screenshots_new
+2023-11-12T09:05:06.3898218Z 	screenshot_humanoids__datum_species_lizard_silverscale was put in data/screenshots_new
+2023-11-12T09:05:06.6851305Z 	screenshot_humanoids__datum_species_mush was put in data/screenshots_new
+2023-11-12T09:05:07.0392950Z 	screenshot_humanoids__datum_species_plasmaman was put in data/screenshots_new
+2023-11-12T09:05:07.5136767Z 	screenshot_humanoids__datum_species_pod was put in data/screenshots_new
+2023-11-12T09:05:07.7567133Z 	screenshot_humanoids__datum_species_skeleton was put in data/screenshots_new
+2023-11-12T09:05:08.2342975Z 	screenshot_humanoids__datum_species_snail was put in data/screenshots_new
+2023-11-12T09:05:08.6975763Z 	screenshot_humanoids__datum_species_vampire was put in data/screenshots_new
+2023-11-12T09:05:09.2496544Z 	screenshot_humanoids__datum_species_zombie was put in data/screenshots_new
+2023-11-12T09:05:09.8588009Z 	screenshot_humanoids__datum_species_zombie_infectious was put in data/screenshots_new
+2023-11-12T09:05:09.8591473Z [1;32mPASS[0m /datum/unit_test/screenshot_humanoids 12s
+2023-11-12T09:05:09.8593884Z ##[endgroup]
+2023-11-12T09:05:10.3359233Z ##[group]/datum/unit_test/screenshot_husk
+2023-11-12T09:05:10.4814584Z 	screenshot_husk_body was put in data/screenshots_new
+2023-11-12T09:05:10.5100421Z 	screenshot_husk_body_missing_limbs was put in data/screenshots_new
+2023-11-12T09:05:10.5103760Z [1;32mPASS[0m /datum/unit_test/screenshot_husk 0.2s
+2023-11-12T09:05:10.5105844Z ##[endgroup]
+2023-11-12T09:05:10.5738946Z ##[group]/datum/unit_test/screenshot_saturnx
+2023-11-12T09:05:10.7302951Z 	screenshot_saturnx_invisibility was put in data/screenshots_new
+2023-11-12T09:05:10.7306714Z [1;32mPASS[0m /datum/unit_test/screenshot_saturnx 0.2s
+2023-11-12T09:05:10.7309565Z ##[endgroup]
+2023-11-12T09:05:10.7993117Z ##[group]/datum/unit_test/security_levels
+2023-11-12T09:05:10.7995233Z [1;32mPASS[0m /datum/unit_test/security_levels 0s
+2023-11-12T09:05:10.7997473Z ##[endgroup]
+2023-11-12T09:05:10.8718075Z ##[group]/datum/unit_test/security_officer_roundstart_distribution
+2023-11-12T09:05:10.9829621Z [1;32mPASS[0m /datum/unit_test/security_officer_roundstart_distribution 0.1s
+2023-11-12T09:05:10.9831233Z ##[endgroup]
+2023-11-12T09:05:11.0917739Z ##[group]/datum/unit_test/security_officer_latejoin_distribution
+2023-11-12T09:05:11.3756560Z [1;32mPASS[0m /datum/unit_test/security_officer_latejoin_distribution 0.3s
+2023-11-12T09:05:11.3757917Z ##[endgroup]
+2023-11-12T09:05:11.6159233Z ##[group]/datum/unit_test/servingtray
+2023-11-12T09:05:11.6420663Z [1;32mPASS[0m /datum/unit_test/servingtray 0s
+2023-11-12T09:05:11.6422707Z ##[endgroup]
+2023-11-12T09:05:11.6722939Z ##[group]/datum/unit_test/simple_animal_freeze
+2023-11-12T09:05:11.6727308Z [1;32mPASS[0m /datum/unit_test/simple_animal_freeze 0s
+2023-11-12T09:05:11.6729459Z ##[endgroup]
+2023-11-12T09:05:11.6858248Z ##[group]/datum/unit_test/siunit
+2023-11-12T09:05:11.6862565Z [1;32mPASS[0m /datum/unit_test/siunit 0s
+2023-11-12T09:05:11.6864627Z ##[endgroup]
+2023-11-12T09:05:11.6994032Z ##[group]/datum/unit_test/slime_mood
+2023-11-12T09:05:11.7086306Z [1;32mPASS[0m /datum/unit_test/slime_mood 0.1s
+2023-11-12T09:05:11.7089418Z ##[endgroup]
+2023-11-12T09:05:11.7646724Z ##[group]/datum/unit_test/slips
+2023-11-12T09:05:11.7998254Z [1;32mPASS[0m /datum/unit_test/slips 0s
+2023-11-12T09:05:11.7999914Z ##[endgroup]
+2023-11-12T09:05:11.8832258Z ##[group]/datum/unit_test/spawn_humans
+2023-11-12T09:05:16.9174068Z [1;32mPASS[0m /datum/unit_test/spawn_humans 5.1s
+2023-11-12T09:05:16.9175480Z ##[endgroup]
+2023-11-12T09:05:16.9826971Z ##[group]/datum/unit_test/human_default_traits
+2023-11-12T09:05:16.9992542Z [1;32mPASS[0m /datum/unit_test/human_default_traits 0s
+2023-11-12T09:05:16.9994648Z ##[endgroup]
+2023-11-12T09:05:17.0453589Z ##[group]/datum/unit_test/spawn_mobs
+2023-11-12T09:05:17.3110840Z [1;32mPASS[0m /datum/unit_test/spawn_mobs 0.3s
+2023-11-12T09:05:17.3113201Z ##[endgroup]
+2023-11-12T09:05:17.8604911Z ##[group]/datum/unit_test/species_change_clothing
+2023-11-12T09:05:18.0037169Z [1;32mPASS[0m /datum/unit_test/species_change_clothing 0.2s
+2023-11-12T09:05:18.0039927Z ##[endgroup]
+2023-11-12T09:05:18.0594811Z ##[group]/datum/unit_test/species_change_held_items
+2023-11-12T09:05:18.1241794Z [1;32mPASS[0m /datum/unit_test/species_change_held_items 0.1s
+2023-11-12T09:05:18.1244171Z ##[endgroup]
+2023-11-12T09:05:18.1531271Z ##[group]/datum/unit_test/species_change_organs
+2023-11-12T09:05:18.2175195Z [1;32mPASS[0m /datum/unit_test/species_change_organs 0.1s
+2023-11-12T09:05:18.2177564Z ##[endgroup]
+2023-11-12T09:05:18.2917259Z ##[group]/datum/unit_test/species_config_sanity
+2023-11-12T09:05:18.2920181Z [1;32mPASS[0m /datum/unit_test/species_config_sanity 0s
+2023-11-12T09:05:18.2922846Z ##[endgroup]
+2023-11-12T09:05:18.3062818Z ##[group]/datum/unit_test/species_unique_id
+2023-11-12T09:05:18.3065971Z [1;32mPASS[0m /datum/unit_test/species_unique_id 0s
+2023-11-12T09:05:18.3068171Z ##[endgroup]
+2023-11-12T09:05:18.3222639Z ##[group]/datum/unit_test/species_whitelist_check
+2023-11-12T09:05:18.3225988Z [1;32mPASS[0m /datum/unit_test/species_whitelist_check 0s
+2023-11-12T09:05:18.3228060Z ##[endgroup]
+2023-11-12T09:05:18.3393256Z ##[group]/datum/unit_test/spell_invocations
+2023-11-12T09:05:18.3397536Z [1;32mPASS[0m /datum/unit_test/spell_invocations 0s
+2023-11-12T09:05:18.3400085Z ##[endgroup]
+2023-11-12T09:05:18.3530030Z ##[group]/datum/unit_test/shadow_jaunt
+2023-11-12T09:05:18.3711590Z [1;32mPASS[0m /datum/unit_test/shadow_jaunt 0s
+2023-11-12T09:05:18.3713925Z ##[endgroup]
+2023-11-12T09:05:18.4080468Z ##[group]/datum/unit_test/mind_swap_spell
+2023-11-12T09:05:18.4445059Z [1;32mPASS[0m /datum/unit_test/mind_swap_spell 0s
+2023-11-12T09:05:18.4447973Z ##[endgroup]
+2023-11-12T09:05:18.4831097Z ##[group]/datum/unit_test/spell_names
+2023-11-12T09:05:18.4836690Z [1;32mPASS[0m /datum/unit_test/spell_names 0s
+2023-11-12T09:05:18.4839793Z ##[endgroup]
+2023-11-12T09:05:18.4973281Z ##[group]/datum/unit_test/shapeshift_spell_validity
+2023-11-12T09:05:18.4982346Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell_validity 0s
+2023-11-12T09:05:18.4985502Z ##[endgroup]
+2023-11-12T09:05:18.5118193Z ##[group]/datum/unit_test/shapeshift_spell
+2023-11-12T09:05:31.3590354Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell 12.8s
+2023-11-12T09:05:31.3593257Z ##[endgroup]
+2023-11-12T09:05:31.3839062Z ##[group]/datum/unit_test/shapeshift_holoparasites
+2023-11-12T09:05:31.4236915Z [1;32mPASS[0m /datum/unit_test/shapeshift_holoparasites 0.1s
+2023-11-12T09:05:31.4240548Z ##[endgroup]
+2023-11-12T09:05:31.4609174Z ##[group]/datum/unit_test/shapeshift_health
+2023-11-12T09:05:32.0958569Z [1;32mPASS[0m /datum/unit_test/shapeshift_health 0.6s
+2023-11-12T09:05:32.0961165Z ##[endgroup]
+2023-11-12T09:05:32.2270540Z ##[group]/datum/unit_test/spritesheets
+2023-11-12T09:05:32.2310129Z [1;32mPASS[0m /datum/unit_test/spritesheets 0s
+2023-11-12T09:05:32.2313287Z ##[endgroup]
+2023-11-12T09:05:32.2444065Z ##[group]/datum/unit_test/stack_singular_name
+2023-11-12T09:05:32.2449554Z [1;32mPASS[0m /datum/unit_test/stack_singular_name 0s
+2023-11-12T09:05:32.2452311Z ##[endgroup]
+2023-11-12T09:05:32.2582343Z ##[group]/datum/unit_test/station_traits
+2023-11-12T09:05:32.2586458Z [1;32mPASS[0m /datum/unit_test/station_traits 0s
+2023-11-12T09:05:32.2589532Z ##[endgroup]
+2023-11-12T09:05:32.3273087Z ##[group]/datum/unit_test/status_effect_ticks
+2023-11-12T09:05:32.3278478Z [1;32mPASS[0m /datum/unit_test/status_effect_ticks 0s
+2023-11-12T09:05:32.3282046Z ##[endgroup]
+2023-11-12T09:05:32.3883615Z ##[group]/datum/unit_test/stomach
+2023-11-12T09:05:32.4148653Z [1;32mPASS[0m /datum/unit_test/stomach 0.1s
+2023-11-12T09:05:32.4152041Z ##[endgroup]
+2023-11-12T09:05:32.4474665Z ##[group]/datum/unit_test/strip_menu_ui_status
+2023-11-12T09:05:32.4955743Z [1;32mPASS[0m /datum/unit_test/strip_menu_ui_status 0s
+2023-11-12T09:05:32.4959231Z ##[endgroup]
+2023-11-12T09:05:32.5763081Z ##[group]/datum/unit_test/stun
+2023-11-12T09:05:32.5938628Z [1;32mPASS[0m /datum/unit_test/stun 0s
+2023-11-12T09:05:32.5941798Z ##[endgroup]
+2023-11-12T09:05:32.6174955Z ##[group]/datum/unit_test/knockdown
+2023-11-12T09:05:32.6344357Z [1;32mPASS[0m /datum/unit_test/knockdown 0s
+2023-11-12T09:05:32.6347424Z ##[endgroup]
+2023-11-12T09:05:32.6656807Z ##[group]/datum/unit_test/paralyze
+2023-11-12T09:05:32.6830553Z [1;32mPASS[0m /datum/unit_test/paralyze 0s
+2023-11-12T09:05:32.6834151Z ##[endgroup]
+2023-11-12T09:05:32.7067888Z ##[group]/datum/unit_test/unconsciousness
+2023-11-12T09:05:32.7247146Z [1;32mPASS[0m /datum/unit_test/unconsciousness 0s
+2023-11-12T09:05:32.7250770Z ##[endgroup]
+2023-11-12T09:05:32.7494899Z ##[group]/datum/unit_test/stun_absorb
+2023-11-12T09:05:32.7661160Z [1;32mPASS[0m /datum/unit_test/stun_absorb 0s
+2023-11-12T09:05:32.7664703Z ##[endgroup]
+2023-11-12T09:05:32.7898786Z ##[group]/datum/unit_test/subsystem_init
+2023-11-12T09:05:32.7903149Z [1;32mPASS[0m /datum/unit_test/subsystem_init 0s
+2023-11-12T09:05:32.7906701Z ##[endgroup]
+2023-11-12T09:05:32.8135238Z ##[group]/datum/unit_test/suit_storage_icons
+2023-11-12T09:05:34.6162263Z 	1 - /obj/item/gun/ballistic/shotgun/hook using invalid icon_state, "hookshotgun"
+2023-11-12T09:05:34.6285969Z 	2 - /obj/item/gun/ballistic/automatic/surplus using invalid icon_state, "surplus"
+2023-11-12T09:05:34.6466661Z 	3 - /obj/item/melee/baton/security/cattleprod/telecrystalprod using invalid icon_state, "telecrystalprod"
+2023-11-12T09:05:34.6533245Z 	4 - /obj/item/melee/sickly_blade/void using invalid icon_state, "void_blade"
+2023-11-12T09:05:34.6538232Z 	5 - /obj/item/melee/sickly_blade/cosmic using invalid icon_state, "cosmic_blade"
+2023-11-12T09:05:34.6541373Z 	6 - /obj/item/melee/sickly_blade/lock using invalid icon_state, "key_blade"
+2023-11-12T09:05:34.6628237Z 	7 - /obj/item/radio/headset/syndicate/alt using invalid worn_icon_state, "syndie_headset"
+2023-11-12T09:05:34.6633020Z 	8 - /obj/item/radio/headset/headset_sec using invalid worn_icon_state, "sec_headset"
+2023-11-12T09:05:34.6636156Z 	9 - /obj/item/radio/headset/headset_sec/alt using invalid worn_icon_state, "sec_headset_alt"
+2023-11-12T09:05:34.6639243Z 	10 - /obj/item/radio/headset/headset_eng using invalid worn_icon_state, "eng_headset"
+2023-11-12T09:05:34.6642514Z 	11 - /obj/item/radio/headset/headset_rob using invalid worn_icon_state, "rob_headset"
+2023-11-12T09:05:34.6645779Z 	12 - /obj/item/radio/headset/headset_med using invalid worn_icon_state, "med_headset"
+2023-11-12T09:05:34.6649005Z 	13 - /obj/item/radio/headset/headset_sci using invalid worn_icon_state, "sci_headset"
+2023-11-12T09:05:34.6652244Z 	14 - /obj/item/radio/headset/headset_medsci using invalid worn_icon_state, "medsci_headset"
+2023-11-12T09:05:34.6655462Z 	15 - /obj/item/radio/headset/headset_srvsec using invalid worn_icon_state, "srvsec_headset"
+2023-11-12T09:05:34.6658687Z 	16 - /obj/item/radio/headset/headset_srvmed using invalid worn_icon_state, "srv_headset"
+2023-11-12T09:05:34.6661917Z 	17 - /obj/item/radio/headset/headset_com using invalid worn_icon_state, "com_headset"
+2023-11-12T09:05:34.6667219Z 	18 - /obj/item/radio/headset/heads/captain/alt using invalid worn_icon_state, "com_headset_alt"
+2023-11-12T09:05:34.6670732Z 	19 - /obj/item/radio/headset/headset_cargo using invalid worn_icon_state, "cargo_headset"
+2023-11-12T09:05:34.6673230Z 	20 - /obj/item/radio/headset/headset_cargo/mining using invalid worn_icon_state, "mine_headset"
+2023-11-12T09:05:34.6675625Z 	21 - /obj/item/radio/headset/headset_cent using invalid worn_icon_state, "cent_headset"
+2023-11-12T09:05:34.6678128Z 	22 - /obj/item/radio/headset/headset_cent/alt using invalid worn_icon_state, "cent_headset_alt"
+2023-11-12T09:05:34.6972394Z 	23 - /obj/item/toy/foam_runic_scepter using invalid worn_icon_state, "vendor_staff"
+2023-11-12T09:05:34.7033817Z 	24 - /obj/item/cultivator/rake using invalid icon_state, "rake"
+2023-11-12T09:05:34.7038164Z 	25 - /obj/item/hatchet/wooden using invalid icon_state, "woodhatchet"
+2023-11-12T09:05:34.7039900Z 	26 - /obj/item/hatchet/cutterblade using invalid icon_state, "cutterblade"
+2023-11-12T09:05:34.7408592Z 	27 - /obj/item/access_key using invalid icon_state, "access_key"
+2023-11-12T09:05:34.7458044Z 	28 - /obj/item/key/janitor using invalid icon_state, "keyjanitor"
+2023-11-12T09:05:34.8393427Z 	29 - /obj/item/universal_scanner using invalid icon_state, "export scanner"
+2023-11-12T09:05:34.8476665Z 	30 - /obj/item/nullrod/tribal_knife using invalid icon_state, "crysknife"
+2023-11-12T09:05:34.8491387Z 	31 - /obj/item/organ/internal/monster_core using invalid icon_state, "hivelord_core"
+2023-11-12T09:05:34.8493709Z 	32 - /obj/item/organ/internal/monster_core/brimdust_sac using invalid icon_state, "brim_sac"
+2023-11-12T09:05:34.8496411Z 	33 - /obj/item/organ/internal/monster_core/regenerative_core/legion using invalid icon_state, "legion_core"
+2023-11-12T09:05:34.8498777Z 	34 - /obj/item/organ/internal/monster_core/rush_gland using invalid icon_state, "lobster_gland"
+2023-11-12T09:05:34.8538527Z 	35 - /obj/item/abductor/gizmo using invalid icon_state, "gizmo_scan"
+2023-11-12T09:05:34.8540751Z 	36 - /obj/item/abductor/silencer using invalid icon_state, "silencer"
+2023-11-12T09:05:34.8543252Z 	37 - /obj/item/abductor/mind_device using invalid icon_state, "mind_device_message"
+2023-11-12T09:05:34.8545406Z 	38 - /obj/item/abductor/alien_omnitool using invalid icon_state, "omnitool"
+2023-11-12T09:05:34.8552089Z 	39 - /obj/item/banner using invalid icon_state, "banner"
+2023-11-12T09:05:34.8554713Z 	40 - /obj/item/banner/security using invalid icon_state, "banner_security"
+2023-11-12T09:05:34.8557066Z 	41 - /obj/item/banner/medical using invalid icon_state, "banner_medical"
+2023-11-12T09:05:34.8559349Z 	42 - /obj/item/banner/science using invalid icon_state, "banner_science"
+2023-11-12T09:05:34.8561592Z 	43 - /obj/item/banner/cargo using invalid icon_state, "banner_cargo"
+2023-11-12T09:05:34.8564170Z 	44 - /obj/item/banner/engineering using invalid icon_state, "banner_engineering"
+2023-11-12T09:05:34.8566536Z 	45 - /obj/item/banner/red using invalid icon_state, "banner-red"
+2023-11-12T09:05:34.8568980Z 	46 - /obj/item/banner/blue using invalid icon_state, "banner-blue"
+2023-11-12T09:05:34.8576281Z 	47 - /obj/item/claymore/cutlass using invalid worn_icon_state, "cutlass"
+2023-11-12T09:05:34.8580270Z 	48 - /obj/item/claymore/highlander/robot using invalid icon_state, "claymore_cyborg"
+2023-11-12T09:05:34.8582334Z 	49 - /obj/item/pillow using invalid icon_state, "pillow_1_t"
+2023-11-12T09:05:34.8584899Z 	50 - /obj/item/pillow/clown using invalid icon_state, "pillow_5_t"
+2023-11-12T09:05:34.8587221Z 	51 - /obj/item/pillow/mime using invalid icon_state, "pillow_6_t"
+2023-11-12T09:05:34.8626613Z 	52 - /obj/item/gun/magic/staff/chaos/true_wabbajack using invalid icon_state, "the_wabbajack"
+2023-11-12T09:05:34.8633965Z 	53 - /obj/item/gun/magic/staff/locker using invalid worn_icon_state, "lockerstaff"
+2023-11-12T09:05:34.8636381Z 	54 - /obj/item/gun/magic/staff/flying using invalid worn_icon_state, "flightstaff"
+2023-11-12T09:05:34.8657485Z 	55 - /obj/item/melee/energy/sword/pirate using invalid icon_state, "e_cutlass"
+2023-11-12T09:05:34.8659958Z 	56 - /obj/item/clothing/glasses/eyepatch using invalid icon_state, "eyepatch"
+2023-11-12T09:05:34.8662250Z 	57 - /obj/item/clothing/glasses/eyepatch/medical using invalid icon_state, "eyepatch_medical"
+2023-11-12T09:05:34.8976969Z 	58 - /obj/item/melee/energy/sword using invalid icon_state, "e_sword"
+2023-11-12T09:05:34.8979094Z 	59 - /obj/item/melee/energy/sword/cyborg/saw using invalid icon_state, "esaw"
+2023-11-12T09:05:34.8988519Z 	60 - /obj/item/tank/jetpack/improvised using invalid worn_icon_state, "jetpack-improvised"
+2023-11-12T09:05:34.8993419Z 	61 - /obj/item/multitool using invalid icon_state, "multitool"
+2023-11-12T09:05:34.8996418Z 	62 - /obj/item/multitool/cyborg using invalid icon_state, "multitool_cyborg"
+2023-11-12T09:05:34.8998725Z 	63 - /obj/item/multitool/circuit using invalid icon_state, "multitool_circuit"
+2023-11-12T09:05:34.9001342Z 	64 - /obj/item/assembly/flash/handheld using invalid icon_state, "flash"
+2023-11-12T09:05:34.9004166Z 	65 - /obj/item/clothing/mask/cigarette using invalid icon_state, "cigoff"
+2023-11-12T09:05:34.9006481Z 	66 - /obj/item/clothing/mask/cigarette/rollie using invalid icon_state, "spliffoff"
+2023-11-12T09:05:34.9008788Z 	67 - /obj/item/clothing/mask/cigarette/candy using invalid icon_state, "candyoff"
+2023-11-12T09:05:34.9011087Z 	68 - /obj/item/clothing/mask/cigarette/cigar using invalid icon_state, "cigaroff"
+2023-11-12T09:05:34.9013684Z 	69 - /obj/item/clothing/mask/cigarette/cigar/cohiba using invalid icon_state, "cigar2off"
+2023-11-12T09:05:34.9016282Z 	70 - /obj/item/clothing/mask/cigarette/pipe using invalid icon_state, "pipeoff"
+2023-11-12T09:05:34.9019334Z 	71 - /obj/item/clothing/mask/cigarette/pipe/cobpipe using invalid icon_state, "cobpipeoff"
+2023-11-12T09:05:34.9021398Z 	72 - /obj/item/disk using invalid icon_state, "datadisk0"
+2023-11-12T09:05:34.9023878Z 	73 - /obj/item/disk/holodisk using invalid icon_state, "holodisk"
+2023-11-12T09:05:34.9026566Z 	74 - /obj/item/disk/nuclear using invalid icon_state, "nucleardisk"
+2023-11-12T09:05:34.9029044Z 	75 - /obj/item/disk/surgery using invalid icon_state, "datadisk1"
+2023-11-12T09:05:34.9031722Z 	76 - /obj/item/disk/cargo/bluespace_pod using invalid icon_state, "cargodisk"
+2023-11-12T09:05:34.9034253Z 	77 - /obj/item/disk/design_disk/bepis using invalid icon_state, "rndmajordisk"
+2023-11-12T09:05:34.9036755Z 	78 - /obj/item/melee/powerfist using invalid icon_state, "powerfist"
+2023-11-12T09:05:34.9044549Z 	79 - /obj/item/melee/skateboard using invalid icon_state, "skateboard_held"
+2023-11-12T09:05:34.9047217Z 	80 - /obj/item/melee/skateboard/pro using invalid icon_state, "skateboard2_held"
+2023-11-12T09:05:34.9049673Z 	81 - /obj/item/melee/skateboard/hoverboard using invalid icon_state, "hoverboard_red_held"
+2023-11-12T09:05:34.9052014Z 	82 - /obj/item/melee/skateboard/hoverboard/admin using invalid icon_state, "hoverboard_nt_held"
+2023-11-12T09:05:34.9054102Z 	83 - /obj/item/melee/baseball_bat using invalid icon_state, "baseball_bat"
+2023-11-12T09:05:34.9056494Z 	84 - /obj/item/melee/baseball_bat/homerun using invalid icon_state, "baseball_bat_home"
+2023-11-12T09:05:34.9058758Z 	85 - /obj/item/melee/baseball_bat/ablative using invalid icon_state, "baseball_bat_metal"
+2023-11-12T09:05:34.9061041Z 	86 - /obj/item/melee/flyswatter using invalid icon_state, "flyswatter"
+2023-11-12T09:05:34.9065209Z 	87 - /obj/item/melee/energy/axe using invalid icon_state, "axe"
+2023-11-12T09:05:34.9067917Z 	88 - /obj/item/melee/energy/blade using invalid icon_state, "blade"
+2023-11-12T09:05:34.9070409Z 	89 - /obj/item/melee/energy/blade/hardlight using invalid icon_state, "lightblade"
+2023-11-12T09:05:34.9072647Z 	90 - /obj/item/melee/synthetic_arm_blade using invalid icon_state, "arm_blade"
+2023-11-12T09:05:34.9074881Z 	91 - /obj/item/melee/sabre using invalid icon_state, "sabre"
+2023-11-12T09:05:34.9077162Z 	92 - /obj/item/melee/beesword using invalid worn_icon_state, "stinger"
+2023-11-12T09:05:34.9079597Z 	93 - /obj/item/melee/supermatter_sword using invalid icon_state, "supermatter_sword_balanced"
+2023-11-12T09:05:34.9085130Z 	94 - /obj/item/melee/cleric_mace using invalid worn_icon_state, "default_worn"
+2023-11-12T09:05:34.9087426Z 	95 - /obj/item/melee/rune_carver using invalid icon_state, "rune_carver"
+2023-11-12T09:05:34.9089642Z 	96 - /obj/item/melee/ghost_sword using invalid icon_state, "spectral"
+2023-11-12T09:05:34.9099563Z 	97 - /obj/item/storage/lockbox/medal using invalid icon_state, "medalbox+l"
+2023-11-12T09:05:34.9101839Z 	98 - /obj/item/storage/bag/trash using invalid icon_state, "trashbag"
+2023-11-12T09:05:34.9104337Z 	99 - /obj/item/storage/bag/trash/bluespace using invalid icon_state, "bluetrashbag"
+2023-11-12T09:05:34.9106526Z 	100 - /obj/item/cane using invalid icon_state, "cane"
+2023-11-12T09:05:34.9109148Z 	101 - /obj/item/cane/white using invalid icon_state, "cane_white"
+2023-11-12T09:05:34.9127968Z 	102 - /obj/item/clothing/mask/facehugger/toy using invalid worn_icon_state, "facehugger"
+2023-11-12T09:05:34.9129996Z 	103 - /obj/item/kitchen/fork using invalid icon_state, "fork"
+2023-11-12T09:05:34.9132741Z 	104 - /obj/item/kitchen/fork/plastic using invalid icon_state, "plastic_fork"
+2023-11-12T09:05:34.9137903Z 	105 - /obj/item/kitchen/spoon using invalid icon_state, "spoon"
+2023-11-12T09:05:34.9140308Z 	106 - /obj/item/kitchen/spoon/plastic using invalid icon_state, "plastic_spoon"
+2023-11-12T09:05:34.9142537Z 	107 - /obj/item/kitchen/spoon/soup_ladle using invalid icon_state, "ladle"
+2023-11-12T09:05:34.9144673Z 	108 - /obj/item/kitchen/tongs using invalid icon_state, "tongs"
+2023-11-12T09:05:34.9192479Z 	109 - /obj/item/bonesetter using invalid icon_state, "bonesetter"
+2023-11-12T09:05:34.9194966Z 	110 - /obj/item/cautery using invalid icon_state, "cautery"
+2023-11-12T09:05:34.9197552Z 	111 - /obj/item/cautery/advanced using invalid icon_state, "e_cautery"
+2023-11-12T09:05:34.9200017Z 	112 - /obj/item/cautery/cruel using invalid icon_state, "cruelcautery"
+2023-11-12T09:05:34.9202572Z 	113 - /obj/item/hemostat using invalid icon_state, "hemostat"
+2023-11-12T09:05:34.9205055Z 	114 - /obj/item/hemostat/supermatter using invalid icon_state, "supermatter_tongs"
+2023-11-12T09:05:34.9207385Z 	115 - /obj/item/hemostat/cruel using invalid icon_state, "cruelhemostat"
+2023-11-12T09:05:34.9209542Z 	116 - /obj/item/retractor using invalid icon_state, "retractor"
+2023-11-12T09:05:34.9211950Z 	117 - /obj/item/retractor/advanced using invalid icon_state, "adv_retractor"
+2023-11-12T09:05:34.9214520Z 	118 - /obj/item/retractor/cruel using invalid icon_state, "cruelretractor"
+2023-11-12T09:05:34.9216984Z 	119 - /obj/item/scalpel using invalid icon_state, "scalpel"
+2023-11-12T09:05:34.9219596Z 	120 - /obj/item/scalpel/supermatter using invalid icon_state, "supermatter_scalpel"
+2023-11-12T09:05:34.9221828Z 	121 - /obj/item/scalpel/advanced using invalid icon_state, "e_scalpel"
+2023-11-12T09:05:34.9224110Z 	122 - /obj/item/scalpel/cruel using invalid icon_state, "cruelscalpel"
+2023-11-12T09:05:34.9226426Z 	123 - /obj/item/surgical_drapes using invalid icon_state, "surgical_drapes"
+2023-11-12T09:05:34.9230490Z 	124 - /obj/item/crowbar/mechremoval using invalid icon_state, "mechremoval0"
+2023-11-12T09:05:34.9245013Z 	125 - /obj/item/crowbar/hammer using invalid icon_state, "clawhammer"
+2023-11-12T09:05:34.9274002Z [1;32mPASS[0m /datum/unit_test/suit_storage_icons 2.1s
+2023-11-12T09:05:34.9277303Z ##[endgroup]
+2023-11-12T09:05:35.0051949Z ##[group]/datum/unit_test/amputation
+2023-11-12T09:05:35.0418593Z [1;32mPASS[0m /datum/unit_test/amputation 0s
+2023-11-12T09:05:35.0421400Z ##[endgroup]
+2023-11-12T09:05:35.0919237Z ##[group]/datum/unit_test/brain_surgery
+2023-11-12T09:05:35.1251285Z [1;32mPASS[0m /datum/unit_test/brain_surgery 0.1s
+2023-11-12T09:05:35.1254329Z ##[endgroup]
+2023-11-12T09:05:35.1587969Z ##[group]/datum/unit_test/head_transplant
+2023-11-12T09:05:35.2257286Z [1;32mPASS[0m /datum/unit_test/head_transplant 0.1s
+2023-11-12T09:05:35.2260747Z ##[endgroup]
+2023-11-12T09:05:35.2834393Z ##[group]/datum/unit_test/multiple_surgeries
+2023-11-12T09:05:35.3338834Z [1;32mPASS[0m /datum/unit_test/multiple_surgeries 0.1s
+2023-11-12T09:05:35.3341725Z ##[endgroup]
+2023-11-12T09:05:35.4031367Z ##[group]/datum/unit_test/start_tend_wounds
+2023-11-12T09:05:35.4361296Z [1;32mPASS[0m /datum/unit_test/start_tend_wounds 0s
+2023-11-12T09:05:35.4364716Z ##[endgroup]
+2023-11-12T09:05:35.4772361Z ##[group]/datum/unit_test/tend_wounds
+2023-11-12T09:05:35.5590830Z [1;32mPASS[0m /datum/unit_test/tend_wounds 0.1s
+2023-11-12T09:05:35.5594252Z ##[endgroup]
+2023-11-12T09:05:35.6747135Z ##[group]/datum/unit_test/tail_wag
+2023-11-12T09:05:35.8571590Z [1;32mPASS[0m /datum/unit_test/tail_wag 0.2s
+2023-11-12T09:05:35.8574630Z ##[endgroup]
+2023-11-12T09:05:35.8824009Z ##[group]/datum/unit_test/teleporter
+2023-11-12T09:05:35.9106477Z [1;32mPASS[0m /datum/unit_test/teleporter 0.1s
+2023-11-12T09:05:35.9109891Z ##[endgroup]
+2023-11-12T09:05:35.9363555Z ##[group]/datum/unit_test/tgui_create_message
+2023-11-12T09:05:35.9367522Z [1;32mPASS[0m /datum/unit_test/tgui_create_message 0s
+2023-11-12T09:05:35.9370812Z ##[endgroup]
+2023-11-12T09:05:35.9501436Z ##[group]/datum/unit_test/timer_sanity
+2023-11-12T09:05:35.9504464Z [1;32mPASS[0m /datum/unit_test/timer_sanity 0s
+2023-11-12T09:05:35.9508070Z ##[endgroup]
+2023-11-12T09:05:35.9637540Z ##[group]/datum/unit_test/trait_addition_and_removal
+2023-11-12T09:05:35.9642216Z [1;32mPASS[0m /datum/unit_test/trait_addition_and_removal 0s
+2023-11-12T09:05:35.9645763Z ##[endgroup]
+2023-11-12T09:05:35.9828636Z ##[group]/datum/unit_test/traitor
+2023-11-12T09:05:37.5946953Z [1;32mPASS[0m /datum/unit_test/traitor 1.6s
+2023-11-12T09:05:37.5948067Z ##[endgroup]
+2023-11-12T09:05:38.4317615Z ##[group]/datum/unit_test/traitor_mail_content_check
+2023-11-12T09:05:38.4490029Z [1;32mPASS[0m /datum/unit_test/traitor_mail_content_check 0s
+2023-11-12T09:05:38.4491508Z ##[endgroup]
+2023-11-12T09:05:38.4962906Z ##[group]/datum/unit_test/trauma_granting
+2023-11-12T09:05:38.5450644Z [1;32mPASS[0m /datum/unit_test/trauma_granting 0.1s
+2023-11-12T09:05:38.5452259Z ##[endgroup]
+2023-11-12T09:05:38.5799327Z ##[group]/datum/unit_test/turf_icons
+2023-11-12T09:05:39.0838086Z [1;32mPASS[0m /datum/unit_test/turf_icons 0.5s
+2023-11-12T09:05:39.0839541Z ##[endgroup]
+2023-11-12T09:05:39.1032413Z ##[group]/datum/unit_test/tutorial_sanity
+2023-11-12T09:05:39.1035529Z [1;32mPASS[0m /datum/unit_test/tutorial_sanity 0s
+2023-11-12T09:05:39.1037920Z ##[endgroup]
+2023-11-12T09:05:39.1166898Z ##[group]/datum/unit_test/verify_config_tags
+2023-11-12T09:05:39.1172282Z [1;32mPASS[0m /datum/unit_test/verify_config_tags 0s
+2023-11-12T09:05:39.1174748Z ##[endgroup]
+2023-11-12T09:05:39.1303312Z ##[group]/datum/unit_test/verify_emoji_names
+2023-11-12T09:05:39.1306816Z [1;32mPASS[0m /datum/unit_test/verify_emoji_names 0s
+2023-11-12T09:05:39.1309155Z ##[endgroup]
+2023-11-12T09:05:39.1436423Z ##[group]/datum/unit_test/moth_food
+2023-11-12T09:05:39.1899509Z [1;32mPASS[0m /datum/unit_test/moth_food 0s
+2023-11-12T09:05:39.1901926Z ##[endgroup]
+2023-11-12T09:05:39.2373626Z ##[group]/datum/unit_test/golem_food
+2023-11-12T09:05:39.2647161Z [1;32mPASS[0m /datum/unit_test/golem_food 0s
+2023-11-12T09:05:39.2649458Z ##[endgroup]
+2023-11-12T09:05:39.2901012Z ##[group]/datum/unit_test/wizard_loadout
+2023-11-12T09:05:39.3687154Z [1;32mPASS[0m /datum/unit_test/wizard_loadout 0.1s
+2023-11-12T09:05:39.3689468Z ##[endgroup]
+2023-11-12T09:05:39.4375880Z ##[group]/datum/unit_test/worn_icons
+2023-11-12T09:05:40.0482290Z [1;32mPASS[0m /datum/unit_test/worn_icons 0.6s
+2023-11-12T09:05:40.0483826Z ##[endgroup]
+2023-11-12T09:05:40.0625703Z ##[group]/datum/unit_test/find_reference_sanity
+2023-11-12T09:05:40.0632296Z [1;32mPASS[0m /datum/unit_test/find_reference_sanity 0s
+2023-11-12T09:05:40.0634532Z ##[endgroup]
+2023-11-12T09:05:40.0765341Z ##[group]/datum/unit_test/find_reference_baseline
+2023-11-12T09:05:40.0771322Z [1;32mPASS[0m /datum/unit_test/find_reference_baseline 0s
+2023-11-12T09:05:40.0773723Z ##[endgroup]
+2023-11-12T09:05:40.0904726Z ##[group]/datum/unit_test/find_reference_exotic
+2023-11-12T09:05:40.0910664Z [1;32mPASS[0m /datum/unit_test/find_reference_exotic 0s
+2023-11-12T09:05:40.0913091Z ##[endgroup]
+2023-11-12T09:05:40.1081989Z ##[group]/datum/unit_test/find_reference_esoteric
+2023-11-12T09:05:40.1091594Z [1;32mPASS[0m /datum/unit_test/find_reference_esoteric 0s
+2023-11-12T09:05:40.1093910Z ##[endgroup]
+2023-11-12T09:05:40.1356236Z ##[group]/datum/unit_test/find_reference_null_key_entry
+2023-11-12T09:05:40.1361917Z [1;32mPASS[0m /datum/unit_test/find_reference_null_key_entry 0s
+2023-11-12T09:05:40.1364019Z ##[endgroup]
+2023-11-12T09:05:40.1495527Z ##[group]/datum/unit_test/find_reference_assoc_investigation
+2023-11-12T09:05:40.1501290Z [1;32mPASS[0m /datum/unit_test/find_reference_assoc_investigation 0s
+2023-11-12T09:05:40.1503468Z ##[endgroup]
+2023-11-12T09:05:40.1629204Z ##[group]/datum/unit_test/find_reference_static_investigation
+2023-11-12T09:05:40.4955432Z [1;32mPASS[0m /datum/unit_test/find_reference_static_investigation 0.3s
+2023-11-12T09:05:40.4956809Z ##[endgroup]
+2023-11-12T09:05:40.5106809Z ##[group]/datum/unit_test/area_contents
+2023-11-12T09:05:41.5891675Z [1;32mPASS[0m /datum/unit_test/area_contents 1s
+2023-11-12T09:05:41.5893012Z ##[endgroup]
+2023-11-12T09:05:41.6151445Z ##[group]/datum/unit_test/atmospherics_sanity
+2023-11-12T09:05:41.6152255Z No starting areas found, defaulting...
+2023-11-12T09:05:41.6155445Z Marking all station areas as goal areas due to marker at (2, 254, 2)
+2023-11-12T09:05:42.2832551Z [1;32mPASS[0m /datum/unit_test/atmospherics_sanity 0.6s
+2023-11-12T09:05:42.2834628Z ##[endgroup]
+2023-11-12T09:05:42.3215674Z ##[group]/datum/unit_test/fish_rescue_hook
+2023-11-12T09:05:49.5841266Z [1;32mPASS[0m /datum/unit_test/fish_rescue_hook 7.2s
+2023-11-12T09:05:49.5842563Z ##[endgroup]
+2023-11-12T09:05:49.6648561Z ##[group]/datum/unit_test/leash/no_teleport
+2023-11-12T09:05:49.7264798Z [1;32mPASS[0m /datum/unit_test/leash/no_teleport 0.1s
+2023-11-12T09:05:49.7267230Z ##[endgroup]
+2023-11-12T09:05:49.7411212Z ##[group]/datum/unit_test/leash/will_teleport
+2023-11-12T09:05:49.7421861Z [1;32mPASS[0m /datum/unit_test/leash/will_teleport 0s
+2023-11-12T09:05:49.7424432Z ##[endgroup]
+2023-11-12T09:05:49.7571233Z ##[group]/datum/unit_test/leash/limit_range
+2023-11-12T09:05:49.7577430Z [1;32mPASS[0m /datum/unit_test/leash/limit_range 0s
+2023-11-12T09:05:49.7579955Z ##[endgroup]
+2023-11-12T09:05:49.7749544Z ##[group]/datum/unit_test/mapload_space_verification
+2023-11-12T09:05:50.3597291Z [1;32mPASS[0m /datum/unit_test/mapload_space_verification 0.6s
+2023-11-12T09:05:50.3598841Z ##[endgroup]
+2023-11-12T09:05:50.3862628Z ##[group]/datum/unit_test/mob_damage
+2023-11-12T09:05:50.4877049Z [1;32mPASS[0m /datum/unit_test/mob_damage 0.1s
+2023-11-12T09:05:50.4878381Z ##[endgroup]
+2023-11-12T09:05:50.5135873Z ##[group]/datum/unit_test/mob_damage/basic
+2023-11-12T09:05:50.5174197Z [1;32mPASS[0m /datum/unit_test/mob_damage/basic 0s
+2023-11-12T09:05:50.5176179Z ##[endgroup]
+2023-11-12T09:05:50.5348335Z ##[group]/datum/unit_test/modify_fantasy_variable
+2023-11-12T09:06:17.8433778Z [1;32mPASS[0m /datum/unit_test/modify_fantasy_variable 27.3s
+2023-11-12T09:06:17.8434791Z ##[endgroup]
+2023-11-12T09:06:24.9200774Z ##[group]/datum/unit_test/monkey_business
+2023-11-12T09:06:44.1178950Z [09:06:44] Runtime in timer.dm,125: Invalid timer: Timer: Timer: 2433 ([0x2100859b]), TTR: 328041, wait:2 Flags: TIMER_CLIENT_TIME, TIMER_STOPPABLE, callBack: [0x2105a831], callBack.object: /datum/looping_sound/showering[0x210085b4](/datum/looping_sound/showering), callBack.delegate:/datum/looping_sound/proc/start_sound_loop(), source: code/datums/looping_sounds/_looping_sound.dm:220Prev: NULL, Next: NULL, SPENT(328041), QDELETED, NO CALLBACK world.time: 942.5, head_offset: 600, practical_offset: 686, REALTIMEOFDAY: 328041
+2023-11-12T09:06:44.1182762Z   proc name: fire (/datum/controller/subsystem/timer/fire)
+2023-11-12T09:06:44.1191977Z   src: Sound Loops (/datum/controller/subsystem/timer/sound_loops)
+2023-11-12T09:06:44.1192834Z   call stack:
+2023-11-12T09:06:44.1193480Z   Sound Loops (/datum/controller/subsystem/timer/sound_loops): fire(0)
+2023-11-12T09:06:44.1194547Z   Sound Loops (/datum/controller/subsystem/timer/sound_loops): fire(0)
+2023-11-12T09:06:44.1195659Z   Sound Loops (/datum/controller/subsystem/timer/sound_loops): ignite(0)
+2023-11-12T09:06:44.1196597Z   Master (/datum/controller/master): RunQueue()
+2023-11-12T09:06:44.1201550Z   Master (/datum/controller/master): Loop(2)
+2023-11-12T09:06:44.1202483Z   Master (/datum/controller/master): StartProcessing(0)
+2023-11-12T09:07:03.3211396Z ##[error][09:06:44] Runtime in timer.dm,125: Invalid timer: Timer: Timer: 2433 ([0x2100859b]), TTR: 328041, wait:2 Flags: TIMER_CLIENT_TIME, TIMER_STOPPABLE, callBack: [0x2105a831], callBack.object: /datum/looping_sound/showering[0x210085b4](/datum/looping_sound/showering), callBack.delegate:/datum/looping_sound/proc/start_sound_loop(), source: code/datums/looping_sounds/_looping_sound.dm:220Prev: NULL, Next: NULL, SPENT(328041), QDELETED, NO CALLBACK world.time: 942.5, head_offset: 600, practical_offset: 686, REALTIMEOFDAY: 328041
+  proc name: fire (/datum/controller/subsystem/timer/fire)
+  src: Sound Loops (/datum/controller/subsystem/timer/sound_loops)
+  call stack:
+  Sound Loops (/datum/controller/subsystem/timer/sound_loops): fire(0)
+  Sound Loops (/datum/controller/subsystem/timer/sound_loops): fire(0)
+  Sound Loops (/datum/controller/subsystem/timer/sound_loops): ignite(0)
+  Master (/datum/controller/master): RunQueue()
+  Master (/datum/controller/master): Loop(2)
+  Master (/datum/controller/master): StartProcessing(0)
+2023-11-12T09:07:03.3224436Z 	FAILURE #1: [09:06:44] Runtime in timer.dm,125: Invalid timer: Timer: Timer: 2433 ([0x2100859b]), TTR: 328041, wait:2 Flags: TIMER_CLIENT_TIME, TIMER_STOPPABLE, callBack: [0x2105a831], callBack.object: /datum/looping_sound/showering[0x210085b4](/datum/looping_sound/showering), callBack.delegate:/datum/looping_sound/proc/start_sound_loop(), source: code/datums/looping_sounds/_looping_sound.dm:220Prev: NULL, Next: NULL, SPENT(328041), QDELETED, NO CALLBACK world.time: 942.5, head_offset: 600, practical_offset: 686, REALTIMEOFDAY: 328041
+2023-11-12T09:07:03.3226826Z   proc name: fire (/datum/controller/subsystem/timer/fire)
+2023-11-12T09:07:03.3227626Z   src: Sound Loops (/datum/controller/subsystem/timer/sound_loops)
+2023-11-12T09:07:03.3228077Z   call stack:
+2023-11-12T09:07:03.3228462Z   Sound Loops (/datum/controller/subsystem/timer/sound_loops): fire(0)
+2023-11-12T09:07:03.3229045Z   Sound Loops (/datum/controller/subsystem/timer/sound_loops): fire(0)
+2023-11-12T09:07:03.3229619Z   Sound Loops (/datum/controller/subsystem/timer/sound_loops): ignite(0)
+2023-11-12T09:07:03.3230129Z   Master (/datum/controller/master): RunQueue()
+2023-11-12T09:07:03.3230524Z   Master (/datum/controller/master): Loop(2)
+2023-11-12T09:07:03.3231037Z   Master (/datum/controller/master): StartProcessing(0) at timer.dm:125
+2023-11-12T09:07:03.3231712Z ##[endgroup]
+2023-11-12T09:07:03.3232839Z ##[error][1;31mFAIL[0m /datum/unit_test/monkey_business 38.4s
+2023-11-12T09:07:05.4669397Z ##[group]/datum/unit_test/strange_reagent
+2023-11-12T09:07:09.1986629Z [1;32mPASS[0m /datum/unit_test/strange_reagent 3.7s
+2023-11-12T09:07:09.1988202Z ##[endgroup]
+2023-11-12T09:07:11.6843550Z ##[group]/datum/unit_test/create_and_destroy
+2023-11-12T09:07:36.2863567Z No elevator ID for elevator music provided at Test Room (126,126,14).
+2023-11-12T09:08:13.7560132Z [1;32mPASS[0m /datum/unit_test/create_and_destroy 62.1s
+2023-11-12T09:08:13.7561471Z ##[endgroup]
+2023-11-12T09:08:13.7852782Z ##[group]/datum/unit_test/dcs_check_list_arguments
+2023-11-12T09:08:13.7940678Z [1;32mPASS[0m /datum/unit_test/dcs_check_list_arguments 0s
+2023-11-12T09:08:13.7942424Z ##[endgroup]
+2023-11-12T09:08:15.2400236Z Shutting down Chat subsystem...
+2023-11-12T09:08:15.2402039Z Shutting down Init Profiler subsystem...
+2023-11-12T09:08:15.2404881Z Shutting down Ban Cache subsystem...
+2023-11-12T09:08:15.2407209Z Shutting down Stat Panels subsystem...
+2023-11-12T09:08:15.2409633Z Shutting down Explosions subsystem...
+2023-11-12T09:08:15.2412008Z Shutting down Pathfinder subsystem...
+2023-11-12T09:08:15.2414438Z Shutting down Minor Mapping subsystem...
+2023-11-12T09:08:15.2416820Z Shutting down Shuttle subsystem...
+2023-11-12T09:08:15.2420930Z Warning: Subsystem `Shuttle` slept 2 times.
+2023-11-12T09:08:15.2421633Z Shutting down Lighting subsystem...
+2023-11-12T09:08:15.2423743Z Shutting down XKeyScore subsystem...
+2023-11-12T09:08:15.2425667Z Shutting down PRISM subsystem...
+2023-11-12T09:08:15.2427615Z Shutting down Icon Smoothing subsystem...
+2023-11-12T09:08:15.2429451Z Shutting down Assets subsystem...
+2023-11-12T09:08:15.2431258Z Shutting down Vote subsystem...
+2023-11-12T09:08:15.2433223Z Shutting down Persistent Paintings subsystem...
+2023-11-12T09:08:15.2435113Z Shutting down Persistence subsystem...
+2023-11-12T09:08:15.2437033Z Shutting down Atmospherics subsystem...
+2023-11-12T09:08:15.2439009Z Shutting down Wiremod Composite Templates subsystem...
+2023-11-12T09:08:15.2440741Z Shutting down Wet floors subsystem...
+2023-11-12T09:08:15.2443279Z Shutting down Weather subsystem...
+2023-11-12T09:08:15.2445531Z Shutting down Wardrobe subsystem...
+2023-11-12T09:08:15.2447137Z Shutting down Verb Manager subsystem...
+2023-11-12T09:08:15.2448994Z Shutting down Tutorials subsystem...
+2023-11-12T09:08:15.2450888Z Shutting down Transport subsystem...
+2023-11-12T09:08:15.2452762Z Shutting down Traitor subsystem...
+2023-11-12T09:08:15.2454635Z Shutting down Throwing subsystem...
+2023-11-12T09:08:15.2456529Z Shutting down tgui subsystem...
+2023-11-12T09:08:15.2458543Z Shutting down Supermatter Cascade subsystem...
+2023-11-12T09:08:15.2460380Z Shutting down Sun subsystem...
+2023-11-12T09:08:15.2462254Z Shutting down Stock Market subsystem...
+2023-11-12T09:08:15.2464168Z Shutting down Speech Controller subsystem...
+2023-11-12T09:08:15.2466003Z Shutting down Space Drift subsystem...
+2023-11-12T09:08:15.2467944Z Shutting down Smoke subsystem...
+2023-11-12T09:08:15.2469878Z Shutting down Singularity subsystem...
+2023-11-12T09:08:15.2472104Z Shutting down Radioactive Nebula subsystem...
+2023-11-12T09:08:15.2473961Z Shutting down Radio subsystem...
+2023-11-12T09:08:15.2476202Z Shutting down Radiation subsystem...
+2023-11-12T09:08:15.2477898Z Shutting down Projectiles subsystem...
+2023-11-12T09:08:15.2479832Z Shutting down Processing subsystem...
+2023-11-12T09:08:15.2482409Z Shutting down Points of Interest subsystem...
+2023-11-12T09:08:15.2484346Z Shutting down Plumbing subsystem...
+2023-11-12T09:08:15.2486233Z Shutting down Ping subsystem...
+2023-11-12T09:08:15.2488172Z Shutting down Parallax subsystem...
+2023-11-12T09:08:15.2490092Z Shutting down pAI subsystem...
+2023-11-12T09:08:15.2492038Z Shutting down Overlay subsystem...
+2023-11-12T09:08:15.7359113Z Shutting down Objects subsystem...
+2023-11-12T09:08:15.7360449Z Shutting down Obj Tab Items subsystem...
+2023-11-12T09:08:15.7363590Z Shutting down NPC Pool subsystem...
+2023-11-12T09:08:15.7365241Z Shutting down Night Shift subsystem...
+2023-11-12T09:08:15.7367764Z Shutting down Movement Loops subsystem...
+2023-11-12T09:08:15.7369511Z Shutting down Movement Handler subsystem...
+2023-11-12T09:08:15.7371589Z Shutting down MouseEntered subsystem...
+2023-11-12T09:08:15.7373527Z Shutting down Mood subsystem...
+2023-11-12T09:08:15.7375649Z Shutting down Modular Computers subsystem...
+2023-11-12T09:08:15.7377558Z Shutting down Mobs subsystem...
+2023-11-12T09:08:15.7379600Z Shutting down Materials subsystem...
+2023-11-12T09:08:15.7381572Z Shutting down Lua Scripting subsystem...
+2023-11-12T09:08:15.7505514Z Shutting down Library Loading subsystem...
+2023-11-12T09:08:15.7507489Z Shutting down Lag Switch subsystem...
+2023-11-12T09:08:15.7509583Z Shutting down Idling NPC Pool subsystem...
+2023-11-12T09:08:15.7511671Z Shutting down Hyperspace Drift subsystem...
+2023-11-12T09:08:15.7513591Z Shutting down Foam subsystem...
+2023-11-12T09:08:15.7515516Z Shutting down Fluid subsystem...
+2023-11-12T09:08:15.7517494Z Shutting down Fishing subsystem...
+2023-11-12T09:08:15.7519635Z Shutting down Fast Processing subsystem...
+2023-11-12T09:08:15.7521688Z Shutting down Escape Menu subsystem...
+2023-11-12T09:08:15.7523697Z Shutting down Eigenstates subsystem...
+2023-11-12T09:08:15.7525621Z Shutting down Disease subsystem...
+2023-11-12T09:08:15.7527699Z Shutting down Digital Clocks subsystem...
+2023-11-12T09:08:15.7529722Z Shutting down Datum Component System subsystem...
+2023-11-12T09:08:15.7531714Z Shutting down Conveyor Belts subsystem...
+2023-11-12T09:08:15.7533950Z Shutting down Communications subsystem...
+2023-11-12T09:08:15.7536091Z Shutting down Clock Component subsystem...
+2023-11-12T09:08:15.7538058Z Shutting down Cliff Falling subsystem...
+2023-11-12T09:08:15.7540124Z Shutting down Circuit Components subsystem...
+2023-11-12T09:08:15.7542040Z Shutting down Burning subsystem...
+2023-11-12T09:08:15.7544007Z Shutting down Blackmarket subsystem...
+2023-11-12T09:08:15.7545998Z Shutting down Basic Avoidance subsystem...
+2023-11-12T09:08:15.7547937Z Shutting down Aura Healing subsystem...
+2023-11-12T09:08:15.7549860Z Shutting down Augury subsystem...
+2023-11-12T09:08:15.7552123Z Shutting down Asset Loading subsystem...
+2023-11-12T09:08:15.7553815Z Shutting down Area Contents subsystem...
+2023-11-12T09:08:15.7555740Z Shutting down Antag HUDs subsystem...
+2023-11-12T09:08:15.7557720Z Shutting down Ambience subsystem...
+2023-11-12T09:08:15.7559697Z Shutting down Addiction subsystem...
+2023-11-12T09:08:15.7562910Z Shutting down Acid subsystem...
+2023-11-12T09:08:15.7564740Z Shutting down Timer subsystem...
+2023-11-12T09:08:15.7566504Z Shutting down Sound Loops subsystem...
+2023-11-12T09:08:15.7568731Z Shutting down Runechat subsystem...
+2023-11-12T09:08:15.7570746Z Shutting down Queue Links subsystem...
+2023-11-12T09:08:15.7572695Z Shutting down Skills subsystem...
+2023-11-12T09:08:15.7574685Z Shutting down Machines subsystem...
+2023-11-12T09:08:15.7576634Z Shutting down Language subsystem...
+2023-11-12T09:08:15.7578608Z Shutting down Atoms subsystem...
+2023-11-12T09:08:15.7601367Z Shutting down Text To Speech subsystem...
+2023-11-12T09:08:15.7603675Z Shutting down Restaurant subsystem...
+2023-11-12T09:08:15.7605588Z Shutting down Economy subsystem...
+2023-11-12T09:08:15.7607616Z Shutting down Spatial Grid subsystem...
+2023-11-12T09:08:15.7609600Z Shutting down Time Tracking subsystem...
+2023-11-12T09:08:15.7611597Z Shutting down Research subsystem...
+2023-11-12T09:08:15.7613755Z Shutting down Early Assets subsystem...
+2023-11-12T09:08:15.7615768Z Shutting down Mapping subsystem...
+2023-11-12T09:08:15.7617822Z Shutting down Trading Card Game subsystem...
+2023-11-12T09:08:15.7619966Z Shutting down Ticker subsystem...
+2023-11-12T09:08:15.7622043Z Warning: Subsystem `Ticker` slept 1 times.
+2023-11-12T09:08:15.7644481Z Unable to locate admins backup file.
+2023-11-12T09:08:15.7654489Z Shutting down AI Controller Ticker subsystem...
+2023-11-12T09:08:15.7656545Z Shutting down AI Behavior Ticker subsystem...
+2023-11-12T09:08:15.7658539Z Shutting down AI movement subsystem...
+2023-11-12T09:08:15.7660519Z Shutting down Jobs subsystem...
+2023-11-12T09:08:15.7662633Z Shutting down IDs and Access subsystem...
+2023-11-12T09:08:15.7664623Z Shutting down Events subsystem...
+2023-11-12T09:08:15.7666630Z Shutting down Reagents subsystem...
+2023-11-12T09:08:15.7668611Z Shutting down Quirks subsystem...
+2023-11-12T09:08:15.7670631Z Shutting down Station subsystem...
+2023-11-12T09:08:15.7672688Z Shutting down Achievements subsystem...
+2023-11-12T09:08:15.7674715Z Shutting down Discord subsystem...
+2023-11-12T09:08:15.7676785Z Shutting down Security Level subsystem...
+2023-11-12T09:08:15.7678830Z Shutting down Vis contents overlays subsystem...
+2023-11-12T09:08:15.7680780Z Shutting down Greyscale subsystem...
+2023-11-12T09:08:15.7683265Z Shutting down Instruments subsystem...
+2023-11-12T09:08:15.7685284Z Shutting down Sounds subsystem...
+2023-11-12T09:08:15.7687269Z Shutting down Input subsystem...
+2023-11-12T09:08:15.7689286Z Shutting down Server Tasks subsystem...
+2023-11-12T09:08:15.7691440Z Shutting down Blackbox subsystem...
+2023-11-12T09:08:15.7700214Z Shutting down Database subsystem...
+2023-11-12T09:08:15.7709204Z Shutting down Garbage subsystem...
+2023-11-12T09:08:18.8763587Z Shutting down Title Screen subsystem...
+2023-11-12T09:08:18.8783727Z Shutting down Profiler subsystem...
+2023-11-12T09:08:18.8789879Z Shutdown complete
+2023-11-12T09:08:18.8797124Z Test run failed!
+2023-11-12T09:08:18.8797462Z Total runtimes: 1
+2023-11-12T09:08:18.8797716Z Unit Tests failed!
+2023-11-12T09:08:22.0106377Z cat: ci_test/data/logs/ci/clean_run.lk: No such file or directory
+2023-11-12T09:08:22.0116872Z ##[error]Process completed with exit code 1.
+2023-11-12T09:08:22.0170857Z ##[group]Run actions/upload-artifact@v3
+2023-11-12T09:08:22.0171222Z with:
+2023-11-12T09:08:22.0171467Z   name: test_artifacts_tramstation
+2023-11-12T09:08:22.0171798Z   path: data/screenshots_new/
+2023-11-12T09:08:22.0172089Z   retention-days: 1
+2023-11-12T09:08:22.0172354Z   if-no-files-found: warn
+2023-11-12T09:08:22.0172621Z ##[endgroup]
+2023-11-12T09:08:22.1010805Z With the provided path, there will be 77 files uploaded
+2023-11-12T09:08:22.1013040Z Starting artifact upload
+2023-11-12T09:08:22.1014930Z For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
+2023-11-12T09:08:22.1016085Z Artifact name is valid!
+2023-11-12T09:08:22.1655325Z Container for artifact "test_artifacts_tramstation" successfully created. Starting upload of file(s)
+2023-11-12T09:08:25.4511686Z Total size of all the files uploaded is 104264 bytes
+2023-11-12T09:08:25.4513089Z File upload process has finished. Finalizing the artifact upload
+2023-11-12T09:08:25.4967864Z Artifact has been finalized. All files have been successfully uploaded!
+2023-11-12T09:08:25.4968795Z
+2023-11-12T09:08:25.4969438Z The raw size of all the files that were specified for upload is 104534 bytes
+2023-11-12T09:08:25.4995080Z The size of all the files that were uploaded is 104264 bytes. This takes into account any gzip compression used to reduce the upload size, time and storage
+2023-11-12T09:08:25.4996373Z
+2023-11-12T09:08:25.5000590Z Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads
+2023-11-12T09:08:25.5002432Z
+2023-11-12T09:08:25.5002844Z Artifact test_artifacts_tramstation has been successfully uploaded!
+2023-11-12T09:08:25.5131976Z ##[group]Run tgstation/byond-client-compatibility-check@v3
+2023-11-12T09:08:25.5132416Z with:
+2023-11-12T09:08:25.5132646Z   dmb-location: tgstation.dmb
+2023-11-12T09:08:25.5132971Z   max-required-client-version: 514
+2023-11-12T09:08:25.5133284Z ##[endgroup]
+2023-11-12T09:08:25.5322365Z ##[group]Run (( 514 ))
+2023-11-12T09:08:25.5322641Z [36;1m(( 514 ))[0m
+2023-11-12T09:08:25.5367699Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2023-11-12T09:08:25.5368129Z ##[endgroup]
+2023-11-12T09:08:25.5463568Z ##[group]Run echo "required-client-version=$(( $( head -n2 tgstation.dmb | tail -n1 | cut -d " " -f 4 ) ))" >> $GITHUB_OUTPUT
+2023-11-12T09:08:25.5464593Z [36;1mecho "required-client-version=$(( $( head -n2 tgstation.dmb | tail -n1 | cut -d " " -f 4 ) ))" >> $GITHUB_OUTPUT[0m
+2023-11-12T09:08:25.5503899Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2023-11-12T09:08:25.5504317Z ##[endgroup]
+2023-11-12T09:08:25.5643709Z ##[group]Run (( 514 <= 514 ))
+2023-11-12T09:08:25.5644042Z [36;1m(( 514 <= 514 ))[0m
+2023-11-12T09:08:25.5682534Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2023-11-12T09:08:25.5682953Z ##[endgroup]
+2023-11-12T09:08:25.5835969Z Post job cleanup.
+2023-11-12T09:08:25.6654082Z [command]/usr/bin/git version
+2023-11-12T09:08:25.6698640Z git version 2.42.0
+2023-11-12T09:08:25.6737360Z Temporarily overriding HOME='/home/runner/work/_temp/8c7eca89-05a8-49f5-91d4-2ad2b8c1f35c' before making global git config changes
+2023-11-12T09:08:25.6738762Z Adding repository directory to the temporary git global config as a safe directory
+2023-11-12T09:08:25.6742986Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2023-11-12T09:08:25.6784154Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2023-11-12T09:08:25.6822086Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2023-11-12T09:08:25.7132368Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2023-11-12T09:08:25.7163927Z http.https://github.com/.extraheader
+2023-11-12T09:08:25.7175279Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2023-11-12T09:08:25.7216423Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2023-11-12T09:08:25.7590917Z Print service container logs: c43e2a4f7a0044eda3c3640d7583be1f_mysqllatest_210664
+2023-11-12T09:08:25.7595897Z ##[command]/usr/bin/docker logs --details 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T09:08:25.7722763Z  2023-11-12 08:59:57+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.2.0-1.el8 started.
+2023-11-12T09:08:25.7724170Z  2023-11-12 08:59:57+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
+2023-11-12T09:08:25.7726315Z  2023-11-12T08:59:57.323609Z 0 [System] [MY-015017] [Server] MySQL Server Initialization - start.
+2023-11-12T09:08:25.7728493Z  2023-11-12T08:59:57.324887Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2023-11-12T09:08:25.7730639Z  2023-11-12 08:59:57+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.2.0-1.el8 started.
+2023-11-12T09:08:25.7731931Z  2023-11-12 08:59:57+00:00 [Note] [Entrypoint]: Initializing database files
+2023-11-12T09:08:25.7733478Z  2023-11-12T08:59:57.324980Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.2.0) initializing of server in progress as process 80
+2023-11-12T09:08:25.7735422Z  2023-11-12T08:59:57.329733Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2023-11-12T09:08:25.7736806Z  2023-11-12T08:59:57.538012Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2023-11-12T09:08:25.7737953Z  2023-11-12 09:00:00+00:00 [Note] [Entrypoint]: Database files initialized
+2023-11-12T09:08:25.7738945Z  2023-11-12 09:00:00+00:00 [Note] [Entrypoint]: Starting temporary server
+2023-11-12T09:08:25.7739945Z  2023-11-12 09:00:00+00:00 [Note] [Entrypoint]: Temporary server started.
+2023-11-12T09:08:25.7740898Z  '/var/lib/mysql/mysql.sock' -> '/var/run/mysqld/mysqld.sock'
+2023-11-12T09:08:25.7741615Z
+2023-11-12T09:08:25.7742199Z  2023-11-12 09:00:02+00:00 [Note] [Entrypoint]: Stopping temporary server
+2023-11-12T09:08:25.7743236Z  2023-11-12 09:00:03+00:00 [Note] [Entrypoint]: Temporary server stopped
+2023-11-12T09:08:25.7744003Z
+2023-11-12T09:08:25.7744708Z  2023-11-12 09:00:03+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
+2023-11-12T09:08:25.7746704Z  2023-11-12T08:59:58.210653Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
+2023-11-12T09:08:25.7748648Z  2023-11-12T09:00:00.300732Z 0 [System] [MY-015018] [Server] MySQL Server Initialization - end.
+2023-11-12T09:08:25.7749899Z  2023-11-12T09:00:00.347787Z 0 [System] [MY-015015] [Server] MySQL Server - start.
+2023-11-12T09:08:25.7751901Z  2023-11-12T09:00:00.530321Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2023-11-12T09:08:25.7754106Z  2023-11-12T09:00:00.531123Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.2.0) starting as process 124
+2023-11-12T09:08:25.7756278Z  2023-11-12T09:00:00.541412Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2023-11-12T09:08:25.7757517Z  2023-11-12T09:00:00.630355Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2023-11-12T09:08:25.7758462Z  2023-11-12T09:00:00.815198Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2023-11-12T09:08:25.7759637Z  2023-11-12T09:00:00.815226Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2023-11-12T09:08:25.7761631Z  2023-11-12T09:00:00.816463Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2023-11-12T09:08:25.7763033Z  2023-11-12T09:00:00.828404Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/run/mysqld/mysqlx.sock
+2023-11-12T09:08:25.7764603Z  2023-11-12T09:00:00.828529Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.2.0'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server - GPL.
+2023-11-12T09:08:25.7765734Z  2023-11-12T09:00:00.829953Z 0 [System] [MY-015016] [Server] MySQL Server - end.
+2023-11-12T09:08:25.7766430Z  Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
+2023-11-12T09:08:25.7767184Z  Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
+2023-11-12T09:08:25.7767935Z  Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
+2023-11-12T09:08:25.7768649Z  Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
+2023-11-12T09:08:25.7769346Z  Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
+2023-11-12T09:08:25.7770052Z  Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
+2023-11-12T09:08:25.7770961Z  2023-11-12T09:00:02.470903Z 10 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.2.0).
+2023-11-12T09:08:25.7772265Z  2023-11-12T09:00:03.257971Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.2.0)  MySQL Community Server - GPL.
+2023-11-12T09:08:25.7773173Z  2023-11-12T09:00:03.260270Z 0 [System] [MY-015016] [Server] MySQL Server - end.
+2023-11-12T09:08:25.7773836Z  2023-11-12T09:00:03.482460Z 0 [System] [MY-015015] [Server] MySQL Server - start.
+2023-11-12T09:08:25.7774963Z  2023-11-12T09:00:03.659729Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2023-11-12T09:08:25.7776201Z  2023-11-12T09:00:03.661194Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.2.0) starting as process 1
+2023-11-12T09:08:25.7777020Z  2023-11-12T09:00:03.666529Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2023-11-12T09:08:25.7777756Z  2023-11-12T09:00:03.752233Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2023-11-12T09:08:25.7778518Z  2023-11-12T09:00:03.907357Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2023-11-12T09:08:25.7779564Z  2023-11-12T09:00:03.907387Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2023-11-12T09:08:25.7781056Z  2023-11-12T09:00:03.908492Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2023-11-12T09:08:25.7782533Z  2023-11-12T09:00:03.922214Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
+2023-11-12T09:08:25.7783946Z  2023-11-12T09:00:03.922317Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.2.0'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2023-11-12T09:08:25.7784877Z
+2023-11-12T09:08:25.7790536Z Stop and remove container: c43e2a4f7a0044eda3c3640d7583be1f_mysqllatest_210664
+2023-11-12T09:08:25.7796028Z ##[command]/usr/bin/docker rm --force 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T09:08:26.0454956Z 37a3cfd21d3298b61164877b4eaf9717ee52eda64115ae9cd1aef5206d293ded
+2023-11-12T09:08:26.0480580Z Remove container network: github_network_bc2270e2d9644957ba98982ec5cf35f2
+2023-11-12T09:08:26.0487395Z ##[command]/usr/bin/docker network rm github_network_bc2270e2d9644957ba98982ec5cf35f2
+2023-11-12T09:08:26.3137535Z github_network_bc2270e2d9644957ba98982ec5cf35f2
+2023-11-12T09:08:26.3289510Z Cleaning up orphan processes


### PR DESCRIPTION
`Flaky test create_and_destroy: /obj/item/organ/internal/ears hard deleted 1 times out of a total del count of 495`
->
`Flaky hard delete: /obj/item/organ/internal/ears`

`Flaky test monkey_business: Invalid timer: Timer: Timer: 2433 ([0x2100859b]), TTR: 328041, wait:2 Flags: TIMER_CLIENT_TIME, TIMER_STOPPABLE, callBack: [0x2105a831], callBack.object: /datum/looping_sound/showering[0x210085b4](/datum/looping_sound/showering), callBack.delegate:/datum/looping_sound/proc/start_sound_loop(), source: code/datums/looping_sounds/_looping_sound.dm:220Prev: NULL, Next: NULL, SPENT(328041), QDELETED, NO CALLBACK world.time: 942.5, head_offset: 600, practical_offset: 686, REALTIMEOFDAY: 328041`
->
`Flaky test monkey_business: Invalid timer: /datum/looping_sound/proc/start_sound_loop() on /datum/looping_sound/showering`


I will close every flaky test report with these patterns so that they are repopulated with the new deduplicated names.