### PR TITLE
Fixes Cameras views on clients 515.1615 or greater

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -13,13 +13,15 @@
 	var/active_offset = 0
 	/// What, if any, submap we render onto
 	var/map = ""
-	/// Due to a Byond bug relating to secondary maps and positional screen_loc arguments, we need to statically set to the loc
-	var/relay_loc_override = null
+	/// Due to a Byond bug where secondary maps have improperly offset render targets, we will need to override this to "LEFT,TOP" for clients >515.1614
+	var/relay_loc = "CENTER"
 
-/datum/plane_master_group/New(key, map = "")
+/datum/plane_master_group/New(key, map = "", relay_loc)
 	. = ..()
 	src.key = key
 	src.map = map
+	if(relay_loc)
+		src.relay_loc = relay_loc
 	build_plane_masters(0, SSmapping.max_plane_offset)
 
 /datum/plane_master_group/Destroy()
@@ -90,7 +92,7 @@
 		for(var/plane_offset in starting_offset to ending_offset)
 			if(plane_offset != 0 && !initial(mytype.allows_offsetting))
 				continue
-			var/atom/movable/screen/plane_master/instance = new mytype(null, null, src, plane_offset, relay_loc_override)
+			var/atom/movable/screen/plane_master/instance = new mytype(null, null, src, plane_offset, relay_loc)
 			plane_masters["[instance.plane]"] = instance
 			prep_plane_instance(instance)
 
@@ -184,7 +186,7 @@
 	// If we're about to display this group to a mob who's client is more recent than the last known version with working CENTER, then we need to remake the relays
 	// with the correct screen_loc using the relay override
 	if(viewing_hud.mymob?.client?.byond_build > MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS)
-		relay_loc_override = "LEFT,TOP"
+		relay_loc = "LEFT,TOP"
 		rebuild_plane_masters()
 	return ..()
 

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -53,10 +53,14 @@
 /// Fully regenerate our group, resetting our planes to their compile time values
 /datum/plane_master_group/proc/rebuild_hud()
 	hide_hud()
-	QDEL_LIST_ASSOC_VAL(plane_masters)
-	build_plane_masters(0, SSmapping.max_plane_offset)
+	rebuild_plane_masters()
 	show_hud()
 	transform_lower_turfs(our_hud, active_offset)
+
+/// Regenerate our plane masters, this is useful if we don't have a mob but still want to rebuild. Such in the case of changing the screen_loc of relays
+/datum/plane_master_group/proc/rebuild_plane_masters()
+	QDEL_LIST_ASSOC_VAL(plane_masters)
+	build_plane_masters(0, SSmapping.max_plane_offset)
 
 /datum/plane_master_group/proc/hide_hud()
 	for(var/thing in plane_masters)
@@ -172,18 +176,16 @@
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
 
-/// This is janky as hell but since something changed with CENTER positioning after build 1609 we have to switch to the bandaid LEFT,TOP positioning
-/// using LEFT,TOP at or before 1614 will result in another broken offset for cameras
+/// This is janky as hell but since something changed with CENTER positioning after build 1614 we have to switch to the bandaid LEFT,TOP positioning
+/// using LEFT,TOP *at* or *before* 1614 will result in another broken offset for cameras
 #define MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS 1614
 
 /datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
 	// If we're about to display this group to a mob who's client is more recent than the last known version with working CENTER, then we need to remake the relays
 	// with the correct screen_loc using the relay override
 	if(viewing_hud.mymob?.client?.byond_build > MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS)
-		for(var/thing in plane_masters)
-			var/atom/movable/screen/plane_master/plane = plane_masters[thing]
-			QDEL_LIST(plane.relays)
-			plane.generate_render_relays(relay_loc_override = "LEFT,TOP")
+		relay_loc_override = "LEFT,TOP"
+		rebuild_plane_masters()
 	return ..()
 
 #undef MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -180,11 +180,10 @@
 	// If we're about to display this group to a mob who's client is more recent than the last known version with working CENTER, then we need to remake the relays
 	// with the correct screen_loc using the relay override
 	if(viewing_hud.mymob?.client?.byond_build > MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS)
-		for(var/thing in plane_masters)
-			var/atom/movable/screen/plane_master/plane = plane_masters[thing]
+		for(var/atom/movable/screen/plane_master/plane as anything in plane_masters)
 			QDEL_LIST(plane.relays)
 			plane.generate_render_relays(relay_loc_override = "LEFT,TOP")
-	. = ..()
+	return ..()
 
 #undef MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS
 

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -173,14 +173,15 @@
 /datum/plane_master_group/popup
 
 /// This is janky as hell but since something changed with CENTER positioning after build 1609 we have to switch to the bandaid LEFT,TOP positioning
-/// using LEFT,TOP at or before 1609 will result in another broken offset for cameras
-#define MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS 1609
+/// using LEFT,TOP at or before 1614 will result in another broken offset for cameras
+#define MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS 1614
 
 /datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
 	// If we're about to display this group to a mob who's client is more recent than the last known version with working CENTER, then we need to remake the relays
 	// with the correct screen_loc using the relay override
 	if(viewing_hud.mymob?.client?.byond_build > MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS)
-		for(var/atom/movable/screen/plane_master/plane as anything in plane_masters)
+		for(var/thing in plane_masters)
+			var/atom/movable/screen/plane_master/plane = plane_masters[thing]
 			QDEL_LIST(plane.relays)
 			plane.generate_render_relays(relay_loc_override = "LEFT,TOP")
 	return ..()

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -13,15 +13,14 @@
 	var/active_offset = 0
 	/// What, if any, submap we render onto
 	var/map = ""
-	/// Due to a Byond bug where secondary maps have improperly offset render targets, we will need to override this to "LEFT,TOP" for clients >515.1614
+	/// Controls the screen_loc that owned plane masters will use when generating relays. Due to a Byond bug, relays using the CENTER positional loc
+	/// Will be improperly offset
 	var/relay_loc = "CENTER"
 
-/datum/plane_master_group/New(key, map = "", relay_loc)
+/datum/plane_master_group/New(key, map = "")
 	. = ..()
 	src.key = key
 	src.map = map
-	if(relay_loc)
-		src.relay_loc = relay_loc
 	build_plane_masters(0, SSmapping.max_plane_offset)
 
 /datum/plane_master_group/Destroy()
@@ -92,7 +91,7 @@
 		for(var/plane_offset in starting_offset to ending_offset)
 			if(plane_offset != 0 && !initial(mytype.allows_offsetting))
 				continue
-			var/atom/movable/screen/plane_master/instance = new mytype(null, null, src, plane_offset, relay_loc)
+			var/atom/movable/screen/plane_master/instance = new mytype(null, null, src, plane_offset)
 			plane_masters["[instance.plane]"] = instance
 			prep_plane_instance(instance)
 

--- a/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
@@ -38,9 +38,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	var/list/atom/movable/render_plane_relay/relays = list()
 	/// if render relays have already be generated
 	var/relays_generated = FALSE
-	/// the screen_loc that the relay connecting plane_masters will render with
-	/// this is needed due to a bug in Byond where secondary maps have incorrect screen_loc offset after 515.1614
-	var/relay_loc = "CENTER"
 
 	/// If this plane master should be hidden from the player at roundstart
 	/// We do this so PMs can opt into being temporary, to reduce load on clients
@@ -67,12 +64,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	/// If this plane master is outside of our visual bounds right now
 	var/is_outside_bounds = FALSE
 
-/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0, relay_loc)
+/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0)
 	. = ..()
 	src.offset = offset
-	if(relay_loc)
-		src.relay_loc = relay_loc
-
 	true_alpha = alpha
 	real_plane = plane
 
@@ -83,7 +77,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 		stack_trace("Plane master created without a description. Document how your thing works so people will know in future, and we can display it in the debug menu")
 	if(start_hidden)
 		hide_plane(home.our_hud?.mymob)
-	generate_render_relays(relay_loc)
+	generate_render_relays()
 
 /atom/movable/screen/plane_master/Destroy()
 	if(home)

--- a/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
@@ -64,7 +64,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	/// If this plane master is outside of our visual bounds right now
 	var/is_outside_bounds = FALSE
 
-/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0)
+/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0, relay_loc_override = null)
 	. = ..()
 	src.offset = offset
 	true_alpha = alpha
@@ -77,7 +77,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 		stack_trace("Plane master created without a description. Document how your thing works so people will know in future, and we can display it in the debug menu")
 	if(start_hidden)
 		hide_plane(home.our_hud?.mymob)
-	generate_render_relays()
+	generate_render_relays(relay_loc_override)
 
 /atom/movable/screen/plane_master/Destroy()
 	if(home)

--- a/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
@@ -38,6 +38,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	var/list/atom/movable/render_plane_relay/relays = list()
 	/// if render relays have already be generated
 	var/relays_generated = FALSE
+	/// the screen_loc that the relay connecting plane_masters will render with
+	/// this is needed due to a bug in Byond where secondary maps have incorrect screen_loc offset after 515.1614
+	var/relay_loc = "CENTER"
 
 	/// If this plane master should be hidden from the player at roundstart
 	/// We do this so PMs can opt into being temporary, to reduce load on clients
@@ -64,9 +67,12 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	/// If this plane master is outside of our visual bounds right now
 	var/is_outside_bounds = FALSE
 
-/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0, relay_loc_override = null)
+/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0, relay_loc)
 	. = ..()
 	src.offset = offset
+	if(relay_loc)
+		src.relay_loc = relay_loc
+
 	true_alpha = alpha
 	real_plane = plane
 
@@ -77,7 +83,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 		stack_trace("Plane master created without a description. Document how your thing works so people will know in future, and we can display it in the debug menu")
 	if(start_hidden)
 		hide_plane(home.our_hud?.mymob)
-	generate_render_relays(relay_loc_override)
+	generate_render_relays(relay_loc)
 
 /atom/movable/screen/plane_master/Destroy()
 	if(home)

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -395,8 +395,7 @@
  * * name for debugging purposes
  * Other vars such as alpha will automatically be applied with the render source
  */
-/atom/movable/screen/plane_master/proc/generate_render_relays(relay_loc_override)
-	var/relay_loc = relay_loc_override ? relay_loc_override : "CENTER"
+/atom/movable/screen/plane_master/proc/generate_render_relays()
 	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -431,7 +431,7 @@
 		render_target = OFFSET_RENDER_TARGET(get_plane_master_render_base(name), offset)
 	if(!relay_loc)
 		relay_loc = "CENTER"
-	// If we're using a submap (say for a popup window) make sure we draw onto it
+		// If we're using a submap (say for a popup window) make sure we draw onto it
 		if(home?.map)
 			relay_loc = "[home.map]:[relay_loc]"
 	var/blend_to_use = blend_override

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -395,8 +395,8 @@
  * * name for debugging purposes
  * Other vars such as alpha will automatically be applied with the render source
  */
-/atom/movable/screen/plane_master/proc/generate_render_relays()
-	var/relay_loc = "CENTER"
+/atom/movable/screen/plane_master/proc/generate_render_relays(relay_loc_override)
+	var/relay_loc = relay_loc_override ? relay_loc_override : "CENTER"
 	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"
@@ -431,7 +431,7 @@
 		render_target = OFFSET_RENDER_TARGET(get_plane_master_render_base(name), offset)
 	if(!relay_loc)
 		relay_loc = "CENTER"
-		// If we're using a submap (say for a popup window) make sure we draw onto it
+	// If we're using a submap (say for a popup window) make sure we draw onto it
 		if(home?.map)
 			relay_loc = "[home.map]:[relay_loc]"
 	var/blend_to_use = blend_override

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -396,8 +396,8 @@
  * Other vars such as alpha will automatically be applied with the render source
  */
 /atom/movable/screen/plane_master/proc/generate_render_relays()
-	// If we're using a submap (say for a popup window) make sure we draw onto it
 	var/relay_loc = home?.relay_loc || "CENTER"
+	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"
 

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -397,6 +397,7 @@
  */
 /atom/movable/screen/plane_master/proc/generate_render_relays()
 	// If we're using a submap (say for a popup window) make sure we draw onto it
+	var/relay_loc = home?.relay_loc || "CENTER"
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/79954

Turns out the cause of cameras breaking was something weird with how Byond determined the CENTER location for screen_locs on secondary popup maps like cameras and the spyglass. This can be remedied by manually using the LEFT,TOP position for the plane relays. However LEFT,TOP breaks the views for clients 1614 and below so I included a jank solution that should allow any client up to this point have the screen displayed correctly

### 515.1609 views working
![dreamseeker_nolb8BLgRb](https://github.com/tgstation/tgstation/assets/46236974/e155c9c3-12c0-4eb5-a4a6-4e3f09dc456d)

### 515.1623 views working
![dreamseeker_I37Z4X04Hf](https://github.com/tgstation/tgstation/assets/46236974/e91b3bd8-ea05-40e7-ab20-6c48810f9879)
## Why It's Good For The Game

Cameras working passed 1614 means you can update the server. At some point I suspect Lummox will fix the CENTER position on secondary maps and when that happens it will likely break the current fix.


## Changelog
:cl:
fix: popup screen locs will work on clients >1614. Security cameras and Spyglass will work
/:cl:
