### PR TITLE
Ejecting cells from microwaves via ctrl click requires proximity.

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -486,7 +486,7 @@
 
 /obj/machinery/microwave/CtrlClick(mob/user)
 	. = ..()
-	if(cell_powered && !isnull(cell) && anchored)
+	if(user.can_perform_action(src) && cell_powered && !isnull(cell) && anchored)
 		user.put_in_hands(cell)
 		balloon_alert(user, "removed cell")
 		cell = null


### PR DESCRIPTION
## About The Pull Request
- Fixes #80806

Was a problem with microwaves in general & not just with the wireless version.


## Changelog
:cl:
fix: ejecting cells from microwaves via ctrl click now requires player proximity.
/:cl: