### PR TITLE
Adds sanity checks to `/obj/projectile/moon_parade`

### DIFF
--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -43,7 +43,8 @@
 	soundloop = new(src,  TRUE)
 
 /obj/projectile/moon_parade/prehit_pierce(atom/A)
-	. = ..()
+	if(!isliving(firer) || !isliving(A))
+		return ..()
 
 	var/mob/living/caster = firer
 	var/mob/living/victim = A
@@ -67,6 +68,7 @@
 		visible_message(span_warning("The parade hits [victim] and a sudden wave of clarity comes over you!"))
 		return PROJECTILE_DELETE_WITHOUT_HITTING
 
+	return ..()
 
 /obj/projectile/moon_parade/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -72,6 +72,8 @@
 
 /obj/projectile/moon_parade/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
+	if(. == BULLET_ACT_BLOCK || !isliving(target))
+		return
 	var/mob/living/victim = target
 
 	RegisterSignal(victim, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(moon_block_move), override=TRUE)
@@ -90,6 +92,8 @@
 /obj/projectile/moon_parade/Destroy()
 	for(var/datum/weakref/mob_ref in mobs_hit)
 		var/mob/living/real_mob = mob_ref.resolve()
+		if(isnull(real_mob))
+			continue
 		UnregisterSignal(real_mob, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE)
 	mobs_hit.Cut()
 	soundloop.stop()

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -74,28 +74,24 @@
 	. = ..()
 	if(. == BULLET_ACT_BLOCK || !isliving(target))
 		return
+
 	var/mob/living/victim = target
 
-	RegisterSignal(victim, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(moon_block_move), override=TRUE)
+	if(!(victim in mobs_hit))
+		RegisterSignal(victim, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(moon_block_move))
+		RegisterSignal(victim, COMSIG_QDELETING, PROC_REF(clear_mob))
+		victim.AddComponent(/datum/component/leash, src, distance = 1)
+		victim.balloon_alert(victim, "you feel unable to move away from the parade!")
+		mobs_hit += victim
 
-	victim.AddComponent(/datum/component/leash, src, distance = 1)
-	victim.balloon_alert(victim,"you feel unable to move away from the parade!")
 	victim.add_mood_event("Moon Insanity", /datum/mood_event/moon_insanity)
-	victim.cause_hallucination(/datum/hallucination/delusion/preset/moon, "delusion/preset/moon hallucination caused by lunar parade")
-
-	//Lowers sanity
+	victim.cause_hallucination(/datum/hallucination/delusion/preset/moon, name)
 	victim.mob_mood.set_sanity(victim.mob_mood.sanity - 20)
 
-	// Uses weakref to prevent qdeleting them
-	mobs_hit |= WEAKREF(victim)
-
 /obj/projectile/moon_parade/Destroy()
-	for(var/datum/weakref/mob_ref in mobs_hit)
-		var/mob/living/real_mob = mob_ref.resolve()
-		if(isnull(real_mob))
-			continue
-		UnregisterSignal(real_mob, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE)
-	mobs_hit.Cut()
+	for(var/mob/living/leftover_mob as anything in mobs_hit)
+		clear_mob(leftover_mob)
+	mobs_hit.Cut() // You never know
 	soundloop.stop()
 	return ..()
 
@@ -104,3 +100,8 @@
 /obj/projectile/moon_parade/proc/moon_block_move(datum/source)
 	SIGNAL_HANDLER
 	return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
+
+/obj/projectile/moon_parade/proc/clear_mob(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(source, list(COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, COMSIG_QDELETING))
+	mobs_hit -= source


### PR DESCRIPTION
## About The Pull Request

Ensures `/obj/projectile/moon_parade` is actually handing living mobs when hitting things. 

![image](https://github.com/tgstation/tgstation/assets/51863163/4a0a1c33-8fc0-43ae-9d3d-29f5334a61d6)

![image](https://github.com/tgstation/tgstation/assets/51863163/463ad14a-d460-4f28-a08b-f591a019aacd)

## Changelog

:cl: Melbert
fix: Lunar Parade has the potential to break less. 
/:cl:


