### PR TITLE
Fixes borg apparatuses being able to pick up inactive items from their own module storage window

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -58,22 +58,22 @@
 /obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
 	if(!stored)
 		// Borgs should not be grabbing their own modules
-		if(!istype(atom.loc, /mob/living/silicon/robot))
-			var/itemcheck = FALSE
-			for(var/storable_type in storable)
-				if(istype(atom, storable_type))
-					itemcheck = TRUE
-					break
-			if(itemcheck)
-				var/obj/item/item = atom
-				item.forceMove(src)
-				stored = item
-				RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
-				update_appearance()
-				return TRUE
-	else
-		stored.melee_attack_chain(user, atom, params)
-		return TRUE
+		if(istype(atom.loc, /mob/living/silicon/robot) || istype(atom.loc, /obj/item/robot_model) || HAS_TRAIT(atom, TRAIT_NODROP))
+			stored.melee_attack_chain(user, atom, params)
+			return TRUE
+
+		var/itemcheck = FALSE
+		for(var/storable_type in storable)
+			if(istype(atom, storable_type))
+				itemcheck = TRUE
+				break
+		if(itemcheck)
+			var/obj/item/item = atom
+			item.forceMove(src)
+			stored = item
+			RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
+			update_appearance()
+			return TRUE
 	return ..()
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check against picking up objects with a `loc` of `/obj/item/robot_model` (which is where inactive borg modules go). Also adds a check against picking up nodrop items.

Also reorganizes the relevant proc to be IF > Early Return, rather than IF/ELSE 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #80074
Probably also fixes #77156
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The various borg apparatuses can no longer pick up other internal borg tools.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
