### PR TITLE
PDA vendor now sells regular PDAs

### DIFF
--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -13,7 +13,7 @@
 		/obj/item/computer_disk/ordnance = 10,
 		/obj/item/computer_disk/quartermaster = 10,
 		/obj/item/computer_disk/command/captain = 3,
-		/obj/item/modular_computer/pda/heads = 10,
+		/obj/item/modular_computer/pda = 10,
 	)
 	refill_canister = /obj/item/vending_refill/cart
 	default_price = PAYCHECK_COMMAND


### PR DESCRIPTION
## About The Pull Request

I don't know when this happened or why but this makes the PTech vending machine sell regular PDAs now instead of Command ones.

## Why It's Good For The Game

PDA replacement should not be giving you all of Command's tablet apps.

## Changelog

:cl:
fix: The HoP's cartridge vending machine now sells regular PDAs instead of base command ones.
/:cl: