### PR TITLE
Heretic monsters can drink heretic reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2828,7 +2828,7 @@
 /datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
 	var/need_mob_update = FALSE
-	if(IS_HERETIC(drinker))
+	if(IS_HERETIC_OR_MONSTER(drinker))
 		drinker.adjust_drowsiness(-10 * REM * seconds_per_tick)
 		drinker.AdjustAllImmobility(-40 * REM * seconds_per_tick)
 		need_mob_update += drinker.adjustStaminaLoss(-10 * REM * seconds_per_tick, updating_stamina = FALSE)


### PR DESCRIPTION
## About The Pull Request

Human heretic monsters (like the husked ones) can now drink the heretic reagent and heal from it like heretics can, rather than dying.

## Why It's Good For The Game

I assume it is unintentional that a reagent for heretics kills heretic allies, especially when they can already do so much like using their knives and even abilities.
It's noob bait at best since people will assume that since they are also heretics, they would heal from the same sources as heretics do.

## Changelog

:cl:
fix: Eldritch reagent (the one that heals heretics) now heal heretic monsters rather than kill them.
/:cl: