### PR TITLE
Refried beans and spanish rice now drop bowls

### DIFF
--- a/code/game/objects/items/food/mexican.dm
+++ b/code/game/objects/items/food/mexican.dm
@@ -305,6 +305,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 6,
 		/datum/reagent/consumable/nutriment/protein = 4,
 	)
+	trash_type = /obj/item/reagent_containers/cup/bowl
 	tastes = list("mashed beans" = 1, "onion" = 3,)
 	foodtypes = VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
@@ -319,6 +320,7 @@
 		/datum/reagent/consumable/nutriment = 6,
 		/datum/reagent/consumable/nutriment/vitamin = 6,
 	)
+	trash_type = /obj/item/reagent_containers/cup/bowl
 	tastes = list("zesty rice" = 1, "tomato sauce" = 3,)
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
## About The Pull Request

I found these 2 foods in the mexican section that requires a bowl to craft the food, but doesn't drop the bowl upon being eaten. This quickly fixes that by making the bowl the trash item like every other instance of this.

## Why It's Good For The Game

Fixes an inconsistency, you're not eating the bowl.

## Changelog

:cl:
fix: Refried beans and Spanish rice now lets you take the bowl back after eating it.
/:cl: