### PR TITLE
Cache heretic delusion icon so it doesn't call `getFlatIcon` li ke 600 times a life tick or something

### DIFF
--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -249,11 +249,13 @@
 	duration = 11 SECONDS
 
 /datum/hallucination/delusion/preset/heretic/make_delusion_image(mob/over_who)
-	delusion_icon_file = getFlatIcon(get_dynamic_human_appearance(/datum/outfit/heretic_hallucination, r_hand = NO_REPLACE))
+	var/static/icon/heretic_icon
+	if(isnull(heretic_icon))
+		heretic_icon = getFlatIcon(get_dynamic_human_appearance(/datum/outfit/heretic, r_hand = NO_REPLACE))
+	delusion_icon_file = heretic_icon
 	return ..()
 
 /datum/hallucination/delusion/preset/heretic/gate
 	delusion_name = "Mind Gate"
 	duration = 60 SECONDS
 	affects_us = TRUE
-


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/51863163/fb7768c3-1e1a-4284-acba-153ddbdb2d26)

Heretic's weeping painting causes everyone who sees it to hallucinate everyone else as heretics. So it caused this hallucination every 5 life ticks.

Which means every 5 life ticks it would call GFI for every mob in view. 
And like everyone on the station would get this effect. 

So everyone on the station is now hallucinating every mob in view is a heretic and it's calling GFI every time. 

So yeah we should probably cache this. 

## Changelog

:cl: Melbert
fix: "The sister and He Who Wept" Heretic painting will no longer cause big lag
/:cl:

