### PR TITLE
More heretic path fixes

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -227,10 +227,7 @@
 		During this process, you will rapidly regenerate stamina and quickly recover from stuns, however, you will be unable to attack. \
 		This spell can be cast in rapid succession, but doing so will increase the cooldown."
 	gain_text = "In the flurry of death, he found peace within himself. Despite insurmountable odds, he forged on."
-	next_knowledge = list(
-		/datum/heretic_knowledge/duel_stance,
-		/datum/heretic_knowledge/rifle,
-	)
+	next_knowledge = list(/datum/heretic_knowledge/duel_stance)
 	spell_to_add = /datum/action/cooldown/spell/realignment
 	cost = 1
 	route = PATH_BLADE
@@ -250,6 +247,7 @@
 		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/rune_carver,
 		/datum/heretic_knowledge/crucible,
+		/datum/heretic_knowledge/rifle,
 	)
 	cost = 1
 	route = PATH_BLADE

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -103,7 +103,7 @@
 	)
 	result_atoms = list(/obj/item/card/id/advanced/heretic)
 	next_knowledge = list(
-		/datum/heretic_knowledge/limited_amount/concierge_rite,
+		/datum/heretic_knowledge/mark/lock_mark,
 		/datum/heretic_knowledge/spell/mind_gate,
 	)
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -120,7 +120,7 @@
 	mark_type = /datum/status_effect/eldritch/lock
 
 /datum/heretic_knowledge/knowledge_ritual/lock
-	next_knowledge = list(/datum/heretic_knowledge/spell/concierge_rite)
+	next_knowledge = list(/datum/heretic_knowledge/limited_amount/concierge_rite)
 	route = PATH_LOCK
 
 /datum/heretic_knowledge/limited_amount/concierge_rite // item that creates 3 max at a time heretic only barriers, probably should limit to 1 only, holy people can also pass
@@ -134,7 +134,7 @@
 		/obj/item/multitool = 1,
 	)
 	result_atoms = list(/obj/item/heretic_labyrinth_handbook)
-	next_knowledge = list(/datum/heretic_knowledge/mark/burglar_finesse)
+	next_knowledge = list(/datum/heretic_knowledge/spell/burglar_finesse)
 	cost = 1
 	route = PATH_LOCK
 

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -109,21 +109,6 @@
 	cost = 1
 	route = PATH_LOCK
 
-/datum/heretic_knowledge/limited_amount/concierge_rite // item that creates 3 max at a time heretic only barriers, probably should limit to 1 only, holy people can also pass
-	name = "Concierge's Rite"
-	desc = "Allows you to transmute a white crayon, a wooden plank, and a multitool to create a Labyrinth Handbook. \
-		It can materialize a barricade at range that only you and people resistant to magic can pass. 3 uses."
-	gain_text = "The Concierge scribbled my name into the Handbook. \"Welcome to your new home, fellow Steward.\""
-	required_atoms = list(
-		/obj/item/toy/crayon/white = 1,
-		/obj/item/stack/sheet/mineral/wood = 1,
-		/obj/item/multitool = 1,
-	)
-	result_atoms = list(/obj/item/heretic_labyrinth_handbook)
-	next_knowledge = list(/datum/heretic_knowledge/mark/lock_mark)
-	cost = 1
-	route = PATH_LOCK
-
 /datum/heretic_knowledge/mark/lock_mark
 	name = "Mark of Lock"
 	desc = "Your Mansus Grasp now applies the Mark of Lock. \
@@ -135,7 +120,22 @@
 	mark_type = /datum/status_effect/eldritch/lock
 
 /datum/heretic_knowledge/knowledge_ritual/lock
-	next_knowledge = list(/datum/heretic_knowledge/spell/burglar_finesse)
+	next_knowledge = list(/datum/heretic_knowledge/spell/concierge_rite)
+	route = PATH_LOCK
+
+/datum/heretic_knowledge/limited_amount/concierge_rite // item that creates 3 max at a time heretic only barriers, probably should limit to 1 only, holy people can also pass
+	name = "Concierge's Rite"
+	desc = "Allows you to transmute a white crayon, a wooden plank, and a multitool to create a Labyrinth Handbook. \
+		It can materialize a barricade at range that only you and people resistant to magic can pass. 3 uses."
+	gain_text = "The Concierge scribbled my name into the Handbook. \"Welcome to your new home, fellow Steward.\""
+	required_atoms = list(
+		/obj/item/toy/crayon/white = 1,
+		/obj/item/stack/sheet/mineral/wood = 1,
+		/obj/item/multitool = 1,
+	)
+	result_atoms = list(/obj/item/heretic_labyrinth_handbook)
+	next_knowledge = list(/datum/heretic_knowledge/mark/burglar_finesse)
+	cost = 1
 	route = PATH_LOCK
 
 /datum/heretic_knowledge/spell/burglar_finesse

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -161,10 +161,7 @@
 		Anyone overtop the wall will be throw aside (or upwards) and sustain damage."
 	gain_text = "Images of foreign and ominous structures began to dance in my mind. Covered head to toe in thick rust, \
 		they no longer looked man made. Or perhaps they never were in the first place."
-	next_knowledge = list(
-		/datum/heretic_knowledge/spell/area_conversion,
-		/datum/heretic_knowledge/rifle,
-	)
+	next_knowledge = list(/datum/heretic_knowledge/spell/area_conversion)
 	spell_to_add = /datum/action/cooldown/spell/pointed/rust_construction
 	cost = 1
 	route = PATH_RUST
@@ -179,6 +176,7 @@
 		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/crucible,
+		/datum/heretic_knowledge/rifle,
 	)
 	spell_to_add = /datum/action/cooldown/spell/aoe/rust_conversion
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/side_blade_rust.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_blade_rust.dm
@@ -46,8 +46,8 @@
 	gain_text = "I met an old man in an anique shop who wielded a very unusual weapon. \
 		I could not purchase it at the time, but they showed me how they made it ages ago."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/realignment,
-		/datum/heretic_knowledge/spell/rust_construction,
+		/datum/heretic_knowledge/duel_stance,
+		/datum/heretic_knowledge/spell/area_conversion,
 		/datum/heretic_knowledge/rifle_ammo,
 	)
 	required_atoms = list(


### PR DESCRIPTION
## About The Pull Request

Fixes Lionhunter Rifle being inaccessible to all paths but Rust and Blade. 

Fixes certain key lock knowledges being inverted. 

## Changelog

:cl: Melbert
fix: Lionhunter Rifle is now available at the same point as Mawed Crucible, making it available to all paths again.
fix: Lock knowledge now goes the correct order. Mark -> Ritual -> Unique item, rather than backwards. 
/:cl:

