### PR TITLE
Midrounds With Minimum Pop Requirements Work Again & Other Fixes

### DIFF
--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -53,8 +53,6 @@
 		GLOB.keyloop_list |= src
 	else if(stat != DEAD || !SSlag_switch?.measures[DISABLE_DEAD_KEYLOOP])
 		GLOB.keyloop_list |= src
-	if(!SSticker.HasRoundStarted())
-		return
 	if(stat == DEAD)
 		add_to_current_dead_players()
 	else
@@ -65,8 +63,6 @@
 	SHOULD_CALL_PARENT(TRUE)
 	GLOB.player_list -= src
 	GLOB.keyloop_list -= src
-	if(!SSticker.HasRoundStarted())
-		return
 	if(stat == DEAD)
 		remove_from_current_dead_players()
 	else
@@ -75,13 +71,9 @@
 
 ///Adds the cliented mob reference to either the list of dead player-mobs or to the list of observers, depending on how they joined the game.
 /mob/proc/add_to_current_dead_players()
-	if(!SSticker.HasRoundStarted())
-		return
 	GLOB.dead_player_list |= src
 
 /mob/dead/observer/add_to_current_dead_players()
-	if(!SSticker.HasRoundStarted())
-		return
 	if(started_as_observer)
 		GLOB.current_observers_list |= src
 		return
@@ -92,13 +84,9 @@
 
 ///Removes the mob reference from either the list of dead player-mobs or from the list of observers, depending on how they joined the game.
 /mob/proc/remove_from_current_dead_players()
-	if(!SSticker.HasRoundStarted())
-		return
 	GLOB.dead_player_list -= src
 
 /mob/dead/observer/remove_from_current_dead_players()
-	if(!SSticker.HasRoundStarted())
-		return
 	if(started_as_observer)
 		GLOB.current_observers_list -= src
 		return
@@ -107,16 +95,12 @@
 
 ///Adds the cliented mob reference to the list of living player-mobs. If the mob is an antag, it adds it to the list of living antag player-mobs.
 /mob/proc/add_to_current_living_players()
-	if(!SSticker.HasRoundStarted())
-		return
 	GLOB.alive_player_list |= src
 	if(mind && (mind.special_role || length(mind.antag_datums)))
 		add_to_current_living_antags()
 
 ///Removes the mob reference from the list of living player-mobs. If the mob is an antag, it removes it from the list of living antag player-mobs.
 /mob/proc/remove_from_current_living_players()
-	if(!SSticker.HasRoundStarted())
-		return
 	GLOB.alive_player_list -= src
 	if(LAZYLEN(mind?.antag_datums))
 		remove_from_current_living_antags()
@@ -124,9 +108,6 @@
 
 ///Adds the cliented mob reference to the list of living antag player-mobs.
 /mob/proc/add_to_current_living_antags()
-	if(!SSticker.HasRoundStarted())
-		return
-
 	if (length(mind.antag_datums) == 0)
 		return
 
@@ -137,6 +118,4 @@
 
 ///Removes the mob reference from the list of living antag player-mobs.
 /mob/proc/remove_from_current_living_antags()
-	if(!SSticker.HasRoundStarted())
-		return
 	GLOB.current_living_antags -= src


### PR DESCRIPTION
## About The Pull Request

Fixes #80851 
Fixes #73622

Thanks to iprice for bringing this to attention and Isratosh for assistance on Sybil.

This PR removes some (hopefully) redundant if(!SSticker.HasRoundStarted()) checks which prevented roundstart mobs from getting added to the living players list and pre-roundstart observers from being added to the observers list.

This affected the ability for midround antagonists with a minimum population requirement to spawn when they should have been able to, pre-roundstart observers could not get polled for ghost roles, and some other silliness regarding antagonists which considered the living station population.

Nobody is really sure why this check was here in the first place outside of some sanity check with an unknown purpose. The only thing it would impact at one point was regal rats, but you can't play as regal rats pre-roundstart anymore, and even then they should be counted amongst the living players of the round, no? Since players can spawn in before roundstart only with admin goofiness now, hopefully removing these checks won't break anything.

## Why It's Good For The Game

This was preventing pretty much any midround antagonist from being picked to spawn outside of Sleeper Agents in most cases. Also, pre-roundstart observers should have access to midround antags and other observer-related activies.

## Changelog

:cl:
fix: Dynamic midround rolls will properly consider roundstart players as part of the living population again, allowing antagonists with a minimum population value to spawn when they should be able to.
fix: Players who observe before roundstart can be considered for midround ghost roles again.
fix: Some antagonists which had elements that scale with living station population now function properly again.
/:cl: