### PR TITLE
Fixes pod launcher BSOD [no gbp]

### DIFF
--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher.jsx
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher.jsx
@@ -3,7 +3,7 @@ import { classes } from 'common/react';
 import { storage } from 'common/storage';
 import { multiline } from 'common/string';
 import { createUuid } from 'common/uuid';
-import { Component, Fragment, useState } from 'react';
+import { Component, Fragment } from 'react';
 
 import { useBackend, useLocalState } from '../backend';
 import {
@@ -25,7 +25,7 @@ const pod_grey = {
 };
 
 const useCompact = () => {
-  const [compact, setCompact] = useState(false);
+  const [compact, setCompact] = useLocalState('compact', false);
   const toggleCompact = () => setCompact(!compact);
   return [compact, toggleCompact];
 };
@@ -830,10 +830,10 @@ class PresetsPage extends Component {
   render() {
     const { presets } = this.state;
     const { act, data } = useBackend();
-    const [presetIndex, setSelectedPreset] = useState(0);
-    const [settingName, setEditingNameStatus] = useState(0);
-    const [newNameText, setText] = useState('');
-    const [hue, setHue] = useState(0);
+    const [presetIndex, setSelectedPreset] = useLocalState('presetIdx', 0);
+    const [settingName, setEditingNameStatus] = useLocalState('settingName', 0);
+    const [newNameText, setText] = useLocalState('nameText', '');
+    const [hue, setHue] = useLocalState('hue', 0);
     return (
       <Section
         scrollable


### PR DESCRIPTION
## About The Pull Request
This fixes an issue caused by a class component and a pseudo hook called useState.
The screen works now.

It's also terribly overdue for a refactor, which I'm working on after looking at it. As a general rule I think tgui interfaces should keep it under 500 lines. This one is 1203. I want to fix it before I do anything else to it for file diff reasons.
## Why It's Good For The Game
Fixes #80850
## Changelog
:cl:
admin: Fixed the bluescreen in the centcom pod launcher.
/:cl:
