### PR TITLE
Fix juke ignoring changes in dm files in the map folder

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -188,6 +188,7 @@ export const DmTarget = new Juke.Target({
   ],
   inputs: [
     '_maps/map_files/generic/**',
+    'maps/**/*.dm
     'code/**',
     'html/**',
     'icons/**',

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -188,7 +188,7 @@ export const DmTarget = new Juke.Target({
   ],
   inputs: [
     '_maps/map_files/generic/**',
-    'maps/**/*.dm'
+    'maps/**/*.dm',
     'code/**',
     'html/**',
     'icons/**',

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -188,7 +188,7 @@ export const DmTarget = new Juke.Target({
   ],
   inputs: [
     '_maps/map_files/generic/**',
-    'maps/**/*.dm
+    'maps/**/*.dm'
     'code/**',
     'html/**',
     'icons/**',


### PR DESCRIPTION
juke refuses to compile dm if it thinks nothing changed.

juke doesn't have a way to bypass this and force a given target to compile (this is a complaint for another repo)

There are dm files inside of this folder that are compiled in.