### PR TITLE
Makes grid check area protection actually work

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -25274,7 +25274,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/trinary/filter,
+/obj/machinery/atmospherics/components/trinary/filter/critical,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "jeg" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -75505,7 +75505,7 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port)
 "tLH" = (
-/obj/machinery/atmospherics/components/trinary/filter{
+/obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/north,

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -1,9 +1,11 @@
 #define BP_MAX_ROOM_SIZE 300
 
-GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/engineering/main, \
-															    /area/station/engineering/supermatter, \
-															    /area/station/engineering/atmospherics_engine, \
-															    /area/station/ai_monitored/turret_protected/ai))
+GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(
+	/area/station/engineering/main,
+	/area/station/engineering/supermatter,
+	/area/station/engineering/atmospherics_engine,
+	/area/station/ai_monitored/turret_protected/ai,
+)))
 
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -271,7 +271,7 @@
 		if(!current_apc.cell || !SSmapping.level_trait(current_apc.z, ZTRAIT_STATION))
 			continue
 		var/area/apc_area = current_apc.area
-		if(GLOB.typecache_powerfailure_safe_areas[apc_area.type])
+		if(is_type_in_typecache(apc_area, GLOB.typecache_powerfailure_safe_areas))
 			continue
 
 		var/duration = rand(duration_min,duration_max)


### PR DESCRIPTION

## About The Pull Request
Okay so turns out, the only thing stopping the exterior sm chamber from being shut down by a grid check are the filters being marked as critical. There's SUPPOSED to be an area based check, but that wasn't being set up properly, so it only protected a single area, no subtypes.

Beyond fixing the very rare case that the sm room becomes vulnerable when the filters are removed/replaced, the atmos engine and ai sat foyer are also now protected. AI upload is NOT protected.

Also, I don't believe it has any impact now that the area check is working, but I've made sure that the canister filters are also marked as critical- They were already on all but northstar and birdshot.

Fixes #80852
## Why It's Good For The Game
fix bug, throw insect into sm
## Changelog
:cl:
fix: Certain areas are now properly protected against grid check. Namely the supermatter should consistently be protected.
/:cl:
