### PR TITLE
Removes a (potentially) no-longer-needed fix from character previews

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -290,6 +290,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/ui_close(mob/user)
 	save_character()
 	save_preferences()
+	deltimer(character_preview_view_timerid)
 	QDEL_NULL(character_preview_view)
 
 /datum/preferences/Topic(href, list/href_list)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -290,7 +290,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/ui_close(mob/user)
 	save_character()
 	save_preferences()
-	deltimer(character_preview_view_timerid)
 	QDEL_NULL(character_preview_view)
 
 /datum/preferences/Topic(href, list/href_list)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -144,13 +144,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		ui.set_autoupdate(FALSE)
 		ui.open()
 
-		// HACK: Without this the character starts out really tiny because of some BYOND bug.
-		// You can fix it by changing a preference, so let's just forcably update the body to emulate this.
-		// Lemon from the future: this issue appears to replicate if the byond map (what we're relaying here)
-		// Is shown while the client's mouse is on the screen. As soon as their mouse enters the main map, it's properly scaled
-		// I hate this place
-		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS, TIMER_DELETE_ME)
-
 /datum/preferences/ui_state(mob/user)
 	return GLOB.always_state
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -88,11 +88,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// If set to TRUE, will update character_profiles on the next ui_data tick.
 	var/tainted_character_profiles = FALSE
 
-	/// the timerid of the char_preview/updatebody() callback
-	var/character_preview_view_timerid
-
 /datum/preferences/Destroy(force)
-	deltimer(character_preview_view_timerid)
 	QDEL_NULL(character_preview_view)
 	QDEL_LIST(middleware)
 	value_cache = null
@@ -153,7 +149,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		// Lemon from the future: this issue appears to replicate if the byond map (what we're relaying here)
 		// Is shown while the client's mouse is on the screen. As soon as their mouse enters the main map, it's properly scaled
 		// I hate this place
-		character_preview_view_timerid = addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS, TIMER_STOPPABLE | TIMER_DELETE_ME)
+		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS, TIMER_DELETE_ME)
 
 /datum/preferences/ui_state(mob/user)
 	return GLOB.always_state

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		// Lemon from the future: this issue appears to replicate if the byond map (what we're relaying here)
 		// Is shown while the client's mouse is on the screen. As soon as their mouse enters the main map, it's properly scaled
 		// I hate this place
-		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS)
+		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS, TIMER_DELETE_ME)
 
 /datum/preferences/ui_state(mob/user)
 	return GLOB.always_state

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -88,7 +88,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// If set to TRUE, will update character_profiles on the next ui_data tick.
 	var/tainted_character_profiles = FALSE
 
+	/// the timerid of the char_preview/updatebody() callback
+	var/character_preview_view_timerid
+
 /datum/preferences/Destroy(force)
+	deltimer(character_preview_view_timerid)
 	QDEL_NULL(character_preview_view)
 	QDEL_LIST(middleware)
 	value_cache = null
@@ -149,7 +153,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		// Lemon from the future: this issue appears to replicate if the byond map (what we're relaying here)
 		// Is shown while the client's mouse is on the screen. As soon as their mouse enters the main map, it's properly scaled
 		// I hate this place
-		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS, TIMER_DELETE_ME)
+		character_preview_view_timerid = addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
 /datum/preferences/ui_state(mob/user)
 	return GLOB.always_state


### PR DESCRIPTION
## About The Pull Request

EDIT: After speaking with folks in discord, the code that was causing this may not even be required anymore.

This is currently being tested to make sure it is in fact no longer needed.

edit edit: currently is TMed on Nova, so far everyone reporting the issue has been on version 1589. Bug is allegedly fixed in Byond 1609+.

edit edit edit: Just got someone on 1620 who has the tiny character preview bug. Looks like it's not actually fixed, at least on that version...

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
code: removes a tg-fix for char previews not showing until hovered or rotated that has been fixed as of byond version 1609+
/:cl:
