### PR TITLE
Make list clear nulls faster

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -422,9 +422,8 @@
 	return list_to_clear.len < start_len
 
 /proc/list_clear_nulls_new(list/list_to_clear)
-	var/start_len = list_to_clear.len
-	list_to_clear.RemoveAll(null)
-	return list_to_clear.len < start_len
+	return (list_to_clear.RemoveAll(null) > 0)
+	
 
 /**
  * Removes any empty weakrefs from the list

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -403,25 +403,6 @@
  * Returns TRUE if the list had nulls, FALSE otherwise
 **/
 /proc/list_clear_nulls(list/list_to_clear)
-	var/static/chain = 1
-	switch(chain)
-		if (1)
-			. = list_clear_nulls_old(arglist(args))
-			if (prob(10))
-				chain = 2
-
-		if (2)
-			. = list_clear_nulls_new(arglist(args))
-			if (prob(10))
-				chain = 1
-		
-/proc/list_clear_nulls_old(list/list_to_clear)
-	var/start_len = list_to_clear.len
-	var/list/new_list = new(start_len)
-	list_to_clear -= new_list
-	return list_to_clear.len < start_len
-
-/proc/list_clear_nulls_new(list/list_to_clear)
 	return (list_to_clear.RemoveAll(null) > 0)
 	
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -406,12 +406,12 @@
 	var/static/chain = 1
 	switch(chain)
 		if (1)
-			. = list_clear_nulls_old(argslist(args))
+			. = list_clear_nulls_old(arglist(args))
 			if (prob(10))
 				chain = 2
 
 		if (2)
-			. = list_clear_nulls_new(argslist(args))
+			. = list_clear_nulls_new(arglist(args))
 			if (prob(10))
 				chain = 1
 		

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -403,9 +403,27 @@
  * Returns TRUE if the list had nulls, FALSE otherwise
 **/
 /proc/list_clear_nulls(list/list_to_clear)
+	var/static/chain = 1
+	switch(chain)
+		if (1)
+			. = list_clear_nulls_old(argslist(args))
+			if (prob(10))
+				chain = 2
+
+		if (2)
+			. = list_clear_nulls_new(argslist(args))
+			if (prob(10))
+				chain = 1
+		
+/proc/list_clear_nulls_old(list/list_to_clear)
 	var/start_len = list_to_clear.len
 	var/list/new_list = new(start_len)
 	list_to_clear -= new_list
+	return list_to_clear.len < start_len
+
+/proc/list_clear_nulls_new(list/list_to_clear)
+	var/start_len = list_to_clear.len
+	list_to_clear.RemoveAll(null)
 	return list_to_clear.len < start_len
 
 /**


### PR DESCRIPTION
The old version makes a new list of n null values, and removes it from the given list.

for larger lists, this newer 515 version should be faster and lead to less list churn.

![image](https://github.com/tgstation/tgstation/assets/7069733/9c23cc8b-06c4-4a54-99b4-2c44608cf434)
