### PR TITLE
Makes placing plating on lava-proof rods delete the rods and not break lighting on that tile for the rest of the round

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -158,14 +158,18 @@
 /obj/structure/lattice/lava/deconstruction_hints(mob/user)
 	return span_notice("The rods look like they could be <b>cut</b>, but the <i>heat treatment will shatter off</i>. There's space for a <i>tile</i>.")
 
-/obj/structure/lattice/lava/attackby(obj/item/C, mob/user, params)
+/obj/structure/lattice/lava/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()
-	if(istype(C, /obj/item/stack/tile/iron))
-		var/obj/item/stack/tile/iron/P = C
-		if(P.use(1))
-			to_chat(user, span_notice("You construct a floor plating, as lava settles around the rods."))
-			playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
-			new /turf/open/floor/plating(locate(x, y, z))
-		else
-			to_chat(user, span_warning("You need one floor tile to build atop [src]."))
+	if(!istype(attacking_item, /obj/item/stack/tile/iron))
 		return
+	var/obj/item/stack/tile/iron/attacking_tiles = attacking_item
+	if(!attacking_tiles.use(1))
+		to_chat(user, span_warning("You need one floor tile to build atop [src]."))
+		return
+	to_chat(user, span_notice("You construct new plating with [src] as support."))
+	playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
+
+	var/turf/turf_we_place_on = get_turf(src)
+	turf_we_place_on.place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+
+	qdel(src)


### PR DESCRIPTION

## About The Pull Request

See title
## Why It's Good For The Game

1. Its a bit odd that the rods are still there and on top of the new tile you placed, considering you were build on top of them.
2. Because building didn't use place on top, the lighting on the tile would be broken and made entirely black for the rest of the round. Slightly annoying when you're constructing something on top of it!
## Changelog
:cl:
qol: The heat-proof catwalk made by heat-proof rods will go away when a tile is placed on it, rather than sticking around and needing to be removed manually
fix: The lighting will not irreparably break on tiles where plating was placed on lava-proof catwalks
code: Some single letter variables and the structure of the code around placing tiles on lava-proof catwalks has been improved
/:cl:
