### PR TITLE
Fixes the deployable component rotating things it isnt supposed to

### DIFF
--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -76,10 +76,8 @@
 		new_direction = direction
 
 	deployed_object = new thing_to_be_deployed(deploy_location)
-	deployed_object.setDir(new_direction)
-
-	// Sets the direction of the resulting object if the variable says to
 	if(direction_setting)
+		deployed_object.setDir(new_direction)
 		deployed_object.update_icon_state()
 
 	deployments -= 1


### PR DESCRIPTION

## About The Pull Request

Actually moves the rotation part of the code under the check for if the component is supposed to rotate things
## Why It's Good For The Game

Despite setting the variable for rotating stuff to no, the component would still rotate stuff, this is bad
## Changelog
:cl:
fix: The deployable component will now actually stop rotating things when the variable to not do that is set
/:cl:
