### PR TITLE
Makes chemical reactions that need a certain container, but accept subtypes of that container, actually work again

### DIFF
--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -65,7 +65,7 @@
 					if(reaction.required_container)
 						if(reaction.required_container_accepts_subtypes && !istype(cached_my_atom, reaction.required_container))
 							continue
-						else if(cached_my_atom.type != reaction.required_container)
+						else if((cached_my_atom.type != reaction.required_container) && !reaction.required_container_accepts_subtypes)
 							continue
 
 					if(isliving(cached_my_atom) && !reaction.mob_react) //Makes it so certain chemical reactions don't occur in mobs

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -66,8 +66,8 @@
 						if(reaction.required_container_accepts_subtypes)
 							if(!istype(cached_my_atom, reaction.required_container))
 								continue
-					else if(cached_my_atom.type != reaction.required_container)
-						continue
+						else if(cached_my_atom.type != reaction.required_container)
+							continue
 
 					if(isliving(cached_my_atom) && !reaction.mob_react) //Makes it so certain chemical reactions don't occur in mobs
 						continue

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -63,10 +63,11 @@
 
 				if(cached_my_atom)
 					if(reaction.required_container)
-						if(reaction.required_container_accepts_subtypes && !istype(cached_my_atom, reaction.required_container))
-							continue
-						else if((cached_my_atom.type != reaction.required_container) && !reaction.required_container_accepts_subtypes)
-							continue
+						if(reaction.required_container_accepts_subtypes)
+							if(!istype(cached_my_atom, reaction.required_container))
+								continue
+					else if(cached_my_atom.type != reaction.required_container)
+						continue
 
 					if(isliving(cached_my_atom) && !reaction.mob_react) //Makes it so certain chemical reactions don't occur in mobs
 						continue


### PR DESCRIPTION

## About The Pull Request

During I think a semi-recent chem refactor, the variable that lets reactions accept subtypes of their required container was made non-functional. This is due to a little logic error in the check for reagent containers, as it checked for the exact path of container regardless of what the variable said.
## Why It's Good For The Game

If a variable says it should do something, it should actually do that thing instead of just nothing
## Changelog
:cl:
fix: The "required_container_accepts_subtypes" variable on chemical reactions now actually works again
/:cl:
