### PR TITLE
Fixes the contractor program being on the syndicate store

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/contractor_program.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contractor_program.dm
@@ -6,7 +6,7 @@
 	program_icon = "tasks"
 	size = 10
 
-	program_flags = PROGRAM_ON_SYNDINET_STORE | PROGRAM_UNIQUE_COPY
+	program_flags = PROGRAM_UNIQUE_COPY
 	can_run_on_flags = PROGRAM_PDA //this is all we've got sprites for :sob:
 	undeletable = TRUE
 	tgui_id = "SyndicateContractor"


### PR DESCRIPTION

## About The Pull Request
Syndicate contractor program can no longer be bought from an emagged computer.

## Why It's Good For The Game
This is most definitely a bug.
The pull request that introduced this bug can be found at #80069
Description or the changelog does not mention that the contractor program can now be downloaded when a computer is emagged.

Image below shows that the contractor program was not meant to be downloadable from the syndie store or ntnet.
![image](https://github.com/tgstation/tgstation/assets/37270891/46c4ce1d-85ad-4d06-bc89-420a6e850cd6)


## Changelog
:cl:
fix: Fixed being able to download the contractor program on the syndie store.
/:cl:
