### PR TITLE
Hub shows if restarting, starting, time to start; Time is more accurate

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -380,9 +380,19 @@ GLOBAL_VAR(restart_counter)
 	if(length(features))
 		new_status += ": [jointext(features, ", ")]"
 
-	new_status += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
-	if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
-		new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
+	if(!SSticker || SSticker?.current_state == GAME_STATE_STARTUP)
+		new_status += "<br><b>STARTING</b>"
+	else if(SSticker)
+		if(SSticker.current_state == GAME_STATE_PREGAME && SSticker.GetTimeLeft() > 0)
+			new_status += "<br>Starting: <b>[round((SSticker.GetTimeLeft())/10)]</b>"
+		else if(SSticker.current_state == GAME_STATE_SETTING_UP)
+			new_status += "<br>Starting: <b>Now</b>"
+		else if(SSticker.IsRoundInProgress())
+			new_status += "<br>Time: <b>[time2text(((world.time - SSticker.round_start_time)/10), "hh:mm")]</b>"
+			if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
+				new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
+		else if(SSticker.current_state == GAME_STATE_FINISHED)
+			new_status += "<br><b>RESTARTING</b>"
 	if(SSmapping.config)
 		new_status += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"
 	if(SSmapping.next_map_config)


### PR DESCRIPTION

## About The Pull Request
Hub shows if game is restarting (game is finished), starting (game is initializing), time to start (inits done)

Also the time, is more accurate to the actual roundstart time
previously it would show "Time 00:00" and when you joined it was actually still in lobby
now "Time 00:00" will mean that the round has started and gone in game

Hopefully this is ok as it's not really a feature, it's just improved feedback to the player

@MrStonedOne 
## Why It's Good For The Game
Time is more accurate to station time, also is handy to know if server is restarting or just starting and in lobby
## Changelog
:cl:
code: Hub status shows if server is restarting, starting, time to start. The "Time" is more accurate and based on roundstart now
/:cl:
