### PR TITLE
Fixed runtime from unowned cooldown actions (carp rift)

### DIFF
--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -177,7 +177,7 @@
 /// Starts a cooldown time for other abilities that share a cooldown with this. Has some niche usage with more complicated attack ai!
 /// Will use default cooldown time if an override is not specified
 /datum/action/cooldown/proc/StartCooldownOthers(override_cooldown_time)
-	if(!length(owner.actions))
+	if(!length(owner?.actions))
 		return // Possible if they have an action they don't control
 	for(var/datum/action/cooldown/shared_ability in owner.actions - src)
 		if(!(shared_cooldown & shared_ability.shared_cooldown))


### PR DESCRIPTION
## About The Pull Request

This might not be the most correct fix but it *makes sense*. 

Some actions can not have an owner if it is unowned, so this check would runtime. 

![image](https://github.com/tgstation/tgstation/assets/51863163/b4787b7f-f481-4601-bdb1-ad001e0fea2a)

I assume carp rift is unowned in some places?

