### PR TITLE
Fixes chameleon hooded suits not making chameleon hats into chameleon hoods

### DIFF
--- a/code/modules/clothing/chameleon/chameleon_action_subtypes.dm
+++ b/code/modules/clothing/chameleon/chameleon_action_subtypes.dm
@@ -103,14 +103,14 @@
 	. = ..()
 	chameleon_blacklist |= typecacheof(list(/obj/item/clothing/suit/armor/abductor, /obj/item/clothing/suit/changeling), only_root_path = TRUE)
 
-/datum/action/item_action/chameleon/change/suit/apply_outfit(mob/user, datum/outfit/applying_from, list/all_items_to_apply)
+/datum/action/item_action/chameleon/change/suit/apply_outfit(datum/outfit/applying_from, list/all_items_to_apply)
 	. = ..()
 	if(!. || !ispath(applying_from.suit, /obj/item/clothing/suit/hooded))
 		return
 	// If we're appling a hooded suit, and wearing a cham hat, make it a hood
 	var/obj/item/clothing/suit/hooded/hooded = applying_from.suit
-	var/datum/action/item_action/chameleon/change/hat/hood_action = locate() in user.actions
-	hood_action?.update_look(user, initial(hooded.hoodtype))
+	var/datum/action/item_action/chameleon/change/hat/hood_action = locate() in owner?.actions
+	hood_action?.update_look(initial(hooded.hoodtype))
 
 /datum/action/item_action/chameleon/change/jumpsuit
 	chameleon_type = /obj/item/clothing/under


### PR DESCRIPTION
## About The Pull Request

`user` is not passed to `apply_outfit`, this proc had misaligned arguments as a result. 

## Changelog

:cl:  Melbert
fix: Chameleon Suits will now automatically set your helmet into a hood if using a hooded suit again
/:cl:


