### PR TITLE
Fixes improper use of audible_message

### DIFF
--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -69,7 +69,7 @@
 
 /datum/symptom/fire/proc/warn_mob(mob/living/living_mob)
 	if(prob(33.33))
-		living_mob.audible_message(self_message = "You hear a crackling noise.")
+		living_mob.show_message(span_hear("You hear a crackling noise."), type = MSG_AUDIBLE)
 	else
 		to_chat(living_mob, span_warning("[pick("You feel hot.", "You smell smoke.")]"))
 


### PR DESCRIPTION
## About The Pull Request

`audible_message` kinda expects a message to show to other people, if you don't give it that it runtimes. Just use show message instead. 
