### PR TITLE
Fixes Blood Drunk Miner (Hunter) dash runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -190,7 +190,7 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/hunter/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(. && prob(12))
-		INVOKE_ASYNC(dash, TYPE_PROC_REF(/datum/action, Trigger), target)
+		INVOKE_ASYNC(dash, TYPE_PROC_REF(/datum/action, Trigger), NONE, target)
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/doom
 	name = "hostile-environment miner"


### PR DESCRIPTION
## About The Pull Request

`Trigger` has two args for CD actions, first is trigger flags and second is target of the action (for AI). In this case it forgot the first. 

## Changelog

:cl: Melbert
fix: Blood Drunk Miner (Hunter version) should dash a bit more.
/:cl:

