### PR TITLE
Fixes weird use of `repeat_string` to try to loop over something in Ringleader's Rise spell

### DIFF
--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -45,7 +45,7 @@
 
 	victim.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100 - victim_sanity, 160)
 	for(var/i in 1 to round((120 - victim_sanity) / 10))
-		victim.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/body), "ringleaders rise")
+		victim.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/body), name)
 	if(victim_sanity < 15)
 		victim.apply_status_effect(/datum/status_effect/moon_converted)
 		caster.log_message("made [victim] insane.", LOG_GAME)

--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -44,7 +44,8 @@
 	var/victim_sanity = victim.mob_mood.sanity
 
 	victim.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100 - victim_sanity, 160)
-	repeat_string((120 - victim_sanity) / 10,victim.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/body),"ringleaders rise"))
+	for(var/i in 1 to round((120 - victim_sanity) / 10))
+		victim.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/body), "ringleaders rise")
 	if(victim_sanity < 15)
 		victim.apply_status_effect(/datum/status_effect/moon_converted)
 		caster.log_message("made [victim] insane.", LOG_GAME)
@@ -60,4 +61,3 @@
 /obj/effect/temp_visual/moon_ringleader/Initialize(mapload)
 	. = ..()
 	transform = transform.Scale(10)
-


### PR DESCRIPTION
## About The Pull Request

`repeat_string` is made to repeat... strings, hallucination datums are not strings. I assumed they were just trying to iterate instead.

![image](https://github.com/tgstation/tgstation/assets/51863163/ee58d6eb-bf3c-43b9-bfae-955aa1c125d7)

## Changelog

:cl: Melbert
fix: Fix Ringleader's Rise not causing as many hallucinations as expected
/:cl:

