### PR TITLE
FIxes being unable to heal constructs with certain cult spells

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -739,15 +739,15 @@
 					to_chat(user,span_warning("[human_bloodbag.p_Theyre()] missing too much blood - you cannot drain [human_bloodbag.p_them()] further!"))
 					return
 		if(isconstruct(target))
-			var/mob/living/simple_animal/construct_thing = target
+			var/mob/living/basic/construct/construct_thing = target
 			var/missing_health = construct_thing.maxHealth - construct_thing.health
 			if(missing_health)
 				if(uses > missing_health)
-					construct_thing.adjustHealth(-missing_health)
+					construct_thing.adjust_health(-missing_health)
 					construct_thing.visible_message(span_warning("[construct_thing] is fully healed by [user]'s blood magic!"))
 					uses -= missing_health
 				else
-					construct_thing.adjustHealth(-uses)
+					construct_thing.adjust_health(-uses)
 					construct_thing.visible_message(span_warning("[construct_thing] is partially healed by [user]'s blood magic!"))
 					uses = 0
 				playsound(get_turf(construct_thing), 'sound/magic/staff_healing.ogg', 25)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -832,9 +832,9 @@ Striking a noncultist, however, will tear their flesh."}
 		var/mob/living/carbon/carbon_cultist = our_target
 		carbon_cultist.reagents.add_reagent(/datum/reagent/fuel/unholywater, 4)
 	if(isshade(our_target) || isconstruct(our_target))
-		var/mob/living/simple_animal/undead_abomination = our_target
-		if(undead_abomination.health+5 < undead_abomination.maxHealth)
-			undead_abomination.adjustHealth(-5)
+		var/mob/living/basic/construct/undead_abomination = our_target
+		if(undead_abomination.health + 5 < undead_abomination.maxHealth)
+			undead_abomination.adjust_health(-5)
 	return PROJECTILE_DELETE_WITHOUT_HITTING
 
 /obj/item/blood_beam
@@ -934,11 +934,11 @@ Striking a noncultist, however, will tear their flesh."}
 						if(H.stat != DEAD)
 							H.reagents.add_reagent(/datum/reagent/fuel/unholywater, 7)
 					if(isshade(target) || isconstruct(target))
-						var/mob/living/simple_animal/M = target
-						if(M.health+15 < M.maxHealth)
-							M.adjustHealth(-15)
+						var/mob/living/basic/construct/healed_guy = target
+						if(healed_guy.health + 15 < healed_guy.maxHealth)
+							healed_guy.adjust_health(-adjust_health)
 						else
-							M.health = M.maxHealth
+							healed_guy.health = healed_guy.maxHealth
 				else
 					var/mob/living/L = target
 					if(L.density)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -936,7 +936,7 @@ Striking a noncultist, however, will tear their flesh."}
 					if(isshade(target) || isconstruct(target))
 						var/mob/living/basic/construct/healed_guy = target
 						if(healed_guy.health + 15 < healed_guy.maxHealth)
-							healed_guy.adjust_health(-adjust_health)
+							healed_guy.adjust_health(-15)
 						else
 							healed_guy.health = healed_guy.maxHealth
 				else


### PR DESCRIPTION
## About The Pull Request

These calls never got updated from when they were made basic. 

Also I'd love to just use `adjustBruteLoss(-amt)` for these but basic mob damage is a bit cringe (it would allow you to exceed health cap and also it would apply brute modifiers) 

## Changelog

:cl: Melbert
fix: Fixes some cult spells being unable to heal constructs (blood rites particularly) 
/:cl:

