### PR TITLE
Fixes Rat King's Abilities To No Longer Require Two Clicks Again

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -6,6 +6,7 @@
 	name = "Rat King's Domain"
 	desc = "Corrupts this area to be more suitable for your rat army."
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
+	click_to_activate = FALSE
 	cooldown_time = 6 SECONDS
 	melee_cooldown_time = 0 SECONDS
 	button_icon = 'icons/mob/actions/actions_animal.dmi'
@@ -41,6 +42,7 @@
 	name = "Raise Army"
 	desc = "Raise an army out of the hordes of mice and pests crawling around the maintenance shafts."
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
+	click_to_activate = FALSE
 	button_icon = 'icons/mob/actions/actions_animal.dmi'
 	button_icon_state = "riot"
 	background_icon_state = "bg_clock"


### PR DESCRIPTION
## About The Pull Request

This PR fixes Rat King's abilities to no longer require clicking twice (once on the ability button, once somewhere in the world space), instead bringing them back to their original behavior of just needing to click once on the ability button to activate them.

## Why It's Good For The Game

Fixes the abilities to return to their original activation behavior. Pretty sure it was a mistake to not have click_to_activate set to FALSE when the abilities got ported over to mob_cooldown actions, especially since these abilities don't have any sort of aiming component to them.

## Changelog
:cl:
fix: Rat King's abilities no longer require the user to click twice in order to activate them.
/:cl: