### PR TITLE
[No GBP] Fixes all borg apparatus-type tools

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -55,25 +55,27 @@
 		return ..()
 	stored.forceMove(user.drop_location())
 
-/obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
-	if(!stored)
-		// Borgs should not be grabbing their own modules
-		if(istype(atom.loc, /mob/living/silicon/robot) || istype(atom.loc, /obj/item/robot_model) || HAS_TRAIT(atom, TRAIT_NODROP))
-			stored.melee_attack_chain(user, atom, params)
-			return TRUE
 
-		var/itemcheck = FALSE
-		for(var/storable_type in storable)
-			if(istype(atom, storable_type))
-				itemcheck = TRUE
-				break
-		if(itemcheck)
-			var/obj/item/item = atom
-			item.forceMove(src)
-			stored = item
-			RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
-			update_appearance()
-			return TRUE
+/obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
+	if(stored)
+		stored.melee_attack_chain(user, atom, params)
+		return TRUE
+
+	if(istype(atom.loc, /mob/living/silicon/robot) || istype(atom.loc, /obj/item/robot_model) || HAS_TRAIT(atom, TRAIT_NODROP))
+		return ..() // Borgs should not be grabbing their own modules
+
+	var/itemcheck = FALSE
+	for(var/storable_type in storable)
+		if(istype(atom, storable_type))
+			itemcheck = TRUE
+			break
+	if(itemcheck)
+		var/obj/item/item = atom
+		item.forceMove(src)
+		stored = item
+		RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
+		update_appearance()
+		return TRUE
 	return ..()
 
 /**

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -55,7 +55,6 @@
 		return ..()
 	stored.forceMove(user.drop_location())
 
-
 /obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
 	if(stored)
 		stored.melee_attack_chain(user, atom, params)


### PR DESCRIPTION

## About The Pull Request
- Makes borg apparatus-type tools able to start the held item's attack chain again.
## Why It's Good For The Game
Bug of my own making.
Fixes #80881
## Changelog
:cl:
fix: Borg tools that hold and use specific items now work correctly again.
/:cl:
Oops.