### PR TITLE
fixes an assumption about whether a borg has a radio for its current model when transforming

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -218,7 +218,7 @@
 	cyborg.model = new_model
 	cyborg.update_module_innate()
 	new_model.rebuild_modules()
-	cyborg.radio.recalculateChannels()
+	cyborg.radio?.recalculateChannels()
 	cyborg.set_modularInterface_theme()
 	cyborg.diag_hud_set_health()
 	cyborg.diag_hud_set_status()


### PR DESCRIPTION

## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/80892

## Why It's Good For The Game

runtimes bad

## Changelog
:cl:
fix: Borg transformations no longer assume borgs will have a radio.
/:cl:
