### PR TITLE
Headslug Eggs Work Again + More Consistent Timing

### DIFF
--- a/code/modules/antagonists/changeling/headslug_eggs.dm
+++ b/code/modules/antagonists/changeling/headslug_eggs.dm
@@ -8,10 +8,16 @@
 	var/datum/mind/origin
 	/// When we're expected to hatch.
 	var/hatch_time = 0
+	/// When this egg last got removed from a body. If -1, the egg hasn't been removed from a body.
+	var/removal_time = -1
 
 /obj/item/organ/internal/body_egg/changeling_egg/Insert(mob/living/carbon/egg_owner, special = FALSE, movement_flags = DELETE_IF_REPLACED)
 	. = ..()
-	hatch_time = world.time + EGG_INCUBATION_TIME
+	hatch_time = world.time + (removal_time == -1 ? EGG_INCUBATION_TIME : (hatch_time - removal_time))
+
+/obj/item/organ/internal/body_egg/changeling_egg/Remove(mob/living/carbon/egg_owner, special, movement_flags)
+	. = ..()
+	removal_time = world.time
 
 /obj/item/organ/internal/body_egg/changeling_egg/egg_process(seconds_per_tick, times_fired)
 	if(owner && hatch_time <= world.time)

--- a/code/modules/antagonists/changeling/headslug_eggs.dm
+++ b/code/modules/antagonists/changeling/headslug_eggs.dm
@@ -6,13 +6,15 @@
 	desc = "Twitching and disgusting."
 	/// The mind of the original changeling that gave forth to the headslug mob.
 	var/datum/mind/origin
-	/// Tracks how long the egg has been growing.
-	var/time = 0
+	/// When we're expected to hatch.
+	var/hatch_time = 0
+
+/obj/item/organ/internal/body_egg/changeling_egg/Insert(mob/living/carbon/egg_owner, special = FALSE, movement_flags = DELETE_IF_REPLACED)
+	. = ..()
+	hatch_time = world.time + EGG_INCUBATION_TIME
 
 /obj/item/organ/internal/body_egg/changeling_egg/egg_process(seconds_per_tick, times_fired)
-	// Changeling eggs grow in dead people
-	time += seconds_per_tick * 10
-	if(time >= EGG_INCUBATION_TIME)
+	if(owner && hatch_time <= world.time)
 		pop()
 
 /// Once the egg is fully grown, we gib the host and spawn a monkey (with the changeling's player controlling it). Very descriptive proc name.

--- a/code/modules/mob/living/basic/space_fauna/changeling/headslug.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/headslug.dm
@@ -75,12 +75,8 @@
 /// Just to be super-duper safe to the player, we do return TRUE if all goes well and read that value in check_and_implant() to be nice to the player.
 /mob/living/basic/headslug/proc/infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)
-	egg.Insert(victim)
 
 	egg.origin = mind
-
-	for(var/obj/item/organ/target in src)
-		target.forceMove(egg)
 
 	visible_message(
 		span_warning("[src] plants something in [victim]'s flesh!"),

--- a/code/modules/mob/living/basic/space_fauna/changeling/headslug.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/headslug.dm
@@ -78,6 +78,9 @@
 
 	egg.origin = mind
 
+	for(var/obj/item/organ/target in src)
+		target.forceMove(egg)
+
 	visible_message(
 		span_warning("[src] plants something in [victim]'s flesh!"),
 		span_danger("We inject our egg into [victim]'s body!"),


### PR DESCRIPTION
## About The Pull Request

This PR makes changeling eggs work again. Apparently at some point, they stopped working entirely, as they never properly got added as an organ to the victim's body (ironically because we were doing TOO MUCH work, not too little). This PR also changes how changeling eggs keep track of time until they hatch in order to make it more consistent.

## Why It's Good For The Game

Changeling eggs should work, right? Also, making the egg timer not completely reliant on a passed in magic number and the whimsies of Life() being proc'd when it should be consistently for 4 minutes should make the egg feel more reliable to use.

## Changelog
:cl:
fix: Changeling eggs laid by headslugs work again
fix: Changeling egg incubation times should feel much more consistent, hatching after 4 minutes
/:cl: