### PR TITLE
Update byond version for ci. Makes unit tests 30 seconds faster.

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1620"
+byond: "515.1626"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=515
-export BYOND_MINOR=1620
+export BYOND_MINOR=1626
 
 #rust_g git tag
 export RUST_G_VERSION=3.0.0


### PR DESCRIPTION
This will make ci more than 30 seconds faster to start the game for unit tests thanks to [ID:2906744](https://www.byond.com/forum/post/2906744)