### PR TITLE
Adds Combat Button to Living HUD (Simple + Basic Mob HUD)

### DIFF
--- a/code/_onclick/hud/living.dm
+++ b/code/_onclick/hud/living.dm
@@ -10,6 +10,11 @@
 	pull_icon.screen_loc = ui_living_pull
 	static_inventory += pull_icon
 
+	action_intent = new /atom/movable/screen/combattoggle/flashy(null, src)
+	action_intent.icon = 'icons/hud/screen_midnight.dmi'
+	action_intent.screen_loc = ui_combat_toggle
+	static_inventory += action_intent
+
 	combo_display = new /atom/movable/screen/combo(null, src)
 	infodisplay += combo_display
 


### PR DESCRIPTION
## About The Pull Request

This PR adds the combat mode toggle to the HUD of simple and basic mobs that don't have hands (the ones with hands already had it). It looks like this:
![image](https://github.com/tgstation/tgstation/assets/47086570/f4649693-25c6-4ebc-ad6e-bcabe9939019)

## Why It's Good For The Game

Simple and basic mobs can currently toggle combat mode by using the keybind for it, however, they can't see whether or not they have it on currently because the button for it is not on their HUD. Some basic mobs, like regal rats, have different interactions when clicking on objects depending on whether or not they have combat mode on, so this is sort of important information to display to the player.

Which this is technically QOL, Jacquerel gave me permission to PR this during the feature freeze.

## Changelog
:cl:
qol: The combat mode toggle button is now present on the HUD for simple and basic mobs.
/:cl: