### PR TITLE
Better errors for adding element to qdeling datum

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -51,7 +51,10 @@
 /// Finds the singleton for the element type given and attaches it to src
 /datum/proc/_AddElement(list/arguments)
 	if(QDELING(src))
-		CRASH("We just tried to add an element to a qdeleted datum, something is fucked")
+		var/datum/element/element_type = arguments[1]
+		stack_trace("We just tried to add the element [element_type] to a qdeleted datum, something is fucked")
+		return
+
 	var/datum/element/ele = SSdcs.GetElement(arguments)
 	if(!ele) // We couldn't fetch the element, likely because it was not an element.
 		return // the crash message has already been sent


### PR DESCRIPTION

## About The Pull Request

Got this from reading #80915

The actual name of the element is not reported anywhere in the stack trace, and while you might be able to figure it out from context clues based on the procs invoked in the stack trace... this isn't guaranteed and just makes it harder to diagnose these weird sporadic runtimes.
## Why It's Good For The Game

easier to figure out a problem when you have as much useful information as possible
## Changelog
irrelevant
