### PR TITLE
Fixes eye pulling message from cranial fissure.

### DIFF
--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -86,6 +86,7 @@
 		victim.balloon_alert(user, "no eyes to take!")
 		return TRUE
 
+	playsound(victim, 'sound/surgery/organ2.ogg', 50, TRUE)
 	victim.balloon_alert(user, "pulling out eyes...")
 	user.visible_message(
 		span_boldwarning("[user] reaches inside [victim]'s skull..."),
@@ -105,6 +106,7 @@
 
 	log_combat(user, victim, "pulled out the eyes of")
 
+	playsound(victim, 'sound/surgery/organ1.ogg', 75, TRUE)
 	user.visible_message(
 		span_boldwarning("[user] rips out [victim]'s eyes!"),
 		span_boldwarning("You rip out [victim]'s eyes!"),

--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -102,8 +102,8 @@
 	log_combat(user, victim, "pulled out the eyes of")
 
 	user.visible_message(
-		span_boldwarning("You rip out [victim]'s eyes!"),
 		span_boldwarning("[user] rips out [victim]'s eyes!"),
+		span_boldwarning("You rip out [victim]'s eyes!"),
 		ignored_mobs = victim,
 	)
 

--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -87,6 +87,10 @@
 		return TRUE
 
 	victim.balloon_alert(user, "pulling out eyes...")
+	user.visible_message(
+		span_boldwarning("[user] reaches inside [victim]'s skull..."),
+		ignored_mobs = user
+	)
 	victim.show_message(
 		span_userdanger("[victim] starts to pull out your eyes!"),
 		MSG_VISUAL,


### PR DESCRIPTION
## About The Pull Request

Fixes #80928 by swapping two strings. This also gives a new string for bystanders when someone STARTS pulling someone's eyes, which felt like an oversight while testing, but i can revert that last part if it is deemed too much of a "feature"

- [x] I tested this on a localhost
## Why It's Good For The Game



Bystanders won't think that they're the culprit of terrible eye-pulling crimes anymore
## Changelog
:cl:
fix: Bystanders will no longer think they've pulled out a victim's eyes after seeing someone else do it.
qol: They will also be able to tell when someone starts pulling out a victim's eyes.
/:cl:
