### PR TITLE
Fixes round event controller pirate spawns

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -15,7 +15,7 @@
 	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event_control/pirates/preRunEvent()
-	if (!SSmapping.is_planetary())
+	if (SSmapping.is_planetary())
 		return EVENT_CANT_RUN
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Free GBP, I think?

It only spawns in space, but it only spawns on a planet... hold up that's never.
## Why It's Good For The Game

Bugfix good.
## Changelog
:cl:
fix: Fixed round event controller pirate spawns.
/:cl:
