### PR TITLE
the fugu gland now uses `update_transform` rather than scale transform directly.

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/fugu_gland.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/fugu_gland.dm
@@ -37,7 +37,7 @@
 	animal.health = min(animal.maxHealth, animal.health * 1.5)
 	animal.melee_damage_lower = max((animal.melee_damage_lower * 2), 10)
 	animal.melee_damage_upper = max((animal.melee_damage_upper * 2), 10)
-	animal.transform *= 2
+	animal.update_transform(2)
 	animal.AddElement(/datum/element/wall_tearer)
 	to_chat(user, span_info("You increase the size of [animal], giving [animal.p_them()] a surge of strength!"))
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This way the mob will still look aligned with the tile it's standing on.

## Changelog

:cl:
fix: Animals enlargened by the fugu gland are now visually aligned with the turf they're standing on.
/:cl:
