### PR TITLE
Fixes section stealing focus [no gbp]

### DIFF
--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -5,34 +5,68 @@
  */
 
 import { canRender, classes } from 'common/react';
-import { forwardRef, ReactNode, RefObject, useRef } from 'react';
+import { forwardRef, ReactNode, RefObject, useEffect, useRef } from 'react';
 
+import { addScrollableNode, removeScrollableNode } from '../events';
 import { BoxProps, computeBoxClassName, computeBoxProps } from './Box';
 
 type Props = Partial<{
+  /** Buttons to render aside the section title. */
   buttons: ReactNode;
+  /** If true, fills all available vertical space. */
   fill: boolean;
+  /** If true, removes all section padding. */
   fitted: boolean;
+  /** Shows or hides the scrollbar. */
   scrollable: boolean;
+  /** Shows or hides the horizontal scrollbar. */
   scrollableHorizontal: boolean;
+  /** Title of the section. */
   title: ReactNode;
   /** @member Callback function for the `scroll` event */
   onScroll: ((this: GlobalEventHandlers, ev: Event) => any) | null;
 }> &
   BoxProps;
 
+/**
+ * ## Section
+ * Section is a surface that displays content and actions on a single topic.
+ *
+ * They should be easy to scan for relevant and actionable information.
+ * Elements, like text and images, should be placed in them in a way that
+ * clearly indicates hierarchy.
+ *
+ * Sections can now be nested, and will automatically font size of the
+ * header according to their nesting level. Previously this was done via `level`
+ * prop, but now it is automatically calculated.
+ *
+ * Section can also be titled to clearly define its purpose.
+ *
+ * ```tsx
+ * <Section title="Cargo">Here you can order supply crates.</Section>
+ * ```
+ *
+ * If you want to have a button on the right side of an section title
+ * (for example, to perform some sort of action), there is a way to do that:
+ *
+ * ```tsx
+ * <Section title="Cargo" buttons={<Button>Send shuttle</Button>}>
+ *   Here you can order supply crates.
+ * </Section>
+ * ```
+ */
 export const Section = forwardRef(
   (props: Props, forwardedRef: RefObject<HTMLDivElement>) => {
     const {
-      className,
-      title,
       buttons,
+      children,
+      className,
       fill,
       fitted,
+      onScroll,
       scrollable,
       scrollableHorizontal,
-      children,
-      onScroll,
+      title,
       ...rest
     } = props;
 
@@ -40,11 +74,17 @@ export const Section = forwardRef(
 
     const hasTitle = canRender(title) || canRender(buttons);
 
-    function handleMouseEnter() {
-      if (!scrollable || !contentRef.current) return;
+    /** We want to be able to scroll on hover, but using focus will steal it from inputs */
+    useEffect(() => {
+      if (!contentRef.current) return;
+      if (!scrollable && !scrollableHorizontal) return;
 
-      contentRef.current.focus();
-    }
+      addScrollableNode(contentRef.current);
+
+      return () => {
+        removeScrollableNode(contentRef.current!);
+      };
+    }, []);
 
     return (
       <div
@@ -69,7 +109,6 @@ export const Section = forwardRef(
         <div className="Section__rest">
           <div
             className="Section__content"
-            onMouseEnter={handleMouseEnter}
             onScroll={onScroll}
             ref={contentRef}
           >


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
using .focus() on section doesn't behave in the way that you'd want it, this means it would steal focus any time someone moves their mouse away from an input and touches a scrollable section. We had events.ts for this purpose, so this should accurately represent how the old section worked.

I also moved the component reference documentation into the onhover effects of section
![Screenshot 2024-01-13 095237](https://github.com/tgstation/tgstation/assets/42397676/a3d80a35-a1db-416e-a26e-2667cb4031f3)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents a really annoying bug where you'd have to hover over inputs to keep typing
Better documentation
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Sections will be more polite by not stealing focus from Input boxes in TGUI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
