### PR TITLE
Fixes assorted head harddels, removes specific organ vars in head

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -155,7 +155,7 @@
 				continue
 			var/obj/item/bodypart/head/as_head = thing
 			var/obj/item/mmi/as_mmi = thing
-			if(istype(thing, /obj/item/organ/internal/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(thing, /obj/item/dullahan_relay))
+			if(istype(thing, /obj/item/organ/internal/brain) || (istype(as_head) && locate(/obj/item/organ/internal/brain) in as_head) || (istype(as_mmi) && as_mmi.brain) || istype(thing, /obj/item/dullahan_relay))
 				living_detected = TRUE
 			if(isitem(as_object))
 				var/obj/item/as_item = as_object

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -52,9 +52,10 @@
 	human.put_in_hands(head)
 
 	// We want to give the head some boring old eyes just so it doesn't look too jank on the head sprite.
-	head.eyes = new /obj/item/organ/internal/eyes(head)
-	head.eyes.eye_color_left = human.eye_color_left
-	head.eyes.eye_color_right = human.eye_color_right
+	var/obj/item/organ/internal/eyes/eyes = new /obj/item/organ/internal/eyes(head)
+	eyes.eye_color_left = human.eye_color_left
+	eyes.eye_color_right = human.eye_color_right
+	eyes.bodypart_insert(my_head)
 	human.update_body()
 	head.update_icon_dropped()
 	human.set_safe_hunger_level()
@@ -248,7 +249,8 @@
 		return // It's so over
 	detached_head.real_name = wearer.real_name
 	detached_head.name = wearer.real_name
-	detached_head.brain.name = "[wearer.name]'s brain"
+	var/obj/item/organ/internal/brain/brain = locate(/obj/item/organ/internal/brain) in detached_head
+	brain.name = "[wearer.name]'s brain"
 
 /obj/item/dullahan_relay/proc/examinate_check(mob/user, atom/source)
 	SIGNAL_HANDLER

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -185,46 +185,6 @@
 		var/datum/wound/loss/dismembering = new
 		return dismembering.apply_dismember(src, wounding_type)
 
-/obj/item/organ/internal/eyes/on_bodypart_insert(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.eyes = src
-	return ..()
-
-/obj/item/organ/internal/ears/on_bodypart_insert(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.ears = src
-	return ..()
-
-/obj/item/organ/internal/tongue/on_bodypart_insert(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.tongue = src
-	return ..()
-
-/obj/item/organ/internal/brain/on_bodypart_insert(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.brain = src
-	return ..()
-
-/obj/item/organ/internal/eyes/on_bodypart_remove(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.eyes = null
-	return ..()
-
-/obj/item/organ/internal/ears/on_bodypart_remove(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.ears = null
-	return ..()
-
-/obj/item/organ/internal/tongue/on_bodypart_remove(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.tongue = null
-	return ..()
-
-/obj/item/organ/internal/brain/on_bodypart_remove(obj/item/bodypart/head/head)
-	if(istype(head))
-		head.brain = null
-	return ..()
-
 /obj/item/bodypart/chest/drop_limb(special, dismembered, move_to_floor = TRUE)
 	if(special)
 		return ..()

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -26,11 +26,6 @@
 	unarmed_effectiveness = 0
 	bodypart_trait_source = HEAD_TRAIT
 
-	var/obj/item/organ/internal/brain/brain //The brain organ
-	var/obj/item/organ/internal/eyes/eyes
-	var/obj/item/organ/internal/ears/ears
-	var/obj/item/organ/internal/tongue/tongue
-
 	/// Do we show the information about missing organs upon being examined? Defaults to TRUE, useful for Dullahan heads.
 	var/show_organs_on_examine = TRUE
 
@@ -104,22 +99,10 @@
 	QDEL_NULL(worn_face_offset)
 	return ..()
 
-/obj/item/bodypart/head/Exited(atom/movable/gone, direction)
-	if(gone == brain)
-		brain = null
-		update_icon_dropped()
-	if(gone == eyes)
-		eyes = null
-		update_icon_dropped()
-	if(gone == ears)
-		ears = null
-	if(gone == tongue)
-		tongue = null
-	return ..()
-
 /obj/item/bodypart/head/examine(mob/user)
 	. = ..()
 	if(show_organs_on_examine && IS_ORGANIC_LIMB(src))
+		var/obj/item/organ/internal/brain/brain = locate(/obj/item/organ/internal/brain) in src
 		if(!brain)
 			. += span_info("The brain has been removed from [src].")
 		else if(brain.suicided || (brain.brainmob && HAS_TRAIT(brain.brainmob, TRAIT_SUICIDED)))
@@ -136,13 +119,13 @@
 		else
 			. += span_info("It's completely lifeless.")
 
-		if(!eyes)
+		if(!(locate(/obj/item/organ/internal/eyes) in src))
 			. += span_info("[real_name]'s eyes have been removed.")
 
-		if(!ears)
+		if(!(locate(/obj/item/organ/internal/ears) in src))
 			. += span_info("[real_name]'s ears have been removed.")
 
-		if(!tongue)
+		if(!(locate(/obj/item/organ/internal/tongue) in src))
 			. += span_info("[real_name]'s tongue has been removed.")
 
 /obj/item/bodypart/head/can_dismember(obj/item/item)
@@ -157,6 +140,7 @@
 /obj/item/bodypart/head/drop_organs(mob/user, violent_removal)
 	if(user)
 		user.visible_message(span_warning("[user] saws [src] open and pulls out a brain!"), span_notice("You saw [src] open and pull out a brain."))
+	var/obj/item/organ/internal/brain/brain = locate(/obj/item/organ/internal/brain) in src
 	if(brain && violent_removal && prob(90)) //ghetto surgery can damage the brain.
 		to_chat(user, span_warning("[brain] was damaged in the process!"))
 		brain.set_organ_damage(brain.maxHealth)
@@ -181,6 +165,7 @@
 	. += get_hair_and_lips_icon(dropped)
 	// We need to get the eyes if we are dropped (ugh)
 	if(dropped)
+		var/obj/item/organ/internal/eyes/eyes = locate(/obj/item/organ/internal/eyes) in src
 		// This is a bit of copy/paste code from eyes.dm:generate_body_overlay
 		if(eyes?.eye_icon_state && (head_flags & HEAD_EYESPRITES))
 			var/image/eye_left = image('icons/mob/human/human_face.dmi', "[eyes.eye_icon_state]_l", -BODY_LAYER, SOUTH)

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -49,12 +49,12 @@
 		else
 			show_eyeless = FALSE
 	else
-		if(!hair_hidden && !brain)
+		if(!hair_hidden && !(locate(/obj/item/organ/internal/brain) in src))
 			show_debrained = TRUE
 		else
 			show_debrained = FALSE
 
-		if(!eyes)
+		if(!(locate(/obj/item/organ/internal/eyes) in src))
 			show_eyeless = TRUE
 		else
 			show_eyeless = FALSE

--- a/code/modules/unit_tests/ling_decap.dm
+++ b/code/modules/unit_tests/ling_decap.dm
@@ -9,11 +9,12 @@
 	var/obj/item/bodypart/head/noggin = ling.get_bodypart(BODY_ZONE_HEAD)
 	noggin.dismember()
 	TEST_ASSERT_NULL(ling.get_bodypart(BODY_ZONE_HEAD), "Changeling failed to be decapitated.")
-	TEST_ASSERT_NULL(noggin.brain.brainmob.mind, "Changeling's mind was moved to their brain after decapitation, but it should have remained in their body.")
+	var/obj/item/organ/internal/brain/brain = locate(/obj/item/organ/internal/brain) in noggin
+	TEST_ASSERT_NULL(brain.brainmob.mind, "Changeling's mind was moved to their brain after decapitation, but it should have remained in their body.")
 
-	var/obj/item/organ/internal/brain/oldbrain = noggin.brain
+	var/obj/item/organ/internal/brain/oldbrain = locate(/obj/item/organ/internal/brain) in noggin
 	noggin.drop_organs()
-	TEST_ASSERT_NULL(noggin.brain, "Changeling's head failed to drop its brain.")
+	TEST_ASSERT_NULL(locate(/obj/item/organ/internal/brain) in noggin, "Changeling's head failed to drop its brain.")
 	TEST_ASSERT_NULL(oldbrain.brainmob.mind, "Changeling's mind was moved to their brain after decapitation and organ dropping, but it should have remained in their body.")
 
 	TEST_ASSERT_EQUAL(ling.stat, CONSCIOUS, "Changeling was not conscious after losing their head.")
@@ -33,9 +34,10 @@
 
 	var/obj/item/bodypart/head/noggin = normal_guy.get_bodypart(BODY_ZONE_HEAD)
 	noggin.dismember()
-	TEST_ASSERT_EQUAL(noggin.brain.brainmob.mind, my_guys_mind, "Dummy's mind was not moved to their brain after decapitation.")
+	var/obj/item/organ/internal/brain/brain = locate(/obj/item/organ/internal/brain) in noggin
+	TEST_ASSERT_EQUAL(brain.brainmob.mind, my_guys_mind, "Dummy's mind was not moved to their brain after decapitation.")
 
-	var/obj/item/organ/internal/brain/oldbrain = noggin.brain
+	var/obj/item/organ/internal/brain/oldbrain = locate(/obj/item/organ/internal/brain) in noggin
 	noggin.drop_organs()
 	TEST_ASSERT_EQUAL(oldbrain.brainmob.mind, my_guys_mind, "Dummy's mind was not moved to their brain after being removed from their head.")
 


### PR DESCRIPTION
Fixes #80926, fixes #80372

The tongue, eyes, ears and brain vars were also being updated and cleared elsewhere, runtiming whenever a regular head got dismembered and then emptied, which would eventually cause a harddel due to improper clean-up

I've fixed the errant proc and just removed those vars because I don't like having duplicate references for no reason (they should always already be in contents)

Not player facing
