### PR TITLE
[NO-GBP] Fixes radshelter not radprotecting against nebula storm

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -87,7 +87,7 @@
 
 /// Used by the radioactive nebula when the station doesnt have enough shielding
 /datum/weather/rad_storm/nebula
-	protected_areas = list(/area/shuttle)
+	protected_areas = list(/area/shuttle, /area/station/maintenance/radshelter)
 
 	weather_overlay = "nebula_radstorm"
 	weather_duration_lower = 100 HOURS


### PR DESCRIPTION
:cl:
fix: Radiation shelters (wherever they are) will protect against nebula storms
/:cl:

Oversight when I originally added the nebula. Didn't realize these were a thing