### PR TITLE
Adds Toxin and Oxyloss prompts to examine.

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -82,6 +82,34 @@
 			else
 				msg += "<B>[t_He] [t_has] severe burns!</B>\n"
 
+		
+		temp = getFireLoss()
+		if(temp)
+			if(temp < 25)
+				msg += "[t_He] [t_has] minor [damage_desc[BURN]].\n"
+			else if (temp < 50)
+				msg += "[t_He] [t_has] <b>moderate</b> [damage_desc[BURN]]!\n"
+			else
+				msg += "<B>[t_He] [t_has] severe [damage_desc[BURN]]!</B>\n"
+
+		temp = getToxLoss()
+		if(temp)
+			if(temp < 25)
+				msg += "They look a little nauseated.\n"
+			else if (temp < 50)
+				msg += "They look pretty sick.\n"
+			else
+				msg += "<B>They are practically green at the gills!</B>\n"
+
+		temp = getOxyLoss()
+		if(temp)
+			if(temp < 25)
+				msg += "They look a little out of breath.\n"
+			else if (temp < 50)
+				msg += "They look like they're a bit blue.\n"
+			else
+				msg += "<B>They look to have blueing lips and seem to be struggling for a good breath!</B>\n"
+
 	if(HAS_TRAIT(src, TRAIT_DUMB))
 		msg += "[t_He] seem[p_s()] to be clumsy and unable to think.\n"
 


### PR DESCRIPTION

## About The Pull Request
This is a simple QoL making it easier for medical/general players to detect what's wrong with someone at a glance.
It mirrors the burns and brute code, just adding gender neutral examines for those who might stumble or be dragged into medical.
![image](https://github.com/tgstation/tgstation/assets/53197594/57d40af7-6994-4d54-b916-40c195a9a64b)
![image](https://github.com/tgstation/tgstation/assets/53197594/8b94c972-951e-428e-8ea0-036164b0113f)
## Why It's Good For The Game
For when medical has a lot going on, someone standing in the lobby yelling they need help can be seen at a glance as how healthy they'd be. If you're really sick IRL, people can tell by just looking at you.
## Changelog
:cl:
qol: made new examine lines for suffocation and toxin.
/:cl:
