### PR TITLE
lock heretics can gain relentless heartbeat again

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -145,6 +145,7 @@
 	gain_text = "Consorting with Burglar spirits is frowned upon, but a Steward will always want to learn about new doors."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/opening_blast,
+		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/blade_upgrade/flesh/lock,
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/painting,


### PR DESCRIPTION
## About The Pull Request

Allows  the relentless heartbeat spell to be unlocked after purchasing burglars fineness.

## Why It's Good For The Game

It lets me have a chance at winning when my targets are more robust than I am.

Also fixes https://github.com/tgstation/tgstation/issues/80961

## Changelog

:cl:
fix: Lock heretics may once again access 'the relentless heartbeat' after purchasing 'burglars fineness'.
/:cl:

