### PR TITLE
Ice cream vat uses a radial menu

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -20,6 +20,8 @@
 #define COMSIG_ATOM_REAGENT_EXAMINE "atom_reagent_examine"
 	/// Stop the generic reagent examine text
 	#define STOP_GENERIC_REAGENT_EXAMINE (1<<0)
+	/// Allows the generic reaegent examine text regardless of whether the user can scan reagents.
+	#define ALLOW_GENERIC_REAGENT_EXAMINE (1<<1)
 ///from base of atom/examine_more(): (/mob, examine_list)
 #define COMSIG_ATOM_EXAMINE_MORE "atom_examine_more"
 /// from atom/examine_more(): (/atom/examining, examine_list)

--- a/code/datums/components/food/ice_cream_holder.dm
+++ b/code/datums/components/food/ice_cream_holder.dm
@@ -223,7 +223,7 @@ GLOBAL_LIST_INIT_TYPED(ice_cream_flavours, /datum/ice_cream_flavour, init_ice_cr
 
 /datum/ice_cream_flavour/New()
 	if(ingredients)
-		ingredients_text = "(Ingredients: [reagent_paths_list_to_text(ingredients, ingredients_text)])"
+		ingredients_text = "Requires: [reagent_paths_list_to_text(ingredients, ingredients_text)]"
 
 /// Adds a new flavour to the ice cream cone.
 /datum/ice_cream_flavour/proc/add_flavour(datum/component/ice_cream_holder/target)

--- a/code/datums/components/food/ice_cream_holder.dm
+++ b/code/datums/components/food/ice_cream_holder.dm
@@ -57,7 +57,6 @@
 	src.sweetener = sweetener
 
 	RegisterSignal(owner, COMSIG_ITEM_ATTACK_ATOM, PROC_REF(on_item_attack_obj))
-	RegisterSignal(owner, COMSIG_ITEM_ATTACK_SECONDARY , PROC_REF(on_item_attack_obj_secondary))
 	RegisterSignal(owner, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
 	if(change_name)
 		RegisterSignal(owner, COMSIG_ATOM_UPDATE_NAME, PROC_REF(on_update_name))
@@ -135,32 +134,17 @@
 		new_overlays += overlay
 		added_offset += ICE_CREAM_SCOOP_OFFSET
 
-///Checks whether we can take ice cream or not.
-/datum/component/ice_cream_holder/proc/can_take_ice_cream(obj/target, mob/user)
-	if(!istype(target, /obj/machinery/icecream_vat))
-		return FALSE
-	if(length(scoops) >= max_scoops)
-		target.balloon_alert(user, "too many scoops!")
-		return FALSE
-	return TRUE
-
 /// Attack the ice cream vat to get some ice cream. This will change as new ways of getting ice cream are added.
 /datum/component/ice_cream_holder/proc/on_item_attack_obj(obj/item/source, obj/target, mob/user)
 	SIGNAL_HANDLER
-	if(!can_take_ice_cream(target, user))
+	if(!istype(target, /obj/machinery/icecream_vat))
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+	if(length(scoops) >= max_scoops)
+		target.balloon_alert(user, "too many scoops!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 	var/obj/machinery/icecream_vat/dispenser = target
 	dispenser.add_flavor_to_cone(src, user, source)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
-
-///Attack the ice cream vat to get some ice cream from the custom beaker since we are using right-click.
-/datum/component/ice_cream_holder/proc/on_item_attack_obj_secondary(obj/item/source, mob/living/carbon/target, mob/attacker, params)
-	SIGNAL_HANDLER
-	if(!can_take_ice_cream(target, attacker))
-		return COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
-	var/obj/machinery/icecream_vat/dispenser = target
-	dispenser.add_flavor_to_cone(src, attacker, source)
-	return COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
 
 /datum/component/ice_cream_holder/proc/check_food_order(obj/item/source, datum/custom_order/our_order)
 	SIGNAL_HANDLER
@@ -230,16 +214,18 @@ GLOBAL_LIST_INIT_TYPED(ice_cream_flavours, /datum/ice_cream_flavour, init_ice_cr
 	var/reagent_amount = 3
 	/// Is this flavour shown in the ice cream vat menu or not?
 	var/hidden = FALSE
+	///Whether this type of ice cream will take custom ingredients from a beaker in the ice cream vat.
+	var/takes_custom_ingredients = FALSE
 
 /datum/ice_cream_flavour/New()
 	if(ingredients)
 		ingredients_text = "Requires: [reagent_paths_list_to_text(ingredients, ingredients_text)]"
 
 /// Adds a new flavour to the ice cream cone.
-/datum/ice_cream_flavour/proc/add_flavour(datum/component/ice_cream_holder/target)
+/datum/ice_cream_flavour/proc/add_flavour(datum/component/ice_cream_holder/target, datum/reagents/custom_ingredients)
 	var/atom/owner = target.parent
 	LAZYADD(target.scoops, name)
-	if(color)
+	if(!takes_custom_ingredients && color)
 		var/image/flavoring = image('icons/obj/service/kitchen.dmi', "icecream_custom")
 		flavoring.color = color
 		LAZYADD(target.scoop_overlays, flavoring)
@@ -343,10 +329,11 @@ GLOBAL_LIST_INIT_TYPED(ice_cream_flavours, /datum/ice_cream_flavour, init_ice_cr
 
 /datum/ice_cream_flavour/custom
 	name = ICE_CREAM_CUSTOM
-	color = "" //has its own mutable appearance overlay
+	color = COLOR_STARLIGHT //has its own mutable appearance overlay it will be overwritten with anyways.
 	desc = "filled with artisanal icecream. Made with real $CUSTOM_NAME. Ain't that something."
 	ingredients = list(/datum/reagent/consumable/milk, /datum/reagent/consumable/ice)
 	ingredients_text = "optional flavorings"
+	takes_custom_ingredients = TRUE
 
 /datum/ice_cream_flavour/custom/korta
 	name = ICE_CREAM_KORTA_CUSTOM
@@ -354,16 +341,15 @@ GLOBAL_LIST_INIT_TYPED(ice_cream_flavours, /datum/ice_cream_flavour, init_ice_cr
 	ingredients = list(/datum/reagent/consumable/korta_milk, /datum/reagent/consumable/ice)
 	ingredients_text = "optional flavorings"
 
-/datum/ice_cream_flavour/custom/add_flavour(datum/component/ice_cream_holder/target, datum/reagents/R, custom_name)
-	if(!R || R.total_volume < 4) //consumable reagents have stronger taste so higher volume are required to allow non-food flavourings to break through better.
+/datum/ice_cream_flavour/custom/add_flavour(datum/component/ice_cream_holder/target, datum/reagents/custom_ingredients)
+	if(!custom_ingredients || custom_ingredients.total_volume < 4) //consumable reagents have stronger taste so higher volume are required to allow non-food flavourings to break through better.
 		return GLOB.ice_cream_flavours[ICE_CREAM_BLAND].add_flavour(target) //Bland, sugary ice and milk.
 	var/image/flavoring = image('icons/obj/service/kitchen.dmi', "icecream_custom")
-	var/datum/reagent/master = R.get_master_reagent()
-	custom_name = lowertext(master.name) // reagent names are capitalized, while items' aren't.
+	var/datum/reagent/master = custom_ingredients.get_master_reagent()
 	flavoring.color = master.color
 	LAZYADD(target.scoop_overlays, flavoring)
 	. = ..() // Make some space for reagents before attempting to transfer some to the target.
-	R.trans_to(target.parent, 4)
+	custom_ingredients.trans_to(target.parent, 4)
 
 /datum/ice_cream_flavour/bland
 	name = ICE_CREAM_BLAND

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -35,7 +35,7 @@
 			if(reagents.flags & TRANSPARENT)
 				if(reagents.total_volume)
 					. += "It contains <b>[reagents.total_volume]</b> units of various reagents[user_sees_reagents ? ":" : "."]"
-					if(user_sees_reagents) //Show each individual reagent for detailed examination
+					if(user_sees_reagents || (reagent_sigreturn & ALLOW_GENERIC_REAGENT_EXAMINE)) //Show each individual reagent for detailed examination
 						for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
 							. += "&bull; [round(current_reagent.volume, CHEMICAL_VOLUME_ROUNDING)] units of [current_reagent.name]"
 						if(reagents.is_reacting)

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -373,7 +373,7 @@
 
 /obj/item/food/icecream/New(loc, list/prefill_flavours)
 	if(ingredients)
-		ingredients_text = "(Ingredients: [reagent_paths_list_to_text(ingredients)])"
+		ingredients_text = "Requires: [reagent_paths_list_to_text(ingredients)]"
 	return ..()
 
 /obj/item/food/icecream/Initialize(mapload, list/prefill_flavours)

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -372,6 +372,8 @@
 	var/list/prefill_flavours
 
 /obj/item/food/icecream/New(loc, list/prefill_flavours)
+	if(ingredients)
+		ingredients_text = "(Ingredients: [reagent_paths_list_to_text(ingredients)])"
 	return ..()
 
 /obj/item/food/icecream/Initialize(mapload, list/prefill_flavours)

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -149,7 +149,9 @@
 /obj/machinery/icecream_vat/AltClick(mob/user)
 	if(!user.can_interact_with(src))
 		return FALSE
-	try_put_in_hand(custom_ice_cream_beaker, user)
+	if(custom_ice_cream_beaker)
+		balloon_alert(user, "removed beaker")
+		try_put_in_hand(custom_ice_cream_beaker, user)
 	return ..()
 
 /obj/machinery/icecream_vat/interact(mob/living/user)

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -1,5 +1,3 @@
-///How many units of each reagent should be added to the icecream vat on Initialize.
-#define PREFILL_AMOUNT 5
 ///How many units of a reagent is needed to make a cone.
 #define CONE_REAGENET_NEEDED 1
 
@@ -273,4 +271,3 @@
 #undef VAT_MODE_ICECREAM
 #undef VAT_MODE_CONES
 #undef CONE_REAGENET_NEEDED
-#undef PREFILL_AMOUNT

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -101,17 +101,10 @@
 	switch(vat_mode)
 		if(VAT_MODE_ICECREAM)
 			context[SCREENTIP_CONTEXT_LMB] = "Select flavor"
-			if(iscyborg(user))
-				context[SCREENTIP_CONTEXT_ALT_LMB] = "Change mode to cones"
-			else
-				context[SCREENTIP_CONTEXT_RMB] = "Change mode to cones"
+			context[SCREENTIP_CONTEXT_RMB] = "Change mode to cones"
 		if(VAT_MODE_CONES)
 			context[SCREENTIP_CONTEXT_LMB] = "Make cone"
-			if(iscyborg(user))
-				context[SCREENTIP_CONTEXT_ALT_LMB] = "Change mode to flavors"
-			else
-				context[SCREENTIP_CONTEXT_RMB] = "Change mode to flavors"
-			istype(held_item, /obj/item/food/icecream)
+			context[SCREENTIP_CONTEXT_RMB] = "Change mode to flavors"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/icecream_vat/attackby(obj/item/reagent_containers/beaker, mob/user, params)
@@ -135,6 +128,11 @@
 		balloon_alert(user, "no reagents to transfer!")
 
 /obj/machinery/icecream_vat/attack_hand_secondary(mob/user, list/modifiers)
+	if(swap_modes(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
+
+/obj/machinery/icecream_vat/attack_robot_secondary(mob/living/silicon/robot/user)
 	if(swap_modes(user))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	return ..()

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -153,10 +153,18 @@
 	switch(vat_mode)
 		if(VAT_MODE_ICECREAM)
 			for(var/flavor_key in ice_cream_icons)
-				choices[flavor_key] = ice_cream_icons[flavor_key]
+				var/datum/ice_cream_flavour/flavor_datum = GLOB.ice_cream_flavours[flavor_key]
+				var/datum/radial_menu_choice/option = new
+				option.image = ice_cream_icons[flavor_key]
+				option.info = span_boldnotice("[flavor_datum.ingredients_text]")
+				choices[flavor_key] = option
 		if(VAT_MODE_CONES)
 			for(var/cone_key in cone_prototypes)
-				choices[cone_key] = cone_prototypes[cone_key]
+				var/obj/item/food/icecream/cone_item = cone_prototypes[cone_key]
+				var/datum/radial_menu_choice/option = new
+				option.image = cone_prototypes[cone_key]
+				option.info = span_boldnotice("[cone_item.ingredients_text]")
+				choices[cone_key] = option
 
 	var/choice = show_radial_menu(
 		user,

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -1,4 +1,12 @@
+///How many units of each reagent should be added to the icecream vat on Initialize.
 #define PREFILL_AMOUNT 5
+///How many units of a reagent is needed to make a cone.
+#define CONE_REAGENET_NEEDED 1
+
+///The vat is set to dispense ice cream.
+#define VAT_MODE_ICECREAM "cones"
+///The vat is set to dispense cones.
+#define VAT_MODE_CONES "ice cream"
 
 /obj/machinery/icecream_vat
 	name = "ice cream vat"
@@ -10,12 +18,20 @@
 	use_power = NO_POWER_USE
 	layer = BELOW_OBJ_LAYER
 	max_integrity = 300
-	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN|INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_OPEN_SILICON|INTERACT_MACHINE_SET_MACHINE
+
+	///Which mode the icecream vat is set to dispense, VAT_MODE_ICECREAM or VAT_MODE_CONES
+	var/vat_mode = VAT_MODE_ICECREAM
+	///Boolean on whether or not to add 'icecream_vat_reagents' into the icecream vat on Initialize.
+	var/preinstall_reagents = TRUE
+	///How much of each product type the ice cream vat can make.
 	var/list/product_types = list()
+	///The selected flavor of ice cream that we'll dispense when hit with an ice cream cone.
 	var/selected_flavour = ICE_CREAM_VANILLA
-	var/obj/item/reagent_containers/beaker
+	///List of ice creams as icons used for the radial menu.
+	var/static/list/ice_cream_icons
 	/// List of prototypes of dispensable ice cream cones. path as key, instance as assoc.
 	var/static/list/obj/item/food/icecream/cone_prototypes
+	///List of all reagenets the icecream vat will spawn with, if preinstall_reagents is TRUE.
 	var/static/list/icecream_vat_reagents = list(
 		/datum/reagent/consumable/milk = 6,
 		/datum/reagent/consumable/korta_milk = 6,
@@ -36,6 +52,9 @@
 		/datum/reagent/consumable/cherryjelly = 6,
 	)
 
+/obj/machinery/icecream_vat/no_preinstalled_reagents
+	preinstall_reagents = FALSE
+
 /obj/machinery/icecream_vat/Initialize(mapload)
 	. = ..()
 
@@ -45,169 +64,165 @@
 			var/obj/item/food/icecream/cone = new cone_path
 			if(cone.ingredients)
 				cone_prototypes[cone_path] = cone
-				cone.ingredients_text = "(Ingredients: [reagent_paths_list_to_text(cone.ingredients)])"
 			else
 				qdel(cone)
+	if(!ice_cream_icons)
+		ice_cream_icons = list()
+		for(var/flavor in GLOB.ice_cream_flavours)
+			var/datum/ice_cream_flavour/flavor_datum = GLOB.ice_cream_flavours[flavor]
+			if(flavor_datum.hidden)
+				continue
+			ice_cream_icons[flavor] = make_ice_cream_color(flavor_datum)
 
-	create_reagents(300, NO_REACT | OPENCONTAINER)
+	RegisterSignal(src, COMSIG_ATOM_REAGENT_EXAMINE, PROC_REF(allow_reagent_scan))
+
+	create_reagents(300, NO_REACT|OPENCONTAINER)
 	reagents.chem_temp = T0C //So ice doesn't melt
+	register_context()
+
+	if(!preinstall_reagents)
+		return
+
 	for(var/flavour in GLOB.ice_cream_flavours)
 		if(GLOB.ice_cream_flavours[flavour].hidden)
 			continue
 		product_types[flavour] = PREFILL_AMOUNT
 	for(var/cone in cone_prototypes)
 		product_types[cone] = PREFILL_AMOUNT
-
 	for(var/reagent in icecream_vat_reagents)
 		reagents.add_reagent(reagent, icecream_vat_reagents[reagent], reagtemp = T0C)
 
-/obj/machinery/icecream_vat/ui_interact(mob/user)
+/obj/machinery/icecream_vat/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(held_item)
+		if(istype(held_item, /obj/item/food/icecream))
+			context[SCREENTIP_CONTEXT_LMB] = "Take scoop of [selected_flavour] ice cream"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	switch(vat_mode)
+		if(VAT_MODE_ICECREAM)
+			context[SCREENTIP_CONTEXT_LMB] = "Select flavor"
+			if(iscyborg(user))
+				context[SCREENTIP_CONTEXT_ALT_LMB] = "Change mode to cones"
+			else
+				context[SCREENTIP_CONTEXT_RMB] = "Change mode to cones"
+		if(VAT_MODE_CONES)
+			context[SCREENTIP_CONTEXT_LMB] = "Make cone"
+			if(iscyborg(user))
+				context[SCREENTIP_CONTEXT_ALT_LMB] = "Change mode to flavors"
+			else
+				context[SCREENTIP_CONTEXT_RMB] = "Change mode to flavors"
+			istype(held_item, /obj/item/food/icecream)
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/icecream_vat/attackby(obj/item/reagent_containers/beaker, mob/user, params)
 	. = ..()
-	var/dat
-	dat += "<b>ICE CREAM</b><br><div class='statusDisplay'>"
-	dat += "<b>Dispensing: [selected_flavour] icecream </b> <br><br>"
-	for(var/flavour in GLOB.ice_cream_flavours)
-		if(GLOB.ice_cream_flavours[flavour].hidden)
-			continue
-		dat += "<b>[capitalize(flavour)] ice cream:</b> <a href='?src=[REF(src)];select=[flavour]'><b>Select</b></a> <a href='?src=[REF(src)];make=[flavour];amount=1'><b>Make</b></a> <a href='?src=[REF(src)];make=[flavour];amount=5'><b>x5</b></a> [product_types[flavour]] scoops left[GLOB.ice_cream_flavours[flavour].ingredients_text].<br>"
-	dat += "<br><b>CONES</b><br><div class='statusDisplay'>"
-	for(var/cone in cone_prototypes)
-		dat += "<b>[capitalize(cone_prototypes[cone].name)]s:</b> <a href='?src=[REF(src)];cone=[cone]'><b>Dispense</b></a> <a href='?src=[REF(src)];make_cone=[cone];amount=1'><b>Make</b></a> <a href='?src=[REF(src)];make_cone=[cone];amount=5'><b>x5</b></a> [product_types[cone]] cones left[cone_prototypes[cone].ingredients_text].<br>"
-	dat += "<br>"
-	if(beaker)
-		dat += "<b>BEAKER CONTENT</b><br><div class='statusDisplay'>"
-		for(var/datum/reagent/R in beaker.reagents.reagent_list)
-			dat += "[R.name]: [R.volume]u<br>"
-		dat += "<a href='?src=[REF(src)];refill=1'><b>Refill from beaker</b></a></div>"
-	dat += "<br>"
-	dat += "<b>VAT CONTENT</b><br>"
-	for(var/datum/reagent/R in reagents.reagent_list)
-		dat += "[R.name]: [R.volume]"
-		dat += "<A href='?src=[REF(src)];disposeI=[R.type]'>Purge</A><BR>"
-	dat += "<a href='?src=[REF(src)];refresh=1'>Refresh</a> <a href='?src=[REF(src)];close=1'>Close</a>"
+	if(.)
+		return
+	if(!beaker || !istype(beaker) || !beaker.reagents || (beaker.item_flags & ABSTRACT) || !beaker.is_open_container())
+		return
 
-	var/datum/browser/popup = new(user, "icecreamvat","Icecream Vat", 700, 500, src)
-	popup.set_content(dat)
-	popup.open()
+	var/added_reagents = FALSE
+	for(var/datum/reagent/beaker_reagents in beaker.reagents.reagent_list)
+		if(beaker_reagents.type in icecream_vat_reagents)
+			added_reagents = TRUE
+			beaker.reagents.trans_to(src, beaker_reagents.volume, target_id = beaker_reagents.type)
 
-/obj/machinery/icecream_vat/attackby(obj/item/O, mob/user, params)
-	if(is_reagent_container(O) && !(O.item_flags & ABSTRACT) && O.is_open_container())
-		. = TRUE //no afterattack
-		var/obj/item/reagent_containers/B = O
-		if(!user.transferItemToLoc(B, src))
-			return
-		replace_beaker(user, B)
-		to_chat(user, span_notice("You add [B] to [src]."))
-		updateUsrDialog()
+	if(added_reagents)
 		update_appearance()
-		return
-	else if(O.is_drainable())
-		return
+		balloon_alert(user, "refilling reagents")
+		playsound(src, 'sound/items/drink.ogg', 25, TRUE)
 	else
-		return ..()
+		balloon_alert(user, "no reagents to transfer!")
 
-/obj/machinery/icecream_vat/proc/RefillFromBeaker()
-	if(!beaker || !beaker.reagents)
+/obj/machinery/icecream_vat/attack_hand_secondary(mob/user, list/modifiers)
+	if(swap_modes(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
+
+/obj/machinery/icecream_vat/AltClick(mob/user)
+	. = ..()
+	swap_modes(user)
+
+/obj/machinery/icecream_vat/interact(mob/living/user)
+	. = ..()
+	if (.)
 		return
-	for(var/datum/reagent/R in beaker.reagents.reagent_list)
-		if(R.type in icecream_vat_reagents)
-			beaker.reagents.trans_to(src, R.volume, target_id = R.type)
-			say("Internalizing reagent.")
-			playsound(src, 'sound/items/drink.ogg', 25, TRUE)
-	return
 
-/obj/machinery/icecream_vat/proc/make(mob/user, make_type, amount, list/ingredients)
-	var/recipe_amount = amount * 3 //prevents reagent duping by requring roughly the amount of reagenst you gain back by grinding.
-	for(var/R in ingredients)
-		if(!reagents.has_reagent(R, recipe_amount))
-			amount = 0
-			break
-	if(amount)
-		for(var/R in ingredients)
-			reagents.remove_reagent(R, recipe_amount)
-		product_types[make_type] += amount
-		var/obj/item/food/icecream/cone = cone_prototypes[make_type]
-		if(cone)
-			visible_message(span_info("[user] cooks up some [cone.name]s."))
-		else
-			visible_message(span_info("[user] whips up some [make_type] icecream."))
-	else
-		to_chat(user, span_warning("You don't have the ingredients to make this!"))
+	var/list/choices = list()
 
-/obj/machinery/icecream_vat/Topic(href, href_list)
-	if(..())
+	switch(vat_mode)
+		if(VAT_MODE_ICECREAM)
+			for(var/flavor_key in ice_cream_icons)
+				choices[flavor_key] = ice_cream_icons[flavor_key]
+		if(VAT_MODE_CONES)
+			for(var/cone_key in cone_prototypes)
+				choices[cone_key] = cone_prototypes[cone_key]
+
+	var/choice = show_radial_menu(
+		user,
+		src,
+		choices,
+		require_near = TRUE,
+		tooltips = TRUE,
+		autopick_single_option = FALSE,
+	)
+
+	if(!choice)
 		return
-	var/mob/user = usr
-	if(href_list["select"])
-		var/datum/ice_cream_flavour/flavour = GLOB.ice_cream_flavours[href_list["select"]]
-		if(!flavour || flavour.hidden) //Nice try, tex.
-			return
-		visible_message(span_notice("[user] sets [src] to dispense [href_list["select"]] flavoured ice cream."))
-		selected_flavour = flavour.name
+	var/datum/ice_cream_flavour/flavor = GLOB.ice_cream_flavours[choice]
+	if(flavor)
+		selected_flavour = flavor.name
+		balloon_alert(user, "making [selected_flavour]")
+	var/obj/item/food/icecream/cone = cone_prototypes[choice]
+	if(cone)
+		make_cone(user, choice, cone.ingredients)
 
-	if(href_list["cone"])
-		var/obj/item/food/icecream/cone_path = text2path(href_list["cone"])
-		if(!cone_path)
-			return
-		if(product_types[cone_path] >= 1)
-			product_types[cone_path]--
-			var/obj/item/food/icecream/cone = new cone_path(get_turf(src))
-			if(!user.put_in_hands(cone))
-				cone.forceMove(drop_location())
-			visible_message(span_info("[user] dispenses a crunchy [cone.name] from [src]."))
-		else
-			to_chat(user, span_warning("There are no [initial(cone_path.name)]s left!"))
-
-	if(href_list["make"])
-		var/datum/ice_cream_flavour/flavour = GLOB.ice_cream_flavours[href_list["make"]]
-		if(!flavour || flavour.hidden) //Nice try, tex.
-			return
-		var/amount = (text2num(href_list["amount"]))
-		make(user, href_list["make"], amount, flavour.ingredients)
-
-	if(href_list["make_cone"])
-		var/path = text2path(href_list["make_cone"])
-		var/obj/item/food/icecream/cone = cone_prototypes[path]
-		if(!cone) //Nice try, tex.
-			return
-		var/amount = (text2num(href_list["amount"]))
-		make(user, path, amount, cone.ingredients)
-
-	if(href_list["disposeI"])
-		reagents.del_reagent(text2path(href_list["disposeI"]))
-
-	if(href_list["refill"])
-		RefillFromBeaker()
-
-	updateDialog()
-
-	if(href_list["refresh"])
-		updateDialog()
-
-	if(href_list["close"])
-		user.unset_machine()
-		user << browse(null,"window=icecreamvat")
-	return
+/obj/machinery/icecream_vat/proc/make_ice_cream_color(datum/ice_cream_flavour/flavor)
+	if(!flavor.color)
+		return
+	var/image/ice_cream_icon = image('icons/obj/service/kitchen.dmi', "icecream_custom")
+	ice_cream_icon.color = flavor.color
+	return ice_cream_icon
 
 /obj/machinery/icecream_vat/deconstruct(disassembled = TRUE)
 	if(!(obj_flags & NO_DECONSTRUCTION))
 		new /obj/item/stack/sheet/iron(loc, 4)
 	qdel(src)
 
-/obj/machinery/icecream_vat/AltClick(mob/living/user)
-	. = ..()
-	if(!can_interact(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+///Makes an ice cream cone of the make_type, using ingredients list as reagents used to make it. Puts in user's hand if possible.
+/obj/machinery/icecream_vat/proc/make_cone(mob/user, make_type, list/ingredients)
+	for(var/reagents_needed in ingredients)
+		if(!reagents.has_reagent(reagents_needed, CONE_REAGENET_NEEDED))
+			balloon_alert(user, "not enough ingredients!")
+			return
+	var/cone_type = cone_prototypes[make_type].type
+	if(!cone_type)
 		return
-	replace_beaker(user)
+	var/obj/item/food/icecream/cone = new cone_type(src)
 
-/obj/machinery/icecream_vat/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	for(var/reagents_used in ingredients)
+		reagents.remove_reagent(reagents_used, CONE_REAGENET_NEEDED)
+	balloon_alert_to_viewers("cooks up [cone.name]", "cooks up [cone.name]")
+	try_put_in_hand(cone, user)
+
+///Swaps the mode to the next one meant to be selected, then tells the user who changed it.
+/obj/machinery/icecream_vat/proc/swap_modes(mob/user)
+	if(!user.can_perform_action(src))
 		return FALSE
-	if(beaker)
-		user.put_in_hands(beaker)
-		beaker = null
-	if(new_beaker)
-		beaker = new_beaker
+	switch(vat_mode)
+		if(VAT_MODE_ICECREAM)
+			vat_mode = VAT_MODE_CONES
+		if(VAT_MODE_CONES)
+			vat_mode = VAT_MODE_ICECREAM
+	balloon_alert(user, "dispensing [vat_mode]")
 	return TRUE
 
+///Allows any user to see what reagents are in the ice cream vat regardless of special gear.
+/obj/machinery/icecream_vat/proc/allow_reagent_scan(datum/source, mob/user, list/examine_list, can_see_insides = FALSE)
+	SIGNAL_HANDLER
+	return ALLOW_GENERIC_REAGENT_EXAMINE
+
+#undef VAT_MODE_ICECREAM
+#undef VAT_MODE_CONES
+#undef CONE_REAGENET_NEEDED
 #undef PREFILL_AMOUNT


### PR DESCRIPTION
## About The Pull Request

Removes the ice cream vat's html window for ice cream, reagents, and cones and replaces it with a radial menu and the ability to simply examine the machine to see its contents.
Soup and Salads currently allow you to see whats inside without the need for science/bar goggles, so following that theme I thought it would make more sense for it to also be the case here (and for feature parity with previous behavior).

#### Controls

Left-click chooses ice cream flavor or ice cream cone
Right-click swaps between which one you will be choosing from

Left click with a beaker will put it inside to use for custom ingredients
Right click with a beaker will transfer its reagents to the machine (any that is used for making ice cream)

Dispensing custom ice cream takes from the beaker inside of the beaker

Video demonstration
https://github.com/tgstation/tgstation/assets/53777086/9ebdcb13-b29f-4b3c-9d5f-54be1f6da888

Custom Ice cream
https://github.com/tgstation/tgstation/assets/53777086/687af270-14e4-4851-bf1f-3c4da4aeb21f

## Why It's Good For The Game

The ice cream machine is genuinely confusing because of it's UI and personally it was unironically the last kitchen tool I learned because I just didn't think it was worth it. This makes it feel way better to use.
It also helps me with https://hackmd.io/XLt5MoRvRxuhFbwtk4VAUA which I've been trying to chisel away at.

## Changelog

:cl:
refactor: Ice cream vats now use a radial menu instead of an HTML one.
/:cl:
