### PR TITLE
Fix bugs regarding immobile shells.

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -154,7 +154,7 @@
  */
 /datum/component/shell/proc/on_set_anchored(atom/movable/source, previous_value)
 	SIGNAL_HANDLER
-	attached_circuit?.on = source.anchored
+	attached_circuit?.set_on(source.anchored)
 
 /**
  * Called when an item hits the parent. This is the method to add the circuitboard to the component.
@@ -318,20 +318,21 @@
 		parent_atom.name = "[initial(parent_atom.name)] ([attached_circuit.display_name])"
 	attached_circuit.set_locked(FALSE)
 
-	if(shell_flags & SHELL_FLAG_REQUIRE_ANCHOR)
-		attached_circuit.on = parent_atom.anchored
-
 	if((shell_flags & SHELL_FLAG_CIRCUIT_UNREMOVABLE) || circuitboard.admin_only)
 		circuitboard.moveToNullspace()
 	else if(circuitboard.loc != parent_atom)
 		circuitboard.forceMove(parent_atom)
 	attached_circuit.set_shell(parent_atom)
+	
+	// call after set_shell() sets on to true
+	if(shell_flags & SHELL_FLAG_REQUIRE_ANCHOR)
+		attached_circuit.set_on(parent_atom.anchored)
 
 /**
  * Removes the circuit from the component. Doesn't do any checks to see for an existing circuit so that should be done beforehand.
  */
 /datum/component/shell/proc/remove_circuit()
-	attached_circuit.on = TRUE
+	// remove_current_shell() also turns off the circuit
 	attached_circuit.remove_current_shell()
 	UnregisterSignal(attached_circuit, list(
 		COMSIG_MOVABLE_MOVED,


### PR DESCRIPTION

## About The Pull Request

In `shell.dm`:
When immobile shells were unsecured it would just directly set `attached_circuit.on` to whatever the shell anchor state was, which bypassed sending the signal `set_on()` sends. By instead using `attached_circuit.set_on()` this state change should actually propagate to the inner modules, rather than say letting an inner module with a clock run regardless of the shell's anchor state.
Similarly, adding a circuit to an unsecured immobile shell would try to set `attached_circuit.on` to the shell anchor state, but in addition to not propagating to inner modules this simply did not work because the `attached_circuit.set_shell(parent_atom)` called later would set it to be on anyway. We resolve this by just, moving the state change until *after* set_shell.
Finally removes the `attached_circuit.on = TRUE` from the `remove_circuit()` proc, because `attached_circuit.remove_current_shell()` immediately sets this to false again anyway.

More related but separate bits probably tomorrow.
## Why It's Good For The Game

Makes immobile shells actually work only when anchored, and resolved some related jank.
## Changelog
:cl:
fix: Immobile shells no longer work regardless of anchor state if you put the circuit in while it's unanchored.
fix: Immobile shells properly propagate their on/off state after wrenching to inner modules.
/:cl:
