### PR TITLE
[NO GBP] Fixes lunatics not having an objective and occasionally not getting their amulettes

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -236,11 +236,15 @@
 			continue
 		var/datum/antagonist/lunatic/lunatic = crewmate.mind.add_antag_datum(/datum/antagonist/lunatic)
 		lunatic.set_master(user.mind, user)
-		if(crewmate.get_active_held_item())
-			new /obj/item/clothing/neck/heretic_focus/moon_amulette(crewmate_turf)
-		else
-			var/obj/item/clothing/neck/heretic_focus/moon_amulette/moon_amulette = new
-			crewmate.put_in_active_hand(moon_amulette)
+		var/obj/item/clothing/neck/heretic_focus/moon_amulette/amulet = new(crewmate_turf)
+		var/static/list/slots = list(
+			"neck" = ITEM_SLOT_NECK,
+			"hands" = ITEM_SLOT_HANDS,
+			"backpack" = ITEM_SLOT_BACKPACK,
+			"right pocket" = ITEM_SLOT_RPOCKET,
+			"left pocket" = ITEM_SLOT_RPOCKET,
+		)
+		crewmate.equip_in_one_of_slots(amulet, slots, qdel_on_fail = FALSE)
 		crewmate.emote("laugh")
 		amount_of_lunatics += 1
 

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -236,8 +236,11 @@
 			continue
 		var/datum/antagonist/lunatic/lunatic = crewmate.mind.add_antag_datum(/datum/antagonist/lunatic)
 		lunatic.set_master(user.mind, user)
-		var/obj/item/clothing/neck/heretic_focus/moon_amulette/moon_amulette = new
-		crewmate.put_in_active_hand(moon_amulette)
+		if(crewmate.get_active_held_item())
+			new /obj/item/clothing/neck/heretic_focus/moon_amulette(crewmate_turf)
+		else
+			var/obj/item/clothing/neck/heretic_focus/moon_amulette/moon_amulette = new
+			crewmate.put_in_active_hand(moon_amulette)
 		crewmate.emote("laugh")
 		amount_of_lunatics += 1
 

--- a/code/modules/antagonists/heretic/moon_lunatic.dm
+++ b/code/modules/antagonists/heretic/moon_lunatic.dm
@@ -18,8 +18,10 @@
 	src.ascended_heretic = heretic_master
 	src.ascended_body = heretic_body
 
-	var/datum/objective/lunatic_obj = new()
-	lunatic_obj.explanation_text = "Assist your master [heretic_master]."
+	var/datum/objective/lunatic/lunatic_obj = new()
+	lunatic_obj.master = heretic_master
+	lunatic_obj.update_explanation_text()
+	objectives += lunatic_obj
 
 	to_chat(owner, span_boldnotice("Ruin the lie, save the truth through obeying [heretic_master] the ringleader!"))
 
@@ -47,3 +49,10 @@
 	description = "THE TRUTH REVEALED, THE LIE SLAIN."
 	mood_change = 10
 
+/datum/objective/lunatic
+	explanation_text = "Assist your ringleader. If you are seeing this, scroll up in chat for who that is and report this"
+	var/datum/mind/master
+
+/datum/objective/lunatic/update_explanation_text()
+	. = ..()
+	explanation_text = "Assist your ringleader [master]"


### PR DESCRIPTION
## About The Pull Request
Lunatics now have an objective and it properly displays. 
Lunatics now get a moonlight amulette on the ground if their hand are full.
## Why It's Good For The Game
Lunatics had no idea who their master was except for their flavor text. This made it kinda confusing. This was worsened when they didnt have the identifying amulette.
## Changelog
:cl:
fix: Lunatics spawned from moon ascension now actually have an objective to assist their ringleader
fix: Lunatics now get a moonlight amulette on the ground if they have full hands
/:cl:
