### PR TITLE
Newspapers now use TGUI

### DIFF
--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -176,14 +176,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	data["crime_description"] = crime_description
 	var/list/wanted_info = list()
 	if(GLOB.news_network.wanted_issue)
-		if(GLOB.news_network.wanted_issue.img)
+		var/has_wanted_issue = !isnull(GLOB.news_network.wanted_issue.img)
+		if(has_wanted_issue)
 			user << browse_rsc(GLOB.news_network.wanted_issue.img, "wanted_photo.png")
 		wanted_info = list(list(
 			"active" = GLOB.news_network.wanted_issue.active,
 			"criminal" = GLOB.news_network.wanted_issue.criminal,
 			"crime" = GLOB.news_network.wanted_issue.body,
 			"author" = GLOB.news_network.wanted_issue.scanned_user,
-			"image" = "wanted_photo.png"
+			"image" = (has_wanted_issue ? "wanted_photo.png" : null)
 		))
 
 	//Code breaking down the channels that have been made on-station thus far. ha
@@ -431,7 +432,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 				return TRUE
 
 		if("printNewspaper")
-			print_paper()
+			print_paper(usr)
 			return TRUE
 
 		if("createBounty")
@@ -600,22 +601,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  * This takes all current feed stories and messages, and prints them onto a newspaper, after checking that the newscaster has been loaded with paper.
  * The newscaster then prints the paper to the floor.
  */
-/obj/machinery/newscaster/proc/print_paper()
+/obj/machinery/newscaster/proc/print_paper(mob/user)
 	if(paper_remaining <= 0)
 		balloon_alert_to_viewers("out of paper!")
 		return TRUE
 	SSblackbox.record_feedback("amount", "newspapers_printed", 1)
-	var/obj/item/newspaper/new_newspaper = new /obj/item/newspaper
-	for(var/datum/feed_channel/iterated_feed_channel in GLOB.news_network.network_channels)
-		new_newspaper.news_content += iterated_feed_channel
-	if(GLOB.news_network.wanted_issue.active)
-		new_newspaper.wantedAuthor = GLOB.news_network.wanted_issue.scanned_user
-		new_newspaper.wantedCriminal = GLOB.news_network.wanted_issue.criminal
-		new_newspaper.wantedBody = GLOB.news_network.wanted_issue.body
-		if(GLOB.news_network.wanted_issue.img)
-			new_newspaper.wantedPhoto = GLOB.news_network.wanted_issue.img
-	new_newspaper.forceMove(drop_location())
-	new_newspaper.creation_time = GLOB.news_network.last_action
+	var/obj/item/newspaper/new_newspaper = new(loc)
+	playsound(loc, SFX_PAGE_TURN, 50, TRUE)
+	try_put_in_hand(new_newspaper, user)
 	paper_remaining--
 
 /**
@@ -677,6 +670,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	new_feed_comment.author = newscaster_username
 	new_feed_comment.body = comment_text
 	new_feed_comment.time_stamp = station_time_timestamp()
+	GLOB.news_network.last_action ++
 	current_message.comments += new_feed_comment
 	usr.log_message("(as [newscaster_username]) commented on message [current_message.return_body(-1)] -- [current_message.body]", LOG_COMMENT)
 	creating_comment = FALSE

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -27,8 +27,11 @@
 	///The page with something scribbled on it, can only have one at a time.
 	var/scribble_page
 
-	///List of information related to a wanted issue, if one existed at the time of creation.
-	var/list/wanted_information
+	///Stored information of the wanted criminal's name, if one existed at the time of creation.
+	var/saved_wanted_criminal
+	///Stored information of the wanted criminal's description, if one existed at the time of creation.
+	var/saved_wanted_body
+	///Stored icon of the wanted criminal, if one existed at the time of creation.
 	var/icon/saved_wanted_icon
 
 /obj/item/newspaper/Initialize(mapload)
@@ -39,12 +42,10 @@
 
 	if(!GLOB.news_network.wanted_issue.active)
 		return
+	saved_wanted_criminal = GLOB.news_network.wanted_issue.criminal
+	saved_wanted_body = GLOB.news_network.wanted_issue.body
 	if(GLOB.news_network.wanted_issue.img)
 		saved_wanted_icon = GLOB.news_network.wanted_issue.img
-	wanted_information = list(list(
-		"wanted_criminal" = GLOB.news_network.wanted_issue.criminal,
-		"wanted_body" = GLOB.news_network.wanted_issue.body,
-	))
 
 /obj/item/newspaper/suicide_act(mob/living/user)
 	user.visible_message(span_suicide(\
@@ -139,7 +140,11 @@
 	data["scribble_message"] = (scribble_page == current_page) ? scribble_text : null
 	if(saved_wanted_icon)
 		user << browse_rsc(saved_wanted_icon, "wanted_photo.png")
-		data["wanted_information"] += list(list("wanted_photo" = "wanted_photo.png"))
+	data["wanted_criminal"] = list(list(
+		"wanted_criminal" = saved_wanted_criminal,
+		"wanted_body" = saved_wanted_body,
+		"wanted_photo" = (saved_wanted_icon ? "wanted_photo.png" : null),
+	))
 	var/list/channel_data = list()
 	if(!current_page || (current_page == news_content.len + 1))
 		channel_data["channel_name"] = null

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -36,6 +36,7 @@
 
 /obj/item/newspaper/Initialize(mapload)
 	. = ..()
+	register_context()
 	creation_time = GLOB.news_network.last_action
 	for(var/datum/feed_channel/iterated_feed_channel in GLOB.news_network.network_channels)
 		news_content += iterated_feed_channel
@@ -46,6 +47,15 @@
 	saved_wanted_body = GLOB.news_network.wanted_issue.body
 	if(GLOB.news_network.wanted_issue.img)
 		saved_wanted_icon = GLOB.news_network.wanted_issue.img
+
+/obj/item/newspaper/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(held_item)
+		if(istype(held_item, /obj/item/pen))
+			context[SCREENTIP_CONTEXT_LMB] = "Scribble"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(held_item.get_temperature())
+			context[SCREENTIP_CONTEXT_LMB] = "Burn"
+			return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/newspaper/suicide_act(mob/living/user)
 	user.visible_message(span_suicide(\

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -64,7 +64,7 @@
 	))
 	user.say(";JOURNALISM IS MY CALLING! EVERYBODY APPRECIATES UNBIASED REPORTI-GLORF", forced = "newspaper suicide")
 	var/obj/item/reagent_containers/cup/glass/bottle/whiskey/last_drink = new(user.loc)
-	playsound(user.loc, 'sound/items/drink.ogg', vol = rand(10, 50), vary = TRUE)
+	playsound(user, 'sound/items/drink.ogg', vol = rand(10, 50), vary = TRUE)
 	last_drink.reagents.trans_to(user, last_drink.reagents.total_volume, transferred_by = user)
 	user.visible_message(span_suicide("[user] downs the contents of [last_drink.name] in one gulp! Shoulda stuck to sudoku!"))
 	return TOXLOSS
@@ -130,7 +130,7 @@
 		else
 			return TRUE
 	SStgui.update_uis(src)
-	playsound(loc, SFX_PAGE_TURN, 50, TRUE)
+	playsound(src, SFX_PAGE_TURN, 50, TRUE)
 	return TRUE
 
 /obj/item/newspaper/ui_static_data(mob/user)
@@ -149,11 +149,10 @@
 	data["scribble_message"] = (scribble_page == current_page) ? scribble_text : null
 	if(saved_wanted_icon)
 		user << browse_rsc(saved_wanted_icon, "wanted_photo.png")
-	data["wanted_information"] = list(list(
-		"wanted_criminal" = saved_wanted_criminal,
-		"wanted_body" = saved_wanted_body,
-		"wanted_photo" = (saved_wanted_icon ? "wanted_photo.png" : null),
-	))
+	data["wanted_criminal"] = saved_wanted_criminal
+	data["wanted_body"] = saved_wanted_body
+	data["wanted_photo"] = (saved_wanted_icon ? "wanted_photo.png" : null)
+
 	var/list/channel_data = list()
 	if(!current_page || (current_page == news_content.len + 1))
 		channel_data["channel_name"] = null
@@ -163,7 +162,7 @@
 		data["channel_data"] = list(channel_data)
 		return data
 	var/datum/feed_channel/current_channel = news_content[current_page]
-	if(current_channel && istype(current_channel))
+	if(istype(current_channel))
 		channel_data["channel_name"] = current_channel.channel_name
 		channel_data["author_name"] = current_channel.return_author(censored_check(current_channel.author_censor_time))
 		channel_data["is_censored"] = censored_check(current_channel.D_class_censor_time)

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -1,3 +1,12 @@
+#define NEWSPAPER_SCREEN_COVER 0
+#define NEWSPAPER_SCREEN_CHANNEL 1
+#define NEWSPAPER_SCREEN_END 2
+
+/**
+ * Newspapers
+ * A static version of the newscaster, that won't update as new stories are added.
+ * Can be scribbed upon to add extra text for future readers.
+ */
 /obj/item/newspaper
 	name = "newspaper"
 	desc = "An issue of The Griffon, the newspaper circulating aboard Nanotrasen Space Stations."
@@ -10,60 +19,97 @@
 	attack_verb_continuous = list("baps")
 	attack_verb_simple = list("bap")
 	resistance_flags = FLAMMABLE
-	var/screen = 0
-	var/pages = 0
-	var/curr_page = 0
+
+	///List of news feeed channels the newspaper can see.
 	var/list/datum/feed_channel/news_content = list()
-	var/scribble=""
-	var/scribble_page = null
-	var/wantedAuthor
-	var/wantedCriminal
-	var/wantedBody
-	var/wantedPhoto
+	///The time the newspaper was made in terms of newscaster's last action, used to tell the newspaper whether a story should be in it.
 	var/creation_time
+	///The screen in the newspaper currently being viewed.
+	var/current_screen = NEWSPAPER_SCREEN_COVER
+	///The page in the newspaper currently being read, used when the screen is on NEWSPAPER_SCREEN_CHANNEL.
+	var/current_page = 0
+	///The currently scribbled text written in scribble_page
+	var/scribble = ""
+	///The page with something scribbled on it, can only have one at a time.
+	var/scribble_page = null
+
+	///List of information related to a wanted issue, if one existed at the time of creation.
+	var/list/wanted_information
+
+/obj/item/newspaper/Initialize(mapload)
+	. = ..()
+	creation_time = GLOB.news_network.last_action
+	for(var/datum/feed_channel/iterated_feed_channel in GLOB.news_network.network_channels)
+		news_content += iterated_feed_channel
+
+	if(!GLOB.news_network.wanted_issue.active)
+		return
+	wanted_information = list(
+		"wanted_criminal" = GLOB.news_network.wanted_issue.criminal,
+		"wanted_body" = GLOB.news_network.wanted_issue.body,
+		"wanted_photo" = GLOB.news_network.wanted_issue.img || null,
+	)
+
+/obj/item/newspaper/attackby(obj/item/attacking_item, mob/user, params)
+	if(burn_paper_product_attackby_check(attacking_item, user))
+		return
+
+	if(!istype(attacking_item, /obj/item/pen))
+		return ..()
+	if(!user.can_write(attacking_item))
+		return
+	if(scribble_page == current_page)
+		user.balloon_alert(user, "already scribbled!")
+		return
+	var/new_scribble_text = tgui_input_text(user, "What do you want to scribble?", "Write something")
+	if(isnull(new_scribble_text))
+		return
+	add_fingerprint(user)
+	if(!do_after(user, 2 SECONDS, src))
+		return
+	user.balloon_alert(user, "scribbled!")
+	scribble_page = current_page
+	scribble = new_scribble_text
 
 /obj/item/newspaper/suicide_act(mob/living/user)
-	user.visible_message(span_suicide("[user] is focusing intently on [src]! It looks like [user.p_theyre()] trying to commit sudoku... until [user.p_their()] eyes light up with realization!"))
-	user.say(";JOURNALISM IS MY CALLING! EVERYBODY APPRECIATES UNBIASED REPORTI-GLORF", forced="newspaper suicide")
-	var/mob/living/carbon/human/H = user
-	var/obj/W = new /obj/item/reagent_containers/cup/glass/bottle/whiskey(H.loc)
-	playsound(H.loc, 'sound/items/drink.ogg', rand(10,50), TRUE)
-	W.reagents.trans_to(H, W.reagents.total_volume, transferred_by = user)
-	user.visible_message(span_suicide("[user] downs the contents of [W.name] in one gulp! Shoulda stuck to sudoku!"))
+	user.visible_message(span_suicide(
+		"[user] is focusing intently on [src]! It looks like [user.p_theyre()] trying to commit sudoku... \
+		until [user.p_their()] eyes light up with realization!",
+	))
+	user.say(";JOURNALISM IS MY CALLING! EVERYBODY APPRECIATES UNBIASED REPORTI-GLORF", forced = "newspaper suicide")
+	var/obj/item/reagent_containers/cup/glass/bottle/whiskey/last_drink = new(user.loc)
+	playsound(user.loc, 'sound/items/drink.ogg', vol = rand(10, 50), vary = TRUE)
+	last_drink.reagents.trans_to(user, last_drink.reagents.total_volume, transferred_by = user)
+	user.visible_message(span_suicide("[user] downs the contents of [last_drink.name] in one gulp! Shoulda stuck to sudoku!"))
 	return TOXLOSS
 
 /obj/item/newspaper/attack_self(mob/user)
 	if(!istype(user) || !user.can_read(src))
 		return
 	var/dat
-	pages = 0
-	switch(screen)
-		if(0) //Cover
+	switch(current_screen)
+		if(NEWSPAPER_SCREEN_COVER)
 			dat+="<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>"
 			dat+="<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen? Space Facilities</FONT></div><HR>"
 			if(!length(news_content))
-				if(wantedAuthor)
-					dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [pages+2]\]</FONT><BR></ul>"
+				if(!isnull(wanted_information))
+					dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [news_content.len + 2]\]</FONT><BR></ul>"
 				else
 					dat+="<I>Other than the title, the rest of the newspaper is unprinted...</I>"
 			else
 				dat+="Contents:<BR><ul>"
-				for(var/datum/feed_channel/NP in news_content)
-					pages++
-				if(wantedAuthor)
-					dat+="<B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [pages+2]\]</FONT><BR>"
+				if(!isnull(wanted_information))
+					dat+="<B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [news_content.len + 2]\]</FONT><BR>"
 				var/temp_page=0
 				for(var/datum/feed_channel/NP in news_content)
 					temp_page++
 					dat+="<B>[NP.channel_name]</B> <FONT SIZE=2>\[page [temp_page+1]\]</FONT><BR>"
 				dat+="</ul>"
-			if(scribble_page == curr_page)
+			if(scribble_page == current_page)
 				dat+="<BR><I>There is a small scribble near the end of this page... It reads: \"[scribble]\"</I>"
 			dat+= "<HR><DIV STYLE='float:right;'><A href='?src=[REF(src)];next_page=1'>Next Page</A></DIV> <div style='float:left;'><A href='?src=[REF(user)];mach_close=newspaper_main'>Done reading</A></DIV>"
-		if(1) // X channel pages inbetween.
-			for(var/datum/feed_channel/NP in news_content)
-				pages++
-			var/datum/feed_channel/C = news_content[curr_page]
+		if(NEWSPAPER_SCREEN_CHANNEL)
+			var/datum/feed_channel/C = news_content[current_page]
 			dat += "<FONT SIZE=4><B>[C.channel_name]</B></FONT><FONT SIZE=1> \[created by: <FONT COLOR='maroon'>[C.return_author(notContent(C.author_censor_time))]</FONT>\]</FONT><BR><BR>"
 			if(notContent(C.D_class_censor_time))
 				dat+="This channel was deemed dangerous to the general welfare of the station and therefore marked with a <B><FONT COLOR='red'>D-Notice</B></FONT>. Its contents were not transferred to the newspaper at the time of printing."
@@ -86,35 +132,33 @@
 							dat+="<img src='tmp_photo[i].png' width = '180'><BR>"
 						dat+="<FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.return_author(notContent(MESSAGE.author_censor_time))]</FONT>\]</FONT><BR><BR>"
 					dat+="</ul>"
-			if(scribble_page == curr_page)
+			if(scribble_page == current_page)
 				dat+="<BR><I>There is a small scribble near the end of this page... It reads: \"[scribble]\"</I>"
 			dat+= "<BR><HR><DIV STYLE='float:left;'><A href='?src=[REF(src)];prev_page=1'>Previous Page</A></DIV> <DIV STYLE='float:right;'><A href='?src=[REF(src)];next_page=1'>Next Page</A></DIV>"
-		if(2) //Last page
-			for(var/datum/feed_channel/NP in news_content)
-				pages++
-			if(wantedAuthor != null)
+		if(NEWSPAPER_SCREEN_END)
+			if(!isnull(wanted_information))
 				dat+="<DIV STYLE='float:center;'><FONT SIZE=4><B>Wanted Issue:</B></FONT SIZE></DIV><BR><BR>"
-				dat+="<B>Criminal name</B>: <FONT COLOR='maroon'>[wantedCriminal]</FONT><BR>"
-				dat+="<B>Description</B>: [wantedBody]<BR>"
-				dat+="<B>Photo:</B>: "
-				if(wantedPhoto)
-					user << browse_rsc(wantedPhoto, "tmp_photow.png")
+				dat+="<B>Criminal name</B>: <FONT COLOR='maroon'>[wanted_information["wanted_criminal"]]</FONT><BR>"
+				dat+="<B>Description</B>: [wanted_information["wanted_body"]]<BR>"
+				dat+="<B>Photo:</B> "
+				if(wanted_information["wanted_photo"])
+					user << browse_rsc(wanted_information["wanted_photo"], "tmp_photow.png")
 					dat+="<BR><img src='tmp_photow.png' width = '180'>"
 				else
 					dat+="None"
 			else
 				dat+="<I>Apart from some uninteresting classified ads, there's nothing on this page...</I>"
-			if(scribble_page == curr_page)
+			if(scribble_page == current_page)
 				dat+="<BR><I>There is a small scribble near the end of this page... It reads: \"[scribble]\"</I>"
 			dat+= "<HR><DIV STYLE='float:left;'><A href='?src=[REF(src)];prev_page=1'>Previous Page</A></DIV>"
-	dat+="<BR><HR><div align='center'>[curr_page+1]</div>"
+	dat+="<BR><HR><div align='center'>[current_page+1]</div>"
 	user << browse(dat, "window=newspaper_main;size=300x400")
 	onclose(user, "newspaper_main")
 
 /obj/item/newspaper/proc/notContent(list/L)
 	if(!L.len)
 		return FALSE
-	for(var/i=L.len;i>0;i--)
+	for(var/i = L.len; i > 0; i--)
 		var/num = abs(L[i])
 		if(creation_time <= num)
 			continue
@@ -127,50 +171,32 @@
 
 /obj/item/newspaper/Topic(href, href_list)
 	var/mob/living/U = usr
-	..()
+	. = ..()
 	if((src in U.contents) || (isturf(loc) && in_range(src, U)))
 		U.set_machine(src)
 		if(href_list["next_page"])
-			if(curr_page == pages+1)
+			if(current_page == news_content.len + 1)
 				return //Don't need that at all, but anyway.
-			if(curr_page == pages) //We're at the middle, get to the end
-				screen = 2
+			if(current_page == news_content.len) //We're at the middle, get to the end
+				current_screen = NEWSPAPER_SCREEN_END
 			else
-				if(curr_page == 0) //We're at the start, get to the middle
-					screen=1
-			curr_page++
+				if(current_page == 0) //We're at the start, get to the middle
+					current_screen = NEWSPAPER_SCREEN_CHANNEL
+			current_page++
 			playsound(loc, SFX_PAGE_TURN, 50, TRUE)
 		else if(href_list["prev_page"])
-			if(curr_page == 0)
+			if(current_page == 0)
 				return
-			if(curr_page == 1)
-				screen = 0
+			if(current_page == 1)
+				current_screen = NEWSPAPER_SCREEN_COVER
 			else
-				if(curr_page == pages+1) //we're at the end, let's go back to the middle.
-					screen = 1
-			curr_page--
+				if(current_page == news_content.len + 1) //we're at the end, let's go back to the middle.
+					current_screen = NEWSPAPER_SCREEN_CHANNEL
+			current_page--
 			playsound(loc, SFX_PAGE_TURN, 50, TRUE)
 		if(ismob(loc))
 			attack_self(loc)
 
-/obj/item/newspaper/attackby(obj/item/W, mob/living/user, params)
-	if(burn_paper_product_attackby_check(W, user))
-		return
-
-	if(istype(W, /obj/item/pen))
-		if(!user.can_write(W))
-			return
-		if(scribble_page == curr_page)
-			to_chat(user, span_warning("There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?"))
-		else
-			var/s = tgui_input_text(user, "Write something", "Newspaper")
-			if (!s)
-				return
-			if(!user.can_perform_action(src))
-				return
-			scribble_page = curr_page
-			scribble = s
-			attack_self(user)
-			add_fingerprint(user)
-	else
-		return ..()
+#undef NEWSPAPER_SCREEN_END
+#undef NEWSPAPER_SCREEN_CHANNEL
+#undef NEWSPAPER_SCREEN_COVER

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -125,7 +125,6 @@
 
 /obj/item/newspaper/ui_static_data(mob/user)
 	var/list/data = list()
-	data["wanted_information"] = wanted_information || null
 	data["channels"] = list()
 	for(var/datum/feed_channel/news_channels as anything in news_content)
 		data["channels"] += list(list(
@@ -140,7 +139,7 @@
 	data["scribble_message"] = (scribble_page == current_page) ? scribble_text : null
 	if(saved_wanted_icon)
 		user << browse_rsc(saved_wanted_icon, "wanted_photo.png")
-	data["wanted_criminal"] = list(list(
+	data["wanted_information"] = list(list(
 		"wanted_criminal" = saved_wanted_criminal,
 		"wanted_body" = saved_wanted_body,
 		"wanted_photo" = (saved_wanted_icon ? "wanted_photo.png" : null),

--- a/code/modules/admin/verbs/admin_newscaster.dm
+++ b/code/modules/admin/verbs/admin_newscaster.dm
@@ -78,14 +78,15 @@
 	data["crime_description"] = crime_description
 	var/list/wanted_info = list()
 	if(GLOB.news_network.wanted_issue)
-		if(GLOB.news_network.wanted_issue.img)
+		var/has_wanted_issue = !isnull(GLOB.news_network.wanted_issue.img)
+		if(has_wanted_issue)
 			user << browse_rsc(GLOB.news_network.wanted_issue.img, "wanted_photo.png")
 		wanted_info = list(list(
 			"active" = GLOB.news_network.wanted_issue.active,
 			"criminal" = GLOB.news_network.wanted_issue.criminal,
 			"crime" = GLOB.news_network.wanted_issue.body,
 			"author" = GLOB.news_network.wanted_issue.scanned_user,
-			"image" = "wanted_photo.png"
+			"image" = (has_wanted_issue ? "wanted_photo.png" : null)
 		))
 
 	//Code breaking down the channels that have been made on-station thus far. ha
@@ -320,6 +321,7 @@
 	new_feed_comment.body = comment_text
 	new_feed_comment.time_stamp = station_time_timestamp()
 	current_message.comments += new_feed_comment
+	GLOB.news_network.last_action ++
 	usr.log_message("(as an admin) commented on message [current_message.return_body(-1)] -- [current_message.body]", LOG_COMMENT)
 	creating_comment = FALSE
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -496,10 +496,6 @@
 	if(incapacitated())
 		return
 
-	if (href_list["mach_close"])
-		var/t1 = "window=[href_list["mach_close"]]"
-		unset_machine()
-		src << browse(null, t1)
 	if (href_list["switchcamera"])
 		switchCamera(locate(href_list["switchcamera"]) in GLOB.cameranet.cameras)
 	if (href_list["showalerts"])

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -861,18 +861,6 @@
 	set hidden = TRUE
 	set category = null
 	return
-/**
- * Topic call back for any mob
- *
- * * Unset machines if "mach_close" sent
- * * refresh the inventory of machines in range if "refresh" sent
- * * handles the strip panel equip and unequip as well if "item" sent
- */
-/mob/Topic(href, href_list)
-	if(href_list["mach_close"])
-		var/t1 = "window=[href_list["mach_close"]]"
-		unset_machine()
-		src << browse(null, t1)
 
 /**
  * Controls if a mouse drop succeeds (return null if it doesnt)

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -90,13 +90,12 @@ const NewscasterChannelCreation = (props) => {
               Enter channel name here:
               <Button
                 color="red"
+                icon="times"
                 position="relative"
                 top="20%"
                 left="15%"
                 onClick={() => act('cancelCreation')}
-              >
-                X
-              </Button>
+              />
             </Box>
             <TextArea
               fluid
@@ -186,12 +185,11 @@ const NewscasterCommentCreation = (props) => {
             <Button
               color="red"
               position="relative"
+              icon="times"
               top="20%"
               left="25%"
               onClick={() => act('cancelCreation')}
-            >
-              X
-            </Button>
+            />
           </Box>
           <TextArea
             fluid
@@ -253,12 +251,11 @@ const NewscasterWantedScreen = (props) => {
                 <Button
                   color="red"
                   position="relative"
+                  icon="times"
                   top="20%"
                   left="15%"
                   onClick={() => act('cancelCreation')}
-                >
-                  X
-                </Button>
+                />
               </Box>
               {!!activeWanted.criminal && (
                 <>

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -6,7 +6,6 @@
  */
 
 import { decodeHtmlEntities } from 'common/string';
-import { marked } from 'marked';
 import { useState } from 'react';
 
 import { useBackend, useSharedState } from '../backend';
@@ -23,7 +22,7 @@ import {
   Tabs,
   TextArea,
 } from '../components';
-import { sanitizeText } from '../sanitize';
+import { processedText } from '../process';
 import { BountyBoardContent } from './BountyBoard';
 import { UserDetails } from './Vending';
 
@@ -512,20 +511,6 @@ const NewscasterChannelSelector = (props) => {
       </Tabs>
     </Section>
   );
-};
-
-export const processedText = (value) => {
-  const textHtml = {
-    __html: sanitizeText(
-      marked(value, {
-        breaks: true,
-        smartypants: true,
-        smartLists: true,
-        baseUrl: 'thisshouldbreakhttp',
-      }),
-    ),
-  };
-  return textHtml;
 };
 
 /** This is where the channels comments get spangled out (tm) */

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -514,7 +514,7 @@ const NewscasterChannelSelector = (props) => {
   );
 };
 
-const processedText = (value) => {
+export const processedText = (value) => {
   const textHtml = {
     __html: sanitizeText(
       marked(value, {

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -90,13 +90,14 @@ const NewscasterChannelCreation = (props) => {
             <Box pb={1}>
               Enter channel name here:
               <Button
-                content="X"
                 color="red"
                 position="relative"
                 top="20%"
                 left="15%"
                 onClick={() => act('cancelCreation')}
-              />
+              >
+                X
+              </Button>
             </Box>
             <TextArea
               fluid
@@ -138,27 +139,30 @@ const NewscasterChannelCreation = (props) => {
               <Box pt={1}>
                 <Button
                   selected={!lockedmode}
-                  content="Public"
                   onClick={() => setLockedmode(false)}
-                />
+                >
+                  Public
+                </Button>
                 <Button
                   selected={!!lockedmode}
-                  content="Private"
                   onClick={() => setLockedmode(true)}
-                />
+                >
+                  Private
+                </Button>
               </Box>
             </Section>
           </Stack.Item>
           <Stack.Item>
             <Box>
               <Button
-                content="Submit Channel"
                 onClick={() =>
                   act('createChannel', {
                     lockedmode: lockedmode,
                   })
                 }
-              />
+              >
+                Submit Channel
+              </Button>
             </Box>
           </Stack.Item>
         </>
@@ -181,13 +185,14 @@ const NewscasterCommentCreation = (props) => {
           <Box pb={1}>
             Enter comment:
             <Button
-              content="X"
               color="red"
               position="relative"
               top="20%"
               left="25%"
               onClick={() => act('cancelCreation')}
-            />
+            >
+              X
+            </Button>
           </Box>
           <TextArea
             fluid
@@ -208,13 +213,14 @@ const NewscasterCommentCreation = (props) => {
         <Stack.Item>
           <Box>
             <Button
-              content={'Submit Comment'}
               onClick={() =>
                 act('createComment', {
                   messageID: viewing_message,
                 })
               }
-            />
+            >
+              Submit Comment
+            </Button>
           </Box>
         </Stack.Item>
       </Stack>
@@ -236,7 +242,7 @@ const NewscasterWantedScreen = (props) => {
     return null;
   }
   return (
-    <Modal textAlign="center" mr={1.5} width={25}>
+    <Modal textAlign="center" mr={1} width={25}>
       {wanted.map((activeWanted) => (
         <>
           <Stack vertical>
@@ -246,22 +252,28 @@ const NewscasterWantedScreen = (props) => {
                   ? 'Active Wanted Issue:'
                   : 'Dismissed Wanted Issue:'}
                 <Button
-                  content="X"
                   color="red"
                   position="relative"
                   top="20%"
-                  left="18%"
+                  left="15%"
                   onClick={() => act('cancelCreation')}
-                />
+                >
+                  X
+                </Button>
               </Box>
-              <Section>
-                <Box bold>{activeWanted.criminal}</Box>
-                <Box italic>{activeWanted.crime}</Box>
-              </Section>
-              <Image src={activeWanted.image ? activeWanted.image : null} />
-              <Box italic>
-                Posted by {activeWanted.author ? activeWanted.author : 'N/A'}
-              </Box>
+              {!!activeWanted.criminal && (
+                <>
+                  <Section>
+                    <Box bold>{activeWanted.criminal}</Box>
+                    <Box italic>{activeWanted.crime}</Box>
+                  </Section>
+                  <Image src={activeWanted.image ? activeWanted.image : null} />
+                  <Box italic>
+                    Posted by{' '}
+                    {activeWanted.author ? activeWanted.author : 'N/A'}
+                  </Box>
+                </>
+              )}
             </Stack.Item>
           </Stack>
           <Divider />
@@ -272,20 +284,22 @@ const NewscasterWantedScreen = (props) => {
           <LabeledList>
             <LabeledList.Item label="Criminal Name">
               <Button
-                content={criminal_name ? criminal_name : ' N/A'}
                 disabled={!security_mode}
                 icon="pen"
                 onClick={() => act('setCriminalName')}
-              />
+              >
+                {criminal_name ? criminal_name : ' N/A'}
+              </Button>
             </LabeledList.Item>
             <LabeledList.Item label="Criminal Activity">
               <Button
-                content={crime_description ? crime_description : ' N/A'}
                 nowrap={false}
                 disabled={!security_mode}
                 icon="pen"
                 onClick={() => act('setCrimeData')}
-              />
+              >
+                {crime_description ? crime_description : ' N/A'}
+              </Button>
             </LabeledList.Item>
           </LabeledList>
           <Section>
@@ -293,22 +307,25 @@ const NewscasterWantedScreen = (props) => {
               icon="camera"
               selected={photo_data}
               disabled={!security_mode}
-              content={photo_data ? 'Remove photo' : 'Attach photo'}
               onClick={() => act('togglePhoto')}
-            />
+            >
+              {photo_data ? 'Remove photo' : 'Attach photo'}
+            </Button>
             <Button
-              content={'Set Wanted Issue'}
               disabled={!security_mode}
               icon="volume-up"
               onClick={() => act('submitWantedIssue')}
-            />
+            >
+              Set Wanted Issue
+            </Button>
             <Button
-              content={'Clear Wanted'}
               disabled={!security_mode}
               icon="times"
               color="red"
               onClick={() => act('clearWantedIssue')}
-            />
+            >
+              Clear Wanted
+            </Button>
           </Section>
         </>
       ) : (
@@ -392,28 +409,29 @@ const NewscasterChannelBox = (props) => {
           <Box>
             <Button
               icon="print"
-              content="Submit Story"
               disabled={
                 (channelLocked && channelAuthor !== user.name) ||
                 channelCensored
               }
               onClick={() => act('createStory', { current: viewing_channel })}
               mt={1}
-            />
+            >
+              Submit Story
+            </Button>
             <Button
               icon="camera"
               selected={photo_data}
-              content="Select Photo"
               disabled={
                 (channelLocked && channelAuthor !== user.name) ||
                 channelCensored
               }
               onClick={() => act('togglePhoto')}
-            />
+            >
+              Select Photo
+            </Button>
             {!!admin_mode && (
               <Button
                 icon="ban"
-                content={'D-Notice'}
                 tooltip="Censor the whole channel and it's \
                   contents as dangerous to the station. Cannot be undone."
                 disabled={!admin_mode || !viewing_channel}
@@ -423,16 +441,19 @@ const NewscasterChannelBox = (props) => {
                     channel: viewing_channel,
                   })
                 }
-              />
+              >
+                D-Notice
+              </Button>
             )}
           </Box>
           <Box>
             <Button
               icon="newspaper"
-              content="Print Newspaper"
               disabled={paper <= 0}
               onClick={() => act('printNewspaper')}
-            />
+            >
+              Print Newspaper
+            </Button>
           </Box>
         </Stack.Item>
       </Stack>

--- a/tgui/packages/tgui/interfaces/Newspaper.tsx
+++ b/tgui/packages/tgui/interfaces/Newspaper.tsx
@@ -6,35 +6,31 @@ import { processedText } from '../process';
 
 type Data = {
   current_page: number;
-  scribble_message: string;
+  scribble_message: string | null;
   channel_has_messages: BooleanLike;
   channels: ChannelNames[];
   channel_data: ChannelData[];
-  wanted_information: WantedInformation[];
+  wanted_criminal: string | null;
+  wanted_body: string | null;
+  wanted_photo: string | null;
 };
 
 type ChannelNames = {
-  name: string;
+  name: string | null;
   page_number: number;
 };
 
-type WantedInformation = {
-  wanted_criminal: string;
-  wanted_body: string;
-  wanted_photo: string;
-};
-
 type ChannelData = {
-  channel_name: string;
-  author_name: string;
+  channel_name: string | null;
+  author_name: string | null;
   is_censored: BooleanLike;
   channel_messages: ChannelMessages[];
 };
 
 type ChannelMessages = {
-  message: string;
-  photo: string;
-  author: string;
+  message: string | null;
+  photo: string | null;
+  author: string | null;
 };
 
 export const Newspaper = (props) => {
@@ -86,7 +82,7 @@ export const Newspaper = (props) => {
 
 const NewspaperIntro = (props) => {
   const { act, data } = useBackend<Data>();
-  const { channels = [], wanted_information = [] } = data;
+  const { channels = [], wanted_criminal = [] } = data;
 
   return (
     <Section>
@@ -102,7 +98,7 @@ const NewspaperIntro = (props) => {
           Page {channel.page_number || 0}: {channel.name}
         </Box>
       ))}
-      {!!wanted_information && (
+      {!!wanted_criminal && (
         <Box bold>Last Page: Important Security Announcement</Box>
       )}
     </Section>
@@ -149,22 +145,18 @@ const NewspaperChannel = (props) => {
 
 const NewspaperEnding = (props) => {
   const { act, data } = useBackend<Data>();
-  const { wanted_information = [] } = data;
+  const { wanted_criminal, wanted_body, wanted_photo } = data;
 
   return (
     <Section>
-      {wanted_information ? (
+      {wanted_criminal ? (
         <>
           <Box bold fontSize="15px">
             Wanted Issue
           </Box>
-          {wanted_information.map((wanted) => (
-            <Box key={wanted.wanted_criminal}>
-              <Box fontSize="12px">Criminal Name: {wanted.wanted_criminal}</Box>
-              <Box>Description: {wanted.wanted_body}</Box>
-              {!!wanted.wanted_photo && <Image src={wanted.wanted_photo} />}
-            </Box>
-          ))}
+          <Box fontSize="12px">Criminal Name: {wanted_criminal}</Box>
+          <Box>Description: {wanted_body}</Box>
+          {!!wanted_photo && <Image src={wanted_photo} />}
         </>
       ) : (
         'Apart from some uninteresting classified ads, theres nothing in this page...'

--- a/tgui/packages/tgui/interfaces/Newspaper.tsx
+++ b/tgui/packages/tgui/interfaces/Newspaper.tsx
@@ -2,7 +2,7 @@ import { BooleanLike } from '../../common/react';
 import { useBackend } from '../backend';
 import { Box, Button, Divider, Image, Section } from '../components';
 import { Window } from '../layouts';
-import { processedText } from './Newscaster';
+import { processedText } from '../process';
 
 type Data = {
   current_page: number;

--- a/tgui/packages/tgui/interfaces/Newspaper.tsx
+++ b/tgui/packages/tgui/interfaces/Newspaper.tsx
@@ -1,0 +1,174 @@
+import { BooleanLike } from '../../common/react';
+import { useBackend } from '../backend';
+import { Box, Button, Divider, Image, Section } from '../components';
+import { Window } from '../layouts';
+import { processedText } from './Newscaster';
+
+type Data = {
+  current_page: number;
+  scribble_message: string;
+  channel_has_messages: BooleanLike;
+  channels: ChannelNames[];
+  channel_data: ChannelData[];
+  wanted_information: WantedInformation[];
+};
+
+type ChannelNames = {
+  name: string;
+  page_number: number;
+};
+
+type WantedInformation = {
+  wanted_criminal: string;
+  wanted_body: string;
+  wanted_photo: string;
+};
+
+type ChannelData = {
+  channel_name: string;
+  author_name: string;
+  is_censored: BooleanLike;
+  channel_messages: ChannelMessages[];
+};
+
+type ChannelMessages = {
+  message: string;
+  photo: string;
+  author: string;
+};
+
+export const Newspaper = (props) => {
+  const { act, data } = useBackend<Data>();
+  const { channels = [], current_page, scribble_message } = data;
+
+  return (
+    <Window width={300} height={400}>
+      <Window.Content backgroundColor="#858387">
+        {current_page === channels.length + 1 ? (
+          <NewspaperEnding />
+        ) : current_page ? (
+          <NewspaperChannel />
+        ) : (
+          <NewspaperIntro />
+        )}
+        {!!scribble_message && (
+          <Box
+            style={{
+              borderTop: '3px dotted rgba(255, 255, 255, 0.8)',
+              borderBottom: '3px dotted rgba(255, 255, 255, 0.8)',
+            }}
+          >
+            {scribble_message}
+          </Box>
+        )}
+        <Section>
+          <Button
+            icon="arrow-left"
+            width="49%"
+            disabled={!current_page}
+            onClick={() => act('prev_page')}
+          >
+            Previous Page
+          </Button>
+          <Button
+            icon="arrow-right"
+            width="50%"
+            disabled={current_page === channels.length + 1}
+            onClick={() => act('next_page')}
+          >
+            Next Page
+          </Button>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const NewspaperIntro = (props) => {
+  const { act, data } = useBackend<Data>();
+  const { channels = [], wanted_information = [] } = data;
+
+  return (
+    <Section>
+      <Box bold fontSize="30px">
+        The Griffon
+      </Box>
+      <Box bold fontSize="15px">
+        For use on Space Facilities only!
+      </Box>
+      <Box fontSize="12px">Table of Contents:</Box>
+      {channels.map((channel) => (
+        <Box key={channel.page_number}>
+          Page {channel.page_number || 0}: {channel.name}
+        </Box>
+      ))}
+      {!!wanted_information && (
+        <Box bold>Last Page: Important Security Announcement</Box>
+      )}
+    </Section>
+  );
+};
+
+const NewspaperChannel = (props) => {
+  const { act, data } = useBackend<Data>();
+  const { channel_has_messages, channel_data = [] } = data;
+
+  return (
+    <Section>
+      {channel_data.map((individual_channel) => (
+        <Box key={individual_channel.channel_name}>
+          <Box bold fontSize="15px">
+            {individual_channel.channel_name}
+          </Box>
+          <Box fontSize="12px">
+            Channel made by: {individual_channel.author_name}
+          </Box>
+          {channel_has_messages ? (
+            <>
+              {individual_channel.channel_messages.map((message) => (
+                <>
+                  <Box key={message.message}>
+                    <Box
+                      dangerouslySetInnerHTML={processedText(message.message)}
+                    />
+                    {!!message.photo && <Image src={message.photo} />}
+                    <Box>Written by: {message.author}</Box>
+                  </Box>
+                  <Divider />
+                </>
+              ))}
+            </>
+          ) : (
+            'No feed stories stem from this channel...'
+          )}
+        </Box>
+      ))}
+    </Section>
+  );
+};
+
+const NewspaperEnding = (props) => {
+  const { act, data } = useBackend<Data>();
+  const { wanted_information = [] } = data;
+
+  return (
+    <Section>
+      {wanted_information ? (
+        <>
+          <Box bold fontSize="15px">
+            Wanted Issue
+          </Box>
+          {wanted_information.map((wanted) => (
+            <Box key={wanted.wanted_criminal}>
+              <Box fontSize="12px">Criminal Name: {wanted.wanted_criminal}</Box>
+              <Box>Description: {wanted.wanted_body}</Box>
+              {!!wanted.wanted_photo && <Image src={wanted.wanted_photo} />}
+            </Box>
+          ))}
+        </>
+      ) : (
+        'Apart from some uninteresting classified ads, theres nothing in this page...'
+      )}
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/process.ts
+++ b/tgui/packages/tgui/process.ts
@@ -1,0 +1,17 @@
+import { marked } from 'marked';
+
+import { sanitizeText } from './sanitize';
+
+export const processedText = (value) => {
+  const textHtml = {
+    __html: sanitizeText(
+      marked(value, {
+        breaks: true,
+        smartypants: true,
+        smartLists: true,
+        baseUrl: 'thisshouldbreakhttp',
+      }),
+    ),
+  };
+  return textHtml;
+};


### PR DESCRIPTION
## About The Pull Request

Newspapers work as a static newscaster that is not affected by things like D-notices and changing wanted issues after its been printed. It doesn't store comments or get any updates after its been printed.
You can also scribble on the paper to leave notes on a specific page, which is a feature I have never seen in my life but it is still here I guess.

Minor things I've added:
- Sound effect when printing the newspaper in the first place
- 2 second do-after when scribbling just for some player feedback and consistency
- Balloon alerts
- Context tips for scribbling and burning

I also fixed an issue with wanted issues on newscasters when there isn't an image.
As a minor note, I replaced the instances of ``content`` in Buttons I saw in newscaster's UI because it's marked as deprecated.

Too lazy to take a video sorry

![image](https://github.com/tgstation/tgstation/assets/53777086/6944965e-e949-4c22-a6a2-1dbe2f2d09c4)
![image](https://github.com/tgstation/tgstation/assets/53777086/5af44877-6170-424d-9766-46d1ad9f77be)
![image](https://github.com/tgstation/tgstation/assets/53777086/5c5cdfc5-541a-417e-a60d-9522227d0687)

## Why It's Good For The Game

Fixes an issue with newscasters and makes newspapers use a nice TGUI that feels more responsive than before.
Helps further https://hackmd.io/XLt5MoRvRxuhFbwtk4VAUA even more.

## Changelog

:cl:
refactor: Newspapers now use TGUI.
fix: Fixed the newscaster's wanted section showing a non-existent photo.
/:cl: