### PR TITLE
Fixes clown ops getting their codes

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -416,6 +416,8 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NUKIEBASE)
 	var/required_role = ROLE_NUCLEAR_OPERATIVE
 	var/datum/team/nuclear/nuke_team
+	///The job type to dress up our nuclear operative as.
+	var/datum/job/job_type = /datum/job/nuclear_operative
 
 /datum/dynamic_ruleset/roundstart/nuclear/ready(population, forced = FALSE)
 	required_candidates = get_antag_cap(population)
@@ -430,8 +432,8 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 			break
 		var/mob/M = pick_n_take(candidates)
 		assigned += M.mind
-		M.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
-		M.mind.special_role = ROLE_NUCLEAR_OPERATIVE
+		M.mind.set_assigned_role(SSjob.GetJobType(job_type))
+		M.mind.special_role = required_role
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/nuclear/execute()
@@ -624,6 +626,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	antag_leader_datum = /datum/antagonist/nukeop/leader/clownop
 	requirements = list(101,101,101,101,101,101,101,101,101,101)
 	required_role = ROLE_CLOWN_OPERATIVE
+	job_type = /datum/job/clown_operative
 
 /datum/dynamic_ruleset/roundstart/nuclear/clown_ops/pre_execute()
 	. = ..()
@@ -634,10 +637,6 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	for(var/obj/machinery/nuclearbomb/syndicate/nuke as anything in nukes)
 		new /obj/machinery/nuclearbomb/syndicate/bananium(nuke.loc)
 		qdel(nuke)
-
-	for(var/datum/mind/clowns in assigned)
-		clowns.set_assigned_role(SSjob.GetJobType(/datum/job/clown_operative))
-		clowns.special_role = ROLE_CLOWN_OPERATIVE
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -87,20 +87,21 @@
 	add_team_hud(mob_override || owner.current, /datum/antagonist/nukeop)
 
 /datum/antagonist/nukeop/proc/assign_nuke()
-	if(nuke_team && !nuke_team.tracked_nuke)
-		nuke_team.memorized_code = random_nukecode()
-		var/obj/machinery/nuclearbomb/syndicate/nuke = locate() in SSmachines.get_machines_by_type(/obj/machinery/nuclearbomb/syndicate)
-		if(nuke)
-			nuke_team.tracked_nuke = nuke
-			if(nuke.r_code == NUKE_CODE_UNSET)
-				nuke.r_code = nuke_team.memorized_code
-			else //Already set by admins/something else?
-				nuke_team.memorized_code = nuke.r_code
-			for(var/obj/machinery/nuclearbomb/beer/beernuke as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/nuclearbomb/beer))
-				beernuke.r_code = nuke_team.memorized_code
-		else
-			stack_trace("Syndicate nuke not found during nuke team creation.")
-			nuke_team.memorized_code = null
+	if(!nuke_team || nuke_team.tracked_nuke)
+		return
+	nuke_team.memorized_code = random_nukecode()
+	var/obj/machinery/nuclearbomb/syndicate/nuke = locate() in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/nuclearbomb/syndicate)
+	if(!nuke)
+		stack_trace("Syndicate nuke not found during nuke team creation.")
+		nuke_team.memorized_code = null
+		return
+	nuke_team.tracked_nuke = nuke
+	if(nuke.r_code == NUKE_CODE_UNSET)
+		nuke.r_code = nuke_team.memorized_code
+	else //Already set by admins/something else?
+		nuke_team.memorized_code = nuke.r_code
+	for(var/obj/machinery/nuclearbomb/beer/beernuke as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/nuclearbomb/beer))
+		beernuke.r_code = nuke_team.memorized_code
 
 /datum/antagonist/nukeop/proc/give_alias()
 	if(nuke_team?.syndicate_name)


### PR DESCRIPTION
## About The Pull Request

Nukies were using ``get_machines_by_type`` in ``assign_nuke`` to get the nuke and set its code, which doesn't work for clown ops because they use a subtype. This fixes it by replacing it with ``get_machines_by_type_and_subtypes`` instead.
while I was messing with clown op code I also made it a little bit less copy paste

![image](https://github.com/tgstation/tgstation/assets/53777086/2db9e859-8d53-4704-a110-7f8a5f33ee0f)

## Why It's Good For The Game

Clown ops now get a code to their nuke rather than it staying as 'ADMIN', pretty cool!

Closes https://github.com/tgstation/tgstation/issues/78306

## Changelog

:cl: Momo8289, Pepsilawn, Sinsinins, JohnFulpWillard
fix: Clown ops now get a code set for their nuke.
/:cl: