### PR TITLE
Fixes whispering not being italics

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -206,7 +206,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		message = "[randomnote] [message] [randomnote]"
 		spans |= SPAN_SINGING
 
-	if(message_mods[WHISPER_MODE]) // whisper away
+	if(LAZYACCESS(message_mods,WHISPER_MODE)) // whisper away
 		spans |= SPAN_ITALICS
 
 	if(!message)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -206,6 +206,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		message = "[randomnote] [message] [randomnote]"
 		spans |= SPAN_SINGING
 
+	if(message_mods[WHISPER_MODE]) // whisper away
+		spans |= SPAN_ITALICS
 
 	if(!message)
 		if(succumbed)


### PR DESCRIPTION

## About The Pull Request

Looks like a refactor forgot to retain the living_say verb for whispering in italics when they moved it to the radio file

![image](https://github.com/tgstation/tgstation/assets/22140677/bd490568-ce30-42f3-bb9f-17ae345c6cb0)

This just fixes that so whispering once again formats
![image](https://github.com/tgstation/tgstation/assets/22140677/a5dde3f2-5a18-4f8d-837d-e158a597eddb)



## Why It's Good For The Game
## Changelog
:cl:
fix: fixes whispering formatting
/:cl:
