### PR TITLE
Borgs now use the hug module to substitute for their hands, making some surgeries possible again

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -23,7 +23,9 @@
 		if(!tool)
 			success = TRUE
 		if(iscyborg(user))
-			success = TRUE
+			var/mob/living/silicon/robot/borg = user
+			if(istype(borg.module_active, /obj/item/borg/cyborghug))
+				success = TRUE
 
 	if(accept_any_item)
 		if(tool && tool_check(user, tool))


### PR DESCRIPTION
## About The Pull Request

Borgs now use the hug module to substitute for their hands. This allows them to actually finish some surgeries, like the stomach pump, which would have them forcing the person to puke indefinetely.

closes: #48941

## Why It's Good For The Game
Hugging -> Hands. It makes sense. Perhaps not entirely intuitive but also easy to remember once you get into it.

You can actually do AND mend this surgery.
![image](https://github.com/tgstation/tgstation/assets/49160555/b419025f-5daf-44b2-828a-c0a14d430d06)

## Changelog
:cl:
fix: Borgs now use the hug module to substitute for hands, allowing them to finish previously unfinishable surgeries
/:cl:
