### PR TITLE
optimises ISEVEN() and ISODD()

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -85,7 +85,7 @@
 #define ISABOUTEQUAL(a, b, deviation) (deviation ? abs((a) - (b)) <= deviation : abs((a) - (b)) <= 0.1)
 
 // Note for even and odd:
-// you can get the same result with 'x % 2 == 0', but calculation(divide by 2) is more expensive than comparison. We don't have to calculate when we know first bitflag determines if a value is odd or even.
+// you can get the same result with 'x % 2 == 0', but getting remainder from mod is more expensive than bitwise operation.
 #define ISEVEN(x) (!((x) & 1))
 
 #define ISODD(x) ((x) & 1)

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -84,6 +84,8 @@
 
 #define ISABOUTEQUAL(a, b, deviation) (deviation ? abs((a) - (b)) <= deviation : abs((a) - (b)) <= 0.1)
 
+// Note for even and odd:
+// you can get the same result with 'x % 2 == 0', but calculation(divide by 2) is more expensive than comparison. We don't have to calculate when we know first bitflag determines if a value is odd or even.
 #define ISEVEN(x) (!((x) & 1))
 
 #define ISODD(x) ((x) & 1)

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -84,9 +84,9 @@
 
 #define ISABOUTEQUAL(a, b, deviation) (deviation ? abs((a) - (b)) <= deviation : abs((a) - (b)) <= 0.1)
 
-#define ISEVEN(x) (x % 2 == 0)
+#define ISEVEN(x) (!((x) & 1))
 
-#define ISODD(x) (x % 2 != 0)
+#define ISODD(x) ((x) & 1)
 
 // Returns true if val is from min to max, inclusive.
 #define ISINRANGE(val, min, max) (min <= val && val <= max)


### PR DESCRIPTION
## About The Pull Request
Optimises ISEVEN() , ISODD() macro

calculation is expensive than ~~comparison~~ bitwise operator. When we know first bitflag makes a value even or odd, we don't have to calculate to get 0 by divide 2.
> Division is extremely cheap. What isn't extremely cheap is finding the remainder of division. Secondly, you aren't comparing, you're doing a bitwise math operation, comaprison is ==. Bitwise math is actually really slow in byond due to how numbers work in the engine, but it is funny it's slower than modulo.

Kapu's comment

### Simulation code
```DM
#define ISEVEN(x) (!((x) & 1))
#define ISODD(x) ((x) & 1)
#define ISEVENMOD(x) (x % 2 == 0)
#define ISODDMOD(x) (x % 2 != 0)

/proc/main()
    set background = 1
    var/const/repeat = 15000000
    var/t1
    var/t2
    for(var/i in 1 to 100)
        TEST1(0)
        TEST2(0)

    var/time1 = world.timeofday 
    for(var/i in 1 to repeat)
        TEST1(i)
    t1 = world.timeofday-time1
    world.log << "bitflag &: [t1] taken"

    var/time2 = world.timeofday
    for(var/i in 1 to repeat)
        TEST2(i)
    t2 = world.timeofday-time2
    world.log << "mod %: [t2] taken"

/proc/TEST1(val)
    return ISODD(val)

/proc/TEST2(val)
    return ISODDMOD(val)
```

> bitflag &: 33 taken
> mod %: 44 taken

### Note
numbers with decimals have the same result.

## Why It's Good For The Game
optimisation
## Changelog
:cl:
code: optimised ISEVEN() and ISODD() macro
/:cl:
