### PR TITLE
`dismember` calls `drop_limb` with `dismembered = TRUE`

### DIFF
--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -39,7 +39,12 @@
 	calculate_bodypart_score()
 
 /datum/quirk/transhumanist/remove()
-	UnregisterSignal(quirk_holder, list(COMSIG_CARBON_REMOVE_LIMB, COMSIG_CARBON_ATTACH_LIMB))
+	UnregisterSignal(quirk_holder, list(
+		COMSIG_CARBON_POST_ATTACH_LIMB,
+		COMSIG_CARBON_POST_REMOVE_LIMB,
+		COMSIG_CARBON_GAIN_ORGAN,
+		COMSIG_CARBON_LOSE_ORGAN,
+	))
 
 /datum/quirk/transhumanist/proc/get_bodypart_score(mob/living/carbon/target, limbs_only = FALSE)
 	var/organic_bodytypes = 0

--- a/code/modules/mob/living/basic/ruin_defender/flesh.dm
+++ b/code/modules/mob/living/basic/ruin_defender/flesh.dm
@@ -152,7 +152,7 @@
 	current_bodypart.dismember()
 	return TRUE//on_limb_lost should be called after that
 
-/mob/living/basic/living_limb_flesh/proc/on_limb_lost(atom/movable/source, mob/living/carbon/old_owner, dismembered)
+/mob/living/basic/living_limb_flesh/proc/on_limb_lost(atom/movable/source, mob/living/carbon/old_owner, special, dismembered)
 	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_BODYPART_REMOVED)
 	UnregisterSignal(old_owner, COMSIG_LIVING_ELECTROCUTE_ACT)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -26,7 +26,7 @@
 	if (wounding_type)
 		LAZYSET(limb_owner.body_zone_dismembered_by, body_zone, wounding_type)
 
-	drop_limb()
+	drop_limb(dismembered = TRUE)
 
 	limb_owner.update_equipment_speed_mods() // Update in case speed affecting item unequipped by dismemberment
 	var/turf/owner_location = limb_owner.loc


### PR DESCRIPTION
## About The Pull Request

Pass `dismembered = TRUE` when calling `drop_limb` from `dismember`. 

At a glance I don't think anything actually checked `dismembered`, making this do (practically) nothing,
however I was writing some code that actually relied on checking this only to find it was always passed as `null`. 

I also audited some signal usages of dismember / drop limb to make sure they're correct. 

## Changelog

I don't think this will affect anything at current. 
