### PR TITLE
Filled trash bags use the correct sprites when worn.

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -37,6 +37,7 @@
 	icon = 'icons/obj/service/janitor.dmi'
 	icon_state = "trashbag"
 	inhand_icon_state = "trashbag"
+	worn_icon_state = "trashbag"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	storage_type = /datum/storage/trash


### PR DESCRIPTION

## About The Pull Request

Fixes #81009.

Trash bags did not have a `worn_icon_state` set, which means that it tried to use an invalid state when worn while not empty. This is now fixed.
## Why It's Good For The Game

Missing sprites bad.
## Changelog
:cl:
fix: Filled trash bags show up properly when worn.
/:cl:
