### PR TITLE
add_blueprint_preround is now a macro and is on mapload

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -97,3 +97,20 @@
 #define VENTCRAWL_ENTRANCE_ALLOWED (1<<1)
 ///Used to check if a machinery is visible. Called by update_pipe_vision(). On by default for all except cryo.
 #define VENTCRAWL_CAN_SEE	(1<<2)
+
+/**
+ * During mapload and before smoothing happens, this will add src to the blueprint data (or queue, to be added during icon smoothing) if necessary.
+ * Args:
+ * loc - The location of the turf to add the blueprints to.
+ */
+#define ADD_BLUEPRINTS_PREROUND(loc) \
+	if(mapload && !SSicon_smooth.initialized) { \
+		var/turf/_turf_loc = loc; \
+		if(isturf(_turf_loc)) { \
+			if(layer == WIRE_LAYER) { \
+				SSicon_smooth.blueprint_queue += src \
+			} else { \
+				_turf_loc.add_blueprints(src) \
+			}; \
+		}; \
+	}; \

--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -113,4 +113,4 @@
 				_turf_loc.add_blueprints(src) \
 			}; \
 		}; \
-	}; \
+	};

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -588,13 +588,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	I.alpha = 128
 	LAZYADD(blueprint_data, I)
 
-/turf/proc/add_blueprints_preround(atom/movable/AM)
-	if(!SSicon_smooth.initialized)
-		if(AM.layer == WIRE_LAYER) //wires connect to adjacent positions after its parent init, meaning we need to wait (in this case, until smoothing) to take its image
-			SSicon_smooth.blueprint_queue += AM
-		else
-			add_blueprints(AM)
-
 /turf/proc/is_transition_turf()
 	return
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -101,12 +101,9 @@
 /obj/machinery/atmospherics/Initialize(mapload)
 	if(mapload && name != initial(name))
 		override_naming = TRUE
-	var/turf/turf_loc = null
-	if(isturf(loc))
-		turf_loc = loc
-		turf_loc.add_blueprints_preround(src)
+	ADD_BLUEPRINTS_PREROUND(loc)
 	SSspatial_grid.add_grid_awareness(src, SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-	SSspatial_grid.add_grid_membership(src, turf_loc, SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
+	SSspatial_grid.add_grid_membership(src, loc, SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
 	if(init_processing)
 		SSair.start_processing_machine(src)
 	return ..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -49,9 +49,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	Connect_cable()
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
 	RegisterSignal(src, COMSIG_RAT_INTERACT, PROC_REF(on_rat_eat))
-	if(isturf(loc))
-		var/turf/turf_loc = loc
-		turf_loc.add_blueprints_preround(src)
+	ADD_BLUEPRINTS_PREROUND(loc)
 
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -95,9 +95,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	stored?.set_pipecleaner_color(pipecleaner_color)
 	update_appearance()
 
-	if(isturf(loc))
-		var/turf/turf_loc = loc
-		turf_loc.add_blueprints_preround(src)
+	ADD_BLUEPRINTS_PREROUND(loc)
 
 /obj/structure/pipe_cleaner/Destroy() // called when a pipe_cleaner is deleted
 	//If we have a stored item at this point, lets just delete it, since that should be

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -24,9 +24,7 @@
 
 /obj/machinery/power/Initialize(mapload)
 	. = ..()
-	if(isturf(loc))
-		var/turf/turf_loc = loc
-		turf_loc.add_blueprints_preround(src)
+	ADD_BLUEPRINTS_PREROUND(loc)
 
 /obj/machinery/power/Destroy()
 	disconnect_from_network()

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -52,9 +52,7 @@
 			dpdir |= REVERSE_DIR(dir)
 
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
-	if(isturf(loc))
-		var/turf/turf_loc = loc
-		turf_loc.add_blueprints_preround(src)
+	ADD_BLUEPRINTS_PREROUND(loc)
 
 /obj/structure/disposalpipe/Destroy()
 	spawn_pipe = FALSE


### PR DESCRIPTION
## About The Pull Request

This proc is called on many different types of machine's Initialize, which I thought was a little too copy-pasted, so I made it a macro and also added a check for mapload, since that is the only time when it actually works.

This shouldn't have any behavior changes

Here's me messing with it in-game
![image](https://github.com/tgstation/tgstation/assets/53777086/150ecdb3-2fb3-4efe-a31b-b7a9c40548b1)

## Why It's Good For The Game

I just thought it was weird that there's no mapload check since that is the only time this should be done, the macro i just made for fun practice

## Changelog

No player-facing changes