### PR TITLE
Fix arm implant hotkeys no longer working after changing species/limbs

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -78,19 +78,32 @@
 
 /obj/item/organ/internal/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)
 	. = ..()
-	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
-	hand = arm_owner.hand_bodyparts[side]
-	if(hand)
-		RegisterSignal(hand, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self)) //If the limb gets an attack-self, open the menu. Only happens when hand is empty
-		RegisterSignal(arm_owner, COMSIG_KB_MOB_DROPITEM_DOWN, PROC_REF(dropkey)) //We're nodrop, but we'll watch for the drop hotkey anyway and then stow if possible.
+	RegisterSignal(arm_owner, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(on_limb_attached))
+	RegisterSignal(arm_owner, COMSIG_KB_MOB_DROPITEM_DOWN, PROC_REF(dropkey)) //We're nodrop, but we'll watch for the drop hotkey anyway and then stow if possible.
+	on_limb_attached(arm_owner, arm_owner.hand_bodyparts[zone == BODY_ZONE_R_ARM ? RIGHT_HANDS : LEFT_HANDS])
 
 /obj/item/organ/internal/cyberimp/arm/on_mob_remove(mob/living/carbon/arm_owner)
 	. = ..()
 	Retract()
+	UnregisterSignal(arm_owner, list(COMSIG_CARBON_POST_ATTACH_LIMB, COMSIG_KB_MOB_DROPITEM_DOWN))
+	on_limb_detached(hand)
+
+/obj/item/organ/internal/cyberimp/arm/proc/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
+	SIGNAL_HANDLER
+	if(!limb || QDELETED(limb) || limb.body_zone != zone)
+		return
 	if(hand)
-		UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
-		UnregisterSignal(arm_owner, COMSIG_KB_MOB_DROPITEM_DOWN)
-		hand = null
+		on_limb_detached(hand)
+	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
+	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
+	hand = limb
+
+/obj/item/organ/internal/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
+	SIGNAL_HANDLER
+	if(source != hand || QDELETED(hand))
+		return
+	UnregisterSignal(hand, list(COMSIG_ITEM_ATTACK_SELF, COMSIG_BODYPART_REMOVED))
+	hand = null
 
 /obj/item/organ/internal/cyberimp/arm/proc/on_item_attack_self()
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Currently, if your arm gets changed for any reason (through surgery or by changing species), it breaks the Z hotkey for activating the toolset implant in said arm until you take the implant out and put it back in. This fixes that.

Somewhat of a port of https://github.com/BeeStation/BeeStation-Hornet/pull/9167

## Why It's Good For The Game

This is clearly unintended behavior, which is bad, bugs are bad.

## Testing Evidence.

https://github.com/tgstation/tgstation/assets/65794972/b5e1e690-ef11-4db6-81ab-85571f83d178

## Changelog
:cl:
fix: Tool arm implant hotkeys will properly work even after you change your arm/species now.
/:cl:
