### PR TITLE
Nanotrasen stops stocking discount Irish Cognac: Cognac is now properly french.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -420,7 +420,7 @@
 	description = "A sweet and strongly alcoholic drink, made after numerous distillations and years of maturing. Classy as fornication."
 	color = "#AB3C05" // rgb: 171, 60, 5
 	boozepwr = 75
-	taste_description = "angry and irish"
+	taste_description = "smooth and french"
 	ph = 3.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_STOCK


### PR DESCRIPTION

## About The Pull Request

For some reason, somebody thought that cognac was an Irish spirit. Please, please look up real-world things you are touching

![image](https://github.com/tgstation/tgstation/assets/16896032/fe70e10b-6a22-497e-9086-a13139b3b174)


## Why It's Good For The Game

I don't want to drink any cheap ass, backwater, nasty ass, dirty, cheap, angry Irish cognac.

## Changelog


:cl:
fix: Nanotrasen is now stocking proper french Cognac instead of discount Irish Cognac. It will now taste Smooth and French
/:cl:
