### PR TITLE
Fixes screwdriver cocktail not being a screwdriver.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -594,7 +594,6 @@
 	// We want to turn only base drinking glasses with screwdriver(cocktail) into screwdrivers(tool),
 	// but we can't check style so we have to check type, and we don't want it match subtypes like istype does
 	if(holder?.my_atom && holder.my_atom.type == /obj/item/reagent_containers/cup/glass/drinkingglass/)
-		message_admins("on_new - atom: [holder?.my_atom] name: [name]")
 		var/list/reagent_change_signals = list(
 			COMSIG_REAGENTS_ADD_REAGENT,
 			COMSIG_REAGENTS_NEW_REAGENT,

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -589,39 +589,6 @@
 	taste_description = "oranges"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/screwdrivercocktail/on_transfer(atom/atom, methods = TOUCH, trans_volume)
-	if(!(methods & INGEST))
-		return ..()
-
-	if(src == atom.reagents.get_master_reagent() && istype(atom, /obj/item/reagent_containers/cup/glass/drinkingglass))
-		var/obj/item/reagent_containers/cup/glass/drinkingglass/drink = atom
-		drink.tool_behaviour = TOOL_SCREWDRIVER
-		var/list/reagent_change_signals = list(
-			COMSIG_REAGENTS_ADD_REAGENT,
-			COMSIG_REAGENTS_NEW_REAGENT,
-			COMSIG_REAGENTS_REM_REAGENT,
-			COMSIG_REAGENTS_DEL_REAGENT,
-			COMSIG_REAGENTS_CLEAR_REAGENTS,
-			COMSIG_REAGENTS_REACTED,
-		)
-		RegisterSignals(drink.reagents, reagent_change_signals, PROC_REF(on_reagent_change))
-
-	return ..()
-
-/datum/reagent/consumable/ethanol/screwdrivercocktail/proc/on_reagent_change(datum/reagents/reagents)
-	SIGNAL_HANDLER
-	if(src != reagents.get_master_reagent())
-		var/obj/item/reagent_containers/cup/glass/drinkingglass/drink = reagents.my_atom
-		drink.tool_behaviour = initial(drink.tool_behaviour)
-		UnregisterSignal(reagents, list(
-			COMSIG_REAGENTS_ADD_REAGENT,
-			COMSIG_REAGENTS_NEW_REAGENT,
-			COMSIG_REAGENTS_REM_REAGENT,
-			COMSIG_REAGENTS_DEL_REAGENT,
-			COMSIG_REAGENTS_CLEAR_REAGENTS,
-			COMSIG_REAGENTS_REACTED,
-		))
-
 /datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
 	var/obj/item/organ/internal/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -41,20 +41,10 @@
 	. = ..()
 	fill_icon_thresholds = null
 
-	// Turn glass into a screwdriver (tool) if it's a screwdriver (cocktail)
-	if(istype(style, /datum/glass_style/drinking_glass/screwdrivercocktail))
-		tool_behaviour = TOOL_SCREWDRIVER
-		usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
-	else
-		tool_behaviour = initial(tool_behaviour)
-		usesound = initial(usesound)
-
 // And having our icon reset restores our fill thresholds
 /obj/item/reagent_containers/cup/glass/drinkingglass/on_cup_reset()
 	. = ..()
 	fill_icon_thresholds ||= list(0)
-	tool_behaviour = initial(tool_behaviour)
-	usesound = initial(usesound)
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -41,10 +41,17 @@
 	. = ..()
 	fill_icon_thresholds = null
 
+	// Turn glass into a screwdriver (tool) if it's a screwdriver (cocktail)
+	if(istype(style, /datum/glass_style/drinking_glass/screwdrivercocktail))
+		tool_behaviour = TOOL_SCREWDRIVER
+	else
+		tool_behaviour = initial(tool_behaviour)
+
 // And having our icon reset restores our fill thresholds
 /obj/item/reagent_containers/cup/glass/drinkingglass/on_cup_reset()
 	. = ..()
 	fill_icon_thresholds ||= list(0)
+	tool_behaviour = initial(tool_behaviour)
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -17,6 +17,7 @@
 	custom_price = PAYCHECK_LOWER
 	//the screwdriver cocktail can make a drinking glass into the world's worst screwdriver. beautiful.
 	toolspeed = 25
+	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 
 	/// The type to compare to glass_style.required_container type, or null to use class type.
 	/// This allows subtypes to utilize parent styles.

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -17,7 +17,6 @@
 	custom_price = PAYCHECK_LOWER
 	//the screwdriver cocktail can make a drinking glass into the world's worst screwdriver. beautiful.
 	toolspeed = 25
-	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 
 	/// The type to compare to glass_style.required_container type, or null to use class type.
 	/// This allows subtypes to utilize parent styles.
@@ -45,14 +44,17 @@
 	// Turn glass into a screwdriver (tool) if it's a screwdriver (cocktail)
 	if(istype(style, /datum/glass_style/drinking_glass/screwdrivercocktail))
 		tool_behaviour = TOOL_SCREWDRIVER
+		usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	else
 		tool_behaviour = initial(tool_behaviour)
+		usesound = initial(usesound)
 
 // And having our icon reset restores our fill thresholds
 /obj/item/reagent_containers/cup/glass/drinkingglass/on_cup_reset()
 	. = ..()
 	fill_icon_thresholds ||= list(0)
 	tool_behaviour = initial(tool_behaviour)
+	usesound = initial(usesound)
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //


### PR DESCRIPTION

## About The Pull Request

Alternative title: The screwdriver cocktail is now the world's worst screwdriver (for real this time).

As mentioned in my writeup in the related issue (#81017), as far as I know, it has never actually worked.
Tl;dr: It requires `on_transfer` to be called with the method as ingestion, but in no way does transferring into a drinking glass ever use that method, and most ways don't even specify a method and thus `on_transfer` doesn't even get called in the first place.
Then I went back to the original pr and tried it, and it didn't work.

Then for resolving it, it feels unwieldy to do all this trickery on the reagent to change a value on the drinking glass when the drinking glass already has the perfect procs for this: the `on_cup_change` and `on_cup_reset` callbacks.
Instead of using `on_transfer` and registering a hell of a lot of signals to re-check the master reagent every time the contents get changed, we just check whether the style we changed into is that of a screwdriver cocktail.
This actually works.

Oh, and I also added use sounds because it didn't have them, which I believe only actually get used when using it as a tool and thus only when it's a screwdriver.
## Why It's Good For The Game

Fixes #81017.
## Changelog
:cl:
fix: As they should've for a while, screwdrivers (cocktail) actually work as screwdrivers (tool).
sound: The screwdriver cocktail also actually plays the screwdriver sound when used.
/:cl:
