### PR TITLE
Make apcs actually play the tool sound when exposing their wires.

### DIFF
--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -77,6 +77,7 @@
 			return
 		toggle_panel_open()
 		balloon_alert(user, "wires [panel_open ? "exposed" : "unexposed"]")
+		W.play_tool_sound(src)
 		update_appearance()
 		return
 


### PR DESCRIPTION

## About The Pull Request

Single line change to `code/modules/power/apc/apc_tool_act.dm` to make it play the tool sound when you open/close the panel with a screwdriver, to make it consistent with almost everything else I tried. Sound? Fix? 
## Why It's Good For The Game

This was really annoying me while I was slamming the screwdriver cocktail into everything I could see to make sure it worked again. Everything within reach was doing it, but not this one.
## Changelog
:cl:
sound: APCs actually play the tool sound when exposing their wires.
/:cl:
