### PR TITLE
One line fix to ever-expanding ports for the modpc circuit.

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -27,7 +27,7 @@
 	 * is called before we get to know which object this has attahed to,
 	 * I hope you're cool with me doing it here.
 	 */
-	if(computer?.has_light)
+	if(computer?.has_light && isnull(lights))
 		lights = add_input_port("Toggle Lights", PORT_TYPE_SIGNAL)
 		red = add_input_port("Red", PORT_TYPE_NUMBER)
 		green = add_input_port("Green", PORT_TYPE_NUMBER)


### PR DESCRIPTION
## About The Pull Request
Only initialize the lights ports once. Thank you mooow for reporting it.

## Why It's Good For The Game
Prevents this when removing and reinserting the circuit:
![immagine](https://github.com/tgstation/tgstation/assets/42542238/cc941170-cf74-4af0-b5b4-881a76e8b983)


## Changelog

:cl:
fix: Fixes a whoopsie with the modpc circuit that generated new ports each time it's removed and reinstalled.
/:cl:
