### PR TITLE
check that the not-teleported atom is a mob before sending balloon alerts

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -66,7 +66,8 @@
 
 	if(!forced)
 		if(!check_teleport_valid(teleatom, destination, channel))
-			teleatom.balloon_alert(teleatom, "something holds you back!")
+			if(ismob(teleatom))
+				teleatom.balloon_alert(teleatom, "something holds you back!")
 			return FALSE
 
 	if(isobserver(teleatom))


### PR DESCRIPTION
## About The Pull Request
Quick and easy runtime error to fix.

## Why It's Good For The Game
Runtime viewer clutter.

## Changelog
N/A