### PR TITLE
Fixing goldgrubs barfing what they shouldn't.

### DIFF
--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -83,7 +83,7 @@
 
 /mob/living/basic/mining/goldgrub/proc/barf_contents(gibbed)
 	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
-	for(var/obj/item/ore as anything in src)
+	for(var/obj/item/stack/ore/ore in src)
 		ore.forceMove(loc)
 	if(!gibbed)
 		visible_message(span_danger("[src] spits out its consumed ores!"))


### PR DESCRIPTION
## About The Pull Request
See #81041.

## Why It's Good For The Game
Fix #81041

## Changelog

:cl:
fix: Goldgrubs should no longer spit out things that aren't ore (e.g. stasised mobs from the polymorph belt).
/:cl:
