### PR TITLE
Fixes ejecting pAIs card without a pAI in it

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -927,17 +927,16 @@
 		return FALSE
 	inserted_pai = card
 	balloon_alert(user, "inserted pai")
-	var/datum/action/innate/pai/messenger/messenger_ability = new(inserted_pai.pai)
-	messenger_ability.Grant(inserted_pai.pai)
+	if(inserted_pai.pai)
+		inserted_pai.pai.give_messenger_ability()
 	update_appearance(UPDATE_ICON)
 	return TRUE
 
 /obj/item/modular_computer/proc/remove_pai(mob/user)
 	if(!inserted_pai)
 		return FALSE
-	var/datum/action/innate/pai/messenger/messenger_ability = locate() in inserted_pai.pai.actions
-	messenger_ability.Remove(inserted_pai.pai)
-	qdel(messenger_ability)
+	if(inserted_pai.pai)
+		inserted_pai.pai.remove_messenger_ability()
 	if(user)
 		user.put_in_hands(inserted_pai)
 		balloon_alert(user, "removed pAI")

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -80,6 +80,9 @@
 	/// Remote signaler
 	var/obj/item/assembly/signaler/internal/signaler
 
+	///The messeenger ability that pAIs get when they are put in a PDA.
+	var/datum/action/innate/pai/messenger/messenger_ability
+
 	// Static lists
 	/// List of all available downloads
 	var/static/list/available_software = list(
@@ -149,6 +152,7 @@
 	return ..(target, action_bitflags)
 
 /mob/living/silicon/pai/Destroy()
+	QDEL_NULL(messenger_ability)
 	QDEL_NULL(atmos_analyzer)
 	QDEL_NULL(hacking_cable)
 	QDEL_NULL(instrument)
@@ -211,6 +215,8 @@
 
 /mob/living/silicon/pai/Initialize(mapload)
 	. = ..()
+	if(istype(loc, /obj/item/modular_computer))
+		give_messenger_ability()
 	START_PROCESSING(SSfastprocess, src)
 	GLOB.pai_list += src
 	make_laws()
@@ -465,3 +471,13 @@
 	if (new_distance < HOLOFORM_MIN_RANGE || new_distance > HOLOFORM_MAX_RANGE)
 		return
 	leash.set_distance(new_distance)
+
+///Gives the messenger ability to the pAI, creating a new one if it doesn't have one already.
+/mob/living/silicon/pai/proc/give_messenger_ability()
+	if(!messenger_ability)
+		messenger_ability = new(src)
+	messenger_ability.Grant(src)
+
+///Removes the messenger ability from the pAI, but does not delete it.
+/mob/living/silicon/pai/proc/remove_messenger_ability()
+	messenger_ability.Remove(src)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -480,4 +480,5 @@
 
 ///Removes the messenger ability from the pAI, but does not delete it.
 /mob/living/silicon/pai/proc/remove_messenger_ability()
-	messenger_ability.Remove(src)
+	if(messenger_ability)
+		messenger_ability.Remove(src)


### PR DESCRIPTION
## About The Pull Request

I had made the bad assumption that a pAI card always had a pAI mob in it, which is not the case.
This fixes the runtime error, thus allowing people to eject a pAI card that doesn't have a pAI in it.
I've also added a check in the pAI's Initialize to give them the ability to use the modPC if they are made in it, so you don't have to eject and reinsert the pAI, fixing another issue.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/81043
Fixes inconsistency and runtime.

## Changelog

:cl:
fix: pAIs downloaded while in a PDA now gets the action button to control said PDA.
fix: pAI cards can now be ejected from a PDA when there is no pAI inhabiting it.
/:cl: