### PR TITLE
[GBP NO UPDATE] Hub time timezone fix

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -388,7 +388,7 @@ GLOBAL_VAR(restart_counter)
 		else if(SSticker.current_state == GAME_STATE_SETTING_UP)
 			new_status += "<br>Starting: <b>Now</b>"
 		else if(SSticker.IsRoundInProgress())
-			new_status += "<br>Time: <b>[time2text(STATION_TIME_PASSED(), "hh:mm")]</b>"
+			new_status += "<br>Time: <b>[time2text(STATION_TIME_PASSED(), "hh:mm", 0)]</b>"
 			if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
 				new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
 		else if(SSticker.current_state == GAME_STATE_FINISHED)


### PR DESCRIPTION

## About The Pull Request
While browsing the hub I noticed Psychonaut Station the Turkish TG always had "Time:" with a value of many hours. I thought they had long rounds until I joined the server and noticed the actual time was 3 hours behind

Turns out time2text() has a timezone arg which defaults to server timezone

I have set it to UTC+0 so it is always consistent since world.time is UTC
## Changelog
:cl:
fix: The hub time should be accurate for servers with different timezones
/:cl:
