### PR TITLE
Fixes boulder processing mining point gain.

### DIFF
--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -211,7 +211,7 @@
 		if(!is_type_in_list(possible_mat, processable_materials))
 			continue
 		var/quantity = chosen_boulder.custom_materials[possible_mat]
-		points_held = round((points_held + (quantity * possible_mat.points_per_unit)) * MINING_POINT_MACHINE_MULTIPLIER) // put point total here into machine
+		points_held = round((points_held + (quantity * possible_mat.points_per_unit * MINING_POINT_MACHINE_MULTIPLIER))) // put point total here into machine
 		processable_ores += possible_mat
 		processable_ores[possible_mat] = quantity
 		chosen_boulder.custom_materials -= possible_mat //Remove it from the boulder now that it's tracked

--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -211,7 +211,7 @@
 		if(!is_type_in_list(possible_mat, processable_materials))
 			continue
 		var/quantity = chosen_boulder.custom_materials[possible_mat]
-		points_held = round((points_held + (quantity * possible_mat.points_per_unit * MINING_POINT_MACHINE_MULTIPLIER))) // put point total here into machine
+		points_held = round(points_held + (quantity * possible_mat.points_per_unit * MINING_POINT_MACHINE_MULTIPLIER)) // put point total here into machine
 		processable_ores += possible_mat
 		processable_ores[possible_mat] = quantity
 		chosen_boulder.custom_materials -= possible_mat //Remove it from the boulder now that it's tracked


### PR DESCRIPTION
## About The Pull Request

Due to a misplaced multiplier, arcmining machines were eating their own point totals.
Now, the refinery and smelter should correctly only take the MINING_POINT_MACHINE_MULTIPLIER define on the amount being added to the points held, not on the total resting in the machine.

## Why It's Good For The Game

Simple, easy fix.
Fixes #81057.

## Changelog

:cl:
fix: The smelter and refinery now properly hold mining points, only taking a small amount out of net gained points.
/:cl:

