### PR TITLE
The "Guide to Advanced Mimery" series now make but the faintest noise when turning their pages

### DIFF
--- a/code/game/objects/items/granters/magic/mime.dm
+++ b/code/game/objects/items/granters/magic/mime.dm
@@ -3,6 +3,7 @@
 	desc = "The missing entry into the legendary saga. Unfortunately it doesn't teach you anything."
 	icon_state ="bookmime"
 	remarks = list("...")
+	book_sounds = list('sound/effects/space_wind.ogg')
 
 /obj/item/book/granter/action/spell/mime/attack_self(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. To fit with the description of volume 1 ("The pages don't make any sound when turned."), they now use the sound of faint rustling instead of the default page-turning sound effect.

Pictured below (you may wish to turn up your volume):

https://github.com/tgstation/tgstation/assets/80640114/e9867815-8e33-47a5-83e2-19fc979e15d6
## Why It's Good For The Game

Makes the book's behaviour consistent with their description, plus it's just fitting, isn't it?.
## Changelog
:cl:
sound: The Guide to Advanced Mimery book series now only make a very faint noise when turning their pages, in order to match their description
/:cl:
