### PR TITLE
The addiction withdrawal blur effect is now properly centered

### DIFF
--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -74,8 +74,8 @@
 /datum/addiction/hallucinogens/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
 	. = ..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = affected_carbon.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.add_filter("hallucinogen_wave", 10, wave_filter(300, 300, 3, 0, WAVE_SIDEWAYS))
 	game_plane_master_controller.add_filter("hallucinogen_blur", 10, angular_blur_filter(0, 0, 3))
+	game_plane_master_controller.add_filter("hallucinogen_wave", 10, wave_filter(300, 300, 3, 0, WAVE_SIDEWAYS))
 
 
 /datum/addiction/hallucinogens/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -317,8 +317,8 @@
 	var/atom/movable/plane_master_controller/game_plane_master_controller = owner.hud_used?.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(!game_plane_master_controller)
 		return FALSE
-	game_plane_master_controller.add_filter("psychic_wave", 10, wave_filter(240, 240, 3, 0, WAVE_SIDEWAYS))
 	game_plane_master_controller.add_filter("psychic_blur", 10, angular_blur_filter(0, 0, 3))
+	game_plane_master_controller.add_filter("psychic_wave", 10, wave_filter(240, 240, 3, 0, WAVE_SIDEWAYS))
 	return TRUE
 
 /datum/status_effect/psychic_projection/on_remove()


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. It also affects the psychic projection ability, since it seemed to suffer from the same problem.
It's an odd interaction, and seems to be the fault of the wave filter. If the blur filter is applied after it, it seems to try and center itself at a certain point of the wave which may not be aligned with the center of the screen. 
(Adding an initial offset to the wave filter makes the blur be misalligned both horizontally *and* vertically, so it seems to try and place itself at the initial position of the wave?)
<details>
<summary> Pictured here with 0.5 offset</summary>

![image](https://github.com/tgstation/tgstation/assets/80640114/60a850bd-8893-4054-8f1f-f389187e37a2)

</details>

One way or another, applying the blur filter before the wave filter keeps it nice and centered.
![image](https://github.com/tgstation/tgstation/assets/80640114/2760b9f2-11a3-484d-9a61-36f8defd43b9)
## Why It's Good For The Game

Closes #81004
## Changelog
:cl:
fix: the blur effects for hallucinogenic withdrawal and psychic projection are now properly centered on the screen
/:cl:
