### PR TITLE
Fixes an issue with library console UI

### DIFF
--- a/tgui/packages/tgui/interfaces/LibraryConsole.jsx
+++ b/tgui/packages/tgui/interfaces/LibraryConsole.jsx
@@ -415,6 +415,7 @@ export const SearchAndDisplay = (props) => {
             </Stack.Item>
             <Stack.Item>
               <Dropdown
+                width="120px"
                 options={search_categories}
                 selected={category}
                 onSelected={(value) =>


### PR DESCRIPTION
## About The Pull Request

Makes the dropdown of the category being searched actually display text rather than being a very small box between two text boxes.

Before
![image](https://github.com/tgstation/tgstation/assets/53777086/35ebdc71-b5fa-4ced-9ab2-18564ed805a4)
After
![image](https://github.com/tgstation/tgstation/assets/53777086/d94a08e4-7a47-478c-9820-bd05a95ced57)

## Why It's Good For The Game

Searching in the library became a little bit better.

## Changelog

:cl:
fix: The library console's category search box now displays the category being searched.
/:cl: