### PR TITLE
[NO GBP] Fixing issues with modular computer and circuits.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_modular_computer.dm
+++ b/code/__DEFINES/dcs/signals/signals_modular_computer.dm
@@ -1,5 +1,10 @@
 // Various modular computer signals.
 
+/// From /obj/item/modular_computer/proc/turn_on: (user)
+#define COMSIG_MODULAR_COMPUTER_TURNED_ON "comsig_modular_computer_turned_on"
+/// From /obj/item/modular_computer/proc/shutdown_computer: (loud)
+#define COMSIG_MODULAR_COMPUTER_SHUT_DOWN "comsig_modular_computer_shut_down"
+
 /// From /obj/item/modular_computer/proc/store_file: (datum/computer_file/file_storing)
 #define COMSIG_MODULAR_COMPUTER_FILE_STORE "comsig_modular_computer_file_store"
 /// From /obj/item/modular_computer/proc/remove_file: (datum/computer_file/file_removing)
@@ -8,6 +13,9 @@
 #define COMSIG_COMPUTER_FILE_STORE "comsig_computer_file_store"
 /// From /obj/item/modular_computer/proc/store_file: ()
 #define COMSIG_COMPUTER_FILE_DELETE "comsig_computer_file_delete"
+
+/// From /obj/item/modular_computer/proc/InsertID: (inserting_id, user)
+#define COMSIG_MODULAR_COMPUTER_INSERTED_ID "comsig_computer_inserted_id"
 
 /// From /datum/computer_file/program/on_start: (user)
 #define COMSIG_COMPUTER_PROGRAM_START "computer_program_start"

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -469,6 +469,9 @@
 ///from /obj/item/assembly/proc/pulsed(mob/pulser)
 #define COMSIG_ASSEMBLY_PULSED "assembly_pulsed"
 
+///from /datum/computer_file/program/nt_pay/_pay(), sent to every physical card of a bank account: (computer, money_received)
+#define COMSIG_ID_CARD_NTPAY_MONEY_RECEIVED "id_card_ntpay_money_received"
+
 ///from base of /obj/item/mmi/set_brainmob(): (mob/living/brain/new_brainmob)
 #define COMSIG_MMI_SET_BRAINMOB "mmi_set_brainmob"
 

--- a/code/__HELPERS/chat_filter.dm
+++ b/code/__HELPERS/chat_filter.dm
@@ -85,6 +85,14 @@
 
 	return null
 
+///Given a pda message, will replace any match in the message with grawlixs.
+/proc/censor_ic_filter_for_pdas(message)
+	if(config.ic_outside_pda_filter_regex)
+		message = config.ic_outside_pda_filter_regex.Replace(message, GLOBAL_PROC_REF(grawlix))
+	if(config.soft_ic_outside_pda_filter_regex)
+		message = config.soft_ic_outside_pda_filter_regex.Replace(message, GLOBAL_PROC_REF(grawlix))
+	return message
+
 /// Logs to the filter log with the given message, match, and scope
 /proc/log_filter(scope, message, filter_result)
 	log_filter_raw("[scope] filter:\n\tMessage: [message]\n\tFilter match: [filter_result[CHAT_FILTER_INDEX_WORD]]")

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1196,3 +1196,10 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 /proc/endswith(input_text, ending)
 	var/input_length = LAZYLEN(ending)
 	return !!findtext(input_text, ending, -input_length)
+
+/// Generate a grawlix string of length of the text argument.
+/proc/grawlix(text)
+	var/grawlix = ""
+	for(var/iteration in 1 to length_char(text))
+		grawlix += pick("@", "$", "?", "!", "#", "§", "*", "£", "%", "☠", "★", "☆", "¿", "⚡")
+	return grawlix

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -277,13 +277,14 @@
 	if(computer_id_slot)
 		return FALSE
 
-	computer_id_slot = inserting_id
 	if(user)
 		if(!user.transferItemToLoc(inserting_id, src))
 			return FALSE
 		to_chat(user, span_notice("You insert \the [inserting_id] into the card slot."))
 	else
 		inserting_id.forceMove(src)
+
+	computer_id_slot = inserting_id
 
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 	if(ishuman(loc))
@@ -292,6 +293,7 @@
 			human_wearer.sec_hud_set_ID()
 	update_appearance()
 	update_slot_icon()
+	SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_INSERTED_ID, inserting_id, user)
 	return TRUE
 
 /**
@@ -488,6 +490,7 @@
 				to_chat(user, span_notice("You press the power button and start up \the [src]."))
 			if(open_ui)
 				update_tablet_open_uis(user)
+		SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_TURNED_ON, user)
 		return TRUE
 	else // Unpowered
 		if(user)
@@ -692,6 +695,7 @@
 		physical.visible_message(span_notice("\The [src] shuts down."))
 	enabled = FALSE
 	update_appearance()
+	SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_SHUT_DOWN, loud)
 
 ///Imprints name and job into the modular computer, and calls back to necessary functions.
 ///Acts as a replacement to directly setting the imprints fields. All fields are optional, the proc will try to fill in missing gaps.

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -38,7 +38,7 @@
 	 * is called before we get to know which object this has attahed to,
 	 * I hope you're cool with me doing it here.
 	 */
-	if(computer.has_light)
+	if(computer.has_light && isnull(lights))
 		lights = add_input_port("Toggle Lights", PORT_TYPE_SIGNAL)
 		red = add_input_port("Red", PORT_TYPE_NUMBER)
 		green = add_input_port("Green", PORT_TYPE_NUMBER)
@@ -91,10 +91,10 @@
 		if(COMPONENT_TRIGGERED_BY(red, port) || COMPONENT_TRIGGERED_BY(green, port) || COMPONENT_TRIGGERED_BY(blue, port))
 			computer.set_flashlight_color(rgb(red.value || 0, green.value || 0, blue.value || 0))
 
-/obj/item/circuit_component/modpc/proc/computer_on(datum/source)
+/obj/item/circuit_component/modpc/proc/computer_on(datum/source, mob/user)
 	SIGNAL_HANDLER
 	is_on.set_output(COMPONENT_SIGNAL)
 
-/obj/item/circuit_component/modpc/proc/computer_off(datum/source)
+/obj/item/circuit_component/modpc/proc/computer_off(datum/source, loud)
 	SIGNAL_HANDLER
 	is_off.set_output(COMPONENT_SIGNAL)

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -8,6 +8,11 @@
 	///When set, will print a piece of paper with the value as text.
 	var/datum/port/input/print
 
+	///Sent when turned on
+	var/datum/port/output/is_on
+	///Sent when shut down
+	var/datum/port/output/is_off
+
 	///Toggles lights on and off. Also RGB.
 	var/datum/port/input/lights
 	var/datum/port/input/red
@@ -22,24 +27,35 @@
 		var/obj/machinery/modular_computer/console = shell
 		computer = console.cpu
 
+	if(isnull(computer))
+		return
+
+	RegisterSignal(computer, COMSIG_MODULAR_COMPUTER_TURNED_ON, PROC_REF(computer_on))
+	RegisterSignal(computer, COMSIG_MODULAR_COMPUTER_SHUT_DOWN, PROC_REF(computer_off))
+
 	/**
 	 * Some mod pc have lights while some don't, but populate_ports()
 	 * is called before we get to know which object this has attahed to,
 	 * I hope you're cool with me doing it here.
 	 */
-	if(computer?.has_light)
+	if(computer.has_light)
 		lights = add_input_port("Toggle Lights", PORT_TYPE_SIGNAL)
 		red = add_input_port("Red", PORT_TYPE_NUMBER)
 		green = add_input_port("Green", PORT_TYPE_NUMBER)
 		blue = add_input_port("Blue", PORT_TYPE_NUMBER)
 
 /obj/item/circuit_component/modpc/unregister_shell(atom/movable/shell)
-	computer = null
+	if(computer)
+		UnregisterSignal(computer, list(COMSIG_MODULAR_COMPUTER_TURNED_ON, COMSIG_MODULAR_COMPUTER_SHUT_DOWN))
+		computer = null
 	return ..()
 
 /obj/item/circuit_component/modpc/populate_ports()
 	on_off = add_input_port("Turn On/Off", PORT_TYPE_SIGNAL)
 	print = add_input_port("Print Text", PORT_TYPE_STRING)
+
+	is_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
+	is_on = add_output_port("Shut Down", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/modpc/pre_input_received(datum/port/input/port)
 	if(isnull(computer))
@@ -74,3 +90,11 @@
 			computer.toggle_flashlight()
 		if(COMPONENT_TRIGGERED_BY(red, port) || COMPONENT_TRIGGERED_BY(green, port) || COMPONENT_TRIGGERED_BY(blue, port))
 			computer.set_flashlight_color(rgb(red.value || 0, green.value || 0, blue.value || 0))
+
+/obj/item/circuit_component/modpc/proc/computer_on(datum/source)
+	SIGNAL_HANDLER
+	is_on.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/modpc/proc/computer_off(datum/source)
+	SIGNAL_HANDLER
+	is_off.set_output(COMPONENT_SIGNAL)

--- a/code/modules/modular_computers/file_system/program_circuit.dm
+++ b/code/modules/modular_computers/file_system/program_circuit.dm
@@ -66,6 +66,8 @@
 		return FALSE
 	if(isnull(associated_program))
 		return FALSE
+	if(!associated_program.computer.enabled)
+		return FALSE
 	if(associated_program.program_flags & PROGRAM_CIRCUITS_RUN_WHEN_CLOSED || COMPONENT_TRIGGERED_BY(start, port))
 		return TRUE
 	var/obj/item/modular_computer/computer = associated_program.computer
@@ -78,16 +80,16 @@
 
 /obj/item/circuit_component/mod_program/proc/on_start(mob/living/user)
 	SIGNAL_HANDLER
-	running.set_value(TRUE)
+	running.set_output(TRUE)
 
 /obj/item/circuit_component/mod_program/proc/kill_prog(datum/port/input/port)
 	associated_program.kill_program()
 
 /obj/item/circuit_component/mod_program/proc/on_kill(mob/living/user)
 	SIGNAL_HANDLER
-	running.set_value(FALSE)
+	running.set_output(FALSE)
 
 /obj/item/circuit_component/mod_program/get_ui_notices()
 	. = ..()
 	if(!(associated_program.program_flags & PROGRAM_CIRCUITS_RUN_WHEN_CLOSED))
-		. += create_ui_notice("Requires program to be running", "purple")
+		. += create_ui_notice("Requires open program for inputs", "purple")

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -17,48 +17,6 @@
 	/// How many pictures were taken already, used for the camera's TGUI photo display
 	var/picture_number = 1
 
-/obj/item/circuit_component/mod_program/camera
-	associated_program = /datum/computer_file/program/maintenance/camera
-	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
-
-	///A target to take a picture of.
-	var/datum/port/input/picture_target
-	///The photographed target
-	var/datum/port/output/photographed
-
-/obj/item/circuit_component/mod_program/camera/populate_ports()
-	. = ..()
-	picture_target = add_input_port("Picture Target", PORT_TYPE_ATOM)
-	photographed = add_output_port("Photographed Entity", PORT_TYPE_ATOM)
-
-/obj/item/circuit_component/mod_program/camera/register_shell(atom/movable/shell)
-	. = ..()
-	var/datum/computer_file/program/maintenance/camera/cam = associated_program
-	RegisterSignal(cam.internal_camera, COMSIG_CAMERA_IMAGE_CAPTURED, PROC_REF(on_image_captured))
-
-/obj/item/circuit_component/mod_program/camera/unregister_shell()
-	var/datum/computer_file/program/maintenance/camera/cam = associated_program
-	UnregisterSignal(cam.internal_camera, COMSIG_CAMERA_IMAGE_CAPTURED)
-	return ..()
-
-/obj/item/circuit_component/mod_program/camera/input_received(datum/port/input/port)
-	var/atom/target = picture_target.value
-	if(!target)
-		var/turf/our_turf = get_location()
-		target = locate(our_turf.x, our_turf.y, our_turf.z)
-		if(!target)
-			return
-	var/datum/computer_file/program/maintenance/camera/cam = associated_program
-	if(!cam.internal_camera.can_target(target))
-		return
-	var/pic_size_x = cam.internal_camera.picture_size_x - 1
-	var/pic_size_y = cam.internal_camera.picture_size_y - 1
-	INVOKE_ASYNC(cam.internal_camera, TYPE_PROC_REF(/obj/item/camera, captureimage), target, null, pic_size_x, pic_size_y)
-
-/obj/item/circuit_component/mod_program/camera/proc/on_image_captured(obj/item/camera/source, atom/target, mob/user)
-	SIGNAL_HANDLER
-	photographed.set_output(target)
-
 /datum/computer_file/program/maintenance/camera/on_install()
 	. = ..()
 	internal_camera = new(computer)
@@ -103,3 +61,53 @@
 			internal_camera.printpicture(usr, internal_picture)
 			computer.stored_paper--
 			computer.visible_message(span_notice("\The [computer] prints out a paper."))
+
+/obj/item/circuit_component/mod_program/camera
+	associated_program = /datum/computer_file/program/maintenance/camera
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
+
+	///A target to take a picture of.
+	var/datum/port/input/picture_target
+	///The photographed target
+	var/datum/port/output/photographed
+	/**
+	 * Pinged when the image has been captured.
+	 * I'm not using the default trigger output here because the process is asynced,
+	 * even though I'm mostly sure it only sleeps if there's a set user.
+	 */
+	var/datum/port/output/photo_taken
+
+/obj/item/circuit_component/mod_program/camera/populate_ports()
+	. = ..()
+	picture_target = add_input_port("Picture Target", PORT_TYPE_ATOM)
+	photographed = add_output_port("Photographed Entity", PORT_TYPE_ATOM)
+	photo_taken = add_output_port("Photo Taken", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/mod_program/camera/register_shell(atom/movable/shell)
+	. = ..()
+	var/datum/computer_file/program/maintenance/camera/cam = associated_program
+	RegisterSignal(cam.internal_camera, COMSIG_CAMERA_IMAGE_CAPTURED, PROC_REF(on_image_captured))
+
+/obj/item/circuit_component/mod_program/camera/unregister_shell()
+	var/datum/computer_file/program/maintenance/camera/cam = associated_program
+	UnregisterSignal(cam.internal_camera, COMSIG_CAMERA_IMAGE_CAPTURED)
+	return ..()
+
+/obj/item/circuit_component/mod_program/camera/input_received(datum/port/input/port)
+	var/atom/target = picture_target.value
+	if(!target)
+		var/turf/our_turf = get_location()
+		target = locate(our_turf.x, our_turf.y, our_turf.z)
+		if(!target)
+			return
+	var/datum/computer_file/program/maintenance/camera/cam = associated_program
+	if(!cam.internal_camera.can_target(target))
+		return
+	var/pic_size_x = cam.internal_camera.picture_size_x - 1
+	var/pic_size_y = cam.internal_camera.picture_size_y - 1
+	INVOKE_ASYNC(cam.internal_camera, TYPE_PROC_REF(/obj/item/camera, captureimage), target, null, pic_size_x, pic_size_y)
+
+/obj/item/circuit_component/mod_program/camera/proc/on_image_captured(obj/item/camera/source, atom/target, mob/user)
+	SIGNAL_HANDLER
+	photographed.set_output(target)
+	photo_taken.set_output(COMPONENT_SIGNAL)

--- a/code/modules/modular_computers/file_system/programs/maintenance/spectre_meter.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/spectre_meter.dm
@@ -143,10 +143,13 @@
 
 	/// Returns the spookiness of each scan.
 	var/datum/port/output/scan_results
+	/// Pinged whenever a scan is done.
+	var/datum/port/output/scanned
 
 /obj/item/circuit_component/mod_program/spectre_meter/populate_ports()
 	. = ..()
 	scan_results = add_output_port("Scan Results", PORT_TYPE_NUMBER)
+	scanned = add_output_port("Scaned", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/mod_program/spectre_meter/register_shell(atom/movable/shell)
 	. = ..()
@@ -166,7 +169,8 @@
 
 /obj/item/circuit_component/mod_program/spectre_meter/proc/on_scan(datum/source, spook_value)
 	SIGNAL_HANDLER
-	scan_results.set_value(spook_value)
+	scan_results.set_output(spook_value)
+	scanned.set_output(COMPONENT_SIGNAL)
 
 #undef SPOOK_VALUE_SAME_TURF_MULT
 #undef SPOOK_VALUE_LIVING_MULT

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_circuit.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_circuit.dm
@@ -1,6 +1,7 @@
 #define MESSENGER_CIRCUIT_MIN_COOLDOWN 5 SECONDS
 #define MESSENGER_CIRCUIT_MAX_COOLDOWN 45 SECONDS
 #define MESSENGER_CIRCUIT_CD_PER_RECIPIENT 1.5 SECONDS
+#define MESSENGER_CIRCUIT_RINGTONE_CD 1.5 SECONDS
 
 /obj/item/circuit_component/mod_program/messenger
 	associated_program = /datum/computer_file/program/messenger
@@ -14,6 +15,8 @@
 	var/datum/port/output/sender_job
 	///Reference to the device that sent the message. Usually a PDA.
 	var/datum/port/output/sender_device
+	///Pinged whenever a message is received.
+	var/datum/port/output/received
 
 	///A message to be sent when triggered
 	var/datum/port/input/message
@@ -25,12 +28,16 @@
 	///Set the ringtone to the input
 	var/datum/port/input/set_ring
 
+	///the cooldown of the ringtone.
+	COOLDOWN_DECLARE(ring_cd)
+
 /obj/item/circuit_component/mod_program/messenger/populate_ports()
 	. = ..()
-	received_message = add_output_port("Received Message", PORT_TYPE_STRING)
+	received_message = add_output_port("Message", PORT_TYPE_STRING)
 	sender_name = add_output_port("Sender Name", PORT_TYPE_STRING)
 	sender_job =  add_output_port("Sender Job", PORT_TYPE_STRING)
 	sender_device = add_output_port("Sender Device", PORT_TYPE_ATOM)
+	received = add_output_port("Received", PORT_TYPE_SIGNAL)
 
 	message = add_input_port("Message", PORT_TYPE_STRING)
 	targets = add_input_port("Targets", PORT_TYPE_LIST(PORT_TYPE_ATOM))
@@ -38,25 +45,22 @@
 	ring = add_input_port("Play Ringtone", PORT_TYPE_SIGNAL, trigger = PROC_REF(play_ringtone))
 	set_ring = add_input_port("Set Ringtone", PORT_TYPE_STRING, trigger = PROC_REF(set_ringtone))
 
-///Sanitize the targets list so it doesn't contain duplicate targets and our own computer.
-/obj/item/circuit_component/mod_program/messenger/pre_input_received(datum/port/port)
-	if(COMPONENT_TRIGGERED_BY(targets, port))
-		targets.value = unique_list(targets.value) - associated_program.computer
-
 /obj/item/circuit_component/mod_program/messenger/input_received(datum/port/port)
 	var/list/messenger_targets = list()
-	for(var/obj/item/modular_computer/modpc in targets.value)
+	for(var/datum/weakref/ref as anything in targets.value)
+		var/obj/item/modular_computer/modpc = ref?.resolve() //entity ports are hardrefs, entity list ports are weakref. :thonking:
+		if(!istype(modpc))
+			continue
 		var/datum/computer_file/program/messenger/messenger = locate() in modpc.stored_files
 		if(messenger)
 			messenger_targets |= messenger
-	var/messenger_length = length(messenger_targets)
-	if(!messenger_length)
+	if(!length(messenger_targets))
 		return
 	var/datum/computer_file/program/messenger/messenger = associated_program
-	if(is_ic_filtered_for_pdas(message.value) || is_soft_ic_filtered_for_pdas(message.value))
-		return
+	var/filterd_message = censor_ic_filter_for_pdas(message.value)
+
 	///We need to async send_message() because some tcomms devices might sleep. Also because of (non-existent) user tgui alerts.
-	INVOKE_ASYNC(messenger, TYPE_PROC_REF(/datum/computer_file/program/messenger, send_message), src, message.value, messenger_targets)
+	INVOKE_ASYNC(messenger, TYPE_PROC_REF(/datum/computer_file/program/messenger, send_message), src, filterd_message, messenger_targets)
 
 /obj/item/circuit_component/mod_program/messenger/register_shell(atom/movable/shell)
 	. = ..()
@@ -76,8 +80,8 @@
 /obj/item/circuit_component/mod_program/messenger/proc/message_received(datum/source, datum/signal/subspace/messaging/tablet_message/signal, message_job, message_name)
 	SIGNAL_HANDLER
 	received_message.set_value(signal.data["message"])
-	sender_name.set_value(message_name)
-	sender_job.set_value(message_job)
+	sender_name.set_output(message_name)
+	sender_job.set_output(message_job)
 
 	var/atom/source_device
 	if(istype(signal.source, /datum/computer_file/program/messenger))
@@ -86,7 +90,8 @@
 	else if(isatom(signal.source))
 		source_device = signal.source
 
-	sender_device.set_value(source_device)
+	sender_device.set_output(source_device)
+	received.set_output(COMPONENT_SIGNAL)
 
 ///Set the cooldown after the message was sent (by us)
 /obj/item/circuit_component/mod_program/messenger/proc/message_sent(datum/source, atom/origin, datum/signal/subspace/messaging/tablet_message/signal)
@@ -103,9 +108,13 @@
 	messenger.set_ringtone(set_ring.value)
 
 /obj/item/circuit_component/mod_program/messenger/proc/play_ringtone(datum/port/port)
+	if(!COOLDOWN_FINISHED(src, ring_cd))
+		return
+	COOLDOWN_START(src, ring_cd, MESSENGER_CIRCUIT_RINGTONE_CD)
 	var/datum/computer_file/program/messenger/messenger = associated_program
 	messenger.computer.ring(messenger.ringtone)
 
 #undef MESSENGER_CIRCUIT_MIN_COOLDOWN
 #undef MESSENGER_CIRCUIT_MAX_COOLDOWN
 #undef MESSENGER_CIRCUIT_CD_PER_RECIPIENT
+#undef MESSENGER_CIRCUIT_RINGTONE_CD

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -470,8 +470,6 @@
 	var/mob/living/sender
 	if(isliving(source))
 		sender = source
-	else if(is_ic_filtered_for_pdas(message) || is_soft_ic_filtered_for_pdas(message))
-		return FALSE
 	message = sanitize_pda_message(message, sender)
 	if(!message)
 		return FALSE
@@ -571,8 +569,8 @@
 	var/mob/sender
 	if(ismob(source))
 		sender = source
-	if(sender && !sender.can_perform_action(computer, ALLOW_RESTING))
-		return FALSE
+		if(!sender.can_perform_action(computer, ALLOW_RESTING))
+			return FALSE
 
 	if(!COOLDOWN_FINISHED(src, last_text))
 		return FALSE

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -40,11 +40,14 @@
 	var/datum/port/input/set_text
 	///The written note output, sent everytime notes are updated.
 	var/datum/port/output/updated_text
+	///Pinged whenever the text is updated
+	var/datum/port/output/updated
 
 /obj/item/circuit_component/mod_program/notepad/populate_ports()
 	. = ..()
 	set_text = add_input_port("Set Notes", PORT_TYPE_STRING)
-	updated_text = add_output_port("Updated Notes", PORT_TYPE_STRING)
+	updated_text = add_output_port("Notes", PORT_TYPE_STRING)
+	updated = add_output_port("Updated", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/mod_program/notepad/register_shell(atom/movable/shell)
 	. = ..()
@@ -58,9 +61,11 @@
 	SIGNAL_HANDLER
 	if(action == "UpdateNote")
 		updated_text.set_output(params["newnote"])
+		updated.set_output(COMPONENT_SIGNAL)
 
 /obj/item/circuit_component/mod_program/notepad/input_received(datum/port/port)
 	var/datum/computer_file/program/notepad/pad = associated_program
 	pad.written_note = set_text.value
 	SStgui.update_uis(pad.computer)
 	updated_text.set_output(pad.written_note)
+	updated.set_output(COMPONENT_SIGNAL)

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -60,6 +60,8 @@
 	SEND_SIGNAL(computer, COMSIG_MODULAR_COMPUTER_NT_PAY_RESULT, payment_result)
 
 /datum/computer_file/program/nt_pay/proc/_pay(token, money_to_send, mob/user)
+	money_to_send = round(money_to_send)
+
 	if(IS_DEPARTMENTAL_ACCOUNT(current_user))
 		if(user)
 			to_chat(user, span_notice("The app is unable to withdraw from that card."))
@@ -95,6 +97,9 @@
 
 	recipient.bank_card_talk("You received [money_to_send] credit(s). Reason: transfer from [current_user.account_holder]")
 	recipient.transfer_money(current_user, money_to_send)
+	for(var/obj/item/card/id/id_card as anything in recipient.bank_cards)
+		SEND_SIGNAL(id_card, COMSIG_ID_CARD_NTPAY_MONEY_RECEIVED, computer, money_to_send)
+
 	current_user.bank_card_talk("You send [money_to_send] credit(s) to [recipient.account_holder]. Now you have [current_user.account_balance] credit(s)")
 
 	return NT_PAY_STATUS_SUCCESS
@@ -110,38 +115,70 @@
 	var/datum/port/input/money_port
 	///Let's us know if the payment has gone through or not.
 	var/datum/port/output/payment_status
+	///The device from which the payment was received
+	var/datum/port/output/payment_device
+	///Amount of a received payment
+	var/datum/port/output/payment_amount
+	///Pinged whether a payment is received
+	var/datum/port/output/payment_received
 
 /obj/item/circuit_component/mod_program/nt_pay/register_shell(atom/movable/shell)
 	. = ..()
-	RegisterSignal(associated_program.computer, COMSIG_MODULAR_COMPUTER_NT_PAY_RESULT, PROC_REF(on_payment_result))
+	var/obj/item/modular_computer/modpc = associated_program.computer
+	RegisterSignal(modpc, COMSIG_MODULAR_COMPUTER_NT_PAY_RESULT, PROC_REF(on_payment_done))
+	RegisterSignal(modpc, COMSIG_MODULAR_COMPUTER_INSERTED_ID, PROC_REF(register_id))
+	if(modpc.computer_id_slot)
+		register_id(inserted_id = modpc.computer_id_slot)
 
 /obj/item/circuit_component/mod_program/nt_pay/unregister_shell()
-	UnregisterSignal(associated_program.computer, COMSIG_MODULAR_COMPUTER_NT_PAY_RESULT)
+	var/obj/item/modular_computer/modpc = associated_program.computer
+	UnregisterSignal(modpc, list(COMSIG_MODULAR_COMPUTER_NT_PAY_RESULT, COMSIG_MODULAR_COMPUTER_INSERTED_ID))
+	if(modpc.computer_id_slot)
+		UnregisterSignal(modpc.computer_id_slot, list(COMSIG_ID_CARD_NTPAY_MONEY_RECEIVED, COMSIG_MOVABLE_MOVED))
 	return ..()
+
+/obj/item/circuit_component/mod_program/nt_pay/proc/register_id(datum/source, obj/item/card/inserted_id, mob/user)
+	SIGNAL_HANDLER
+	RegisterSignal(inserted_id, COMSIG_ID_CARD_NTPAY_MONEY_RECEIVED, PROC_REF(on_payment_received))
+	RegisterSignal(inserted_id, COMSIG_MOVABLE_MOVED, PROC_REF(unregister_id))
+
+/obj/item/circuit_component/mod_program/nt_pay/proc/unregister_id(obj/item/card/gone)
+	SIGNAL_HANDLER
+	UnregisterSignal(gone, list(COMSIG_ID_CARD_NTPAY_MONEY_RECEIVED, COMSIG_MOVABLE_MOVED))
 
 /obj/item/circuit_component/mod_program/nt_pay/populate_ports()
 	. = ..()
 	token_port = add_input_port("Token", PORT_TYPE_STRING)
 	money_port = add_input_port("Amount", PORT_TYPE_NUMBER)
 	payment_status = add_output_port("Status", PORT_TYPE_NUMBER)
+	payment_device = add_output_port("Payment Sender", PORT_TYPE_ATOM)
+	payment_amount = add_output_port("Received Amount", PORT_TYPE_NUMBER)
+	payment_received = add_output_port("Received Payment", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/mod_program/nt_pay/get_ui_notices()
 	. = ..()
+	. += create_ui_notice("Outputs require inserted ID", "orange")
 	. += create_ui_notice("NT-Pay Statuses:")
+	. += create_ui_notice("Success - [NT_PAY_STATUS_SUCCESS]", "green")
 	. += create_ui_notice("Fail (No Account) - [NT_PAY_STATUS_NO_ACCOUNT]", "red")
 	. += create_ui_notice("Fail (Dept Account) - [NT_PAY_STATUS_DEPT_ACCOUNT]", "red")
 	. += create_ui_notice("Fail (Invalid Token) - [NT_PAY_STATUS_INVALID_TOKEN]", "red")
 	. += create_ui_notice("Fail (Sender = Receiver) - [NT_PAY_SATUS_SENDER_IS_RECEIVER]", "red")
 	. += create_ui_notice("Fail (Invalid Amount) - [NT_PAY_STATUS_INVALID_MONEY]", "red")
-	. += create_ui_notice("Success - [NT_PAY_STATUS_SUCCESS]", "green")
 
 /obj/item/circuit_component/mod_program/nt_pay/input_received(datum/port/port)
 	var/datum/computer_file/program/nt_pay/program = associated_program
 	program.make_payment(token_port.value, money_port.value)
 
-/obj/item/circuit_component/mod_program/nt_pay/proc/on_payment_result(datum/source, payment_result)
+/obj/item/circuit_component/mod_program/nt_pay/proc/on_payment_done(datum/source, payment_result)
 	SIGNAL_HANDLER
 	payment_status.set_output(payment_result)
+
+/obj/item/circuit_component/mod_program/nt_pay/proc/on_payment_received(datum/source, obj/item/modular_computer/computer, money_received)
+	SIGNAL_HANDLER
+	payment_device.set_output(computer)
+	payment_amount.set_output(money_received)
+	payment_received.set_output(COMPONENT_SIGNAL)
 
 #undef NT_PAY_STATUS_NO_ACCOUNT
 #undef NT_PAY_STATUS_DEPT_ACCOUNT

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -460,11 +460,11 @@
 		SStgui.update_uis(radar.computer)
 	if(radar.trackable(radar_atom))
 		var/turf/turf = get_turf(radar_atom)
-		x_pos.set_value(turf.x)
-		y_pos.set_value(turf.y)
+		x_pos.set_output(turf.x)
+		y_pos.set_output(turf.y)
 	else
-		x_pos.set_value(null)
-		y_pos.set_value(null)
+		x_pos.set_output(null)
+		y_pos.set_output(null)
 
 /**
  * Check if we can track the object. When making different definitions of this proc for subtypes, include typical
@@ -491,14 +491,16 @@
 	target.set_value(null)
 	var/datum/computer_file/program/radar/radar = associated_program
 	var/atom/selected_atom = radar.find_atom()
-	selected_by_app.set_value(selected_atom)
+	selected_by_app.set_output(selected_atom)
 	if(radar.trackable(selected_atom))
 		var/turf/turf = get_turf(radar.selected)
-		x_pos.set_value(turf.x)
-		y_pos.set_value(turf.y)
+		x_pos.set_output(turf.x)
+		y_pos.set_output(turf.y)
 	else
-		x_pos.set_value(null)
-		y_pos.set_value(null)
+		x_pos.set_output(null)
+		y_pos.set_output(null)
+
+	trigger_output.set_output(COMPONENT_SIGNAL)
 
 
 /obj/item/circuit_component/mod_program/radar/medical

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -100,7 +100,7 @@
 
 /obj/item/circuit_component/mod_program/status
 	associated_program = /datum/computer_file/program/status
-	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	///When the trigger is signaled, this will be the upper text of status displays.
 	var/datum/port/input/upper_text
@@ -108,6 +108,11 @@
 	var/datum/port/input/bottom_text
 	///A list port that, when signaled, will set the status image to one of its values
 	var/datum/port/input/status_display_pics
+
+/obj/item/circuit_component/mod_program/status/populate_ports()
+	. = ..()
+	upper_text = add_input_port("Upper text", PORT_TYPE_STRING)
+	bottom_text = add_input_port("Bottom text", PORT_TYPE_STRING)
 
 /obj/item/circuit_component/mod_program/status/populate_options()
 	status_display_pics = add_option_port("Set Status Display Picture", GLOB.status_display_approved_pictures, trigger = PROC_REF(set_picture))

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -71,6 +71,7 @@
 
 /obj/item/circuit_component/mod_program/ntnetmonitor
 	associated_program = /datum/computer_file/program/ntnetmonitor
+	circuit_flags = CIRCUIT_FLAG_OUTPUT_SIGNAL
 	///The stored NTnet relay or PDA to be used as the target of triggers
 	var/datum/port/input/target
 	///Sets `intrusion_detection_alarm` when triggered
@@ -103,8 +104,8 @@
 	var/list/computers_with_messenger = list()
 	for(var/messenger_ref as anything in GLOB.pda_messengers)
 		var/datum/computer_file/program/messenger/messenger = GLOB.pda_messengers[messenger_ref]
-		computers_with_messenger += messenger.computer
-	all_messengers.set_value(computers_with_messenger)
+		computers_with_messenger |= WEAKREF(messenger.computer)
+	all_messengers.set_output(computers_with_messenger)
 
 /obj/item/circuit_component/mod_program/ntnetmonitor/proc/toggle_ids(datum/port/port)
 	SSmodular_computers.intrusion_detection_enabled = !SSmodular_computers.intrusion_detection_enabled


### PR DESCRIPTION
## About The Pull Request
It turns out the messenger circuit wasn't working as intended, because list components tend to convert datum keys into weakrefs, creating incoherence between composite datum/atom and simple datum/atom datatypes, which at least just spares us from the headache of clearing the refs on del from lists too.

So, taking the shortest path, I decided to adapt the messenger to the weak ref usage.

Another thing, instead of refusing altogether to send message that trigger the pda filter regexes, the messenger circuit will instead replace the matches with grawlix, since we have no way to inform whoever's responsible for said message about the filters in an orthodox way.

Beside that, I've noticed several of the circuits from my PR were lacking trigger outputs or similar when needed, pretty making them only as half as functional, at least to a noob like me.

And another small issue with missing ports from the status display circuit.

One more suggestion from moocow is to add a cooldown to the ringtone trigger for the messenger circuit, because he said it's pretty spammy and some admins are fickle.

## Why It's Good For The Game
Bugfixing and improvements.

## Changelog

:cl:
fix: Fixed the messenger circuit not sending messages.
fix: Added several ports to modpc circuits that were missing or needing them.
fix: Fixes ever-expanding ports whenever circuits are re-inserted in a modular computer.
/:cl:
