### PR TITLE
Fixes RPG titles alignment

### DIFF
--- a/code/modules/events/wizard/rpgtitles.dm
+++ b/code/modules/events/wizard/rpgtitles.dm
@@ -43,7 +43,7 @@ GLOBAL_DATUM(rpgtitle_controller, /datum/rpgtitle_controller)
 	//we must prepare for the mother of all strings
 	new_crewmember.maptext_height = max(new_crewmember.maptext_height, 32)
 	new_crewmember.maptext_width = max(new_crewmember.maptext_width, 112)
-	new_crewmember.maptext_x = -24 - new_crewmember.base_pixel_x
+	new_crewmember.maptext_x = -38 - new_crewmember.base_pixel_x
 	new_crewmember.maptext_y = -32
 
 	//list of lists involving strings related to a biotype flag, their position in the list equal to the position they were defined as bitflags.


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/81013 RPG titles having incorrect alignment

![image](https://github.com/tgstation/tgstation/assets/83487515/3be96289-f74a-4463-9e68-69cc450110ed)

## Changelog

:cl: LT3
fix: Fixed alignment of RPG titles
/:cl: