### PR TITLE
Fix wrong arg pass to translate_language

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -204,8 +204,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 #undef ENCODE_HTML_EMPHASIS
 
-///	Modifies the message by comparing the languages of the speaker with the languages of the hearer. Called on the hearer.
-/atom/movable/proc/translate_language(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods = list())
+/// Modifies the message by comparing the languages of the speaker with the languages of the hearer. Called on the hearer.
+/atom/movable/proc/translate_language(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods)
 	if(!language)
 		return "makes a strange sound."
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/understood = TRUE
 	if(!is_custom_emote) // we do not translate emotes
 		var/untranslated_raw_message = raw_message
-		raw_message = translate_language(src, message_language, raw_message) // translate
+		raw_message = translate_language(speaker, message_language, raw_message) // translate
 		if(raw_message != untranslated_raw_message)
 			understood = FALSE
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/understood = TRUE
 	if(!is_custom_emote) // we do not translate emotes
 		var/untranslated_raw_message = raw_message
-		raw_message = translate_language(speaker, message_language, raw_message) // translate
+		raw_message = translate_language(speaker, message_language, raw_message, spans, message_mods) // translate
 		if(raw_message != untranslated_raw_message)
 			understood = FALSE
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -902,7 +902,7 @@
 	return get_dist(src, A) <= max(viewscale[1]*0.5,viewscale[2]*0.5)
 
 /mob/living/silicon/ai/proc/relay_speech(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
-	var/raw_translation = translate_language(speaker, message_language, raw_message)
+	var/raw_translation = translate_language(speaker, message_language, raw_message, spans, message_mods)
 	var/atom/movable/source = speaker.GetSource() || speaker // is the speaker virtual/radio
 	var/treated_message = source.say_quote(raw_translation, spans, message_mods)
 


### PR DESCRIPTION
## About The Pull Request

The first argument of `translate_language` is the speaker, not the hearer. 

## Changelog

Has no effect currently
