### PR TITLE
Kidnapping traitor objective properly returns victim

### DIFF
--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -274,23 +274,13 @@
 	if(!sent_mob || QDELETED(sent_mob)) //suicided and qdeleted themselves
 		return
 
-	var/list/possible_turfs = list()
-
-	for(var/turf/open/open_turf in dropoff_area.get_turfs_from_all_zlevels())
-		if(open_turf.is_blocked_turf() || isspaceturf(open_turf))
-			continue
-		possible_turfs += open_turf
-
-	if(!LAZYLEN(possible_turfs))
-		var/turf/new_turf = get_safe_random_station_turf()
-		if(!new_turf) //SOMEHOW
-			to_chat(sent_mob, span_hypnophrase(span_reallybig("A million voices echo in your head... <i>\"Seems where you got sent here from won't \
-				be able to handle our pod... You will die here instead.\"</i></span>")))
-			if (sent_mob.can_heartattack())
-				sent_mob.set_heartattack(TRUE)
-			return
-
-		possible_turfs += new_turf
+	var/turf/return_turf = get_safe_random_station_turf()
+	if(!return_turf) //SOMEHOW
+		to_chat(sent_mob, span_hypnophrase(span_reallybig("A million voices echo in your head... <i>\"Seems where you got sent here from won't \
+			be able to handle our pod... You will die here instead.\"</i></span>")))
+		if (sent_mob.can_heartattack())
+			sent_mob.set_heartattack(TRUE)
+		return
 
 	var/obj/structure/closet/supplypod/return_pod = new()
 	return_pod.bluespace = TRUE
@@ -317,4 +307,4 @@
 	sent_mob.set_eye_blur_if_lower(100 SECONDS)
 	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
 
-	new /obj/effect/pod_landingzone(pick(possible_turfs), return_pod)
+	new /obj/effect/pod_landingzone(return_turf, return_pod)


### PR DESCRIPTION

## About The Pull Request
Fixes #81022 
The original idea was for kidnapping victims to be returned to the same area they were kidnapped from (dropoff_area), but this was always a typepath to an area and not a datum reference (and was set to null immediately after kidnapping with ungenerate_objective()) and it always fell back to the get_safe_random_station_turf() method. This worked fine until #80644 attempted to optimize it, causing a runtime and returning early.

This removes the code to return them to the same area and instead just uses get_safe_random_station_turf(), runtime-free.
## Why It's Good For The Game
Kidnapping victims now actually return to the station after 3 minutes with their stuff. I think returning to a random area is cooler than the same area they were sent from anyways, I can imagine a traitor just waiting it out if they wanted them dead and unable to snitch.
## Changelog
:cl:
fix: Kidnapping traitor objective now properly returns the victim to the station with their items
/:cl:
