### PR TITLE
Gives designs a variable that lets them not be automatically pixel shifted when printed by lathes of both types

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -276,8 +276,9 @@
 		created = new design.build_path(target)
 		created.set_custom_materials(materials_per_item.Copy())
 
-	created.pixel_x = created.base_pixel_x + rand(-6, 6)
-	created.pixel_y = created.base_pixel_y + rand(-6, 6)
+	if(!design.prevent_automatic_shift)
+		created.pixel_x = created.base_pixel_x + rand(-6, 6)
+		created.pixel_y = created.base_pixel_y + rand(-6, 6)
 	for(var/atom/movable/content in created)
 		content.set_custom_materials(list()) // no
 	created.forceMove(target)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -59,6 +59,8 @@ other types of metals and chemistry for reagents).
 	var/search_metadata
 	/// For protolathe designs that don't require reagents: If they can be exported to autolathes with a design disk or not.
 	var/autolathe_exportable = TRUE
+	/// Prevents lathes from automatically pixel shifting the result of this design
+	var/prevent_automatic_shift = FALSE
 
 /datum/design/error_design
 	name = "ERROR"

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -326,8 +326,9 @@
 		created = new design.build_path(get_turf(src))
 		created.set_custom_materials(materials_per_item.Copy())
 
-	created.pixel_x = created.base_pixel_x + rand(-6, 6)
-	created.pixel_y = created.base_pixel_y + rand(-6, 6)
+	if(!design.prevent_automatic_shift)
+		created.pixel_x = created.base_pixel_x + rand(-6, 6)
+		created.pixel_y = created.base_pixel_y + rand(-6, 6)
 	for(var/atom/movable/content in created)
 		content.set_custom_materials(list()) // no
 


### PR DESCRIPTION

## About The Pull Request

Adds the prevent_automatic_shift variable to designs that, as the name might imply, prevents the items that design prints from being automatically shifted around when printed from an autolathe or protolathe.
## Why It's Good For The Game

Sometimes I do not want certain designs to be pixel shifted when they are printed.
## Changelog
:cl:
code: Designs have a variable that makes them not be pixel shifted automatically by lathes when printed now
/:cl:
