### PR TITLE
Fix neck snap not checking for the right mob to snap

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -197,7 +197,7 @@
 
 /datum/martial_art/cqc/harm_act(mob/living/attacker, mob/living/defender)
 	if(!can_use(attacker))
-		return FALSE
+		return MARTIAL_ATTACK_FAIL
 
 	if(attacker.resting && defender.stat != DEAD && defender.body_position == STANDING_UP)
 		defender.visible_message(span_danger("[attacker] leg sweeps [defender]!"), \
@@ -209,10 +209,14 @@
 		defender.Knockdown(5 SECONDS)
 		log_combat(attacker, defender, "sweeped (CQC)")
 		reset_streak()
-		return TRUE
-	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
-		var/obj/item/bodypart/head = defender.get_bodypart("head")
-		if(head)
+		return MARTIAL_ATTACK_SUCCESS
+	if(attacker.grab_state == GRAB_KILL \
+		&& attacker.zone_selected == BODY_ZONE_HEAD \
+		&& attacker.pulling == defender \
+		&& defender.stat != DEAD \
+	)
+		var/obj/item/bodypart/head = defender.get_bodypart(BODY_ZONE_HEAD)
+		if(!isnull(head))
 			playsound(defender, 'sound/effects/wounds/crack1.ogg', 100)
 			defender.visible_message(
 				span_danger("[attacker] snaps the neck of [defender]!"),
@@ -226,12 +230,11 @@
 			if(!HAS_TRAIT(defender, TRAIT_NODEATH))
 				defender.death()
 				defender.investigate_log("has had [defender.p_their()] neck snapped by [attacker].", INVESTIGATE_DEATHS)
-
-			return TRUE
+			return MARTIAL_ATTACK_SUCCESS
 
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))
-		return TRUE
+		return MARTIAL_ATTACK_SUCCESS
 	log_combat(attacker, defender, "attacked (CQC)")
 	attacker.do_attack_animation(defender)
 	var/picked_hit_type = pick("CQC", "Big Boss")
@@ -249,7 +252,7 @@
 	to_chat(attacker, span_danger("You [picked_hit_type] [defender]!"))
 	log_combat(attacker, defender, "[picked_hit_type]s (CQC)")
 
-	return TRUE
+	return MARTIAL_ATTACK_SUCCESS
 
 /datum/martial_art/cqc/disarm_act(mob/living/attacker, mob/living/defender)
 	if(!can_use(attacker))

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -107,9 +107,13 @@
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/attacker, mob/living/defender)
-	if((attacker.grab_state == GRAB_KILL) && attacker.zone_selected == BODY_ZONE_HEAD && defender.stat != DEAD)
-		var/obj/item/bodypart/head = defender.get_bodypart("head")
-		if(head)
+	if(attacker.grab_state == GRAB_KILL \
+		&& attacker.zone_selected == BODY_ZONE_HEAD \
+		&& attacker.pulling == defender \
+		&& defender.stat != DEAD \
+	)
+		var/obj/item/bodypart/head = defender.get_bodypart(BODY_ZONE_HEAD)
+		if(!isnull(head))
 			playsound(defender, 'sound/effects/wounds/crack1.ogg', 100)
 			defender.visible_message(
 				span_danger("[attacker] snaps the neck of [defender]!"),
@@ -123,9 +127,11 @@
 			if(!HAS_TRAIT(defender, TRAIT_NODEATH))
 				defender.death()
 				defender.investigate_log("has had [defender.p_their()] neck snapped by [attacker].", INVESTIGATE_DEATHS)
+			return MARTIAL_ATTACK_SUCCESS
+
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))
-		return TRUE
+		return MARTIAL_ATTACK_SUCCESS
 
 	var/obj/item/bodypart/affecting = defender.get_bodypart(defender.get_random_valid_zone(attacker.zone_selected))
 	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
@@ -137,8 +143,7 @@
 	defender.apply_damage(rand(10,15), attacker.get_attack_type(), affecting, wound_bonus = CANT_WOUND)
 	playsound(defender, 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 	log_combat(attacker, defender, "punched (Sleeping Carp)")
-
-	return TRUE
+	return MARTIAL_ATTACK_SUCCESS
 
 /datum/martial_art/the_sleeping_carp/disarm_act(mob/living/attacker, mob/living/defender)
 	if(!can_deflect(attacker)) //allows for deniability


### PR DESCRIPTION
## About The Pull Request

Fixes #81084 

Nowhere did this procs checked that defender = the guy who is neck grabbed. 

I cleaned these up a bit as well since I was here. 

## Changelog

:cl: Melbert
fix: You can no longer neck snap anyone with martial arts assuming you've got someone in a tight grip. 
/:cl:

