### PR TITLE
Adds a missing check to `can_look_up`

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2045,7 +2045,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 ///Checks if the user is incapacitated or on cooldown.
 /mob/living/proc/can_look_up()
-	return !(incapacitated(IGNORE_RESTRAINTS))
+	if(next_move > world.time)
+		return FALSE
+	if(incapacitated(IGNORE_RESTRAINTS))
+		return FALSE
+	return TRUE
 
 /**
  * look_up Changes the perspective of the mob to any openspace turf above the mob


### PR DESCRIPTION
## About The Pull Request

`///Checks if the user is incapacitated or on cooldown.`.

Adds the "or on cooldown" part of the proc into the proc. 

## Changelog

:cl: Melbert
fix: Click CD applies to looking up and down correctly. 
/:cl:

