### PR TITLE
Temp keybinds patch for 515.1628

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -3,6 +3,9 @@
 /client/verb/keyDown(_key as text)
 	set instant = TRUE
 	set hidden = TRUE
+	
+	if (length(_key) == 1) // Ensure letter keys are uppercase 
+		_key = uppertext(_key)
 
 	client_keysend_amount += 1
 
@@ -82,6 +85,9 @@
 /client/verb/keyUp(_key as text)
 	set instant = TRUE
 	set hidden = TRUE
+	
+	if (length(_key) == 1) // Ensure letter keys are uppercase 
+		_key = uppertext(_key)
 
 	var/key_combo = key_combos_held[_key]
 	if(key_combo)


### PR DESCRIPTION
1628 make pressing `A` come in as `a` (with or without shift). this patches around that. our code expects alphabet characters to come in as uppercase letters in all situations.

This can likely be merged or just test merged until 1629 comes out, either or. In general we might consider making keys not be dependent on the casing of byond strings to never change, and also maybe add defines for them so there isn't a bunch of `Shift`s and `NorthWest`s (home key) and `Tab`s hard coded in strings.

I was gonna do that but the surface area is a mess on changing `Shift`s to `SHIFT`s and the like.
