### PR TITLE
Removes infinite sources of plasma from icebox

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -2,7 +2,7 @@
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/snow/icemoon = 19, /turf/open/misc/ice/icemoon = 1)
 	weighted_closed_turf_types = list(
 		/turf/closed/mineral/snowmountain/icemoon = 100,
-		/turf/closed/mineral/gibtonite/ice = 4,
+		/turf/closed/mineral/gibtonite/ice/icemoon = 4,
 	)
 
 


### PR DESCRIPTION

## About The Pull Request

The gibotonite that arcane had setup to spawn on icebox was uh, the wrong kind, it was the cursed SNOWDIN gibonite, which is made to live in a plasma environment. Rookie error really should have remembered that ice/icemoon exists this is a GREAT codebase

Speaking of, I've noticed that gibonite is the only ore that spawns in an actual mineral wall here (IE the blue rock walls) so you can really trivially avoid it. that feels wrong

## Changelog
:cl:
fix: Icebox will no longer spawn a fuck ton of plasma after gibonite blows. YW besties
/:cl:
