### PR TITLE
Adds new Role restricted Traitor item: Reticence Assasination Exosuit

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -372,11 +372,10 @@
 
 
 /datum/uplink_item/role_restricted/reticence
-
-name = "Reticence Cloaked Assasination exosuit"
+     name = "Reticence Cloaked Assasination exosuit"
 	desc = "A silent, fast, and nigh-invisible but exepctionally fragile miming exosuit! \
 	 fully equipped with a Near-Silenced pistol, and a RCD for your best assasination needs."
-	item = /obj/vehicle/sealed/mecha/reticence
+	item = /obj/vehicle/sealed/mecha/reticence/loaded
 	cost = 20
 	restricted_roles = list(JOB_MIME)
 	restricted = TRUE

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -369,3 +369,15 @@
 	restricted_roles = list(JOB_ASSISTANT, JOB_MIME, JOB_CLOWN)
 	restricted = TRUE
 	refundable = FALSE
+
+
+/datum/uplink_item/role_restricted/reticence
+
+name = "Reticence Cloaked Assasination exosuit"
+	desc = "A silent, fast, and nigh-invisible but exepctionally fragile miming exosuit! \
+	 fully equipped with a Near-Silenced pistol, and a RCD for your best assasination needs."
+	item = /obj/vehicle/sealed/mecha/reticence
+	cost = 20
+	restricted_roles = list(JOB_MIME)
+	restricted = TRUE
+	refundable = FALSE


### PR DESCRIPTION

## About The Pull Request

Adds a decade old item that has been in the code for a LONG LONG TIME but yet still unobtainable without admin intervention

as a traitor item as it was (supposedly?) designed as

screenshots of the item
![image](https://github.com/tgstation/tgstation/assets/118483925/eb73dc81-f957-4c7b-8b8f-035311440e22)
![image](https://github.com/tgstation/tgstation/assets/118483925/2b431736-824c-4ba1-b2d9-4480b71ab261)

and a ameteur demonstration video

https://github.com/tgstation/tgstation/assets/118483925/641dfc9c-d548-4e56-a106-6f85a5c12ad4




Note: this is my first ever addition PR in tgstation, please inform me if you believe i have made any issues!
## Why It's Good For The Game

makes a decade old mime-themed item, obtainable by mime traitors
this item is a **VERY FRAGILE** silent, fast, "assasination" exosuit
the suit has barely any armor and exactly 100 durability making it extremely fragile to oncoming attacks, however, it includes a RCD, a silenced pistol and the ability to punch open structures

effectively making this a glass cannon

personally i think this item should have been obtainable by mime traitors in the first place, but i dont get why it never was, i believe it to be a fairly balanced item for any ordinary traitor to use ((unlike certain items))

so i believe its a good addition
## Changelog
:cl:
add: Added Reticence Assasination Exosuit For 20 TC to mime traitors
/:cl:
