### PR TITLE
Fix runtime from triggering rush organ via goliath grab

### DIFF
--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -23,7 +23,7 @@
 
 /obj/item/organ/internal/monster_core/rush_gland/on_mob_insert(mob/living/carbon/organ_owner)
 	. = ..()
-	RegisterSignal(organ_owner, COMSIG_GOLIATH_TENTACLED_GRABBED, PROC_REF(trigger_organ_action))
+	RegisterSignal(organ_owner, COMSIG_GOLIATH_TENTACLED_GRABBED, PROC_REF(trigger_organ_action_on_sig))
 
 /obj/item/organ/internal/monster_core/rush_gland/on_mob_remove(mob/living/carbon/organ_owner, special)
 	. = ..()
@@ -31,6 +31,10 @@
 
 /obj/item/organ/internal/monster_core/rush_gland/on_triggered_internal()
 	owner.apply_status_effect(/datum/status_effect/lobster_rush/extended)
+
+/obj/item/organ/internal/monster_core/rush_gland/proc/trigger_organ_action_on_sig(datum/source)
+	SIGNAL_HANDLER
+	trigger_organ_action()
 
 /**
  * Status effect: Makes you run really fast and ignore speed penalties for a short duration.

--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -34,8 +34,7 @@
 
 /obj/item/organ/internal/monster_core/rush_gland/proc/trigger_organ_action_on_sig(datum/source)
 	SIGNAL_HANDLER
-	ASYNC
-		trigger_organ_action()
+	INVOKE_ASYNC(src, PROC_REF(trigger_organ_action))
 
 /**
  * Status effect: Makes you run really fast and ignore speed penalties for a short duration.

--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -34,7 +34,8 @@
 
 /obj/item/organ/internal/monster_core/rush_gland/proc/trigger_organ_action_on_sig(datum/source)
 	SIGNAL_HANDLER
-	trigger_organ_action()
+	ASYNC
+		trigger_organ_action()
 
 /**
  * Status effect: Makes you run really fast and ignore speed penalties for a short duration.


### PR DESCRIPTION
## About The Pull Request

`trigger_organ_action`'s first and only argument is trigger flags to pass to `Trigger`

The first argument if signals is the datum sending the signal

![image](https://github.com/tgstation/tgstation/assets/51863163/ebde6e12-f5de-41f9-829e-0727cc8b3072)


## Changelog

:cl: Melbert
fix: Rush Gland now triggers correctly on being grabbed by a Goliath
/:cl:

