### PR TITLE
Re-adds some cat things that got lost in their refactor as basic pets.

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/cat.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat.dm
@@ -55,6 +55,7 @@
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/pet_bonus, "purrs!")
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_CLAW)
+	add_cell_sample()
 	add_verb(src, /mob/living/proc/toggle_resting)
 	add_traits(list(TRAIT_CATLIKE_GRACE, TRAIT_VENTCRAWLER_ALWAYS), INNATE_TRAIT)
 	ai_controller.set_blackboard_key(BB_HUNTABLE_PREY, typecacheof(huntable_items))
@@ -64,6 +65,9 @@
 		RegisterSignal(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(pre_attack))
 	if(can_interact_with_stove)
 		RegisterSignal(src, COMSIG_LIVING_EARLY_UNARMED_ATTACK, PROC_REF(pre_unarmed_attack))
+
+/mob/living/basic/pet/cat/proc/add_cell_sample()
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CAT, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
 /mob/living/basic/pet/cat/proc/pre_attack(mob/living/source, atom/movable/target)
 	SIGNAL_HANDLER
@@ -151,6 +155,8 @@
 		/obj/item/food/breadslice/plain = 1
 	)
 
+/mob/living/basic/pet/cat/breadcat/add_cell_sample()
+	return
 
 /mob/living/basic/pet/cat/original
 	name = "Batsy"
@@ -162,6 +168,9 @@
 	collar_icon_state = null
 	unique_pet = TRUE
 	held_state = "original"
+
+/mob/living/basic/pet/cat/original/add_cell_sample()
+	return
 
 /mob/living/basic/pet/cat/kitten
 	name = "kitten"

--- a/code/modules/mob/living/basic/pets/cat/cat.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat.dm
@@ -54,6 +54,7 @@
 	. = ..()
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/pet_bonus, "purrs!")
+	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_CLAW)
 	add_verb(src, /mob/living/proc/toggle_resting)
 	add_traits(list(TRAIT_CATLIKE_GRACE, TRAIT_VENTCRAWLER_ALWAYS), INNATE_TRAIT)
 	ai_controller.set_blackboard_key(BB_HUNTABLE_PREY, typecacheof(huntable_items))

--- a/code/modules/mob/living/basic/pets/cat/keeki.dm
+++ b/code/modules/mob/living/basic/pets/cat/keeki.dm
@@ -35,6 +35,9 @@
 	)
 	AddElement(/datum/element/consumable_mob, reagents_list = on_consume)
 
+/mob/living/basic/pet/cat/cak/add_cell_sample()
+	return
+
 /mob/living/basic/pet/cat/cak/CheckParts(list/parts)
 	. = ..()
 	var/obj/item/organ/internal/brain/candidate = locate(/obj/item/organ/internal/brain) in contents


### PR DESCRIPTION

## About The Pull Request

When cats were turned into basic mobs it seems a few things were lost in translation, being footsteps and cytology cell swabbing. All this pr does is basically re-add the lines that did such, though _slightly barely_ differently due to now being basic pets.
## Why It's Good For The Game

Lets you get feliform cells again. Also cats not having footstep sounds feels eerie.
## Changelog
:cl:
fix: Cats can be swabbed for feliform cells again. 
sound: Cats have had their mastery of silent walking revoked, and have their pitter-pattering footsteps back again.
/:cl:
