### PR TITLE
Fixes Tramstation external atmos ports

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2734,6 +2734,9 @@
 	},
 /obj/item/book/manual/wiki/atmospherics,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "amL" = (
@@ -2857,6 +2860,7 @@
 /area/station/engineering/storage/tech)
 "any" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "anB" = (
@@ -2886,6 +2890,7 @@
 /obj/structure/sign/warning/secure_area{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "anU" = (
@@ -6216,7 +6221,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
-/obj/structure/sign/clock/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "aYn" = (
@@ -9718,6 +9723,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"cmM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cmW" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
@@ -11317,7 +11332,7 @@
 /area/station/service/kitchen)
 "cPg" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/sign/warning/electric_shock,
+/obj/structure/sign/warning/electric_shock/directional/west,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - SMES";
 	dir = 10;
@@ -18477,6 +18492,9 @@
 	},
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fvx" = (
@@ -21848,7 +21866,7 @@
 "gIj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
-	name = "Oxygen Tank Injection Port"
+	name = ssssssssssssssssss
 	},
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/stripes/line,
@@ -21860,6 +21878,7 @@
 	dir = 1
 	},
 /obj/item/airlock_painter/decal,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gIG" = (
@@ -23523,8 +23542,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8;
+	name = "Exfiltrate Port"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction/engineering)
@@ -24357,6 +24377,10 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
+"hIt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "hIE" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/cleanable/dirt,
@@ -24625,7 +24649,7 @@
 /area/station/service/library)
 "hNE" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "hNI" = (
@@ -25545,6 +25569,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ifn" = (
@@ -27235,7 +27260,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "iNR" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -27243,8 +27267,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/clock/directional/west,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "iNV" = (
@@ -30726,7 +30750,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -31956,7 +31980,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kpq" = (
-/obj/machinery/atmospherics/pipe/color_adapter,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "kpt" = (
@@ -39975,6 +39999,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "nel" = (
@@ -40417,8 +40442,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - Engineering Entry East"
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Oxygen Tank Injection Port"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction/engineering)
@@ -43436,6 +43462,15 @@
 /obj/effect/turf_decal/trimline/dark_blue/corner,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
+"omN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "onc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -43794,7 +43829,8 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "ovi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "ovC" = (
@@ -46106,8 +46142,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Oxygen Tank Injection Port"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction/engineering)
@@ -47526,8 +47563,9 @@
 	dir = 10
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8;
+	name = "Exfiltrate Port"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction/engineering)
@@ -48723,6 +48761,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qkM" = (
@@ -50105,9 +50144,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qKE" = (
@@ -51470,6 +51509,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rin" = (
@@ -52536,7 +52576,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/machinery/camera/emp_proof/directional/north{
 	c_tag = "Engineering - Atmospherics North"
 	},
@@ -53576,6 +53616,10 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"rWn" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rWt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -55578,7 +55622,7 @@
 "sGO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -59226,7 +59270,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "tTW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 5
 	},
 /turf/open/floor/iron,
@@ -61071,7 +61115,6 @@
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/machinery/firealarm/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uyJ" = (
@@ -64838,7 +64881,8 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
 "vJA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
 "vJC" = (
@@ -64851,7 +64895,7 @@
 "vKd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
@@ -65429,6 +65473,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"vUk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vUu" = (
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
@@ -66187,6 +66237,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/eva)
+"wjB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/break_room)
 "wjP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68053,6 +68107,10 @@
 /obj/machinery/door/window/right/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal)
+"wWv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "wWF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -104574,9 +104632,9 @@ fal
 pcu
 llU
 tpm
+wjB
 vJA
-vJA
-ulV
+wjB
 gYI
 cEq
 gYI
@@ -104833,7 +104891,7 @@ cgd
 vIC
 pOZ
 hoT
-hZr
+wWv
 amA
 pvC
 qsP
@@ -105090,7 +105148,7 @@ akM
 wRi
 oFd
 ntL
-hZr
+wWv
 gIu
 ifk
 qkG
@@ -105349,14 +105407,14 @@ nku
 pso
 hZr
 amC
-lJm
+cmM
 any
 anO
-aog
+omN
 kpq
 rDj
 tTW
-bZW
+vUk
 wQm
 skM
 bZW
@@ -105604,7 +105662,7 @@ oNq
 kcP
 hNE
 ovi
-hZr
+hIt
 fvn
 lJm
 rfW
@@ -105855,7 +105913,7 @@ aaa
 hZr
 gZE
 hJN
-wQm
+rWn
 xml
 vTF
 akP

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -21866,7 +21866,7 @@
 "gIj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
-	name = ssssssssssssssssss
+	name = "Oxygen Tank Injection Port"
 	},
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/stripes/line,


### PR DESCRIPTION
## About The Pull Request

- Fixes the disconnected external air in/out pipes in Tramstation atmos
- Fixes a floating lightswitch in janitor's closet
- Fixes floating sign in engineering SMES room

![image](https://github.com/tgstation/tgstation/assets/83487515/e98e3a0e-13fb-49cf-96aa-66d7ba6fe886)

## Changelog

:cl: LT3
fix: Tramstation external atmos ports are now properly connected
/:cl:
