### PR TITLE
Oppenheimer now starts with airplane mode enabled

### DIFF
--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -393,6 +393,7 @@
 	health = 40
 	maxHealth = 40
 	maints_access_required = list(ACCESS_SYNDICATE)
+	bot_mode_flags = BOT_MODE_ON | BOT_MODE_CAN_BE_SAPIENT | BOT_MODE_ROUNDSTART_POSSESSION
 	radio_key = /obj/item/encryptionkey/syndicate
 	radio_channel = RADIO_CHANNEL_SYNDICATE
 	damage_type_healer = HEAL_ALL_DAMAGE


### PR DESCRIPTION

## About The Pull Request
The nuclear operative medbot, Oppenheimer, now starts with airplane mode enabled (aka, remote control disabled), so the presence of operatives on the station Z-level is not immediately given away to AIs.

![image](https://github.com/tgstation/tgstation/assets/44104681/990ec84c-e7e8-4557-b036-3e840566e957)

Fixes #81105
## Why It's Good For The Game
It'd be pretty lame to have your stealth ops operation ruined because you forgot to turn on airplane mode, no? I don't think this was intentional by any means, seems like an oversight.
## Changelog
:cl:
fix: Oppenheimer, the nukie medbot, has been reprogrammed to use Airplane Mode as a factory default. The station AI is no longer immediately aware of his presence!
/:cl:
