### PR TITLE
One line cat breeding fix.

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/cat_ai.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat_ai.dm
@@ -2,6 +2,7 @@
 	blackboard = list(
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_HOSTILE_MEOWS = list("Mawwww", "Mrewwww", "mhhhhng..."),
+		BB_BABIES_PARTNER_TYPES = list(/mob/living/basic/pet/cat),
 		BB_BABIES_CHILD_TYPES = list(/mob/living/basic/pet/cat/kitten),
 	)
 


### PR DESCRIPTION

## About The Pull Request

Alternative title: "Resolve Jerry Tramstation's impotence."

While cats had all the other requirements for breeding, the ai subtree for it returns early as no `BB_BABIES_PARTNER_TYPES` had been set for the cat ai and thus it would never actually try to breed.
This pr just adds a `BB_BABIES_PARTNER_TYPES` value to `code/modules/mob/living/basic/pets/cat/cat_ai.dm`, so they can actually have kittens again.
## Why It's Good For The Game

Fixes cat breeding bug.
And c'mooooon, look at theeeeem:
![image](https://github.com/tgstation/tgstation/assets/42909981/1c046dae-7541-4b7c-a1eb-c2fe92ef94d4)
## Changelog
:cl:
fix: Jerry Tramstation can get laid again! (Fixed cat breeding.)
/:cl:
