### PR TITLE
Clear kitten begging target after begging.

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/kitten_ai.dm
+++ b/code/modules/mob/living/basic/pets/cat/kitten_ai.dm
@@ -33,13 +33,13 @@
 	. = ..()
 	var/atom/target = controller.blackboard[target_key]
 	if(QDELETED(target))
-		finish_action(controller, FALSE)
+		finish_action(controller, FALSE, target_key)
 	var/mob/living/living_pawn = controller.pawn
 	var/list/meowing_list = controller.blackboard[meows_key]
 	if(length(meowing_list))
 		living_pawn.say(pick(meowing_list), forced = "ai_controller")
 	living_pawn._pointed(target)
-	finish_action(controller, TRUE)
+	finish_action(controller, TRUE, target_key)
 
 /datum/ai_behavior/beacon_for_food/finish_action(datum/ai_controller/controller, success, target_key)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

### Alternative title: "Remove kitten omniscience."

>If you were to ever have the hubris of entering a kitten's line of sight while holding a food they like, like a dead mouse, they would start pointing and meowing at you. It's their food, after all. You should give it to them.
However, if you were to drop the item, they would continue pointing.
If you were to leave the area, they would continue pointing.
Even if you were to run, to hide, to break down and cry.
They would continue pointing. Meowing
Forever.
And Ever.
You can't run. You can't hide. You can't fool them.
That ever sweet scent stays with you, lingering. It marks you.
Wherever you are, whenever you are, the wretched beasts will know.
Even in death your corpse will be theirs to torment.
For you, oh marked one, this is now a fact of life.
_And you better bring your masters their food._

Putting aside how funny the kitten-based triangulation device is, this feels like an oversight.
`/.../beacon_for_food/finish_action(...)` even tries to clear the begging target from the blackboard, but `/.../beacon_for_food/perform(...)` never actually passes in the key.
## Why It's Good For The Game

Kittens no longer beg at you forever wherever you are, even after dropping the food they were begging for.
![image](https://github.com/tgstation/tgstation/assets/42909981/146d9f93-57e6-4408-aba3-6c693add0841)
Like forever, wherever.
![image](https://github.com/tgstation/tgstation/assets/42909981/d62dbd12-15d1-4bc7-9696-d3b50f1b91d8)
![image](https://github.com/tgstation/tgstation/assets/42909981/46da6905-b29c-43a4-b2f1-bdbd27d0e96d)
## Changelog
:cl:
fix: Removed kitten omniscience. (They stop pointing at you now.)
/:cl:
