### PR TITLE
Stop blobs from spamming the apc power down noise.

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -265,8 +265,6 @@
 		return
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)
-	if(machine_stat & BROKEN)
-		return
 	set_broken()
 
 /obj/machinery/power/apc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armor_penetration = 0)
@@ -301,6 +299,8 @@
 	return TRUE
 
 /obj/machinery/power/apc/proc/set_broken()
+	if(machine_stat & BROKEN)
+		return
 	if(malfai && operating)
 		malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10,0,1000)
 	operating = FALSE

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -265,6 +265,8 @@
 		return
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)
+	if(machine_stat & BROKEN)
+		return
 	set_broken()
 
 /obj/machinery/power/apc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armor_penetration = 0)


### PR DESCRIPTION

## About The Pull Request

It was mentioned to me that APCs were spamming the power down noise when broken, so I looked into it.
After further questioning and testing, this turned out to be a blob-specific issue.

Blobs present on the same tile as an APC were continuously calling the `set_broken()` proc:
```dm
/obj/machinery/power/apc/blob_act(obj/structure/blob/B)
	set_broken()
```
```dm
/obj/machinery/power/apc/proc/set_broken()
    if(malfai && operating)
        malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10,0,1000)
    operating = FALSE
    atom_break()
    if(occupier)
        malfvacate(TRUE)
    update()
```
Which was causing `update()` to be continuously called on the APC, which was in turn spamming the power down noise:
```dm
/obj/machinery/power/apc/proc/update()
    if(operating && !shorted && !failure_timer)
        (...)
    else
        (...)
        playsound(src.loc, 'sound/machines/terminal_off.ogg', 50, FALSE)
    area.power_change()
```
So we fixed this by just adding an if statement to check if it's broken or not before breaking it:
```dm
/obj/machinery/power/apc/blob_act(obj/structure/blob/B)
	if(machine_stat & BROKEN)
		return
	set_broken()
```
## Why It's Good For The Game

Fixes noise spam bug.
Ough my ears.
## Changelog
:cl:
fix: Blobs sitting on APCs no longer break them when already broken, and so no longer spam the power down noise.
/:cl:
