### PR TITLE
Adds better buildtool errors when using byond 514 or older

### DIFF
--- a/tools/build/lib/byond.js
+++ b/tools/build/lib/byond.js
@@ -153,9 +153,12 @@ export const DreamMaker = async (dmeFile, options = {}) => {
       Juke.logger.error(`Unexpected DreamMaker return, ensure "${dmPath}" is correct DM path.`)
       throw new Juke.ExitCode(1);
     }
-    const requiredMajorVersion = 515; // for -D Functionality
-    if(version[1] < requiredMajorVersion){
-      Juke.logger.error(`${requiredMajorVersion} DM version required`)
+    const requiredMajorVersion = 515;
+    const requiredMinorVersion = 1597 // First with -D switch functionality
+    const major = Number(version[1]);
+    const minor = Number(version[2]);
+    if(major < requiredMajorVersion || major == requiredMajorVersion && minor < requiredMinorVersion){
+      Juke.logger.error(`${requiredMajorVersion}.${requiredMinorVersion} DM version required`)
       throw new Juke.ExitCode(1);
     }
   }


### PR DESCRIPTION
Every time someone asks what -DCBT means i lose sleep so here's a slightly invasive solution.
Build will now check if the dm version is at least 515.1597 (first version with -D switch), at the cost of having to run dry dm.exe run.