### PR TITLE
Design datum time cleanup

### DIFF
--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -226,7 +226,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -244,7 +244,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/scattershot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3)
-	construction_time = 20
+	construction_time = 2 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -262,7 +262,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -280,7 +280,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/incendiary
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3)
-	construction_time = 20
+	construction_time = 2 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -298,7 +298,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,/datum/material/silver=SHEET_MATERIAL_AMOUNT*3,/datum/material/uranium=SHEET_MATERIAL_AMOUNT)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -316,7 +316,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,/datum/material/silver=SHEET_MATERIAL_AMOUNT*4)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -334,7 +334,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -352,7 +352,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -370,7 +370,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -388,7 +388,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*11,/datum/material/gold=SHEET_MATERIAL_AMOUNT*3,/datum/material/silver=SHEET_MATERIAL_AMOUNT*4)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -406,7 +406,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/flashbang
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2,/datum/material/gold=SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 20
+	construction_time = 2 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -424,7 +424,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*11,/datum/material/gold=SHEET_MATERIAL_AMOUNT*3,/datum/material/silver=SHEET_MATERIAL_AMOUNT*4)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -442,7 +442,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/missiles_pep
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*4,/datum/material/gold=SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 20
+	construction_time = 2 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -460,7 +460,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,/datum/material/gold=SHEET_MATERIAL_AMOUNT*5,/datum/material/uranium=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -478,7 +478,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/clusterbang
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3,/datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT * 1.5,/datum/material/uranium=HALF_SHEET_MATERIAL_AMOUNT * 1.5)
-	construction_time = 20
+	construction_time = 2 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_WEAPONS,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -496,7 +496,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/wormhole_generator
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -517,7 +517,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/teleporter
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,/datum/material/diamond=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -538,7 +538,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/rcd
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*15,/datum/material/gold=SHEET_MATERIAL_AMOUNT*10,/datum/material/plasma=SHEET_MATERIAL_AMOUNT*12.5,/datum/material/silver=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 1200
+	construction_time = 2 MINUTES
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -559,7 +559,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/thrusters/gas
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*12.5,/datum/material/titanium=SHEET_MATERIAL_AMOUNT * 2.5,/datum/material/silver=SHEET_MATERIAL_AMOUNT*1.5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -579,7 +579,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/gravcatapult
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -600,7 +600,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5,/datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT,/datum/material/silver=SHEET_MATERIAL_AMOUNT)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -621,7 +621,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/armor/anticcw_armor_booster
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,/datum/material/silver=SHEET_MATERIAL_AMOUNT * 2.5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -642,7 +642,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,/datum/material/gold=SHEET_MATERIAL_AMOUNT * 2.5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -663,7 +663,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,/datum/material/diamond=SHEET_MATERIAL_AMOUNT*3.25)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
@@ -678,7 +678,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*4, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/plasma =SHEET_MATERIAL_AMOUNT)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -698,7 +698,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/mecha_kineticgun
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*4, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -718,7 +718,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -735,7 +735,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/lmg
 	materials = list(/datum/material/iron= SHEET_MATERIAL_AMOUNT *2)
-	construction_time = 20
+	construction_time = 2 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -752,7 +752,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/sleeper
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL,
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
@@ -766,7 +766,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*1.5, /datum/material/glass =SHEET_MATERIAL_AMOUNT)
-	construction_time = 200
+	construction_time = 2 SECONDS0
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL,
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
@@ -779,7 +779,7 @@
 	id = "mech_medi_beam"
 	build_type = MECHFAB
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*7.5, /datum/material/glass = SHEET_MATERIAL_AMOUNT*4, /datum/material/plasma =SHEET_MATERIAL_AMOUNT*1.5, /datum/material/gold = SHEET_MATERIAL_AMOUNT*4, /datum/material/diamond =SHEET_MATERIAL_AMOUNT)
-	construction_time = 250
+	construction_time = 25 SECONDS
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL,

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -766,7 +766,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*1.5, /datum/material/glass =SHEET_MATERIAL_AMOUNT)
-	construction_time = 2 SECONDS0
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL,
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -5,7 +5,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/robot_suit
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 500
+	construction_time = 50 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -16,7 +16,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/bodypart/chest/robot
 	materials = list(/datum/material/iron= SHEET_MATERIAL_AMOUNT*20)
-	construction_time = 350
+	construction_time = 35 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -27,7 +27,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/bodypart/head/robot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2.5)
-	construction_time = 350
+	construction_time = 35 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -38,7 +38,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/bodypart/arm/left/robot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -49,7 +49,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/bodypart/arm/right/robot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -60,7 +60,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/bodypart/leg/left/robot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -71,7 +71,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/bodypart/leg/right/robot
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
@@ -145,7 +145,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/ripley
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -159,7 +159,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*3.75,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -170,7 +170,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_left_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -181,7 +181,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_right_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -192,7 +192,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_left_leg
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -203,7 +203,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_right_leg
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -215,7 +215,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/odysseus
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -226,7 +226,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_torso
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*6)
-	construction_time = 180
+	construction_time = 18 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -240,7 +240,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*3,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -251,7 +251,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_left_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -262,7 +262,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_right_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -273,7 +273,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_left_leg
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3.5)
-	construction_time = 130
+	construction_time = 13 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -284,7 +284,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_right_leg
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*3.5)
-	construction_time = 130
+	construction_time = 13 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -296,7 +296,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/gygax
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -312,7 +312,7 @@
 		/datum/material/gold=SHEET_MATERIAL_AMOUNT,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -328,7 +328,7 @@
 		/datum/material/gold=SHEET_MATERIAL_AMOUNT,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -343,7 +343,7 @@
 		/datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/silver=HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -358,7 +358,7 @@
 		/datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/silver=HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -373,7 +373,7 @@
 		/datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/silver=HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -388,7 +388,7 @@
 		/datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/silver=HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -404,7 +404,7 @@
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 600
+	construction_time = 60 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -416,7 +416,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/durand
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*12.5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -431,7 +431,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -446,7 +446,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -460,7 +460,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -474,7 +474,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -488,7 +488,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -502,7 +502,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -517,7 +517,7 @@
 		/datum/material/uranium=SHEET_MATERIAL_AMOUNT*12.5,
 		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*10,
 	)
-	construction_time = 600
+	construction_time = 60 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -529,7 +529,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/honker
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -544,7 +544,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -559,7 +559,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -573,7 +573,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -587,7 +587,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -601,7 +601,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -615,7 +615,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -627,7 +627,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/phazon
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -642,7 +642,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*10,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -657,7 +657,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -671,7 +671,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -685,7 +685,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -699,7 +699,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -713,7 +713,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -728,7 +728,7 @@
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*10,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -740,7 +740,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/savannah_ivanov
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -754,7 +754,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*3.75,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -768,7 +768,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*3,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -779,7 +779,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/savannah_ivanov_left_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -790,7 +790,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/savannah_ivanov_right_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -801,7 +801,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/savannah_ivanov
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*12.5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -816,7 +816,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -831,7 +831,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -845,7 +845,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -859,7 +859,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -873,7 +873,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -887,7 +887,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -902,7 +902,7 @@
 		/datum/material/uranium=SHEET_MATERIAL_AMOUNT*12.5,
 		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*10,
 	)
-	construction_time = 600
+	construction_time = 60 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_SAVANNAH_IVANOV + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -914,7 +914,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/clarke
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*10)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CLARKE + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -928,7 +928,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*3.75,
 		)
-	construction_time = 200
+	construction_time = 20 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CLARKE + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -942,7 +942,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*3,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CLARKE + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -953,7 +953,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/clarke_left_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CLARKE + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -964,7 +964,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/clarke_right_arm
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*7.5)
-	construction_time = 150
+	construction_time = 15 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CLARKE + RND_SUBCATEGORY_MECHFAB_CHASSIS
 	)
@@ -979,7 +979,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -995,7 +995,7 @@
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 5,
 		/datum/material/titanium = SHEET_MATERIAL_AMOUNT *5,
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_CHASSIS,
@@ -1007,7 +1007,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1019,7 +1019,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/paddy_claw
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_PADDY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1031,7 +1031,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/drill
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1052,7 +1052,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2.5,
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT *1.25,
 	)
-	construction_time = 50
+	construction_time = 5 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1065,7 +1065,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/extinguisher
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1083,7 +1083,7 @@
 		/datum/material/silver=SHEET_MATERIAL_AMOUNT,
 		/datum/material/plasma=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1104,7 +1104,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_HONK,
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
@@ -1120,7 +1120,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 300
+	construction_time = 30 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_HONK,
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
@@ -1136,7 +1136,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 500
+	construction_time = 50 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_HONK,
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
@@ -1152,7 +1152,7 @@
 		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/bananium=SHEET_MATERIAL_AMOUNT*3.75,
 	)
-	construction_time = 400
+	construction_time = 40 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_HONK,
 		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
@@ -1165,7 +1165,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/radio
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2.5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1183,7 +1183,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/air_tank
 	materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MINING,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1205,7 +1205,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/rename
 	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT * 2.5)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1219,7 +1219,7 @@
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT*10,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1235,7 +1235,7 @@
 		/datum/material/plasma =SHEET_MATERIAL_AMOUNT * 2.5,
 		/datum/material/uranium =SHEET_MATERIAL_AMOUNT*3,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1251,7 +1251,7 @@
 		/datum/material/gold =SHEET_MATERIAL_AMOUNT,
 		/datum/material/diamond =SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SECURITY
 	)
@@ -1266,7 +1266,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*3,
 		/datum/material/diamond =SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 80
+	construction_time = 8 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MINING
 	)
@@ -1281,7 +1281,7 @@
 		/datum/material/gold =SHEET_MATERIAL_AMOUNT,
 		/datum/material/uranium =HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 40
+	construction_time = 4 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MINING
 	)
@@ -1296,7 +1296,7 @@
 		/datum/material/plasma =SHEET_MATERIAL_AMOUNT*2,
 		/datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MINING
 	)
@@ -1311,7 +1311,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/diamond =SHEET_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1326,7 +1326,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/bananium =HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1340,7 +1340,7 @@
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
 	)
-	construction_time = 80
+	construction_time = 8 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1356,7 +1356,7 @@
 		/datum/material/plasma =SHEET_MATERIAL_AMOUNT*4,
 		/datum/material/uranium =SHEET_MATERIAL_AMOUNT*4,
 	)
-	construction_time = 80
+	construction_time = 8 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
@@ -1372,7 +1372,7 @@
 		/datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2.5,
 		/datum/material/diamond =SHEET_MATERIAL_AMOUNT * 1.5,
 	)
-	construction_time = 80
+	construction_time = 8 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
@@ -1388,7 +1388,7 @@
 		/datum/material/silver =SHEET_MATERIAL_AMOUNT*2,
 		/datum/material/gold =SHEET_MATERIAL_AMOUNT * 1.5,
 	)
-	construction_time = 80
+	construction_time = 8 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
@@ -1403,7 +1403,7 @@
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*2,
 		/datum/material/silver =SHEET_MATERIAL_AMOUNT*2,
 	)
-	construction_time = 40
+	construction_time = 4 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
@@ -1417,7 +1417,7 @@
 		/datum/material/gold =SHEET_MATERIAL_AMOUNT,
 		/datum/material/uranium =HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 40
+	construction_time = 4 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
 	)
@@ -1431,7 +1431,7 @@
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT,
 	)
-	construction_time = 40
+	construction_time = 4 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
 	)
@@ -1445,7 +1445,7 @@
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT*1.125,
 		/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*0.75,
 	)
-	construction_time = 40
+	construction_time = 4 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
 	)
@@ -1543,7 +1543,7 @@
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT*100,
 		/datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
@@ -1558,7 +1558,7 @@
 		/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5,
 		/datum/material/gold =SMALL_MATERIAL_AMOUNT * 2,
 	)
-	construction_time = 50
+	construction_time = 5 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CONTROL_INTERFACES
 	)
@@ -1573,7 +1573,7 @@
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT*5,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
 	)
@@ -1584,7 +1584,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/inducer
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/silver = SHEET_MATERIAL_AMOUNT * 2)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
 	)
@@ -1598,7 +1598,7 @@
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT,
 		/datum/material/titanium =SMALL_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
 	)
@@ -1612,7 +1612,7 @@
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT,
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT*1.125,
 	) //Need glass for the new beaker too
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
@@ -1626,7 +1626,7 @@
 		/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/glass =SMALL_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
@@ -1640,7 +1640,7 @@
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT*2,
 		/datum/material/glass =SMALL_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 120
+	construction_time = 12 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
 	)
@@ -1654,7 +1654,7 @@
 		/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/glass =SMALL_MATERIAL_AMOUNT*5,
 	)
-	construction_time = 75
+	construction_time = 7.5 SECONDS
 	build_path = /obj/item/mmi
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CONTROL_INTERFACES
@@ -1679,7 +1679,7 @@
 		/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*1.35,
 		/datum/material/gold =SMALL_MATERIAL_AMOUNT*5
 	)
-	construction_time = 75
+	construction_time = 7.5 SECONDS
 	build_path = /obj/item/mmi/posibrain
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CONTROL_INTERFACES
@@ -1693,7 +1693,7 @@
 	build_type = MECHFAB
 	build_path =/obj/item/mecha_parts/mecha_tracking
 	materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 50
+	construction_time = 5 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MISC,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
@@ -1715,7 +1715,7 @@
 		/datum/material/glass =SMALL_MATERIAL_AMOUNT*5,
 		/datum/material/silver =SMALL_MATERIAL_AMOUNT * 2,
 	)
-	construction_time = 50
+	construction_time = 5 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_CONTROL_INTERFACES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CONTROL_INTERFACES,
@@ -1739,7 +1739,7 @@
 		/datum/material/plasma =SMALL_MATERIAL_AMOUNT * 2,
 		/datum/material/titanium =SMALL_MATERIAL_AMOUNT * 2,
 	)
-	construction_time = 50
+	construction_time = 5 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_CONTROL_INTERFACES,
 		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_CONTROL_INTERFACES,
@@ -1760,7 +1760,7 @@
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7.5,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT * 7.5,
 	)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/assembly/flash/handheld
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -390,7 +390,7 @@
 	desc = "This simple implant adds an internals connector to your back, allowing you to use internals without a mask and protecting you from being choked."
 	id = "ci-breather"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 35
+	construction_time = 3.5 SECONDS
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*6, /datum/material/glass = SMALL_MATERIAL_AMOUNT*2.5)
 	build_path = /obj/item/organ/internal/cyberimp/mouth/breathing_tube
 	category = list(
@@ -404,7 +404,7 @@
 	id = "ci-surgery"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list (/datum/material/iron = SHEET_MATERIAL_AMOUNT*1.25, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
-	construction_time =SMALL_MATERIAL_AMOUNT * 2
+	construction_time = 2 SECONDS
 	build_path = /obj/item/organ/internal/cyberimp/arm/surgery
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
@@ -417,7 +417,7 @@
 	id = "ci-toolset"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list (/datum/material/iron = SHEET_MATERIAL_AMOUNT*1.25, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
-	construction_time =SMALL_MATERIAL_AMOUNT * 2
+	construction_time = 2 SECONDS
 	build_path = /obj/item/organ/internal/cyberimp/arm/toolset
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
@@ -429,7 +429,7 @@
 	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."
 	id = "ci-medhud"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -447,7 +447,7 @@
 	desc = "These cybernetic eyes will display a security HUD over everything you see. Wiggle eyes to control."
 	id = "ci-sechud"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -465,7 +465,7 @@
 	desc = "These cybernetic eyes will display a diagnostic HUD over everything you see. Wiggle eyes to control."
 	id = "ci-diaghud"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -483,7 +483,7 @@
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
 	id = "ci-xray"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
+	construction_time = 6 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -510,7 +510,7 @@
 	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."
 	id = "ci-thermals"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
+	construction_time = 6 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -535,7 +535,7 @@
 	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping. Twitch ear to toggle."
 	id = "ci-antidrop"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
+	construction_time = 6 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -553,7 +553,7 @@
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
 	id = "ci-antistun"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
+	construction_time = 6 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -571,7 +571,7 @@
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving."
 	id = "ci-nutriment"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(
 		/datum/material/iron =SMALL_MATERIAL_AMOUNT*5,
 		/datum/material/glass =SMALL_MATERIAL_AMOUNT*5,
@@ -588,7 +588,7 @@
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are hungry."
 	id = "ci-nutrimentplus"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
@@ -606,7 +606,7 @@
 	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
 	id = "ci-reviver"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
+	construction_time = 6 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*8,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*8,
@@ -624,7 +624,7 @@
 	desc = "This implant will allow you to use gas from environment or your internals for propulsion in zero-gravity areas."
 	id = "ci-thrusters"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 80
+	construction_time = 8 SECONDS
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT*2,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT,
@@ -708,7 +708,7 @@
 	desc = "A basic cybernetic liver."
 	id = "cybernetic_liver"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/liver/cybernetic
 	category = list(
@@ -731,7 +731,7 @@
 	name = "Upgraded Cybernetic Liver"
 	desc = "An upgraded cybernetic liver."
 	id = "cybernetic_liver_tier3"
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5, /datum/material/silver=SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/liver/cybernetic/tier3
 	category = list(
@@ -744,7 +744,7 @@
 	desc = "A basic cybernetic heart."
 	id = "cybernetic_heart"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/heart/cybernetic
 	category = list(
@@ -767,7 +767,7 @@
 	name = "Upgraded Cybernetic Heart"
 	desc = "An upgraded cybernetic heart."
 	id = "cybernetic_heart_tier3"
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5, /datum/material/silver=SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/heart/cybernetic/tier3
 	category = list(
@@ -780,7 +780,7 @@
 	desc = "A basic pair of cybernetic lungs."
 	id = "cybernetic_lungs"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/lungs/cybernetic
 	category = list(
@@ -803,7 +803,7 @@
 	name = "Upgraded Cybernetic Lungs"
 	desc = "A pair of upgraded cybernetic lungs."
 	id = "cybernetic_lungs_tier3"
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5, /datum/material/silver =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/lungs/cybernetic/tier3
 	category = list(
@@ -816,7 +816,7 @@
 	desc = "A basic cybernetic stomach."
 	id = "cybernetic_stomach"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/stomach/cybernetic
 	category = list(
@@ -839,7 +839,7 @@
 	name = "Upgraded Cybernetic Stomach"
 	desc = "An upgraded cybernetic stomach."
 	id = "cybernetic_stomach_tier3"
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5, /datum/material/silver =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/stomach/cybernetic/tier3
 	category = list(
@@ -852,7 +852,7 @@
 	desc = "A Basic pair of cybernetic ears."
 	id = "cybernetic_ears"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 30
+	construction_time = 3 SECONDS
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*2.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*4)
 	build_path = /obj/item/organ/internal/ears/cybernetic
 	category = list(
@@ -865,7 +865,7 @@
 	desc = "A pair of cybernetic ears."
 	id = "cybernetic_ears_u"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*5,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*5,
@@ -882,7 +882,7 @@
 	desc = "A pair of whisper-sensitive cybernetic ears."
 	id = "cybernetic_ears_whisper"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*5,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*5,
@@ -899,7 +899,7 @@
 	desc = "A pair of wall-penetrating cybernetic ears."
 	id = "cybernetic_ears_xray"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*5,
 		/datum/material/glass = SMALL_MATERIAL_AMOUNT*5,
@@ -916,7 +916,7 @@
 	desc = "A basic pair of cybernetic eyes."
 	id = "cybernetic_eyes"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 30
+	construction_time = 3 SECONDS
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*2.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*4)
 	build_path = /obj/item/organ/internal/eyes/robotic/basic
 	category = list(
@@ -949,7 +949,7 @@
 	desc = "These reactive micro-shields will protect you from welders and flashes without obscuring your vision."
 	id = "ci-welding"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*6, /datum/material/glass = SMALL_MATERIAL_AMOUNT*4)
 	build_path = /obj/item/organ/internal/eyes/robotic/shield
 	category = list(
@@ -967,7 +967,7 @@
 	desc = "A pair of cybernetic eyes that can emit multicolored light"
 	id = "ci-gloweyes"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 40
+	construction_time = 4 SECONDS
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*6, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/organ/internal/eyes/robotic/glow
 	category = list(

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -8,7 +8,7 @@
 	id = "basic_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE |MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/glass =SMALL_MATERIAL_AMOUNT * 0.5)
-	construction_time=100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/cell/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
@@ -21,7 +21,7 @@
 	id = "high_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.6)
-	construction_time=100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/cell/high/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_2
@@ -34,7 +34,7 @@
 	id = "super_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.7)
-	construction_time=100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_3
@@ -47,7 +47,7 @@
 	id = "hyper_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.8)
-	construction_time=100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/cell/hyper/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_3
@@ -60,7 +60,7 @@
 	id = "bluespace_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 8, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 1.2, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 1.6, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 1.6, /datum/material/titanium =SMALL_MATERIAL_AMOUNT * 3, /datum/material/bluespace =SMALL_MATERIAL_AMOUNT)
-	construction_time=100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/cell/bluespace/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_4
@@ -107,7 +107,7 @@
 	id = "turbine_part_compressor"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/turbine_parts/compressor
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_TURBINE
@@ -120,7 +120,7 @@
 	id = "turbine_part_rotor"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/turbine_parts/rotor
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_TURBINE
@@ -133,7 +133,7 @@
 	id = "turbine_part_stator"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 100
+	construction_time = 10 SECONDS
 	build_path = /obj/item/turbine_parts/stator
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_TURBINE


### PR DESCRIPTION
## About The Pull Request

Fast little PR, with the autolathe and design datum time changes, I saw that we didn't have design datums moved over to using time defines uniformly, and in a few cases the times were using material quantity defines (oops!), so I've quickly moved those over to using our correct time defines as guided by common sense.

## Why It's Good For The Game

Cleans up the code for this section going forward so that when everyone copypastes a new design datum for the next feature at least we're using consistent and correct standards.

## Changelog

No player facing changes.
