### PR TITLE
Fixes the Wizarditis Timestop joke

### DIFF
--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -161,8 +161,10 @@
 	random_spells += sneeze_spacetime
 
 	var/datum/action/cooldown/spell/timestop/sneeze_timestop = new(src)
-	sneeze_timestop.timestop_range = 1 // heh
+	sneeze_timestop.timestop_range = 0 // heh
 	sneeze_timestop.timestop_duration = 5 SECONDS
+	sneeze_timestop.owner_is_immune_to_all_timestop = FALSE
+	sneeze_timestop.owner_is_immune_to_self_timestop = FALSE
 	random_spells += sneeze_timestop
 
 	var/datum/action/cooldown/spell/aoe/repulse/sneeze_repulse = new(src)

--- a/code/modules/spells/spell_types/self/stop_time.dm
+++ b/code/modules/spells/spell_types/self/stop_time.dm
@@ -16,9 +16,14 @@
 	/// The duration of the time stop.
 	var/timestop_duration = 10 SECONDS
 
+	/// if TRUE, the owner is immune to all time stop, from anyone
+	var/owner_is_immune_to_all_timestop = TRUE
+	/// if TRUE, the owner is immune to their own timestop (but not other people's, if above is FALSE)
+	var/owner_is_immune_to_self_timestop = TRUE
+
 /datum/action/cooldown/spell/timestop/Grant(mob/grant_to)
 	. = ..()
-	if(owner)
+	if(!isnull(owner) && owner_is_immune_to_all_timestop)
 		ADD_TRAIT(owner, TRAIT_TIME_STOP_IMMUNE, REF(src))
 
 /datum/action/cooldown/spell/timestop/Remove(mob/remove_from)
@@ -27,4 +32,17 @@
 
 /datum/action/cooldown/spell/timestop/cast(atom/cast_on)
 	. = ..()
-	new /obj/effect/timestop/magic(get_turf(cast_on), timestop_range, timestop_duration, list(cast_on))
+	var/list/default_immune_atoms = list()
+	if(owner_is_immune_to_self_timestop)
+		default_immune_atoms += cast_on
+	new /obj/effect/timestop/magic(get_turf(cast_on), timestop_range, timestop_duration, default_immune_atoms)
+
+/datum/action/cooldown/spell/timestop/vv_edit_var(var_name, var_value)
+	. = ..()
+	if(var_name != NAMEOF(src, owner_is_immune_to_all_timestop) || isnull(owner))
+		return
+
+	if(var_value)
+		ADD_TRAIT(owner, TRAIT_TIME_STOP_IMMUNE, REF(src))
+	else
+		REMOVE_TRAIT(owner, TRAIT_TIME_STOP_IMMUNE, REF(src))


### PR DESCRIPTION
## About The Pull Request

I made it so Wizarditis Timestop just freezes yourself but forgot timestop makes you immune to timestop. 

So now I added some vars to timestop both to fix this and also for admins to mess around with. 

## Changelog

:cl: Melbert
fix: Wizarditis Timestop now has the desired effect. 
admin: Admins can now VV Timestop to make the caster not immune to their own Timestop. If they really wanted. 
/:cl:


