### PR TITLE
Make rootbread soup craftable by using egg reagents instead of raw unpeeled egg

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1483,12 +1483,15 @@
 	drink_type = MEAT | VEGETABLES
 
 /datum/chemical_reaction/food/soup/rootbread_soup
-	required_reagents = list(/datum/reagent/water = 50)
+	required_reagents = list(
+		/datum/reagent/water = 50,
+		/datum/reagent/consumable/eggyolk = 2,
+		/datum/reagent/consumable/eggwhite = 4
+	)
 	required_ingredients = list(
 		/obj/item/food/breadslice/root = 2,
 		/obj/item/food/grown/garlic = 1,
-		/obj/item/food/grown/chili = 1,
-		/obj/item/food/egg = 1
+		/obj/item/food/grown/chili = 1
 	)
 	results = list(
 		/datum/reagent/consumable/nutriment/soup/rootbread = 30,


### PR DESCRIPTION

## About The Pull Request

While playing hop I was told that, well: apparently it wasn't possible to make rootbread soup, as it required a whole raw unpeeled egg to be in the pot, while attempting to put it in the pot would break it into its reagents.
This pr makes it instead use the egg reagents to represent poaching the egg in the soup to reflect the sprite. And also that one irl rootbread soup chef station 13 blogpost.
## Why It's Good For The Game

It was not possible to make rootbread soup due to eggs breaking on contact with soup pots, now it is.
## Changelog
:cl:
fix: Rootbread soup now uses poached egg (egg reagents in soup pot) instead of raw unpeeled egg (which would break into reagents upon coming into contact with the soup pot) and is thus craftable again.
/:cl:
