### PR TITLE
Shivs and bone daggers are no longer electrically conductive

### DIFF
--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -152,13 +152,10 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A sharpened bone. The bare minimum in survival."
 	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
+	obj_flags = parent_type::obj_flags & ~CONDUCTS_ELECTRICITY
 	force = 15
 	throwforce = 15
 	custom_materials = null
-
-/obj/item/knife/combat/bone/Initialize(mapload)
-	flags_1 &= ~CONDUCTS_ELECTRICITY
-	return ..()
 
 /obj/item/knife/combat/cyborg
 	name = "cyborg knife"
@@ -174,16 +171,13 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A makeshift glass shiv."
+	obj_flags = parent_type::obj_flags & ~CONDUCTS_ELECTRICITY
 	force = 8
 	throwforce = 12
 	attack_verb_continuous = list("shanks", "shivs")
 	attack_verb_simple = list("shank", "shiv")
 	armor_type = /datum/armor/none
 	custom_materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT * 4)
-
-/obj/item/knife/shiv/Initialize(mapload)
-	flags_1 &= ~CONDUCTS_ELECTRICITY
-	return ..()
 
 /obj/item/knife/shiv/plasma
 	name = "plasma shiv"


### PR DESCRIPTION
## About The Pull Request

Makes shivs and bone daggers not conduct electricity (i.e. you don't get shocked from hitting an electrified grill with it).

In #80033 `CONDUCTS_ELECTRICITY` was moved to `obj_flags` instead of the `flags_1` it was before and given a new constant for it. The author generally replaced the `flags_1` with `obj_flags` but seems to have forgotten to do this for the bone dagger and glass shiv `Initialize` calls, while replacing the flag to the new constant though. Meaning that they weren't non-conductive anymore.

## Why It's Good For The Game

These aren't meant to conduct electricity, this resolves that issue of them doing that currently.

## Changelog

:cl:
fix: Bone daggers and shivs are now longer electrically conductive
/:cl:
