### PR TITLE
Ambient loops refresh when entering a mob

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -536,8 +536,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 ///Tries to play looping ambience to the mobs.
 /mob/proc/refresh_looping_ambience()
-	SIGNAL_HANDLER
-
 	var/area/my_area = get_area(src)
 
 	if(!(client?.prefs.read_preference(/datum/preference/toggle/sound_ship_ambience)) || !my_area.ambient_buzz)

--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -34,6 +34,7 @@
 	static_lighting = FALSE
 	base_lighting_alpha = 255
 	has_gravity = STANDARD_GRAVITY
+	ambient_buzz = null
 
 /area/misc/testroom
 	requires_power = FALSE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -99,6 +99,8 @@
 
 	update_client_colour()
 	update_mouse_pointer()
+	refresh_looping_ambience()
+
 	if(client)
 		if(client.view_size)
 			client.view_size.resetToDefault() // Resets the client.view in case it was changed.


### PR DESCRIPTION

## About The Pull Request

Added an update call to looping ambient sounds to `/mob/Login()`. And removed ship ambience from the lobby area. 
Doesn't fix the issue of ambient sounds not updating for ghosts since they cannot enter areas. Should all dead mobs get updates to ambience at all? Who knows
## Why It's Good For The Game

silence when starting the game is noticeably annoying.
## Changelog
:cl:
fix: Ambient loops will now refresh when entering a mob.
/:cl:
