### PR TITLE
Makes the encrypted bitrunning cache indestructible

### DIFF
--- a/code/modules/bitrunning/objects/loot_crate.dm
+++ b/code/modules/bitrunning/objects/loot_crate.dm
@@ -20,6 +20,7 @@
 	desc = "Needs to be decrypted at the safehouse to be opened."
 	locked = TRUE
 	damage_deflection = 30
+	resistance_flags =  INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/structure/closet/crate/secure/bitrunning/encrypted/can_unlock(mob/living/user, obj/item/card/id/player_id, obj/item/card/id/registered_id)
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

This gives the encrypted bitrunning crate a bunch of resistances, making it (theoretically) impossible to destroy.
## Why It's Good For The Game

The crate getting shot down by mobs or players and softlocking a domain really kinda sucks!
## Changelog
:cl: Rhials
fix: The encrypted bitrunner cache is now impervious to most conventional means of destruction.
/:cl:
