### PR TITLE
Arcane makes good on his promise to get rid of lathe tax as a result of mineral balance

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -15,10 +15,7 @@
 ///Paygrade for Heads of Staff.
 #define PAYCHECK_COMMAND 100
 
-//How many credits a player is charged if they print something from a departmental lathe they shouldn't have access to.
-#define LATHE_TAX 10
-//How much POWER a borg's cell is taxed if they print something from a departmental lathe.
-#define SILICON_LATHE_TAX 2000
+
 
 #define STATION_TARGET_BUFFER 25
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -10,7 +10,7 @@
 	/// The material storage used by this fabricator.
 	var/datum/component/remote_materials/materials
 
-	/// Which departments forego the lathe tax when using this lathe.
+	/// Which departments are allowed to process this design
 	var/allowed_department_flags = ALL
 
 	/// What's flick()'d on print.
@@ -253,33 +253,6 @@
 		power += round(design.materials[material] * print_quantity / 35)
 	power = min(active_power_usage, power)
 	use_power(power)
-
-	// Charge the lathe tax at least once per ten items.
-	var/total_cost = LATHE_TAX * max(round(print_quantity / 10), 1)
-	if(!charges_tax)
-		total_cost = 0
-	if(isliving(user))
-		var/mob/living/living_user = user
-		var/obj/item/card/id/card = living_user.get_idcard(TRUE)
-
-		if(!card && istype(user.pulling, /obj/item/card/id))
-			card = user.pulling
-
-		if(card && card.registered_account)
-			var/datum/bank_account/our_acc = card.registered_account
-			if(our_acc.account_job.departments_bitflags & allowed_department_flags)
-				total_cost = 0 // We are not charging crew for printing their own supplies and equipment.
-
-	if(total_cost)
-		if(iscyborg(user))
-			var/mob/living/silicon/robot/borg = user
-			if(!borg.cell)
-				return FALSE
-			borg.cell.use(SILICON_LATHE_TAX)
-
-		else if(attempt_charge(src, user, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
-			say("Insufficient funds to complete prototype. Please present a holochip or valid ID card.")
-			return FALSE
 
 	if(production_animation)
 		flick(production_animation, src)


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/41715314/9ea9b578-d394-4a0e-971c-7f1099acae4a)
![image](https://github.com/tgstation/tgstation/assets/41715314/ab06a6b8-ab7c-4db4-86a8-e91d4f0bb771)
![image](https://github.com/tgstation/tgstation/assets/41715314/5d08ee4b-4005-4175-9f21-a0295f1596c5)

With the merge of #78524, we have a significant amount more control over how many materials are entering the round, as if it's overtuned, we can adjust the mineral spawning percentages, and if it's undertuned we can do vice-versa. Similarly with ore vents, we can adjust how much of every resource will spawn, allowing for items that can be printed via the lathe to have a significant more impact on how much they cost depending on round balance.

Going forward, this data can be found using the mineral logging and graphing tool found in `tools\silo_grapher\silo_graph_script.py` to make future balance decisions. These tools combined allow for a full suite of resource controls going in and out of the round for decisions to be made on item printing. 

## Why It's Good For The Game

We needed better control on resources going in and out of the round for the massive, massive quantity of items in game limited by being extremely cheap to print on the lathe.

We have those resource controls now, and the tools to adjust the balance as necessary. Therefore, I'm fine with us axing this.

Fixes #67009, and fixes #66601.

I would wait out the last bit of the freeze but ahh fuck it I don't see why not to do it now

## Changelog

:cl:
del: The lathe tax on printing items has been removed from the game for both humans and silicons.
/:cl: