### PR TITLE
The construction console drone becomes visible again while its in use

### DIFF
--- a/code/game/objects/structures/construction_console/construction_console.dm
+++ b/code/game/objects/structures/construction_console/construction_console.dm
@@ -80,12 +80,12 @@
 /obj/machinery/computer/camera_advanced/base_construction/GrantActions(mob/living/user)
 	..()
 	//When the eye is in use, make it visible to players so they know when someone is building.
-	SetInvisibility(INVISIBILITY_NONE, id=type)
+	eyeobj.SetInvisibility(INVISIBILITY_NONE, id=type)
 
 /obj/machinery/computer/camera_advanced/base_construction/remove_eye_control(mob/living/user)
 	..()
 	//Set back to default invisibility when not in use.
-	RemoveInvisibility(type)
+	eyeobj.RemoveInvisibility(type)
 
 /**
  * A mob used by [/obj/machinery/computer/camera_advanced/base_construction] for building in specific areas.


### PR DESCRIPTION

## About The Pull Request

The construction console (in game only used as the aux base construction console) summons a little drone while its active. This drone's invisibility is turned off, and when the user logs out, its reset to default. However, after the invisibility refactor, it was the console's invisibility that was being removed and reapplied. This PR fixes that, and properly applies it to the drone.

## Why It's Good For The Game

I want to know where the RCD is about to place the wall, so I can place the items where I want them to go.

## Changelog


:cl:
fix: The construction console drone becomes visible again while its in use
/:cl:
