### PR TITLE
Un-undefs healthscan mode defines (moves them to a defines file) 

### DIFF
--- a/code/__DEFINES/devices.dm
+++ b/code/__DEFINES/devices.dm
@@ -13,3 +13,12 @@
 #define INSPECTOR_TIME_MODE_SLOW 1
 #define INSPECTOR_TIME_MODE_FAST 2
 #define INSPECTOR_TIME_MODE_HONK 3
+
+// Health scan modes
+/// Healthscan prints health of the target
+#define SCANNER_CONDENSED 0
+/// Healthscan prints health of each bodypart of the target in addition to broad health
+#define SCANNER_VERBOSE 1
+/// Used to prevent health analyzers from switching modes when they shouldn't.
+/// Functions the same as [SCANNER_CONDENSED]
+#define SCANNER_NO_MODE -1

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -2,10 +2,6 @@
 #define SCANMODE_HEALTH 0
 #define SCANMODE_WOUND 1
 #define SCANMODE_COUNT 2 // Update this to be the number of scan modes if you add more
-#define SCANNER_CONDENSED 0
-#define SCANNER_VERBOSE 1
-// Not updating above count because you're not meant to switch to this mode.
-#define SCANNER_NO_MODE -1
 
 /obj/item/healthanalyzer
 	name = "health analyzer"
@@ -681,9 +677,6 @@
 #undef SCANMODE_HEALTH
 #undef SCANMODE_WOUND
 #undef SCANMODE_COUNT
-#undef SCANNER_CONDENSED
-#undef SCANNER_VERBOSE
-#undef SCANNER_NO_MODE
 
 #undef AID_EMOTION_NEUTRAL
 #undef AID_EMOTION_HAPPY


### PR DESCRIPTION
## About The Pull Request

`healthscan` is a global proc, but if you want to call the proc with a different scan mode, you can't use the defines as they're def'd and undef'd in the health analyzer file. 

So I moved them to a global define file. 

