### PR TITLE
Fixes ripley conversion kits

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -385,7 +385,7 @@
 		equipment.detach(newmech)
 		equipment.attach(newmech, righthandgun)
 	newmech.dna_lock = markone.dna_lock
-	newmech.mecha_flags |= PANEL_OPEN // don't override any other flags or shit gets fucked
+	newmech.mecha_flags |= markone.mecha_flags // don't directly set the flags to the old ones or shit gets fucked
 	newmech.strafe = markone.strafe
 	//Integ set to the same percentage integ as the old mecha, rounded to be whole number
 	newmech.update_integrity(round((markone.get_integrity() / markone.max_integrity) * newmech.get_integrity()))

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -385,7 +385,8 @@
 		equipment.detach(newmech)
 		equipment.attach(newmech, righthandgun)
 	newmech.dna_lock = markone.dna_lock
-	newmech.mecha_flags |= markone.mecha_flags // don't directly set the flags to the old ones or shit gets fucked
+	newmech.mecha_flags |= markone.mecha_flags & ~initial(markone.mecha_flags) // transfer any non-inherent flags like PANEL_OPEN and LIGHTS_ON
+	set_light_on(newmech.mecha_flags & LIGHTS_ON) // in case the lights were on
 	newmech.strafe = markone.strafe
 	//Integ set to the same percentage integ as the old mecha, rounded to be whole number
 	newmech.update_integrity(round((markone.get_integrity() / markone.max_integrity) * newmech.get_integrity()))

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -385,7 +385,7 @@
 		equipment.detach(newmech)
 		equipment.attach(newmech, righthandgun)
 	newmech.dna_lock = markone.dna_lock
-	newmech.mecha_flags = markone.mecha_flags
+	newmech.mecha_flags |= PANEL_OPEN // don't override any other flags or shit gets fucked
 	newmech.strafe = markone.strafe
 	//Integ set to the same percentage integ as the old mecha, rounded to be whole number
 	newmech.update_integrity(round((markone.get_integrity() / markone.max_integrity) * newmech.get_integrity()))

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -385,8 +385,7 @@
 		equipment.detach(newmech)
 		equipment.attach(newmech, righthandgun)
 	newmech.dna_lock = markone.dna_lock
-	newmech.mecha_flags |= markone.mecha_flags & ~initial(markone.mecha_flags) // transfer any non-inherent flags like PANEL_OPEN and LIGHTS_ON
-	set_light_on(newmech.mecha_flags & LIGHTS_ON) // in case the lights were on
+	newmech.mecha_flags |= markone.mecha_flags // don't directly set the flags to the old ones or shit gets fucked
 	newmech.strafe = markone.strafe
 	//Integ set to the same percentage integ as the old mecha, rounded to be whole number
 	newmech.update_integrity(round((markone.get_integrity() / markone.max_integrity) * newmech.get_integrity()))

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -386,7 +386,7 @@
 		equipment.attach(newmech, righthandgun)
 	newmech.dna_lock = markone.dna_lock
 	newmech.mecha_flags |= markone.mecha_flags & ~initial(markone.mecha_flags) // transfer any non-inherent flags like PANEL_OPEN and LIGHTS_ON
-	set_light_on(newmech.mecha_flags & LIGHTS_ON) // in case the lights were on
+	newmech.set_light_on(newmech.mecha_flags & LIGHTS_ON) // in case the lights were on
 	newmech.strafe = markone.strafe
 	//Integ set to the same percentage integ as the old mecha, rounded to be whole number
 	newmech.update_integrity(round((markone.get_integrity() / markone.max_integrity) * newmech.get_integrity()))


### PR DESCRIPTION
## About The Pull Request

Fixes Mk-II Ripley exosuits not being enclosed, and converted mechs not having lights on if they did before.

## Why It's Good For The Game

Closes #81034

## Changelog
:cl:
fix: Mk-II Ripley exosuits are spaceproof again.
fix: Converted mechs now have their lights on if they did before the conversion.
/:cl:
