### PR TITLE
All Within Theoretical Limits lets people be in the SM room

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -348,7 +348,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	// handle the engineers that saved the engine from cascading, if there were any
 	if(get_status() < SUPERMATTER_EMERGENCY && !isnull(saviors))
 		for(var/datum/weakref/savior_ref as anything in saviors)
-			var/mob/living/savior = savior_ref.resolve()
+			var/mob/living/savior = savior_ref?.resolve()
 			if(!istype(savior)) // didn't live to tell the tale, sadly.
 				continue
 			savior.client?.give_award(/datum/award/achievement/jobs/theoretical_limits, savior)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -613,7 +613,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			if(!istype(delamination_strategy, /datum/sm_delam/cascade))
 				return
 
-			for(var/mob/living/lucky_engi as anything in mobs_in_area_type(list(/area/station/engineering/supermatter)))
+			for(var/mob/living/lucky_engi as anything in mobs_in_area_type(list(\
+				/area/station/engineering/supermatter,\
+				/area/station/engineering/supermatter/room,\
+				/area/station/engineering/supermatter/waste)))
 				if(isnull(lucky_engi.client))
 					continue
 				if(isanimal_or_basicmob(lucky_engi))


### PR DESCRIPTION
## About The Pull Request

The All Within Theoretical Limits now works when the person is in the SM areas, rather than being in the SM itself.

This is the area you currently have to be in to get the achievement on Icebox
![image](https://github.com/tgstation/tgstation/assets/53777086/96b10dfe-ac29-4a4b-9e54-e56b84df30a4)

## Why It's Good For The Game

When you are fixing a supermatter, you are generally doing it by messing with its pipes, so you should be getting the achievement if you did the work necessary to earn it.

## Changelog

:cl:
fix: All Within Theoretical Limits achievement now unlocks if you're in the SM room as it gets saved, rather than having to be in the chamber itself.
/:cl: