### PR TITLE
Fixes some issues with slime feeding

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -36,7 +36,7 @@
 
 	var/list/choices = list()
 	for(var/mob/living/nearby_mob in view(1,src))
-		if(nearby_mob != src && Adjacent(nearby_mob) && nearby_mob.stat < DEAD)
+		if(nearby_mob != src && Adjacent(nearby_mob) && nearby_mob.appears_alive())
 			choices += nearby_mob
 
 	if(length(choices) == 1)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -30,10 +30,18 @@
 	if(stat)
 		return FALSE
 
+	if(buckled)
+		stop_feeding()
+		return TRUE
+
 	var/list/choices = list()
 	for(var/mob/living/nearby_mob in view(1,src))
-		if(nearby_mob != src && Adjacent(nearby_mob))
+		if(nearby_mob != src && Adjacent(nearby_mob) && nearby_mob.stat < DEAD))
 			choices += nearby_mob
+
+	if(length(choices) == 1)
+		start_feeding(choices[1])
+		return TRUE
 
 	var/choice = tgui_input_list(src, "Who do you wish to feed on?", "Slime Feed", sort_names(choices))
 	if(isnull(choice))

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -36,7 +36,7 @@
 
 	var/list/choices = list()
 	for(var/mob/living/nearby_mob in view(1,src))
-		if(nearby_mob != src && Adjacent(nearby_mob) && nearby_mob.stat < DEAD))
+		if(nearby_mob != src && Adjacent(nearby_mob) && nearby_mob.stat < DEAD)
 			choices += nearby_mob
 
 	if(length(choices) == 1)


### PR DESCRIPTION
## About The Pull Request

Using feed while feeding on someone will now unbuckle you rather than prompt you to buckle to someone else like it's supposed to
The list of people to buckle to no longer includes dead people (which is beneficial for the last fix)
If there's only one person to buckle to then it will skip the UI and eat that person.

## Why It's Good For The Game

Fixes to slime.

## Changelog

:cl:
fix: Slimes using Feed while buckled now stops feeding.
fix: Slimes are no longer prompted to feed off of dead people.
fix: Slimes that can only feed onto one person now immediately feeds off of them.
/:cl: