### PR TITLE
[NO GBP] Fix "All Within Theoretical Limits" not being granted when delamination variants change

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -587,9 +587,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			)
 
 	for(var/i in delamination_countdown_time to 0 step -10)
-		if(last_delamination_strategy != delamination_strategy)
-			count_down_messages = delamination_strategy.count_down_messages()
-
 		var/message
 		var/healed = FALSE
 
@@ -620,9 +617,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				LAZYADD(saviors, WEAKREF(lucky_engi))
 
 			return // delam averted
-
-		if(last_delamination_strategy != delamination_strategy)
-			last_delamination_strategy = delamination_strategy
 
 		sleep(1 SECONDS)
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -589,7 +589,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/i in delamination_countdown_time to 0 step -10)
 		if(last_delamination_strategy != delamination_strategy)
 			count_down_messages = delamination_strategy.count_down_messages()
-			last_delamination_strategy = delamination_strategy
 
 		var/message
 		var/healed = FALSE
@@ -610,7 +609,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(healed)
 			final_countdown = FALSE
 
-			if(!istype(delamination_strategy, /datum/sm_delam/cascade))
+			if(!istype(last_delamination_strategy, /datum/sm_delam/cascade))
 				return
 
 			for(var/mob/living/lucky_engi as anything in mobs_in_area_type(list(/area/station/engineering/supermatter)))
@@ -621,6 +620,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				LAZYADD(saviors, WEAKREF(lucky_engi))
 
 			return // delam averted
+
+		if(last_delamination_strategy != delamination_strategy)
+			last_delamination_strategy = delamination_strategy
+
 		sleep(1 SECONDS)
 
 	delamination_strategy.delaminate(src)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -318,7 +318,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	damage_factors = calculate_damage()
 	if(damage == 0) // Clear any in game forced delams if on full health.
 		set_delam(SM_DELAM_PRIO_IN_GAME, SM_DELAM_STRATEGY_PURGE)
-	else if(damage <= explosion_point)
+	else if(!final_countdown)
 		set_delam(SM_DELAM_PRIO_NONE, SM_DELAM_STRATEGY_PURGE) // This one cant clear any forced delams.
 	delamination_strategy.delam_progress(src)
 	if(damage > explosion_point && !final_countdown)
@@ -564,7 +564,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		header = "Meltdown Incoming",
 	)
 
-	var/datum/sm_delam/last_delamination_strategy = delamination_strategy
 	var/list/count_down_messages = delamination_strategy.count_down_messages()
 
 	radio.talk_into(
@@ -606,7 +605,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(healed)
 			final_countdown = FALSE
 
-			if(!istype(last_delamination_strategy, /datum/sm_delam/cascade))
+			if(!istype(delamination_strategy, /datum/sm_delam/cascade))
 				return
 
 			for(var/mob/living/lucky_engi as anything in mobs_in_area_type(list(/area/station/engineering/supermatter)))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -617,7 +617,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				LAZYADD(saviors, WEAKREF(lucky_engi))
 
 			return // delam averted
-
 		sleep(1 SECONDS)
 
 	delamination_strategy.delaminate(src)


### PR DESCRIPTION
## About The Pull Request

I made a change in #80324 that prevents delamination variants from updating after the countdown is reached, however AWTL wouldn't obey this because the countdown proc sleeps while the crystal comes back from the countdown stage, so the `delamination_strategy` var will have changed. I removed 3 dead lines of code (because delam variants never change during the countdown).

Fixes #79528 this time hopefully
## Why It's Good For The Game

work, damn it
## Changelog
:cl:
fix: All Within Theoretical Limits should properly unlock now when the crystal comes back from the countdown.
/:cl:
