### PR TITLE
Fixes text effects for runechat.

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.
 #define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
 	var/static/regex/##varname = regex("(?<!\\\\)[char](.+?)(?<!\\\\)[char]", "g");\
-	input = varname.Replace_char(input, "<[html]>$1</[html]>")
+	input = varname.Replace_char(input, "<[html]>$1</[html]>&#8203;") //zero-widht space to force maptext to respect closing tags.
 
 /// Scans the input sentence for speech emphasis modifiers, notably |italics|, +bold+, and _underline_ -mothblocks
 /atom/movable/proc/say_emphasis(input)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.
 #define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
 	var/static/regex/##varname = regex("(?<!\\\\)[char](.+?)(?<!\\\\)[char]", "g");\
-	input = varname.Replace_char(input, "<[html]>$1</[html]>&#8203;") //zero-widht space to force maptext to respect closing tags.
+	input = varname.Replace_char(input, "<[html]>$1</[html]>&#8203;") //zero-width space to force maptext to respect closing tags.
 
 /// Scans the input sentence for speech emphasis modifiers, notably |italics|, +bold+, and _underline_ -mothblocks
 /atom/movable/proc/say_emphasis(input)

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -1,4 +1,4 @@
-@You can wrap portions of your  messages with |, + or _ characters to <i>italicize</i>, <b>embolden</b> or <u>underline</u> them respectively. You can also escape these modifiers by adding backslashes before the mentioned characters.
+@You can <i>italicize</i>, <b>embolden</b> or <u>underline</u> portions of your messages by enclosing them with |, + or _ respectively. You can also avoid this by adding backslashes (they won't show in the message) before these characters.
 ♪ Hey, have you ever tried appending the % character before your messages when speaking in-game? ♫
 A Scientist will pay top dollar for your frogs!
 A thrown glass of water can make a slippery tile, allowing you to slow down your pursuers in a pinch.

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -1,4 +1,4 @@
-@You can use the |, + and _ characters to emphasize parts of what you say in-game (e.g. say"my _ass_ |is| +heavy+." will be outputted as "my <u>ass</u> <i>is</i> <b>heavy</b>."). You can also escape these emphasizers by appending backslashes before them (e.g. say"1\+2\+3" will come out as "1+2+3" and not "1\<b>2\</b>3").
+@You can wrap portions of your  messages with |, + or _ characters to <i>italicize</i>, <b>embolden</b> or <u>underline</u> them respectively. You can also escape these modifiers by adding backslashes before the mentioned characters.
 ♪ Hey, have you ever tried appending the % character before your messages when speaking in-game? ♫
 A Scientist will pay top dollar for your frogs!
 A thrown glass of water can make a slippery tile, allowing you to slow down your pursuers in a pinch.


### PR DESCRIPTION

## About The Pull Request
This stuff has been cramping 100% heavy roleplay style for too long.

Somehow, the way maptext is formatted* seems to break tag ends found around a line break. This usually happens when a space with width is found by the end of the line, and I don't recall ever encountering the issue otherwise.
Apparently, I've also found out that concatenating two spaces, regardless of width, seems to fix the issue just fine, and that brings in the solution to this whole pedantic problem: a <b>zero-width space</b> at the end of the closing tag.

*That's handled behind the curtains by the engine, so I can only throw wild guesses to why it happens.

Oh, by the by, I've also changed the tip about text modifiers I've made over a year ago. It was too confusing to read.

## Why It's Good For The Game
Comparison between before and after, and how it looks in the UI.
![immagine](https://github.com/tgstation/tgstation/assets/42542238/a3130c29-134b-4ddc-a73a-1e5609d3c0f6)

This should fix #73470.

## Changelog

:cl:
fix: Fixed text effects for runechat messages (the stuff enclosed in +, | and _ characters).
spellcheck: Improved the tip for say/text effects.
/:cl:
