### PR TITLE
Cult pylons won't convert floorless floors

### DIFF
--- a/code/modules/antagonists/cult/cult_structure_pylon.dm
+++ b/code/modules/antagonists/cult/cult_structure_pylon.dm
@@ -45,12 +45,12 @@
 		if(istype(nearby_turf, /turf/open/floor/engine/cult))
 			cultturfs |= nearby_turf
 			continue
-		var/static/list/blacklisted_pylon_turfs = GLOB.turfs_without_ground + typecacheof(list(
+		var/static/list/blacklisted_pylon_turfs = typecacheof(list(
 			/turf/closed,
 			/turf/open/floor/engine/cult,
 			/turf/open/misc/asteroid,
 		))
-		if(is_type_in_typecache(nearby_turf, blacklisted_pylon_turfs))
+		if(isgroundlessturf(nearby_turf) || is_type_in_typecache(nearby_turf, blacklisted_pylon_turfs))
 			continue
 		validturfs |= nearby_turf
 

--- a/code/modules/antagonists/cult/cult_structure_pylon.dm
+++ b/code/modules/antagonists/cult/cult_structure_pylon.dm
@@ -45,12 +45,9 @@
 		if(istype(nearby_turf, /turf/open/floor/engine/cult))
 			cultturfs |= nearby_turf
 			continue
-		var/static/list/blacklisted_pylon_turfs = typecacheof(list(
+		var/static/list/blacklisted_pylon_turfs = GLOB.turfs_without_ground + typecacheof(list(
 			/turf/closed,
 			/turf/open/floor/engine/cult,
-			/turf/open/space,
-			/turf/open/lava,
-			/turf/open/chasm,
 			/turf/open/misc/asteroid,
 		))
 		if(is_type_in_typecache(nearby_turf, blacklisted_pylon_turfs))


### PR DESCRIPTION
## About The Pull Request

Cult pylons read from our existing list of "turfs which don't count as floor despite being open turfs" instead of having its own one, which did not include openspace turfs.
This prevents it from "papering over" things like stairwells and sealing people inside their base.

![image](https://github.com/tgstation/tgstation/assets/7483112/f91ad4a3-8546-4861-9098-31817ea30821)

## Why It's Good For The Game

It's not supposed to do that, and fixing it this way is futureproof to a greater degree.

## Changelog

:cl:
fix: Cult pylons will no longer cover up "open space" (or water) with cult floors
/:cl:
