### PR TITLE
Fixes ore vent descriptions stacking, fixes potential exploits with ore vent scanning

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -283,19 +283,26 @@
 		balloon_alert_to_viewers("vent tapped!")
 		return
 	if(!COOLDOWN_FINISHED(src, wave_cooldown))
-		balloon_alert_to_viewers("protect the node drone!")
-		return
-	if(scan_only)
-		discovered = TRUE
-		generate_description(user)
-		balloon_alert_to_viewers("vent scanned!")
+		if(!scan_only)
+			balloon_alert_to_viewers("protect the node drone!")
 		return
 	if(!discovered)
+		if(scan_only)
+			discovered = TRUE
+			generate_description(user)
+			balloon_alert_to_viewers("vent scanned!")
+			return
+
+		if(DOING_INTERACTION_WITH_TARGET(user, src))
+			balloon_alert(user, "already scanning!")
+			return
 		balloon_alert(user, "scanning...")
 		playsound(src, 'sound/items/timer.ogg', 30, TRUE)
-		if(do_after(user, 4 SECONDS))
-			discovered = TRUE
-			balloon_alert(user, "vent scanned!")
+		if(!do_after(user, 4 SECONDS, src))
+			return
+
+		discovered = TRUE
+		balloon_alert(user, "vent scanned!")
 		generate_description(user)
 		var/obj/item/card/id/user_id_card = user.get_idcard(TRUE)
 		if(isnull(user_id_card))
@@ -303,7 +310,8 @@
 		user_id_card.registered_account.mining_points += (MINER_POINT_MULTIPLIER)
 		user_id_card.registered_account.bank_card_talk("You've been awarded [MINER_POINT_MULTIPLIER] mining points for discovery of an ore vent.")
 		return
-
+	if(scan_only)
+		return
 	if(tgui_alert(user, excavation_warning, "Begin defending ore vent?", list("Yes", "No")) != "Yes")
 		return
 	if(!COOLDOWN_FINISHED(src, wave_cooldown))
@@ -332,12 +340,12 @@
  * Ore_string is passed to examine().
  */
 /obj/structure/ore_vent/proc/generate_description(mob/user)
-	for(var/mineral_count in 1 to length(mineral_breakdown))
-		var/datum/material/resource = mineral_breakdown[mineral_count]
-		if(mineral_count == length(mineral_breakdown))
-			ore_string += "and " + span_bold(initial(resource.name)) + "."
-		else
-			ore_string += span_bold(initial(resource.name)) + ", "
+	ore_string = ""
+	var/list/mineral_names = list()
+	for(var/datum/material/resource as anything in mineral_breakdown)
+		mineral_names += initial(resource.name)
+
+	ore_string = "[english_list(mineral_names)]."
 	if(user)
 		ore_string += "\nThis vent was first discovered by [user]."
 /**


### PR DESCRIPTION
## About The Pull Request

- Scanning ore vents did a do_after to do the actual scan, but if the do_after failed, it didn't cancel the scan proc, and rewarded you points anyways. So you could just keep cancelling the scan for free points?

- Also there was nothing preventing someone from stacking scans on the same vent

- Also, when generating the ore description, always override existing descriptions. Given `generate_description` can be called multiple times, prevents it from stacking on itself. 

## Changelog

:cl: Melbert
fix: Fixed ore vent descriptions looking weird sometimes
fix: Fixed being able to scan an ore vent multiple times at once
fix: Fixed gaining scan points from scannning an ore vent without finishing the scan
/:cl:
