### PR TITLE
Changes one wall in syndicate lavaland base to stop it from being nuked by a chemist

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -62,9 +62,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
-"aL" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/testlab)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5700,7 +5697,7 @@ pa
 pa
 ae
 ae
-aL
+ae
 ae
 ae
 ae
@@ -5999,7 +5996,7 @@ ab
 ab
 as
 as
-as
+PW
 dI
 NE
 ew


### PR DESCRIPTION

## About The Pull Request

changes one explosive wall in the chemistry room to the corner of the room in order to avoid chemists nuking the entire base by simply yeeting a potas water grenade into the experimentation chamber

![image](https://github.com/tgstation/tgstation/assets/118483925/4c8b2238-ffd7-41b0-a1f8-b17056620c17)
## Why It's Good For The Game


makes it easier to not accidently fuck over 4 people by trying to do your job as a bioweapon scientist
## Changelog
:cl:
fix: makes the experiment chamber in syndicate lavaland base no longer explode when testing grenades
/:cl:
