### PR TITLE
Station Goals are now handled by SSstation instead of a global list

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -491,11 +491,14 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 		return ""
 
 /datum/controller/subsystem/ticker/proc/goal_report()
+	var/list/goals = SSstation.get_station_goals()
+	if(!length(goals))
+		return null
+
 	var/list/parts = list()
-	if(GLOB.station_goals.len)
-		for(var/datum/station_goal/goal as anything in GLOB.station_goals)
-			parts += goal.get_result()
-		return "<div class='panel stationborder'><ul>[parts.Join()]</ul></div>"
+	for(var/datum/station_goal/goal as anything in SSstation.get_station_goals())
+		parts += goal.get_result()
+	return "<div class='panel stationborder'><ul>[parts.Join()]</ul></div>"
 
 ///Generate a report for how much money is on station, as well as the richest crewmember on the station.
 /datum/controller/subsystem/ticker/proc/market_report()

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -329,16 +329,16 @@ SUBSYSTEM_DEF(dynamic)
 		if(ruleset.weight <= 0 || ruleset.cost <= 0)
 			continue
 		min_threat = min(ruleset.cost, min_threat)
+
 	var/greenshift = GLOB.dynamic_forced_extended || (threat_level < min_threat && shown_threat < min_threat) //if both shown and real threat are below any ruleset, its extended time
+	SSstation.generate_station_goals(greenshift ? INFINITY : CONFIG_GET(number/station_goal_budget))
 
-	generate_station_goals(greenshift ? INFINITY : CONFIG_GET(number/station_goal_budget))
-
-	if (GLOB.station_goals.len > 0)
-		var/list/texts = list("<hr><b>Special Orders for [station_name()]:</b><BR>")
-		for(var/datum/station_goal/station_goal as anything in GLOB.station_goals)
+	var/list/datum/station_goal/goals = SSstation.get_station_goals()
+	if(length(goals))
+		var/list/texts = list("<hr><b>Special Orders for [station_name()]:</b><br>")
+		for(var/datum/station_goal/station_goal as anything in goals)
 			station_goal.on_report()
 			texts += station_goal.get_report()
-
 		. += texts.Join("<hr>")
 
 	var/list/trait_list_strings = list()

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -15,7 +15,8 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	var/list/antag_protected_roles = list()
 	///A list of trait roles that should never be able to roll antag
 	var/list/antag_restricted_roles = list()
-	/// Assosciative list of goal type -> goal instance
+
+	/// Assosciative list of station goal type -> goal instance
 	var/list/datum/station_goal/goals_by_type = list()
 
 /datum/controller/subsystem/processing/station/Initialize()

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -77,7 +77,6 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		if(!ispath(goal_type_or_instance, /datum/station_goal))
 			CRASH("Invalid station goal type path [goal_type_or_instance] was requested!")
 		goal_type_or_instance = new goal_type_or_instance
-	goals_by_type[goal_type_or_instance.type] = goal_type_or_instance
 
 ///Rolls for the amount of traits and adds them to the traits list
 /datum/controller/subsystem/processing/station/proc/SetupTraits()

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -58,7 +58,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		chosen_goals += picked
 
 	for(var/chosen in chosen_goals)
-		add_new_station_goal(chosen)
+		new chosen()
 
 /// Returns all station goals that are currently active
 /datum/controller/subsystem/processing/station/proc/get_station_goals()
@@ -70,13 +70,6 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /// Returns a specific station goal by type
 /datum/controller/subsystem/processing/station/proc/get_station_goal(goal_type)
 	return goals_by_type[goal_type]
-
-/// Generates a station goal and registers it
-/datum/controller/subsystem/processing/station/proc/add_new_station_goal(datum/station_goal/goal_type_or_instance)
-	if(!istype(goal_type_or_instance))
-		if(!ispath(goal_type_or_instance, /datum/station_goal))
-			CRASH("Invalid station goal type path [goal_type_or_instance] was requested!")
-		goal_type_or_instance = new goal_type_or_instance
 
 ///Rolls for the amount of traits and adds them to the traits list
 /datum/controller/subsystem/processing/station/proc/SetupTraits()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -67,6 +67,9 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
+	/// List of initialized station goals
+	var/list/datum/station_goal/goals_by_type = list()
+
 /datum/controller/subsystem/ticker/Initialize()
 	var/list/byond_sound_formats = list(
 		"mid" = TRUE,
@@ -225,7 +228,6 @@ SUBSYSTEM_DEF(ticker)
 	if(GLOB.revolutionary_win)
 		return TRUE
 	return FALSE
-
 
 /datum/controller/subsystem/ticker/proc/setup()
 	to_chat(world, span_boldannounce("Starting game..."))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -67,9 +67,6 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
-	/// List of initialized station goals
-	var/list/datum/station_goal/goals_by_type = list()
-
 /datum/controller/subsystem/ticker/Initialize()
 	var/list/byond_sound_formats = list(
 		"mid" = TRUE,

--- a/code/game/machinery/satellite/satellite_control.dm
+++ b/code/game/machinery/satellite/satellite_control.dm
@@ -44,10 +44,9 @@
 		))
 	data["notice"] = notice
 
-
-	var/datum/station_goal/station_shield/goal = locate() in GLOB.station_goals
-	if(goal)
-		data["meteor_shield"] = 1
+	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(__IMPLIED_TYPE__)
+	if(!isnull(goal))
+		data["meteor_shield"] = TRUE
 		data["meteor_shield_coverage"] = goal.get_coverage()
 		data["meteor_shield_coverage_max"] = goal.coverage_goal
 	return data

--- a/code/game/machinery/satellite/satellite_control.dm
+++ b/code/game/machinery/satellite/satellite_control.dm
@@ -44,7 +44,7 @@
 		))
 	data["notice"] = notice
 
-	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(__IMPLIED_TYPE__)
+	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(/datum/station_goal/station_shield)
 	if(!isnull(goal))
 		data["meteor_shield"] = TRUE
 		data["meteor_shield_coverage"] = goal.get_coverage()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1350,7 +1350,7 @@
 				return
 			G.report_message = description
 		message_admins("[key_name(usr)] created \"[G.name]\" station goal.")
-		GLOB.station_goals += G
+		SSstation.add_new_station_goal(G)
 		modify_goals()
 
 	else if(href_list["change_lag_switch"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1350,7 +1350,6 @@
 				return
 			G.report_message = description
 		message_admins("[key_name(usr)] created \"[G.name]\" station goal.")
-		SSstation.add_new_station_goal(G)
 		modify_goals()
 
 	else if(href_list["change_lag_switch"])

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -546,8 +546,8 @@
 
 /datum/admins/proc/modify_goals()
 	var/dat = ""
-	for(var/datum/station_goal/S in GLOB.station_goals)
-		dat += "[S.name] - <a href='?src=[REF(S)];[HrefToken()];announce=1'>Announce</a> | <a href='?src=[REF(S)];[HrefToken()];remove=1'>Remove</a><br>"
+	for(var/datum/station_goal/goal as anything in SSstation.get_station_goals())
+		dat += "[goal.name] - <a href='?src=[REF(goal)];[HrefToken()];announce=1'>Announce</a> | <a href='?src=[REF(goal)];[HrefToken()];remove=1'>Remove</a><br>"
 	dat += "<br><a href='?src=[REF(src)];[HrefToken()];add_station_goal=1'>Add New Goal</a>"
 	usr << browse(dat, "window=goals;size=400x400")
 

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -101,8 +101,8 @@
 		F.parent = src
 		fillers += F
 
-	var/datum/station_goal/dna_vault/dna_vault_goal = locate() in GLOB.station_goals
-	if (!isnull(dna_vault_goal))
+	var/datum/station_goal/dna_vault/dna_vault_goal = SSstation.get_station_goal(__IMPLIED_TYPE__)
+	if(!isnull(dna_vault_goal))
 		animals_max = dna_vault_goal.animal_count
 		plants_max = dna_vault_goal.plant_count
 		dna_max = dna_vault_goal.human_count

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -101,7 +101,7 @@
 		F.parent = src
 		fillers += F
 
-	var/datum/station_goal/dna_vault/dna_vault_goal = SSstation.get_station_goal(__IMPLIED_TYPE__)
+	var/datum/station_goal/dna_vault/dna_vault_goal = SSstation.get_station_goal(/datum/station_goal/dna_vault)
 	if(!isnull(dna_vault_goal))
 		animals_max = dna_vault_goal.animal_count
 		plants_max = dna_vault_goal.plant_count

--- a/code/modules/station_goals/generate_goals.dm
+++ b/code/modules/station_goals/generate_goals.dm
@@ -1,13 +1,1 @@
 /// Creates the initial station goals.
-/proc/generate_station_goals(goal_budget)
-	var/list/possible = subtypesof(/datum/station_goal)
-	// Remove all goals that require space if space is not present
-	if(SSmapping.is_planetary())
-		for(var/datum/station_goal/goal as anything in possible)
-			if(initial(goal.requires_space))
-				possible -= goal
-	var/goal_weights = 0
-	while(possible.len && goal_weights < goal_budget)
-		var/datum/station_goal/picked = pick_n_take(possible)
-		goal_weights += initial(picked.weight)
-		GLOB.station_goals += new picked

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -14,8 +14,9 @@
 // Satellites be actived to generate a shield that will block unorganic matter from passing it.
 /datum/station_goal/station_shield
 	name = "Station Shield"
-	var/coverage_goal = 500
 	requires_space = TRUE
+	var/coverage_goal = 500
+	VAR_PRIVATE/cached_coverage_length
 
 /datum/station_goal/station_shield/get_report()
 	return list(
@@ -37,17 +38,27 @@
 /datum/station_goal/station_shield/check_completion()
 	if(..())
 		return TRUE
-	if(get_coverage() >= coverage_goal)
+	if(cached_coverage_length >= coverage_goal)
 		return TRUE
 	return FALSE
 
-/datum/station_goal/proc/get_coverage()
+/datum/station_goal/station_shield/proc/get_coverage()
+	return cached_coverage_length
+
+/// Gets the coverage of all active meteor shield satellites
+/// Can be expensive, ensure you need this before calling it
+/datum/station_goal/station_shield/proc/update_coverage()
 	var/list/coverage = list()
 	for(var/obj/machinery/satellite/meteor_shield/shield_satt as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/satellite/meteor_shield))
 		if(!shield_satt.active || !is_station_level(shield_satt.z))
 			continue
-		coverage |= view(shield_satt.kill_range, shield_satt)
-	return coverage.len
+		for(var/turf/covered in view(shield_satt.kill_range, get_turf(shield_satt)))
+			coverage |= covered
+	cached_coverage_length = length(coverage)
+
+/client/verb/debug_check_one_two()
+	for(var/turf/covered in view(src))
+		to_chat(src, span_notice("[loc_name(covered)]"))
 
 /obj/machinery/satellite/meteor_shield
 	name = "\improper Meteor Shield Satellite"
@@ -108,6 +119,9 @@
 		return FALSE
 	if(obj_flags & EMAGGED)
 		update_emagged_meteor_sat(user)
+
+	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(__IMPLIED_TYPE__)
+	goal?.update_coverage()
 
 /obj/machinery/satellite/meteor_shield/Destroy()
 	. = ..()

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -52,13 +52,9 @@
 	for(var/obj/machinery/satellite/meteor_shield/shield_satt as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/satellite/meteor_shield))
 		if(!shield_satt.active || !is_station_level(shield_satt.z))
 			continue
-		for(var/turf/covered in view(shield_satt.kill_range, get_turf(shield_satt)))
+		for(var/turf/covered in view(shield_satt.kill_range, shield_satt))
 			coverage |= covered
 	cached_coverage_length = length(coverage)
-
-/client/verb/debug_check_one_two()
-	for(var/turf/covered in view(src))
-		to_chat(src, span_notice("[loc_name(covered)]"))
 
 /obj/machinery/satellite/meteor_shield
 	name = "\improper Meteor Shield Satellite"
@@ -120,7 +116,7 @@
 	if(obj_flags & EMAGGED)
 		update_emagged_meteor_sat(user)
 
-	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(__IMPLIED_TYPE__)
+	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(/datum/station_goal/station_shield)
 	goal?.update_coverage()
 
 /obj/machinery/satellite/meteor_shield/Destroy()

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -38,6 +38,7 @@
 /datum/station_goal/station_shield/check_completion()
 	if(..())
 		return TRUE
+	update_coverage()
 	if(cached_coverage_length >= coverage_goal)
 		return TRUE
 	return FALSE

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -1,6 +1,3 @@
-/// List of available station goals for the crew to be working on
-GLOBAL_LIST_EMPTY_TYPED(station_goals, /datum/station_goal)
-
 /datum/station_goal
 	var/name = "Generic Goal"
 	var/weight = 1 //In case of multiple goals later.
@@ -30,13 +27,8 @@ GLOBAL_LIST_EMPTY_TYPED(station_goals, /datum/station_goal)
 	else
 		return "<li>[name] : [span_redtext("Failed!")]</li>"
 
-/datum/station_goal/Destroy()
-	GLOB.station_goals -= src
-	return ..()
-
 /datum/station_goal/Topic(href, href_list)
 	..()
-
 	if(!check_rights(R_ADMIN) || !usr.client.holder.CheckAdminHref(href, href_list))
 		return
 

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -38,6 +38,13 @@
 	else if(href_list["remove"])
 		qdel(src)
 
+/datum/station_goal/New()
+	if(type in SSstation.goals_by_type)
+		stack_trace("Creating a new station_goal of type [type] when one already exists in SSstation.goals_by_type this is not supported anywhere. I trust you tho")
+	else
+		SSstation.goals_by_type[type] = src
+	return ..()
+
 /datum/station_goal/Destroy(force)
 	if(SSstation.goals_by_type[type] == src)
 		SSstation.goals_by_type -= type

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -37,3 +37,8 @@
 		send_report()
 	else if(href_list["remove"])
 		qdel(src)
+
+/datum/station_goal/Destroy(force)
+	if(SSstation.goals_by_type[type] == src)
+		SSstation.goals_by_type -= type
+	return ..()


### PR DESCRIPTION

## About The Pull Request

You can now get station goals in a slightly better way over using a `locate() in` call on a global list.
The Meteor Satellite goal no longer stores a giant list of ALL OBJECTS in view. And now correctly only counts turfs.
## Changelog
:cl:
fix: Meteor Satellites no longer erroneously count every piece of paper as a protected turf.
fix: As a result the station goal is slightly more difficult
/:cl:
