### PR TITLE
northstar mail sorting room access and door nitpick

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -77361,11 +77361,13 @@
 	},
 /area/station/service/chapel)
 "ulv" = (
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/door/airlock/mining{
-	name = "Mining Decontamination"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mail Sorting"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/storage)
 "ulB" = (
@@ -86743,6 +86745,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/storage)
 "wEQ" = (


### PR DESCRIPTION
## About The Pull Request

back from the grave for yet another minor access nitpick that was brought to my attention.

northstars mail room had an awkward access woopsy attached to it, from the screenshot here you can see the top right door uses all mining access for some unknown reason, i'm assuming that this was simply forgotten in a rework of the department so i'm fixing it as it was shown to me in a dream (a cargo player told me it irritated them and others). 

![Screenshot 2024-01-29 162437](https://github.com/tgstation/tgstation/assets/120208006/e02278a1-1d44-406a-8ded-07de9040fd68)

i also went ahead and replaced the door it used to also use the mail sorting room door that the top uses, as it was originally using the mining decontamination room door, which is another reason i was thinkin' it got reworked and overlooked, as the decontamination rooms just four tiles above it and uses high security doors.

the actual access changes made were that i removed the all/supply/mining access required on the door and gave it any/supply/general, mining, and bitden, along with replacing the top doors access with any/supply/general, mining, and bitden access so people who get jobchanged into a cargo job have an easier time actually getting in in case the HoP forgets, i factchecked this with delta and a couple of other maps, which split the idea because delta does what i'm doing, but maps like meta and icebox use all/supply/general and nothing else, so if anyone has any problems with this i can change it to all/supply/general, i just view this as a safer bet for people who might get jobchanged by the HoP whos playing clash royale while filing ID accesses.

## Why It's Good For The Game

i don't see a point to having two separate doors for the same room to have different access restrictions when both doors also come from the same room, plus the door being named mining decontamination when it doesn't lead into mining decontamination anymore irks me now that i saw it and it must be changed or else i will weep. the access changes for the doors allows people who get jobchanges into the department an easier time if for some reason they needed to keep access from their previous job but can't fit everything, for instance a slow round for a psych who wants to game but keep psych access.

## Changelog


:cl:

fix: the top and top righthand doors of northstars cargo mail sorting room now use any supply general, mining, and bitden access, and the top righthand door no longer says its mining decontamination and uses the proper mail sorting room airlock instead.

/:cl: