### PR TITLE
Fix Ore Vent's well being on improper plane

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -84,7 +84,7 @@
 		SSore_generation.processed_vents += src
 		icon_state = icon_state_tapped
 		update_appearance(UPDATE_ICON_STATE)
-		add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER, src, ABOVE_MOB_LAYER))
+		add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER, src))
 	return ..()
 
 /obj/structure/ore_vent/Destroy()
@@ -269,7 +269,7 @@
 		user_id_card.registered_account.mining_points += point_reward_val
 		user_id_card.registered_account.bank_card_talk("You have been awarded [point_reward_val] mining points for your efforts.")
 	node.pre_escape() //Visually show the drone is done and flies away.
-	add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER, src, GAME_PLANE))
+	add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER, src))
 
 /**
  * Called when the ore vent is tapped by a scanning device.

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -84,7 +84,7 @@
 		SSore_generation.processed_vents += src
 		icon_state = icon_state_tapped
 		update_appearance(UPDATE_ICON_STATE)
-		add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER, src))
+		add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER))
 	return ..()
 
 /obj/structure/ore_vent/Destroy()
@@ -269,7 +269,7 @@
 		user_id_card.registered_account.mining_points += point_reward_val
 		user_id_card.registered_account.bank_card_talk("You have been awarded [point_reward_val] mining points for your efforts.")
 	node.pre_escape() //Visually show the drone is done and flies away.
-	add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER, src))
+	add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER))
 
 /**
  * Called when the ore vent is tapped by a scanning device.


### PR DESCRIPTION
## About The Pull Request

Removed explicit plane set to `GAME_PLANE` and `ABOVE_MOB_LAYER` thus fixing issue when well was drawn on improper plane, possibly the ghost one.

## Why It's Good For The Game

This PR fixes a visual bug.

![Pic](https://github.com/tgstation/tgstation/assets/137328283/6d867b25-8aec-4f36-ae69-b2b1a918d908)

## Changelog

:cl:
fix: fixed ore vent's well being drawn over ash storm. 
/:cl:

