### PR TITLE
Pirate-themed guns now fit on pirate clothes

### DIFF
--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -27,7 +27,13 @@
 	icon_state = "pirate"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
-	allowed = list(/obj/item/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/cup/glass/bottle/rum)
+	allowed = list(
+		/obj/item/melee/energy/sword/pirate,
+		/obj/item/clothing/glasses/eyepatch,
+		/obj/item/reagent_containers/cup/glass/bottle/rum,
+		/obj/item/gun/energy/laser/musket,
+		/obj/item/gun/energy/disabler/smoothbore,
+	)
 	species_exception = list(/datum/species/golem)
 
 /obj/item/clothing/suit/costume/pirate/armored


### PR DESCRIPTION
## About The Pull Request

The laser musket and smoothbore disabler are themed heavily towards pirate stuff (main thinking of the movie treasure planet) so I thought since the guns aren't held up as great as traditional guns, pirates should at least be able to wear them on their suits, so this does exactly that.

## Why It's Good For The Game

It encourages pirate costume wearing people to use pirate-themed guns which I think is a positive.

## Changelog

:cl:
balance: Pirate suits can now hold the laser musket and smoothbore disabler.
/:cl: