### PR TITLE
Mech wire panels can no longer be accessed while the mech is occupied.

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -344,21 +344,9 @@
 	..()
 	. = TRUE
 
-	if(!(mecha_flags & PANEL_OPEN) && LAZYLEN(occupants))
-		for(var/mob/occupant as anything in occupants)
-			occupant.show_message(
-				span_userdanger("[user] is trying to open the maintenance panel of [src]!"), MSG_VISUAL,
-				span_userdanger("You hear someone trying to open the maintenance panel of [src]!"), MSG_AUDIBLE,
-			)
-		visible_message(span_danger("[user] is trying to open the maintenance panel of [src]!"))
-		if(!do_after(user, 5 SECONDS, src))
-			return
-		for(var/mob/occupant as anything in occupants)
-			occupant.show_message(
-				span_userdanger("[user] has opened the maintenance panel of [src]!"), MSG_VISUAL,
-				span_userdanger("You hear someone opening the maintenance panel of [src]!"), MSG_AUDIBLE,
-			)
-		visible_message(span_danger("[user] has opened the maintenance panel of [src]!"))
+	if(LAZYLEN(occupants))
+		balloon_alert(user, "panel blocked")
+		return
 
 	mecha_flags ^= PANEL_OPEN
 	balloon_alert(user, (mecha_flags & PANEL_OPEN) ? "panel open" : "panel closed")

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -35,13 +35,14 @@
 		return FALSE
 	return ..()
 
-///proc called when a new non-mmi/AI mob enters this mech
+///proc called when a new non-mmi mob enters this mech
 /obj/vehicle/sealed/mecha/proc/moved_inside(mob/living/newoccupant)
 	if(!(newoccupant?.client))
 		return FALSE
 	if(ishuman(newoccupant) && !Adjacent(newoccupant))
 		return FALSE
 	add_occupant(newoccupant)
+	mecha_flags &= ~PANEL_OPEN //Close panel if open
 	newoccupant.forceMove(src)
 	newoccupant.update_mouse_pointer()
 	add_fingerprint(newoccupant)
@@ -92,6 +93,7 @@
 
 	brain_obj.set_mecha(src)
 	add_occupant(brain_mob)//Note this forcemoves the brain into the mech to allow relaymove
+	mecha_flags &= ~PANEL_OPEN //Close panel if open
 	mecha_flags |= SILICON_PILOT
 	brain_mob.reset_perspective(src)
 	brain_mob.remote_control = src


### PR DESCRIPTION

## About The Pull Request
- The screwdriver_act() proc is blocked if the mech's occupant list isn't empty.
- Entering a mech also force-sets the panel closed.
- Fixes an incorrect comment.
## Why It's Good For The Game
I think mech wires were dumb to begin with, but that's not the hill I'm here to die on today.

The ability to mess with mech wires while the mech is piloted doesn't really make anti-mech combat better. Pilot gets a big giant text warning, if they're looking at the text window, but if not the wires can be quick-snipped once the do-after is done. If you were in the middle of typing, you have a short window to close the text box and get back to moving before the panel is open (and you cannot close it without exiting the mech). At the same time, there's no real way to combo into it, so it's _only_ really useful against mechs otherwise distracted, or as cheese when the mech is in a corner. Then we put things like weapon disabling and forced overclocking (and thus, damage) into the wires, so cutting everything cripples the vehicle.

In short, it's stupid powerful when it works, and yet it only works against inattentive players unaware of the mech wire system. An overly cheesy anti-mech strat when the go-to should be EMPs.

You can still steal unoccupied mechs, I guess, go nuts.
## Changelog
:cl:
balance: Mech wire panels are now blocked when the mech is occupied. I guess it was moved to be behind the seat.
/:cl:
