### PR TITLE
Lathes no use power to print piecemeal AND respect area.requires_power

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -221,40 +221,37 @@
 		return
 
 	//use power
-	var/power = 0
+	var/total_charge = 0
 	for(var/material in design.materials)
-		power += round(design.materials[material] * material_cost_coefficient * build_count)
-	power = min(active_power_usage, power)
-	if(!directly_use_power(power))
-		say("Not enough power in local network to begin production.")
-		return
+		total_charge += round(design.materials[material] * material_cost_coefficient * build_count)
+	var/charge_per_item = total_charge / build_count
 
 	var/total_time = (design.construction_time * design.lathe_time_factor * build_count) ** 0.8
 	var/time_per_item = total_time / build_count
-	start_making(design, build_count, time_per_item, material_cost_coefficient)
+	start_making(design, build_count, time_per_item, material_cost_coefficient, charge_per_item)
 	return TRUE
 
 /// Begins the act of making the given design the given number of items
 /// Does not check or use materials/power/etc
-/obj/machinery/autolathe/proc/start_making(datum/design/design, build_count, build_time_per_item, material_cost_coefficient)
+/obj/machinery/autolathe/proc/start_making(datum/design/design, build_count, build_time_per_item, material_cost_coefficient, charge_per_item)
 	PROTECTED_PROC(TRUE)
 
 	busy = TRUE
 	icon_state = "autolathe_n"
 	update_static_data_for_all_viewers()
 
-	addtimer(CALLBACK(src, PROC_REF(do_make_item), design, material_cost_coefficient, build_time_per_item, build_count), build_time_per_item)
+	addtimer(CALLBACK(src, PROC_REF(do_make_item), design, material_cost_coefficient, build_time_per_item, charge_per_item, build_count), build_time_per_item)
 
 /// Callback for start_making, actually makes the item
 /// Called using timers started by start_making
-/obj/machinery/autolathe/proc/do_make_item(datum/design/design, material_cost_coefficient, time_per_item, items_remaining)
+/obj/machinery/autolathe/proc/do_make_item(datum/design/design, material_cost_coefficient, time_per_item, charge_per_item, items_remaining)
 	PROTECTED_PROC(TRUE)
 
 	if(!items_remaining) // how
 		finalize_build()
 		return
 
-	if(!is_operational)
+	if(!directly_use_power(charge_per_item))
 		say("Unable to continue production, power failure.")
 		finalize_build()
 		return

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -143,17 +143,17 @@
  * - Amount: How much power the APC's cell is to be costed.
  */
 /obj/machinery/proc/directly_use_power(amount)
-	var/area/A = get_area(src)
-	var/obj/machinery/power/apc/local_apc
-	if(!A)
+	var/area/my_area = get_area(src)
+	if(isnull(my_area))
+		stack_trace("machinery is somehow not in an area, nullspace?")
 		return FALSE
-	local_apc = A.apc
-	if(!local_apc)
+	if(!my_area.requires_power)
+		return TRUE
+
+	var/obj/machinery/power/apc/my_apc = my_area.apc
+	if(isnull(my_apc))
 		return FALSE
-	if(!local_apc.cell)
-		return FALSE
-	local_apc.cell.use(amount)
-	return TRUE
+	return my_apc.cell.use(amount)
 
 /**
  * Attempts to draw power directly from the APC's Powernet rather than the APC's battery. For high-draw machines, like the cell charger

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -243,40 +243,39 @@
 		return FALSE
 
 	//use power
-	var/power = active_power_usage
+	var/total_charge = 0
 	for(var/material in design.materials)
-		power += round(design.materials[material] * coefficient * print_quantity / 35)
-	power = min(active_power_usage, power)
-	use_power(power)
+		total_charge += round(design.materials[material] * coefficient * print_quantity / 35)
+	var/charge_per_item = total_charge / print_quantity
 
 	if(production_animation)
 		flick(production_animation, src)
 
 	var/total_time = (design.construction_time * design.lathe_time_factor * print_quantity) ** 0.8
 	var/time_per_item = total_time / print_quantity
-	start_making(design, print_quantity, time_per_item, coefficient)
+	start_making(design, print_quantity, time_per_item, coefficient, charge_per_item)
 
 	return TRUE
 
 /// Begins the act of making the given design the given number of items
 /// Does not check or use materials/power/etc
-/obj/machinery/rnd/production/proc/start_making(datum/design/design, build_count, build_time_per_item, build_efficiency)
+/obj/machinery/rnd/production/proc/start_making(datum/design/design, build_count, build_time_per_item, build_efficiency, charge_per_item)
 	PROTECTED_PROC(TRUE)
 
 	busy = TRUE
 	update_static_data_for_all_viewers()
-	addtimer(CALLBACK(src, PROC_REF(do_make_item), design, build_efficiency, build_time_per_item, build_count), build_time_per_item)
+	addtimer(CALLBACK(src, PROC_REF(do_make_item), design, build_efficiency, build_time_per_item, charge_per_item, build_count), build_time_per_item)
 
 /// Callback for start_making, actually makes the item
 /// Called using timers started by start_making
-/obj/machinery/rnd/production/proc/do_make_item(datum/design/design, build_efficiency, time_per_item, items_remaining)
+/obj/machinery/rnd/production/proc/do_make_item(datum/design/design, build_efficiency, time_per_item, charge_per_item, items_remaining)
 	PROTECTED_PROC(TRUE)
 
 	if(!items_remaining) // how
 		finalize_build()
 		return
 
-	if(!is_operational)
+	if(!directly_use_power(charge_per_item))
 		say("Unable to continue production, power failure.")
 		finalize_build()
 		return


### PR DESCRIPTION
check for area.requires_power
## About The Pull Request

If the area is supposed to not require power, we should respect that
Also it doesnt make sense to use all the power at once even though we print items in series not parallel

fixes #81155

## Changelog
:cl:
fix: lathes now respect always-powered areas
balance: lathes now use power as they print instead of all at once
/:cl:
