### PR TITLE
Fixes runtime from examining mod PCs

### DIFF
--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -70,7 +70,8 @@
 /obj/machinery/modular_computer/examine(mob/user)
 	. = cpu?.examine(user) || ..()
 	. += span_info("You can toggle interaction between computer and its machinery frame with [EXAMINE_HINT("Right-Click")] while empty-handed.")
-	. += span_info("Currently interacting with [EXAMINE_HINT(HAS_TRAIT_FROM(src, TRAIT_MODPC_INTERACTING_WITH_FRAME, REF(user)) ? "frame" : "computer")].")
+	var/frame_or_pc = HAS_TRAIT_FROM(src, TRAIT_MODPC_INTERACTING_WITH_FRAME, REF(user)) ? "frame" : "computer"
+	. += span_info("Currently interacting with [EXAMINE_HINT(frame_or_pc)].")
 
 /obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

It's a classic
![image](https://github.com/tgstation/tgstation/assets/51863163/297cbecd-c32d-4c10-8c25-000d8a95310c)

`EXAMINE_HINT(x)` resolves to `"<b>" + x + "</b>"`

When placed in this line directly, you get: 

`["<b>" + HAS_TRAIT_FROM(...) ? "..." : "..." + "</b>"]`

You see the issue, right?

This resolves as you would expect: 
`("<b>" + HAS_TRAIT_FROM(...)) ? ("...") : ("..." + "</b>")`

Which, of course, runtimes as it's adding a string to an integer (0). 

By pulling it out to its own var we can get around this: 

`["<b>" + frame_or_pc + "</b>"]`

## Changelog

:cl: Melbert
fix: Fixed examining modular PCs
/:cl:


