### PR TITLE
Makes point_types not be dumb

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -4,13 +4,6 @@
 //! Techweb names for new point types. Can be used to define specific point values for specific types of research (science, security, engineering, etc.)
 #define TECHWEB_POINT_TYPE_GENERIC "General Research"
 
-#define TECHWEB_POINT_TYPE_DEFAULT TECHWEB_POINT_TYPE_GENERIC
-
-//! Associative names for techweb point values, see: [all_nodes][code/modules/research/techweb/all_nodes.dm]
-#define TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES list(\
-	TECHWEB_POINT_TYPE_GENERIC = "General Research",\
-	)
-
 //! Amount of points gained per second by a single R&D server, see: [research][code/controllers/subsystem/research.dm]
 #define TECHWEB_SINGLE_SERVER_INCOME 52.3
 

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(research)
 		/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	)
 	var/list/errored_datums = list()
-	///List of all
+	///List of all point types that techwebs will have.
 	var/list/point_types = list(TECHWEB_POINT_TYPE_GENERIC)
 	//----------------------------------------------
 	var/list/single_server_income = list(

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -38,9 +38,12 @@ SUBSYSTEM_DEF(research)
 		/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	)
 	var/list/errored_datums = list()
-	var/list/point_types = list() //typecache style type = TRUE list
+	///List of all
+	var/list/point_types = list(TECHWEB_POINT_TYPE_GENERIC)
 	//----------------------------------------------
-	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_SINGLE_SERVER_INCOME)
+	var/list/single_server_income = list(
+		TECHWEB_POINT_TYPE_GENERIC = TECHWEB_SINGLE_SERVER_INCOME,
+	)
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
 
 	//Aiming for 1.5 hours to max R&D
@@ -67,7 +70,6 @@ SUBSYSTEM_DEF(research)
 	var/list/datum/scientific_partner/scientific_partners = list()
 
 /datum/controller/subsystem/research/Initialize()
-	point_types = TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES
 	initialize_all_techweb_designs()
 	initialize_all_techweb_nodes()
 	populate_ordnance_experiments()

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -38,8 +38,8 @@ SUBSYSTEM_DEF(research)
 		/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	)
 	var/list/errored_datums = list()
-	///List of all point types that techwebs will have.
-	var/list/point_types = list(TECHWEB_POINT_TYPE_GENERIC)
+	///Associated list of all point types that techwebs will have and their respective 'abbreviated' name.
+	var/list/point_types = list(TECHWEB_POINT_TYPE_GENERIC = "Gen. Res.")
 	//----------------------------------------------
 	var/list/single_server_income = list(
 		TECHWEB_POINT_TYPE_GENERIC = TECHWEB_SINGLE_SERVER_INCOME,

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -111,7 +111,8 @@
 
 /datum/computer_file/program/science/ui_static_data(mob/user)
 	. = list(
-		"static_data" = list()
+		"static_data" = list(),
+		"point_types_abbreviations" = SSresearch.point_types,
 	)
 
 	// Build node cache...

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -236,7 +236,8 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/ui_static_data(mob/user)
 	. = list(
-		"static_data" = list()
+		"static_data" = list(),
+		"point_types_abbreviations" = SSresearch.point_types,
 	)
 
 	// Build node cache...

--- a/code/modules/research/techweb/__techweb_helpers.dm
+++ b/code/modules/research/techweb/__techweb_helpers.dm
@@ -23,7 +23,7 @@
 /proc/techweb_point_display_generic(pointlist)
 	var/list/ret = list()
 	for(var/i in pointlist)
-		if(SSresearch.point_types[i])
+		if(i in SSresearch.point_types)
 			ret += "[SSresearch.point_types[i]]: [pointlist[i]]"
 		else
 			ret += "ERRORED POINT TYPE: [pointlist[i]]"
@@ -32,7 +32,7 @@
 /proc/techweb_point_display_rdconsole(pointlist, last_pointlist)
 	var/list/ret = list()
 	for(var/i in pointlist)
-		var/research_line = "[SSresearch.point_types[i] || "ERRORED POINT TYPE"]: [pointlist[i]]"
+		var/research_line = "[(i in SSresearch.point_types) || "ERRORED POINT TYPE"]: [pointlist[i]]"
 		if(last_pointlist[i] > 0)
 			research_line += " (+[(last_pointlist[i]) * ((SSresearch.flags & SS_TICKER)? (600 / (world.tick_lag * SSresearch.wait)) : (600 / SSresearch.wait))]/ minute)"
 		ret += research_line

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -107,7 +107,7 @@
 
 /datum/techweb/proc/add_point_list(list/pointlist)
 	for(var/i in pointlist)
-		if(SSresearch.point_types[i] && pointlist[i] > 0)
+		if((i in SSresearch.point_types) && pointlist[i] > 0)
 			research_points[i] += pointlist[i]
 
 /datum/techweb/proc/add_points_all(amount)
@@ -118,7 +118,7 @@
 
 /datum/techweb/proc/remove_point_list(list/pointlist)
 	for(var/i in pointlist)
-		if(SSresearch.point_types[i] && pointlist[i] > 0)
+		if((i in SSresearch.point_types) && pointlist[i] > 0)
 			research_points[i] = max(0, research_points[i] - pointlist[i])
 
 /datum/techweb/proc/remove_points_all(amount)
@@ -129,7 +129,7 @@
 
 /datum/techweb/proc/modify_point_list(list/pointlist)
 	for(var/i in pointlist)
-		if(SSresearch.point_types[i] && pointlist[i] != 0)
+		if((i in SSresearch.point_types) && pointlist[i] != 0)
 			research_points[i] = max(0, research_points[i] + pointlist[i])
 
 /datum/techweb/proc/modify_points_all(amount)
@@ -170,19 +170,19 @@
 	return researched_nodes - hidden_nodes
 
 /datum/techweb/proc/add_point_type(type, amount)
-	if(!SSresearch.point_types[type] || (amount <= 0))
+	if(!(type in SSresearch.point_types) || (amount <= 0))
 		return FALSE
 	research_points[type] += amount
 	return TRUE
 
 /datum/techweb/proc/modify_point_type(type, amount)
-	if(!SSresearch.point_types[type])
+	if(!(type in SSresearch.point_types))
 		return FALSE
 	research_points[type] = max(0, research_points[type] + amount)
 	return TRUE
 
 /datum/techweb/proc/remove_point_type(type, amount)
-	if(!SSresearch.point_types[type] || (amount <= 0))
+	if(!(type in SSresearch.point_types) || (amount <= 0))
 		return FALSE
 	research_points[type] = max(0, research_points[type] - amount)
 	return TRUE

--- a/tgui/packages/tgui/interfaces/Techweb.jsx
+++ b/tgui/packages/tgui/interfaces/Techweb.jsx
@@ -86,13 +86,6 @@ const useRemappedBackend = () => {
   };
 };
 
-// Utility Functions
-
-const abbreviations = {
-  'General Research': 'Gen. Res.',
-};
-const abbreviateName = (name) => abbreviations[name] ?? name;
-
 // Actual Components
 
 export const Techweb = (props) => {
@@ -492,7 +485,14 @@ const TechNodeDetail = (props) => {
 
 const TechNode = (props) => {
   const { act, data } = useRemappedBackend();
-  const { node_cache, design_cache, experiments, points, nodes } = data;
+  const {
+    node_cache,
+    design_cache,
+    experiments,
+    points = [],
+    nodes,
+    point_types_abbreviations = [],
+  } = data;
   const { node, nodetails, nocontrols } = props;
   const { id, can_unlock, tier } = node;
   const {
@@ -597,7 +597,7 @@ const TechNode = (props) => {
                       : Math.min(1, (points[k.type] || 0) / reqPts)
                   }
                 >
-                  {abbreviateName(k.type)} ({nodeProg}/{reqPts})
+                  {point_types_abbreviations[k.type]} ({nodeProg}/{reqPts})
                 </ProgressBar>
               </Flex.Item>
             );


### PR DESCRIPTION
## About The Pull Request

We currently have a list of point types that is meant to be list(``DEFINE`` = name) but it's completely useless since the define is just the name anyways. It's not used for anything, it has no purpose to be this way. It seems more like a holdover from when there were multiple types of research points (it was made for that purpose, even before nanite points were a thing) but even for that, it serves no purpose.

I reworked it now to be the abbreviated name of the research point type, de-hardcoding techwebs a little bit and removing the need for downstreams to edit the techweb UI.

## Why It's Good For The Game

This at least looks better and makes more sense at people just looking over it.

## Changelog

No player-facing changes.