### PR TITLE
Lowers contractor baton cost. Baton can only be bought by roundstart traitors, while midroll/latejoin traitors cannot buy a baton (They must buy the contractor kit for one).

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -57,7 +57,7 @@
 	// There will still be a timelock on uplink items
 	name = "\improper Infiltrator"
 	give_secondary_objectives = FALSE
-	uplink_flag_given = UPLINK_TRAITORS | UPLINK_INFILTRATORS
+	uplink_flag_given = UPLINK_INFILTRATORS
 
 /datum/antagonist/traitor/infiltrator/sleeper_agent
 	name = "\improper Syndicate Sleeper Agent"

--- a/code/modules/uplink/uplink_items/contractor.dm
+++ b/code/modules/uplink/uplink_items/contractor.dm
@@ -13,7 +13,7 @@
 	item = /obj/item/storage/box/syndicate/contract_kit
 	category = /datum/uplink_category/contractor
 	cost = 20
-	purchasable_from = UPLINK_INFILTRATORS
+	purchasable_from = ~(UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS | UPLINK_TRAITORS)
 
 /datum/uplink_item/bundles_tc/contract_kit/purchase(mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	. = ..()

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -99,7 +99,7 @@
 	These shocks are capable of affecting the inner circuitry of most robots as well, applying a short stun. \
 	Has the added benefit of affecting the vocal cords of your victim, causing them to slur as if inebriated."
 	item = /obj/item/melee/baton/telescopic/contractor_baton
-	cost = 12
+	cost = 7
 	surplus = 50
 	limited_stock = 1
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS | UPLINK_INFILTRATORS)


### PR DESCRIPTION

## About The Pull Request
Contractor baton 12 -> 7 TC
Mid/latejoin traitors can no longer buy a baton (They must buy the contractor kit)
Fix midroll/latejoin traitors having access to roundstart traitor shop.
## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/66163761/61d1c243-72bd-43e1-b404-666da06d1c4e)

![image](https://github.com/tgstation/tgstation/assets/66163761/1d58c782-925e-446b-8fe4-8fbfc32774e7)
## Changelog
:cl:
balance: Contractor baton costs 7 TC (down from 12 TC)
balance: Midroll/Latejoin traitors can no longer buy the baton, they must buy the whole kit
fix: Midroll/Latejoin traitors no longer have access to roundstart traitor exclusive items
/:cl:
