### PR TITLE
Spider egg radial menus now require proximity

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -236,5 +236,5 @@
 		display_spiders[initial(spider.name)] = option
 	sort_list(display_spiders)
 
-	var/chosen_spider = show_radial_menu(user, egg, display_spiders, radius = 38)
+	var/chosen_spider = show_radial_menu(user, egg, display_spiders, radius = 38, require_near = TRUE)
 	return spider_list[chosen_spider]


### PR DESCRIPTION

## About The Pull Request

Spider radial menus now require proximity, and will close if you move away from them.

![it works](https://github.com/tgstation/tgstation/assets/28870487/8197f8d4-6336-42b0-a690-9aadc7e47cb9)
## Why It's Good For The Game

Clicking the egg and not picking anything leaves the radial open. If you try to use any other eggs the menu will not open until you track down the radial menu and close it properly. If you aren't aware of this, it'll feel like all of the eggs are broken and lead to confusion. This has happened to myself and others.
## Changelog
:cl: Rhials
qol: Spider eggs will now close their spawn menu when you move away from them.
/:cl:
