### PR TITLE
Fixes Mob Action Cooldowns (Ash Drake)

### DIFF
--- a/code/datums/actions/mobs/assume_form.dm
+++ b/code/datums/actions/mobs/assume_form.dm
@@ -29,9 +29,10 @@
 	return ..()
 
 /datum/action/cooldown/mob_cooldown/assume_form/Activate(atom/target_atom)
-	StartCooldown(360 SECONDS, 360 SECONDS)
+	disable_cooldown_actions()
 	determine_intent(target_atom)
 	StartCooldown()
+	enable_cooldown_actions()
 	return TRUE
 
 /// Rapid proc to test if we can assume the form of a given atom. Returns TRUE if we can, FALSE if we can't. Done like this so we can be nice and explicit.

--- a/code/datums/actions/mobs/defensive_mode.dm
+++ b/code/datums/actions/mobs/defensive_mode.dm
@@ -19,9 +19,10 @@
 	return ..()
 
 /datum/action/cooldown/mob_cooldown/defensive_mode/Activate(atom/target_atom)
-	StartCooldown(360 SECONDS, 360 SECONDS)
+	disable_cooldown_actions()
 	activate_defence(owner)
 	StartCooldown()
+	enable_cooldown_actions()
 	return TRUE
 
 /datum/action/cooldown/mob_cooldown/defensive_mode/proc/activate_defence(mob/living/basic/owner_mob)

--- a/code/datums/actions/mobs/fire_breath.dm
+++ b/code/datums/actions/mobs/fire_breath.dm
@@ -93,7 +93,7 @@
 	button_icon = 'icons/effects/fire.dmi'
 	button_icon_state = "1"
 	desc = "Breathe flames in all directions."
-	cooldown_time = 3 SECONDS
+	cooldown_time = 5 SECONDS
 	click_to_activate = FALSE
 	/// How many fire lines do we produce to turn a full circle?
 	var/sectors = 12

--- a/code/datums/actions/mobs/fire_breath.dm
+++ b/code/datums/actions/mobs/fire_breath.dm
@@ -93,7 +93,7 @@
 	button_icon = 'icons/effects/fire.dmi'
 	button_icon_state = "1"
 	desc = "Breathe flames in all directions."
-	cooldown_time = 5 SECONDS
+	cooldown_time = 10.5 SECONDS
 	click_to_activate = FALSE
 	/// How many fire lines do we produce to turn a full circle?
 	var/sectors = 12

--- a/code/datums/actions/mobs/fire_breath.dm
+++ b/code/datums/actions/mobs/fire_breath.dm
@@ -20,8 +20,10 @@
 	var/mech_damage = 45
 
 /datum/action/cooldown/mob_cooldown/fire_breath/Activate(atom/target_atom)
+	disable_cooldown_actions()
 	attack_sequence(target_atom)
 	StartCooldown()
+	enable_cooldown_actions()
 	return TRUE
 
 /// Apply our specific fire breathing shape, in proc form so we can override it in subtypes


### PR DESCRIPTION
## About The Pull Request

Fixes #80236 

Ash drake abilities were rewritten to not be slept and instead use async which messed up the cooldown timing

Also rewrites several cooldowns to not use a 360 second cooldown hack

## Why It's Good For The Game

Abilities being used at the proper time is very cool

## Changelog

:cl:
fix: Ash drake's fire breath attack has proper cooldowns again
/:cl: