### PR TITLE
Fix Blink component indexing null props

### DIFF
--- a/tgui/packages/tgui/components/Blink.jsx
+++ b/tgui/packages/tgui/components/Blink.jsx
@@ -55,14 +55,14 @@ export class Blink extends Component {
     clearTimeout(this.timer);
   }
 
-  render(props) {
+  render() {
     return (
       <span
         style={{
           visibility: this.state.hidden ? 'hidden' : 'visible',
         }}
       >
-        {props.children}
+        {this.props.children}
       </span>
     );
   }


### PR DESCRIPTION
`render(props)` is an Inferno-ism, and not a part of React. A quick search shows nothing else in the codebase relies on this.