### PR TITLE
Gives paradox clone their own ghost polling icon

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -36,6 +36,8 @@
 	var/makeBody = TRUE
 	/// The rule needs this many applicants to be properly executed.
 	var/required_applicants = 1
+	///Path of an item to show up in ghost polls for applicants to sign up.
+	var/signup_item_path = /obj/structure/sign/poster/contraband/syndicate_recruitment
 
 /datum/dynamic_ruleset/midround/from_ghosts/check_candidates()
 	var/dead_count = dead_players.len + list_observers.len
@@ -133,7 +135,14 @@
 		return
 
 	SSdynamic.log_dynamic_and_announce("Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
-	candidates = SSpolling.poll_ghost_candidates("Looking for volunteers to become [antag_flag] for [name]", check_jobban = antag_flag_override, role = antag_flag || antag_flag_override, poll_time = 30 SECONDS, pic_source = /obj/structure/sign/poster/contraband/syndicate_recruitment, role_name_text = antag_flag)
+	candidates = SSpolling.poll_ghost_candidates(
+		question = "Looking for volunteers to become [antag_flag] for [name]",
+		check_jobban = antag_flag_override,
+		role = antag_flag || antag_flag_override,
+		poll_time = 30 SECONDS,
+		pic_source = signup_item_path,
+		role_name_text = antag_flag,
+	)
 
 	if(!candidates || candidates.len <= 0)
 		SSdynamic.log_dynamic_and_announce("The ruleset [name] received no applications.")
@@ -879,6 +888,7 @@
 	weight = 4
 	cost = 3
 	repeatable = TRUE
+	signup_item_path = /obj/effect/bluespace_stream
 	var/list/possible_spawns = list() ///places the antag can spawn
 
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/forget_startup()

--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -95,3 +95,9 @@
 		explanation_text = "Free Objective"
 		CRASH("WARNING! [ADMIN_LOOKUPFLW(owner)] paradox clone objectives forged without an original!")
 	explanation_text = "Murder and replace [target.name], the [!target_role_type ? target.assigned_role.title : target.special_role]. Remember, your mission is to blend in, do not kill anyone else unless you have to!"
+
+///Static bluespace stream used in its ghost poll icon.
+/obj/effect/bluespace_stream
+	name = "bluespace stream"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "bluestream"


### PR DESCRIPTION
## About The Pull Request

Currently all ghost roles, when polling for players, shows a syndicate poster. This is lame as hell, especially since most of the roles aren't even Syndicate aligned.
This adds support to have your own icons for it, and adds one for the Paradox clone since I already had an idea for it.

## Why It's Good For The Game

Paradox clones are not syndicate aligned and it does not make sense to portray that to players, this looks much better, and hopefully soon other antags will follow suite.
![image](https://github.com/tgstation/tgstation/assets/53777086/b6016ff1-9914-42a8-bd9f-e72ba5539e11)

## Changelog

:cl:
add: Paradox clones now have a bluespace stream instead of a syndicate poster as their ghost poll icon.
/:cl: