### PR TITLE
Moves teleblocker/beacon implants to the techweb, new research node. Exile implants can now be printed

### DIFF
--- a/code/__DEFINES/research/research_categories.dm
+++ b/code/__DEFINES/research/research_categories.dm
@@ -187,6 +187,7 @@
 #define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS "/Cybernetic Implanting Tools"
 #define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY "/Cybernetic Utility Implants"
 #define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_MISC "/Cybernetic Miscellaneous Implants"
+#define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY "/Cybernetic Security Implants"
 #define RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS "/Cybernetic Advanced Limbs"
 
 // Limb Categories

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -342,17 +342,3 @@
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/glasses/sunglasses = 1)
 	crate_name = "sunglasses crate"
-
-/datum/supply_pack/security/armory/beacon_imp
-	name = "Beacon Implants Crate"
-	desc = "Contains five Beacon implants."
-	cost = CARGO_CRATE_VALUE * 5.5
-	contains = list(/obj/item/storage/box/beaconimp)
-	crate_name = "beacon implant crate"
-
-/datum/supply_pack/security/armory/teleport_blocker_imp
-	name = "Bluespace Grounding Implants Crate"
-	desc = "Contains five Bluespace Grounding implants."
-	cost = CARGO_CRATE_VALUE * 7
-	contains = list(/obj/item/storage/box/teleport_blocker)
-	crate_name = "bluespace grounding implant crate"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -679,27 +679,63 @@
 
 /datum/design/implant_chem
 	name = "Chemical Implant Case"
-	desc = "A glass case containing an implant."
+	desc = "A glass case containing a chemical implant."
 	id = "implant_chem"
 	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT*7)
+	materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT * 7)
 	build_path = /obj/item/implantcase/chem
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_MISC
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/implant_tracking
 	name = "Tracking Implant Case"
-	desc = "A glass case containing an implant."
+	desc = "A glass case containing a tracking implant."
 	id = "implant_tracking"
 	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/implantcase/tracking
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_MISC
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/implant_beacon
+	name = "Beacon Implant Case"
+	desc = "A glass case containing a beacon implant."
+	id = "implant_beacon"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SMALL_MATERIAL_AMOUNT * 3)
+	build_path = /obj/item/implantcase/beacon
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/implant_bluespace
+	name = "Bluespace Grounding Implant Case"
+	desc = "A glass case containing a teleport blocker implant."
+	id = "implant_bluespace"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SMALL_MATERIAL_AMOUNT * 3)
+	build_path = /obj/item/implantcase/teleport_blocker
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/implant_exile
+	name = "Exile Implant Case"
+	desc = "A glass case containing an exile implant."
+	id = "implant_exile"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 5, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 3)
+	build_path = /obj/item/implantcase/exile
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 //Cybernetic organs
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -699,7 +699,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/implant_beacon
 	name = "Beacon Implant Case"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -699,7 +699,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/implant_beacon
 	name = "Beacon Implant Case"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1355,7 +1355,7 @@
 		"implant_beacon",
 		"implant_bluespace",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/cyber_organs
 	id = "cyber_organs"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1350,7 +1350,7 @@
 	id = "adv_subdermal_implants"
 	display_name = "Advanced Subdermal Implants"
 	description = "Subdermal implants that leverage bluespace research to control their bluespace signature."
-	prereq_ids = list("biotech", "micro_bluespace")
+	prereq_ids = list("subdermal_implants", "micro_bluespace")
 	design_ids = list(
 		"implant_beacon",
 		"implant_bluespace",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1339,11 +1339,23 @@
 		"c38_trac",
 		"implant_chem",
 		"implant_tracking",
+		"implant_exile",
 		"implantcase",
 		"implanter",
 		"locator",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+
+/datum/techweb_node/advanced_implants
+	id = "adv_subdermal_implants"
+	display_name = "Advanced Subdermal Implants"
+	description = "Subdermal implants that leverage bluespace research to control their bluespace signature."
+	prereq_ids = list("biotech", "micro_bluespace")
+	design_ids = list(
+		"implant_beacon",
+		"implant_bluespace",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/cyber_organs
 	id = "cyber_organs"


### PR DESCRIPTION

## About The Pull Request

This adjusts some of the techweb stuff related to security implants. I meant to do this in the original PR but got LAZY because I wanted to push it out the door, and then the feature freeze happened.

Teleport Blocker and Beacon implants have been moved from cargo to the departmental lathe, printable at (where else?) security. **They can no longer be purchased from cargo.** They are behind a new research node, which requires Subdermal Implants and Miniature bluespace research. This node costs 2500 points. 

Exile implants can now be printed from the security lathe.

Security Implants now have their own lathe category.

![image](https://github.com/tgstation/tgstation/assets/28870487/30543350-7db9-442f-95a2-9bf53cadba80)

This also slightly adjusts the descriptions for the implant case designs to reflect their contents.
## Why It's Good For The Game

First and foremost -- I really had meant to do this in the original PR.

Throwing these implants into cargo was intended to gate access to them until later in the round. In hindsight, cargo doesn't really accomplish that in the way I'd hoped. It's still available roundstart, and no price will change that. Having these be handled by science is a much more sound idea.

(Also security already has enough to be ordering from cargo, and not nearly enough reasons to be yelling at science!)

Exile implants should be easier to access, especially for how little impact they actually have. The simple convenience may be the difference between a peaceful resolution or being beaten to death in the back of the brig.

Adjustments to the lathe categories, descriptions are for slightly better UX.
## Changelog
:cl: Rhials
balance: Beacon and Teleport Blocker implants have been moved from cargo to the security lathe. 
balance: A new research node has been created, requiring Subdermal Implants and Miniature Bluespace, to unlock Beacon/Teleport Blocker implants.
balance: Exile implants can now be printed from the security lathe after researching basic cybernetic implants.
/:cl:
