### PR TITLE
Fix lag when viewing ore silo long logs list

### DIFF
--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -1,8 +1,6 @@
 #define MACHINE_VIEW 0
 #define LOGS_VIEW 1
 
-#define ENTRIES_PER_PAGE 30
-
 /obj/machinery/ore_silo
 	name = "ore silo"
 	desc = "An all-in-one bluespace storage and transmission system for the station's mineral distribution needs."
@@ -15,8 +13,6 @@
 
 	/// Currently selected UI tab, possible values are: `MACHINE_VIEW` or `1` and `LOGS_VIEW` or `0`.
 	var/current_view = MACHINE_VIEW
-	/// Currently opened log page, range is between `1` and `INFINITY`.
-	var/current_page = 1
 
 	/// List of all connected components that are on hold from accessing materials.
 	var/list/holds = list()
@@ -155,15 +151,8 @@
 				)
 
 		if(LOGS_VIEW)
-			var/list/datum/ore_silo_log/logs = GLOB.silo_access_logs[REF(src)]
-			var/logs_length = length(logs)
-
-			data["lastPage"] = ceil(logs_length / ENTRIES_PER_PAGE)
-			data["currentPage"] = current_page
-
 			data["logs"] = list()
-			for(var/index in (current_page - 1) * ENTRIES_PER_PAGE + 1 to min(current_page * ENTRIES_PER_PAGE, logs_length))
-				var/datum/ore_silo_log/entry = logs[index]
+			for(var/datum/ore_silo_log/entry as anything in GLOB.silo_access_logs[REF(src)])
 				data["logs"] += list(
 					list(
 						"rawMaterials" = entry.get_raw_materials(""),
@@ -190,14 +179,6 @@
 
 		if("logs")
 			current_view = LOGS_VIEW
-			return TRUE
-
-		if("page")
-			var/page = text2num(params["id"])
-			if(isnull(page))
-				return
-
-			current_page = max(page, 1)
 			return TRUE
 
 		if("remove")
@@ -344,8 +325,6 @@
 		separator = ", "
 		msg += "[amount < 0 ? "-" : "+"][val] [M.name]"
 	return msg.Join()
-
-#undef ENTRIES_PER_PAGE
 
 #undef LOGS_VIEW
 #undef MACHINE_VIEW

--- a/tgui/packages/tgui/interfaces/OreSilo.tsx
+++ b/tgui/packages/tgui/interfaces/OreSilo.tsx
@@ -1,5 +1,6 @@
 import { classes } from 'common/react';
 import { capitalize } from 'common/string';
+import { useState } from 'react';
 
 import { useBackend } from '../backend';
 import {
@@ -35,7 +36,7 @@ type Log = {
   noun: string;
 };
 
-enum View {
+enum Tab {
   Machines,
   Logs,
 }
@@ -43,14 +44,15 @@ enum View {
 type Data = {
   SHEET_MATERIAL_AMOUNT: number;
   materials: Material[];
-  machines?: Machine[];
-  logs?: Log[];
-  view: View;
+  machines: Machine[];
+  logs: Log[];
 };
 
 export const OreSilo = (props: any) => {
   const { act, data } = useBackend<Data>();
-  const { SHEET_MATERIAL_AMOUNT, machines, logs, view } = data;
+  const { SHEET_MATERIAL_AMOUNT, machines, logs } = data;
+
+  const [currentTab, setCurrentTab] = useState<Tab>(Tab.Logs);
 
   return (
     <Window title="Ore Silo" width={620} height={600}>
@@ -60,29 +62,29 @@ export const OreSilo = (props: any) => {
             <Tabs fluid>
               <Tabs.Tab
                 icon="plug"
-                selected={view === View.Machines}
-                onClick={() => act('machinery')}
+                selected={currentTab === Tab.Machines}
+                onClick={() => setCurrentTab(Tab.Machines)}
               >
                 Connections
               </Tabs.Tab>
               <Tabs.Tab
                 icon="book-bookmark"
-                selected={view === View.Logs}
-                onClick={() => act('logs')}
+                selected={currentTab === Tab.Logs}
+                onClick={() => setCurrentTab(Tab.Logs)}
               >
                 Logs
               </Tabs.Tab>
             </Tabs>
           </Stack.Item>
           <Stack.Item grow>
-            {view === View.Machines ? (
+            {currentTab === Tab.Machines ? (
               <MachineList
                 machines={machines!}
                 onPause={(index) => act('hold', { id: index })}
                 onRemove={(index) => act('remove', { id: index })}
               />
             ) : null}
-            {view === View.Logs ? <LogsList logs={logs!} /> : null}
+            {currentTab === Tab.Logs ? <LogsList logs={logs!} /> : null}
           </Stack.Item>
           <Stack.Item>
             <Section fill>

--- a/tgui/packages/tgui/interfaces/OreSilo.tsx
+++ b/tgui/packages/tgui/interfaces/OreSilo.tsx
@@ -4,7 +4,6 @@ import { capitalize } from 'common/string';
 import { useBackend } from '../backend';
 import {
   Box,
-  Button,
   Icon,
   Image,
   LabeledList,
@@ -13,6 +12,7 @@ import {
   Stack,
   Tabs,
   Tooltip,
+  VirtualList,
 } from '../components';
 import { Window } from '../layouts';
 import { MaterialAccessBar } from './Fabrication/MaterialAccessBar';
@@ -44,16 +44,13 @@ type Data = {
   SHEET_MATERIAL_AMOUNT: number;
   materials: Material[];
   machines?: Machine[];
-  currentPage: number;
-  lastPage: number;
   logs?: Log[];
   view: View;
 };
 
 export const OreSilo = (props: any) => {
   const { act, data } = useBackend<Data>();
-  const { SHEET_MATERIAL_AMOUNT, machines, currentPage, lastPage, logs, view } =
-    data;
+  const { SHEET_MATERIAL_AMOUNT, machines, logs, view } = data;
 
   return (
     <Window title="Ore Silo" width={620} height={600}>
@@ -85,14 +82,7 @@ export const OreSilo = (props: any) => {
                 onRemove={(index) => act('remove', { id: index })}
               />
             ) : null}
-            {view === View.Logs ? (
-              <LogsList
-                logs={logs!}
-                lastPage={lastPage!}
-                currentPage={currentPage!}
-                onFlip={(index) => act('page', { id: index })}
-              />
-            ) : null}
+            {view === View.Logs ? <LogsList logs={logs!} /> : null}
           </Stack.Item>
           <Stack.Item>
             <Section fill>
@@ -212,47 +202,19 @@ const MachineDisplay = (props: MachineProps) => {
 
 type LogsListProps = {
   logs: Log[];
-  lastPage: number;
-  currentPage: number;
-  onFlip: (index: number) => void;
 };
 
 const LogsList = (props: LogsListProps) => {
-  const { logs, lastPage, currentPage, onFlip } = props;
+  const { logs } = props;
 
   return logs.length > 0 ? (
-    <Stack fill vertical>
-      <Stack.Item grow>
-        <Box pr={1} height="100%" overflowY="scroll">
-          {logs.map((log, index) => (
-            <LogEntry key={index} log={log} />
-          ))}
-        </Box>
-      </Stack.Item>
-      <Stack.Item>
-        <Stack>
-          <Stack.Item>
-            <Button
-              icon="backward-step"
-              disabled={currentPage - 1 < 1}
-              onClick={() => onFlip(currentPage - 1)}
-            />
-          </Stack.Item>
-          <Stack.Item grow>
-            <Box bold textAlign="center">
-              {`${currentPage} / ${lastPage}`}
-            </Box>
-          </Stack.Item>
-          <Stack.Item>
-            <Button
-              icon="forward-step"
-              disabled={currentPage + 1 > lastPage}
-              onClick={() => onFlip(currentPage + 1)}
-            />
-          </Stack.Item>
-        </Stack>
-      </Stack.Item>
-    </Stack>
+    <Box pr={1} height="100%" overflowY="scroll">
+      <VirtualList>
+        {logs.map((log, index) => (
+          <LogEntry key={index} log={log} />
+        ))}
+      </VirtualList>
+    </Box>
   ) : (
     <NoticeBox>No log entries currently present!</NoticeBox>
   );


### PR DESCRIPTION
![6OrHcTlN6Z](https://github.com/tgstation/tgstation/assets/137328283/89ed9091-e85b-4032-bae1-19200d5ad10d)


## About The Pull Request

- Logs tab is now using a virtual list that renders only visible components, thus preventing lag when logs list grows too long. More about it [here](https://github.com/tgstation/tgstation/pull/81016#issuecomment-1921765723).
- Minor tweaks to Ore Silo UI to account for new backend changes and TG style guide.

## Changelog

:cl:
fix: Separated logs list into pages in ore silo UI, thus fixing lag when logs list grows too long.
/:cl:

