### PR TITLE
Reactions now use volume averaged purity

### DIFF
--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -316,7 +316,7 @@
 	purity = delta_ph
 
 	//Then adjust purity of result with beaker reagent purity.
-	purity *= average_purity()
+	purity *= holder.get_average_purity()
 
 	//Then adjust it from the input modifier
 	purity *= purity_modifier
@@ -399,23 +399,3 @@
 	//i.e. we have created all the reagents needed for this reaction
 	if(total_step_added >= step_target_vol)
 		to_delete = TRUE
-
-/*
-* Calculates the total sum normalised purity of ALL reagents in a holder
-* Currently calculates it irrespective of required reagents at the start, but this should be changed if this is powergamed to required reagents
-* It's not currently because overly_impure affects all reagents
-*/
-/datum/equilibrium/proc/average_purity()
-	PRIVATE_PROC(TRUE)
-
-	var/list/cached_reagents = holder.reagent_list
-
-	var/num_of_reagents = cached_reagents.len
-	if(!num_of_reagents)//I've never seen it get here with 0, but in case - it gets here when it blows up from overheat
-		stack_trace("No reactants found mid reaction for [reaction.type]. Beaker: [holder.my_atom]")
-		return 0 //we exploded and cleared reagents - but lets not kill the process
-
-	var/cached_purity
-	for(var/datum/reagent/reagent as anything in cached_reagents)
-		cached_purity += reagent.purity
-	return cached_purity / num_of_reagents

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -304,17 +304,15 @@
 
 	//find how much ration of products to create
 	var/multiplier = INFINITY
-	for(var/reagent in cached_required_reagents)
-		multiplier = min(multiplier, get_reagent_amount(reagent) / cached_required_reagents[reagent])
+	for(var/datum/reagent/requirement as anything in cached_required_reagents)
+		multiplier = min(multiplier, get_reagent_amount(requirement) / cached_required_reagents[requirement])
 	multiplier = round(multiplier)
 	if(!multiplier)//Incase we're missing reagents - usually from on_reaction being called in an equlibrium when the results.len == 0 handlier catches a misflagged reaction
 		return FALSE
 
 	//remove the required reagents
-	for(var/datum/reagent/_reagent as anything in cached_required_reagents)//this is not an object
-		if (!has_reagent(_reagent))
-			continue
-		remove_reagent(_reagent, (multiplier * cached_required_reagents[_reagent]))
+	for(var/datum/reagent/requirement as anything in cached_required_reagents)//this is not an object
+		remove_reagent(requirement, cached_required_reagents[requirement] * multiplier)
 
 	//add the result reagents whose yield depend on the average purity
 	var/yield
@@ -331,7 +329,6 @@
 		if(!ismob(cached_my_atom)) // No bubbling mobs
 			if(selected_reaction.mix_sound)
 				playsound(get_turf(cached_my_atom), selected_reaction.mix_sound, 80, TRUE)
-
 			my_atom.audible_message(span_notice("[iconhtml] [selected_reaction.mix_message]"))
 
 		//use slime extract

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -306,8 +306,8 @@
 	var/multiplier = INFINITY
 	for(var/datum/reagent/requirement as anything in cached_required_reagents)
 		multiplier = min(multiplier, get_reagent_amount(requirement) / cached_required_reagents[requirement])
-	multiplier = round(multiplier)
-	if(!multiplier)//Incase we're missing reagents - usually from on_reaction being called in an equlibrium when the results.len == 0 handlier catches a misflagged reaction
+	multiplier = round(multiplier, CHEMICAL_QUANTISATION_LEVEL)
+	if(!multiplier)//Incase we're missing reagents - usually from on_reaction being called in an equlibrium when the results.len == 0 handler catches a misflagged reaction
 		return FALSE
 
 	//remove the required reagents


### PR DESCRIPTION
## About The Pull Request
Cause it only makes sense

Currently the purity of reagents created in a reaction is computed as follows

`total sum of purity of all reagents present / total number of reagents`

This is incorrect because regardless of how much "volume" of an impure/pure reagent is present the purity of the final solution is unaffected. Logically if we have more amount of an impure reagent the more impure the final solution should be & same for opposite case. This is the case for ph, where if we have a large volume of say "acidic" reagent then changes in other reagents have a small effect to the overall "acidity" of the solution. The same concept now applies for purity as well

`get_average_purity()`accounts for volume thus yielding more realistic results. The effect becomes more significant with larger volumes of reagents.

:cl:
fix: reactions now compute purity of reagents based on their volume, meaning larger amounts of reagents created will have more significant effects on the final purity of the solution
/:cl:
