### PR TITLE
Fixes burning a bible giving you an infinite amount of curses.

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -308,6 +308,7 @@
  * While it lasts, parent gets a cursed aura filter.
  */
 /datum/component/omen/bible
+	incidents_left = 1
 
 /datum/component/omen/bible/RegisterWithParent()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Burning a bible now gives you 1 curse, instead of INFINITY curses.
## Why It's Good For The Game
It looks like https://github.com/tgstation/tgstation/pull/78899 forgot about bible curses.
I think this was an oversight.
## Changelog
:cl:
fix: burning a bible no longer gives you INFINITY curses
/:cl:
