### PR TITLE
Machinery cannot be interacted with by AI when its turf is off-camera

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -668,6 +668,9 @@
 /obj/machinery/ui_act(action, list/params)
 	add_fingerprint(usr)
 	update_last_used(usr)
+	if(isAI(usr) && !GLOB.cameranet.checkTurfVis(get_turf(src))) //We check if they're an AI specifically here, so borgs can still access off-camera stuff.
+		to_chat(usr, span_warning("You can no longer connect to this device!"))
+		return FALSE
 	return ..()
 
 /obj/machinery/Topic(href, href_list)


### PR DESCRIPTION

## About The Pull Request

When an AI interacts with a machine, it will now check if the turf it occupies is on the cameranet. This should ensure that wallmounted machinery shouldn't be accessible from the other side of a wall.

This image summarizes what this applies to:

![image](https://github.com/tgstation/tgstation/assets/28870487/783d241b-c37f-4319-b4b3-8dde75cec528)

Blue APC should be visible. Red should not. Normally, if red is covered completely by static, it becomes inaccessible. The red APC remaining visible is only the result of the perspective. We can't black out the entire wall when it goes off-camera since it can still be seen from the other side. The blue APC is technically stationed on a turf in a different room and is the only one in camera view, which would also be blocked out and would be needlessly inaccessible. Walls that remain in view from only one "side" of the wall, have all of their wallmounts accessible to the AI despite not (logically) having a camera pointed at them.

Damn, when is the wallening gonna get here?

Anyways, since the AI cam is a top-down view that only technically respects cameras, you see things you aren't supposed to see. We can't solve it by covering the entire tile, or leaving it uncovered, so this is the best we got.

I got mixed up looking for where exactly to put this check. There might be a better solution for this but I do not see it at the moment.
## Why It's Good For The Game

Wallmounts being accessible due to loopholes in perspective makes things confusing for players who don't see the world the same way.

It would also be dishonest of me not to mention why I started on this PR, and why this is marked as a balance PR - This was done to un-jank the pain of doing console hack objectives. It's a bit nonsensical to have to take out cameras on the other side of a wall just to make sure your APC doesn't get powered down. 
## Changelog
:cl: Rhials
balance: Wallmounts now respect cameranets, and cannot be accessed from a view of the adjacent wall.
/:cl:
