### PR TITLE
Fixes a spurious runtime in AI code

### DIFF
--- a/code/datums/ai/generic/find_and_set.dm
+++ b/code/datums/ai/generic/find_and_set.dm
@@ -11,8 +11,11 @@
 	if (controller.blackboard_key_exists(set_key))
 		finish_action(controller, TRUE)
 		return
+	if(QDELETED(controller.pawn))
+		finish_action(controller, FALSE)
+		return
 	var/find_this_thing = search_tactic(controller, locate_path, search_range)
-	if(QDELETED(controller.pawn) || isnull(find_this_thing))
+	if(isnull(find_this_thing))
 		finish_action(controller, FALSE)
 		return
 	controller.set_blackboard_key(set_key, find_this_thing)

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -77,6 +77,8 @@
 	for(var/atom/found_item in found)
 		if(LAZYACCESS(ignore_list, REF(found_item)))
 			continue
+		if(QDELETED(controller.pawn))
+			break
 		var/list/path = get_path_to(controller.pawn, found_item, max_distance = BOT_CLEAN_PATH_LIMIT, access = controller.get_access())
 		if(!length(path))
 			controller.set_blackboard_key_assoc_lazylist(BB_TEMPORARY_IGNORE_LIST, REF(found_item), TRUE)

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -75,10 +75,10 @@
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
 	var/list/ignore_list = controller.blackboard[BB_TEMPORARY_IGNORE_LIST]
 	for(var/atom/found_item in found)
-		if(LAZYACCESS(ignore_list, REF(found_item)))
-			continue
 		if(QDELETED(controller.pawn))
 			break
+		if(LAZYACCESS(ignore_list, REF(found_item)))
+			continue
 		var/list/path = get_path_to(controller.pawn, found_item, max_distance = BOT_CLEAN_PATH_LIMIT, access = controller.get_access())
 		if(!length(path))
 			controller.set_blackboard_key_assoc_lazylist(BB_TEMPORARY_IGNORE_LIST, REF(found_item), TRUE)


### PR DESCRIPTION
## About The Pull Request

Tin.

![300618628-255ded6c-09c8-4c5b-8557-2f8f2dfcc821](https://github.com/tgstation/tgstation/assets/13398309/4c30ab2d-cd15-411d-92fc-470effef8af3)

No more of this. It's been annoying downstream for the past few days, so here's the fix. `find_this_thing()` should not be getting called when `controller.pawn` is qdeleted so I just moved that check up a couple lines.

## Why It's Good For The Game

Makes CI functional again. Tested downstream with 5 CI runs, the runtime did not occur in any of them where it was happening just about every run previously.

## Changelog

:cl:
fix: fixes a runtime in AI search_tactic
/:cl:

