### PR TITLE
Better Ghost Hair

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -248,7 +248,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/lum = read_color[3]
 
 	// Clamp so it still has color, can't get too bright/desaturated
-
 	sat -= 15
 	if(sat < 30)
 		sat = min(read_color[2], 30)


### PR DESCRIPTION

## About The Pull Request

What we were doing before was basically just take the difference of each component against 255, multiply it with 0.4, and then add that in.

This was bad, and looked bad. Fucked up hue something fierce, just not good.

I noticed this in my rgb2num work, but it didn't occur to me to deal with it.

Now seems like a good time tho.

We'll use hsv to deal w this. First, reduce the saturation by 15% and bump luminosity by 15%. 
Then we'll just clamp them to sensible max/minimums to prevent blowing them out totally, and we good.

## Why It's Good For The Game

Should make ghost hair look a bit nicer, I'm happy with it

![image](https://github.com/tgstation/tgstation/assets/58055496/11370960-bce4-41bd-8e1c-3cc4d0760625)
![image](https://github.com/tgstation/tgstation/assets/58055496/7261f4d9-9578-4fb1-b67b-0c20367e08ab)
![image](https://github.com/tgstation/tgstation/assets/58055496/828eda46-4578-4102-a0d9-6aa01b2295cb)
![image](https://github.com/tgstation/tgstation/assets/58055496/d5ef493b-a1c9-4799-94c6-fc811da6b1ba)
![image](https://github.com/tgstation/tgstation/assets/58055496/4cc8a938-e0bc-4330-b8dc-3986bc849605)
![image](https://github.com/tgstation/tgstation/assets/58055496/1cbb9954-ecca-467e-98b7-ebfb22e52637)


Closes #81261

## Changelog

:cl:
add: Ghost hair looks better now. Insert nerd shit about RGB vs HSL color space here, go watch a youtube video or whatever.
/:cl:
