### PR TITLE
health assembly altclick sanity

### DIFF
--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -38,6 +38,9 @@
 	return secured
 
 /obj/item/assembly/health/AltClick(mob/living/user)
+	if(!can_interact(user))
+		return
+
 	if(alarm_health == HEALTH_THRESHOLD_CRIT)
 		alarm_health = HEALTH_THRESHOLD_DEAD
 		to_chat(user, span_notice("You toggle [src] to \"detect death\" mode."))


### PR DESCRIPTION

## About The Pull Request

checks can_interact now

## Why It's Good For The Game
bug bad

## Changelog
:cl:
fix: you may not toggle health assemblies from any range, even while crit
/:cl:
