### PR TITLE
pillow altclick sanity

### DIFF
--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -104,6 +104,8 @@
 
 /obj/item/pillow/AltClick(mob/user)
 	. = ..()
+	if(!can_interact(user))
+		return
 	if(!pillow_trophy)
 		balloon_alert(user, "no tag!")
 		return

--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -104,7 +104,7 @@
 
 /obj/item/pillow/AltClick(mob/user)
 	. = ..()
-	if(!can_interact(user))
+	if(!can_interact(user) || !user.can_hold_items(src))
 		return
 	if(!pillow_trophy)
 		balloon_alert(user, "no tag!")


### PR DESCRIPTION

## About The Pull Request

you may no longer rip out the tag with the power of your mind at range

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: you may no longer rip pillow tags at range without telekinesis or crit or any other time you shouldnt be capable of it
/:cl:
