### PR TITLE
autolathe altclick sanity

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -389,6 +389,8 @@
 
 /obj/machinery/autolathe/AltClick(mob/user)
 	. = ..()
+	if(!can_interact(user))
+		return
 	if(drop_direction)
 		balloon_alert(user, "drop direction reset")
 		drop_direction = 0


### PR DESCRIPTION

## About The Pull Request

you may no longer reset drop direction at range and stuff

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: you may no longer reset autolathe drop direction at times when you shouldnt be able to
/:cl:
