### PR TITLE
ethereal disco ball altclick sanity

### DIFF
--- a/code/game/objects/items/etherealdiscoball.dm
+++ b/code/game/objects/items/etherealdiscoball.dm
@@ -31,6 +31,9 @@
 
 /obj/structure/etherealball/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	. = ..()
+	if(!can_interact(user))
+		return
+
 	if(TurnedOn)
 		TurnOff()
 		to_chat(user, span_notice("You turn the disco ball off!"))


### PR DESCRIPTION

## About The Pull Request

im getting tired of writing this but you may no longer altclick to unanchor or anchor when crit or at range or otherwise

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: you may no longer altclick ethereal disco balls while unconscious to anchor/unanchor
/:cl:
