### PR TITLE
tape recorder altclick sanity

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -63,6 +63,8 @@
 
 /obj/item/taperecorder/AltClick(mob/user)
 	. = ..()
+	if(!can_interact(user))
+		return
 	play()
 
 /obj/item/taperecorder/proc/update_available_icons()


### PR DESCRIPTION

## About The Pull Request

you can no longer altclick them at range to play them

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: you may no longer altclick tape recorders at range to play them
/:cl:
