### PR TITLE
Cryo tubes will dump legions spawned inside them when opened

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -239,8 +239,10 @@
 		return
 	. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-[on && is_operational ? "on" : "off"]", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
 
-/obj/machinery/cryo_cell/dump_inventory_contents(list/subset = list(occupant))
-	//only drop the mob and nothing else by default when opening the machine
+/obj/machinery/cryo_cell/dump_inventory_contents(list/subset = list())
+	//only drop mobs when opening the machine
+	for (var/mob/living/living_guy in contents)
+		subset += living_guy
 	return ..(subset)
 
 /obj/machinery/cryo_cell/Exited(atom/movable/gone, direction)


### PR DESCRIPTION
## About The Pull Request

Someone reported this on discord and didn't make an issue report, gross
Anyway if you get turned into a legion via legion cancer it spawns in your loc, if your loc is a cryo tube then it only dumps specifically the person who was placed into the tube rather than all mobs when opened, so it resulted in a tube which would endlessly spawn legion skulls until destroyed.

I fixed this by making cryo tubes dump all mobs regardless of how they are placed into the tube.
I don't think there were _likely_ to be other related edge cases because xeno larvae use turf instead of loc when created, but I think spawning in loc is more fun so I fixed that rather than just making it spawn in the turf.

## Changelog

:cl:
fix: Being consumed by the flesh of the necropolis while inside a cryo tube will no longer convert the tube into a legion spawn point until the tube is destroyed
/:cl:
