### PR TITLE
Don't gain every faction of a mob you make sentient

### DIFF
--- a/code/datums/mind/antag.dm
+++ b/code/datums/mind/antag.dm
@@ -215,7 +215,7 @@
 	enslaved_to = WEAKREF(creator)
 
 	current.faction |= creator.faction
-	creator.faction |= current.faction
+	creator.faction |= "[REF(current)]"
 
 	current.log_message("has been enslaved to [key_name(creator)].", LOG_GAME)
 	log_admin("[key_name(current)] has been enslaved to [key_name(creator)].")


### PR DESCRIPTION
## About The Pull Request

Fixes #80548

Repro steps for linked bug were actually much _simpler_ than the reporter thought.
Steps required to make yourself permanently passive to megafauna:
- Acquire sentience potion
- Successfully make any mining mob sentient
That's it!

This is because for some reason the `enslave_mind_to_creator`'s faction manipulation was _mutual_.
It would not only give your new minion all of your factions... but you all of theirs as well.

I don't see why making a Goliath sentient should make every mining mob treat you as a friend for the rest of the round, so now it won't do that.
Frankly I'm not even sure that the enslaved mob should keep all of their old factions either, maybe it should just hard copy yours... I'm not making that change in this PR though.

## Changelog

:cl:
fix: Making a mob sentient no longer gives you all of their factions.
/:cl:
