### PR TITLE
Adds Climbing to a Bunch of Old Stuff

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -69,6 +69,8 @@
 		),
 	)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+	AddElement(/datum/element/climbable)
+	AddElement(/datum/element/elevation, pixel_shift = 8)
 
 /obj/machinery/space_heater/Destroy()
 	SSair.stop_processing_machine(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -825,6 +825,11 @@
 	pass_flags_self = LETPASSTHROW //You can throw objects over this, despite it's density.
 	max_integrity = 20
 
+/obj/structure/rack/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/climbable)
+	AddElement(/datum/element/elevation, pixel_shift = 12)
+
 /obj/structure/rack/examine(mob/user)
 	. = ..()
 	. += span_notice("It's held together by a couple of <b>bolts</b>.")

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -43,6 +43,8 @@
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 	SSair.start_processing_machine(src)
+	AddElement(/datum/element/climbable, climb_time = 3 SECONDS, climb_stun = 3 SECONDS)
+	AddElement(/datum/element/elevation, pixel_shift = 8)
 
 /obj/machinery/portable_atmospherics/Destroy()
 	disconnect()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -31,6 +31,8 @@
 	var/mutable_appearance/assembliesoverlay
 	/// The person who attached an assembly to this dispenser, for bomb logging purposes
 	var/last_rigger = ""
+	/// is it climbable? some of our wall-mounted dispensers should not have this
+	var/climbable = FALSE
 
 // This check is necessary for assemblies to automatically detect that we are compatible
 /obj/structure/reagent_dispensers/IsSpecialAssembly()
@@ -53,6 +55,9 @@
 
 	if(icon_state == "water" && check_holidays(APRIL_FOOLS))
 		icon_state = "water_fools"
+	if(climbable)
+		AddElement(/datum/element/climbable, climb_time = 4 SECONDS, climb_stun = 4 SECONDS)
+		AddElement(/datum/element/elevation, pixel_shift = 14)
 
 /obj/structure/reagent_dispensers/examine(mob/user)
 	. = ..()
@@ -233,6 +238,7 @@
 	desc = "A water tank."
 	icon_state = "water"
 	openable = TRUE
+	climbable = TRUE
 
 /obj/structure/reagent_dispensers/watertank/high
 	name = "high-capacity water tank"
@@ -247,6 +253,7 @@
 	reagent_id = /datum/reagent/firefighting_foam
 	tank_volume = 500
 	openable = TRUE
+	climbable = TRUE
 
 /obj/structure/reagent_dispensers/fueltank
 	name = "fuel tank"
@@ -255,6 +262,7 @@
 	reagent_id = /datum/reagent/fuel
 	openable = TRUE
 	accepts_rig = TRUE
+	climbable = TRUE
 
 /obj/structure/reagent_dispensers/fueltank/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

What it says. a lot of old atmospherics stuff and a few other unintuitive things lacked climbability sometimes leading to stupid situations where you could get stuck or their use as inappropriate obstacles.

Canisters, pumps/scrubbers, welding/water/foam tanks, heaters, and racks can now be climbed.

![image](https://github.com/tgstation/tgstation/assets/3894717/1e5582c5-8b41-42c6-99e8-810970adc1e9)
![image](https://github.com/tgstation/tgstation/assets/3894717/78c31589-1088-4e25-8194-d27316e526e2)
![image](https://github.com/tgstation/tgstation/assets/3894717/bc7625a5-6d0f-4b4a-adb3-a52e9eb8d04b)


## Why It's Good For The Game

i remember when tables were a kit you could carry, immediately assemble, and then use to two-click table somebody to kill them. somehow this seems overdue. 

## Changelog

:cl:
qol: portable air pumps, scrubbers, heaters, canisters, liquid tanks, and racks are now climbable.
/:cl:

