### PR TITLE
[FIX] Removes accidental? RR from contractor GBJ

### DIFF
--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -229,6 +229,7 @@
 	if(!possible_drop_loc.len)
 		to_chat(victim, span_hypnophrase("A million voices echo in your head... \"Seems where you got sent here from won't \
 			be able to handle our pod... if we wanted the occupant to survive. Brace yourself, corporate dog.\""))
+		for(var/turf/possible_drop in contract.dropoff.contents)
 			possible_drop_loc.Add(possible_drop)
 		if(iscarbon(victim))
 			var/mob/living/carbon/carbon_victim = victim

--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -228,12 +228,12 @@
 
 	if(!possible_drop_loc.len)
 		to_chat(victim, span_hypnophrase("A million voices echo in your head... \"Seems where you got sent here from won't \
-			be able to handle our pod... You will die here instead.\""))
+			be able to handle our pod... if we wanted the occupant to survive. Brace yourself, corporate dog.\""))
+			possible_drop_loc.Add(possible_drop)
 		if(iscarbon(victim))
 			var/mob/living/carbon/carbon_victim = victim
 			if(carbon_victim.can_heartattack())
 				carbon_victim.set_heartattack(TRUE)
-		return
 
 	var/pod_rand_loc = rand(1, possible_drop_loc.len)
 	var/obj/structure/closet/supplypod/return_pod = new()


### PR DESCRIPTION
## About The Pull Request
fixes #80963 
previously if the place you got sent from was uninhabitable you'd just be left for dead. if you were already dead, you might never find out why.
Now, even if the location you got sent from is fucked, you'll just get zapped with the heart attack gun and blasted off there anyway. 

## Why It's Good For The Game

RRing people to off-map Z-levels with no way of escape is not intended for contractor afaik. 

## Changelog

:cl:
fix: fixes contractor abduction RRing people in the offmap hideout without any feedback. You might not like how it turns out, but your body will get back to the station now.
/:cl:
