### PR TITLE
[FIX] Prevents Buckling Megas, Blobs, Constructs, Slimes, and Dragons

### DIFF
--- a/code/modules/mob/living/basic/blob_minions/blob_mob.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_mob.dm
@@ -17,6 +17,7 @@
 	lighting_cutoff_green = 40
 	lighting_cutoff_blue = 30
 	initial_language_holder = /datum/language_holder/empty
+	can_buckle_to = FALSE
 
 /mob/living/basic/blob_minion/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/cult/constructs/_construct.dm
+++ b/code/modules/mob/living/basic/cult/constructs/_construct.dm
@@ -12,6 +12,7 @@
 	pressure_resistance = 100
 	speed = 0
 	unique_name = TRUE
+	can_buckle_to = FALSE
 	initial_language_holder = /datum/language_holder/construct
 	death_message = "collapses in a shattered heap."
 

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -46,6 +46,7 @@
 	death_sound = 'sound/creatures/space_dragon_roar.ogg'
 	death_message = "screeches in agony as it collapses to the floor, its life extinguished."
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
+	can_buckle_to = FALSE
 
 	/// The colour of the space dragon
 	var/chosen_colour

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -27,6 +27,7 @@
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
+	can_buckle_to = FALSE
 	/// Crusher loot dropped when the megafauna is killed with a crusher
 	var/list/crusher_loot
 	/// Achievement given to surrounding players when the megafauna is killed

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -35,6 +35,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 25
 	wound_bonus = -45
+	can_buckle_to = FALSE
 
 	verb_say = "blorbles"
 	verb_ask = "inquisitively blorbles"


### PR DESCRIPTION
## About The Pull Request

fixes #80946 

not sure why it borrowed the wrong commit msg

## Why It's Good For The Game

on the one hand it's funny but on the other hand it's dumb to be able to buckle massive mobs to tiny-sprite objects they might not be able to get out of without just destroying their own chair - assuming they can, which in the case of some things you can buckle to, you can't (looking at roller beds.)

## Changelog

:cl:
fix: removed ability to buckle megafauna, constructs, blob minions, dragons, and slimes.
/:cl:
