### PR TITLE
[FIX] Makes Ghetto Surgery Behave In Line With Expectations

### DIFF
--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -156,8 +156,8 @@
 		/obj/item/melee/arm_blade = 75,
 		/obj/item/fireaxe = 50,
 		/obj/item/hatchet = 35,
-		/obj/item/knife/butcher = 25,
-		/obj/item = 20) //20% success (sort of) with any sharp item with a force >= 10
+		/obj/item/knife/butcher = 35,
+		/obj/item = 25) //20% success (sort of) with any sharp item with a force >= 10
 	time = 54
 	preop_sound = list(
 		/obj/item/circular_saw = 'sound/surgery/saw.ogg',

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -65,7 +65,7 @@
 
 	return FALSE
 
-#define SURGERY_SLOWDOWN_CAP_MULTIPLIER 3 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
+#define SURGERY_SLOWDOWN_CAP_MULTIPLIER 2.5 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
 ///Modifier given to surgery speed for dissected bodies.
 #define SURGERY_SPEED_DISSECTION_MODIFIER 0.8
 ///Modifier given to users with TRAIT_MORBID on certain surgeries

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -65,7 +65,7 @@
 
 	return FALSE
 
-#define SURGERY_SLOWDOWN_CAP_MULTIPLIER 2 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
+#define SURGERY_SLOWDOWN_CAP_MULTIPLIER 3 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
 ///Modifier given to surgery speed for dissected bodies.
 #define SURGERY_SPEED_DISSECTION_MODIFIER 0.8
 ///Modifier given to users with TRAIT_MORBID on certain surgeries


### PR DESCRIPTION
## About The Pull Request

fixes #81142

Ghetto surgery was putting the floor on surgery success chances at 1% on pretty routine surgery steps due to their speed. Seems like an oversight to me as, even on a proper surgery table, you'd be looking at a 1% chance to succeed on a bone saw step.

I've had two minds about how to address this. One was to make the surgery success chance floored at the listed values for the tool, but that would make floor surgery relatively more effective and also take some of the use out for other modifiers like sterilizine, booze, and any others we add in the future.

Instead, I did a little math - 

> the bone saw step has a time of 54 deciseconds
the cleaver has a value of 25, or a .25 implement_speed_mod when divided by 100* _edit for clarity_
this means that if calculating speed_mod, you've got 1/.25 assuming no other variables are different - or a speed_mod of 4.
this makes modded_time 4 * 54, or 216 - about twenty-two seconds.
SURGERY_SLOWDOWN_CAP_MULTIPLIER is 2
fail_prob then ends up being the smaller of 99 or 216 - 54(2),
216-108, gives you 108, which is larger than 99, so gives you a 1% chance to succeed by default, the bare minimum.

raising SURGERY_SLOWDOWN_CAP_MULTIPLIER to 2.5 gives you instead about a 20% chance of success. 
216 - 135 = 81, or a 19% chance. 

previously, if you tried to do it with the cleaver, you'd be looking at a modded surgery time of 108 deciseconds, or about 11.
after this change, 14  - so there is a tradeoff if there were balance concerns, but it seems like the tools available should not default to being basically impossible to use if their given values are not literally 1 in code or the wiki.

doesn't change regular surgery. just surgery under suboptimal conditions or using ghetto tools. 

also the butcher knife is literally for hacking through bones. gave it a chance at least on par with the hatchet and raised the 'item' greater than 10 force chance up to match its intended ~20% (assuming otherwise perfect conditions.) 

## Why It's Good For The Game

expected behavior good, trap options and false choices bad

## Changelog

:cl:
fix: fixes ghetto surgery by gently adjusting time sensitivity cap and making the cleaver not unintuitively bad at bone-sawing.
/:cl: