### PR TITLE
Contractor loadout adjustment + Price tweak

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -773,33 +773,6 @@
 	new /obj/item/modular_computer/pda/syndicate_contract_uplink(src)
 	new /obj/item/storage/box/syndicate/contractor_loadout(src)
 	new /obj/item/melee/baton/telescopic/contractor_baton(src)
-
-	// All about 4 TC or less - some nukeops only items, but fit nicely to the theme.
-	var/static/list/item_list = list(
-		/obj/item/storage/backpack/duffelbag/syndie/x4,
-		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/gun/syringe/syndicate,
-		/obj/item/pen/edagger,
-		/obj/item/pen/sleepy,
-		/obj/item/flashlight/emp,
-		/obj/item/reagent_containers/syringe/mulligan,
-		/obj/item/clothing/shoes/chameleon/noslip,
-		/obj/item/storage/medkit/tactical,
-		/obj/item/encryptionkey/syndicate,
-		/obj/item/clothing/glasses/thermal/syndi,
-		/obj/item/slimepotion/slime/sentience/nuclear,
-		/obj/item/storage/box/syndie_kit/imp_radio,
-		/obj/item/storage/box/syndie_kit/imp_uplink,
-		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
-		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
-		/obj/item/reagent_containers/hypospray/medipen/stimulants,
-		/obj/item/storage/box/syndie_kit/imp_freedom,
-		/obj/item/toy/eightball/haunted,
-	)
-	for(var/i in 1 to 3)
-		var/selected_item = pick_n_take(item_list)
-		new selected_item(src)
-
 	// Paper guide is always last.
 	new /obj/item/paper/contractor_guide(src)
 
@@ -810,12 +783,17 @@
 	illustration = "writing_syndie"
 
 /obj/item/storage/box/syndicate/contractor_loadout/PopulateContents()
+	new /obj/item/mod/control/pre_equipped/infiltrator(src)
 	new /obj/item/clothing/head/helmet/space/syndicate/contract(src)
 	new /obj/item/clothing/suit/space/syndicate/contract(src)
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
-	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/card/id/advanced/chameleon(src)
+	new /obj/item/computer_disk/syndicate/camera_app(src)
+	new /obj/item/clothing/glasses/thermal/syndi(src)
+	new /obj/item/storage/toolbox/syndicate(src)
+	new /obj/item/jammer(src)
+	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter(src)
 
 #undef KIT_RECON

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -789,7 +789,6 @@
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/card/id/advanced/chameleon(src)
-	new /obj/item/computer_disk/syndicate/camera_app(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
 	new /obj/item/storage/toolbox/syndicate(src)
 	new /obj/item/jammer(src)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -285,6 +285,7 @@
 
 	starting_programs = list(
 		/datum/computer_file/program/contract_uplink,
+		/datum/computer_file/program/secureye/syndicate,
 	)
 
 /**

--- a/code/modules/uplink/uplink_items/contractor.dm
+++ b/code/modules/uplink/uplink_items/contractor.dm
@@ -12,7 +12,7 @@
 		Can include otherwise unobtainable items."
 	item = /obj/item/storage/box/syndicate/contract_kit
 	category = /datum/uplink_category/contractor
-	cost = 16
+	cost = 20
 	purchasable_from = ~(UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS | UPLINK_TRAITORS)
 
 /datum/uplink_item/bundles_tc/contract_kit/purchase(mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)

--- a/code/modules/uplink/uplink_items/contractor.dm
+++ b/code/modules/uplink/uplink_items/contractor.dm
@@ -12,7 +12,7 @@
 		Can include otherwise unobtainable items."
 	item = /obj/item/storage/box/syndicate/contract_kit
 	category = /datum/uplink_category/contractor
-	cost = 20
+	cost = 16
 	purchasable_from = ~(UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS | UPLINK_TRAITORS)
 
 /datum/uplink_item/bundles_tc/contract_kit/purchase(mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)


### PR DESCRIPTION
## About The Pull Request
Removes RNG items from the possible pool of items that gets given to contractors when they buy their kit.
Contract kit:
![image](https://github.com/tgstation/tgstation/assets/66163761/d6009273-6ede-44b4-a2a4-6db4c9030400)
## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/66163761/ac08bfe9-4186-4e8e-a15b-0077d1e7433f)
![image](https://github.com/tgstation/tgstation/assets/66163761/a1d19780-9a97-407e-af75-842548cd7010)

The idea is that contractors should have the things they need in order to begin contracting in the first place.
They are given thermals + SyndEye to find targets.
Modsuit/Contractor Suit/Chameleon mask+jumpsuit to conceal/disguise their identity.
Their Jammer + Baton in order to pull off successful abductions without getting dogpiled by the entire station.

In their current state, contractors are too weak, when at the end of the day, the most harm they are doing is temporarily removing a crew member for like 5 minutes. They should have a bit more power now in order to have a bit more impact into the round.
## Changelog
:cl:
balance: Contractor kit no longer gets RNG items, it's a specific pool now
/:cl:
