### PR TITLE
Automated IV drips now respect the layer set in the plumbing constructor

### DIFF
--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -11,7 +11,7 @@
 	. = ..()
 	AddComponent(/datum/component/plumbing/iv_drip, bolt, layer)
 	AddComponent(/datum/component/simple_rotation)
-/datum/component/plumbing/iv_drip
+
 /obj/machinery/iv_drip/plumbing/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(attached)
 		context[SCREENTIP_CONTEXT_RMB] = "Take needle out"

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 	use_internal_storage = TRUE
 
-/obj/machinery/iv_drip/plumbing/Initialize(mapload, bolt=anchored, layer)
+/obj/machinery/iv_drip/plumbing/Initialize(mapload, bolt, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/iv_drip, bolt, layer)
 	AddComponent(/datum/component/simple_rotation)

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -7,11 +7,11 @@
 	density = TRUE
 	use_internal_storage = TRUE
 
-/obj/machinery/iv_drip/plumbing/Initialize(mapload)
+/obj/machinery/iv_drip/plumbing/Initialize(mapload, bolt=anchored, layer)
 	. = ..()
-	AddComponent(/datum/component/plumbing/iv_drip, anchored)
+	AddComponent(/datum/component/plumbing/iv_drip, bolt, layer)
 	AddComponent(/datum/component/simple_rotation)
-
+/datum/component/plumbing/iv_drip
 /obj/machinery/iv_drip/plumbing/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(attached)
 		context[SCREENTIP_CONTEXT_RMB] = "Take needle out"


### PR DESCRIPTION

## About The Pull Request
Automated IV drips will now be on the layer set by the plumbing constructor when created, whereas before they would be built on layer 3 regardless of the set layer
## Why It's Good For The Game
Bug bad
## Changelog
:cl:
fix: Automated IV drips will now be on the layer set by the plumbing constructor when created.
/:cl:
