### PR TITLE
The CC Commander Headset now can be set to high-volume

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -320,6 +320,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/headset_cent/commander
 	keyslot2 = /obj/item/encryptionkey/heads/captain
+	command = TRUE
 
 /obj/item/radio/headset/headset_cent/alt
 	name = "\improper CentCom bowman headset"


### PR DESCRIPTION

## About The Pull Request
You got no idea how many times I've had to go to VV and set command=1 because the fucking Interns don't read chat.
With this PR, we no longer have to manually set that crap and can scream into the Intern's ears in big letters with less steps.
The only outfits that use this type of headset are the CC Commander, Special Ops Officer, Soviet Admiral, Debug Outfit, and Admin Outfit, so I think it's cool
## Changelog
:cl:
qol: You no longer need to manually set the CC Commander's Headset to high-volume.
/:cl:
