### PR TITLE
RD and QM coats can hold their telebatons. QM coat can also hold items that a regular jacket can hold

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -236,10 +236,14 @@
 	icon_state = "qm_coat"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	allowed = list(
+
+/obj/item/clothing/suit/jacket/quartermaster/Initialize(mapload)
+	. = ..()
+	allowed += list(
 		/obj/item/stamp,
 		/obj/item/storage/bag/mail,
 		/obj/item/universal_scanner,
+		/obj/item/melee/baton/telescopic,
 	)
 
 /obj/item/clothing/suit/toggle/lawyer/greyscale
@@ -395,7 +399,10 @@
 
 /obj/item/clothing/suit/jacket/research_director/Initialize(mapload)
 	. = ..()
-	allowed += /obj/item/storage/bag/xeno
+	allowed += list(
+		/obj/item/storage/bag/xeno,
+		/obj/item/melee/baton/telescopic,
+	)
 
 // Atmos
 /obj/item/clothing/suit/atmos_overalls


### PR DESCRIPTION

## About The Pull Request
RD's and QM's coats can now hold telebatons.
QM's coat can now hold items that any regular jacket can hold, such as small oxygen tanks. 
## Why It's Good For The Game
RD and QM coats were the only head of staff suits that couldn't hold telebatons (even their winter coats can hold them). Both were added recently, so I think it's an oversight, but I'm labeling this as a balance change anyway.
It's also really weird that QM's coat couldn't even hold internals before.
More consistency for head of staff suits
## Changelog
:cl:
balance: RD and QM coats can hold telebatons now
qol: Quartermaster's coat can hold items that a normal jacket can hold, such as small oxygen tanks
/:cl:
