### PR TITLE
Fixes some irregularities in heretic research tree

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -151,7 +151,7 @@
 		/datum/heretic_knowledge/painting,
 	)
 	spell_to_add = /datum/action/cooldown/spell/pointed/burglar_finesse
-	cost = 2
+	cost = 1
 	route = PATH_LOCK
 
 /datum/heretic_knowledge/blade_upgrade/flesh/lock //basically a chance-based weeping avulsion version of the former

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -115,13 +115,7 @@
 	desc = "Grants you Lunar Parade, a spell that - after a short charge - sends a carnival forward \
 		when hitting someone they are forced to join the parade and suffer hallucinations."
 	gain_text = "The music like a reflection of the soul compelled them, like moths to a flame they followed"
-	next_knowledge = list(
-		/datum/heretic_knowledge/moon_amulette,
-		/datum/heretic_knowledge/reroll_targets,
-		/datum/heretic_knowledge/unfathomable_curio,
-		/datum/heretic_knowledge/curse/paralysis,
-		/datum/heretic_knowledge/painting,
-		)
+	next_knowledge = list(/datum/heretic_knowledge/moon_amulette)
 	spell_to_add = /datum/action/cooldown/spell/pointed/projectile/moon_parade
 	cost = 1
 	route = PATH_MOON
@@ -133,7 +127,13 @@
 			if the item is used on someone with low sanity they go berserk attacking everyone \
 			, if their sanity isnt low enough it decreases their mood."
 	gain_text = "At the head of the parade he stood, the moon condensed into one mass, a reflection of the soul."
-	next_knowledge = list(/datum/heretic_knowledge/blade_upgrade/moon)
+	next_knowledge = list(
+		/datum/heretic_knowledge/blade_upgrade/moon,
+		/datum/heretic_knowledge/reroll_targets,
+		/datum/heretic_knowledge/unfathomable_curio,
+		/datum/heretic_knowledge/curse/paralysis,
+		/datum/heretic_knowledge/painting,
+		)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
 		/obj/item/organ/internal/heart = 1,

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -133,7 +133,7 @@
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/curse/paralysis,
 		/datum/heretic_knowledge/painting,
-		)
+	)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
 		/obj/item/organ/internal/heart = 1,

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -149,7 +149,6 @@
 	desc = "Your blade now deals brain damage, causes  random hallucinations and does sanity damage."
 	gain_text = "His wit was sharp as a blade, cutting through the lie to bring us joy."
 	next_knowledge = list(/datum/heretic_knowledge/spell/moon_ringleader)
-	cost = 1
 	route = PATH_MOON
 
 /datum/heretic_knowledge/blade_upgrade/moon/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)

--- a/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
@@ -63,7 +63,7 @@
 		They also have the ability to create a ring of fire around themselves for a length of time."
 	gain_text = "I combined my principle of hunger with my desire for destruction. The Marshal knew my name, and the Nightwatcher gazed on."
 	next_knowledge = list(
-		/datum/heretic_knowledge/summon/stalker,
+		/datum/heretic_knowledge/spell/flame_birth,
 		/datum/heretic_knowledge/spell/moon_ringleader,
 	)
 	required_atoms = list(

--- a/code/modules/antagonists/heretic/knowledge/side_flesh_void.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_flesh_void.dm
@@ -26,7 +26,6 @@
 		Also has a chance to transfer wounds from you to the victim."
 	gain_text = "\"No matter the man, we bleed all the same.\" That's what the Marshal told me."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/apetra_vulnera,
 		/datum/heretic_knowledge/spell/void_phase,
 		/datum/heretic_knowledge/summon/raw_prophet,
 	)

--- a/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
@@ -23,7 +23,7 @@
 	gain_text = "The mansus holds many a curio, some are not meant for the mortal eye."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/burglar_finesse,
-		/datum/heretic_knowledge/spell/moon_parade,
+		/datum/heretic_knowledge/moon_amulette,
 	)
 	required_atoms = list(
 		/obj/item/organ/internal/lungs = 1,
@@ -48,7 +48,7 @@
 				They yearn for mortal eyes again, and I shall grant that wish."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/burglar_finesse,
-		/datum/heretic_knowledge/spell/moon_parade,
+		/datum/heretic_knowledge/moon_amulette,
 	)
 	required_atoms = list(/obj/item/canvas = 1)
 	result_atoms = list(/obj/item/canvas)


### PR DESCRIPTION

## About The Pull Request

Once again, I fix a few errors in the heretic research tree:

- the lunar path no longer unlocks its sidepaths and reroll one research before every other path, and this side knowledge in turn no longer unlocks the earlier knowledge of the moon path
- blood siphon no longer unlocks apetra vulnera in addition to its proper main path nodes
- ashen ritual now unlocks the nightwatcher's rebirth, instead of unlocking the lonely ritual
- lunar blade upgrade is no longer cheaper than those of the other paths
- burglar's finesse now costs 1 point like other knowledge of its level
## Why It's Good For The Game

Heretic tree should not be irregular for no reason, I think. If any of those quirks were intentional, please let me know.
## Changelog
:cl:
fix: smoothed out a few asymmetries in the heretic research tree
/:cl:
