### PR TITLE
Cyborgs stun arm is now on-par with stunbatons.

### DIFF
--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -20,7 +20,7 @@
 	var/charge_cost = 200
 	var/cooldown_check = 0
 	/// cooldown between attacks
-	var/cooldown = 4 SECONDS // same as baton
+	var/cooldown = 2.5 SECONDS // same as baton
 
 /obj/item/borg/stun/attack(mob/living/attacked_mob, mob/living/user)
 	if(cooldown_check > world.time)


### PR DESCRIPTION

## About The Pull Request
Changes the cooldown from 4 seconds to 2.5 seconds (as the current stunbatons use)
## Why It's Good For The Game
1)The cyborg stun arm lacks one of the most important effects of the normal stunbaton , that is , the knockdown
2)It just sucks. 4 second cooldowns without any form of disarm is crippling and always ends with the borg getting flashed and wrecked.
## Changelog
:cl:
balance: Cyborg stun arms attack delay is now the same as a stunbaton (from 4 seconds to 2.5 seconds)
/:cl:
