### PR TITLE
You can no longer convert objective targets to your blood brother team

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -63,8 +63,8 @@
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
 
-	for(var/datum/objective/assassinate/assassinate_objective as anything in source.mind.get_all_objectives())
-		if(flashed == assassinate_objective.target.current)
+	for(var/datum/objective/brother_objective in source.mind.get_all_objectives())
+		if(flashed == brother_objective.target.current)
 			flashed.balloon_alert(source, "that's your target!")
 			return
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -63,6 +63,11 @@
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
 
+	for(var/datum/objective/assassinate/assassinate_objective as anything in source.mind.get_all_objectives())
+		if(flashed == assassinate_objective.target.current)
+			flashed.balloon_alert(source, "that's your target!")
+			return
+
 	if (flashed.mind.has_antag_datum(/datum/antagonist/brother))
 		flashed.balloon_alert(source, "[flashed.p_theyre()] loyal to someone else!")
 		return


### PR DESCRIPTION
## About The Pull Request

You can no longer convert your objective targets to your blood brother team.

This means the usual "commit violence against this user" objectives, but also includes protect objectives and should (theoretically) prevent you from converting targets from other conflicting objectives such as mutiny/sacrifice/obsession targets.
## Why It's Good For The Game

This kind of fucks up the whole antagonist on a conceptual level. Pick ANYONE else please!
## Changelog
:cl: Rhials
fix: You can no longer convert assassination targets to your blood brother team.
/:cl:
