### PR TITLE
Health analyzer displays blood alcohol content

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -239,6 +239,7 @@
 	var/blood_percent = round((patient.blood_volume / BLOOD_VOLUME_NORMAL)*100)
 	var/blood_type = patient.dna.blood_type
 	var/blood_warning = " "
+	var/blood_alcohol = patient.get_blood_alcohol_content()
 
 	for(var/thing in patient.diseases) //Disease Information
 		var/datum/disease/D = thing
@@ -354,6 +355,7 @@
 	data["bleed_status"] = bleed_status
 	data["blood_levels"] = blood_percent - (chaos_modifier * (rand(1,35)))
 	data["blood_status"] = blood_status
+	data["blood_alcohol"] = blood_alcohol
 	data["chemical_list"] = chemical_list
 	data["overdose_list"] = overdose_list
 	data["addict_list"] = addict_list

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -382,15 +382,13 @@
 				render_list += "<span class='info ml-1'>Blood level: [blood_percent]%, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
 
 	// Blood Alcohol Content
-	if(isliving(target))
-		var/mob/living/living_target = target
-		var/datum/status_effect/inebriated/inebriation = living_target.has_status_effect(/datum/status_effect/inebriated)
-		if(!isnull(inebriation))
-			var/blood_alcohol_content = round(inebriation.drunk_value * DRUNK_POWER_TO_BLOOD_ALCOHOL, 0.01)
-			if(blood_alcohol_content >= 0.24)
-				render_list += "<span class='alert ml-1'>Blood alcohol content: <b>CRITICAL [blood_alcohol_content]%</b></span>\n"
-			else
-				render_list += "<span class='info ml-1'>Blood alcohol content: [blood_alcohol_content]%</span>\n"
+	var/datum/status_effect/inebriated/inebriation = target.has_status_effect(/datum/status_effect/inebriated)
+	if(!isnull(inebriation))
+		var/blood_alcohol_content = round(inebriation.drunk_value * DRUNK_POWER_TO_BLOOD_ALCOHOL, 0.01)
+		if(blood_alcohol_content >= 0.24)
+			render_list += "<span class='alert ml-1'>Blood alcohol content: <b>CRITICAL [blood_alcohol_content]%</b></span>\n"
+		else
+			render_list += "<span class='info ml-1'>Blood alcohol content: [blood_alcohol_content]%</span>\n"
 
 	// Cybernetics
 	if(iscarbon(target))

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -380,7 +380,7 @@
 
 	// Blood Alcohol Content
 	var/blood_alcohol_content = target.get_blood_alcohol_content()
-	if(blood_alcohol_content)
+	if(blood_alcohol_content > 0)
 		if(blood_alcohol_content >= 0.24)
 			render_list += "<span class='alert ml-1'>Blood alcohol content: <b>CRITICAL [blood_alcohol_content]%</b></span>\n"
 		else

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -3,6 +3,9 @@
 #define SCANMODE_WOUND 1
 #define SCANMODE_COUNT 2 // Update this to be the number of scan modes if you add more
 
+// Conversion between internal drunk power and common blood alcohol content
+#define DRUNK_POWER_TO_BLOOD_ALCOHOL 0.003
+
 /obj/item/healthanalyzer
 	name = "health analyzer"
 	icon = 'icons/obj/devices/scanner.dmi'
@@ -372,11 +375,22 @@
 				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
 				blood_type = R ? R.name : blood_id
 			if(carbontarget.blood_volume <= BLOOD_VOLUME_SAFE && carbontarget.blood_volume > BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_percent] %, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
+				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_percent]%, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
 			else if(carbontarget.blood_volume <= BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_percent] %</b>, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
+				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_percent]%</b>, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
 			else
-				render_list += "<span class='info ml-1'>Blood level: [blood_percent] %, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
+				render_list += "<span class='info ml-1'>Blood level: [blood_percent]%, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
+
+	// Blood Alcohol Content
+	if(isliving(target))
+		var/mob/living/living_target = target
+		var/datum/status_effect/inebriated/inebriation = living_target.has_status_effect(/datum/status_effect/inebriated)
+		if(!isnull(inebriation))
+			var/blood_alcohol_content = round(inebriation.drunk_value * DRUNK_POWER_TO_BLOOD_ALCOHOL, 0.01)
+			if(blood_alcohol_content >= 0.24)
+				render_list += "<span class='alert ml-1'>Blood alcohol content: <b>CRITICAL [blood_alcohol_content]%</b></span>\n"
+			else
+				render_list += "<span class='info ml-1'>Blood alcohol content: [blood_alcohol_content]%</span>\n"
 
 	// Cybernetics
 	if(iscarbon(target))
@@ -683,3 +697,5 @@
 #undef AID_EMOTION_WARN
 #undef AID_EMOTION_ANGRY
 #undef AID_EMOTION_SAD
+
+#undef DRUNK_POWER_TO_BLOOD_ALCOHOL

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -3,9 +3,6 @@
 #define SCANMODE_WOUND 1
 #define SCANMODE_COUNT 2 // Update this to be the number of scan modes if you add more
 
-// Conversion between internal drunk power and common blood alcohol content
-#define DRUNK_POWER_TO_BLOOD_ALCOHOL 0.003
-
 /obj/item/healthanalyzer
 	name = "health analyzer"
 	icon = 'icons/obj/devices/scanner.dmi'
@@ -382,9 +379,8 @@
 				render_list += "<span class='info ml-1'>Blood level: [blood_percent]%, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
 
 	// Blood Alcohol Content
-	var/datum/status_effect/inebriated/inebriation = target.has_status_effect(/datum/status_effect/inebriated)
-	if(!isnull(inebriation))
-		var/blood_alcohol_content = round(inebriation.drunk_value * DRUNK_POWER_TO_BLOOD_ALCOHOL, 0.01)
+	var/blood_alcohol_content = target.get_blood_alcohol_content()
+	if(blood_alcohol_content)
 		if(blood_alcohol_content >= 0.24)
 			render_list += "<span class='alert ml-1'>Blood alcohol content: <b>CRITICAL [blood_alcohol_content]%</b></span>\n"
 		else
@@ -695,5 +691,3 @@
 #undef AID_EMOTION_WARN
 #undef AID_EMOTION_ANGRY
 #undef AID_EMOTION_SAD
-
-#undef DRUNK_POWER_TO_BLOOD_ALCOHOL

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -1,4 +1,6 @@
 #define BLOOD_DRIP_RATE_MOD 90 //Greater number means creating blood drips more often while bleeding
+// Conversion between internal drunk power and common blood alcohol content
+#define DRUNK_POWER_TO_BLOOD_ALCOHOL 0.003
 
 /****************************************************
 				BLOOD SYSTEM
@@ -376,4 +378,13 @@
 	if(!B)
 		B = new(T)
 
+/mob/living/proc/get_blood_alcohol_content()
+	var/blood_alcohol_content = 0
+	var/datum/status_effect/inebriated/inebriation = has_status_effect(/datum/status_effect/inebriated)
+	if(!isnull(inebriation))
+		blood_alcohol_content = round(inebriation.drunk_value * DRUNK_POWER_TO_BLOOD_ALCOHOL, 0.01)
+
+	return blood_alcohol_content
+
 #undef BLOOD_DRIP_RATE_MOD
+#undef DRUNK_POWER_TO_BLOOD_ALCOHOL

--- a/tgui/packages/tgui/interfaces/MedicalKiosk.jsx
+++ b/tgui/packages/tgui/interfaces/MedicalKiosk.jsx
@@ -188,6 +188,7 @@ const MedicalKioskScanResults2 = (props) => {
     bleed_status,
     blood_levels,
     blood_status,
+    blood_alcohol,
   } = data;
   return (
     <Section title="Symptom Based Checkup">
@@ -213,6 +214,19 @@ const MedicalKioskScanResults2 = (props) => {
         </LabeledList.Item>
         <LabeledList.Item label="Blood Information">
           {blood_status}
+        </LabeledList.Item>
+        <LabeledList.Item label="Blood Alcohol">
+          <ProgressBar
+            value={blood_alcohol}
+            minValue={0}
+            maxValue={0.3}
+            ranges={{
+              blue: [-Infinity, 0.24],
+              bad: [0.24, Infinity],
+            }}
+          >
+            <AnimatedNumber value={blood_alcohol} />
+          </ProgressBar>
         </LabeledList.Item>
       </LabeledList>
     </Section>

--- a/tgui/packages/tgui/interfaces/MedicalKiosk.jsx
+++ b/tgui/packages/tgui/interfaces/MedicalKiosk.jsx
@@ -221,8 +221,8 @@ const MedicalKioskScanResults2 = (props) => {
             minValue={0}
             maxValue={0.3}
             ranges={{
-              blue: [-Infinity, 0.24],
-              bad: [0.24, Infinity],
+              blue: [-Infinity, 0.23],
+              bad: [0.23, Infinity],
             }}
           >
             <AnimatedNumber value={blood_alcohol} />

--- a/tgui/packages/tgui/interfaces/MedicalKiosk.jsx
+++ b/tgui/packages/tgui/interfaces/MedicalKiosk.jsx
@@ -188,7 +188,6 @@ const MedicalKioskScanResults2 = (props) => {
     bleed_status,
     blood_levels,
     blood_status,
-    blood_alcohol,
   } = data;
   return (
     <Section title="Symptom Based Checkup">
@@ -214,19 +213,6 @@ const MedicalKioskScanResults2 = (props) => {
         </LabeledList.Item>
         <LabeledList.Item label="Blood Information">
           {blood_status}
-        </LabeledList.Item>
-        <LabeledList.Item label="Blood Alcohol">
-          <ProgressBar
-            value={blood_alcohol}
-            minValue={0}
-            maxValue={0.3}
-            ranges={{
-              blue: [-Infinity, 0.23],
-              bad: [0.23, Infinity],
-            }}
-          >
-            <AnimatedNumber value={blood_alcohol} />
-          </ProgressBar>
         </LabeledList.Item>
       </LabeledList>
     </Section>
@@ -262,6 +248,7 @@ const MedicalKioskScanResults4 = (props) => {
     overdose_list = [],
     addict_list = [],
     hallucinating_status,
+    blood_alcohol,
   } = data;
   return (
     <Section title="Chemical and Psychoactive Analysis">
@@ -294,6 +281,19 @@ const MedicalKioskScanResults4 = (props) => {
         </LabeledList.Item>
         <LabeledList.Item label="Psychoactive Status">
           {hallucinating_status}
+        </LabeledList.Item>
+        <LabeledList.Item label="Blood Alcohol Content">
+          <ProgressBar
+            value={blood_alcohol}
+            minValue={0}
+            maxValue={0.3}
+            ranges={{
+              blue: [-Infinity, 0.23],
+              bad: [0.23, Infinity],
+            }}
+          >
+            <AnimatedNumber value={blood_alcohol} />
+          </ProgressBar>
         </LabeledList.Item>
       </LabeledList>
     </Section>


### PR DESCRIPTION
## About The Pull Request

Health analyzer includes a blood alcohol content if the scanned target is inebriated.

## Why It's Good For The Game

It's useful to know, sometimes their blood is filtered, stomach pumped, but this effect will still be in action.

## Changelog

:cl: LT3
qol: Health analyzer will now display blood alcohol content
/:cl: