### PR TITLE
Mechs now use proper name when renamed

### DIFF
--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -190,7 +190,7 @@
 			if(userinput == format_text(name)) //default mecha names may have improper span artefacts in their name, so we format the name
 				to_chat(usr, span_notice("You rename [name] to... well, [userinput]."))
 				return
-			name = userinput
+			name = "\proper [userinput]"
 			chassis_camera?.update_c_tag(src)
 		if("toggle_safety")
 			set_safety(usr)


### PR DESCRIPTION
## About The Pull Request

When you rename a mech, it now becomes a proper name.

## Why It's Good For The Game

People give their guns people names, and in my experience people also give mechs people names, it would be cool if they were referred to 'thing' instead of 'the thing', to encourage that.

## Changelog

:cl:
spellcheck: Mechs that have been renamed now are proper names, so are not described as 'the' mech.
/:cl: