### PR TITLE
Fix `/datum/ui_state/greyscale_menu_state` for non-atom datums

### DIFF
--- a/code/modules/tgui/states/greyscale_menu.dm
+++ b/code/modules/tgui/states/greyscale_menu.dm
@@ -9,6 +9,6 @@ GLOBAL_DATUM_INIT(greyscale_menu_state, /datum/ui_state/greyscale_menu_state, ne
 /datum/ui_state/greyscale_menu_state/can_use_topic(src_object, mob/user)
 	var/datum/greyscale_modify_menu/menu = src_object
 	if(!isatom(menu.target))
-		return TRUE
+		return UI_INTERACTIVE
 
 	return GLOB.default_state.can_use_topic(menu.target, user)


### PR DESCRIPTION
## About The Pull Request

`can_use_topic` returns a UI define like `UI_INTERACTIVE`, not `TRUE` / `FALSE`

This line is intended to allow greyscale menus to be used when targeting non-atoms, however it prevents that entirely. #77322

## Changelog

Not necessary since _we_ don't have any GAGS menu usage that targets a datum... currently. 