### PR TITLE
Science Xenos no longer turn the roundend report all bold

### DIFF
--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -138,7 +138,7 @@
 	else
 		thank_you_message = "xenofauna combat effectiveness"
 
-	parts += "<span class='neutraltext'>Nanotrasen thanks the crew of [station_name()] for providing much needed research data on <b>[thank_you_message]<b>.</span>"
+	parts += "<span class='neutraltext'>Nanotrasen thanks the crew of [station_name()] for providing much needed research data on <b>[thank_you_message]</b>.</span>"
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div> <br>"
 


### PR DESCRIPTION
## About The Pull Request

Fixes the 2% xeno's roundend report from turning the rest of the report into bold letters.

## Why It's Good For The Game

look it's not all bold anymore
![image](https://github.com/tgstation/tgstation/assets/53777086/5b46dc02-5fb5-4d16-aedf-fc1c11aad045)

## Changelog

:cl:
fix: Science Xenos no longer turn the entire roundend report into bold letters.
/:cl: