### PR TITLE
Tramstation Isolation cell doors actually open on their timer

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11853,7 +11853,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell C"
+	name = "Isolation Cell C";
+	id = "Isolation_C"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22002,7 +22003,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell B"
+	name = "Isolation Cell B";
+	id = "Isolation_B"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26835,7 +26837,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell D"
+	name = "Isolation Cell D";
+	id = "Isolation_D"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58742,12 +58745,13 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell A"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	name = "Isolation Cell A";
+	id = "Isolation_A"
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "tJR" = (
@@ -69026,7 +69030,9 @@
 /area/station/commons/fitness/recreation)
 "xog" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Isolation Wing"
+	name = "Isolation Wing";
+	unres_sensor = 1;
+	unres_sides = 8
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1803,6 +1803,7 @@
 /obj/machinery/door/airlock/security
 	name = "security airlock"
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
+	var/id = null
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 	normal_integrity = 450
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -43,6 +43,10 @@
 			if (M.id == id)
 				doors += WEAKREF(M)
 
+		for(var/obj/machinery/door/airlock/security/M in urange(20, src))
+			if (M.id == id)
+				doors += WEAKREF(M)
+
 		for(var/obj/machinery/flasher/F in urange(20, src))
 			if(F.id == id)
 				flashers += WEAKREF(F)


### PR DESCRIPTION

## About The Pull Request
Setting a timer in the tramstation isolation cells now actually opens the corresponding cell door.

In addition, the door out of the isolation wing has unrestricted access from the west.

Added a "id" var to security airlocks to accomplish this (that the windoors already had).
## Why It's Good For The Game
A lot of security players still don't use genpop on tramstation, and it's incredibly lame if you're given a measly 3 minute-sentence, but security misses the radio announcement that the timer has expired and you've had your radio confiscated. I'm assuming this was an oversight (why were there timers in the first place if they didn't work?), but in any event, this brings tramstation isolation brigging to parity with other maps.

## Changelog
:cl: PapaMichael
fix: tramstation isolation cells now properly open on their timer.
/:cl:
