### PR TITLE
Service now has their own color in crew monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -1,7 +1,7 @@
 /// How often the sensor data is updated
 #define SENSORS_UPDATE_PERIOD (10 SECONDS) //How often the sensor data updates.
 /// The job sorting ID associated with otherwise unknown jobs
-#define UNKNOWN_JOB_ID 81
+#define UNKNOWN_JOB_ID 998
 
 /obj/machinery/computer/crew
 	name = "crew monitoring console"
@@ -126,7 +126,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		JOB_SHAFT_MINER = 51,
 		JOB_CARGO_TECHNICIAN = 52,
 		JOB_BITRUNNER = 53,
-		// 60+: Civilian/other
+		// 60+: Service
 		JOB_HEAD_OF_PERSONNEL = 60,
 		JOB_BARTENDER = 61,
 		JOB_COOK = 62,
@@ -232,7 +232,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		var/list/entry = list(
 			"ref" = REF(tracked_living_mob),
 			"name" = "Unknown",
-			"ijob" = UNKNOWN_JOB_ID
+			"ijob" = UNKNOWN_JOB_ID,
 		)
 
 		// ID and id-related data

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -28,6 +28,7 @@ export const COLORS = {
     science: '#9b59b6',
     engineering: '#f1c40f',
     cargo: '#f39c12',
+    service: '#7cc46a',
     centcom: '#00c100',
     other: '#c38312',
   },

--- a/tgui/packages/tgui/interfaces/CrewConsole.jsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.jsx
@@ -38,6 +38,9 @@ const jobToColor = (jobId) => {
   if (jobId >= 50 && jobId < 60) {
     return COLORS.department.cargo;
   }
+  if (jobId >= 60 && jobId < 200) {
+    return COLORS.department.service;
+  }
   if (jobId >= 200 && jobId < 230) {
     return COLORS.department.centcom;
   }


### PR DESCRIPTION
## About The Pull Request

Service before was colored the 'other' color, which doesn't make sense seeing as it's its own department. It also looked very similar to cargo, so this also makes it easier to distinguish the 2 departments.

I also moved 'Unknown' to be directly above Assistant, so CentCom officials will now display above unknown people.

## Why It's Good For The Game

It makes it much easier to distinguish the departments this way.
![image](https://github.com/tgstation/tgstation/assets/53777086/c328eb56-0711-4f02-995e-6146461e9160)

## Changelog

:cl:
qol: Service personnel now show up in green in the crew monitor console.
/:cl:
