### PR TITLE
Reduces Time For Nightmare To Gain a Critical Strike

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare_equipment.dm
+++ b/code/modules/antagonists/nightmare/nightmare_equipment.dm
@@ -64,7 +64,7 @@
 	remove_crit()
 
 /obj/item/light_eater/proc/prepare_crit_timer()
-	crit_timer = addtimer(CALLBACK(src, PROC_REF(add_crit)), 15 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
+	crit_timer = addtimer(CALLBACK(src, PROC_REF(add_crit)), 7 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
 
 /obj/item/light_eater/proc/stop_crit_timer()
 	deltimer(crit_timer)

--- a/tgui/packages/tgui/interfaces/AntagInfoNightmare.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoNightmare.tsx
@@ -63,7 +63,7 @@ export const AntagInfoNightmare = (props) => {
                 </LabeledList.Item>
                 <LabeledList.Item label="Light Eater">
                   Your twisted appendage. It will consume the light of what it
-                  touches, be it victim or object. After 15 seconds of being in
+                  touches, be it victim or object. After 7 seconds of being in
                   jaunt, stabbing a foe will stun them or do extra damage.
                 </LabeledList.Item>
               </LabeledList>


### PR DESCRIPTION
## About The Pull Request

This PR reduces the amount of time it takes for Nightmare to gain a critical strike whilst in jaunt (15 > 7 seconds)

## Why It's Good For The Game

Having watched players use the new mechanic added to Nightmare's Light Eater in #80670, I've recognized that the 15 second requirement is extremely clunky in practice, as it was a carryover from when Nightmare got crits from being out of jaunt as opposed to staying in. Since Nightmare's job requires it to usually be out of jaunt smashing lights or APCs when it isn't engaged in combat, reducing the time it takes while in jaunt to gain a critical strike allows Nightmare to get more use out of the mechanic without throwing off their general game plan so much.

## Changelog

:cl:
balance: Nightmare's Light Eater takes less time in jaunt to gain a critical strike, being reduced to 7 seconds from 15 seconds.
/:cl: