### PR TITLE
Disable rust version checking in tgs precompile.sh hook

### DIFF
--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Deploying rust-g..."
 git checkout "$RUST_G_VERSION"
-env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --target=i686-unknown-linux-gnu
+env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd ..
 


### PR DESCRIPTION
Updates tgs/precompile.sh hook to match what is deployed on campbell.

rust-lang/cargo#12654 has set a policy of setting this to be the latest version-2, which kills any kind of signal this could have ever had.

cargo's subcrates like `home` are used in almost any complex rust package, so this basically sets the tone for all packages and all crates published after October 8th.

A min compiler version should be based on an actual need to use a specific compiler version because of specific features that version has or bugs that version doesn't have. This is signal. Setting to some evergreen value as a matter of course is not signal, its noise.

I will not subject myself nor our downstreams to such nonsense.
