### PR TITLE
Restore non-functional ash mark ability

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -84,8 +84,9 @@
 /datum/heretic_knowledge/mark/ash_mark
 	name = "Mark of Ash"
 	desc = "Your Mansus Grasp now applies the Mark of Ash. The mark is triggered from an attack with your Ashen Blade. \
-		When triggered, the victim takes additional stamina and burn damage, and the mark is transferred to any nearby heathens. \
-		Damage dealt is decreased with each transfer."
+		When triggered, the victim takes additional stamina and burn damage, and the mark is transferred to a nearby heathen. \
+		Damage dealt is decreased with each transfer. \
+		Triggering the mark will also greatly reduce the cooldown of your Mansus Grasp."
 	gain_text = "He was a very particular man, always watching in the dead of night. \
 		But in spite of his duty, he regularly tranced through the Manse with his blazing lantern held high. \
 		He shone brightly in the darkness, until the blaze begin to die."

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -101,7 +101,7 @@
 	// Also refunds 75% of charge!
 	var/datum/action/cooldown/spell/touch/mansus_grasp/grasp = locate() in source.actions
 	if(grasp)
-		grasp.next_use_time = min(round(grasp.next_use_time - grasp.cooldown_time * 0.75, 0), 0)
+		grasp.next_use_time -= grasp.cooldown_time*0.75
 		grasp.build_all_button_icons()
 
 /datum/heretic_knowledge/knowledge_ritual/ash

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -102,7 +102,7 @@
 	// Also refunds 75% of charge!
 	var/datum/action/cooldown/spell/touch/mansus_grasp/grasp = locate() in source.actions
 	if(grasp)
-		grasp.next_use_time -= grasp.cooldown_time*0.75
+		grasp.next_use_time -= round(grasp.cooldown_time*0.75)
 		grasp.build_all_button_icons()
 
 /datum/heretic_knowledge/knowledge_ritual/ash

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -95,17 +95,6 @@
 	route = PATH_MOON
 	mark_type = /datum/status_effect/eldritch/moon
 
-/datum/heretic_knowledge/mark/moon_mark/trigger_mark(mob/living/source, mob/living/target)
-	. = ..()
-	if(!.)
-		return
-
-	// Also refunds 75% of charge!
-	var/datum/action/cooldown/spell/touch/mansus_grasp/grasp = locate() in source.actions
-	if(grasp)
-		grasp.next_use_time = min(round(grasp.next_use_time - grasp.cooldown_time * 0.75, 0), 0)
-		grasp.build_all_button_icons()
-
 /datum/heretic_knowledge/knowledge_ritual/moon
 	next_knowledge = list(/datum/heretic_knowledge/spell/moon_parade)
 	route = PATH_MOON


### PR DESCRIPTION

## About The Pull Request

Apparently, ash mark is supposed to replenish mansus grasp cooldown by 75% when triggered, but this is neither reflected by the research description, nor functional ingame. This edit makes it work, and adds the effect to the description.

Additionally, that same block of code was present in moon mark research also. I removed that because I assume it is intended to be an ash-only feature, and moon only had it because of copy-pasting.

And since we're at it, I also reworded the mark description to be more clear about the mark only transferring to a single heathen at a time.
## Why It's Good For The Game

I don't think we should have code which does not work. The options are to either remove it, or make it work, and the latter is more fun.
## Changelog
:cl:
fix: ash mark now properly lowers the cooldown of mansus grasp when triggered
/:cl:
