### PR TITLE
Legcuffs on Aliens Work as Intended

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -408,6 +408,14 @@
 
 	apply_overlay(BACK_LAYER)
 
+/mob/living/carbon/update_worn_legcuffs()
+	remove_overlay(LEGCUFF_LAYER)
+	clear_alert("legcuffed")
+	if(legcuffed)
+		overlays_standing[LEGCUFF_LAYER] = mutable_appearance('icons/mob/simple/mob.dmi', "legcuff1", -LEGCUFF_LAYER)
+		apply_overlay(LEGCUFF_LAYER)
+		throw_alert("legcuffed", /atom/movable/screen/alert/restrained/legcuffed, new_master = src.legcuffed)
+
 /mob/living/carbon/update_worn_head()
 	remove_overlay(HEAD_LAYER)
 

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -473,14 +473,6 @@ There are several things that need to be remembered:
 		overlays_standing[BACK_LAYER] = back_overlay
 	apply_overlay(BACK_LAYER)
 
-/mob/living/carbon/human/update_worn_legcuffs()
-	remove_overlay(LEGCUFF_LAYER)
-	clear_alert("legcuffed")
-	if(legcuffed)
-		overlays_standing[LEGCUFF_LAYER] = mutable_appearance('icons/mob/simple/mob.dmi', "legcuff1", -LEGCUFF_LAYER)
-		apply_overlay(LEGCUFF_LAYER)
-		throw_alert("legcuffed", /atom/movable/screen/alert/restrained/legcuffed, new_master = src.legcuffed)
-
 /mob/living/carbon/human/get_held_overlays()
 	var/list/hands = list()
 	for(var/obj/item/worn_item in held_items)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -230,7 +230,7 @@
 
 /mob/living/carbon/human/equipped_speed_mods()
 	. = ..()
-	for(var/sloties in get_all_worn_items() - list(l_store, r_store, s_store))
+	for(var/sloties in get_all_worn_items() - list(l_store, r_store, s_store, back, wear_mask, wear_neck, head, handcuffed, legcuffed))
 		var/obj/item/thing = sloties
 		. += thing?.slowdown
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -128,6 +128,12 @@
 
 	return not_handled
 
+/mob/living/carbon/equipped_speed_mods()
+	. = ..()
+	for(var/sloties in get_all_worn_items())
+		var/obj/item/thing = sloties
+		. += thing?.slowdown
+
 /// This proc is called after an item has been successfully handled and equipped to a slot.
 /mob/living/carbon/proc/has_equipped(obj/item/item, slot, initial = FALSE)
 	return item.on_equipped(src, slot, initial)


### PR DESCRIPTION
## About The Pull Request

Currently on live, if you throw a bola at a xenomorph or use a beartrap on them, the legcuff will successfully attach itself to the xenomorph but nothing will happen. It will not be present visually nor apply slowdown to the xenomorph at all, and it also gives the xenomorph no indication that it is attached to them or option to remove it. This PR fixes that problem by moving some human-specific code downwards, allowing xenomorphs to visually have legcuffs applied to them, be slowed down by them and to take them off by themselves.

Note that as with all cuff-related items, xenomorphs will break the item immediately upon attempting to resist it at all. Therefore, this PR doesn't really do anything balance-related, although maybe you can buy yourself a half-second while the xenomorph you just bola'd realizes they need to take it off before chasing you down again.

Another thing to note is that queens and praetorians don't look right with these overlays applied (they float to the left of their sprite), but that's a bigger issue with a lot of the overlays in general (fire being a big one), to be fixed in another PR.

## Why It's Good For The Game

This has bothered me for a while now, so its about time I do something about it. Even if using bolas or beartraps on xenomorphs is practically useless, if we're gonna let players do it then we're going to let them do it right.

## Changelog
:cl:
fix: Xenomorphs now have legcuffs applied to them properly.
/:cl: