### PR TITLE
Welding goggles balance

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -448,7 +448,8 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	flash_protect = FLASH_PROTECTION_WELDER
 	flags_cover = GLASSESCOVERSEYES
-	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*2.5)
+	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 3)
+	custom_premium_price = PAYCHECK_CREW * 3
 	tint = 2
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	glass_colour_type = /datum/client_colour/glass_colour/gray

--- a/code/modules/clothing/head/welding.dm
+++ b/code/modules/clothing/head/welding.dm
@@ -7,6 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/clothing/masks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing/masks_righthand.dmi'
 	custom_materials = list(/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.75, /datum/material/glass=SMALL_MATERIAL_AMOUNT * 4)
+	custom_price = PAYCHECK_LOWER * 3
 	flash_protect = FLASH_PROTECTION_WELDER
 	tint = 2
 	armor_type = /datum/armor/utility_welding

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -93,10 +93,11 @@
 	name = "Welding Goggles"
 	desc = "Protects the eyes from bright flashes; approved by the mad scientist association."
 	id = "welding_goggles"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/clothing/glasses/welding
 	category = list(
+		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_ENGINEERING
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -93,7 +93,7 @@
 	name = "Welding Goggles"
 	desc = "Protects the eyes from bright flashes; approved by the mad scientist association."
 	id = "welding_goggles"
-	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 3)
 	build_path = /obj/item/clothing/glasses/welding
 	category = list(

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -94,13 +94,12 @@
 	desc = "Protects the eyes from bright flashes; approved by the mad scientist association."
 	id = "welding_goggles"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 3)
 	build_path = /obj/item/clothing/glasses/welding
 	category = list(
-		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/welding_mask
 	name = "Welding Gas Mask"

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -27,6 +27,7 @@
 		/obj/item/multitool = 2,
 		/obj/item/weldingtool/hugetank = 2,
 		/obj/item/clothing/head/utility/welding = 2,
+		/obj/item/clothing/glasses/welding = 2,
 		/obj/item/clothing/gloves/color/yellow = 1,
 	)
 	refill_canister = /obj/item/vending_refill/youtool

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -14,6 +14,7 @@
 		/obj/item/analyzer = 5,
 		/obj/item/t_scanner = 5,
 		/obj/item/screwdriver = 5,
+		/obj/item/clothing/head/utility/welding = 2,
 		/obj/item/flashlight/glowstick = 3,
 		/obj/item/flashlight/glowstick/red = 3,
 		/obj/item/flashlight = 5,
@@ -26,7 +27,6 @@
 		/obj/item/storage/belt/utility = 2,
 		/obj/item/multitool = 2,
 		/obj/item/weldingtool/hugetank = 2,
-		/obj/item/clothing/head/utility/welding = 2,
 		/obj/item/clothing/glasses/welding = 2,
 		/obj/item/clothing/gloves/color/yellow = 1,
 	)


### PR DESCRIPTION
## About The Pull Request

Balances welding goggles cost and adds and YouTool

## Why It's Good For The Game

Moths need double eye protection for welding, but can't get both sets without the protolathe access. This gives them a source to buy without pestering a department. Since they are an upgrade over the welding helmet, adjusted the material cost and vendor price over the helmet.

## Changelog

:cl: LT3
balance: Welding goggles price increase
balance: Welding goggles are available in the YouTool vendor
/:cl: