### PR TITLE
Barcode scanners can now be printed.

### DIFF
--- a/code/modules/library/barcode_scanner.dm
+++ b/code/modules/library/barcode_scanner.dm
@@ -6,6 +6,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
 	///Weakref to the library computer we are connected to.
 	var/datum/weakref/computer_ref
 	///The current scanning mode (BARCODE_SCANNER_CHECKIN|BARCODE_SCANNER_INVENTORY)

--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -580,3 +580,14 @@
 		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MOUNTS,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/barcode_scanner
+	name = "Barcode Scanner"
+	id = "barcode_scanner"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
+	build_path = /obj/item/barcodescanner
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_SERVICE,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1187,6 +1187,7 @@
 		"crewconsole",
 		"idcard",
 		"libraryconsole",
+		"barcode_scanner",
 		"mining",
 		"rdcamera",
 		"seccamera",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1180,14 +1180,14 @@
 	description = "Computers and how they work."
 	prereq_ids = list("datatheory")
 	design_ids = list(
+		"bankmachine",
+		"barcode_scanner",
 		"cargo",
 		"cargorequest",
 		"comconsole",
-		"bankmachine",
 		"crewconsole",
 		"idcard",
 		"libraryconsole",
-		"barcode_scanner",
 		"mining",
 		"rdcamera",
 		"seccamera",


### PR DESCRIPTION
## About The Pull Request

Currently the only way to get a barcode scanner is by spawning as a Curator, this is lame and prevents people to job change into a librarian, so now it can be printed like basically all other service job's tools.

Part of computer tech
![image](https://github.com/tgstation/tgstation/assets/53777086/26254e14-b957-41e4-9349-bd4bf848c18c)

## Why It's Good For The Game

You no longer have to spawn as a Curator to be able to work in the Library, and Curators can now replace their otherwise completely irreplaceable equipment.

## Changelog

:cl:
qol: The barcode scanner is now part of computer tech and can be printed at the service techfab.
/:cl: