### PR TITLE
Fix set_light colour parameters for ethereal disco ball

### DIFF
--- a/code/game/objects/items/etherealdiscoball.dm
+++ b/code/game/objects/items/etherealdiscoball.dm
@@ -61,7 +61,7 @@
 /obj/structure/etherealball/proc/DiscoFever()
 	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
 	current_color = random_color()
-	set_light(range, power, current_color)
+	set_light(range, power, "#[current_color]")
 	add_atom_colour("#[current_color]", FIXED_COLOUR_PRIORITY)
 	update_appearance()
 	TimerID = addtimer(CALLBACK(src, PROC_REF(DiscoFever)), 5, TIMER_STOPPABLE)  //Call ourselves every 0.5 seconds to change colors


### PR DESCRIPTION
:cl: optimumtact, whomst didn't write this CL entry.
fix: Fixed the colorful lights of the ethereal disco ball.
/:cl: