### PR TITLE
Client colo(u)r no longer uses Client.color, now coloring the render game plane instead

### DIFF
--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -47,24 +47,24 @@
 	var/list/color = rgb2num(HTMLstring)
 	return rgb(255 - color[1], 255 - color[2], 255 - color[3])
 
-///Flash a color on the client
+///Flash a color on the passed mob
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)
-	var/client/flashed_client
+	var/mob/flashed_mob
 	if(ismob(mob_or_client))
-		var/mob/client_mob = mob_or_client
-		if(client_mob.client)
-			flashed_client = client_mob.client
-		else
-			return
+		flashed_mob = mob_or_client
 	else if(istype(mob_or_client, /client))
-		flashed_client = mob_or_client
+		var/client/flashed_client = mob_or_client
+		flashed_mob = flashed_client.mob
 
-	if(!istype(flashed_client))
+	if(!istype(flashed_mob))
 		return
 
-	var/animate_color = flashed_client.color
-	flashed_client.color = flash_color
-	animate(flashed_client, color = animate_color, time = flash_time)
+	var/datum/client_colour/temp/temp_color = new(flashed_mob)
+	temp_color.colour = flash_color
+	temp_color.fade_in = flash_time * 0.25
+	temp_color.fade_out = flash_time * 0.25
+	QDEL_IN(temp_color, (flash_time * 0.5) + 1)
+	flashed_mob.add_client_colour(temp_color)
 
 /// Blends together two colors (passed as 3 or 4 length lists) using the screen blend mode
 /// Much like multiply, screen effects the brightness of the resulting color
@@ -103,4 +103,3 @@
 
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
-

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -63,6 +63,7 @@
 	. = ..()
 	if(!same_z_layer)
 		relayer_fullscreens()
+		update_client_colour()
 
 /mob/proc/relayer_fullscreens()
 	var/turf/our_lad = get_turf(src)
@@ -223,4 +224,3 @@
 	icon_state = "noise"
 	color = "#04a8d1"
 	alpha = 80
-

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -63,7 +63,6 @@
 	. = ..()
 	if(!same_z_layer)
 		relayer_fullscreens()
-		update_client_colour()
 
 /mob/proc/relayer_fullscreens()
 	var/turf/our_lad = get_turf(src)


### PR DESCRIPTION
## About The Pull Request

Rather than utilizing `client.color`, client color datums now apply their colors to the render game plane. 

This means 
1. The player's HUD is no longer affected by client colors. Being colorblind (in game) no longer makes all hud elements grey as well, only the world. 
2. Overall, less harsh colors. 

## Why It's Good For The Game

1. The player's HUD, being an OOC concept, should remain unaffected by stuff like glasses and blindness. This is how it worked in the past, before plane cube (IIRC), but it was lost in the transition. 
2. Overall just looks a lot better, IMO. 

Here's what meson goggles with glasses colors active looks like:

Before: 

![image](https://github.com/tgstation/tgstation/assets/51863163/081b69b2-e545-48f8-9016-071107b2c4c1)

After: 

![image](https://github.com/tgstation/tgstation/assets/51863163/8a823a82-3953-4889-9594-ccae87843c00)


## Changelog

:cl: Melbert
qol: Glasses colors should be a lot less harsh, and being blind no longer also blinds your hud. 
/:cl:
