### PR TITLE
Fix null in blood brother checking

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -63,7 +63,7 @@
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
 
-	for(var/datum/objective/brother_objective in source.mind.get_all_objectives())
+	for(var/datum/objective/brother_objective as anything in source.mind.get_all_objectives())
 		// If the objective has a target, are we flashing them?
 		if(flashed == brother_objective.target?.current)
 			flashed.balloon_alert(source, "that's your target!")

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -64,7 +64,8 @@
 		return
 
 	for(var/datum/objective/brother_objective in source.mind.get_all_objectives())
-		if(flashed == brother_objective.target.current)
+		// If the objective has a target, are we flashing them?
+		if(flashed == brother_objective.target?.current)
 			flashed.balloon_alert(source, "that's your target!")
 			return
 


### PR DESCRIPTION
## About The Pull Request
BB conversions were borked a little in #81305
Currently they cannot flash people because of a missing null check in the conversion code.

## Why It's Good For The Game
It is good when things work

## Changelog
:cl:
fix: blood brothers should now properly succeed in converting non-targets
/:cl:
