### PR TITLE
Fixes icebox ore generation

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -1,7 +1,7 @@
 /datum/map_generator/cave_generator/icemoon
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/snow/icemoon = 19, /turf/open/misc/ice/icemoon = 1)
 	weighted_closed_turf_types = list(
-		/turf/closed/mineral/snowmountain/icemoon = 100,
+		/turf/closed/mineral/random/snow = 100,
 		/turf/closed/mineral/gibtonite/ice/icemoon = 4,
 	)
 
@@ -70,7 +70,7 @@
 /datum/map_generator/cave_generator/icemoon/surface/noruins //use this for when you don't want ruins to spawn in a certain area
 
 /datum/map_generator/cave_generator/icemoon/deep
-	weighted_closed_turf_types = list(/turf/closed/mineral/snowmountain/icemoon = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/random/snow = 1)
 	weighted_mob_spawn_list = list(
 		SPAWN_MEGAFAUNA = 1,
 		/mob/living/basic/mining/ice_demon = 100,


### PR DESCRIPTION
## About The Pull Request

Simple as the title, the last PR https://github.com/tgstation/tgstation/pull/81103 i think missed the ores that go around the vents as seen below
![image](https://github.com/tgstation/tgstation/assets/22140677/a6ba27b5-ce9e-4989-828a-67d81eca624b)

It's calling wall turfs that have no ore generation inbedded in them, this corrects that
![image](https://github.com/tgstation/tgstation/assets/22140677/52307a76-b992-4d23-be68-f81b019dbac1)

## Why It's Good For The Game
## Changelog
:cl:
fix: icebox ore generation underground is normal again
/:cl:
