### PR TITLE
Reviving stasis now puts you in stasis

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -40,6 +40,7 @@
 		return
 
 	changeling.fakedeath(CHANGELING_TRAIT)
+	ADD_TRAIT(changeling, TRAIT_STASIS, CHANGELING_TRAIT)
 	addtimer(CALLBACK(src, PROC_REF(ready_to_regenerate), changeling), fakedeath_duration * duration_modifier, TIMER_UNIQUE)
 	// Basically, these let the ling exit stasis without giving away their ling-y-ness if revived through other means
 	RegisterSignal(changeling, SIGNAL_REMOVETRAIT(TRAIT_DEATHCOMA), PROC_REF(fakedeath_reset))
@@ -54,6 +55,7 @@
 		revive_ready = FALSE
 		build_all_button_icons(UPDATE_BUTTON_NAME|UPDATE_BUTTON_ICON)
 
+	REMOVE_TRAIT(changeling, TRAIT_STASIS, CHANGELING_TRAIT)
 	UnregisterSignal(changeling, SIGNAL_REMOVETRAIT(TRAIT_DEATHCOMA))
 	UnregisterSignal(changeling, COMSIG_MOB_STATCHANGE)
 


### PR DESCRIPTION
## About The Pull Request

In the title, Changeling's "Revival Stasis" ability with the description "We fall into a stasis", now puts you in stasis

## Why It's Good For The Game

I just found out that this doesn't actually put you in stasis and it's kinda fucked up, it's in the name it's in the description, why is it not the actual case?

It would be nice if Changelings can use this ability to actually fake death from critical condition without risking a death gasp when they die for real just because you got oxygen damage while in your "stasis", thus going against the defibrillator explosion ability.

## Changelog

:cl:
add: Changeling's reviving stasis ability now puts you in stasis.
/:cl: