### PR TITLE
SM cascade warnings only show to players in game

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/cascade_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/cascade_delam.dm
@@ -28,8 +28,7 @@
 		"Something feels very off.",
 		"A drowning sense of dread washes over you.",
 	)
-	for(var/mob/victim as anything in GLOB.player_list)
-		to_chat(victim, span_danger(pick(messages)))
+	dispatch_announcement_to_players(span_danger(pick(messages)), should_play_sound = FALSE)
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/81337

## Changelog

:cl: LT3
fix: SM cascade delam messages no longer display to clients not in game
/:cl: