### PR TITLE
fix return_inv() returning a null sometimes, causing get_all_gear() to runtime

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -605,12 +605,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  */
 /datum/storage/proc/return_inv(recursive = TRUE)
 	var/list/ret = list()
-	ret |= real_location.contents
 
 	for(var/atom/found_thing as anything in real_location)
 		ret |= found_thing
-		if(recursive)
-			ret |= found_thing.atom_storage?.return_inv(ret, recursive = TRUE)
+		if(recursive && found_thing.atom_storage)
+			ret |= found_thing.atom_storage.return_inv(recursive = TRUE)
 
 	return ret
 


### PR DESCRIPTION

## About The Pull Request

Fixes the return_inv() proc of datum/storage returning a null in addition to inventory items. This caused get_all_gear() proc of mob/living to runtime at times, because it would try to recursively access a null's inventory...
## Why It's Good For The Game

Bugs bad.
## Changelog
:cl:
fix: fix heretic's rust mark failing to damage any items if the victim has any container on them with another item inside, and maybe other bugs of similar nature
/:cl:
