### PR TITLE
fixes the crystallizer providing itself as the dangerous recipe made + fixes the max temperature on the HFR interface

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -228,8 +228,8 @@
 			var/obj/creation = new path(get_step(src, SOUTH))
 			creation.name = "[quality_control] [creation.name]"
 			if(selected_recipe.dangerous)
-				investigate_log("has been created in the crystallizer.", INVESTIGATE_ENGINE)
-				message_admins("[src] has been created in the crystallizer [ADMIN_JMP(src)].")
+				investigate_log("[creation.name] has been created in the crystallizer.", INVESTIGATE_ENGINE)
+				message_admins("[creation.name] has been created in the crystallizer [ADMIN_JMP(src)].")
 
 
 	quality_loss = 0

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.tsx
@@ -18,7 +18,7 @@ type GasCellProps = {
 };
 
 type RecipeProps = {
-  base_max_temperature: number;
+  baseMaxTemperature: number;
   enableRecipeSelection: boolean;
   onRecipe: (recipe: string) => void;
 };
@@ -88,7 +88,7 @@ const recipe_effect_structure: Recipe[] = [
     override_base: 0.85,
     scale: 1.15,
     tooltip: (v, d) =>
-      'Maximum: ' + (d.base_max_temperature * v).toExponential() + ' K',
+      'Maximum: ' + (d.baseMaxTemperature * v).toExponential() + ' K',
   },
 ];
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.tsx
@@ -18,7 +18,7 @@ type GasCellProps = {
 };
 
 type RecipeProps = {
-  baseMaxTemperature: number;
+  base_max_temperature: number;
   enableRecipeSelection: boolean;
   onRecipe: (recipe: string) => void;
 };
@@ -88,7 +88,7 @@ const recipe_effect_structure: Recipe[] = [
     override_base: 0.85,
     scale: 1.15,
     tooltip: (v, d) =>
-      'Maximum: ' + (d.baseMaximumTemperature * v).toExponential() + ' K',
+      'Maximum: ' + (d.base_max_temperature * v).toExponential() + ' K',
   },
 ];
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.tsx
@@ -86,7 +86,7 @@ const HypertorusMainControls = (props) => {
       </Stack>
       <Collapsible title="Recipe selection">
         <HypertorusRecipes
-          base_max_temperature={base_max_temperature}
+          baseMaxTemperature={base_max_temperature}
           enableRecipeSelection={power_level === 0}
           onRecipe={(id) => act('fuel', { mode: id })}
         />

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.tsx
@@ -86,7 +86,7 @@ const HypertorusMainControls = (props) => {
       </Stack>
       <Collapsible title="Recipe selection">
         <HypertorusRecipes
-          baseMaxTemperature={base_max_temperature}
+          base_max_temperature={base_max_temperature}
           enableRecipeSelection={power_level === 0}
           onRecipe={(id) => act('fuel', { mode: id })}
         />


### PR DESCRIPTION

## About The Pull Request
the crystallizer gave itself as the dangerous recipe created instead of the created thing

the HFR temp thingie was typed incorrectly
## Why It's Good For The Game
the correct information is shown ingame
![image](https://github.com/tgstation/tgstation/assets/59183821/a3b12370-c3f5-4563-ac67-b79aeeccbe6f)
yummy yummy temperature
## Changelog
:cl:
fix: The HFR now provides the max temperature for recipes
fix: the crystallizer now provides the dangerous object created instead of itself in admin logging
/:cl:
