### PR TITLE
Fix finger gun chat messages

### DIFF
--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -46,4 +46,5 @@
 
 /datum/action/cooldown/spell/pointed/projectile/finger_guns/before_cast(atom/cast_on)
 	. = ..()
-	invocation = span_notice("<b>[cast_on]</b> fires [cast_on.p_their()] finger gun!")
+	if(!isnull(owner))
+		invocation = span_notice("<b>[owner]</b> fires [owner.p_their()] finger gun!")

--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -46,5 +46,7 @@
 
 /datum/action/cooldown/spell/pointed/projectile/finger_guns/before_cast(atom/cast_on)
 	. = ..()
-	if(!isnull(owner))
+	if(isnull(owner))
+		invocation = initial(invocation)
+	else
 		invocation = span_notice("<b>[owner]</b> fires [owner.p_their()] finger gun!")


### PR DESCRIPTION
## About The Pull Request

It should not say "[the guy that you're aiming at] fires their gun"

## Changelog

:cl: Melbert
fix: Fixed Finger Guns giving a misleading chat message
/:cl:

