### PR TITLE
Fix `get_visual_offset` results being reversed

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -233,8 +233,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 	//Irregular objects
 	var/list/icon_dimensions = get_icon_dimensions(checked_atom.icon)
-	var/checked_atom_icon_height = icon_dimensions["width"]
-	var/checked_atom_icon_width = icon_dimensions["height"]
+	var/checked_atom_icon_height = icon_dimensions["height"]
+	var/checked_atom_icon_width = icon_dimensions["width"]
 	if(checked_atom_icon_height != world.icon_size || checked_atom_icon_width != world.icon_size)
 		pixel_x_offset += ((checked_atom_icon_width / world.icon_size) - 1) * (world.icon_size * 0.5)
 		pixel_y_offset += ((checked_atom_icon_height / world.icon_size) - 1) * (world.icon_size * 0.5)


### PR DESCRIPTION
## About The Pull Request

Height -> width, width -> height

## Changelog

:cl: Melbert
fix: You know that one bug that makes the cryo cells on Deltastation unusuable? Well it's not fixed but at least those cryo cells are usuable again, maybe at the cost of another station's cryo cells. Who knows!
/:cl:
