### PR TITLE
`pixel_w` and `pixel_z` are included in `get_visual_offset`

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -228,8 +228,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	//Find checked_atom's matrix so we can use it's X/Y pixel shifts
 	var/matrix/atom_matrix = matrix(checked_atom.transform)
 
-	var/pixel_x_offset = checked_atom.pixel_x + atom_matrix.get_x_shift()
-	var/pixel_y_offset = checked_atom.pixel_y + atom_matrix.get_y_shift()
+	var/pixel_x_offset = checked_atom.pixel_x + checked_atom.pixel_w + atom_matrix.get_x_shift()
+	var/pixel_y_offset = checked_atom.pixel_y + checked_atom.pixel_z + atom_matrix.get_y_shift()
 
 	//Irregular objects
 	var/list/icon_dimensions = get_icon_dimensions(checked_atom.icon)


### PR DESCRIPTION
## About The Pull Request

Closes #81095

Includes `pixel_w` and `pixel_z` in calculating an icon's `get_visual_offset`. 

Why? In particular, `get_visual_offset` is supposed to return how _visually_ offset an atom is from its loc. 

`pixel_w` and `pixel_z`, while they do not physically represent the same things as `pixel_x` and `pixel_y` (in that they're actually vertical (as seen with client dir)), still contribute to where an atom visually sits to the user. 

You may call this another nail in the client dir coffin if you wish. This proc is intended for visual use anyways, so anything using it for physical boundaries is wrong anyways. 

## Changelog

:cl: Melbert
fix: Fixed some situations in which you couldn't interact with heretic runes
/:cl:

