### PR TITLE
Removes Halloween Screen Tint

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -80,10 +80,6 @@
 /atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
-	if(check_holidays(HALLOWEEN))
-		// Makes things a tad greyscale (leaning purple) and drops low colors for vibes
-		// We're basically using alpha as better constant here btw
-		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.13,0, 0.13,0.7,0.13,0, 0.13,0.13,0.75,0, -0.06,-0.09,-0.08,1, 0,0,0,0)))
 
 /atom/movable/screen/plane_master/rendering_plate/game_plate/show_to(mob/mymob)
 	. = ..()


### PR DESCRIPTION
## What

Reverts tgstation/tgstation#79062

## Why

It was a good idea (I swear) but as an everpresent effect it is far too oppressive and opinionated. It causes issues for people with less then perfect vision, fucked monitor setups (many people it seems) or those who play in the day (can you tell when I do most of my development?)

I plan on reusing the concept of bracketing to implement conditional nightvision that makes bright things blow out your screen and such, but that's not happening for a while. I still think it was pretty but it's not worth it

## Changelog
:cl:
del: Removes halloween screen tint, we're taking him to retire by the seaside (he was alone and unloved)
/:cl: