### PR TITLE
Lock mark now causes the victim to drop their items when triggered

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -112,8 +112,9 @@
 /datum/heretic_knowledge/mark/lock_mark
 	name = "Mark of Lock"
 	desc = "Your Mansus Grasp now applies the Mark of Lock. \
-		Attack a marked person to bar them from all passages for the duration of the mark. \
-		This will make it so that they have no access whatsoever, even public access doors will reject them."
+		The victim will be barred from all passages for the duration of the mark, or until it is triggered. \
+		This will make it so that they have no access whatsoever, even public access doors will reject them. \
+		Attack a marked person with your sickly blade to trigger the mark, making them drop most of their items."
 	gain_text = "The Gatekeeper was a corrupt Steward. She hindered her fellows for her own twisted amusement."
 	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/lock)
 	route = PATH_LOCK

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -261,6 +261,19 @@
 	REMOVE_TRAIT(owner, TRAIT_ALWAYS_NO_ACCESS, STATUS_EFFECT_TRAIT)
 	return ..()
 
+/datum/status_effect/eldritch/lock/on_effect()
+	// Drop every item the mob has with a 50% chance
+	for(var/obj/item/thing in owner.get_all_gear())
+		// Since dropping the suit will also drop several other slots, make the chance of dropping it lower further.
+		// This only checks whether the item is a suit, and so will affect not only the equipped suit, but also any other suits they happen to have in their inventory. Do we care? Not really.
+		var/drop_probability = 50
+		if(istype(thing,/obj/item/clothing/under))
+			drop_probability = 25
+		if(prob(drop_probability))
+			owner.dropItemToGround(thing)
+
+	return ..()
+
 // MARK OF MOON
 
 /datum/status_effect/eldritch/moon


### PR DESCRIPTION

## About The Pull Request

Out of all heretic's mark effects, the lock path is the only one with no effect on trigger. This is odd, because it seems like we would want to reward the heretic for triggering the mark, but in lock mark's case, all this does is cancel the ongoing effect and give no reward in exchange, actively discouraging using the sickly blade and triggering the mark. Other marks with an ongoing effect all have a trigger effect too, to give a reward for ending the former. This PR adds an effect that makes the victim drop most of their items (50% chance for each item, but only a 25% chance for jumpsuits, because dropping a jumpsuit usually means dopping several other items too).
## Why It's Good For The Game

Heretics should want to trigger their marks, or at least get something out of it apart from just cancelling a beneficial effect. Dropping items thematically fits with lock's theme of burglary and access.
## Changelog
:cl:
add: Mark of the lock now causes the victims to drop most of their items when triggered.
/:cl:
