### PR TITLE
Nuka Cola causes irradiation

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -454,8 +454,9 @@
 	affected_mob.set_drugginess(1 MINUTES * REM * seconds_per_tick)
 	affected_mob.adjust_dizzy(3 SECONDS * REM * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-40 * REM * seconds_per_tick)
+	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
 	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM * seconds_per_tick, 100)
 
 /datum/reagent/consumable/rootbeer
 	name = "root beer"

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -456,7 +456,7 @@
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
 	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
 	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM * seconds_per_tick, 100)
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM * seconds_per_tick, 90)
 
 /datum/reagent/consumable/rootbeer
 	name = "root beer"

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -456,7 +456,8 @@
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
 	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
 	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM * seconds_per_tick, 90)
+	if (SSradiation.can_irradiate_basic(affected_mob))
+		affected_mob.AddComponent(/datum/component/irradiated)
 
 /datum/reagent/consumable/rootbeer
 	name = "root beer"


### PR DESCRIPTION
## About The Pull Request

Nuka Cola now causes irradiation. 

## Why It's Good For The Game

Most of our speed bonuses, such as Methamphetamine, comes with a downside (the usual one being brain damage), because speed is king. 

When you give people a speed boost that comes with absolutely NO downsides outside of visual, it turns out people abuse it, a lot. 

Even a small speed boost ends up being abused.  It is not uncommon to see security officers saddled with two, three bottles. Nor is it uncommon to see tiders use it to escape said officers, or antags to escape said tiders. Do you see the problem here? It has become a situation where not having it puts you at a disadvantage, which is sad. 

Irradiation fits thematically, too. And it also shows you when someone's using it, since they start glowing green. 

## Changelog

:cl: Melbert
balance: Scientists have discovered Nuka Cola is not good for short term health. 
/:cl:


