### PR TITLE
Cucumber Lemonade now has a price

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -1170,6 +1170,7 @@
 	quality = DRINK_GOOD
 	taste_description = "citrus soda with cucumber"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	glass_price = DRINK_PRICE_HIGH
 
 /datum/reagent/consumable/cucumberlemonade/on_mob_life(mob/living/carbon/doll, seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

One of the bar restaurant bots asks for cucumber lemonade but it has no price attached to it, so it takes this drink (that requires help from botany) and gives nothing in exchange, this fixes that.

## Why It's Good For The Game

bug fix

## Changelog

:cl:
fix: Bar bots asking for Cucumber Lemonade now gives you money for completing it.
/:cl: