### PR TITLE
Space dragon no longer turns the entire roundend report bold

### DIFF
--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -263,7 +263,7 @@
 			players_to_carp_taken[carpy.key] += 1
 		var/list = ""
 		for(var/carp_user in players_to_carp_taken)
-			list += "<li><b>[carp_user]<b>, who played <b>[players_to_carp_taken[carp_user]]</b> space carps.</li>"
+			list += "<li><b>[carp_user]</b>, who played <b>[players_to_carp_taken[carp_user]]</b> space carps.</li>"
 		parts += list
 		parts += "</ul>"
 


### PR DESCRIPTION
## About The Pull Request

Fixes the entire roundend report turning bold if there was a space dragon with carp.

## Why It's Good For The Game

yet another roundend report issue fixed.

## Changelog

:cl:
fix: Space Dragon's carp allies no longer turn the entire roundend report into bold.
/:cl: