### PR TITLE
Adds a signal to buying items from the uplink (& fixes TC misinfo)

### DIFF
--- a/code/__DEFINES/dcs/signals/uplink.dm
+++ b/code/__DEFINES/dcs/signals/uplink.dm
@@ -1,0 +1,2 @@
+///Signal sent to a mob when they purchase an item from their uplink: (datum/uplink_handler/uplink_handler_source, atom/spawned_item, mob/user)
+#define COMSIG_ON_UPLINK_PURCHASE "comsig_on_uplink_purchase"

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -113,15 +113,6 @@
 	new /obj/effect/decal/cleanable/ash(get_turf(uplink_item))
 	qdel(uplink_item)
 
-/// Adds telecrystals to the uplink. It is bad practice to use this outside of the component itself.
-/datum/component/uplink/proc/add_telecrystals(telecrystals_added)
-	set_telecrystals(uplink_handler.telecrystals + telecrystals_added)
-
-/// Sets the telecrystals of the uplink. It is bad practice to use this outside of the component itself.
-/datum/component/uplink/proc/set_telecrystals(new_telecrystal_amount)
-	uplink_handler.telecrystals = new_telecrystal_amount
-	uplink_handler.on_update()
-
 /datum/component/uplink/InheritComponent(datum/component/uplink/uplink)
 	lockable |= uplink.lockable
 	active |= uplink.active

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -135,7 +135,7 @@
 	if(!silent)
 		to_chat(user, span_notice("You slot [telecrystals] into [parent] and charge its internal uplink."))
 	var/amt = telecrystals.amount
-	uplink_handler.telecrystals += amt
+	uplink_handler.add_telecrystals(amt)
 	telecrystals.use(amt)
 	log_uplink("[key_name(user)] loaded [amt] telecrystals into [parent]'s uplink")
 

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -22,7 +22,7 @@
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
 	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(target.type), PROC_REF(used))
-	
+
 /datum/element/uplink_reimburse/Detach(datum/target)
 	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(target.type), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
 
@@ -47,10 +47,11 @@
 
 	to_chat(user, span_notice("You tap [uplink_comp.uplink_handler] with [refund_item], and a moment after [refund_item] disappears in a puff of red smoke!"))
 	do_sparks(2, source = uplink_comp.uplink_handler)
-	uplink_comp.add_telecrystals(refundable_tc)
+	uplink_comp.uplink_handler.add_telecrystals(refundable_tc)
 	qdel(refund_item)
+
 /// If the item is used, it needs to no longer be refundable
 /datum/element/uplink_reimburse/proc/used(datum/target)
 	SIGNAL_HANDLER
-	
+
 	Detach(target)

--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -457,9 +457,14 @@
 				if(check_rights(R_FUN))
 					var/datum/component/uplink/U = find_syndicate_uplink()
 					if(U)
-						var/crystals = input("Amount of telecrystals for [key]","Syndicate uplink", U.uplink_handler.telecrystals) as null | num
-						if(!isnull(crystals))
-							U.uplink_handler.telecrystals = crystals
+						var/crystals = tgui_input_number(
+							user = usr,
+							message = "Amount of telecrystals for [key]",
+							title = "Syndicate uplink",
+							default = U.uplink_handler.telecrystals,
+							)
+						if(crystals && isnum(crystals))
+							U.uplink_handler.set_telecrystals(crystals)
 							message_admins("[key_name_admin(usr)] changed [current]'s telecrystal count to [crystals].")
 							log_admin("[key_name(usr)] changed [current]'s telecrystal count to [crystals].")
 			if("progression")

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -21,7 +21,7 @@
 
 		var/datum/component/uplink/hidden_uplink = uplink.GetComponent(/datum/component/uplink)
 		if(hidden_uplink)
-			hidden_uplink.add_telecrystals(amount)
+			hidden_uplink.uplink_handler.add_telecrystals(amount)
 			use(amount)
 			to_chat(user, span_notice("You press [src] onto yourself and charge your hidden uplink."))
 	return ITEM_INTERACT_SUCCESS

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -118,7 +118,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
 
 	for (var/datum/component/uplink/uplink in uplinks)
-		uplink.add_telecrystals(tc_per_nukie)
+		uplink.uplink_handler.add_telecrystals(tc_per_nukie)
 		tc_to_distribute -= tc_per_nukie
 
 	for (var/mob/living/L in orphans)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -63,7 +63,7 @@
 		var/extra_tc = CEILING(GLOB.joined_player_list.len/5, 5)
 		var/datum/component/uplink/uplink = owner.find_syndicate_uplink()
 		if (uplink)
-			uplink.add_telecrystals(extra_tc)
+			uplink.uplink_handler.add_telecrystals(extra_tc)
 
 	var/datum/component/uplink/uplink = owner.find_syndicate_uplink()
 	if(uplink)
@@ -617,7 +617,7 @@
 	nukie.mind.add_antag_datum(antag_datum, src)
 
 	var/datum/component/uplink/uplink = nukie.mind.find_syndicate_uplink()
-	uplink?.set_telecrystals(tc_to_spawn)
+	uplink?.uplink_handler.set_telecrystals(tc_to_spawn)
 
 	// add some pizzazz
 	do_sparks(4, FALSE, spawn_loc)

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -191,7 +191,7 @@
 	handle_cleanup()
 	log_traitor("[key_name(handler.owner)] [objective_state == OBJECTIVE_STATE_INACTIVE? "missed" : "failed"] [to_debug_string()]")
 	if(penalty_cost)
-		handler.telecrystals -= penalty_cost
+		handler.add_telecrystals(-penalty_cost)
 		objective_state = OBJECTIVE_STATE_FAILED
 	else
 		objective_state = OBJECTIVE_STATE_INVALID

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -227,7 +227,7 @@
 /// Called when rewards should be given to the user.
 /datum/traitor_objective/proc/completion_payout()
 	handler.progression_points += progression_reward
-	handler.telecrystals += telecrystal_reward
+	handler.add_telecrystals(telecrystal_reward)
 
 /// Used for sending data to the uplink UI
 /datum/traitor_objective/proc/uplink_ui_data(mob/user)

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -255,7 +255,11 @@
 
 	to_act_on.ui_perform_action(user, action)
 
-///Adds telecrystals to the uplink handler and updates the UI for any players watching.
+///Helper to add telecrystals to the uplink handler, calling set_telecrystals.
 /datum/uplink_handler/proc/add_telecrystals(amount)
-	telecrystals += amount
-	update_static_data_for_all_viewers()
+	set_telecrystals(telecrystals + amount)
+
+///Sets how many telecrystals the uplink handler has, then updates the UI for any players watching.
+/datum/uplink_handler/proc/set_telecrystals(amount)
+	telecrystals = amount
+	on_update()

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -254,3 +254,8 @@
 		return
 
 	to_act_on.ui_perform_action(user, action)
+
+///Adds telecrystals to the uplink handler and updates the UI for any players watching.
+/datum/uplink_handler/proc/add_telecrystals(amount)
+	telecrystals += amount
+	update_static_data_for_all_viewers()

--- a/code/modules/mob/living/basic/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/basic/drone/extra_drone_types.dm
@@ -33,7 +33,7 @@
 /mob/living/basic/drone/syndrone/Initialize(mapload)
 	. = ..()
 	var/datum/component/uplink/hidden_uplink = internal_storage.GetComponent(/datum/component/uplink)
-	hidden_uplink.set_telecrystals(telecrystal_count)
+	hidden_uplink.uplink_handler.set_telecrystals(telecrystal_count)
 
 /obj/effect/mob_spawn/ghost_role/drone/syndrone
 	name = "syndrone shell"

--- a/code/modules/modular_computers/computers/item/disks/virus_disk.dm
+++ b/code/modules/modular_computers/computers/item/disks/virus_disk.dm
@@ -154,7 +154,7 @@
 		hidden_uplink.uplink_handler.generate_objectives()
 		SStraitor.register_uplink_handler(hidden_uplink.uplink_handler)
 	else
-		hidden_uplink.add_telecrystals(telecrystals)
+		hidden_uplink.uplink_handler.add_telecrystals(telecrystals)
 	telecrystals = 0
 	hidden_uplink.locked = FALSE
 	hidden_uplink.active = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -357,6 +357,7 @@
 #include "code\__DEFINES\dcs\signals\signals_wash.dm"
 #include "code\__DEFINES\dcs\signals\signals_wizard.dm"
 #include "code\__DEFINES\dcs\signals\signals_xeno_control.dm"
+#include "code\__DEFINES\dcs\signals\uplink.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_attack.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_explosion.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_lighting.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a signal when someone buys an item from the uplink and removes single-letter vars from the ``spawn_item`` proc, and adds/standardizes add/removing of telecrystals from uplinks (and admin setting how much TC they have) to ensure the UI always has the right amount of telecrystals displayed in it.

## Why It's Good For The Game

There are reasons why someone would want to hook up to a traitor's uplink and listen to items they purchase to do any special effect on-purchase, so this adds support to do anything in the future with it.
Also tells players how much TC they actually have without forcing them to close/reopen the UI every time they insert some TC in it by hand.

## Changelog

:cl:
fix: Uplinks now update their UI when you add telecrystals in them, so you don't need to close and reopen it.
/:cl: