### PR TITLE
Fixes the typepath of the shove blocker module.

### DIFF
--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -579,7 +579,7 @@
 #undef STORMTROOPER_MODE
 #undef SHARPSHOOTER_MODE
 
-/obj/item/mod/module/anti_stagger
+/obj/item/mod/module/shove_blocker
 	name = "MOD bulwark module"
 	desc = "Layers upon layers of shock dampening plates, just to stop you from getting shoved into a wall by an angry mob."
 	icon_state = "bulwark"


### PR DESCRIPTION

## About The Pull Request

The bulwark module had the wrong typepath for most of the descriptive elements and its complexity. So the shove block was a free module. And technically not incompatible with itself. Oh my.

Not super relevant for actual play, as there is no access to this module anywhere currently, but who knows.

## Why It's Good For The Game

Typepaths.

## Changelog
:cl:
fix: The shove blocker module parent type now has the correct typepath.
/:cl:
