### PR TITLE
Fixes high power consumption for lathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -274,7 +274,7 @@
 	var/charge_per_item = 0
 	for(var/material in design.materials)
 		charge_per_item += design.materials[material]
-	charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * material_cost_coefficient * 0.1 * active_power_usage)
+	charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * material_cost_coefficient * 0.05 * active_power_usage)
 	var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
 
 	//do the printing sequentially

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -97,7 +97,7 @@
 
 	flick("autolathe_[item_inserted.has_material_type(/datum/material/glass) ? "r" : "o"]", src)
 
-	directly_use_power(round((amount_inserted / SHEET_MATERIAL_AMOUNT) * active_power_usage * 0.0025))
+	directly_use_power(ROUND_UP((amount_inserted / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * 0.01 * active_power_usage))
 
 /obj/machinery/autolathe/ui_interact(mob/user, datum/tgui/ui)
 	if(!is_operational)
@@ -273,7 +273,7 @@
 	var/charge_per_item = 0
 	for(var/material in design.materials)
 		charge_per_item += design.materials[material]
-	charge_per_item = min(active_power_usage, round(charge_per_item * material_cost_coefficient))
+	charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * material_cost_coefficient * 0.1 * active_power_usage)
 	var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
 
 	//do the printing sequentially

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -97,7 +97,8 @@
 
 	flick("autolathe_[item_inserted.has_material_type(/datum/material/glass) ? "r" : "o"]", src)
 
-	directly_use_power(ROUND_UP((amount_inserted / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * 0.01 * active_power_usage))
+	//we use initial(active_power_usage) because higher tier parts will have higher active usage but we have no benifit from it
+	directly_use_power(ROUND_UP((amount_inserted / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * 0.01 * initial(active_power_usage)))
 
 /obj/machinery/autolathe/ui_interact(mob/user, datum/tgui/ui)
 	if(!is_operational)

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -337,7 +337,7 @@
 			var/charge_per_item = 0
 			for(var/material in design.materials)
 				charge_per_item += design.materials[material]
-			charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * coefficient * 0.1 * active_power_usage)
+			charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * coefficient * 0.05 * active_power_usage)
 			var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
 
 			//start production

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -144,7 +144,8 @@
 /obj/machinery/rnd/proc/process_item(obj/item/item_inserted, list/mats_consumed, amount_inserted)
 	PRIVATE_PROC(TRUE)
 
-	if(directly_use_power(ROUND_UP((amount_inserted / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * 0.01 * active_power_usage)))
+	//we use initial(active_power_usage) because higher tier parts will have higher active usage but we have no benifit from it
+	if(directly_use_power(ROUND_UP((amount_inserted / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * 0.01 * initial(active_power_usage))))
 		var/mat_name = "iron"
 
 		var/highest_mat = 0
@@ -285,7 +286,8 @@
 			if(isnull(amount))
 				return
 
-			if(!directly_use_power(ROUND_UP((amount / MAX_STACK_SIZE) * 0.01 * active_power_usage)))
+			//we use initial(active_power_usage) because higher tier parts will have higher active usage but we have no benifit from it
+			if(!directly_use_power(ROUND_UP((amount / MAX_STACK_SIZE) * 0.01 * initial(active_power_usage))))
 				say("No power to dispense sheets")
 				return
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -23,6 +23,7 @@
 	. = ..()
 
 	cached_designs = list()
+
 	materials = AddComponent(
 		/datum/component/remote_materials, \
 		mapload, \
@@ -64,7 +65,6 @@
 	var/mutable_appearance/stripe = mutable_appearance('icons/obj/machines/research.dmi', "protolathe_stripe[panel_open ? "_t" : ""]")
 	stripe.color = stripe_color
 	. += stripe
-
 
 /obj/machinery/rnd/production/examine(mob/user)
 	. = ..()
@@ -207,6 +207,7 @@
  */
 /obj/machinery/rnd/production/proc/build_efficiency(path)
 	PRIVATE_PROC(TRUE)
+	SHOULD_BE_PURE(TRUE)
 
 	if(ispath(path, /obj/item/stack/sheet) || ispath(path, /obj/item/stack/ore/bluespace_crystal))
 		return 1

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -144,7 +144,7 @@
 /obj/machinery/rnd/proc/process_item(obj/item/item_inserted, list/mats_consumed, amount_inserted)
 	PRIVATE_PROC(TRUE)
 
-	if(directly_use_power(round((amount_inserted / SHEET_MATERIAL_AMOUNT) * active_power_usage * 0.00025)))
+	if(directly_use_power(ROUND_UP((amount_inserted / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * 0.01 * active_power_usage)))
 		var/mat_name = "iron"
 
 		var/highest_mat = 0
@@ -285,6 +285,10 @@
 			if(isnull(amount))
 				return
 
+			if(!directly_use_power(ROUND_UP((amount / MAX_STACK_SIZE) * 0.01 * active_power_usage)))
+				say("No power to dispense sheets")
+				return
+
 			materials.eject_sheets(material, amount)
 			return TRUE
 
@@ -330,7 +334,7 @@
 			var/charge_per_item = 0
 			for(var/material in design.materials)
 				charge_per_item += design.materials[material]
-			charge_per_item = min(active_power_usage, round(charge_per_item * coefficient))
+			charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * coefficient * 0.1 * active_power_usage)
 			var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
 
 			//start production


### PR DESCRIPTION
## About The Pull Request
This employs a formula that creates a relationship between total stacks of material used & the machines active power consumption

- When inserting/ejecting a full stack of materials, lathes use 1% of the machine active power usage. To put it in player terms if your apc has a normal high capacity power cell it will use 2% of power when inserting a full stack(50 sheets) of material or when ejecting a full stack of materials

-  Fixes #81366. When printing multiple items that would require a full stack of materials (50 sheets or roughly 5000 matter units) It now uses 5% of the machine active power usage. To see the comparision we will see the same examples used in the issue

    **Old Behaviour**
    - Printing 10 large beakers for tier 1 lathe would consume 48% of apc cell
    - Printing 1 circular saw for tier 1 lathe would consume 32% of apc cell
    
    **New Behaviour**
    - Printing 10 large beakers for tier 1 lathe now consumes just 5% of apc cell
    - Printing 1 circular saw for tier 1 lathe now consumes just 1% of apc cell
    - Higher tier parts will consume more power to compensate for the lower material costs because the machines active power usage increases with higher tier parts, assuming your apc has a normal high capacity power cell
      -  Printing 10 large beakers for tier 4 lathe now consumes 12% of apc cell
      -  Printing 1 circular saw for tier 4 lathe now consumes 5% of apc cell
      
This formula is experimental and i just made it up so let's see how this plays out

## Changelog
:cl:
fix: lathes now use moderate power for printing operations
/:cl:
