### PR TITLE
Freedom implant and Biodegrade works on knotted shoes

### DIFF
--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -17,16 +17,30 @@
 /obj/item/implant/freedom/activate()
 	. = ..()
 	var/mob/living/carbon/carbon_imp_in = imp_in
-	if(!carbon_imp_in.handcuffed && !carbon_imp_in.legcuffed)
+	if(!can_trigger(carbon_imp_in))
 		balloon_alert(carbon_imp_in, "no restraints!")
 		return
 
 	uses--
 
 	carbon_imp_in.uncuff()
+	var/obj/item/clothing/shoes/shoes = carbon_imp_in.shoes
+	if(istype(shoes) && shoes.tied == SHOES_KNOTTED)
+		shoes.adjust_laces(SHOES_TIED, carbon_imp_in)
+
 	if(!uses)
 		addtimer(CALLBACK(carbon_imp_in, TYPE_PROC_REF(/atom, balloon_alert), carbon_imp_in, "implant degraded!"), 1 SECONDS)
 		qdel(src)
+
+/obj/item/implant/freedom/proc/can_trigger(mob/living/carbon/implanted_in)
+	if(implanted_in.handcuffed || implanted_in.legcuffed)
+		return TRUE
+
+	var/obj/item/clothing/shoes/shoes = implanted_in.shoes
+	if(istype(shoes) && shoes.tied == SHOES_KNOTTED)
+		return TRUE
+
+	return FALSE
 
 /obj/item/implant/freedom/get_data()
 	return "<b>Implant Specifications:</b><BR> \

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -65,6 +65,18 @@
 		..()
 		return TRUE
 
+	var/obj/item/clothing/shoes/shoes = user.shoes
+	if(istype(shoes) && shoes.tied == SHOES_KNOTTED && !(shoes.resistance_flags & (INDESTRUCTIBLE|UNACIDABLE|ACID_PROOF)))
+		new /obj/effect/decal/cleanable/greenglow(shoes.drop_location())
+		user.visible_message(
+			span_warning("[user] vomits a glob of acid on [user.p_their()] tied up [shoes.name], melting [shoes.p_them()] into a pool of goo!"),
+			span_warning("We vomit acidic ooze onto our tied up [shoes.name], melting [shoes.p_them()] into a pool of goo!"),
+		)
+		log_combat(user, shoes, "melted own shoes", addition = "(biodegrade)")
+		qdel(shoes)
+		..()
+		return TRUE
+
 	user.balloon_alert(user, "already free!")
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

- Freedom Implant will un-knot knotted shoes. 
- Biodegrade will melt knotted shoes. 

## Why It's Good For The Game

Just a niche interaction idea I had. Knotted shoes are, obviously, obstructing your movement so these two tools that aim to un-obstruct your movement should do something about it, right?

Also it would be funny to see a Ling melt their own shoes. Biodegrade prioritizes handcuffs over anything else so it shouldn't be of great concern. 

## Changelog

:cl: Melbert
add: Freedom Implants and Biodegrade can you free you of the shackles of knotted shoes. 
/:cl:


