### PR TITLE
[NO GBP] Fixes raw ectoplasmic anomaly refining

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -7,6 +7,7 @@
 #define MAX_CORES_HALLUCINATION 8
 #define MAX_CORES_BIOSCRAMBLER 8
 #define MAX_CORES_DIMENSIONAL 8
+#define MAX_CORES_ECTOPLASMIC 8
 
 ///Defines for the different types of explosion a flux anomaly can have
 #define FLUX_NO_EXPLOSION 0

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -62,6 +62,7 @@ SUBSYSTEM_DEF(research)
 		/obj/item/assembly/signaler/anomaly/hallucination = MAX_CORES_HALLUCINATION,
 		/obj/item/assembly/signaler/anomaly/bioscrambler = MAX_CORES_BIOSCRAMBLER,
 		/obj/item/assembly/signaler/anomaly/dimensional = MAX_CORES_DIMENSIONAL,
+		/obj/item/assembly/signaler/anomaly/ectoplasm = MAX_CORES_ECTOPLASMIC,
 	)
 
 	/// Lookup list for ordnance briefers.

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -178,9 +178,14 @@
 		candidate_list += GLOB.current_observers_list
 		candidate_list += GLOB.dead_player_list
 
-	var/list/candidates = SSpolling.poll_candidates("Would you like to participate in a spooky ghost swarm? (Warning: you will not be able to return to your body!)", check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, group = candidate_list, pic_source = src, role_name_text = "ghost swarm")
+	var/list/candidates = SSpolling.poll_candidates("Would you like to participate in a spooky ghost swarm?", check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, group = candidate_list, pic_source = src, role_name_text = "ghost swarm")
 	for(var/mob/dead/observer/candidate_ghost as anything in candidates)
 		var/mob/living/basic/ghost/swarm/new_ghost = new(get_turf(src))
+		new_ghost.AddComponent( \
+			/datum/component/temporary_body, \
+			old_mind = candidate_ghost.mind, \
+			old_body = candidate_ghost.mind.current, \
+		)
 		ghosts_spawned += new_ghost
 		new_ghost.ghostize(FALSE)
 		new_ghost.key = candidate_ghost.key

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -178,14 +178,9 @@
 		candidate_list += GLOB.current_observers_list
 		candidate_list += GLOB.dead_player_list
 
-	var/list/candidates = SSpolling.poll_candidates("Would you like to participate in a spooky ghost swarm?", check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, group = candidate_list, pic_source = src, role_name_text = "ghost swarm")
+	var/list/candidates = SSpolling.poll_candidates("Would you like to participate in a spooky ghost swarm? (Warning: you will not be able to return to your body!)", check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, group = candidate_list, pic_source = src, role_name_text = "ghost swarm")
 	for(var/mob/dead/observer/candidate_ghost as anything in candidates)
 		var/mob/living/basic/ghost/swarm/new_ghost = new(get_turf(src))
-		new_ghost.AddComponent( \
-			/datum/component/temporary_body, \
-			old_mind = candidate_ghost.mind, \
-			old_body = candidate_ghost.mind.current, \
-		)
 		ghosts_spawned += new_ghost
 		new_ghost.ghostize(FALSE)
 		new_ghost.key = candidate_ghost.key


### PR DESCRIPTION

## About The Pull Request

This adds a proper cap for raw ectoplasmic cores, so they can actually be refined now. Cool!
## Why It's Good For The Game

Broken thing need fix oops argh.

Closes #81369.
## Changelog
:cl: Rhials
fix: You can now refine ectoplasmic raw cores at the implosion machine thing.
/:cl:
