### PR TITLE
MuleBOT UI/ID Fixes

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -35810,10 +35810,7 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/delivery,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mKD" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -30045,10 +30045,7 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/delivery,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #3";
-	suffix = "#3"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "htQ" = (
@@ -81530,10 +81527,7 @@
 	id = "warehouse_shutters";
 	name = "warehouse shutters control"
 	},
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "upB" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -58769,10 +58769,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/east,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rUz" = (
@@ -75177,10 +75174,7 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xaH" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -36569,10 +36569,7 @@
 	location = "QM #2"
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "lQH" = (
@@ -41744,10 +41741,7 @@
 	location = "QM #6"
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #6";
-	suffix = "#6"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "nIQ" = (
@@ -47921,10 +47915,7 @@
 	location = "QM #3"
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #3";
-	suffix = "#3"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "pXC" = (
@@ -52540,10 +52531,7 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "rCL" = (

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -343,11 +343,7 @@
 			if(new_id)
 				set_id(new_id)
 		if("sethome")
-			var/new_home
-			if(pda)
-				new_home = tgui_input_list(user, "Enter Home", "Mulebot Settings", GLOB.deliverybeacontags, home_destination)
-			else
-				new_home = params["value"]
+			var/new_home = tgui_input_list(user, "Enter Home", "Mulebot Settings", GLOB.deliverybeacontags, home_destination)
 			if(new_home)
 				home_destination = new_home
 		if("unload")

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -84,7 +84,8 @@
 
 	set_id(suffix || assign_random_name())
 	suffix = null
-	name = "\improper MULEbot [id]"
+	if(name == "\improper MULEbot")
+		name = "\improper MULEbot [id]"
 	set_home(loc)
 
 /mob/living/simple_animal/bot/mulebot/Exited(atom/movable/gone, direction)
@@ -335,13 +336,10 @@
 			if(new_dest)
 				set_destination(new_dest)
 		if("setid")
-			var/new_id
-			if(pda)
-				new_id = tgui_input_text(user, "Enter ID", "ID Assignment", id, MAX_NAME_LEN)
-			else
-				new_id = params["value"]
+			var/new_id = tgui_input_text(user, "Enter ID", "ID Assignment", id, MAX_NAME_LEN)
 			if(new_id)
 				set_id(new_id)
+				name = "\improper MULEbot [new_id]"
 		if("sethome")
 			var/new_home = tgui_input_list(user, "Enter Home", "Mulebot Settings", GLOB.deliverybeacontags, home_destination)
 			if(new_home)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -141,8 +141,8 @@
 	id = new_id
 
 /mob/living/simple_animal/bot/mulebot/proc/set_home(turf/home_loc)
-	if(isnull(home_loc))
-		CRASH("MULEbot [id] was requested to set a home location but no turf was provided")
+	if(!istype(home_loc))
+		CRASH("MULEbot [id] was requested to set a home location to [home_loc ? "an invalid home loc ([home_loc.type])" : "null"]")
 
 	var/obj/machinery/navbeacon/home_beacon = locate() in home_loc
 	if(!isnull(home_beacon))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -79,12 +79,13 @@
 
 	cell = new /obj/item/stock_parts/cell/upgraded(src, 2000)
 
-	var/static/mulebot_count = 0
-	mulebot_count += 1
-	set_id(suffix || id || "#[mulebot_count]")
-	suffix = null
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/mulebot)
 	diag_hud_set_mulebotcell()
+
+	set_id(suffix || assign_random_name())
+	suffix = null
+	name = "\improper MULEbot [id]"
+	set_home(loc)
 
 /mob/living/simple_animal/bot/mulebot/Exited(atom/movable/gone, direction)
 	. = ..()
@@ -137,6 +138,18 @@
 
 /mob/living/simple_animal/bot/mulebot/proc/set_id(new_id)
 	id = new_id
+
+/mob/living/simple_animal/bot/mulebot/proc/set_home(turf/home_loc)
+	if(isnull(home_loc))
+		CRASH("MULEbot [id] was requested to set a home location but no turf was provided")
+
+	var/obj/machinery/navbeacon/home_beacon = locate() in home_loc
+	if(!isnull(home_beacon))
+		home_destination = home_beacon.location
+		log_transport("[id]: MULEbot successfuly set home location to ID [home_destination] at [home_beacon.x], [home_beacon.y], [home_beacon.z]")
+		return
+
+	log_transport("[id]: MULEbot failed to set home at [home_loc.x], [home_loc.y], [home_loc.z]")
 
 /mob/living/simple_animal/bot/mulebot/bot_reset()
 	..()

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -49,6 +49,7 @@
 			var/mob/living/simple_animal/bot/mulebot/simple_mulebot = simple_bot
 			mulelist += list(list(
 				"name" = simple_mulebot.name,
+				"id" = simple_mulebot.id,
 				"dest" = simple_mulebot.destination,
 				"power" = simple_mulebot.cell ? simple_mulebot.cell.percent() : 0,
 				"home" = simple_mulebot.home_destination,
@@ -56,9 +57,8 @@
 				"autoPickup" = simple_mulebot.auto_pickup,
 				"reportDelivery" = simple_mulebot.report_delivery,
 				"mule_ref" = REF(simple_mulebot),
+				"load" = simple_mulebot.get_load_name(),
 			))
-			if(simple_mulebot.load)
-				data["load"] = simple_mulebot.load.name
 			newbot["mule_check"] = TRUE
 		botlist += list(newbot)
 

--- a/tgui/packages/tgui/interfaces/Mule.jsx
+++ b/tgui/packages/tgui/interfaces/Mule.jsx
@@ -110,28 +110,30 @@ export const Mule = (props) => {
                   onChange={(e, value) => act('setid', { value })}
                 />
               </LabeledList.Item>
+              <LabeledList.Item label="Home">
+                <Button content={home} onClick={() => act('sethome')} />
+              </LabeledList.Item>
               <LabeledList.Item label="Destination">
                 <Dropdown
                   over
                   selected={destination || 'None'}
                   options={destinations}
-                  width="150px"
+                  width="188px"
                   onSelected={(value) => act('destination', { value })}
                 />
+              </LabeledList.Item>
+              <LabeledList.Item label="Actions">
                 <Button
                   icon="stop"
+                  color="bad"
                   content="Stop"
                   onClick={() => act('stop')}
                 />
-                <Button icon="play" content="Go" onClick={() => act('go')} />
-              </LabeledList.Item>
-              <LabeledList.Item label="Home">
-                <Dropdown
-                  over
-                  selected={home}
-                  options={destinations}
-                  width="150px"
-                  onSelected={(value) => act('destination', { value })}
+                <Button
+                  icon="play"
+                  color="average"
+                  content="Go"
+                  onClick={() => act('go')}
                 />
                 <Button
                   icon="home"

--- a/tgui/packages/tgui/interfaces/Mule.jsx
+++ b/tgui/packages/tgui/interfaces/Mule.jsx
@@ -3,7 +3,6 @@ import {
   Button,
   Dropdown,
   Flex,
-  Input,
   LabeledList,
   ProgressBar,
   Section,
@@ -105,10 +104,7 @@ export const Mule = (props) => {
           >
             <LabeledList>
               <LabeledList.Item label="ID">
-                <Input
-                  value={id}
-                  onChange={(e, value) => act('setid', { value })}
-                />
+                <Button content={id} onClick={() => act('setid')} />
               </LabeledList.Item>
               <LabeledList.Item label="Home">
                 <Button content={home} onClick={() => act('sethome')} />

--- a/tgui/packages/tgui/interfaces/NtosRoboControl.jsx
+++ b/tgui/packages/tgui/interfaces/NtosRoboControl.jsx
@@ -153,8 +153,9 @@ export const RobotInfo = (props) => {
             <LabeledList.Item label="Status">{robot.mode}</LabeledList.Item>
             {mule && (
               <>
+                <LabeledList.Item label="Bot ID">{mule.id}</LabeledList.Item>
                 <LabeledList.Item label="Loaded Cargo">
-                  {data.load || 'N/A'}
+                  {mule.load || 'N/A'}
                 </LabeledList.Item>
                 <LabeledList.Item label="Home">{mule.home}</LabeledList.Item>
                 <LabeledList.Item label="Destination">

--- a/tools/UpdatePaths/Scripts/81380_mulebot_vars.txt
+++ b/tools/UpdatePaths/Scripts/81380_mulebot_vars.txt
@@ -1,1 +1,3 @@
+# Removes hardcoded mulebot home destinations and suffixes
+
 /mob/living/simple_animal/bot/mulebot : /mob/living/simple_animal/bot/mulebot{@OLD;home_destination=@SKIP;suffix=@SKIP}

--- a/tools/UpdatePaths/Scripts/88888_mulebot_vars.txt
+++ b/tools/UpdatePaths/Scripts/88888_mulebot_vars.txt
@@ -1,0 +1,1 @@
+/mob/living/simple_animal/bot/mulebot : /mob/living/simple_animal/bot/mulebot{@OLD;home_destination=@SKIP;suffix=@SKIP}


### PR DESCRIPTION
## About The Pull Request

- Fixes https://github.com/tgstation/tgstation/issues/81363
- Fixes unable to set MuleBOT home from control panel
- Fixes missing MuleBOT ID from Botkeeper PDA app
- Adds input validation for changing MuleBOT ID from control panel
- Removes hardcoding of MuleBOT IDs and home destinations
- MuleBOT will now automatically set its home to the navigation beacon on its initialization turf

## Changelog

:cl: LT3
fix: MULEbot will correctly display its loaded cargo on BotKeeper
fix: MULEbot home beacon can be set from control panel
code: MULEbot home location is automatically set on init
/:cl:
