### PR TITLE
Fixes the energy cake slice's on-eat effect triggering before it is eaten

### DIFF
--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -292,15 +292,11 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_FOOD_EATEN, PROC_REF(bite_taken))
 
-/obj/item/food/cakeslice/birthday/energy/Destroy(force)
-	UnregisterSignal(src, COMSIG_FOOD_EATEN)
-	. = ..()
-
 /obj/item/food/cakeslice/birthday/energy/attack(mob/living/target_mob, mob/living/user)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM) && target_mob != user) //Prevents pacifists from attacking others directly
 		balloon_alert(user, "that's dangerous!")
 		return FALSE
-	..()
+	return ..()
 
 /obj/item/food/cakeslice/birthday/energy/proc/bite_taken(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -288,16 +288,23 @@
 	tastes = list("cake" = 3, "a Vlad's Salad" = 1)
 	crafting_complexity = FOOD_COMPLEXITY_4
 
-/obj/item/food/cakeslice/birthday/energy/proc/energy_bite(mob/living/user)
-	to_chat(user, "<font color='red' size='5'>As you eat the cake slice, you accidentally hurt yourself on the embedded energy dagger!</font>")
-	user.apply_damage(18, BRUTE, BODY_ZONE_HEAD)
-	playsound(user, 'sound/weapons/blade1.ogg', 5, TRUE)
-
-/obj/item/food/cakeslice/birthday/energy/attack(mob/living/target_mob, mob/living/user)
+/obj/item/food/cakeslice/birthday/energy/Initialize(mapload)
 	. = ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM) && target_mob != user) //Prevents pacifists from attacking others directly
+	RegisterSignal(src, COMSIG_FOOD_EATEN, PROC_REF(bite_taken))
+
+/obj/item/food/cakeslice/birthday/energy/Destroy(force)
+	UnregisterSignal(src, COMSIG_FOOD_EATEN)
+	. = ..()
+
+/obj/item/food/cakeslice/birthday/energy/proc/bite_taken(mob/living/eater, mob/living/feeder)
+	SIGNAL_HANDLER
+	if(HAS_TRAIT(feeder, TRAIT_PACIFISM) && eater != feeder) //Prevents pacifists from attacking others directly
 		return
-	energy_bite(target_mob, user)
+	to_chat(eater, "<font color='red' size='5'>As you eat the cake slice, you accidentally hurt yourself on the embedded energy dagger!</font>")
+	if(eater != feeder)
+		log_combat(feeder, eater, "fed an energy cake to", src)
+	eater.apply_damage(18, BRUTE, BODY_ZONE_HEAD)
+	playsound(eater, 'sound/weapons/blade1.ogg', 5, TRUE)
 
 /obj/item/food/cake/apple
 	name = "apple cake"

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -296,11 +296,14 @@
 	UnregisterSignal(src, COMSIG_FOOD_EATEN)
 	. = ..()
 
-/obj/item/food/cakeslice/birthday/energy/proc/bite_taken(datum/source, mob/living/eater, mob/living/feeder)
-	SIGNAL_HANDLER
+/obj/item/food/cakeslice/birthday/energy/attack(mob/living/target_mob, mob/living/user)
+	. = ..()
 	if(HAS_TRAIT(feeder, TRAIT_PACIFISM) && eater != feeder) //Prevents pacifists from attacking others directly
 		balloon_alert(feeder, "that's dangerous!")
-		return
+		return FALSE
+
+/obj/item/food/cakeslice/birthday/energy/proc/bite_taken(datum/source, mob/living/eater, mob/living/feeder)
+	SIGNAL_HANDLER
 	to_chat(eater, "<font color='red' size='5'>As you eat the cake slice, you accidentally hurt yourself on the embedded energy dagger!</font>")
 	if(eater != feeder)
 		log_combat(feeder, eater, "fed an energy cake to", src)

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -296,9 +296,10 @@
 	UnregisterSignal(src, COMSIG_FOOD_EATEN)
 	. = ..()
 
-/obj/item/food/cakeslice/birthday/energy/proc/bite_taken(mob/living/eater, mob/living/feeder)
+/obj/item/food/cakeslice/birthday/energy/proc/bite_taken(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER
 	if(HAS_TRAIT(feeder, TRAIT_PACIFISM) && eater != feeder) //Prevents pacifists from attacking others directly
+		balloon_alert(feeder, "that's dangerous!")
 		return
 	to_chat(eater, "<font color='red' size='5'>As you eat the cake slice, you accidentally hurt yourself on the embedded energy dagger!</font>")
 	if(eater != feeder)

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -297,10 +297,10 @@
 	. = ..()
 
 /obj/item/food/cakeslice/birthday/energy/attack(mob/living/target_mob, mob/living/user)
-	. = ..()
-	if(HAS_TRAIT(feeder, TRAIT_PACIFISM) && eater != feeder) //Prevents pacifists from attacking others directly
-		balloon_alert(feeder, "that's dangerous!")
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && target_mob != user) //Prevents pacifists from attacking others directly
+		balloon_alert(user, "that's dangerous!")
 		return FALSE
+	..()
 
 /obj/item/food/cakeslice/birthday/energy/proc/bite_taken(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

This makes the energy cake deal its damage/effects AFTER being fed, instead of before.

It also adds combat logging to force-fed energy cakes, just in case.

Also, this adds a balloon alert to the pacifist check. Cool!
## Why It's Good For The Game

Fixes a wacky combat bug, and adds some minor adjustments made along the way.

Closes #81351.
## Changelog
:cl: Rhials
fix: The Energy Cake slice now does its on-eat effect AFTER being eaten, instead of before.
/:cl:
