### PR TITLE
Fix Knit Flesh

### DIFF
--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -182,6 +182,7 @@
 	carbon_victim.add_atom_colour(COLOR_DARK_RED, TEMPORARY_COLOUR_PRIORITY)
 	if(!do_after(caster, time_it_takes, carbon_victim, extra_checks = CALLBACK(src, PROC_REF(extraction_checks), picked_organ, hand, victim, caster)))
 		carbon_victim.balloon_alert(caster, "interrupted!")
+		carbon_victim.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_DARK_RED)
 		return FALSE
 
 	// Visible message done before Remove()

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -91,8 +91,8 @@
 		return FALSE
 
 	var/organ_hp_to_heal = to_heal.maxHealth * organ_percent_healing
-	if(to_heal.damage < organ_hp_to_heal)
-		to_heal.set_organ_damage(organ_hp_to_heal)
+	if(to_heal.damage > 0)
+		to_heal.set_organ_damage(max(0 , to_heal.damage - organ_hp_to_heal))
 		to_heal.balloon_alert(caster, "organ healed")
 		playsound(to_heal, 'sound/magic/staff_healing.ogg', 30)
 		new /obj/effect/temp_visual/cult/sparks(get_turf(to_heal))

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -91,17 +91,15 @@
 		return FALSE
 
 	var/organ_hp_to_heal = to_heal.maxHealth * organ_percent_healing
-	if(to_heal.damage > 0)
-		to_heal.set_organ_damage(max(0 , to_heal.damage - organ_hp_to_heal))
-		to_heal.balloon_alert(caster, "organ healed")
-		playsound(to_heal, 'sound/magic/staff_healing.ogg', 30)
-		new /obj/effect/temp_visual/cult/sparks(get_turf(to_heal))
-		caster.visible_message(
-			span_warning("[caster]'s hand glows a brilliant red as [caster.p_they()] restore \the [to_heal] to good condition!"),
-			span_notice("Your hand glows a brilliant red as you restore \the [to_heal] to good condition!"),
-		)
-	else
-		to_heal.balloon_alert(caster, "already in good condition!")
+	to_heal.set_organ_damage(max(0 , to_heal.damage - organ_hp_to_heal))
+	to_heal.balloon_alert(caster, "organ healed")
+	playsound(to_heal, 'sound/magic/staff_healing.ogg', 30)
+	new /obj/effect/temp_visual/cult/sparks(get_turf(to_heal))
+	var/condition = (to_heal.damage > 0) ? "better" : "perfect"
+	caster.visible_message(
+		span_warning("[caster]'s hand glows a brilliant red as [caster.p_they()] restore \the [to_heal] to [condition] condition!"),
+		span_notice("Your hand glows a brilliant red as you restore \the [to_heal] to [condition] condition!"),
+	)
 
 	return TRUE
 

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -85,6 +85,9 @@
 
 /// If cast on an organ, we'll restore it's health and even un-fail it.
 /datum/action/cooldown/spell/touch/flesh_surgery/proc/heal_organ(obj/item/melee/touch_attack/hand, obj/item/organ/to_heal, mob/living/carbon/caster)
+	if(to_heal.damage == 0)
+		to_heal.balloon_alert(caster, "already in good condition!")
+		return FALSE
 	to_heal.balloon_alert(caster, "healing organ...")
 	if(!do_after(caster, 1 SECONDS, to_heal, extra_checks = CALLBACK(src, PROC_REF(heal_checks), hand, to_heal, caster)))
 		to_heal.balloon_alert(caster, "interrupted!")

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -118,7 +118,7 @@
 	playsound(to_heal, 'sound/magic/staff_healing.ogg', 30)
 	new /obj/effect/temp_visual/cult/sparks(get_turf(to_heal))
 	caster.visible_message(
-		span_warning("[caster]'s hand glows a brilliant red as [caster.p_they()] restore [to_heal] to good condition!"),
+		span_warning("[caster]'s hand glows a brilliant red as [caster.p_they()] restore[caster.p_s()] [to_heal] to good condition!"),
 		span_notice("Your hand glows a brilliant red as you restore [to_heal] to good condition!"),
 	)
 	return TRUE
@@ -167,14 +167,14 @@
 
 		time_it_takes = 6 SECONDS
 		caster.visible_message(
-			span_danger("[caster]'s hand glows a brilliant red as [caster.p_they()] reach directly into [caster.p_their()] own [parsed_zone]!"),
+			span_danger("[caster]'s hand glows a brilliant red as [caster.p_they()] reach[caster.p_es()] directly into [caster.p_their()] own [parsed_zone]!"),
 			span_userdanger("Your hand glows a brilliant red as you reach directly into your own [parsed_zone]!"),
 		)
 
 	else
 		carbon_victim.visible_message(
-			span_danger("[caster]'s hand glows a brilliant red as [caster.p_they()] reach directly into [carbon_victim]'s [parsed_zone]!"),
-			span_userdanger("[caster]'s hand glows a brilliant red as [caster.p_they()] reach directly into your [parsed_zone]!"),
+			span_danger("[caster]'s hand glows a brilliant red as [caster.p_they()] reach[caster.p_es()] directly into [carbon_victim]'s [parsed_zone]!"),
+			span_userdanger("[caster]'s hand glows a brilliant red as [caster.p_they()] reach[caster.p_es()] directly into your [parsed_zone]!"),
 		)
 
 	carbon_victim.balloon_alert(caster, "extracting [chosen_organ]...")

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -195,8 +195,8 @@
 
 	else
 		carbon_victim.visible_message(
-			span_bolddanger("[caster]'s pulls [carbon_victim]'s [chosen_organ] out of [carbon_victim.p_their()] [parsed_zone]!!"),
-			span_userdanger("[caster]'s pulls your [chosen_organ] out of [carbon_victim.p_their()] [parsed_zone]!!"),
+			span_bolddanger("[caster] pulls [carbon_victim]'s [chosen_organ] out of [carbon_victim.p_their()] [parsed_zone]!!"),
+			span_userdanger("[caster] pulls your [chosen_organ] out of your [parsed_zone]!!"),
 		)
 
 	picked_organ.Remove(carbon_victim)


### PR DESCRIPTION

## About The Pull Request

Fixes Knit Flesh damaging organs instead of healing them, and also the red color overlay staying on victims forever if the organ extraction process is interrupted. Also improves some grammar and wording of the chat messages of the spell.
## Why It's Good For The Game

When a spell says it heals organs, it should not damage them instead. Also people should not stay red forever I think. And lastly we wants our chat messages to use proper english, don't we?.
## Changelog
:cl:
fix: knit flesh now heals organs as intended, and does not cause its victims to be red forever if interrupted
spellcheck: knit flesh chat messages are no longer gramatically incorrect
/:cl:
