### PR TITLE
 Fix last words being double-encoded when done from the alert popup

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -464,7 +464,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	var/mob/living/living_owner = owner
 	var/last_whisper
 	if(!HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
-		last_whisper = tgui_input_text(usr, "Do you have any last words?", "Goodnight, Sweet Prince")
+		last_whisper = tgui_input_text(usr, "Do you have any last words?", "Goodnight, Sweet Prince", encode = FALSE) // saycode already handles sanitization
 	if(isnull(last_whisper))
 		if(!HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
 			return


### PR DESCRIPTION
## About The Pull Request

Fixes succumb last words, when typed in the tgui input popup, being double-encoded/sanitized, resulting in things like this: 
![image](https://github.com/tgstation/tgstation/assets/65794972/0d60afba-becc-4ed2-8032-dee50433402c)

Upstream port of https://github.com/Monkestation/Monkestation2.0/pull/1182

## Why It's Good For The Game

This bug is annoying and makes text uglier and less readable. Also, bugs are bad. Do I even need to fill this part out for a blatant bugfix?

## Changelog
:cl:
fix: Fix succumb last words being double-encoded (i.e `i'm` becoming `i&#39;lm`)
/:cl:
