### PR TITLE
Adds a Touchy quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -5,6 +5,7 @@
 // Shifted to glob so they are generated at world start instead of risking players doing preference stuff before the subsystem inits
 GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/nearsighted),
+	list(/datum/quirk/item_quirk/blindness, /datum/quirk/touchy),
 	list(/datum/quirk/jolly, /datum/quirk/depression, /datum/quirk/apathetic, /datum/quirk/hypersensitive),
 	list(/datum/quirk/no_taste, /datum/quirk/vegetarian, /datum/quirk/deviant_tastes, /datum/quirk/gamer),
 	list(/datum/quirk/pineapple_liker, /datum/quirk/pineapple_hater, /datum/quirk/gamer),

--- a/code/datums/quirks/negative_quirks/unusual.dm
+++ b/code/datums/quirks/negative_quirks/unusual.dm
@@ -14,6 +14,7 @@
 /datum/quirk/touchy/remove()
 	UnregisterSignal(quirk_holder, COMSIG_CLICK_SHIFT)
 
+///Checks if the mob is besides the  thing being examined, if they aren't then we cancel their examinate.
 /datum/quirk/touchy/proc/examinate_check(mob/examiner, atom/examined)
 	SIGNAL_HANDLER
 

--- a/code/datums/quirks/negative_quirks/unusual.dm
+++ b/code/datums/quirks/negative_quirks/unusual.dm
@@ -1,0 +1,21 @@
+/datum/quirk/touchy
+	name = "Touchy"
+	desc = "You are very touchy and have to physically be able to touch something to examine it."
+	icon = FA_ICON_HAND
+	value = -2
+	gain_text = span_danger("You feel like you can't examine things from a distance.")
+	lose_text = span_notice("You feel like you can examine things from a distance.")
+	medical_record_text = "Patient is unable to tell objects apart from a distance."
+	hardcore_value = 4
+
+/datum/quirk/touchy/add(client/client_source)
+	RegisterSignal(quirk_holder, COMSIG_CLICK_SHIFT, PROC_REF(examinate_check))
+
+/datum/quirk/touchy/remove()
+	UnregisterSignal(quirk_holder, COMSIG_CLICK_SHIFT)
+
+/datum/quirk/touchy/proc/examinate_check(mob/examiner, atom/examined)
+	SIGNAL_HANDLER
+
+	if(!examined.Adjacent(examiner))
+		return COMSIG_MOB_CANCEL_CLICKON

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1672,6 +1672,7 @@
 #include "code\datums\quirks\negative_quirks\softspoken.dm"
 #include "code\datums\quirks\negative_quirks\tin_man.dm"
 #include "code\datums\quirks\negative_quirks\unstable.dm"
+#include "code\datums\quirks\negative_quirks\unusual.dm"
 #include "code\datums\quirks\neutral_quirks\bald.dm"
 #include "code\datums\quirks\neutral_quirks\colorist.dm"
 #include "code\datums\quirks\neutral_quirks\deviant_tastes.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a new quirk for -2 points that requires you to be next to something to examine them, like blindness but without the timer or actual blindness itself.

## Why It's Good For The Game

For the player using the quirk, it's 2 points for losing the ability to simply examine everything around you, making it harder to tell what someone has in their hands when they are charging at you, for example. You need to get up and close to things to see what they are.
For people being examined, it's just another possible excuse to be near them, opening up plausible deniability for actions such as sleepy pens, changeling stings, etc.

## Changelog

:cl: Atlasle, JohnFulpWillard
add: Adds the Touchy quirk, you need to be next to something to examine it, for 2 extra quirk points.
/:cl: