### PR TITLE
Fixes funky closet type

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -31,7 +31,7 @@
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/cup/glass/colocup(src)
 
-/obj/structure/closet/secure/closet/bar/lavaland_bartender_clothes
+/obj/structure/closet/secure_closet/bar/lavaland_bartender_clothes
 	name = "bartender's closet"
 
 /obj/structure/closet/secure_closet/bar/lavaland_bartender_clothes/PopulateContents()
@@ -39,4 +39,3 @@
 	new /obj/item/clothing/glasses/sunglasses/reagent(src)
 	new /obj/item/clothing/suit/costume/hawaiian(src)
 	new /obj/item/clothing/shoes/sandal/beach(src)
-


### PR DESCRIPTION
## About The Pull Request

`secure/closet` -> `secure_closet`.

Changes nothing besides making the mapped in closet use the right name. 

## Changelog

:cl: Melbert
fix: Lavaland Beech Bartender's clothing storage is named the right thing now
/:cl:

