### PR TITLE
reduced lathe power consumption to 5% of current values

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -273,7 +273,7 @@
 	var/charge_per_item = 0
 	for(var/material in design.materials)
 		charge_per_item += design.materials[material]
-	charge_per_item = min(active_power_usage, round(charge_per_item * material_cost_coefficient))
+	charge_per_item = min(active_power_usage, round(charge_per_item * material_cost_coefficient * 0.05))
 	var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
 
 	//do the printing sequentially

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -330,7 +330,7 @@
 			var/charge_per_item = 0
 			for(var/material in design.materials)
 				charge_per_item += design.materials[material]
-			charge_per_item = min(active_power_usage, round(charge_per_item * coefficient))
+			charge_per_item = min(active_power_usage, round(charge_per_item * coefficient * 0.05))
 			var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
 
 			//start production


### PR DESCRIPTION

## About The Pull Request

The recent refactor of lathes had an oversight that amps up power consumption by a factor of 100. This is meant to remedy it while still keeping power consumption a little higher

Adjusts lathe power consumption to 5% of current values

## Why It's Good For The Game
Circular saw currently takes 32% of base APC power to print from an unupgraded lathe, there isn't enough juice in that APC for a single doctor to print everything they need, let alone 4 or more

## Changelog
:cl:
fix: Lathe power consumption down 95%
/:cl:
