### PR TITLE
Fixes Statues emitting solid lights

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -573,43 +573,40 @@ Moving interrupts
 	var/static/list/plane_whitelist = list(FLOAT_PLANE, GAME_PLANE, FLOOR_PLANE)
 
 	/// Ideally we'd have knowledge what we're removing but i'd have to be done on target appearance retrieval
-	var/list/overlays_to_remove = list()
+	var/list/overlays_to_keep = list()
 	for(var/mutable_appearance/special_overlay as anything in content_ma.overlays)
 		var/mutable_appearance/real = new()
 		real.appearance = special_overlay
 		if(PLANE_TO_TRUE(real.plane) in plane_whitelist)
-			continue
-		overlays_to_remove += real
-	content_ma.overlays -= overlays_to_remove
+			content_ma.overlays -= real
+			real.plane = FLOAT_PLANE
+			overlays_to_keep += real
+		else
+			content_ma.overlays -= real
+	content_ma.overlays = overlays_to_keep
 
-	var/list/underlays_to_remove = list()
+	var/list/underlays_to_keep = list()
 	for(var/mutable_appearance/special_underlay as anything in content_ma.underlays)
 		var/mutable_appearance/real = new()
 		real.appearance = special_underlay
 		if(PLANE_TO_TRUE(real.plane) in plane_whitelist)
-			continue
-		underlays_to_remove += real
-	content_ma.underlays -= underlays_to_remove
+			content_ma.underlays -= real
+			real.plane = FLOAT_PLANE
+			underlays_to_keep += real
+		else
+			content_ma.underlays -= real
+	content_ma.underlays = underlays_to_keep
 
 	content_ma.appearance_flags &= ~KEEP_APART //Don't want this
 	content_ma.filters = filter(type="color",color=greyscale_with_value_bump,space=FILTER_COLOR_HSV)
-	update_content_planes()
+	content_ma.plane = FLOAT_PLANE
+	content_ma.layer = FLOAT_LAYER
 	update_appearance()
 
 /obj/structure/statue/custom/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	if(same_z_layer)
 		return ..()
-	update_content_planes()
 	update_appearance()
-
-/obj/structure/statue/custom/proc/update_content_planes()
-	if(!content_ma)
-		return
-	var/turf/our_turf = get_turf(src)
-	// MA's stored in the overlays list are not actually mutable, they've been flattened
-	// This proc unflattens them, updates them, and then reapplies
-	var/list/created = update_appearance_planes(list(content_ma), GET_TURF_PLANE_OFFSET(our_turf))
-	content_ma = created[1]
 
 /obj/structure/statue/custom/update_overlays()
 	. = ..()

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -579,7 +579,6 @@ Moving interrupts
 		real.appearance = special_overlay
 		if(PLANE_TO_TRUE(real.plane) in plane_whitelist)
 			content_ma.overlays -= real
-			real.plane = FLOAT_PLANE
 			overlays_to_keep += real
 		else
 			content_ma.overlays -= real
@@ -591,7 +590,6 @@ Moving interrupts
 		real.appearance = special_underlay
 		if(PLANE_TO_TRUE(real.plane) in plane_whitelist)
 			content_ma.underlays -= real
-			real.plane = FLOAT_PLANE
 			underlays_to_keep += real
 		else
 			content_ma.underlays -= real
@@ -599,14 +597,23 @@ Moving interrupts
 
 	content_ma.appearance_flags &= ~KEEP_APART //Don't want this
 	content_ma.filters = filter(type="color",color=greyscale_with_value_bump,space=FILTER_COLOR_HSV)
-	content_ma.plane = FLOAT_PLANE
-	content_ma.layer = FLOAT_LAYER
+	update_content_planes()
 	update_appearance()
 
 /obj/structure/statue/custom/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	if(same_z_layer)
 		return ..()
+	update_content_planes()
 	update_appearance()
+
+/obj/structure/statue/custom/proc/update_content_planes()
+	if(!content_ma)
+		return
+	var/turf/our_turf = get_turf(src)
+	// MA's stored in the overlays list are not actually mutable, they've been flattened
+	// This proc unflattens them, updates them, and then reapplies
+	var/list/created = update_appearance_planes(list(content_ma), GET_TURF_PLANE_OFFSET(our_turf))
+	content_ma = created[1]
 
 /obj/structure/statue/custom/update_overlays()
 	. = ..()

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -578,10 +578,7 @@ Moving interrupts
 		var/mutable_appearance/real = new()
 		real.appearance = special_overlay
 		if(PLANE_TO_TRUE(real.plane) in plane_whitelist)
-			content_ma.overlays -= real
 			overlays_to_keep += real
-		else
-			content_ma.overlays -= real
 	content_ma.overlays = overlays_to_keep
 
 	var/list/underlays_to_keep = list()

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -586,10 +586,7 @@ Moving interrupts
 		var/mutable_appearance/real = new()
 		real.appearance = special_underlay
 		if(PLANE_TO_TRUE(real.plane) in plane_whitelist)
-			content_ma.underlays -= real
 			underlays_to_keep += real
-		else
-			content_ma.underlays -= real
 	content_ma.underlays = underlays_to_keep
 
 	content_ma.appearance_flags &= ~KEEP_APART //Don't want this


### PR DESCRIPTION

## About The Pull Request
Fixes #63653
![Screenshot 2024-02-10 003356](https://github.com/tgstation/tgstation/assets/16868239/2fc8b2f0-81a0-40d9-9b52-bd04e66a30df)
Custom sculpted statues no longer include the light layers of objects such as lanterns and PDA lights.
## Why It's Good For The Game
No longer have to worry if sculpting someone with their lights on.
Can safely sculpt a vibebot without covering your screen in a solid circle.
## Changelog
:cl:
fix: Sculpted statues stop including light layers.
/:cl:
