### PR TITLE
Return old ore spawn

### DIFF
--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -33,11 +33,11 @@
 /// The chance of ore spawning in a wall that is VENT_PROX_HIGH tiles to a vent.
 #define VENT_CHANCE_HIGH 18
 /// The chance of ore spawning in a wall that is VENT_PROX_MEDIUM tiles to a vent.
-#define VENT_CHANCE_MEDIUM 9
+#define VENT_CHANCE_MEDIUM 10
 /// The chance of ore spawning in a wall that is VENT_PROX_LOW tiles to a vent.
-#define VENT_CHANCE_LOW 5
+#define VENT_CHANCE_LOW 8
 /// The chance of ore spawning in a wall that is VENT_PROX_FAR tiles to a vent.
-#define VENT_CHANCE_FAR 1
+#define VENT_CHANCE_FAR 7
 
 /// The number of points a miner gets for discovering a vent, multiplied by BOULDER_SIZE when completing a wave defense minus the discovery bonus.
 #define MINER_POINT_MULTIPLIER 100

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -145,7 +145,7 @@
 	if(distance < VENT_PROX_HIGH)
 		return rand(4,5)
 	if(distance < VENT_PROX_MEDIUM)
-		return rand(3,4)
+		return rand(2,4)
 	if(distance < VENT_PROX_LOW)
 		return rand(1,4)
 	if(distance < VENT_PROX_FAR)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -143,13 +143,13 @@
 	if(distance < VENT_PROX_VERY_HIGH)
 		return 5
 	if(distance < VENT_PROX_HIGH)
-		return 4
+		return rand(4,5)
 	if(distance < VENT_PROX_MEDIUM)
-		return 3
+		return rand(3,4)
 	if(distance < VENT_PROX_LOW)
-		return 2
+		return rand(1,4)
 	if(distance < VENT_PROX_FAR)
-		return 1
+		return rand(1,3)
 	return 0
 
 /turf/closed/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)


### PR DESCRIPTION
## About The Pull Request
Some time has passed since the introduction of ore vents (PR #78524 from @ArcaneMusic). They have changed the work of the miners: now they must fight with fauna to capture vents and get resources. On my (and not only) opinion, this change should have been an addition to the shaft, so you could choose whether fight for resources or dig them old way.

This PR makes chances of ore spawn higher, if say fast. In detail:
* Ore have random number of ore in vein based on its proximity to vent (old-old was flat 1 to 5 for all veins)
* * 5 near vent (3 tiles) (as in vent update)
* * 4 to 5 in 6 tiles (4 in vent update)
* * 2 to 4 in 15 tiles (3 in vent update) 
* * 1 to 4 in 32 tiles (2 in vent update)
* * 1 to 3 in 64 tiles (1 in vent update)
* Ore vein have a higher chance of spawn (old-old was 10 flat percents)
* * 10% in 15-tiles radius (just as before)
* * 8% in 32-tiles (lower, than before)
* * 7% in 64-tiles (also lower)

## Why It's Good For The Game

Shaft miners will be able to chose either to fight or to dig. Amount of ore collecting with only old way is reduced for the sake of balance. Now mining explosion, cutter and drills useful again. It also will cause less deaths from novice miners, because they won't be need to fight with fauna. And vents still in the game, that's mean resources won't run off in long rounds. Also ashwalkers and other roles have access to resources without fighting.
## Changelog
:cl:
balance: Change ore spawn to be more old-styled.
/:cl:
