### PR TITLE
Venus Human Traps have an orbit menu category, recieve antag datum on spawn

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -30,6 +30,10 @@
 		if(flower_bud.trait_flags & SPACEVINE_COLD_RESISTANT)
 			spawned_human_trap.unsuitable_cold_damage = 0
 
+/obj/effect/mob_spawn/ghost_role/venus_human_trap/special(mob/living/spawned_mob, mob/mob_possessor)
+	. = ..()
+	spawned_mob.mind.add_antag_datum(/datum/antagonist/venus_human_trap)
+
 /// Called when the attached flower bud has borne fruit (ie. is ready)
 /obj/effect/mob_spawn/ghost_role/venus_human_trap/proc/bear_fruit()
 	ready = TRUE

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -11,6 +11,7 @@
 	flavour_text = "You are a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!"
 	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
 	spawner_job_path = /datum/job/venus_human_trap
+	invisibility = INVISIBILITY_ABSTRACT //The flower bud structure is our visible component, we just handle logic.
 	/// Physical structure housing the spawner
 	var/obj/structure/alien/resin/flower_bud/flower_bud
 	/// Used to determine when to notify ghosts

--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -10,7 +10,7 @@ export const ANTAG2COLOR = {
   'Xenomorph Infestation': 'violet',
   'Spacetime Aberrations': 'white',
   'Deviant Crew': 'white',
-  'Invasive Overgrowth': 'olive',
+  'Invasive Overgrowth': 'green',
 } as const;
 
 export const THREAT = {

--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -10,6 +10,7 @@ export const ANTAG2COLOR = {
   'Xenomorph Infestation': 'violet',
   'Spacetime Aberrations': 'white',
   'Deviant Crew': 'white',
+  'Invasive Overgrowth': 'olive',
 } as const;
 
 export const THREAT = {


### PR DESCRIPTION
## About The Pull Request

Venus Human Traps now have their own category in the orbit menu. It is a pleasant shade of green, just like vines are.

![image](https://github.com/tgstation/tgstation/assets/28870487/90615559-a45b-44a6-8fb4-39a9172a8e3a)

Venus Human Traps are also now given their antagonist datum upon spawning from a flower. The datum isn't really anything special but it's consistent with the other antag spawners.

This also makes the spawner piece of the VHT flower bud invisible. It's an abstract object meant to handle the logic for spawning, and only the structure should be visible. This currently manifests as there being two, identical flower buds on the same tile when a flower bud spawns. I did not want to get into untangling the two objects in this PR.
## Why It's Good For The Game

Venus human traps being lumped in with the humans in the "Alive" menu is WEIRD. Now ghosts can give a gigantic vine infestation the attention it truly deserves.

Fixes a minor visual incongruity found while doing all this.
## Changelog
:cl: Rhials
qol: Venus Human Traps are now visible in the orbit menu. Cool!
fix: Spawning as a Venus Human Trap now properly gives you an antag datum/objective.
fix: Venus human trap flowers no longer have a second, identical flower under themselves.
/:cl:
