### PR TITLE
Makes the wizard's pets not fight to the death

### DIFF
--- a/_maps/templates/lazy_templates/wizard_den.dmm
+++ b/_maps/templates/lazy_templates/wizard_den.dmm
@@ -229,7 +229,8 @@
 "nV" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /mob/living/simple_animal/hostile/ooze/gelatinous{
-	name = "Jimmy"
+	name = "Jimmy";
+	faction = list("slime", "Wizard")
 	},
 /turf/open/floor/grass,
 /area/centcom/wizard_station)
@@ -536,7 +537,8 @@
 /area/centcom/wizard_station)
 "AW" = (
 /mob/living/simple_animal/pet/gondola{
-	name = "Jommy"
+	name = "Jommy";
+	faction = list("gondola", "Wizard")
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,


### PR DESCRIPTION

## About The Pull Request

Adds the `"Wizard"` to the wizard's pets Jimmy and Jommy, preventing Jimmy from killing Jommy and trying to kill his owner.

Fixes #81410

## Why It's Good For The Game

The wizard federation is supposed to train their pets better than this.

## Changelog
:cl:
fix: The wizard's pets Jimmy and Jommy no longer fight to the death.
/:cl:
