### PR TITLE
Fixes xeno larva click interaction

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -229,6 +229,9 @@
 /mob/living/carbon/alien/larva/resolve_right_click_attack(atom/target, list/modifiers)
 	return target.attack_larva_secondary(src, modifiers)
 
+/mob/living/carbon/alien/larva/can_unarmed_attack() //We bite stuff, and our head is always free.
+	return TRUE
+
 /atom/proc/attack_larva(mob/user, list/modifiers)
 	return
 


### PR DESCRIPTION

## About The Pull Request

Xeno larva can now bite people, or nudge them with their heads, once again.

At some point, they stopped being able to do their usual bite. Their lack of active hands would lead to the "you look at your arm and sigh" message but like. You don't have arms you are a worm.

I don't think this changes any other larva click interactions.
## Why It's Good For The Game

You can bite people to grow faster as xeno again.

You can bonk stuff with your head as xeno again.
## Changelog
:cl:
fix: You can now click things as an alien larva again.
/:cl:
