### PR TITLE
Mindshields are able to cure hypnosis upon implanting one

### DIFF
--- a/code/modules/antagonists/hypnotized/hypnotized.dm
+++ b/code/modules/antagonists/hypnotized/hypnotized.dm
@@ -17,3 +17,7 @@
 /datum/antagonist/hypnotized/Destroy()
 	QDEL_NULL(trauma)
 	return ..()
+
+/datum/antagonist/hypnotized/on_mindshield(mob/implanter)
+	owner.remove_antag_datum(/datum/antagonist/hypnotized)
+	return COMPONENT_MINDSHIELD_DECONVERTED


### PR DESCRIPTION

## About The Pull Request
Says in the title. This does not prevent any sources of hypnosis that were already possible with a mindshield, but any active hypnosis objective will be removed when implanting.
## Why It's Good For The Game
Most other forms of brainwashing are able to be cured by mindshields, notably revs and brainwashing surgery, which are both very similar to hypnosis. Mindshields can currently stop people from being hypnoflashed, but can't cure it after a flash. I think this is a little inconsistent and confusing (especially considering that brainwashing surgery, which is harder to use and obtain than a hypnoflash, is able to be cured by mindshields, but hypnosis cannot be)
## Changelog
:cl:
balance: Mindshields can now remove hypnosis brain traumas
/:cl:
