### PR TITLE
Revenants no longer make noise walking into gibs

### DIFF
--- a/code/datums/elements/ELEMENT_TEMPLATE.md
+++ b/code/datums/elements/ELEMENT_TEMPLATE.md
@@ -5,8 +5,8 @@ See _element.dm for detailed explanations
 
 ```dm
 /datum/element/myelement
-	element_flags = ELEMENT_BESPOKE | ELEMENT_COMPLEX_DETACH | ELEMENT_DETACH_ON_HOST_DESTROY | ELEMENT_NOTAREALFLAG    // code/__DEFINES/dcs/flags.dm
-	//argument_hash_start_idx = 2                                                                                  // Use with ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_COMPLEX_DETACH | ELEMENT_DETACH_ON_HOST_DESTROY | ELEMENT_NOTAREALFLAG // code/__DEFINES/dcs/flags.dm
+	//argument_hash_start_idx = 2  // Use with ELEMENT_BESPOKE
 	var/list/myvar = list()
 
 /datum/element/myelement/Attach(datum/target)

--- a/code/datums/elements/squish_sound.dm
+++ b/code/datums/elements/squish_sound.dm
@@ -17,7 +17,7 @@
 /datum/element/squish_sound/proc/on_cross(atom/movable/source, atom/movable/crossed)
 	SIGNAL_HANDLER
 
-	if(!isliving(crossed) || || (crossed.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || crossed.throwing)
+	if(!isliving(crossed) || (crossed.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || crossed.throwing)
 		return
 	playsound(
 		source = source,

--- a/code/datums/elements/squish_sound.dm
+++ b/code/datums/elements/squish_sound.dm
@@ -17,8 +17,6 @@
 /datum/element/squish_sound/proc/on_cross(atom/movable/source, atom/movable/crossed)
 	SIGNAL_HANDLER
 
-	if(!source.has_gravity())
-		return
 	if(!isliving(crossed) || || (crossed.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || crossed.throwing)
 		return
 	playsound(

--- a/code/datums/elements/squish_sound.dm
+++ b/code/datums/elements/squish_sound.dm
@@ -1,0 +1,29 @@
+///Plays a sound when walked into, lower sounding if the person walking into it has light stepping.
+/datum/element/squish_sound
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	///The sound to play when something holding this element is entered.
+	var/sound_to_play
+
+/datum/element/squish_sound/Attach(
+	datum/target,
+	sound = 'sound/effects/footstep/gib_step.ogg',
+)
+	. = ..()
+	sound_to_play = sound
+	RegisterSignal(target, COMSIG_MOVABLE_CROSS, PROC_REF(on_cross))
+
+///Plays the set sound upon being entered, as long as the person walking into it can actually walk.
+/datum/element/squish_sound/proc/on_cross(atom/movable/source, atom/movable/crossed)
+	SIGNAL_HANDLER
+
+	if(!source.has_gravity())
+		return
+	if(!isliving(crossed) || HAS_TRAIT(crossed, TRAIT_MOVE_FLYING))
+		return
+	playsound(
+		source = source,
+		soundin = sound_to_play,
+		vol = HAS_TRAIT(crossed, TRAIT_LIGHT_STEP) ? 20 : 50,
+		vary = TRUE,
+	)

--- a/code/datums/elements/squish_sound.dm
+++ b/code/datums/elements/squish_sound.dm
@@ -19,7 +19,7 @@
 
 	if(!source.has_gravity())
 		return
-	if(!isliving(crossed) || HAS_TRAIT(crossed, TRAIT_MOVE_FLYING))
+	if(!isliving(crossed) || || (crossed.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || crossed.throwing)
 		return
 	playsound(
 		source = source,

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -115,6 +115,7 @@
 
 /obj/effect/decal/cleanable/blood/gibs/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
+	AddElement(/datum/element/squish_sound)
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, PROC_REF(on_pipe_eject))
 
 /obj/effect/decal/cleanable/blood/gibs/Destroy()
@@ -132,11 +133,6 @@
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
 	return FALSE
-
-/obj/effect/decal/cleanable/blood/gibs/on_entered(datum/source, atom/movable/L)
-	if(isliving(L) && has_gravity(loc))
-		playsound(loc, 'sound/effects/footstep/gib_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 20 : 50, TRUE)
-	return ..()
 
 /obj/effect/decal/cleanable/blood/gibs/proc/on_pipe_eject(atom/source, direction)
 	SIGNAL_HANDLER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1468,6 +1468,7 @@
 #include "code\datums\elements\soft_landing.dm"
 #include "code\datums\elements\spooky.dm"
 #include "code\datums\elements\squish.dm"
+#include "code\datums\elements\squish_sound.dm"
 #include "code\datums\elements\sticker.dm"
 #include "code\datums\elements\strippable.dm"
 #include "code\datums\elements\structure_repair.dm"


### PR DESCRIPTION
## About The Pull Request

Turns the hardcoded sound that plays when you walk into some gibs into an Element and adds a check for flying to avoid playing the sound, fixing Revenants, Holoparasites, and other mobs that fly from making noise when "walking" into a pool of blood.

## Why It's Good For The Game

I was observing a revenant and heard them making noise from walking over blood, thought it was kinda f*cked up

## Changelog

:cl:
fix: Revenants (and other flying mobs) will not make noise when walking into pools of gibs,
/:cl: