### PR TITLE
Fixes bluespace launchpads from not working in shuttles

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -152,7 +152,7 @@
 		return "ERROR: Launchpad busy."
 
 	var/area/surrounding = get_area(src)
-	if(is_centcom_level(z) || istype(surrounding, /area/shuttle))
+	if(is_centcom_level(z) || istype(surrounding, /area/shuttle/supply) ||istype(surrounding, /area/shuttle/transport))
 		return "ERROR: Launchpad not operative. Heavy area shielding makes teleporting impossible."
 
 	return null


### PR DESCRIPTION

## About The Pull Request
Fixes #81314 
does what it says on the tin, I made the check more discriminatory by checking supply and ferry areas instead (the two ways the crew can get to centcom).
## Why It's Good For The Game
it is what it is
## Changelog
:cl:
fix: You can now use bluespace launchpads from shuttles (except cargo and ferry shuttles)
/:cl:
