### PR TITLE
Fixes engines being pointed at the wrong direction in old ferries such as base, meat and lighthouse

### DIFF
--- a/_maps/shuttles/ferry_base.dmm
+++ b/_maps/shuttles/ferry_base.dmm
@@ -62,6 +62,12 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
+"J" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
 "U" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -72,17 +78,17 @@
 
 (1,1,1) = {"
 a
-b
+J
 k
-b
+J
 a
 "}
 (2,1,1) = {"
-b
+J
 g
 l
 g
-b
+J
 "}
 (3,1,1) = {"
 c
@@ -148,9 +154,9 @@ q
 c
 "}
 (12,1,1) = {"
-c
+b
 e
 m
 e
-c
+b
 "}

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "ab" = (
 /obj/machinery/power/shuttle_engine/propulsion/left{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/transport)
@@ -257,6 +257,13 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/transport)
+"sy" = (
+/obj/machinery/power/shuttle_engine/propulsion/left{
+	dir = 8;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/transport)
 "ZS" = (
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood,
@@ -299,7 +306,7 @@ ac
 aa
 "}
 (3,1,1) = {"
-ab
+sy
 af
 ag
 ag

--- a/_maps/shuttles/ferry_meat.dmm
+++ b/_maps/shuttles/ferry_meat.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "b" = (
 /obj/machinery/power/shuttle_engine/propulsion{
-	dir = 4
+	dir = 8
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)


### PR DESCRIPTION

## About The Pull Request
I noticed that the engines were backwards on some of the old shuttles, probably some fucky wucky updatepaths. We should at least do the bare minimum maintenance on these admin only ferries
## Why It's Good For The Game
## Changelog
:cl:
fix: Fixes backwards engines in a few of centcom's ferries!
