### PR TITLE
Fix paperwork not displaying the writing utensil font, colour, and boldness

### DIFF
--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -674,8 +674,8 @@ export class PreviewView extends Component<PreviewViewProps> {
     bold: boolean = false,
   ): string => {
     return `<span style="color:${color};font-family:${font};${
-        bold ? 'font-weight: bold;' : ''
-      }">${text}</span>`;
+      bold ? 'font-weight: bold;' : ''
+    }">${text}</span>`;
   };
 
   // Parses the given raw text through marked for applying markdown.

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -673,9 +673,9 @@ export class PreviewView extends Component<PreviewViewProps> {
     color: string,
     bold: boolean = false,
   ): string => {
-    return `<span style={{color:${color};font-family:${font};${
-      bold ? 'font-weight: bold;' : ''
-    }}}>${text}</span>`;
+    return `<span style="color:${color};font-family:${font};${
+        bold ? 'font-weight: bold;' : ''
+      }">${text}</span>`;
   };
 
   // Parses the given raw text through marked for applying markdown.


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/42909981/89b80bda-4d18-4b04-88d1-8ad78c006dff)

Paperwork was somehow only using the writing utensil's font, colour, and boldness within player-created input fields or the big writing field, but never in the proper paperwork. This is apparently because at some point `setFontInText`'s wrapping of it in a span tag with the proper style had swapped from using `style="stuff"` to `style={{stuff}}`, which doesn't actually seem to work here.
Swapping this back seems to make it perfectly functional again.
I don't know either.
## Why It's Good For The Game

Fixes more paperwork jank.
## Changelog
:cl:
fix: Paperwork should actually use the writing utensil's font, colour, and boldness outside of input fields again.
/:cl:
