### PR TITLE
Mapload anomalies are no longer orbit points-of-interest

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -27,7 +27,8 @@
 /obj/effect/anomaly/Initialize(mapload, new_lifespan, drops_core = TRUE)
 	. = ..()
 
-	SSpoints_of_interest.make_point_of_interest(src)
+	if(!mapload)
+		SSpoints_of_interest.make_point_of_interest(src)
 
 	START_PROCESSING(SSobj, src)
 	impact_area = get_area(src)


### PR DESCRIPTION

## About The Pull Request

Mapped-in anomalies no longer register as points-of-interest in the orbit menu. This is primarily for the hollow anomalies from the anomaly research ruin. Player-stabilized anomalies, and regular event anomalies, will still show up here.
## Why It's Good For The Game

These damn things take up over half the misc tab. Less clutter in the orbit menu.

![image](https://github.com/tgstation/tgstation/assets/28870487/099cda4d-42e2-478d-ac21-fe0ec7a21e60)
## Changelog
:cl: Rhials
qol: Map hazard anomalies are no longer treated as points-of-interest in the orbit menu.
/:cl:
