### PR TITLE
Makes some space ruin area names more distinct

### DIFF
--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -33,7 +33,7 @@
 // Ruins of "onehalf" ship
 
 /area/ruin/space/has_grav/onehalf/hallway
-	name = "\improper Hallway"
+	name = "\improper Half-Station Hallway"
 
 /area/ruin/space/has_grav/onehalf/drone_bay
 	name = "\improper Mining Drone Bay"
@@ -42,7 +42,7 @@
 	name = "\improper Crew Quarters"
 
 /area/ruin/space/has_grav/onehalf/bridge
-	name = "\improper Bridge"
+	name = "\improper Half-Station Bridge"
 
 /area/ruin/space/has_grav/powered/dinner_for_two
 	name = "Dinner for Two"
@@ -638,25 +638,25 @@
 	name = "Waystation Maintenance"
 
 /area/ruin/space/has_grav/waystation/qm
-	name = "Quartermaster Office"
+	name = "Waystation Quartermaster Office"
 
 /area/ruin/space/has_grav/waystation/dorms
-	name = "Living Space"
+	name = "Waystation Living Space"
 
 /area/ruin/space/has_grav/waystation/kitchen
-	name = "Kitchen"
+	name = "Waystation Kitchen"
 
 /area/ruin/space/has_grav/waystation/cargobay
-	name = "Cargo Bay"
+	name = "Waystation Cargo Bay"
 
 /area/ruin/space/has_grav/waystation/securestorage
-	name = "Secure Storage"
+	name = "Waystation Secure Storage"
 
 /area/ruin/space/has_grav/waystation/cargooffice
-	name = "Cargo Office"
+	name = "Waystation Cargo Office"
 
 /area/ruin/space/has_grav/powered/waystation/assaultpod
-	name = "Assault Pod"
+	name = "Waystation Assault Pod"
 
 /area/ruin/space/has_grav/waystation/power
 	name = "Waystation Electrical"


### PR DESCRIPTION

## About The Pull Request

This slightly changes some space ruin area names. They should be slightly more distinctive and collide less with actual station locations (I.E. there can be two "The Quartermaster's Office" areas or two "The Bridge" areas).
## Why It's Good For The Game

Slightly more naming consistency, less confusion in the jump-to-area menu.
## Changelog
:cl: Rhials
spellcheck: Some space ruin area names have been made more distinct.
/:cl:
