### PR TITLE
Moves inter-round caches to cache/. Deletes tmp/ between rounds. Keeps tts from killing servers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 #Ignore everything in datafolder and subdirectories
 /data/**/*
 /tmp/**/*
+/cache/**/*
 
 #Ignore byond config folder.
 /cfg/**/*

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -19,6 +19,9 @@ SUBSYSTEM_DEF(server_maint)
 	world.hub_password = "" //quickly! before the hubbies see us.
 
 /datum/controller/subsystem/server_maint/Initialize()
+	if (fexists("tmp/"))
+		fdel("tmp/")
+
 	if (CONFIG_GET(flag/hub))
 		world.update_hub_visibility(TRUE)
 	//Keep in mind, because of how delay works adding a list here makes each list take wait * delay more time to clear
@@ -82,6 +85,8 @@ SUBSYSTEM_DEF(server_maint)
 			return
 
 /datum/controller/subsystem/server_maint/Shutdown()
+	if (fexists("tmp/"))
+		fdel("tmp/")
 	kick_clients_in_lobby(span_boldannounce("The round came to an end with you in the lobby."), TRUE) //second parameter ensures only afk clients are kicked
 	var/server = CONFIG_GET(string/server)
 	for(var/thing in GLOB.clients)

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -1,4 +1,4 @@
-#define ASSET_CROSS_ROUND_CACHE_DIRECTORY "tmp/assets"
+#define ASSET_CROSS_ROUND_CACHE_DIRECTORY "cache/assets"
 
 //These datums are used to populate the asset cache, the proc "register()" does this.
 //Place any asset datums you create in asset_list_items.dm

--- a/config/config.txt
+++ b/config/config.txt
@@ -532,9 +532,9 @@ URGENT_AHELP_COOLDOWN 300
 MOTD motd.txt
 #MOTD motd_extra.txt
 
-## Assets can opt-in to caching their results into `tmp`.
+## Assets can opt-in to caching their results into `cache/`.
 ## This is important, as preferences assets take upwards of 30 seconds (without sleeps) to collect.
-## The cache is assumed to be cleared by TGS recompiling, which deletes `tmp`.
+## The cache is assumed to be cleared by TGS recompiling, which deletes `cache/`.
 ## This should be disabled (through `CACHE_ASSETS 0`) on development,
 ## but enabled on production (the default).
 CACHE_ASSETS 0


### PR DESCRIPTION
Fun fact, the only reason tts isn't killing our hard drive is because of auto-update. every time auto-update breaks, the hard drive fills up.

I skimmed all uses of `tmp` and found what i think is the only thing that assumes these will hang around between rounds.

I was gonna make this also handle deleting cache/ if tgs wasn't around by hashing the dmb and rsc files and checking this hash, but that will need this feature request [ID:2912240](https://www.byond.com/forum/post/2912240) unless i want to work around it for something we don't even need in prod.

I decided to have `tmp/` be deleted in both shutdown and startup so that clean shutdowns leave things... well.... clean, while still deleting in startup so that unclean shutdowns still cleans things.