### PR TITLE
Adds unit test for tail wag emote, fixes tail wag emote

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -136,9 +136,9 @@
 	//I am so sorry my son
 	//We bypass helpers here cause we already have the tail
 	if(oranges_accessory.wag_flags & WAG_WAGGING) //We verified the tail exists in can_run_emote()
-		oranges_accessory.stop_wag(src)
+		oranges_accessory.stop_wag(user)
 	else
-		oranges_accessory.start_wag(src)
+		oranges_accessory.start_wag(user)
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()

--- a/code/modules/unit_tests/tail_wag.dm
+++ b/code/modules/unit_tests/tail_wag.dm
@@ -20,6 +20,18 @@
 	if(dummy_tail.wag_flags & WAG_WAGGING)
 		TEST_FAIL("Tail did not stop wagging when it should have!")
 
+	// TESTING WAG EMOTE
+
+	// start wagging
+	dummy.emote("wag")
+	if(!(dummy_tail.wag_flags & WAG_WAGGING))
+		TEST_FAIL("Tail did not start wagging after using the *wag emote!")
+
+	// stop wagging
+	dummy.emote("wag")
+	if(dummy_tail.wag_flags & WAG_WAGGING)
+		TEST_FAIL("Tail did not stop wagging after using the *wag emote!")
+
 	// TESTING WAG_ABLE FLAG
 
 	// flip the wag flag to unwaggable


### PR DESCRIPTION
## About The Pull Request

<details> <summary>Funnier for who, Lemon?!</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/4cd755fa-ed92-4b99-802c-f22591f8238c)

</details>

https://github.com/tgstation/tgstation/pull/81400 broke the tail wag emote. This will make it work again.

I did test it.  _cough_.


<details> <summary>Before</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/57589b8c-49b4-4d3f-81cf-e43432ac1a8c)

</details>

<details> <summary>After</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/3770d21f-4553-49c0-a60f-11c71be37430)

</details>

My fault for not writing a better unit test I guess.

## Why It's Good For The Game

Fixes a bug.

## Changelog

:cl:
fix: *wag emote is now functional again
/:cl:
