### PR TITLE
Operand Swap for QuirksPage.tsx

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -8,10 +8,10 @@ import { getRandomization, PreferenceList } from './MainPage';
 import { ServerPreferencesFetcher } from './ServerPreferencesFetcher';
 import { useRandomToggleState } from './useRandomToggleState';
 
-function getValueClass(value: number) {
-  if (value > 0) {
+function getColorValueClass(quirk: Quirk) {
+  if (quirk.value > 0) {
     return 'positive';
-  } else if (value < 0) {
+  } else if (quirk.value < 0) {
     return 'negative';
   } else {
     return 'neutral';
@@ -131,7 +131,7 @@ function QuirkDisplay(props: QuirkDisplayProps) {
         >
           <Stack vertical fill>
             <Stack.Item
-              className={`${className}--${getValueClass(value)}`}
+              className={`${className}--${getColorValueClass(quirk)}`}
               style={{
                 borderBottom: '1px solid black',
                 padding: '2px',


### PR DESCRIPTION
## About The Pull Request

The changes included in this PR were requested by maintainers of [Nova Sector](https://github.com/NovaSector/NovaSector).

- Changed the input operand of `getValueClass`, replacing the `value` number with the full `quirk` object.
- Renamed `getValueClass` to `getColorValueClass`.

## Why It's Good For The Game

A downstream repository has requested that I make this change, so they can easily maintain their own changes to it.

The change should allow them to add more heading colors for quirks on the Character Preferences page.

This change is purely semantic, and there are no visible changes to the game,
