### PR TITLE
Fix love not working right before Valentines day (VERY HIGHI priority)

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -61,6 +61,7 @@
 		/datum/atom_hud/alternate_appearance/basic/one_person,
 		"in_love",
 		image(icon = 'icons/effects/effects.dmi', icon_state = "love_hearts", loc = date),
+		null,
 		new_owner,
 	))
 

--- a/code/game/atom/alternate_appearance.dm
+++ b/code/game/atom/alternate_appearance.dm
@@ -166,8 +166,8 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 		return TRUE
 	return FALSE
 
-/datum/atom_hud/alternate_appearance/basic/one_person/New(key, image/I, mob/living/M)
-	..(key, I, FALSE)
-	seer = M
+/datum/atom_hud/alternate_appearance/basic/one_person/New(key, image/I, options, mob/living/seer)
+	src.seer = seer
+	return ..()
 
 /datum/atom_hud/alternate_appearance/basic/food_demands

--- a/code/modules/wiremod/components/bci/hud/bar_overlay.dm
+++ b/code/modules/wiremod/components/bci/hud/bar_overlay.dm
@@ -58,6 +58,7 @@
 		/datum/atom_hud/alternate_appearance/basic/one_person,
 		"bar_overlay_[REF(src)]",
 		cool_overlay,
+		null,
 		owner,
 	)
 	alt_appearance.show_to(owner)

--- a/code/modules/wiremod/components/bci/hud/counter_overlay.dm
+++ b/code/modules/wiremod/components/bci/hud/counter_overlay.dm
@@ -76,6 +76,7 @@
 		/datum/atom_hud/alternate_appearance/basic/one_person,
 		"counter_overlay_[REF(src)]",
 		counter,
+		null,
 		owner,
 	)
 	alt_appearance.show_to(owner)
@@ -101,6 +102,7 @@
 			/datum/atom_hud/alternate_appearance/basic/one_person,
 			"counter_overlay_[REF(src)]_[i]",
 			number,
+			null,
 			owner,
 		)
 		number_alt_appearance.show_to(owner)

--- a/code/modules/wiremod/components/bci/hud/object_overlay.dm
+++ b/code/modules/wiremod/components/bci/hud/object_overlay.dm
@@ -118,6 +118,7 @@
 		/datum/atom_hud/alternate_appearance/basic/one_person,
 		"object_overlay_[REF(src)]",
 		cool_overlay,
+		null,
 		owner,
 	)
 	alt_appearance.show_to(owner)


### PR DESCRIPTION
## About The Pull Request

The parent new call is what handles showing the alt appearance to the mob

So we add the alt appearance to our date, try to show to any mob, it fails (there is no seer), then set seer

Fixes this by fixing the order

## Changelog

:cl: Melbert
fix: You can once again see love on Valentines Day
/:cl:

