### PR TITLE
Reduces chat/audio spam when multiple ghost polls are being called

### DIFF
--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -1,6 +1,3 @@
-///The maximum number of polls active at once before we stop playing the sound (to prevent audio spam/loud noises).
-#define AUDIBLE_NOTIFICATION_LIMIT 3
-
 SUBSYSTEM_DEF(polling)
 	name = "Polling"
 	flags = SS_BACKGROUND | SS_NO_INIT
@@ -119,7 +116,7 @@ SUBSYSTEM_DEF(polling)
 		if(ignore_category)
 			act_never = "<a href='?src=[REF(poll_alert_button)];never=1'>\[Never For This Round]</a>"
 
-		if(length(currently_polling) <= AUDIBLE_NOTIFICATION_LIMIT) //We make sure we aren't spamming chat or the player's ears.
+		if(!duplicate_message_check(alert_poll)) //Only notify people once. They'll notice if there are multiple and we don't want to spam people's ears.
 			SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg')
 			to_chat(candidate_mob, span_boldnotice(examine_block("Now looking for candidates [role_name_text ? "to play as \an [role_name_text]." : "\"[question]\""] [act_jump] [act_signup] [act_never]")))
 
@@ -197,13 +194,8 @@ SUBSYSTEM_DEF(polling)
 
 	// Take care of updating the remaining screen alerts if a similar poll is found, or deleting them.
 	if(length(finishing_poll.alert_buttons))
-		var/polls_of_same_type_left = FALSE
-		for(var/datum/candidate_poll/running_poll as anything in currently_polling)
-			if(running_poll.poll_key == finishing_poll.poll_key && running_poll.time_left() > 0)
-				polls_of_same_type_left = TRUE
-				break
 		for(var/atom/movable/screen/alert/poll_alert/alert as anything in finishing_poll.alert_buttons)
-			if(polls_of_same_type_left)
+			if(duplicate_message_check(finishing_poll))
 				alert.update_stacks_overlay()
 			else
 				alert.owner.clear_alert("[finishing_poll.poll_key]_poll_alert")
@@ -217,6 +209,13 @@ SUBSYSTEM_DEF(polling)
 	if(soonest_to_complete)
 		msg += " | Next: [DisplayTimeText(soonest_to_complete.time_left())] ([length(soonest_to_complete.signed_up)] candidates)"
 	return ..()
+
+///Is there a multiple of the given event type running right now?
+/datum/controller/subsystem/polling/proc/duplicate_message_check(datum/candidate_poll/poll_to_check)
+	for(var/datum/candidate_poll/running_poll as anything in currently_polling)
+		if((running_poll.poll_key == poll_to_check.poll_key && running_poll != poll_to_check) && running_poll.time_left() > 0)
+			return TRUE
+	return FALSE
 
 /datum/controller/subsystem/polling/proc/get_next_poll_to_finish()
 	var/lowest_time_left = INFINITY
@@ -232,5 +231,3 @@ SUBSYSTEM_DEF(polling)
 		return FALSE
 
 	return next_poll_to_finish
-
-#undef AUDIBLE_NOTIFICATION_LIMIT

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -116,7 +116,7 @@ SUBSYSTEM_DEF(polling)
 		if(ignore_category)
 			act_never = "<a href='?src=[REF(poll_alert_button)];never=1'>\[Never For This Round]</a>"
 
-		if(!duplicate_message_check(alert_poll)) //Only notify people once. They'll notice if there are multiple and we don't want to spam people's ears.
+		if(!duplicate_message_check(alert_poll)) //Only notify people once. They'll notice if there are multiple and we don't want to spam people.
 			SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg')
 			to_chat(candidate_mob, span_boldnotice(examine_block("Now looking for candidates [role_name_text ? "to play as \an [role_name_text]." : "\"[question]\""] [act_jump] [act_signup] [act_never]")))
 

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -1,3 +1,6 @@
+///The maximum number of polls active at once before we stop playing the sound (to prevent audio spam/loud noises).
+#define AUDIBLE_NOTIFICATION_LIMIT 3
+
 SUBSYSTEM_DEF(polling)
 	name = "Polling"
 	flags = SS_BACKGROUND | SS_NO_INIT
@@ -49,7 +52,6 @@ SUBSYSTEM_DEF(polling)
 		if(!is_eligible(candidate_mob, role, check_jobban, ignore_category))
 			continue
 
-		SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg')
 		if(flash_window)
 			window_flash(candidate_mob.client)
 
@@ -116,7 +118,10 @@ SUBSYSTEM_DEF(polling)
 		var/act_never = ""
 		if(ignore_category)
 			act_never = "<a href='?src=[REF(poll_alert_button)];never=1'>\[Never For This Round]</a>"
-		to_chat(candidate_mob, span_boldnotice(examine_block("Now looking for candidates [role_name_text ? "to play as \an [role_name_text]." : "\"[question]\""] [act_jump] [act_signup] [act_never]")))
+
+		if(length(currently_polling) <= AUDIBLE_NOTIFICATION_LIMIT) //We make sure we aren't spamming chat or the player's ears.
+			SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg')
+			to_chat(candidate_mob, span_boldnotice(examine_block("Now looking for candidates [role_name_text ? "to play as \an [role_name_text]." : "\"[question]\""] [act_jump] [act_signup] [act_never]")))
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, poll_alert_button)
@@ -227,3 +232,5 @@ SUBSYSTEM_DEF(polling)
 		return FALSE
 
 	return next_poll_to_finish
+
+#undef AUDIBLE_NOTIFICATION_LIMIT


### PR DESCRIPTION

## About The Pull Request

This slightly modifies the polling subsystem. The sound/chat popup for a new role is now only given on the first "stack" of a role signup.

Let's say 3 loneops roll at once (ty admins), you'll still get the toast popup for 3x loneop rolls, but you'll only get one text highlight in the chat, and only one audio stinger.

Even if the first 2 loneops don't have anyone sign up for it, using the text or toast signup options will still sign you up for the last roll as it completes. This shouldn't make signing up any harder, just quieter.
## Why It's Good For The Game

Less spam in chat. Less headset-blasting audio bleeps. Cool!

Closes #80998.
## Changelog
:cl: Rhials
fix: Ghost role polls should spam you less when multiple of the same roll occur in succession.
/:cl:
