### PR TITLE
Swearing emote upgrade

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -307,3 +307,25 @@ GLOBAL_LIST_INIT(status_display_state_pictures, list(
 	"blank",
 	"shuttle",
 ))
+
+GLOBAL_LIST_INIT(profanities, list(
+	"ASSHOLE",
+	"BLOODY HELL",
+	"BULLSHIT",
+	"BALLS",
+	"CRAP",
+	"CUNT",
+	"COCKSUCKER",
+	"DAMN",
+	"DARN",
+	"FUCK",
+	"FUCKING",
+	"FUCKER",
+	"HECK",
+	"HELL",
+	"MOTHERFUCKER",
+	"SHIT",
+	"TITS",
+	"TWAT",
+	"PISS",
+))

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -160,7 +160,7 @@
 			if(1)
 				owner.emote("twitch")
 			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
+				owner.emote("swear")
 		var/x_offset_old = owner.pixel_x
 		var/y_offset_old = owner.pixel_y
 		var/x_offset = owner.pixel_x + rand(-2,2)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -724,6 +724,11 @@
 /datum/emote/living/swear
 	key = "swear"
 	key_third_person = "swears"
-	message = "says a swear word!"
+	message = ""
 	message_mime = "makes a rude gesture!"
 	emote_type = EMOTE_AUDIBLE
+
+/datum/emote/living/swear/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+
+	user.say("[pick(GLOB.profanities)]!!")


### PR DESCRIPTION

## About The Pull Request

Now using the swearing emote makes you say one of the profanities from a global profanities list.
Now Tourette's uses this emote instead of their small code with a tiny choice of profanities.

You **cannot** exceed the message (spam) limit with this. 
You **cannot** bypass being mute or a mime with this emote.
## Why It's Good For The Game

Swearing emote was rather underwhelming like most emotes, now it has a bigger use!
Keybind it on your keyboard and express how much you hate a double-esword Traitor ambushing you without being distracted to nervously type it out on the keyboard like "SHTEIS!1"

Also, Tourette's having more bad words to say out is great.
## Changelog
:cl:
add: Using "*swear" emote now actually makes your character swear
add: Tourette's Syndrome now has more bad words to say
/:cl:
