### PR TITLE
Stun Baton Eyecandy | Glows and Sparks

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -616,7 +616,6 @@
 
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 	addtimer(CALLBACK(src, PROC_REF(apply_stun_effect_end), target), 2 SECONDS)
-	do_sparks(3, TRUE, src)
 
 /// After the initial stun period, we check to see if the target needs to have the stun applied.
 /obj/item/melee/baton/security/proc/apply_stun_effect_end(mob/living/target)
@@ -690,8 +689,13 @@
 	throw_stun_chance = 10
 	slot_flags = ITEM_SLOT_BACK
 	convertible = FALSE
+	var/obj/item/assembly/igniter/sparkler
 	///Determines whether or not we can improve the cattleprod into a new type. Prevents turning the cattleprod subtypes into different subtypes, or wasting materials on making it....another version of itself.
 	var/can_upgrade = TRUE
+
+/obj/item/melee/baton/security/cattleprod/Initialize(mapload)
+	. = ..()
+	sparkler = new (src)
 
 /obj/item/melee/baton/security/cattleprod/attackby(obj/item/item, mob/user, params)//handles sticking a crystal onto a stunprod to make an improved cattleprod
 	if(!istype(item, /obj/item/stack))
@@ -724,6 +728,16 @@
 	qdel(src)
 	var/obj/item/melee/baton/security/cattleprod/brand_new_prod = new our_prod(user.loc)
 	user.put_in_hands(brand_new_prod)
+
+/obj/item/melee/baton/security/cattleprod/baton_effect()
+	if(!sparkler.activate())
+		return BATON_ATTACK_DONE
+	return ..()
+
+/obj/item/melee/baton/security/cattleprod/Destroy()
+	if(sparkler)
+		QDEL_NULL(sparkler)
+	return ..()
 
 /obj/item/melee/baton/security/boomerang
 	name = "\improper OZtek Boomerang"

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -439,7 +439,6 @@
 	var/cell_hit_cost = 1000
 	var/can_remove_cell = TRUE
 	var/convertible = TRUE //if it can be converted with a conversion kit
-	var/datum/effect_system/spark_spread/spark_system //sparks baton when turned on and off
 
 /datum/armor/baton_security
 	bomb = 50

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -557,9 +557,8 @@
 	update_appearance()
 	add_fingerprint(user)
 
-/// Toggles the light of the stun baton.
+/// Toggles the stun baton's light
 /obj/item/melee/baton/security/proc/toggle_light(mob/user)
-	var/old_light_on = light_on
 	set_light_on(!light_on)
 	return
 
@@ -572,6 +571,7 @@
 	if(active && cell.charge < cell_hit_cost)
 		//we're below minimum, turn off
 		active = FALSE
+		set_light_on(FALSE)
 		update_appearance()
 		playsound(src, SFX_SPARKS, 75, TRUE, -1)
 
@@ -687,13 +687,8 @@
 	throw_stun_chance = 10
 	slot_flags = ITEM_SLOT_BACK
 	convertible = FALSE
-	var/obj/item/assembly/igniter/sparkler
 	///Determines whether or not we can improve the cattleprod into a new type. Prevents turning the cattleprod subtypes into different subtypes, or wasting materials on making it....another version of itself.
 	var/can_upgrade = TRUE
-
-/obj/item/melee/baton/security/cattleprod/Initialize(mapload)
-	. = ..()
-	sparkler = new (src)
 
 /obj/item/melee/baton/security/cattleprod/attackby(obj/item/item, mob/user, params)//handles sticking a crystal onto a stunprod to make an improved cattleprod
 	if(!istype(item, /obj/item/stack))
@@ -726,16 +721,6 @@
 	qdel(src)
 	var/obj/item/melee/baton/security/cattleprod/brand_new_prod = new our_prod(user.loc)
 	user.put_in_hands(brand_new_prod)
-
-/obj/item/melee/baton/security/cattleprod/baton_effect()
-	if(!sparkler.activate())
-		return BATON_ATTACK_DONE
-	return ..()
-
-/obj/item/melee/baton/security/cattleprod/Destroy()
-	if(sparkler)
-		QDEL_NULL(sparkler)
-	return ..()
 
 /obj/item/melee/baton/security/boomerang
 	name = "\improper OZtek Boomerang"

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -431,6 +431,7 @@
 	light_system = OVERLAY_LIGHT
 	light_on = FALSE
 	light_color = LIGHT_COLOR_ORANGE
+	light_power = 1
 
 
 	var/throw_stun_chance = 35

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -427,6 +427,11 @@
 	on_stun_volume = 50
 	active = FALSE
 	context_living_rmb_active = "Harmful Stun"
+	light_range = 2
+	light_system = OVERLAY_LIGHT
+	light_on = FALSE
+	light_color = LIGHT_COLOR_ORANGE
+
 
 	var/throw_stun_chance = 35
 	var/obj/item/stock_parts/cell/cell
@@ -434,6 +439,7 @@
 	var/cell_hit_cost = 1000
 	var/can_remove_cell = TRUE
 	var/convertible = TRUE //if it can be converted with a conversion kit
+	var/datum/effect_system/spark_spread/spark_system //sparks baton when turned on and off
 
 /datum/armor/baton_security
 	bomb = 50
@@ -541,6 +547,8 @@
 		active = !active
 		balloon_alert(user, "turned [active ? "on" : "off"]")
 		playsound(src, SFX_SPARKS, 75, TRUE, -1)
+		toggle_light(user)
+		do_sparks(1, TRUE, src)
 	else
 		active = FALSE
 		if(!cell)
@@ -549,6 +557,11 @@
 			balloon_alert(user, "out of charge!")
 	update_appearance()
 	add_fingerprint(user)
+
+/obj/item/melee/baton/security/proc/toggle_light(mob/user)
+	var/old_light_on = light_on
+	set_light_on(!light_on)
+	return light_on != old_light_on // If the value of light_on didn't change, return false. Otherwise true.
 
 /obj/item/melee/baton/security/proc/deductcharge(deducted_charge)
 	if(!cell)

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -664,7 +664,7 @@
 	if (!cell || cell.charge < cell_hit_cost)
 		return
 	active = !active
-	set_light_on(!light_on)
+	toggle_light()
 	do_sparks(1, TRUE, src)
 	playsound(src, SFX_SPARKS, 75, TRUE, -1)
 	update_appearance()

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -431,7 +431,7 @@
 	light_system = OVERLAY_LIGHT
 	light_on = FALSE
 	light_color = LIGHT_COLOR_ORANGE
-	light_power = 1
+	light_power = 0.5
 
 
 	var/throw_stun_chance = 35

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -664,6 +664,8 @@
 	if (!cell || cell.charge < cell_hit_cost)
 		return
 	active = !active
+	set_light_on(!light_on)
+	do_sparks(1, TRUE, src)
 	playsound(src, SFX_SPARKS, 75, TRUE, -1)
 	update_appearance()
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -427,7 +427,7 @@
 	on_stun_volume = 50
 	active = FALSE
 	context_living_rmb_active = "Harmful Stun"
-	light_range = 2
+	light_range = 1.5
 	light_system = OVERLAY_LIGHT
 	light_on = FALSE
 	light_color = LIGHT_COLOR_ORANGE
@@ -557,10 +557,11 @@
 	update_appearance()
 	add_fingerprint(user)
 
+/// Toggles the light of the stun baton.
 /obj/item/melee/baton/security/proc/toggle_light(mob/user)
 	var/old_light_on = light_on
 	set_light_on(!light_on)
-	return light_on != old_light_on // If the value of light_on didn't change, return false. Otherwise true.
+	return
 
 /obj/item/melee/baton/security/proc/deductcharge(deducted_charge)
 	if(!cell)
@@ -614,6 +615,7 @@
 
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 	addtimer(CALLBACK(src, PROC_REF(apply_stun_effect_end), target), 2 SECONDS)
+	do_sparks(3, TRUE, src)
 
 /// After the initial stun period, we check to see if the target needs to have the stun applied.
 /obj/item/melee/baton/security/proc/apply_stun_effect_end(mob/living/target)


### PR DESCRIPTION

## About The Pull Request
Adds a soft glow and sparks to the stun baton and stun prod. Video below:
https://github.com/tgstation/tgstation/assets/70779744/468351ef-0574-46b9-8d32-58cf40651f3a
## Why It's Good For The Game
![metro-cop](https://github.com/tgstation/tgstation/assets/70779744/63b53d1f-6489-49b2-8c91-1e6faaa8370e)

Looks cool.
## Changelog
:cl:
add: In an attempt to stop the greytide, NanoTrasen has increased security's baton energy output. This has, through testing, done nothing but make the device spark more than it used to.
/:cl:
