### PR TITLE
[NO GBP] Thermomachine & multideck connector connections fixes

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -280,8 +280,8 @@
  * * given_layer - the piping_layer we are checking
  */
 /obj/machinery/atmospherics/proc/connection_check(obj/machinery/atmospherics/target, given_layer)
-	//if target is not multiz then we have to check if the target & src connect in the same direction
-	if(!istype(target, /obj/machinery/atmospherics/pipe/multiz) && !((initialize_directions & get_dir(src, target)) && (target.initialize_directions & get_dir(target, src))))
+	//check if the target & src connect in the same direction
+	if(!((initialize_directions & get_dir(src, target)) && (target.initialize_directions & get_dir(target, src))))
 		return FALSE
 
 	//both target & src can't be connected either way

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -268,6 +268,10 @@
 	if(!.)
 		return FALSE
 	set_init_directions()
+	reconnect_nodes()
+	return TRUE
+
+/obj/machinery/atmospherics/components/proc/reconnect_nodes()
 	for(var/i in 1 to device_type)
 		var/obj/machinery/atmospherics/node = nodes[i]
 		if(node)
@@ -285,7 +289,6 @@
 			node.add_member(src)
 			update_parents()
 		SSair.add_to_rebuild_queue(src)
-	return TRUE
 
 /**
  * Disconnects all nodes from ourselves, remove us from the node's nodes.

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -129,7 +129,7 @@
 	if(!initial(icon))
 		return
 	var/mutable_appearance/thermo_overlay = new(initial(icon))
-	. += get_pipe_image(thermo_overlay, "pipe", dir, COLOR_LIME, piping_layer)
+	. += get_pipe_image(thermo_overlay, "pipe", dir, pipe_color, piping_layer)
 
 /obj/machinery/atmospherics/components/unary/thermomachine/examine(mob/user)
 	. = ..()
@@ -222,6 +222,8 @@
 		return ITEM_INTERACT_SUCCESS
 	piping_layer = (piping_layer >= PIPING_LAYER_MAX) ? PIPING_LAYER_MIN : (piping_layer + 1)
 	to_chat(user, span_notice("You change the circuitboard to layer [piping_layer]."))
+	if(anchored)
+		reconnect_nodes()
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 
@@ -233,6 +235,8 @@
 	set_pipe_color(GLOB.pipe_paint_colors[GLOB.pipe_paint_colors[color_index]])
 	visible_message(span_notice("[user] set [src]'s pipe color to [GLOB.pipe_color_name[pipe_color]]."), ignored_mobs = user)
 	to_chat(user, span_notice("You set [src]'s pipe color to [GLOB.pipe_color_name[pipe_color]]."))
+	if(anchored)
+		reconnect_nodes()
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -9,7 +9,7 @@
 	initialize_directions = SOUTH
 
 	layer = HIGH_OBJ_LAYER
-	device_type = UNARY
+	device_type = TRINARY
 	paintable = FALSE
 
 	construction_type = /obj/item/pipe/directional
@@ -54,8 +54,8 @@
 	for(var/obj/machinery/atmospherics/pipe/multiz/above in GET_TURF_ABOVE(local_turf))
 		if(!is_connectable(above, piping_layer))
 			continue
-		nodes += above
-		above.nodes += src //Two way travel :)
+		nodes[2] = above
+		above.nodes[3] = src //Two way travel :)
 	for(var/obj/machinery/atmospherics/pipe/multiz/below in GET_TURF_BELOW(local_turf))
 		if(!is_connectable(below, piping_layer))
 			continue


### PR DESCRIPTION
## About The Pull Request

Finally made things works way they had to. No more pain in changing layers/colors for thermomachine and multiz side connections with huge list of deleted objects.

Thermomachines now actually reconnect if they're anchored. Additionally their pipe icon now changes it's color.
Multideck connectors are now trinary devices. nodes[1] - front node on same z level; nodes[2] - top node on upper z level; nodes[3] - bottom node on lower z level;

## Why It's Good For The Game

Makes things much more easier for atmos techs in thermomachines.
Clears huge list of useless deleted objects in multideck connector's nodes list.

## Changelog
:cl: mogeoko
fix: Thermomachines now reconnect to pipes on multitool's act.
fix: Multi-deck connectors won't connect pipes not located in front/top/bottom of it.
/:cl:

