### PR TITLE
General maintenance for file cabinets

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -248,12 +248,11 @@
 		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(get_turf(humanc))) //if hands full then just drops on the floor
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
+///Tells all the employment cabinets to add the employee file if they have been touched in-round only, to ensure they all have parity.
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
-	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.
-	for(var/C in GLOB.employmentCabinets)
-		var/obj/structure/filingcabinet/employment/employmentCabinet = C
-		if(!employmentCabinet.virgin)
-			employmentCabinet.addFile(employee)
+	for(var/obj/structure/filingcabinet/employment/cabinets as anything in GLOB.employment_cabinets)
+		if(cabinets.paperwork_populated)
+			cabinets.add_employee_file(employee)
 
 /// Creates, assigns and returns the new_character to spawn as. Assumes a valid mind.assigned_role exists.
 /mob/dead/new_player/proc/create_character(atom/destination)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -1,12 +1,3 @@
-/* Filing cabinets!
- * Contains:
- * Filing Cabinets
- * Security Record Cabinets
- * Medical Record Cabinets
- * Employment Contract Cabinets
- */
-
-
 /*
  * Filing Cabinets
  */
@@ -15,12 +6,16 @@
 	desc = "A large cabinet with drawers."
 	icon = 'icons/obj/service/bureaucracy.dmi'
 	icon_state = "filingcabinet"
+	base_icon_state = "filingcabinet"
 	density = TRUE
 	anchored = TRUE
+	///Boolean on whether the cabinet has been populated yet, set on first touch as to include as many latejoins as possible.
+	var/paperwork_populated = FALSE
 
 /obj/structure/filingcabinet/chestdrawer
 	name = "chest drawer"
 	icon_state = "chestdrawer"
+	base_icon_state = "chestdrawer"
 
 /obj/structure/filingcabinet/chestdrawer/wheeled
 	name = "rolling chest drawer"
@@ -29,43 +24,62 @@
 
 /obj/structure/filingcabinet/filingcabinet //not changing the path to avoid unnecessary map issues, but please don't name stuff like this in the future -Pete
 	icon_state = "tallcabinet"
+	base_icon_state = "tallcabinet"
 
 /obj/structure/filingcabinet/Initialize(mapload)
 	. = ..()
-	if(mapload)
-		for(var/obj/item/I in loc)
-			if(I.w_class < WEIGHT_CLASS_NORMAL) //there probably shouldn't be anything placed ontop of filing cabinets in a map that isn't meant to go in them
-				I.forceMove(src)
+	if(!mapload)
+		return
+	for(var/obj/item/items_mapped_in in loc)
+		if(items_mapped_in.w_class < WEIGHT_CLASS_NORMAL) //there probably shouldn't be anything placed ontop of filing cabinets in a map that isn't meant to go in them
+			items_mapped_in.forceMove(src)
 
 /obj/structure/filingcabinet/deconstruct(disassembled = TRUE)
 	if(!(obj_flags & NO_DECONSTRUCTION))
 		new /obj/item/stack/sheet/iron(loc, 2)
-		for(var/obj/item/I in src)
-			I.forceMove(loc)
+		for(var/obj/item/paperwork in contents)
+			paperwork.forceMove(drop_location())
 	qdel(src)
 
-/obj/structure/filingcabinet/attackby(obj/item/P, mob/living/user, params)
-	var/list/modifiers = params2list(params)
-	if(P.tool_behaviour == TOOL_WRENCH && LAZYACCESS(modifiers, RIGHT_CLICK))
-		to_chat(user, span_notice("You begin to [anchored ? "unwrench" : "wrench"] [src]."))
-		if(P.use_tool(src, user, 20, volume=50))
-			to_chat(user, span_notice("You successfully [anchored ? "unwrench" : "wrench"] [src]."))
-			set_anchored(!anchored)
-	else if(P.w_class < WEIGHT_CLASS_NORMAL)
-		if(!user.transferItemToLoc(P, src))
-			return
-		to_chat(user, span_notice("You put [P] in [src]."))
-		icon_state = "[initial(icon_state)]-open"
-		sleep(0.5 SECONDS)
-		icon_state = initial(icon_state)
-	else if(!user.combat_mode)
-		to_chat(user, span_warning("You can't put [P] in [src]!"))
-	else
-		return ..()
-
-/obj/structure/filingcabinet/attack_hand(mob/living/carbon/user, list/modifiers)
+/obj/structure/filingcabinet/attack_hand(mob/living/user, list/modifiers)
+	if(!paperwork_populated)
+		populate()
 	. = ..()
 	ui_interact(user)
+
+/obj/structure/filingcabinet/wrench_act_secondary(mob/living/user, obj/item/tool)
+	. = ..()
+	default_unfasten_wrench(user, tool, time = 2 SECONDS)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/structure/filingcabinet/attackby(obj/item/attacking_item, mob/user, params)
+	if(attacking_item.w_class >= WEIGHT_CLASS_NORMAL)
+		balloon_alert(user, "doesn't fit!")
+		return ..()
+	if(!user.transferItemToLoc(attacking_item, src))
+		return ..()
+	icon_state = "[base_icon_state]-open"
+	addtimer(VARSET_CALLBACK(src, icon_state, base_icon_state), 0.5 SECONDS)
+
+/obj/structure/filingcabinet/attack_tk(mob/user)
+	if(!paperwork_populated)
+		populate()
+	if(anchored)
+		return attack_self_tk(user)
+	return ..()
+
+/obj/structure/filingcabinet/attack_self_tk(mob/user)
+	if(!contents.len)
+		balloon_alert(user, "nothing inside!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+	if(!prob(40 + contents.len * 5))
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+	var/obj/item/random_item = pick(contents)
+	random_item.forceMove(loc)
+	if(prob(25))
+		step_rand(random_item)
+	balloon_alert(user, "pulled [random_item]!")
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/structure/filingcabinet/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -79,7 +93,7 @@
 	data["cabinet_name"] = "[name]"
 	data["contents"] = list()
 	data["contents_ref"] = list()
-	for(var/obj/item/content in src)
+	for(var/obj/item/content in contents)
 		data["contents"] += "[content]"
 		data["contents_ref"] += "[REF(content)]"
 
@@ -96,59 +110,30 @@
 			var/obj/item/content = locate(params["ref"]) in src
 			if(istype(content) && in_range(src, usr))
 				usr.put_in_hands(content)
-				icon_state = "[initial(icon_state)]-open"
-				addtimer(VARSET_CALLBACK(src, icon_state, initial(icon_state)), 5)
+				icon_state = "[base_icon_state]-open"
+				addtimer(VARSET_CALLBACK(src, icon_state, base_icon_state), 0.5 SECONDS)
 				return TRUE
 
-/obj/structure/filingcabinet/attack_tk(mob/user)
-	if(anchored)
-		return attack_self_tk(user)
-	return ..()
-
-/obj/structure/filingcabinet/attack_self_tk(mob/user)
-	. = COMPONENT_CANCEL_ATTACK_CHAIN
-	if(contents.len)
-		if(prob(40 + contents.len * 5))
-			var/obj/item/I = pick(contents)
-			I.forceMove(loc)
-			if(prob(25))
-				step_rand(I)
-			to_chat(user, span_notice("You pull \a [I] out of [src] at random."))
-			return
-	to_chat(user, span_notice("You find nothing in [src]."))
+///Base proc in populating filing cabinets, setting the paperwork populated var to TRUE.
+/obj/structure/filingcabinet/proc/populate()
+	paperwork_populated = TRUE
 
 /*
  * Security Record Cabinets
  */
-/obj/structure/filingcabinet/security
-	var/virgin = TRUE
-
-/obj/structure/filingcabinet/security/proc/populate()
-	if(!virgin)
+/obj/structure/filingcabinet/security/populate()
+	if(paperwork_populated || !length(GLOB.manifest.general))
 		return
-	for(var/datum/record/crew/target in GLOB.manifest.general)
+	for(var/datum/record/crew/target as anything in GLOB.manifest.general)
 		var/obj/item/paper/rapsheet = target.get_rapsheet()
 		rapsheet.forceMove(src)
-		virgin = FALSE //tabbing here is correct- it's possible for people to try and use it
-					//before the records have been generated, so we do this inside the loop.
-
-/obj/structure/filingcabinet/security/attack_hand(mob/user, list/modifiers)
-	populate()
-	return ..()
-
-/obj/structure/filingcabinet/security/attack_tk()
-	populate()
 	return ..()
 
 /*
  * Medical Record Cabinets
  */
-/obj/structure/filingcabinet/medical
-	///This var is so that its filled on crew interaction to be as accurate (including latejoins) as possible, true until first interact
-	var/virgin = TRUE
-
-/obj/structure/filingcabinet/medical/proc/populate()
-	if(!virgin)
+/obj/structure/filingcabinet/medical/populate()
+	if(paperwork_populated || !length(GLOB.manifest.general))
 		return
 	for(var/datum/record/crew/record in GLOB.manifest.general)
 		var/obj/item/paper/med_record_paper = new /obj/item/paper(src)
@@ -159,50 +144,36 @@
 		med_record_paper.add_raw_text(med_record_text)
 		med_record_paper.name = "paper - '[record.name]'"
 		med_record_paper.update_appearance()
-		virgin = FALSE //tabbing here is correct- it's possible for people to try and use it
-						//before the records have been generated, so we do this inside the loop.
-
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/structure/filingcabinet/medical/attack_hand(mob/user, list/modifiers)
-	populate()
-	return ..()
-
-/obj/structure/filingcabinet/medical/attack_tk()
-	populate()
 	return ..()
 
 /*
  * Employment contract Cabinets
  */
-
-GLOBAL_LIST_EMPTY(employmentCabinets)
+GLOBAL_LIST_EMPTY(employment_cabinets)
 
 /obj/structure/filingcabinet/employment
 	icon_state = "employmentcabinet"
-	///This var is so that its filled on crew interaction to be as accurate (including latejoins) as possible, true until first interact
-	var/virgin = TRUE
+	base_icon_state = "employmentcabinet"
 
 /obj/structure/filingcabinet/employment/Initialize(mapload)
 	. = ..()
-	GLOB.employmentCabinets += src
+	GLOB.employment_cabinets += src
 
 /obj/structure/filingcabinet/employment/Destroy()
-	GLOB.employmentCabinets -= src
+	GLOB.employment_cabinets -= src
 	return ..()
 
-/obj/structure/filingcabinet/employment/proc/fillCurrent()
-	//This proc fills the cabinet with the current crew.
-	for(var/datum/record/locked/target in GLOB.manifest.locked)
+///Fills the filing cabinet with the records of all currently-existing crewmembers.
+/obj/structure/filingcabinet/employment/populate()
+	if(paperwork_populated || !length(GLOB.manifest.locked))
+		return
+	for(var/datum/record/locked/target as anything in GLOB.manifest.locked)
 		var/datum/mind/filed_mind = target.mind_ref.resolve()
-		if(filed_mind && ishuman(filed_mind.current))
-			addFile(filed_mind.current)
+		if(filed_mind)
+			add_employee_file(filed_mind.current)
 
-/obj/structure/filingcabinet/employment/proc/addFile(mob/living/carbon/human/employee)
-	new /obj/item/paper/employment_contract(src, employee.mind.name)
-
-/obj/structure/filingcabinet/employment/interact(mob/user)
-	if(virgin)
-		fillCurrent()
-		virgin = FALSE
 	return ..()
 
+///Adds an individual employment contract to the filing cabinet.
+/obj/structure/filingcabinet/employment/proc/add_employee_file(mob/living/employee)
+	new /obj/item/paper/employment_contract(src, employee.mind.name)


### PR DESCRIPTION
## About The Pull Request

This PR brings more modern code standards to filing cabinets as it has bugged me for a while, including balloon alerts.

replaces initial(icon_state) with base_icon_state
uses wrench_secondary instead of checking modifiers for right click and attacking with a wrench
removes check for ishuman to add someone to the file cabinet, anyone on the manifest should be added to the record list.
replaces to-chat with balloon alert, though I removed the one saying 'you inserted [thing] into the cabinet' because it was quite useless, you know what you are adding since it is in your hand, and the icon state changing is enough feedback to the player of the action they did.
adds autodoc
removes copypaste 'virgin' var, replaced with a populated var on the base file cabinet that they all use.
replaces camelCase and single-letter vars
removes a sleep

## Why It's Good For The Game

General maintenance for yet another pretty old part of the codebase, god rest their soul.

## Changelog

:cl:
qol: File cabinets now use balloon alerts instead of messages to your chat.
/:cl: