### PR TITLE
Nukie Mediborgs no longer kill slimes with their nanites

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1278,7 +1278,7 @@
 	need_mob_update = affected_mob.adjustBruteLoss(-5 * REM * seconds_per_tick, updating_health = FALSE) //A ton of healing - this is a 50 telecrystal investment.
 	need_mob_update += affected_mob.adjustFireLoss(-5 * REM * seconds_per_tick, updating_health = FALSE)
 	need_mob_update += affected_mob.adjustOxyLoss(-15 * REM * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjustToxLoss(-5 * REM * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjustToxLoss(-5 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 	need_mob_update += affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15 * REM * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH


### PR DESCRIPTION

## About The Pull Request

Makes it so that regenerative nanites no longer harm slimepeople and in fact heal them. This was originally PRed downstream by myself in [Bubberstation](https://github.com/Bubberstation/Bubberstation/pull/1143) and i've thought to PR it upstream as well to avoid conflicts in the future, i do think it's a ok change for upstream as well, whilst Nukies cannot be slimepeople on TG similar to Bubber, they can (in theory) induct a traitor slimeperson into the team who wouldn't be able to get healed from the nukie borg. The traitor could also emag the nukie borg to flip them from working for the nukies. Odds of either of those happening? Very implausible. However, i still i don't see how it would negatively affect nukies either.
## Why It's Good For The Game

It's kind of dumb that these magical syndicate nanites that are meant to be able to heal virtually any wound flounder in the face of slimepeople. 
## Changelog
:cl:
fix: Restorative Nanites now heal Slimepeople just as well as they do other people.
/:cl:
