### PR TITLE
General maintenance for ore box

### DIFF
--- a/code/modules/mining/satchel_ore_box.dm
+++ b/code/modules/mining/satchel_ore_box.dm
@@ -5,58 +5,68 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "orebox"
 	name = "ore box"
-	desc = "A heavy wooden box, which can be filled with a lot of ores."
+	desc = "A heavy wooden box, which can be filled with a lot of ores or boulders"
 	density = TRUE
-	pressure_resistance = 5*ONE_ATMOSPHERE
+	pressure_resistance = 5 * ONE_ATMOSPHERE
 
-/obj/structure/ore_box/attackby(obj/item/W, mob/user, params)
-	if (istype(W, /obj/item/stack/ore) || istype(W, /obj/item/boulder))
-		if(!user.transferItemToLoc(W, src))
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	else if(W.atom_storage)
-		W.atom_storage.remove_type(/obj/item/stack/ore, src, INFINITY, TRUE, FALSE, user, null)
-		to_chat(user, span_notice("You empty the ore in [W] into \the [src]."))
-	else
-		return ..()
+/obj/structure/ore_box/Initialize(mapload)
+	. = ..()
+	register_context()
+
+///Dumps all contents of this ore box on the turf
+/obj/structure/ore_box/proc/dump_box_contents()
+	var/drop = drop_location()
+	for(var/obj/item/weapon in src)
+		weapon.forceMove(drop)
+
+/obj/structure/ore_box/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/mineral/wood(loc, 4)
+
+	dump_box_contents()
+
+	return ..()
+
+/obj/structure/ore_box/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = NONE
+	if(isnull(held_item))
+		return
+
+	if(held_item.tool_behaviour == TOOL_CROWBAR)
+		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
+		return CONTEXTUAL_SCREENTIP_SET
+	else if(istype(held_item, /obj/item/stack/ore) || istype(held_item, /obj/item/boulder))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert Item"
+		return CONTEXTUAL_SCREENTIP_SET
+	else if(held_item.atom_storage)
+		context[SCREENTIP_CONTEXT_LMB] = "Transfer Contents"
+		return CONTEXTUAL_SCREENTIP_SET
+
+
+/obj/structure/ore_box/examine(mob/living/user)
+	. = ..()
+	if(in_range(src, user) || isobserver(user))
+		. += span_notice("Can be [EXAMINE_HINT("pried")] apart.")
+		ui_interact(user)
 
 /obj/structure/ore_box/crowbar_act(mob/living/user, obj/item/I)
-	if(I.use_tool(src, user, 50, volume=50))
+	. = ITEM_INTERACT_BLOCKING
+	if(I.use_tool(src, user, 50, volume = 50))
 		user.visible_message(span_notice("[user] pries \the [src] apart."),
 			span_notice("You pry apart \the [src]."),
 			span_hear("You hear splitting wood."))
-		deconstruct(TRUE, user)
-	return TRUE
+		deconstruct(TRUE)
+		return ITEM_INTERACT_SUCCESS
 
-/obj/structure/ore_box/examine(mob/living/user)
-	if(Adjacent(user) && istype(user))
-		ui_interact(user)
-	. = ..()
-
-/obj/structure/ore_box/attack_hand(mob/user, list/modifiers)
-	. = ..()
-	if(.)
-		return
-	if(Adjacent(user))
-		ui_interact(user)
-
-/obj/structure/ore_box/attack_robot(mob/user)
-	if(Adjacent(user))
-		ui_interact(user)
-
-/obj/structure/ore_box/proc/dump_box_contents()
-	var/drop = drop_location()
-	var/turf/our_turf = get_turf(src)
-	for(var/obj/item/O in src)
-		if(QDELETED(O))
-			continue
-		if(QDELETED(src))
-			break
-		O.forceMove(drop)
-		SET_PLANE(O, PLANE_TO_TRUE(O.plane), our_turf)
-		if(TICK_CHECK)
-			stoplag()
-			our_turf = get_turf(src)
-			drop = drop_location()
+/obj/structure/ore_box/attackby(obj/item/weapon, mob/user, params)
+	if(istype(weapon, /obj/item/stack/ore) || istype(weapon, /obj/item/boulder))
+		user.transferItemToLoc(weapon, src)
+		return TRUE
+	else if(weapon.atom_storage)
+		weapon.atom_storage.remove_type(/obj/item/stack/ore, src, INFINITY, TRUE, FALSE, user, null)
+		to_chat(user, span_notice("You empty the ore in [weapon] into \the [src]."))
+		return TRUE
+	else
+		return ..()
 
 /obj/structure/ore_box/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -65,43 +75,36 @@
 		ui.open()
 
 /obj/structure/ore_box/ui_data()
-	var/item_contents = list()
-	var/boulder_count = 0
+	var/list/materials = list()
+	var/name
+	var/amount
 	for(var/obj/item/stack/ore/potental_ore as anything in contents)
 		if(istype(potental_ore, /obj/item/stack/ore))
-			item_contents[potental_ore.type] += potental_ore.amount
+			name = potental_ore.name
+			amount = potental_ore.amount
 		else
-			boulder_count++
+			name = "Boulders"
+			amount = 1
 
-	var/data = list()
+		var/item_found = FALSE
+		for(var/list/item as anything in materials)
+			if(item["name"] == name)
+				item_found = TRUE
+				item["amount"] += amount
+				break
+		if(!item_found)
+			materials += list(list("name" = name, "amount" = amount))
 
-	data["materials"] = list()
-
-	for(var/obj/item/stone as anything in item_contents)
-		if(ispath(stone, /obj/item/stack/ore))
-			var/obj/item/stack/ore/found_ore = stone
-			var/name = initial(found_ore.name)
-			data["materials"] += list(list("name" = name, "amount" = item_contents[stone], "id" = type))
-	data["boulders"] = boulder_count
-	return data
+	return list("materials" = materials)
 
 /obj/structure/ore_box/ui_act(action, params)
 	. = ..()
 	if(.)
 		return
-	if(!Adjacent(usr))
-		return
-	switch(action)
-		if("removeall")
-			dump_box_contents()
-			to_chat(usr, span_notice("You open the release hatch on the box.."))
 
-/obj/structure/ore_box/deconstruct(disassembled = TRUE, mob/user)
-	var/obj/item/stack/sheet/mineral/wood/WD = new (loc, 4)
-	if(user && !QDELETED(WD))
-		WD.add_fingerprint(user)
-	dump_box_contents()
-	qdel(src)
+	if(action == "removeall")
+		dump_box_contents()
+		return TRUE
 
 /// Special override for notify_contents = FALSE.
 /obj/structure/ore_box/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents = FALSE)

--- a/tgui/packages/tgui/interfaces/OreBox.tsx
+++ b/tgui/packages/tgui/interfaces/OreBox.tsx
@@ -4,40 +4,42 @@ import { useBackend } from '../backend';
 import { Box, Button, Section, Table } from '../components';
 import { Window } from '../layouts';
 
-type Data = {
-  materials: Material[];
-  boulders: number;
-};
-
 type Material = {
-  type: string;
   name: string;
   amount: number;
 };
 
-const OREBOX_INFO = `All ores will be placed in here when you are wearing a
-mining stachel on your belt or in a pocket while dragging the ore box.`;
+type Data = {
+  materials: Material[];
+};
 
 export const OreBox = (props) => {
   const { act, data } = useBackend<Data>();
-  const { materials, boulders } = data;
+  const { materials } = data;
 
   return (
     <Window width={335} height={415}>
       <Window.Content scrollable>
         <Section
-          title="Ores"
-          buttons={<Button content="Empty" onClick={() => act('removeall')} />}
+          title="Ores & Boulders"
+          buttons={
+            <Button
+              disabled={materials.length === 0}
+              onClick={() => act('removeall')}
+            >
+              Empty
+            </Button>
+          }
         >
           <Table>
             <Table.Row header>
-              <Table.Cell>Ore</Table.Cell>
+              <Table.Cell>Item</Table.Cell>
               <Table.Cell collapsing textAlign="right">
                 Amount
               </Table.Cell>
             </Table.Row>
-            {materials.map((material) => (
-              <Table.Row key={material.type}>
+            {materials.map((material, id) => (
+              <Table.Row key={id}>
                 <Table.Cell>{toTitleCase(material.name)}</Table.Cell>
                 <Table.Cell collapsing textAlign="right">
                   <Box color="label" inline>
@@ -46,21 +48,12 @@ export const OreBox = (props) => {
                 </Table.Cell>
               </Table.Row>
             ))}
-            {boulders > 0 && (
-              <Table.Row>
-                <Table.Cell>Boulders</Table.Cell>
-                <Table.Cell collapsing textAlign="right">
-                  <Box color="label" inline>
-                    {boulders}
-                  </Box>
-                </Table.Cell>
-              </Table.Row>
-            )}
           </Table>
         </Section>
         <Section>
           <Box>
-            {OREBOX_INFO}
+            Ores can be loaded here via a mining satchel or by hand. Boulders
+            can also be stored here
             <br />
             Gibtonite is not accepted.
           </Box>


### PR DESCRIPTION
## About The Pull Request
**1. Qol**
- Adds examines & screentips for crowbar, ore & boulder insertion
- Empty button of ore box greys out when the box is empty

**2. Code**
- Cleaned up `dump_box_contents()` proc. It was doing way too much excessive checking for if the box or its contents was deleted & was setting the plane of the ore when dropped onto the turf via tick check? Just completely unnecessary
- Removed `type` when sending ui data, use the `id` provided by the ui instead. Boulders & ores are wrapped up in the same `materials` list & we use only 1 for loop when checking for content types
- Corrected return value of `crowbar_act`
- `attack_hand()` & `attack_robot()` are unnecessary because `ui_interact()` covers both cases

**3. Spellcheck**
  - Corrected description & ui notice of ore box to specify it can carry boulders as well

## Changelog
:cl:
qol: adds examines & screentips for ore box
code: cleans up some procs for ore box
spellcheck: corrected description & ui notice of ore box to specify it can hold boulders too
/:cl:
