### PR TITLE
Fixes `product_categories` not working for non-constructable vending machines.

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -236,6 +236,11 @@
 		voice = vendor_voice_by_type[type]
 
 	if(build_inv) //non-constructable vending machine
+		///Non-constructible vending machines do not have a refill canister to populate its products list from,
+		///Which apparently is still needed in the case we use product categories instead.
+		if(product_categories)
+			for(var/list/category as anything in product_categories)
+				products |= category["products"]
 		build_inventories()
 
 	slogan_list = splittext(product_slogans, ";")


### PR DESCRIPTION
## About The Pull Request
This is something I've discovered while working on the previous PR.

## Why It's Good For The Game
Prevents future issues with non-constructable vending machines that use categories, since we don't have any such thing rn.

## Changelog
N/A