### PR TITLE
Fixes valentine love again, for real this time, "why did no one report this" edition

### DIFF
--- a/code/game/atom/alternate_appearance.dm
+++ b/code/game/atom/alternate_appearance.dm
@@ -164,9 +164,10 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/basic/one_person/mobShouldSee(mob/M)
 	if(M == seer)
 		return TRUE
+
 	return FALSE
 
-/datum/atom_hud/alternate_appearance/basic/one_person/New(key, image/I, options, mob/living/seer)
+/datum/atom_hud/alternate_appearance/basic/one_person/New(key, image/I, options = NONE, mob/living/seer)
 	src.seer = seer
 	return ..()
 

--- a/code/game/atom/alternate_appearance.dm
+++ b/code/game/atom/alternate_appearance.dm
@@ -164,7 +164,6 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/basic/one_person/mobShouldSee(mob/M)
 	if(M == seer)
 		return TRUE
-
 	return FALSE
 
 /datum/atom_hud/alternate_appearance/basic/one_person/New(key, image/I, options = NONE, mob/living/seer)


### PR DESCRIPTION
## About The Pull Request

Basic one-person huds now default to having no AA flags set, rather than `AA_TARGET_SEE_APPEARANCE` set

I thought it would be fine to let basic huds just use default hud flags without realizing the default flags were very self-defeating for this. Also also kinda dumb. Why does it default to letting the target see the hud? Whatever I guess. 

This fixes Valentines seeing love hearts on themselves in addition to their companion

I'm surprised no one reported this. 

## Changelog

:cl: Melbert
fix: Valentines no longer see themselves covered in hearts. They only see their Valentine covered in hearts. 
/:cl:

