### PR TITLE
Adds support for different achievement dmis

### DIFF
--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -113,7 +113,7 @@
 			"name" = award.name,
 			"desc" = award.desc,
 			"category" = award.category,
-			"icon_class" = assets.icon_class_name(award.icon),
+			"icon_class" = assets.icon_class_name("achievement-[award.icon_state]"),
 			"value" = data[achievement_type],
 			)
 		award_data += award.get_ui_data(user.ckey)

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -2,8 +2,10 @@
 	///Name of the achievement, If null it won't show up in the achievement browser. (Handy for inheritance trees)
 	var/name
 	var/desc = "You did it."
-	///The icon state for this award. The icon file is found in ui_icons/achievements.
-	var/icon = "default"
+	///The dmi icon file that holds the award's icon state.
+	var/icon = ACHIEVEMENTS_SET
+	///The icon state for this award.
+	var/icon_state = "default"
 
 	var/category = "Normal"
 
@@ -80,7 +82,7 @@
 ///Achievements are one-off awards for usually doing cool things.
 /datum/award/achievement
 	desc = "Achievement for epic people"
-	icon = "" // This should warn contributors that do not declare an icon when contributing new achievements.
+	icon_state = "" // This should warn contributors that do not declare an icon when contributing new achievements.
 	///How many players have earned this achievement
 	var/times_achieved = 0
 
@@ -171,7 +173,7 @@
 /datum/award/score/achievements_score
 	name = "Achievements Unlocked"
 	desc = "Don't worry, metagaming is all that matters."
-	icon = "elephant" //Obey the reference
+	icon_state = "elephant" //Obey the reference
 	database_id = ACHIEVEMENTS_SCORE
 
 /datum/award/score/achievements_score/get_ui_data(key)

--- a/code/datums/achievements/boss_achievements.dm
+++ b/code/datums/achievements/boss_achievements.dm
@@ -5,119 +5,119 @@
 	name = "Tendril Exterminator"
 	desc = "Watch your step"
 	database_id = BOSS_MEDAL_TENDRIL
-	icon = "tendril"
+	icon_state = "tendril"
 
 /datum/award/achievement/boss/boss_killer
 	name = "Boss Killer"
 	desc = "You've come a long ways from asking how to switch hands."
 	database_id = "Boss Killer"
-	icon = "firstboss"
+	icon_state = "firstboss"
 
 /datum/award/achievement/boss/blood_miner_kill
 	name = "Blood-Drunk Miner Killer"
 	desc = "I guess he couldn't handle his drink that well."
 	database_id = BOSS_MEDAL_MINER
-	icon = "miner"
+	icon_state = "miner"
 
 /datum/award/achievement/boss/demonic_miner_kill
 	name = "Demonic-Frost Miner Killer"
 	desc = "Definitely harder than the Blood-Drunk Miner."
 	database_id = BOSS_MEDAL_FROSTMINER
-	icon = "frostminer"
+	icon_state = "frostminer"
 
 /datum/award/achievement/boss/bubblegum_kill
 	name = "Bubblegum Killer"
 	desc = "I guess he wasn't made of candy after all"
 	database_id = BOSS_MEDAL_BUBBLEGUM
-	icon = "bbgum"
+	icon_state = "bbgum"
 
 /datum/award/achievement/boss/colossus_kill
 	name = "Colossus Killer"
 	desc = "The bigger they are... the better the loot"
 	database_id = BOSS_MEDAL_COLOSSUS
-	icon = "colossus"
+	icon_state = "colossus"
 
 /datum/award/achievement/boss/drake_kill
 	name = "Drake Killer"
 	desc = "Now I can wear Rune Platebodies!"
 	database_id = BOSS_MEDAL_DRAKE
-	icon = "drake"
+	icon_state = "drake"
 
 /datum/award/achievement/boss/hierophant_kill
 	name = "Hierophant Killer"
 	desc = "Hierophant, but not triumphant."
 	database_id = BOSS_MEDAL_HIEROPHANT
-	icon = "hierophant"
+	icon_state = "hierophant"
 
 /datum/award/achievement/boss/legion_kill
 	name = "Legion Killer"
 	desc = "We were many..now we are none."
 	database_id = BOSS_MEDAL_LEGION
-	icon = "legion"
+	icon_state = "legion"
 
 /datum/award/achievement/boss/wendigo_kill
 	name = "Wendigo Killer"
 	desc = "You've now ruined years of mythical storytelling."
 	database_id = BOSS_MEDAL_WENDIGO
-	icon = "wendigo"
+	icon_state = "wendigo"
 
 /datum/award/achievement/boss/blood_miner_crusher
 	name = "Blood-Drunk Miner Crusher"
 	desc = "I guess he couldn't handle his drink that well."
 	database_id = BOSS_MEDAL_MINER_CRUSHER
-	icon = "miner"
+	icon_state = "miner"
 
 /datum/award/achievement/boss/demonic_miner_crusher
 	name = "Demonic-Frost Miner Crusher"
 	desc = "Definitely harder than the Blood-Drunk Miner."
 	database_id = BOSS_MEDAL_FROSTMINER_CRUSHER
-	icon = "frostminer"
+	icon_state = "frostminer"
 
 /datum/award/achievement/boss/bubblegum_crusher
 	name = "Bubblegum Crusher"
 	desc = "I guess he wasn't made of candy after all"
 	database_id = BOSS_MEDAL_BUBBLEGUM_CRUSHER
-	icon = "bbgum"
+	icon_state = "bbgum"
 
 /datum/award/achievement/boss/colossus_crusher
 	name = "Colossus Crusher"
 	desc = "The bigger they are... the better the loot"
 	database_id = BOSS_MEDAL_COLOSSUS_CRUSHER
-	icon = "colossus"
+	icon_state = "colossus"
 
 /datum/award/achievement/boss/drake_crusher
 	name = "Drake Crusher"
 	desc = "Now I can wear Rune Platebodies!"
 	database_id = BOSS_MEDAL_DRAKE_CRUSHER
-	icon = "drake"
+	icon_state = "drake"
 
 /datum/award/achievement/boss/hierophant_crusher
 	name = "Hierophant Crusher"
 	desc = "Hierophant, but not triumphant."
 	database_id = BOSS_MEDAL_HIEROPHANT_CRUSHER
-	icon = "hierophant"
+	icon_state = "hierophant"
 
 /datum/award/achievement/boss/legion_crusher
 	name = "Legion Crusher"
 	desc = "We were many... now we are none."
 	database_id = BOSS_MEDAL_LEGION_CRUSHER
-	icon = "legion"
+	icon_state = "legion"
 
 /datum/award/achievement/boss/wendigo_crusher
 	name = "Wendigo Crusher"
 	desc = "You've now ruined years of mythical storytelling."
 	database_id = BOSS_MEDAL_WENDIGO_CRUSHER
-	icon = "wendigo"
+	icon_state = "wendigo"
 
 //should be removed soon
 /datum/award/achievement/boss/king_goat_kill
 	name = "King Goat Killer"
 	desc = "The king is dead, long live the king!"
 	database_id = BOSS_MEDAL_KINGGOAT
-	icon = "goatboss"
+	icon_state = "goatboss"
 
 /datum/award/achievement/boss/king_goat_crusher
 	name = "King Goat Crusher"
 	desc = "The king is dead, long live the king!"
 	database_id = BOSS_MEDAL_KINGGOAT_CRUSHER
-	icon = "goatboss"
+	icon_state = "goatboss"

--- a/code/datums/achievements/job_achievements.dm
+++ b/code/datums/achievements/job_achievements.dm
@@ -8,7 +8,7 @@
 	name = "All Within Theoretical Limits"
 	desc = "I never thought I'd see a resonance cascade, let alone prevent one..."
 	database_id = MEDAL_THEORETICAL_LIMITS
-	icon = "theoreticallimits"
+	icon_state = "theoreticallimits"
 
 //medical
 
@@ -16,13 +16,13 @@
 	name = "Mister Sandman"
 	desc = "Mechanically speaking, there's no real benefit to being unconscious during surgery. Weird how insistent this doctor is about using the N2O anyway though, huh?"
 	database_id = MEDAL_SANDMAN
-	icon = "basemisc"
+	icon_state = "basemisc"
 
 /datum/award/achievement/jobs/helbitaljanken
 	name = "Helbitaljanken"
 	desc = "You janked hard"
 	database_id = MEDAL_HELBITALJANKEN
-	icon = "helbital"
+	icon_state = "helbital"
 
 //mining
 
@@ -30,7 +30,7 @@
 	name = "Frenching"
 	desc = "Just a taste, for science!"
 	database_id = MEDAL_FRENCHING
-	icon = "frenchingthebubble"
+	icon_state = "frenchingthebubble"
 
 //science
 
@@ -38,13 +38,13 @@
 	name = "Feat of Strength"
 	desc = "If the rod is immovable, is it passing you or are you passing it?"
 	database_id = MEDAL_RODSUPLEX
-	icon = "featofstrength"
+	icon_state = "featofstrength"
 
 /datum/award/achievement/jobs/snail
 	name = "KKKiiilll mmmeee"
 	desc = "You were a little too ambitious, but hey, I guess you're still alive?"
 	database_id = MEDAL_SNAIL
-	icon = "snail"
+	icon_state = "snail"
 
 //all of service! hip hip!
 
@@ -52,18 +52,18 @@
 	name = "Centcom Grade: Shitty Service"
 	desc = "Well, you at least tried. How about trying harder?"
 	database_id = MEDAL_BAD_SERVICE
-	icon = "service_bad"
+	icon_state = "service_bad"
 
 /datum/award/achievement/jobs/service_okay
 	name = "Centcom Grade: Acceptable Service"
 	desc = "Well, it'll do! You and your department did just fine."
 	database_id = MEDAL_OKAY_SERVICE
-	icon = "service_okay"
+	icon_state = "service_okay"
 
 /datum/award/achievement/jobs/service_good
 	name = "Centcom Grade: Exemplary Service"
 	desc = "Centcom is very impressed with your department!"
 	database_id = MEDAL_GOOD_SERVICE
-	icon = "service_good"
+	icon_state = "service_good"
 
 //civilian achievies! while not recognized by the code, it is recognized by our hearts

--- a/code/datums/achievements/mafia_achievements.dm
+++ b/code/datums/achievements/mafia_achievements.dm
@@ -7,103 +7,103 @@
 	name = "Assistant Victory"
 	desc = "If you got killed instead of someone more important, you just flexed the true strength of your \"\"\"\"role\"\"\"\"."
 	database_id = MAFIA_MEDAL_ASSISTANT
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/detective
 	name = "Detective Victory"
 	desc = "If you did this with a Medical Doctor in the game, i'm not really that impressed."
 	database_id = MAFIA_MEDAL_DETECTIVE
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/psychologist
 	name = "Psychologist Victory"
 	desc = "You learned how to not reveal someone random night one! Or... maybe you're just a lucky bastard."
 	database_id = MAFIA_MEDAL_PSYCHOLOGIST
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/chaplain
 	name = "Chaplain Victory"
 	desc = "Useless... until the one night the thoughtfeeder confidently claims themselves as detective. Mafia's true bullshit detector."
 	database_id = MAFIA_MEDAL_CHAPLAIN
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/md
 	name = "Medical Doctor Victory"
 	desc = "Congratulations on learning how to not talk!"
 	database_id = MAFIA_MEDAL_MD
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/officer
 	name = "Security Officer Victory"
 	desc = "Don't worry, you can win this if you're dead! You... did use your ability to become dead, right?"
 	database_id = MAFIA_MEDAL_OFFICER
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/lawyer
 	name = "Lawyer Victory"
 	desc = "Oh don't mind me, i'm just the worst rol- Oops, I just instantly ended the game."
 	database_id = MAFIA_MEDAL_LAWYER
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/hop
 	name = "Head of Personnel Victory"
 	desc = "King of Assistants, waster of a single mafia's night, thrower of games."
 	database_id = MAFIA_MEDAL_HOP
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/warden
 	name = "Warden Victory"
 	desc = "Make changelings think you're detective, go on lockdown, actual detective investigates you and dies. Cha cha real smooth!"
 	database_id = MAFIA_MEDAL_WARDEN
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/hos
 	name = "Head of Security Victory"
 	desc = "Certified not shitcurity."
 	database_id = MAFIA_MEDAL_HOS
-	icon = "town"
+	icon_state = "town"
 
 /datum/award/achievement/mafia/changeling
 	name = "Changeling Victory"
 	desc = "I think the changelings are metacomming."
 	database_id = MAFIA_MEDAL_CHANGELING
-	icon = "mafia"
+	icon_state = "mafia"
 
 /datum/award/achievement/mafia/thoughtfeeder
 	name = "Thoughtfeeder Victory"
 	desc = "Clown's best friend. And Obsessed. And fugitive? Whose side are you on?!"
 	database_id = MAFIA_MEDAL_THOUGHTFEEDER
-	icon = "mafia"
+	icon_state = "mafia"
 
 /datum/award/achievement/mafia/traitor
 	name = "Traitor Victory"
 	desc = "Guys, we still have two more changelings to ki-!! TRAITOR VICTORY !!"
 	database_id = MAFIA_MEDAL_TRAITOR
-	icon = "neutral"
+	icon_state = "neutral"
 
 /datum/award/achievement/mafia/nightmare
 	name = "Nightmare Victory"
 	desc = "DID YOUR LIGHT FLICKER?!"
 	database_id = MAFIA_MEDAL_NIGHTMARE
-	icon = "neutral"
+	icon_state = "neutral"
 
 /datum/award/achievement/mafia/fugitive
 	name = "Fugitive Victory"
 	desc = "I'm just the description on an achievement, but if you end up having to choose between town and changelings, go changelings."
 	database_id = MAFIA_MEDAL_FUGITIVE
-	icon = "neutral"
+	icon_state = "neutral"
 
 /datum/award/achievement/mafia/obsessed
 	name = "Obsessed Victory"
 	desc = "You got your target lynched, so instead of being spiteful and annoying, you're just smug and annoying."
 	database_id = MAFIA_MEDAL_OBSESSED
-	icon = "neutral"
+	icon_state = "neutral"
 
 /datum/award/achievement/mafia/clown
 	name = "Clown Victory"
 	desc = "Did you know this works on traitors, despite their immunity? If you hit the jackpot and manage to kill one, they'll salt into the next dimension. Clown tips!"
 	database_id = MAFIA_MEDAL_CLOWN
-	icon = "neutral"
+	icon_state = "neutral"
 
 ///ALL THE ACHIEVEMENTS FOR MISC MAFIA ODDITIES///
 
@@ -111,4 +111,4 @@
 	name = "Universally Hated"
 	desc = "Managed to get more than 12 votes when put up on trial, jesus christ."
 	database_id = MAFIA_MEDAL_HATED
-	icon = "hated"
+	icon_state = "hated"

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -48,7 +48,7 @@
 	name = "My Watchlist Status is Not Important"
 	desc = "You may be under the impression that violent video games are a harmless pastime, but the security and medical personnel swarming your location with batons and knockout gas look like they disagree."
 	database_id = MEDAL_GAMER
-	icon = "live_sec_reaction"
+	icon_state = "live_sec_reaction"
 
 /datum/award/achievement/misc/vendor_squish
 	name = "I Was a Teenage Anarchist"
@@ -69,7 +69,7 @@
 	name = "One Lean, Mean, Cleaning Machine"
 	desc = "How does it feel to know that your workplace values a mop bucket on wheels more than you?" // i can do better than this give me time
 	database_id = MEDAL_CLEANBOSS
-	icon = "cleanboss"
+	icon_state = "cleanboss"
 
 /datum/award/achievement/misc/rule8
 	name = "Rule 8"

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -1,48 +1,48 @@
 /datum/award/achievement/misc
 	category = "Misc"
-	icon = "basemisc" //for those achievements that still need an actual icon, later.
+	icon_state = "basemisc" //for those achievements that still need an actual icon, later.
 
 /datum/award/achievement/misc/meteor_examine
 	name = "Your Life Before Your Eyes"
 	desc = "Take a close look at hurtling space debris"
 	database_id = MEDAL_METEOR
-	icon = "meteors"
+	icon_state = "meteors"
 
 /datum/award/achievement/misc/pulse
 	name = "Jackpot"
 	desc = "Win a pulse rifle from an arcade machine"
 	database_id = MEDAL_PULSE
-	icon = "jackpot"
+	icon_state = "jackpot"
 
 /datum/award/achievement/misc/time_waste
 	name = "Time waster"
 	desc = "Speak no evil, hear no evil, see just errors"
 	database_id = MEDAL_TIMEWASTE
-	icon = "timewaste"
+	icon_state = "timewaste"
 
 /datum/award/achievement/misc/round_and_full
 	name = "Round and Full"
 	desc = "Well at least you aren't down the river, I hear they eat people there."
 	database_id = MEDAL_CLOWNCARKING
-	icon = "clownking"
+	icon_state = "clownking"
 
 /datum/award/achievement/misc/the_best_driver
 	name = "The Best Driver"
 	desc = "100 honks later"
 	database_id = MEDAL_THANKSALOT
-	icon = "clownthanks"
+	icon_state = "clownthanks"
 
 /datum/award/achievement/misc/getting_an_upgrade
 	name = "Getting an upgrade"
 	desc = "Make your first unique material item!"
 	database_id = MEDAL_MATERIALCRAFT
-	icon = "upgrade"
+	icon_state = "upgrade"
 
 /datum/award/achievement/misc/rocket_holdup
 	name = "Disk, Please!"
 	desc = "Is the man currently pointing a loaded rocket launcher at your head point blank really dumb enough to pull the trigger? Do you really want to find out?"
 	database_id = MEDAL_DISKPLEASE
-	icon = "rocket_holdup"
+	icon_state = "rocket_holdup"
 
 /datum/award/achievement/misc/gamer
 	name = "My Watchlist Status is Not Important"
@@ -75,155 +75,155 @@
 	name = "Rule 8"
 	desc = "Call an admin this is ILLEGAL!!"
 	database_id = MEDAL_RULE8
-	icon = "rule8"
+	icon_state = "rule8"
 
 /datum/award/achievement/misc/speed_round
 	name = "Long shift"
 	desc = "Well, that didn't take long."
 	database_id = MEDAL_LONGSHIFT
-	icon = "longshift"
+	icon_state = "longshift"
 
 /datum/award/achievement/misc/lookoutsir
 	name = "Look Out, Sir!"
 	desc = "Either awarded for making the ultimate sacrifice for your comrades, or a really dumb attempt at grenade jumping."
 	database_id = MEDAL_LOOKOUTSIR
-	icon = "martyr" // purple heart on an explosive danger warning sign (well, sort of)
+	icon_state = "martyr" // purple heart on an explosive danger warning sign (well, sort of)
 
 /datum/award/achievement/misc/gottem
 	name = "HA, GOTTEM"
 	desc = "Made you look!"
 	database_id = MEDAL_GOTTEM
-	icon = "gottem"
+	icon_state = "gottem"
 
 /datum/award/achievement/misc/ascension
 	name = "Ascension"
 	desc = "Caedite eos. Novit enim Dominus qui sunt eius."
 	database_id = MEDAL_ASCENSION
-	icon = "ascension"
+	icon_state = "ascension"
 
 /datum/award/achievement/misc/ash_ascension
 	name = "Nightwatcher's Eyes"
 	desc = "You've risen above the flames, became one with the ashes. You've been reborn as one with the Nightwatcher."
 	database_id = MEDAL_ASH_ASCENSION
-	icon = "ashascend"
+	icon_state = "ashascend"
 
 /datum/award/achievement/misc/flesh_ascension
 	name = "Vortex of Arms"
 	desc = "You've became something more, something greater. A piece of the emperor resides within you, and you within him."
 	database_id = MEDAL_FLESH_ASCENSION
-	icon = "fleshascend"
+	icon_state = "fleshascend"
 
 /datum/award/achievement/misc/rust_ascension
 	name = "Hills of Rust"
 	desc = "You've summoned a piece of the Hill of rust, and so the Hills welcome you."
 	database_id = MEDAL_RUST_ASCENSION
-	icon = "rustascend"
+	icon_state = "rustascend"
 
 /datum/award/achievement/misc/void_ascension
 	name = "All that perish"
 	desc = "Place of a different being, different time. Everything ends there... but maybe it is just the beginning?"
 	database_id = MEDAL_VOID_ASCENSION
-	icon = "voidascend"
+	icon_state = "voidascend"
 
 /datum/award/achievement/misc/blade_ascension
 	name = "Silver and Steel"
 	desc = "You've become the master of all duellists - the paragon of blades."
 	database_id = MEDAL_BLADE_ASCENSION
-	icon = "bladeascend"
+	icon_state = "bladeascend"
 
 /datum/award/achievement/misc/cosmic_ascension
 	name = "It arrived"
 	desc = "You managed to teleport an entity on the station that really shouldn't be there."
 	database_id = MEDAL_COSMOS_ASCENSION
-	icon = "cosmicascend"
+	icon_state = "cosmicascend"
 
 /datum/award/achievement/misc/lock_ascension
 	name = "Secrets of the Locked Labyrinth"
 	desc = "You managed to open a gate into the mansus."
 	database_id = MEDAL_LOCK_ASCENSION
-	icon = "lockascend"
+	icon_state = "lockascend"
 
 /datum/award/achievement/misc/moon_ascension
 	name = "The Last Act"
 	desc = "You managed to become the ringleader and slay the lie."
 	database_id = MEDAL_MOON_ASCENSION
-	icon = "moonascend"
+	icon_state = "moonascend"
 
 /datum/award/achievement/misc/grand_ritual_finale
 	name = "Archmage"
 	desc = "Made a big impression on the station with your phenomenal cosmic power."
 	database_id = MEDAL_ARCHMAGE
-	icon = "archmage"
+	icon_state = "archmage"
 
 /datum/award/achievement/misc/toolbox_soul
 	name = "SOUL'd Out"
 	desc = "My eternal soul was destroyed to make a toolbox look funny and all I got was this achievement..."
 	database_id = MEDAL_TOOLBOX_SOUL
-	icon = "toolbox_soul"
+	icon_state = "toolbox_soul"
 
 /datum/award/achievement/misc/hot_damn
 	name = "Hot Damn!"
 	desc = "Sometimes you need to make some noise to make a point."
 	database_id = MEDAL_HOT_DAMN
-	icon = "hotdamn"
+	icon_state = "hotdamn"
 
 /datum/award/achievement/misc/cayenne_disk
 	name = "Very Important Piscis"
 	desc = "You can rest well now."
 	database_id = MEDAL_CAYENNE_DISK
-	icon = "cayenne_disk"
+	icon_state = "cayenne_disk"
 
 /datum/award/achievement/misc/tram_surfer
 	name = "Tram Surfer"
 	desc = "Lights out, guerilla radio!"
 	database_id = MEDAL_TRAM_SURFER
-	icon = "tram_surfer"
+	icon_state = "tram_surfer"
 
 /datum/award/achievement/misc/cult_shuttle_omfg
 	name = "WHAT JUST HAPPENED"
 	desc = "As a blood cultist, be part of a team that summons 3 shuttle curses within 10 seconds. Imagine cleaning up after them, g r o s s!"
 	database_id = MEDAL_CULT_SHUTTLE_OMFG
-	icon = "cult_shuttle_omfg"
+	icon_state = "cult_shuttle_omfg"
 
 /datum/award/achievement/misc/clickbait
 	name = "Clickbait"
 	desc = "Where's my free smartphone?!?"
 	database_id = MEDAL_CLICKBAIT
-	icon = "bait"
+	icon_state = "bait"
 
 /datum/award/achievement/misc/narsupreme
 	name = "If Nar'Sie is so good, why isn't there a..."
 	desc = "Even interdimensional space deitys need a friend."
 	database_id = MEDAL_NARSUPREME
-	icon = "narsupreme"
+	icon_state = "narsupreme"
 
 /datum/award/achievement/misc/springlock
 	name = "The Man Inside the MODsuit"
 	desc = "Ignore the warning label on a springlock MODsuit."
 	database_id = MEDAL_SPRINGLOCK
-	icon = "springlock"
+	icon_state = "springlock"
 
 /datum/award/achievement/misc/healthy
 	name = "The Picture of Health"
 	desc = "Don't be such a baby, it's just a heart attack. You've bounced back from worse!"
 	database_id = MEDAL_HEALTHY
-	icon = "picofhealth"
+	icon_state = "picofhealth"
 
 /datum/award/achievement/misc/gods_wrath
 	name = "God's Wrath"
 	desc = "Did you think you could get away with defiling the word of God?"
 	database_id = MEDAL_GODS_WRATH
-	icon = "godswrath"
+	icon_state = "godswrath"
 
 /datum/award/achievement/misc/earthquake_victim
 	name = "A Nasty Fall"
 	desc = "...And the earth opened its mouth and swallowed them and their station- all the HOP's men and all their possessions."
 	database_id = MEDAL_EARTHQUAKE_VICTIM
-	icon = "earthquake"
+	icon_state = "earthquake"
 
 /datum/award/achievement/misc/debt_extinguished
 	name = "Outdebted"
 	desc = "I've paid my dues, shift after shift... I've done my sentence but commited no griff..."
 	database_id = MEDAL_DEBT_EXTINGUISHED
-	icon = "outdebted"
+	icon_state = "outdebted"
 

--- a/code/datums/achievements/skill_achievements.dm
+++ b/code/datums/achievements/skill_achievements.dm
@@ -5,10 +5,10 @@
 	name = "Legendary miner"
 	desc = "No mere rock can stop me!"
 	database_id = MEDAL_LEGENDARY_MINER
-	icon = "mining"
+	icon_state = "mining"
 
 /datum/award/achievement/skill/legendary_fisher
 	name = "Legendary fisher"
 	desc = "Give a spaceman a fish and you feed him for a while; teach a spaceman to fish and you feed him until the shuttle arrives."
 	database_id = MEDAL_LEGENDARY_FISHER
-	icon = "fishing_hat"
+	icon_state = "fishing_hat"

--- a/code/modules/asset_cache/assets/achievements.dm
+++ b/code/modules/asset_cache/assets/achievements.dm
@@ -1,5 +1,11 @@
 /datum/asset/spritesheet/simple/achievements
-	name ="achievements"
+	name = "achievements"
 
 /datum/asset/spritesheet/simple/achievements/create_spritesheets()
-	InsertAll("", ACHIEVEMENTS_SET)
+	InsertAll("achievement", ACHIEVEMENTS_SET)
+	// catch achievements which are pulling icons from another file
+	for(var/datum/award/other_award as anything in subtypesof(/datum/award))
+		var/icon = initial(other_award.icon)
+		if (icon != ACHIEVEMENTS_SET)
+			var/icon_state = initial(other_award.icon_state)
+			Insert("achievement-[icon_state]", icon, icon_state=icon_state)

--- a/code/modules/unit_tests/achievements.dm
+++ b/code/modules/unit_tests/achievements.dm
@@ -2,13 +2,13 @@
 /datum/unit_test/achievements
 
 /datum/unit_test/achievements/Run()
-	var/award_icons = icon_states(ACHIEVEMENTS_SET)
 	for(var/datum/award/award as anything in subtypesof(/datum/award))
 		if(!initial(award.name)) //Skip abstract achievements types
 			continue
 		var/init_icon = initial(award.icon)
-		if(!init_icon || !(init_icon in award_icons))
-			TEST_FAIL("Award [initial(award.name)] has an unexistent icon: \"[init_icon || "null"]\"")
+		var/init_icon_state = initial(award.icon_state)
+		if(!init_icon_state || !(init_icon_state in init_icon))
+			TEST_FAIL("Award [initial(award.name)] has an unexistent icon in [init_icon]: \"[init_icon_state || "null"]\"")
 		if(length(initial(award.database_id)) > 32) //sql schema limit
 			TEST_FAIL("Award [initial(award.name)] database id is too long")
 		var/init_category = initial(award.category)

--- a/code/modules/unit_tests/achievements.dm
+++ b/code/modules/unit_tests/achievements.dm
@@ -7,8 +7,8 @@
 			continue
 		var/init_icon = initial(award.icon)
 		var/init_icon_state = initial(award.icon_state)
-		if(!init_icon_state || !(init_icon_state in init_icon))
-			TEST_FAIL("Award [initial(award.name)] has an unexistent icon in [init_icon]: \"[init_icon_state || "null"]\"")
+		if(!init_icon_state || !icon_exists(init_icon, init_icon_state))
+			TEST_FAIL("Award [initial(award.name)] has a non-existent icon in [init_icon]: \"[init_icon_state || "null"]\"")
 		if(length(initial(award.database_id)) > 32) //sql schema limit
 			TEST_FAIL("Award [initial(award.name)] database id is too long")
 		var/init_category = initial(award.category)


### PR DESCRIPTION
## About The Pull Request

I am back to pushing my code improvements upstream, sorry in advance.
As the title says, this adds support for achievement icons to be in different dmi files than the default, pretty much the exact same way that Language icons (for chat assets) do.

## Why It's Good For The Game

It is one of the few things in game (the only other thing i can think of that does this rn is barsigns) that cannot have their icon changed when trying to make a subtype, this is very limiting and very annoying, especially since dmi conflicts are one of the worst types to deal with, this would make my life a lot easier.

## Changelog

No player-facing changes.