### PR TITLE
Fix lizardperson spine preference dropdown not showing up

### DIFF
--- a/code/modules/surgery/organs/external/spines.dm
+++ b/code/modules/surgery/organs/external/spines.dm
@@ -7,6 +7,8 @@
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_EXTERNAL_SPINES
 
+	preference = "feature_lizard_spines"
+
 	dna_block = DNA_SPINES_BLOCK
 	restyle_flags = EXTERNAL_RESTYLE_FLESH
 


### PR DESCRIPTION

## About The Pull Request

I was recently told about the fact that apparently spines are missing from lizardperson customization.
Looking into it, it seems like this was caused by #80952 performing an unrelated line removal, presumably by accident while copying something over.
![image](https://github.com/tgstation/tgstation/assets/42909981/b7b306ed-16b9-4d27-b0db-55d3590b1003)
Re-adding this line seems to make it work fine.
## Why It's Good For The Game

Fixes the lizardperson spine preference dropdown not showing up in the character menu.
## Changelog
:cl:
fix: Fixed the lizardperson spine preference dropdown not showing up in the character menu.
/:cl:
