### PR TITLE
Fixes Cargo Lockbox Iconstates

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -237,6 +237,8 @@
 	name = "order lockbox"
 	desc = "A box used to secure small cargo orders from being looted by those who didn't order it. Yeah, cargo tech, that means you."
 	icon_state = "secure"
+	icon_closed = "secure"
+	icon_locked = "secure_locked"
 	icon_broken = "secure+b"
 	inhand_icon_state = "sec-case"
 	lefthand_file = 'icons/mob/inhands/equipment/briefcase_lefthand.dmi'
@@ -265,8 +267,10 @@
 
 	if(privacy_lock)
 		atom_storage.locked = STORAGE_NOT_LOCKED
+		icon_state = icon_locked
 	else
 		atom_storage.locked = STORAGE_FULLY_LOCKED
+		icon_state = icon_closed
 	privacy_lock = atom_storage.locked
 	user.visible_message(span_notice("[user] [privacy_lock ? "" : "un"]locks [src]'s privacy lock."),
 					span_notice("You [privacy_lock ? "" : "un"]lock [src]'s privacy lock."))


### PR DESCRIPTION

## About The Pull Request

The cargo lockboxes didn't update iconstates when locked. Seems like an oversight given that their parent object does this and there's unused sprites for this behaviour in this item, so this enables it to use those sprites that are already in code.

## Why It's Good For The Game

It's hard to know if someone has taken their items or not because an unlocked case looks identical to a locked one. Also fixes an oversight idk.

## Changelog
:cl:
fix: cargo lockboxes update iconstates correctly now
/:cl:
