### PR TITLE
Fixes space cats not being able to survive in space.

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/cat.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat.dm
@@ -134,6 +134,7 @@
 	icon_state = "spacecat"
 	icon_living = "spacecat"
 	icon_dead = "spacecat_dead"
+	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = TCMB
 	maximum_survivable_temperature = T0C + 40
 	held_state = "spacecat"


### PR DESCRIPTION

## About The Pull Request

### Alternative title: "Cat CAN into space."

Seems the basic cats refactor missed another line change.
![image](https://github.com/tgstation/tgstation/assets/42909981/e41622f1-d0f5-4b6c-a4e5-ceb26afc86a2)
![image](https://github.com/tgstation/tgstation/assets/42909981/f9cca4be-502c-43b6-a691-7e86c72dc6fa)
Re-adding `unsuitable_atmos_damage = 0`, which the basic animals also have, seems to fix this just fine.
## Why It's Good For The Game

Fixes #81479.
## Changelog
:cl:
fix: Space cats CAN into space. (They're back to surviving being in unsuitable atmos.)
/:cl:
