### PR TITLE
Adds a proper skeletal rack subtype

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -19620,13 +19620,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/light_switch/directional/west,
+/obj/structure/rack/skeletal,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "hei" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24819,13 +24819,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "iWB" = (
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/light/small/directional/east,
+/obj/structure/rack/skeletal,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "iWD" = (

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -2433,16 +2433,12 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "Ju" = (
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/book/codex_gigas,
 /obj/machinery/camera/directional/south{
 	c_tag = "Monastery Archives Aft";
 	network = list("ss13","monastery")
 	},
+/obj/structure/rack/skeletal,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Jv" = (

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -464,15 +464,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/food/grown/sugarcane,
 /obj/item/food/grown/sugarcane,
 /obj/item/food/grown/sugarcane,
 /obj/item/reagent_containers/cup/bucket/wooden,
+/obj/structure/rack/skeletal,
 /turf/open/floor/wood/airless,
 /area/shuttle/pirate/flying_dutchman)
 "vT" = (
@@ -550,17 +546,13 @@
 	dir = 10
 	},
 /obj/machinery/light/floor,
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/reagent_containers/condiment/milk{
 	pixel_x = -5
 	},
 /obj/item/reagent_containers/condiment/milk{
 	pixel_x = 5
 	},
+/obj/structure/rack/skeletal,
 /turf/open/floor/wood/airless,
 /area/shuttle/pirate/flying_dutchman)
 "zE" = (

--- a/_maps/virtual_domains/pirates.dmm
+++ b/_maps/virtual_domains/pirates.dmm
@@ -474,14 +474,10 @@
 /area/virtual_domain/fullbright)
 "AF" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/storage/bag/money/dutchmen{
 	pixel_y = 13
 	},
+/obj/structure/rack/skeletal,
 /turf/open/floor/wood/parquet,
 /area/virtual_domain)
 "AP" = (

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -827,6 +827,7 @@
 
 /obj/structure/rack/skeletal
 	name = "skeletal minibar"
+	desc = "Rattle me boozes!"
 	icon = 'icons/obj/fluff/general.dmi'
 	icon_state = "minibar"
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -825,15 +825,15 @@
 	pass_flags_self = LETPASSTHROW //You can throw objects over this, despite it's density.
 	max_integrity = 20
 
-/obj/structure/rack/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/climbable)
-	AddElement(/datum/element/elevation, pixel_shift = 12)
-
 /obj/structure/rack/skeletal
 	name = "skeletal minibar"
 	icon = 'icons/obj/fluff/general.dmi'
 	icon_state = "minibar"
+
+/obj/structure/rack/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/climbable)
+	AddElement(/datum/element/elevation, pixel_shift = 12)
 
 /obj/structure/rack/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -830,6 +830,11 @@
 	AddElement(/datum/element/climbable)
 	AddElement(/datum/element/elevation, pixel_shift = 12)
 
+/obj/structure/rack/skeletal
+	name = "skeletal minibar"
+	icon = 'icons/obj/fluff/general.dmi'
+	icon_state = "minibar"
+
 /obj/structure/rack/examine(mob/user)
 	. = ..()
 	. += span_notice("It's held together by a couple of <b>bolts</b>.")


### PR DESCRIPTION
## About The Pull Request

This is mapped in a few places and I thought it would be better to have a subtype of rack to use rather than varediting the icon and state.

## Why It's Good For The Game

The less varedited icons the better imo, it's way easier to ensure icons aren't fucked up this way and easier to fix too.

## Changelog

No player-facing changes.
