### PR TITLE
Blob Zombies Appear Correctly

### DIFF
--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -53,11 +53,14 @@
 
 /mob/living/basic/blob_minion/zombie/update_overlays()
 	. = ..()
-	copy_overlays(corpse, FALSE)
+	copy_overlays(corpse, TRUE)
+
+/mob/living/basic/blob_minion/zombie/copy_overlays(atom/other, cut_old)
+	. = ..()
 	var/mutable_appearance/blob_head_overlay = mutable_appearance('icons/mob/nonhuman-player/blob.dmi', "blob_head")
 	blob_head_overlay.color = LAZYACCESS(atom_colours, FIXED_COLOUR_PRIORITY) || COLOR_WHITE
 	color = initial(color) // reversing what our component did lol, but we needed the value for the overlay
-	. += blob_head_overlay
+	overlays += blob_head_overlay
 
 /// Create an explosion of spores on death
 /mob/living/basic/blob_minion/zombie/proc/death_burst()

--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -51,12 +51,9 @@
 	. = ..()
 	death()
 
-/mob/living/basic/blob_minion/zombie/update_overlays()
-	. = ..()
+//Sets up our appearance
+/mob/living/basic/blob_minion/zombie/proc/set_up_zombie_appearance()
 	copy_overlays(corpse, TRUE)
-
-/mob/living/basic/blob_minion/zombie/copy_overlays(atom/other, cut_old)
-	. = ..()
 	var/mutable_appearance/blob_head_overlay = mutable_appearance('icons/mob/nonhuman-player/blob.dmi', "blob_head")
 	blob_head_overlay.color = LAZYACCESS(atom_colours, FIXED_COLOUR_PRIORITY) || COLOR_WHITE
 	color = initial(color) // reversing what our component did lol, but we needed the value for the overlay
@@ -76,6 +73,7 @@
 	new_corpse.forceMove(src)
 	corpse = new_corpse
 	update_appearance(UPDATE_ICON)
+	set_up_zombie_appearance()
 	RegisterSignal(corpse, COMSIG_LIVING_REVIVE, PROC_REF(on_corpse_revived))
 
 /// Dynamic changeling reentry

--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -53,7 +53,7 @@
 
 /mob/living/basic/blob_minion/zombie/update_overlays()
 	. = ..()
-	copy_overlays(corpse, TRUE)
+	copy_overlays(corpse, FALSE)
 	var/mutable_appearance/blob_head_overlay = mutable_appearance('icons/mob/nonhuman-player/blob.dmi', "blob_head")
 	blob_head_overlay.color = LAZYACCESS(atom_colours, FIXED_COLOUR_PRIORITY) || COLOR_WHITE
 	color = initial(color) // reversing what our component did lol, but we needed the value for the overlay


### PR DESCRIPTION
## About The Pull Request

Fixes #81414

This PR makes it so blob zombies no longer appear without their blob heads. This bug made it extremely confusing to tell who was who for both sides on a blob-coated battlefield.

## Why It's Good For The Game

This bug sucks and we shouldn't stand for its existence.

## Changelog
:cl:
fix: Blob Zombies now render their blob heads correctly again.
/:cl: