### PR TITLE
Indestructible items are properly rejected by material containers

### DIFF
--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -314,7 +314,7 @@
 			if(SEND_SIGNAL(src, COMSIG_MATCONTAINER_PRE_USER_INSERT, target_item, user) & MATCONTAINER_BLOCK_INSERT)
 				continue
 			//item is either indestructible, not allowed for redemption or not in the allowed types
-			if((target_item.resistance_flags & INDESTRUCTIBLE) || (target_item.item_flags & NO_MAT_REDEMPTION) || !is_type_in_typecache(target_item, allowed_item_typecache))
+			if((target_item.resistance_flags & INDESTRUCTIBLE) || (target_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(target_item, allowed_item_typecache)))
 				if(!(mat_container_flags & MATCONTAINER_SILENT) && i == 1) //count only child items the 1st time around
 					var/list/status_data = chat_msgs["[MATERIAL_INSERT_ITEM_FAILURE]"] || list()
 					var/list/item_data = status_data[target_item.name] || list()

--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -275,10 +275,9 @@
 	var/inserted = 0
 	//All messages to be displayed to chat
 	var/list/chat_msgs = list()
-
 	//differs from held_item when using TK
 	var/active_held = user.get_active_held_item()
-
+	//storage items to retrive items from
 	var/static/list/storage_items
 	if(isnull(storage_items))
 		storage_items = list(
@@ -288,7 +287,7 @@
 		)
 
 	//1st iteration consumes all items that do not have contents inside
-	//2nd iteration consumes items who do have contents inside(but they were consumed in the 1st iteration si its empty now)
+	//2nd iteration consumes items who do have contents inside(but they were consumed in the 1st iteration so its empty now)
 	for(var/i in 1 to 2)
 		//no point inserting more items
 		if(inserted == MATERIAL_INSERT_ITEM_NO_SPACE)
@@ -311,15 +310,11 @@
 			//can't allow abstract, hologram items
 			if((target_item.item_flags & ABSTRACT) || (target_item.flags_1 & HOLOGRAM_1))
 				continue
-			//untouchable, move it out the way, code copied from recycler
-			if(target_item.resistance_flags & INDESTRUCTIBLE)
-				target_item.forceMove(get_turf(parent))
-				continue
 			//user defined conditions
 			if(SEND_SIGNAL(src, COMSIG_MATCONTAINER_PRE_USER_INSERT, target_item, user) & MATCONTAINER_BLOCK_INSERT)
 				continue
-			//item is either not allowed for redemption, not in the allowed types
-			if((target_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(target_item, allowed_item_typecache)))
+			//item is either indestructible, not allowed for redemption or not in the allowed types
+			if((target_item.resistance_flags & INDESTRUCTIBLE) || (target_item.item_flags & NO_MAT_REDEMPTION) || !is_type_in_typecache(target_item, allowed_item_typecache))
 				if(!(mat_container_flags & MATCONTAINER_SILENT) && i == 1) //count only child items the 1st time around
 					var/list/status_data = chat_msgs["[MATERIAL_INSERT_ITEM_FAILURE]"] || list()
 					var/list/item_data = status_data[target_item.name] || list()
@@ -327,6 +322,10 @@
 					status_data[target_item.name] = item_data
 					chat_msgs["[MATERIAL_INSERT_ITEM_FAILURE]"] = status_data
 
+				if(target_item.resistance_flags & INDESTRUCTIBLE)
+					if(i == 1 && target_item != active_held) //move it out of any storage medium its in so it doesn't get consumed with its parent, but only if that storage medium is not our hand
+						target_item.forceMove(get_turf(context))
+					continue
 				//storage items usually come here but we make the exception only on the 1st iteration
 				//this is so players can insert items from their bags into machines for convinience
 				if(!is_type_in_list(target_item, storage_items))


### PR DESCRIPTION
## About The Pull Request
- Fixes #81486

Happens only with items that are Indestructible like the pai card, It's a 2 part fix
- First display error message saying the item was rejected
- If the item is indestructible but was put inside another object like an bag or anything else, then move the object to turf where this object was inserted(`context`) & not the ore silo(`parent`) thus fixing the teleportation bug 

## Changelog
:cl:
fix: Indestructible items like the pai card don't teleport to the ore silo when you insert them into silo linked machine & also displays a message saying it was rejected.
/:cl:
