### PR TITLE
remove unused animated tail spines code

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -25,7 +25,6 @@
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/wings_open, GLOB.wings_open_list)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/frills, GLOB.frills_list)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/spines, GLOB.spines_list)
-	init_sprite_accessory_subtypes(/datum/sprite_accessory/spines_animated, GLOB.animated_spines_list)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/tail_spines, GLOB.tail_spines_list)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/legs, GLOB.legs_list)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/caps, GLOB.caps_list)

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -26,7 +26,6 @@ GLOBAL_LIST_EMPTY(frills_list)
 GLOBAL_LIST_EMPTY(spines_list)
 GLOBAL_LIST_EMPTY(tail_spines_list)
 GLOBAL_LIST_EMPTY(legs_list)
-GLOBAL_LIST_EMPTY(animated_spines_list)
 
 	//Mutant Human bits
 GLOBAL_LIST_EMPTY(tails_list_human)

--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -2076,19 +2076,11 @@
 	icon = 'icons/mob/human/species/lizard/lizard_spines.dmi'
 	em_block = TRUE
 
-/datum/sprite_accessory/spines_animated
-	icon = 'icons/mob/human/species/lizard/lizard_spines.dmi'
-	em_block = TRUE
-
 /datum/sprite_accessory/tail_spines
 	icon = 'icons/mob/human/species/lizard/lizard_spines.dmi'
 	em_block = TRUE
 
 /datum/sprite_accessory/spines/none
-	name = "None"
-	icon_state = "none"
-
-/datum/sprite_accessory/spines_animated/none
 	name = "None"
 	icon_state = "none"
 
@@ -2100,19 +2092,11 @@
 	name = "Short"
 	icon_state = "short"
 
-/datum/sprite_accessory/spines_animated/short
-	name = "Short"
-	icon_state = "short"
-
 /datum/sprite_accessory/tail_spines/short
 	name = "Short"
 	icon_state = "short"
 
 /datum/sprite_accessory/spines/shortmeme
-	name = "Short + Membrane"
-	icon_state = "shortmeme"
-
-/datum/sprite_accessory/spines_animated/shortmeme
 	name = "Short + Membrane"
 	icon_state = "shortmeme"
 
@@ -2124,10 +2108,6 @@
 	name = "Long"
 	icon_state = "long"
 
-/datum/sprite_accessory/spines_animated/long
-	name = "Long"
-	icon_state = "long"
-
 /datum/sprite_accessory/tail_spines/long
 	name = "Long"
 	icon_state = "long"
@@ -2136,19 +2116,11 @@
 	name = "Long + Membrane"
 	icon_state = "longmeme"
 
-/datum/sprite_accessory/spines_animated/longmeme
-	name = "Long + Membrane"
-	icon_state = "longmeme"
-
 /datum/sprite_accessory/tail_spines/longmeme
 	name = "Long + Membrane"
 	icon_state = "longmeme"
 
 /datum/sprite_accessory/spines/aquatic
-	name = "Aquatic"
-	icon_state = "aqua"
-
-/datum/sprite_accessory/spines_animated/aquatic
 	name = "Aquatic"
 	icon_state = "aqua"
 


### PR DESCRIPTION

isn't used anymore since tails were refactored
## Changelog
:cl:
code: Removed unused global lists and sprite accessories related to tail spines
/:cl:
