### PR TITLE
remove plasmaman check in survival boxes

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -30,10 +30,8 @@
 	if(!isnull(mask_type))
 		new mask_type(src)
 
-	if(!isplasmaman(loc))
+	if(!isnull(internal_type))
 		new internal_type(src)
-	else
-		new /obj/item/tank/internals/plasmaman/belt(src)
 
 	if(!isnull(medipen_type))
 		new medipen_type(src)


### PR DESCRIPTION

## About The Pull Request
it's already done in wardrobe_removal() there is no need for this check
## Changelog
:cl:
code: removed redundant check for plasmamen in survival box code
/:cl:
