### PR TITLE
Spawners menu now displays the amount of uses left appropriately

### DIFF
--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -30,9 +30,9 @@
 		this["important_warning"] = ""
 		this["amount_left"] = 0
 		for(var/spawner_obj in GLOB.mob_spawners[spawner])
+			var/obj/effect/mob_spawn/ghost_role/mob_spawner = spawner_obj
 			if(!this["desc"])
 				if(istype(spawner_obj, /obj/effect/mob_spawn))
-					var/obj/effect/mob_spawn/ghost_role/mob_spawner = spawner_obj
 					if(!mob_spawner.allow_spawn(user, silent = TRUE))
 						continue
 					this["you_are_text"] = mob_spawner.you_are_text
@@ -41,8 +41,9 @@
 				else
 					var/obj/object = spawner_obj
 					this["desc"] = object.desc
-			this["amount_left"] += 1
-		if(this["amount_left"] > 0)
+			this["amount_left"] += mob_spawner.uses
+			this["infinite"] += mob_spawner.infinite_use
+		if(this["amount_left"] > 0 || this["infinite"])
 			data["spawners"] += list(this)
 	for(var/mob_type in GLOB.joinable_mobs)
 		var/list/this = list()

--- a/tgui/packages/tgui/interfaces/SpawnersMenu.tsx
+++ b/tgui/packages/tgui/interfaces/SpawnersMenu.tsx
@@ -10,6 +10,7 @@ type SpawnersMenuContext = {
 type spawner = {
   name: string;
   amount_left: number;
+  infinite: boolean;
   desc?: string;
   you_are_text?: string;
   flavor_text?: string;
@@ -31,9 +32,15 @@ export const SpawnersMenu = (props) => {
                 title={capitalizeAll(spawner.name)}
                 buttons={
                   <Stack>
-                    <Stack.Item fontSize="14px" color="green">
-                      {spawner.amount_left} left
-                    </Stack.Item>
+                    {spawner.infinite ? (
+                      <Stack.Item fontSize="14px" color="green">
+                        Infinite
+                      </Stack.Item>
+                    ) : (
+                      <Stack.Item fontSize="14px" color="green">
+                        {spawner.amount_left} left
+                      </Stack.Item>
+                    )}
                     <Stack.Item>
                       <Button
                         content="Jump"


### PR DESCRIPTION
## About The Pull Request
Prior to this PR, if an individual spawner allowed more than one uses, it would still display as one use in the menu. Not only that, but infinite spawners would also show as having just one use. Both of these behaviors have been fixed, resulting in a much more accurate depiction of how many uses are left on each spawner.

![image](https://github.com/tgstation/tgstation/assets/58045821/77508cdd-66bf-4d85-9dd7-c25f8ccd41b6)
(The first spawner isn't normally infinite, I just used VV to edit its `infinite_uses` to `1` for the sake of proving that the display worked).


## Why It's Good For The Game
Being able to know that a spawner is infinite is a good thing for players, just like being able to know how many uses are left if an individual spawner can be used by more than one player.

## Changelog

:cl: GoldenAlpharex
fix: The Spawners menu now accurately displays the amount of uses left in each spawner option, taking into account individual spawners that either allow more than one use, or an infinite amount of uses.
/:cl: