### PR TITLE
Changes airlock access for a couple of doors on birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -9201,21 +9201,6 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"dzW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/east{
-	id = "qm_warehouse_aft";
-	name = "Warehouse Door Control";
-	pixel_x = -24;
-	pixel_y = -23;
-	req_access = list("cargo")
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "dAh" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -61182,6 +61167,21 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/hop)
+"vdl" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/east{
+	id = "qm_warehouse_aft";
+	name = "Warehouse Door Control";
+	pixel_x = -24;
+	pixel_y = -23;
+	req_access = list("cargo")
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "vdm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
@@ -62686,7 +62686,8 @@
 /obj/machinery/door/airlock/command{
 	name = "Centcom Dock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/textured_half,
 /area/station/command/corporate_dock)
 "vzY" = (
@@ -66412,10 +66413,11 @@
 	},
 /area/station/science/xenobiology)
 "wIm" = (
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/machinery/door/airlock/hatch{
 	name = "Centcom Dock"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "wIp" = (
@@ -88534,7 +88536,7 @@ pJQ
 wZF
 pqv
 wZF
-dzW
+vdl
 slY
 ueX
 rVQ

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -9201,6 +9201,21 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
+"dzW" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/east{
+	id = "qm_warehouse_aft";
+	name = "Warehouse Door Control";
+	pixel_x = -24;
+	pixel_y = -23;
+	req_access = list("cargo")
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "dAh" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -18462,10 +18477,10 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "gKL" = (
@@ -88519,7 +88534,7 @@ pJQ
 wZF
 pqv
 wZF
-sxA
+dzW
 slY
 ueX
 rVQ


### PR DESCRIPTION

## About The Pull Request
Its probably unintended that the maint door above tool storage only had 'cargo' access instead of cargo and maint access. It now has cargo and maint access.

![image](https://github.com/tgstation/tgstation/assets/54517726/14996005-27d9-4c0d-8044-f9fb04328dc8)
Also the CC dock on birdshot has only bridge access on it, officials and the like dont have bridge access so i added general CC access so they can go in and out instead of using maints
![image](https://github.com/tgstation/tgstation/assets/54517726/d372229f-4587-4151-8a8a-6e5665bf30a8)
## Why It's Good For The Game
Probably unintended and people wont get confused as to why it wont open
## Changelog
:cl:

fix: The door above tool storage on birdshot now has maintenance access on it and officials can now enter the CC dock room.

/:cl:
