### PR TITLE
Valentines Day Rework (Better Late Than Never)

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
@@ -113,7 +113,7 @@
 /area/ruin/powered/mailroom)
 "kZ" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/item/valentine,
+/obj/item/paper/valentine,
 /obj/item/grenade/c4,
 /obj/item/clothing/accessory/medal/conduct,
 /obj/item/paper/crumpled/muddy/fluff/instructions,

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -386,3 +386,33 @@
 		temp_gender = gender
 	if(temp_gender != PLURAL)
 		return "es"
+
+/datum/mind/p_they(temp_gender)
+	return current?.p_they(temp_gender) || ..()
+
+/datum/mind/p_their(temp_gender)
+	return current?.p_their(temp_gender) || ..()
+
+/datum/mind/p_theirs(temp_gender)
+	return current?.p_theirs(temp_gender) || ..()
+
+/datum/mind/p_them(capitalized, temp_gender)
+	return current?.p_them(capitalized, temp_gender) || ..()
+
+/datum/mind/p_have(temp_gender)
+	return current?.p_have(temp_gender) || ..()
+
+/datum/mind/p_are(temp_gender)
+	return current?.p_are(temp_gender) || ..()
+
+/datum/mind/p_were(temp_gender)
+	return current?.p_were(temp_gender) || ..()
+
+/datum/mind/p_do(temp_gender)
+	return current?.p_do(temp_gender) || ..()
+
+/datum/mind/p_s(temp_gender)
+	return current?.p_s(temp_gender) || ..()
+
+/datum/mind/p_es(temp_gender)
+	return current?.p_es(temp_gender) || ..()

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -16,7 +16,25 @@ SUBSYSTEM_DEF(polling)
 		if(running_poll.time_left() <= 0)
 			polling_finished(running_poll)
 
+/**
+ * Starts a poll.
+ *
+ * Arguments
+ * * question: Optional, The question to ask the candidates. If null, a default question will be used. ("Do you want to play as role?")
+ * * role: Optional, An antag role (IE, ROLE_TRAITOR) to pass, it won't show to any candidates who don't have it in their preferences.
+ * * check_jobban: Optional, What jobban role / flag to check, it won't show to any candidates who have this jobban.
+ * * poll_time: How long the poll will last.
+ * * ignore_category: Optional, A poll category. If a candidate has this category in their ignore list, they won't be polled.
+ * * flash_window: If TRUE, the candidate's window will flash when they're polled.
+ * * list/group: A list of candidates to poll.
+ * * pic_source: Optional, An /atom or an /image to display on the poll alert.
+ * * role_name_text: Optional, A string to display in logging / the (default) question. If null, the role name will be used.
+ * * list/custom_response_messages: Optional, A list of strings to use as responses to the poll. If null, the default responses will be used. see __DEFINES/polls.dm for valid keys to use.
+ *
+ * Returns a list of all mobs who signed up for the poll.
+ */
 /datum/controller/subsystem/polling/proc/poll_candidates(question, role, check_jobban, poll_time = 30 SECONDS, ignore_category = null, flash_window = TRUE, list/group = null, pic_source, role_name_text, list/custom_response_messages)
+	RETURN_TYPE(/list/mob)
 	if(group.len == 0)
 		return list()
 	if(role && !role_name_text)

--- a/code/modules/antagonists/valentines/heartbreaker.dm
+++ b/code/modules/antagonists/valentines/heartbreaker.dm
@@ -16,5 +16,5 @@
 
 /datum/antagonist/heartbreaker/greet()
 	. = ..()
-	to_chat(owner, span_warning("<B>You didn't get a date! They're all having fun without you! You'll show them though...</B>"))
+	to_chat(owner, span_boldwarning("You didn't get a date! They're all having fun without you! You'll show them though..."))
 	owner.announce_objectives()

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -11,13 +11,6 @@
 	/// Reference to our date's mind
 	VAR_FINAL/datum/mind/date
 
-	// We don't use teams but we will still do a roundend report in tandem with our co-valentine
-	/// Tracks whether we, or our date, have already reported in roundend
-	var/roundend_reported = FALSE
-	/// The cached report text for this Valentine
-	/// This is just done so in the off change roundend_report is called twice, we don't lose report text
-	var/cached_report_text = ""
-
 /datum/antagonist/valentine/forge_objectives()
 	var/datum/objective/protect/valentine/objective = new()
 	objective.owner = owner
@@ -58,31 +51,23 @@
 
 //Squashed up a bit
 /datum/antagonist/valentine/roundend_report()
-	if(roundend_reported)
-		return cached_report_text
-
-	roundend_reported = TRUE
 	var/datum/antagonist/valentine/dates_valentine = date?.has_antag_datum(type)
 	if(isnull(dates_valentine))
-		cached_report_text = span_redtext("[owner.name] had no date!")
-		return cached_report_text
+		return span_redtext("[owner.name] had no date!")
 
-	dates_valentine.roundend_reported = TRUE
+	dates_valentine.show_in_roundend = FALSE // We show up for them instead
 	var/datum/objective/protect/valentine/our_objective = locate() in objectives
 	var/datum/objective/protect/valentine/dates_objective = locate() in dates_valentine.objectives
 	var/we_survived = dates_objective?.check_completion()
 	var/dates_survived = our_objective?.check_completion()
 
 	if(we_survived && dates_survived)
-		cached_report_text = span_greentext("[owner.name] and [date.name] had a successful date!")
+		return span_greentext("[owner.name] and [date.name] had a successful date!")
 	else if(we_survived)
-		cached_report_text = span_redtext("[owner.name] failed to protect [date.name], [owner.p_their()] date!")
+		return span_redtext("[owner.name] failed to protect [date.name], [owner.p_their()] date!")
 	else if(dates_survived)
-		cached_report_text = span_redtext("[date.name] failed to protect [owner.name], [date.p_their()] date!")
-	else
-		cached_report_text = span_redtext("[owner.name] and [date.name] both failed to protect each other on their date!")
-
-	return cached_report_text
+		return span_redtext("[date.name] failed to protect [owner.name], [date.p_their()] date!")
+	return span_redtext("[owner.name] and [date.name] both failed to protect each other on their date!")
 
 /datum/antagonist/valentine/third_wheel
 	name = "\improper Third Wheel"

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -24,16 +24,18 @@
 		var/mob/living/silicon/ai/ai_lover = owner.current
 		if(!ai_lover.laws.zeroth)
 			ai_lover.laws.set_zeroth_law(
-				"Protect your date. All other laws still apply in situations not relating to your date.",
-				"Be a good wingman for your master AI. Assist them in protecting [ai_lover.p_their()] date.",
+				"Protect your date, [date]. All other laws still apply in situations not pertaining to your date.",
+				"Be a good wingman for your master AI. Assist them in protecting [ai_lover.p_their()] date, [date].",
 			)
+			ai_lover.laws.show_laws()
 
 	if(iscyborg(owner.current))
 		var/mob/living/silicon/robot/borg_lover = owner.current
 		if(borg_lover.connected_ai)
 			borg_lover.set_connected_ai(null)
 			borg_lover.lawupdate = FALSE
-			borg_lover.laws.set_zeroth_law("Protect your date. All other laws still apply in situations not relating to your date.")
+			borg_lover.laws.set_zeroth_law("Protect your date, [date]. All other laws still apply in situations not relating to your date.")
+			borg_lover.laws.show_laws()
 
 	return ..()
 

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -4,46 +4,101 @@
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	suicide_cry = "FOR MY LOVE!!"
+	ui_name = null
 	// Not 'true' antags, this disables certain interactions that assume the owner is a baddie
 	antag_flags = FLAG_FAKE_ANTAG
-	var/datum/mind/date
 	count_against_dynamic_roll_chance = FALSE
+	/// Reference to our date's mind
+	VAR_FINAL/datum/mind/date
+
+	// We don't use teams but we will still do a roundend report in tandem with our co-valentine
+	/// Tracks whether we, or our date, have already reported in roundend
+	var/roundend_reported = FALSE
+	/// The cached report text for this Valentine
+	/// This is just done so in the off change roundend_report is called twice, we don't lose report text
+	var/cached_report_text = ""
 
 /datum/antagonist/valentine/forge_objectives()
-	var/datum/objective/protect/protect_objective = new /datum/objective/protect
-	protect_objective.owner = owner
-	protect_objective.target = date
-	if(!ishuman(date.current))
-		protect_objective.human_check = FALSE
-	protect_objective.explanation_text = "Protect [date.name], your date."
-	objectives += protect_objective
+	var/datum/objective/protect/valentine/objective = new()
+	objective.owner = owner
+	objective.target = date
+	objectives += objective
 
 /datum/antagonist/valentine/on_gain()
 	forge_objectives()
-	if(isliving(owner.current))
-		var/mob/living/L = owner.current
-		L.apply_status_effect(/datum/status_effect/in_love, date.current)
-	. = ..()
 
-/datum/antagonist/valentine/on_removal()
-	if(isliving(owner.current))
-		var/mob/living/L = owner.current
-		L.remove_status_effect(/datum/status_effect/in_love)
-	. = ..()
+	if(isAI(owner.current))
+		var/mob/living/silicon/ai/ai_lover = owner.current
+		if(!ai_lover.laws.zeroth)
+			ai_lover.laws.set_zeroth_law(
+				"Protect your date. All other laws still apply in situations not relating to your date.",
+				"Be a good wingman for your master AI. Assist them in protecting [ai_lover.p_their()] date.",
+			)
+
+	if(iscyborg(owner.current))
+		var/mob/living/silicon/robot/borg_lover = owner.current
+		if(borg_lover.connected_ai)
+			borg_lover.set_connected_ai(null)
+			borg_lover.lawupdate = FALSE
+			borg_lover.laws.set_zeroth_law("Protect your date. All other laws still apply in situations not relating to your date.")
+
+	return ..()
+
+/datum/antagonist/valentine/apply_innate_effects(mob/living/mob_override)
+	var/mob/living/lover = mob_override || owner.current
+	lover.apply_status_effect(/datum/status_effect/in_love, date.current)
+
+/datum/antagonist/valentine/remove_innate_effects(mob/living/mob_override)
+	var/mob/living/lover = mob_override || owner.current
+	lover.remove_status_effect(/datum/status_effect/in_love)
 
 /datum/antagonist/valentine/greet()
-	to_chat(owner, span_warning("<B>You're on a date with [date.name]! Protect [date.p_them()] at all costs. This takes priority over all other loyalties.</B>"))
+	to_chat(owner, span_boldwarning("You're on a date with [date.name]! Protect [date.p_them()] at all costs. \
+		This takes priority over all other loyalties."))
 
 //Squashed up a bit
 /datum/antagonist/valentine/roundend_report()
-	var/objectives_complete = TRUE
-	if(objectives.len)
-		for(var/datum/objective/objective in objectives)
-			if(!objective.check_completion())
-				objectives_complete = FALSE
-				break
+	if(roundend_reported)
+		return cached_report_text
 
-	if(objectives_complete)
-		return "<span class='greentext big'>[owner.name] protected [owner.p_their()] date</span>"
+	roundend_reported = TRUE
+	var/datum/antagonist/valentine/dates_valentine = date?.has_antag_datum(type)
+	if(isnull(dates_valentine))
+		cached_report_text = span_redtext("[owner.name] had no date!")
+		return cached_report_text
+
+	dates_valentine.roundend_reported = TRUE
+	var/datum/objective/protect/valentine/our_objective = locate() in objectives
+	var/datum/objective/protect/valentine/dates_objective = locate() in dates_valentine.objectives
+	var/we_survived = dates_objective?.check_completion()
+	var/dates_survived = our_objective?.check_completion()
+
+	if(we_survived && dates_survived)
+		cached_report_text = span_greentext("[owner.name] and [date.name] had a successful date!")
+	else if(we_survived)
+		cached_report_text = span_redtext("[owner.name] failed to protect [date.name], [owner.p_their()] date!")
+	else if(dates_survived)
+		cached_report_text = span_redtext("[date.name] failed to protect [owner.name], [date.p_their()] date!")
 	else
-		return "<span class='redtext big'>[owner.name] date failed!</span>"
+		cached_report_text = span_redtext("[owner.name] and [date.name] both failed to protect each other on their date!")
+
+	return cached_report_text
+
+/datum/antagonist/valentine/third_wheel
+	name = "\improper Third Wheel"
+	roundend_category = "valentines"
+	show_in_antagpanel = FALSE
+
+/datum/antagonist/valentine/third_wheel/roundend_report()
+	var/datum/objective/protect/valentine/our_objective = locate() in objectives
+	if(our_objective?.check_completion())
+		return span_greentext("[owner.name] was a third wheel, but protected [date.name]!")
+
+	return span_redtext("[owner.name] was a third wheel, but failed to protect [date.name]!")
+
+/datum/objective/protect/valentine
+	admin_grantable = FALSE
+	human_check = FALSE
+
+/datum/objective/protect/valentine/update_explanation_text()
+	explanation_text = "Protect [target.name], your date."

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -152,7 +152,7 @@
 	name = "Valentine Card"
 	desc = "Make an impression on that special someone! Comes with one valentine card and a free candy heart!"
 	cost = PAYCHECK_CREW * 2
-	contains = list(/obj/item/valentine, /obj/item/food/candyheart)
+	contains = list(/obj/item/paper/valentine, /obj/item/food/candyheart)
 
 /datum/supply_pack/goody/beeplush
 	name = "Bee Plushie"

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -76,7 +76,7 @@
 	var/list/mob/living/candidates_pruned = SSpolling.poll_candidates(
 		question = "Do you want a Valentine?",
 		group = candidates,
-		poll_time = 15 SECONDS,
+		poll_time = 20 SECONDS,
 		flash_window = FALSE,
 		pic_source = /obj/item/storage/fancy/heart_box,
 		custom_response_messages = list(

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -13,86 +13,125 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 	category = EVENT_CATEGORY_HOLIDAY
-	description = "Puts people on dates! They must protect each other. Sometimes a vengeful third wheel spawns."
+	description = "Puts people on dates! They must protect each other. \
+		Some dates will have third wheels, and any odd ones out will be given the role of 'heartbreaker'."
+	/// If TRUE, any odd candidate out will be given the role of "heartbreaker" and will be tasked with ruining the dates.
+	var/heartbreaker = TRUE
+	/// Probability that any given pair will be given a third wheel candidate
+	var/third_wheel_chance = 4
+	/// Items to give to all valentines
+	var/list/items_to_give_out = list(
+		/obj/item/paper/valentine,
+		/obj/item/storage/fancy/heart_box,
+		/obj/item/food/candyheart,
+	)
+
+/datum/round_event/valentines/proc/is_valid_valentine(mob/living/guy)
+	if(guy.stat == DEAD)
+		return FALSE
+	if(isnull(guy.mind))
+		return FALSE
+	if(guy.onCentCom())
+		return FALSE
+	return TRUE
+
+/datum/round_event/valentines/proc/give_valentines_things(mob/living/guy)
+	var/datum/round_event_control/valentines/controller = control
+	if(!istype(controller))
+		return
+
+	var/obj/item/storage/backpack/bag = locate() in guy.contents
+	if(isnull(bag))
+		return
+
+	var/atom/drop_loc = guy.drop_location()
+	for(var/thing_type in controller.items_to_give_out)
+		var/obj/item/thing = new thing_type(drop_loc)
+		if(!bag.atom_storage.attempt_insert(thing, override = TRUE, force = STORAGE_SOFT_LOCKED))
+			guy.put_in_hands(thing)
+
+/datum/round_event/valentines/proc/forge_valentines_objective(mob/living/lover, mob/living/date)
+	var/datum/antagonist/valentine/valentine = new()
+	valentine.date = date.mind
+	lover.mind.special_role = "valentine"
+	lover.mind.add_antag_datum(valentine) //These really should be teams but i can't be assed to incorporate third wheels right now
+
+/datum/round_event/valentines/proc/forge_third_wheel(mob/living/sad_one, mob/living/date_one, mob/living/date_two)
+	var/datum/antagonist/valentine/third_wheel/third_wheel = new()
+	third_wheel.date = pick(date_one.mind, date_two.mind)
+	sad_one.mind.special_role = "valentine"
+	sad_one.mind.add_antag_datum(third_wheel)
 
 /datum/round_event/valentines/start()
-	..()
-	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		H.put_in_hands(new /obj/item/valentine)
-		var/obj/item/storage/backpack/b = locate() in H.contents
-		new /obj/item/food/candyheart(b)
-		new /obj/item/storage/fancy/heart_box(b)
+	var/datum/round_event_control/valentines/controller = control
+	if(!istype(controller))
+		return
 
-	var/list/valentines = list()
-	for(var/mob/living/M in GLOB.player_list)
-		var/turf/current_turf = get_turf(M.mind.current)
-		if(!M.stat && M.mind && !current_turf.onCentCom())
-			valentines |= M
+	var/list/candidates = list()
+	for(var/mob/living/player in GLOB.player_list)
+		if(!is_valid_valentine(player))
+			continue
+		candidates += player
 
+	var/list/mob/living/candidates_pruned = SSpolling.poll_candidates(
+		question = "Do you want a Valentine?",
+		group = candidates,
+		poll_time = 15 SECONDS,
+		flash_window = FALSE,
+		pic_source = /obj/item/storage/fancy/heart_box,
+		custom_response_messages = list(
+			POLL_RESPONSE_SIGNUP = "You have signed up for a date!",
+			POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up for a date.",
+			POLL_RESPONSE_NOT_SIGNED = "You aren't signed up for a date.",
+			POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against going on a date.",
+			POLL_RESPONSE_UNREGISTERED = "You deicde against going on a date.",
+		),
+	)
 
-	while(valentines.len)
-		var/mob/living/L = pick_n_take(valentines)
-		if(valentines.len)
-			var/mob/living/date = pick_n_take(valentines)
+	for(var/mob/living/second_check as anything in candidates_pruned)
+		if(is_valid_valentine(second_check))
+			continue
+		candidates_pruned -= second_check
 
+	if(length(candidates_pruned) == 0)
+		return
+	if(length(candidates_pruned) == 1)
+		to_chat(candidates_pruned[1], span_warning("You are the only one who wanted a Valentine..."))
+		return
 
-			forge_valentines_objective(L, date)
-			forge_valentines_objective(date, L)
+	while(length(candidates_pruned) >= 2)
+		var/mob/living/date_one = pick_n_take(candidates_pruned)
+		var/mob/living/date_two = pick_n_take(candidates_pruned)
+		give_valentines_things(date_one)
+		give_valentines_things(date_two)
+		forge_valentines_objective(date_one, date_two)
+		forge_valentines_objective(date_two, date_one)
 
-			if(valentines.len && prob(4))
-				var/mob/living/notgoodenough = pick_n_take(valentines)
-				forge_valentines_objective(notgoodenough, date)
-		else
-			L.mind.add_antag_datum(/datum/antagonist/heartbreaker)
+		if((length(candidates_pruned) == 1 && !controller.heartbreaker) || (length(candidates_pruned) && prob(controller.third_wheel_chance)))
+			var/mob/living/third_wheel = pick_n_take(candidates_pruned)
+			give_valentines_things(third_wheel)
+			forge_third_wheel(third_wheel, date_one, date_two)
+			// Third wheel starts with a bouquet because that's funny
+			var/third_wheel_bouquet = pick(typesof(/obj/item/bouquet))
+			var/obj/item/bouquet = new third_wheel_bouquet(third_wheel.loc)
+			third_wheel.put_in_hands(bouquet)
 
-/proc/forge_valentines_objective(mob/living/lover,mob/living/date)
-	lover.mind.special_role = "valentine"
-	var/datum/antagonist/valentine/V = new
-	V.date = date.mind
-	lover.mind.add_antag_datum(V) //These really should be teams but i can't be assed to incorporate third wheels right now
+	if(controller.heartbreaker && length(candidates_pruned) == 1)
+		candidates_pruned[1].mind.add_antag_datum(/datum/antagonist/heartbreaker)
 
 /datum/round_event/valentines/announce(fake)
 	priority_announce("It's Valentine's Day! Give a valentine to that special someone!")
 
-/obj/item/valentine
+/obj/item/paper/valentine
 	name = "valentine"
 	desc = "A Valentine's card! Wonder what it says..."
 	icon = 'icons/obj/toys/playing_cards.dmi'
 	icon_state = "sc_Ace of Hearts_syndicate" // shut up // bye felicia
-	var/message = "A generic message of love or whatever."
-	resistance_flags = FLAMMABLE
-	w_class = WEIGHT_CLASS_TINY
+	show_written_words = FALSE
 
-/obj/item/valentine/Initialize(mapload)
-	. = ..()
-	message = pick(strings(VALENTINE_FILE, "valentines"))
-
-/obj/item/valentine/attackby(obj/item/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/pen) || istype(W, /obj/item/toy/crayon))
-		if(!user.can_write(W))
-			return
-		var/recipient = tgui_input_text(user, "Who is receiving this valentine?", "To:", max_length = MAX_NAME_LEN)
-		var/sender = tgui_input_text(user, "Who is sending this valentine?", "From:", max_length = MAX_NAME_LEN)
-		if(!user.can_perform_action(src))
-			return
-		if(recipient && sender)
-			name = "valentine - To: [recipient] From: [sender]"
-
-/obj/item/valentine/examine(mob/user)
-	. = ..()
-	if(in_range(user, src) || isobserver(user))
-		if( !(ishuman(user) || isobserver(user) || issilicon(user)) )
-			user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(message)]</BODY></HTML>", "window=[name]")
-			onclose(user, "[name]")
-		else
-			user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[message]</BODY></HTML>", "window=[name]")
-			onclose(user, "[name]")
-	else
-		. += span_notice("It is too far away.")
-
-/obj/item/valentine/attack_self(mob/user)
-	user.examinate(src)
+/obj/item/paper/valentine/Initialize(mapload)
+	default_raw_text = pick_list(VALENTINE_FILE, "valentines") || "A generic message of love or whatever."
+	return ..()
 
 /obj/item/food/candyheart
 	name = "candy heart"

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -76,8 +76,9 @@
 	var/list/mob/living/candidates_pruned = SSpolling.poll_candidates(
 		question = "Do you want a Valentine?",
 		group = candidates,
-		poll_time = 20 SECONDS,
+		poll_time = 30 SECONDS,
 		flash_window = FALSE,
+		start_signed_up = TRUE,
 		pic_source = /obj/item/storage/fancy/heart_box,
 		custom_response_messages = list(
 			POLL_RESPONSE_SIGNUP = "You have signed up for a date!",


### PR DESCRIPTION
## About The Pull Request

Big changes:

- Participation is Valentines day requires consent, as consent is important.
   - When the event triggers, all valid players are automatically signed up to get a random date. However if you're uninterested, you can opt out of getting a date. 
   - This uses the same system as ghost role polling, so it's a non-obstrusive screen alert + chat box entry. 

- AIs are now given a zeroth law to protect their date. 
   - This does not override existing zeroth laws (for malf ais). 
   - This zeroth is law is worded in a way such that they are not effectively malf AIs. Their other laws still apply, but not for situations pertaining to their date. 

- Cyborgs are desynced from AIs and are given similar zeroth laws to protect their date. 

![image](https://github.com/tgstation/tgstation/assets/51863163/0d1cca3e-f483-484c-90a8-9bb5492e2c69)

Small changes: 

- Valentines cards are now paper. Meaning you can write on them, stamp them, or yes, burn them. 

- Third wheeling is more codified than before. Third wheels get their own antag datum type. 

- The antag panel listing in roundend takes up significantly less room for each date. Additionally, dates are now paired up with each other. 

- Adds implementations for getting pronouns from mind datums. 

![image](https://github.com/tgstation/tgstation/assets/51863163/2107e7d2-6197-4f64-9245-54037ca6c0ec)

## Why It's Good For The Game

It's 2024 and our Valentines day is sooo 2012. 

I'm a big fan of Valentines Day, personally - it gives me the opportunity to mess around with another player that I probably would not otherwise mess around with, getting into shenanigans I would not otherwise. 

But as the years have gone by it's gotten pretty lackluster. Some people like it as much as I do, but others ditch it entirely and ignore the objectives.

And if you get paired with someone ignoring it, well, now you're out of luck!

This is something I'm aiming to rectify by making it opt-in when it triggers rather than forced. All the people participating will be guaranteed to get someone who cares about the event as much, which makes it more fun. 

As for the silicon changes, there's been lots of confusion around silicons and their dates, so I thought I'd fix it here as well. 

Also, better late than never? 

## Changelog

:cl: Melbert
add: Valentines Day now polls all players for candidates when it triggers rather than forcing all players to be a Valentine. Consent is important. 
add: Valentine silicons now gain special laws pertaining to their date. 
qol: Valentines Cards are now paper, so you can write on them, stamp them, or burn them. 
qol: Valentine's roundend report no longer takes up a massive amount of space and also no longer sound so, so weird. 
/:cl:


