### PR TITLE
Fixes blocking movement being weird

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -11,6 +11,9 @@
 	// If we're not movin anywhere, we aren't movin anywhere
 	// Safe because nothing adds to movement_dir after this moment
 	if(!movement_dir)
+		// No input == our removal would have done nothing
+		// So we can safely forget about it
+		user.next_move_dir_sub = NONE
 		return FALSE
 
 	if(user.next_move_dir_sub)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -47,8 +47,8 @@
 /client/Move(new_loc, direct)
 	if(world.time < move_delay) //do not move anything ahead of this check please
 		return FALSE
-	next_move_dir_add = 0
-	next_move_dir_sub = 0
+	next_move_dir_add = NONE
+	next_move_dir_sub = NONE
 	var/old_move_delay = move_delay
 	move_delay = world.time + world.tick_lag //this is here because Move() can now be called mutiple times per tick
 	if(!direct || !new_loc)


### PR DESCRIPTION

## About The Pull Request

I was failing to clear the input removal if we had no movement So you'd step, stop moving, and retain it

Then whenever we rotate, we continue to hold onto that removal forever. Weird.

Handles... part of? #81501

## Changelog
:cl:
fix:Blocking movement works properly again
/:cl:
