### PR TITLE
Changes the crystallizer wrench screentip to the correct button

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -55,7 +55,7 @@
 		if(TOOL_SCREWDRIVER)
 			context[SCREENTIP_CONTEXT_LMB] = "[panel_open ? "Close" : "Open"] panel"
 		if(TOOL_WRENCH)
-			context[SCREENTIP_CONTEXT_LMB] = "Rotate"
+			context[SCREENTIP_CONTEXT_RMB] = "Rotate"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/atmospherics/components/binary/crystallizer/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION

## About The Pull Request
it says left click, that does nothing, you need to right click it to rotate
## Why It's Good For The Game
correct ingame information
## Changelog
:cl:
fix: The crystallizer screentip for rotating it has been updated with the correct button
/:cl:
