### PR TITLE
Fixes a spurious runtime off loading the museum away mission

### DIFF
--- a/_maps/RandomZLevels/museum.dmm
+++ b/_maps/RandomZLevels/museum.dmm
@@ -3147,7 +3147,6 @@
 /obj/structure/transport/linear/tram/slow,
 /obj/structure/thermoplastic,
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
-/obj/effect/spawner/random/maintenance/five,
 /turf/open/chasm/true/no_smooth,
 /area/awaymission/museum)
 "Cc" = (


### PR DESCRIPTION

## About The Pull Request

It loaded a random spawner on top of a chasm. The spawner has a chance to drop the dust decal, which errors when trying to spawn on a chasm

Yayeeeeeet
