### PR TITLE
Traitor Traitor Panel Fixes

### DIFF
--- a/code/__HELPERS/memory_helpers.dm
+++ b/code/__HELPERS/memory_helpers.dm
@@ -115,7 +115,7 @@
 
 /// Helder to wipe the passed memory type ONLY from our list of memories
 /datum/mind/proc/wipe_memory_type(memory_type)
-	qdel(memories?[memory_type])
+	qdel(memories[memory_type])
 	memories -= memory_type
 
 /// Helper to create quick copies of all of our memories

--- a/code/__HELPERS/memory_helpers.dm
+++ b/code/__HELPERS/memory_helpers.dm
@@ -113,6 +113,11 @@
 /datum/mind/proc/wipe_memory()
 	QDEL_LIST_ASSOC_VAL(memories)
 
+/// Helder to wipe the passed memory type ONLY from our list of memories
+/datum/mind/proc/wipe_memory_type(memory_type)
+	qdel(memories?[memory_type])
+	memories -= memory_type
+
 /// Helper to create quick copies of all of our memories
 /// Quick copies aren't full copies - just basic copies containing necessities.
 /// They cannot be used in stories.

--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -451,7 +451,7 @@
 					current.dropItemToGround(W, TRUE) //The TRUE forces all items to drop, since this is an admin undress.
 			if("takeuplink")
 				take_uplink()
-				wipe_memory()//Remove any memory they may have had.
+				wipe_memory_type(/datum/memory/key/traitor_uplink/implant)
 				log_admin("[key_name(usr)] removed [current]'s uplink.")
 			if("crystals")
 				if(check_rights(R_FUN))
@@ -462,8 +462,8 @@
 							message = "Amount of telecrystals for [key]",
 							title = "Syndicate uplink",
 							default = U.uplink_handler.telecrystals,
-							)
-						if(crystals && isnum(crystals))
+						)
+						if(isnum(crystals))
 							U.uplink_handler.set_telecrystals(crystals)
 							message_admins("[key_name_admin(usr)] changed [current]'s telecrystal count to [crystals].")
 							log_admin("[key_name(usr)] changed [current]'s telecrystal count to [crystals].")

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -123,6 +123,9 @@
 		uplink_handler.has_objectives = FALSE
 		uplink_handler.can_replace_objectives = null
 		uplink_handler.replace_objectives = null
+	owner.take_uplink()
+	owner.special_role = null
+	owner.forget_crafting_recipe(/datum/crafting_recipe/syndicate_uplink_beacon)
 	return ..()
 
 /datum/antagonist/traitor/proc/traitor_objective_to_html(datum/traitor_objective/to_display)
@@ -181,11 +184,6 @@
 /datum/antagonist/traitor/proc/generate_replacement_codes()
 	replacement_uplink_code = "[pick(GLOB.phonetic_alphabet)] [rand(10,99)]"
 	replacement_uplink_frequency = sanitize_frequency(rand(MIN_UNUSED_FREQ, MAX_FREQ), free = FALSE, syndie = FALSE)
-
-/datum/antagonist/traitor/on_removal()
-	owner.special_role = null
-	owner.forget_crafting_recipe(/datum/crafting_recipe/syndicate_uplink_beacon)
-	return ..()
 
 /datum/antagonist/traitor/proc/pick_employer()
 	if(!employer)


### PR DESCRIPTION
## About The Pull Request

- Fixes #81514
   - Setting TC checked for `value && isnum(value)` which was dumb when `value` could be `0`. 

- Removing Traitor auto-takes uplink from the mob 

- Removing Uplink now removes just the uplink code from memory, rather than all memories

## Changelog

:cl: Melbert
admin: You can now set someone's TC to 0
admin: Removing Traitor from automatically removes the uplink from them 
admin: Removing Uplink from someone no longer wipes ALL of their memories
/:cl:

