### PR TITLE
[NO GBP] Removes a double newscaster from the arrivals sec post on Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56637,10 +56637,6 @@
 "uhI" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	name = "Security Requests Console"
-	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "uhP" = (


### PR DESCRIPTION

## About The Pull Request

This fixes a double newscaster in meta arrivals sec post.

![image](https://github.com/tgstation/tgstation/assets/28870487/fed928fe-20c3-4404-9d7a-ea499d4f3729)

I got really confused when I saw this in-game, because I thought I had fixed it already. I looked into it but apparently I just moved an intercom and just didn't fix this in #77706? I literally have the double newscaster in the pic, but I guess I just forgot to also fix that?? I'm tagging this as no GBP because I cannot believe I missed this and it should have been fixed in the first PR.

Anyways its gone now!

![image](https://github.com/tgstation/tgstation/assets/28870487/a21d26f3-53a2-4585-881f-18ba53980f6b)

Say, aren't wallmounts supposed to fall down when not supported by a tile...?
## Why It's Good For The Game

There needs to be 1 not 2 of them there man.
## Changelog
:cl: Rhials
fix: Removes the double-newscaster from the arrivals sec post.
/:cl:
