### PR TITLE
Fixes smoothing breaking if a map is loaded post init

### DIFF
--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -75,7 +75,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	thing.smoothing_flags |= SMOOTH_QUEUED
 	// If we're currently locked into mapload BY something
 	// Then put us in a deferred list that we release when this mapload run is finished
-	if(initialized && length(SSatoms.initialized_state))
+	if(initialized && length(SSatoms.initialized_state) && SSatoms.initialized == INITIALIZATION_INNEW_MAPLOAD)
 		var/source = SSatoms.get_initialized_source()
 		LAZYADD(deferred_by_source[source], thing)
 		return

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	var/list/blueprint_queue = list()
 	var/list/smooth_queue = list()
 	var/list/deferred = list()
+	var/list/deferred_by_source = list()
 
 /datum/controller/subsystem/icon_smooth/fire()
 	// We do not want to smooth icons of atoms whose neighbors are not initialized yet,
@@ -61,16 +62,30 @@ SUBSYSTEM_DEF(icon_smooth)
 
 	return SS_INIT_SUCCESS
 
+/// Releases a pool of delayed smooth attempts from a particular source
+/datum/controller/subsystem/icon_smooth/proc/free_deferred(source_to_free)
+	smooth_queue += deferred_by_source[source_to_free]
+	deferred_by_source -= source_to_free
+	if(!can_fire)
+		can_fire = TRUE
 
 /datum/controller/subsystem/icon_smooth/proc/add_to_queue(atom/thing)
 	if(thing.smoothing_flags & SMOOTH_QUEUED)
 		return
 	thing.smoothing_flags |= SMOOTH_QUEUED
+	// If we're currently locked into mapload BY something
+	// Then put us in a deferred list that we release when this mapload run is finished
+	if(initialized && length(SSatoms.initialized_state))
+		var/source = SSatoms.get_initialized_source()
+		LAZYADD(deferred_by_source[source], thing)
+		return
 	smooth_queue += thing
 	if(!can_fire)
 		can_fire = TRUE
 
 /datum/controller/subsystem/icon_smooth/proc/remove_from_queues(atom/thing)
+	// Lack of removal from deferred_by_source is safe because the lack of SMOOTH_QUEUED will just free it anyway
+	// Hopefully this'll never cause a harddel (dies)
 	thing.smoothing_flags &= ~SMOOTH_QUEUED
 	smooth_queue -= thing
 	if(blueprint_queue)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -4,8 +4,6 @@
 #define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN) || BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
-/// Max float with integer precision
-#define TIMER_ID_MAX (2**24)
 
 /**
  * # Timer Subsystem
@@ -731,4 +729,3 @@ SUBSYSTEM_DEF(timer)
 #undef BUCKET_LEN
 #undef BUCKET_POS
 #undef TIMER_MAX
-#undef TIMER_ID_MAX

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -213,7 +213,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Sanitize
 	lastchangelog = sanitize_text(lastchangelog, initial(lastchangelog))
 	default_slot = sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
-	toggles = sanitize_integer(toggles, 0, (2**24)-1, initial(toggles))
+	toggles = sanitize_integer(toggles, 0, SHORT_REAL_LIMIT-1, initial(toggles))
 	be_special = sanitize_be_special(SANITIZE_LIST(be_special))
 	key_bindings = sanitize_keybindings(key_bindings)
 	favorite_outfits = SANITIZE_LIST(favorite_outfits)


### PR DESCRIPTION

## About The Pull Request

We'd finish a set of atom creation, then try and smooth those atoms The problem is they might try and smooth with an uninitialized neighbor, which wouldn't have its smoothing vars parsed.

This fixes that by pooling "to be smoothed" things into a list based off the source of the init stoppage, which we then release when we're done.

Also fixes things staying in mapload, even during a sleep. This can cause massive headaches so it's good to avoid.

This has a cost but it's minuscule (on the order of like 0.006s (6ms over all of init), so I'm happy with it.

## Why It's Good For The Game

Closes #77040

## Changelog
:cl:
fix: Maps loaded in after roundstart will no longer have broken smoothing
/:cl:
