### PR TITLE
Facehuggers no longer knock you out for 2 minutes straight and instead will paralyze you and cause you to scream.

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -2,8 +2,8 @@
 
 //TODO: Make these basic mobs
 
-#define MIN_IMPREGNATION_TIME 100 //time it takes to impregnate someone
-#define MAX_IMPREGNATION_TIME 150
+#define MIN_IMPREGNATION_TIME 25 //time it takes to impregnate someone
+#define MAX_IMPREGNATION_TIME 50
 
 #define MIN_ACTIVE_TIME 200 //time between being dropped and going idle
 #define MAX_ACTIVE_TIME 400
@@ -182,8 +182,9 @@
 
 	if(!sterile)
 		M.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
-		M.Unconscious(MAX_IMPREGNATION_TIME/0.3) //something like 25 ticks = 20 seconds with the default settings
-
+		M.emote("scream")
+		M.Paralyze(MAX_IMPREGNATION_TIME/0.3) //something like 25 ticks = 20 seconds with the default settings
+		
 	GoIdle() //so it doesn't jump the people that tear it off
 
 	addtimer(CALLBACK(src, PROC_REF(Impregnate), M), rand(MIN_IMPREGNATION_TIME, MAX_IMPREGNATION_TIME))


### PR DESCRIPTION
## About The Pull Request

Facehuggers no longer knock you out for 2 minutes straight and instead will paralyze you and cause you to scream, allowing counterplay to exist beyond just being a prophet and having future sight to know when a xeno is gonna pop out of a vent. I mean, damn, I get fired today and decide ok I'll play some Space Station 13 and what do I gotta deal with? The same trash unfixed broken antag mechanic that's been in the game for 15 years that you people won't let us remove because soul or something, this shit just ruined my entire night, fuck xenos, fuck this antag type, and fuck 2 minute hard stuns with zero counter that can be applied instantly by someone who just spent the last 5 minutes sitting in a vent camping to ruin someone's round.

Every time I play this fucking game xenomorphs ruin it for me. I swear to god. Every single time.

## Why It's Good For The Game

Facehuggers no longer knock you out for 2 minutes straight and instead will paralyze you and cause you to scream, allowing counterplay to exist beyond just being a prophet and having future sight to know when a xeno is gonna pop out of a vent. I mean, damn, I get fired today and decide ok I'll play some Space Station 13 and what do I gotta deal with? The same trash unfixed broken antag mechanic that's been in the game for 15 years that you people won't let us remove because soul or something, this shit just ruined my entire night, fuck xenos, fuck this antag type, and fuck 2 minute hard stuns with zero counter that can be applied instantly by someone who just spent the last 5 minutes sitting in a vent camping to ruin someone's round.

## Changelog

:cl:
balance: Facehuggers no longer knock you out for 2 minutes straight and instead will paralyze you and cause you to scream, allowing more counterplay.
/:cl:

cobby edit: CL