### PR TITLE
Xenomorph stomachs and vore will no longer destroy items directly, refactored it to use acid_act()

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -197,13 +197,7 @@
 	for(var/atom/movable/thing as anything in stomach_contents)
 		if(!digestable_cache[thing.type])
 			continue
-		thing.reagents.trans_to(src, 4)
-
-		if(isliving(thing))
-			var/mob/living/lad = thing
-			lad.adjustBruteLoss(6)
-		else if(!thing.reagents.total_volume) // Mobs can't get dusted like this, too important
-			qdel(thing)
+		thing.acid_act(75, 10)
 
 /obj/item/organ/internal/stomach/alien/proc/consume_thing(atom/movable/thing)
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
@@ -211,9 +205,6 @@
 	if(isliving(thing))
 		var/mob/living/lad = thing
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, PROC_REF(content_died))
-		if(lad.stat == DEAD)
-			qdel(lad)
-			return
 	stomach_contents += thing
 	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced
 


### PR DESCRIPTION
## About The Pull Request

senomorph stomachs and vore will no longer destroy items and mobs directly, refactored it to use acid_act()
fixes xenomorph vore accidentally destroying mobs it wasn't supposed to destroy, im thinking this was modified list in place shenanigans

## Why It's Good For The Game

this shit is jank as hell and better done this way and results in less weird edge cases, and also makes xenomorphs feel less bullshit

## Changelog

:cl:
balance: xenomorph stomachs will no longer destroy items directly, refactored it to use acid_act()
fix: fixes xenomorph vore accidentally destroying mobs it wasn't supposed to destroy, im thinking this was modified list in place shenanigans
/:cl:
