### PR TITLE
forcefully pushing and crushing disposal outlets and chutes and bins deconstructs them

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -305,6 +305,16 @@
 		to_dump.pixel_x = to_dump.base_pixel_x + rand(-5, 5)
 		to_dump.pixel_y = to_dump.base_pixel_y + rand(-5, 5)
 
+/obj/machinery/disposal/force_pushed(atom/movable/pusher, force = MOVE_FORCE_DEFAULT, direction)
+	. = ..()
+	visible_message(span_warning("[src] is ripped free from the floor!"))
+	deconstruct()
+
+/obj/machinery/disposal/move_crushed(atom/movable/pusher, force = MOVE_FORCE_DEFAULT, direction)
+	. = ..()
+	visible_message(span_warning("[src] is ripped free from the floor!"))
+	deconstruct()
+
 // Disposal bin
 // Holds items for disposal into pipe system
 // Draws air from turf, gradually charges internal reservoir

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -137,6 +137,24 @@
 	eject_range = EJECT_RANGE_YEET
 	return TRUE
 
+/obj/structure/disposaloutlet/force_pushed(atom/movable/pusher, force = MOVE_FORCE_DEFAULT, direction)
+	. = ..()
+	if(!isnull(stored))
+		stored.forceMove(loc)
+		transfer_fingerprints_to(stored)
+		stored = null
+		visible_message(span_warning("[src] is ripped free from the floor!"))
+		qdel(src)
+
+/obj/structure/disposaloutlet/move_crushed(atom/movable/pusher, force = MOVE_FORCE_DEFAULT, direction)
+	. = ..()
+	if(!isnull(stored))
+		stored.forceMove(loc)
+		transfer_fingerprints_to(stored)
+		stored = null
+		visible_message(span_warning("[src] is ripped free from the floor!"))
+		qdel(src)
+
 #undef EJECT_SPEED_SLOW
 #undef EJECT_SPEED_MED
 #undef EJECT_SPEED_FAST


### PR DESCRIPTION

## About The Pull Request

if a goliath and such forcefully move chutes,bins,disposal outlets and maybe one other they are reverted into disposal constructs instead of being a poor mans eigenstatium locker

## Why It's Good For The Game

CC moment

## Changelog
:cl:
fix: forcefully pushing disposal outlets and chutes deconstructs them instead of making them behave like budget eigenstatium lockers
/:cl:
