### PR TITLE
BBQ ribs can be grilled & adds qdel checks for grills

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -750,6 +750,19 @@
 	foodtypes = MEAT | SUGAR
 	crafting_complexity = FOOD_COMPLEXITY_2
 
+///Special private component to handle how bbq is grilled, not meant to be used anywhere else
+/datum/component/grillable/bbq
+
+/datum/component/grillable/bbq/finish_grilling(atom/grill_source)
+	//when on a grill allow it to roast without deleting itself
+	if(istype(grill_source, /obj/machinery/grill))
+		grill_source.visible_message(span_notice("[parent] is grilled to perfection"))
+	else //when on a girddle allow it burn to a mouldy mess
+		return ..()
+
+/obj/item/food/bbqribs/make_grillable()
+	AddComponent(/datum/component/grillable/bbq, /obj/item/food/badrecipe, rand(30 SECONDS, 40 SECONDS), FALSE)
+
 /obj/item/food/meatclown
 	name = "meat clown"
 	desc = "A delicious, round piece of meat clown. How horrifying."

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -757,7 +757,7 @@
 	//when on a grill allow it to roast without deleting itself
 	if(istype(grill_source, /obj/machinery/grill))
 		grill_source.visible_message(span_notice("[parent] is grilled to perfection"))
-	else //when on a girddle allow it burn to a mouldy mess
+	else //when on a girddle allow it to burn into an mouldy mess
 		return ..()
 
 /obj/item/food/bbqribs/make_grillable()

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -756,7 +756,7 @@
 /datum/component/grillable/bbq/finish_grilling(atom/grill_source)
 	//when on a grill allow it to roast without deleting itself
 	if(istype(grill_source, /obj/machinery/grill))
-		grill_source.visible_message(span_notice("[parent] is grilled to perfection"))
+		grill_source.visible_message(span_notice("[parent] is grilled to perfection!"))
 	else //when on a girddle allow it to burn into an mouldy mess
 		return ..()
 

--- a/code/modules/food_and_drinks/machinery/grill.dm
+++ b/code/modules/food_and_drinks/machinery/grill.dm
@@ -78,7 +78,6 @@
 	..()
 
 /obj/machinery/grill/process(seconds_per_tick)
-	..()
 	update_appearance()
 	if(grill_fuel <= 0)
 		return
@@ -94,7 +93,7 @@
 			grilled_item = null
 			finish_grill()
 			return
-		grill_time += seconds_per_tick
+		grill_time += seconds_per_tick * 10 //convert to deciseconds
 		grilled_item.reagents.add_reagent(/datum/reagent/consumable/char, 0.5 * seconds_per_tick)
 		grill_fuel -= GRILL_FUELUSAGE_ACTIVE * seconds_per_tick
 		grilled_item.AddComponent(/datum/component/sizzle)
@@ -129,9 +128,16 @@
 
 /obj/machinery/grill/proc/finish_grill()
 	if(!QDELETED(grilled_item))
-		if(grill_time >= 20)
+		var/time_limit = 20 SECONDS
+		//when items grill themselves in their own unique ways we want to follow their constraints
+		var/datum/component/grillable/custom_grilling = grilled_item.GetComponent(/datum/component/grillable)
+		if(!isnull(custom_grilling))
+			time_limit = custom_grilling.required_cook_time
+
+		if(grill_time >= time_limit)
 			grilled_item.AddElement(/datum/element/grilled_item, grill_time)
 		UnregisterSignal(grilled_item, COMSIG_ITEM_GRILLED)
+
 	grill_time = 0
 	grill_loop.stop()
 

--- a/code/modules/food_and_drinks/machinery/grill.dm
+++ b/code/modules/food_and_drinks/machinery/grill.dm
@@ -90,6 +90,10 @@
 			smoke.start()
 	if(grilled_item)
 		SEND_SIGNAL(grilled_item, COMSIG_ITEM_GRILL_PROCESS, src, seconds_per_tick)
+		if(QDELETED(grilled_item))
+			grilled_item = null
+			finish_grill()
+			return
 		grill_time += seconds_per_tick
 		grilled_item.reagents.add_reagent(/datum/reagent/consumable/char, 0.5 * seconds_per_tick)
 		grill_fuel -= GRILL_FUELUSAGE_ACTIVE * seconds_per_tick


### PR DESCRIPTION
## About The Pull Request
- Fixes #81511. BBQ ribs can be grilled again and takes anywhere between 30 to 40 seconds to get proper grilled ribs or turn into a mouldy mess. 20 seconds would only yield lightly grilled ribs and that's not good.
- Grill checks if the item got deleted to avoid runtimes. Also cook time is set based on the individual items type & not a constant of 20 seconds

## Changelog
:cl:
fix: Grill checks if the item got deleted to avoid runtimes. Also cook time is set based on the individual items type & not a constant of 20 seconds
fix: BBQ ribs can be grilled on a grill but now takes anywhere between 30 to 40 seconds to get proper smoked ribs and not lightly smoked ribs or turn into a mouldy mess on a girddle. Delicious.
/:cl:
