### PR TITLE
Reverts map vote to single method

### DIFF
--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -1,7 +1,7 @@
 /datum/vote/map_vote
 	name = "Map"
 	message = "Vote for next round's map!"
-	count_method = VOTE_COUNT_METHOD_MULTI
+	count_method = VOTE_COUNT_METHOD_SINGLE
 	winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
 
 /datum/vote/map_vote/New()


### PR DESCRIPTION
## About The Pull Request

Reverts map vote to single selection rather than multi selection

## Why It's Good For The Game

Now that map vote is weighted, multi selection serves no purpose anymore other than allowing people to gain "additional weight" in the vote, which is unfair. It's weighted, everyone should have 1 vote. 

![image](https://github.com/tgstation/tgstation/assets/51863163/c1831505-f638-4036-8d53-d3524f4a5d4a)

## Changelog

:cl: Melbert
del: You can only vote for 1 map at a time again
/:cl:


