### PR TITLE
Joker wont automatically reactivate itself

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -548,6 +548,7 @@
 						var/truegenes = GET_SEQUENCE(path)
 						newgene = truegenes[genepos]
 						joker_ready = world.time + JOKER_TIMEOUT - (JOKER_UPGRADE * (connected_scanner.precision_coeff-1))
+						tgui_view_state["jokerActive"] = FALSE
 					else
 						var/current_letter = gene_letters.Find(sequence[genepos])
 						newgene = (current_letter == gene_letter_count) ? gene_letters[1] : gene_letters[current_letter + 1]


### PR DESCRIPTION
## About The Pull Request

The DNA console's Joker button, when used and goes through its cooldown, currently automatically reactivates itself, which causes Geneticists who aren't aware of this and who do not want to use their joker yet, waste it and have to wait its cooldown once again.

## Why It's Good For The Game

You are waiting at minimum a 300 second timer (on t4) between Joker uses, so I do not expect people to think that this is something that would remain active once its cooldown has expired. It's just better UI.

## Changelog

:cl:
fix: The DNA scanner's joker button no longer instantly activates itself when the cooldown between uses is done.
/:cl: