### PR TITLE
Monster cores work while resting

### DIFF
--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -143,7 +143,7 @@
 	return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/organ/internal/monster_core/attack_self(mob/user)
-	if (!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+	if (!user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_RESTING))
 		return
 	try_apply(user, user)
 


### PR DESCRIPTION
## About The Pull Request

Currently to use items like the regenerative core, you can either attack yourself (or someone else), or use Z to use the item in-hand, unless you are lying down in which case you have to specifically click, and can't use in-hand. It's kinda dumb and this has been an issue I had since I've started playing, and today I thought "wait why did I just never fix it then?", so now I am.

## Why It's Good For The Game

Mostly explained in the about section, you can already use cores while resting, this just means you can't use Z instead of having to click on your character sprite.

## Changelog

:cl:
fix: Regenerative cores (and other monster organs) now work when using it in-hand while resting.
/:cl: