### PR TITLE
[no gbp] Removes unused proc from deathmatch, deathmatch has 8 seconds delay as to not give lighting a stroke

### DIFF
--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -6,9 +6,6 @@
 	/// All loadouts
 	var/list/datum/outfit/loadouts
 
-	/// All currently present spawnpoints, to be processed by a loading map
-	var/list/spawnpoint_processing = list()
-
 /datum/deathmatch_controller/New()
 	. = ..()
 	if (GLOB.deathmatch_game)
@@ -35,13 +32,6 @@
 	lobbies[new_host] = lobbies[host]
 	lobbies[host] = null
 	lobbies.Remove(host)
-
-/datum/deathmatch_controller/proc/load_lazyarena(map_key)
-	if(!isnull(map_key) && !isnull(maps[map_key]))
-		var/datum/lazy_template/deathmatch/temp = maps[map_key]
-		return temp.lazy_load() //returns rezervation
-
-	return FALSE
 
 /datum/deathmatch_controller/ui_state(mob/user)
 	return GLOB.observer_state

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -17,6 +17,8 @@
 	var/ready_count
 	/// List of loadouts, either gotten from the deathmatch controller or the map
 	var/list/loadouts
+	/// Current map player spawn locations, cleared after spawning
+	var/list/player_spawns = list()
 
 /datum/deathmatch_lobby/New(mob/player)
 	. = ..()
@@ -52,20 +54,26 @@
 		return
 	playing = TRUE
 
+	RegisterSignal(map, COMSIG_LAZY_TEMPLATE_LOADED, PROC_REF(find_spawns))
 	location = map.lazy_load()
 	if (!location)
 		to_chat(get_mob_by_ckey(host), span_warning("Couldn't reserve/load a map location (all locations used?), try again later, or contact a coder."))
 		playing = FALSE
+		UnregisterSignal(map, COMSIG_LAZY_TEMPLATE_LOADED)
 		return FALSE
+	
+	addtimer(CALLBACK(src, PROC_REF(start_game_after_delay)), 8 SECONDS)
 
-	if (!length(GLOB.deathmatch_game.spawnpoint_processing))
-		clear_reservation()
-		playing = FALSE
-		return FALSE
+/datum/deathmatch_lobby/proc/find_spawns(datum/lazy_template/source, list/atoms)
+	SIGNAL_HANDLER
+	for(var/thing in atoms)
+		if(istype(thing, /obj/effect/landmark/deathmatch_player_spawn)) 
+			player_spawns += thing
 
-	var/list/spawns = GLOB.deathmatch_game.spawnpoint_processing.Copy()
-	GLOB.deathmatch_game.spawnpoint_processing.Cut()
-	if (!length(spawns) || length(spawns) < length(players))
+	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
+
+/datum/deathmatch_lobby/proc/start_game_after_delay()
+	if (!length(player_spawns) || length(player_spawns) < length(players))
 		stack_trace("Failed to get spawns when loading deathmatch map [map.name] for lobby [host].")
 		clear_reservation()
 		playing = FALSE
@@ -79,13 +87,12 @@
 			continue
 
 		// pick spawn and remove it.
-		var/picked_spawn = pick_n_take(spawns)
+		var/picked_spawn = pick_n_take(player_spawns)
 		spawn_observer_as_player(key, get_turf(picked_spawn))
 		qdel(picked_spawn)
 
 	// Remove rest of spawns.
-	for (var/unused_spawn in spawns)
-		qdel(unused_spawn)
+	QDEL_LIST(player_spawns)
 
 	for (var/observer_key in observers)
 		var/mob/observer = observers[observer_key]["mob"]
@@ -305,6 +312,7 @@
 	.["host"] = (user.ckey == host)
 	.["admin"] = check_rights_for(user.client, R_ADMIN)
 	.["global_chat"] = global_chat
+	.["playing"] = playing
 	.["loadouts"] = list()
 	for (var/datum/outfit/deathmatch_loadout/loadout as anything in loadouts)
 		.["loadouts"] += initial(loadout.display_name)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -54,23 +54,22 @@
 		return
 	playing = TRUE
 
-	RegisterSignal(map, COMSIG_LAZY_TEMPLATE_LOADED, PROC_REF(find_spawns))
+	RegisterSignal(map, COMSIG_LAZY_TEMPLATE_LOADED, PROC_REF(find_spawns_and_start_delay))
 	location = map.lazy_load()
 	if (!location)
 		to_chat(get_mob_by_ckey(host), span_warning("Couldn't reserve/load a map location (all locations used?), try again later, or contact a coder."))
 		playing = FALSE
 		UnregisterSignal(map, COMSIG_LAZY_TEMPLATE_LOADED)
 		return FALSE
-	
-	addtimer(CALLBACK(src, PROC_REF(start_game_after_delay)), 8 SECONDS)
 
-/datum/deathmatch_lobby/proc/find_spawns(datum/lazy_template/source, list/atoms)
+/datum/deathmatch_lobby/proc/find_spawns_and_start_delay(datum/lazy_template/source, list/atoms)
 	SIGNAL_HANDLER
 	for(var/thing in atoms)
 		if(istype(thing, /obj/effect/landmark/deathmatch_player_spawn)) 
 			player_spawns += thing
 
 	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
+	addtimer(CALLBACK(src, PROC_REF(start_game_after_delay)), 8 SECONDS)
 
 /datum/deathmatch_lobby/proc/start_game_after_delay()
 	if (!length(player_spawns) || length(player_spawns) < length(players))

--- a/code/modules/deathmatch/deathmatch_mapping.dm
+++ b/code/modules/deathmatch/deathmatch_mapping.dm
@@ -10,15 +10,3 @@
 
 /obj/effect/landmark/deathmatch_player_spawn
 	name = "Deathmatch Player Spawner"
-
-/obj/effect/landmark/deathmatch_player_spawn/Initialize(mapload)
-	. = ..()
-	if (isnull(GLOB.deathmatch_game))
-		return INITIALIZE_HINT_QDEL
-	GLOB.deathmatch_game.spawnpoint_processing += src
-
-/obj/effect/landmark/deathmatch_player_spawn/Destroy()
-	. = ..()
-	if(isnull(GLOB.deathmatch_game))
-		return
-	GLOB.deathmatch_game.spawnpoint_processing -= src

--- a/tgui/packages/tgui/interfaces/DeathmatchLobby.tsx
+++ b/tgui/packages/tgui/interfaces/DeathmatchLobby.tsx
@@ -26,6 +26,7 @@ type Data = {
   host: BooleanLike;
   admin: BooleanLike;
   global_chat: BooleanLike;
+  playing: BooleanLike;
   loadouts: string[];
   maps: string[];
   map: {
@@ -171,6 +172,14 @@ export const DeathmatchLobby = (props) => {
               <Box textAlign="center">Loadout Description</Box>
               <Divider />
               <Box textAlign="center">{data.loadoutdesc}</Box>
+              {!!data.playing && (
+                <>
+                  <Divider />
+                  <Box textAlign="center">
+                    The game is currently in progress, or loading.
+                  </Box>
+                </>
+              )}
             </Section>
           </Flex.Item>
         </Flex>


### PR DESCRIPTION

## About The Pull Request

removes an unused proc, and spawners should be slightly more reliable

deathmatch now has a 8 second delay before spawning you in as to give lighting and smoothing a breather
the match being in progress is now shown in lobby UI

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/70376633/8a275232-e186-4685-ab28-94c077532870)

also unused proc bad

## Changelog
:cl:
code: deathmatch lobbies take 8 seconds to start as to give lighting a breather
/:cl:
