### PR TITLE
[NO GBP]Some BRM Fixes

### DIFF
--- a/code/modules/mining/boulder_processing/brm.dm
+++ b/code/modules/mining/boulder_processing/brm.dm
@@ -242,6 +242,8 @@
  * * boulders_remaining - how many boulders we want to try & collect spawning a boulder every TELEPORTATION_TIME seconds
  */
 /obj/machinery/brm/proc/pre_collect_boulder(feedback = TRUE, boulders_remaining = 1)
+	PRIVATE_PROC(TRUE)
+
 	batch_processing = TRUE
 
 	//not within operation parameters

--- a/code/modules/mining/boulder_processing/brm.dm
+++ b/code/modules/mining/boulder_processing/brm.dm
@@ -188,7 +188,9 @@
 /**
  * Toggles automatic boulder retrieval on.
  * Adjusts the teleportation sound, icon state, and begins processing.
- * @param mob/user The user who toggled the BRM.
+ * Arguments
+ *
+ * * mob/user - the player who has toggled us
  */
 /obj/machinery/brm/proc/toggle_auto_on(mob/user)
 	PRIVATE_PROC(TRUE)
@@ -225,7 +227,7 @@
 		return PROCESS_KILL
 
 	//have some cooldown after processing the previous batch of boulders
-	if(!COOLDOWN_FINISHED(src, batch_start_cooldown))
+	if(batch_processing || !COOLDOWN_FINISHED(src, batch_start_cooldown))
 		return
 
 	pre_collect_boulder(FALSE, boulders_processing_max)
@@ -234,17 +236,17 @@
  * Begins to collect a boulder from the available boulders list in SSore_generation.
  * Boulders must be in the available boulders list.
  * A selected boulder is picked randomly.
- * The actual movement is then handled by collect_boulder() after a timed callback.
  * Arguments
  *
  * * feedback - should we play sound and display allert if now boulders are available
  * * boulders_remaining - how many boulders we want to try & collect spawning a boulder every TELEPORTATION_TIME seconds
- * * new_batch - is this the very 1st boulder processed from boulders_remaining. Used to wait for all the boulders to be collected
  */
-/obj/machinery/brm/proc/pre_collect_boulder(feedback = TRUE, boulders_remaining = 1, new_batch = TRUE)
-	PRIVATE_PROC(TRUE)
+/obj/machinery/brm/proc/pre_collect_boulder(feedback = TRUE, boulders_remaining = 1)
+	batch_processing = TRUE
 
+	//not within operation parameters
 	if(!anchored || panel_open || !is_operational || machine_stat & (BROKEN | NOPOWER))
+		batch_processing = FALSE
 		return FALSE
 
 	//There is an boulder in our loc. it has be removed so we don't clog up our loc with even more boulders
@@ -260,57 +262,25 @@
 		batch_processing = FALSE
 		return FALSE
 
-	//we are trying to process a new batch of boulders
-	if(new_batch)
-		if(batch_processing) //the previous one hasen't completed yet, wait
-			return FALSE
-		batch_processing = TRUE
-
-	var/obj/item/boulder/random_boulder = pick(SSore_generation.available_boulders)
-	if(random_boulder.processed_by)
-		return FALSE
-	SSore_generation.available_boulders -= random_boulder
-	random_boulder.processed_by = src
-	random_boulder.Shake(shake_interval = TELEPORTATION_TIME)
-	addtimer(CALLBACK(src, PROC_REF(collect_boulder), random_boulder, feedback, boulders_remaining), TELEPORTATION_TIME)
-	return TRUE
-
-/**
- * Callback to spawn a boulder collected in pre_collect_boulder(). Can be used to collect
- * multiple boulders by setting boulders_remaining but must only be called by pre_collect_boulder()
- * and not directly
- * Arguments
- *
- * * obj/item/boulder/random_boulder - the boulder we are trying to move out
- * * feedback - see pre_collect_boulder()
- * * boulders_remaining - passed back to pre_collect_boulder() if count > 0
- */
-/obj/machinery/brm/proc/collect_boulder(obj/item/boulder/random_boulder, feedback, boulders_remaining)
-	if(QDELETED(random_boulder))
-		playsound(loc, 'sound/machines/synth_no.ogg', 30 , TRUE)
-		balloon_alert_to_viewers("target lost!")
-		return FALSE
-
-	if(locate(/obj/item/boulder) in loc)
-		batch_processing = FALSE
-		return
-
+	//pick & spawn the boulder
 	flick("brm-flash", src)
 	playsound(src, toggled_on ? AUTO_TELEPORT_SOUND : MANUAL_TELEPORT_SOUND, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	var/obj/item/boulder/random_boulder = pick(SSore_generation.available_boulders)
+	SSore_generation.available_boulders -= random_boulder
 	random_boulder.forceMove(drop_location())
 	random_boulder.pixel_x = rand(-2, 2)
 	random_boulder.pixel_y = rand(-2, 2)
-	random_boulder.processed_by = null
 	balloon_alert_to_viewers("boulder appears!")
 	use_power(active_power_usage)
 
+	//try again if we have more boulders to work with
 	boulders_remaining -= 1
 	if(boulders_remaining <= 0)
 		COOLDOWN_START(src, batch_start_cooldown, BATCH_COOLDOWN)
 		batch_processing = FALSE
 		return TRUE
 	else
-		return pre_collect_boulder(feedback, boulders_remaining, FALSE)
+		addtimer(CALLBACK(src, PROC_REF(pre_collect_boulder), feedback, boulders_remaining, FALSE), TELEPORTATION_TIME)
 
 #undef MANUAL_TELEPORT_SOUND
 #undef AUTO_TELEPORT_SOUND


### PR DESCRIPTION
## About The Pull Request
- The time from which the boulder is picked to when it's teleported onto the conveyer belt is 1.5 seconds. During that time the boulder could get deleted due to many factors and we lose our materials. No one like's that that so now both steps are combined into 1 proc so we no longer loose boulders during teleportation.
- Batch processing cooldown was not working when `boulder_processing_max` is > 1. Now it does

## Changelog
:cl:
fix: boulders are no longer lost when teleported by the BRM
fix: batch processing cooldown works when teleporting multiple boulders
/:cl: