### PR TITLE
Adds .dmm-pal to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,9 @@ Temporary Items
 /_maps/**/backup/
 /_maps/templates.dm
 
+#dmm palette file. You really should be using StrongDMM instead.
+*.dmm-pal
+
 #dmdoc default folder
 /dmdoc
 


### PR DESCRIPTION
## About The Pull Request
Dream Maker map palette. Used by the map-making tool, still really awful.

## Why It's Good For The Game
Useless file for our repo.

## Changelog
N/A