### PR TITLE
[no gbp] marks deathmatch areas as NOTELEPORT, and abductor and event proof

### DIFF
--- a/code/modules/deathmatch/deathmatch_mapping.dm
+++ b/code/modules/deathmatch/deathmatch_mapping.dm
@@ -2,7 +2,7 @@
 	name = "Deathmatch Arena"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	area_flags = UNIQUE_AREA | UNIQUE_AREA
+	area_flags = UNIQUE_AREA | NOTELEPORT | ABDUCTOR_PROOF | EVENT_PROTECTED
 
 /area/deathmatch/fullbright
 	static_lighting = FALSE


### PR DESCRIPTION

## About The Pull Request

marks deathmatch areas as NOTELEPORT, and abductor and event proof

## Why It's Good For The Game

ok just incase they shouldnt be able to get out of here

## Changelog
:cl:
fix: you may not teleport in or out of deathmatch arenas
/:cl:
