### PR TITLE
Fixes some eronous usages of apply_wound, replaces them with cause_wound_of_type_and_severity, and makes this stance clear in docuemntation

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -170,6 +170,7 @@
 
 /**
  * apply_wound() is used once a wound type is instantiated to assign it to a bodypart, and actually come into play.
+ * DO NOT USE THIS TO APPLY NEW WOUNDS. USE cause_wound_of_type_and_severity!
  *
  *
  * Arguments:

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -511,12 +511,11 @@
 		return BRUTELOSS
 
 	patient.emote("scream")
-	for(var/i in patient.bodyparts)
-		var/obj/item/bodypart/bone = i // fine to just, use these raw, its a meme anyway
-		var/datum/wound/blunt/bone/severe/oof_ouch = new
-		oof_ouch.apply_wound(bone, wound_source = "bone gel")
-		var/datum/wound/blunt/bone/critical/oof_OUCH = new
-		oof_OUCH.apply_wound(bone, wound_source = "bone gel")
+	if (iscarbon(patient))
+		var/mob/living/carbon/carbon_patient = patient
+		for(var/i in carbon_patient.bodyparts)
+			var/obj/item/bodypart/bone = i
+			carbon_patient.cause_wound_of_type_and_severity(WOUND_BLUNT, bone, WOUND_SEVERITY_SEVERE, WOUND_SEVERITY_CRITICAL, wound_source = "bone gel")
 
 	for(var/i in patient.bodyparts)
 		var/obj/item/bodypart/bone = i

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -259,8 +259,10 @@
 		I finally began to understand. And then, blood rained from the heavens."
 	next_knowledge = list(/datum/heretic_knowledge/summon/stalker)
 	route = PATH_FLESH
-	///What type of wound do we apply on hit
-	var/wound_type = /datum/wound/slash/flesh/severe
+	/// What type of wound we apply on hit
+	var/wound_type = WOUND_SLASH
+	/// The severity of the wound we apply
+	var/wound_severity = WOUND_SEVERITY_CRITICAL
 
 /datum/heretic_knowledge/blade_upgrade/flesh/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	if(!iscarbon(target) || source == target)
@@ -268,8 +270,8 @@
 
 	var/mob/living/carbon/carbon_target = target
 	var/obj/item/bodypart/bodypart = pick(carbon_target.bodyparts)
-	var/datum/wound/crit_wound = new wound_type()
-	crit_wound.apply_wound(bodypart, attack_direction = get_dir(source, target))
+
+	carbon_target.cause_wound_of_type_and_severity(wound_type, bodypart, wound_severity)
 
 /datum/heretic_knowledge/summon/stalker
 	name = "Lonely Ritual"

--- a/code/modules/antagonists/heretic/magic/apetravulnera.dm
+++ b/code/modules/antagonists/heretic/magic/apetravulnera.dm
@@ -16,14 +16,16 @@
 
 	cast_range = 4
 	/// What type of wound we apply
-	var/wound_type = /datum/wound/slash/flesh/critical/cleave
+	var/wound_type = WOUND_SLASH
+	/// The severity of the wound we apply
+	var/wound_severity = WOUND_SEVERITY_CRITICAL
 
 /datum/action/cooldown/spell/pointed/apetra_vulnera/is_valid_target(atom/cast_on)
 	return ..() && ishuman(cast_on)
 
 /datum/action/cooldown/spell/pointed/apetra_vulnera/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	
+
 	if(IS_HERETIC_OR_MONSTER(cast_on))
 		return FALSE
 
@@ -42,18 +44,16 @@
 		if(bodypart.brute_dam < 15)
 			continue
 		a_limb_got_damaged = TRUE
-		var/datum/wound/slash/crit_wound = new wound_type()
-		crit_wound.apply_wound(bodypart)
-	
+		cast_on.cause_wound_of_type_and_severity(wound_type, bodypart, wound_severity)
+
 	if(!a_limb_got_damaged)
-		var/datum/wound/slash/crit_wound = new wound_type()
-		crit_wound.apply_wound(pick(cast_on.bodyparts))
+		cast_on.cause_wound_of_type_and_severity(wound_type, pick(cast_on.bodyparts), wound_severity)
 
 	cast_on.visible_message(
 		span_danger("[cast_on]'s scratches and bruises are torn open by an unholy force!"),
 		span_danger("Your scratches and bruises are torn open by some horrible unholy force!")
 	)
-	
+
 	new /obj/effect/temp_visual/cleave(get_turf(cast_on))
 
 	return TRUE

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -19,7 +19,9 @@
 	/// The radius of the cleave effect
 	var/cleave_radius = 1
 	/// What type of wound we apply
-	var/wound_type = /datum/wound/slash/flesh/critical/cleave
+	var/wound_type = WOUND_SLASH
+	/// The severity of the wound we apply
+	var/wound_severity = WOUND_SEVERITY_CRITICAL
 
 /datum/action/cooldown/spell/pointed/cleave/is_valid_target(atom/cast_on)
 	return ..() && ishuman(cast_on)
@@ -45,8 +47,8 @@
 		)
 
 		var/obj/item/bodypart/bodypart = pick(victim.bodyparts)
-		var/datum/wound/slash/flesh/crit_wound = new wound_type()
-		crit_wound.apply_wound(bodypart)
+
+		victim.cause_wound_of_type_and_severity(wound_type, bodypart, wound_severity)
 		victim.apply_damage(20, BURN, wound_bonus = CANT_WOUND)
 
 		new /obj/effect/temp_visual/cleave(get_turf(victim))
@@ -56,7 +58,7 @@
 /datum/action/cooldown/spell/pointed/cleave/long
 	name = "Lesser Cleave"
 	cooldown_time = 60 SECONDS
-	wound_type = /datum/wound/slash/flesh/severe
+	wound_type = WOUND_SEVERITY_SEVERE
 
 /obj/effect/temp_visual/cleave
 	icon = 'icons/effects/eldritch.dmi'

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -149,7 +149,8 @@
 		log_wound(owner, new_wound, damage, wound_bonus, bare_wound_bonus, base_roll) // dismembering wounds are logged in the apply_wound() for loss wounds since they delete themselves immediately, these will be immediately returned
 		return new_wound
 
-// try forcing a specific wound, but only if there isn't already a wound of that severity or greater for that type on this bodypart
+/// try forcing a specific wound, but only if there isn't already a wound of that severity or greater for that type on this bodypart
+/// DO NOT USE THIS TO APPLY NEW WOUNDS. USE cause_wound_of_type_and_severity!
 /obj/item/bodypart/proc/force_wound_upwards(datum/wound/potential_wound, smited = FALSE, wound_source)
 	SHOULD_NOT_OVERRIDE(TRUE)
 


### PR DESCRIPTION

## About The Pull Request

Title. 

Reminder. You are not supposed to use apply_wound or force_wound_upwards if you can help it, because you need to be able to apply different wound series if need be.
## Why It's Good For The Game

bugs bad, code standards good
## Changelog
:cl:
code: Various heretic abilities now use cause_wound_of_type_and_severity instead of apply_wound
/:cl:
