### PR TITLE
sec-hailers no longer apply filters on TTS when pushed out of the way.

### DIFF
--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -8,6 +8,7 @@
 	strip_delay = 40
 	equip_delay_other = 40
 	var/modifies_speech = FALSE
+	///Whether the mask is pushed out of the food hole or not.
 	var/mask_adjusted = FALSE
 	var/adjusted_flags = null
 	///Did we install a filtering cloth?

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	///Cigarette in the mask
 	var/obj/item/clothing/mask/cigarette/cig
 	voice_filter = "lowpass=f=750,volume=2"
+
 /datum/armor/mask_gas
 	bio = 100
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -400,11 +400,12 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			var/mob/living/carbon/human/human_speaker = src
 			if(istype(human_speaker.wear_mask, /obj/item/clothing/mask))
 				var/obj/item/clothing/mask/worn_mask = human_speaker.wear_mask
-				if(worn_mask.voice_override)
-					voice_to_use = worn_mask.voice_override
-				if(worn_mask.voice_filter)
-					filter += worn_mask.voice_filter
-				use_radio = worn_mask.use_radio_beeps_tts
+				if(!worn_mask.mask_adjusted)
+					if(worn_mask.voice_override)
+						voice_to_use = worn_mask.voice_override
+					if(worn_mask.voice_filter)
+						filter += worn_mask.voice_filter
+					use_radio = worn_mask.use_radio_beeps_tts
 		if(use_radio)
 			special_filter += TTS_FILTER_RADIO
 		if(issilicon(src))


### PR DESCRIPTION
## About The Pull Request
Previously, pushing the mask out of the way did not prevent TTS from being filtered.

## Why It's Good For The Game
If the mask isn't in the way, it shouldn't do that. Simple as that.

## Changelog

:cl:
fix: sec-hailers no longer apply filters on TTS when pushed out of the way.
/:cl:
