### PR TITLE
[NO GBP] fixing issues with cutouts and potted plants

### DIFF
--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -13,8 +13,6 @@
 
 /datum/component/tactical/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(modify))
-	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(unmodify))
-	RegisterSignal(parent, COMSIG_ATOM_UPDATED_ICON, PROC_REF(tactical_update))
 	var/obj/item/item = parent
 	if(ismob(item.loc))
 		var/mob/holder = item.loc
@@ -23,8 +21,6 @@
 /datum/component/tactical/UnregisterFromParent()
 	UnregisterSignal(parent, list(
 		COMSIG_ITEM_EQUIPPED,
-		COMSIG_ITEM_DROPPED,
-		COMSIG_ATOM_UPDATED_ICON,
 	))
 	unmodify()
 
@@ -40,10 +36,10 @@
 			unmodify(source, user)
 		return
 
-	if(current_slot) //If the current slot is set, this means the icon was updated or the item changed z-levels.
-		user.remove_alt_appearance("sneaking_mission[REF(src)]")
-	else
-		RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(tactical_update))
+	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(tactical_update))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(unmodify))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATED_ICON, PROC_REF(tactical_update))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 
 	current_slot = slot
 
@@ -58,19 +54,22 @@
 /datum/component/tactical/proc/unmodify(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
-	var/obj/item/master = parent
 	if(!user)
-		if(!ismob(master.loc))
-			return
-		user = master.loc
+		user = source.loc
+	if(!istype(user))
+		return
 
 	user.remove_alt_appearance("sneaking_mission[REF(src)]")
 	current_slot = null
-	UnregisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED)
+	UnregisterSignal(parent, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_ITEM_DROPPED, COMSIG_ATOM_UPDATED_ICON, COMSIG_MOVABLE_MOVED))
 
-/datum/component/tactical/proc/tactical_update(datum/source)
+/datum/component/tactical/proc/tactical_update(obj/item/source)
 	SIGNAL_HANDLER
-	var/obj/item/master = parent
-	if(!ismob(master.loc))
+	if(!ismob(source.loc))
 		return
-	modify(master, master.loc, current_slot)
+	modify(source, source.loc, current_slot)
+
+///We really want to make sure that, if things ever slightly breaks, that the alt appearance will be removed anyway.
+/datum/component/tactical/proc/on_moved(obj/item/source, atom/oldloc, direction, forced)
+	SIGNAL_HANDLER
+	unmodify(source, oldloc)

--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -53,7 +53,8 @@
 
 /datum/component/tactical/proc/unmodify(obj/item/source, mob/user)
 	SIGNAL_HANDLER
-
+	if(!source)
+		source = parent
 	if(!user)
 		user = source.loc
 	if(!istype(user))

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -22,7 +22,7 @@
 	if(starting_cutout)
 		return INITIALIZE_HINT_LATELOAD
 	if(!pushed_over)
-		AddComponent(/datum/component/tactical)
+		tacticool = AddComponent(/datum/component/tactical)
 
 /obj/item/cardboard_cutout/Destroy()
 	tacticool = null

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -341,15 +341,15 @@
 	name = "Slaughter Demon"
 	applied_name = "slaughter demon"
 	applied_desc = "A cardboard cutout of a slaughter demon."
-	direct_icon = 'icons/mob/simple/mob.dmi'
-	direct_icon_state = "daemon"
+	direct_icon = 'icons/mob/simple/demon.dmi'
+	direct_icon_state = "slaughter_demon"
 
 /datum/cardboard_cutout/laughter_demon
 	name = "Laughter Demon"
 	applied_name = "laughter demon"
 	applied_desc = "A cardboard cutout of a laughter demon."
-	direct_icon = 'icons/mob/simple/mob.dmi'
-	direct_icon_state = "bowmon"
+	direct_icon = 'icons/mob/simple/demon.dmi'
+	direct_icon_state = "bow_demon"
 
 /datum/cardboard_cutout/security_officer
 	name = "Private Security Officer"

--- a/code/modules/unit_tests/cardboard_cutouts.dm
+++ b/code/modules/unit_tests/cardboard_cutouts.dm
@@ -2,6 +2,14 @@
 /datum/unit_test/cardboard_cutouts
 
 /datum/unit_test/cardboard_cutouts/Run()
+	for(var/datum/cardboard_cutout/cutout as anything in subtypesof(/datum/cardboard_cutout))
+		var/direct_icon = initial(cutout.direct_icon)
+		if(isnull(direct_icon)) //these are dynamically generated.
+			continue
+		var/direct_state = initial(cutout.direct_icon_state)
+		if(!icon_exists(direct_icon, direct_state))
+			TEST_FAIL("[cutout] has a non-existant icon state at: [direct_icon] - [direct_state]")
+
 	var/obj/item/cardboard_cutout/normal_cutout = new
 	test_screenshot("normal_cutout", getFlatIcon(normal_cutout))
 


### PR DESCRIPTION
## About The Pull Request
This should fix #81560 and fix #81561,

## Why It's Good For The Game
Oh no, another invisibility exploit.

## Changelog

:cl:
fix: fixed an issue with tactical appearance (potted plants / cardboard cutouts) not going away after giving the item to someone else.
fix: Fixed slaughter demon cutouts being invisible. Also fixed another issue with the tactical appearance not going away when the cardboard cutout is pushed down.
/:cl:
