### PR TITLE
Fix organs being replaced when not needed

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -348,7 +348,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				qdel(existing_organ)
 			continue
 
-		 // we don't want to remove organs that are not the default for this species
+		// we don't want to remove organs that are not the default for this species
 		if(!isnull(existing_organ))
 			if(!isnull(old_species) && existing_organ.type != old_species.get_mutant_organ_type_for_slot(slot))
 				continue

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -348,9 +348,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				qdel(existing_organ)
 			continue
 
-		if(!isnull(old_species) && !isnull(existing_organ))
-			if(existing_organ.type != old_species.get_mutant_organ_type_for_slot(slot))
-				continue // we don't want to remove organs that are not the default for this species
+		 // we don't want to remove organs that are not the default for this species
+		if(!isnull(existing_organ))
+			if(!isnull(old_species) && existing_organ.type != old_species.get_mutant_organ_type_for_slot(slot))
+				continue
+			else if(!replace_current && existing_organ.type != get_mutant_organ_type_for_slot(slot))
+				continue
 
 		// at this point we already know new_organ is not null
 		if(existing_organ?.type == new_organ)


### PR DESCRIPTION

## About The Pull Request

So it seems `regenerate_organs` on species was actually replacing organs not belonging to the species regardless, which was making it so the `HEAL_ORGANS` flag which is supposed to heal your organs and supposedly replace missing ones too.
However, this made it so anything using that would also remove and replace all organs not native to your species, including prosthetic organs, cybernetic organs, organs alien to your species, and the nightmare heart itself when you're not a nightmare and it tries to revive and convert you.

This just makes it mimic its behaviour when used to convert from one species to another, which is to not replace organs alien to your previous species, and making it also not replace those when `replace_current = FALSE`.
## Why It's Good For The Game

Fixes #81546.
Fixes ethereal reviving eating your prosthetics.
## Changelog
:cl:
fix: Ethereal heart revive doesn't delete organs alien to your species, like prosthetics, cybernetics, and possibly itself.
fix: Nightmare heart revive doesn't delete organs alien to your species, like itself, upon which it would stop the conversion to shadowperson.
/:cl:
