### PR TITLE
Item Blood Overlay Optimization

### DIFF
--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -13,10 +13,6 @@
 
 /datum/element/decal/blood/generate_appearance(_icon, _icon_state, _dir, _plane, _layer, _color, _alpha, _smoothing, source)
 	var/obj/item/I = source
-	if(!_icon)
-		_icon = 'icons/effects/blood.dmi'
-	if(!_icon_state)
-		_icon_state = "itemblood"
 	var/icon = I.icon
 	var/icon_state = I.icon_state
 	if(!icon || !icon_state)
@@ -26,18 +22,11 @@
 	var/icon/icon_for_size = icon(icon, icon_state)
 	var/scale_factor_x = icon_for_size.Width()/world.icon_size
 	var/scale_factor_y = icon_for_size.Height()/world.icon_size
-	var/static/list/blood_splatter_appearances = list()
-	//try to find a pre-processed blood-splatter. otherwise, make a new one
-	var/index = "[scale_factor_x]-[scale_factor_y]"
-	pic = blood_splatter_appearances[index]
-	pic.color = _color
-
-	if(!pic)
-		var/mutable_appearance/blood_splatter = mutable_appearance(_icon, _icon_state, appearance_flags = RESET_COLOR) //MA of the blood that we apply
-		blood_splatter.transform = blood_splatter.transform.Scale(scale_factor_x, scale_factor_y)
-		blood_splatter.blend_mode = BLEND_INSET_OVERLAY
-		pic = blood_splatter
-		blood_splatter_appearances[index] = pic
+	var/mutable_appearance/blood_splatter = mutable_appearance('icons/effects/blood.dmi', "itemblood", appearance_flags = RESET_COLOR) //MA of the blood that we apply
+	blood_splatter.transform = blood_splatter.transform.Scale(scale_factor_x, scale_factor_y)
+	blood_splatter.blend_mode = BLEND_INSET_OVERLAY
+	blood_splatter.color = _color
+	pic = blood_splatter
 	return TRUE
 
 /datum/element/decal/blood/proc/get_examine_name(datum/source, mob/user, list/override)

--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -23,18 +23,20 @@
 		// It's something which takes on the look of other items, probably
 		icon = I.icon
 		icon_state = I.icon_state
+	var/icon/icon_for_size = icon(icon, icon_state)
+	var/scale_factor_x = icon_for_size.Width()/world.icon_size
+	var/scale_factor_y = icon_for_size.Height()/world.icon_size
 	var/static/list/blood_splatter_appearances = list()
 	//try to find a pre-processed blood-splatter. otherwise, make a new one
-	var/index = "[REF(icon)]-[icon_state]"
+	var/index = "[scale_factor_x]-[scale_factor_y]"
 	pic = blood_splatter_appearances[index]
+	pic.color = _color
 
 	if(!pic)
-		var/icon/blood_splatter_icon = icon(I.icon, I.icon_state, , 1) //icon of the item that will become splattered
-		var/icon/blood_icon = icon(_icon, _icon_state) //icon of the blood that we apply
-		blood_icon.Scale(blood_splatter_icon.Width(), blood_splatter_icon.Height())
-		blood_splatter_icon.Blend("#fff", ICON_ADD) //fills the icon_state with white (except where it's transparent)
-		blood_splatter_icon.Blend(blood_icon, ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
-		pic = mutable_appearance(blood_splatter_icon, I.icon_state)
+		var/mutable_appearance/blood_splatter = mutable_appearance(_icon, _icon_state, appearance_flags = RESET_COLOR) //MA of the blood that we apply
+		blood_splatter.transform = blood_splatter.transform.Scale(scale_factor_x, scale_factor_y)
+		blood_splatter.blend_mode = BLEND_INSET_OVERLAY
+		pic = blood_splatter
 		blood_splatter_appearances[index] = pic
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Previously it cached by (icon and icon state) of the item and modified the blood decal overlay with icon procs

Now there is no cache and everything is done with MAs and overlays, except for reading the width and height of the item's icon in order to scale the blood splatter
## Why It's Good For The Game
There was no need to cache the blood splatter since it is exactly the same sprite for every item
## Changelog
:cl:
refactor: Bloody item overlays no longer use icon procs to generate the overlay
/:cl:
