### PR TITLE
Fix dead mobs changing their mob `tag` causing obsever weakrefs to not function

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -14,7 +14,6 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	flags_1 |= INITIALIZED_1
 	// Initial is non standard here, but ghosts move before they get here so it's needed. this is a cold path too so it's ok
 	SET_PLANE_IMPLICIT(src, initial(plane))
-	tag = "mob_[next_mob_id++]"
 	add_to_mob_list()
 
 	prepare_huds()


### PR DESCRIPTION
## About The Pull Request

Fixes #81578 
Fixes #81559
Fixes #81308

In #69634 mob tag generation was moved to `/mob/New`

But dead mobs also do this in initialize

![image](https://github.com/tgstation/tgstation/assets/51863163/ac5cc2fa-2360-4a5d-b992-0fe43e4f6122)

So dead mobs skipped over a tag

This is whatever, until it's not: 

If something makes a weakref of an observer in `/observer/Initialize` before its parent call, which shuffles the mob tag around, uh oh now our weakref points to a non-existent ref!

So what's making the weakref? No clue but apparently chasms

## Changelog

:cl: Melbert
fix: Chasms no longer break your verbs
/:cl:




