### PR TITLE
Adds a missing servo into the MK1 Ripley crate ordered from cargo

### DIFF
--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -25,6 +25,7 @@
 					/obj/item/mecha_parts/part/ripley_left_leg,
 					/obj/item/stock_parts/capacitor,
 					/obj/item/stock_parts/scanning_module,
+					/obj/item/stock_parts/servo,
 					/obj/item/circuitboard/mecha/ripley/main,
 					/obj/item/circuitboard/mecha/ripley/peripherals,
 					/obj/item/mecha_parts/mecha_equipment/drill,


### PR DESCRIPTION

## About The Pull Request
So cargo can order a box containing all the components you need to build a ripley mech from the ground up.

Except a servo, which is required in the building process, and is needed for the mech to move around anywhere.
This adds the missing part, so that the only thing you need is metal and tools. (And a battery.)
## Why It's Good For The Game
If you order a crate containing (almost) all the components you need to build a mech, and its missing a key part, I wouldn't call that a very complete set. So having the servo included makes it complete.

Also, the chances are this crate was forgotten about when the servos became a needed part of mech construction, so this fixes the consistency.
## Changelog
:cl:
fix: Adds a missing servo component into the MK1 Ripley Crate ordered from cargo.
/:cl:
