### PR TITLE
Allows dragging from boxes into All-In-One Grinders

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -27,6 +27,7 @@
 	holdingitems = list()
 	beaker = new /obj/item/reagent_containers/cup/beaker/large(src)
 	warn_of_dust()
+	RegisterSignal(src, COMSIG_STORAGE_DUMP_CONTENT, PROC_REF(on_storage_dump))
 
 /// Add a description to the current beaker warning of blended dust, if it doesn't already have that warning.
 /obj/machinery/reagentgrinder/proc/warn_of_dust()
@@ -204,6 +205,26 @@
 		to_chat(user, span_notice("You add [weapon] to [src]."))
 		holdingitems[weapon] = TRUE
 		return FALSE
+
+/obj/machinery/reagentgrinder/proc/on_storage_dump(datum/source, datum/storage/storage, mob/user)
+	SIGNAL_HANDLER
+
+	for(var/obj/item/to_dump in storage.real_location)
+		if(holdingitems.len >= limit)
+			break
+
+		if(!to_dump.grind_results && !to_dump.juice_typepath)
+			continue
+
+		if(!storage.attempt_remove(to_dump, src, silent = TRUE))
+			continue
+
+		holdingitems[to_dump] = TRUE
+		to_dump.pixel_x = to_dump.base_pixel_x + rand(-5, 5)
+		to_dump.pixel_y = to_dump.base_pixel_y + rand(-5, 5)
+
+	to_chat(user, span_notice("You dump [storage.parent] into [src]."))
+	return STORAGE_DUMP_HANDLED
 
 /obj/machinery/reagentgrinder/ui_interact(mob/user) // The microwave Menu //I am reasonably certain that this is not a microwave
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -220,8 +220,6 @@
 			continue
 
 		holdingitems[to_dump] = TRUE
-		to_dump.pixel_x = to_dump.base_pixel_x + rand(-5, 5)
-		to_dump.pixel_y = to_dump.base_pixel_y + rand(-5, 5)
 
 	to_chat(user, span_notice("You dump [storage.parent] into [src]."))
 	return STORAGE_DUMP_HANDLED


### PR DESCRIPTION

## About The Pull Request
Simply allows you to drag from storage containers directly onto All-In-One Grinders. Current behavior just spills it on the same tile.

## Why It's Good For The Game
I already had to put all these items in the box in the first place, this just makes it slightly easier on the way back.

## Changelog
:cl:
qol: Allows dragging from boxes into All-In-One Grinders
/:cl:
