### PR TITLE
Power crepes are now finger food

### DIFF
--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -246,6 +246,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	tastes = list("cherry" = 1, "crepe" = 1)
 	foodtypes = GRAIN | FRUIT | SUGAR
+	food_flags = FOOD_FINGER_FOOD
 	crafting_complexity = FOOD_COMPLEXITY_5
 
 /obj/item/food/branrequests


### PR DESCRIPTION

## About The Pull Request
Power crepes are now finger food, meaning you can eat them while walking. I think this makes sense because the power crepe is massive enough to just take a bite out of while you walk.
## Why It's Good For The Game
Power crepes are a very expensive food item, the should at least be easy to eat.
## Changelog
:cl:
balance: Power crepes are now finger food
/:cl:
