### PR TITLE
Alternate job titles (chef, department security) actually imprint this title onto your PDA

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -88,6 +88,17 @@
 		if(!visualsOnly)
 			other_chefs.cooks++
 
+/datum/outfit/job/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	// Update PDA to match possible new trim.
+	var/obj/item/card/id/worn_id = H.wear_id
+	var/obj/item/modular_computer/pda/pda = H.get_item_by_slot(pda_slot)
+	if(!istype(worn_id) || !istype(pda))
+		return
+	var/assignment = worn_id.get_trim_assignment()
+	if(!isnull(assignment))
+		pda.imprint_id(H.real_name, assignment)
+
 /datum/outfit/job/cook/get_types_to_preload()
 	. = ..()
 	. += /obj/item/clothing/suit/apron/chef

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -88,16 +88,16 @@
 		if(!visualsOnly)
 			other_chefs.cooks++
 
-/datum/outfit/job/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+/datum/outfit/job/cook/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+	. = ..()
 	// Update PDA to match possible new trim.
-	var/obj/item/card/id/worn_id = H.wear_id
-	var/obj/item/modular_computer/pda/pda = H.get_item_by_slot(pda_slot)
+	var/obj/item/card/id/worn_id = user.wear_id
+	var/obj/item/modular_computer/pda/pda = user.get_item_by_slot(pda_slot)
 	if(!istype(worn_id) || !istype(pda))
 		return
 	var/assignment = worn_id.get_trim_assignment()
 	if(!isnull(assignment))
-		pda.imprint_id(H.real_name, assignment)
+		pda.imprint_id(user.real_name, assignment)
 
 /datum/outfit/job/cook/get_types_to_preload()
 	. = ..()

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -117,6 +117,12 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
 		spawning.sec_hud_set_ID()
 
+		// Update PDA to match new trim.
+		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
+		var/assignment = worn_id.get_trim_assignment()
+		if(istype(pda) && !isnull(assignment))
+			pda.imprint_id(spawning.real_name, assignment)
+
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))
 
 	if(!CONFIG_GET(flag/sec_start_brig) && (destination || spawn_point))


### PR DESCRIPTION

## About The Pull Request

An issue I noticed while debugging chef not showing up on the crew monitor: while the security and cook jobs can have alternate ID trims with alternate job titles, they do not actually imprint this onto their PDAs.
This just makes the Cook job imprint their current ID onto the PDA in `post_equip`, and Security Officer does so after applying the trim in `setup_department` (called in `after_roundstart_spawn` and `after_latejoin_spawn`).
## Why It's Good For The Game

Fixes the PDA to ID mismatch for alternate job titles for Cook and Security Office.
## Changelog
:cl:
fix: Chef and department security have the assignment on their ID imprinted onto their PDA by default, instead of defaulting to Cook/Security Officer and requiring you to do so manually.
/:cl:
