### PR TITLE
Explosion Block (A hidden stat on things like reinforced walls) is more effective against heavy and light tiers of explosions

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -121,25 +121,26 @@ SUBSYSTEM_DEF(explosions)
 		var/our_x = explode.x
 		var/our_y = explode.y
 		var/dist = CHEAP_HYPOTENUSE(our_x, our_y, x0, y0)
+		var/block = 0
 
 		if(newmode == "Yes")
 			if(explode != epicenter)
 				var/our_block = cached_exp_block[get_step_towards(explode, epicenter)]
-				dist += our_block
+				block += our_block
 				cached_exp_block[explode] = our_block + explode.explosive_resistance
 			else
 				cached_exp_block[explode] = explode.explosive_resistance
 
 		dist = round(dist, 0.01)
-		if(dist < dev)
+		if(dist + block < dev)
 			explode.color = "red"
 			explode.maptext = MAPTEXT("[dist]")
-		else if (dist < heavy)
+		else if (dist + block * 1.5 < heavy)
 			explode.color = "yellow"
-			explode.maptext = MAPTEXT("[dist]")
-		else if (dist < light)
+			explode.maptext = MAPTEXT("[dist + block * 1.5]")
+		else if (dist + block * 3 < light)
 			explode.color = "blue"
-			explode.maptext = MAPTEXT("[dist]")
+			explode.maptext = MAPTEXT("[dist + block * 3]")
 		else
 			continue
 
@@ -390,7 +391,7 @@ SUBSYSTEM_DEF(explosions)
 		var/our_x = explode.x
 		var/our_y = explode.y
 		var/dist = CHEAP_HYPOTENUSE(our_x, our_y, x0, y0)
-
+		var/block = 0
 		// Using this pattern, block will flow out from blocking turfs, essentially caching the recursion
 		// This is safe because if get_step_towards is ever anything but caridnally off, it'll do a diagonal move
 		// So we always sample from a "loop" closer
@@ -400,16 +401,16 @@ SUBSYSTEM_DEF(explosions)
 				cached_exp_block[explode] = explode.explosive_resistance
 			else
 				var/our_block = cached_exp_block[get_step_towards(explode, epicenter)]
-				dist += our_block
+				block += our_block
 				cached_exp_block[explode] = our_block + explode.explosive_resistance
 
 
 		var/severity = EXPLODE_NONE
-		if(dist < devastation_range)
+		if(dist + block < devastation_range)
 			severity = EXPLODE_DEVASTATE
-		else if(dist < heavy_impact_range)
+		else if(dist + block * 1.5 < heavy_impact_range)
 			severity = EXPLODE_HEAVY
-		else if(dist < light_impact_range)
+		else if(dist + block * 3 < light_impact_range)
 			severity = EXPLODE_LIGHT
 
 		if(explode == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -138,9 +138,9 @@ SUBSYSTEM_DEF(explosions)
 		else if (dist + block * 1.5 < heavy)
 			explode.color = "yellow"
 			explode.maptext = MAPTEXT("[dist + block * 1.5]")
-		else if (dist + block * 2 < light)
+		else if (dist + block * 2.5 < light)
 			explode.color = "blue"
-			explode.maptext = MAPTEXT("[dist + block * 3]")
+			explode.maptext = MAPTEXT("[dist + block * 2.5]")
 		else
 			continue
 
@@ -410,7 +410,7 @@ SUBSYSTEM_DEF(explosions)
 			severity = EXPLODE_DEVASTATE
 		else if(dist + block * 1.5 < heavy_impact_range)
 			severity = EXPLODE_HEAVY
-		else if(dist + block * 2 < light_impact_range)
+		else if(dist + block * 2.5 < light_impact_range)
 			severity = EXPLODE_LIGHT
 
 		if(explode == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -1,4 +1,8 @@
 #define EXPLOSION_THROW_SPEED 4
+#define EXPLOSION_BLOCK_LIGHT 2.5
+#define EXPLOSION_BLOCK_HEAVY 1.5
+#define EXPLOSION_BLOCK_DEV 1
+
 GLOBAL_LIST_EMPTY(explosions)
 
 SUBSYSTEM_DEF(explosions)
@@ -132,15 +136,15 @@ SUBSYSTEM_DEF(explosions)
 				cached_exp_block[explode] = explode.explosive_resistance
 
 		dist = round(dist, 0.01)
-		if(dist + block < dev)
+		if(dist + (block * EXPLOSION_BLOCK_DEV) < dev)
 			explode.color = "red"
 			explode.maptext = MAPTEXT("[dist]")
-		else if (dist + block * 1.5 < heavy)
+		else if (dist + (block * EXPLOSION_BLOCK_HEAVY) < heavy)
 			explode.color = "yellow"
-			explode.maptext = MAPTEXT("[dist + block * 1.5]")
-		else if (dist + block * 2.5 < light)
+			explode.maptext = MAPTEXT("[dist + (block * EXPLOSION_BLOCK_HEAVY)]")
+		else if (dist + (block * EXPLOSION_BLOCK_LIGHT) < light)
 			explode.color = "blue"
-			explode.maptext = MAPTEXT("[dist + block * 2.5]")
+			explode.maptext = MAPTEXT("[dist + (block * EXPLOSION_BLOCK_LIGHT)]")
 		else
 			continue
 
@@ -406,11 +410,11 @@ SUBSYSTEM_DEF(explosions)
 
 
 		var/severity = EXPLODE_NONE
-		if(dist + block < devastation_range)
+		if(dist + (block * EXPLOSION_BLOCK_DEV) < devastation_range)
 			severity = EXPLODE_DEVASTATE
-		else if(dist + block * 1.5 < heavy_impact_range)
+		else if(dist + (block * EXPLOSION_BLOCK_HEAVY) < heavy_impact_range)
 			severity = EXPLODE_HEAVY
-		else if(dist + block * 2.5 < light_impact_range)
+		else if(dist + (block * EXPLOSION_BLOCK_LIGHT) < light_impact_range)
 			severity = EXPLODE_LIGHT
 
 		if(explode == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag
@@ -715,3 +719,6 @@ SUBSYSTEM_DEF(explosions)
 	currentpart = SSEXPLOSIONS_TURFS
 
 #undef EXPLOSION_THROW_SPEED
+#undef EXPLOSION_BLOCK_LIGHT
+#undef EXPLOSION_BLOCK_HEAVY
+#undef EXPLOSION_BLOCK_DEV

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -138,7 +138,7 @@ SUBSYSTEM_DEF(explosions)
 		else if (dist + block * 1.5 < heavy)
 			explode.color = "yellow"
 			explode.maptext = MAPTEXT("[dist + block * 1.5]")
-		else if (dist + block * 3 < light)
+		else if (dist + block * 2 < light)
 			explode.color = "blue"
 			explode.maptext = MAPTEXT("[dist + block * 3]")
 		else
@@ -395,7 +395,7 @@ SUBSYSTEM_DEF(explosions)
 		// Using this pattern, block will flow out from blocking turfs, essentially caching the recursion
 		// This is safe because if get_step_towards is ever anything but caridnally off, it'll do a diagonal move
 		// So we always sample from a "loop" closer
-		// It's kind of behaviorly unimpressive that that's a problem for the future
+		// It's kind of behaviorly unimpressive but that's a problem for the future
 		if(reactionary)
 			if(explode == epicenter)
 				cached_exp_block[explode] = explode.explosive_resistance
@@ -410,7 +410,7 @@ SUBSYSTEM_DEF(explosions)
 			severity = EXPLODE_DEVASTATE
 		else if(dist + block * 1.5 < heavy_impact_range)
 			severity = EXPLODE_HEAVY
-		else if(dist + block * 3 < light_impact_range)
+		else if(dist + block * 2 < light_impact_range)
 			severity = EXPLODE_LIGHT
 
 		if(explode == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag


### PR DESCRIPTION
## About The Pull Request

As of right now if a 5/10/20 bomb goes through a reinforced wall it has its ranges subtracted by a flat value of 2 (explosion block is a flat subtraction to each tier) and essentially gets turned into a 3/8/18.

This pr just buffs the effect of explosion block against heavy and light. The modifier is 1.5x against heavy and 2.5x against light (I might nerf 2.5x down to 2x) I dont want to nullify shockwaves because they should always be impactful at weakening the station.

In the same situation a 5/10/20 bomb goes through a reinforced wall, it has its ranged subtracted and ends up 3/7/15


Here is an image of a max cap (5/10/20, do note that currently tg server config is like 8/16/32 or something crazy) in tram sci, notice there is roughly 2 layers of reinforced walls on the right and it makes it through the first layer and hits the second, it would likely destroy the entire first layer of reinforced walls and remove several tiles from the second making a second explosion able to go into genetics entirely unmitigated.
![image](https://github.com/tgstation/tgstation/assets/62126254/dbbcb834-e734-43c8-a50a-6b13d850d941)


In practice the 2nd layer of walls remains miraculously unscathed due to light explosions having an rng diceroll on destroying reinforced walls

![image](https://github.com/tgstation/tgstation/assets/62126254/42c5ab23-9d72-4b49-be83-04d9e160a9a3)

A second blast still gets through since the 1st layer is no longer there to protect it.

![image](https://github.com/tgstation/tgstation/assets/62126254/e86e36b6-f9ea-42b8-8918-23d2e72a7416)


Do note on live servers it would be much bigger due to max cap being 8/16/32 , going through 1 reinforced walls would result in 6/13/27 which is still far larger than the 5/10/20 shown.

## Why It's Good For The Game

Its probably not the best approach to fixing the problem and I probably made it too good at mitigating light but..

As of right now reinforced walls are so weak at stopping or mitigating explosions that they are spammed alittle bit more than they should be on a lot of maps and the nukie ship has a laughably silly explosion block of 20!!! Just to be able to make it somewhat safe.

Every once in awhile atmos becomes a hot topic for debate because of some new form of spammable explosive that is getting nerfed because of the way they can easily wipe the station but we never took a look at how explosions are done, if this pr is merged it won't kill those types of gimmicks but it will necessitate actually thinking about how you plan to bomb the station since now you will need to repeatedly bomb to get through hardpoints (remember even if a reinforced wall mitigates an explosion it can be dismantled by it and let subsequent explosions through) or simply position those bombs directly inside of areas of interest

Another important note is that rooms that map makers intend to be explosive resistant should be able to better contain 1 explosion so less situations of everyone in sci getting cucked by toxins messing up (unless its so bad that they bomb themselves twice)


If this pr is merged I would suggest keeping an eye on heavy firelocks, they are more expensive than reinforced walls but allow movement through them which means they are a lot more practical for spamming explosive block.

I personally wanted to make foam and other materials good at uniquely blocking different tiers of explosions but I recall being told that was a little bit too complicated, if this pr doesn't go well I might try that.
## Changelog
:cl:

balance: Reinforced sections of station hull have gotten better at mitigating explosive shockwaves.
/:cl:
