### PR TITLE
Tram mob throwing adjustments

### DIFF
--- a/code/datums/elements/window_smash.dm
+++ b/code/datums/elements/window_smash.dm
@@ -24,6 +24,9 @@
 	for(var/obj/structure/window/window in target_turf)
 		window.smash_and_injure(flying_mob, old_loc, direction)
 
+	for(var/obj/structure/grille/grille in target_turf)
+		grille.smash_and_injure(flying_mob, old_loc, direction)
+
 /datum/element/window_smashing/Detach(datum/source)
 	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 	passwindow_off(source, TRAM_PASSENGER_TRAIT)

--- a/code/modules/transport/linear_controller.dm
+++ b/code/modules/transport/linear_controller.dm
@@ -35,6 +35,9 @@
 	///if true, the platform cannot be manually moved.
 	var/controls_locked = FALSE
 
+	/// probability of being thrown hard during an emergency stop
+	var/throw_chance = 17.5
+
 /datum/transport_controller/linear/New(obj/structure/transport/linear/transport_module)
 	transport_id = transport_module.transport_id
 	create_modular_set = transport_module.create_modular_set

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -17,17 +17,15 @@
 	var/travel_remaining = 0
 	///how far in total we'll be travelling
 	var/travel_trip_length = 0
-
 	///multiplier on how much damage/force the tram imparts on things it hits
 	var/collision_lethality = 1
+	/// reference to the navigation landmark associated with this tram. since we potentially span multiple z levels we dont actually
+	/// know where on us this platform is. as long as we know THAT its on us we can just move the distance and direction between this
+	/// and the destination landmark.
 	var/obj/effect/landmark/transport/nav_beacon/tram/nav/nav_beacon
-	/// reference to the destination landmarks we consider ourselves "at" or travelling towards. since we potentially span multiple z levels we dont actually
-	/// know where on us this platform is. as long as we know THAT its on us we can just move the distance and direction between this
-	/// and the destination landmark.
+	/// reference to the landmark we consider ourself stationary at.
 	var/obj/effect/landmark/transport/nav_beacon/tram/platform/idle_platform
-	/// reference to the destination landmarks we consider ourselves travelling towards. since we potentially span multiple z levels we dont actually
-	/// know where on us this platform is. as long as we know THAT its on us we can just move the distance and direction between this
-	/// and the destination landmark.
+	/// reference to the destination landmark we consider ourselves travelling towards.
 	var/obj/effect/landmark/transport/nav_beacon/tram/platform/destination_platform
 
 	var/current_speed = 0
@@ -284,7 +282,11 @@
 			degraded_stop()
 			return PROCESS_KILL
 
-		normal_stop()
+		if((controller_status & COMM_ERROR) && prob(5)) // malfunctioning tram has a small chance to e-stop
+			degraded_stop()
+		else
+			normal_stop()
+
 		return PROCESS_KILL
 
 	else if(world.time >= scheduled_move)
@@ -538,7 +540,8 @@
 	set_status_code(COMM_ERROR, TRUE)
 	SEND_TRANSPORT_SIGNAL(COMSIG_COMMS_STATUS, src, FALSE)
 	paired_cabinet.generate_repair_signals()
-	collision_lethality = 1.25
+	collision_lethality *= 1.25
+	throw_chance *= 1.25
 	log_transport("TC: [specific_transport_id] starting Tram Malfunction event.")
 
 /**
@@ -553,6 +556,7 @@
 	set_status_code(COMM_ERROR, FALSE)
 	paired_cabinet.clear_repair_signals()
 	collision_lethality = initial(collision_lethality)
+	throw_chance = initial(throw_chance)
 	SEND_TRANSPORT_SIGNAL(COMSIG_COMMS_STATUS, src, TRUE)
 	log_transport("TC: [specific_transport_id] ending Tram Malfunction event.")
 

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -935,7 +935,7 @@
 	for(var/mob/living/passenger in transport_contents)
 		to_chat(passenger, span_userdanger("The tram comes to a sudden, grinding stop!"))
 		var/mob_throw_chance = transport_controller_datum.throw_chance
-		if(prob(mob_throw_chance ? mob_throw_chance : 17.5) || HAS_TRAIT(passenger, TRAIT_CURSED)) // sometimes you go through a window, especially with bad luck
+		if(prob(mob_throw_chance || 17.5) || HAS_TRAIT(passenger, TRAIT_CURSED)) // sometimes you go through a window, especially with bad luck
 			passenger.AddElement(/datum/element/window_smashing, duration = 1.5 SECONDS)
 		var/throw_target = get_edge_target_turf(src, throw_direction)
 		passenger.throw_at(throw_target, 30, 7, force = MOVE_FORCE_OVERPOWERING)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -935,9 +935,7 @@
 	for(var/mob/living/passenger in transport_contents)
 		to_chat(passenger, span_userdanger("The tram comes to a sudden, grinding stop!"))
 		var/mob_throw_chance = transport_controller_datum.throw_chance
-		if(isnull(mob_throw_chance)) // controller datum may be qdel'd
-			mob_throw_chance = 17.5
-		if(prob(mob_throw_chance) || HAS_TRAIT(passenger, TRAIT_CURSED)) // sometimes you go through a window, especially with bad luck
+		if(prob(mob_throw_chance ? mob_throw_chance : 17.5) || HAS_TRAIT(passenger, TRAIT_CURSED)) // sometimes you go through a window, especially with bad luck
 			passenger.AddElement(/datum/element/window_smashing, duration = 1.5 SECONDS)
 		var/throw_target = get_edge_target_turf(src, throw_direction)
 		passenger.throw_at(throw_target, 30, 7, force = MOVE_FORCE_OVERPOWERING)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -934,7 +934,10 @@
 /obj/structure/transport/linear/tram/proc/estop_throw(throw_direction)
 	for(var/mob/living/passenger in transport_contents)
 		to_chat(passenger, span_userdanger("The tram comes to a sudden, grinding stop!"))
-		if(prob(17.5)) // sometimes you go through a window
+		var/mob_throw_chance = transport_controller_datum.throw_chance
+		if(isnull(mob_throw_chance)) // controller datum may be qdel'd
+			mob_throw_chance = 17.5
+		if(prob(mob_throw_chance) || HAS_TRAIT(passenger, TRAIT_CURSED)) // sometimes you go through a window, especially with bad luck
 			passenger.AddElement(/datum/element/window_smashing, duration = 1.5 SECONDS)
 		var/throw_target = get_edge_target_turf(src, throw_direction)
 		passenger.throw_at(throw_target, 30, 7, force = MOVE_FORCE_OVERPOWERING)


### PR DESCRIPTION
## About The Pull Request

- Corrects grille breaking related to PR https://github.com/tgstation/tgstation/pull/81594
- Throw chance moved to a var on the controller instead of hardcoded
- Corrects a bit of documentation on tram controller landmarks
- Fixes the collision multiplier being set to a static value during malfunction instead of the intended multiplier
- Includes throw chance in tram malfunction
- Cursed mobs now guaranteed to be thrown

## Changelog

:cl: LT3
code: Tram throwing now breaks grilles consistently
code: Tram malfunction lethality/throw chance are now a multiplier instead of flat value
code: Tram throw chance can be adjusted
code: Unlucky trait is now used in tram throw calculation 
/:cl:
