### PR TITLE
Fixes arcade cabinets being un-hittable

### DIFF
--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -71,8 +71,9 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/storage/box/party_poppers = 2))
 
 /obj/machinery/computer/arcade
-	name = "random arcade"
-	desc = "random arcade machine"
+	name = "\proper the arcade cabinet which shouldn't exist"
+	desc = "This arcade cabinet has no games installed, and in fact, should not exist. \
+		Report the location of this machine to your local diety."
 	icon_state = "arcade"
 	icon_keyboard = null
 	icon_screen = "invaders"
@@ -136,19 +137,21 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		new empprize(loc)
 	explosion(src, devastation_range = -1, light_impact_range = 1+num_of_prizes, flame_range = 1+num_of_prizes)
 
-/obj/machinery/computer/arcade/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/stack/arcadeticket))
-		var/obj/item/stack/arcadeticket/T = O
-		var/amount = T.get_amount()
-		if(amount <2)
-			to_chat(user, span_warning("You need 2 tickets to claim a prize!"))
-			return
-		prizevend(user)
-		T.pay_tickets()
-		T.update_appearance()
-		O = T
-		to_chat(user, span_notice("You turn in 2 tickets to the [src] and claim a prize!"))
-		return
+/obj/machinery/computer/arcade/item_interaction(mob/living/user, obj/item/tool, list/modifiers, is_right_clicking)
+	. = ..()
+	if(. & ITEM_INTERACT_ANY_BLOCKER)
+		return .
+	if(!istype(tool, /obj/item/stack/arcadeticket))
+		return .
+
+	var/obj/item/stack/arcadeticket/tickets = tool
+	if(!tickets.use(2))
+		balloon_alert(user, "need 2 tickets!")
+		return ITEM_INTERACT_BLOCKING
+
+	prizevend(user)
+	balloon_alert(user, "prize claimed")
+	return ITEM_INTERACT_SUCCESS
 
 // ** BATTLE ** //
 /obj/machinery/computer/arcade/battle

--- a/code/game/objects/items/stacks/tickets.dm
+++ b/code/game/objects/items/stacks/tickets.dm
@@ -14,8 +14,7 @@
 
 /obj/item/stack/arcadeticket/update_icon_state()
 	. = ..()
-	var/amount = get_amount()
-	switch(amount)
+	switch(get_amount())
 		if(12 to INFINITY)
 			icon_state = "arcade-ticket_4"
 		if(6 to 12)
@@ -24,11 +23,6 @@
 			icon_state = "arcade-ticket_2"
 		else
 			icon_state = "arcade-ticket"
-
-/obj/item/stack/arcadeticket/proc/pay_tickets()
-	amount -= 2
-	if (amount == 0)
-		qdel(src)
 
 /obj/item/stack/arcadeticket/thirty
 	amount = 30

--- a/code/game/objects/items/stacks/tickets.dm
+++ b/code/game/objects/items/stacks/tickets.dm
@@ -8,10 +8,6 @@
 	max_amount = 30
 	merge_type = /obj/item/stack/arcadeticket
 
-/obj/item/stack/arcadeticket/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
-	. = ..()
-	update_appearance()
-
 /obj/item/stack/arcadeticket/update_icon_state()
 	. = ..()
 	switch(get_amount())


### PR DESCRIPTION
## About The Pull Request

What if we put all of our item based interactions in the same function that attacks are handled? Great idea, I'm sure no one will ever forget to call parent

Fixes that. 

Also cleans up ticket code. 

Also renames the base type so mappers stop mapping it in. 

## Changelog

:cl: Melbert
fix: You can now take our your anger upon arcade cabinets upon losing (they can be hit again) 
/:cl:
