### PR TITLE
Adds alternate, non-murder objectives to Paradox Clone

### DIFF
--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -1,3 +1,6 @@
+//Chance to get an objective to kill your original, instead of a fluff objective
+#define KILL_OBJECTIVE_CHANCE 50
+
 /datum/antagonist/paradox_clone
 	name = "\improper Paradox Clone"
 	roundend_category = "Paradox Clone"
@@ -46,11 +49,22 @@
 /datum/antagonist/paradox_clone/proc/setup_clone()
 	var/datum/mind/original_mind = original_ref?.resolve()
 
-	var/datum/objective/assassinate/paradox_clone/kill = new
-	kill.owner = owner
-	kill.target = original_mind
-	kill.update_explanation_text()
-	objectives += kill
+	if(prob(KILL_OBJECTIVE_CHANCE))
+		var/datum/objective/assassinate/paradox_clone/kill = new
+		kill.owner = owner
+		kill.target = original_mind
+		kill.update_explanation_text()
+		objectives += kill
+	else
+		var/list/explanation_texts = list(
+		"You're the superior [original_mind.name]! Show everyone how cool you are and prove to the crew that you're the only one worthy of having that name!",
+		"You're the best, so obviously, the other [original_mind.name] is the best too. Prove your loyalty to them, and assist them with whatever they're doing this shift!",
+		"You're obviously the REAL [original_mind.name]. Anyone else who looks like you should be given the cold shoulder, no matter how much they try to interact with you.",
+		"The other [original_mind.name] is a FRAUD! Do what you can to make their job as difficult as possible.",
+		)
+		var/explanation_text = pick(explanation_texts)
+		var/datum/objective/paradox_clone_fluff/fluff = new(explanation_text)
+		objectives += fluff
 
 	owner.set_assigned_role(SSjob.GetJobType(/datum/job/paradox_clone))
 
@@ -96,8 +110,13 @@
 		CRASH("WARNING! [ADMIN_LOOKUPFLW(owner)] paradox clone objectives forged without an original!")
 	explanation_text = "Murder and replace [target.name], the [!target_role_type ? target.assigned_role.title : target.special_role]. Remember, your mission is to blend in, do not kill anyone else unless you have to!"
 
+/datum/objective/paradox_clone_fluff
+	name = "paradox clone fluff objective"
+
 ///Static bluespace stream used in its ghost poll icon.
 /obj/effect/bluespace_stream
 	name = "bluespace stream"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "bluestream"
+
+#undef KILL_OBJECTIVE_CHANCE


### PR DESCRIPTION

## About The Pull Request
When a paradox clone spawns, they will have a 50% chance of getting a new "fluff" objective, instead of the objective to murder the original. These objectives range from treating the original as your rival and trying to discredit them, to trying to become a loyal friend to your original.
## Why It's Good For The Game
Whether or not Paraclones will still be able to kill their original with one of these new objectives, and how security can treat non-violent Paraclones is a Policy Discussion, but I believe this change will encourage more paranoia and interesting RP opportunities. 

Your clone is being really nice to you? Do they just want to be your friend, or are they trying to get you to drop your guard? 

Your clone is trying to make your job difficult? How are you going to handle that?

[Policy thread that encouraged this PR, along with other discussion](https://tgstation13.org/phpBB/viewtopic.php?f=33&t=35541)
## Changelog
:cl: PapaMichael
add: Paradox Clones now have a chance to spawn with alternate, non-murdery objectives.
/:cl:
