### PR TITLE
deathmatch ui qol and deathmatch plasmamen are made humans

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -17,6 +17,8 @@
 
 	if(!isnull(species_override))
 		user.set_species(species_override)
+	else if (istype(user.dna.species, /datum/species/plasmaman)) //plasmamen get lit on fire and die
+		user.set_species(/datum/species/human)
 	for(var/datum/action/act as anything in granted_spells)
 		var/datum/action/new_ability = new act(user)
 		new_ability.Grant(user)
@@ -31,7 +33,7 @@
 	name = "Deathmatch: Assistant loadout"
 	display_name = "Assistant"
 	desc = "A simple assistant loadout: greyshirt and a toolbox"
-	
+
 	l_hand = /obj/item/storage/toolbox/mechanical
 	uniform = /obj/item/clothing/under/color/grey
 	back = /obj/item/storage/backpack
@@ -48,7 +50,7 @@
 	name = "Deathmatch: Operative"
 	display_name = "Operative"
 	desc = "A syndicate operative."
-	
+
 	uniform = /obj/item/clothing/under/syndicate
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
@@ -59,7 +61,7 @@
 	name = "Deathmatch: Ranged Operative"
 	display_name = "Ranged Operative"
 	desc = "A syndicate operative with a gun and a knife."
-	
+
 	l_hand = /obj/item/gun/ballistic/automatic/pistol
 	l_pocket = /obj/item/knife/combat
 	backpack_contents = list(/obj/item/ammo_box/magazine/m9mm = 5)
@@ -68,7 +70,7 @@
 	name = "Deathmatch: Melee Operative"
 	display_name = "Melee Operative"
 	desc = "A syndicate operative with multiple knives."
-	
+
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	suit = /obj/item/clothing/suit/armor/vest
 	head = /obj/item/clothing/head/helmet
@@ -80,7 +82,7 @@
 	name = "Deathmatch: Security Officer"
 	display_name = "Security Officer"
 	desc = "A security officer."
-	
+
 	uniform = /datum/outfit/job/security::uniform
 	suit = /datum/outfit/job/security::suit
 	suit_store = /datum/outfit/job/security::suit_store
@@ -100,7 +102,7 @@
 	name = "DM: Instagib"
 	display_name = "Instagib"
 	desc = "Assistant with an instakill rifle."
-	
+
 	l_hand = /obj/item/gun/energy/laser/instakill
 
 /datum/outfit/deathmatch_loadout/operative/sniper
@@ -143,7 +145,7 @@
 	name = "Deathmatch: Battler Base"
 	display_name = "Battler"
 	desc = "What is a battler whith out weapone?."
-	
+
 	shoes = /obj/item/clothing/shoes/combat
 	uniform = /obj/item/clothing/under/syndicate
 	gloves = /obj/item/clothing/gloves/combat
@@ -154,14 +156,14 @@
 	name = "Deathmatch: Soldier"
 	display_name = "Soldier"
 	desc = "Ready for combat."
-	
+
 	l_hand = /obj/item/gun/ballistic/rifle/boltaction
 	l_pocket = /obj/item/knife/combat
 	uniform = /obj/item/clothing/under/syndicate/rus_army
 	suit = /obj/item/clothing/suit/armor/vest
 	head = /obj/item/clothing/head/helmet/rus_helmet
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
-	
+
 	backpack_contents = list(
 		/obj/item/grenade/smokebomb = 2,
 		/obj/item/ammo_box/strilka310 = 2,
@@ -199,7 +201,7 @@
 	name = "Deathmatch: North Star"
 	display_name = "North Star"
 	desc = "flip flip flip"
-	
+
 	uniform = /obj/item/clothing/under/suit/carpskin
 	head = /obj/item/clothing/head/fedora/carpskin
 	gloves = /obj/item/clothing/gloves/rapid
@@ -212,7 +214,7 @@
 	name = "Deathmatch: Janitor"
 	display_name = "Janitor"
 	desc = "Regular work"
-	
+
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
 	suit = /obj/item/clothing/suit/caution
 	head = /obj/item/reagent_containers/cup/bucket
@@ -229,7 +231,7 @@
 	name = "Deathmatch: Surgeon"
 	display_name = "Surgeon"
 	desc = "Treatment has come"
-	
+
 	uniform = /obj/item/clothing/under/rank/medical/scrubs/blue
 	suit = /obj/item/clothing/suit/apron/surgical
 	head = /obj/item/clothing/head/utility/surgerycap
@@ -238,7 +240,7 @@
 	l_pocket = /obj/item/reagent_containers/hypospray/combat
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/penthrite
 	l_hand = /obj/item/chainsaw
-	
+
 	backpack_contents = list(
 		/obj/item/storage/medkit/tactical,
 		/obj/item/reagent_containers/hypospray/medipen/stimulants,
@@ -248,7 +250,7 @@
 	name = "Deathmatch: Raider"
 	display_name = "Raider"
 	desc = "Not from Shadow Legends"
-	
+
 	l_hand = /obj/item/nullrod/claymore/chainsaw_sword
 	r_pocket = /obj/item/switchblade
 	uniform = /obj/item/clothing/under/costume/jabroni
@@ -260,7 +262,7 @@
 	name = "DM: Clown"
 	display_name = "Clown (Man Of Honk)"
 	desc = "Who called this honking clown"
-	
+
 	uniform = /datum/outfit/job/clown::uniform
 	belt = /datum/outfit/job/clown::belt
 	shoes = /datum/outfit/job/clown::shoes
@@ -285,7 +287,7 @@
 	name = "Deathmatch: Coder"
 	display_name = "Coder"
 	desc = "What"
-	
+
 	l_hand = /obj/item/toy/katana
 	uniform = /obj/item/clothing/under/costume/schoolgirl
 	suit = /obj/item/clothing/suit/costume/joker
@@ -299,7 +301,7 @@
 	name = "Deathmatch: Engineer"
 	display_name = "Engineer"
 	desc = "Meet the engineer"
-	
+
 	l_hand = /obj/item/storage/toolbox/emergency/turret
 	uniform = /obj/item/clothing/under/rank/engineering/engineer
 	shoes = /obj/item/clothing/shoes/magboots
@@ -311,7 +313,7 @@
 	name = "Deathmatch: Scientist"
 	display_name = "Scientist"
 	desc = "What a nerd"
-	
+
 	uniform = /obj/item/clothing/under/rank/rnd/scientist
 	suit = /obj/item/clothing/suit/armor/reactive/stealth
 	mask = /obj/item/clothing/mask/gas
@@ -353,7 +355,7 @@
 	name = "Deathmatch: Ripper"
 	display_name = "Ripper"
 	desc = "Die die die!!!"
-	
+
 	l_hand = /obj/item/gun/ballistic/shotgun/hook
 	r_hand = /obj/item/gun/ballistic/shotgun/hook
 	uniform = /obj/item/clothing/under/costume/skeleton
@@ -366,7 +368,7 @@
 	name = "Deathmatch: Cowboy"
 	display_name = "Cowboy"
 	desc = "Yeehaw partner"
-	
+
 	r_hand  = /obj/item/clothing/mask/cigarette/cigar
 	l_hand = /obj/item/melee/curator_whip
 	l_pocket = /obj/item/lighter

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -17,7 +17,7 @@
 
 	if(!isnull(species_override))
 		user.set_species(species_override)
-	else if (istype(user.dna.species, /datum/species/plasmaman)) //plasmamen get lit on fire and die
+	else if (istype(user.dna.species.outfit_important_for_life)) //plasmamen get lit on fire and die
 		user.set_species(/datum/species/human)
 	for(var/datum/action/act as anything in granted_spells)
 		var/datum/action/new_ability = new act(user)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -65,7 +65,7 @@
 /datum/deathmatch_lobby/proc/find_spawns_and_start_delay(datum/lazy_template/source, list/atoms)
 	SIGNAL_HANDLER
 	for(var/thing in atoms)
-		if(istype(thing, /obj/effect/landmark/deathmatch_player_spawn)) 
+		if(istype(thing, /obj/effect/landmark/deathmatch_player_spawn))
 			player_spawns += thing
 
 	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
@@ -147,10 +147,10 @@
 	if(players.len)
 		var/list/winner_info = players[pick(players)]
 		if(!isnull(winner_info["mob"]))
-			winner = winner_info["mob"] //only one should remain anyway but incase of a draw 
-	
+			winner = winner_info["mob"] //only one should remain anyway but incase of a draw
+
 	announce(span_reallybig("THE GAME HAS ENDED.<BR>THE WINNER IS: [winner ? winner.real_name : "no one"]."))
-	
+
 	for(var/ckey in players)
 		var/mob/loser = players[ckey]["mob"]
 		UnregisterSignal(loser, list(COMSIG_MOB_GHOSTIZED, COMSIG_QDELETING))
@@ -174,7 +174,7 @@
 			if(player_info["mob"] && player_info["mob"] == player)
 				ckey = potential_ckey
 				break
-	
+
 	if(!islist(players[ckey])) // if we STILL didnt find a good ckey
 		return
 
@@ -183,7 +183,7 @@
 	var/mob/dead/observer/ghost = !player.client ? player.get_ghost() : player.ghostize() //this doesnt work on those who used the ghost verb
 	if(!isnull(ghost))
 		add_observer(ghost, (host == ckey))
-	
+
 	announce(span_reallybig("[player.real_name] HAS DIED.<br>[players.len] REMAIN."))
 
 	if(!gibbed && !QDELING(player)) // for some reason dusting or deleting in chasm storage messes up tgui bad
@@ -239,7 +239,7 @@
 					players[key]["host"] = TRUE
 					break
 			GLOB.deathmatch_game.passoff_lobby(ckey, host)
-	
+
 	remove_ckey_from_play(ckey)
 
 /datum/deathmatch_lobby/proc/join(mob/player)
@@ -295,6 +295,11 @@
 /datum/deathmatch_lobby/ui_state(mob/user)
 	return GLOB.observer_state
 
+/// fills the lobby with fake players for the sake of UI debug, can only be called via VV
+/datum/deathmatch_lobby/proc/fakefill(count)
+	for(var/i = 1 to count)
+		players["[rand(1,999)]"] = list("mob" = usr, "host" = FALSE, "ready" = FALSE, "loadout" = pick(loadouts))
+
 /datum/deathmatch_lobby/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, null)
 	if(!ui)
@@ -314,7 +319,7 @@
 	.["admin"] = check_rights_for(user.client, R_ADMIN)
 	.["global_chat"] = global_chat
 	.["playing"] = playing
-	.["loadouts"] = list()
+	.["loadouts"] = list("Randomize")
 	for (var/datum/outfit/deathmatch_loadout/loadout as anything in loadouts)
 		.["loadouts"] += initial(loadout.display_name)
 	.["map"] = list()
@@ -371,6 +376,9 @@
 				return FALSE
 			if (params["player"] != usr.ckey && host != usr.ckey)
 				return FALSE
+			if (params["loadout"] == "Randomize")
+				players[params["player"]]["loadout"] = pick(loadouts)
+				return TRUE
 			for (var/datum/outfit/deathmatch_loadout/possible_loadout as anything in loadouts)
 				if (params["loadout"] != initial(possible_loadout.display_name))
 					continue

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -107,6 +107,7 @@
 	desc = "Choose your battler!"
 	max_players = 10
 	allowed_loadouts = list(
+		/datum/outfit/deathmatch_loadout/battler/soldier, // First because its a good and easy loadout and is picked by default
 		/datum/outfit/deathmatch_loadout/battler/bloodminer,
 		/datum/outfit/deathmatch_loadout/battler/clown,
 		/datum/outfit/deathmatch_loadout/battler/cowboy,
@@ -117,7 +118,6 @@
 		/datum/outfit/deathmatch_loadout/battler/raider,
 		/datum/outfit/deathmatch_loadout/battler/ripper,
 		/datum/outfit/deathmatch_loadout/battler/scientist,
-		/datum/outfit/deathmatch_loadout/battler/soldier,
 		/datum/outfit/deathmatch_loadout/battler/surgeon,
 		/datum/outfit/deathmatch_loadout/battler/tgcoder,
 		/datum/outfit/deathmatch_loadout/naked,

--- a/tgui/packages/tgui/interfaces/DeathmatchLobby.tsx
+++ b/tgui/packages/tgui/interfaces/DeathmatchLobby.tsx
@@ -44,11 +44,11 @@ type Data = {
 export const DeathmatchLobby = (props) => {
   const { act, data } = useBackend<Data>();
   return (
-    <Window title="Deathmatch Lobby" width={560} height={400}>
+    <Window title="Deathmatch Lobby" width={560} height={420}>
       <Window.Content>
         <Flex height="94%">
-          <Flex.Item width="350px">
-            <Section height="99%">
+          <Flex.Item width="63%">
+            <Section fill scrollable>
               <Table>
                 <Table.Row>
                   <Table.Cell collapsing />
@@ -148,6 +148,7 @@ export const DeathmatchLobby = (props) => {
               </Box>
               <Divider />
               {data.map.desc}
+              <Divider />
               <Box textAlign="center">
                 Maximum Play Time: <b>{`${data.map.time / 600}min`}</b>
                 <br />


### PR DESCRIPTION

## About The Pull Request

![2024-02-22 18_33_26-Space Station 13](https://github.com/tgstation/tgstation/assets/70376633/3eeb086a-ce07-4677-8ac0-a319ba3e47f6)

there is a new option in the loadout dropdown "Randomize", using it picks a random loadout
also the UI scrolls now so it can survive more players
and plasmamen are set into humans as to not need to create more plasmaman specific outfits

## Why It's Good For The Game

player list going out of its section = bug bad
plasmamen getting lit on fire instantly and dying = bad
Closes #81622
## Changelog
:cl:
add: Added an option to deathmatch loadout dropdown that allows you to pick a random loadout
fix: In deathmatch, plasmamen are made humans and the UI supports more players
/:cl:
