### PR TITLE
Admin Gib smite now drops the brain/head again

### DIFF
--- a/code/modules/admin/smites/gib.dm
+++ b/code/modules/admin/smites/gib.dm
@@ -4,4 +4,4 @@
 
 /datum/smite/gib/effect(client/user, mob/living/target)
 	. = ..()
-	target.gib(DROP_ORGANS|DROP_BODYPARTS)
+	target.gib(DROP_ORGANS|DROP_BRAIN|DROP_BODYPARTS)


### PR DESCRIPTION

## About The Pull Request

I noticed this after trying to solve a downstream bug that is unique to there, i think when DROP_BRAIN was implimented it was just missed for the smite.

## Why It's Good For The Game

Gib now Gibs gibbingly

## Changelog
:cl:
admin: admin gib smite drops heads/brains again
/:cl:
