### PR TITLE
Fixes feeding through masks using spoons and ladles

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -237,9 +237,9 @@
 
 	if(target_mob.is_mouth_covered(ITEM_SLOT_HEAD) || target_mob.is_mouth_covered(ITEM_SLOT_MASK))
 		if(target_mob == user)
-			to_chat(user, span_danger("You can't eat with your mouth covered!"))
+			target_mob.balloon_alert(user, "can't eat with mouth covered!")
 		else
-			to_chat(user, span_danger("You can't feed [target_mob] with [target_mob.p_their()] mouth covered!"))
+			target_mob.balloon_alert(user, "[target_mob.p_their()] mouth is covered!")
 		return TRUE
 
 	if(target_mob == user)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -237,9 +237,9 @@
 
 	if(target_mob.is_mouth_covered(ITEM_SLOT_HEAD) || target_mob.is_mouth_covered(ITEM_SLOT_MASK))
 		if(target_mob == user)
-			to_chat(user, span_notice("You can't eat with your mouth covered!"))
+			to_chat(user, span_danger("You can't eat with your mouth covered!"))
 		else
-			to_chat(user, span_notice("You can't feed [target_mob] with [target_mob.p_their()] mouth covered!"))
+			to_chat(user, span_danger("You can't feed [target_mob] with [target_mob.p_their()] mouth covered!"))
 		return TRUE
 
 	if(target_mob == user)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -235,6 +235,13 @@
 	if(!target_mob.reagents || reagents.total_volume <= 0)
 		return  ..()
 
+	if(target_mob.is_mouth_covered(ITEM_SLOT_HEAD) || target_mob.is_mouth_covered(ITEM_SLOT_MASK))
+		if(target_mob == user)
+			to_chat(user, span_notice("You can't eat with your mouth covered!"))
+		else
+			to_chat(user, span_notice("You can't feed [target_mob] with [target_mob.p_their()] mouth covered!"))
+		return TRUE
+
 	if(target_mob == user)
 		user.visible_message(
 			span_notice("[user] scoops a spoonful into [user.p_their()] mouth."),


### PR DESCRIPTION

## About The Pull Request
Fixes unintended behavior allowing people with covered mouths to be fed through spoons and ladles. Also adds warnings when trying to feed someone with their mouth covered. Fixes #81576 

## Why It's Good For The Game
Makes the behavior consistent with every other reagent container you can drink from. 

## Changelog
:cl:
fix: you can no longer feed people with covered mouths using spoons or ladles
/:cl:
