### PR TITLE
Alternate job titles such as chef and department security get injected to the manifest normally, and show up as the right department.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -160,7 +160,10 @@ SUBSYSTEM_DEF(job)
 			continue
 		new_all_occupations += job
 		name_occupations[job.title] = job
+		for(var/alt_title in job.alternate_titles)
+			name_occupations[alt_title] = job
 		type_occupations[job_type] = job
+
 		if(job.job_flags & JOB_NEW_PLAYER_JOINABLE)
 			new_joinable_occupations += job
 			if(!LAZYLEN(job.departments_list))

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -102,7 +102,14 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
 		return
 
-	var/assignment = person.mind.assigned_role.title
+	// Attempt to get assignment from ID, otherwise default to mind.
+	var/assignment
+	var/obj/item/card/id/id_card = person.get_idcard(hand_first = FALSE)
+	if(!isnull(id_card))
+		assignment = id_card.get_trim_assignment()
+	if(isnull(assignment))
+		assignment = person.mind.assigned_role.title
+
 	var/mutable_appearance/character_appearance = new(person.appearance)
 	var/person_gender = "Other"
 	if(person.gender == "male")

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -103,12 +103,8 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		return
 
 	// Attempt to get assignment from ID, otherwise default to mind.
-	var/assignment
 	var/obj/item/card/id/id_card = person.get_idcard(hand_first = FALSE)
-	if(!isnull(id_card))
-		assignment = id_card.get_trim_assignment()
-	if(isnull(assignment))
-		assignment = person.mind.assigned_role.title
+	var/assignment = id_card?.get_trim_assignment() || person.mind.assigned_role.title
 
 	var/mutable_appearance/character_appearance = new(person.appearance)
 	var/person_gender = "Other"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -114,8 +114,11 @@
 	/// String. If set to a non-empty one, it will be the key for the policy text value to show this role on spawn.
 	var/policy_index = ""
 
-	///RPG job names, for the memes
+	/// RPG job names, for the memes
 	var/rpg_title
+
+	/// Alternate titles to register as pointing to this job. 
+	var/list/alternate_titles = list()
 
 	/// Does this job ignore human authority?
 	var/ignore_human_authority = FALSE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -118,7 +118,7 @@
 	var/rpg_title
 
 	/// Alternate titles to register as pointing to this job. 
-	var/list/alternate_titles = list()
+	var/list/alternate_titles
 
 	/// Does this job ignore human authority?
 	var/ignore_human_authority = FALSE

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -46,6 +46,9 @@
 	)
 
 	rpg_title = "Tavern Chef"
+	alternate_titles = list(
+		JOB_CHEF,
+	)
 	job_flags = STATION_JOB_FLAGS
 
 /datum/job/cook/award_service(client/winner, award)

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -38,6 +38,12 @@
 		/obj/item/melee/baton/security/boomerang/loaded = 1
 	)
 	rpg_title = "Guard"
+	alternate_titles = list(
+		JOB_SECURITY_OFFICER_MEDICAL,
+		JOB_SECURITY_OFFICER_ENGINEERING,
+		JOB_SECURITY_OFFICER_SUPPLY,
+		JOB_SECURITY_OFFICER_SCIENCE,
+	)
 	job_flags = STATION_JOB_FLAGS
 
 


### PR DESCRIPTION
## About The Pull Request

Previously injecting to the manifest would use solely the mind's assigned role, thus injecting player with alternate job titles such as chef and department security as the job they're based off rather than their actual ID trim.
Then if the manifest were to be updated later on, they would show up as being departmentless because getting the manifest checks for an assigned job, which these don't have as they're just alternate titles for an existing job.

This resolves the first part by checking if it's possible to get a trim from a held ID and using that before attempting to default to the mind's assigned role. As building/updating the manifest is done after equipping, this lets alternate job titles be assigned as their actual job.
Then the second part is resolved by adding a list of alternate titles for the job subsystem to register as being that job, so that a job can have multiple titles which refer to it.
## Why It's Good For The Game

It's annoying to not be able to find these in the right spot on the manifest, if at all in the first place.
Edit: Fixes #81378.
Edit: Fixes #67703.

## Changelog
:cl:
fix: Alternate job titles such as chef and department security actually get injected to the manifest as their respective ID trims, instead of being assigned the job they're based off.
fix: Alternate job titles such as chef and department security actually show up under the right department on the manifest, instead of no department.
/:cl:
