### PR TITLE
Fix custom job titles displaying with question mark icons in medical/security records.

### DIFF
--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -65,6 +65,7 @@
 			quirk_notes = target.quirk_notes,
 			rank = target.rank,
 			species = target.species,
+			trim = target.trim,
 		))
 
 	data["records"] = records

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -128,6 +128,7 @@
 			note = target.security_note,
 			rank = target.rank,
 			species = target.species,
+			trim = target.trim,
 			wanted_status = target.wanted_status,
 		))
 

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
@@ -90,7 +90,7 @@ const CrewTab = (props: { record: MedicalRecord }) => {
   const { act, data } = useBackend<MedicalRecordData>();
   const { assigned_view } = data;
   const { record } = props;
-  const { crew_ref, name, rank } = record;
+  const { crew_ref, name, trim } = record;
 
   /** Sets the record to preview */
   const selectRecord = (record: MedicalRecord) => {
@@ -109,7 +109,7 @@ const CrewTab = (props: { record: MedicalRecord }) => {
       selected={selectedRecord?.crew_ref === crew_ref}
     >
       <Box>
-        <Icon name={JOB2ICON[rank] || 'question'} /> {name}
+        <Icon name={JOB2ICON[trim] || 'question'} /> {name}
       </Box>
     </Tabs.Tab>
   );

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -26,6 +26,7 @@ export type MedicalRecord = {
   quirk_notes: string;
   rank: string;
   species: string;
+  trim: string;
 };
 
 export type MedicalNote = {

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
@@ -91,7 +91,7 @@ const CrewTab = (props: { record: SecurityRecord }) => {
   const { act, data } = useBackend<SecurityRecordsData>();
   const { assigned_view } = data;
   const { record } = props;
-  const { crew_ref, name, rank, wanted_status } = record;
+  const { crew_ref, name, trim, wanted_status } = record;
 
   /** Chooses a record */
   const selectRecord = (record: SecurityRecord) => {
@@ -112,7 +112,7 @@ const CrewTab = (props: { record: SecurityRecord }) => {
       selected={isSelected}
     >
       <Box bold={isSelected} color={CRIMESTATUS2COLOR[wanted_status]}>
-        <Icon name={JOB2ICON[rank] || 'question'} /> {name}
+        <Icon name={JOB2ICON[trim] || 'question'} /> {name}
       </Box>
     </Tabs.Tab>
   );

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -23,6 +23,7 @@ export type SecurityRecord = {
   note: string;
   rank: string;
   species: string;
+  trim: string;
   wanted_status: string;
   voice: string;
 };


### PR DESCRIPTION

## About The Pull Request

Medical/Security records display a nice little icon next to each name in their list of registered crew, based on what their job on the station is.
However, this is based off of `rank` and thus the actual job title, meaning anyone with a hop-customized job title would have a question mark icon instead.
By changing it to use `trim`, which is set from the ID's trim rather than title when updating the manifest, custom titles work perfectly fine and the records instead display an icon based on the ID's trim.
## Why It's Good For The Game

Better than having a question mark icon for every single custom job, _especially_ when it's just a hop adding a modifier to an existing job to reflect extra access.
## Changelog
:cl:
fix: Medical/security records now show an icon based on the registered trim, rather than showing a question mark for records with customized titles.
/:cl:
