### PR TITLE
Minor newscaster UI fix

### DIFF
--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -326,11 +326,11 @@ const NewscasterWantedScreen = (props) => {
         </>
       ) : (
         <Box>
-          {wanted.map((activeWanted) => (
+          {wanted.map((activeWanted) =>
             activeWanted.active
               ? 'Please contact your local security officer if spotted.'
-              : 'No wanted issue posted. Have a secure day.'
-          ))}
+              : 'No wanted issue posted. Have a secure day.',
+          )}
         </Box>
       )}
     </Modal>

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -326,9 +326,11 @@ const NewscasterWantedScreen = (props) => {
         </>
       ) : (
         <Box>
-          {wanted.active
+          {wanted.map((activeWanted) => (
+            activeWanted.active
             ? 'Please contact your local security officer if spotted.'
-            : 'No wanted issue posted. Have a secure day.'}
+            : 'No wanted issue posted. Have a secure day.'
+          ))}
         </Box>
       )}
     </Modal>

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -328,8 +328,8 @@ const NewscasterWantedScreen = (props) => {
         <Box>
           {wanted.map((activeWanted) => (
             activeWanted.active
-            ? 'Please contact your local security officer if spotted.'
-            : 'No wanted issue posted. Have a secure day.'
+              ? 'Please contact your local security officer if spotted.'
+              : 'No wanted issue posted. Have a secure day.'
           ))}
         </Box>
       )}


### PR DESCRIPTION
## About The Pull Request

Currently newscasters note "No wanted issue posted. Have a secure day." regardless of whether there's an active wanted issue posted or not.
Looking into the code, `Newscaster.jsx` does actually detail an alternate message for when there _is_ an active wanted issue. It's just only active when `wanted.active` holds true, while I believe the `active` it's trying to access cannot be accessed without using `wanted.map(...)`.
Making it use `wanted.map(...)` solves this.

<details>
  <summary>Image</summary>
  
![image](https://github.com/tgstation/tgstation/assets/42909981/434d1449-7663-4416-b88a-c1d89e836cd5)
  
</details>

## Why It's Good For The Game

Fixes #81600.
## Changelog
:cl:
fix: Newscasters no longer say "No wanted issue posted. Have a secure day." when there is, in fact, an active wanted issue currently posted.
/:cl:
