### PR TITLE
Meatwheat Made Consistent

### DIFF
--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -340,7 +340,6 @@
 	icon_state = "meatwheat_clump"
 	bite_consumption = 4
 	tastes = list("meat" = 1, "wheat" = 1)
-	foodtypes = GRAIN
 
 /obj/item/food/meat/slab/gorilla
 	name = "gorilla meat"

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -89,7 +89,7 @@
 	gender = PLURAL
 	bite_consumption_mod = 0.5
 	seed = /obj/item/seeds/wheat/meat
-	foodtypes = MEAT | GRAIN
+	foodtypes = MEAT
 	grind_results = list(/datum/reagent/consumable/flour = 0, /datum/reagent/blood = 0)
 	tastes = list("meatwheat" = 1)
 	can_distill = FALSE


### PR DESCRIPTION

## About The Pull Request
Removes the GRAIN foodtype from meatwheat, it's just meat.
## Why It's Good For The Game
In the current iteration of meatwheat, it flip-flops between foodtypes while you're preparing it.

First it's meat and wheat
![Screenshot 2024-02-22 212818](https://github.com/tgstation/tgstation/assets/73589390/3a4da0ef-9550-4551-8ec7-6057b93f4d8e)
then it's wheat
![Screenshot 2024-02-22 212854](https://github.com/tgstation/tgstation/assets/73589390/7bd07c16-503b-4ab3-8df8-6d99951c0429)
then it's meat!
![Screenshot 2024-02-22 212909](https://github.com/tgstation/tgstation/assets/73589390/0a570619-7ad4-4041-b887-8019b78a2e91)

This should JUST be meat, it's meatwheat not wheatwheat, and the reagents don't hint towards it being wheat.
## Changelog
:cl:
fix: meatwheat is now firmly made out of meat, instead of sometimes being wheat and sometimes being meat and sometimes being both.
/:cl:
