### PR TITLE
You can do more things while floored

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -117,7 +117,7 @@
 			return FALSE
 	return TRUE
 
-/atom/ui_status(mob/user)
+/atom/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 	//Check if both user and atom are at the same location
 	if(!can_interact(user))

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -277,7 +277,7 @@
 /datum/wires/ui_host()
 	return holder
 
-/datum/wires/ui_status(mob/user)
+/datum/wires/ui_status(mob/user, datum/ui_state/state)
 	if(interactable(user))
 		return ..()
 	return UI_CLOSE

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -76,7 +76,7 @@
 		ui = new(user, src, "CameraConsole", name)
 		ui.open()
 
-/obj/machinery/computer/security/ui_status(mob/user)
+/obj/machinery/computer/security/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 	if(. == UI_DISABLED)
 		return UI_CLOSE

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -44,7 +44,7 @@
 	icon_state = "[base_icon_state][music_player.active_song_sound ? "-active" : null]"
 	return ..()
 
-/obj/machinery/jukebox/ui_status(mob/user)
+/obj/machinery/jukebox/ui_status(mob/user, datum/ui_state/state)
 	if(isobserver(user))
 		return ..()
 	if(!anchored)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -46,6 +46,7 @@ Possible to do for anyone motivated enough:
 	max_integrity = 300
 	armor_type = /datum/armor/machinery_holopad
 	circuit = /obj/item/circuitboard/machine/holopad
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 	// Blue, dim light
 	light_power = 0.8
 	light_color = LIGHT_COLOR_BLUE
@@ -271,7 +272,7 @@ Possible to do for anyone motivated enough:
 
 	return ..()
 
-/obj/machinery/holopad/ui_status(mob/user)
+/obj/machinery/holopad/ui_status(mob/user, datum/ui_state/state)
 	if(!is_operational)
 		return UI_CLOSE
 	if(outgoing_call && !calling)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -1168,7 +1168,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(properties["team_color"])
 		team_color = properties["team_color"]
 
-/obj/machinery/porta_turret/lasertag/ui_status(mob/user)
+/obj/machinery/porta_turret/lasertag/ui_status(mob/user, datum/ui_state/state)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(team_color == "blue" && istype(H.wear_suit, /obj/item/clothing/suit/redtag))

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1455,7 +1455,7 @@
 /obj/item/card/id/advanced/chameleon/ui_state(mob/user)
 	return GLOB.always_state
 
-/obj/item/card/id/advanced/chameleon/ui_status(mob/user)
+/obj/item/card/id/advanced/chameleon/ui_status(mob/user, datum/ui_state/state)
 	var/target = theft_target?.resolve()
 
 	if(!target)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -747,6 +747,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	custom_price = PAYCHECK_CREW * 2.5
 
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
+
 	instant = TRUE
 	edible = FALSE
 	has_cap = TRUE

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -31,6 +31,7 @@
 	attack_verb_continuous = list("attacks", "colours")
 	attack_verb_simple = list("attack", "colour")
 	grind_results = list()
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 
 	/// Icon state to use when capped
 	var/icon_capped
@@ -746,8 +747,6 @@
 	desc = "A metallic container containing tasty paint."
 	w_class = WEIGHT_CLASS_SMALL
 	custom_price = PAYCHECK_CREW * 2.5
-
-	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 
 	instant = TRUE
 	edible = FALSE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -10,6 +10,7 @@
 	worn_icon_state = "radio"
 	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	dog_fashion = /datum/dog_fashion/back
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_ALLOW_USER_LOCATION | INTERACT_ATOM_IGNORE_MOBILITY
 
 	obj_flags = CONDUCTS_ELECTRICITY
 	slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -431,7 +431,7 @@ effective or pretty fucking useless.
 		toolbox = null
 		qdel(src)
 
-/obj/machinery/porta_turret/syndicate/toolbox/ui_status(mob/user)
+/obj/machinery/porta_turret/syndicate/toolbox/ui_status(mob/user, datum/ui_state/state)
 	if(faction_check(user.faction, faction))
 		return ..()
 

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -521,7 +521,7 @@
 	///How much charge is used up for each matter unit.
 	var/mass_to_energy = 16
 
-/obj/item/construction/rcd/exosuit/ui_status(mob/user)
+/obj/item/construction/rcd/exosuit/ui_status(mob/user, datum/ui_state/state)
 	if(ismecha(owner))
 		return owner.ui_status(user)
 	return UI_CLOSE

--- a/code/game/objects/items/rcd/RCL.dm
+++ b/code/game/objects/items/rcd/RCL.dm
@@ -16,7 +16,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/max_amount = 90
 	var/active = FALSE
-	actions_types = list(/datum/action/item_action/rcl_col,/datum/action/item_action/rcl_gui,)
+	actions_types = list(/datum/action/item_action/rcl_col,/datum/action/item_action/rcl_gui)
 	var/list/colors = list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white")
 	var/current_color_index = 1
 	var/ghetto = FALSE

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -381,7 +381,7 @@
 	else
 		return ..()
 
-/obj/item/robot_suit/ui_status(mob/user)
+/obj/item/robot_suit/ui_status(mob/user, datum/ui_state/state)
 	if(isobserver(user))
 		return ..()
 	var/obj/item/held_item = user.get_active_held_item()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -110,7 +110,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 29)
 		toggle_cabinet(user)
 
 /obj/structure/extinguisher_cabinet/attack_hand_secondary(mob/living/user)
-	if(!user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
+	if(!user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING))
 		return ..()
 	toggle_cabinet(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -54,7 +54,7 @@
 /obj/effect/fun_balloon/sentience/ui_state(mob/user)
 	return GLOB.admin_state
 
-/obj/effect/fun_balloon/sentience/ui_status(mob/user)
+/obj/effect/fun_balloon/sentience/ui_status(mob/user, datum/ui_state/state)
 	if(popped)
 		return UI_CLOSE
 	if(isAdminObserver(user)) // ignore proximity if we're an admin

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -71,7 +71,7 @@
 		if(do_after(user,100, target = src))
 			TeleporterSend()
 
-/obj/machinery/abductor/console/ui_status(mob/user)
+/obj/machinery/abductor/console/ui_status(mob/user, datum/ui_state/state)
 	if(!isabductor(user) && !isobserver(user))
 		return UI_CLOSE
 	return ..()

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -22,7 +22,7 @@
 		gland_colors[i] = random_color()
 		amounts[i] = rand(1,5)
 
-/obj/machinery/abductor/gland_dispenser/ui_status(mob/user)
+/obj/machinery/abductor/gland_dispenser/ui_status(mob/user, datum/ui_state/state)
 	if(!isabductor(user) && !isobserver(user))
 		return UI_CLOSE
 	return ..()

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -59,7 +59,7 @@
 			span_notice("You successfully break out of [src]!"))
 		open_machine()
 
-/obj/machinery/abductor/experiment/ui_status(mob/user)
+/obj/machinery/abductor/experiment/ui_status(mob/user, datum/ui_state/state)
 	if(user == occupant)
 		return UI_CLOSE
 	return ..()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -181,7 +181,7 @@
 	. = ..()
 	refreshBeam()
 
-/obj/item/assembly/infra/ui_status(mob/user)
+/obj/item/assembly/infra/ui_status(mob/user, datum/ui_state/state)
 	if(is_secured(user))
 		return ..()
 	return UI_CLOSE

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -134,7 +134,7 @@
 		. += "prox_scanning"
 		attached_overlays += "prox_scanning"
 
-/obj/item/assembly/prox_sensor/ui_status(mob/user)
+/obj/item/assembly/prox_sensor/ui_status(mob/user, datum/ui_state/state)
 	if(is_secured(user))
 		return ..()
 	return UI_CLOSE

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -68,7 +68,7 @@
 	. = ..()
 	holder?.update_appearance()
 
-/obj/item/assembly/signaler/ui_status(mob/user)
+/obj/item/assembly/signaler/ui_status(mob/user, datum/ui_state/state)
 	if(is_secured(user))
 		return ..()
 	return UI_CLOSE

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -83,7 +83,7 @@
 		. += "timer_timing"
 		attached_overlays += "timer_timing"
 
-/obj/item/assembly/timer/ui_status(mob/user)
+/obj/item/assembly/timer/ui_status(mob/user, datum/ui_state/state)
 	if(is_secured(user))
 		return ..()
 	return UI_CLOSE

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		if(AIR_ALARM_BUILD_COMPLETE)
 			. += span_notice("Right-click to [locked ? "unlock" : "lock"] the interface.")
 
-/obj/machinery/airalarm/ui_status(mob/user)
+/obj/machinery/airalarm/ui_status(mob/user, datum/ui_state/state)
 	if(user.has_unlimited_silicon_privilege && aidisabled)
 		to_chat(user, "AI control has been disabled.")
 	else if(!shorted)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -21,6 +21,7 @@
 	max_integrity = 200
 	obj_flags = CAN_BE_HIT
 	armor_type = /datum/armor/machinery_atmospherics
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 
 	///Check if the object can be unwrenched
 	var/can_unwrench = FALSE

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -213,7 +213,7 @@
 
 // UI Stuff
 
-/obj/machinery/atmospherics/components/ui_status(mob/user)
+/obj/machinery/atmospherics/components/ui_status(mob/user, datum/ui_state/state)
 	if(allowed(user))
 		return ..()
 	to_chat(user, span_danger("Access denied."))

--- a/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
@@ -4,6 +4,7 @@
 	base_icon_state = "bluespace_sender"
 	name = "Bluespace Gas Sender"
 	desc = "Sends gases to the bluespace network to be shared with the connected vendors, who knows what's beyond!"
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
 
 	density = TRUE
 	max_integrity = 300

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -5,6 +5,8 @@
 	icon_state = "thermo_base"
 	plane = GAME_PLANE
 
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
+
 	name = "Temperature control unit"
 	desc = "Heats or cools gas in connected pipes."
 
@@ -257,7 +259,7 @@
 		return ITEM_INTERACT_SUCCESS
 	return
 
-/obj/machinery/atmospherics/components/unary/thermomachine/ui_status(mob/user)
+/obj/machinery/atmospherics/components/unary/thermomachine/ui_status(mob/user, datum/ui_state/state)
 	if(interactive)
 		return ..()
 	return UI_CLOSE

--- a/code/modules/economy/holopay.dm
+++ b/code/modules/economy/holopay.dm
@@ -137,7 +137,7 @@
 		ui = new(user, src, "HoloPay")
 		ui.open()
 
-/obj/structure/holopay/ui_status(mob/user)
+/obj/structure/holopay/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 	if(!in_range(user, src) && !isobserver(user))
 		return UI_CLOSE

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -458,7 +458,7 @@
 	update_appearance(UPDATE_ICON)
 
 
-/obj/machinery/biogenerator/ui_status(mob/user)
+/obj/machinery/biogenerator/ui_status(mob/user, datum/ui_state/state)
 	if(machine_stat & BROKEN || panel_open)
 		return UI_CLOSE
 

--- a/code/modules/library/admin_only.dm
+++ b/code/modules/library/admin_only.dm
@@ -80,7 +80,7 @@
 	page_count = round(max(bookcount - 1, 0) / BOOKS_PER_PAGE) //This is just floor()
 	search_page = clamp(search_page, 0, page_count)
 
-/obj/machinery/computer/libraryconsole/admin_only_do_not_map_in_you_fucker/ui_status(mob/user)
+/obj/machinery/computer/libraryconsole/admin_only_do_not_map_in_you_fucker/ui_status(mob/user, datum/ui_state/state)
 	if(!check_rights_for(user.client, R_BAN))
 		return UI_CLOSE
 	if(!SSdbcore.Connect())
@@ -339,7 +339,7 @@
 		ui.set_autoupdate(FALSE) // Nothing is changing here brother
 		ui.open()
 
-/datum/admin_book_viewer/ui_status(mob/user)
+/datum/admin_book_viewer/ui_status(mob/user, datum/ui_state/state)
 	if(!check_rights_for(user.client, R_BAN))
 		return UI_CLOSE
 	return UI_INTERACTIVE

--- a/code/modules/library/skill_learning/skill_station.dm
+++ b/code/modules/library/skill_learning/skill_station.dm
@@ -10,7 +10,7 @@
 	occupant_typecache = list(/mob/living/carbon) //todo make occupant_typecache per type
 	state_open = TRUE
 	// Only opens UI when inside; also, you can use the machine while lying down (for paraplegics and the like)
-	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_IGNORE_MOBILITY
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 	circuit = /obj/item/circuitboard/machine/skill_station
 	/// Currently implanting/removing
 	var/working = FALSE

--- a/code/modules/mob/living/silicon/ai/robot_control.dm
+++ b/code/modules/mob/living/silicon/ai/robot_control.dm
@@ -14,7 +14,7 @@
 		return FALSE
 	return TRUE
 
-/datum/robot_control/ui_status(mob/user)
+/datum/robot_control/ui_status(mob/user, datum/ui_state/state)
 	if(is_interactable(user))
 		return ..()
 	return UI_CLOSE

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -68,7 +68,7 @@
 	QDEL_NULL(proxy_view)
 	current_color = COLOR_MATRIX_IDENTITY
 
-/obj/item/mod/paint/ui_status(mob/user)
+/obj/item/mod/paint/ui_status(mob/user, datum/ui_state/state)
 	if(check_menu(editing_mod, user))
 		return ..()
 	return UI_CLOSE

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -13,7 +13,7 @@
 
 	steel_sheet_cost = 2
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT * 3, /datum/material/glass=SMALL_MATERIAL_AMOUNT, /datum/material/plastic=SMALL_MATERIAL_AMOUNT)
-	interaction_flags_atom = INTERACT_ATOM_ALLOW_USER_LOCATION | INTERACT_ATOM_IGNORE_MOBILITY
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_ALLOW_USER_LOCATION | INTERACT_ATOM_IGNORE_MOBILITY
 
 	icon_state_menu = "menu"
 	max_capacity = 64

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -88,7 +88,7 @@
 	cam_screen.display_to(user)
 	user.client.register_map_obj(cam_background)
 
-/datum/computer_file/program/secureye/ui_status(mob/user)
+/datum/computer_file/program/secureye/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 	if(. == UI_DISABLED)
 		return UI_CLOSE

--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -92,7 +92,7 @@
 		ui = new(user, src, "PaiCard")
 		ui.open()
 
-/obj/item/pai_card/ui_status(mob/user)
+/obj/item/pai_card/ui_status(mob/user, datum/ui_state/state)
 	if(user in get_nested_locs(src))
 		return UI_INTERACTIVE
 	return ..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -333,7 +333,7 @@
 		return
 	. += span_warning("You cannot read it!")
 
-/obj/item/paper/ui_status(mob/user,/datum/ui_state/state)
+/obj/item/paper/ui_status(mob/user, datum/ui_state/state)
 	// Are we on fire?  Hard to read if so
 	if(resistance_flags & ON_FIRE)
 		return UI_CLOSE

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -598,8 +598,7 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 		toner_cartridge.charges = 0
 
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
-	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
-	if(!istype(target) || target.anchored || target.buckled || !Adjacent(target) || !user.can_perform_action(src) || target == ass || copier_blocked())
+	if(!istype(target) || target.anchored || target.buckled || !Adjacent(target) || !user.can_perform_action(src, action_bitflags = ALLOW_RESTING) || target == ass || copier_blocked())
 		return
 	add_fingerprint(user)
 	if(target == user)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -393,7 +393,7 @@
 	update_appearance()
 	remote_control_user = null
 
-/obj/machinery/power/apc/ui_status(mob/user)
+/obj/machinery/power/apc/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 	if(!QDELETED(remote_control_user) && user == remote_control_user)
 		. = UI_INTERACTIVE

--- a/code/modules/reagents/chemistry/holder/ui_data.dm
+++ b/code/modules/reagents/chemistry/holder/ui_data.dm
@@ -9,7 +9,7 @@
 		ui.open()
 
 
-/datum/reagents/ui_status(mob/user)
+/datum/reagents/ui_status(mob/user, datum/ui_state/state)
 	return UI_INTERACTIVE //please advise
 
 /datum/reagents/ui_state(mob/user)

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -315,7 +315,7 @@
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(remove_thermometer), user)
 
-/obj/item/thermometer/ui_status(mob/user)
+/obj/item/thermometer/ui_status(mob/user, datum/ui_state/state)
 	if(!(in_range(src, user)))
 		return UI_CLOSE
 	return UI_INTERACTIVE

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -326,6 +326,7 @@
 	name = "disposal unit"
 	desc = "A pneumatic waste disposal unit."
 	icon_state = "disposal"
+	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 
 // attack by item places it in to disposal
 /obj/machinery/disposal/bin/attackby(obj/item/I, mob/user, params)

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -52,7 +52,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	data["bsa_unlock"] = GLOB.bsa_unlock
 	return data
 
-/obj/machinery/keycard_auth/ui_status(mob/user)
+/obj/machinery/keycard_auth/ui_status(mob/user, datum/ui_state/state)
 	if(isdrone(user))
 		return UI_CLOSE
 	if(!isanimal_or_basicmob(user))

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -446,7 +446,7 @@
 /obj/item/organ/internal/eyes/robotic/glow/ui_state(mob/user)
 	return GLOB.default_state
 
-/obj/item/organ/internal/eyes/robotic/glow/ui_status(mob/user)
+/obj/item/organ/internal/eyes/robotic/glow/ui_status(mob/user, datum/ui_state/state)
 	if(!QDELETED(owner))
 		if(owner == user)
 			return min(

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -71,10 +71,9 @@
 		return UI_UPDATE
 	return UI_INTERACTIVE
 
-/mob/living/shared_ui_interaction(src_object)
+/mob/living/shared_ui_interaction(atom/src_object)
 	. = ..()
-	var/obj/item/object = src_object
-	if(!(mobility_flags & MOBILITY_UI) && !(object.interaction_flags_atom & INTERACT_ATOM_IGNORE_MOBILITY) && . == UI_INTERACTIVE)
+	if(!(mobility_flags & MOBILITY_UI) && !(src_object.interaction_flags_atom & INTERACT_ATOM_IGNORE_MOBILITY) && . == UI_INTERACTIVE)
 		return UI_UPDATE
 
 /mob/living/silicon/ai/shared_ui_interaction(src_object)

--- a/code/modules/transport/elevator/elev_panel.dm
+++ b/code/modules/transport/elevator/elev_panel.dm
@@ -254,7 +254,7 @@
 		ui = new(user, src, "ElevatorPanel", name)
 		ui.open()
 
-/obj/machinery/elevator_control_panel/ui_status(mob/user)
+/obj/machinery/elevator_control_panel/ui_status(mob/user, datum/ui_state/state)
 	// We moved up a z-level, probably via the elevator itself, so don't preserve the UI.
 	if(user.z != z)
 		return UI_CLOSE

--- a/code/modules/transport/tram/tram_controls.dm
+++ b/code/modules/transport/tram/tram_controls.dm
@@ -83,7 +83,7 @@
 /obj/machinery/computer/tram_controls/ui_state(mob/user)
 	return GLOB.not_incapacitated_state
 
-/obj/machinery/computer/tram_controls/ui_status(mob/user,/datum/tgui/ui)
+/obj/machinery/computer/tram_controls/ui_status(mob/user, datum/tgui/ui)
 	var/datum/transport_controller/linear/tram/tram = transport_ref?.resolve()
 
 	if(tram?.controller_active)

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -9,7 +9,7 @@
 		ui.open()
 		ui_view.display_to(user)
 
-/obj/vehicle/sealed/mecha/ui_status(mob/user)
+/obj/vehicle/sealed/mecha/ui_status(mob/user, datum/ui_state/state)
 	if(contains(user))
 		return UI_INTERACTIVE
 	return min(

--- a/code/modules/wiremod/components/admin/proccall.dm
+++ b/code/modules/wiremod/components/admin/proccall.dm
@@ -88,7 +88,7 @@
 	. = list()
 	.["possible_types"] = GLOB.wiremod_fundamental_types
 
-/obj/item/circuit_component/proccall/ui_status(mob/user)
+/obj/item/circuit_component/proccall/ui_status(mob/user, datum/ui_state/state)
 	if(!check_rights_for(user.client, R_VAREDIT))
 		return UI_CLOSE
 	return UI_INTERACTIVE

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -413,7 +413,7 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 		return FALSE
 	return ..()
 
-/obj/item/integrated_circuit/ui_status(mob/user)
+/obj/item/integrated_circuit/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 
 	if (isobserver(user))


### PR DESCRIPTION
## About The Pull Request

While on the floor, you can:
- Use the UIs of Atmos machinery (except thermomachine and bluespace gas vendor), Holopads, Crayons (spray cans too), radios, and Disposal bins
- Close extinguisher cabinets with Right-Click
- Click and drag yourself onto a photocopier to climb onto it.

I also changed all instances of ``ui_status`` to have all the args it's being passed, I was messing with it a bit but it's gonna be for a later PR.

## Why It's Good For The Game

It's an extra layer of harmless realism, also nice QoL for people who do not have functional legs and do not have a wheelchair.

## Changelog

:cl:
qol: You can use atmos machines, holopads, crayons, spray cans, and disposal bins while floored.
fix: You can close extinguisher cabinets while floored.
fix: You can climb onto a photocopier from the floor.
/:cl: