### PR TITLE
Birdshot Chapel Fixes & Improvements

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -338,6 +338,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
+"agF" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/bamboo/right{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "agI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -567,8 +574,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "alg" = (
-/obj/structure/altar_of_gods,
-/obj/item/book/bible,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel/office)
 "alh" = (
@@ -2383,7 +2391,7 @@
 /obj/structure/flora/bush/sunny/style_random,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "aWC" = (
 /obj/machinery/computer/department_orders/engineering{
 	dir = 8
@@ -4591,7 +4599,7 @@
 "bOl" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "bOp" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/blue{
@@ -6021,7 +6029,7 @@
 	},
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "css" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -7252,7 +7260,7 @@
 	},
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "cPi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8814,10 +8822,9 @@
 "dty" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "dtC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
@@ -20387,7 +20394,7 @@
 	},
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "hpQ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/spawner/directional/south,
@@ -21682,7 +21689,7 @@
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "hNY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -25951,7 +25958,7 @@
 	},
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "jsc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -26689,6 +26696,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"jEU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "jEZ" = (
 /obj/structure/hedge,
 /obj/effect/decal/cleanable/dirt,
@@ -36530,7 +36544,7 @@
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "mYT" = (
 /obj/structure/table,
 /obj/item/assembly/igniter{
@@ -40232,7 +40246,7 @@
 	},
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "oqI" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -43246,7 +43260,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "pug" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -44146,7 +44160,7 @@
 /obj/structure/flora/bush/sunny/style_random,
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "pHQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -44428,7 +44442,7 @@
 	dir = 9
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "pMr" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -44445,7 +44459,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "pMA" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -45260,7 +45274,7 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "pYG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45331,9 +45345,11 @@
 /area/station/cargo/storage)
 "qaA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "qaH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark_red/corner{
@@ -45394,8 +45410,11 @@
 "qbr" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qbw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -46037,19 +46056,13 @@
 /area/station/maintenance/starboard/greater)
 "qkv" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qkw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qkF" = (
 /turf/open/floor/iron,
 /area/station/commons)
@@ -46619,10 +46632,10 @@
 /area/station/maintenance/aft)
 "quJ" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/flora/tree/stump,
 /obj/machinery/light/small/directional/south,
+/obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "quS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47117,15 +47130,11 @@
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qCi" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/sofa/bamboo/right{
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qCq" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -47156,12 +47165,8 @@
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/hop)
 "qCR" = (
-/obj/structure/chair/sofa/bamboo/left{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qCU" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/table/reinforced,
@@ -47797,6 +47802,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
+"qOp" = (
+/obj/structure/table/wood,
+/obj/item/book/bible,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "qOt" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -48539,7 +48549,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "qZG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
@@ -48588,7 +48598,7 @@
 "ram" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "raz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Lavatorie"
@@ -48598,12 +48608,12 @@
 /area/station/commons/toilet/restrooms)
 "raC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/sofa/bamboo/left{
-	dir = 8
-	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/chair/sofa/bamboo/left{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "raE" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -48623,16 +48633,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "raX" = (
+/obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/bamboo/right{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/landmark/start/chaplain,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "rba" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "rbc" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/tram,
@@ -48648,7 +48658,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "rbo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -50051,7 +50061,7 @@
 	dir = 5
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "ryt" = (
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -50094,10 +50104,9 @@
 /area/station/science/breakroom)
 "rzu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "rzG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -50141,7 +50150,7 @@
 	dir = 9
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "rAg" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -50911,7 +50920,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "rMa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52052,7 +52061,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "sdm" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -53380,9 +53389,8 @@
 /area/station/security/warden)
 "syv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "syx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -53408,7 +53416,7 @@
 "syG" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "syN" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -53434,7 +53442,7 @@
 "szy" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "szz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54137,7 +54145,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "sMq" = (
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron,
@@ -54871,14 +54879,14 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "sYK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "sZn" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/wood{
@@ -55113,7 +55121,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "tdh" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -56403,7 +56411,7 @@
 "tzJ" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "tAq" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -56569,7 +56577,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "tCm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
@@ -56728,7 +56736,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "tEW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57562,7 +57570,7 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "tTR" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -57997,7 +58005,7 @@
 	dir = 6
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "uab" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58016,7 +58024,7 @@
 	},
 /obj/structure/flora/tree/stump,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "uax" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58032,7 +58040,7 @@
 	},
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "uaP" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/chair/stool/bar/directional/east,
@@ -59102,7 +59110,7 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "utD" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/stripes/corner{
@@ -60490,7 +60498,7 @@
 /obj/structure/flora/tree/jungle/small/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "uSi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60519,8 +60527,13 @@
 /turf/open/floor/iron,
 /area/station/science/lower)
 "uSC" = (
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/station/service/hydroponics/garden/monastery)
+/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/sofa/bamboo/left{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "uSG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60848,11 +60861,9 @@
 /turf/closed/wall,
 /area/station/science/lower)
 "uXN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/structure/altar_of_gods,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "uXU" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
@@ -61606,15 +61617,14 @@
 /area/station/engineering/atmos)
 "vkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "vkG" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "vkJ" = (
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 9;
@@ -62665,7 +62675,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "vzV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62676,8 +62686,12 @@
 /area/station/security/tram)
 "vzW" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/bamboo/left{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "vzX" = (
 /obj/machinery/door/airlock/command{
 	name = "Centcom Dock"
@@ -62737,8 +62751,12 @@
 /area/station/security/tram)
 "vAA" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/bamboo/left{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "vAC" = (
 /obj/structure/flora/bush/large/style_random{
 	pixel_y = -3
@@ -62764,8 +62782,11 @@
 "vAR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "vAT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63783,7 +63804,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "vSL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -63807,7 +63828,7 @@
 "vSX" = (
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "vSY" = (
 /obj/structure/table,
 /obj/item/chisel{
@@ -64895,7 +64916,7 @@
 	},
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "wjM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -64987,7 +65008,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "wlJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65006,7 +65027,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "wme" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -65177,7 +65198,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "woD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -67355,7 +67376,7 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "wWc" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -68877,7 +68898,7 @@
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "xpU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70760,7 +70781,7 @@
 "xPR" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "xPW" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/floor/wood/parquet,
@@ -70988,7 +71009,7 @@
 "xRZ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "xSe" = (
 /obj/structure/table/glass,
 /obj/structure/microscope,
@@ -71508,7 +71529,7 @@
 /area/station/maintenance/starboard/greater)
 "xYD" = (
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "xYE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71649,8 +71670,11 @@
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
 "yaG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "yaI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -72349,7 +72373,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden/monastery)
+/area/station/service/chapel)
 "yjE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine)
@@ -84959,12 +84983,12 @@ mhk
 mhk
 mhk
 csp
-xYD
+qZB
 uaa
-yaG
+qCR
 ram
 ryp
-xYD
+qZB
 xYD
 xRZ
 wBm
@@ -85473,12 +85497,12 @@ rYD
 mhk
 jrZ
 xYD
-xYD
+jEU
 uXN
-uSC
-uSC
+qCR
+raX
 vkz
-xYD
+agF
 syG
 pHN
 wAW
@@ -85730,9 +85754,9 @@ pbu
 mhk
 mYS
 xYD
-xPR
-uXN
-uSC
+yaG
+qOp
+qCR
 uSC
 vkz
 vAA
@@ -85987,12 +86011,12 @@ xLO
 mhk
 ptZ
 sYF
-tzJ
+yaG
 qkw
 qCR
 raX
 rzu
-xYD
+agF
 xYD
 wlQ
 wBm
@@ -86246,7 +86270,7 @@ mhk
 oqE
 qbr
 hNT
-yaG
+qCR
 rba
 rAb
 vAR


### PR DESCRIPTION
## About The Pull Request
Slightly remaps Birdshot's Monastery Garden, moves the altar, and changes the area so Sparring Sect chaplains have a place to fight.
Fixes: #81614

![Screenshot 2024-02-22 230737](https://github.com/tgstation/tgstation/assets/73589390/b18d7a95-261b-41ca-b997-01a0b8480ad1)
## Why It's Good For The Game
The Chaplain didn't really have a place to preach before, and they also had nowhere to spar! This converts the garden into a more useable space.
## Changelog
:cl:
qol: The chapel has been slightly overhauled on Birdshot, with the chaplain now having a place to preach sermons.
fix: Sparring chaplains are now able to operate on Birdshot!
/:cl:
