### PR TITLE
Fix runtime when food processor handles items without reagents

### DIFF
--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -69,8 +69,9 @@
 		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
 			var/atom/processed_food = new recipe.output(drop_location())
-			processed_food.reagents.clear_reagents()
-			what.reagents.copy_to(processed_food, what.reagents.total_volume, multiplier = 1 / cached_multiplier)
+			if(processed_food.reagents && what.reagents)
+				processed_food.reagents.clear_reagents()
+				what.reagents.copy_to(processed_food, what.reagents.total_volume, multiplier = 1 / cached_multiplier)
 			if(cached_mats)
 				processed_food.set_custom_materials(cached_mats, 1 / cached_multiplier)
 

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -69,7 +69,7 @@
 		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
 			var/atom/processed_food = new recipe.output(drop_location())
-			if(processed_food.reagents && what.reagents)
+			if(!isnull(processed_food.reagents) && !isnull(what.reagents))
 				processed_food.reagents.clear_reagents()
 				what.reagents.copy_to(processed_food, what.reagents.total_volume, multiplier = 1 / cached_multiplier)
 			if(cached_mats)

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -69,7 +69,7 @@
 		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
 			var/atom/processed_food = new recipe.output(drop_location())
-			if(!isnull(processed_food.reagents) && !isnull(what.reagents))
+			if(processed_food.reagents && what.reagents)
 				processed_food.reagents.clear_reagents()
 				what.reagents.copy_to(processed_food, what.reagents.total_volume, multiplier = 1 / cached_multiplier)
 			if(cached_mats)


### PR DESCRIPTION

## About The Pull Request

### Alternate title: "Stop the popsicle stick maximizer."

<details>
<summary>The popsicle stick maximizer in question</summary>

![image](https://github.com/tgstation/tgstation/assets/42909981/29f636f3-6509-4cf9-9093-9fcd0ea5de4f)

</details>

So when using the food processor to produce popsicle sticks from logs, it seemed to never actually delete the log, letting you create more and more and more and more and more and etc popsicle sticks.
This seemed to be caused by the popsicles not actually having reagents to clear nor copy to, and thus it caused a runtime before it got the opportunity to delete the log.

<details>
<summary>Runtime</summary>

![image](https://github.com/tgstation/tgstation/assets/42909981/bd853870-64e9-4b47-aead-38e6955b7dab)

</details>

Adding a check to make sure neither of these are null before proceeding to use them resolves this issue.
## Why It's Good For The Game

Less runtimes, less popsicle stick maximizing.
Fixes #81644.
## Changelog
:cl:
fix: Disabled the popsicle stick maximizer. (Producing popsicle sticks actually deletes the input logs.)
/:cl:
