### PR TITLE
Change threat level distribution

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -995,12 +995,10 @@ SUBSYSTEM_DEF(dynamic)
  * rand() calls without arguments returns a value between 0 and 1, allowing for smaller intervals.
  */
 /datum/controller/subsystem/dynamic/proc/lorentz_to_amount(centre = 0.5, scale = 0.3, max_threat = 100, interval = 1)
-	var/lorentz_result = -1
-	while (lorentz_result < 0 || lorentz_result > 1)
-		lorentz_result = LORENTZ_DISTRIBUTION(centre, scale)
-	var/std_threat = lorentz_result * max_threat
-
-	return round(std_threat, interval)
+	var/std_threat = -1
+	while (std_threat <= 0 || std_threat >= max_threat)
+		std_threat = round(LORENTZ_DISTRIBUTION(centre, scale) * max_threat, interval)
+	return std_threat
 
 /proc/reopen_roundstart_suicide_roles()
 	var/include_command = CONFIG_GET(flag/reopen_roundstart_suicide_roles_command_positions)

--- a/code/controllers/subsystem/dynamic/readme.md
+++ b/code/controllers/subsystem/dynamic/readme.md
@@ -4,7 +4,7 @@
 
 Dynamic rolls threat based on a special sauce formula:
 
-> [dynamic_curve_width][/datum/controller/global_vars/var/dynamic_curve_width] \* tan((3.1416 \* (rand() - 0.5) \* 57.2957795)) + [dynamic_curve_centre][/datum/controller/global_vars/var/dynamic_curve_centre]
+> [dynamic_curve_width][/datum/controller/global_vars/var/dynamic_curve_width] \* tan((3.1416 \* (rand() - 0.5))) + [dynamic_curve_centre][/datum/controller/global_vars/var/dynamic_curve_centre]
 
 This threat is split into two separate budgets--`round_start_budget` and `mid_round_budget`. For example, a round with 50 threat might be split into a 30 roundstart budget, and a 20 midround budget. The roundstart budget is used to apply antagonists applied on readied players when the roundstarts (`/datum/dynamic_ruleset/roundstart`). The midround budget is used for two types of rulesets:
 - `/datum/dynamic_ruleset/midround` - Rulesets that apply to either existing alive players, or to ghosts. Think Blob or Space Ninja, which poll ghosts asking if they want to play as these roles.
@@ -173,10 +173,10 @@ The "Dynamic" key has the following configurable values:
 - `pop_per_requirement` - The default value of `pop_per_requirement` for any ruleset that does not explicitly set it. Defaults to 6.
 - `latejoin_delay_min`, `latejoin_delay_max` - The time range, in deciseconds (take your seconds, and multiply by 10), for a latejoin to attempt rolling. Once this timer is finished, a new one will be created within the same range.
 	- Suppose you have a `latejoin_delay_min` of 600 (60 seconds, 1 minute) and a `latejoin_delay_max` of 1800 (180 seconds, 3 minutes). Once the round starts, a random number in this range will be picked--let's suppose 1.5 minutes. After 1.5 minutes, Dynamic will decide if a latejoin threat should be created (a probability of `/datum/controller/subsystem/dynamic/proc/get_injection_chance()`). Regardless of its decision, a new timer will be started within the range of 1 to 3 minutes, repeatedly.
-- `threat_curve_centre` - A number between -5 and +5. A negative value will give a more peaceful round and a positive value will give a round with higher threat.
-- `threat_curve_width` - A number between 0.5 and 4. Higher value will favour extreme rounds and lower value rounds closer to the average.
-- `roundstart_split_curve_centre` - A number between -5 and +5. Equivalent to threat_curve_centre, but for the budget split. A negative value will weigh towards midround rulesets, and a positive value will weight towards roundstart ones.
-- `roundstart_split_curve_width` - A number between 0.5 and 4. Equivalent to threat_curve_width, but for the budget split. Higher value will favour more variance in splits and lower value rounds closer to the average.
+- `threat_curve_centre` - A number between 0 and 1. 0.5 is centered on the middle of the range. For max threat 100, this means 0.5 is centered on 50 threat level.
+- `threat_curve_width` - A number between 0 and 1. Higher value will favour extreme rounds and lower value rounds closer to the average.
+- `roundstart_split_curve_centre` - A number between 0 and 1. Equivalent to threat_curve_centre, but for the budget split. A value less than 0.5 will weigh towards midround rulesets, and a value more than 0.5 will weigh towards roundstart ones.
+- `roundstart_split_curve_width` - A number between 0 and 1. Equivalent to threat_curve_width, but for the budget split. Higher value will favour more variance in splits and lower value rounds closer to the average.
 - `random_event_hijack_minimum` - The minimum amount of time for antag random events to be hijacked. (See [Random Event Hijacking](#random-event-hijacking))
 - `random_event_hijack_maximum` - The maximum amount of time for antag random events to be hijacked. (See [Random Event Hijacking](#random-event-hijacking))
 - `hijacked_random_event_injection_chance` - The amount of injection chance to give to Dynamic when a random event is hijacked. (See [Random Event Hijacking](#random-event-hijacking))


### PR DESCRIPTION

## About The Pull Request
Changed the distribution of the threat level to make it less confusing code-wise and parameter-wise. Default config options were changed and existing config options of servers currently using dynamic will have to be changed. Currently not tested by me.
#### Desmos
Desmos versions of the curve to see how changing the parameters changes the curve. c is centre, w is width, m is max threat.
Original curve: https://www.desmos.com/calculator/khkjdvf3is
New curve: https://www.desmos.com/calculator/anmhx3xusx
## Why It's Good For The Game
Probably doesn't affect the game that much, but it makes it easier to understand the config options, the code, and the system itself. And I personally think it generates better-looking distribution curves. This change probably isn't too noticeable to people playing if the config options are reconfigured correctly.
## Changelog
:cl:
config: threat and round start split curve config options affect the new curve differently
server: changed threat level distribution curve
/:cl:
