### PR TITLE
Fixes random CI error

### DIFF
--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -1,7 +1,7 @@
 ///A simple component that replacess the user's appearance with that of the parent item when equipped.
 /datum/component/tactical
 	///The allowed slots for the effect.
-	var/list/allowed_slots
+	var/allowed_slots
 	///A cached of where the item is currently equipped.
 	var/current_slot
 

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -2,21 +2,32 @@
  * Two Handed Component
  *
  * When applied to an item it will make it two handed
- *
+ * Only one of the component can exist on an item.
  */
 /datum/component/two_handed
-	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS // Only one of the component can exist on an item
-	var/wielded = FALSE /// Are we holding the two handed item properly
-	var/force_multiplier = 0 /// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
-	var/force_wielded = 0 /// The force of the item when weilded
-	var/force_unwielded = 0 /// The force of the item when unweilded
-	var/wieldsound = FALSE /// Play sound when wielded
-	var/unwieldsound = FALSE /// Play sound when unwielded
-	var/attacksound = FALSE /// Play sound on attack when wielded
-	var/require_twohands = FALSE /// Does it have to be held in both hands
-	var/icon_wielded = FALSE /// The icon that will be used when wielded
-	var/obj/item/offhand/offhand_item = null /// Reference to the offhand created for the item
-	var/sharpened_increase = 0 /// The amount of increase recived from sharpening the item
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	/// Are we holding the two handed item properly
+	var/wielded = FALSE
+	/// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
+	var/force_multiplier = 0
+	/// The force of the item when weilded
+	var/force_wielded = 0
+	/// The force of the item when unweilded
+	var/force_unwielded = 0
+	/// Boolean whether to play sound when wielded
+	var/wieldsound = FALSE
+	/// Boolean whether to play sound when unwielded
+	var/unwieldsound = FALSE
+	/// Boolean whether to play sound on attack, if wielded
+	var/attacksound = FALSE
+	/// Boolean on whether it has to be held in both hands
+	var/require_twohands = FALSE
+	/// The icon that will be used when wielded
+	var/icon_wielded = FALSE
+	/// Reference to the offhand created for the item
+	var/obj/item/offhand/offhand_item = null
+	/// The amount of increase recived from sharpening the item
+	var/sharpened_increase = 0
 	/// A callback on the parent to be called when the item is wielded
 	var/datum/callback/wield_callback
 	/// A callback on the parent to be called when the item is unwielded
@@ -36,9 +47,18 @@
  * * force_unwielded (optional) The force setting when the item is unwielded, do not use with force_multiplier
  * * icon_wielded (optional) The icon to be used when wielded
  */
-/datum/component/two_handed/Initialize(require_twohands=FALSE, wieldsound=FALSE, unwieldsound=FALSE, attacksound=FALSE, \
-										force_multiplier=0, force_wielded=0, force_unwielded=0, icon_wielded=FALSE, \
-										datum/callback/wield_callback, datum/callback/unwield_callback)
+/datum/component/two_handed/Initialize(
+	require_twohands = FALSE,
+	wieldsound = FALSE,
+	unwieldsound = FALSE,
+	attacksound = FALSE,
+	force_multiplier = 0,
+	force_wielded = 0,
+	force_unwielded = 0,
+	icon_wielded = FALSE,
+	datum/callback/wield_callback,
+	datum/callback/unwield_callback,
+)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -63,9 +83,20 @@
 	return ..()
 
 // Inherit the new values passed to the component
-/datum/component/two_handed/InheritComponent(datum/component/two_handed/new_comp, original, require_twohands, wieldsound, unwieldsound, attacksound, \
-											force_multiplier, force_wielded, force_unwielded, icon_wielded, \
-											datum/callback/wield_callback, datum/callback/unwield_callback)
+/datum/component/two_handed/InheritComponent(
+	datum/component/two_handed/new_comp,
+	original,
+	require_twohands,
+	wieldsound,
+	unwieldsound,
+	attacksound,
+	force_multiplier,
+	force_wielded,
+	force_unwielded,
+	icon_wielded,
+	datum/callback/wield_callback,
+	datum/callback/unwield_callback,
+)
 	if(!original)
 		return
 	if(require_twohands)
@@ -101,32 +132,19 @@
 	RegisterSignal(parent, COMSIG_ITEM_APPLY_FANTASY_BONUSES, PROC_REF(apply_fantasy_bonuses))
 	RegisterSignal(parent, COMSIG_ITEM_REMOVE_FANTASY_BONUSES, PROC_REF(remove_fantasy_bonuses))
 
-/datum/component/two_handed/proc/apply_fantasy_bonuses(obj/item/source, bonus)
-	SIGNAL_HANDLER
-	force_wielded = source.modify_fantasy_variable("force_wielded", force_wielded, bonus)
-	force_unwielded = source.modify_fantasy_variable("force_unwielded", force_unwielded, bonus)
-	if(wielded && ismob(source.loc))
-		unwield(source.loc)
-	if(force_multiplier)
-		force_multiplier = source.modify_fantasy_variable("force_multiplier", force_multiplier, bonus/10, minimum = 1)
-
-/datum/component/two_handed/proc/remove_fantasy_bonuses(obj/item/source, bonus)
-	SIGNAL_HANDLER
-	force_wielded = source.reset_fantasy_variable("force_wielded", force_wielded)
-	force_unwielded = source.reset_fantasy_variable("force_unwielded", force_unwielded)
-	if(wielded && ismob(source.loc))
-		unwield(source.loc)
-	force_multiplier = source.reset_fantasy_variable("force_multiplier", force_multiplier)
-
 // Remove all siginals registered to the parent item
 /datum/component/two_handed/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED,
-								COMSIG_ITEM_DROPPED,
-								COMSIG_ITEM_ATTACK_SELF,
-								COMSIG_ITEM_ATTACK,
-								COMSIG_ATOM_UPDATE_ICON,
-								COMSIG_MOVABLE_MOVED,
-								COMSIG_ITEM_SHARPEN_ACT))
+	UnregisterSignal(parent, list(
+		COMSIG_ITEM_EQUIPPED,
+		COMSIG_ITEM_DROPPED,
+		COMSIG_ITEM_ATTACK_SELF,
+		COMSIG_ITEM_ATTACK,
+		COMSIG_ATOM_UPDATE_ICON,
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_ITEM_SHARPEN_ACT,
+		COMSIG_ITEM_APPLY_FANTASY_BONUSES,
+		COMSIG_ITEM_REMOVE_FANTASY_BONUSES,
+	))
 
 /// Triggered on equip of the item containing the component
 /datum/component/two_handed/proc/on_equip(datum/source, mob/user, slot)
@@ -365,9 +383,25 @@
 	sharpened_increase = min(amount, (max_amount - wielded_val))
 	return COMPONENT_BLOCK_SHARPEN_APPLIED
 
+/datum/component/two_handed/proc/apply_fantasy_bonuses(obj/item/source, bonus)
+	SIGNAL_HANDLER
+	force_wielded = source.modify_fantasy_variable("force_wielded", force_wielded, bonus)
+	force_unwielded = source.modify_fantasy_variable("force_unwielded", force_unwielded, bonus)
+	if(wielded && ismob(source.loc))
+		unwield(source.loc)
+	if(force_multiplier)
+		force_multiplier = source.modify_fantasy_variable("force_multiplier", force_multiplier, bonus/10, minimum = 1)
+
+/datum/component/two_handed/proc/remove_fantasy_bonuses(obj/item/source, bonus)
+	SIGNAL_HANDLER
+	force_wielded = source.reset_fantasy_variable("force_wielded", force_wielded)
+	force_unwielded = source.reset_fantasy_variable("force_unwielded", force_unwielded)
+	if(wielded && ismob(source.loc))
+		unwield(source.loc)
+	force_multiplier = source.reset_fantasy_variable("force_multiplier", force_multiplier)
+
 /**
  * The offhand dummy item for two handed items
- *
  */
 /obj/item/offhand
 	name = "offhand"


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/81329
Closes https://github.com/tgstation/tgstation/issues/81538

I made some improvements to tactical and twohanded in general, but here's the fixes I made:
- Two-handed now unregisters signals for fantasy bonuses
- Tactical was registering signals for update icons, which in the case of kirbyplants was called every time the item was picked up due to two-handed's ``update_appearance`` call, so every time you picked up the plant it would actually register signals twice, applying overlays twice, etc. I removed the signal to update icon because it didn't really make sense, we update on equip/move/z move, which should be all the cases we need.

For some reason someone made Monkeys able to hold two-handed items now, and it appears that in monkey business a monkey can try to pick up a kirby plant, causing this CI error to be sporadic.

## Why It's Good For The Game

Fixes a CI error by removing a useless signal that was causing kirby plants to register a bunch of signals twice over every time you picked one up.

![monkeybusiness](https://github.com/tgstation/tgstation/assets/53777086/e4daea46-7eb3-4092-b452-82a85ac33c9c)

## Changelog

Nothing player facing.