### PR TITLE
[NO GBP] fixes item blood overlays "leaking" onto other objects

### DIFF
--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -11,12 +11,12 @@
 	UnregisterSignal(source, COMSIG_ATOM_GET_EXAMINE_NAME)
 	if(isitem(source))
 		var/obj/item/source_item = source
-		REMOVE_KEEP_TOGETHER(source_item, "item_blood_overlay")
+		REMOVE_KEEP_TOGETHER(source_item, type)
 	return ..()
 
 /datum/element/decal/blood/generate_appearance(_icon, _icon_state, _dir, _plane, _layer, _color, _alpha, _smoothing, source)
 	var/obj/item/I = source
-	ADD_KEEP_TOGETHER(I, "item_blood_overlay")
+	ADD_KEEP_TOGETHER(I, type)
 	var/icon = I.icon
 	var/icon_state = I.icon_state
 	if(!icon || !icon_state)

--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -9,6 +9,9 @@
 
 /datum/element/decal/blood/Detach(atom/source)
 	UnregisterSignal(source, COMSIG_ATOM_GET_EXAMINE_NAME)
+	if(isitem(source))
+		var/obj/item/source_item = source
+		REMOVE_KEEP_TOGETHER(source_item, "item_blood_overlay")
 	return ..()
 
 /datum/element/decal/blood/generate_appearance(_icon, _icon_state, _dir, _plane, _layer, _color, _alpha, _smoothing, source)

--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -13,6 +13,7 @@
 
 /datum/element/decal/blood/generate_appearance(_icon, _icon_state, _dir, _plane, _layer, _color, _alpha, _smoothing, source)
 	var/obj/item/I = source
+	ADD_KEEP_TOGETHER(I, "item_blood_overlay")
 	var/icon = I.icon
 	var/icon_state = I.icon_state
 	if(!icon || !icon_state)


### PR DESCRIPTION
Looks like KEEP_TOGETHER is necessary after all

before
![Screenshot 2024-02-24 144648](https://github.com/tgstation/tgstation/assets/46101244/e973b372-8391-4678-bc26-28b9d32f05af)

after
![Screenshot 2024-02-24 144001](https://github.com/tgstation/tgstation/assets/46101244/b6c25fcd-9c7f-4f3a-8b8f-69d98b81d424)


## Changelog
:cl:
fix: Blood overlays on items no longer leak onto other objects
/:cl:
