### PR TITLE
Fixed Typo in Mech Construction Steps

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -457,9 +457,9 @@
 			. += span_notice("[icon2html(ME, user)] \A [ME].")
 	if(mecha_flags & PANEL_OPEN)
 		if(servo)
-			. += span_notice("Micro-servos reduce movement power usage by [100 - round(100 / servo.rating)]%")
+			. += span_notice("Servo reduces movement power usage by [100 - round(100 / servo.rating)]%")
 		else
-			. += span_warning("It's missing a micro-servo.")
+			. += span_warning("It's missing a servo.")
 		if(capacitor)
 			. += span_notice("Capacitor increases armor against energy attacks by [capacitor.rating * 5].")
 		else

--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -197,24 +197,24 @@
 			"key" = /obj/item/stock_parts/servo,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanning module is secured, the <b> micro-servo</b> can be added.",
-			"forward_message" = "added micro-servo",
+			"desc" = "Scanning module is secured, the <b>servo</b> can be added.",
+			"forward_message" = "added servo",
 			"backward_message" = "unsecured capacitor"
 		),
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Micro-servo is installed, and can be <b>screwed</b> into place.",
-			"forward_message" = "secured micro-servo",
-			"backward_message" = "removed micro-servo"
+			"desc" = "Servo is installed, and can be <b>screwed</b> into place.",
+			"forward_message" = "secured servo",
+			"backward_message" = "removed servo"
 		),
 		list(
 			"key" = /obj/item/stock_parts/cell,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Micro-servo is secured, and the <b>power cell</b> can be added.",
+			"desc" = "Servo is secured, and the <b>power cell</b> can be added.",
 			"forward_message" = "added power cell",
-			"backward_message" = "unsecured micro-servo"
+			"backward_message" = "unsecured servo"
 		),
 		list(
 			"key" = TOOL_SCREWDRIVER,
@@ -534,7 +534,7 @@
 		list(
 			"key" = /obj/item/stock_parts/servo,
 			"action" = ITEM_MOVE_INSIDE,
-			"desc" = "Humor <b>micro-servo</b> can be added!",
+			"desc" = "Humor <b>servo</b> can be added!",
 			"forward_message" = "added smile"
 		),
 		list(
@@ -680,24 +680,24 @@
 			"key" = /obj/item/stock_parts/servo,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Capacitor is secured, the <b>micro-servo</b> can be added.",
-			"forward_message" = "added micro-servo",
+			"desc" = "Capacitor is secured, the <b>servo</b> can be added.",
+			"forward_message" = "added servo",
 			"backward_message" = "unsecured capacitor"
 		),
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Micro-servo is installed, and can be <b>screwed</b> into place.",
-			"forward_message" = "secured micro-servo",
-			"backward_message" = "removed micro-servo"
+			"desc" = "Servo is installed, and can be <b>screwed</b> into place.",
+			"forward_message" = "secured servo",
+			"backward_message" = "removed servo"
 		),
 		list(
 			"key" = /obj/item/stack/ore/bluespace_crystal,
 			"amount" = 1,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Micro-servo is secured, and the <b>bluespace crystal</b> can be added.",
+			"desc" = "Servo is secured, and the <b>bluespace crystal</b> can be added.",
 			"forward_message" = "added bluespace crystal",
-			"backward_message" = "unsecured micro-servo"
+			"backward_message" = "unsecured servo"
 		),
 		list(
 			"key" = /obj/item/stack/cable_coil,

--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -97,7 +97,7 @@
 	if(isnull(capacitor))
 		missing_parts += "capacitor"
 	if(isnull(servo))
-		missing_parts += "micro-servo"
+		missing_parts += "servo"
 	if(length(missing_parts))
 		if(TIMER_COOLDOWN_FINISHED(src, COOLDOWN_MECHA_MESSAGE))
 			to_chat(occupants, "[icon2html(src, occupants)][span_warning("Missing [english_list(missing_parts)].")]")


### PR DESCRIPTION

## About The Pull Request
Removes the servo tier in mech construction examine text, so it's more consistent with other parts.
## Why It's Good For The Game
I hate inconsistency of servos containing tier in mech construction.
## Changelog
:cl: MrDas
spellcheck: The tier of servo in mech construction is no longer explicitly stated.
/:cl:
