### PR TITLE
Makes shadow eyes sensitive to light

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -95,6 +95,7 @@
 	icon = 'icons/obj/medical/organs/shadow_organs.dmi'
 	color_cutoffs = list(20, 10, 40)
 	pepperspray_protect = TRUE
+	flash_protect = FLASH_PROTECTION_SENSITIVE
 
 /// the key to some of their powers
 /obj/item/organ/internal/brain/shadow


### PR DESCRIPTION
## About The Pull Request

was getting wrapped in with #81618, here atomized out.

makes shadow eyes (that nightmares and shadowpeople have) light-sensitive. 

## Why It's Good For The Game

main consequences of this PR:
- nightmares need welding helmets or similar to get full flash protection
- this makes sense because the light literally kills them, why are they better-adapted than moths
- this is good because the recent moves to give nightmares more abilities for ambush hit-and-runs (terrify, stun-crits) have also made them stronger in protracted fights
- adding a bit more risk for nightmares in protracted fights is good because the antag hits its thematic peak when it's involved in terrible ambushes at inopportune moments, not when it's making constant harassment or dueling in the dark
- this adds more risk to nightmares by making them need to limit their vision in order to get full flash protection - which matters more when people have time to anticipate that you're close and on the attack, giving them a chance to whip their flash out

also seriously: shadow eyes. not sensitive to light?

## Changelog

:cl:
balance: the shadow eyes of nightmares and shadowpeople more broadly are now sensitive to light, requiring additional protection.
/:cl:
