### PR TITLE
Blood filtering now removes a minor amount of toxin damage.

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -67,6 +67,7 @@
 		for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
 			if(!length(bloodfilter.whitelist) || (chem.type in bloodfilter.whitelist))
 				target.reagents.remove_reagent(chem.type, min(chem.volume * 0.22, 10))
+	target.adjustToxLoss(-5, forced = TRUE)
 	display_results(
 		user,
 		target,


### PR DESCRIPTION

## About The Pull Request
The basic premise of this is that bloodfiltering removes a small amount of toxin damage, to prevent this being abusable it will only repeat when they have reagents in their system. It works on slimes, however the trade off is that it's worse than medications (80% seiver at 1000k is like... 6 toxin per second, this is about 2.5 per second if my math is right) and will purge any meds in the subjects sytem. (Even the beneficial ones, use it wisely)
## Why It's Good For The Game
If you're filtering someone's blood, surely cycling clean blood around their system would purge some of the toxins (since that's kinda what our bloodstream does, in combination with our liver and kidneys). It is also convenient for those times where you are out of medications (Blackouts, breaches or it's otherwise unsafe to get them) and need to heal someone's toxins... click by click if required.
## Changelog
:cl:
qol: made blood filtration surgery remove a small amount of toxin damage.
/:cl:
