### PR TITLE
Allow voting statistics to be hidden

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -302,6 +302,7 @@ SUBSYSTEM_DEF(vote)
 				"question" = current_vote.override_question,
 				"timeRemaining" = current_vote.time_remaining,
 				"countMethod" = current_vote.count_method,
+				"displayStatistics" = current_vote.display_statistics,
 				"choices" = choices,
 				"vote" = vote_data,
 			)

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -32,6 +32,8 @@
 	var/count_method = VOTE_COUNT_METHOD_SINGLE
 	/// The method for selecting a winner.
 	var/winner_method = VOTE_WINNER_METHOD_SIMPLE
+	/// Should we show details about the number of votes submitted for each option?
+	var/display_statistics = TRUE
 
 /**
  * Used to determine if this vote is a possible
@@ -193,21 +195,22 @@
 	if(total_votes <= 0)
 		return span_bold("Vote Result: Inconclusive - No Votes!")
 
-	returned_text += "\nResults:"
-	for(var/option in choices)
-		returned_text += "\n"
-		var/votes = choices[option]
-		var/percentage_text = ""
-		if(votes > 0)
-			var/actual_percentage = round((votes / total_votes) * 100, 0.1)
-			var/text = "[actual_percentage]"
-			var/spaces_needed = 5 - length(text)
-			for(var/_ in 1 to spaces_needed)
-				returned_text += " "
-			percentage_text += "[text]%"
-		else
-			percentage_text = "    0%"
-		returned_text += "[percentage_text] | [span_bold(option)]: [choices[option]]"
+	if (display_statistics)
+		returned_text += "\nResults:"
+		for(var/option in choices)
+			returned_text += "\n"
+			var/votes = choices[option]
+			var/percentage_text = ""
+			if(votes > 0)
+				var/actual_percentage = round((votes / total_votes) * 100, 0.1)
+				var/text = "[actual_percentage]"
+				var/spaces_needed = 5 - length(text)
+				for(var/_ in 1 to spaces_needed)
+					returned_text += " "
+				percentage_text += "[text]%"
+			else
+				percentage_text = "    0%"
+			returned_text += "[percentage_text] | [span_bold(option)]: [choices[option]]"
 
 	if(!real_winner) // vote has no winner or cannot be won, but still had votes
 		return returned_text

--- a/code/datums/votes/custom_vote.dm
+++ b/code/datums/votes/custom_vote.dm
@@ -47,6 +47,17 @@
 			to_chat(vote_creator, span_boldwarning("Unknown winner method. Contact a coder."))
 			return FALSE
 
+	var/display_stats = tgui_alert(
+		vote_creator,
+		"Should voting statistics be public?",
+		"Show voting stats?",
+		list("Yes", "No"),
+	)
+
+	if(display_stats == null)
+		return FALSE
+	display_statistics = display_stats == "Yes"
+
 	override_question = tgui_input_text(vote_creator, "What is the vote for?", "Custom Vote")
 	if(!override_question)
 		return FALSE

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -3,6 +3,7 @@
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_SINGLE
 	winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
+	display_statistics = FALSE
 
 /datum/vote/map_vote/New()
 	. = ..()

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -35,6 +35,7 @@ type ActiveVote = {
   vote: Vote;
   question: string | null;
   timeRemaining: number;
+  displayStatistics: boolean;
   choices: Option[];
   countMethod: number;
 };
@@ -209,7 +210,9 @@ const ChoicesPanel = (props) => {
                         name="vote-yea"
                       />
                     )}
-                  {choice.votes} Votes
+                  {currentVote.displayStatistics
+                    ? choice.votes + ' Votes'
+                    : null}
                 </LabeledList.Item>
                 <LabeledList.Divider />
               </Box>


### PR DESCRIPTION
## About The Pull Request

Allows polls to hide the voting statistics, both while the poll is running and when it completes, so that people vote in isolation of knowing what other people are voting for.
It looks like this:

![image](https://github.com/tgstation/tgstation/assets/7483112/d17a1784-ecfa-4c7b-8cb2-88aef7f7dcdb)
![image](https://github.com/tgstation/tgstation/assets/7483112/c83db170-7338-48dd-8ab6-cfbc20414abe)

This functionality is also available for custom votes triggered by admins, if they want it.

## Why It's Good For The Game

Put simply, if likely to be controversially, sometimes people get upset that an event with a 5% chance of happening occurs 5% of the time. Now they really won't know what the chance was, only that it was picked by a weighted choice.

Lack of knowledge about what other people are currently voting for should also curb "meme votes" where people pile onto something they see other people voting for, your vote in a poll with hidden stats can only be influenced by your own opinion because you can't see what the crowd is doing in order to join their bandwagon.

## Changelog

:cl:
add: Displaying the voting statistics is now optional on a per-poll basis, and is disabled for map voting.
/:cl:
