### PR TITLE
[NO GBP] Fixes spurious CI failures from museum ash spawns (for real this time)

### DIFF
--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -9,7 +9,7 @@
 /obj/effect/spawner/random/maintenance/no_decals
 
 /obj/effect/spawner/random/maintenance/no_decals/can_spawn(atom/loot)
-	return !istype(loot, /obj/effect/decal)
+	return !ispath(loot, /obj/effect/decal)
 
 /obj/effect/spawner/random/maintenance/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I saw this runtime again despite thinking I fixed it and then realized I needed to be calling `ispath()` since we are not working with an instantiated object with these lists. Oops

## Why It's Good For The Game

Working code is good

## Changelog

Nothing player facing