### PR TITLE
Add compile option for compiling in `MAP_TEST` mode, which disables common annoyances when testing new maps

### DIFF
--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -24,6 +24,9 @@
 #ifdef UNIT_TESTS
 	GLOB.unit_test_mapping_logs += text
 #endif
+#ifdef MAP_TEST
+	message_admins("Mapping: [text]")
+#endif
 	logger.Log(LOG_CATEGORY_DEBUG_MAPPING, text)
 	if(skip_world_log)
 		return

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -142,3 +142,12 @@
 #warn In order to build, run BUILD.bat in the root directory.
 #warn Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
 #endif
+
+/// Runs the game in "map test mode"
+/// Map test mode prevents common annoyances, such as rats from spawning and random light fixture breakage,
+/// so mappers can test important facets of their map (working powernet, atmos, good light coverage) without these interfering.
+// #define MAP_TEST
+
+#ifdef MAP_TEST
+#warn Compiling in MAP_TEST mode. Certain game mechanics will be disabled.
+#endif

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -359,6 +359,7 @@ SUBSYSTEM_DEF(dynamic)
 
 		. += "<hr><b>Additional Notes: </b><BR><BR>" + footnote_pile
 
+#ifndef MAP_TEST
 	print_command_report(., "[command_name()] Status Summary", announce=FALSE)
 	if(greenshift)
 		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", SSstation.announcer.get_rand_report_sound(), color_override = "green")
@@ -366,6 +367,7 @@ SUBSYSTEM_DEF(dynamic)
 		if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_BLUE)
 			SSsecurity_level.set_level(SEC_LEVEL_BLUE, announce = FALSE)
 		priority_announce("[SSsecurity_level.current_security_level.elevating_to_announcement]\n\nA summary has been copied and printed to all communications consoles.", "Security level elevated.", ANNOUNCER_INTERCEPT, color_override = SSsecurity_level.current_security_level.announcement_color)
+#endif
 
 	return .
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -50,7 +50,11 @@ SUBSYSTEM_DEF(events)
 //checks if we should select a random event yet, and reschedules if necessary
 /datum/controller/subsystem/events/proc/checkEvent()
 	if(scheduled <= world.time)
+#ifdef MAP_TEST
+		message_admins("Random event skipped (Game is compiled in MAP_TEST mode)")
+#else
 		spawnEvent()
+#endif
 		reschedule()
 
 //decides which world.time we should select another random event at.

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -7,13 +7,15 @@ SUBSYSTEM_DEF(minor_mapping)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/minor_mapping/Initialize()
-	#ifdef UNIT_TESTS // This whole subsystem just introduces a lot of odd confounding variables into unit test situations, so let's just not bother with doing an initialize here.
+// This whole subsystem just introduces a lot of odd confounding variables into unit test situations,
+// so let's just not bother with doing an initialize here.
+#if defined(MAP_TEST) || defined(UNIT_TESTS)
 	return SS_INIT_NO_NEED
-	#else
+#else
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
 	place_satchels(satchel_amount = 2)
 	return SS_INIT_SUCCESS
-	#endif // the mice are easily the bigger problem, but let's just avoid anything that could cause some bullshit.
+#endif
 
 /// Spawns some critters on exposed wires, usually but not always mice
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(to_spawn=10)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -118,6 +118,12 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	var/neutral_trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/neutral_station_traits)))
 	var/negative_trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/negative_station_traits)))
 
+#ifdef MAP_TEST
+	positive_trait_budget = 0
+	neutral_trait_budget = 0
+	negative_trait_budget = 0
+#endif
+
 	pick_traits(STATION_TRAIT_POSITIVE, positive_trait_budget)
 	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_budget)
 	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_budget)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -36,7 +36,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 
 /obj/effect/landmark/start/proc/after_round_start()
 	// We'd like to keep these around for unit tests, so we can check that they exist.
-#ifndef UNIT_TESTS
+#if !defined(UNIT_TESTS) && !defined(MAP_TEST)
 	if(delete_after_roundstart)
 		qdel(src)
 #endif

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -274,6 +274,10 @@ GLOBAL_PROTECT(admin_verbs_poll)
 				add_verb(src, /client/proc/play_web_sound)
 		if(rights & R_SPAWN)
 			add_verb(src, GLOB.admin_verbs_spawn)
+#ifdef MAP_TEST
+		remove_verb(src, /client/proc/enable_mapping_verbs)
+		add_verb(src, list(/client/proc/disable_mapping_verbs, GLOB.admin_verbs_debug_mapping))
+#endif
 
 /client/proc/remove_admin_verbs()
 	remove_verb(src, list(
@@ -1191,4 +1195,3 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		QDEL_NULL(segment.ai_controller)
 		segment.AddComponent(/datum/component/mob_chain, front = previous)
 		previous = segment
-

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -122,6 +122,7 @@
 
 /obj/machinery/light/LateInitialize()
 	. = ..()
+#ifndef MAP_TEST
 	switch(fitting)
 		if("tube")
 			if(prob(2))
@@ -129,6 +130,7 @@
 		if("bulb")
 			if(prob(5))
 				break_light_tube(TRUE)
+#endif
 	update(trigger = FALSE)
 
 /obj/machinery/light/Destroy()


### PR DESCRIPTION
## About The Pull Request

Adds `MAP_TEST` compile flag. 

This compile flag blocks common things which make it difficult to test a map. 

Things this applies to: 

- Rats no longer spawn. 
   - Rat spawning will (obviously) break up the powernet, which is INCREDIBLY annoying when trying to test if all the rooms of the station are wired correctly (or testing which rooms lose power first, etc)

- Light tubes no longer break on initialize. 
   - Random light breakages can easily cause mappers to accidentally over light a room.

- Roundstart command report is not printed. 
   - Might be a personal preference, but it's kinda annoying to hear the alert over and over again. 

- Random events do not trigger. 
   - Some events such as gravity generator outage can trigger with 0 population. 
   - Random camera breakage event can cause over-placement of cameras. 
   - Other stuff tends to just get in the way. 

- Station traits do not trigger. 
   - Probably the biggest annoyance. Many traits modify the map in some way which disrupts testing. 

- Roundstart landmarks don't self deletes. 
   - Allows mappers to use sdql to find them. 

- Mapping verbs start enabled. 

Obviously more things can be added if they come up. 