### PR TITLE
Converts the slot machine over to TGUI

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -158,7 +158,6 @@
 		ui.open()
 
 /obj/machinery/computer/slot_machine/ui_static_data(mob/user)
-	. = ..()
 	var/list/data = list()
 	data["icons"] = list()
 	for(var/icon_name in icons)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -96,14 +96,14 @@
 		icon_screen = "slots_screen"
 	return ..()
 
-/obj/machinery/computer/slot_machine/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/coin))
-		var/obj/item/coin/C = I
+/obj/machinery/computer/slot_machine/attackby(obj/item/inserted, mob/living/user, params)
+	if(istype(inserted, /obj/item/coin))
+		var/obj/item/coin/inserted_coin = inserted
 		if(paymode == COIN)
 			if(prob(2))
-				if(!user.transferItemToLoc(C, drop_location(), silent = FALSE))
+				if(!user.transferItemToLoc(inserted_coin, drop_location(), silent = FALSE))
 					return
-				C.throw_at(user, 3, 10)
+				inserted_coin.throw_at(user, 3, 10)
 				if(prob(10))
 					balance = max(balance - SPIN_PRICE, 0)
 				to_chat(user, span_warning("[src] spits your coin back out!"))
@@ -112,23 +112,23 @@
 				if(!user.temporarilyRemoveItemFromInventory(C))
 					return
 				balloon_alert(user, "coin insterted")
-				balance += C.value
-				qdel(C)
+				balance += inserted_coin.value
+				qdel(inserted_coin)
 		else
 			balloon_alert(user, "holochips only!")
 
-	else if(istype(I, /obj/item/holochip))
+	else if(istype(inserted, /obj/item/holochip))
 		if(paymode == HOLOCHIP)
-			var/obj/item/holochip/H = I
-			if(!user.temporarilyRemoveItemFromInventory(H))
+			var/obj/item/holochip/inserted_chip = inserted
+			if(!user.temporarilyRemoveItemFromInventory(inserted_chip))
 				return
 			balloon_alert("credits inserted")
-			balance += H.credits
-			qdel(H)
+			balance += inserted_chip.credits
+			qdel(inserted_chip)
 		else
 			balloon_alert(user, "coins only!")
 
-	else if(I.tool_behaviour == TOOL_MULTITOOL)
+	else if(inserted.tool_behaviour == TOOL_MULTITOOL)
 		if(balance > 0)
 			visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
 		else
@@ -383,12 +383,12 @@
 		if(value <= 0)
 			CRASH("Coin value of zero, refusing to payout in dispenser")
 		while(amount >= value)
-			var/obj/item/coin/C = new cointype(loc) //DOUBLE THE PAIN
+			var/obj/item/coin/thrown_coin = new cointype(loc) //DOUBLE THE PAIN
 			amount -= value
 			if(throwit && target)
-				C.throw_at(target, 3, 10)
+				thrown_coin.throw_at(target, 3, 10)
 			else
-				random_step(C, 2, 40)
+				random_step(thrown_coin, 2, 40)
 
 	playsound(src, pick(list('sound/machines/coindrop.ogg', 'sound/machines/coindrop2.ogg')), 50, TRUE)
 	return amount

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -121,7 +121,7 @@
 			var/obj/item/holochip/inserted_chip = inserted
 			if(!user.temporarilyRemoveItemFromInventory(inserted_chip))
 				return
-			balloon_alert("credits inserted")
+			balloon_alert(user, "credits inserted")
 			balance += inserted_chip.credits
 			qdel(inserted_chip)
 		else
@@ -133,10 +133,10 @@
 		else
 			if(paymode == HOLOCHIP)
 				paymode = COIN
-				visible_message("<b>[src]</b> says, 'This machine now works with COINS!'")
+				balloon_alert(user, "now using coins")
 			else
 				paymode = HOLOCHIP
-				visible_message("<b>[src]</b> says, 'This machine now works with HOLOCHIPS!'")
+				balloon_alert(user, "now using holochips")
 	else
 		return ..()
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -47,7 +47,6 @@
 	var/static/list/coinvalues
 	var/list/reels = list(list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0)
 	var/static/list/ray_filter = list(type = "rays", y = 16, size = 40, density = 4, color = COLOR_RED_LIGHT, factor = 15, flags = FILTER_OVERLAY)
-	var/debug = TRUE
 
 /obj/machinery/computer/slot_machine/Initialize(mapload)
 	. = ..()
@@ -184,6 +183,7 @@
 	data["money"] = money
 	data["plays"] = plays
 	data["jackpots"] = jackpots
+	data["paymode"] = paymode
 	return data
 
 
@@ -291,14 +291,14 @@
 	var/linelength = get_lines()
 	var/did_player_win = TRUE
 
-	if(debug || reels[1][2]["icon_name"] + reels[2][2]["icon_name"] + reels[3][2]["icon_name"] + reels[4][2]["icon_name"] + reels[5][2]["icon_name"] == "[SEVEN][SEVEN][SEVEN][SEVEN][SEVEN]")
+	if(reels[1][2]["icon_name"] + reels[2][2]["icon_name"] + reels[3][2]["icon_name"] + reels[4][2]["icon_name"] + reels[5][2]["icon_name"] == "[SEVEN][SEVEN][SEVEN][SEVEN][SEVEN]")
 		var/prize = money + JACKPOT
 		visible_message("<b>[src]</b> says, 'JACKPOT! You win [prize] credits!'")
 		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!")
 		jackpots += 1
 		money = 0
 		if(paymode == HOLOCHIP)
-			new /obj/item/holochip(loc, JACKPOT)
+			new /obj/item/holochip(loc, prize)
 		else
 			for(var/i in 1 to 5)
 				cointype = pick(subtypesof(/obj/item/coin))

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -34,9 +34,8 @@
 	var/paymode = HOLOCHIP //toggles between HOLOCHIP/COIN, defined above
 	var/cointype = /obj/item/coin/iron //default cointype
 	/// Icons that can be displayed by the slot machine.
-	var/list/icons = list(
+	var/static/list/icons = list(
 		"lemon" = list("value" = 2, "colour" = "yellow"),
-		"blender-phone" = list("value" = 2, "colour" = "blue"),
 		"star" = list("value" = 2, "colour" = "yellow"),
 		"bomb" = list("value" = 2, "colour" = "red"),
 		"biohazard" = list("value" = 2, "colour" = "green"),

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -245,6 +245,7 @@
 	give_prizes(the_name, user)
 	update_appearance()
 
+/// Check if the machine can be spun
 /obj/machinery/computer/slot_machine/proc/can_spin(mob/user)
 	if(machine_stat & NOPOWER)
 		balloon_alert(user, "no power!")
@@ -260,6 +261,7 @@
 		return FALSE
 	return TRUE
 
+/// Sets the spinning states of all reels to value, with a delay between them
 /obj/machinery/computer/slot_machine/proc/toggle_reel_spin(value, delay = 0) //value is 1 or 0 aka on or off
 	for(var/list/reel in reels)
 		if(!value)
@@ -268,10 +270,12 @@
 		if(delay)
 			sleep(delay)
 
+/// Same as toggle_reel_spin, but without the delay and runs synchronously
 /obj/machinery/computer/slot_machine/proc/toggle_reel_spin_sync(value)
 	for(var/list/reel in reels)
 		reels[reel] = value
 
+/// Randomize the states of all reels
 /obj/machinery/computer/slot_machine/proc/randomize_reels()
 
 	for(var/reel in reels)
@@ -281,6 +285,7 @@
 			var/chosen = pick(icons)
 			reel[1] = icons[chosen] + list("icon_name" = chosen)
 
+/// Checks if any prizes have been won, and pays them out
 /obj/machinery/computer/slot_machine/proc/give_prizes(usrname, mob/user)
 	var/linelength = get_lines()
 	var/did_player_win = TRUE
@@ -328,9 +333,11 @@
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, remove_filter), "jackpot_rays"), 3 SECONDS)
 		playsound(src, 'sound/machines/roulettejackpot.ogg', 50, TRUE)
 
+/// Checks for a jackpot (5 matching icons in the middle row) with the given icon name
 /obj/machinery/computer/slot_machine/proc/check_jackpot(name)
 	return reels[1][2]["icon_name"] + reels[2][2]["icon_name"] + reels[3][2]["icon_name"] + reels[4][2]["icon_name"] + reels[5][2]["icon_name"] == "[name][name][name][name][name]"
 
+/// Finds the largest number of consecutive matching icons in a row
 /obj/machinery/computer/slot_machine/proc/get_lines()
 	var/amountthesame
 
@@ -350,12 +357,14 @@
 
 	return amountthesame
 
+
 /obj/machinery/computer/slot_machine/proc/give_money(amount)
 	var/amount_to_give = money >= amount ? amount : money
 	var/surplus = amount_to_give - give_payout(amount_to_give)
 	money = max(0, money - amount)
 	balance += surplus
 
+/// Pay out the specified amount in either coins or holochips
 /obj/machinery/computer/slot_machine/proc/give_payout(amount)
 	if(paymode == HOLOCHIP)
 		cointype = /obj/item/holochip
@@ -372,7 +381,9 @@
 
 	return amount
 
-/obj/machinery/computer/slot_machine/proc/dispense(amount = 0, cointype = /obj/item/coin/silver, mob/living/target, throwit = 0)
+/// Dispense the given amount. If machine is set to use coins, will use the specified coin type.
+/// If throwit and target are set, will launch the payment at the target
+/obj/machinery/computer/slot_machine/proc/dispense(amount = 0, cointype = /obj/item/coin/silver, throwit = FALSE, mob/living/target)
 	if(paymode == HOLOCHIP)
 		var/obj/item/holochip/chip = new /obj/item/holochip(loc,amount)
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -40,7 +40,7 @@
 		"bomb" = list("value" = 2, "colour" = "red"),
 		"biohazard" = list("value" = 2, "colour" = "green"),
 		"apple-whole" = list("value" = 2, "colour" = "red"),
-		"7" = list("value" = 1, "colour" = "yellow"),
+		SEVEN = list("value" = 1, "colour" = "yellow"),
 		"dollar-sign" = list("value" = 2, "colour" = "green")
 	)
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -10,7 +10,7 @@
 #define JACKPOT 10000
 #define SPIN_TIME 65 //As always, deciseconds.
 #define REEL_DEACTIVATE_DELAY 7
-#define SEVEN FA_ICON_SEVEN
+#define SEVEN "7"
 #define HOLOCHIP 1
 #define COIN 2
 
@@ -109,7 +109,7 @@
 				to_chat(user, span_warning("[src] spits your coin back out!"))
 
 			else
-				if(!user.temporarilyRemoveItemFromInventory(C))
+				if(!user.temporarilyRemoveItemFromInventory(inserted_coin))
 					return
 				balloon_alert(user, "coin insterted")
 				balance += inserted_coin.value
@@ -158,7 +158,6 @@
 	if(!ui)
 		ui = new(user, src, "SlotMachine", name)
 		ui.open()
-	return TRUE
 
 /obj/machinery/computer/slot_machine/ui_static_data(mob/user)
 	. = ..()

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -360,11 +360,11 @@
 
 	return amountthesame
 
-
+/// Give the specified amount of money. If the amount is greater than the amount of prize money available, add the difference as balance
 /obj/machinery/computer/slot_machine/proc/give_money(amount)
-	var/amount_to_give = money >= amount ? amount : money
-	var/surplus = amount_to_give - give_payout(amount_to_give)
-	money = max(0, money - amount)
+	var/amount_to_give = min(amount, money)
+	var/surplus = amount - give_payout(amount_to_give)
+	money -= amount_to_give
 	balance += surplus
 
 /// Pay out the specified amount in either coins or holochips

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -191,7 +191,7 @@
 
 	switch(action)
 		if("spin")
-			spin(usr)
+			spin(ui.user)
 		if("payout")
 			if(balance > 0)
 				give_payout(balance)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -328,6 +328,7 @@
 
 	else
 		balloon_alert(user, "no luck!")
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50)
 		did_player_win = FALSE
 
 	if(did_player_win)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -184,7 +184,7 @@
 	return data
 
 
-/obj/machinery/computer/slot_machine/ui_act(action, list/params)
+/obj/machinery/computer/slot_machine/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -94,7 +94,8 @@
 		icon_screen = "slots_screen"
 	return ..()
 
-/obj/machinery/computer/slot_machine/attackby(obj/item/inserted, mob/living/user, params)
+
+/obj/machinery/computer/slot_machine/item_interaction(mob/living/user, obj/item/inserted, list/modifiers, is_right_clicking)
 	if(istype(inserted, /obj/item/coin))
 		var/obj/item/coin/inserted_coin = inserted
 		if(paymode == COIN)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -170,7 +170,6 @@
 	return data
 
 /obj/machinery/computer/slot_machine/ui_data(mob/user)
-	. = ..()
 	var/list/data = list()
 	var/list/reel_states = list()
 	for(var/reel_state in reels)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -192,10 +192,12 @@
 	switch(action)
 		if("spin")
 			spin(ui.user)
+			return TRUE
 		if("payout")
 			if(balance > 0)
 				give_payout(balance)
 				balance = 0
+				return TRUE
 
 /obj/machinery/computer/slot_machine/emp_act(severity)
 	. = ..()

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -24,7 +24,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/computer/slot_machine
 	light_color = LIGHT_COLOR_BROWN
-	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON
+	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON // don't need to be literate to play slots
 	var/money = 3000 //How much money it has CONSUMED
 	var/plays = 0
 	var/working = FALSE
@@ -39,7 +39,7 @@
 		FA_ICON_BOMB = list("value" = 2, "colour" = "red"),
 		FA_ICON_BIOHAZARD = list("value" = 2, "colour" = "green"),
 		FA_ICON_APPLE_WHOLE = list("value" = 2, "colour" = "red"),
-		SEVEN = list("value" = 1, "colour" = "yellow"),
+		FA_ICON_7 = list("value" = 1, "colour" = "yellow"),
 		FA_ICON_DOLLAR_SIGN = list("value" = 2, "colour" = "green"),
 	)
 
@@ -120,7 +120,7 @@
 			var/obj/item/holochip/inserted_chip = inserted
 			if(!user.temporarilyRemoveItemFromInventory(inserted_chip))
 				return
-			balloon_alert(user, "credits inserted")
+			balloon_alert(user, "[inserted_chip.credits] credit[inserted_chip.credits == 1 ? "" : "s"] inserted")
 			balance += inserted_chip.credits
 			qdel(inserted_chip)
 		else

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -10,7 +10,7 @@
 #define JACKPOT 10000
 #define SPIN_TIME 65 //As always, deciseconds.
 #define REEL_DEACTIVATE_DELAY 7
-#define SEVEN "7"
+#define SEVEN FA_ICON_SEVEN
 #define HOLOCHIP 1
 #define COIN 2
 
@@ -35,13 +35,13 @@
 	var/cointype = /obj/item/coin/iron //default cointype
 	/// Icons that can be displayed by the slot machine.
 	var/static/list/icons = list(
-		"lemon" = list("value" = 2, "colour" = "yellow"),
-		"star" = list("value" = 2, "colour" = "yellow"),
-		"bomb" = list("value" = 2, "colour" = "red"),
-		"biohazard" = list("value" = 2, "colour" = "green"),
-		"apple-whole" = list("value" = 2, "colour" = "red"),
+		FA_ICON_LEMON = list("value" = 2, "colour" = "yellow"),
+		FA_ICON_STAR = list("value" = 2, "colour" = "yellow"),
+		FA_ICON_BOMB = list("value" = 2, "colour" = "red"),
+		FA_ICON_BIOHAZARD = list("value" = 2, "colour" = "green"),
+		FA_ICON_APPLE_WHOLE = list("value" = 2, "colour" = "red"),
 		SEVEN = list("value" = 1, "colour" = "yellow"),
-		"dollar-sign" = list("value" = 2, "colour" = "green"),
+		FA_ICON_DOLLAR_SIGN = list("value" = 2, "colour" = "green"),
 	)
 
 	var/static/list/coinvalues

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -41,7 +41,7 @@
 		"biohazard" = list("value" = 2, "colour" = "green"),
 		"apple-whole" = list("value" = 2, "colour" = "red"),
 		SEVEN = list("value" = 1, "colour" = "yellow"),
-		"dollar-sign" = list("value" = 2, "colour" = "green")
+		"dollar-sign" = list("value" = 2, "colour" = "green"),
 	)
 
 	var/static/list/coinvalues

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -376,10 +376,10 @@
 
 /obj/machinery/computer/slot_machine/proc/dispense(amount = 0, cointype = /obj/item/coin/silver, mob/living/target, throwit = 0)
 	if(paymode == HOLOCHIP)
-		var/obj/item/holochip/H = new /obj/item/holochip(loc,amount)
+		var/obj/item/holochip/chip = new /obj/item/holochip(loc,amount)
 
 		if(throwit && target)
-			H.throw_at(target, 3, 10)
+			chip.throw_at(target, 3, 10)
 	else
 		var/value = coinvalues["[cointype]"]
 		if(value <= 0)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -10,7 +10,7 @@
 #define JACKPOT 10000
 #define SPIN_TIME 65 //As always, deciseconds.
 #define REEL_DEACTIVATE_DELAY 7
-#define SEVEN "7"
+#define SEVEN "fa-7"
 #define HOLOCHIP 1
 #define COIN 2
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -24,8 +24,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/computer/slot_machine
 	light_color = LIGHT_COLOR_BROWN
-	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_SET_MACHINE // don't need to be literate to play slots
-	tgui_id = "SlotMachine"
+	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON
 	var/money = 3000 //How much money it has CONSUMED
 	var/plays = 0
 	var/working = FALSE
@@ -232,7 +231,6 @@
 
 	toggle_reel_spin(1)
 	update_appearance()
-	updateDialog()
 	var/spin_loop = addtimer(CALLBACK(src, PROC_REF(do_spin)), 2, TIMER_LOOP|TIMER_STOPPABLE)
 
 	addtimer(CALLBACK(src, PROC_REF(finish_spinning), spin_loop, user, the_name), SPIN_TIME - (REEL_DEACTIVATE_DELAY * reels.len))
@@ -240,7 +238,6 @@
 
 /obj/machinery/computer/slot_machine/proc/do_spin()
 	randomize_reels()
-	updateDialog()
 	use_power(active_power_usage)
 
 /obj/machinery/computer/slot_machine/proc/finish_spinning(spin_loop, mob/user, the_name)
@@ -249,7 +246,6 @@
 	deltimer(spin_loop)
 	give_prizes(the_name, user)
 	update_appearance()
-	updateDialog()
 
 /obj/machinery/computer/slot_machine/proc/can_spin(mob/user)
 	if(machine_stat & NOPOWER)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -287,7 +287,11 @@
 	var/linelength = get_lines()
 	var/did_player_win = TRUE
 
-	if(reels[1][2]["icon_name"] + reels[2][2]["icon_name"] + reels[3][2]["icon_name"] + reels[4][2]["icon_name"] + reels[5][2]["icon_name"] == "[SEVEN][SEVEN][SEVEN][SEVEN][SEVEN]")
+	if(check_jackpot(FA_ICON_BOMB))
+		var/obj/item/grenade/flashbang/bang = new(get_turf(src))
+		bang.arm_grenade(null, 1 SECONDS)
+
+	else if(check_jackpot(SEVEN))
 		var/prize = money + JACKPOT
 		visible_message("<b>[src]</b> says, 'JACKPOT! You win [prize] credits!'")
 		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!")
@@ -325,6 +329,9 @@
 		animate(get_filter("jackpot_rays"), offset = 10, time = 3 SECONDS, loop = -1)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, remove_filter), "jackpot_rays"), 3 SECONDS)
 		playsound(src, 'sound/machines/roulettejackpot.ogg', 50, TRUE)
+
+/obj/machinery/computer/slot_machine/proc/check_jackpot(name)
+	return reels[1][2]["icon_name"] + reels[2][2]["icon_name"] + reels[3][2]["icon_name"] + reels[4][2]["icon_name"] + reels[5][2]["icon_name"] == "[name][name][name][name][name]"
 
 /obj/machinery/computer/slot_machine/proc/get_lines()
 	var/amountthesame

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -10,7 +10,7 @@
 #define JACKPOT 10000
 #define SPIN_TIME 65 //As always, deciseconds.
 #define REEL_DEACTIVATE_DELAY 7
-#define SEVEN "fa-7"
+#define JACKPOT_SEVENS FA_ICON_7
 #define HOLOCHIP 1
 #define COIN 2
 
@@ -297,7 +297,7 @@
 		var/obj/item/grenade/flashbang/bang = new(get_turf(src))
 		bang.arm_grenade(null, 1 SECONDS)
 
-	else if(check_jackpot(SEVEN))
+	else if(check_jackpot(JACKPOT_SEVENS))
 		var/prize = money + JACKPOT
 		visible_message("<b>[src]</b> says, 'JACKPOT! You win [prize] credits!'")
 		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!")
@@ -413,7 +413,7 @@
 #undef HOLOCHIP
 #undef JACKPOT
 #undef REEL_DEACTIVATE_DELAY
-#undef SEVEN
+#undef JACKPOT_SEVENS
 #undef SMALL_PRIZE
 #undef SPIN_PRICE
 #undef SPIN_TIME

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -169,6 +169,7 @@
 		icon += list("icon" = icon_name)
 		data["icons"] += list(icon)
 	data["cost"] = SPIN_PRICE
+	data["jackpot"] = JACKPOT
 
 	return data
 
@@ -296,7 +297,6 @@
 		visible_message("<b>[src]</b> says, 'JACKPOT! You win [prize] credits!'")
 		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!")
 		jackpots += 1
-		balance += money - give_payout(JACKPOT)
 		money = 0
 		if(paymode == HOLOCHIP)
 			new /obj/item/holochip(loc, JACKPOT)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -162,7 +162,8 @@
 
 /obj/machinery/computer/slot_machine/ui_static_data(mob/user)
 	. = ..()
-	var/list/data = list("icons" = list())
+	var/list/data = list()
+	data["icons"] = list()
 	for(var/icon_name in icons)
 		var/list/icon = icons[icon_name]
 		icon += list("icon" = icon_name)

--- a/tgui/packages/tgui/interfaces/SlotMachine.tsx
+++ b/tgui/packages/tgui/interfaces/SlotMachine.tsx
@@ -30,10 +30,6 @@ type SlotsReelProps = {
   reel: IconInfo[];
 };
 
-const randomChoice = (arr: any[]) => {
-  return arr[Math.floor(Math.random() * arr.length)];
-};
-
 const pluralS = (amount: number) => {
   return amount === 1 ? '' : 's';
 };
@@ -120,7 +116,6 @@ export const SlotMachine = (props) => {
         </Section>
         <hr />
         <Section
-          className="reelsContainer"
           style={{
             flexDirection: 'row',
             display: 'flex',

--- a/tgui/packages/tgui/interfaces/SlotMachine.tsx
+++ b/tgui/packages/tgui/interfaces/SlotMachine.tsx
@@ -84,8 +84,10 @@ export const SlotMachine = (props) => {
 
   return (
     <Window>
-      <Section style={{ justifyContent: 'center', textAlign: 'center' }}>
-        <h1>Slots!</h1>
+      <Section
+        title="Slots!"
+        style={{ justifyContent: 'center', textAlign: 'center' }}
+      >
         <Section style={{ textAlign: 'left' }}>
           <p>
             Only <b>{cost}</b> credit{pluralS(cost)} for a chance to win big!
@@ -129,7 +131,7 @@ export const SlotMachine = (props) => {
         <hr />
         <Button
           onClick={() => act('spin')}
-          disabled={rolling || !(balance >= cost)}
+          disabled={rolling || balance < cost}
         >
           Spin!
         </Button>

--- a/tgui/packages/tgui/interfaces/SlotMachine.tsx
+++ b/tgui/packages/tgui/interfaces/SlotMachine.tsx
@@ -111,9 +111,8 @@ export const SlotMachine = (props) => {
             </b>{' '}
             and won{' '}
             <b>
-              {jackpots} jackpot{pluralS(jackpots)}
+              {jackpots} jackpot{pluralS(jackpots)}!
             </b>
-            !
           </p>
         </Section>
         <hr />

--- a/tgui/packages/tgui/interfaces/SlotMachine.tsx
+++ b/tgui/packages/tgui/interfaces/SlotMachine.tsx
@@ -1,0 +1,149 @@
+import { useBackend } from '../backend';
+import { Button, Icon, Section } from '../components';
+import { Window } from '../layouts';
+
+type IconInfo = {
+  value: number;
+  colour: string;
+  icon_name: string;
+};
+
+type BackendData = {
+  icons: IconInfo[];
+  state: any[];
+  balance: number;
+  working: boolean;
+  money: number;
+  cost: number;
+  plays: number;
+  jackpots: number;
+};
+
+type SlotsTileProps = {
+  icon: string;
+  color?: string;
+  background?: string;
+};
+
+type SlotsReelProps = {
+  reel: IconInfo[];
+};
+
+const randomChoice = (arr: any[]) => {
+  return arr[Math.floor(Math.random() * arr.length)];
+};
+
+const pluralS = (amount: number) => {
+  return amount === 1 ? '' : 's';
+};
+
+const SlotsReel = (props: SlotsReelProps) => {
+  const { reel } = props;
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        flexDirection: 'column',
+      }}
+    >
+      {reel.map((slot, i) => (
+        <SlotsTile
+          key={i}
+          // background={i === 1 ? 'gold' : undefined}
+          icon={slot.icon_name}
+          color={slot.colour}
+        />
+      ))}
+    </div>
+  );
+};
+
+const SlotsTile = (props: SlotsTileProps) => {
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        padding: '1rem',
+        margin: '0.5rem',
+        display: 'inline-block',
+        width: '5rem',
+        background: props.background || 'rgba(62, 97, 137, 1)',
+      }}
+    >
+      <Icon className={`color-${props.color}`} size={2.5} name={props.icon} />
+    </div>
+  );
+};
+
+export const SlotMachine = (props) => {
+  const { act, data } = useBackend<BackendData>();
+  // icons: The list of possible icons, including colour and name
+  // backendState: the current state of the slots according to the backend
+  const {
+    plays,
+    jackpots,
+    money,
+    cost,
+    state,
+    balance,
+    working: rolling,
+  } = data;
+
+  return (
+    <Window>
+      <Section style={{ justifyContent: 'center', textAlign: 'center' }}>
+        <h1>Slots!</h1>
+        <Section style={{ textAlign: 'left' }}>
+          <p>
+            Only <b>{cost}</b> credit{pluralS(cost)} for a chance to win big!
+          </p>
+          <p>
+            Available prize money:{' '}
+            <b>
+              {money} credit{pluralS(money)}
+            </b>{' '}
+            (Jackpot is always 100%)
+          </p>
+          <p>
+            So far people have spun{' '}
+            <b>
+              {plays} time{pluralS(plays)},
+            </b>{' '}
+            and won{' '}
+            <b>
+              {jackpots} jackpot{pluralS(jackpots)}
+            </b>
+            !
+          </p>
+        </Section>
+        <hr />
+        <Section
+          className="reelsContainer"
+          style={{
+            flexDirection: 'row',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          {state.map((reel, i) => {
+            return <SlotsReel key={i} reel={reel} />;
+          })}
+        </Section>
+        <hr />
+        <Button
+          onClick={() => act('spin')}
+          disabled={rolling || !(balance > cost)}
+        >
+          Spin!
+        </Button>
+        <Section>
+          <b>Balance: {balance}</b>
+          <br />
+          <Button onClick={() => act('payout')} disabled={!(balance > 0)}>
+            Refund balance
+          </Button>
+        </Section>
+      </Section>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/SlotMachine.tsx
+++ b/tgui/packages/tgui/interfaces/SlotMachine.tsx
@@ -18,6 +18,7 @@ type BackendData = {
   plays: number;
   jackpots: number;
   jackpot: number;
+  paymode: number;
 };
 
 type SlotsTileProps = {
@@ -80,6 +81,7 @@ export const SlotMachine = (props) => {
     balance,
     jackpot,
     working: rolling,
+    paymode,
   } = data;
 
   return (
@@ -98,12 +100,14 @@ export const SlotMachine = (props) => {
               {money} credit{pluralS(money)}
             </b>{' '}
           </p>
-          <p>
-            Current jackpot:{' '}
-            <b>
-              {money + jackpot} credit{pluralS(money + jackpot)}!
-            </b>
-          </p>
+          {paymode === 1 && (
+            <p>
+              Current jackpot:{' '}
+              <b>
+                {money + jackpot} credit{pluralS(money + jackpot)}!
+              </b>
+            </p>
+          )}
           <p>
             So far people have spun{' '}
             <b>

--- a/tgui/packages/tgui/interfaces/SlotMachine.tsx
+++ b/tgui/packages/tgui/interfaces/SlotMachine.tsx
@@ -17,6 +17,7 @@ type BackendData = {
   cost: number;
   plays: number;
   jackpots: number;
+  jackpot: number;
 };
 
 type SlotsTileProps = {
@@ -47,12 +48,7 @@ const SlotsReel = (props: SlotsReelProps) => {
       }}
     >
       {reel.map((slot, i) => (
-        <SlotsTile
-          key={i}
-          // background={i === 1 ? 'gold' : undefined}
-          icon={slot.icon_name}
-          color={slot.colour}
-        />
+        <SlotsTile key={i} icon={slot.icon_name} color={slot.colour} />
       ))}
     </div>
   );
@@ -86,6 +82,7 @@ export const SlotMachine = (props) => {
     cost,
     state,
     balance,
+    jackpot,
     working: rolling,
   } = data;
 
@@ -102,7 +99,12 @@ export const SlotMachine = (props) => {
             <b>
               {money} credit{pluralS(money)}
             </b>{' '}
-            (Jackpot is always 100%)
+          </p>
+          <p>
+            Current jackpot:{' '}
+            <b>
+              {money + jackpot} credit{pluralS(money + jackpot)}!
+            </b>
           </p>
           <p>
             So far people have spun{' '}
@@ -132,7 +134,7 @@ export const SlotMachine = (props) => {
         <hr />
         <Button
           onClick={() => act('spin')}
-          disabled={rolling || !(balance > cost)}
+          disabled={rolling || !(balance >= cost)}
         >
           Spin!
         </Button>


### PR DESCRIPTION
## About The Pull Request
This PR is the long-awaited de-soulification of the slot machine, converting it over to TGUI. It also updates the jackpot, since it appears to have been quite broken. It will now give all of the available prize money plus 10000 credits. I'm fairly sure this is what was supposed to happen, but I honestly could not tell, so if this ends up being a balance change then so be it. Also adds a new funny kind of jackpot when you get 5 bombs in the middle row. Other than that, generally cleans up and updates some of the slot machine code.

The styling of the slot machine ui is nothing fancy right now, and I'm open to suggestions about how the ui should look.

Fixes #71314

- [x] Convert slot machine to TGUI
- [x] Fix slot machine jackpot
- [x] General code cleanup

https://github.com/tgstation/tgstation/assets/42454181/b61aae3c-f471-45d6-bee6-aca55514bcc3
## Why It's Good For The Game
Converts a super old and outdated UI over to TGUI, fixes the jackpot, and includes general code improvements for the slot machine.
## Changelog
:cl:
fix: Fixes the slot machine's jackpot. It should now give all of the available prize money + 10,000 credits as payout for a jackpot.
refactor: Converts the slot machine's UI over to TGUI
add: The slot machine now has a whole new type of jackpot! This one's a banger!
/:cl:
