### PR TITLE
Fix: AI Hologram Copying Station Members

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -699,7 +699,7 @@
 				if("Station Member")
 					var/list/personnel_list = list()
 
-					for(var/datum/record/crew/record in GLOB.manifest.locked)//Look in data core locked.
+					for(var/datum/record/locked/record in GLOB.manifest.locked)//Look in data core locked.
 						personnel_list["[record.name]: [record.rank]"] = record.character_appearance//Pull names, rank, and image.
 
 					if(!length(personnel_list))


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug which disables the AI hologram's ability to copy the appearance of crew members. Fixes #78403

The bug was caused by developer error in PR #72725 when the typepath `/datum/record/crew` was used to access `GLOB.manifest.locked`, which is a list of `/datum/record/locked`. To fix the bug I replaced the erroneous typepath with `/datum/record/locked`.

## Why It's Good For The Game

This PR fixes the broken feature that used to allow the AI to select from the crew records to set its hologram's appearance.

![image](https://github.com/tgstation/tgstation/assets/17753498/f6cdca47-0795-4b41-8c6c-922a38f597ee) ![image](https://github.com/tgstation/tgstation/assets/17753498/bfb49bf6-2842-405c-b88f-70b707f5d109)

## Changelog

:cl: A.C.M.O.
fix: Fixed the AI hologram's ability to copy the appearance of crew members.
/:cl:
