### PR TITLE
wew `lad: variable defined but not used`

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -203,7 +203,6 @@
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
 	RegisterSignal(thing, COMSIG_QDELETING, PROC_REF(content_deleted))
 	if(isliving(thing))
-		var/mob/living/lad = thing
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, PROC_REF(content_died))
 	stomach_contents += thing
 	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced


### PR DESCRIPTION
## About The Pull Request
Thanks Floofies for the PR title.

This removes a warning that flew under the radar, passed the CI without me taking a deeper look basically.

## Why It's Good For The Game
Removing an unused variable.

## Changelog
N/A