### PR TITLE
Removes unused tgui_id var

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -136,8 +136,6 @@
 	var/market_verb = "Customer"
 	var/payment_department = ACCOUNT_ENG
 
-	/// For storing and overriding ui id
-	var/tgui_id // ID of TGUI interface
 	///Is this machine currently in the atmos machinery queue?
 	var/atmos_processing = FALSE
 	/// world.time of last use by [/mob/living]

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -8,7 +8,6 @@
 	light_color = LIGHT_COLOR_DIM_YELLOW
 	use_power = ACTIVE_POWER_USE
 	circuit = /obj/item/circuitboard/computer/powermonitor
-	tgui_id = "PowerMonitor"
 
 	var/datum/weakref/attached_wire_ref
 	var/datum/weakref/local_apc_ref


### PR DESCRIPTION
## About The Pull Request

This var is used for modular PCs to swap between programs but it is unused on the machinery entirely, if someone wants to re-add it as something that is actually used then feel free but currently it is useless and confused me for a moment on tgui stuff, so I thought I should kill it.

## Why It's Good For The Game

Unused var die.

## Changelog

Nothing player-facing.