### PR TITLE
Lowers thermic constant of Cryostylane reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -419,7 +419,7 @@
 	determin_ph_range = 6
 	temp_exponent_factor = 0.5
 	ph_exponent_factor = 1
-	thermic_constant = -7.5
+	thermic_constant = -1.5
 	H_ion_release = 0
 	rate_up_lim = 10
 	purity_min = 0.2

--- a/tgui/packages/tgui/interfaces/ChemRecipeDebug.tsx
+++ b/tgui/packages/tgui/interfaces/ChemRecipeDebug.tsx
@@ -368,7 +368,7 @@ export const ChemRecipeDebug = (props) => {
                         step={0.1}
                         stepPixelSize={3}
                         value={editReaction?.editValue || 0}
-                        minValue={0}
+                        minValue={-1000}
                         maxValue={1000}
                         disabled={editReaction === null}
                         onDrag={(e, value) =>


### PR DESCRIPTION
## About The Pull Request
- Fixes #81687

Thermic constant of Cryostylane reaction now reduced from -7.5 to -1.5.

Meaning for every 1u of Cryostylane created the overall temperature of the holder reduces by 1.5k so for e.g. if you create 30u of cryostylane without any heating the temps reduces by 30 * 1.5 = 45k(the drop of temperature increases as the reaction temps grows closer to optimal temperature in our case -200k)

When testing upon adding 30u of water, nitrogen & stable plasma and cooling the mixture to 270k via tier1 chem heater you acheive 30u of Cryostylane at 82% purity and the final temps are 180k

P.S. adjusted range of chem debuger to include negative values. Helped me in debugging this

## Changelog
:cl:
fix: Cryostylane reaction now has a moderate & not extreme cooling effect. Helps you achieve more pure amounts of  Cryostylane
/:cl:
