### PR TITLE
fixes inability to create material airlocks

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -325,6 +325,7 @@
 	door.update_appearance()
 
 	qdel(src)
+	return door
 
 /obj/structure/door_assembly/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/door_assembly_types.dm
+++ b/code/game/objects/structures/door_assembly_types.dm
@@ -293,4 +293,5 @@
 /obj/structure/door_assembly/door_assembly_material/finish_door()
 	var/obj/machinery/door/airlock/door = ..()
 	door.set_custom_materials(custom_materials)
+	door.update_appearance()
 	return door


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/81710

runtime due to parent proc not returning the airlock
also added an update_appearance()
## Changelog
:cl:
fix: You can build material airlocks again
/:cl:
