### PR TITLE
[NO GBP] Reverses the logic for body collision to determine knockdown

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -85,7 +85,7 @@
 				span_userdanger("You violently crash into [victim][extra_speed ? " extra hard" : ""], but [victim] managed to block the worst of it!"))
 			log_combat(src, victim, "crashed into and was blocked by")
 			return
-		else if(HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
+		else if(HAS_TRAIT(victim, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 			victim.take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
 			victim.apply_damage(10 + 10 * extra_speed, STAMINA)
 			victim.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)


### PR DESCRIPTION

## About The Pull Request

The body that is thrown at someone having knockdown proofing is not what determines whether the victim of the collision is knocked over, but the victim themselves having this trait.

## Why It's Good For The Game

I have ADHD.

## Changelog
:cl:
fix: Being in a Swat Suit appropriately protects you from collisions with a body, rather than the body thrown at you having these protections protecting YOU, the victim of the collision.
/:cl:
