### PR TITLE
Temporary bees animate on death and no longer produce corpses

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -683,11 +683,11 @@
 	duration = 0.4 SECONDS
 
 /// Plays a dispersing animation on hivelord and legion minions so they don't just vanish
-/obj/effect/temp_visual/hive_spawn_wither
+/obj/effect/temp_visual/despawn_effect
 	name = "withering spawn"
 	duration = 1 SECONDS
 
-/obj/effect/temp_visual/hive_spawn_wither/Initialize(mapload, atom/copy_from)
+/obj/effect/temp_visual/despawn_effect/Initialize(mapload, atom/copy_from)
 	if (isnull(copy_from))
 		. = ..()
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -651,17 +651,15 @@
 	button_icon_state = "queen_item"
 	cooldown_time = 30 SECONDS
 	///The mob we're going to spawn
-	var/spawn_type = /mob/living/basic/bee
+	var/spawn_type = /mob/living/basic/bee/timed/short
 	///How many are we going to spawn
 	var/spawn_count = 6
-	///How long our summoned mobs last for
-	var/spawn_lifespan = 25 SECONDS
 
 /datum/action/cooldown/hivehead_spawn_minions/PreActivate(atom/target)
 	if(owner.movement_type & VENTCRAWLING)
 		owner.balloon_alert(owner, "unavailable here")
 		return
-	. = ..()
+	return ..()
 
 /datum/action/cooldown/hivehead_spawn_minions/Activate(atom/target)
 	. = ..()
@@ -672,8 +670,6 @@
 	for(var/i in 1 to spawns)
 		var/mob/living/basic/summoned_minion = new spawn_type(get_turf(owner))
 		summoned_minion.faction = list("[REF(owner)]")
-		if(spawn_lifespan != 0 SECONDS)
-			QDEL_IN(summoned_minion, spawn_lifespan)
 		minion_additional_changes(summoned_minion)
 
 ///Our tell that we're using this ability. Usually a sound and a visible message.area
@@ -703,8 +699,6 @@
 	cooldown_time = 15 SECONDS
 	spawn_type = /mob/living/basic/legion_brood
 	spawn_count = 4
-	//Legion heads go away by themselves, we don't have to handle that
-	spawn_lifespan = 0 SECONDS
 
 /datum/action/cooldown/hivehead_spawn_minions/legion/do_tell()
 	owner.visible_message(span_warning("[owner]'s head begins to shake as legion begin to pour out!"), span_warning("We release the legion."), span_hear("You hear a loud squishing sound!"))

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -106,8 +106,12 @@
 	beegent = null
 	if(flags_1 & HOLOGRAM_1 || gibbed)
 		return ..()
-	new /obj/item/trash/bee(loc, src)
+	spawn_corpse()
 	return ..()
+
+/// Leave something to remember us by
+/mob/living/basic/bee/proc/spawn_corpse()
+	new /obj/item/trash/bee(loc, src)
 
 /mob/living/basic/bee/proc/pre_attack(mob/living/puncher, atom/target)
 	SIGNAL_HANDLER
@@ -213,12 +217,20 @@
 	var/datum/reagent/toxin = pick(typesof(/datum/reagent/toxin))
 	assign_reagent(GLOB.chemical_reagents_list[toxin])
 
-/mob/living/basic/bee/short
-	desc = "These bees seem unstable and won't survive for long."
+/// A bee which despawns after a short amount of time (beespawns?)
+/mob/living/basic/bee/timed
+	/// How long do we live?
+	var/lifespan = 50 SECONDS
 
-/mob/living/basic/bee/short/Initialize(mapload, timetolive=50 SECONDS)
+/mob/living/basic/bee/timed/short
+	lifespan = 25 SECONDS
+
+/mob/living/basic/bee/timed/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(death)), timetolive)
+	addtimer(CALLBACK(src, PROC_REF(death)), lifespan)
+
+/mob/living/basic/bee/timed/spawn_corpse()
+	new /obj/effect/temp_visual/despawn_effect(get_turf(src), /* copy_from = */ src)
 
 /obj/item/queen_bee
 	name = "queen bee"

--- a/code/modules/mob/living/basic/lavaland/hivelord/hivelord.dm
+++ b/code/modules/mob/living/basic/lavaland/hivelord/hivelord.dm
@@ -110,5 +110,5 @@
 
 /mob/living/basic/hivelord_brood/death(gibbed)
 	if (!gibbed)
-		new /obj/effect/temp_visual/hive_spawn_wither(get_turf(src), /* copy_from = */ src)
+		new /obj/effect/temp_visual/despawn_effect(get_turf(src), /* copy_from = */ src)
 	return ..()

--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -42,7 +42,7 @@
 
 /mob/living/basic/legion_brood/death(gibbed)
 	if (!gibbed)
-		new /obj/effect/temp_visual/hive_spawn_wither(get_turf(src), /* copy_from = */ src)
+		new /obj/effect/temp_visual/despawn_effect(get_turf(src), /* copy_from = */ src)
 	return ..()
 
 /mob/living/basic/legion_brood/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -203,7 +203,6 @@
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
 	RegisterSignal(thing, COMSIG_QDELETING, PROC_REF(content_deleted))
 	if(isliving(thing))
-		var/mob/living/lad = thing
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, PROC_REF(content_died))
 	stomach_contents += thing
 	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -194,7 +194,7 @@
 			beeagents += R
 		var/bee_amount = round(created_volume * 0.2)
 		for(var/i in 1 to bee_amount)
-			var/mob/living/basic/bee/short/new_bee = new(location)
+			var/mob/living/basic/bee/timed/new_bee = new(location)
 			if(LAZYLEN(beeagents))
 				new_bee.assign_reagent(pick(beeagents))
 


### PR DESCRIPTION
## About The Pull Request

I requested this as a change on the Hive Head PR but Ghommie didn't notice and merged it anyway so I had to do it myself instead of forcing the underclass to do it for me 😔

![dreamseeker_d8pI4uCCqt](https://github.com/tgstation/tgstation/assets/7483112/bff1a2d7-98c7-49d2-854b-a16f709520ab)

Anyway now bees created by the "beesplosion" reaction and by the Hive Head changeling power no longer produce corpses, and have a death animation.

## Why It's Good For The Game

It looks better.
It was weird that the bees would create corpses if killed but not if they expired.

## Changelog

:cl:
image: adds a visual effect for hive head bees despawning
/:cl:
