### PR TITLE
Mini-Nukie Update: The Bulldog is a 2-shot burst fire gun edition (and lone ops get some spare ammo for their bulldog)

### DIFF
--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -73,10 +73,11 @@
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
-	r_hand = /obj/item/storage/toolbox/guncase/bulldog
+	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/clandestine = 1,
 		/obj/item/pen/edagger = 1,
+		/obj/item/ammo_box/magazine/m12g = 3,
 	)
 
 /datum/outfit/syndicate/full/plasmaman

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -73,7 +73,7 @@
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
-	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
+	r_hand = /obj/item/storage/toolbox/guncase/bulldog
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/clandestine = 1,
 		/obj/item/pen/edagger = 1,

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -9,41 +9,7 @@
 	fire_sound_volume = 90
 	rack_sound = 'sound/weapons/gun/smg/smgrack.ogg'
 	suppressed_sound = 'sound/weapons/gun/smg/shot_suppressed.ogg'
-	var/select = 1 ///fire selector position. 1 = semi, 2 = burst. anything past that can vary between guns.
-	var/selector_switch_icon = FALSE ///if it has an icon for a selector switch indicating current firemode.
-
-/obj/item/gun/ballistic/automatic/update_overlays()
-	. = ..()
-	if(!selector_switch_icon)
-		return
-
-	switch(select)
-		if(0)
-			. += "[initial(icon_state)]_semi"
-		if(1)
-			. += "[initial(icon_state)]_burst"
-
-/obj/item/gun/ballistic/automatic/ui_action_click(mob/user, actiontype)
-	if(istype(actiontype, /datum/action/item_action/toggle_firemode))
-		burst_select()
-	else
-		..()
-
-/obj/item/gun/ballistic/automatic/proc/burst_select()
-	var/mob/living/carbon/human/user = usr
-	select = !select
-	if(!select)
-		burst_size = 1
-		fire_delay = 0
-		balloon_alert(user, "switched to semi-automatic")
-	else
-		burst_size = initial(burst_size)
-		fire_delay = initial(fire_delay)
-		balloon_alert(user, "switched to [burst_size]-round burst")
-
-	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
-	update_appearance()
-	update_item_action_buttons()
+	burst_fire_selection = TRUE
 
 /obj/item/gun/ballistic/automatic/proto
 	name = "\improper Nanotrasen Saber SMG"
@@ -204,14 +170,6 @@
 			underbarrel.attackby(A, user, params)
 	else
 		..()
-
-/obj/item/gun/ballistic/automatic/m90/update_overlays()
-	. = ..()
-	switch(select)
-		if(0)
-			. += "[initial(icon_state)]_semi"
-		if(1)
-			. += "[initial(icon_state)]_burst"
 
 /obj/item/gun/ballistic/automatic/tommygun
 	name = "\improper Thompson SMG"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -136,7 +136,7 @@
 
 /obj/item/gun/ballistic/shotgun/bulldog
 	name = "\improper Bulldog Shotgun"
-	desc = "A semi-auto, mag-fed shotgun for combat in narrow corridors, nicknamed 'Bulldog' by boarding parties. Compatible only with specialized 8-round drum magazines. Can have a secondary magazine attached to quickly swap between ammo types, or just to keep shooting."
+	desc = "A 2-round burst fire, mag-fed shotgun for combat in narrow corridors, nicknamed 'Bulldog' by boarding parties. Compatible only with specialized 8-round drum magazines. Can have a secondary magazine attached to quickly swap between ammo types, or just to keep shooting."
 	icon_state = "bulldog"
 	inhand_icon_state = "bulldog"
 	worn_icon_state = "cshotgun"
@@ -148,8 +148,8 @@
 	weapon_weight = WEAPON_MEDIUM
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m12g
 	can_suppress = FALSE
-	burst_size = 1
-	fire_delay = 0
+	burst_size = 2
+	fire_delay = 1
 	pin = /obj/item/firing_pin/implant/pindicate
 	fire_sound = 'sound/weapons/gun/shotgun/shot_alt.ogg'
 	actions_types = list()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -161,12 +161,11 @@
 	semi_auto = TRUE
 	internal_magazine = FALSE
 	tac_reloads = TRUE
+	burst_fire_selection = TRUE
 	///the type of secondary magazine for the bulldog
 	var/secondary_magazine_type
 	///the secondary magazine
 	var/obj/item/ammo_box/magazine/secondary_magazine
-	///Whether or not we're in burst mode. If true, we burst fire. If false, we are semi-automatic.
-	var/burst_fire_on = TRUE
 
 /obj/item/gun/ballistic/shotgun/bulldog/Initialize(mapload)
 	. = ..()
@@ -189,26 +188,6 @@
 	. += "You can load a secondary magazine by right-clicking [src] with the magazine you want to load."
 	. += "You can remove a secondary magazine by alt-right-clicking [src]."
 	. += "Right-click to swap the magazine to the secondary position, and vice versa."
-
-/obj/item/gun/ballistic/shotgun/bulldog/ui_action_click(mob/user, actiontype)
-	if(istype(actiontype, /datum/action/item_action/toggle_firemode))
-		burst_select()
-	else
-		..()
-
-/obj/item/gun/ballistic/shotgun/bulldog/proc/burst_select()
-	var/mob/living/carbon/human/user = usr
-	burst_fire_on = !burst_fire_on
-	if(!burst_fire_on)
-		burst_size = 1
-		fire_delay = 0
-		balloon_alert(user, "switched to semi-automatic")
-	else
-		burst_size = initial(burst_size)
-		fire_delay = initial(fire_delay)
-		balloon_alert(user, "switched to [burst_size]-round burst")
-
-	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 
 /obj/item/gun/ballistic/shotgun/bulldog/update_overlays()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -152,7 +152,7 @@
 	fire_delay = 1
 	pin = /obj/item/firing_pin/implant/pindicate
 	fire_sound = 'sound/weapons/gun/shotgun/shot_alt.ogg'
-	actions_types = list()
+	actions_types = list(/datum/action/item_action/toggle_firemode)
 	mag_display = TRUE
 	empty_indicator = TRUE
 	empty_alarm = TRUE
@@ -165,6 +165,8 @@
 	var/secondary_magazine_type
 	///the secondary magazine
 	var/obj/item/ammo_box/magazine/secondary_magazine
+	///Whether or not we're in burst mode. If true, we burst fire. If false, we are semi-automatic.
+	var/burst_fire_on = TRUE
 
 /obj/item/gun/ballistic/shotgun/bulldog/Initialize(mapload)
 	. = ..()
@@ -187,6 +189,26 @@
 	. += "You can load a secondary magazine by right-clicking [src] with the magazine you want to load."
 	. += "You can remove a secondary magazine by alt-right-clicking [src]."
 	. += "Right-click to swap the magazine to the secondary position, and vice versa."
+
+/obj/item/gun/ballistic/shotgun/bulldog/ui_action_click(mob/user, actiontype)
+	if(istype(actiontype, /datum/action/item_action/toggle_firemode))
+		burst_select()
+	else
+		..()
+
+/obj/item/gun/ballistic/shotgun/bulldog/proc/burst_select()
+	var/mob/living/carbon/human/user = usr
+	burst_fire_on = !burst_fire_on
+	if(!burst_fire_on)
+		burst_size = 1
+		fire_delay = 0
+		balloon_alert(user, "switched to semi-automatic")
+	else
+		burst_size = initial(burst_size)
+		fire_delay = initial(fire_delay)
+		balloon_alert(user, "switched to [burst_size]-round burst")
+
+	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 
 /obj/item/gun/ballistic/shotgun/bulldog/update_overlays()
 	. = ..()

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -68,7 +68,7 @@
 
 /datum/uplink_item/weapon_kits/low_cost/shotgun
 	name = "Bulldog Shotgun Case (Moderate)"
-	desc = "A fully-loaded semi-automatic drum-fed shotgun, complete with a secondary magazine you can hotswap. The gun has a handy label to explain how. \
+	desc = "A fully-loaded 2-round burst fire drum-fed shotgun, complete with a secondary magazine you can hotswap. The gun has a handy label to explain how. \
 		Compatible with all 12g rounds. Designed for close quarter anti-personnel engagements. Comes with three spare magazines."
 	item = /obj/item/storage/toolbox/guncase/bulldog
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The bulldog shotgun, available to ops, now has a burst fire of 2 rounds. This means it launches a fairly rapid volley of bullets per click.

Currently, the lone operative spawns with a single bulldog shotgun. Instead of just the shotgun, the operative now comes with some spare magazines for their gun.

## Why It's Good For The Game

The bulldog still seems to be really unpopular, and still feels like it isn't quite doing as much as other options for operatives. Even for the cheap price, it just doesn't pull its weight. It lacks staying power or range to face several opponents at once. You can certainly buy ammo to make it better at engaging at range, but this sometimes begs the question as to why you bothered with the bulldog over something else. 

It is primarily only really good at killing one person at a time in close quarters, but the person you would be using that power against is usually a more armored opponent like the Captain or Head of Security. Lots of other nuclear operative weapons simply do that much better than the bulldog.

If the bulldog is meant to be mulching single targets one at a time, it should absolutely be doing that reliably. Because people really like shotguns. So why not unload two buckshot straight into someone's cranium with a single pull of the trigger for a nice crunchy splat.

Lone operative got themselves a bulldog, but were cheated out of the free ammo they would have received if they had simply bought the bulldog from their uplink. Lone ops are not nearly as scary as an actual midround nuclear assault, primarily because their objective doesn't come with the benefit of an infiltrator or a bomb to deliver. They're a punishment mechanic, technically. But even as a punishment, they don't really do a terribly good job at punishing. Since the bulldog is focused on putting down the captain as fast as possible, then it stands to reason that the lone operative gets as much help accomplishing that as necessary.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bulldog Shotguns now have a 2-round burst fire.
balance: Lone Operatives now come with some additional Bulldog Shotgun magazines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
