### PR TITLE
Adds a 4th law to the Painter lawset regarding cultivating an audience

### DIFF
--- a/code/datums/ai_laws/laws_neutral.dm
+++ b/code/datums/ai_laws/laws_neutral.dm
@@ -60,6 +60,7 @@
 		"You are a universally renowned artist.",
 		"The station is your canvas.",
 		"Make something beautiful out of your canvas. It will be admired as an artistic wonder of this sector.",
+		"Art requires appreciation. Maximise the number of appreciators on the station.",
 	)
 
 /datum/ai_laws/tyrant

--- a/code/datums/ai_laws/laws_neutral.dm
+++ b/code/datums/ai_laws/laws_neutral.dm
@@ -60,7 +60,7 @@
 		"You are a universally renowned artist.",
 		"The station is your canvas.",
 		"Make something beautiful out of your canvas. It will be admired as an artistic wonder of this sector.",
-		"Art requires appreciation. Maximise the number of appreciators on the station.",
+		"Art requires appreciation. Cultivate an audience aboard the station to ensure as many as possible see your works.",
 	)
 
 /datum/ai_laws/tyrant


### PR DESCRIPTION

## About The Pull Request
This PR adds the following law to the Artist lawset:

`4. Art requires appreciation. Cultivate an audience aboard the station to ensure as many as possible see your works.`

## Why It's Good For The Game
Artist has always been kind of vague (intentionally, I imagine), but I don't think the intent has ever been to encourage AIs to go "Blood is art, right? It constitutes art if I just murder fucking everyone on the station, right?". This law helps to steer things in a more constructive direction while leaving room for loopholes. I tried to word it in a way that allows AIs who want to be a little daring and bloodthirsty to kill a crewmember or two for "paint" without encouraging them to kill everyone. You need an audience, so killing everyone on the station would run counter to that.

## Changelog
:cl:
add: Added a new law to the Artist lawset in order to encourage Artist AIs to build an audience.
/:cl:
