### PR TITLE
Fixes bows not loosening their strings once fired

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -264,8 +264,7 @@
 				casing.bounce_away(TRUE)
 				SEND_SIGNAL(casing, COMSIG_CASING_EJECTED)
 		else if(empty_chamber)
-			UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-			chambered = null
+			clear_chambered()
 	if (chamber_next_round && (magazine?.max_ammo > 1))
 		chamber_round()
 


### PR DESCRIPTION
## About The Pull Request
So, there's this one place that could have just called `clear_chambered` because it does the exact same operations, but didn't.

Here's `gun/ballistic/proc/clear_chambered()`:
https://github.com/tgstation/tgstation/blob/ce04e2b7ee279e025bd53e87296e7dfd70b9474a/code/modules/projectiles/guns/ballistic.dm#L285-L288

and here's `gun/ballistic/bow/clear_chambered()`, which is responsible for setting `drawn` to false:
https://github.com/tgstation/tgstation/blob/ce04e2b7ee279e025bd53e87296e7dfd70b9474a/code/modules/projectiles/guns/ballistic/bows/_bow.dm#L52-L54

You can connect the dots.

## Why It's Good For The Game
This will fix #81462.

## Changelog


:cl:
fix: Fixed (cross)bows' strings not loosening once fired.
/:cl:
