### PR TITLE
Universalizing ruin names 

### DIFF
--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -13,62 +13,62 @@
 // above ground only
 
 /datum/map_template/ruin/icemoon/gas
-	name = "Lizard Gas Station"
+	name = "Ice-Ruin Lizard Gas Station"
 	id = "lizgasruin"
 	description = "A gas station. It appears to have been recently open and is in mint condition."
 	suffix = "icemoon_surface_gas.dmm"
 
 /datum/map_template/ruin/icemoon/lust
-	name = "Ruin of Lust"
+	name = "Ice-Ruin Ruin of Lust"
 	id = "lust"
 	description = "Not exactly what you expected."
 	suffix = "icemoon_surface_lust.dmm"
 
 /datum/map_template/ruin/icemoon/asteroid
-	name = "Asteroid Site"
+	name = "Ice-Ruin Asteroid Site"
 	id = "asteroidsite"
 	description = "Surprised to see us here?"
 	suffix = "icemoon_surface_asteroid.dmm"
 
 /datum/map_template/ruin/icemoon/engioutpost
-	name = "Engineer Outpost"
+	name = "Ice-Ruin Engineer Outpost"
 	id = "engioutpost"
 	description = "Blown up by an unfortunate accident."
 	suffix = "icemoon_surface_engioutpost.dmm"
 
 /datum/map_template/ruin/icemoon/fountain
-	name = "Fountain Hall"
+	name = "Ice-Ruin Fountain Hall"
 	id = "ice_fountain"
 	description = "The fountain has a warning on the side. DANGER: May have undeclared side effects that only become obvious when implemented."
 	prefix = "_maps/RandomRuins/AnywhereRuins/"
 	suffix = "fountain_hall.dmm"
 
 /datum/map_template/ruin/icemoon/abandoned_homestead
-	name = "Abandoned Homestead"
+	name = "Ice-Ruin Abandoned Homestead"
 	id = "abandoned_homestead"
 	description = "This homestead was once host to a happy homesteading family. It's now host to hungry bears."
 	suffix = "icemoon_underground_abandoned_homestead.dmm"
 
 /datum/map_template/ruin/icemoon/entemology
-	name = "Insect Research Station"
+	name = "Ice-Ruin Insect Research Station"
 	id = "bug_habitat"
 	description = "An independently funded research outpost, long abandoned. Their mission, to boldly go where no insect life would ever live, ever, and look for bugs."
 	suffix = "icemoon_surface_bughabitat.dmm"
 
 /datum/map_template/ruin/icemoon/pizza
-	name = "Moffuchi's Pizzeria"
+	name = "Ice-Ruin Moffuchi's Pizzeria"
 	id = "pizzeria"
 	description = "Moffuchi's Family Pizzeria chain has a reputation for providing affordable artisanal meals of questionable edibility. This particular pizzeria seems to have been abandoned for some time."
 	suffix = "icemoon_surface_pizza.dmm"
 
 /datum/map_template/ruin/icemoon/frozen_phonebooth
-	name = "Frozen Phonebooth"
+	name = "Ice-Ruin Frozen Phonebooth"
 	id = "frozen_phonebooth"
 	description = "A venture by nanotrasen to help popularize the use of holopads. This one was sent to a icemoon."
 	suffix = "icemoon_surface_phonebooth.dmm"
 
 /datum/map_template/ruin/icemoon/smoking_room
-	name = "Smoking Room"
+	name = "Ice-Ruin Smoking Room"
 	id = "smoking_room"
 	description = "Here lies Charles Morlbaro. He died the way he lived."
 	suffix = "icemoon_surface_smoking_room.dmm"
@@ -76,7 +76,7 @@
 // above and below ground together
 
 /datum/map_template/ruin/icemoon/mining_site
-	name = "Mining Site"
+	name = "Ice-Ruin Mining Site"
 	id = "miningsite"
 	description = "Ruins of a site where people once mined with primitive tools for ore."
 	suffix = "icemoon_surface_mining_site.dmm"
@@ -84,7 +84,7 @@
 	always_spawn_with = list(/datum/map_template/ruin/icemoon/underground/mining_site_below = PLACE_BELOW)
 
 /datum/map_template/ruin/icemoon/underground/mining_site_below
-	name = "Mining Site Underground"
+	name = "Ice-Ruin Mining Site Underground"
 	id = "miningsite-underground"
 	description = "Who knew ladders could be so useful?"
 	suffix = "icemoon_underground_mining_site.dmm"
@@ -94,60 +94,60 @@
 // below ground only
 
 /datum/map_template/ruin/icemoon/underground
-	name = "underground ruin"
+	name = "Ice-Ruin underground ruin"
 	ruin_type = ZTRAIT_ICE_RUINS_UNDERGROUND
 	default_area = /area/icemoon/underground/unexplored
 
 /datum/map_template/ruin/icemoon/underground/abandonedvillage
-	name = "Abandoned Village"
+	name = "Ice-Ruin Abandoned Village"
 	id = "abandonedvillage"
 	description = "Who knows what lies within?"
 	suffix = "icemoon_underground_abandoned_village.dmm"
 
 /datum/map_template/ruin/icemoon/underground/library
-	name = "Buried Library"
+	name = "Ice-Ruin Buried Library"
 	id = "buriedlibrary"
 	description = "A once grand library, now lost to the confines of the Ice Moon."
 	suffix = "icemoon_underground_library.dmm"
 
 /datum/map_template/ruin/icemoon/underground/wrath
-	name = "Ruin of Wrath"
+	name = "Ice-Ruin Ruin of Wrath"
 	id = "wrath"
 	description = "You'll fight and fight and just keep fighting."
 	suffix = "icemoon_underground_wrath.dmm"
 
 /datum/map_template/ruin/icemoon/underground/hermit
-	name = "Frozen Shack"
+	name = "Ice-Ruin Frozen Shack"
 	id = "hermitshack"
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "icemoon_underground_hermit.dmm"
 
 /datum/map_template/ruin/icemoon/underground/lavaland
-	name = "Lavaland Site"
+	name = "Ice-Ruin Lavaland Site"
 	id = "lavalandsite"
 	description = "I guess we never really left you huh?"
 	suffix = "icemoon_underground_lavaland.dmm"
 
 /datum/map_template/ruin/icemoon/underground/puzzle
-	name = "Ancient Puzzle"
+	name = "Ice-Ruin Ancient Puzzle"
 	id = "puzzle"
 	description = "Mystery to be solved."
 	suffix = "icemoon_underground_puzzle.dmm"
 
 /datum/map_template/ruin/icemoon/underground/bathhouse
-	name = "Bath House"
+	name = "Ice-Ruin Bath House"
 	id = "bathhouse"
 	description = "A warm, safe place."
 	suffix = "icemoon_underground_bathhouse.dmm"
 
 /datum/map_template/ruin/icemoon/underground/wendigo_cave
-	name = "Wendigo Cave"
+	name = "Ice-Ruin Wendigo Cave"
 	id = "wendigocave"
 	description = "Into the jaws of the beast."
 	suffix = "icemoon_underground_wendigo_cave.dmm"
 
 /datum/map_template/ruin/icemoon/underground/free_golem
-	name = "Free Golem Ship"
+	name = "Ice-Ruin Free Golem Ship"
 	id = "golem-ship"
 	description = "Lumbering humanoids, made out of precious metals, move inside this ship. They frequently leave to mine more minerals, which they somehow turn into more of them. \
 	Seem very intent on research and individual liberty, and also geology-based naming?"
@@ -155,33 +155,33 @@
 	suffix = "golem_ship.dmm"
 
 /datum/map_template/ruin/icemoon/underground/mailroom
-	name = "Frozen-over Post Office"
+	name = "Ice-Ruin Frozen-over Post Office"
 	id = "mailroom"
 	description = "This is where all of your paychecks went. Signed, the management."
 	suffix = "icemoon_underground_mailroom.dmm"
 
 /datum/map_template/ruin/icemoon/underground/frozen_comms
-	name = "Frozen Communicatons Outpost"
+	name = "Ice-Ruin Frozen Communicatons Outpost"
 	id = "frozen_comms"
 	description = "3 Peaks Radio, where the 2000's live forever."
 	suffix = "icemoon_underground_frozen_comms.dmm"
 
 //TODO: Bottom-Level ONLY Spawns after Refactoring Related Code
 /datum/map_template/ruin/icemoon/underground/plasma_facility
-	name = "Abandoned Plasma Facility"
+	name = "Ice-Ruin Abandoned Plasma Facility"
 	id = "plasma_facility"
 	description = "Rumors have developed over the many years of Freyja plasma mining. These rumors suggest that the ghosts of dead mistreated excavation staff have returned to \
 	exact revenge on their (now former) employers. Coorperate reminds all staff that rumors are just that: Old Housewife tales meant to scare misbehaving kids to bed."
 	suffix = "icemoon_underground_abandoned_plasma_facility.dmm"
 
 /datum/map_template/ruin/icemoon/underground/hotsprings
-	name = "Hot Springs"
+	name = "Ice-Ruin Hot Springs"
 	id = "hotsprings"
 	description = "Just relax and take a dip, nothing will go wrong, I swear!"
 	suffix = "icemoon_underground_hotsprings.dmm"
 
 /datum/map_template/ruin/icemoon/underground/vent
-	name = "Icemoon Ore Vent"
+	name = "Ice-Ruin Icemoon Ore Vent"
 	id = "ore_vent_i"
 	description = "A vent that spews out ore. Seems to be a natural phenomenon." //Make this a subtype that only spawns medium and large vents. Some smalls will go to the top level.
 	suffix = "icemoon_underground_ore_vent.dmm"
@@ -191,7 +191,7 @@
 	always_place = TRUE
 
 /datum/map_template/ruin/icemoon/ruin/vent
-	name = "Surface Icemoon Ore Vent"
+	name = "Ice-Ruin Surface Icemoon Ore Vent"
 	id = "ore_vent_i"
 	description = "A vent that spews out ore. Seems to be a natural phenomenon. Smaller than the underground ones."
 	suffix = "icemoon_surface_ore_vent.dmm"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -10,27 +10,27 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/biodome/beach
-	name = "Biodome Beach"
+	name = "Lava-Ruin Biodome Beach"
 	id = "biodome-beach"
 	description = "Seemingly plucked from a tropical destination, this beach is calm and cool, with the salty waves roaring softly in the background. \
 	Comes with a rustic wooden bar and suicidal bartender."
 	suffix = "lavaland_biodome_beach.dmm"
 
 /datum/map_template/ruin/lavaland/biodome/winter
-	name = "Biodome Winter"
+	name = "Lava-Ruin Biodome Winter"
 	id = "biodome-winter"
 	description = "For those getaways where you want to get back to nature, but you don't want to leave the fortified military compound where you spend your days. \
 	Includes a unique(*) laser pistol display case, and the recently introduced I.C.E(tm)."
 	suffix = "lavaland_surface_biodome_winter.dmm"
 
 /datum/map_template/ruin/lavaland/biodome/clown
-	name = "Biodome Clown Planet"
+	name = "Lava-Ruin Biodome Clown Planet"
 	id = "biodome-clown"
 	description = "WELCOME TO CLOWN PLANET! HONK HONK HONK etc.!"
 	suffix = "lavaland_biodome_clown_planet.dmm"
 
 /datum/map_template/ruin/lavaland/cube
-	name = "The Wishgranter Cube"
+	name = "Lava-Ruin The Wishgranter Cube"
 	id = "wishgranter-cube"
 	description = "Nothing good can come from this. Learn from their mistakes and turn around."
 	suffix = "lavaland_surface_cube.dmm"
@@ -38,7 +38,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/seed_vault
-	name = "Seed Vault"
+	name = "Lava-Ruin Seed Vault"
 	id = "seed-vault"
 	description = "The creators of these vaults were a highly advanced and benevolent race, and launched many into the stars, hoping to aid fledgling civilizations. \
 	However, all the inhabitants seem to do is grow drugs and guns."
@@ -47,7 +47,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/ash_walker
-	name = "Ash Walker Nest"
+	name = "Lava-Ruin Ash Walker Nest"
 	id = "ash-walker"
 	description = "A race of unbreathing lizards live here, that run faster than a human can, worship a broken dead city, and are capable of reproducing by something involving tentacles? \
 	Probably best to stay clear."
@@ -56,7 +56,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/syndicate_base
-	name = "Syndicate Lava Base"
+	name = "Lava-Ruin Syndicate Lava Base"
 	id = "lava-base"
 	description = "A secret base researching illegal bioweapons, it is closely guarded by an elite team of syndicate agents."
 	suffix = "lavaland_surface_syndicate_base1.dmm"
@@ -64,7 +64,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/free_golem
-	name = "Free Golem Ship"
+	name = "Lava-Ruin Free Golem Ship"
 	id = "golem-ship"
 	description = "Lumbering humanoids, made out of precious metals, move inside this ship. They frequently leave to mine more minerals, which they somehow turn into more of them. \
 	Seem very intent on research and individual liberty, and also geology-based naming?"
@@ -74,7 +74,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/gaia
-	name = "Patch of Eden"
+	name = "Lava-Ruin Patch of Eden"
 	id = "gaia"
 	description = "Who would have thought that such a peaceful place could be on such a horrific planet?"
 	cost = 5
@@ -86,32 +86,32 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/sin/envy
-	name = "Ruin of Envy"
+	name = "Lava-Ruin Ruin of Envy"
 	id = "envy"
 	description = "When you get what they have, then you'll finally be happy."
 	suffix = "lavaland_surface_envy.dmm"
 
 /datum/map_template/ruin/lavaland/sin/gluttony
-	name = "Ruin of Gluttony"
+	name = "Lava-Ruin Ruin of Gluttony"
 	id = "gluttony"
 	description = "If you eat enough, then eating will be all that you do."
 	suffix = "lavaland_surface_gluttony.dmm"
 
 /datum/map_template/ruin/lavaland/sin/greed
-	name = "Ruin of Greed"
+	name = "Lava-Ruin Ruin of Greed"
 	id = "greed"
 	description = "Sure you don't need magical powers, but you WANT them, and \
 		that's what's important."
 	suffix = "lavaland_surface_greed.dmm"
 
 /datum/map_template/ruin/lavaland/sin/pride
-	name = "Ruin of Pride"
+	name = "Lava-Ruin Ruin of Pride"
 	id = "pride"
 	description = "Wormhole lifebelts are for LOSERS, whom you are better than."
 	suffix = "lavaland_surface_pride.dmm"
 
 /datum/map_template/ruin/lavaland/sin/sloth
-	name = "Ruin of Sloth"
+	name = "Lava-Ruin Ruin of Sloth"
 	id = "sloth"
 	description = "..."
 	suffix = "lavaland_surface_sloth.dmm"
@@ -119,7 +119,7 @@
 	cost = 0
 
 /datum/map_template/ruin/lavaland/ratvar
-	name = "Dead God"
+	name = "Lava-Ruin Dead God"
 	id = "ratvar"
 	description = "Ratvar's final resting place."
 	suffix = "lavaland_surface_dead_ratvar.dmm"
@@ -127,7 +127,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/hierophant
-	name = "Hierophant's Arena"
+	name = "Lava-Ruin Hierophant's Arena"
 	id = "hierophant"
 	description = "A strange, square chunk of metal of massive size. Inside awaits only death and many, many squares."
 	suffix = "lavaland_surface_hierophant.dmm"
@@ -135,7 +135,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/blood_drunk_miner
-	name = "Blood-Drunk Miner"
+	name = "Lava-Ruin Blood-Drunk Miner"
 	id = "blooddrunk"
 	description = "A strange arrangement of stone tiles and an insane, beastly miner contemplating them."
 	suffix = "lavaland_surface_blooddrunk1.dmm"
@@ -143,15 +143,15 @@
 	allow_duplicates = FALSE //will only spawn one variant of the ruin
 
 /datum/map_template/ruin/lavaland/blood_drunk_miner/guidance
-	name = "Blood-Drunk Miner (Guidance)"
+	name = "Lava-Ruin Blood-Drunk Miner (Guidance)"
 	suffix = "lavaland_surface_blooddrunk2.dmm"
 
 /datum/map_template/ruin/lavaland/blood_drunk_miner/hunter
-	name = "Blood-Drunk Miner (Hunter)"
+	name = "Lava-Ruin Blood-Drunk Miner (Hunter)"
 	suffix = "lavaland_surface_blooddrunk3.dmm"
 
 /datum/map_template/ruin/lavaland/blood_drunk_miner/random
-	name = "Blood-Drunk Miner (Random)"
+	name = "Lava-Ruin Blood-Drunk Miner (Random)"
 	suffix = null
 	always_place = TRUE
 
@@ -160,14 +160,14 @@
 	return ..()
 
 /datum/map_template/ruin/lavaland/ufo_crash
-	name = "UFO Crash"
+	name = "Lava-Ruin UFO Crash"
 	id = "ufo-crash"
 	description = "Turns out that keeping your abductees unconscious is really important. Who knew?"
 	suffix = "lavaland_surface_ufo_crash.dmm"
 	cost = 5
 
 /datum/map_template/ruin/lavaland/xeno_nest
-	name = "Xenomorph Nest"
+	name = "Lava-Ruin Xenomorph Nest"
 	id = "xeno-nest"
 	description = "These xenomorphs got bored of horrifically slaughtering people on space stations, and have settled down on a nice lava-filled hellscape to focus on what's really important in life. \
 	Quality memes."
@@ -175,7 +175,7 @@
 	cost = 20
 
 /datum/map_template/ruin/lavaland/fountain
-	name = "Fountain Hall"
+	name = "Lava-Ruin Fountain Hall"
 	id = "lava_fountain"
 	description = "The fountain has a warning on the side. DANGER: May have undeclared side effects that only become obvious when implemented."
 	prefix = "_maps/RandomRuins/AnywhereRuins/"
@@ -183,14 +183,14 @@
 	cost = 5
 
 /datum/map_template/ruin/lavaland/survivalcapsule
-	name = "Survival Capsule Ruins"
+	name = "Lava-Ruin Survival Capsule Ruins"
 	id = "survivalcapsule"
 	description = "What was once sanctuary to the common miner, is now their tomb."
 	suffix = "lavaland_surface_survivalpod.dmm"
 	cost = 5
 
 /datum/map_template/ruin/lavaland/pizza
-	name = "Ruined Pizza Party"
+	name = "Lava-Ruin Ruined Pizza Party"
 	id = "pizza"
 	description = "Little Timmy's birthday pizza bash took a turn for the worse when a bluespace anomaly passed by."
 	suffix = "lavaland_surface_pizzaparty.dmm"
@@ -198,7 +198,7 @@
 	cost = 5
 
 /datum/map_template/ruin/lavaland/cultaltar
-	name = "Summoning Ritual"
+	name = "Lava-Ruin Summoning Ritual"
 	id = "cultaltar"
 	description = "A place of vile worship, the scrawling of blood in the middle glowing eerily. A demonic laugh echoes throughout the caverns."
 	suffix = "lavaland_surface_cultaltar.dmm"
@@ -206,7 +206,7 @@
 	cost = 10
 
 /datum/map_template/ruin/lavaland/hermit
-	name = "Makeshift Shelter"
+	name = "Lava-Ruin Makeshift Shelter"
 	id = "hermitcave"
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "lavaland_surface_hermit.dmm"
@@ -214,7 +214,7 @@
 	cost = 10
 
 /datum/map_template/ruin/lavaland/miningripley
-	name = "Ripley"
+	name = "Lava-Ruin Ripley"
 	id = "ripley"
 	description = "A heavily-damaged mining ripley, property of a very unfortunate miner. You might have to do a bit of work to fix this thing up."
 	suffix = "lavaland_surface_random_ripley.dmm"
@@ -222,14 +222,14 @@
 	cost = 5
 
 /datum/map_template/ruin/lavaland/dark_wizards
-	name = "Dark Wizard Altar"
+	name = "Lava-Ruin Dark Wizard Altar"
 	id = "dark_wizards"
 	description = "A ruin with dark wizards. What secret do they guard?"
 	suffix = "lavaland_surface_wizard.dmm"
 	cost = 5
 
 /datum/map_template/ruin/lavaland/strong_stone
-	name = "Strong Stone"
+	name = "Lava-Ruin Strong Stone"
 	id = "strong_stone"
 	description = "A stone that seems particularly powerful."
 	suffix = "lavaland_strong_rock.dmm"
@@ -237,14 +237,14 @@
 	cost = 2
 
 /datum/map_template/ruin/lavaland/puzzle
-	name = "Ancient Puzzle"
+	name = "Lava-Ruin Ancient Puzzle"
 	id = "puzzle"
 	description = "Mystery to be solved."
 	suffix = "lavaland_surface_puzzle.dmm"
 	cost = 5
 
 /datum/map_template/ruin/lavaland/elite_tumor
-	name = "Pulsating Tumor"
+	name = "Lava-Ruin Pulsating Tumor"
 	id = "tumor"
 	description = "A strange tumor which houses a powerful beast..."
 	suffix = "lavaland_surface_elite_tumor.dmm"
@@ -253,7 +253,7 @@
 	allow_duplicates = TRUE
 
 /datum/map_template/ruin/lavaland/elephant_graveyard
-	name = "Elephant Graveyard"
+	name = "Lava-Ruin Elephant Graveyard"
 	id = "Graveyard"
 	description = "An abandoned graveyard, calling to those unable to continue."
 	suffix = "lavaland_surface_elephant_graveyard.dmm"
@@ -261,7 +261,7 @@
 	cost = 10
 
 /datum/map_template/ruin/lavaland/bileworm_nest
-	name = "Bileworm Nest"
+	name = "Lava-Ruin Bileworm Nest"
 	id = "bileworm_nest"
 	description = "A small sanctuary from the harsh wilderness... if you're a bileworm, that is."
 	cost = 5
@@ -269,7 +269,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/lava_phonebooth
-	name = "Phonebooth"
+	name = "Lava-Ruin Phonebooth"
 	id = "lava_phonebooth"
 	description = "A venture by nanotrasen to help popularize the use of holopads. This one somehow made its way here."
 	suffix = "lavaland_surface_phonebooth.dmm"
@@ -277,7 +277,7 @@
 	cost = 5
 
 /datum/map_template/ruin/lavaland/battle_site
-	name = "Battle Site"
+	name = "Lava-Ruin Battle Site"
 	id = "battle_site"
 	description = "The long past site of a battle between beast and humanoids. The victor is unknown, but the losers are clear."
 	suffix = "lavaland_battle_site.dmm"
@@ -285,7 +285,7 @@
 	cost = 3
 
 /datum/map_template/ruin/lavaland/vent
-	name = "Ore Vent"
+	name = "Lava-Ruin Ore Vent"
 	id = "ore_vent"
 	description = "A vent that spews out ore. Seems to be a natural phenomenon."
 	suffix = "lavaland_surface_ore_vent.dmm"
@@ -295,7 +295,7 @@
 	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/watcher_grave
-	name = "Watchers' Grave"
+	name = "Lava-Ruin Watchers' Grave"
 	id = "watcher-grave"
 	description = "A lonely cave where an orphaned child awaits a new parent."
 	suffix = "lavaland_surface_watcher_grave.dmm"
@@ -303,7 +303,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/mook_village
-	name = "Mook Village"
+	name = "Lava-Ruin Mook Village"
 	id = "mook_village"
 	description = "A village hosting a community of friendly mooks!"
 	suffix = "lavaland_surface_mookvillage.dmm"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -469,7 +469,7 @@
 /datum/map_template/ruin/space/space_phonebooth
 	id = "Space_phonebooth"
 	suffix = "phonebooth.dmm"
-	name = "Space-Ruin Space Phonebooth"
+	name = "Space-Ruin Phonebooth"
 	description = "A venture by nanotrasen to help popularize the use of holopads."
 
 /datum/map_template/ruin/space/the_outlet

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -10,65 +10,65 @@
 /datum/map_template/ruin/space/zoo
 	id = "zoo"
 	suffix = "abandonedzoo.dmm"
-	name = "Biological Storage Facility"
+	name = "Space-Ruin Biological Storage Facility"
 	description = "In case society crumbles, we will be able to restore our zoos to working order with the breeding stock kept in these 100% secure and unbreachable storage facilities. \
 	At no point has anything escaped. That's our story, and we're sticking to it."
 
 /datum/map_template/ruin/space/asteroid1
 	id = "asteroid1"
 	suffix = "asteroid1.dmm"
-	name = "Asteroid 1"
+	name = "Space-Ruin Asteroid 1"
 	description = "I-spy with my little eye, something beginning with R."
 
 /datum/map_template/ruin/space/asteroid2
 	id = "asteroid2"
 	suffix = "asteroid2.dmm"
-	name = "Asteroid 2"
+	name = "Space-Ruin Asteroid 2"
 	description = "Oh my god, a giant rock!"
 
 /datum/map_template/ruin/space/asteroid3
 	id = "asteroid3"
 	suffix = "asteroid3.dmm"
-	name = "Asteroid 3"
+	name = "Space-Ruin Asteroid 3"
 	description = "This asteroid floating in space has no official designation, because the scientist that discovered it deemed it 'super dull'."
 
 /datum/map_template/ruin/space/asteroid4
 	id = "asteroid4"
 	suffix = "asteroid4.dmm"
-	name = "Asteroid 4"
+	name = "Space-Ruin Asteroid 4"
 	description = "Nanotrasen Escape Pods have a 100%* success rate, and a 99%* customer satisfaction rate. \
 	*Please note that these statistics are taken from pods that have successfully docked with a recovery vessel."
 
 /datum/map_template/ruin/space/asteroid5
 	id = "asteroid5"
 	suffix = "asteroid5.dmm"
-	name = "Asteroid 5"
+	name = "Space-Ruin Asteroid 5"
 	description = "Oh my god, another giant rock!"
 
 /datum/map_template/ruin/space/asteroid6
 	id = "asteroid6"
 	suffix = "asteroid6.dmm"
-	name = "Asteroid 6"
+	name = "Space-Ruin Asteroid 6"
 	description = "This asteroid has brittle bone disease, so it is fortunate asteroids dont have bones."
 
 /datum/map_template/ruin/space/deep_storage
 	id = "deep-storage"
 	suffix = "deepstorage.dmm"
-	name = "Survivalist Bunker"
+	name = "Space-Ruin Survivalist Bunker"
 	description = "Assume the best, prepare for the worst. Generally, you should do so by digging a three-man heavily fortified bunker into a giant unused asteroid. \
 	Then make it self sufficient, mask any evidence of construction, hook it covertly into the telecommunications network and hope for the best."
 
 /datum/map_template/ruin/space/bigderelict1
 	id = "bigderelict1"
 	suffix = "bigderelict1.dmm"
-	name = "Derelict Tradepost"
+	name = "Space-Ruin Derelict Tradepost"
 	description = "A once-bustling tradestation that handled imports and exports from nearby stations now lays eerily dormant. \
 	The last received message was a distress call from one of the on-board officers, but we had no success in making contact again."
 
 /datum/map_template/ruin/space/derelict_construction
 	id = "derelict_construction"
 	suffix = "derelict_construction.dmm"
-	name = "Derelict Construction"
+	name = "Space-Ruin Derelict Construction"
 	description = "Construction supplies are in high demand due to non-trivial damage routinely sustained by most space stations in this sector. \
 	Space pirates who dont attempt to rob corporate research stations with only 3 collaborators live long enough to sell captured construction \
 	equipment back to the highest bidder."
@@ -76,14 +76,14 @@
 /datum/map_template/ruin/space/derelict_sulaco
 	id = "derelict_sulaco"
 	suffix = "derelict_sulaco.dmm"
-	name = "Derelict Sulaco"
+	name = "Space-Ruin Derelict Sulaco"
 	description = "Nothing to see here citizen, move along, certainly no xeno outbreaks here. That purple stuff? It's uh... space nectar... but don't eat it! \
 	It's the bridge of a top secret military ship."
 
 /datum/map_template/ruin/space/derelict2
 	id = "derelict2"
 	suffix = "derelict2.dmm"
-	name = "Dinner for Two"
+	name = "Space-Ruin Dinner for Two"
 	description = "Oh this is the night\n\
 		It's a beautiful night\n\
 		And we call it bella notte"
@@ -91,161 +91,161 @@
 /datum/map_template/ruin/space/derelict3
 	id = "derelict3"
 	suffix = "derelict3.dmm"
-	name = "Derelict 3"
+	name = "Space-Ruin Derelict 3"
 	description = "These hulks were once part of a larger structure, where the three great \[REDACTED\] were forged."
 
 /datum/map_template/ruin/space/derelict4
 	id = "derelict4"
 	suffix = "derelict4.dmm"
-	name = "Derelict 4"
+	name = "Space-Ruin Derelict 4"
 	description = "CentCom ferries have never crashed, will never crash, there is no current investigation into a crashed ferry, and we will not let Internal Affairs trample over high security \
 	information in the name of this baseless witchhunt."
 
 /datum/map_template/ruin/space/derelict5
 	id = "derelict5"
 	suffix = "derelict5.dmm"
-	name = "Derelict 5"
+	name = "Space-Ruin Derelict 5"
 	description = "The plan is, we put a whole bunch of crates full of treasure in this disused warehouse, launch it into space, and then ignore it. Forever."
 
 /datum/map_template/ruin/space/derelict6
 	id = "derelict6"
 	suffix = "derelict6.dmm"
-	name = "Derelict 6"
+	name = "Space-Ruin Derelict 6"
 	description = "The hush-hush of Nanotrasen when it comes to stations seemingly vanishing off the radar is an interesting topic, theories of nuclear destruction float about while Nanotrasen \
 	flat-out denies said stations ever existing."
 
 /datum/map_template/ruin/space/derelict7
 	id = "derelict7"
 	suffix = "derelict7.dmm"
-	name = "Derelict 7"
+	name = "Space-Ruin Derelict 7"
 	description = "The official report says there was a 'huge explosion' which was 'radical' and 'tubular'. Nothing is said about the explosion's cause."
 
 /datum/map_template/ruin/space/derelict8
 	id = "derelict8"
 	suffix = "derelict8.dmm"
-	name = "Derelict 8"
+	name = "Space-Ruin Derelict 8"
 	description = "An auxiliary storage bay might be the least respected room on any functional station, but studies show they are the least likely to be hit in an artillery strike."
 
 /datum/map_template/ruin/space/derelict9
 	id = "derelict9"
 	suffix = "derelict9.dmm"
-	name = "Derelict 9"
+	name = "Space-Ruin Derelict 9"
 	description = "Someone already found this high-security supply cache already, but were unable to get inside. Perhaps the next visitor will have more luck."
 
 /datum/map_template/ruin/space/empty_shell
 	id = "empty-shell"
 	suffix = "emptyshell.dmm"
-	name = "Empty Shell"
+	name = "Space-Ruin Empty Shell"
 	description = "Cosy, rural property available for young professional couple. Only twelve parsecs from the nearest hyperspace lane!"
 
 /datum/map_template/ruin/space/the_lizards_gas
 	id = "the-lizards-gas"
 	suffix = "thelizardsgas.dmm"
-	name = "The Lizard's Gas"
+	name = "Space-Ruin The Lizard's Gas"
 	description = "A refueling station stocked with enough plasma for any space-worthy vessel. Well, maybe if it weren't 50 years ago."
 
 /datum/map_template/ruin/space/intact_empty_ship
 	id = "intact-empty-ship"
 	suffix = "intactemptyship.dmm"
-	name = "Authorship"
+	name = "Space-Ruin Authorship"
 	description = "Just somewhere quiet, where I can focus on my work with no interruptions."
 
 /datum/map_template/ruin/space/caravanambush
 	id = "caravanambush"
 	suffix = "caravanambush.dmm"
-	name = "Syndicate Ambush"
+	name = "Space-Ruin Syndicate Ambush"
 	description = "A caravan route used by passing cargo freights has been ambushed by a salvage team manned by the syndicate. \
 	The caravan managed to send off a distress message before being surrounded, their video feed cutting off as the sound of gunfire and a parrot was heard."
 
 /datum/map_template/ruin/space/originalcontent
 	id = "paperwizard"
 	suffix = "originalcontent.dmm"
-	name = "A Giant Ball of Paper in Space"
+	name = "Space-Ruin A Giant Ball of Paper in Space"
 	description = "Sightings of a giant wad of paper hurling through the depths of space have been recently reported by multiple outposts near this sector. \
 	A giant wad of paper, really? Damn prank callers."
 
 /datum/map_template/ruin/space/mech_transport
 	id = "mech-transport"
 	suffix = "mechtransport.dmm"
-	name = "CF Corsair"
+	name = "Space-Ruin CF Corsair"
 	description = "Well, when is it getting here? I have bills to pay; very well-armed clients who want their shipments as soon as possible! I don't care, just find it!"
 
 /datum/map_template/ruin/space/onehalf
 	id = "onehalf"
 	suffix = "onehalf.dmm"
-	name = "DK Excavator 453"
+	name = "Space-Ruin DK Excavator 453"
 	description = "Based on the trace elements we've detected on the gutted asteroids, we suspect that a mining ship using a restricted engine is somewhere in the area. \
 	We'd like to request a patrol vessel to investigate."
 
 /datum/map_template/ruin/space/spacehotel
 	id = "spacehotel"
 	suffix = "spacehotel.dmm"
-	name = "The Twin-Nexus Hotel"
+	name = "Space-Ruin The Twin-Nexus Hotel"
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 
 /datum/map_template/ruin/space/turreted_outpost
 	id = "turreted-outpost"
 	suffix = "turretedoutpost.dmm"
-	name = "Unnamed Turreted Outpost"
+	name = "Space-Ruin Unnamed Turreted Outpost"
 	description = "We'd ask them to stop blaring that ruskiepop music, but none of us are brave enough to go near those death turrets they have."
 
 /datum/map_template/ruin/space/oldshuttle
 	id = "spaceman-origins"
 	suffix = "shuttlerelic.dmm"
-	name = "Strange Ship"
+	name = "Space-Ruin Strange Ship"
 	description = "A ship seemingly lost, drifting along the stars. This thing looks like it belongs in ancient times."
 
 /datum/map_template/ruin/space/way_home
 	id = "way-home"
 	suffix = "way_home.dmm"
-	name = "Salvation"
+	name = "Space-Ruin Salvation"
 	description = "In the darkest times, we will find our way home."
 
 /datum/map_template/ruin/space/djstation
 	id = "djstation"
 	suffix = "dj_station.dmm"
-	name = "DJ Station"
+	name = "Space-Ruin DJ Station"
 	description = "Until very recently this pirate radio station was used to harangue local space stations over a variety of perceived \"ethics violations\". \
 	It seems like someone finally got sick of it, but the equipment still works."
 
 /datum/map_template/ruin/space/thederelict
 	id = "thederelict"
 	suffix = "russian_derelict.dmm"
-	name = "Kosmicheskaya Stantsiya 13"
+	name = "Space-Ruin Kosmicheskaya Stantsiya 13"
 	description = "The true fate of Kosmicheskaya Stantsiya 13 is an open question to this day. Most corporations deny its existence, for fear of questioning on what became of its crew."
 
 /datum/map_template/ruin/space/abandonedteleporter
 	id = "abandonedteleporter"
 	suffix = "abandonedteleporter.dmm"
-	name = "Abandoned Teleporter"
+	name = "Space-Ruin Abandoned Teleporter"
 	description = "In space construction the teleporter is often the first system brought online. \
 	This lonely, half-built teleporter is a sign of a proposed structure that for one reason or another just never got built."
 
 /datum/map_template/ruin/space/crashedclownship
 	id = "crashedclownship"
 	suffix = "crashedclownship.dmm"
-	name = "Crashed Clown Ship"
+	name = "Space-Ruin Crashed Clown Ship"
 	description = "For centuries the promise of a new clown homeworld has been the siren call for countless clown vessels. \
 	Alas, the clown's lust for shenanigans means that successful voyages are almost unheard of, with most vessels falling to hilarious consequences almost immediately."
 
 /datum/map_template/ruin/space/crashedship
 	id = "crashedship"
 	suffix = "crashedship.dmm"
-	name = "Crashed Ship"
+	name = "Space-Ruin Crashed Ship"
 	description = "The SSCV Atrus was chartered to survey over 600 planets in its maiden voyage. \
 	Hopefully the SSC is content with an indepth analysis of just this asteroid."
 
 /datum/map_template/ruin/space/listeningstation
 	id = "listeningstation"
 	suffix = "listeningstation.dmm"
-	name = "Syndicate Listening Station"
+	name = "Space-Ruin Syndicate Listening Station"
 	description = "Listening stations form the backbone of the syndicate's information-gathering operations. \
 	Assignment to these stations is dreaded by most agents, as it entails long and lonely shifts listening to nearby stations chatter incessantly about the most meaningless things."
 
 /datum/map_template/ruin/space/old_ai_sat
 	id = "oldAIsat"
 	suffix = "oldAIsat.dmm"
-	name = "Abandoned Telecommunications Satellite"
+	name = "Space-Ruin Abandoned Telecommunications Satellite"
 	description = "When the inspector told the employees that they were all fired, and that their jobs \"could be done by trained lizards anyway\", they reacted badly. \
 	This event and others is the reason why Central always sends an ERT squad with their competent inspectors. Incompetent inspectors are told they can \"do it alone\" because they're \"that pro\". \
 	Incompetent inspectors believe this."
@@ -253,258 +253,258 @@
 /datum/map_template/ruin/space/oldteleporter
 	id = "oldteleporter"
 	suffix = "oldteleporter.dmm"
-	name = "Detached Teleporter"
+	name = "Space-Ruin Detached Teleporter"
 	description = "The structure of this surprisingly intact teleporter suggests that it was once part of a larger structure, but what remains of said structure, if anything, can only be guessed at."
 
 /datum/map_template/ruin/space/vaporwave
 	id = "vaporwave"
 	suffix = "vaporwave.dmm"
-	name = "Aesthetic Outpost"
+	name = "Space-Ruin Aesthetic Outpost"
 	description = "Pause and remember-- You are unique.You are special. Every mistake, trial, and hardship has helped to sculpt your real beauty. \
 	Stop hating yourself and start appreciating and loving yourself!"
 
 /datum/map_template/ruin/space/bus
 	id = "bus"
 	suffix = "bus.dmm"
-	name = "Waylaid Buses"
+	name = "Space-Ruin Waylaid Buses"
 	description = "There seems to be a pair of buses that pulled over for repairs. What were they doing...? Their shipment sure  seems to be filled with a strange mix. \
 	Anyway, it looks like some people tried to fix it up for a long time but didn't really get anywhere..."
 
 /datum/map_template/ruin/space/oldstation
 	id = "oldstation"
 	suffix = "oldstation.dmm"
-	name = "Ancient Space Station"
+	name = "Space-Ruin Ancient Space Station"
 	description = "The crew of a space station awaken one hundred years after a crisis. Awaking to a derelict space station on the verge of collapse, and a hostile force of invading \
 	hivebots. Can the surviving crew overcome the odds and survive and rebuild, or will the cold embrace of the stars become their new home?"
 
 /datum/map_template/ruin/space/gondoland
 	id = "gondolaasteroid"
 	suffix = "gondolaasteroid.dmm"
-	name = "Gondoland"
+	name = "Space-Ruin Gondoland"
 	description = "Just an ordinary rock- wait, what's that thing?"
 
 /datum/map_template/ruin/space/whiteshipruin_box
 	id = "whiteshipruin_box"
 	suffix = "whiteshipruin_box.dmm"
-	name = "NT Medical Ship"
+	name = "Space-Ruin NT Medical Ship"
 	description = "An ancient ship, said to be among the first discovered derelicts near Space Station 13 that was still in working order. \
 	Aged and deprecated by time, this relic of a vessel is now broken beyond repair."
 
 /datum/map_template/ruin/space/whiteshipdock
 	id = "whiteshipdock"
 	suffix = "whiteshipdock.dmm"
-	name = "Whiteship Dock"
+	name = "Space-Ruin Whiteship Dock"
 	description = "An abandoned but functional vessel parked in deep space, ripe for the taking."
 
 /datum/map_template/ruin/space/cat_experiments
 	id = "meow"
 	suffix = "mrow_thats_right.dmm"
-	name = "Feline-Human Combination Den"
+	name = "Space-Ruin Feline-Human Combination Den"
 	description = "With heated debates over the legality of the catperson and their status in the workforce, there's always a place for the blackmarket to slip in for some cash. Whether the results \
 	are morally sound or not is another issue entirely."
 
 /datum/map_template/ruin/space/hilbertresearchfacility
 	id = "hilbert_facility"
 	suffix = "hilbertresearchfacility.dmm"
-	name = "Hilbert Research Facility"
+	name = "Space-Ruin Hilbert Research Facility"
 	description = "A research facility of great bluespace discoveries. Long since abandoned, willingly or not..."
 
 /datum/map_template/ruin/space/clownplanet
 	id = "clownplanet"
 	suffix = "clownplanet.dmm"
-	name = "Clown Planet"
+	name = "Space-Ruin Clown Planet"
 	description = "Thought lost in 2552, this minor planet has recently been rediscovered."
 
 /datum/map_template/ruin/space/clericden
 	id = "clericden"
 	suffix = "clericden.dmm"
-	name = "Cleric's Den"
+	name = "Space-Ruin Cleric's Den"
 	description = "Once part of a larger monastery, this holy order of long dead clerics practiced far less non-violence than they preached. Appears to have been untouched by looters, however. Odd."
 
 /datum/map_template/ruin/space/forgottenship
 	id = "forgottenship"
 	suffix = "forgottenship.dmm"
-	name = "Syndicate Forgotten Ship"
+	name = "Space-Ruin Syndicate Forgotten Ship"
 	description = "Seemingly abandoned ship went of course right into NT controlled space. It seems that malfunction caused most systems to turn off, except for sleepers."
 
 /datum/map_template/ruin/space/old_syndie_infiltrator
 	id = "old_infiltrator"
 	suffix = "old_infiltrator.dmm"
-	name = "Abandoned Infiltrator"
+	name = "Space-Ruin Abandoned Infiltrator"
 	description = "Only one in five Gorlex Marauder strike forces return from their regular raids into Nanotrasen space. \
 		For the other four... well, their ship doesn't just disappear when their target evacuates."
 
 /datum/map_template/ruin/space/hellfactory
 	id = "hellfactory"
 	suffix = "hellfactory.dmm"
-	name = "Heck Brewery"
+	name = "Space-Ruin Heck Brewery"
 	description = "An abandoned warehouse and brewing facility, which has been recently rediscovered. Reports claim that the security system entered an ultra-hard lockdown, but these reports are inconclusive."
 
 /datum/map_template/ruin/space/space_billboard
 	id = "space_billboard"
 	suffix = "space_billboard.dmm"
-	name = "Space Billboard"
+	name = "Space-Ruin Space Billboard"
 	description = "Frequently found alongside well-traversed sublight routes, space billboards have fallen out of favour in recent years as advertisers finally realised that people are incapable of reading billboards going by at over 2/3rds the speed of light."
 
 /datum/map_template/ruin/space/spinwardsmoothies
 	id = "spinwardsmoothies"
 	suffix = "spinwardsmoothies.dmm"
-	name = "Spinward Smoothies"
+	name = "Space-Ruin Spinward Smoothies"
 	description = "A branch of the beloved Spinward Smoothies chain of smoothie bars."
 
 /datum/map_template/ruin/space/cyborg_mothership
 	id = "cyborg_mothership"
 	suffix = "cyborg_mothership.dmm"
-	name = "Cyborg Mothership"
+	name = "Space-Ruin Cyborg Mothership"
 	description = "An abandoned cyborg mothership that was overtaken by space vines and hivebots. It appears that it hosted an experimental AI focused on mining before it was depowered."
 
 /datum/map_template/ruin/space/dangerous_research
 	id = "dangerous_research"
 	suffix = "dangerous_research.dmm"
-	name = "Alternate Sciences Research Center"
+	name = "Space-Ruin Alternate Sciences Research Center"
 	description = "When you're messing with the occult, who knows what you're going to get?"
 
 /datum/map_template/ruin/space/anomaly_research
 	id = "anomaly_research"
 	suffix = "anomaly_research.dmm"
-	name = "Anomaly Research"
+	name = "Space-Ruin Anomaly Research"
 	description = "A secret research lab embedded in arctic rock, belonging to a Dr Anna Molly. What could she have been researching?"
 
 /datum/map_template/ruin/space/meateor
 	id = "meateor"
 	suffix = "meateor.dmm"
-	name = "Meateor"
+	name = "Space-Ruin Meateor"
 	description = "A big chunk of meat floating in space. How did it get there?"
 
 /datum/map_template/ruin/space/the_faceoff
 	id = "the_faceoff"
 	suffix = "the_faceoff.dmm"
-	name = "The Faceoff"
+	name = "Space-Ruin The Faceoff"
 	description = "What do you get when a meeting of the enemy corporations get crashed?"
 
 /datum/map_template/ruin/space/meatstation
 	id = "meatderelict"
 	suffix = "meatderelict.dmm"
-	name = "Bioresearch Outpost"
+	name = "Space-Ruin Bioresearch Outpost"
 	description = "A bioresearch experiment gone wrong."
 
 /datum/map_template/ruin/space/ghost_restaurant
 	id = "space_ghost_restaurant.dmm"
 	suffix = "space_ghost_restaurant.dmm"
-	name = "Space Ghost Restaurant"
+	name = "Space-Ruin Space Ghost Restaurant"
 	description = "Ever wondered where the restaurant robots come from? On this ruined station, NTgrub interns dressed up robots in clothes, and sent them to stations to cook their meal orders for them."
 
 /datum/map_template/ruin/space/atmosasteroidruin
 	id = "atmosasteroidruin"
 	suffix = "atmosasteroidruin.dmm"
-	name = "Atmos Asteroid"
+	name = "Space-Ruin Atmos Asteroid"
 	description = "A dead atmos tech in a continuously pressurizing ruin."
 
 /datum/map_template/ruin/space/massdriverrouter
 	id = "fasttravel"
 	suffix = "fasttravel.dmm"
-	name = "Mass driver Router"
+	name = "Space-Ruin Mass driver Router"
 	description = "An old, still functional router for some long destroyed system."
 
 /datum/map_template/ruin/space/prey_pod
 	id = "prey"
 	suffix = "prey_pod.dmm"
-	name = "Crashed Mimic Escape Pod"
+	name = "Space-Ruin Crashed Mimic Escape Pod"
 	description = "A pod with a person who has died to a mimic."
 
 /datum/map_template/ruin/space/travelers_rest
 	id = "travelers_rest"
 	suffix = "travelers_rest.dmm"
-	name = "Traveler's Rest"
+	name = "Space-Ruin Traveler's Rest"
 	description = "An abandoned capsule floating through space. It seems as if somebody was in here not too long ago."
 
 /datum/map_template/ruin/space/prison_shuttle
 	id = "prison_shuttle"
 	suffix = "prison_shuttle.dmm"
-	name = "Crashed Prisoner Shuttle"
+	name = "Space-Ruin Crashed Prisoner Shuttle"
 	description = "A prisoner transport shuttle that had crashed into a stray asteroid long ago."
 
 /datum/map_template/ruin/space/botanical_haven
 	id = "botanical_haven"
 	suffix = "botanical_haven.dmm"
-	name = "Botanical Haven"
+	name = "Space-Ruin Botanical Haven"
 	description = "A small sanctuary for plants and botanists, hidden away in a rusted structure."
 
 /datum/map_template/ruin/space/pod_crash
 	id = "pod_crash"
 	suffix = "pod_crash.dmm"
-	name = "Pod Crash"
+	name = "Space-Ruin Pod Crash"
 	description = "A tragic display of what happens to drivers who pda and pod."
 
 /datum/map_template/ruin/space/interdyne
 	id = "interdyne"
 	suffix = "interdyne.dmm"
-	name = "Interdyne Spinward Research Base"
+	name = "Space-Ruin Interdyne Spinward Research Base"
 	description = "An Interdyne facility abandoned due to the accidental discovery of Romerol"
 
 /datum/map_template/ruin/space/waystation
 	id = "waystation"
 	suffix = "waystation.dmm"
-	name = "Waystation"
+	name = "Space-Ruin Waystation"
 	description = "A waytation for a backwater subsector of Spinward gets attacked by the syndicate due to bad luck."
 
 /datum/map_template/ruin/space/allamericandiner
 	id = "allamericandiner"
 	suffix = "allamericandiner.dmm"
-	name = "The All-American Diner"
+	name = "Space-Ruin The All-American Diner"
 	description = "A mothballed \"Restaurant\" station of the popular \"The All-American Diner\" franchise."
 
 /datum/map_template/ruin/space/mimesvclowns
 	id = "mimesvclowns"
 	suffix = "mimesvsclowns.dmm"
-	name = "Abandoned Mime Outpost"
+	name = "Space-Ruin Abandoned Mime Outpost"
 	description = "When you fight mimes, you better bring more than slips."
 
 /datum/map_template/ruin/space/transit_booth
 	id = "transit_booth"
 	suffix = "transit_booth.dmm"
-	name = "Transit Booth"
+	name = "Space-Ruin Transit Booth"
 	description = "Make sure to check out the duty-free store!"
 
 /datum/map_template/ruin/space/space_phonebooth
 	id = "Space_phonebooth"
 	suffix = "phonebooth.dmm"
-	name = "Space Phonebooth"
+	name = "Space-Ruin Space Phonebooth"
 	description = "A venture by nanotrasen to help popularize the use of holopads."
 
 /datum/map_template/ruin/space/the_outlet
 	id = "the_outlet"
 	suffix = "the_outlet.dmm"
-	name = "calebs krazy clothing outlet"
+	name = "Space-Ruin calebs krazy clothing outlet"
 	description = "A decrepit clothing store built into an asteroid. It appears long since abandoned and has fallen into disrepair."
 
 /datum/map_template/ruin/space/infested_frigate
 	id = "infested_frigate"
 	suffix = "infested_frigate.dmm"
-	name = "SYN-C Brutus"
+	name = "Space-Ruin SYN-C Brutus"
 	description = "This wasn't an outbreak, this was a repelled attack."
 
 /datum/map_template/ruin/space/garbagetruck1
 	id = "garbagetruck1"
 	suffix = "garbagetruck1.dmm"
-	name = "Decommissioned Garbage Truck NX1"
+	name = "Space-Ruin Decommissioned Garbage Truck NX1"
 	description = "An NX-760 interstellar transport barge. At the end of their life cycle, they are often filled with trash and launched into unexplored space to become someone else's problem. This one is full of kitchen waste, and rodents."
 
 /datum/map_template/ruin/space/garbagetruck2
 	id = "garbagetruck2"
 	suffix = "garbagetruck2.dmm"
-	name = "Decommissioned Garbage Truck NX2"
+	name = "Space-Ruin Decommissioned Garbage Truck NX2"
 	description = "An NX-760 interstellar transport barge. At the end of their life cycle, they are often filled with trash and launched into unexplored space to become someone else's problem. This one is full of medical waste, and a syndicate agent."
 
 /datum/map_template/ruin/space/garbagetruck3
 	id = "garbagetruck3"
 	suffix = "garbagetruck3.dmm"
-	name = "Decommissioned Garbage Truck NX3"
+	name = "Space-Ruin Decommissioned Garbage Truck NX3"
 	description = "An NX-760 interstellar transport barge. At the end of their life cycle, they are often filled with trash and launched into unexplored space to become someone else's problem. This one is full of industrial garbage, and a russian drug den."
 
 /datum/map_template/ruin/space/garbagetruck4
 	id = "garbagetruck4"
 	suffix = "garbagetruck4.dmm"
-	name = "Decommissioned Garbage Truck NX4"
+	name = "Space-Ruin Decommissioned Garbage Truck NX4"
 	description = "An NX-760 interstellar transport barge. At the end of their life cycle, they are often filled with trash and launched into unexplored space to become someone else's problem. This one is full of commercial trash, and spiders."
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -680,8 +680,7 @@
 
 		names[name] = ruin_landmark
 
-	var/ruinname = input("Select ruin", "Jump to Ruin") as null|anything in sort_list(names)
-
+	var/ruinname = tgui_input_list(usr, "Select ruin", "Jump to Ruin", names)
 
 	var/obj/effect/landmark/ruin/landmark = names[ruinname]
 
@@ -715,7 +714,7 @@
 			themed_names[name] = list(ruin, theme, list(ruin.default_area))
 		names += sort_list(themed_names)
 
-	var/ruinname = input("Select ruin", "Spawn Ruin") as null|anything in names
+	var/ruinname = tgui_input_list(usr, "Select ruin", "Spawn Ruin", names)
 	var/data = names[ruinname]
 	if (!data)
 		return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -680,7 +680,7 @@
 
 		names[name] = ruin_landmark
 
-	var/ruinname = tgui_input_list(usr, "Select ruin", "Jump to Ruin", names)
+	var/ruinname = tgui_input_list(usr, "Select ruin", "Jump to Ruin", sort_list(names))
 
 	var/obj/effect/landmark/ruin/landmark = names[ruinname]
 
@@ -714,7 +714,7 @@
 			themed_names[name] = list(ruin, theme, list(ruin.default_area))
 		names += sort_list(themed_names)
 
-	var/ruinname = tgui_input_list(usr, "Select ruin", "Spawn Ruin", names)
+	var/ruinname = tgui_input_list(usr, "Select ruin", "Spawn Ruin", sort_list(names))
 	var/data = names[ruinname]
 	if (!data)
 		return

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -3,8 +3,7 @@
 	set name = "Map template - Place"
 
 	var/datum/map_template/template
-
-	var/map = input(src, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in sort_list(SSmapping.map_templates)
+	var/map = tgui_input_list(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template", sort_list(SSmapping.map_templates))
 	if(!map)
 		return
 	template = SSmapping.map_templates[map]


### PR DESCRIPTION
## About The Pull Request

This is not player-facing, however it's a good QOL that i made for downstream modular ruins. The pick-list of maps makes it a bit.. annoying to really grab a ruin quickly - so all this does is add an ID to the front of them for Space, Lava and Ice respectively.

![image](https://github.com/tgstation/tgstation/assets/22140677/db31a003-7a31-4899-b730-fc05e5a3bb1d)

![image](https://github.com/tgstation/tgstation/assets/22140677/f1f733bf-cc7d-4fb2-aadf-112152a4cdd9)



## Why It's Good For The Game
## Changelog
:cl:Zergspower
admin: renames ruin names to have an identifier in front of it
refactor: converts map plate and jump to ruin to tguilist
/:cl:
