### PR TITLE
Adds notification when toggling hud implant

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_eyes.dm
@@ -16,7 +16,7 @@
 	var/HUD_type = 0
 	var/HUD_trait = null
 	/// Whether the HUD implant is on or off
-	var/toggled_on = TRUE 
+	var/toggled_on = TRUE
 
 
 /obj/item/organ/internal/cyberimp/eyes/hud/proc/toggle_hud(mob/living/carbon/eye_owner)
@@ -25,11 +25,13 @@
 			var/datum/atom_hud/hud = GLOB.huds[HUD_type]
 			hud.hide_from(eye_owner)
 		toggled_on = FALSE
+		balloon_alert(eye_owner, "hud disabled")
 	else
 		if(HUD_type)
 			var/datum/atom_hud/hud = GLOB.huds[HUD_type]
 			hud.show_to(eye_owner)
 		toggled_on = TRUE
+		balloon_alert(eye_owner, "hud enabled")
 
 /obj/item/organ/internal/cyberimp/eyes/hud/Insert(mob/living/carbon/eye_owner, special = FALSE, movement_flags)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Does what it says on the tin. When you toggle a hud implant on/off, you'll get a balloon notification telling you if it was enabled/disabled.

Fixes #81654
## Why It's Good For The Game
Good for implants where it might not be immediately obvious whether they're on or off, like the diagnostic HUD.
## Changelog
:cl:
qol: HUD implants will now notify you when toggled on or off
/:cl:
