### PR TITLE
Buying the advanced plastic surgery disk now gives you the right disk

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -184,7 +184,7 @@
 	desc = "A bootleg copy of an collector item, this disk contains the procedure to perform advanced plastic surgery, allowing you to model someone's face and voice based on a picture taken by a camera on your offhand. \
 	All changes are superficial and does not change ones genetic makeup. \
 	Insert into an Operating Console to enable the procedure."
-	item = /obj/item/disk/surgery/brainwashing
+	item = /obj/item/disk/surgery/advanced_plastic_surgery
 	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_ROBOTICIST)
 	cost = 1
 	surplus = 50


### PR DESCRIPTION
## About The Pull Request

Buying the advanced plastic surgery disk currently gives you a brainwashing disk instead, this fixes that.

## Why It's Good For The Game

big oversight, you now get the right program you bought.

## Changelog

:cl:
fix: Buying the advanced plastic surgery disk from the uplink now gives you advanced plastic surgery instead of brainwashing.
/:cl:
