### PR TITLE
hippocratic bust no longer gives permanent medhud

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -603,20 +603,20 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. += span_notice("You can activate the bust in-hand to swear or forswear a Hippocratic Oath! This has no effects except pacifism or bragging rights. Does not remove other sources of pacifism. Do not eat.")
 
 /obj/item/statuebust/hippocratic/equipped(mob/living/carbon/human/user, slot)
-	..()
+	. = ..()
 	if(!(slot & ITEM_SLOT_HANDS))
 		return
-	var/datum/atom_hud/our_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-	our_hud.show_to(user)
+	if(!HAS_TRAIT(user, TRAIT_MEDICAL_HUD))
+		var/datum/atom_hud/our_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+		our_hud.show_to(user)
 	ADD_TRAIT(user, TRAIT_MEDICAL_HUD, type)
 
 /obj/item/statuebust/hippocratic/dropped(mob/living/carbon/human/user)
-	..()
-	if(HAS_TRAIT_NOT_FROM(user, TRAIT_MEDICAL_HUD, type))
-		return
-	var/datum/atom_hud/our_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-	our_hud.hide_from(user)
+	. = ..()
 	REMOVE_TRAIT(user, TRAIT_MEDICAL_HUD, type)
+	if(!HAS_TRAIT(user, TRAIT_MEDICAL_HUD))
+		var/datum/atom_hud/our_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+		our_hud.hide_from(user)
 
 /obj/item/statuebust/hippocratic/attack_self(mob/user)
 	if(!iscarbon(user))


### PR DESCRIPTION
## About The Pull Request

The hippocratic bust currently gives you permanent medhuds if you already had a hud on you (and since this is a medical heirloom item, chances of that happening is pretty high) then just unequip it, because it will early return on drop and not take away the medical hud trait from the user if they have a trait that isn't from the bust.

## Why It's Good For The Game

Minor fix to remove a permanent hud to players.

## Changelog

:cl:
fix: The Hippocratic bust no longer gives permanent medHUDs.
/:cl: