### PR TITLE
Pete's corpse no longer eats vines

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -100,7 +100,7 @@
 /// Handles automagically eating a plant when we move into a turf that has one.
 /mob/living/basic/goat/proc/on_move(datum/source, atom/entering_loc)
 	SIGNAL_HANDLER
-	if(!isturf(entering_loc))
+	if(!isturf(entering_loc) || stat == DEAD)
 		return
 
 	var/list/edible_plants = list()


### PR DESCRIPTION

## About The Pull Request

Pete can no longer eat vines while dead.

<!-- Describe The Pull Request. Please be sure every change is documented or this
 can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/28870487/b3156bf2-386d-427f-91b8-61a4dfe83424)

This should probably not be happening even though it was funny to watch.
## Changelog
:cl:
fix: Pete can no longer eat vines while dead.
/:cl:
