### PR TITLE
Remove 2 instances of duplicate argument names

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -375,18 +375,18 @@
 
 // PDA signal responses
 
-/datum/component/uplink/proc/new_ringtone(atom/source, new_ring_text)
+/datum/component/uplink/proc/new_ringtone(datum/source, mob/living/user, new_ring_text)
 	SIGNAL_HANDLER
 
 	if(trim(lowertext(new_ring_text)) != trim(lowertext(unlock_code)))
 		if(trim(lowertext(new_ring_text)) == trim(lowertext(failsafe_code)))
-			failsafe(source)
+			failsafe(user)
 			return COMPONENT_STOP_RINGTONE_CHANGE
 		return
 	locked = FALSE
-	if(ismob(source))
-		interact(null, source)
-		to_chat(source, span_hear("The computer softly beeps."))
+	if(ismob(user))
+		interact(null, user)
+		to_chat(user, span_hear("The computer softly beeps."))
 	return COMPONENT_STOP_RINGTONE_CHANGE
 
 /datum/component/uplink/proc/check_detonate()

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -375,7 +375,7 @@
 
 // PDA signal responses
 
-/datum/component/uplink/proc/new_ringtone(datum/source, atom/source, new_ring_text)
+/datum/component/uplink/proc/new_ringtone(atom/source, new_ring_text)
 	SIGNAL_HANDLER
 
 	if(trim(lowertext(new_ring_text)) != trim(lowertext(unlock_code)))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -55,8 +55,7 @@
 	max_total_storage,
 	list/canhold,
 	list/canthold,
-	storage_type = /datum/storage,
-	storage_type,
+	storage_type
 )
 	// If no type was passed in, default to what we already have
 	storage_type ||= src.storage_type

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -55,7 +55,7 @@
 	max_total_storage,
 	list/canhold,
 	list/canthold,
-	storage_type
+	storage_type,
 )
 	// If no type was passed in, default to what we already have
 	storage_type ||= src.storage_type

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -51,7 +51,7 @@
 	UnregisterSignal(SSdcs, COMSIG_STARLIGHT_COLOR_CHANGED)
 	var/list/z_offsets = SSmapping.z_level_to_plane_offset
 	if(length(lighting_effects) > 1)
-		for(var/area_zlevel as anything in 1 to get_highest_zlevel())
+		for(var/area_zlevel in 1 to get_highest_zlevel())
 			if(z_offsets[area_zlevel])
 				for(var/turf/T as anything in get_turfs_by_zlevel(area_zlevel))
 					T.cut_overlay(lighting_effects[z_offsets[T.z] + 1])


### PR DESCRIPTION

## About The Pull Request

I fixed 2 instances of procs having multiple arguments with the same name. BYOND does not error on these, instead ignoring all but the last. It's best to remove these for clarity.

## Why It's Good For The Game

N/A