### PR TITLE
Pathfinding will now initially run until tick_check before queuing work in the subsystem.

### DIFF
--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -64,10 +64,15 @@ SUBSYSTEM_DEF(pathfinder)
 /datum/controller/subsystem/pathfinder/proc/pathfind(atom/movable/caller, atom/end, max_distance = 30, mintargetdist, access = list(), simulated_only = TRUE, turf/exclude, skip_first = TRUE, diagonal_handling = DIAGONAL_REMOVE_CLUNKY, list/datum/callback/on_finish)
 	var/datum/pathfind/jps/path = new()
 	path.setup(caller, access, max_distance, simulated_only, exclude, on_finish, end, mintargetdist, skip_first, diagonal_handling)
-	if(path.start())
+	if(!path.start())
+		return FALSE
+	if(!path.search_step()) //run a step
+		path.early_exit()
+		return FALSE
+	if(TICK_CHECK) //queue additional processing in the subsystem if we reached the limit before exiting
 		active_pathing += path
 		return TRUE
-	return FALSE
+	path.finished() 
 
 /// Initiates a swarmed pathfind. Returns TRUE if we're good, FALSE if something's failed
 /// If a valid pathmap exists for the TARGET turf we'll use that, otherwise we have to build a new one

--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -72,7 +72,9 @@ SUBSYSTEM_DEF(pathfinder)
 	if(TICK_CHECK) //queue additional processing in the subsystem if we reached the limit before exiting
 		active_pathing += path
 		return TRUE
-	path.finished() 
+	
+	path.finished()
+	return TRUE
 
 /// Initiates a swarmed pathfind. Returns TRUE if we're good, FALSE if something's failed
 /// If a valid pathmap exists for the TARGET turf we'll use that, otherwise we have to build a new one

--- a/code/modules/unit_tests/leash.dm
+++ b/code/modules/unit_tests/leash.dm
@@ -30,17 +30,14 @@
 
 /datum/unit_test/leash/proc/on_leash_force_teleport()
 	SIGNAL_HANDLER
-	stack_trace("on_leash_force_teleport")
 	forcibly_teleported = TRUE
 
 /datum/unit_test/leash/proc/on_leash_path_complete()
 	SIGNAL_HANDLER
-	stack_trace("on_leash_path_complete")
 	leash_wait?.completed()
 
 /datum/unit_test/leash/proc/on_leash_path_started()
 	SIGNAL_HANDLER
-	stack_trace("on_leash_path_started")
 	leash_wait?.started()
 
 /datum/unit_test/leash/proc/move_away(atom/movable/mover, distance)

--- a/code/modules/unit_tests/leash.dm
+++ b/code/modules/unit_tests/leash.dm
@@ -30,14 +30,17 @@
 
 /datum/unit_test/leash/proc/on_leash_force_teleport()
 	SIGNAL_HANDLER
+	stack_trace("on_leash_force_teleport")
 	forcibly_teleported = TRUE
 
 /datum/unit_test/leash/proc/on_leash_path_complete()
 	SIGNAL_HANDLER
+	stack_trace("on_leash_path_complete")
 	leash_wait?.completed()
 
 /datum/unit_test/leash/proc/on_leash_path_started()
 	SIGNAL_HANDLER
+	stack_trace("on_leash_path_started")
 	leash_wait?.started()
 
 /datum/unit_test/leash/proc/move_away(atom/movable/mover, distance)


### PR DESCRIPTION
beepsky chasing people isn't working because it takes 2 to 3 ticks before pathfinding would run and return results even if the perp was 2 tiles away because it would have to wait for the next pathfinding tick and then wait for the next `UNTIL` tick in `getpathto` to return the results.

Two to three ticks just so happens to be how long the most common run delay is so basically the pathfind would expire just as soon as it was returned.

This makes it much faster.
:cl:
fix: removed pathfind's startup delay of 2-3 ticks for small distances.
balance: maybe buffs beepsky pursuit.
/:cl:
