### PR TITLE
Lots of description changes and grammar fixes for heretics

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -419,7 +419,7 @@
 	desc = "Patient seems to oxidise things around them at random, and seem to believe they are aiding a creature in climbing a mountin."
 	scan_desc = "C_)L(#_I_##M;B"
 	gain_text = span_warning("The rusted climb shall finish at the peak")
-	lose_text = span_notice("The rusted climb? Whats that? An odd dream to be sure.")
+	lose_text = span_notice("The rusted climb? What's that? An odd dream to be sure.")
 	random_gain = FALSE
 
 /datum/brain_trauma/severe/rusting/on_life(seconds_per_tick, times_fired)

--- a/code/datums/mood_events/eldritch_painting_events.dm
+++ b/code/datums/mood_events/eldritch_painting_events.dm
@@ -17,7 +17,7 @@
 	mood_change = 5
 	timeout = 3 MINUTES
 
-/datum/mood_event/eldritch_painting/weeping_withdrawl
+/datum/mood_event/eldritch_painting/weeping_withdrawal
 	description = "My mind is clear from his influence."
 	mood_change = 1
 	timeout = 3 MINUTES

--- a/code/datums/mood_events/eldritch_painting_events.dm
+++ b/code/datums/mood_events/eldritch_painting_events.dm
@@ -23,7 +23,7 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/eldritch_painting/desire_heretic
-	description = "A part gained, the manus takes and gives. What did it take from me?"
+	description = "A part gained, the mansus takes and gives. What did it take from me?"
 	mood_change = -2
 	timeout = 3 MINUTES
 

--- a/code/modules/antagonists/heretic/items/eldritch_painting.dm
+++ b/code/modules/antagonists/heretic/items/eldritch_painting.dm
@@ -92,7 +92,7 @@
 	if(!IS_HERETIC(examiner))
 		to_chat(examiner, span_hypnophrase("Respite, for now...."))
 		examiner.mob_mood.mood_events.Remove("eldritch_weeping")
-		examiner.add_mood_event("weeping_withdrawl", /datum/mood_event/eldritch_painting/weeping_withdrawl)
+		examiner.add_mood_event("weeping_withdrawal", /datum/mood_event/eldritch_painting/weeping_withdrawal)
 		return
 
 	to_chat(examiner, span_notice("Oh, what arts! Just gazing upon it clears your mind."))

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -42,7 +42,7 @@
 
 /datum/heretic_knowledge/ashen_grasp
 	name = "Grasp of Ash"
-	desc = "Your Mansus Grasp will burn the eyes of the victim, causing damage and blindness."
+	desc = "Your Mansus Grasp will burn the eyes of the victim, damaging them and blurring their vision."
 	gain_text = "The Nightwatcher was the first of them, his treason started it all. \
 		Their lantern, expired to ash - their watch, absent."
 	next_knowledge = list(/datum/heretic_knowledge/spell/ash_passage)
@@ -70,7 +70,7 @@
 
 /datum/heretic_knowledge/spell/ash_passage
 	name = "Ashen Passage"
-	desc = "Grants you Ashen Passage, a silent but short range jaunt."
+	desc = "Grants you Ashen Passage, a spell that lets you phase out of reality and traverse a short distance, passing though any walls."
 	gain_text = "He knew how to walk between the planes."
 	next_knowledge = list(
 		/datum/heretic_knowledge/mark/ash_mark,
@@ -181,6 +181,7 @@
 		When completed, you become a harbinger of flames, gaining two abilites. \
 		Cascade, which causes a massive, growing ring of fire around you, \
 		and Oath of Flame, causing you to passively create a ring of flames as you walk. \
+		Some ashen spells you already knew will be empowered as well. \
 		You will also become immune to flames, space, and similar environmental hazards."
 	gain_text = "The Watch is dead, the Nightwatcher burned with it. Yet his fire burns evermore, \
 		for the Nightwatcher brought forth the rite to mankind! His gaze continues, as now I am one with the flames, \

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -83,7 +83,8 @@
 /datum/heretic_knowledge/mark/cosmic_mark
 	name = "Mark of Cosmos"
 	desc = "Your Mansus Grasp now applies the Mark of Cosmos. The mark is triggered from an attack with your Cosmic Blade. \
-		When triggered, the victim is returned to the location where the mark was originally applied to them. \
+		When triggered, the victim is returned to the location where the mark was originally applied to them, \
+		leaving a cosmic field in their place. \
 		They will then be paralyzed for 2 seconds."
 	gain_text = "The Beast now whispered to me occasionally, only small tidbits of their circumstances. \
 		I can help them, I have to help them."
@@ -99,8 +100,7 @@
 	name = "Star Touch"
 	desc = "Grants you Star Touch, a spell which places a star mark upon your target \
 		and creates a cosmic field at your feet and to the turfs next to you. Targets which already have a star mark \
-		will be forced to sleep for 4 seconds. When the victim is hit it also creates a beam that \
-		deals a bit of fire damage and damages the cells. \
+		will be forced to sleep for 4 seconds. When the victim is hit it also creates a beam that burns them. \
 		The beam lasts a minute, until the beam is obstructed or until a new target has been found."
 	gain_text = "After waking in a cold sweat I felt a palm on my scalp, a sigil burned onto me. \
 		My veins now emitted a strange purple glow, the Beast knows I will surpass its expectations."
@@ -111,7 +111,7 @@
 
 /datum/heretic_knowledge/spell/star_blast
 	name = "Star Blast"
-	desc = "Fires a projectile that moves very slowly and creates cosmic fields on impact. \
+	desc = "Fires a projectile that moves very slowly, raising a short-lived wall of cosmic fields where it goes. \
 		Anyone hit by the projectile will receive burn damage, a knockdown, and give people in a three tile range a star mark."
 	gain_text = "The Beast was behind me now at all times, with each sacrifice words of affirmation coursed through me."
 	next_knowledge = list(
@@ -244,7 +244,8 @@
 		You can also give it commands through speech. \
 		The Star Gazer is a strong ally who can even break down reinforced walls. \
 		The Star Gazer has an aura that will heal you and damage opponents. \
-		Star Touch can now teleport you to the Star Gazer when activated in your hand."
+		Star Touch can now teleport you to the Star Gazer when activated in your hand. \
+		Your cosmic expansion spell and your blades also become greatly empowered."
 	gain_text = "The Beast held out its hand, I grabbed hold and they pulled me to them. Their body was towering, but it seemed so small and feeble after all their tales compiled in my head. \
 		I clung on to them, they would protect me, and I would protect it. \
 		I closed my eyes with my head laid against their form. I was safe. \

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -42,7 +42,8 @@
 
 /datum/heretic_knowledge/cosmic_grasp
 	name = "Grasp of Cosmos"
-	desc = "Your Mansus Grasp will give people a star mark (cosmic ring) and create a cosmic field where you stand."
+	desc = "Your Mansus Grasp will give people a star mark (cosmic ring) and create a cosmic field where you stand. \
+		People with a star mark can not pass cosmic fields."
 	gain_text = "Some stars dimmed, others' magnitude increased. \
 		With newfound strength I could channel the nebula's power into myself."
 	next_knowledge = list(/datum/heretic_knowledge/spell/cosmic_runes)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -122,6 +122,7 @@
 /datum/heretic_knowledge/limited_amount/flesh_ghoul
 	name = "Imperfect Ritual"
 	desc = "Allows you to transmute a corpse and a poppy to create a Voiceless Dead. \
+		The corpse does not need to have a soul. \
 		Voiceless Dead are mute ghouls and only have 50 health, but can use Bloody Blades effectively. \
 		You can only create two at a time."
 	gain_text = "I found notes of a dark ritual, unfinished... yet still, I pushed forward."

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -189,7 +189,8 @@
 	desc = "The ascension ritual of the Path of Knock. \
 		Bring 3 corpses without organs in their torso to a transmutation rune to complete the ritual. \
 		When completed, you gain the ability to transform into empowered eldritch creatures \
-		and in addition, create a tear to the Labyrinth's heart; \
+		and your keyblades will become even deadlier. \
+		In addition, you will create a tear to the Labyrinth's heart; \
 		a tear in reality located at the site of this ritual. \
 		Eldritch creatures will endlessly pour from this rift \
 		who are bound to obey your instructions."

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -92,9 +92,12 @@
 /datum/heretic_knowledge/key_ring
 	name = "Key Keeper’s Burden"
 	desc = "Allows you to transmute a wallet, an iron rod, and an ID card to create an Eldritch Card. \
-		It functions the same as an ID Card, but attacking it with an ID card fuses it and gains its access. \
-		You can use it in-hand to change its form to a card you fused. \
-		Does not preserve the card used in the ritual."
+		Hit a pair of airlocks with it to create a pair of portals, which will teleport you between them, but teleport non-heretics randomly. \
+		You can ctrl-click the card to invert this behavior for created portals. \
+		Each card may only sustain a single pair of portals at the same time. \
+		It also functions and appears the same as a regular ID Card. \
+		Attacking it with a normal ID card consumes it and gains its access, and you can use it in-hand to change its appearance to a card you fused. \
+		Does not preserve the card originally used in the ritual."
 	gain_text = "The Keeper sneered. \"These plastic rectangles are a mockery of keys, and I curse every door that desires them.\""
 	required_atoms = list(
 		/obj/item/storage/wallet = 1,

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -152,9 +152,9 @@
 
 /datum/heretic_knowledge/spell/moon_ringleader
 	name = "Ringleaders Rise"
-	desc = "Grants you Ringleaders Rise, an aoe spell that deals more brain damage the lower the sanity of everyone in the AoE,\
-			causes hallucinations with those who have less sanity getting more. \
-			If their sanity is low enough turns them insane, the spell then halves their sanity."
+	desc = "Grants you Ringleaders Rise, an AoE spell that deals more brain damage the lower the sanity of everyone in the AoE \
+			and causes hallucinations, with those who have less sanity getting more. \
+			If their sanity is low enough this turns them insane, the spell then halves their sanity."
 	gain_text = "I grabbed his hand and we rose, those who saw the truth rose with us. \
 		The ringleader pointed up and the dim light of truth illuminated us further."
 	next_knowledge = list(

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -46,7 +46,7 @@
 /datum/heretic_knowledge/moon_grasp
 	name = "Grasp of Lunacy"
 	desc = "Your Mansus Grasp will cause your victims to hallucinate everyone as lunar mass, \
-		and hides your identity for a short dur	ation."
+		and hides your identity for a short duration."
 	gain_text = "The troupe on the side of the moon showed me truth, and I took it."
 	next_knowledge = list(/datum/heretic_knowledge/spell/moon_smile)
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -169,8 +169,8 @@
 	name = "The Last Act"
 	desc = "The ascension ritual of the Path of Moon. \
 		Bring 3 corpses with more than 50 brain damage to a transmutation rune to complete the ritual. \
-		When completed, you become a harbinger of madness gaining and aura of passive sanity decrease \
-		, confusion increase and if their sanity is low enough brain damage and blindness. \
+		When completed, you become a harbinger of madness gaining and aura of passive sanity decrease, \
+		confusion increase and, if their sanity is low enough, brain damage and blindness. \
 		1/5th of the crew will turn into acolytes and follow your command, they will all recieve moonlight amulettes."
 	gain_text = "We dived down towards the crowd, his soul splitting off in search of greater venture \
 		for where the Ringleader had started the parade, I shall continue it unto the suns demise \

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -45,7 +45,7 @@
 
 /datum/heretic_knowledge/moon_grasp
 	name = "Grasp of Lunacy"
-	desc = "Your Mansus Grasp will cause them to hallucinate everyone as lunar mass, \
+	desc = "Your Mansus Grasp will cause your victims to hallucinate everyone as lunar mass, \
 		and hides your identity for a short dur	ation."
 	gain_text = "The troupe on the side of the moon showed me truth, and I took it."
 	next_knowledge = list(/datum/heretic_knowledge/spell/moon_smile)
@@ -85,9 +85,8 @@
 
 /datum/heretic_knowledge/mark/moon_mark
 	name = "Mark of Moon"
-	desc = "Your Mansus Grasp now applies the Mark of Moon. The mark is triggered from an attack with your Moon Blade. \
-		When triggered, the victim is confused, and when the mark is applied they are pacified \
-		until attacked."
+	desc = "Your Mansus Grasp now applies the Mark of Moon, pacifying the victim until attacked. \
+		The mark can also be triggered from an attack with your Moon Blade, leaving the victim confused."
 	gain_text = "The troupe on the moon would dance all day long \
 		and in that dance the moon would smile upon us \
 		but when the night came its smile would dull forced to gaze on the earth."

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -111,9 +111,9 @@
 
 /datum/heretic_knowledge/moon_amulette
 	name = "Moonlight Amulette"
-	desc = "Allows you to transmute 2 sheets of glass, a heart and a tie \
-			if the item is used on someone with low sanity they go berserk attacking everyone \
-			, if their sanity isnt low enough it decreases their mood."
+	desc = "Allows you to transmute 2 sheets of glass, a heart and a tie to create a Moonlight Amulette. \
+			If the item is used on someone with low sanity they go berserk attacking everyone, \
+			if their sanity isn't low enough it decreases their mood."
 	gain_text = "At the head of the parade he stood, the moon condensed into one mass, a reflection of the soul."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/moon,

--- a/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
@@ -21,7 +21,7 @@
 	name = "Curse of Paralysis"
 	desc = "Allows you to transmute a hatchet and both a left and right leg to cast a curse of immobility on a crew member. \
 		While cursed, the victim will be unable to walk. You can additionally supply an item that a victim has touched \
-		or is covered in the victim's blood to empower the curse."
+		or is covered in the victim's blood to make the curse last longer."
 	gain_text = "The flesh of humanity is weak. Make them bleed. Show them their fragility."
 	next_knowledge = list(
 		/datum/heretic_knowledge/mad_mask,
@@ -58,8 +58,8 @@
 
 /datum/heretic_knowledge/summon/ashy
 	name = "Ashen Ritual"
-	desc = "Allows you to transmute a head, a pile of ash, and a book to create an Ash Man. \
-		Ash Men have a short range jaunt and the ability to cause bleeding in foes at range. \
+	desc = "Allows you to transmute a head, a pile of ash, and a book to create an Ash Spirit. \
+		Ash Spirits have a short range jaunt and the ability to cause bleeding in foes at range. \
 		They also have the ability to create a ring of fire around themselves for a length of time."
 	gain_text = "I combined my principle of hunger with my desire for destruction. The Marshal knew my name, and the Nightwatcher gazed on."
 	next_knowledge = list(

--- a/code/modules/antagonists/heretic/knowledge/side_cosmos_ash.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_cosmos_ash.dm
@@ -36,8 +36,9 @@
 /datum/heretic_knowledge/eldritch_coin
 	name = "Eldritch Coin"
 	desc = "Allows you to transmute a sheet of plasma and a diamond to create an Eldritch Coin. \
-		The coin will open or close nearby doors when landing on heads and bolt or unbolt nearby doors \
-		when landing on tails. If the coin gets inserted into an airlock it emags the door destroying the coin."
+		The coin will open or close nearby doors when landing on heads and toggle their bolts \
+		when landing on tails. If you insert the coin into an airlock, it will be consumed \
+		to fry its electronics, opening the airlock permanently unless bolted. "
 	gain_text = "The Mansus is a place of all sorts of sins. But greed held a special role."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/cosmic_expansion,

--- a/code/modules/antagonists/heretic/knowledge/side_lock_flesh.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_flesh.dm
@@ -2,7 +2,8 @@
 /datum/heretic_knowledge/spell/opening_blast
 	name = "Wave Of Desperation"
 	desc = "Grants you Wave Of Desparation, a spell which can only be cast while restrained. \
-		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby."
+		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby. \
+		However, you will fall unconscious a short time after casting this spell."
 	gain_text = "My shackles undone in dark fury, their feeble bindings crumble before my power."
 	next_knowledge = list(
 		/datum/heretic_knowledge/summon/raw_prophet,

--- a/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
@@ -16,10 +16,10 @@
 
 /datum/heretic_knowledge/unfathomable_curio
 	name = "Unfathomable Curio"
-	desc = "Allows you to transmute 3 rods, a brain and a belt into an Unfathomable Curio\
-			, a belt that can hold blades and items for rituals. Whilst worn will also \
+	desc = "Allows you to transmute 3 rods, lungs and any belt into an Unfathomable Curio\
+			, a belt that can hold blades and items for rituals. Whilst worn it will also \
 			veil you, allowing you to take 5 hits without suffering damage, this veil will recharge very slowly \
-			outside of combat. When examined the examiner will suffer brain damage and blindness."
+			outside of combat."
 	gain_text = "The mansus holds many a curio, some are not meant for the mortal eye."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/burglar_finesse,

--- a/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
@@ -38,12 +38,12 @@
 	name = "Unsealed Arts"
 	desc = "Allows you to transmute a canvas and an additional item to create a piece of art, these paintings \
 			have different effects depending on the additional item added. Possible paintings: \
-			The sister and He Who Wept: Eyes. When a non-heretic looks at the painting they will begin to hallucinate everyone as heretics. \
-			The First Desire: Any bodypart. Increases the hunger of non-heretics, when examined drops an organ or body part at your feet. \
-			Great chaparral over rolling hills: Any grown food. Spreads kudzu when placed, when examined grants a flower. \
-			Lady out of gates: Gloves. Causes non-heretics to scratch themselves, when examined removes all your mutations. \
-			Climb over the rusted mountain: Trash. Causes non-heretics to rust the floor they walk on. \
-			These effects are mitigated for a few minutes when a non-heretic suffering an effect examines the painting that caused the effect."
+			The sister and He Who Wept: Eyes. Clears your own mind, but curses non-heretics with hallucinations. \
+			The First Desire: Any bodypart. Supplies you with random organs, but curses non-heretics with a hunger for flesh. \
+			Great chaparral over rolling hills: Any grown food. Spreads kudzu when placed and examined by non-heretics. Also supplies you with poppies and harebells. \
+			Lady out of gates: Gloves. Clears your mutations, but mutates non-heretics and curses them with scratching. \
+			Climb over the rusted mountain: Trash. Curses non-heretics to rust the floor they walk on. \
+			Non-heretics can counter most of these effects by examining one of these paintings."
 	gain_text = "A wind of inspiration blows through me, past the walls and past the gate inspirations lie, yet to be depicted. \
 				They yearn for mortal eyes again, and I shall grant that wish."
 	next_knowledge = list(

--- a/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
@@ -44,7 +44,7 @@
 	name = "Curse of Corrosion"
 	desc = "Allows you to transmute wirecutters, a pool of vomit, and a heart to cast a curse of sickness on a crew member. \
 		While cursed, the victim will repeatedly vomit while their organs will take constant damage. You can additionally supply an item \
-		that a victim has touched or is covered in the victim's blood to empower the curse."
+		that a victim has touched or is covered in the victim's blood to make the curse last longer."
 	gain_text = "The body of humanity is temporary. Their weaknesses cannot be stopped, like iron falling to rust. Show them all."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/area_conversion,

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -144,7 +144,8 @@
 	name = "Maid in the Mirror"
 	desc = "Allows you to transmute five sheets of titanium, a flash, a suit of armor, and a pair of lungs \
 		to create a Maid in the Mirror. Maid in the Mirrors are decent combatants that can become incorporeal by \
-		phasing in and out of the mirror realm, serving as powerful scouts and ambushers."
+		phasing in and out of the mirror realm, serving as powerful scouts and ambushers. \
+		However, they are weak to mortal gaze and take damage by being examined."
 	gain_text = "Within each reflection, lies a gateway into an unimaginable world of colors never seen and \
 		people never met. The ascent is glass, and the walls are knives. Each step is blood, if you do not have a guide."
 	next_knowledge = list(

--- a/code/modules/antagonists/heretic/magic/cosmic_runes.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_runes.dm
@@ -1,6 +1,7 @@
 /datum/action/cooldown/spell/cosmic_rune
 	name = "Cosmic Rune"
-	desc = "Creates a cosmic rune at your position, only two can exist at a time. Invoking one rune transports you to the other."
+	desc = "Creates a cosmic rune at your position, only two can exist at a time. Invoking one rune transports you to the other. \
+		Anyone with a star mark gets transported along with you."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/pointed/projectile/moon_parade
 	name = "Lunar parade"
-	desc = "This unleashes the parade towards a target."
+	desc = "This unleashes the parade, making everyone in its way join it and suffer hallucinations."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'

--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -1,7 +1,8 @@
 /datum/action/cooldown/spell/aoe/moon_ringleader
 	name = "Ringleaders Rise"
-	desc = "Big AoE spell that deals more brain damage the lower the sanity of everyone in the AoE and it also causes hallucinations with those who have less sanity getting more. \
-			If their sanity is low enough they snap and go insane, the spell then halves their sanity."
+	desc = "Big AoE spell that deals brain damage and causes hallucinations to everyone in the AoE. \
+			The worse their sanity, the stronger this spell becomes. \
+			If their sanity is low enough, they even snap and go insane, and the spell then further halves their sanity."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/aoe/fiery_rebirth
 	name = "Nightwatcher's Rebirth"
-	desc = "A spell that extinguishes you drains nearby heathens engulfed in flames of their life force, \
+	desc = "A spell that extinguishes you and drains nearby heathens engulfed in flames of their life force, \
 		healing you for each victim drained. Those in critical condition \
 		will have the last of their vitality drained, killing them."
 	background_icon_state = "bg_heretic"

--- a/code/modules/antagonists/heretic/magic/rust_charge.dm
+++ b/code/modules/antagonists/heretic/magic/rust_charge.dm
@@ -1,7 +1,9 @@
 // Rust charge, a charge action that can only be started on rust (and only destroys rust tiles)
 /datum/action/cooldown/mob_cooldown/charge/rust
 	name = "Rust Charge"
-	desc = "A charge that must be started on a rusted tile and will destroy any rusted objects you come into contact with, will deal high damage to others and rust around you during the charge. As it is the rust that empoweres you for this ability, no focus is needed"
+	desc = "A charge that must be started on a rusted tile and will destroy any rusted objects you come into contact with, \
+		will deal high damage to others and rust around you during the charge. \
+		As it is the rust that empowers you with this ability, no focus is needed."
 	charge_distance = 10
 	charge_damage = 50
 	cooldown_time = 45 SECONDS

--- a/code/modules/antagonists/heretic/magic/star_blast.dm
+++ b/code/modules/antagonists/heretic/magic/star_blast.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/pointed/projectile/star_blast
 	name = "Star Blast"
-	desc = "This spell fires a disk with cosmic energies at a target."
+	desc = "This spell fires a disk with cosmic energies at a target, spreading the star mark."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -1,7 +1,8 @@
 /datum/action/cooldown/spell/touch/star_touch
 	name = "Star Touch"
-	desc = "Marks someone with a star mark or puts someone with a star mark to sleep for 4 seconds, removing the star mark. \
-		You and your target are linked with a cosmic ray, burning them for up to a minute, or \
+	desc = "Manifests cosmic fields on tiles next to you while marking the victim with a star mark \
+		or consuming an already present star mark to put them to sleep for 4 seconds. \
+		They will then be linked to you with a cosmic ray, burning them for up to a minute, or \
 		until they can escape your sight. Star Touch can also remove Cosmic Runes, or teleport you \
 		to your Star Gazer when used on yourself."
 	background_icon_state = "bg_heretic"

--- a/code/modules/antagonists/heretic/status_effects/debuffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/debuffs.dm
@@ -280,7 +280,7 @@
 
 /datum/status_effect/moon_converted/on_remove()
 	// Span warning and unconscious so they realize they aren't evil anymore
-	to_chat(owner, span_warning("Your mind is cleared from the effect of the manus, your alligiences are as they were before"))
+	to_chat(owner, span_warning("Your mind is cleared from the effect of the mansus, your alligiences are as they were before"))
 	REMOVE_TRAIT(owner, TRAIT_MUTE, REF(src))
 	owner.AdjustUnconscious(5 SECONDS, ignore_canstun = FALSE)
 	owner.log_message("[owner] is no longer insane.", LOG_GAME)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -614,7 +614,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 
 /obj/item/coin/eldritch
 	name = "eldritch coin"
-	desc = "Everytime it lands it bolts or opens doors, except for you."
+	desc = "A surprisingly heavy, ornate coin. Its sides seem to depict a different image each time you look."
 	icon_state = "coin_heretic"
 	custom_materials = list(/datum/material/diamond =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/plasma =HALF_SHEET_MATERIAL_AMOUNT)
 	sideslist = list("heretic", "blade")


### PR DESCRIPTION

## About The Pull Request

Changes a lot of text. Apart from grammar fixes, here are the notable changes:

- Ash jaunt description just said it is a "short range jaunt" without explaining what exactly a jaunt is. I believe it is better to describe without comparing to another spell the player may not have experience with.
- Cosmic grasp now explains what the deal is with star marks and cosmic fields. It is still possible to crosspath into a star mark spell, skipping this description, but I assume a player like that is experienced enough to know what the star mark does anyway...
- The knowledge for ash spirits no longer refers to them as "Ash Men" - "Ash Spirit" is the mob's actual name. If you think "Ash Man" is a better name, I can change it around so that the mob gets renamed that instead.
- Removes the lines from paradoxical curio's description about causing brain damage on examination - many heretic items cause adverse effects to heathens who try to interact with them, and there is never a need to clutter the description with them.
- Changes the eldritch coin description, because the old one was, in my opinion, awkward. I changed it to be more inline with the other items' descriptions, and to not tell non-heretics what its purpose is. If you liked the old one better, I can revert this change.
## Why It's Good For The Game

Grammar good. Accurate descriptions good.
## Changelog
:cl:
fix: made some heretic descriptions more accurate
spellcheck: improved english of the heretical eldritch patrons
/:cl:
