### PR TITLE
Fixes some snowless outdoor AI satellite tiles 

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -47339,7 +47339,7 @@
 	start_active = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/area/icemoon/surface/outdoors/nospawn)
 "oxB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -56034,7 +56034,7 @@
 	start_active = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/area/icemoon/surface/outdoors/nospawn)
 "rbs" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light/directional/east,


### PR DESCRIPTION

## About The Pull Request

This fixes two funky camera spots with misconfigured areas. This leads to single tiles of non-storm space.

![image](https://github.com/tgstation/tgstation/assets/28870487/5bc63d7c-0565-42f7-9463-a4a7b99ec9c0)

![image](https://github.com/tgstation/tgstation/assets/28870487/555b8275-9e59-4c07-8f20-fd3a100d77ba)

Anyways, this doesn't happen anymore. As far as I'm aware, this isn't due to any camera shenanigans either since the other outdoor AI sat cams use the icebox outdoor area and dont have any problems. 
## Why It's Good For The Game

Clean clean fix fix ugly ugly go away.
## Changelog
:cl: Rhials
fix: Fixes some tiles outside the Icebox AI satellite not getting hit by storms.
/:cl:
