### PR TITLE
[NO GBP] Extremely tiny stupid nitpick changes to the smoking room ruin

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_smoking_room.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_smoking_room.dmm
@@ -54,6 +54,10 @@
 /obj/structure/chair/comfy{
 	dir = 1
 	},
+/obj/effect/decal/remains/human/smokey{
+	pixel_x = -3;
+	pixel_y = 9
+	},
 /turf/open/floor/carpet/blue,
 /area/ruin/smoking_room/room)
 "k" = (
@@ -245,11 +249,6 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "R" = (
-/obj/effect/spawner/random/entertainment/cigarette_pack,
-/obj/effect/decal/cleanable/ash/large{
-	pixel_x = -1;
-	pixel_y = 5
-	},
 /obj/structure/showcase/machinery/tv/broken,
 /turf/open/floor/carpet/blue,
 /area/ruin/smoking_room/room)
@@ -279,17 +278,12 @@
 /turf/open/floor/stone,
 /area/ruin/smoking_room/house)
 "W" = (
-/obj/effect/spawner/random/entertainment/cigarette_pack,
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /obj/effect/spawner/random/entertainment/cigarette_pack,
 /obj/effect/decal/cleanable/ash/large,
 /obj/structure/sign/calendar/directional/east,
-/obj/effect/decal/remains/human/smokey{
-	pixel_x = -3;
-	pixel_y = 9
-	},
 /turf/open/floor/carpet/blue,
 /area/ruin/smoking_room/room)
 "X" = (


### PR DESCRIPTION

## About The Pull Request

Ok so this just does some really really tiny changes to the smoking room of the smoking room ruin. I added this way back during march mapness and have always wanted to touch up this last area.

These are basically just touch-ups that are two years too late because they felt so insignificant and small that making an entire PR to change them felt excessive. I still feel that way but I'm also a perfectionist and this would linger in my head until the day I die.

Anyways, there should be slightly less awkwardly placed spawners, decals blocked from view. You also have to walk past the smoky remains to reach the second special lighter, instead of the first.

That's it, that's everything. You don't even get screenshots here. Sorry.
## Why It's Good For The Game

I have an obsession with revisiting and completing old, unfinished work.
## Changelog
:cl: Rhials
fix: Some tiny tiny changes to the smoking room ruin to make it a little less ugly.
/:cl:
