### PR TITLE
Feeds OOC messages back to client if blocked in validate_client()

### DIFF
--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -3,4 +3,4 @@
 
 /// Checks to see if a /client has fully gone through New() as a safeguard against certain operations.
 /// Should return the boolean value of the fully_created var, which should be TRUE if New() has finished running. FALSE otherwise.
-#define CLIENT_FULLY_INITIALIZED(target) (target.fully_created)
+#define VALIDATE_CLIENT_INITIALIZATION(target) (target.fully_created)

--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -1,11 +1,2 @@
 /// Checks if the given target is either a client or a mock client
 #define IS_CLIENT_OR_MOCK(target) (istype(target, /client) || istype(target, /datum/client_interface))
-
-/// Ensures that the client has been fully initialized via New(), and can't somehow execute actions before that. Security measure.
-/// WILL RETURN OUT OF THE ENTIRE PROC COMPLETELY IF THE CLIENT IS NOT FULLY INITIALIZED. BE WARNED IF YOU WANT RETURN VALUES.
-#define VALIDATE_CLIENT(target)\
-	if (!target.fully_created) {\
-		to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."));\
-		log_access("Client [key_name(target)] attempted to execute a verb before being fully initialized.");\
-		return\
-	}

--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -1,2 +1,6 @@
 /// Checks if the given target is either a client or a mock client
 #define IS_CLIENT_OR_MOCK(target) (istype(target, /client) || istype(target, /datum/client_interface))
+
+/// Checks to see if a /client has fully gone through New() as a safeguard against certain operations.
+/// Should return the boolean value of the fully_created var, which should be TRUE if New() has finished running. FALSE otherwise.
+#define CLIENT_FULLY_INITIALIZED(target) (target.fully_created)

--- a/code/__HELPERS/clients.dm
+++ b/code/__HELPERS/clients.dm
@@ -11,13 +11,8 @@
 			return FALSE
 	return TRUE
 
-/// Ensures that the client has been fully initialized via New(), and can't somehow execute actions before that. Security measure.
-/// Will return false if the client is not fully initialized and send an error out. True otherwise.
-/proc/validate_client(client/target)
-	. = FALSE
-	if(target.fully_created)
-		return TRUE
-
+/// Proc that just logs whenever an uninitialized client tries to do something before they have fully gone through New().
+/// Intended to be used in conjunction with the `CLIENT_FULLY_INITIALIZED()` macro, but can be dropped anywhere when we look at the `fully_created` var on /client.
+/proc/unvalidated_client_error(client/target)
 	to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."))
 	log_access("Client [key_name(target)] attempted to execute a verb before being fully initialized.")
-	return FALSE

--- a/code/__HELPERS/clients.dm
+++ b/code/__HELPERS/clients.dm
@@ -12,7 +12,7 @@
 	return TRUE
 
 /// Proc that just logs whenever an uninitialized client tries to do something before they have fully gone through New().
-/// Intended to be used in conjunction with the `CLIENT_FULLY_INITIALIZED()` macro, but can be dropped anywhere when we look at the `fully_created` var on /client.
+/// Intended to be used in conjunction with the `VALIDATE_CLIENT_INITIALIZATION()` macro, but can be dropped anywhere when we look at the `fully_created` var on /client.
 /proc/unvalidated_client_error(client/target)
 	to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."))
 	log_access("Client [key_name(target)] attempted to execute a verb before being fully initialized.")

--- a/code/__HELPERS/clients.dm
+++ b/code/__HELPERS/clients.dm
@@ -10,3 +10,14 @@
 		if (ch < 48 || ch > 57) //0-9
 			return FALSE
 	return TRUE
+
+/// Ensures that the client has been fully initialized via New(), and can't somehow execute actions before that. Security measure.
+/// Will return false if the client is not fully initialized and send an error out. True otherwise.
+/proc/validate_client(client/target)
+	. = FALSE
+	if(target.fully_created)
+		return TRUE
+
+	to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."))
+	log_access("Client [key_name(target)] attempted to execute a verb before being fully initialized.")
+	return FALSE

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -10,7 +10,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
-	var/client_initalized = CLIENT_FULLY_INITIALIZED(src)
+	var/client_initalized = VALIDATE_CLIENT_INITIALIZATION(src)
 	if(isnull(mob) || !client_initalized)
 		if(!client_initalized)
 			unvalidated_client_error() // we only want to throw this warning message when it's directly related to client failure.

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -10,8 +10,11 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
-	if(isnull(mob) || !CLIENT_FULLY_INITIALIZED(src))
-		unvalidated_client_error()
+	var/client_initalized = CLIENT_FULLY_INITIALIZED(src)
+	if(isnull(mob) || !client_initalized)
+		if(!client_initalized)
+			unvalidated_client_error() // we only want to throw this warning message when it's directly related to client failure.
+
 		to_chat(usr, span_warning("Failed to send your OOC message. You attempted to send the following message:\n[span_big(msg)]"))
 		return
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -10,7 +10,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
-	if(isnull(mob) || !validate_client(src))
+	if(isnull(mob) || !CLIENT_FULLY_INITIALIZED(src))
+		unvalidated_client_error()
 		to_chat(usr, span_warning("Failed to send your OOC message. You attempted to send the following message:\n[span_big(msg)]"))
 		return
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -11,7 +11,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		return
 
 	if(isnull(mob) || !validate_client(src))
-		to_chat(usr, span_warning("Failed to send your OOC message. You attempted to send the following message:\n[msg]"))
+		to_chat(usr, span_warning("Failed to send your OOC message. You attempted to send the following message:\n[span_big(msg)]"))
 		return
 
 	if(isnull(holder))

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -10,12 +10,11 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
-	if(!mob)
+	if(isnull(mob) || !validate_client(src))
+		to_chat(usr, span_warning("Failed to send your OOC message. You attempted to send the following message:\n[msg]"))
 		return
 
-	VALIDATE_CLIENT(src)
-
-	if(!holder)
+	if(isnull(holder))
 		if(!GLOB.ooc_allowed)
 			to_chat(src, span_danger("OOC is globally muted."))
 			return


### PR DESCRIPTION

## About The Pull Request

Basically, if your long and well-thought-out OOC message gets eaten due to your client not being fully initialized, the server will feed back the message to you so you can copy-paste and try again.

In order to facilitate this, I turned `validate_client` into a proc. This didn't have the ubiquitous usage that we were hoping for (where it could be dropped and placed anywhere) and I don't think I liked the "always exit out of proc" stuff anyhow. Also adds some code niceties.

There's probably a way cooler way to do this with tgui_say and whatever but I don't use tgui_say (byond command bar my beloved) so we'll cope with this.
## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/34697715/a96f7168-aad3-4772-9abe-7a6aa2b8779a)

Let me know if I should revert the `span_big()` stuff, I just added it because I wanted it to be obvious to the player instead of look like a generic error message.
## Changelog
:cl:
qol: If your OOC message gets eaten due to some weird circumstance in how your message is handled, it will feed the applicable message back to you so you can copy-paste and try to send it again.
/:cl:
