### PR TITLE
Bumps up several GitHub `actions` to the Node 20 Version

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run auto changelog
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -20,10 +20,10 @@ jobs:
         echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
     - name: Checkout
       if: steps.secrets_set.outputs.SECRETS_ENABLED
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Restore BYOND cache
       if: steps.secrets_set.outputs.SECRETS_ENABLED
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/BYOND
         key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -22,44 +22,44 @@ jobs:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore SpacemanDMM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ hashFiles('dependencies.sh') }}
           restore-keys: |
             ${{ runner.os }}-spacemandmm-
       - name: Restore Yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Restore Node cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.nvm
           key: ${{ runner.os }}-node-${{ hashFiles('dependencies.sh') }}
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Restore Bootstrap cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-rust-${{ hashFiles('tools/ci/ci_dependencies.sh')}}
           restore-keys: |
             ${{ runner.os }}-rust-
       - name: Restore Cutter cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tools/icon_cutter/cache
           key: ${{ runner.os }}-cutter-${{ hashFiles('dependencies.sh') }}
@@ -124,9 +124,9 @@ jobs:
       group: compile_all_maps-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore BYOND cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond
@@ -153,7 +153,7 @@ jobs:
       group: find_all_maps-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Find Maps
         id: map_finder
         run: |
@@ -220,7 +220,7 @@ jobs:
     name: Compare Screenshot Tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # If we ever add more artifacts, this is going to break, but it'll be obvious.
       - name: Download screenshot tests
         uses: actions/download-artifact@v3
@@ -244,7 +244,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} > artifacts/screenshot_comparisons/pull_request_number.txt
       - name: Upload bad screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bad-screenshots
           path: artifacts/screenshot_comparisons
@@ -258,9 +258,9 @@ jobs:
       group: test_windows-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore Yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -221,6 +221,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Setup directory
+        run: mkdir -p artifacts
       # If we ever add more artifacts, this is going to break, but it'll be obvious.
       - name: Download screenshot tests
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -223,7 +223,7 @@ jobs:
       - uses: actions/checkout@v4
       # If we ever add more artifacts, this is going to break, but it'll be obvious.
       - name: Download screenshot tests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: ls -R

--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       #Parse the Codeowner file on non draft PRs
       - name: CodeOwnersParser

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install  dos2unix
       - name: "Checkout"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 25
           persist-credentials: false

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -8,7 +8,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build and Publish Docker Image to Registry
         uses: elgohr/Publish-Docker-Github-Action@v5

--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -16,7 +16,7 @@ jobs:
         echo "ACTIONS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
     - name: Checkout
       if: steps.value_holder.outputs.ACTIONS_ENABLED
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup git
       if: steps.value_holder.outputs.ACTIONS_ENABLED
       run: |
@@ -24,7 +24,7 @@ jobs:
         git config --global user.email "<>"
     - name: Checkout alternate branch
       if: steps.value_holder.outputs.ACTIONS_ENABLED
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: "gbp-balances" # The branch name
         path: gbp-balances

--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -18,7 +18,7 @@ jobs:
         echo "ACTIONS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
     - name: Checkout
       if: steps.value_holder.outputs.ACTIONS_ENABLED
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup git
       if: steps.value_holder.outputs.ACTIONS_ENABLED
       run: |
@@ -26,7 +26,7 @@ jobs:
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - name: Checkout alternate branch
       if: steps.value_holder.outputs.ACTIONS_ENABLED
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: "gbp-balances" # The branch name
         path: gbp-balances

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency: gen-docs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}

--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Remove guide comments
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Rerun flaky tests
       uses: actions/github-script@v6
       with:
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Report flaky tests
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -28,9 +28,9 @@ jobs:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore BYOND cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
@@ -64,7 +64,7 @@ jobs:
           bash tools/ci/run_server.sh ${{ inputs.map }}
       - name: Upload screenshot tests
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_artifacts_${{ inputs.map }}
           path: data/screenshots_new/

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -66,7 +66,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test_artifacts_${{ inputs.map }}
+          name: test_artifacts_${{ inputs.map }}_${{ inputs.major }}_${{ inputs.minor }}
           path: data/screenshots_new/
           retention-days: 1
       - name: Check client Compatibility

--- a/.github/workflows/show_screenshot_test_results.yml
+++ b/.github/workflows/show_screenshot_test_results.yml
@@ -25,7 +25,7 @@ jobs:
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Checkout
         if: steps.secrets_set.outputs.SECRETS_ENABLED
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Prepare module
         if: steps.secrets_set.outputs.SECRETS_ENABLED
         run: |

--- a/.github/workflows/test_merge_bot.yml
+++ b/.github/workflows/test_merge_bot.yml
@@ -23,7 +23,7 @@ jobs:
             echo "GET_TEST_MERGES_URL=$SECRET_EXISTS" >> $GITHUB_OUTPUT
         - name: Checkout
           if: steps.secrets_set.outputs.GET_TEST_MERGES_URL
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Prepare module
           if: steps.secrets_set.outputs.GET_TEST_MERGES_URL
           run: |

--- a/.github/workflows/tgs_test.yml
+++ b/.github/workflows/tgs_test.yml
@@ -62,7 +62,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test TGS Integration
         run: dotnet run -c Release --project tools/tgs_test ${{ github.repository }} /tgs_instances/tgstation ${{ env.TGS_API_PORT }} ${{ github.event.pull_request.head.sha || github.sha }} ${{ secrets.GITHUB_TOKEN }} ${{ env.PR_NUMBER }}

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update the TGS DMAPI
     steps:
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Branch
       run: |


### PR DESCRIPTION
## About The Pull Request

Node 16 actions are deprecated, we need to use Node 20 actions now (as noted by this handy screenshot which spams it on every CI run)

![image](https://github.com/tgstation/tgstation/assets/34697715/24ea3013-c762-4027-951c-d598b1eec8a3)

You may see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ for more information.