### PR TITLE
Makes Ethereal Charging Loop Just About Everywhere

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -221,7 +221,7 @@
 			return
 		stomach.drain_time = world.time + APC_DRAIN_TIME
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, balloon_alert), ethereal, "draining power"), alert_timer_duration)
-		if(do_after(user, APC_DRAIN_TIME, target = src))
+		while(do_after(user, APC_DRAIN_TIME, target = src))
 			if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
 				return
 			balloon_alert(ethereal, "received charge")
@@ -243,9 +243,10 @@
 		balloon_alert(ethereal, "can't transfer power!")
 		return
 	if(istype(stomach))
-		balloon_alert(ethereal, "transferred power")
-		stomach.adjust_charge(-APC_POWER_GAIN)
-		cell.give(APC_POWER_GAIN)
+		while(do_after(user, APC_DRAIN_TIME, target = src))
+			balloon_alert(ethereal, "transferred power")
+			stomach.adjust_charge(-APC_POWER_GAIN)
+			cell.give(APC_POWER_GAIN)
 	else
 		balloon_alert(ethereal, "can't transfer power!")
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -246,7 +246,7 @@
 				return
 			to_chat(H, span_notice("You begin clumsily channeling power from [src] into your body."))
 			stomach.drain_time = world.time + CELL_DRAIN_TIME
-			if(do_after(user, CELL_DRAIN_TIME, target = src))
+			while(do_after(user, CELL_DRAIN_TIME, target = src))
 				if((charge < CELL_POWER_DRAIN) || (stomach.crystal_charge > charge_limit))
 					return
 				if(istype(stomach))


### PR DESCRIPTION
## About The Pull Request
Basically,


For APCs.
![dreamseeker_bfZeNmkOPh](https://github.com/tgstation/tgstation/assets/12636964/39eddc7b-7389-4586-a392-4a8d2437e93b)


For recharging APCs.
![dreamseeker_mlKuDR2JJW](https://github.com/tgstation/tgstation/assets/12636964/1f28850c-57a7-43b2-9663-81b2f3b34ce9)


For recharging from cells. The Ethereal offscreen was blue, you'll just have to trust me that this was a color-coded PR.
![dreamseeker_bcP0126NlF](https://github.com/tgstation/tgstation/assets/12636964/c20eff96-3112-4b9b-a733-c320528adb5e)

## Why It's Good For The Game
It's kind of CBT as-is right now to have to click this stuff over and over, especially when light tubes have it that much more convenient than everything else. I figure some while loops would make the situation better for them.

## Changelog
:cl:
qol: Ethereal charging now loops when they're charging (from) APCs or from power cells!
/:cl: