### PR TITLE
fixes extra prob() in living flesh Life proc

### DIFF
--- a/code/modules/mob/living/basic/ruin_defender/flesh.dm
+++ b/code/modules/mob/living/basic/ruin_defender/flesh.dm
@@ -49,12 +49,12 @@
 	if(isnull(current_bodypart) || isnull(current_bodypart.owner))
 		return
 	var/mob/living/carbon/human/victim = current_bodypart.owner
-	if(prob(SPT_PROB(3, SSMOBS_DT)))
+	if(SPT_PROB(3, SSMOBS_DT))
 		to_chat(victim, span_warning("The thing posing as your limb makes you feel funny...")) //warn em
 	//firstly as a sideeffect we drain nutrition from our host
 	victim.adjust_nutrition(-1.5)
 
-	if(!prob(SPT_PROB(1.5, SSMOBS_DT)))
+	if(!SPT_PROB(1.5, SSMOBS_DT))
 		return
 
 	if(istype(current_bodypart, /obj/item/bodypart/arm))


### PR DESCRIPTION

## About The Pull Request
SRT_PROB is prob() already, removed extra in `/mob/living/basic/living_limb_flesh/Life`
## Why It's Good For The Game
in this commit https://github.com/tgstation/tgstation/pull/79149/commits/913802c076daefa533f3a2a3f2011ebb54d71659 in this pr https://github.com/tgstation/tgstation/pull/79149 the author did it by accident, I think. Because It is very low chance
## Changelog
:cl:
fix: fixed the chances of living flesh actions
/:cl:
