### PR TITLE
Unreverses a revolver in deathmatch

### DIFF
--- a/_maps/map_files/Deathmatch/arena.dmm
+++ b/_maps/map_files/Deathmatch/arena.dmm
@@ -151,7 +151,7 @@
 /turf/open/indestructible/dark/smooth_large,
 /area/deathmatch)
 "lQ" = (
-/obj/item/gun/ballistic/revolver/reverse,
+/obj/item/gun/ballistic/revolver/syndicate,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/light_emitter{
 	set_cap = 2;


### PR DESCRIPTION

## About The Pull Request

Replaces the reverse revolver in the underground thunderdome with a normal one.

## Why It's Good For The Game

Accidentally trolling deathmatch players if they don't pass the knowledge check is cruel.

## Changelog
:cl:
fix: Unreverses the syndicate revolver in the Underground Thunderdome deathmatch map.
/:cl:
