### PR TITLE
fixes basic mobs with ranged attacks attacking in containers

### DIFF
--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -50,7 +50,7 @@
 	if(living_mob.see_invisible < the_target.invisibility) //Target's invisible to us, forget it
 		return FALSE
 
-	if(isturf(living_mob.loc) && isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
+	if(!ismob(living_mob.loc) && isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
 		return FALSE
 
 	if(isliving(the_target)) //Targeting vs living mobs

--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -50,7 +50,9 @@
 	if(living_mob.see_invisible < the_target.invisibility) //Target's invisible to us, forget it
 		return FALSE
 
-	if(!ismob(living_mob.loc) && isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
+	if(!isturf(living_mob.loc))
+		return FALSE
+	if(isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
 		return FALSE
 
 	if(isliving(the_target)) //Targeting vs living mobs


### PR DESCRIPTION
## About The Pull Request
see title - changes an isturf check to an !ismob check for an attacking basic mob's loc in can_attack(), as previously this allowed mobs to shoot from inside containers

## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/31829017/ffe03955-78f2-4e6e-b15c-9fdf6d85d588)
## Changelog

:cl:
fix: Basic mobs no longer have the (unintended) ability to shoot out of containers, like bluespace body bags.
/:cl:
