### PR TITLE
Fixes missing args in a few procs registered to COMSIG_LIVING_ELECTROCUTE_ACT

### DIFF
--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -33,7 +33,7 @@
 	SIGNAL_HANDLER
 	adjust_charge(amount / 3.5)
 
-/obj/item/organ/internal/stomach/ethereal/proc/on_electrocute(datum/source = owner, shock_damage, shock_source, siemens_coeff = 1, flags = NONE)
+/obj/item/organ/internal/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, shock_source, siemens_coeff = 1, flags = NONE)
 	SIGNAL_HANDLER
 	if(flags & SHOCK_ILLUSION)
 		return

--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -33,7 +33,7 @@
 	SIGNAL_HANDLER
 	adjust_charge(amount / 3.5)
 
-/obj/item/organ/internal/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, siemens_coeff = 1, flags = NONE)
+/obj/item/organ/internal/stomach/ethereal/proc/on_electrocute(datum/source = owner, shock_damage, shock_source, siemens_coeff = 1, flags = NONE)
 	SIGNAL_HANDLER
 	if(flags & SHOCK_ILLUSION)
 		return

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -184,7 +184,7 @@
 
 	parent.cell.give(amount)
 
-/obj/item/circuit_component/bci_core/proc/on_electrocute(datum/source, shock_damage, siemens_coefficient, flags)
+/obj/item/circuit_component/bci_core/proc/on_electrocute(datum/source, shock_damage, shock_source, siemens_coefficient, flags)
 	SIGNAL_HANDLER
 
 	if (isnull(parent.cell))


### PR DESCRIPTION
## About The Pull Request

That's it really. 

![image](https://github.com/tgstation/tgstation/assets/13398309/08bd4dd7-b5e7-4c22-91b7-1dadf5776508)

It's supposed to have a `shock_source` arg, but 2/3 of the procs that are registered to this signal don't include that in their args list.

## Why It's Good For The Game

Out of order positional args = bad.

## Changelog

Nothing player facing (probably)
