### PR TITLE
Makes the Omen coupon only trigger bad luck once, like it used to

### DIFF
--- a/code/modules/cargo/coupon.dm
+++ b/code/modules/cargo/coupon.dm
@@ -84,7 +84,7 @@
 	to_chat(cursed, span_warning("The coupon reads '<b>fuck you</b>' in large, bold text... is- is that a prize, or?"))
 
 	if(!cursed.GetComponent(/datum/component/omen))
-		cursed.AddComponent(/datum/component/omen)
+		cursed.AddComponent(/datum/component/omen, 1)
 		return TRUE
 	if(HAS_TRAIT(cursed, TRAIT_CURSED))
 		to_chat(cursed, span_warning("What a horrible night... To have a curse!"))


### PR DESCRIPTION

## About The Pull Request
Tin
## Why It's Good For The Game
Idk when it happened, but someone managed to not input an `incidents_left` for the coupon's component addition, which made it default to `INFINITE`. As such, this would actually leave you with a **_worse_** curse than the quirk itself, since EVERYTHING would be more likely to hit you.
## Changelog
:cl: Wallem
fix: The cursed coupon now only triggers a cursed event once, rather than infinite times.
/:cl:
