### PR TITLE
Thermal Pistol Rework Attempt Two: You Spin to Win (it uses the crank energy weapon mechanics)

### DIFF
--- a/code/datums/components/crank_recharge.dm
+++ b/code/datums/components/crank_recharge.dm
@@ -2,6 +2,8 @@
 /datum/component/crank_recharge
 	/// Our cell to charge
 	var/obj/item/stock_parts/cell/charging_cell
+	/// Whether we spin our gun to reload (and therefore need the relevant trait)
+	var/spin_to_win = FALSE
 	/// How much charge we give our cell on each crank
 	var/charge_amount
 	/// How long is the cooldown time between each charge
@@ -14,13 +16,14 @@
 	var/is_charging = FALSE
 	COOLDOWN_DECLARE(charge_sound_cooldown)
 
-/datum/component/crank_recharge/Initialize(charging_cell, charge_amount = 500, cooldown_time = 2 SECONDS, charge_sound = 'sound/weapons/laser_crank.ogg', charge_sound_cooldown_time = 1.8 SECONDS)
+/datum/component/crank_recharge/Initialize(charging_cell, spin_to_win = FALSE, charge_amount = 500, cooldown_time = 2 SECONDS, charge_sound = 'sound/weapons/laser_crank.ogg', charge_sound_cooldown_time = 1.8 SECONDS)
 	. = ..()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(isnull(charging_cell) || !istype(charging_cell, /obj/item/stock_parts/cell))
 		return COMPONENT_INCOMPATIBLE
 	src.charging_cell = charging_cell
+	src.spin_to_win = spin_to_win
 	src.charge_amount = charge_amount
 	src.cooldown_time = cooldown_time
 	src.charge_sound = charge_sound
@@ -45,6 +48,10 @@
 		return
 	if(is_charging)
 		return
+	if(spin_to_win && !HAS_TRAIT(user, TRAIT_GUNFLIP))
+		source.balloon_alert(user, "need holster to spin!")
+		return
+
 	is_charging = TRUE
 	if(COOLDOWN_FINISHED(src, charge_sound_cooldown))
 		COOLDOWN_START(src, charge_sound_cooldown, charge_sound_cooldown_time)
@@ -56,4 +63,6 @@
 	charging_cell.give(charge_amount)
 	source.update_appearance()
 	is_charging = FALSE
+	if(spin_to_win)
+		source.SpinAnimation(4, 2) //What a badass
 	source.balloon_alert(user, "charged")

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -330,8 +330,8 @@
 /datum/supply_pack/security/armory/thermal
 	name = "Thermal Pistol Crate"
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, \
-		using nanites as the basis for their ammo."
-	cost = CARGO_CRATE_VALUE * 7
+		using nanites as the basis for their ammo. Can be shaken to reload."
+	cost = CARGO_CRATE_VALUE * 10
 	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
 	crate_name = "thermal pistol crate"
 

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -72,3 +72,55 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/smoothbore/prime)
 	charge_sections = 2
 	spread = 0 //could be like 5, but having just very tiny spread kinda feels like bullshit
+
+//Inferno and Cryo Pistols
+
+/obj/item/gun/energy/laser/thermal //the common parent of these guns, it just shoots hard bullets, somoene might like that?
+	name = "nanite pistol"
+	desc = "A modified handcannon with a metamorphic reserve of decommissioned weaponized nanites. Spit globs of angry robots into the bad guys."
+	icon_state = "infernopistol"
+	inhand_icon_state = null
+	ammo_type = list(/obj/item/ammo_casing/energy/nanite)
+	shaded_charge = TRUE
+	ammo_x_offset = 1
+	obj_flags = UNIQUE_RENAME
+	can_bayonet = TRUE
+	knife_x_offset = 19
+	knife_y_offset = 13
+	w_class = WEIGHT_CLASS_NORMAL
+	dual_wield_spread = 5 //as intended by the coders
+
+/obj/item/gun/energy/laser/thermal/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS)
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = 125, \
+		cooldown_time = 0.5 SECONDS, \
+		charge_sound = 'sound/weapons/kinetic_reload.ogg', \
+		charge_sound_cooldown_time = 0.5 SECONDS, \
+	)
+
+/obj/item/gun/energy/laser/thermal/add_seclight_point()
+	AddComponent(/datum/component/seclite_attachable, \
+		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
+		light_overlay = "flight", \
+		overlay_x = 15, \
+		overlay_y = 9)
+
+/obj/item/gun/energy/laser/thermal/inferno //the magma gun
+	name = "inferno pistol"
+	desc = "A modified handcannon with a metamorphic reserve of decommissioned weaponized nanites. Spit globs of molten angry robots into the bad guys. \
+		While it doesn't manipulate temperature in and of itself, it does cause an violent eruption in anyone who is severely cold. Able to generate \
+		ammunition by manually spinning the weapon's nanite canister."
+	icon_state = "infernopistol"
+	ammo_type = list(/obj/item/ammo_casing/energy/nanite/inferno)
+
+/obj/item/gun/energy/laser/thermal/cryo //the ice gun
+	name = "cryo pistol"
+	desc = "A modified handcannon with a metamorphic reserve of decommissioned weaponized nanites. Spit shards of frozen angry robots into the bad guys. \
+		While it doesn't manipulate temperature in and of itself, it does cause an internal explosion in anyone who is severely hot. Able to generate \
+		ammunition by manually spinning the weapon's nanite canister."
+	icon_state = "cryopistol"
+	ammo_type = list(/obj/item/ammo_casing/energy/nanite/cryo)

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -98,9 +98,9 @@
 		charging_cell = get_cell(), \
 		spin_to_win = TRUE, \
 		charge_amount = 125, \
-		cooldown_time = 0.5 SECONDS, \
+		cooldown_time = 0.8 SECONDS, \
 		charge_sound = 'sound/weapons/kinetic_reload.ogg', \
-		charge_sound_cooldown_time = 0.5 SECONDS, \
+		charge_sound_cooldown_time = 0.8 SECONDS, \
 	)
 
 /obj/item/gun/energy/laser/thermal/add_seclight_point()

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -96,6 +96,7 @@
 	AddComponent( \
 		/datum/component/crank_recharge, \
 		charging_cell = get_cell(), \
+		spin_to_win = TRUE, \
 		charge_amount = 125, \
 		cooldown_time = 0.5 SECONDS, \
 		charge_sound = 'sound/weapons/kinetic_reload.ogg', \

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -187,48 +187,6 @@
 /obj/item/gun/energy/laser/redtag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan)
 
-//Inferno and Cryo Pistols
-
-/obj/item/gun/energy/laser/thermal //the common parent of these guns, it just shoots hard bullets, somoene might like that?
-	name = "nanite pistol"
-	desc = "A modified handcannon with a metamorphic reserve of decommissioned weaponized nanites. Spit globs of angry robots into the bad guys."
-	icon_state = "infernopistol"
-	inhand_icon_state = null
-	ammo_type = list(/obj/item/ammo_casing/energy/nanite)
-	shaded_charge = TRUE
-	ammo_x_offset = 1
-	obj_flags = UNIQUE_RENAME
-	can_bayonet = TRUE
-	knife_x_offset = 19
-	knife_y_offset = 13
-	w_class = WEIGHT_CLASS_NORMAL
-	dual_wield_spread = 10 //as intended by the coders
-
-/obj/item/gun/energy/laser/thermal/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS)
-
-/obj/item/gun/energy/laser/thermal/add_seclight_point()
-	AddComponent(/datum/component/seclite_attachable, \
-		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
-		light_overlay = "flight", \
-		overlay_x = 15, \
-		overlay_y = 9)
-
-/obj/item/gun/energy/laser/thermal/inferno //the magma gun
-	name = "inferno pistol"
-	desc = "A modified handcannon with a metamorphic reserve of decommissioned weaponized nanites. Spit globs of molten angry robots into the bad guys. \
-		While it doesn't manipulate temperature in and of itself, it does cause an violent eruption in anyone who is severely cold."
-	icon_state = "infernopistol"
-	ammo_type = list(/obj/item/ammo_casing/energy/nanite/inferno)
-
-/obj/item/gun/energy/laser/thermal/cryo //the ice gun
-	name = "cryo pistol"
-	desc = "A modified handcannon with a metamorphic reserve of decommissioned weaponized nanites. Spit shards of frozen angry robots into the bad guys. \
-		While it doesn't manipulate temperature in and of itself, it does cause an internal explosion in anyone who is severely hot."
-	icon_state = "cryopistol"
-	ammo_type = list(/obj/item/ammo_casing/energy/nanite/cryo)
-
 // luxury shuttle funnies
 /obj/item/firing_pin/paywall/luxury
 	multi_payment = TRUE


### PR DESCRIPTION

## About The Pull Request

Thermal pistols now can be 'cranked' in order to reload them, similar to a smoothbore disabler. Each 'crank' recharges one shot out of 8 shots. 

And by crank, I mean you SPIN THE GUN. In order to spin guns, you need a holster. So, without a holster, you can't utilize this mechanic of the pistols.

(Also they're more accurate while dual-wielded hoo haa)

Thermal pistol crates are now slightly more expensive, at 2000 credits. (is this even a balancing point now that we have stocks?)

## Why It's Good For The Game

People really liked what was going on in this [PR with the gun flipping resulting in a reload](https://github.com/tgstation/tgstation/pull/76076). However, it was...maybe a little too strong.

As a more middle ground approach, the gun crank component was a particularly helpful addition to the game that allows for things like...slow bullet-by-bullet reloading of even energy weapons.

## Changelog
:cl:
balance: Thermal pistols can now be 'cranked' to recharge shots. You must have a holster equipped in order to utilize this feature. Also, they have a tighter dual-wield cone.
balance: Thermal pistol crates are now 2000 credits, up from 1400 credits.
/:cl:
