### PR TITLE
Moffers Crafting Recipe

### DIFF
--- a/code/datums/components/crafting/entertainment.dm
+++ b/code/datums/components/crafting/entertainment.dm
@@ -1,3 +1,22 @@
+/datum/crafting_recipe/moffers
+	name = "Moffers"
+	result = /obj/item/clothing/shoes/clown_shoes/moffers
+	time = 6 SECONDS //opportunity to rethink your life
+	reqs = list(
+		/obj/item/stack/sheet/animalhide/mothroach = 2,
+		/obj/item/clothing/shoes/clown_shoes = 1,
+	)
+	parts = list(/obj/item/clothing/shoes/clown_shoes = 1)
+	blacklist = list(
+		/obj/item/clothing/shoes/clown_shoes/combat,
+		/obj/item/clothing/shoes/clown_shoes/banana_shoes,
+		/obj/item/clothing/shoes/clown_shoes/banana_shoes/combat,
+		/obj/item/clothing/shoes/clown_shoes/jester,
+		/obj/item/clothing/shoes/clown_shoes/meown_shoes,
+		/obj/item/clothing/shoes/clown_shoes/moffers,
+	)
+	category = CAT_ENTERTAINMENT
+
 /datum/crafting_recipe/mothplush
 	name = "Moth Plushie"
 	result = /obj/item/toy/plush/moth


### PR DESCRIPTION
## About The Pull Request

Adds a crafting recipe to make Moffers clown shoes, using 2 mothroach hides and 1 pair of clown shoes, to the entertainment section of the crafting menu. Only the basic clown shoes can be used to make it, so other clown shoes like meown shoes won't work.


https://github.com/tgstation/tgstation/assets/105574010/527424d7-107b-4a62-aa29-92056be2b136

![Screenshot 2024-03-04 095521](https://github.com/tgstation/tgstation/assets/105574010/ba3b53f4-3ebf-4f32-b61c-734360e00de2)

## Why It's Good For The Game

Creates an additional use for mothroach hides so that they're not only for making moth plushies, giving another mechanical reason to butcher mothroaches. This will also allow the clown to psychotically pull the hide of a mothroach over each of their shoes and parade them around proudly to the horror of anyone watching.

## Changelog
:cl:
add: Added Moffers as a crafting recipe in the entertainment section.
/:cl:
