### PR TITLE
OpenDream TypeMaker Prep

### DIFF
--- a/code/__DEFINES/procpath.dm
+++ b/code/__DEFINES/procpath.dm
@@ -15,12 +15,12 @@
 	// below, their accesses are optimized away.
 
 	/// A text string of the verb's name.
-	var/name as text|null
+	var/name = null as text|null
 	/// The verb's help text or description.
-	var/desc as text|null
+	var/desc = null as text|null
 	/// The category or tab the verb will appear in.
-	var/category as text|null
+	var/category = null as text|null
 	/// Only clients/mobs with `see_invisibility` higher can use the verb.
-	var/invisibility as num|null
+	var/invisibility = null as num|null
 	/// Whether or not the verb appears in statpanel and commandbar when you press space
-	var/hidden as num|null
+	var/hidden = null as num|null

--- a/code/__DEFINES/procpath.dm
+++ b/code/__DEFINES/procpath.dm
@@ -15,12 +15,12 @@
 	// below, their accesses are optimized away.
 
 	/// A text string of the verb's name.
-	var/name as text
+	var/name as text|null
 	/// The verb's help text or description.
-	var/desc as text
+	var/desc as text|null
 	/// The category or tab the verb will appear in.
-	var/category as text
+	var/category as text|null
 	/// Only clients/mobs with `see_invisibility` higher can use the verb.
-	var/invisibility as num
+	var/invisibility as num|null
 	/// Whether or not the verb appears in statpanel and commandbar when you press space
-	var/hidden as num
+	var/hidden as num|null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -497,7 +497,7 @@
 	log_message("points at [pointing_at]", LOG_EMOTE)
 	visible_message("<span class='infoplain'>[span_name("[src]")] points at [pointing_at].</span>", span_notice("You point at [pointing_at]."))
 
-/mob/living/verb/succumb(whispered as null)
+/mob/living/verb/succumb(whispered as num|null)
 	set hidden = TRUE
 	if (!CAN_SUCCUMB(src))
 		if(HAS_TRAIT(src, TRAIT_SUCCUMB_OVERRIDE))

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -2,7 +2,7 @@
 //This proc is the most basic of the procs. All it does is make a new mob on the same tile and transfer over a few variables.
 //Returns the new mob
 //Note that this proc does NOT do MMI related stuff!
-/mob/proc/change_mob_type(new_type = null, turf/location = null, new_name = null as text, delete_old_mob = FALSE)
+/mob/proc/change_mob_type(new_type = null, turf/location = null, new_name = null as text|null, delete_old_mob = FALSE)
 
 	if(isnewplayer(src))
 		to_chat(usr, span_danger("Cannot convert players who have not entered yet."))


### PR DESCRIPTION
## About The Pull Request

OpenDream is adding support for proc and var typechecking using `as` in https://github.com/OpenDreamProject/OpenDream/pull/1705

BYOND silently ignores most uses of `as`, but OpenDream can leverage it for static typing.

E.g. the following code will error in OpenDream while doing nothing in BYOND:
```
/datum/proc/meep() as text
    return "meep"

/datum/foobar/meep()
    return 5
```
`Warning OD2701 at code.dm:29:8: /datum/foobar/meep(): Invalid return type "num", expected "text"`

Pragmas allow these type emissions to be warnings, errors, or suppressed entirely.

This PR modifies some existing uses of `as` in TG to prevent `ImplicitNullType` warnings (which is when a var with a null value doesn't explicitly have the `|null` type specified). This specific pragma is a bit opinionated so it could simply be disabled, but since this has no impact on BYOND behavior I don't see a reason not to fix these examples anyways.

## Why It's Good For The Game

Typechecking.

## Changelog

no cl no fun
