### PR TITLE
Changes animation of status alerts (makes it bounce slightly like Project Zomboid) 

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -68,8 +68,8 @@
 	if(client && hud_used)
 		hud_used.reorganize_alerts()
 	if(!no_anim)
-		thealert.transform = matrix(32, 6, MATRIX_TRANSLATE)
-		animate(thealert, transform = matrix(), time = 2.5, easing = CUBIC_EASING)
+		thealert.transform = matrix(32, 0, MATRIX_TRANSLATE)
+		animate(thealert, transform = matrix(), time = 1 SECONDS, easing = ELASTIC_EASING)
 	if(timeout_override)
 		thealert.timeout = timeout_override
 	if(thealert.timeout)


### PR DESCRIPTION
## About The Pull Request

Changes the easing and slows down status alert animations.

https://github.com/tgstation/tgstation/assets/51863163/3e5a7789-5c38-446d-9c9c-197fe1a320d2

## Why It's Good For The Game

I was playing Project Zomboid a while back, a game which has a similar alert system that we have (in that they stack up on the right side of the screen), and I wondered "why don't our screen alerts animate, why do they just pop up?"

And the answer to that is they do animate. But their animation is... 0.25 seconds long. Which is at worst, not noticeable, and at best, glitchy looking. 

So I just... changed the easing and slowed it down a bit. 

Now, when an alert enters the screen, it does a little bounce. 

I believe this will make screen alerts a bit less unpleasant to look at and a bit more noticeable for newer players. This also has a neat effect (as demonstrated in the video) of making "updating" alerts stand out a bit more. Before when something like "wounded" would update, it would just appear to be glitching out of the right side of the screen. Now it wiggles to show you it's updated. 

And of course, this can be played with in the future. If we wanted to go full Zomboid style we can scale the power of the bounce down for less important alerts / scale it up for more pertinent alerts. Or bounce things which are actively a hazard like pressure or fire or temperature. 

Also, we can give alerts a bit more of a static order. In the demo video it swaps around which is kinda ugly, but we can fix that. 

## Changelog

:cl: Melbert
add: The animation that plays when an alert pops up on your screen is different. 
/:cl:

