### PR TITLE
Fixes jank with moving down Zs as a ghost

### DIFF
--- a/code/modules/mob/dead/observer/observer_movement.dm
+++ b/code/modules/mob/dead/observer/observer_movement.dm
@@ -1,9 +1,9 @@
 /mob/dead/observer/down()
-	set name = "Move Downwards"
+	set name = "Move Down"
 	set category = "IC"
 
 	if(zMove(DOWN, z_move_flags = ZMOVE_FEEDBACK))
-		to_chat(src, span_notice("You move downwards."))
+		to_chat(src, span_notice("You move down."))
 
 /mob/dead/observer/up()
 	set name = "Move Upwards"

--- a/code/modules/mob/dead/observer/observer_movement.dm
+++ b/code/modules/mob/dead/observer/observer_movement.dm
@@ -1,11 +1,17 @@
+/mob/dead/observer/down()
+	set name = "Move Downwards"
+	set category = "IC"
+
+	if(zMove(DOWN, z_move_flags = ZMOVE_FEEDBACK))
+		to_chat(src, span_notice("You move upwards."))
+
 /mob/dead/observer/up()
 	set name = "Move Upwards"
 	set category = "IC"
 
 	if(zMove(UP, z_move_flags = ZMOVE_FEEDBACK))
-		to_chat(src, "<span class='notice'>You move upwards.</span>")
+		to_chat(src, span_notice("You move upwards."))
 
 /mob/dead/observer/can_z_move(direction, turf/start, turf/destination, z_move_flags = NONE, mob/living/rider)
 	z_move_flags |= ZMOVE_IGNORE_OBSTACLES  //observers do not respect these FLOORS you speak so much of.
 	return ..()
-

--- a/code/modules/mob/dead/observer/observer_movement.dm
+++ b/code/modules/mob/dead/observer/observer_movement.dm
@@ -3,7 +3,7 @@
 	set category = "IC"
 
 	if(zMove(DOWN, z_move_flags = ZMOVE_FEEDBACK))
-		to_chat(src, span_notice("You move upwards."))
+		to_chat(src, span_notice("You move downwards."))
 
 /mob/dead/observer/up()
 	set name = "Move Upwards"


### PR DESCRIPTION
## About The Pull Request

Caused by goof's PR. Because for some reason observers overridde `up` to skip checks but not `down`. 

## Changelog

:cl: Melbert
fix: Moving "down" as an observer is no longer janky. 
/:cl:

