### PR TITLE
Bump min compiler version to 515.1627

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -5,4 +5,4 @@
 # Format is version: map
 # Example:
 # 500.1337: runtimestation
-515.1621: runtimestation
+515.1624: runtimestation

--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -5,4 +5,4 @@
 # Format is version: map
 # Example:
 # 500.1337: runtimestation
-515.1624: runtimestation
+515.1626: runtimestation

--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -5,4 +5,4 @@
 # Format is version: map
 # Example:
 # 500.1337: runtimestation
-515.1626: runtimestation
+515.1627: runtimestation

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,11 +2,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1621
+#define MIN_COMPILER_BUILD 1624
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 515.1621 or higher
+#error You need version 515.1624 or higher
 #endif
 
 // Keep savefile compatibilty at minimum supported level

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,11 +2,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1624
+#define MIN_COMPILER_BUILD 1626
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 515.1624 or higher
+#error You need version 515.1626 or higher
 #endif
 
 // Keep savefile compatibilty at minimum supported level

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,11 +2,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1626
+#define MIN_COMPILER_BUILD 1627
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 515.1626 or higher
+#error You need version 515.1627 or higher
 #endif
 
 // Keep savefile compatibilty at minimum supported level


### PR DESCRIPTION
## About The Pull Request

Here we go again.

1624 fixed some bugs with `::`, which we're starting to make more use of. 

![image](https://github.com/tgstation/tgstation/assets/51863163/73c40c58-fcd5-463e-9ec7-2cf2fadcefb4)

Case in point: This test run https://github.com/tgstation/tgstation/actions/runs/8147514803/job/22268415319?pr=81726

But then we need the fixes for 1624 so we go to 1626. 

But also 1627 has compiler improvements so might as well
