### PR TITLE
Curtains behave like curtains should, by not being a wall

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -760,11 +760,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
 	open = !open
 	if(open)
 		layer = SIGN_LAYER
-		set_density(FALSE)
 		set_opacity(FALSE)
 	else
 		layer = WALL_OBJ_LAYER
-		set_density(TRUE)
 		if(opaque_closed)
 			set_opacity(TRUE)
 


### PR DESCRIPTION
## About The Pull Request
 This has bothered more for far too long that curtains suddenly become solid objects instead of, well, behaving like curtains in any form do and just bend out of your way. They function the same from an opacity POV but i just removed the density toggle so they'll always allow passthrough.

![image](https://github.com/tgstation/tgstation/assets/22140677/9311242f-fb5d-4640-b7f3-82ad243133f2)
![image](https://github.com/tgstation/tgstation/assets/22140677/fd3d5a5d-8458-4595-9e2e-2b83426d8e61)


## Why It's Good For The Game

You can have your privacy and have realistic curtains

## Changelog
:cl:Zergspower
qol: Curtains and shower curtains are no longer solid objects that defy common sense
/:cl:
