### PR TITLE
Add ability to swap IDs inside computers

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -280,7 +280,7 @@
 		inserting_id.forceMove(src)
 
 	if(!isnull(computer_id_slot))
-		RemoveID(user, TRUE)
+		RemoveID(user, silent = TRUE)
 
 	computer_id_slot = inserting_id
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -411,6 +411,10 @@
 /obj/item/modular_computer/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()
 
+	if(computer_id_slot && isidcard(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Swap ID"
+		. = CONTEXTUAL_SCREENTIP_SET
+
 	if(held_item?.tool_behaviour == TOOL_SCREWDRIVER && internal_cell)
 		context[SCREENTIP_CONTEXT_RMB] = "Remove Cell"
 		. = CONTEXTUAL_SCREENTIP_SET

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -267,30 +267,29 @@
 
 /**
  * InsertID
- * Attempt to insert the ID in either card slot.
+ * Attempt to insert the ID in either card slot, if ID is present - attempts swap
  * Args:
  * inserting_id - the ID being inserted
  * user - The person inserting the ID
  */
 /obj/item/modular_computer/InsertID(obj/item/card/inserting_id, mob/user)
-	//all slots taken
-	if(computer_id_slot)
+	if(!isnull(user) && !user.transferItemToLoc(inserting_id, src))
 		return FALSE
 
-	if(user)
-		if(!user.transferItemToLoc(inserting_id, src))
-			return FALSE
-		to_chat(user, span_notice("You insert \the [inserting_id] into the card slot."))
 	else
 		inserting_id.forceMove(src)
 
+	if(!isnull(computer_id_slot))
+		RemoveID(user, TRUE)
+
 	computer_id_slot = inserting_id
 
+	if(!isnull(user))
+		to_chat(user, span_notice("You insert \the [inserting_id] into the card slot."))
+		balloon_alert(user, "inserted ID")
+
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-	if(ishuman(loc))
-		var/mob/living/carbon/human/human_wearer = loc
-		if(human_wearer.wear_id == src)
-			human_wearer.sec_hud_set_ID()
+
 	update_appearance()
 	update_slot_icon()
 	SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_INSERTED_ID, inserting_id, user)
@@ -300,8 +299,9 @@
  * Removes the ID card from the computer, and puts it in loc's hand if it's a mob
  * Args:
  * user - The mob trying to remove the ID, if there is one
+ * silent - Boolean, determines whether fluff text would be printed
  */
-/obj/item/modular_computer/RemoveID(mob/user)
+/obj/item/modular_computer/RemoveID(mob/user, silent = FALSE)
 	if(!computer_id_slot)
 		return ..()
 
@@ -314,14 +314,12 @@
 		computer_id_slot.forceMove(drop_location())
 
 	computer_id_slot = null
-	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-	balloon_alert(user, "removed ID")
-	to_chat(user, span_notice("You remove the card from the card slot."))
 
-	if(ishuman(loc))
-		var/mob/living/carbon/human/human_wearer = loc
-		if(human_wearer.wear_id == src)
-			human_wearer.sec_hud_set_ID()
+	if(!silent && !isnull(user))
+		to_chat(user, span_notice("You remove the card from the card slot."))
+		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
+		balloon_alert(user, "removed ID")
+
 	update_slot_icon()
 	update_appearance()
 	return TRUE

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -290,6 +290,11 @@
 
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 
+	if(ishuman(loc))
+		var/mob/living/carbon/human/human_wearer = loc
+		if(human_wearer.wear_id == src)
+			human_wearer.sec_hud_set_ID()
+
 	update_appearance()
 	update_slot_icon()
 	SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_INSERTED_ID, inserting_id, user)
@@ -319,6 +324,11 @@
 		to_chat(user, span_notice("You remove the card from the card slot."))
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 		balloon_alert(user, "removed ID")
+
+	if(ishuman(loc))
+		var/mob/living/carbon/human/human_wearer = loc
+		if(human_wearer.wear_id == src)
+			human_wearer.sec_hud_set_ID()
 
 	update_slot_icon()
 	update_appearance()


### PR DESCRIPTION
![Preview](https://github.com/tgstation/tgstation/assets/137328283/1c611e91-656f-444e-aa09-9a90b8dfd1d0)

## About The Pull Request

This PR adds the ability to swap IDs in computers. Slightly modified `InsertID` and `RemoveID` to support mentioned changes. Edited `add_context` to add screentip.

## Why It's Good For The Game

In current implementation, all modular computers don't allow inserting a card if one is already present. It's a bit uncomfortable 'cause you need to remove it and only then insert a new one. This change makes inserting IDs as simple as one click!

## Changelog

:cl:
qol: ID cards in modular computers can now be swapped.
/:cl:
