### PR TITLE
Fix access management program not updating on ID authentication

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -51,7 +51,7 @@
 		authenticated_user = auth_card.registered_name ? auth_card.registered_name : "Unknown"
 		job_templates = is_centcom ? SSid_access.centcom_job_templates.Copy() : SSid_access.station_job_templates.Copy()
 		valid_access = is_centcom ? SSid_access.get_region_access_list(list(REGION_CENTCOM)) : SSid_access.get_region_access_list(list(REGION_ALL_STATION))
-		update_static_data(user)
+		computer.update_static_data_for_all_viewers()
 		return TRUE
 
 	// Otherwise, we're minor and now we have to build a list of restricted departments we can change access for.
@@ -67,7 +67,7 @@
 		minor = TRUE
 		valid_access |= SSid_access.get_region_access_list(region_access)
 		authenticated_card = "[auth_card.name] \[LIMITED ACCESS\]"
-		update_static_data(user)
+		computer.update_static_data_for_all_viewers()
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

While doing my other ID/manifest-related prs, I noticed that the access management program doesn't update properly when you authenticate, causing it to not show which templates you can apply until you manually refresh the UI (close&open, yadayada).

This seemed to be because it calls `update_static_data(user)` on the program itself, which attempts to find a UI attached to the program for that user which it then can't find. Calling such on the *computer* lets it actually find and update the UI.
We then decide to replace it with `update_static_data_for_all_viewers()` as multiple people could be looking at the consoles in which this happens most commonly.
## Why It's Good For The Game

It was getting *really* annoying, this fixes that.
## Changelog
:cl:
fix: Plexagon Access Management actually updates the shown template list on authentication, avoiding needing to refresh/reopen/somesuch the program manually.
/:cl:
