### PR TITLE
Removes sentient disease being instantly killed the second manufactured diseases show up on screen

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -134,9 +134,10 @@
 				if(bypasses_immunity) //viruses with bypasses_immunity get a free pass on beating normal advanced diseases
 					competition.cure(FALSE)
 				if(totalTransmittable() > competition.totalResistance())
-					competition.cure(FALSE)
-				else
-					return FALSE //we are not strong enough to bully our way in
+					if(istype(competition, /datum/disease/advance/sentient_disease))
+						continue
+					else
+						return FALSE
 	infect(infectee, make_copy)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Removes sentient disease being instantly killed the second manufactured diseases show up on screen

## Why It's Good For The Game

The designer who was blocking this change has left for the forseeable future and since I originally made this PR not a soul has tried to improve Sentient Disease in the last 2 years  so I'm re-PRing this.

## Changelog
:cl:
balance: Removes sentient disease being instantly killed the second manufactured diseases show up on screen
/:cl:
