### PR TITLE
Boulder refineries can process golems

### DIFF
--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -198,7 +198,7 @@
 /// What effects actually happens to a golem when it is "processed"
 /obj/machinery/bouldertech/proc/maim_golem(mob/living/carbon/human/rockman)
 	Shake(duration = 1 SECONDS)
-	rockman.visible_message(span_warning("[rockman] is proccessed by [src]!"), span_userdanger("You get processed into bits by [src]!"))
+	rockman.visible_message(span_warning("[rockman] is processed by [src]!"), span_userdanger("You get processed into bits by [src]!"))
 	rockman.investigate_log("was gibbed by [src] for being a golem", INVESTIGATE_DEATHS)
 	rockman.gib(DROP_ALL_REMAINS)
 	return TRUE

--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -125,8 +125,10 @@
 	if(!anchored)
 		return FALSE
 	if(istype(mover, /obj/item/boulder))
-		var/obj/item/boulder/boulder = mover
-		return can_process_boulder(boulder)
+		return can_process_boulder(mover)
+	if(isgolem(mover))
+		var/mob/living/carbon/human/rockman = mover
+		return rockman.body_position == LYING_DOWN
 	return ..()
 
 /**
@@ -140,7 +142,7 @@
 	SHOULD_BE_PURE(TRUE)
 
 	//machine not operational
-	if(!anchored || panel_open || !is_operational || machine_stat & (BROKEN | NOPOWER))
+	if(!anchored || panel_open || !is_operational)
 		return FALSE
 
 	//not a valid boulder
@@ -177,13 +179,40 @@
 
 	return TRUE
 
+/**
+ * Accepts a golem to be processed, mainly for memes
+ */
+/obj/machinery/bouldertech/proc/accept_golem(mob/living/carbon/human/rockman)
+	if(!is_operational || !anchored)
+		return FALSE
+	if(!COOLDOWN_FINISHED(src, accept_cooldown))
+		return FALSE
+	if(rockman.body_position != LYING_DOWN)
+		return FALSE
+	if(!maim_golem(rockman))
+		return FALSE
+	playsound(src, usage_sound, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	COOLDOWN_START(src, accept_cooldown, 3 SECONDS)
+	return TRUE
+
+/// What effects actually happens to a golem when it is "processed"
+/obj/machinery/bouldertech/proc/maim_golem(mob/living/carbon/human/rockman)
+	Shake(duration = 1 SECONDS)
+	rockman.visible_message(span_warning("[rockman] is proccessed by [src]!"), span_userdanger("You get processed into bits by [src]!"))
+	rockman.investigate_log("was gibbed by [src] for being a golem", INVESTIGATE_DEATHS)
+	rockman.gib(DROP_ALL_REMAINS)
+	return TRUE
+
 /obj/machinery/bouldertech/proc/on_entered(datum/source, atom/movable/atom_movable)
 	SIGNAL_HANDLER
 
-	if(!can_process_boulder(atom_movable))
+	if(istype(atom_movable, /obj/item/boulder))
+		INVOKE_ASYNC(src, PROC_REF(accept_boulder), atom_movable)
 		return
 
-	INVOKE_ASYNC(src, PROC_REF(accept_boulder), atom_movable)
+	if(isgolem(atom_movable))
+		INVOKE_ASYNC(src, PROC_REF(accept_golem), atom_movable)
+		return
 
 /**
  * Looks for a boost to the machine's efficiency, and applies it if found.

--- a/code/modules/mining/boulder_processing/refinery.dm
+++ b/code/modules/mining/boulder_processing/refinery.dm
@@ -85,3 +85,9 @@
 /obj/machinery/bouldertech/refinery/smelter/on_set_is_operational(old_value)
 	set_light_on(TRUE)
 
+/obj/machinery/bouldertech/refinery/smelter/maim_golem(mob/living/carbon/human/rockman)
+	rockman.visible_message(span_warning("[rockman] is proccessed by [src]!"), span_userdanger("You get melted into rock by [src]!"))
+	rockman.investigate_log("was melted by [src] for being a golem", INVESTIGATE_DEATHS)
+	rockman.dust()
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), src, 'sound/machines/ding.ogg', 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE), 2.5 SECONDS)
+	return TRUE

--- a/code/modules/mining/boulder_processing/refinery.dm
+++ b/code/modules/mining/boulder_processing/refinery.dm
@@ -86,7 +86,7 @@
 	set_light_on(TRUE)
 
 /obj/machinery/bouldertech/refinery/smelter/maim_golem(mob/living/carbon/human/rockman)
-	rockman.visible_message(span_warning("[rockman] is proccessed by [src]!"), span_userdanger("You get melted into rock by [src]!"))
+	rockman.visible_message(span_warning("[rockman] is processed by [src]!"), span_userdanger("You get melted into rock by [src]!"))
 	rockman.investigate_log("was melted by [src] for being a golem", INVESTIGATE_DEATHS)
 	rockman.dust()
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), src, 'sound/machines/ding.ogg', 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE), 2.5 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Golems (if lying down) can enter (and be processed by) boulder refineries. 

## Why It's Good For The Game

Rocks are rocks

## Changelog

:cl: Melbert
add: Boulder refineries and smelters can refine Golems. 
/:cl:


