### PR TITLE
Skittish will no longer re-lock lockers you've dived into.

### DIFF
--- a/code/datums/elements/skittish.dm
+++ b/code/datums/elements/skittish.dm
@@ -51,8 +51,6 @@
 			scooby.set_resting(FALSE, silent = TRUE)
 		return
 
-	closet.togglelock(scooby, silent = TRUE)
-
 	if(closet.horizontal)
 		scooby.set_resting(FALSE, silent = TRUE)
 


### PR DESCRIPTION
## About The Pull Request

Skittish will no longer re-lock lockers you've dived into.

## Why It's Good For The Game

Amount of times I've walked into a security locker this week and wasted 2 minutes of my time each time is immense. Plus, if you can't unlock a locker from inside of it, how are you locking it from inside of it? It doesn't make sense.

## Changelog
:cl:
balance: Skittish will no longer re-lock lockers you've dived into.
/:cl:
