### PR TITLE
Makes revenants able to emag medibots (and other basic bots)

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
@@ -206,6 +206,12 @@
 			bot.bot_cover_flags &= ~BOT_COVER_LOCKED
 			bot.bot_cover_flags |= BOT_COVER_OPEN
 			bot.emag_act(caster)
+	for(var/mob/living/basic/bot/bot in victim)
+		if(!(bot.bot_access_flags & BOT_COVER_EMAGGED))
+			new /obj/effect/temp_visual/revenant(bot.loc)
+			bot.bot_access_flags |= BOT_CONTROL_PANEL_OPEN
+			bot.bot_access_flags |= BOT_MAINTS_PANEL_OPEN
+			bot.emag_act(caster)
 	for(var/mob/living/carbon/human/human in victim)
 		if(human == caster)
 			continue


### PR DESCRIPTION

## About The Pull Request
Makes Revenants able to emag basic bots. Revenant's Malfunction Ability only checked for simple_animal/bot so when Medibots, Cleanbots, and Hygeinebots were turned into basic mobs Revenants lost the ability to emag them.

## Why It's Good For The Game
Being able to hack bots is pretty much the main function of malfunction, especially Medibots. Revenants not being able to hack them really reduces their ability to cause chaos.

## Changelog
:cl:

fix: Revenants can now again emag Medibots, Cleanbots, and Hygienebots.

/:cl:
