### PR TITLE
Fixes tgui text input trimming the last char if the input hits the max length

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -58,6 +58,12 @@
 /// Removes everything enclose in < and > inclusive of the bracket, and limits the length of the message.
 #define STRIP_HTML_FULL(text, limit) (GLOB.html_tags.Replace(copytext(text, 1, limit), ""))
 
+/**
+ * stuff like `copytext(input, length(input))` will trim the last character of the input,
+ * because DM does it so it copies until the char BEFORE the `end` arg, so we need to bump `end` by 1 in these cases.
+ */
+#define PREVENT_CHARACTER_TRIM_LOSS(integer) (integer + 1)
+
 /// Folder directory for strings
 #define STRING_DIRECTORY "strings"
 

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -32,9 +32,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length)
+				return stripped_multiline_input(user, message, title, default, max_length + 1)
 			else
-				return stripped_input(user, message, title, default, max_length)
+				return stripped_input(user, message, title, default, max_length + 1)
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
@@ -162,4 +162,4 @@
 /datum/tgui_input_text/proc/set_entry(entry)
 	if(!isnull(entry))
 		var/converted_entry = encode ? html_encode(entry) : entry
-		src.entry = trim(converted_entry, max_length)
+		src.entry = trim(converted_entry, max_length + 1)

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -32,9 +32,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length + 1)
+				return stripped_multiline_input(user, message, title, default, PREVENT_CHARACTER_TRIM_LOSS(max_length))
 			else
-				return stripped_input(user, message, title, default, max_length + 1)
+				return stripped_input(user, message, title, default, PREVENT_CHARACTER_TRIM_LOSS(max_length))
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
@@ -162,4 +162,4 @@
 /datum/tgui_input_text/proc/set_entry(entry)
 	if(!isnull(entry))
 		var/converted_entry = encode ? html_encode(entry) : entry
-		src.entry = trim(converted_entry, max_length + 1)
+		src.entry = trim(converted_entry, PREVENT_CHARACTER_TRIM_LOSS(max_length))


### PR DESCRIPTION
## About The Pull Request
There's a one character discrepancy between the maximum length in the tgui input panel and that of the copied text, that's because `copytext("123456", 6)` will actually return `"12345"`, cutting off the last digit, so we need to increment the `max_length` by one if we want the right amount of characters to be return. This is also somewhat detailed in the DM lang "bluebook", and is in line with how `list.Copy()` also works.


## Why It's Good For The Game
This fixes the museum password pad, which trimmed the last character of the input because of this oversight.

## Changelog

:cl:
fix: Fixed the tgui text input trimming the last character of the input if it hits the maximum length.
fix: This also fixes the PIN pad leading to the right wing of the museum away mission.
/:cl:
