### PR TITLE
[no GBP] (webedit) removes a nanomachine pizza box from meat tower

### DIFF
--- a/_maps/map_files/Deathmatch/meatower.dmm
+++ b/_maps/map_files/Deathmatch/meatower.dmm
@@ -198,7 +198,7 @@
 /obj/machinery/conveyor/auto{
 	dir = 4
 	},
-/obj/item/pizzabox/margherita/robo,
+/obj/item/pizzabox/margherita,
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},


### PR DESCRIPTION

## About The Pull Request
This is a webedit and on my phone
Removes a nanomachine pizza from the chef deathmatch map

## Why It's Good For The Game
Fixes #81860 
## Changelog
:cl:
del: Removed a nanomachine pizza from the deathmatch meat tower map that allowed you to become a borg
/:cl:
