### PR TITLE
Summon Simians Max Level Reward Change

### DIFF
--- a/code/modules/spells/spell_types/conjure/simian.dm
+++ b/code/modules/spells/spell_types/conjure/simian.dm
@@ -8,7 +8,7 @@
 
 	school = SCHOOL_CONJURATION
 	cooldown_time = 1.5 MINUTES
-	cooldown_reduction_per_rank = 10 SECONDS
+	cooldown_reduction_per_rank = 15 SECONDS
 
 	invocation = "OOGA OOGA OOGA!!!!"
 	invocation_type = INVOCATION_SHOUT

--- a/code/modules/spells/spell_types/conjure/simian.dm
+++ b/code/modules/spells/spell_types/conjure/simian.dm
@@ -8,10 +8,13 @@
 
 	school = SCHOOL_CONJURATION
 	cooldown_time = 1.5 MINUTES
-	cooldown_reduction_per_rank = 15 SECONDS
+	cooldown_reduction_per_rank = 10 SECONDS
 
 	invocation = "OOGA OOGA OOGA!!!!"
 	invocation_type = INVOCATION_SHOUT
+
+	///Our gorilla transformation spell, additionally granted to the user at max level.
+	var/datum/action/cooldown/spell/shapeshift/gorilla/gorilla_transformation
 
 	summon_radius = 2
 	summon_type = list(
@@ -25,9 +28,10 @@
 	. = ..()
 	summon_amount++ // MORE, MOOOOORE
 	if(spell_level == spell_max_level) // We reward the faithful.
-		summon_type = list(/mob/living/carbon/human/species/monkey/angry, /mob/living/basic/gorilla)
+		gorilla_transformation = new(owner)
+		gorilla_transformation.Grant(owner)
 		spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC // Max level lets you cast it naked, for monkey larp.
-		to_chat(owner, span_notice("Your simian power has reached maximum capacity! You can now cast this spell naked, and you will create adult Gorillas with each cast."))
+		to_chat(owner, span_notice("Your simian power has reached maximum capacity! You can now cast this spell naked, and have additionally been granted a gorilla transformation spell!"))
 
 /datum/action/cooldown/spell/conjure/simian/cast(atom/cast_on)
 	. = ..()

--- a/code/modules/spells/spell_types/shapeshift/gorilla.dm
+++ b/code/modules/spells/spell_types/shapeshift/gorilla.dm
@@ -1,0 +1,9 @@
+
+/datum/action/cooldown/spell/shapeshift/gorilla
+	name = "Gorilla Form"
+	desc = "Take on the shape of a powerful gorilla."
+	invocation = "B'NA NAH-SLEMA!"
+	invocation_type = INVOCATION_SHOUT
+	spell_requirements = NONE
+
+	possible_shapes = list(/mob/living/basic/gorilla)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5680,6 +5680,7 @@
 #include "code\modules\spells\spell_types\shapeshift\_shape_status.dm"
 #include "code\modules\spells\spell_types\shapeshift\_shapeshift.dm"
 #include "code\modules\spells\spell_types\shapeshift\dragon.dm"
+#include "code\modules\spells\spell_types\shapeshift\gorilla.dm"
 #include "code\modules\spells\spell_types\shapeshift\polar_bear.dm"
 #include "code\modules\spells\spell_types\shapeshift\shapechange.dm"
 #include "code\modules\spells\spell_types\teleport\_teleport.dm"


### PR DESCRIPTION
## About The Pull Request

Summon Simian now, as opposed to summoning actual gorillas at max level, the caster is instead granted a free gorilla transformation spell instead.

## Why It's Good For The Game

I wasn't exactly aware that Summon Simians could summon actual gorillas when I buffed gorillas mainly for traitors, so wizards could use the max level spell to spam powerful gorillas who could easily wipe the station in a very short amount of time. Ideally, this change should reign in max level Summon Simians while still giving users a reason to max it out.

## Changelog
:cl:
balance: Max level Summon Simians now grants the wizard a free gorilla transformation spell as opposed to allowing the wizard to summon fully-grown gorillas.
/:cl: