### PR TITLE
Fixes spies having multi-use autosurgeons

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -157,14 +157,26 @@
 /obj/item/autosurgeon/syndicate/thermal_eyes
 	starting_organ = /obj/item/organ/internal/eyes/robotic/thermals
 
+/obj/item/autosurgeon/syndicate/thermal_eyes/single_use
+	uses = 1
+
 /obj/item/autosurgeon/syndicate/xray_eyes
 	starting_organ = /obj/item/organ/internal/eyes/robotic/xray
+
+/obj/item/autosurgeon/syndicate/xray_eyes/single_use
+	uses = 1
 
 /obj/item/autosurgeon/syndicate/anti_stun
 	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stun
 
+/obj/item/autosurgeon/syndicate/anti_stun/single_use
+	uses = 1
+
 /obj/item/autosurgeon/syndicate/reviver
 	starting_organ = /obj/item/organ/internal/cyberimp/chest/reviver
+
+/obj/item/autosurgeon/syndicate/reviver/single_use
+	uses = 1
 
 /obj/item/autosurgeon/syndicate/commsagent
 	desc = "A device that automatically - painfully - inserts an implant. It seems someone's specially \
@@ -177,6 +189,9 @@
 
 /obj/item/autosurgeon/syndicate/emaggedsurgerytoolset
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/surgery/emagged
+
+/obj/item/autosurgeon/syndicate/emaggedsurgerytoolset/single_use
+	uses = 1
 
 /obj/item/autosurgeon/syndicate/contraband_sechud
 	desc = "Contains a contraband SecHUD implant, undetectable by health scanners."

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -744,19 +744,17 @@
 	cost = 6
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_SPY
 
-/datum/uplink_item/implants/nuclear/reviverplus
+/datum/uplink_item/implants/nuclear/reviver
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/reviver
 	cost = 8
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_SPY
 
 /datum/uplink_item/implants/nuclear/thermals
 	name = "Thermal Eyes"
 	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/thermal_eyes
 	cost = 8
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_SPY
 
 /datum/uplink_item/implants/nuclear/implants/xray
 	name = "X-ray Vision Implant"
@@ -769,7 +767,6 @@
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/anti_stun
 	cost = 8
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_SPY
 
 // Badass (meme items)
 

--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -127,7 +127,7 @@
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/anti_stun/single_use
 
-/datum/uplink_item/implants/spy_unique/reviverplus
+/datum/uplink_item/implants/spy_unique/reviver
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/reviver/single_use

--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -124,15 +124,15 @@
 
 /datum/uplink_item/implants/spy_unique/antistun
 	name = /datum/uplink_item/implants/nuclear/antistun::name
-  	desc = /datum/uplink_item/implants/nuclear/antistun::desc
+	desc = /datum/uplink_item/implants/nuclear/antistun::desc
 	item = /obj/item/autosurgeon/syndicate/anti_stun/single_use
 
 /datum/uplink_item/implants/spy_unique/reviver
 	name = /datum/uplink_item/implants/nuclear/reviver::name
-  	desc = /datum/uplink_item/implants/nuclear/reviver::desc
+	desc = /datum/uplink_item/implants/nuclear/reviver::desc
 	item = /obj/item/autosurgeon/syndicate/reviver/single_use
 
 /datum/uplink_item/implants/spy_unique/thermals
 	name = /datum/uplink_item/implants/nuclear/thermals::name
-  	desc = /datum/uplink_item/implants/nuclear/thermals::desc
+	desc = /datum/uplink_item/implants/nuclear/thermals::desc
 	item = /obj/item/autosurgeon/syndicate/thermal_eyes/single_use

--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -121,3 +121,18 @@
 	name = "Syndicate First Medic Kit"
 	desc = "A syndicate tactical combat medkit, but only stocked enough to do basic first aid."
 	item = /obj/item/storage/medkit/tactical_lite
+
+/datum/uplink_item/implants/spy_unique/antistun
+	name = "CNS Rebooter Implant"
+	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
+	item = /obj/item/autosurgeon/syndicate/anti_stun/single_use
+
+/datum/uplink_item/implants/spy_unique/reviverplus
+	name = "Reviver Implant"
+	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
+	item = /obj/item/autosurgeon/syndicate/reviver/single_use
+
+/datum/uplink_item/implants/spy_unique/thermals
+	name = "Thermal Eyes"
+	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autosurgeon."
+	item = /obj/item/autosurgeon/syndicate/thermal_eyes/single_use

--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -123,16 +123,16 @@
 	item = /obj/item/storage/medkit/tactical_lite
 
 /datum/uplink_item/implants/spy_unique/antistun
-	name = "CNS Rebooter Implant"
-	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
+	name = /datum/uplink_item/implants/nuclear/antistun::name
+  	desc = /datum/uplink_item/implants/nuclear/antistun::desc
 	item = /obj/item/autosurgeon/syndicate/anti_stun/single_use
 
 /datum/uplink_item/implants/spy_unique/reviver
-	name = "Reviver Implant"
-	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
+	name = /datum/uplink_item/implants/nuclear/reviver::name
+  	desc = /datum/uplink_item/implants/nuclear/reviver::desc
 	item = /obj/item/autosurgeon/syndicate/reviver/single_use
 
 /datum/uplink_item/implants/spy_unique/thermals
-	name = "Thermal Eyes"
-	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autosurgeon."
+	name = /datum/uplink_item/implants/nuclear/thermals::name
+  	desc = /datum/uplink_item/implants/nuclear/thermals::desc
 	item = /obj/item/autosurgeon/syndicate/thermal_eyes/single_use


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/81827

## Why It's Good For The Game

Autosurgeons are deliberately not resuable for almost all instances they show up in the game. 

This is fine for a single use insertion of a highly illegal organ, the autosurgeon then allowing you to entirely ignore surgery and player interaction to get various power boosts via cybernetics from that point onwards seems unintended.

## Changelog
:cl:
fix: Spies no longer have access to infinite use autosurgeons.
/:cl:
