### PR TITLE
Fixes forensics hard del

### DIFF
--- a/code/modules/forensics/_forensics.dm
+++ b/code/modules/forensics/_forensics.dm
@@ -46,7 +46,6 @@
 		return
 
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_act))
-	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_parent_qdeleted))
 
 	src.parent = parent
 	src.fingerprints = fingerprints
@@ -69,7 +68,6 @@
 
 /datum/forensics/Destroy(force)
 	UnregisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT)
-	UnregisterSignal(parent, COMSIG_QDELETING)
 	parent = null
 	return ..()
 
@@ -98,12 +96,6 @@
 		wipe_blood_DNA()
 	if(clean_types & CLEAN_TYPE_FIBERS)
 		wipe_fibers()
-
-/// When parent atom goes poof, so should the forensics datum
-/datum/forensics/proc/on_parent_qdeleted(datum/source)
-	SIGNAL_HANDLER
-
-	qdel(src)
 
 /// Adds the given list into fingerprints
 /datum/forensics/proc/add_fingerprint_list(list/fingerprints)

--- a/code/modules/forensics/_forensics.dm
+++ b/code/modules/forensics/_forensics.dm
@@ -46,6 +46,7 @@
 		return
 
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_act))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_parent_qdeleted))
 
 	src.parent = parent
 	src.fingerprints = fingerprints
@@ -68,6 +69,7 @@
 
 /datum/forensics/Destroy(force)
 	UnregisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT)
+	UnregisterSignal(parent, COMSIG_QDELETING)
 	parent = null
 	return ..()
 
@@ -96,6 +98,12 @@
 		wipe_blood_DNA()
 	if(clean_types & CLEAN_TYPE_FIBERS)
 		wipe_fibers()
+
+/// When parent atom goes poof, so should the forensics datum
+/datum/forensics/proc/on_parent_qdeleted(datum/source)
+	SIGNAL_HANDLER
+
+	qdel(src)
 
 /// Adds the given list into fingerprints
 /datum/forensics/proc/add_fingerprint_list(list/fingerprints)

--- a/code/modules/forensics/forensics_helpers.dm
+++ b/code/modules/forensics/forensics_helpers.dm
@@ -1,5 +1,7 @@
 /// Adds a list of fingerprints to the atom
 /atom/proc/add_fingerprint_list(list/fingerprints_to_add) //ASSOC LIST FINGERPRINT = FINGERPRINT
+	if (QDELETED(src))
+		return
 	if (isnull(fingerprints_to_add))
 		return
 	if (forensics)
@@ -10,7 +12,7 @@
 
 /// Adds a single fingerprint to the atom
 /atom/proc/add_fingerprint(mob/suspect, ignoregloves = FALSE) //Set ignoregloves to add prints irrespective of the mob having gloves on.
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 	if (isnull(forensics))
 		forensics = new(src)
@@ -19,6 +21,8 @@
 
 /// Add a list of fibers to the atom
 /atom/proc/add_fiber_list(list/fibers_to_add) //ASSOC LIST FIBERTEXT = FIBERTEXT
+	if (QDELETED(src))
+		return
 	if (isnull(fibers_to_add))
 		return
 	if (forensics)
@@ -29,6 +33,8 @@
 
 /// Adds a single fiber to the atom
 /atom/proc/add_fibers(mob/living/carbon/human/suspect)
+	if (QDELETED(src))
+		return
 	var/old = 0
 	if(suspect.gloves && istype(suspect.gloves, /obj/item/clothing))
 		var/obj/item/clothing/gloves/suspect_gloves = suspect.gloves
@@ -47,6 +53,8 @@
 
 /// Adds a list of hiddenprints to the atom
 /atom/proc/add_hiddenprint_list(list/hiddenprints_to_add) //NOTE: THIS IS FOR ADMINISTRATION FINGERPRINTS, YOU MUST CUSTOM SET THIS TO INCLUDE CKEY/REAL NAMES! CHECK FORENSICS.DM
+	if (QDELETED(src))
+		return
 	if (isnull(hiddenprints_to_add))
 		return
 	if (forensics)
@@ -57,6 +65,8 @@
 
 /// Adds a single hiddenprint to the atom
 /atom/proc/add_hiddenprint(mob/suspect)
+	if (QDELETED(src))
+		return
 	if (isnull(forensics))
 		forensics = new(src)
 	forensics.add_hiddenprint(suspect)
@@ -67,6 +77,8 @@
 	return FALSE
 
 /obj/add_blood_DNA(list/blood_DNA_to_add)
+	if (QDELETED(src))
+		return
 	. = ..()
 	if (isnull(blood_DNA_to_add))
 		return .
@@ -98,6 +110,8 @@
 	return FALSE
 
 /mob/living/carbon/human/add_blood_DNA(list/blood_DNA_to_add, list/datum/disease/diseases)
+	if (QDELETED(src))
+		return
 	if(wear_suit)
 		wear_suit.add_blood_DNA(blood_DNA_to_add)
 		update_worn_oversuit()


### PR DESCRIPTION
## About The Pull Request

Should fix this CI error.

![firefox_JiarBI7EY5](https://github.com/tgstation/tgstation/assets/13398309/b456900c-e97c-4184-8615-98752ee6349a)

`parent` used to be a weakref but since it's not any longer (as of #81751) we need to manage the ref more carefully. 

The forensic datum should be getting `QDEL_NULL`'d in `atom/Destroy()` but I think what was likely happening was somehow, something was adding a forensics datum again after the atom was qdeleted. This should hopefully prevent that from happening.

## Why It's Good For The Game

Less CI errors

## Changelog

Nothing player facing
