### PR TITLE
Stops mines from blowing up CI

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -117,8 +117,7 @@
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	if(ismob(triggerer))
-		mineEffect(triggerer)
+	mineEffect(triggerer)
 	triggered = TRUE
 	SEND_SIGNAL(src, COMSIG_MINE_TRIGGERED, triggerer)
 	qdel(src)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -117,7 +117,8 @@
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	mineEffect(triggerer)
+	if(ismob(triggerer))
+		mineEffect(triggerer)
 	triggered = TRUE
 	SEND_SIGNAL(src, COMSIG_MINE_TRIGGERED, triggerer)
 	qdel(src)

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -292,6 +292,8 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	returnable_list += typesof(/obj/item/hilbertshotel)
 	//this boi spawns turf changing stuff, and it stacks and causes pain. Let's just not
 	returnable_list += typesof(/obj/effect/sliding_puzzle)
+	//these can explode and cause the turf to be destroyed at unexpected moments
+	returnable_list += typesof(/obj/effect/mine/explosive)
 	//Stacks baseturfs, can't be tested here
 	returnable_list += typesof(/obj/effect/temp_visual/lava_warning)
 	//Stacks baseturfs, can't be tested here

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -293,7 +293,9 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	//this boi spawns turf changing stuff, and it stacks and causes pain. Let's just not
 	returnable_list += typesof(/obj/effect/sliding_puzzle)
 	//these can explode and cause the turf to be destroyed at unexpected moments
-	returnable_list += typesof(/obj/effect/mine/explosive)
+	returnable_list += typesof(/obj/effect/mine)
+	returnable_list += typesof(/obj/effect/spawner/random/contraband/landmine)
+	returnable_list += typesof(/obj/item/minespawner)
 	//Stacks baseturfs, can't be tested here
 	returnable_list += typesof(/obj/effect/temp_visual/lava_warning)
 	//Stacks baseturfs, can't be tested here

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -292,8 +292,6 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	returnable_list += typesof(/obj/item/hilbertshotel)
 	//this boi spawns turf changing stuff, and it stacks and causes pain. Let's just not
 	returnable_list += typesof(/obj/effect/sliding_puzzle)
-	//these can explode and cause the turf to be destroyed at unexpected moments
-	returnable_list += typesof(/obj/effect/mine/explosive)
 	//Stacks baseturfs, can't be tested here
 	returnable_list += typesof(/obj/effect/temp_visual/lava_warning)
 	//Stacks baseturfs, can't be tested here


### PR DESCRIPTION
## About The Pull Request

Makes this GO AWAY.

![image](https://github.com/tgstation/tgstation/assets/13398309/71d01448-2c73-420e-af9c-191fd1e9f8d1)

Fixes https://github.com/tgstation/tgstation/issues/81249
Fixes https://github.com/NovaSector/NovaSector/issues/930
Fixes https://github.com/NovaSector/NovaSector/issues/1077

Half of https://github.com/tgstation/tgstation/issues/81448 resolved by this.

---

So landmines are very often _deciding to blow up during the unit tests_, causing the floor to not be a floor.
This was always a potential issue but was exacerbated by the museum PR which made the following change:

![image](https://github.com/tgstation/tgstation/assets/13398309/51d0e3a8-acf1-4d89-9511-e5ff0ad7a533)

---

**My solution is to stop them from spawning.** create_and_destroy is already a bug-minefield, it does not also need to be a _literal_ minefield.

I've ran 4 tests so far and where this issue was cropping up every other PR, it has still not occurred with this fix. I'm not going to say for certain that it's fixed just yet but I am optimistic. I'll update in a few hours.

edit: Unfortunately my optimism was misguided and on the 8th run it failed. This doesn't fix it. 

## Why It's Good For The Game

This CI error was coming up all the time and I'm sick of it.

## Changelog

:cl:
fix: fixes a spurious CI runtime caused by explosive mines quite literally blowing up the unit test area
/:cl: