### PR TITLE
Saymode won't process custom say emotes

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/original_message = message
 	message = get_message_mods(message, message_mods)
 	saymode = SSradio.saymodes[message_mods[RADIO_KEY]]
-	if (!forced)
+	if (!forced && !saymode)
 		message = check_for_custom_say_emote(message, message_mods)
 
 	if(!message)


### PR DESCRIPTION

## About The Pull Request

Closes #62666 

Every saymode does some snowflake thing for sending out its messages to the relevant mobs, and none of those snowflake things have handling for custom say emotes. 

We could manually go through and add the required handling, but for each implementation, it would get messy fast. So it's a bit easier to just prevent mobs using saymode from attempting to "emote" over them. Especially since it doesn't make sense in a lot of situations that we use saymodes. 

## Changelog

:cl: Melbert
fix: Silicons can use asterisks in binary without fear of saying something interesting. 
/:cl:

