### PR TITLE
[NO GBP] The museum piggy bank now spawns with at least 400 creds in it.

### DIFF
--- a/code/game/objects/items/piggy_bank.dm
+++ b/code/game/objects/items/piggy_bank.dm
@@ -46,7 +46,7 @@
 	persistence_cb = CALLBACK(src, PROC_REF(save_cash))
 	SSticker.OnRoundend(persistence_cb)
 
-	if(initial_value & initial_value + calculate_dosh_amount() <= maximum_value)
+	if(initial_value && initial_value + calculate_dosh_amount() <= maximum_value)
 		new /obj/item/holochip(src, initial_value)
 
 /obj/item/piggy_bank/proc/save_cash()


### PR DESCRIPTION
## About The Pull Request
Used the wrong operator in a control statement.

## Why It's Good For The Game
Title.

## Changelog

:cl:
fix: The museum piggy bank now spawns with at least 400 creds in it.
/:cl:
