### PR TITLE
Makes robotic talk use GetVoice for carbons, fixing voice changer issue

### DIFF
--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -17,6 +17,11 @@
 		spans
 	)
 
+	var/namepart = name
+	// If carbon, use voice to account for voice changers
+	if(iscarbon(src))
+		namepart = GetVoice()
+
 	for(var/mob/M in GLOB.player_list)
 		if(M.binarycheck())
 			if(isAI(M))
@@ -24,7 +29,7 @@
 					M,
 					span_binarysay("\
 						Robotic Talk, \
-						<a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([designation])")]</a> \
+						<a href='?src=[REF(M)];track=[html_encode(namepart)]'>[span_name("[namepart] ([designation])")]</a> \
 						<span class='message'>[quoted_message]</span>\
 					"),
 					avoid_highlighting = src == M
@@ -34,7 +39,7 @@
 					M,
 					span_binarysay("\
 						Robotic Talk, \
-						[span_name("[name]")] <span class='message'>[quoted_message]</span>\
+						[span_name("[namepart]")] <span class='message'>[quoted_message]</span>\
 					"),
 					avoid_highlighting = src == M
 				)
@@ -56,7 +61,7 @@
 				span_binarysay("\
 					[follow_link] \
 					Robotic Talk, \
-					[span_name("[name]")] <span class='message'>[quoted_message]</span>\
+					[span_name("[namepart]")] <span class='message'>[quoted_message]</span>\
 				"),
 				avoid_highlighting = src == M
 			)


### PR DESCRIPTION

## About The Pull Request

I noticed that when using a chameleon set and agent ID to change my voice and then using the binary encryption key to talk over binary, it would actually show as "Real Name (as ID)" rather than "ID" as expected.
Looking into the code, this seemed to be because robotic talk would use `name` rather than getting the voice of the speaker, which is set to the *visible name* of the speaker, leading to it using the visible name rather than their voice.
This pr changes it to use `GetVoice` to have a result consistent with regular comms.
## Why It's Good For The Game

When you use a chameleon mask with an agent ID it lets you mask your voice over comms even if your face isn't fully covered, it's your voice after all, but over robotic comms it cares about your visible name rather than your voice even though you're still talking into a headset.
This pr makes it consistent with the behaviour of voice changing over regular comms.
## Changelog
:cl:
fix: When a carbon talks over robotic it uses their voice instead of visible name. Meaning, voice changers work like they do over other comms regardless of face covering.
/:cl:
