### PR TITLE
Fix mode-toggle examine in simple health analyzers

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -33,7 +33,8 @@
 
 /obj/item/healthanalyzer/examine(mob/user)
 	. = ..()
-	. += span_notice("Alt-click [src] to toggle the limb damage readout.")
+	if(src.mode != SCANNER_NO_MODE)
+		. += span_notice("Alt-click [src] to toggle the limb damage readout.")
 
 /obj/item/healthanalyzer/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins to analyze [user.p_them()]self with [src]! The display shows that [user.p_theyre()] dead!"))


### PR DESCRIPTION
## About The Pull Request
Simple health analyzers (i.e. wound and disease analyzers) had a message about alt-clicking to toggle their mode, but could not actually toggle modes.
![image](https://github.com/tgstation/tgstation/assets/152340324/83cdb7ba-9657-43ce-8294-2c02908975c9)
This message now only appears on analyzers that can actually toggle between modes.
## Why It's Good For The Game
Bugs bad
## Changelog
:cl: PapaMichael
fix: Removed erroneous information on some health analyzer's examine text.
/:cl:
