### PR TITLE
Prevent borgs resisting from grabs when they are locked down

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -959,7 +959,7 @@
 	if(lockcharge)
 		balloon_alert(src, "locked down!")
 		return FALSE
-	. = ..()
+	return ..()
 
 /mob/living/silicon/robot/execute_resist()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -955,13 +955,18 @@
 	buckle_mob_flags= RIDER_NEEDS_ARM // just in case
 	return ..()
 
+/mob/living/silicon/robot/can_resist()
+	if(lockcharge)
+		balloon_alert(src, "locked down!")
+		return FALSE
+	. = ..()
+
 /mob/living/silicon/robot/execute_resist()
 	. = ..()
 	if(!has_buckled_mobs())
 		return
 	for(var/mob/unbuckle_me_now as anything in buckled_mobs)
 		unbuckle_mob(unbuckle_me_now, FALSE)
-
 
 /mob/living/silicon/robot/proc/TryConnectToAI()
 	set_connected_ai(select_active_ai_with_fewest_borgs(z))


### PR DESCRIPTION
## About The Pull Request
Prevents borgs resisting from grabs when they are locked

![image](https://github.com/tgstation/tgstation/assets/8430839/3fc8dee4-3539-4891-9a91-bc27b3610da2)

(yes, there's small baloonies message barely visible)
## Why It's Good For The Game
Isn't it fun to try and pull some locked down borg while they press B like hundred times per second so you can't even move them.
## Changelog
:cl:
fix: As a borg you shouldn't be able to resist from grab while locked down
/:cl:
