### PR TITLE
Add `LOWMEMORYMODE` versions of all the build/run tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,23 @@
 		{
 			"type": "byond",
 			"request": "launch",
+			"name": "Launch DreamSeeker (low memory mode)",
+			"preLaunchTask": "Build All (low memory mode)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
 			"name": "Launch DreamDaemon",
 			"preLaunchTask": "Build All",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon (low memory mode)",
+			"preLaunchTask": "Build All (low memory mode)",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
 			"dreamDaemon": true
 		},
@@ -27,6 +42,18 @@
 				"-trusted"
 			],
 			"preLaunchTask": "Build All"
+		},
+		{
+			"name": "Debug External Libraries (low memory mode)",
+			"type": "cppvsdbg",
+			"request": "launch",
+			"program": "${command:dreammaker.returnDreamDaemonPath}",
+			"cwd": "${workspaceRoot}",
+			"args": [
+				"${command:dreammaker.getFilenameDmb}",
+				"-trusted"
+			],
+			"preLaunchTask": "Build All (low memory mode)"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 			"type": "process",
 			"command": "tools/build/build",
 			"windows": {
-				"command": ".\\tools\\build\\build.bat",
+				"command": ".\\tools\\build\\build.bat"
 			},
 			"options": {
 				"env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 			"type": "process",
 			"command": "tools/build/build",
 			"windows": {
-				"command": ".\\tools\\build\\build.bat"
+				"command": ".\\tools\\build\\build.bat",
 			},
 			"options": {
 				"env": {
@@ -23,6 +23,30 @@
 			},
 			"dependsOn": "dm: reparse",
 			"label": "Build All"
+		},
+		{
+			"type": "process",
+			"command": "tools/build/build",
+			"args": ["-DLOWMEMORYMODE"],
+			"windows": {
+				"command": ".\\tools\\build\\build.bat",
+				"args": ["-DLOWMEMORYMODE"]
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build"
+			},
+			"dependsOn": "dm: reparse",
+			"label": "Build All (low memory mode)"
 		},
 		{
 			"type": "dreammaker",


### PR DESCRIPTION

## About The Pull Request

This simply adds versions of the build/run vscode tasks that add `-DLOWMEMORYMODE` when calling the build script, which compiles the server with the `LOWMEMORYMODE` define, for faster testing of features.

![image](https://github.com/tgstation/tgstation/assets/65794972/ca679fef-2415-475b-86c0-2b40757f9bc3)
