### PR TITLE
Prevent bioware list deletion runtime for human destroy (what the fuck is a bioware?).

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -61,7 +61,7 @@
 /mob/living/carbon/human/Destroy()
 	QDEL_NULL(physiology)
 	if(biowares)
-		QDEL_LIST(biowares)
+		QDEL_LAZY_LIST(biowares)
 	GLOB.human_list -= src
 
 	if (mob_mood)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -61,7 +61,7 @@
 /mob/living/carbon/human/Destroy()
 	QDEL_NULL(physiology)
 	if(biowares)
-		QDEL_LAZY_LIST(biowares)
+		QDEL_LAZYLIST(biowares)
 	GLOB.human_list -= src
 
 	if (mob_mood)


### PR DESCRIPTION

## About The Pull Request
Prevent bioware list deletion runtime (biowares remove themselves from the biowares list when deleted) by making it a lazy list delete.
## Why It's Good For The Game
Removes a runtime.
## Changelog
:cl:
fix: Prevent runtime from humans with biowares gettingn deleted.
/:cl:
