### PR TITLE
Fix "Overweight" trait unintended interaction

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -799,9 +799,11 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 		state = HUNGER_STATE_FINE
 		return
 
+	/*
 	if(HAS_TRAIT(hungry, TRAIT_FAT))
 		state = HUNGER_STATE_FAT
 		return
+	*/
 
 	switch(hungry.nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -116,10 +116,12 @@
 		clear_mood_event(MOOD_CATEGORY_NUTRITION)
 		return FALSE
 
+	/*
 	if(HAS_TRAIT(mob_parent, TRAIT_FAT) && !HAS_TRAIT(mob_parent, TRAIT_VORACIOUS))
 		add_mood_event(MOOD_CATEGORY_NUTRITION, /datum/mood_event/fat)
 		return TRUE
-
+	*/
+	
 	switch(mob_parent.nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)
 			add_mood_event(MOOD_CATEGORY_NUTRITION, HAS_TRAIT(mob_parent, TRAIT_VORACIOUS) ? /datum/mood_event/wellfed : /datum/mood_event/too_wellfed)

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -47,10 +47,12 @@
 	hud_used?.hunger?.update_appearance()
 	mob_mood?.update_nutrition_moodlets()
 
+/*
 	if(HAS_TRAIT(src, TRAIT_FAT))
 		add_movespeed_modifier(/datum/movespeed_modifier/obesity)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
+*/
 
 /mob/living/carbon/human/proc/on_nohunger(datum/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
The hunger hud update changed how the Overweight trait is handled, making it give any character using it the speed malus that the trait already gives, but also giving them an extra speed malus as if they were overfed at all times. Currently there's no way to get rid of the permanently overfed state without manually removing the "Overweight" trait directly from the mob that has it, this PR removes that permanent overfed state.

## Why It's Good For The Game
I don't think anyone taking the overweight trait was supposed to be both slowed from the trait itself and forced into the overfed state permanently, so this just solves that issue.

## Changelog
:cl:
fix: Overweight trait no longer permanently makes a character overfed
/:cl:
