### PR TITLE
Several Urinal Bug Fixes

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -167,7 +167,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 
 /obj/structure/urinal/Initialize(mapload)
 	. = ..()
-	hidden_item = new /obj/item/food/urinalcake
+	if(mapload)
+		hidden_item = new /obj/item/food/urinalcake(src)
 	find_and_hang_on_wall()
 
 /obj/structure/urinal/attack_hand(mob/living/user, list/modifiers)
@@ -227,8 +228,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 		exposed = !exposed
 	return TRUE
 
+/obj/structure/urinal/wrench_act_secondary(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(user)
+	deconstruct(TRUE)
+	to_chat(user, span_notice("You remove [src] from the wall."))
+	return TRUE
+
 /obj/structure/urinal/deconstruct(disassembled = TRUE)
 	if(!(obj_flags & NO_DECONSTRUCTION))
+		for(var/obj/urinal_item in contents)
+			urinal_item.forceMove(drop_location())
 		new /obj/item/wallframe/urinal(loc)
 	qdel(src)
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -231,7 +231,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 /obj/structure/urinal/wrench_act_secondary(mob/living/user, obj/item/tool)
 	tool.play_tool_sound(user)
 	deconstruct(TRUE)
-	to_chat(user, span_notice("You remove [src] from the wall."))
+	loc.balloon_alert(user, "removed")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/urinal/deconstruct(disassembled = TRUE)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -232,7 +232,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	tool.play_tool_sound(user)
 	deconstruct(TRUE)
 	to_chat(user, span_notice("You remove [src] from the wall."))
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/urinal/deconstruct(disassembled = TRUE)
 	if(!(obj_flags & NO_DECONSTRUCTION))


### PR DESCRIPTION
## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/81903.
You can now use wrenches to deconstruct urinals.
Urinal cakes are only added on map load and so making new urinals won't create new cakes.
Spawns urinal cakes in the urinal so it's in their contents.
## Changelog
:cl:
fix: Urinals can be deconstructed by right clicking with a wrench.
fix: You can no longer get infinite urinal cakes.
fix: Urinals no longer erase items inside them from existence when unwrenched.
/:cl: