### PR TITLE
Fugitive hunter spawn delay works again

### DIFF
--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -105,7 +105,7 @@
 
 /datum/round_event/ghost_role/fugitives/proc/check_spawn_hunters(backstory, remaining_time)
 	//if the emergency shuttle has been called, spawn hunters now to give them a chance
-	if(remaining_time == 0 || SSshuttle.emergency.mode != EMERGENCY_IDLE_OR_RECALLED)
+	if(remaining_time == 0 || !EMERGENCY_IDLE_OR_RECALLED)
 		spawn_hunters(backstory)
 		return
 	addtimer(CALLBACK(src, PROC_REF(check_spawn_hunters), backstory, remaining_time - 1 MINUTES), 1 MINUTES)


### PR DESCRIPTION

## About The Pull Request

Fugitives hunters no longer spawn after 1 minute under any conditions.

The culprit was improper use of a macro, checking the shuttle status against it instead of just using it.
## Why It's Good For The Game

Fugitives get some more breathing room and time to gear up.
## Changelog
:cl: Rhials
fix: Fugitive hunters no longer spawn after 1 minute of the fugitives' arrival.
/:cl:
