### PR TITLE
Posters return to your hand when cut down/not hung up, abductor posters more resilient to wirecutters

### DIFF
--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -211,7 +211,7 @@
 	pixel_x = 0
 	pixel_y = 0
 	var/obj/item/poster/rolled_poster = new poster_item_type(location, src) // /obj/structure/sign/poster/wanted/roll_and_drop() has some snowflake handling due to icon memes, if you make a major change to this, don't forget to update it too. <3
-	if(!user || !user.put_in_hands(rolled_poster))
+	if(!user?.put_in_hands(rolled_poster))
 		forceMove(rolled_poster)
 	return rolled_poster
 

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -180,7 +180,7 @@
 			qdel(src)
 		else
 			to_chat(user, span_notice("You carefully remove the poster from the wall."))
-			roll_and_drop(Adjacent(user) ? get_turf(user) : loc)
+			roll_and_drop(Adjacent(user) ? get_turf(user) : loc, user)
 
 /obj/structure/sign/poster/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -207,11 +207,12 @@
 		return FALSE
 	return !user.gloves || !(user.gloves.body_parts_covered & HANDS) || HAS_TRAIT(user, TRAIT_FINGERPRINT_PASSTHROUGH) || HAS_TRAIT(user.gloves, TRAIT_FINGERPRINT_PASSTHROUGH)
 
-/obj/structure/sign/poster/proc/roll_and_drop(atom/location)
+/obj/structure/sign/poster/proc/roll_and_drop(atom/location, mob/user)
 	pixel_x = 0
 	pixel_y = 0
 	var/obj/item/poster/rolled_poster = new poster_item_type(location, src) // /obj/structure/sign/poster/wanted/roll_and_drop() has some snowflake handling due to icon memes, if you make a major change to this, don't forget to update it too. <3
-	forceMove(rolled_poster)
+	if(!user || !user.put_in_hands(rolled_poster))
+		forceMove(rolled_poster)
 	return rolled_poster
 
 //separated to reduce code duplication. Moved here for ease of reference and to unclutter r_wall/attackby()
@@ -246,7 +247,7 @@
 
 	var/turf/user_drop_location = get_turf(user) //cache this so it just falls to the ground if they move. also no tk memes allowed.
 	if(!do_after(user, PLACE_SPEED, placed_poster, extra_checks = CALLBACK(placed_poster, TYPE_PROC_REF(/obj/structure/sign/poster, snowflake_closed_turf_check), src)))
-		placed_poster.roll_and_drop(user_drop_location)
+		placed_poster.roll_and_drop(user_drop_location, user)
 		return
 
 	placed_poster.on_placed_poster(user)

--- a/code/game/objects/effects/wanted_poster.dm
+++ b/code/game/objects/effects/wanted_poster.dm
@@ -93,9 +93,10 @@
 		poster_icon.Blend(letter_icon, ICON_OVERLAY)
 		startX = startX + 4
 
-/obj/structure/sign/poster/wanted/roll_and_drop(atom/location)
+/obj/structure/sign/poster/wanted/roll_and_drop(atom/location, mob/user)
 	pixel_x = 0
 	pixel_y = 0
 	var/obj/item/poster/rolled_poster = new poster_item_type(location, original_icon, wanted_name, desc, posterHeaderText, posterHeaderColor)
-	forceMove(rolled_poster)
+	if(!user?.put_in_hands(rolled_poster))
+		forceMove(rolled_poster)
 	return rolled_poster

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -140,7 +140,7 @@
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O, /obj/structure/sign/poster))
 			var/obj/structure/sign/poster/P = O
-			P.roll_and_drop(src)
+			INVOKE_ASYNC(P, TYPE_PROC_REF(/obj/structure/sign/poster, roll_and_drop), src)
 	if(decon_type)
 		ChangeTurf(decon_type, flags = CHANGETURF_INHERIT_AIR)
 	else

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -19,7 +19,7 @@
 
 /obj/structure/sign/poster/abductor/attackby(obj/item/tool, mob/user, params)
 	if(tool.toolspeed >= 0.2)
-		to_chat(user, span_warning("Your [tool.name] is too weak to cut through the superior adhesive on the [name]!"))
+		balloon_alert(user, "tool too weak!")
 		return FALSE
 	return ..()
 

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -17,6 +17,12 @@
 		return
 	return ..()
 
+/obj/structure/sign/poster/abductor/attackby(obj/item/tool, mob/user, params)
+	if(tool.toolspeed >= 0.2)
+		to_chat(user, span_warning("Your [tool.name] is too weak to cut through the superior adhesive on the [name]!"))
+		return FALSE
+	return ..()
+
 /obj/structure/sign/poster/abductor/random
 	name = "random abductor poster"
 	icon_state = "random_abductor"


### PR DESCRIPTION

## About The Pull Request

Posters now drop into your hand when you cancel the hanging process, or snip them down with wirecutters. If they can't drop into your hands, they go to the floor.

Oh, also, this makes it so that abductor wirecutters (or any wirecutters with a toolspeed better than 0.2 in case of varedits/future additions) are too weak to cut down abductor posters.
## Why It's Good For The Game

Posters getting dropped to the ground when cancelling the hanging process has always really annoyed me and I want it to not happen anymore.

If you want to get those unsightly abductor posters out of your department you'll have to loot the abductor scientist first (or just take the wall down but that's admitting defeat).
## Changelog
:cl: Rhials
qol: Posters now return to your hand when the hanging process is cancelled, or they are snipped down. 
qol: Abductor posters can now only be cut down with abductor-tier wirecutters.
/:cl:
