### PR TITLE
Fixes glowsticks not processing amd doing the cracking message.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -95,7 +95,7 @@
 	return light_on != old_light_on // If the value of light_on didn't change, return false. Otherwise true.
 
 /obj/item/flashlight/attack_self(mob/user)
-	toggle_light(user)
+	return toggle_light(user)
 
 /obj/item/flashlight/attack_hand_secondary(mob/user, list/modifiers)
 	attack_self(user)


### PR DESCRIPTION
Makes the flashligjt's attack_self() return toggle_light)£. Glowsticos assumed that the parent function would return trie if successful.
## About The Pull Request
Mobile webedit free gbp apeedrun! Fix glowsticks notb saying it cracked and bot processing after snapping it.
## Why It's Good For The Game
So glowsticks snap and process.
## Changelog
:cl:
fix: Fixes glowsticks not informing the user they snapped, and also fixes them not processing after snapping.
/:cl:
