### PR TITLE
Fixes a runtime with the crew manifest.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -461,7 +461,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 	update_dna_identity()
 
-/datum/dna/stored //subtype used by brain mob's stored_dna
+/datum/dna/stored //subtype used by brain mob's stored_dna and the crew manifest
 
 /datum/dna/stored/add_mutation(mutation_name) //no mutation changes on stored dna.
 	return

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -114,7 +114,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		person_gender = "Male"
 	if(person.gender == "female")
 		person_gender = "Female"
-	var/datum/dna/record_dna = new()
+	var/datum/dna/stored/record_dna = new()
 	person.dna.copy_dna(record_dna)
 
 	var/datum/record/locked/lockfile = new(


### PR DESCRIPTION
## About The Pull Request
`/datum/dna/stored` is a specific subtype of `/datum/dna` that ignores mutations. Wonderful for crew records on top of brain mobs tbf. The crew manifest now uses it.

## Why It's Good For The Game
This will fix #81842.

## Changelog
N/A