### PR TITLE
Basic Mobs Can Now Get Wet (and can therefore clear the `slimed` status effect)

### DIFF
--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -12,6 +12,8 @@
 #define FLAMMABLE_MOB (1<<3)
 /// Mob never takes damage from unarmed attacks
 #define IMMUNE_TO_FISTS (1<<4)
+/// Mob is immune to getting wet
+#define IMMUNE_TO_GETTING_WET (1<<5)
 
 /// Temporary trait applied when an attack forecast animation has completed
 #define TRAIT_BASIC_ATTACK_FORECAST "trait_basic_attack_forecast"

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -30,8 +30,7 @@
 		qdel(src)
 		return
 	if(isbasicmob(owner))
-		var/mob/living/basic/basic_owner = owner
-		if(!(basic_owner.basic_mob_flags & FLAMMABLE_MOB))
+		if(!check_basic_mob_immunity(owner))
 			qdel(src)
 			return
 
@@ -93,6 +92,10 @@
 /datum/status_effect/fire_handler/proc/adjust_stacks(new_stacks)
 	stacks = max(0, min(stack_limit, stacks + new_stacks))
 	cache_stacks()
+
+/// Checks if the applicable basic mob is immune to the status effect we're trying to apply. Returns TRUE if it is, FALSE if it isn't.
+/datum/status_effect/fire_handler/proc/check_basic_mob_immunity(mob/living/basic/basic_owner)
+	return (basic_owner.basic_mob_flags & FLAMMABLE_MOB)
 
 /**
  * Refresher for mob's fire_stacks
@@ -292,3 +295,6 @@
 	if(particle_effect)
 		return
 	particle_effect = new(owner, /particles/droplets)
+
+/datum/status_effect/fire_handler/wet_stacks/check_basic_mob_immunity(mob/living/basic/basic_owner)
+	return !(basic_owner.basic_mob_flags & IMMUNE_TO_GETTING_WET)


### PR DESCRIPTION
## About The Pull Request

A year ago in #73601 (b7da743e7dca0ed0b8f96b02e184d8aed230526a), we made it such that we wouldn't apply the `/datum/status_effect/fire_handler` to any basic mob that wasn't a "flammable" mob. However, guess what? The way we handle "wet stacks" is handled by a subtype, `/datum/status_effect/fire_handler/wet_stacks`. This means that any mob that wasn't flammable wouldn't also get wet, meaning that they would literally _never_ get the `slimed` status effect off them (since that is reliant on wet stacks).

In order to rectify this, let's actually account for the case in the code to ensure that mobs that should get wet do get wet (I made it an opt-out flag because I can't think of a single mob that can't get wet and didn't want to balloon the diff trying to think of every mob that should be able to get wet, etc.), and now it's all fixed hunky-dory.
## Why It's Good For The Game

Fixes #81888

Basic mobs should be able to get wet. It's an oversight with how the wet_stack handler is tacked onto the backend of the fire_handler latticework- ideally these two would be two separate systems (or it would at least not be named `fire_handler` so people don't make this confusion in the future without realizing that it handles more than just... `fire`) but I don't have time to do a full cleansing and refactor of this code.
## Changelog
:cl:
fix: All basic mobs are able to get wet. This means, among other things, that you can clear the "slimed" status effect off your holoparasite or dog or whatever.
/:cl:
