### PR TITLE
Skateboard tweaks and buffs.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -13,6 +13,9 @@
 /// Called when an organ gets surgically removed (mob/living/user, mob/living/carbon/old_owner, target_zone, obj/item/tool)
 #define COMSIG_ORGAN_SURGICALLY_REMOVED "organ_surgically_removed"
 
+///Called when movement intent is toggled.
+#define COMSIG_MOVE_INTENT_TOGGLED "move_intent_toggled"
+
 ///from base of mob/update_transform()
 #define COMSIG_LIVING_POST_UPDATE_TRANSFORM "living_post_update_transform"
 

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -169,6 +169,41 @@
 /datum/component/riding/vehicle/scooter/skateboard
 	vehicle_move_delay = 1.5
 	ride_check_flags = RIDER_NEEDS_LEGS | UNBUCKLE_DISABLED_RIDER
+	///If TRUE, the vehicle will be slower (but safer) to ride on walk intent.
+	var/can_slow_down = TRUE
+
+/datum/component/riding/vehicle/scooter/skateboard/RegisterWithParent()
+	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+
+/datum/component/riding/vehicle/scooter/skateboard/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	examine_list += span_notice("Going slow and nice at [EXAMINE_HINT("walk")] speed will prevent crashing into things.")
+
+/datum/component/riding/vehicle/scooter/skateboard/vehicle_mob_buckle(datum/source, mob/living/rider, force = FALSE)
+	. = ..()
+	if(can_slow_down)
+		RegisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED, PROC_REF(toggle_move_delay))
+		toggle_move_delay(rider)
+
+/datum/component/riding/vehicle/scooter/skateboard/handle_unbuckle(mob/living/rider)
+	. = ..()
+	if(can_slow_down)
+		toggle_move_delay(rider)
+		UnregisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED)
+
+/datum/component/riding/vehicle/scooter/skateboard/proc/toggle_move_delay(mob/living/rider)
+	SIGNAL_HANDLER
+	vehicle_move_delay = initial(vehicle_move_delay)
+	if(rider.move_intent == MOVE_INTENT_WALK)
+		vehicle_move_delay += 0.6
+
+/datum/component/riding/vehicle/scooter/skateboard/pro
+	vehicle_move_delay = 1
+
+/datum/component/riding/vehicle/scooter/skateboard/hover
+	vehicle_move_delay = 1
+	override_allow_spacemove = TRUE
 
 /datum/component/riding/vehicle/scooter/skateboard/handle_specials()
 	. = ..()
@@ -179,6 +214,7 @@
 
 /datum/component/riding/vehicle/scooter/skateboard/wheelys
 	vehicle_move_delay = 0
+	can_slow_down = FALSE
 
 /datum/component/riding/vehicle/scooter/skateboard/wheelys/handle_specials()
 	. = ..()

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -243,7 +243,7 @@
 		return
 	var/turf/open/our_turf = movable.loc
 	var/turf/turf_below = GET_TURF_BELOW(our_turf)
-	if(our_turf.zPassOut(DOWN) && (isnull(turf_below) || (isopenspaceturf(turf_below) && turf_below.zPassIn(DOWN))))
+	if(our_turf.zPassOut(DOWN) && (isnull(turf_below) || (isopenspaceturf(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN))))
 		override_allow_spacemove = FALSE
 		if(turf_below)
 			our_turf.zFall(movable, falling_from_move = is_moving)

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -181,7 +181,8 @@
 
 /datum/component/riding/vehicle/scooter/skateboard/RegisterWithParent()
 	. = ..()
-	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	if(can_slow_down)
+		RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	var/obj/vehicle/ridden/scooter/skateboard/board = parent
 	if(istype(board))
 		board.can_slow_down = can_slow_down

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -182,6 +182,9 @@
 /datum/component/riding/vehicle/scooter/skateboard/RegisterWithParent()
 	. = ..()
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	var/obj/vehicle/ridden/scooter/skateboard/board = parent
+	if(istype(board))
+		board.can_slow_down = can_slow_down
 
 /datum/component/riding/vehicle/scooter/skateboard/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -422,7 +422,7 @@
 	if(z_move_flags & ZMOVE_CAN_FLY_CHECKS && !(movement_type & (FLYING|FLOATING)) && has_gravity(start))
 		if(z_move_flags & ZMOVE_FEEDBACK)
 			if(rider)
-				to_chat(rider, span_warning("[src] is is not capable of flight."))
+				to_chat(rider, span_warning("[src] [p_are()] incapable of flight."))
 			else
 				to_chat(src, span_warning("You are not Superman."))
 		return FALSE

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -249,7 +249,7 @@
 /turf/open/lava/proc/can_burn_stuff(atom/movable/burn_target)
 	if(QDELETED(burn_target))
 		return LAVA_BE_IGNORING
-	if(burn_target.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) //you're flying over it.
+	if(burn_target.movement_type & MOVETYPES_NOT_TOUCHING_GROUND || !burn_target.has_gravity()) //you're flying over it.
 		return LAVA_BE_IGNORING
 
 	if(isobj(burn_target))
@@ -268,7 +268,7 @@
 	var/mob/living/burn_living = burn_target
 	var/atom/movable/burn_buckled = burn_living.buckled
 	if(burn_buckled)
-		if(burn_buckled.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
+		if(burn_buckled.movement_type & MOVETYPES_NOT_TOUCHING_GROUND || !burn_buckled.has_gravity())
 			return LAVA_BE_PROCESSING
 		if(isobj(burn_buckled))
 			var/obj/burn_buckled_obj = burn_buckled

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -510,6 +510,8 @@
 			selector.update_appearance()
 	update_move_intent_slowdown()
 
+	SEND_SIGNAL(user, COMSIG_MOVE_INTENT_TOGGLED)
+
 ///Moves a mob upwards in z level
 /mob/verb/up()
 	set name = "Move Upwards"

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -49,6 +49,8 @@
 	var/board_item_type = /obj/item/melee/skateboard
 	///Stamina drain multiplier
 	var/instability = 10
+	///If true, riding the skateboard with walk intent on will prevent crashing.
+	var/can_slow_down = TRUE
 
 /obj/vehicle/ridden/scooter/skateboard/Initialize(mapload)
 	. = ..()
@@ -88,7 +90,7 @@
 	if(!bumped_thing.density || !has_buckled_mobs() || world.time < next_crash)
 		return
 	var/mob/living/rider = buckled_mobs[1]
-	if(rider.move_intent == MOVE_INTENT_WALK) //Going slow prevents you from crashing.
+	if(rider.move_intent == MOVE_INTENT_WALK && can_slow_down) //Going slow prevents you from crashing.
 		return
 
 	next_crash = world.time + 10

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -225,6 +225,7 @@
 	name = "improvised skateboard"
 	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars."
 	board_item_type = /obj/item/melee/skateboard/improvised
+	instability = 12
 
 //CONSTRUCTION
 /obj/item/scooter_frame

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -193,10 +193,6 @@
 	instability = 3
 	icon_state = "hoverboard_red"
 
-/obj/vehicle/ridden/scooter/skateboard/hoverboard/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/forced_gravity, 0)
-
 /obj/vehicle/ridden/scooter/skateboard/hoverboard/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/hover)
 
@@ -208,11 +204,6 @@
 		if(z_move_flags & ZMOVE_FEEDBACK)
 			to_chat(rider, span_warning("[src] [p_are()] not powerful enough to fly upwards."))
 		return FALSE
-
-/obj/vehicle/ridden/scooter/skateboard/hoverboard/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
-	if(length(buckled_mobs))
-		return TRUE //stop floating while someone's riding it.
-	return ..()
 
 /obj/vehicle/ridden/scooter/skateboard/hoverboard/admin
 	name = "\improper Board Of Directors"


### PR DESCRIPTION
## About The Pull Request
I have been dissatified with the situation of skateboards for a long while now, especially with the 'pro' and 'hoverboard' versions that provide negligeable bonuses for the high price they warrant.

On top of all things, this PR makes the aforementioned two subtypes faster than the standard and improvised skateboards.
Second, the hoverboard now hovers and can be used in zero g (more info in the CL). The thing costs about 2000, so this is pretty much deserved.
Third, skateboards respect move intents. While in walk intent, you will ride it slowly, but you also won't crash against other things.
Fourth, improvised skateboards are a nick more unstable and not mechanically on par with standard skateboards.

## Why It's Good For The Game
Skateboard were cooler back when you would go fast and die young by crashing into an airlock/spessman/wall at stim speed imho, also see the first paragrath of the above section.

## Changelog

:cl:
balance: The pro skateboard and hoverboard are now faster.
balance: The improvised skateboard is a nick more unstable than the standard, so the two aren't exactly the same.
add: Riding a skateboard on walk intent will prevent you from crashing into things, at the cost of speed.
add: hoverboards now actually hovers and can be used even in zero g. There are a caveat to it: It cannot be ridden on open space gaps deeper than one level or actual space, unless there're objects that prevent falls, like lattice or catwalks.
/:cl:
