### PR TITLE
Doors check if they require an ID and access when an item is thrown at them

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -239,7 +239,7 @@
 		var/obj/item/I = AM
 		if(!density || (I.w_class < WEIGHT_CLASS_NORMAL && !LAZYLEN(I.GetAccess())))
 			return
-		if(check_access(I) && requiresID())
+		if(requiresID() && check_access(I))
 			open()
 		else
 			do_animate("deny")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -239,7 +239,7 @@
 		var/obj/item/I = AM
 		if(!density || (I.w_class < WEIGHT_CLASS_NORMAL && !LAZYLEN(I.GetAccess())))
 			return
-		if(check_access(I))
+		if(check_access(I) && requiresID())
 			open()
 		else
 			do_animate("deny")


### PR DESCRIPTION
## About The Pull Request

Doors now check if they require an ID and access when an ID is thrown at them, instead of just access.
## Why It's Good For The Game

If someone disables ID scan, you can no longer get around it by chucking your ID at the door.

Fixes #81859
## Changelog
:cl:
fix: Doors with ID scan disabled will no longer open when an ID is thrown at them
/:cl:
