### PR TITLE
[NO GBP] Fixes every single uplink getting free cybernetic implants

### DIFF
--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -122,17 +122,17 @@
 	desc = "A syndicate tactical combat medkit, but only stocked enough to do basic first aid."
 	item = /obj/item/storage/medkit/tactical_lite
 
-/datum/uplink_item/implants/spy_unique/antistun
+/datum/uplink_item/spy_unique/antistun
 	name = /datum/uplink_item/implants/nuclear/antistun::name
 	desc = /datum/uplink_item/implants/nuclear/antistun::desc
 	item = /obj/item/autosurgeon/syndicate/anti_stun/single_use
 
-/datum/uplink_item/implants/spy_unique/reviver
+/datum/uplink_item/spy_unique/reviver
 	name = /datum/uplink_item/implants/nuclear/reviver::name
 	desc = /datum/uplink_item/implants/nuclear/reviver::desc
 	item = /obj/item/autosurgeon/syndicate/reviver/single_use
 
-/datum/uplink_item/implants/spy_unique/thermals
+/datum/uplink_item/spy_unique/thermals
 	name = /datum/uplink_item/implants/nuclear/thermals::name
 	desc = /datum/uplink_item/implants/nuclear/thermals::desc
 	item = /obj/item/autosurgeon/syndicate/thermal_eyes/single_use


### PR DESCRIPTION

## About The Pull Request

Fixes every single uplink giving out free cybernetic implants

fixes https://github.com/tgstation/tgstation/issues/81912

## Why It's Good For The Game

As funny as it is to produce hundreds of reviver implants out of thin air, this is a bug.

## Changelog
:cl:
fix: A recent glitch within the Syndicate-coded uplinks resulted in a number of Cybersun-branded cybernetics being distributed for absolutely no cost at all, except to the company itself. This embarrassment has resulted in increased tensions within the Syndicate as a culprit for this costly mistake is sought out.
/:cl:
