### PR TITLE
Drunk people no longer feel cold

### DIFF
--- a/code/datums/elements/basic_body_temp_sensitive.dm
+++ b/code/datums/elements/basic_body_temp_sensitive.dm
@@ -47,14 +47,15 @@
 
 	if(basic_mob.bodytemperature < min_body_temp)
 		basic_mob.adjust_health(cold_damage * seconds_per_tick)
-		switch(cold_damage)
-			if(1 to 5)
-				basic_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 1)
-			if(5 to 10)
-				basic_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 2)
-			if(10 to INFINITY)
-				basic_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 3)
-		gave_alert = TRUE
+		if(!basic_mob.has_status_effect(/datum/status_effect/inebriated))
+			switch(cold_damage)
+				if(1 to 5)
+					basic_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 1)
+				if(5 to 10)
+					basic_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 2)
+				if(10 to INFINITY)
+					basic_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 3)
+			gave_alert = TRUE
 
 	else if(basic_mob.bodytemperature > max_body_temp)
 		basic_mob.adjust_health(heat_damage * seconds_per_tick)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1384,7 +1384,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			humi.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/hot, 3)
 
 	// Body temperature is too cold, and we do not have resist traits
-	else if(bodytemp < bodytemp_cold_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTCOLD))
+	else if(bodytemp < bodytemp_cold_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTCOLD) && !humi.has_status_effect(/datum/status_effect/inebriated))
 		// clear any hot moods and apply cold mood
 		humi.clear_mood_event("hot")
 		humi.add_mood_event("cold", /datum/mood_event/cold)


### PR DESCRIPTION
## About The Pull Request

Simple PR, if you're drunk then you no longer feel the effects (or get the warnings) of cold temperatures.
This makes things like cryosting and the coldness of space give you no warning or tell of why you're being hurt, but it also means you don't suffer its slowdown.

## Why It's Good For The Game

It's a small bit of realism that doesn't do much to change the game, but gives some extra bonus/drawback to alcohol that isn't really changing the game by any means.

## Changelog

:cl: JohnFulpWillard, Atlasle
balance: You no longer feel cold if you're drunk. You still take damage, but get no warning or slowdown.
/:cl:
