### PR TITLE
Revamps irradiated meteor effects

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -124,6 +124,22 @@
 	desc = "You know who to call."
 	light_power = 2
 
+/obj/effect/decal/cleanable/greenglow/radioactive
+	name = "radioactive goo"
+	desc = "Holy crap, stop looking at this and move away immediately! It's radioactive!"
+	light_power = 5
+	light_range = 3
+	light_color = LIGHT_COLOR_NUCLEAR
+
+/obj/effect/decal/cleanable/greenglow/radioactive/Initialize(mapload, list/datum/disease/diseases)
+	. = ..()
+	AddComponent(
+		/datum/component/radioactive_emitter, \
+		cooldown_time = 5 SECONDS, \
+		range = 4, \
+		threshold = RAD_MEDIUM_INSULATION, \
+	)
+
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"
 	desc = "Somebody should remove that."

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -265,8 +265,8 @@
 /obj/effect/meteor/irradiated/meteor_effect()
 	..()
 	explosion(src, heavy_impact_range = 1, light_impact_range = 3, flash_range = 6, adminlog = FALSE)
-	for(var/turf/surviving_ground in range(2, get_turf(src)))
-		if(isfloorturf(surviving_ground) && prob(70))
+	for(var/turf/open/floor/surviving_ground in range(2, get_turf(src)))
+		if(prob(70))
 			new /obj/effect/decal/cleanable/greenglow/radioactive(get_turf(surviving_ground))
 
 //Cluster meteor

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -257,15 +257,17 @@
 	desc = "An irradiated chunk of space rock. You could probably stop and appreciate its incandescent green glow, if it weren't moving so fast."
 	icon_state = "glowing"
 	heavy = TRUE
+	hits = 9
 	meteordrop = list(/obj/item/stack/ore/uranium)
-	threat = 15
+	threat = 35
 	signature = "radiation"
 
 /obj/effect/meteor/irradiated/meteor_effect()
 	..()
-	explosion(src, light_impact_range = 4, flash_range = 3, adminlog = FALSE)
-	new /obj/effect/decal/cleanable/greenglow(get_turf(src))
-	radiation_pulse(src, max_range = 3, threshold = RAD_MEDIUM_INSULATION, chance = 80)
+	explosion(src, heavy_impact_range = 1, light_impact_range = 3, flash_range = 6, adminlog = FALSE)
+	for(var/turf/surviving_ground in range(2, get_turf(src)))
+		if(isfloorturf(surviving_ground) && prob(70))
+			new /obj/effect/decal/cleanable/greenglow/radioactive(get_turf(surviving_ground))
 
 //Cluster meteor
 /obj/effect/meteor/cluster

--- a/code/modules/meteors/meteor_waves.dm
+++ b/code/modules/meteors/meteor_waves.dm
@@ -5,14 +5,14 @@ GLOBAL_VAR_INIT(meteor_wave_delay, 625) //minimum wait between waves in tenths o
 
 //Meteors probability of spawning during a given wave
 GLOBAL_LIST_INIT(meteors_normal, list(/obj/effect/meteor/dust=3, /obj/effect/meteor/medium=8, /obj/effect/meteor/big=3, \
-						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3, /obj/effect/meteor/carp=1, /obj/effect/meteor/bluespace=1, \
+						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=2, /obj/effect/meteor/carp=1, /obj/effect/meteor/bluespace=1, \
 						  /obj/effect/meteor/banana=1, /obj/effect/meteor/emp = 1)) //for normal meteor event
 
 GLOBAL_LIST_INIT(meteors_threatening, list(/obj/effect/meteor/medium=4, /obj/effect/meteor/big=8, /obj/effect/meteor/flaming=3, \
 						  /obj/effect/meteor/irradiated=3, /obj/effect/meteor/cluster=1, /obj/effect/meteor/carp=1, /obj/effect/meteor/bluespace=2, /obj/effect/meteor/emp = 2)) //for threatening meteor event
 
 GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=75, \
-						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/cluster=8, /obj/effect/meteor/tunguska=1, \
+						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=8, /obj/effect/meteor/cluster=8, /obj/effect/meteor/tunguska=1, \
 						  /obj/effect/meteor/carp=2, /obj/effect/meteor/bluespace=10, /obj/effect/meteor/emp = 8)) //for catastrophic meteor event
 
 GLOBAL_LIST_INIT(meateors, list(/obj/effect/meteor/meaty=5, /obj/effect/meteor/meaty/xeno=1)) //for meaty ore event


### PR DESCRIPTION

## About The Pull Request

Irradiated meteors have been given a little tune-up, because they are kind of underwhelming right now.

Presently, they do less damage than a standard meteor. At some point its impact effect was reduced to a single radiation pulse (which does absolutely nothing).

Now, they hit harder, deeper, and leave behind a pile of radioactive sludge. Let's see how it looks:

![image](https://github.com/tgstation/tgstation/assets/28870487/d4670bc7-fe42-4f6b-ab1b-b56f55b1b12e)

Oof, wouldn't want that hitting MY department!

You'll have to clean up the radioactive sludge, and should probably wear protective equipment while doing so. Also, they will show up slightly less often now, as they are more threatening now.
## Why It's Good For The Game

Re-implements Flavor for an effect that lost its taste since being added 10 years ago. An irradiated meteor doesn't do anything besides look pretty and green right now.

Currently irradiated meteors are really boring and not threatening -- antithetical to the idea of a "radioactive meteor". Now, there's a much more interactive and measurable impact when one hits.
## Changelog
:cl: Rhials
balance: Irradiated meteors now hit harder and leave behind radioactive goop.
/:cl:
