### PR TITLE
Cyborgs now require Silicon hours to play instead of just Crew hours to improve Malfunctioning AI gameplay and encourage more mid-round cyborgification

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -10,6 +10,7 @@
 	minimal_player_age = 21
 	exp_requirements = 120
 	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_SILICON
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CYBORG"
 


### PR DESCRIPTION
## About The Pull Request

Cyborgs now require Silicon hours to play instead of just Crew hours to improve Malfunctioning AI gameplay and encourage more mid-round cyborgification.

## Why It's Good For The Game

Cyborgs are a very special job in terms of the gameplay and expectations of the player, due to following the laws and orders of the AI at all times and is liable to get ordered by the crew to do things that are only doable by cyborgs that may be niche interactions they might not know how to do. 

By making it so that you have to get time in as a silicon via getting turned into one by Robotics for a shift or two before you can start the round as a Cyborg, players will learn the system of laws, how to follow crew orders, and the expectations that come with that.

This will massively improve Malfunctioning AI gameplay as they can now expect their cyborgs to be more competent at doing things as a Cyborg, instead of new people who just turned a new job on for the first time and don't understand anything about it.

Also, not enough people get turned into cyborgs mid-round and I'd like to see more of that occuring.

## Changelog

:cl:
balance: Cyborgs now require Silicon hours to play instead of just Crew hours to improve Malfunctioning AI gameplay and encourage more mid-round cyborgification.
/:cl:

