### PR TITLE
Fix server hang in budgetordering

### DIFF
--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -57,7 +57,7 @@
 
 	return FALSE
 
-/datum/computer_file/program/budgetorders/ui_data()
+/datum/computer_file/program/budgetorders/ui_data(mob/user)
 	var/list/data = list()
 	data["location"] = SSshuttle.supply.getStatusText()
 	data["department"] = "Cargo"
@@ -79,12 +79,12 @@
 	if(buyer)
 		data["points"] = buyer.account_balance
 
-//Otherwise static data, that is being applied in ui_data as the crates visible and buyable are not static, and are determined by inserted ID.
+	//Otherwise static data, that is being applied in ui_data as the crates visible and buyable are not static, and are determined by inserted ID.
 	data["requestonly"] = requestonly
 	data["supplies"] = list()
 	for(var/pack in SSshuttle.supply_packs)
 		var/datum/supply_pack/P = SSshuttle.supply_packs[pack]
-		if(!is_visible_pack(usr, P.access_view , null, P.contraband) || P.hidden)
+		if(!is_visible_pack(user, P.access_view , null, P.contraband) || P.hidden)
 			continue
 		if(!data["supplies"][P.group])
 			data["supplies"][P.group] = list(
@@ -102,7 +102,7 @@
 			"access" = P.access
 		))
 
-//Data regarding the User's capability to buy things.
+	//Data regarding the User's capability to buy things.
 	data["has_id"] = id_card
 	data["away"] = SSshuttle.supply.getDockedId() == docking_away
 	data["self_paid"] = self_paid


### PR DESCRIPTION
fixes #81949

usr is almost always null here so this will almost always runtime the inner proc which triggers a large enough amount of error logging to soft lock the server since this happens in a proc called by a loop in a proc called multiple times a second by a high priority mc subsystem.

Atm opening the budgetordering computer has the risk of causing high enough time dilation to disrupt or kill the round so this should be fast tracked to a merge