### PR TITLE
Making the fuck you coupon trigger only once, take two

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -223,7 +223,7 @@
 	balloon_alert(user, "ooh, free coupon")
 	var/obj/item/coupon/attached_coupon = new
 	user.put_in_hands(attached_coupon)
-	attached_coupon.generate(rigged_omen ? COUPON_OMEN : null)
+	attached_coupon.generate(rigged_omen ? COUPON_OMEN : null, null, user)
 	attached_coupon = null
 	spawn_coupon = FALSE
 	name = "discarded cigarette packet"

--- a/code/modules/cargo/coupon.dm
+++ b/code/modules/cargo/coupon.dm
@@ -98,6 +98,7 @@
 /obj/item/coupon/proc/curse_heart(mob/living/cursed)
 	if(!iscarbon(cursed))
 		cursed.gib(DROP_ALL_REMAINS)
+		burn_evilly()
 		return TRUE
 
 	var/mob/living/carbon/player = cursed
@@ -105,6 +106,11 @@
 	to_chat(player, span_mind_control("What could that coupon mean?"))
 	to_chat(player, span_userdanger("...The suspense is killing you!"))
 	player.set_heartattack(status = TRUE)
+	burn_evilly()
+
+/obj/item/coupon/proc/burn_evilly()
+	visible_message(span_warning("[src] burns up in a sinister flash, taking an evil energy with it..."))
+	burn()
 
 /obj/item/coupon/attack_atom(obj/O, mob/living/user, params)
 	if(!istype(O, /obj/machinery/computer/cargo))

--- a/code/modules/cargo/coupon.dm
+++ b/code/modules/cargo/coupon.dm
@@ -63,7 +63,7 @@
 		update_name()
 
 /// Choose what our prize is :D
-/obj/item/coupon/proc/generate(discount, datum/supply_pack/discounted_pack)
+/obj/item/coupon/proc/generate(discount, datum/supply_pack/discounted_pack, mob/user)
 	src.discounted_pack = discounted_pack || pick(GLOB.discountable_packs[pick_weight(GLOB.pack_discount_odds)])
 	var/static/list/chances = list("0.10" = 4, "0.15" = 8, "0.20" = 10, "0.25" = 8, "0.50" = 4, COUPON_OMEN = 1)
 	discount_pct_off = discount || pick_weight(chances)
@@ -77,14 +77,14 @@
 	name = "coupon - fuck you"
 	desc = "The small text reads, 'You will be slaughtered'... That doesn't sound right, does it?"
 
-	if(!ismob(loc))
+	var/mob/cursed = user || loc
+	if(!ismob(cursed))
 		return FALSE
 
-	var/mob/cursed = loc
 	to_chat(cursed, span_warning("The coupon reads '<b>fuck you</b>' in large, bold text... is- is that a prize, or?"))
 
 	if(!cursed.GetComponent(/datum/component/omen))
-		cursed.AddComponent(/datum/component/omen, 1)
+		cursed.AddComponent(/datum/component/omen, src, 1)
 		return TRUE
 	if(HAS_TRAIT(cursed, TRAIT_CURSED))
 		to_chat(cursed, span_warning("What a horrible night... To have a curse!"))


### PR DESCRIPTION

## About The Pull Request

So a previous pr attempted to fix the fuck you coupon, by adding 1 to the arguments.
```dm
(tgstation/code/modules/cargo/coupon.dm, line 87)
cursed.AddComponent(/datum/component/omen, 1)
```
But this was setting the `vessel` rather than the `incidents_left` argument to 1.
```dm
(tgstation/code/datums/components/omen.dm, line 20)
/datum/component/omen/Initialize(obj/vessel, incidents_left, luck_mod, damage_mod)
```
Moving this argument over one fixes the issue.
```dm
cursed.AddComponent(/datum/component/omen, null, 1)
```

However! We're now skipping over the `vessel` value, which is used to burn up a curse's vessel once the curse is expended.
Setting this to `src` rather than `null` means the fuck you coupon actually gets 'expended', which I think it better than just using `null` or `incidents_left = 1`. The coupon's useless once it's done, and this way it's cooler anyway.
For consistency, we then also add this behaviour to when the coupon gives you a heart attack instead.

Then! I noticed there was a _second_ bug with fuck you coupons, where it would stop prematurely if the location wasn't a mob.
```dm
(tgstation/code/modules/cargo/coupon.dm, line 80-81)
if(!ismob(loc))
	return FALSE
```
However, this also happens when you don't have a free hand for it to put the coupon in, and thus entirely negating the curse and just giving you a useless fuck you coupon.
We fix this by just adding a `user` argument to `generate`, which it prefers to use when available, and is set to the user ripping off the coupon in the first place.
## Why It's Good For The Game

Fixes #81946.
As fuck you coupons are pretty much useless after expending their curse, and we have to add the vessel value anyway, I thought it'd be more fitting to add the coupon as the vessel rather than just putting in null. Then, for consistency, I felt it'd be best to make them *also* burn when giving you a heart attack when you already have a curse.
Y'know, it's expending the coupon for it's one-time fuck you!

Also fixes fuck you coupons not actually applying their curse if you didn't have any free hands for it to put the coupon in when ripping it off.
## Changelog
:cl:
fix: Fuck you coupons ACTUALLY trigger only once again. As a consequence, they also burn up when expended for their one-time fuck you.
fix: Fuck you coupons work regardless of whether you had a free hand or not.
/:cl:
