### PR TITLE
Adds a missing recharger to the Birdshot science testing range

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -5554,6 +5554,7 @@
 "ciT" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/recharger,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
 "cjm" = (


### PR DESCRIPTION

## About The Pull Request
As per the title, adds a recharger to the testing range in science on Birdshot.
I noticed that this was missing from the room, and without it there's no way to recharge the nearby practice weaponry. So I added one for the practice weapons and for the consistency with testing ranges in other maps.
## Why It's Good For The Game
If you have a firing range with (practice) weaponry and no way to recharge them after firing, it kind of sucks. By adding one, we both fix this problem and the inconsistency with other testing ranges.
## Changelog
:cl:
fix: A missing recharger has been added into science's testing range on Birdshot station.
/:cl:
