### PR TITLE
Fixes Spontaneous Harddel with Boned Fish Revive Ability

### DIFF
--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -216,7 +216,7 @@ GLOBAL_LIST_INIT(fish_traits, init_subtypes_w_path_keys(/datum/fish_trait, list(
 		addtimer(CALLBACK(src, PROC_REF(revive), WEAKREF(source)), rand(1 MINUTES, 2 MINUTES))
 
 /datum/fish_trait/revival/proc/revive(datum/weakref/fish_ref)
-	var/obj/item/fish/source = fish_ref.Resolve()
+	var/obj/item/fish/source = fish_ref.resolve()
 	if(QDELETED(source) || source.status != FISH_DEAD)
 		return
 	source.set_status(FISH_ALIVE)

--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -213,9 +213,10 @@ GLOBAL_LIST_INIT(fish_traits, init_subtypes_w_path_keys(/datum/fish_trait, list(
 /datum/fish_trait/revival/proc/check_status(obj/item/fish/source)
 	SIGNAL_HANDLER
 	if(source.status == FISH_DEAD)
-		addtimer(CALLBACK(src, PROC_REF(revive), source), rand(1 MINUTES, 2 MINUTES))
+		addtimer(CALLBACK(src, PROC_REF(revive), WEAKREF(source)), rand(1 MINUTES, 2 MINUTES))
 
-/datum/fish_trait/revival/proc/revive(obj/item/fish/source)
+/datum/fish_trait/revival/proc/revive(datum/weakref/fish_ref)
+	var/obj/item/fish/source = fish_ref.Resolve()
 	if(QDELETED(source) || source.status != FISH_DEAD)
 		return
 	source.set_status(FISH_ALIVE)


### PR DESCRIPTION
## About The Pull Request

You can find an example of the failing stack trace here: https://github.com/tgstation/tgstation/actions/runs/8242191499/job/22540786029?pr=81937#step:10:1323

Here's a screenshot:

![image](https://github.com/tgstation/tgstation/assets/34697715/2a7c1c70-c82e-4790-b8e5-e05187a77f1a)

Explanation: The boned fish's revive ability added a timer that would randomly fire in the next one-to-two minutes. Due to this inherent randomness, create-and-destroy would locate the fact that we were hanging refs to this fish since the timer may not have processed by the time the fish was deleted (probably if the timer was considerably more than one minute), so in order to fix this let's just add the `TIMER_DELETE_ME` flag to the revive ability so that the timer get's `qdel`'d on the fish's `Destroy()`. simple

i probably cocked up some detail of the above explanation but the timer flag was literally created to prevent stuff like this from happening so let's use it

## Changelog

don't matter
