### PR TITLE
Wall-mounted button fix

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -136,7 +136,7 @@
 		return
 
 	if(!user.combat_mode && !(W.item_flags & NOBLUDGEON))
-		return attack_hand(user)
+		return interact(user)
 	else
 		return ..()
 
@@ -157,7 +157,7 @@
 
 /obj/machinery/button/attack_ai(mob/user)
 	if(!silicon_access_disabled && !panel_open)
-		return attack_hand(user)
+		return interact(user)
 
 /obj/machinery/button/attack_robot(mob/user)
 	return attack_ai(user)


### PR DESCRIPTION

## About The Pull Request
Fixes #81961

Changes buttons to no longer call attack_hand, which doesn't exists, and instead calls interact, which does.
## Why It's Good For The Game
Less bugs are good. I hate having to break them with a chainsaw to replace them.
## Changelog
:cl:
fix: fixed a few things
/:cl:
