### PR TITLE
Adds evidence bag boxes to the Lawyer's wardrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -493,6 +493,7 @@
 		/obj/item/clothing/under/rank/civilian/lawyer/black/skirt = 1,
 		/obj/item/clothing/shoes/laceup = 2,
 		/obj/item/radio/headset/headset_srv = 2,
+		/obj/item/storage/box/evidence = 2,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/law_wardrobe
 	payment_department = ACCOUNT_SRV


### PR DESCRIPTION
## About The Pull Request
Adds 2 boxes of evidence baggies to list of available items from the LawDrobe.
## Why It's Good For The Game
Lawyers have a few uses for these bags. They help when handling evidence because they prevent contamination of forensics, and they aid in courtroom roleplay - the lawyer presenting a plastic baggie labelled EXHIBIT A containing a bloodstained knife is a staple of courtroom dramas. However, on most maps they have no legitimate access to evidence bags (sec vendor, sec lathe, sec office and holding cells are inaccessible to lawyers).
## Changelog
:cl:
qol: The LawDrobe now stocks two (2) boxes of evidence bags.
/:cl:
