### PR TITLE
Fix buttons not letting you take out their electronics

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -21,6 +21,7 @@
 	armor_type = /datum/armor/machinery_button
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	interaction_flags_machine = parent_type::interaction_flags_machine | INTERACT_MACHINE_OPEN
 
 /obj/machinery/button/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF


### PR DESCRIPTION

## About The Pull Request

So as part of its AI-like fuckery changes, #81681 changed `attack_hand` to `interact` in `buttons.dm`.
```dm
(code/game/machinery/buttons.dm, line 187, #81681)
- /obj/machinery/button/attack_hand(mob/user, list/modifiers)
+ /obj/machinery/button/interact(mob/user)
```
Now, buttons use this proc both for activating itself, yes, but also for letting people take out the electronics _when the panel is open_.
```dm
(code/game/machinery/buttons.dm, line 187-206)
/obj/machinery/button/interact(mob/user)
	(...)
	if(panel_open)
		if(device || board)
			(...)
			balloon_alert(user, "electronics removed")
			to_chat(user, span_notice("You remove electronics from the button frame."))
```
And, well, `interact` gets called from `attack_hand`! So it's fine, right?

Well, not entirely. Interact _doesn't_ get called in that whole convoluted chain if the panel is open, unless it has `INTERACT_MACHINE_OPEN` set in its `interaction_flags_machine`.


But so, just adding `interaction_flags_machine = parent_type::interaction_flags_machine | INTERACT_MACHINE_OPEN` solves the issue.
## Why It's Good For The Game

Fixes #81961.
## Changelog
:cl:
fix: Buttons let you take out their electronics again, hooray.
/:cl:
