### PR TITLE
Fixes lag in search bars

### DIFF
--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -150,17 +150,6 @@ export function Input(props: Props) {
     }, 1);
   }, []);
 
-  /** Updates the initial value on props change */
-  useEffect(() => {
-    const input = inputRef.current;
-    if (!input) return;
-
-    const newValue = toInputValue(value);
-    if (input.value === newValue) return;
-
-    input.value = newValue;
-  }, [value]);
-
   return (
     <Box
       className={classes([


### PR DESCRIPTION
## About The Pull Request
- Fixes #81132
- Fixes #80853

To properly reproduce the issue you only need to type slowly in the search bar(type the word "basic") of the shared engineering techfab in metastation.

https://github.com/tgstation/tgstation/assets/110812394/1c2a5791-66e2-468a-9827-6541966c18a9

I don't fully understand why this fixes it so i need an explanation before it gets merged. 

This was implemented back in #80614 to fix this

> Problem goes a little deeper than simply adding "selfClear" prop - ntos messenger is looking for more of a controlled component. Whenever messages are sent, it attempts to update the value in the input box

But upon testing the chat messenger with this removed it appears to work fine so not sure what got fixed where but one thing i can assert is that it definitely has nothing to do with debounce.

## Changelog
:cl:
fix: search bars don't swallow characters or lag behind your typing speed
/:cl:
