### PR TITLE
Fixes the RTD, RLD, and the engi rebar crossbow not fitting on a engi winter coat's storage slot

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -520,6 +520,9 @@
 		/obj/item/pipe_dispenser,
 		/obj/item/storage/bag/construction,
 		/obj/item/t_scanner,
+		/obj/item/construction/rld,
+		/obj/item/construction/rtd,
+		/obj/item/gun/ballistic/rifle/rebarxbow
 	)
 	armor_type = /datum/armor/wintercoat_engineering
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The engi rebar crossbow is now storable on an engi winter coat, like I originally intended.
Also, the RTD and RLD are as well, because the other rapid whatever devices are.

## Why It's Good For The Game

I originally wanted the crossbow to have this - its why it has wearable sprites - but for some reason I forgot to add it, probably due to getting lost in guncode soup. Also, The fact the RCD and RPD are storable but the RTD and RLD aren't, along with the fact the RTD and RLD are newer is probably an oversight, so it changes that.

## Changelog

:cl: Webcomicartist
fix: Fixed RLD,RTD and Rebar crossbow not being storable on the engineering winter coat slot.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
