### PR TITLE
Gulag boulder mining adjustments

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -74,7 +74,7 @@
 	attack_verb_simple = list("bluespace polybash", "bluespace polybatter", "bluespace polybludgeon", "bluespace polythrash", "bluespace polysmash")
 	novariants = TRUE
 	grind_results = list(/datum/reagent/bluespace = 20)
-	point_value = 30
+	point_value = 90
 	merge_type = /obj/item/stack/sheet/bluespace_crystal
 	material_type = /datum/material/bluespace
 	var/crystal_type = /obj/item/stack/ore/bluespace_crystal/refined

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/rglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/iron = 10)
-	point_value = 4
+	point_value = 12
 	matter_amount = 6
 	tableVariant = /obj/structure/table/reinforced/rglass
 
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	material_flags = NONE
 	merge_type = /obj/item/stack/sheet/plasmarglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10, /datum/reagent/iron = 10)
-	point_value = 23
+	point_value = 69
 	matter_amount = 8
 	tableVariant = /obj/structure/table/reinforced/plasmarglass
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	sheettype = "diamond"
 	mats_per_unit = list(/datum/material/diamond=SHEET_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/carbon = 20)
-	point_value = 25
+	point_value = 75
 	merge_type = /obj/item/stack/sheet/mineral/diamond
 	material_type = /datum/material/diamond
 	walltype = /turf/closed/wall/mineral/diamond
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	sheettype = "uranium"
 	mats_per_unit = list(/datum/material/uranium=SHEET_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/uranium = 20)
-	point_value = 20
+	point_value = 60
 	merge_type = /obj/item/stack/sheet/mineral/uranium
 	material_type = /datum/material/uranium
 	walltype = /turf/closed/wall/mineral/uranium
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	max_integrity = 100
 	mats_per_unit = list(/datum/material/plasma=SHEET_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/toxin/plasma = 20)
-	point_value = 20
+	point_value = 60
 	merge_type = /obj/item/stack/sheet/mineral/plasma
 	material_type = /datum/material/plasma
 	walltype = /turf/closed/wall/mineral/plasma
@@ -192,7 +192,7 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	sheettype = "gold"
 	mats_per_unit = list(/datum/material/gold=SHEET_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/gold = 20)
-	point_value = 20
+	point_value = 60
 	merge_type = /obj/item/stack/sheet/mineral/gold
 	material_type = /datum/material/gold
 	walltype = /turf/closed/wall/mineral/gold
@@ -219,7 +219,7 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	sheettype = "silver"
 	mats_per_unit = list(/datum/material/silver=SHEET_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/silver = 20)
-	point_value = 20
+	point_value = 60
 	merge_type = /obj/item/stack/sheet/mineral/silver
 	material_type = /datum/material/silver
 	tableVariant = /obj/structure/table/optable
@@ -245,7 +245,7 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	sheettype = "bananium"
 	mats_per_unit = list(/datum/material/bananium=SHEET_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/consumable/banana = 20)
-	point_value = 50
+	point_value = 150
 	merge_type = /obj/item/stack/sheet/mineral/bananium
 	material_type = /datum/material/bananium
 	walltype = /turf/closed/wall/mineral/bananium
@@ -276,7 +276,7 @@ GLOBAL_LIST_INIT(bananium_recipes, list ( \
 	throw_range = 3
 	sheettype = "titanium"
 	mats_per_unit = list(/datum/material/titanium=SHEET_MATERIAL_AMOUNT)
-	point_value = 20
+	point_value = 60
 	merge_type = /obj/item/stack/sheet/mineral/titanium
 	material_type = /datum/material/titanium
 	walltype = /turf/closed/wall/mineral/titanium
@@ -308,7 +308,7 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 	throw_range = 3
 	sheettype = "plastitanium"
 	mats_per_unit = list(/datum/material/alloy/plastitanium=SHEET_MATERIAL_AMOUNT)
-	point_value = 45
+	point_value = 135
 	material_type = /datum/material/alloy/plastitanium
 	merge_type = /obj/item/stack/sheet/mineral/plastitanium
 	material_flags = NONE
@@ -482,7 +482,7 @@ GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	singular_name = "metal hydrogen sheet"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FIRE_PROOF | LAVA_PROOF | ACID_PROOF | INDESTRUCTIBLE
-	point_value = 100
+	point_value = 300
 	mats_per_unit = list(/datum/material/metalhydrogen = SHEET_MATERIAL_AMOUNT)
 	material_type = /datum/material/metalhydrogen
 	merge_type = /obj/item/stack/sheet/mineral/metal_hydrogen
@@ -497,7 +497,7 @@ GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	inhand_icon_state = "sheet-zaukerite"
 	singular_name = "zaukerite crystal"
 	w_class = WEIGHT_CLASS_NORMAL
-	point_value = 120
+	point_value = 360
 	mats_per_unit = list(/datum/material/zaukerite = SHEET_MATERIAL_AMOUNT)
 	merge_type = /obj/item/stack/sheet/mineral/zaukerite
 	material_type = /datum/material/zaukerite

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/iron
 	grind_results = list(/datum/reagent/iron = 20)
-	point_value = 2
+	point_value = 6
 	tableVariant = /obj/structure/table
 	material_type = /datum/material/iron
 	matter_amount = 4
@@ -277,7 +277,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
 	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
-	point_value = 23
+	point_value = 69
 	tableVariant = /obj/structure/table/reinforced
 	material_flags = NONE
 	matter_amount = 12

--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -108,6 +108,7 @@
 /obj/item/boulder/proc/manual_process(obj/item/weapon, mob/living/user, override_speed_multiplier, continued = FALSE)
 	var/process_speed = 0
 	//Handle weapon conditions.
+	var/skill_modifier = user.mind?.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER) || 1
 	if(weapon)
 		if(HAS_TRAIT(weapon, TRAIT_INSTANTLY_PROCESSES_BOULDERS))
 			durability = 0
@@ -118,25 +119,24 @@
 
 	// Handle user conditions/override conditions.
 	else if (override_speed_multiplier || HAS_TRAIT(user, TRAIT_BOULDER_BREAKER))
-		if(user)
-			if(HAS_TRAIT(user, TRAIT_INSTANTLY_PROCESSES_BOULDERS))
-				durability = 0
+		if(HAS_TRAIT(user, TRAIT_INSTANTLY_PROCESSES_BOULDERS))
+			durability = 0
 		else if(override_speed_multiplier)
 			process_speed = override_speed_multiplier
 		else
 			process_speed = INATE_BOULDER_SPEED_MULTIPLIER
 		playsound(src, 'sound/effects/rocktap1.ogg', 50)
 		if(!continued)
-			to_chat(user, span_notice("You scrape away at \the [src]... speed is [process_speed]."))
+			to_chat(user, span_notice("You scrape away at \the [src]...  speed is [process_speed * skill_modifier]."))
 	else
 		CRASH("No weapon, acceptable user, or override speed multiplier passed to manual_process()")
 	if(durability > 0)
-		if(!do_after(user, (2 * process_speed SECONDS), target = src))
+		if(!do_after(user, (2 * process_speed * skill_modifier SECONDS), target = src))
 			return
 		if(!user.Adjacent(src))
 			return
 		durability--
-		user.apply_damage(4, STAMINA)
+		user.apply_damage(4 * skill_modifier, STAMINA)
 	if(durability <= 0)
 		convert_to_ore()
 		to_chat(user, span_notice("You finish working on \the [src], and it crumbles into ore."))

--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -127,7 +127,7 @@
 			process_speed = INATE_BOULDER_SPEED_MULTIPLIER
 		playsound(src, 'sound/effects/rocktap1.ogg', 50)
 		if(!continued)
-			to_chat(user, span_notice("You scrape away at \the [src]...  speed is [process_speed * skill_modifier]."))
+			to_chat(user, span_notice("You scrape away at \the [src]..."))
 	else
 		CRASH("No weapon, acceptable user, or override speed multiplier passed to manual_process()")
 	if(durability > 0)


### PR DESCRIPTION
## About The Pull Request

This PR does two fairly simple things.
Firstly, it triples the gulag point value of every material except glass.
Secondly, it allows mining skill increases to effect the speed of boulder breaking and reduce the stamina "exertion" you take.

I tried this out personally on Lavaland and Icebox and while this is very much dependent on RNG (and storm timing) this got earning 1000 points purely from mining and smashing boulders down to _about_ ten minutes of work, which I believe is the rough estimate of how much effort it was before that. It may skew a bit higher than that if the ash storm happens at a bad time or the game gives you predominantly iron, but not a _lot_ higher.

The mining skill = faster smashing thing is... barely perceptible after ten minutes of mining to be honest but it's saving _some_ time and I think if it gives you the exp it might as well benefit from it too.

I didn't do anything for _glass_ because you can just pick that up off the ground in Lavaland and I didn't want to make _that_ the ideal route to getting your sentence finished.

## Why It's Good For The Game

Since ArcMining was merged, the gulag has changed to a system primarily about digging up boulders and smashing them with a pickaxe for random rewards. I think the chain gang thing is pretty flavourful, but the inability to just target high-value materials (because you could see them on the mining scanner) and the overall decrease in output has made it take a lot longer to get a similar amount of points.

People are sending prisoners out to mine for 1000 points of materials assuming this is about 10 minutes work, when in reality it was more like 30-35 minutes. Longer on Lavaland, where you need to take breaks for ash storms.

This was not an intentional "nerf" to prisoner miners and should hopefully bring it back down to somewhere closer to the previous level.

## Changelog

:cl:
balance: All materials except glass are now worth more gulag points than before.
balance: Mining skill decreases the time it takes to break boulders, and makes it less tiring.
/:cl:
