### PR TITLE
Placing things in a paperbin actually plays sounds.

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -132,7 +132,7 @@
 		update_appearance()
 	else if(istype(I, /obj/item/pen) && !bin_pen)
 		var/obj/item/pen/pen = I
-		if(!user.transferItemToLoc(pen, src))
+		if(!user.transferItemToLoc(pen, src, silent = FALSE))
 			return
 		to_chat(user, span_notice("You put [pen] in [src]."))
 		bin_pen = pen

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -124,7 +124,7 @@
 		return
 	if(istype(I, /obj/item/paper))
 		var/obj/item/paper/paper = I
-		if(!user.transferItemToLoc(paper, src))
+		if(!user.transferItemToLoc(paper, src, silent = FALSE))
 			return
 		to_chat(user, span_notice("You put [paper] in [src]."))
 		paper_stack += paper


### PR DESCRIPTION

## About The Pull Request

In contrast to my previous pr:
Really just changes the `user.transferItemToLoc(...)` used for transferring paper to the bin to have a `silent = FALSE` parameter.
Also did it for pens for good measure, though I believe most pens don't have such sounds yet.
## Why It's Good For The Game

Placing paper on a table makes sounds, placing paper in a bin makes no sound. This feels awkward.
This changes that to actually make a sound.
Also adds `silent = FALSE` to placing pens on it for good measure, though most pens don't have such sounds yet.
## Changelog
:cl:
sound: Placing paper in a paperbin is no longer silent.
/:cl:
