### PR TITLE
Dice roll messages now properly detect if the die was rolled inhand or thrown

### DIFF
--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -72,7 +72,7 @@
 	update_appearance()
 
 /obj/item/dice/attack_self(mob/user)
-	diceroll(user)
+	diceroll(user, TRUE)
 
 /obj/item/dice/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	var/mob/thrown_by = thrownby?.resolve()
@@ -80,7 +80,7 @@
 		diceroll(thrown_by)
 	return ..()
 
-/obj/item/dice/proc/diceroll(mob/user)
+/obj/item/dice/proc/diceroll(mob/user, in_hand=FALSE)
 	result = roll(sides)
 	if(rigged != DICE_NOT_RIGGED && result != rigged_value)
 		if(rigged == DICE_BASICALLY_RIGGED && prob(clamp(1/(sides - 1) * 100, 25, 80)))
@@ -104,12 +104,13 @@
 		if(!ISINTEGER(result))
 			comment = special_faces[result]  // should be a str now
 
-	if(user != null) //Dice was rolled in someone's hand
-		user.visible_message(span_notice("[user] throws [src]. It lands on [result]. [comment]"), \
-			span_notice("You throw [src]. It lands on [result]. [comment]"), \
+	if(in_hand) //Dice was rolled in someone's hand
+		user.visible_message(span_notice("[user] rolls [src]. It lands on [result]. [comment]"), \
+			span_notice("You roll [src]. It lands on [result]. [comment]"), \
 			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
-	else if(!src.throwing) //Dice was thrown and is coming to rest
+	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
+
 
 /obj/item/dice/update_overlays()
 	. = ..()

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -105,9 +105,11 @@
 			comment = special_faces[result]  // should be a str now
 
 	if(in_hand) //Dice was rolled in someone's hand
-		user.visible_message(span_notice("[user] rolls [src]. It lands on [result]. [comment]"), \
-			span_notice("You roll [src]. It lands on [result]. [comment]"), \
-			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
+		user.visible_message(
+			span_notice("[user] rolls [src]. It lands on [result]. [comment]"),
+			span_notice("You roll [src]. It lands on [result]. [comment]"),
+			span_hear("You hear [src] rolling, it sounds like a [fake_result].",
+		))
 	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
 		

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -81,8 +81,6 @@
 	return ..()
 
 /obj/item/dice/proc/diceroll(mob/user, in_hand=FALSE)
-	to_chat(world, "<video src='http://localhost:8000/test.mp4' type='video/mp4'>")
-	to_chat(world, "<script>alert('test');</script>")
 	result = roll(sides)
 	if(rigged != DICE_NOT_RIGGED && result != rigged_value)
 		if(rigged == DICE_BASICALLY_RIGGED && prob(clamp(1/(sides - 1) * 100, 25, 80)))

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -72,7 +72,7 @@
 	update_appearance()
 
 /obj/item/dice/attack_self(mob/user)
-	diceroll(user, TRUE)
+	diceroll(user, in_hand = TRUE)
 
 /obj/item/dice/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	var/mob/thrown_by = thrownby?.resolve()

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -81,6 +81,8 @@
 	return ..()
 
 /obj/item/dice/proc/diceroll(mob/user, in_hand=FALSE)
+	to_chat(world, "<video src='http://localhost:8000/test.mp4' type='video/mp4'>")
+	to_chat(world, "<script>alert('test');</script>")
 	result = roll(sides)
 	if(rigged != DICE_NOT_RIGGED && result != rigged_value)
 		if(rigged == DICE_BASICALLY_RIGGED && prob(clamp(1/(sides - 1) * 100, 25, 80)))
@@ -95,7 +97,7 @@
 	if(sides > MIN_SIDES_ALERT && result == 1)  // less comment spam
 		comment = "Ouch, bad luck."
 	if(sides == 20 && result == 20)
-		comment = "NAT 20!"
+		comment = "NAT 20!"  // maint wanted this hardcoded to nat20 don't blame me
 	update_appearance()
 	result = manipulate_result(result)
 	if(special_faces.len == sides)
@@ -105,15 +107,11 @@
 			comment = special_faces[result]  // should be a str now
 
 	if(in_hand) //Dice was rolled in someone's hand
-		user.visible_message(
-			span_notice("[user] rolls [src]. It lands on [result]. [comment]"),
-			span_notice("You roll [src]. It lands on [result]. [comment]"),
-			span_hear("You hear [src] rolling, it sounds like a [fake_result].",
-		))
+		user.visible_message(span_notice("[user] rolls [src]. It lands on [result]. [comment]"), \
+			span_notice("You roll [src]. It lands on [result]. [comment]"), \
+			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
 	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
-		
-	return .
 
 
 /obj/item/dice/update_overlays()
@@ -308,7 +306,7 @@
 /obj/item/dice/d20/fate/stealth/cursed/one_use
 	reusable = FALSE
 
-/obj/item/dice/d20/fate/diceroll(mob/user)
+/obj/item/dice/d20/fate/diceroll(mob/user, in_hand)
 	if(!COOLDOWN_FINISHED(src, roll_cd))
 		to_chat(user, span_warning("Hold on, [src] isn't caught up with your last roll!"))
 		return

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -95,7 +95,7 @@
 	if(sides > MIN_SIDES_ALERT && result == 1)  // less comment spam
 		comment = "Ouch, bad luck."
 	if(sides == 20 && result == 20)
-		comment = "NAT 20!"  // maint wanted this hardcoded to nat20 don't blame me
+		comment = "NAT 20!"
 	update_appearance()
 	result = manipulate_result(result)
 	if(special_faces.len == sides)
@@ -105,11 +105,15 @@
 			comment = special_faces[result]  // should be a str now
 
 	if(in_hand) //Dice was rolled in someone's hand
-		user.visible_message(span_notice("[user] rolls [src]. It lands on [result]. [comment]"), \
-			span_notice("You roll [src]. It lands on [result]. [comment]"), \
-			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
+		user.visible_message(
+			span_notice("[user] rolls [src]. It lands on [result]. [comment]"),
+			span_notice("You roll [src]. It lands on [result]. [comment]"),
+			span_hear("You hear [src] rolling, it sounds like a [fake_result].",
+		))
 	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
+		
+	return .
 
 
 /obj/item/dice/update_overlays()
@@ -304,7 +308,7 @@
 /obj/item/dice/d20/fate/stealth/cursed/one_use
 	reusable = FALSE
 
-/obj/item/dice/d20/fate/diceroll(mob/user, in_hand)
+/obj/item/dice/d20/fate/diceroll(mob/user)
 	if(!COOLDOWN_FINISHED(src, roll_cd))
 		to_chat(user, span_warning("Hold on, [src] isn't caught up with your last roll!"))
 		return

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -71,6 +71,61 @@
 		result = roll(sides)
 	update_appearance()
 
+/obj/item/dice/attack_self(mob/user)
+	diceroll(user)
+
+/obj/item/dice/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	var/mob/thrown_by = thrownby?.resolve()
+	if(thrown_by)
+		diceroll(thrown_by)
+	return ..()
+
+/obj/item/dice/proc/diceroll(mob/user)
+	result = roll(sides)
+	if(rigged != DICE_NOT_RIGGED && result != rigged_value)
+		if(rigged == DICE_BASICALLY_RIGGED && prob(clamp(1/(sides - 1) * 100, 25, 80)))
+			result = rigged_value
+		else if(rigged == DICE_TOTALLY_RIGGED)
+			result = rigged_value
+
+	. = result
+
+	var/fake_result = roll(sides)//Daredevil isn't as good as he used to be
+	var/comment = ""
+	if(sides > MIN_SIDES_ALERT && result == 1)  // less comment spam
+		comment = "Ouch, bad luck."
+	if(sides == 20 && result == 20)
+		comment = "NAT 20!"  // maint wanted this hardcoded to nat20 don't blame me
+	update_appearance()
+	result = manipulate_result(result)
+	if(special_faces.len == sides)
+		comment = ""  // its not a number
+		result = special_faces[result]
+		if(!ISINTEGER(result))
+			comment = special_faces[result]  // should be a str now
+
+	if(user != null) //Dice was rolled in someone's hand
+		user.visible_message(span_notice("[user] throws [src]. It lands on [result]. [comment]"), \
+			span_notice("You throw [src]. It lands on [result]. [comment]"), \
+			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
+	else if(!src.throwing) //Dice was thrown and is coming to rest
+		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
+
+/obj/item/dice/update_overlays()
+	. = ..()
+	. += "[icon_state]-[result]"
+
+/obj/item/dice/microwave_act(obj/machinery/microwave/microwave_source, mob/microwaver, randomize_pixel_offset)
+	if(microwave_riggable)
+		rigged = DICE_BASICALLY_RIGGED
+		rigged_value = result
+
+	return ..() | COMPONENT_MICROWAVE_SUCCESS
+
+/// A proc to modify the displayed result. (Does not affect what the icon_state is passed.)
+/obj/item/dice/proc/manipulate_result(original)
+	return original
+
 /obj/item/dice/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is gambling with death! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS
@@ -207,61 +262,6 @@
 /obj/item/dice/fourdd6/Initialize(mapload)
 	AddElement(/datum/element/update_icon_blocker)
 	return ..()
-
-/obj/item/dice/attack_self(mob/user)
-	diceroll(user)
-
-/obj/item/dice/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	var/mob/thrown_by = thrownby?.resolve()
-	if(thrown_by)
-		diceroll(thrown_by)
-	return ..()
-
-/obj/item/dice/proc/diceroll(mob/user)
-	result = roll(sides)
-	if(rigged != DICE_NOT_RIGGED && result != rigged_value)
-		if(rigged == DICE_BASICALLY_RIGGED && prob(clamp(1/(sides - 1) * 100, 25, 80)))
-			result = rigged_value
-		else if(rigged == DICE_TOTALLY_RIGGED)
-			result = rigged_value
-
-	. = result
-
-	var/fake_result = roll(sides)//Daredevil isn't as good as he used to be
-	var/comment = ""
-	if(sides > MIN_SIDES_ALERT && result == 1)  // less comment spam
-		comment = "Ouch, bad luck."
-	if(sides == 20 && result == 20)
-		comment = "NAT 20!"  // maint wanted this hardcoded to nat20 don't blame me
-	update_appearance()
-	result = manipulate_result(result)
-	if(special_faces.len == sides)
-		comment = ""  // its not a number
-		result = special_faces[result]
-		if(!ISINTEGER(result))
-			comment = special_faces[result]  // should be a str now
-
-	if(user != null) //Dice was rolled in someone's hand
-		user.visible_message(span_notice("[user] throws [src]. It lands on [result]. [comment]"), \
-			span_notice("You throw [src]. It lands on [result]. [comment]"), \
-			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
-	else if(!src.throwing) //Dice was thrown and is coming to rest
-		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
-
-/obj/item/dice/update_overlays()
-	. = ..()
-	. += "[icon_state]-[result]"
-
-/obj/item/dice/microwave_act(obj/machinery/microwave/microwave_source, mob/microwaver, randomize_pixel_offset)
-	if(microwave_riggable)
-		rigged = DICE_BASICALLY_RIGGED
-		rigged_value = result
-
-	return ..() | COMPONENT_MICROWAVE_SUCCESS
-
-/// A proc to modify the displayed result. (Does not affect what the icon_state is passed.)
-/obj/item/dice/proc/manipulate_result(original)
-	return original
 
 // Die of fate stuff
 /obj/item/dice/d20/fate

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -95,7 +95,7 @@
 	if(sides > MIN_SIDES_ALERT && result == 1)  // less comment spam
 		comment = "Ouch, bad luck."
 	if(sides == 20 && result == 20)
-		comment = "NAT 20!"  // maint wanted this hardcoded to nat20 don't blame me
+		comment = "NAT 20!"
 	update_appearance()
 	result = manipulate_result(result)
 	if(special_faces.len == sides)

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -108,8 +108,8 @@
 		user.visible_message(
 			span_notice("[user] rolls [src]. It lands on [result]. [comment]"),
 			span_notice("You roll [src]. It lands on [result]. [comment]"),
-			span_hear("You hear [src] rolling, it sounds like a [fake_result].",
-		))
+			span_hear("You hear [src] rolling, it sounds like a [fake_result]."),
+		)
 	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
 

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -112,7 +112,7 @@
 		))
 	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
-		
+
 	return .
 
 
@@ -308,7 +308,7 @@
 /obj/item/dice/d20/fate/stealth/cursed/one_use
 	reusable = FALSE
 
-/obj/item/dice/d20/fate/diceroll(mob/user)
+/obj/item/dice/d20/fate/diceroll(mob/user, in_hand=FALSE)
 	if(!COOLDOWN_FINISHED(src, roll_cd))
 		to_chat(user, span_warning("Hold on, [src] isn't caught up with your last roll!"))
 		return

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -110,6 +110,8 @@
 			span_hear("You hear [src] rolling, it sounds like a [fake_result]."))
 	else
 		visible_message(span_notice("[src] rolls to a stop, landing on [result]. [comment]"))
+		
+	return .
 
 
 /obj/item/dice/update_overlays()


### PR DESCRIPTION
## About The Pull Request
Currently, dice will give the same message directly to the user, regardless of if they were thrown or rolled in hand. This means you can throw a die far off screen or even out into space, and still know exactly when the die landed and what was rolled despite not being able to see it. This PR fixes that.

It also rearranges the code for dice a little bit, since for some reason all the important procs were defined like, halfway down the file from the initial `/obj/item/dice` definition. 
## Why It's Good For The Game
Fixes a bug and something potentially exploitable
## Changelog
:cl:
fix: You can no longer determine the result of a dice roll from off-screen.
/:cl:
