### PR TITLE
Removes adamantine extracts from DM scientist loadout

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -309,33 +309,6 @@
 	back = /obj/item/fireaxe
 	gloves = /obj/item/clothing/gloves/color/yellow
 
-/datum/outfit/deathmatch_loadout/battler/scientist
-	name = "Deathmatch: Scientist"
-	display_name = "Scientist"
-	desc = "What a nerd"
-
-	uniform = /obj/item/clothing/under/rank/rnd/scientist
-	suit = /obj/item/clothing/suit/armor/reactive/stealth
-	mask = /obj/item/clothing/mask/gas
-	l_hand = /obj/item/reagent_containers/syringe/plasma
-	l_pocket = /obj/item/slimecross/stabilized/sepia
-	r_pocket = /obj/item/slimecross/stabilized/purple
-	backpack_contents = list(
-		/obj/item/reagent_containers/cup/bottle/plasma,
-		/obj/item/slimecross/burning/grey,
-		/obj/item/slimecross/burning/adamantine,
-		/obj/item/slimecross/burning/gold,
-		/obj/item/slimecross/burning/blue,
-		/obj/item/slimecross/burning/sepia,
-		/obj/item/slimecross/chilling/green,
-		/obj/item/slimecross/chilling/grey,
-		/obj/item/slimecross/industrial/oil,
-		/obj/item/slimecross/charged/silver,
-		/obj/item/slimecross/charged/black,
-		/obj/item/slimecross/burning/rainbow,
-		/obj/item/slimecross/chilling/adamantine,
-	)
-
 /datum/outfit/deathmatch_loadout/battler/bloodminer
 	name = "Deathmatch: Blood Miner"
 	display_name = "Blood Miner"

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -323,7 +323,6 @@
 	backpack_contents = list(
 		/obj/item/reagent_containers/cup/bottle/plasma,
 		/obj/item/slimecross/burning/grey,
-		/obj/item/slimecross/burning/adamantine,
 		/obj/item/slimecross/burning/gold,
 		/obj/item/slimecross/burning/blue,
 		/obj/item/slimecross/burning/sepia,
@@ -333,7 +332,6 @@
 		/obj/item/slimecross/charged/silver,
 		/obj/item/slimecross/charged/black,
 		/obj/item/slimecross/burning/rainbow,
-		/obj/item/slimecross/chilling/adamantine,
 	)
 
 /datum/outfit/deathmatch_loadout/battler/bloodminer

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -309,6 +309,33 @@
 	back = /obj/item/fireaxe
 	gloves = /obj/item/clothing/gloves/color/yellow
 
+/datum/outfit/deathmatch_loadout/battler/scientist
+	name = "Deathmatch: Scientist"
+	display_name = "Scientist"
+	desc = "What a nerd"
+
+	uniform = /obj/item/clothing/under/rank/rnd/scientist
+	suit = /obj/item/clothing/suit/armor/reactive/stealth
+	mask = /obj/item/clothing/mask/gas
+	l_hand = /obj/item/reagent_containers/syringe/plasma
+	l_pocket = /obj/item/slimecross/stabilized/sepia
+	r_pocket = /obj/item/slimecross/stabilized/purple
+	backpack_contents = list(
+		/obj/item/reagent_containers/cup/bottle/plasma,
+		/obj/item/slimecross/burning/grey,
+		/obj/item/slimecross/burning/adamantine,
+		/obj/item/slimecross/burning/gold,
+		/obj/item/slimecross/burning/blue,
+		/obj/item/slimecross/burning/sepia,
+		/obj/item/slimecross/chilling/green,
+		/obj/item/slimecross/chilling/grey,
+		/obj/item/slimecross/industrial/oil,
+		/obj/item/slimecross/charged/silver,
+		/obj/item/slimecross/charged/black,
+		/obj/item/slimecross/burning/rainbow,
+		/obj/item/slimecross/chilling/adamantine,
+	)
+
 /datum/outfit/deathmatch_loadout/battler/bloodminer
 	name = "Deathmatch: Blood Miner"
 	display_name = "Blood Miner"

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -119,7 +119,6 @@
 		/datum/outfit/deathmatch_loadout/battler/northstar,
 		/datum/outfit/deathmatch_loadout/battler/raider,
 		/datum/outfit/deathmatch_loadout/battler/ripper,
-		/datum/outfit/deathmatch_loadout/battler/scientist,
 		/datum/outfit/deathmatch_loadout/battler/surgeon,
 		/datum/outfit/deathmatch_loadout/battler/tgcoder,
 		/datum/outfit/deathmatch_loadout/naked,

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -119,6 +119,7 @@
 		/datum/outfit/deathmatch_loadout/battler/northstar,
 		/datum/outfit/deathmatch_loadout/battler/raider,
 		/datum/outfit/deathmatch_loadout/battler/ripper,
+		/datum/outfit/deathmatch_loadout/battler/scientist,
 		/datum/outfit/deathmatch_loadout/battler/surgeon,
 		/datum/outfit/deathmatch_loadout/battler/tgcoder,
 		/datum/outfit/deathmatch_loadout/naked,


### PR DESCRIPTION
## About The Pull Request
Removes the adamantine extract 
## Why It's Good For The Game
Adamantine shield and armor is busted. There is a roughly 80 percent chance of block with the shield,
and you can tank hits with the armor.
## Changelog
:cl:
del: Removed scientist's admantine extract from deathmatch
/:cl:
