### PR TITLE
Training in heavy gravity gives you more experience points

### DIFF
--- a/code/game/objects/structures/gym/punching_bag.dm
+++ b/code/game/objects/structures/gym/punching_bag.dm
@@ -44,17 +44,22 @@
 	flick("[icon_state]-punch", src)
 	playsound(loc, pick(hit_sounds), 25, TRUE, -1)
 
+	if(!iscarbon(user))
+		return
+
+	var/is_heavy_gravity = user.has_gravity() > STANDARD_GRAVITY
+
 	var/stamina_exhaustion = 3
 	if(ishuman(user))
 		var/mob/living/carbon/human/boxer = user
 		var/obj/item/clothing/gloves/boxing/boxing_gloves = boxer.get_item_by_slot(ITEM_SLOT_GLOVES)
 		if(istype(boxing_gloves))
 			stamina_exhaustion = 2
+	if (is_heavy_gravity)
+		stamina_exhaustion *= 1.5
 
-	if(!iscarbon(user))
-		return
 	user.adjustStaminaLoss(stamina_exhaustion)
-	user.mind?.adjust_experience(/datum/skill/fitness, 0.1)
+	user.mind?.adjust_experience(/datum/skill/fitness, is_heavy_gravity ? 0.2 : 0.1)
 	user.apply_status_effect(/datum/status_effect/exercised)
 
 /obj/structure/punching_bag/wrench_act_secondary(mob/living/user, obj/item/tool)

--- a/code/game/objects/structures/gym/weight_machine.dm
+++ b/code/game/objects/structures/gym/weight_machine.dm
@@ -133,7 +133,7 @@
 		user.adjust_nutrition(-5) // feel the burn
 
 		if(iscarbon(user))
-			var/gravity_modifier = user.has_gravity() > STANDARD_GRAVITY ? 1.5 : 1
+			var/gravity_modifier = user.has_gravity() > STANDARD_GRAVITY ? 2 : 1
 			// remember the real xp gain is from sleeping after working out
 			user.mind.adjust_experience(/datum/skill/fitness, WORKOUT_XP * gravity_modifier)
 			user.apply_status_effect(/datum/status_effect/exercised, EXERCISE_STATUS_DURATION)

--- a/code/game/objects/structures/gym/weight_machine.dm
+++ b/code/game/objects/structures/gym/weight_machine.dm
@@ -133,8 +133,9 @@
 		user.adjust_nutrition(-5) // feel the burn
 
 		if(iscarbon(user))
+			var/gravity_modifier = user.has_gravity() > STANDARD_GRAVITY ? 1.5 : 1
 			// remember the real xp gain is from sleeping after working out
-			user.mind.adjust_experience(/datum/skill/fitness, WORKOUT_XP)
+			user.mind.adjust_experience(/datum/skill/fitness, WORKOUT_XP * gravity_modifier)
 			user.apply_status_effect(/datum/status_effect/exercised, EXERCISE_STATUS_DURATION)
 
 	end_workout()
@@ -161,8 +162,13 @@
 
 	if(!iscarbon(user) || isnull(user.mind))
 		return TRUE
+
+	var/affected_gravity = user.has_gravity()
+	if (!affected_gravity)
+		return TRUE // No weight? I could do this all day
+	var/gravity_modifier = affected_gravity > STANDARD_GRAVITY ? 0.75 : 1
 	// the amount of workouts you can do before you hit stamcrit
-	var/workout_reps = total_workout_reps[user.mind.get_skill_level(/datum/skill/fitness)]
+	var/workout_reps = total_workout_reps[user.mind.get_skill_level(/datum/skill/fitness)] * gravity_modifier
 	// total stamina drain of 1 workout calculated based on the workout length
 	var/stamina_exhaustion = FLOOR(user.maxHealth / workout_reps / WORKOUT_LENGTH, 0.1)
 	user.adjustStaminaLoss(stamina_exhaustion * seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request

If you use exercise equipment in an area with unusually high gravity, you will get tired faster but will also earn a greater amount of fitness experience points.
As far as I am aware the only particularly reliable way for regular crew to gain access to high gravity is the bone-crushing strength (and radiation?) of the gravity generator, but you could also use gravitational anomalies or gravitational holoparasites for this if they are available.

Conversely, if you lift weights when there's no gravity it won't cost you any stamina at all!

## Why It's Good For The Game

I'll be honest this is a largely pointless and trivial change which interacts with a similarly useless system, but I thought it would be a cute interaction.
Training by wearing heavily weighted clothing or in an area where gravity is increased are _somewhat_ common tropes in fiction (I have no idea if people do this in real life) and I think our players would appreciate the incredibly niche circumstances where they can benefit from this.

I also think if even one round features someone building a gym in the gravity generator room and encouraging people to get buff while it crushes them into paste then this was a good addition.

## Changelog

:cl:
balance: If you work out under heavier-than-earth gravity, you will get gains faster.
/:cl:
