### PR TITLE
Allow hemiplegic users to pick which side is disabled

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -24,3 +24,8 @@ GLOBAL_LIST_INIT(limb_choice_transhuman, list(
 	"Left Leg" = /obj/item/bodypart/leg/left/robot,
 	"Right Leg" = /obj/item/bodypart/leg/right/robot,
 ))
+
+GLOBAL_LIST_INIT(side_choice_hemiplegic, list(
+	"Left Side" = /datum/brain_trauma/severe/paralysis/hemiplegic/left,
+	"Right Side" = /datum/brain_trauma/severe/paralysis/hemiplegic/right,
+))

--- a/code/datums/quirks/negative_quirks/hemiplegic.dm
+++ b/code/datums/quirks/negative_quirks/hemiplegic.dm
@@ -12,10 +12,20 @@
 		/obj/item/reagent_containers/cup/glass/drinkingglass/filled/half_full,
 	)
 
-/datum/quirk/hemiplegic/add(client/client_source)
+/datum/quirk_constant_data/hemiplegic
+	associated_typepath = /datum/quirk/hemiplegic
+	customization_options = list(/datum/preference/choiced/hemiplegic)
+
+/datum/quirk/hemiplegic/add_unique(client/client_source)
+	var/datum/brain_trauma/severe/paralysis/hemiplegic/side_choice = GLOB.side_choice_hemiplegic[client_source?.prefs?.read_preference(/datum/preference/choiced/hemiplegic)]
+	if(isnull(side_choice))  // Client gone or they chose a random side
+		side_choice = GLOB.side_choice_hemiplegic[pick(GLOB.side_choice_hemiplegic)]
+
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	var/trauma_type = pick(/datum/brain_trauma/severe/paralysis/hemiplegic/left, /datum/brain_trauma/severe/paralysis/hemiplegic/right)
-	human_holder.gain_trauma(trauma_type, TRAUMA_RESILIENCE_ABSOLUTE)
+	var/side_string = "[side_choice::paralysis_type]"
+
+	medical_record_text = "Patient has an untreatable impairment in motor function on the [side_string] half of their body."
+	human_holder.gain_trauma(side_choice, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/hemiplegic/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder

--- a/code/datums/quirks/negative_quirks/hemiplegic.dm
+++ b/code/datums/quirks/negative_quirks/hemiplegic.dm
@@ -22,9 +22,8 @@
 		side_choice = GLOB.side_choice_hemiplegic[pick(GLOB.side_choice_hemiplegic)]
 
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	var/side_string = "[side_choice::paralysis_type]"
 
-	medical_record_text = "Patient has an untreatable impairment in motor function on the [side_string] half of their body."
+	medical_record_text = "Patient has an untreatable impairment in motor function on the [side_choice::paralysis_type] half of their body."
 	human_holder.gain_trauma(side_choice, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/hemiplegic/remove()

--- a/code/modules/client/preferences/hemiplegic.dm
+++ b/code/modules/client/preferences/hemiplegic.dm
@@ -1,0 +1,17 @@
+/datum/preference/choiced/hemiplegic
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "hemiplegic"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/hemiplegic/init_possible_values()
+	return list("Random") + GLOB.side_choice_hemiplegic
+
+/datum/preference/choiced/hemiplegic/is_accessible(datum/preferences/preferences)
+	. = ..()
+	if (!.)
+		return FALSE
+
+	return "Hemiplegic" in preferences.all_quirks
+
+/datum/preference/choiced/hemiplegic/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3609,6 +3609,7 @@
 #include "code\modules\client\preferences\ghost.dm"
 #include "code\modules\client\preferences\ghost_lighting.dm"
 #include "code\modules\client\preferences\glasses.dm"
+#include "code\modules\client\preferences\hemiplegic.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
 #include "code\modules\client\preferences\item_outlines.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/hemiplegic.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/hemiplegic.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../base';
+
+export const hemiplegic: FeatureChoiced = {
+  name: 'Hemiplegic',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION

## About The Pull Request

Broadly this code is copied over from the preference code used for picking prosthetic limbs, with a few changes to make it fit.
It also changes how the quirk displays in the medical records, now mentioning which side is disabled instead of just half their body.
## Why It's Good For The Game

So of course, first and foremost, I want it personally.
I'm now running a hemiplegic character on Manuel, and I want to able to pick which side is hemiplegic to match me using heterochromatic eyes to make it look like they're missing an eye. It's minor, but I think it'd be nice.

Then, because of that, I think it'd be nice to have for posterity. If I want it, and I can code it, then the next person who wants it doesn't have to, y'know?

Lastly, gameplay-wise, it doesn't really matter which side is hemiplegic, you're permanently missing an arm and a leg either way. So I feel there's practically no 'powergaming concerns' to be had when it's this utter shitass to use regardless and the benefits to be gained would be infinitesimally small in comparison.
## Changelog
:cl:
add: Hemiplegic now lets you pick which side is disabled.
add: The medical records text for hemiplegics now shows which side is disabled.
/:cl:
