### PR TITLE
Fixes timezone offset

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -119,7 +119,7 @@ GLOBAL_VAR(restart_counter)
 	// From a really fucking old commit (91d7150)
 	// I wanted to move it but I think this needs to be after /world/New is called but before any sleeps?
 	// - Dominion/Cyberboss
-	GLOB.timezoneOffset = text2num(world.timezone) * 36000
+	GLOB.timezoneOffset = world.timezone * 36000
 
 	// First possible sleep()
 	InitTgs()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -119,7 +119,7 @@ GLOBAL_VAR(restart_counter)
 	// From a really fucking old commit (91d7150)
 	// I wanted to move it but I think this needs to be after /world/New is called but before any sleeps?
 	// - Dominion/Cyberboss
-	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
+	GLOB.timezoneOffset = text2num(world.timezone) * 36000
 
 	// First possible sleep()
 	InitTgs()


### PR DESCRIPTION
## About The Pull Request

I'm gonna start off by saying I am in EST, which is important to this PR.

Ever run a local server while not living in the UK and realizing that time is just frozen for you? Basically, this is why.

We have ``GLOB.timezoneOffset`` which basically the time difference between BYOND's default timezone, UTC, and the timezone the server is being hosted in, however when you open a local host you may find that this isn't the case.
![image](https://github.com/tgstation/tgstation/assets/53777086/bd502942-250f-4b00-a7b7-1f93a6907bb2)

This should be 144000 for me (results may vary on your location) because of my timezone
![image](https://github.com/tgstation/tgstation/assets/53777086/955a5abc-44af-4d65-b064-29ed5b46348f)
![image](https://github.com/tgstation/tgstation/assets/53777086/632ee628-5cd0-43ce-b179-4e0d66cc24f0)

514 did mess a little bit with timezones, adding a new arg in ``time2text``
![image](https://github.com/tgstation/tgstation/assets/53777086/86966b20-1b9b-47f3-93ef-62f7b8ac92d9)

But it also added a new var, ``world.timezone``, which handles basically everything we want for timezone offset stuff. By default, this is UTC, which is perfect for our case.
![image](https://github.com/tgstation/tgstation/assets/53777086/893231d4-79c2-4bd4-8653-b9ad41884023)

So I just swapped out our non-functional ``time2text(0,"hh")`` with ``world.timezone``, and

![image](https://github.com/tgstation/tgstation/assets/53777086/f7193ad2-0e49-41b5-ac4d-f9c28b3b5cfd)

Incredible! It works!

Time is even ticking again!

![image](https://github.com/tgstation/tgstation/assets/53777086/5b69d066-3768-495e-bf83-885d6faeabe1)

What an amazing feat, thanks 514!

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/81180

## Changelog

:cl:
fix: Time on servers hosted outside of the UK should now properly have their timezone offset.
/:cl: