### PR TITLE
[NO GBP] Fixes plasmaman nukeop reinforcements being given the wrong outfits

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -55,6 +55,12 @@
 		/datum/outfit/syndicate/full = /datum/outfit/syndicate/full/plasmaman,
 		/datum/outfit/syndicate/leader = /datum/outfit/syndicate/leader/plasmaman,
 		/datum/outfit/syndicate/reinforcement = /datum/outfit/syndicate/reinforcement/plasmaman,
+		/datum/outfit/syndicate/reinforcement/cybersun = /datum/outfit/syndicate/reinforcement/plasmaman,
+		/datum/outfit/syndicate/reinforcement/donk = /datum/outfit/syndicate/reinforcement/plasmaman,
+		/datum/outfit/syndicate/reinforcement/gorlex = /datum/outfit/syndicate/reinforcement/plasmaman,
+		/datum/outfit/syndicate/reinforcement/interdyne = /datum/outfit/syndicate/reinforcement/plasmaman,
+		/datum/outfit/syndicate/reinforcement/mi13 = /datum/outfit/syndicate/reinforcement/plasmaman,
+		/datum/outfit/syndicate/reinforcement/waffle = /datum/outfit/syndicate/reinforcement/plasmaman,
 	)
 
 	/// If the bones themselves are burning clothes won't help you much


### PR DESCRIPTION

## About The Pull Request

This updates the plasmaman species outfit registry to consider all reinforcement outfits the game can pick for you. I mistakenly only overwrote the base type of reinforcement costumes, meaning plasmamen wouldn't actually be given a plasmaman outfit and would burst into flames and die upon spawning.

Now, every reinforcement outfit redirects to the base plasmaman reinforcement outfit, because making 5 new plasmaman variants of existing outfits felt like an unwieldy solution.
## Why It's Good For The Game

I was told that plasmamen die when spawned in as nukie reinforcements. They probably shouldn't be doing that.
## Changelog
:cl: Rhials
fix: Plasmamen nukie reinforcements are now properly given a plasmaman-safe outfit.
/:cl:
