### PR TITLE
Fix psyker echolocation lag

### DIFF
--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -4,11 +4,11 @@
 	/// Time between echolocations.
 	var/cooldown_time = 1.8 SECONDS
 	/// Time for the image to start fading out.
-	var/image_expiry_time = 1.5 SECONDS
+	var/image_expiry_time = 1.4 SECONDS
 	/// Time for the image to fade in.
-	var/fade_in_time = 0.5 SECONDS
+	var/fade_in_time = 0.4 SECONDS
 	/// Time for the image to fade out and delete itself.
-	var/fade_out_time = 0.5 SECONDS
+	var/fade_out_time = 0.4 SECONDS
 	/// Are images static? If yes, spawns them on the turf and makes them not change location. Otherwise they change location and pixel shift with the original.
 	var/images_are_static = TRUE
 	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images.


### PR DESCRIPTION

## About The Pull Request
Fixes a slowly increasing lag for psykers, subtly introduced by #80042
Turns out the code expects all of the images to fully fade out before any new images start fading in, thus the expiry time + fade out time must not exceed the cooldown time.

Note that this will still be laggier than if you're NOT a psyker because of how things are rendered, but it should stay consistent. 
Fixes #81446
Fixes #80442
Fixes #80798
## Why It's Good For The Game
letting literally thousands of images build up on the client is not a good thing, turns out.
## Changelog
:cl:
fix: Psyker vision no longer causes infinitely worsening lag
/:cl:
