### PR TITLE
adds tooltip to the newscaster `Print Newspaper` button telling you to insert paper if it's empty

### DIFF
--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -447,6 +447,7 @@ const NewscasterChannelBox = (props) => {
           <Box>
             <Button
               icon="newspaper"
+              tooltip={paper <= 0 ? 'Insert paper first!' : ''}
               disabled={paper <= 0}
               onClick={() => act('printNewspaper')}
             >


### PR DESCRIPTION

## About The Pull Request

before inserting paper:
![image](https://github.com/tgstation/tgstation/assets/94711066/2afca5ec-159e-4df2-b5bf-9909b245a6da) 

after inserting paper:
![image](https://github.com/tgstation/tgstation/assets/94711066/d9ae9535-88bb-43db-b7c6-514cc4e633d3)

after using last paper:
![image](https://github.com/tgstation/tgstation/assets/94711066/6292349a-15cf-4190-8784-f803b390ad8e)
## Why It's Good For The Game
I did not know you could put paper in there and I was confused about why I wasn't able to print any newspapers :(
## Changelog
:cl:
qol: added tooltip to newscaster to tell people that they need to insert paper if they want to print a newspaper
/:cl:
