### PR TITLE
Cleanbots can't acid people unless emagged.

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -330,7 +330,7 @@
 		INVOKE_ASYNC(our_mop, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, target)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(!iscarbon(target) && !is_type_in_typecache(target, huntable_trash))
+	if(!(iscarbon(target) && (bot_access_flags & BOT_COVER_EMAGGED)) && !is_type_in_typecache(target, huntable_trash))
 		return NONE
 
 	visible_message(span_danger("[src] sprays hydrofluoric acid at [target]!"))


### PR DESCRIPTION

## About The Pull Request
Returns a long lost restriction to cleanbots of not being able to spray acid on people unless emagged. Labeling as a fix since it's potentially quite destructive, annoying, and presumably not intended. (likely introduced by #80128)
## Why It's Good For The Game
Letting people go from ghosts to melting clothes and PDAs in 3 clicks is maybe not great
## Changelog
:cl:
fix: Cleanbots once again require an emag to spray acid on people. They can still acid trash objects normally.
/:cl:
