### PR TITLE
Fix polling mutating its target's plane and layer

### DIFF
--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(polling)
 	// Start firing
 	total_polls++
 
-	if(!jump_target && isatom(alert_pic))
+	if(isnull(jump_target) && isatom(alert_pic))
 		jump_target = alert_pic
 
 	var/datum/candidate_poll/new_poll = new(role_name_text, question, poll_time, ignore_category, jump_target, custom_response_messages)
@@ -129,13 +129,15 @@ SUBSYSTEM_DEF(polling)
 				break
 
 		// Image to display
-		var/image/poll_image = image('icons/effects/effects.dmi', icon_state = "static")
-		if(alert_pic)
-			if(!ispath(alert_pic))
-				var/mutable_appearance/picture_source = alert_pic
-				poll_image = picture_source
-			else
-				poll_image = image(alert_pic)
+		var/image/poll_image
+		if(ispath(alert_pic, /atom))
+			poll_image = image(alert_pic)
+		else if(isatom(alert_pic))
+			poll_image = new /mutable_appearance(alert_pic)
+		else if(!isnull(alert_pic))
+			poll_image = alert_pic
+		else
+			poll_image = image('icons/effects/effects.dmi', icon_state = "static")
 
 		if(poll_image)
 			poll_image.layer = FLOAT_LAYER


### PR DESCRIPTION
## About The Pull Request
This PR fixes polling for an atom causing its plane and layer to mutate

```dm
		var/mutable_appearance/picture_source = alert_pic
		poll_image = picture_source
```
```dm
		poll_image.layer = FLOAT_LAYER
		poll_image.plane = poll_alert_button.plane
```
See the issue?

Passing an atom as an `alert_pic` would set `poll_image = alert_pic` which would in turn change `poll_image`'s plane and layer

This is supposed to be `new(alert_pic)`, to make a mutable appearance *based on* the atom's appearance. 

I also did a minor bit of cleanup

## Changelog

:cl: Melbert
fix: Fixes polling for things causing said things to have their planes and layers screwed up (causing random objects or mobs to appear above runechat and blindness, for example)
/:cl:

