### PR TITLE
now spiders get extra damage by fly swatter

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -799,7 +799,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/melee/flyswatter/Initialize(mapload)
 	. = ..()
-	if (!splattable)
+	if (isnull(splattable))
 		splattable = typecacheof(list(
 			/mob/living/basic/ant,
 			/mob/living/basic/butterfly,

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -809,7 +809,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			/obj/effect/decal/cleanable/ants,
 			/obj/item/queen_bee,
 		))
-	if (!strong_against)
+	if (isnull(strong_against))
 		strong_against = typecacheof(list(
 			/mob/living/basic/spider,
 		))

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -811,8 +811,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		))
 	if (!strong_against)
 		strong_against = typecacheof(list(
-			/mob/living/basic/spider/giant,
-			/mob/living/basic/spider/growing/young,
+			/mob/living/basic/spider,
 		))
 
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -804,6 +804,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		/mob/living/basic/butterfly,
 		/mob/living/basic/cockroach,
 		/mob/living/basic/spider/growing/spiderling,
+		/mob/living/basic/spider/growing/young,
 		/mob/living/basic/bee,
 		/obj/effect/decal/cleanable/ants,
 		/obj/item/queen_bee,

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -791,27 +791,29 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	hitsound = 'sound/effects/snap.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	/// Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
-	var/list/splattable
+	var/static/list/splattable
 	/// Things in this list which take a lot more damage from the fly swatter, but not be necessarily killed by it.
-	var/list/strong_against
+	var/static/list/strong_against
 	/// How much extra damage the fly swatter does against mobs it is strong against
 	var/extra_strength_damage = 24
 
 /obj/item/melee/flyswatter/Initialize(mapload)
 	. = ..()
-	splattable = typecacheof(list(
-		/mob/living/basic/ant,
-		/mob/living/basic/butterfly,
-		/mob/living/basic/cockroach,
-		/mob/living/basic/spider/growing/spiderling,
-		/mob/living/basic/spider/growing/young,
-		/mob/living/basic/bee,
-		/obj/effect/decal/cleanable/ants,
-		/obj/item/queen_bee,
-	))
-	strong_against = typecacheof(list(
-		/mob/living/basic/spider/giant,
-	))
+	if (!splattable)
+		splattable = typecacheof(list(
+			/mob/living/basic/ant,
+			/mob/living/basic/butterfly,
+			/mob/living/basic/cockroach,
+			/mob/living/basic/spider/growing/spiderling,
+			/mob/living/basic/bee,
+			/obj/effect/decal/cleanable/ants,
+			/obj/item/queen_bee,
+		))
+	if (!strong_against)
+		strong_against = typecacheof(list(
+			/mob/living/basic/spider/giant,
+			/mob/living/basic/spider/growing/young,
+		))
 
 
 /obj/item/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/81981

## Why It's Good For The Game

Allows flyswatter to act as we would imagine. Makes list static so we don't have to make it every flyswatter.

## Changelog

:cl:
fix: now spiders get extra damage by fly swatter
/:cl:
