### PR TITLE
Fixes sec computers having infinite distance

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -50,7 +50,7 @@
 
 /obj/machinery/computer/security/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
-	if(!user.can_perform_action(src, NEED_DEXTERITY|ALLOW_SILICON_REACH)) //prevents monkeys from using camera consoles
+	if(!user.client) //prevents errors by trying to pass clients that don't exist.
 		return
 	// Update UI
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
## About The Pull Request

Camera consoles no longer have infinite range, which was caused by the ``can_perform_action`` check causing an early return before ``try_update_ui`` could run and update your visibility on the console.

This has been a bug for a long time and I've constantly procrastinated on fixing it but it was brought up when discussing Human AI bugs so I went in to look around and found out what caused it, so I can finally say I did it.

## Why It's Good For The Game

Security cameras no longer have infinite range.

## Changelog

:cl:
fix: Security camera consoles no longer have infinite range.
/:cl: