### PR TITLE
Lathes stop printing properly when facing material problems 

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -380,6 +380,7 @@
 		finalize_build()
 		return
 	if(!materials.can_use_resource())
+		say("Unable to continue production, materials on hold.")
 		finalize_build()
 		return
 
@@ -387,6 +388,7 @@
 	var/list/design_materials = design.materials
 	if(!materials.mat_container.has_materials(design_materials, material_cost_coefficient, is_stack ? items_remaining : 1))
 		say("Unable to continue production, missing materials.")
+		finalize_build()
 		return
 	materials.use_materials(design_materials, material_cost_coefficient, is_stack ? items_remaining : 1, "built", "[design.name]")
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #81972. The build process properly exits if material run out during printing 
- Lathes also display message if materials are on hold while printing 

# Changelog
:cl:
fix: Lathes don't hang if materials run out mid printing. Also displays message if materials are put on hold while printing
/:cl:
