### PR TITLE
Make screentips and examine names use a shared proc, so prosopagnosia or other name hiders actually work with screentips

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -932,7 +932,7 @@
 		active_hud.screentip_text.maptext = ""
 	else
 		//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-		active_hud.screentip_text.maptext = "<span class='context' style='text-align: center; color: [active_hud.screentip_color]'>[name][extra_context]</span>"
+		active_hud.screentip_text.maptext = "<span class='context' style='text-align: center; color: [active_hud.screentip_color]'>[get_observed_name(user)][extra_context]</span>"
 
 /**
  * This proc is used for telling whether something can pass by this atom in a given direction, for use by the pathfinding system.

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -104,3 +104,7 @@
 /// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name. add_id_name will control whether or not we append "(as [id_name])".
 /atom/proc/get_visible_name(add_id_name)
 	return name
+
+/// Used by mobs to determine what to display for this atom's screentips/examine, for example for prosopagnosia.
+/atom/proc/get_observed_name(mob/user)
+	return name

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -6,20 +6,10 @@
 	var/t_him = p_them()
 	var/t_has = p_have()
 	var/t_is = p_are()
-	var/obscure_name
-	var/obscure_examine
 
-	if(isliving(user))
-		var/mob/living/L = user
-		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(L, TRAIT_INVISIBLE_MAN))
-			obscure_name = TRUE
-		if(HAS_TRAIT(src, TRAIT_UNKNOWN))
-			obscure_name = TRUE
-			obscure_examine = TRUE
+	. = list("<span class='info'>This is <EM>[get_observed_name(user)]</EM>!")
 
-	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
-
-	if(obscure_examine)
+	if(isliving(user) && HAS_TRAIT(src, TRAIT_UNKNOWN))
 		return list("<span class='warning'>You're struggling to make out any details...")
 
 	var/obscured = check_obscured_slots()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -56,6 +56,14 @@
 		return pda.saved_identification
 	return if_no_id
 
+/// Proc for getting the name as observed by a mob, used for screentips and examine, checking if there's anything modifying how said mob observes us.
+/mob/living/carbon/human/get_observed_name(mob/user)
+	if(isliving(user))
+		var/mob/living/living_user = user
+		if(HAS_TRAIT(living_user, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(living_user, TRAIT_INVISIBLE_MAN) || HAS_TRAIT(src, TRAIT_UNKNOWN))
+			return "Unknown"
+	return ..()
+
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere
 /mob/living/carbon/human/get_visible_name(add_id_name = TRUE)
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))


### PR DESCRIPTION

## About The Pull Request

So when I first started using the Prosopagnosia quirk, I was _very_ confused by the fact that it didn't seem to actually hide any names. And then I realized it only hides names on the examine, which is trivialized by the fact that screentips show you the name anyway.

So! I looked into the code.
```dm
(/code/modules/mob/living/carbon/human/examine.dm, line 1-20)
/mob/living/carbon/human/examine(mob/user)
	(...)
	var/obscure_name
	var/obscure_examine

	if(isliving(user))
		var/mob/living/L = user
		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(L, TRAIT_INVISIBLE_MAN))
			obscure_name = TRUE
		if(HAS_TRAIT(src, TRAIT_UNKNOWN))
			obscure_name = TRUE
			obscure_examine = TRUE

	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
```
Lo and behold, the code for hiding names based on prosopagnosia is *specific* to examining humans.
Case in point:
```dm
(/code/game/atom/_atom.dm, line 935)
active_hud.screentip_text.maptext = "<span class='context' style='text-align: center; color: [active_hud.screentip_color]'>[name][extra_context]</span>"
```
Screentips just use the name variable directly.

Sooooooo we just split this name obscuring check off into its own proc, `get_observed_name(mob/user)`.
```dm
(/code/game/atom/atom_examine.dm, line 109-110)
/atom/proc/get_observed_name(mob/user)
	return name

(/code/modules/mob/living/carbon/human/human_helpers.dm, line 59-65)
/mob/living/carbon/human/get_observed_name(mob/user)
	if(isliving(user))
		var/mob/living/living_user = user
		if(HAS_TRAIT(living_user, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(living_user, TRAIT_INVISIBLE_MAN) || HAS_TRAIT(src, TRAIT_UNKNOWN))
			return "Unknown"
	return ..()
```
And then just use that for both of them! This seems to fix the issue just fine.
## Why It's Good For The Game

Things that hid the examine name didn't actually hide the screentip name, like prosopagnosia or the unknown trait, making it completely trivial to get around them.
This fixes that.
## Changelog
:cl:
fix: Screentips actually account for name obscurers like prosopagnosia. For this sake, screentips and examine names now use the same proc, so please report any issues with this.
/:cl:
