### PR TITLE
exclude deathmatch loadouts from outfit_sanity

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -12,6 +12,9 @@
 
 /datum/outfit/deathmatch_loadout/pre_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
 	. = ..()
+#ifdef UNIT_TESTS
+	return
+#endif
 	if(isdummy(user))
 		return
 

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -12,9 +12,6 @@
 
 /datum/outfit/deathmatch_loadout/pre_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
 	. = ..()
-#ifdef UNIT_TESTS
-	return
-#endif
 	if(isdummy(user))
 		return
 

--- a/code/modules/unit_tests/outfit_sanity.dm
+++ b/code/modules/unit_tests/outfit_sanity.dm
@@ -39,14 +39,15 @@
 	back = /obj/item/storage/backpack
 	backpack_contents = list(/obj/item/clothing/mask/cigarette/cigar/havana)
 
-
-
 /datum/unit_test/outfit_sanity/Run()
 	var/datum/outfit/prototype_outfit = /datum/outfit
 	var/prototype_name = initial(prototype_outfit.name)
 	var/mob/living/carbon/human/H = allocate(/mob/living/carbon/human/consistent)
 
-	for (var/outfit_type in subtypesof(/datum/outfit))
+	var/list/outfitsToCheck = subtypesof(/datum/outfit)
+	outfitsToCheck ^= subtypesof(/datum/outfit/deathmatch_loadout)
+
+	for (var/outfit_type in outfitsToCheck)
 		// Only make one human and keep undressing it because it's much faster
 		for (var/obj/item/I in H.get_equipped_items(include_pockets = TRUE))
 			qdel(I)

--- a/code/modules/unit_tests/outfit_sanity.dm
+++ b/code/modules/unit_tests/outfit_sanity.dm
@@ -44,10 +44,10 @@
 	var/prototype_name = initial(prototype_outfit.name)
 	var/mob/living/carbon/human/H = allocate(/mob/living/carbon/human/consistent)
 
-	var/list/outfitsToCheck = subtypesof(/datum/outfit)
-	outfitsToCheck ^= subtypesof(/datum/outfit/deathmatch_loadout)
+	var/list/outfits_to_check = subtypesof(/datum/outfit)
+	outfits_to_check -= typesof(/datum/outfit/deathmatch_loadout)
 
-	for (var/outfit_type in outfitsToCheck)
+	for (var/outfit_type in outfits_to_check)
 		// Only make one human and keep undressing it because it's much faster
 		for (var/obj/item/I in H.get_equipped_items(include_pockets = TRUE))
 			qdel(I)


### PR DESCRIPTION
## About The Pull Request
resolves #82022 

## Why It's Good For The Game
species override for deathmatch is a neat feature but would in many cases break outfit_sanity integration test 