### PR TITLE
Fixes conveyor ID in northstar boulder processing room.

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -53609,7 +53609,8 @@
 "nKc" = (
 /obj/structure/cable,
 /obj/machinery/conveyor/inverted{
-	dir = 10
+	dir = 10;
+	id = "mining"
 	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
@@ -73992,7 +73993,8 @@
 /obj/structure/cable,
 /obj/machinery/bouldertech/refinery/smelter,
 /obj/machinery/conveyor/inverted{
-	dir = 10
+	dir = 10;
+	id = "mining"
 	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
@@ -74666,7 +74668,8 @@
 "tkZ" = (
 /obj/structure/cable,
 /obj/machinery/conveyor/inverted{
-	dir = 6
+	dir = 6;
+	id = "mining"
 	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)


### PR DESCRIPTION
## About The Pull Request

3 of the conveyor belts on north star are currently missing the "mining" id, meaning that the conveyor belt wasn't going and moving when the lever in the room was thrown. This quickly corrects that.

## Why It's Good For The Game

Fixes #81945. 🐛 💥 .

## Changelog

:cl:
fix: Fixes the conveyor belts found on north star's boulder processing room to all work when the lever is thrown.
/:cl: