### PR TITLE
Adds missing pepperspray dispenser to tramstation's science outpost.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -49930,6 +49930,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "qIc" = (


### PR DESCRIPTION
## About The Pull Request
Tramstation was reported as missing a pepper spray dispenser in their science security outpost, which other security outposts across the map have. This adds it to the outpost along the north wall where's it's open.
![image](https://github.com/tgstation/tgstation/assets/41715314/c089073d-b22d-4d76-8854-3d3ef102dc0a)


## Why It's Good For The Game

Improves consistency within the mapping. Fixes #81760. 🐛💥 

## Changelog

:cl:
fix: Tramstation now has a pepperspray dispenser in it's science security outpost, as with other security outposts.
/:cl:

