### PR TITLE
Abilities with no owner control isnt given to ghosts

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -230,7 +230,7 @@
 		return
 
 	for(var/datum/action/action as anything in take_from.actions)
-		if(!action.show_to_observers)
+		if(!action.show_to_observers || !action.owner_has_control)
 			continue
 		action.GiveAction(src)
 	RegisterSignal(take_from, COMSIG_MOB_GRANTED_ACTION, PROC_REF(on_observing_action_granted))
@@ -251,7 +251,7 @@
 /mob/proc/on_observing_action_granted(mob/living/source, datum/action/action)
 	SIGNAL_HANDLER
 
-	if(!action.show_to_observers)
+	if(!action.show_to_observers || !action.owner_has_control)
 		return
 	action.GiveAction(src)
 

--- a/code/modules/mob/living/basic/guardian/guardian_types/protector.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/protector.dm
@@ -16,7 +16,6 @@
 /mob/living/basic/guardian/protector/Initialize(mapload, datum/guardian_fluff/theme)
 	. = ..()
 	shield = new(src)
-	shield.owner_has_control = FALSE // Hide it from the user, it's integrated with guardian UI
 	shield.Grant(src)
 
 /mob/living/basic/guardian/protector/Destroy()
@@ -49,6 +48,7 @@
 	background_icon_state = "base"
 	cooldown_time = 1 SECONDS
 	click_to_activate = FALSE
+	owner_has_control = FALSE // Hide it from the user, it's integrated with guardian UI
 
 /datum/action/cooldown/mob_cooldown/protector_shield/Activate(mob/living/target)
 	if (!isliving(target))


### PR DESCRIPTION
## About The Pull Request

Actions that don't give the user control (so don't give them an action button) will now no longer give them to ghosts either. Ghosts should see the same information as the player when observing them. They don't need to see guardian's protection mode and bileworm's spitting, for example.

## Why It's Good For The Game

Explained in the about the pull request already, ghosts should have the same information as the player they are orbiting, not see the hidden actions. It makes it annoying for contributors to have to manually set every ability meant to not be seen by players to also not be seen by ghosts.

## Changelog

:cl:
fix: Action abilities hidden from players are now not shown to observers either.
/:cl: