### PR TITLE
[NO GBP] The deathmatch modifiers modal menu can actually be opened now.

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -432,6 +432,9 @@
 	keytype = /obj/item/key/lasso
 	vehicle_move_delay = 4
 
+/datum/component/riding/creature/goliath/deathmatch
+	keytype = null
+
 /datum/component/riding/creature/goliath/Initialize(mob/living/riding_mob, force, ride_check_flags, potion_boost)
 	. = ..()
 	var/mob/living/basic/mining/goliath/goliath = parent

--- a/code/datums/elements/inverted_movement.dm
+++ b/code/datums/elements/inverted_movement.dm
@@ -11,4 +11,6 @@
 	return ..()
 
 /datum/element/inverted_movement/proc/invert_movement(mob/living/source, move_args)
-	move_args[MOVE_ARG_DIRECTION] = REVERSE_DIR(move_args[MOVE_ARG_DIRECTION])
+	var/new_direct = REVERSE_DIR(move_args[MOVE_ARG_DIRECTION])
+	move_args[MOVE_ARG_DIRECTION] = new_direct
+	move_args[MOVE_ARG_NEW_LOC] = get_step(source, new_direct)

--- a/code/datums/elements/inverted_movement.dm
+++ b/code/datums/elements/inverted_movement.dm
@@ -11,6 +11,7 @@
 	return ..()
 
 /datum/element/inverted_movement/proc/invert_movement(mob/living/source, move_args)
+	SIGNAL_HANDLER
 	var/new_direct = REVERSE_DIR(move_args[MOVE_ARG_DIRECTION])
 	move_args[MOVE_ARG_DIRECTION] = new_direct
 	move_args[MOVE_ARG_NEW_LOC] = get_step(source, new_direct)

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -111,6 +111,7 @@
 /obj/structure/closet/supplypod/deadmatch_missile
 	name = "cruise missile"
 	desc = "A big ass missile, likely launched from some far-off deep space missile silo."
+	icon_state = "smissile"
 	decal = null
 	door = null
 	fin_mask = null

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -74,11 +74,10 @@
 	desc = "A blood-red styled drop pod."
 	specialised = TRUE
 
-/obj/structure/closet/supplypod/podspawn/deathmatch/Entered(atom/movable/arrived)
-	. = ..()
-	if(isliving(arrived))
-		var/mob/living/critter = arrived
+/obj/structure/closet/supplypod/podspawn/deathmatch/preOpen()
+	for(var/mob/living/critter in contents)
 		critter.faction = list(FACTION_HOSTILE) //No infighting, but also KILL!!
+	return ..()
 
 /obj/structure/closet/supplypod/extractionpod
 	name = "Syndicate Extraction Pod"

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -22,7 +22,7 @@
 	/// A list of paths of modifiers enabled for the match.
 	var/list/modifiers = list()
 	/// Is the modifiers modal menu open (for the host)
-	var/list/mod_menu_open = FALSE
+	var/mod_menu_open = FALSE
 
 /datum/deathmatch_lobby/New(mob/player)
 	. = ..()

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -21,6 +21,8 @@
 	var/list/player_spawns = list()
 	/// A list of paths of modifiers enabled for the match.
 	var/list/modifiers = list()
+	/// Is the modifiers modal menu open (for the host)
+	var/list/mod_menu_open = FALSE
 
 /datum/deathmatch_lobby/New(mob/player)
 	. = ..()
@@ -357,7 +359,7 @@
 	.["map"]["max_players"] = map.max_players
 
 	.["mod_menu_open"] = FALSE
-	if((is_host || is_admin)  && players[user.ckey]["mod_menu_open"])
+	if((is_host || is_admin) && mod_menu_open)
 		.["mod_menu_open"] = TRUE
 		for(var/modpath in GLOB.deathmatch_game.modifiers)
 			var/datum/deathmatch_modifier/mod = GLOB.deathmatch_game.modifiers[modpath]
@@ -485,10 +487,10 @@
 					global_chat = !global_chat
 					return TRUE
 		if("open_mod_menu")
-			players[usr.ckey]["mod_menu_open"] = TRUE
+			mod_menu_open = TRUE
 			return TRUE
 		if("exit_mod_menu")
-			players[usr.ckey] -= "mod_menu_open"
+			mod_menu_open = FALSE
 			return TRUE
 		if("toggle_modifier")
 			var/datum/deathmatch_modifier/modpath = text2path(params["modpath"])
@@ -521,5 +523,5 @@
 
 /datum/deathmatch_lobby/ui_close(mob/user)
 	. = ..()
-	if(players[user.ckey])
-		players[user.ckey] -= "mod_menu_open"
+	if(user.ckey == host)
+		mod_menu_open = FALSE

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -111,7 +111,7 @@
 	announce(span_reallybig("GO!"))
 	if(length(modifiers))
 		var/list/modifier_names = list()
-		for(var/datum/deathmatch_modifier/modifier in modifiers)
+		for(var/datum/deathmatch_modifier/modifier as anything in modifiers)
 			modifier_names += uppertext(initial(modifier.name))
 		announce(span_boldnicegreen("THIS MATCH MODIFIERS: [english_list(modifier_names, and_text = " ,")]."))
 	return TRUE

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -353,8 +353,8 @@
 
 /datum/deathmatch_modifier/wasted/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
 	player.adjust_drunk_effect(rand(30, 35))
-	var/metabolism_rate = /datum/reagent/consumable/ethanol/kahlua::metabolization_rate
-	player.reagents.add_reagent(/datum/reagent/consumable/ethanol/kahlua, initial(lobby.map.automatic_gameend_time) * 0.35 / metabolism_rate)
+	var/metabolism_rate = /datum/reagent/consumable/ethanol/jack_rose::metabolization_rate
+	player.reagents.add_reagent(/datum/reagent/consumable/ethanol/jack_rose, initial(lobby.map.automatic_gameend_time) * 0.35 / metabolism_rate)
 
 /datum/deathmatch_modifier/monkeys
 	name = "Monkeyfication"

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -381,16 +381,20 @@
 		/obj/effect/mine/explosive, //too lethal.
 		/obj/effect/mine/kickmine, //will kick the client, lol
 		/obj/effect/mine/gas, //Just spawns oxygen.
+		/obj/effect/mine/gas/n2o, //no sleeping please.
 	)
 
-	///1 every 10 turfs, but it will actually spawn fewer mines since groundless and closed turfs are skipped.
-	var/mines_to_spawn = length(lobby.location.reserved_turfs) * 0.1
+	///1 every 11 turfs, but it will actually spawn fewer mines since groundless and closed turfs are skipped.
+	var/mines_to_spawn = length(lobby.location.reserved_turfs) * 0.09
 	for(var/iteration in 1 to mines_to_spawn)
 		var/turf/target_turf = pick(lobby.location.reserved_turfs)
 		if(!isopenturf(target_turf) || isgroundlessturf(target_turf))
 			continue
 		///don't spawn mine next to player spawns.
 		if(locate(/obj/effect/landmark/deathmatch_player_spawn) in range(1, target_turf))
+			continue
+		///skip belt loops or they'll explode right away.
+		if(locate(/obj/machinery/conveyor) in target_turf.contents)
 			continue
 		var/mine_path = pick(mines)
 		new mine_path (target_turf)

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -402,16 +402,6 @@
 /datum/deathmatch_modifier/flipping/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
 	player.SpinAnimation(speed = 0.9 SECONDS, loops = -1)
 
-/datum/deathmatch_modifier/screen_flipping
-	name = "Rotating Screen"
-	description = "♪ You spin me right round, baby right round ♪"
-
-/datum/deathmatch_modifier/screen_flipping/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
-	var/atom/movable/plane_master_controller/pm_controller = player.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	var/clockwise = prob(50)
-	for(var/atom/movable/screen/plane_master/plane as anything in pm_controller.get_planes())
-		plane.SpinAnimation(4.5 SECONDS, clockwise = clockwise)
-
 /datum/deathmatch_modifier/random
 	name = "Random Modifiers"
 	description = "Picks 3 to 5 random modifiers as the game is about to start"

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -194,7 +194,7 @@
 		/mob/living/basic/cow/moonicorn,
 		/mob/living/basic/mining/wolf,
 		/mob/living/basic/mining/goldgrub,
-		/mob/living/basic/mining/goliath/saddled,
+		/mob/living/basic/mining/goliath/deathmatch,
 		))
 	var/mob/living/basic/mount = new mount_path (player.loc)
 	mount.tamed(player, null)

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
@@ -160,11 +160,18 @@
 /mob/living/basic/mining/goliath/ranged_secondary_attack(atom/atom_target, modifiers)
 	tentacle_line?.Trigger(target = atom_target)
 
-/mob/living/basic/mining/goliath/saddled
+/// Version of the goliath that already starts saddled and doesn't require a lasso to be ridden.
+/mob/living/basic/mining/goliath/deathmatch
+	saddled = TRUE
+	buckle_lying = 0
 
-/mob/living/basic/mining/goliath/saddled/Initialize(mapload)
+/mob/living/basic/mining/goliath/deathmatch/Initialize(mapload)
 	. = ..()
 	make_rideable()
+
+/mob/living/basic/mining/goliath/deathmatch/make_rideable()
+	add_overlay("goliath_saddled")
+	AddElement(/datum/element/ridable, /datum/component/riding/creature/goliath/deathmatch)
 
 /// Legacy Goliath mob with different sprites, largely the same behaviour
 /mob/living/basic/mining/goliath/ancient

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -229,7 +229,7 @@
 /obj/vehicle/ridden/wheelchair/motorized/improved
 
 /obj/vehicle/ridden/wheelchair/motorized/improved/add_component_parts()
-	component_parts += GLOB.stock_part_datums[/datum/stock_part/capacitor/tier2]
+	component_parts += GLOB.stock_part_datums[/datum/stock_part/capacitor]
 	component_parts += GLOB.stock_part_datums[/datum/stock_part/servo/tier2]
-	component_parts += GLOB.stock_part_datums[/datum/stock_part/servo/tier2]
+	component_parts += GLOB.stock_part_datums[/datum/stock_part/servo]
 	power_cell = new /obj/item/stock_parts/cell/upgraded/plus(src)

--- a/tgui/packages/tgui/interfaces/DeathmatchLobby.tsx
+++ b/tgui/packages/tgui/interfaces/DeathmatchLobby.tsx
@@ -244,7 +244,7 @@ export const DeathmatchLobby = (props) => {
 const ModSelector = (props) => {
   const { act, data } = useBackend<Data>();
   const { admin, host, mod_menu_open, modifiers = [] } = data;
-  if (!mod_menu_open || !host || !admin) {
+  if (!mod_menu_open || !(host || admin)) {
     return null;
   }
   return (


### PR DESCRIPTION
## About The Pull Request
I've fucked up the logic, so it requires the user to be both the host and an admin to open it, which was the case when I tested it locally. This PR fixes that and other issues (and **un**dumbs some of the code). The spinning screen modifier has also been scrapped for being downright awful and breaking my screen.

## Why It's Good For The Game
Fixing stuff I've thankfully noticed early.

## Changelog

:cl:
fix: The deathmatch modifiers modal menu can actually be opened now. Also fixed a bunch of issues it had.
/:cl:
