### PR TITLE
Gulag Teleporter Will Now Always Properly Strip Inventory

### DIFF
--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -138,7 +138,7 @@ The console is located at computer/gulag_teleporter.dm
 /// Strips the occupant of any items that are not allowed to be teleported to the gulag.
 /// Will either place those items in the linked_reclaimer or on the ground if the reclaimer is deleted.
 /obj/machinery/gulag_teleporter/proc/strip_prisoner(mob/living/carbon/human/victim)
-	if(linked_reclaimer)
+	if(!QDELETED(linked_reclaimer))
 		linked_reclaimer.stored_items[victim] = list()
 
 	for(var/obj/item/thing in victim)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -135,27 +135,30 @@ The console is located at computer/gulag_teleporter.dm
 	if(!locked)
 		open_machine()
 
-// strips and stores all occupant's items
-/obj/machinery/gulag_teleporter/proc/strip_occupant()
+/// Strips the occupant of any items that are not allowed to be teleported to the gulag.
+/// Will either place those items in the linked_reclaimer or on the ground if the reclaimer is deleted.
+/obj/machinery/gulag_teleporter/proc/strip_prisoner(mob/living/carbon/human/victim)
 	if(linked_reclaimer)
-		linked_reclaimer.stored_items[occupant] = list()
-	var/mob/living/mob_occupant = occupant
-	for(var/obj/item/W in mob_occupant)
-		if(!is_type_in_typecache(W, telegulag_required_items))
-			if(mob_occupant.temporarilyRemoveItemFromInventory(W))
-				if(istype(W, /obj/item/restraints/handcuffs))
-					W.forceMove(get_turf(src))
-					continue
-				if(linked_reclaimer)
-					linked_reclaimer.stored_items[mob_occupant] += W
-					W.forceMove(linked_reclaimer)
-				else
-					W.forceMove(src)
+		linked_reclaimer.stored_items[victim] = list()
+
+	for(var/obj/item/thing in victim)
+		if(is_type_in_typecache(thing, telegulag_required_items))
+			continue
+
+		if(!victim.temporarilyRemoveItemFromInventory(thing))
+			continue
+
+		if(QDELETED(linked_reclaimer) || istype(thing, /obj/item/restraints/handcuffs))
+			thing.forceMove(get_turf(src))
+			continue
+
+		linked_reclaimer.stored_items[victim] += thing
+		thing.forceMove(linked_reclaimer)
 
 /obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/record/crew/target)
 	if(!ishuman(occupant))
 		return
-	strip_occupant()
+	strip_prisoner(occupant)
 	var/mob/living/carbon/human/prisoner = occupant
 	if(!isplasmaman(prisoner) && jumpsuit_type)
 		var/suit_or_skirt = prisoner.jumpsuit_style == PREF_SKIRT ? jumpskirt_type : jumpsuit_type //Check player prefs for jumpsuit or jumpskirt toggle, then give appropriate prison outfit.


### PR DESCRIPTION

## About The Pull Request

Fixes #81931

I believe what was happening (as mentioned in the issue report) is that `occupant` would become temporarily null as the "stripping" proc would run during the escape (and the server might have yielded a few ticks during those move cycles)- so let's rectify this by decreasing the dependence on that variable by passing in the argument of our prisoner to that same proc to ensure that if we teleport, they are definitely stripped without having to deal with null weirdness.

I also cleaned up the code as well as another bug where if the reclaimer was broken, we would forceMove stuff _into the machine itself_, rather than the turf of the machine. that feels really weird so I just patched that up (makes the code look a lot better too since we can cram it in the "handcuffs" case).
## Why It's Good For The Game

Prisoners shouldn't have their gear if they get into the gulag. I know it's a bit weird because it might be a skill issue on the security officer's behalf should they keep the door unlocked but it's even stranger for it to just not work the way it was intended.
## Changelog
:cl:
fix: Prisoners who are teleported to the Nanotrasen Work Camp should now always be stripped of their gear to prevent escapes.
/:cl:
