### PR TITLE
Fixes Headsets Being Wonky On Non-Poly Parrots

### DIFF
--- a/code/modules/mob/living/basic/pets/parrot/parrot_items.dm
+++ b/code/modules/mob/living/basic/pets/parrot/parrot_items.dm
@@ -2,7 +2,7 @@
 	key = STRIPPABLE_ITEM_PARROT_HEADSET
 
 /datum/strippable_item/parrot_headset/get_item(atom/source)
-	var/mob/living/basic/parrot/poly/parrot_source = source
+	var/mob/living/basic/parrot/parrot_source = source
 	return istype(parrot_source) ? parrot_source.ears : null
 
 /datum/strippable_item/parrot_headset/try_equip(atom/source, obj/item/equipping, mob/user)


### PR DESCRIPTION

## About The Pull Request

Fixes #81861

Basically we just typecasted too hard on the headset strippable item so it was impossible to get headsets from non-Poly parrots. pretty silly mistake because literally everything else is meant to typecast to just `/mob/living/basic/parrot`. one line fix and leroy jenkins
## Why It's Good For The Game

parrots shouldn't "eat" headsets and make them entirely unretrievable once placed on their ears.
## Changelog
:cl:
fix: If you place a headset on a non-Poly Parrot, you should be able to remove it from the parrot as-expected now rather than having the parrot send it to the shadow realm.
/:cl:
