### PR TITLE
[no gbp] sentience potion reason set via alt-click

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -709,7 +709,7 @@
 /obj/item/slimepotion/slime/sentience/AltClick(mob/living/user)
 	if(!can_interact(user))
 		return
-	potion_reason = tgui_input_text(user, "Enter reason for offering potion", "Intelligence Potion", "[potion_reason]", multiline = TRUE)
+	potion_reason = tgui_input_text(user, "Enter reason for offering potion", "Intelligence Potion", potion_reason, multiline = TRUE)
 
 /obj/item/slimepotion/slime/sentience/attack(mob/living/dumb_mob, mob/user)
 	if(being_used || !isliving(dumb_mob))

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -690,6 +690,24 @@
 	icon_state = "potpink"
 	var/being_used = FALSE
 	var/sentience_type = SENTIENCE_ORGANIC
+	var/potion_reason
+
+/obj/item/slimepotion/slime/sentience/examine(mob/user)
+	. = ..()
+	. += span_notice("Alt-click to set potion offer reason. [potion_reason ? "Current reason: [span_warning(potion_reason)]" : null]")
+
+/obj/item/slimepotion/slime/sentience/Initialize(mapload)
+	register_context()
+	return ..()
+
+/obj/item/slimepotion/slime/sentience/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Set potion offer reason"
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/item/slimepotion/slime/sentience/AltClick(mob/living/user)
+	if(!can_interact(user))
+		return
+	potion_reason = tgui_input_text(user, "Enter reason for offering potion", "Intelligence Potion", "[potion_reason]", multiline = TRUE)
 
 /obj/item/slimepotion/slime/sentience/attack(mob/living/dumb_mob, mob/user)
 	if(being_used || !isliving(dumb_mob))
@@ -703,8 +721,8 @@
 	if(!dumb_mob.compare_sentience_type(sentience_type)) // Will also return false if not a basic or simple mob, which are the only two we want anyway
 		balloon_alert(user, "invalid creature!")
 		return
-	var/potion_reason = tgui_input_text(user, "For what reason?", "Intelligence Potion", multiline = TRUE, timeout = 2 MINUTES)
 	if(isnull(potion_reason))
+		balloon_alert(user, "no reason for offering set!")
 		return
 	balloon_alert(user, "offering...")
 	being_used = TRUE

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -688,8 +688,10 @@
 	desc = "A miraculous chemical mix that grants human like intelligence to living beings."
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "potpink"
+	/// Are we being offered to a mob, and therefore is a ghost poll currently in progress for the sentient mob?
 	var/being_used = FALSE
 	var/sentience_type = SENTIENCE_ORGANIC
+	/// Reason for offering potion. This will be displayed in the poll alert to ghosts.
 	var/potion_reason
 
 /obj/item/slimepotion/slime/sentience/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/82047

You set the reason for sentience potion via alt clicking potion
## Changelog
:cl:
qol: Sentience potion reason is set via alt-click
/:cl:
