### PR TITLE
Eye of God Update: Loads of QoL, and makes it somewhat more useful to have permanently grafted to your face.

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -897,25 +897,25 @@
 	name = "Fire Ants!"
 	desc = span_warning("JESUS FUCKING CHRIST IT BURNS! CLICK TO GET THOSE THINGS OFF!")
 
-/datum/status_effect/stagger
-	id = "stagger"
+/datum/status_effect/rebuked
+	id = "rebuked"
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 30 SECONDS
 	tick_interval = 1 SECONDS
 	alert_type = null
 
-/datum/status_effect/stagger/on_apply()
-	owner.next_move_modifier *= 1.5
+/datum/status_effect/rebuked/on_apply()
+	owner.next_move_modifier *= 2
 	if(ishostile(owner))
 		var/mob/living/simple_animal/hostile/simple_owner = owner
 		simple_owner.ranged_cooldown_time *= 2.5
 	return TRUE
 
-/datum/status_effect/stagger/on_remove()
+/datum/status_effect/rebuked/on_remove()
 	. = ..()
 	if(QDELETED(owner))
 		return
-	owner.next_move_modifier /= 1.5
+	owner.next_move_modifier /= 2
 	if(ishostile(owner))
 		var/mob/living/simple_animal/hostile/simple_owner = owner
 		simple_owner.ranged_cooldown_time /= 2.5

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -915,7 +915,7 @@
 	. = ..()
 	if(QDELETED(owner))
 		return
-	owner.next_move_modifier * 0.5
+	owner.next_move_modifier *= 0.5
 	if(ishostile(owner))
 		var/mob/living/simple_animal/hostile/simple_owner = owner
 		simple_owner.ranged_cooldown_time /= 2.5

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -915,7 +915,7 @@
 	. = ..()
 	if(QDELETED(owner))
 		return
-	owner.next_move_modifier /= 2
+	owner.next_move_modifier * 0.5
 	if(ishostile(owner))
 		var/mob/living/simple_animal/hostile/simple_owner = owner
 		simple_owner.ranged_cooldown_time /= 2.5

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -838,7 +838,7 @@
 
 /datum/action/cooldown/spell/pointed/scan
 	name = "Scan"
-	desc = "Scan an enemy, to get their location and stagger them, increasing their time between attacks."
+	desc = "Scan an enemy, to get their location and rebuke them, increasing their time between attacks."
 	background_icon_state = "bg_clock"
 	overlay_icon_state = "bg_clock_border"
 	button_icon = 'icons/mob/actions/actions_items.dmi'
@@ -875,7 +875,6 @@
 	var/mob/living/living_owner = owner
 	var/mob/living/living_scanned = cast_on
 	living_scanned.apply_status_effect(/datum/status_effect/rebuked)
-	living_scanned.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
 	var/datum/status_effect/agent_pinpointer/scan_pinpointer = living_owner.apply_status_effect(/datum/status_effect/agent_pinpointer/scan)
 	scan_pinpointer.scan_target = living_scanned
 

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -875,7 +875,7 @@
 	var/mob/living/living_owner = owner
 	var/mob/living/living_scanned = cast_on
 	living_scanned.apply_status_effect(/datum/status_effect/rebuked)
-	living_scanned.adjust_staggered_up_to(10 SECONDS, 10 SECONDS)
+	living_scanned.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
 	var/datum/status_effect/agent_pinpointer/scan_pinpointer = living_owner.apply_status_effect(/datum/status_effect/agent_pinpointer/scan)
 	scan_pinpointer.scan_target = living_scanned
 

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -800,11 +800,12 @@
 	icon_state = "godeye"
 	inhand_icon_state = null
 	vision_flags = SEE_TURFS
+	clothing_traits = list(TRAIT_MADNESS_IMMUNE)
 	// Blue, light blue
 	color_cutoffs = list(15, 30, 40)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	custom_materials = null
-	var/datum/action/cooldown/scan/scan_ability
+	var/datum/action/cooldown/spell/pointed/scan/scan_ability
 
 /obj/item/clothing/glasses/godeye/Initialize(mapload)
 	. = ..()
@@ -835,49 +836,60 @@
 	victim.emote("scream")
 	victim.flash_act()
 
-/datum/action/cooldown/scan
+/datum/action/cooldown/spell/pointed/scan
 	name = "Scan"
 	desc = "Scan an enemy, to get their location and stagger them, increasing their time between attacks."
 	background_icon_state = "bg_clock"
 	overlay_icon_state = "bg_clock_border"
 	button_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "scan"
+	school = SCHOOL_HOLY
+	cooldown_time = 35 SECONDS
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
+	antimagic_flags = MAGIC_RESISTANCE_MIND //Even god cannot penetrate the tin foil hat
 
-	click_to_activate = TRUE
-	cooldown_time = 45 SECONDS
 	ranged_mousepointer = 'icons/effects/mouse_pointers/scan_target.dmi'
 
-/datum/action/cooldown/scan/IsAvailable(feedback = FALSE)
-	return ..() && isliving(owner)
-
-/datum/action/cooldown/scan/Activate(atom/scanned)
-	StartCooldown(15 SECONDS)
-
-	if(owner.stat != CONSCIOUS)
+/datum/action/cooldown/spell/pointed/scan/is_valid_target(atom/cast_on)
+	if(!isliving(cast_on))
 		return FALSE
-	if(!isliving(scanned) || scanned == owner)
-		owner.balloon_alert(owner, "invalid scanned!")
+	var/mob/living/living_cast_on = cast_on
+	if(living_cast_on.stat == DEAD)
+		to_chat(owner, span_warning("[cast_on] is dead!"))
 		return FALSE
+
+	return TRUE
+
+/datum/action/cooldown/spell/pointed/scan/cast(mob/living/cast_on)
+	. = ..()
+
+	if(cast_on.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+		to_chat(owner, span_warning("As we apply our dissecting vision, we are abruptly cut short. \
+			They have some kind of enigmatic mental defense. It seems we've been foiled."))
+		return
+
+	if(cast_on == owner)
+		to_chat(owner, span_warning("The last time a god stared too closely into their own reflection, they became transfixed for all of time. Do not let us become like them."))
+		return
 
 	var/mob/living/living_owner = owner
-	var/mob/living/living_scanned = scanned
-	living_scanned.apply_status_effect(/datum/status_effect/stagger)
+	var/mob/living/living_scanned = cast_on
+	living_scanned.apply_status_effect(/datum/status_effect/rebuked)
+	living_scanned.adjust_staggered_up_to(10 SECONDS, 10 SECONDS)
 	var/datum/status_effect/agent_pinpointer/scan_pinpointer = living_owner.apply_status_effect(/datum/status_effect/agent_pinpointer/scan)
 	scan_pinpointer.scan_target = living_scanned
 
-	living_scanned.set_jitter_if_lower(100 SECONDS)
-	to_chat(living_scanned, span_warning("You've been staggered!"))
-	living_scanned.add_filter("scan", 2, list("type" = "outline", "color" = COLOR_YELLOW, "size" = 1))
+	to_chat(living_scanned, span_warning("You briefly see a flash of [living_owner]'s face before being knocked off-balance by an unseen force!"))
+	living_scanned.add_filter("scan", 2, list("type" = "outline", "color" = COLOR_RED, "size" = 1))
 	addtimer(CALLBACK(living_scanned, TYPE_PROC_REF(/datum, remove_filter), "scan"), 30 SECONDS)
+
+	healthscan(living_owner, living_scanned, 1, TRUE)
 
 	owner.playsound_local(get_turf(owner), 'sound/magic/smoke.ogg', 50, TRUE)
 	owner.balloon_alert(owner, "[living_scanned] scanned")
 	addtimer(CALLBACK(src, PROC_REF(send_cooldown_end_message), cooldown_time))
 
-	StartCooldown()
-	return TRUE
-
-/datum/action/cooldown/scan/proc/send_cooldown_end_message()
+/datum/action/cooldown/spell/pointed/scan/proc/send_cooldown_end_message()
 	owner?.balloon_alert(owner, "scan recharged")
 
 /datum/status_effect/agent_pinpointer/scan

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -852,10 +852,11 @@
 
 /datum/action/cooldown/spell/pointed/scan/is_valid_target(atom/cast_on)
 	if(!isliving(cast_on))
+		owner.balloon_alert(owner, "[cast_on] isn't a valid target!")
 		return FALSE
 	var/mob/living/living_cast_on = cast_on
 	if(living_cast_on.stat == DEAD)
-		to_chat(owner, span_warning("[cast_on] is dead!"))
+		owner.balloon_alert(owner, "[living_cast_on] is dead!")
 		return FALSE
 
 	return TRUE

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -856,7 +856,7 @@
 		return FALSE
 	var/mob/living/living_cast_on = cast_on
 	if(living_cast_on.stat == DEAD)
-		owner.balloon_alert(owner, "[living_cast_on] is dead!")
+		owner.balloon_alert(owner, "target is dead!")
 		return FALSE
 
 	return TRUE

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -852,7 +852,7 @@
 
 /datum/action/cooldown/spell/pointed/scan/is_valid_target(atom/cast_on)
 	if(!isliving(cast_on))
-		owner.balloon_alert(owner, "[cast_on] isn't a valid target!")
+		owner.balloon_alert(owner, "not a valid target!")
 		return FALSE
 	var/mob/living/living_cast_on = cast_on
 	if(living_cast_on.stat == DEAD)

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_trophy.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_trophy.dm
@@ -1,4 +1,4 @@
-/// Lobstrosity crusher trophy. Staggers targets, increasing their click cooldown.
+/// Lobstrosity crusher trophy. Rebukes targets, increasing their click cooldown.
 /obj/item/crusher_trophy/lobster_claw
 	name = "lobster claw"
 	icon_state = "lobster_claw"
@@ -7,7 +7,7 @@
 	bonus_value = 1
 
 /obj/item/crusher_trophy/lobster_claw/effect_desc()
-	return "mark detonation to briefly stagger the target for [bonus_value] seconds"
+	return "mark detonation to briefly rebuke the target for [bonus_value] seconds"
 
 /obj/item/crusher_trophy/lobster_claw/on_mark_detonation(mob/living/target, mob/living/user)
-	target.apply_status_effect(/datum/status_effect/stagger, bonus_value SECONDS)
+	target.apply_status_effect(/datum/status_effect/rebuked, bonus_value SECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -181,7 +181,7 @@
 
 /// Sets/adds the next time the megafauna can use a melee or ranged attack, in deciseconds. It is a list to allow using named args. Use the ignore_staggered var if youre setting the cooldown to ranged_cooldown_time.
 /mob/living/simple_animal/hostile/megafauna/proc/update_cooldowns(list/cooldown_updates, ignore_staggered = FALSE)
-	if(!ignore_staggered && has_status_effect(/datum/status_effect/stagger))
+	if(!ignore_staggered && has_status_effect(/datum/status_effect/rebuked))
 		for(var/update in cooldown_updates)
 			cooldown_updates[update] *= 2
 	if(cooldown_updates[COOLDOWN_UPDATE_SET_MELEE])


### PR DESCRIPTION
## About The Pull Request

The eye of god now protects from the madness inducing effects of supermatter crystals and singularities. This trait is shared by the meson night vision goggles (which this is a better version of)

The Scan ability has been refactored into a pointed spell.

The Scan ability has a lower cooldown of 35 seconds.

Scan now gives an advanced health scan readout of the target.

Scanning someone alerts the target as to who is responsible, rather than being completely silent as to the culprit (much to the annoyance of anyone who is victimized by someone using this on them)

The status effect that was called Stagger (not Staggered, which is separate) is now called Rebuked.

Rebuked applies a x2 action delay cooldown, rather than x1.5.

## Why It's Good For The Game

The eye of god is generally viewed as not particularly useful. Sure, it is a night vision meson without the flash vulnerability, which is nice. But it wasn't seen as a terribly exciting tendril drop. The scan power is so underwhelming, most people do not actually know what the effects of it are. It largely is only useful for fighting megafauna, since the stagger effect typically matters more for their cooldowns than other monster cooldowns. And even then, not by much. The action cooldown effect on anything else isn't often understood or felt by both victim or user.

So, the vast majority of the time, miners use it to troll people by, and I am quoting one player who was witness to me doing so to a particularly annoying Head of Security, 'pissing on them' by making them glow yellow. Someone else described it as a 'miner's jarate'. You get the idea.

I changed the highlight color to red to avoid this crude comparison. And also, I've made it more obviously an attack when someone uses it on you AND you now know who used it to begin with. And on top of all this, I've given the eye of god both useful utility and a bit of a power boost to encourage miners to actually stick the fucking thing into their skull. I think miners will appreciate health scanning bosses in particular, something you normally can't do in the middle of a fight with one.

## Changelog
:cl:
qol: The eye of god now protects from the madness inducing effects of supermatter crystals and singularities. This trait is shared by the meson night vision goggles (which this is a better version of)
refactor: The Scan ability has been refactored into a pointed spell.
balance: The Scan ability has a lower cooldown of 35 seconds.
balance: The Scan ability now gives an advanced health scan readout of the target.
balance: Scanning someone alerts the target as to who is responsible, rather than being completely silent as to the culprit (much to the annoyance of anyone who is victimized by someone using this on them)
code: The status effect that was called Stagger (not Staggered, which is separate) is now called Rebuked.
balance: Rebuked applies a x2 action delay cooldown, rather than x1.5.
/:cl:
