### PR TITLE
Fixes an issue with strip menus making duplicate windows

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -51,7 +51,7 @@
 	if (!isnull(should_strip_proc_path) && !call(source, should_strip_proc_path)(user))
 		return
 
-	var/datum/strip_menu/strip_menu
+	var/datum/strip_menu/strip_menu = LAZYACCESS(strip_menus, source)
 
 	if (isnull(strip_menu))
 		strip_menu = new(source, src)


### PR DESCRIPTION

## About The Pull Request
Fixes an oversight in #57889, where the strip_menus list is set, but never accessed, leading to whenever you drag to open the menu, it always opens a new window.

## Why It's Good For The Game
Noticed this while porting the TGUI strip menu, and I figured I should fix it here too. From the design of the strippable element, it seems that this was the original design, but somehow got lost along the way.

## Changelog
:cl:
Fix: Opening a mob's strip menu multiple times will now properly update the window.
/:cl:
