### PR TITLE
Allows the use of wirecutters for Tend Wounds

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -38,6 +38,7 @@
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_SCREWDRIVER = 65,
+		TOOL_WIRECUTTER = 60,
 		/obj/item/pen = 55)
 	repeatable = TRUE
 	time = 25


### PR DESCRIPTION

## About The Pull Request
I've always found it weird that we can clamp bleeders, excise infection, and attach grafts to hearts with wirecutters, yet we can't use this same logic to stitch someone back together via Tend Wounds with wirecutters. This update remedies that. 
This will only touch the Tend Wounds surgery procedure as I don't see using wirecutters to fix someone's brain as a good idea since the tool is a tad bulky in design, but something as broad as regular damage to a body should be fine. (But feel free to start a conversation about that, I'm curious what other medical mains think)
I will respect the original PR though and have the wirecutters set for 60, below the screwdriver's 65. I have tested the code and made sure that the wirecutters were usable on the hemostat step.
## Why It's Good For The Game
This adds consistency to Tend Wounds and follows the logic other surgeries give as it's reasonable to think that if you can clamp bleeders with wirecutters then surely you can tend basic wounds with them. I've definitely seen a few ghetto surgeons do exactly this and accidentally kill a person they were trying to save, so I hope that this tweak will prevent these accidental deaths in the future.
## Changelog
:cl:
qol: Can now use wirecutters when performing Tend Wounds.
/:cl:
