### PR TITLE
Adds a shower drain fluff item

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
+++ b/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
@@ -245,12 +245,7 @@
 /area/ruin/space/has_grav/allamericandiner)
 "nq" = (
 /obj/machinery/shower/directional/east,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/item/soap,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/allamericandiner)
@@ -610,12 +605,7 @@
 /area/ruin/space/has_grav/allamericandiner)
 "CF" = (
 /obj/machinery/shower/directional/west,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/item/soap,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/allamericandiner)

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -2483,12 +2483,7 @@
 	pixel_x = 15;
 	pixel_y = 12
 	},
-/obj/structure/fluff{
-	desc = "Ew, I think I see a hairball.";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/dangerous_research/dorms)

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -973,12 +973,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "NU" = (
-/obj/structure/fluff{
-	desc = "Ew, I think I see a hairball.";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/shower/directional/east,
 /obj/item/soap/syndie,
 /obj/machinery/light/blacklight/directional/north,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14749,12 +14749,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/stripes/white/end,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -3408,12 +3408,7 @@
 /area/station/maintenance/floor2/starboard/aft)
 "aSI" = (
 /obj/machinery/shower/directional/west,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/commons/fitness/recreation)
@@ -26842,12 +26837,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gYI" = (
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor{
 	name = "bathroom tiles"
@@ -44797,12 +44787,7 @@
 "lBR" = (
 /obj/machinery/shower/directional/east,
 /obj/item/bikehorn/rubberducky,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/white/small,
 /area/station/commons/fitness/recreation)
 "lCf" = (
@@ -55983,12 +55968,7 @@
 	},
 /area/station/hallway/floor1/fore)
 "oqc" = (
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/qm)
@@ -82419,12 +82399,7 @@
 	},
 /area/station/security/prison)
 "vlh" = (
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/trimline/neutral,
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/freezer,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11659,12 +11659,7 @@
 "cVk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/shower/directional/east,
-/obj/structure/fluff{
-	desc = "Ew, I think I see a hairball.";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -16755,12 +16750,7 @@
 /area/station/science/auxlab/firing_range)
 "ePS" = (
 /obj/machinery/shower/directional/west,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
@@ -22531,12 +22521,7 @@
 /area/station/commons/fitness/recreation)
 "gWt" = (
 /obj/effect/turf_decal/box,
-/obj/structure/fluff{
-	desc = "Ew, I think I see a hairball.";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
@@ -32937,12 +32922,7 @@
 	},
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/bot,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -60070,12 +60050,7 @@
 	},
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/box,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ujw" = (
@@ -69067,12 +69042,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xrf" = (
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /obj/machinery/duct,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/freezer,

--- a/_maps/shuttles/pirate_irs.dmm
+++ b/_maps/shuttles/pirate_irs.dmm
@@ -1033,12 +1033,7 @@
 	layer = 4
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/mining_zones/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "Dy" = (

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -86,6 +86,8 @@
 	desc = "Ew, I think I see a hairball."
 	icon = 'icons/obj/mining_zones/survival_pod.dmi'
 	icon_state = "fan_tiny"
+	plane = FLOOR_PLANE
+	layer = LOW_OBJ_LAYER
 
 /**
  * A variety of statue in disrepair; parts are broken off and a gemstone is missing

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -25,6 +25,7 @@
 			qdel(src)
 		return
 	..()
+
 /**
  * Empty terrariums are created when a preserved terrarium in a lavaland seed vault is activated.
  */
@@ -34,6 +35,7 @@
 	icon = 'icons/obj/mining_zones/spawners.dmi'
 	icon_state = "terrarium_open"
 	density = TRUE
+
 /**
  * Empty sleepers are created by a good few ghost roles in lavaland.
  */
@@ -51,6 +53,7 @@
 
 /obj/structure/fluff/empty_sleeper/syndicate
 	icon_state = "sleeper_s-open"
+
 /**
  * Empty cryostasis sleepers are created when a malfunctioning cryostasis sleeper in a lavaland shelter is activated.
  */
@@ -74,6 +77,15 @@
 	density = TRUE
 	deconstructible = FALSE
 	layer = EDGED_TURF_LAYER
+
+/**
+ * shower drain placed usually under showers just so it looks like something picks the water up.
+ */
+/obj/structure/fluff/shower_drain
+	name = "shower drain"
+	desc = "Ew, I think I see a hairball."
+	icon = 'icons/obj/mining_zones/survival_pod.dmi'
+	icon_state = "fan_tiny"
 
 /**
  * A variety of statue in disrepair; parts are broken off and a gemstone is missing


### PR DESCRIPTION
## About The Pull Request

Turns the varedited fluff item into its own item so it no longer has a varedited icon & icon state.

## Why It's Good For The Game

We're varediting this fluff item 17 times on current tg master and it's pretty bad. Varediting icon/icon state in maps should be discouraged and hopefully banned later, it's not hard to make a subtype of an item so we should be able to expect mappers to do that rather than this.

## Changelog

Nothing player-facing.