### PR TITLE
[NO GBP] Fixes action_type on clothing to be a list on two items that where static

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -54,10 +54,7 @@
 
 /obj/item/clothing/Initialize(mapload)
 	if(clothing_flags & VOICEBOX_TOGGLABLE)
-		if (islist(actions_types))
-			actions_types.Add(/datum/action/item_action/toggle_voice_box)
-		else
-			actions_types = list(/datum/action/item_action/toggle_voice_box)
+		actions_types += list(/datum/action/item_action/toggle_voice_box)
 	. = ..()
 	AddElement(/datum/element/venue_price, FOOD_PRICE_CHEAP)
 	if(can_be_bloody && ((body_parts_covered & FEET) || (flags_inv & HIDESHOES)))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -54,7 +54,10 @@
 
 /obj/item/clothing/Initialize(mapload)
 	if(clothing_flags & VOICEBOX_TOGGLABLE)
-		actions_types += /datum/action/item_action/toggle_voice_box
+		if (islist(actions_types))
+			actions_types.Add(/datum/action/item_action/toggle_voice_box)
+		else
+			actions_types = list(/datum/action/item_action/toggle_voice_box)
 	. = ..()
 	AddElement(/datum/element/venue_price, FOOD_PRICE_CHEAP)
 	if(can_be_bloody && ((body_parts_covered & FEET) || (flags_inv & HIDESHOES)))

--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -204,7 +204,7 @@
 /obj/item/clothing/mask/facescarf
 	name = "facescarf"
 	desc = "Cover your face like in the cowboy movies. It also has breathtube so you can wear it everywhere!"
-	actions_types = /datum/action/item_action/adjust
+	actions_types = list(/datum/action/item_action/adjust)
 	icon_state = "facescarf"
 	inhand_icon_state = "greyscale_facescarf"
 	alternate_worn_layer = BACK_LAYER


### PR DESCRIPTION
## About The Pull Request

This changes the action_types on the face scarf from being a static datum to being a list. This is a bug I noticed while working on a PR downstream where i was attempting to add an action to a set of items and this caused a miss-matched type CI error. This realistically shouldn't be the case as everything else on the code base that uses action_types is also a list. So for consistency sake and to remove bugs this will fix the var to be a list instead of static.

## Why It's Good For The Game

Less bugs, more consistency with variables.

## Changelog

I don't really think this needs a change log, not really player noticeable or player facing. The relative impact on players is minor