### PR TITLE
Makes the Captain's Spare safe actually secure from being smashed open now that it's been removed from a wall.

### DIFF
--- a/code/game/objects/structures/secure_safe.dm
+++ b/code/game/objects/structures/secure_safe.dm
@@ -79,6 +79,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
 	base_icon_state = "safe"
 	armor_type = /datum/armor/safe_caps_spare
 	max_integrity = 300
+	damage_deflection = 30 // prevents stealing the captain's spare using null rods/lavaland monsters/AP projectiles
 	density = TRUE
 	anchored_tabletop_offset = 4
 	custom_materials = list(/datum/material/gold = SMALL_MATERIAL_AMOUNT)


### PR DESCRIPTION
## About The Pull Request
Makes the Captain's Spare safe actually secure from being smashed open now that it's been removed from a wall. Damage Deflection of 30 has been added to it.

## Why It's Good For The Game

Because the Captain's Safe was moved off of the wall it's now vulnerable to direct attack and projectiles way, way more than before and now there's a lot of avenues to inflict AP damage, which is directly subtracted from the armor value before application of damage. I've added a damage deflection of 30 to make it 

## Changelog

:cl:
balance: Makes the Captain's Spare safe actually secure from being smashed open now that it's been removed from a wall. Damage Deflection of 30 has been added to it.
/:cl: