### PR TITLE
Lowers the cost of hypnogrenades by half and adds warnings regarding it's finnickyness

### DIFF
--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -1,7 +1,7 @@
 /obj/item/grenade/hypnotic
 	name = "flashbang"
 	desc = "A modified flashbang which uses hypnotic flashes and mind-altering soundwaves to induce an instant trance upon detonation. \
-		 It seems you can set an hypnotic phrase that's uttered when triggered"
+		It seems you can set an hypnotic phrase that's uttered when triggered"
 	icon_state = "flashbang"
 	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
@@ -48,8 +48,8 @@
 	if(soft_filter_result)
 		if(tgui_alert(user,"Your command contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to use it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
 			return
-		message_admins("[ADMIN_LOOKUPFLW(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term for an AI law. Law: \"[html_encode(hypno_text_input)]\"")
-		log_admin_private("[key_name(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term for an AI law. Law: \"[hypno_text_input]\"")
+		message_admins("[ADMIN_LOOKUPFLW(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term for an Hypnotic command. Command: \"[html_encode(hypno_text_input)]\"")
+		log_admin_private("[key_name(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term for an Hypnotic command. Command: \"[hypno_text_input]\"")
 	hypno_text = hypno_text_input
 
 /obj/item/grenade/hypnotic/detonate(mob/living/lanced_by)

--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -7,50 +7,12 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7
-	///hypno text that is said when the grenade is triggered
-	var/hypno_text
-	verb_say = "beeps"
-	verb_ask = "inquires"
-	verb_yell = "blares"
-	verb_exclaim = "bleeps"
-
-/obj/item/grenade/hypnotic/Initialize(mapload)
-	. = ..()
-	register_context()
-
-/obj/item/grenade/hypnotic/add_context(atom/source, list/context, obj/item/held_item, mob/user)
-	. = ..()
-	context[SCREENTIP_CONTEXT_RMB] = "Set Hypno Text"
-	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/grenade/hypnotic/apply_grenade_fantasy_bonuses(quality)
 	flashbang_range = modify_fantasy_variable("flashbang_range", flashbang_range, quality)
 
 /obj/item/grenade/hypnotic/remove_grenade_fantasy_bonuses(quality)
 	flashbang_range = reset_fantasy_variable("flashbang_range", flashbang_range)
-
-/obj/item/grenade/hypnotic/attack_self_secondary(mob/user, modifiers)
-	. = ..()
-	input_hypnotic_text(user)
-
-/obj/item/grenade/hypnotic/attack_hand_secondary(mob/user, list/modifiers)
-	. = ..()
-	input_hypnotic_text(user)
-
-/obj/item/grenade/hypnotic/proc/input_hypnotic_text(mob/user)
-	var/hypno_text_input = tgui_input_text(user, "Enter a hypnotic command.", "Hypnotic Command Phrase", TRUE)
-	if(!hypno_text_input)
-		return
-	if(is_ic_filtered(hypno_text_input))
-		to_chat(user, span_warning("Error: Hypnotic commmand contains invalid text."))
-		return
-	var/list/soft_filter_result = is_soft_ooc_filtered(hypno_text_input)
-	if(soft_filter_result)
-		if(tgui_alert(user,"Your command contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to use it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
-			return
-		message_admins("[ADMIN_LOOKUPFLW(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term for an Hypnotic command. Command: \"[html_encode(hypno_text_input)]\"")
-		log_admin_private("[key_name(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term for an Hypnotic command. Command: \"[hypno_text_input]\"")
-	hypno_text = hypno_text_input
 
 /obj/item/grenade/hypnotic/detonate(mob/living/lanced_by)
 	. = ..()
@@ -66,8 +28,6 @@
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, flashbang_range + 2, 4, LIGHT_COLOR_PURPLE, 2)
 	for(var/mob/living/living_mob in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(living_mob), living_mob)
-	if(hypno_text) //Sanity check if it's hypno text is null
-		say(hypno_text)
 	qdel(src)
 
 /obj/item/grenade/hypnotic/proc/bang(turf/turf, mob/living/living_mob)

--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -1,7 +1,6 @@
 /obj/item/grenade/hypnotic
 	name = "flashbang"
-	desc = "A modified flashbang which uses hypnotic flashes and mind-altering soundwaves to induce an instant trance upon detonation. \
-		It seems you can set an hypnotic phrase that's uttered when triggered"
+	desc = "A modified flashbang which uses hypnotic flashes and mind-altering soundwaves to induce an instant trance upon detonation."
 	icon_state = "flashbang"
 	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -232,7 +232,8 @@
 
 /datum/uplink_item/device_tools/hypnotic_grenade
 	name = "Hypnotic Grenade"
-	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers."
+	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers. \
+		It has an automatic subliminal speech system installed that automatically inducts targets with the hypnotic phrase that you can set."
 	item = /obj/item/grenade/hypnotic
 	cost = 12
 

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -233,8 +233,7 @@
 /datum/uplink_item/device_tools/hypnotic_grenade
 	name = "Hypnotic Grenade"
 	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers. \
-		Be warned however, that this grenade is finnicky to use and utilize. \
-		Ensure proper protection and instant uttering of hypnotic command before triggering the grenade."
+		Equipment to protect yourself from the effects is not provided. Ensure you are ready before pulling the pin."
 	item = /obj/item/grenade/hypnotic
 	cost = 6
 

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -233,9 +233,10 @@
 /datum/uplink_item/device_tools/hypnotic_grenade
 	name = "Hypnotic Grenade"
 	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers. \
-		It has an automatic subliminal speech system installed that automatically inducts targets with the hypnotic phrase that you can set."
+		Be warned however, that this grenade is finnicky to use and utilize. \
+		Ensure proper protection and instant uttering of hypnotic command before triggering the grenade."
 	item = /obj/item/grenade/hypnotic
-	cost = 12
+	cost = 6
 
 /datum/uplink_item/device_tools/singularity_beacon
 	name = "Power Beacon"


### PR DESCRIPTION
## About The Pull Request
Lowers the cost of hypnogrenades by half and adds warnings regarding it's finnickyness
## Why It's Good For The Game
Hypnotic grenades, with it's steep cost of 12 TC (1TC MORE of that of the **syndicate bomb**(an item that has a far reaching impact and damage to the station as a whole rather than a one use aoe grenade), at it's current state. it's extremely clunky and risky to use. since it's very easy to blurt out your hypnotic phrase too early or too late (remember, without protection. you yourself are suceptible to to it's effect and stun) before someone says something stupid, it doesn't even have to be in-person but through the radio too.

It would make sense for it to be unreliable if it was half of it's obscene price. 6TC~ or somewhere near that range for it to be unpredictable to use (also with proper warnings of it's dangerousness). But as a it's current state. It's just a noobtrap.

The first iteration of hypnoflash in it's original PR, it's intended for it to be unpredictable and unreliable to use, considering it was 6TC to use and buy. But it raises some concerns on it being so cheap as a one-use AoE OHK item (for non-protected victims).

Just one nerf to the original iteration of hypnoflash would suffice for it to be used as a good niche situational item. Being reliable to use at 12TC or unreliable and risky to use at 6TC. One of those two nerfs, not both would make the item balanced and usable. but in this situation where both nerfs are applied is a classic case of double nerfing something to irrelevancy.
This PR makes it so that it's far more easy and less clunky to use hypnotic grenades.
## Changelog
:cl:
balance :Lowers the cost of hypnogrenades by half and adds warnings regarding it's finnickyness
/:cl:
