### PR TITLE
[NO-GBP] Genetic sequencer scanning makeup now detects when targets moves out of range

### DIFF
--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -23,6 +23,16 @@
 	/// genetic makeup data that's scanned
 	var/list/genetic_makeup_buffer = list()
 
+/obj/item/sequence_scanner/Initialize(mapload)
+	. = ..()
+	var/static/list/hovering_mob_typechecks = list(
+		/mob/living/targets = list(
+			SCREENTIP_CONTEXT_ALT_LMB = "Scan Genetic Mutation",
+			SCREENTIP_CONTEXT_ALT_RMB = "Scan Genetic Makeup"
+		)
+	)
+	AddElement(/datum/element/contextual_screentip_mob_typechecks, hovering_mob_typechecks)
+
 /obj/item/sequence_scanner/examine(mob/user)
 	. = ..()
 	. += span_notice("Use primary attack to scan mutations, Secondary attack to scan genetic makeup")
@@ -55,7 +65,7 @@
 	//no scanning if its a husk, DNA-less Species or DNA that isn't able to be copied by a changeling/disease
 	if (!HAS_TRAIT(interacting_with, TRAIT_GENELESS) && !HAS_TRAIT(interacting_with, TRAIT_BADDNA) && !HAS_TRAIT(interacting_with, TRAIT_NO_DNA_COPY))
 		user.visible_message(span_warning("[user] is scanning [interacting_with]'s genetic makeup."))
-		if(!do_after(user, 3 SECONDS))
+		if(!do_after(user, 3 SECONDS, interacting_with))
 			balloon_alert(user, "scan failed!")
 			user.visible_message(span_warning("[user] fails to scan [interacting_with]'s genetic makeup."))
 			return ITEM_INTERACT_BLOCKING

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -23,16 +23,6 @@
 	/// genetic makeup data that's scanned
 	var/list/genetic_makeup_buffer = list()
 
-/obj/item/sequence_scanner/Initialize(mapload)
-	. = ..()
-	var/static/list/hovering_mob_typechecks = list(
-		/mob/living/targets = list(
-			SCREENTIP_CONTEXT_ALT_LMB = "Scan Genetic Mutation",
-			SCREENTIP_CONTEXT_ALT_RMB = "Scan Genetic Makeup"
-		)
-	)
-	AddElement(/datum/element/contextual_screentip_mob_typechecks, hovering_mob_typechecks)
-
 /obj/item/sequence_scanner/examine(mob/user)
 	. = ..()
 	. += span_notice("Use primary attack to scan mutations, Secondary attack to scan genetic makeup")


### PR DESCRIPTION

## About The Pull Request
Does what it says on the tin, adds a missing target argument in the timer function
## Why It's Good For The Game
## Changelog
:cl:
fix: You can't complete a genetic makeup scan when the targets moves out of target anymore using a genetic sequencer
/:cl:
