### PR TITLE
Adds contextual screentips to air alarms

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -125,6 +125,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	GLOB.air_alarms += src
 	update_appearance()
 	find_and_hang_on_wall()
+	register_context()
 
 /obj/machinery/airalarm/process()
 	if(!COOLDOWN_FINISHED(src, warning_cooldown))

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_contextual_tips.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_contextual_tips.dm
@@ -1,5 +1,7 @@
 /obj/machinery/airalarm/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
+	if(isnull(held_item))
+		return 
 
 	if(held_item.tool_behaviour == TOOL_CROWBAR)
 		if(buildstage == AIR_ALARM_BUILD_NO_WIRES)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_contextual_tips.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_contextual_tips.dm
@@ -1,0 +1,18 @@
+/obj/machinery/airalarm/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(held_item.tool_behaviour == TOOL_CROWBAR)
+		if(buildstage == AIR_ALARM_BUILD_NO_WIRES)
+			context[SCREENTIP_CONTEXT_LMB] = "Pry out Electronics"
+
+	else if(held_item.tool_behaviour == TOOL_SCREWDRIVER && buildstage == AIR_ALARM_BUILD_COMPLETE)
+		context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Expose wires" : "Unexpose wires"
+
+	else if(held_item.tool_behaviour == TOOL_WIRECUTTER)
+		if (panel_open)
+			context[SCREENTIP_CONTEXT_LMB] = "Manipulate wires"
+
+	else if(held_item.tool_behaviour == TOOL_WRENCH)
+		if(buildstage == AIR_ALARM_BUILD_NO_CIRCUIT)
+			context[SCREENTIP_CONTEXT_LMB] = "Detatch Alarm"
+	return CONTEXTUAL_SCREENTIP_SET

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3301,6 +3301,7 @@
 #include "code\modules\atmospherics\machinery\datum_pipeline.dm"
 #include "code\modules\atmospherics\machinery\air_alarm\_air_alarm.dm"
 #include "code\modules\atmospherics\machinery\air_alarm\air_alarm_circuit.dm"
+#include "code\modules\atmospherics\machinery\air_alarm\air_alarm_contextual_tips.dm"
 #include "code\modules\atmospherics\machinery\air_alarm\air_alarm_interact.dm"
 #include "code\modules\atmospherics\machinery\air_alarm\air_alarm_modes.dm"
 #include "code\modules\atmospherics\machinery\air_alarm\air_alarm_thresholds.dm"


### PR DESCRIPTION

## About The Pull Request
Adds contextual screentips for air alarms, so that it's consistent with it's power-related cousin the APC
## Why It's Good For The Game
It bugged me when I saw there's tooltips for almost every other wall machinery except for the air alarm. I figured why not?
## Changelog
:cl:
qol: Adds contextual screentips to air alarms
/:cl:
