### PR TITLE
Suppresses excessive logging that results from fights in the deathmatch

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -127,6 +127,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define NO_DEATH_MESSAGE (1<<14)
 /// This area should have extra shielding from certain event effects
 #define EVENT_PROTECTED (1<<15)
+/// This Area Doesn't have Flood or Bomb Logging
+#define QUIET_LOGS (1<<16)
 
 /*
 	These defines are used specifically with the atom/pass_flags bitmask

--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define NO_DEATH_MESSAGE (1<<14)
 /// This area should have extra shielding from certain event effects
 #define EVENT_PROTECTED (1<<15)
-/// This Area Doesn't have Flood or Bomb Logging
+/// This Area Doesn't have Flood or Bomb admin logging
 #define QUIET_LOGS (1<<16)
 
 /*

--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define NO_DEATH_MESSAGE (1<<14)
 /// This area should have extra shielding from certain event effects
 #define EVENT_PROTECTED (1<<15)
-/// This Area Doesn't have Flood or Bomb admin logging
+/// This Area Doesn't have Flood or Bomb Admin Messages, but will still log
 #define QUIET_LOGS (1<<16)
 
 /*

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -327,7 +327,3 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 
 #define isprojectilespell(thing) (istype(thing, /datum/action/cooldown/spell/pointed/projectile))
 #define is_multi_tile_object(atom) (atom.bound_width > world.icon_size || atom.bound_height > world.icon_size)
-
-// Area Checker
-/// Returns whether or not the given location is a deathmatch area
-#define isdeathmatch(location) (istype(get_area(location), /area/deathmatch))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -327,3 +327,7 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 
 #define isprojectilespell(thing) (istype(thing, /datum/action/cooldown/spell/pointed/projectile))
 #define is_multi_tile_object(atom) (atom.bound_width > world.icon_size || atom.bound_height > world.icon_size)
+
+// Area Checker
+/// Returns whether or not the given location is a deathmatch area
+#define isdeathmatch(location) (istype(get_area(location), /area/deathmatch))

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -80,5 +80,5 @@
 
 	GLOB.bombers += bomb_message
 
-	if(message_admins)
+	if(message_admins && !istype(bomb.loc, /area/deathmatch)) //don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -80,5 +80,5 @@
 
 	GLOB.bombers += bomb_message
 
-	if(message_admins && !istype(bomb.loc, /area/deathmatch)) // Don't spam the logs with deathmatch bombs
+	if(message_admins && !istype(get_area(bomb), /area/deathmatch)) // Don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -80,5 +80,5 @@
 
 	GLOB.bombers += bomb_message
 
-	if(message_admins && !istype(bomb.loc, /area/deathmatch)) //don't spam the logs with deathmatch bombs
+	if(message_admins && !istype(bomb.loc, /area/deathmatch)) // Don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -80,5 +80,5 @@
 
 	GLOB.bombers += bomb_message
 
-	if(message_admins && !istype(get_area(bomb), /area/deathmatch)) // Don't spam the logs with deathmatch bombs
+	if(message_admins && !isdeathmatch(bomb)) // Don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -79,6 +79,6 @@
 		log_game(bomb_message)
 
 	GLOB.bombers += bomb_message
-
-	if(message_admins && !isdeathmatch(bomb)) // Don't spam the logs with deathmatch bombs
+	var/area/bomb_area = get_area(bomb)
+	if(message_admins && !(bomb_area.area_flags & QUIET_LOGS)) // Don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")

--- a/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
@@ -154,7 +154,6 @@
 			blame_msg = " with no known fingerprints"
 	else
 		source_msg = "with no known source"
-
-	if(!istype(holder, /obj/machinery/plumbing) && !istype(get_area(location), /area/deathmatch)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
+	if(!istype(holder, /obj/machinery/plumbing) && !isdeathmatch(location)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
 		message_admins("\A [flood] flood started at [ADMIN_VERBOSEJMP(location)] [source_msg][blame_msg].")
 	log_game("\A [flood] flood started at [location || "nonexistant location"] [holder ? "from [holder] last touched by [holder || "N/A"]" : "with no known source"].")

--- a/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
@@ -155,6 +155,6 @@
 	else
 		source_msg = "with no known source"
 
-	if(!istype(holder, /obj/machinery/plumbing) && !istype(location.loc, /area/deathmatch)) //excludes standard plumbing equipment aswell as deathmatch from spamming admins with this shit
+	if(!istype(holder, /obj/machinery/plumbing) && !istype(location.loc, /area/deathmatch)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
 		message_admins("\A [flood] flood started at [ADMIN_VERBOSEJMP(location)] [source_msg][blame_msg].")
 	log_game("\A [flood] flood started at [location || "nonexistant location"] [holder ? "from [holder] last touched by [holder || "N/A"]" : "with no known source"].")

--- a/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
@@ -155,6 +155,6 @@
 	else
 		source_msg = "with no known source"
 
-	if(!istype(holder, /obj/machinery/plumbing)) //excludes standard plumbing equipment from spamming admins with this shit
+	if(!istype(holder, /obj/machinery/plumbing) && !istype(location.loc, /area/deathmatch)) //excludes standard plumbing equipment aswell as deathmatch from spamming admins with this shit
 		message_admins("\A [flood] flood started at [ADMIN_VERBOSEJMP(location)] [source_msg][blame_msg].")
 	log_game("\A [flood] flood started at [location || "nonexistant location"] [holder ? "from [holder] last touched by [holder || "N/A"]" : "with no known source"].")

--- a/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
@@ -154,6 +154,7 @@
 			blame_msg = " with no known fingerprints"
 	else
 		source_msg = "with no known source"
-	if(!istype(holder, /obj/machinery/plumbing) && !isdeathmatch(location)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
+	var/area/fluid_area = get_area(location)
+	if(!istype(holder, /obj/machinery/plumbing) && !(fluid_area.area_flags & QUIET_LOGS)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
 		message_admins("\A [flood] flood started at [ADMIN_VERBOSEJMP(location)] [source_msg][blame_msg].")
 	log_game("\A [flood] flood started at [location || "nonexistant location"] [holder ? "from [holder] last touched by [holder || "N/A"]" : "with no known source"].")

--- a/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
@@ -155,6 +155,6 @@
 	else
 		source_msg = "with no known source"
 
-	if(!istype(holder, /obj/machinery/plumbing) && !istype(location.loc, /area/deathmatch)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
+	if(!istype(holder, /obj/machinery/plumbing) && !istype(get_area(location), /area/deathmatch)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
 		message_admins("\A [flood] flood started at [ADMIN_VERBOSEJMP(location)] [source_msg][blame_msg].")
 	log_game("\A [flood] flood started at [location || "nonexistant location"] [holder ? "from [holder] last touched by [holder || "N/A"]" : "with no known source"].")

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -432,16 +432,17 @@
 
 	var/where = "[AREACOORD(location)]"
 	var/contained = length(contained_reagents) ? "[contained_reagents.Join(", ", " \[", "\]")] @ [chemholder.chem_temp]K" : null
+	var/area/fluid_area = get_area(location)
 	if(carry.my_atom?.fingerprintslast) //Some reagents don't have a my_atom in some cases
 		var/mob/M = get_mob_by_key(carry.my_atom.fingerprintslast)
 		var/more = ""
 		if(M)
 			more = "[ADMIN_LOOKUPFLW(M)] "
-		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !isdeathmatch(location)) // I like to be able to see my logs thank you
+		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !(fluid_area.area_flags & QUIET_LOGS)) // I like to be able to see my logs thank you
 			message_admins("Smoke: ([ADMIN_VERBOSEJMP(location)])[contained]. Key: [more ? more : carry.my_atom.fingerprintslast].")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last touched by [carry.my_atom.fingerprintslast].")
 	else
-		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !isdeathmatch(location)) // Deathmatch has way too much smoke to log
+		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !(fluid_area.area_flags & QUIET_LOGS)) // Deathmatch has way too much smoke to log
 			message_admins("Smoke: ([ADMIN_VERBOSEJMP(location)])[contained]. No associated key.")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
 

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -437,11 +437,11 @@
 		var/more = ""
 		if(M)
 			more = "[ADMIN_LOOKUPFLW(M)] "
-		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !istype(location, /area/deathmatch)) // I like to be able to see my logs thank you
+		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !isdeathmatch(location)) // I like to be able to see my logs thank you
 			message_admins("Smoke: ([ADMIN_VERBOSEJMP(location)])[contained]. Key: [more ? more : carry.my_atom.fingerprintslast].")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last touched by [carry.my_atom.fingerprintslast].")
 	else
-		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !istype(location, /area/deathmatch)) // Deathmatch has way too much smoke to log
+		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !isdeathmatch(location)) // Deathmatch has way too much smoke to log
 			message_admins("Smoke: ([ADMIN_VERBOSEJMP(location)])[contained]. No associated key.")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
 

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -437,11 +437,11 @@
 		var/more = ""
 		if(M)
 			more = "[ADMIN_LOOKUPFLW(M)] "
-		if(!istype(carry.my_atom, /obj/machinery/plumbing))
+		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !istype(location, /area/deathmatch)) // I like to be able to see my logs thank you
 			message_admins("Smoke: ([ADMIN_VERBOSEJMP(location)])[contained]. Key: [more ? more : carry.my_atom.fingerprintslast].")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last touched by [carry.my_atom.fingerprintslast].")
 	else
-		if(!istype(carry.my_atom, /obj/machinery/plumbing))
+		if(!istype(carry.my_atom, /obj/machinery/plumbing) && !istype(location, /area/deathmatch)) // Deathmatch has way too much smoke to log
 			message_admins("Smoke: ([ADMIN_VERBOSEJMP(location)])[contained]. No associated key.")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
 

--- a/code/modules/deathmatch/deathmatch_mapping.dm
+++ b/code/modules/deathmatch/deathmatch_mapping.dm
@@ -2,7 +2,7 @@
 	name = "Deathmatch Arena"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	area_flags = UNIQUE_AREA | NOTELEPORT | ABDUCTOR_PROOF | EVENT_PROTECTED
+	area_flags = UNIQUE_AREA | NOTELEPORT | ABDUCTOR_PROOF | EVENT_PROTECTED | QUIET_LOGS
 
 /area/deathmatch/fullbright
 	static_lighting = FALSE


### PR DESCRIPTION
## About The Pull Request

So this is a PR i have had testmerged downstream for like a month now because deathmatch SPAMS the hell out of admin logs. This makes doing admin work kinda annoying when all the useful logs are drowned out by people trying to smoke each other to death endlessly. I don't know how bad the problem is upstream, but I'd imagine TG admins would likely express the same gratitude to have less active logging in game, in the case something important happens that they need to see.

This should still keep logging things to the actual log files so the logs will still exist, but this merely suppresses the massive spam of logs that admins actively see.

## Why It's Good For The Game

Lets admins do their job a little bit better being able to see when things happen in the logs. Deathmatch logs can be rather disruptive towards admins.

## Changelog

:cl: SomeRandomOwl
admin: Deathmatch Bombs, Smoke, and Liquid floods are now suppressed in the logs and will not actively spam admin logs.
code: adds a area flag to suppress logging for floods and bombs
/:cl: