### PR TITLE
Converts ore_mined talley into only recording typepaths.

### DIFF
--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -162,7 +162,7 @@
 			stack_trace("boulder found containing material type [picked.type] with no set ore_type")
 			continue
 		cracked_ore = new cracked_ore_type (drop_location(), quantity)
-		SSblackbox.record_feedback("tally", "ore_mined", quantity, cracked_ore)
+		SSblackbox.record_feedback("tally", "ore_mined", quantity, cracked_ore.type)
 
 ///Moves boulder contents to the drop location, and then deletes the boulder.
 /obj/item/boulder/proc/break_apart()


### PR DESCRIPTION
## About The Pull Request

This Pull request makes it so that the blackbox `ore_mined` talley will now only record the mineral stack's typepath as opposed to a 50/50 mix of names and typepaths.

## Why It's Good For The Game

Fixes #82042. Logging should be as descriptive as possible while also avoiding the possibility for misunderstanding, so using the typepath for logging on the blackbox is preferred. 

## Changelog

:cl:
code: Mineral logging now collects ore names more cleanly.
/:cl: