### PR TITLE
[No GBP] Vending examine message now properly shows the name of the vending refill required.

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -348,7 +348,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	if(isnull(refill_canister))
 		return // you can add the comment here instead
 	if((total_loaded_stock() / total_max_stock()) < 1)
-		. += span_notice("\The [src] can be restocked with [span_boldnotice("\a [refill_canister]")] with the panel open.")
+		. += span_notice("\The [src] can be restocked with [span_boldnotice("\a [initial(refill_canister).name]")] with the panel open.")
 	else
 		. += span_notice("\The [src] is fully stocked.")
 	if(credits_contained < CREDITS_DUMP_THRESHOLD && credits_contained > 0)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -348,7 +348,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	if(isnull(refill_canister))
 		return // you can add the comment here instead
 	if((total_loaded_stock() / total_max_stock()) < 1)
-		. += span_notice("\The [src] can be restocked with [span_boldnotice("\a [initial(refill_canister).name]")] with the panel open.")
+		. += span_notice("\The [src] can be restocked with [span_boldnotice("\a [initial(refill_canister.machine_name)] [initial(refill_canister.name)]")] with the panel open.")
 	else
 		. += span_notice("\The [src] is fully stocked.")
 	if(credits_contained < CREDITS_DUMP_THRESHOLD && credits_contained > 0)


### PR DESCRIPTION
## About The Pull Request

Vending refills were piping in the typepath of the refill as opposed to the name since their examine was referencing a type path. This instead pulls the `machine_name` and `name` to form the correct string on examine to confirm that the value is accurate.
![image](https://github.com/tgstation/tgstation/assets/41715314/88db4bb7-a529-4dee-bd9e-e83ff4b66b9a)

## Why It's Good For The Game
Fixes #82095. That should probably not be shown in-game as is and now actually showcases the correct message on examine.

## Changelog
:cl:
fix: Vending machines now show the correct vending refill name when examine and not full.
/:cl:

