### PR TITLE
fixes fake laser lenses falling out of pirates

### DIFF
--- a/code/modules/mob/living/basic/trooper/pirate.dm
+++ b/code/modules/mob/living/basic/trooper/pirate.dm
@@ -55,7 +55,7 @@
 	r_hand = /obj/item/gun/energy/laser
 	ai_controller = /datum/ai_controller/basic_controller/trooper/ranged
 	/// Type of bullet we use
-	var/casingtype = /obj/item/ammo_casing/energy/laser
+	var/projectiletype = /obj/projectile/beam/laser
 	/// Sound to play when firing weapon
 	var/projectilesound = 'sound/weapons/laser.ogg'
 	/// number of burst shots
@@ -67,7 +67,7 @@
 	. = ..()
 	AddComponent(\
 		/datum/component/ranged_attacks,\
-		casing_type = casingtype,\
+		projectile_type = projectiletype,\
 		projectile_sound = projectilesound,\
 		cooldown_time = ranged_cooldown,\
 		burst_shots = burst_shots,\


### PR DESCRIPTION
## About The Pull Request

fixes #81812 

pirate basic mobs use casingtype instead of projectiletype. 

This meant pirates shooting lasers were trying to drop casings with their projectiles. switching it to use projectiletype for the /trooper/pirate/ranged types fixes the issue, though it would need to be respecified for pirates using ballistic weapons if we want them to drop the stuff later. 

## Why It's Good For The Game

fix good. fake bullet casings bad

## Changelog

:cl:
fix: basic mob pirates no longer drop fake energy weapon lenses when shooting you to death with lasers.
/:cl:

