### PR TITLE
Fixes an odd bug with record consoles

### DIFF
--- a/code/__DEFINES/computers.dm
+++ b/code/__DEFINES/computers.dm
@@ -11,3 +11,6 @@
 #define CATEGORY_BEPIS "Bepis Tech"
 #define CATEGORY_BITRUNNING_FLAIR "Misc"
 #define CATEGORY_BITRUNNING_TECH "Tech"
+
+///Helper macro for record computers' preview views, used to ensure consistency in all use cases.
+#define USER_PREVIEW_ASSIGNED_VIEW(user_ckey) "preview_[user_ckey]_[REF(src)]_records"

--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -31,7 +31,7 @@
 		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		create_character_preview_view(user)
+		character_preview_view = create_character_preview_view(user)
 		ui = new(user, src, "MedicalRecords")
 		ui.set_autoupdate(FALSE)
 		ui.open()

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -18,6 +18,10 @@
 
 	return data
 
+/obj/machinery/computer/records/ui_close(mob/user)
+	QDEL_NULL(character_preview_view)
+	return ..()
+
 /obj/machinery/computer/records/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
 	if(.)
@@ -108,6 +112,7 @@
 	var/atom/movable/screen/map_view/char_preview/new_view = new(null, src)
 	new_view.generate_view(assigned_view)
 	new_view.display_to(user)
+	return new_view
 
 /// Takes a record and updates the character preview view to match it.
 /obj/machinery/computer/records/proc/update_preview(mob/user, assigned_view, datum/record/crew/target)

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -13,14 +13,16 @@
 	if(!has_access)
 		return data
 
-	data["assigned_view"] = "preview_[user.ckey]_[REF(src)]_records"
+	data["assigned_view"] = USER_PREVIEW_ASSIGNED_VIEW(user.ckey)
 	data["station_z"] = !!(z && is_station_level(z))
 
 	return data
 
 /obj/machinery/computer/records/ui_close(mob/user)
-	QDEL_NULL(character_preview_view)
-	return ..()
+	. = ..()
+	user.client?.screen_maps -= USER_PREVIEW_ASSIGNED_VIEW(user.ckey)
+	if((LAZYLEN(open_uis) <= 1) && character_preview_view) //only delete the preview if we're the last one to close the console.
+		QDEL_NULL(character_preview_view)
 
 /obj/machinery/computer/records/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
@@ -105,7 +107,7 @@
 
 /// Creates a character preview view for the UI.
 /obj/machinery/computer/records/proc/create_character_preview_view(mob/user)
-	var/assigned_view = "preview_[user.ckey]_[REF(src)]_records"
+	var/assigned_view = USER_PREVIEW_ASSIGNED_VIEW(user.ckey)
 	if(user.client?.screen_maps[assigned_view])
 		return
 


### PR DESCRIPTION
## About The Pull Request

1. Record computers never had ``character_preview_view`` set because it was never returned, and it was additionally never deleted. This caused an odd bug that, if you joined a round, ghosted, sent yourself back to lobby, then rejoined, record consoles would no longer have a character preview view. This fixes that, and also adds a define because I didn't like the copypasta it had going on.

Security records currently have a big difference from the previous version in that every person on the UI sees their own thing (it's local instead of shared), which is a bigger problem that affects the whole computer and really should be addressed.

This PR compliments https://github.com/tgstation/tgstation/pull/82105 - This was a bug I found while working on that.

## Why It's Good For The Game

Fixes an odd bug with security records that I've been trying to find out the cause to for a while.

## Changelog

:cl:
fix: Clients joining a round twice as a crewmember (via admins or otherwise) no longer break security/medical record consoles permanently.
/:cl: