### PR TITLE
Deconstruct Wooden/Cardboard Crates Without Welder

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -367,7 +367,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			context[SCREENTIP_CONTEXT_LMB] = opened ? "Close" : "Open"
 		screentip_change = TRUE
 
-	if(istype(held_item) && held_item.tool_behaviour == TOOL_WELDER)
+	if(istype(held_item, cutting_tool))
 		if(opened)
 			context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
 			screentip_change = TRUE

--- a/code/game/objects/structures/crates_lockers/crates/cardboard.dm
+++ b/code/game/objects/structures/crates_lockers/crates/cardboard.dm
@@ -11,6 +11,7 @@
 	open_sound_volume = 25
 	close_sound_volume = 25
 	paint_jobs = null
+	cutting_tool = /obj/item/wirecutters
 
 /obj/structure/closet/crate/cardboard/mothic
 	name = "\improper Mothic Fleet box"

--- a/code/game/objects/structures/crates_lockers/crates/wooden.dm
+++ b/code/game/objects/structures/crates_lockers/crates/wooden.dm
@@ -10,6 +10,7 @@
 	open_sound_volume = 25
 	close_sound_volume = 50
 	paint_jobs = null
+	cutting_tool = /obj/item/crowbar
 
 /obj/structure/closet/crate/wooden/toy
 	name = "toy box"


### PR DESCRIPTION

## About The Pull Request

Wooden crates are now deconstructed with a crowbar. Cardboard crates are now deconstructed with wirecutters. The context tips for deconstruction are determined by the required tool now.
## Why It's Good For The Game

It doesn't make sense to deconstruct those crate types with a welder, they would just burn. The logic for different cutting tool types was already in there, and mentioned in a comment, but the variable was not assigned to the sub types; I also changed the context tip to use that instead of checking the held item for welder behavior.
## Changelog
:cl:
add: Crowbars/wirecutters now deconstruct wooden/cardboard crates/boxes
/:cl:
