### PR TITLE
[NO GBP] Removes energy lens from mimesvsclowns ruin.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/mimesvsclowns.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mimesvsclowns.dmm
@@ -202,9 +202,9 @@
 "GR" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/clown,
-/obj/item/ammo_casing/energy/c3dbullet,
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/a357/spent,
 /turf/open/floor/plating/airless,
 /area/ruin)
 "Ij" = (


### PR DESCRIPTION

## About The Pull Request
This should have been removed in #79811 but I missed one.
## Why It's Good For The Game
Laser lenses shouldn't be obtainable.
## Changelog
:cl:
fix: A broken item was removed from the mimesvsclowns ruin. In its place is a spent revolver round.
/:cl:
