### PR TITLE
Deathmatch Modifiers Tweaks and Additions

### DIFF
--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -107,3 +107,6 @@
 
 /obj/effect/forcefield/cosmic_field/fast
 	initial_duration = 5 SECONDS
+
+/obj/effect/forcefield/cosmic_field/extrafast
+	initial_duration = 2.5 SECONDS

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -110,13 +110,9 @@
 /obj/structure/closet/supplypod/deadmatch_missile
 	name = "cruise missile"
 	desc = "A big ass missile, likely launched from some far-off deep space missile silo."
-	icon_state = "smissile"
-	decal = null
-	door = null
-	fin_mask = null
-	explosionSize = list(0,1,2,2)
+	style = STYLE_RED_MISSILE
+	explosionSize = list(0,0,2,2)
 	effectShrapnel = TRUE
-	rubble_type = RUBBLE_THIN
 	specialised = TRUE
 	delays = list(POD_TRANSIT = 2.6 SECONDS, POD_FALLING = 0.4 SECONDS)
 	effectMissile = TRUE

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -111,7 +111,7 @@
 	name = "cruise missile"
 	desc = "A big ass missile, likely launched from some far-off deep space missile silo."
 	style = STYLE_RED_MISSILE
-	explosionSize = list(0,0,2,2)
+	explosionSize = list(0,1,2,2)
 	effectShrapnel = TRUE
 	specialised = TRUE
 	delays = list(POD_TRANSIT = 2.6 SECONDS, POD_FALLING = 0.4 SECONDS)


### PR DESCRIPTION
## About The Pull Request
After playing more than a few matches, I came to notice a couple lingering issues with deathmatch modifiers, and also I came up with more ideas.

For starters, the echolocation modifier doesn't work, and even if it worked, I believe it'd be ass, so I'm removing it. The perma-flipping also doesn't work quite well and gets interrupted by stuff like knockdowns and the such, plus it's just fluff, so I'm removing it too. Second, I've forgot to set the style of the deadmatch missiles, so they look like normal pods right now.

About what's being added rather than removed: There're now a "No Slowdown" modifier, a "Random Teleports" one that randomly teleports everyone (and whatever they're buckled too) every 12 to 24 seconds, "Snail Crawl" which works much like snailpeople's, "Forcefield Trail" which also works pretty much like the cosmic heretic trail, albeit lasting way shorter, and finally a "Manual Blinking/Breathing", if you truly hate players to a misanthropistic level.

So yeah, 2 removed modifiers, and 5 new ones.

## Why It's Good For The Game
Fixing a couple of issues, and lading the feature with a few more options.

## Changelog

:cl:
del: Removed the (non-working) "Perma-Flipping" and "Echolocation" deathmatch modifiers.
add: Added "No Slowdown", "Random Teleports", "Snail Crawl", "Forcefield Trail" and "Manual Blinking/Breathing" modifiers.
fix: Fixed deathmatch cruise missiles looking like standard pods.
/:cl:
