### PR TITLE
Change define terminology - Click to Press

### DIFF
--- a/code/__DEFINES/_click.dm
+++ b/code/__DEFINES/_click.dm
@@ -11,9 +11,9 @@
 #define BUTTON "button"
 
 //Keys held down during the mouse action
-#define CTRL_CLICK "ctrl"
-#define ALT_CLICK "alt"
-#define SHIFT_CLICK "shift"
+#define CTRL_PRESS "ctrl"
+#define ALT_PRESS "alt"
+#define SHIFT_PRESS "shift"
 
 //Cells involved if using a Grid control
 #define DRAG_CELL "drag-cell"

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -48,16 +48,16 @@
 	if(!can_see(A))
 		return
 
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
-		if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
+		if(LAZYACCESS(modifiers, CTRL_PRESS))
 			CtrlShiftClickOn(A)
 			return
 		ShiftClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK)) // alt and alt-gr (rightalt)
+	if(LAZYACCESS(modifiers, ALT_PRESS)) // alt and alt-gr (rightalt)
 		AltClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_PRESS))
 		CtrlClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -77,28 +77,28 @@
 	if(SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, modifiers) & COMSIG_MOB_CANCEL_CLICKON)
 		return
 
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 			ShiftMiddleClickOn(A)
 			return
-		if(LAZYACCESS(modifiers, CTRL_CLICK))
+		if(LAZYACCESS(modifiers, CTRL_PRESS))
 			CtrlShiftClickOn(A)
 			return
 		ShiftClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
-		if(LAZYACCESS(modifiers, CTRL_CLICK))
+		if(LAZYACCESS(modifiers, CTRL_PRESS))
 			CtrlMiddleClickOn(A)
 		else
 			MiddleClickOn(A, params)
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK)) // alt and alt-gr (rightalt)
+	if(LAZYACCESS(modifiers, ALT_PRESS)) // alt and alt-gr (rightalt)
 		if(LAZYACCESS(modifiers, RIGHT_CLICK))
 			alt_click_on_secondary(A)
 		else
 			AltClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_PRESS))
 		CtrlClickOn(A)
 		return
 
@@ -542,7 +542,7 @@
 
 /mob/dead/observer/MouseWheelOn(atom/A, delta_x, delta_y, params)
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		var/view = 0
 		if(delta_y > 0)
 			view = -1

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -18,8 +18,8 @@
 		return
 
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
-		if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
+		if(LAZYACCESS(modifiers, CTRL_PRESS))
 			CtrlShiftClickOn(A)
 			return
 		if(LAZYACCESS(modifiers, MIDDLE_CLICK))
@@ -30,10 +30,10 @@
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 		MiddleClickOn(A, params)
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK)) // alt and alt-gr (rightalt)
+	if(LAZYACCESS(modifiers, ALT_PRESS)) // alt and alt-gr (rightalt)
 		AltClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_PRESS))
 		CtrlClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, RIGHT_CLICK) && !module_active)

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -50,10 +50,10 @@
 		return FALSE
 
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS))
 		begin_creating_bind(usr)
 		return TRUE
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		var/datum/hud/our_hud = usr.hud_used
 		our_hud.position_action(src, SCRN_OBJ_DEFAULT)
 		return TRUE
@@ -351,7 +351,7 @@ GLOBAL_LIST_INIT(palette_removed_matrix, list(1.4,0,0,0, 0.7,0.4,0,0, 0.4,0,0.6,
 
 	var/list/modifiers = params2list(params)
 
-	if(LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS))
 		for(var/datum/action/action as anything in usr.actions) // Reset action positions to default
 			for(var/datum/hud/hud as anything in action.viewers)
 				var/atom/movable/screen/movable/action_button/button = action.viewers[hud]

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -867,10 +867,10 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(!. || isnull(poll))
 		return
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, ALT_CLICK) && poll.ignoring_category)
+	if(LAZYACCESS(modifiers, ALT_PRESS) && poll.ignoring_category)
 		set_never_round()
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK) && poll.jump_to_me)
+	if(LAZYACCESS(modifiers, CTRL_PRESS) && poll.jump_to_me)
 		jump_to_jump_target()
 		return
 	handle_sign_up()
@@ -1053,7 +1053,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(usr != owner)
 		return FALSE
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
+	if(LAZYACCESS(modifiers, SHIFT_PRESS)) // screen objects don't do the normal Click() stuff so we'll cheat
 		to_chat(usr, span_boldnotice("[name]</span> - <span class='info'>[desc]"))
 		return FALSE
 	var/datum/our_master = master_ref?.resolve()

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -272,7 +272,7 @@
 			to_chat(new_player, span_notice("You have been added to the queue to join the game. Your position in queue is [SSticker.queued_players.len]."))
 		return
 
-	if(!LAZYACCESS(params2list(params), CTRL_CLICK))
+	if(!LAZYACCESS(params2list(params), CTRL_PRESS))
 		GLOB.latejoin_menu.ui_interact(new_player)
 	else
 		to_chat(new_player, span_warning("Opening emergency fallback late join menu! If THIS doesn't show, ahelp immediately!"))

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -147,7 +147,7 @@
 /atom/movable/screen/floor_menu/Click(location,control,params)
 	var/list/modifiers = params2list(params)
 
-	if(LAZYACCESS(modifiers, RIGHT_CLICK) || LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, RIGHT_CLICK) || LAZYACCESS(modifiers, ALT_PRESS))
 		usr.down()
 		return
 

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -16,25 +16,25 @@
 		return
 
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 			ShiftMiddleClickOn(A)
 			return
-		if(LAZYACCESS(modifiers, CTRL_CLICK))
+		if(LAZYACCESS(modifiers, CTRL_PRESS))
 			CtrlShiftClickOn(A)
 			return
 		ShiftClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
-		if(LAZYACCESS(modifiers, CTRL_CLICK))
+		if(LAZYACCESS(modifiers, CTRL_PRESS))
 			CtrlMiddleClickOn(A)
 		else
 			MiddleClickOn(A, params)
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS))
 		AltClickNoInteract(src, A)
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_PRESS))
 		CtrlClickOn(A)
 		return
 

--- a/code/_onclick/overmind.dm
+++ b/code/_onclick/overmind.dm
@@ -6,13 +6,13 @@
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 		MiddleClickOn(A, params)
 		return
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		ShiftClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS))
 		AltClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_PRESS))
 		CtrlClickOn(A)
 		return
 	var/turf/T = get_turf(A)

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -9,11 +9,11 @@
 	var/autofire_stat = AUTOFIRE_STAT_IDLE
 	var/mouse_parameters
 	/// Time between individual shots.
-	var/autofire_shot_delay = 0.3 SECONDS 
+	var/autofire_shot_delay = 0.3 SECONDS
 	/// This seems hacky but there can be two MouseDown() without a MouseUp() in between if the user holds click and uses alt+tab, printscreen or similar.
-	var/mouse_status = AUTOFIRE_MOUSEUP 
+	var/mouse_status = AUTOFIRE_MOUSEUP
 	/// Should dual wielding be allowed?
-	var/allow_akimbo 
+	var/allow_akimbo
 
 	///windup autofire vars
 	///Whether the delay between shots increases over time, simulating a spooling weapon
@@ -121,15 +121,15 @@
 	SIGNAL_HANDLER
 	var/list/modifiers = params2list(params) //If they're shift+clicking, for example, let's not have them accidentally shoot.
 
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_PRESS))
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 		return
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS))
 		return
 	if(source.mob.throw_mode)
 		return

--- a/code/datums/components/ranged_mob_full_auto.dm
+++ b/code/datums/components/ranged_mob_full_auto.dm
@@ -99,15 +99,15 @@
 		return // Avoid a double mousedown with no mouseup
 	var/list/modifiers = params2list(params)
 
-	if (LAZYACCESS(modifiers, SHIFT_CLICK))
+	if (LAZYACCESS(modifiers, SHIFT_PRESS))
 		return
-	if (LAZYACCESS(modifiers, CTRL_CLICK))
+	if (LAZYACCESS(modifiers, CTRL_PRESS))
 		return
 	if (LAZYACCESS(modifiers, MIDDLE_CLICK))
 		return
 	if (LAZYACCESS(modifiers, RIGHT_CLICK))
 		return
-	if (LAZYACCESS(modifiers, ALT_CLICK))
+	if (LAZYACCESS(modifiers, ALT_PRESS))
 		return
 	var/mob/living/living_parent = parent
 	if (!isturf(living_parent.loc) || living_parent.Adjacent(target))

--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -116,7 +116,7 @@
 
 /datum/component/shy/proc/on_clickon(datum/source, atom/target, list/modifiers)
 	SIGNAL_HANDLER
-	if(modifiers[SHIFT_CLICK]) //let them examine their surroundings.
+	if(modifiers[SHIFT_PRESS]) //let them examine their surroundings.
 		return
 	return is_shy(target) && COMSIG_MOB_CANCEL_CLICKON
 

--- a/code/datums/components/shy_in_room.dm
+++ b/code/datums/components/shy_in_room.dm
@@ -53,7 +53,7 @@
 
 /datum/component/shy_in_room/proc/on_clickon(datum/source, atom/target, list/modifiers)
 	SIGNAL_HANDLER
-	if(modifiers[SHIFT_CLICK]) //let them examine their surroundings.
+	if(modifiers[SHIFT_PRESS]) //let them examine their surroundings.
 		return
 	return is_shy(target) && COMSIG_MOB_CANCEL_CLICKON
 

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -71,7 +71,7 @@
 /datum/component/tackler/proc/checkTackle(mob/living/carbon/user, atom/clicked_atom, list/modifiers)
 	SIGNAL_HANDLER
 
-	if(modifiers[ALT_CLICK] || modifiers[SHIFT_CLICK] || modifiers[CTRL_CLICK] || modifiers[MIDDLE_CLICK])
+	if(modifiers[ALT_PRESS] || modifiers[SHIFT_PRESS] || modifiers[CTRL_PRESS] || modifiers[MIDDLE_CLICK])
 		return
 
 	if(!user.throw_mode || user.get_active_held_item() || user.pulling || user.buckled || user.incapacitated())

--- a/code/datums/elements/skill_reward.dm
+++ b/code/datums/elements/skill_reward.dm
@@ -21,7 +21,7 @@
 
 /datum/element/skill_reward/proc/on_attack_hand(datum/source, mob/living/user, list/modifiers)
 	SIGNAL_HANDLER
-	if(!LAZYACCESS(modifiers, CTRL_CLICK) && !check_equippable(user)) //Allows other players to drag it around at least.
+	if(!LAZYACCESS(modifiers, CTRL_PRESS) && !check_equippable(user)) //Allows other players to drag it around at least.
 		to_chat(user, span_warning("You feel completely and utterly unworthy to even touch \the [source]."))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -116,7 +116,7 @@
 	SIGNAL_HANDLER
 
 	/// Basically, we only proceed if we're in throw mode with a tailed carbon in our grasp with at least a neck grab and we're not restrained in some way
-	if(LAZYACCESS(modifiers, ALT_CLICK) || LAZYACCESS(modifiers, SHIFT_CLICK) || LAZYACCESS(modifiers, CTRL_CLICK) || LAZYACCESS(modifiers, MIDDLE_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS) || LAZYACCESS(modifiers, SHIFT_PRESS) || LAZYACCESS(modifiers, CTRL_PRESS) || LAZYACCESS(modifiers, MIDDLE_CLICK))
 		return
 	if(!user.throw_mode || user.get_active_held_item() || user.zone_selected != BODY_ZONE_PRECISE_GROIN)
 		return

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -826,11 +826,11 @@
 				return
 
 		if(href_list["statpanel_item_shiftclick"])
-			paramslist[SHIFT_CLICK] = "1"
+			paramslist[SHIFT_PRESS] = "1"
 		if(href_list["statpanel_item_ctrlclick"])
-			paramslist[CTRL_CLICK] = "1"
+			paramslist[CTRL_PRESS] = "1"
 		if(href_list["statpanel_item_altclick"])
-			paramslist[ALT_CLICK] = "1"
+			paramslist[ALT_PRESS] = "1"
 
 		var/mouseparams = list2params(paramslist)
 		usr_client.Click(src, loc, null, mouseparams)

--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -30,9 +30,9 @@
 	var/list/modifiers = params2list(params)
 	var/left_click = LAZYACCESS(modifiers, LEFT_CLICK)
 	var/right_click = LAZYACCESS(modifiers, RIGHT_CLICK)
-	var/alt_click = LAZYACCESS(modifiers, ALT_CLICK)
+	var/alt_press = LAZYACCESS(modifiers, ALT_PRESS)
 
-	if(left_click && alt_click)
+	if(left_click && alt_press)
 		if (istype(object, /turf) || isobj(object) || istype(object, /mob))
 			objholder = object.type
 			to_chat(c, span_notice("[initial(object.name)] ([object.type]) selected."))

--- a/code/modules/buildmode/submodes/area_edit.dm
+++ b/code/modules/buildmode/submodes/area_edit.dm
@@ -51,7 +51,7 @@
 		if(!storedarea)
 			to_chat(c, span_warning("Configure or select the area you want to paint first!"))
 			return
-		if(LAZYACCESS(modifiers, ALT_CLICK))
+		if(LAZYACCESS(modifiers, ALT_PRESS))
 			var/turf/T = get_turf(object)
 			if(get_area(T) != storedarea)
 				log_admin("Build Mode: [key_name(c)] added [AREACOORD(T)] to [storedarea]")

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -16,10 +16,10 @@
 
 	var/left_click = LAZYACCESS(modifiers, LEFT_CLICK)
 	var/right_click = LAZYACCESS(modifiers, RIGHT_CLICK)
-	var/alt_click = LAZYACCESS(modifiers, ALT_CLICK)
-	var/ctrl_click = LAZYACCESS(modifiers, CTRL_CLICK)
+	var/alt_press = LAZYACCESS(modifiers, ALT_PRESS)
+	var/ctrl_press = LAZYACCESS(modifiers, CTRL_PRESS)
 
-	if(istype(object,/turf) && left_click && !alt_click && !ctrl_click)
+	if(istype(object,/turf) && left_click && !alt_press && !ctrl_press)
 		var/turf/clicked_turf = object
 		if(isplatingturf(object))
 			clicked_turf.place_on_top(/turf/open/floor/iron, flags = CHANGETURF_INHERIT_AIR)
@@ -39,10 +39,10 @@
 		else if(isobj(object))
 			qdel(object)
 		return
-	else if(istype(object,/turf) && alt_click && left_click)
+	else if(istype(object,/turf) && alt_press && left_click)
 		log_admin("Build Mode: [key_name(c)] built an airlock at [AREACOORD(object)]")
 		new/obj/machinery/door/airlock(get_turf(object))
-	else if(istype(object,/turf) && ctrl_click && left_click)
+	else if(istype(object,/turf) && ctrl_press && left_click)
 		var/obj/structure/window/reinforced/window
 		if(BM.build_dir in GLOB.diagonals)
 			window = new /obj/structure/window/reinforced/fulltile(get_turf(object))

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -39,7 +39,7 @@
 	var/list/modifiers = params2list(params)
 
 	if(LAZYACCESS(modifiers, LEFT_CLICK)) //rectangular
-		if(LAZYACCESS(modifiers, ALT_CLICK))
+		if(LAZYACCESS(modifiers, ALT_PRESS))
 			var/list/deletion_area = block(get_turf(cornerA),get_turf(cornerB))
 			for(var/beep in deletion_area)
 				var/turf/T = beep

--- a/code/modules/client/preferences/mod_select.dm
+++ b/code/modules/client/preferences/mod_select.dm
@@ -5,7 +5,7 @@
 	savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/choiced/mod_select/init_possible_values()
-	return list(MIDDLE_CLICK, ALT_CLICK)
+	return list(MIDDLE_CLICK, ALT_PRESS)
 
 /datum/preference/choiced/mod_select/create_default_value()
 	return MIDDLE_CLICK

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -266,7 +266,7 @@
 /datum/fishing_challenge/proc/handle_click(mob/source, atom/target, modifiers)
 	SIGNAL_HANDLER
 	//You need to be holding the rod to use it.
-	if(!source.get_active_held_item(used_rod) || LAZYACCESS(modifiers, SHIFT_CLICK) || LAZYACCESS(modifiers, CTRL_CLICK) || LAZYACCESS(modifiers, ALT_CLICK))
+	if(!source.get_active_held_item(used_rod) || LAZYACCESS(modifiers, SHIFT_PRESS) || LAZYACCESS(modifiers, CTRL_PRESS) || LAZYACCESS(modifiers, ALT_PRESS))
 		return
 	if(phase == WAIT_PHASE) //Reset wait
 		send_alert("miss!")

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -200,10 +200,10 @@
 
 /mob/living/basic/revenant/ClickOn(atom/A, params) //revenants can't interact with the world directly, so we gotta do some wacky override stuff
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(LAZYACCESS(modifiers, SHIFT_PRESS))
 		ShiftClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, ALT_CLICK))
+	if(LAZYACCESS(modifiers, ALT_PRESS))
 		AltClickNoInteract(src, A)
 		return
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -298,7 +298,7 @@
 	switch(value)
 		if(MIDDLE_CLICK)
 			mod.selected_module.used_signal = COMSIG_MOB_MIDDLECLICKON
-		if(ALT_CLICK)
+		if(ALT_PRESS)
 			mod.selected_module.used_signal = COMSIG_MOB_ALTCLICKON
 	RegisterSignal(mod.wearer, mod.selected_module.used_signal, TYPE_PROC_REF(/obj/item/mod/module, on_special_click))
 

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -43,7 +43,7 @@
 /datum/brain_trauma/special/honorbound/proc/attack_honor(mob/living/carbon/human/honorbound, atom/clickingon, list/modifiers)
 	SIGNAL_HANDLER
 
-	if(modifiers[ALT_CLICK] || modifiers[SHIFT_CLICK] || modifiers[CTRL_CLICK] || modifiers[MIDDLE_CLICK])
+	if(modifiers[ALT_PRESS] || modifiers[SHIFT_PRESS] || modifiers[CTRL_PRESS] || modifiers[MIDDLE_CLICK])
 		return
 	if(!isliving(clickingon))
 		return

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -296,7 +296,7 @@
 	if(cannonmode != CLOWN_CANNON_READY || !length(return_controllers_with_flag(VEHICLE_CONTROL_KIDNAPPED)))
 		return
 	//The driver can still examine things and interact with his inventory.
-	if(modifiers[SHIFT_CLICK] || (ismovable(target) && !isturf(target.loc)))
+	if(modifiers[SHIFT_PRESS] || (ismovable(target) && !isturf(target.loc)))
 		return
 	var/mob/living/unlucky_sod = pick(return_controllers_with_flag(VEHICLE_CONTROL_KIDNAPPED))
 	mob_exit(unlucky_sod, silent = TRUE)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -636,7 +636,7 @@
 		return
 	if(isAI(user)) //For AIs: If safeties are off, use mech functions. If safeties are on, use AI functions.
 		. = COMSIG_MOB_CANCEL_CLICKON
-	if(modifiers[SHIFT_CLICK]) //Allows things to be examined.
+	if(modifiers[SHIFT_PRESS]) //Allows things to be examined.
 		return
 	if(!isturf(target) && !isturf(target.loc)) // Prevents inventory from being drilled
 		return

--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -155,7 +155,7 @@
 		clicked_atom.set_output(target)
 		secondary_attack.set_output(COMPONENT_SIGNAL)
 		. = COMSIG_MOB_CANCEL_CLICKON
-	else if(modifiers[LEFT_CLICK] && !modifiers[SHIFT_CLICK] && !modifiers[ALT_CLICK] && !modifiers[CTRL_CLICK])
+	else if(modifiers[LEFT_CLICK] && !modifiers[SHIFT_PRESS] && !modifiers[ALT_PRESS] && !modifiers[CTRL_PRESS])
 		clicked_atom.set_output(target)
 		attack.set_output(COMPONENT_SIGNAL)
 		. = COMSIG_MOB_CANCEL_CLICKON


### PR DESCRIPTION

## About The Pull Request
Changes inaccurate term definition.
Minor nitpick, but this PR changes `_CLICK` into `_PRESS`
Because you don't **click** `alt`, `ctrl`, `shift`.
sometimes it's weird to see when you see such things:
```dm
if(LAZYACCESS(modifiers, SHIFT_CLICK))
  does_thing()
```
This will be possibly interpreted as all kinds of clicks with shift action.
Even if we know how that exactly works, ambiguousness isn't good.

```dm
if(LAZYACCESS(modifiers, SHIFT_PRESS))
  does_thing()
```
Now, you read this is exactly `press`.


This PR didn't change some signals, or procs like `ctrl_click` because those are called after `some click + ctrl (key action)`. Those make sense to be called as already, but the defines I touched aren't.
## Why It's Good For The Game
better code readibility
## Changelog
:cl:
code: macro defines (CTRL_CLICK, ALT_CLICK, SHIFT_CLICK) are changed to "_PRESS" instead of "_CLICK".
/:cl:
