### PR TITLE
Fixes patronising paintings when there's no curators.

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -276,14 +276,15 @@
 	var/datum/bank_account/service_account = SSeconomy.get_dep_account(ACCOUNT_SRV)
 	service_account.adjust_money(offer_amount * SERVICE_PERCENTILE_CUT)
 	///We give the curator(s) a cut (unless they're themselves the patron), as it's their job to curate and promote art among other things.
-	var/list/curator_accounts = SSeconomy.bank_accounts_by_job[/datum/job/curator] - account
-	var/curators_length = length(curator_accounts)
-	if(curators_length)
-		var/curator_cut = round(offer_amount * CURATOR_PERCENTILE_CUT / curators_length)
-		if(curator_cut)
-			for(var/datum/bank_account/curator as anything in curator_accounts)
-				curator.adjust_money(curator_cut, "Painting: Patronage cut")
-				curator.bank_card_talk("Cut on patronage received, account now holds [curator.account_balance] cr.")
+	if(SSeconomy.bank_accounts_by_job[/datum/job/curator])
+		var/list/curator_accounts = SSeconomy.bank_accounts_by_job[/datum/job/curator] - account
+		var/curators_length = length(curator_accounts)
+		if(curators_length)
+			var/curator_cut = round(offer_amount * CURATOR_PERCENTILE_CUT / curators_length)
+			if(curator_cut)
+				for(var/datum/bank_account/curator as anything in curator_accounts)
+					curator.adjust_money(curator_cut, "Painting: Patronage cut")
+					curator.bank_card_talk("Cut on patronage received, account now holds [curator.account_balance] cr.")
 
 	painting_metadata.patron_ckey = user.ckey
 	painting_metadata.patron_name = user.real_name


### PR DESCRIPTION
Fixes #82091

:cl:
fix: Painting patronage works again when there's no curator present during the round.
/:cl: