### PR TITLE
Enforces checks on dual wielding items

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -122,7 +122,7 @@
 
 // register signals withthe parent item
 /datum/component/two_handed/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
+	RegisterSignal(parent, COMSIG_ITEM_POST_EQUIPPED, PROC_REF(on_equip))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_attack_self))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(on_attack))
@@ -135,7 +135,7 @@
 // Remove all siginals registered to the parent item
 /datum/component/two_handed/UnregisterFromParent()
 	UnregisterSignal(parent, list(
-		COMSIG_ITEM_EQUIPPED,
+		COMSIG_ITEM_POST_EQUIPPED,
 		COMSIG_ITEM_DROPPED,
 		COMSIG_ITEM_ATTACK_SELF,
 		COMSIG_ITEM_ATTACK,
@@ -191,6 +191,7 @@
 /datum/component/two_handed/proc/wield(mob/living/carbon/user)
 	if(wielded)
 		return
+
 	var/atom/atom_parent = parent
 	if(HAS_TRAIT(user, TRAIT_NO_TWOHANDING))
 		if(require_twohands)
@@ -198,23 +199,24 @@
 			user.dropItemToGround(parent, force = TRUE)
 		else
 			atom_parent.balloon_alert(user, "too weak to wield with both hands!")
-		return
+		return COMPONENT_EQUIPPED_FAILED
 	if(user.get_inactive_held_item())
 		if(require_twohands)
 			atom_parent.balloon_alert(user, "can't carry in one hand!")
 			user.dropItemToGround(parent, force = TRUE)
 		else
 			atom_parent.balloon_alert(user, "holding something in other hand!")
-		return
+		return COMPONENT_EQUIPPED_FAILED
 	if(user.usable_hands < 2)
 		if(require_twohands)
-			user.dropItemToGround(parent, force=TRUE)
+			user.dropItemToGround(parent, force = TRUE)
 		atom_parent.balloon_alert(user, "not enough hands!")
-		return
+		return COMPONENT_EQUIPPED_FAILED
 
 	// wield update status
 	if(SEND_SIGNAL(parent, COMSIG_TWOHANDED_WIELD, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)
-		return // blocked wield from item
+		user.dropItemToGround(parent, force = TRUE)
+		return COMPONENT_EQUIPPED_FAILED // blocked wield from item
 	wielded = TRUE
 	ADD_TRAIT(parent, TRAIT_WIELDED, REF(src))
 	RegisterSignal(user, COMSIG_MOB_SWAPPING_HANDS, PROC_REF(on_swapping_hands))


### PR DESCRIPTION
## About The Pull Request
- Fixes #82043

The issue goes deeper than just the chainsaw. The problem is we are dropping our item too early if the dual handed checks fail. This doesn't fully stop the equipping process and still causes the action buttons to be added as if the equipping process succeeded

The solution is too unequip/drop the item and reverse all steps related to the equipping process after it has fully completed inside `COMSIG_ITEM_POST_EQUIPPED` to properly reverse the effects of equipping and also cancel further actions by returning `COMPONENT_EQUIPPED_FAILED`

## Changelog
:cl:
fix: failing to equip a dual handed item should properly clear out all status effects related to equipping it, for e.g. remove the action button from chainsaw
/:cl:
