### PR TITLE
Storage items won't hold abstract/hologram items

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -347,6 +347,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(QDELETED(to_insert) || !istype(to_insert))
 		return FALSE
 
+	//stops you from putting stuff like off-hand thingy inside. Hologram storages can accept only hologram items
+	if((to_insert.item_flags & ABSTRACT) || ((parent.flags_1 & HOLOGRAM_1) && !(to_insert.flags_1 & HOLOGRAM_1)))
+		return FALSE
+
 	if(locked > force)
 		if(messages && user)
 			user.balloon_alert(user, "closed!")
@@ -774,10 +778,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /// Signal handler for whenever we're attacked by an object.
 /datum/storage/proc/on_attackby(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
-
-	//stops you from putting stuff like off-hand thingy inside
-	if((thing.item_flags & ABSTRACT) || (thing.flags_1 & HOLOGRAM_1))
-		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!thing.attackby_storage_insert(src, parent, user))
 		return

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -348,7 +348,12 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	//stops you from putting stuff like off-hand thingy inside. Hologram storages can accept only hologram items
-	if((to_insert.item_flags & ABSTRACT) || ((parent.flags_1 & HOLOGRAM_1) && !(to_insert.flags_1 & HOLOGRAM_1)))
+	if(to_insert.item_flags & ABSTRACT)
+		return FALSE
+	if(parent.flags_1 & HOLOGRAM_1)
+		if(!(to_insert.flags_1 & HOLOGRAM_1))
+			return FALSE
+	else if(to_insert.flags_1 & HOLOGRAM_1)
 		return FALSE
 
 	if(locked > force)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -775,6 +775,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_attackby(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
+	//stops you from putting stuff like off-hand thingy inside
+	if((thing.item_flags & ABSTRACT) || (thing.flags_1 & HOLOGRAM_1))
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
 	if(!thing.attackby_storage_insert(src, parent, user))
 		return
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #82019

Yeah you can't put stuff that don't exist inside storage items that actually exist.

## Changelog
:cl:
fix: abstract(like the dual hand thingy on your hand) & hologram things can't be put inside storage items
/:cl:
