### PR TITLE
Give Error Messages On Subsystem Initialization Failure CI

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -104,6 +104,9 @@
 	/// Previous subsystem in the queue of subsystems to run this tick
 	var/datum/controller/subsystem/queue_prev
 
+	/// String to store an applicable error message for a subsystem crashing, used to help debug crashes in contexts such as Continuous Integration/Unit Tests
+	var/initialization_failure_message = null
+
 	//Do not blindly add vars here to the bottom, put it where it goes above
 	//If your var only has two values, put it in as a flag.
 

--- a/code/controllers/subsystem/lua.dm
+++ b/code/controllers/subsystem/lua.dm
@@ -38,7 +38,9 @@ SUBSYSTEM_DEF(lua)
 		return SS_INIT_SUCCESS
 	catch(var/exception/e)
 		// Something went wrong, best not allow the subsystem to run
-		warning("Error initializing SSlua: [e.name]")
+		var/crash_message = "Error initializing SSlua: [e.name]"
+		initialization_failure_message = crash_message
+		warning(crash_message)
 		return SS_INIT_FAILURE
 
 /datum/controller/subsystem/lua/OnConfigLoad()

--- a/code/modules/unit_tests/subsystem_init.dm
+++ b/code/modules/unit_tests/subsystem_init.dm
@@ -5,10 +5,19 @@
 	for(var/datum/controller/subsystem/subsystem as anything in Master.subsystems)
 		if(subsystem.flags & SS_NO_INIT)
 			continue
-		if(!subsystem.initialized)
-			var/message = "[subsystem] ([subsystem.type]) is a subsystem meant to initialize but doesn't get set as initialized."
+		if(subsystem.initialized)
+			continue
 
-			if (subsystem.flags & SS_OK_TO_FAIL_INIT)
-				TEST_NOTICE(src, "[message]\nThis subsystem is marked as SS_OK_TO_FAIL_INIT. This is still a bug, but it is non-blocking.")
-			else
-				TEST_FAIL(message)
+		var/should_fail = !(subsystem.flags & SS_OK_TO_FAIL_INIT)
+		var/list/message_strings = list("[subsystem] ([subsystem.type]) is a subsystem meant to initialize but could not get initialized.")
+
+		if(!isnull(subsystem.initialization_failure_message))
+			message_strings += "The subsystem reported the following: [subsystem.initialization_failure_message]"
+
+		if(should_fail)
+			TEST_FAIL(jointext(message_strings, "\n"))
+			continue
+
+		message_strings += "This subsystem is marked as SS_OK_TO_FAIL_INIT. This is still a bug, but it is non-blocking."
+		TEST_NOTICE(src, jointext(message_strings, "\n"))
+


### PR DESCRIPTION
## About The Pull Request

Noticed during #82138

Basically, the unit test that makes sure that all of the subsystems that had to initialize properly initialized is good with the Notice annotation, but it had a flaw - it didn't tell you _why_ the subsystem failed to initialize:

![image](https://github.com/tgstation/tgstation/assets/34697715/3cd719d2-2f1f-42a9-8c36-d5c37b8a330c)

Basically this PR just adds a variable, `initialization_failure_message` (i have it on good authority that variables that don't get changed from their compile time variable don't take up extra memory), and we just append the failure message to this notice should it occur so all of the information is available in one spot, rather than have the coder dig through the CI Run Log to figure out what the specific error was should it occur on something that isn't SSlua.

also small cute code cleanup :3