### PR TITLE
Fixes music importing newlining

### DIFF
--- a/code/modules/instruments/songs/editor.dm
+++ b/code/modules/instruments/songs/editor.dm
@@ -94,9 +94,10 @@
 		if("import_song")
 			var/song_text = ""
 			do
-				song_text = tgui_input_text(user, "Please paste the entire song, formatted:", name, max_length = (MUSIC_MAXLINES * MUSIC_MAXLINECHARS))
+				song_text = tgui_input_text(user, "Please paste the entire song, formatted:", name, max_length = (MUSIC_MAXLINES * MUSIC_MAXLINECHARS), multiline = TRUE)
 				if(!in_range(parent, user))
 					return
+
 				if(length_char(song_text) >= MUSIC_MAXLINES * MUSIC_MAXLINECHARS)
 					var/should_continue = tgui_alert(user, "Your message is too long! Would you like to continue editing it?", "Warning", list("Yes", "No"))
 					if(should_continue != "Yes")


### PR DESCRIPTION
## About The Pull Request

Makes the instrument song importing tgui input text use multiline which means BPM is now on its own line instead of taking the first line of the song with it, getting it cut from the import.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/82148

## Changelog

:cl:
fix: Importing songs into instruments no longer cuts the first line of the song.
/:cl: