### PR TITLE
Fix curators not getting a cut from patronized paintings

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -276,8 +276,9 @@
 	var/datum/bank_account/service_account = SSeconomy.get_dep_account(ACCOUNT_SRV)
 	service_account.adjust_money(offer_amount * SERVICE_PERCENTILE_CUT)
 	///We give the curator(s) a cut (unless they're themselves the patron), as it's their job to curate and promote art among other things.
-	if(SSeconomy.bank_accounts_by_job[/datum/job/curator])
-		var/list/curator_accounts = SSeconomy.bank_accounts_by_job[/datum/job/curator] - account
+	var/datum/job/curator_singleton = SSjob.GetJobType(/datum/job/curator)
+	if(SSeconomy.bank_accounts_by_job[curator_singleton])
+		var/list/curator_accounts = SSeconomy.bank_accounts_by_job[curator_singleton] - account
 		var/curators_length = length(curator_accounts)
 		if(curators_length)
 			var/curator_cut = round(offer_amount * CURATOR_PERCENTILE_CUT / curators_length)


### PR DESCRIPTION

## About The Pull Request

So I was looking into #82091 previously, but then #82124 got to it while I was still debugging.
Now I noticed what they did was different from what I was doing, so I made a review, but checking in on it today I noticed it was merged without it being addressed. Looking into, it's because my review didn't actually go through even though it looked like it. Thanks github.

Well, lesson learnt! Anyhow. Here's the why for this pr:

While testing this on my end to make a fix, even _with_ a curator present `SSeconomy.bank_accounts_by_job[/datum/job/curator]` would return null. Looking through the code it seems like it's indexed by the job _singletons_, while the painting code tries to index it by job _type_.

So we test this assumption!
```dm
var/datum/job/curator_singleton = SSjob.GetJobType(/datum/job/curator)
message_admins("patron bank_accounts_by_job index test - curator_singleton: [SSeconomy.bank_accounts_by_job[curator_singleton]] - job_type: [SSeconomy.bank_accounts_by_job[/datum/job/curator]]")
```
Running this with a curator present we get:
![image](https://github.com/tgstation/tgstation/assets/42909981/12aa80ee-242c-437a-9e56-1f1bac6ac2b9)
Where indexing by the curator singleton gets us the accounts list, but using the curator job type doesn't.

So I believe using the curator singleton instead should properly fix this:
```dm
var/datum/job/curator_singleton = SSjob.GetJobType(/datum/job/curator)
if(SSeconomy.bank_accounts_by_job[curator_singleton])
	var/list/curator_accounts = SSeconomy.bank_accounts_by_job[curator_singleton] - account
```
## Why It's Good For The Game

Fixes patronizing paintings not giving curators a cut.
## Changelog
:cl:
fix: Fixed patronizing paintings not giving a cut to the curators.
/:cl:
