### PR TITLE
Space dragons are no longer acceptable dna for the omnitrixbelt

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -17,6 +17,7 @@
 	icon_dead = "spacedragon_dead"
 	health_doll_icon = "spacedragon"
 	faction = list(FACTION_CARP)
+	mob_biotypes = MOB_SPECIAL
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	gender = NEUTER
 	maxHealth = 400


### PR DESCRIPTION
## About The Pull Request

We've had people able to transform into space dragons with no limitations for quite a while now. Whenever dragons are killed multiple people will rush the polymorph belt and become space dragons. this version of the space dragon faces none of the limitations of the regular antagonist, such as not needing to place portals. 

## Why It's Good For The Game

Crewmembers should not be able to become space dragons en masse after doing a single anom core test. This isn't healthy and leads to headaches for admins and players who aren't a part of the dragon spam.

## Changelog

:cl:
balance: The polymorph belt will no longer register space dragons as acceptable DNA.
/:cl:
