### PR TITLE
Fixes lua error logging and a few timer.lua functions

### DIFF
--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -97,9 +97,11 @@ GLOBAL_PROTECT(lua_usr)
 
 /datum/lua_state/process(seconds_per_tick)
 	if(timer_enabled)
-		call_function_return_first("__Timer_timer_process", seconds_per_tick)
+		var/result = call_function("__Timer_timer_process", seconds_per_tick)
+		log_result(result, verbose = FALSE)
 		for(var/function as anything in functions_to_execute)
-			call_function_return_first(list("__Timer_callbacks", function))
+			result = call_function(list("__Timer_callbacks", function))
+			log_result(result, verbose = FALSE)
 		functions_to_execute.Cut()
 
 /datum/lua_state/proc/call_function(function, ...)

--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -97,9 +97,9 @@ GLOBAL_PROTECT(lua_usr)
 
 /datum/lua_state/process(seconds_per_tick)
 	if(timer_enabled)
-		call_function("__Timer_timer_process", seconds_per_tick)
+		call_function_return_first("__Timer_timer_process", seconds_per_tick)
 		for(var/function as anything in functions_to_execute)
-			call_function(list("__Timer_callbacks", function))
+			call_function_return_first(list("__Timer_callbacks", function))
 		functions_to_execute.Cut()
 
 /datum/lua_state/proc/call_function(function, ...)

--- a/lua/timer.lua
+++ b/lua/timer.lua
@@ -77,7 +77,7 @@ function Timer.start_loop(time, amount, func)
 	if amount == 1 then
 		return __add_internal_timer(func, time * 10, false)
 	end
-	local callback = SS13.new("/datum/callback", SS13.state, "call_function")
+	local callback = SS13.new("/datum/callback", SS13.state, "call_function_return_first")
 	local timedevent = dm.global_proc("_addtimer", callback, time * 10, 40, nil, debug.info(1, "sl"))
 	local doneAmount = 0
 	local newFunc = function()

--- a/lua/timer.lua
+++ b/lua/timer.lua
@@ -24,11 +24,13 @@ end
 
 function __stop_internal_timer(func)
 	local timer = __Timer_timers[func]
-	if timer and not timer.executing then
-		__Timer_timers[func] = nil
-		__Timer_callbacks[func] = nil
-	else
-		timer.terminate = true
+	if timer then
+		if not timer.executing then
+			__Timer_timers[func] = nil
+			__Timer_callbacks[func] = nil
+		else
+			timer.terminate = true
+		end
 	end
 end
 

--- a/lua/timer.lua
+++ b/lua/timer.lua
@@ -89,7 +89,7 @@ function Timer.start_loop(time, amount, func)
 		end
 	end
 	funcId = __add_internal_timer(newFunc, time * 10, true)
-	return newFunc
+	return funcId
 end
 
 function Timer.end_loop(id)

--- a/lua/timer.lua
+++ b/lua/timer.lua
@@ -78,12 +78,13 @@ function Timer.start_loop(time, amount, func)
 	if amount == 1 then
 		return __add_internal_timer(func, time * 10, false)
 	end
+	-- Lua counts from 1 so let's keep consistent with that
 	local doneAmount = 1
 	local funcId
 	local newFunc = function()
 		func(doneAmount)
 		doneAmount += 1
-		if doneAmount >= amount then
+		if doneAmount > amount then
 			Timer.end_loop(funcId)
 		end
 	end

--- a/lua/timer.lua
+++ b/lua/timer.lua
@@ -36,7 +36,7 @@ __Timer_timer_processing = __Timer_timer_processing or false
 SS13.state:set_var("timer_enabled", 1)
 __Timer_timer_process = function(seconds_per_tick)
 	if __Timer_timer_processing then
-		return
+		return 0
 	end
 	__Timer_timer_processing = true
 	local time = dm.world:get_var("time")
@@ -53,6 +53,7 @@ __Timer_timer_process = function(seconds_per_tick)
 		end
 	end
 	__Timer_timer_processing = false
+	return 1
 end
 
 function Timer.wait(time)
@@ -77,17 +78,16 @@ function Timer.start_loop(time, amount, func)
 	if amount == 1 then
 		return __add_internal_timer(func, time * 10, false)
 	end
-	local callback = SS13.new("/datum/callback", SS13.state, "call_function_return_first")
-	local timedevent = dm.global_proc("_addtimer", callback, time * 10, 40, nil, debug.info(1, "sl"))
-	local doneAmount = 0
+	local doneAmount = 1
+	local funcId
 	local newFunc = function()
-		func()
+		func(doneAmount)
 		doneAmount += 1
 		if doneAmount >= amount then
-			Timer.end_loop(timedevent)
+			Timer.end_loop(funcId)
 		end
 	end
-	__add_internal_timer(newFunc, time * 10, true)
+	funcId = __add_internal_timer(newFunc, time * 10, true)
 	return newFunc
 end
 

--- a/tgui/packages/tgui/interfaces/DnaConsole/MutationInfo.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/MutationInfo.jsx
@@ -15,6 +15,7 @@ import {
   CHROMOSOME_NONE,
   CHROMOSOME_USED,
   MUT_COLORS,
+  MUT_EXTRA,
 } from './constants';
 
 /**

--- a/tgui/packages/tgui/interfaces/DnaConsole/MutationInfo.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/MutationInfo.jsx
@@ -15,7 +15,6 @@ import {
   CHROMOSOME_NONE,
   CHROMOSOME_USED,
   MUT_COLORS,
-  MUT_EXTRA,
 } from './constants';
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Lua errors don't get logged when `call_function` is called

Timer.start_loop was just straight up broken due to me not properly testing it, so this fixes that.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Makes debugging lua scripts easier. Also fixes bugs.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed lua error logging.
fix: Fixed the SS13.start_loop function not working properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
