### PR TITLE
Adds some generic species lore, descriptions, etc. to a few species

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -2032,6 +2032,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/create_pref_liver_perks()
 	RETURN_TYPE(/list)
 
+	if(isnull(mutantliver) || (TRAIT_LIVERLESS_METABOLISM in inherent_traits))
+		return null
+
 	var/list/to_add = list()
 
 	var/alcohol_tolerance = initial(mutantliver.alcohol_tolerance)
@@ -2071,6 +2074,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 /datum/species/proc/create_pref_lung_perks()
 	RETURN_TYPE(/list)
+
+	if(isnull(mutantlungs) || (TRAIT_NOBREATH in inherent_traits))
+		return null
 
 	var/list/to_add = list()
 

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -10,7 +10,6 @@
 		TRAIT_NODISMEMBER,
 		TRAIT_NOHUNGER,
 		TRAIT_NO_UNDERWEAR,
-		TRAIT_REMOTE_TASTING,
 		TRAIT_VIRUSIMMUNE,
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/abductor
@@ -29,7 +28,6 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/abductor,
 	)
 
-
 /datum/species/abductor/get_physical_attributes()
 	return "Abductors do not need to breathe, eat, do not have blood, a heart, stomach, or lungs and cannot be infected by human viruses. \
 		Their hardy physique prevents their skin from being wounded or dismembered, but their chunky tridactyl hands make it hard to operate human equipment."
@@ -43,3 +41,62 @@
 	. = ..()
 	var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
 	abductor_hud.hide_from(C)
+
+/datum/species/abductor/get_species_description()
+	return "Abductors, colloquially known as \"Greys\" (or \"Grays\"), \
+		are, three fingered, pale skinned inquisitive aliens who can't communicate well to the average crew-member."
+
+/datum/species/abductor/get_species_lore()
+	return list(
+		"Little are known about Abductors. \
+		While they (as a species) have been known to abduct other species of 'lesser intellect' for experimentation, \
+		some have been known to - on rare occasions - work with the very species they abduct, for reasons unknown.",
+	)
+
+/datum/species/abductor/create_pref_traits_perks()
+	var/list/perks = list()
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_WIND,
+		SPECIES_PERK_NAME = "Lungs Optional",
+		SPECIES_PERK_DESC = "Abductors don't need to breathe, though exposure to a vacuum is still a hazard.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_SHIELD,
+		SPECIES_PERK_NAME = "Resilient Skin",
+		SPECIES_PERK_DESC = "The grey (or gray) skin of an Abductor is tough and resistant. \
+			They cannot be wounded or dismembered by conventional means.",
+	))
+	return perks
+
+/datum/species/abductor/create_pref_unique_perks()
+	var/list/perks = list()
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_SYRINGE,
+		SPECIES_PERK_NAME = "Disease Immunity",
+		SPECIES_PERK_DESC = "Abductors are immune to all viral infections found naturally on the station.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK, // It may be a stretch to call nohunger a neutral perk but the Abductor's tongue describes it as much, so.
+		SPECIES_PERK_ICON = FA_ICON_UTENSILS,
+		SPECIES_PERK_NAME = "Hungry for Knowledge",
+		SPECIES_PERK_DESC = "Abductors have a greater hunger for knowledge than food, and as such don't need to eat. \
+			Which is fortunate, as their speech matrix prevents them from consuming food.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+		SPECIES_PERK_ICON = FA_ICON_VOLUME_XMARK,
+		SPECIES_PERK_NAME = "Superlingual Matrix",
+		SPECIES_PERK_DESC = "Abductors cannot physically speak with their natural tongue. \
+			They intead naturally communicate telepathically to other Abductors, a process which all other species cannot hear. \
+			Great for secret conversations, not so great for ordering something from the bar.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_HANDSHAKE_SLASH,
+		SPECIES_PERK_NAME = "Tridactyl Hands",
+		SPECIES_PERK_DESC = "Abductor hands are not designed for human equipment. Utilizing the station's equipment is difficult for them.",
+	))
+	return perks

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -51,3 +51,52 @@
 	return "Androids are almost, but not quite, identical to fully augmented humans. \
 	Unlike those, though, they're completely immune to toxin damage, don't have blood or organs (besides their head), don't get hungry, and can reattach their limbs! \
 	That said, an EMP will devastate them and they cannot process any chemicals."
+
+/datum/species/android/get_species_description()
+	return "Androids are an entirely synthetic species."
+
+/datum/species/android/get_species_lore()
+	return list(
+		"Androids are a synthetic species created by Nanotrasen as an intermediary between humans and cyborgs."
+	)
+
+/datum/species/android/create_pref_traits_perks()
+	var/list/perks = list()
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_SHIELD_ALT,
+		SPECIES_PERK_NAME = "Android Aptitude",
+		SPECIES_PERK_DESC = "As a synthetic lifeform, Androids are immune to many forms of damage humans are susceptible to. \
+			Fire, cold, heat, pressure, radiation, and toxins are all ineffective against them. \
+			They also can't overdose on drugs, don't need to breathe or eat, can't catch on fire, and are immune to being pierced.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_COGS,
+		SPECIES_PERK_NAME = "Modular Lifeform",
+		SPECIES_PERK_DESC = "Android limbs are modular, allowing them to easily reattach severed bodyparts.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_DNA,
+		SPECIES_PERK_NAME = "Not Human After All",
+		SPECIES_PERK_DESC = "There is no humanity behind the eyes of the Android, and as such, they have no DNA to genetically alter.",
+	))
+	return perks
+
+/datum/species/android/create_pref_unique_perks()
+	var/list/perks = list()
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+		SPECIES_PERK_ICON = FA_ICON_SHIELD_HEART,
+		SPECIES_PERK_NAME = "Some Components Optional",
+		SPECIES_PERK_DESC = "Androids have very few internal organs. While they can survive without many of them, \
+			they don't have any benefits from them either.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_ROBOT,
+		SPECIES_PERK_NAME = "Synthetic",
+		SPECIES_PERK_DESC = "Being synthetic, Androids are vulnernable to EMPs.",
+	))
+	return perks

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -64,6 +64,16 @@
 	return "Golems are hardy creatures made out of stone, which are thus naturally resistant to many dangers, including asphyxiation, fire, radiation, electricity, and viruses.\
 		They gain special abilities depending on the type of material consumed, but they need to consume material to keep their body animated."
 
+/datum/species/golem/get_species_description()
+	return "Golems are lithoid creatures who eat rocks and minerals to survive and adapt."
+
+/datum/species/golem/get_species_lore()
+	return list(
+		"While Golems have long been commonly found on frontier worlds, peacefully mining and otherwise living in harmony with the environment, \
+		it is belived they were originally constructed in Nanotrasen laboratories as a form of cheap labor. Whatever happened up to this point is unknown, \
+		but they have since gained freedom and are now a rare sight in the galaxy.",
+	)
+
 /datum/species/golem/create_pref_unique_perks()
 	var/list/to_add = list()
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -70,7 +70,7 @@
 /datum/species/golem/get_species_lore()
 	return list(
 		"While Golems have long been commonly found on frontier worlds, peacefully mining and otherwise living in harmony with the environment, \
-		it is belived they were originally constructed in Nanotrasen laboratories as a form of cheap labor. Whatever happened up to this point is unknown, \
+		it is believed they were originally constructed in Nanotrasen laboratories as a form of cheap labor. Whatever happened up to this point is unknown, \
 		but they have since gained freedom and are now a rare sight in the galaxy.",
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -117,6 +117,12 @@
 		"Jellypeople are actively being experimented on my Nanotrasen scientists, who are trying to unlock the secrets of their unique biology.",
 	)
 
+/datum/species/jelly/prepare_human_for_preview(mob/living/carbon/human/human)
+	human.dna.features["mcolor"] = COLOR_PINK
+	human.hairstyle = "Bob Hair 2"
+	human.hair_color = COLOR_PINK
+	human.update_body(is_creating = TRUE)
+
 // Slimes have both TRAIT_NOBLOOD and an exotic bloodtype set, so they need to be handled uniquely here.
 // They may not be roundstart but in the unlikely event they become one might as well not leave a glaring issue open.
 /datum/species/jelly/create_pref_blood_perks()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -109,6 +109,14 @@
 	qdel(consumed_limb)
 	H.blood_volume += 20
 
+/datum/species/jelly/get_species_description()
+	return "Jellypeople are a strange and alien species with three eyes, made entirely out of gel."
+
+/datum/species/jelly/get_species_lore()
+	return list(
+		"Jellypeople are actively being experimented on my Nanotrasen scientists, who are trying to unlock the secrets of their unique biology.",
+	)
+
 // Slimes have both TRAIT_NOBLOOD and an exotic bloodtype set, so they need to be handled uniquely here.
 // They may not be roundstart but in the unlikely event they become one might as well not leave a glaring issue open.
 /datum/species/jelly/create_pref_blood_perks()

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -81,7 +81,7 @@
 
 /datum/species/pod/get_species_lore()
 	return list(
-		"Little is known about the origins of the Podpeople. \
+		"Not much is known about the origins of the Podpeople. \
 		Many assume them to be the result of a long forgotten botanical experiment, slowly mutating for years on years until they became the beings they are today. \
 		Ever since they were uncovered long ago, their kind have been found on board stations and planets across the galaxy, \
 		often working in hydroponics bays, kitchens, or science departments, working with plants and other botanical lifeforms.",

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -76,6 +76,17 @@
 	return "Podpeople are in many ways the inverse of shadows, healing in light and starving with the dark. \
 		Their bodies are like tinder and easy to char."
 
+/datum/species/pod/get_species_description()
+	return "Podpeople are largely peaceful plant based lifeforms, resembling a humanoid figure made of leaves, flowers, and vines."
+
+/datum/species/pod/get_species_lore()
+	return list(
+		"Little is known about the origins of the Podpeople. \
+		Many assume them to be the result of a long forgotten botanical experiment, slowly mutating for years on years until they became the beings they are today. \
+		Ever since they were uncovered long ago, their kind have been found on board stations and planets across the galaxy, \
+		often working in hydroponics bays, kitchens, or science departments, working with plants and other botanical lifeforms.",
+	)
+
 /datum/species/pod/create_pref_unique_perks()
 	var/list/to_add = list()
 

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -72,6 +72,11 @@
 	if(chem.type == /datum/reagent/toxin/plantbgone)
 		affected.adjustToxLoss(3 * REM * seconds_per_tick)
 
+/datum/species/pod/prepare_human_for_preview(mob/living/carbon/human/human)
+	human.dna.features["mcolor"] = "#886600"
+	human.dna.features["pod_hair"] = "Rose"
+	human.update_body(is_creating = TRUE)
+
 /datum/species/pod/get_physical_attributes()
 	return "Podpeople are in many ways the inverse of shadows, healing in light and starving with the dark. \
 		Their bodies are like tinder and easy to char."

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -26,6 +26,9 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/snail
 	)
 
+/datum/species/snail/prepare_human_for_preview(mob/living/carbon/human/human)
+	human.dna.features["mcolor"] = COLOR_BEIGE
+	human.update_body(is_creating = TRUE)
 
 /datum/species/snail/get_physical_attributes()
 	return "Snailpeople emit a viscous, slippery ooze when crawling along the ground, which they are somewhat faster at than other species. \

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -1,5 +1,6 @@
 /datum/species/snail
-	name = "Snailperson"
+	name = "\improper Snailperson"
+	plural_form = "Snailpeople"
 	id = SPECIES_SNAIL
 	inherent_traits = list(
 		TRAIT_MUTANT_COLORS,
@@ -29,6 +30,44 @@
 /datum/species/snail/get_physical_attributes()
 	return "Snailpeople emit a viscous, slippery ooze when crawling along the ground, which they are somewhat faster at than other species. \
 		They are almost purely made of water, making them extremely susceptible to shocks, and salt will scour them heavily."
+
+/datum/species/snail/get_species_description()
+	return "Snailpeople are viscous, slimy beings with a shell on their back."
+
+/datum/species/snail/get_species_lore()
+	return list(
+		"Normally, Snailpeople are a result of a genetic experiment gone wrong, but they have since become recognized species in their own right, \
+		similar to the Felinid.",
+	)
+
+/datum/species/snail/create_pref_unique_perks()
+	var/list/to_add = list()
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+		SPECIES_PERK_ICON = FA_ICON_RUNNING,
+		SPECIES_PERK_NAME = "Turbo",
+		SPECIES_PERK_DESC = "Snailpeople walk and run very slow, but crawl around very fast. While crawling, they leave a trail of slippery slime behind them.",
+	))
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+		SPECIES_PERK_ICON = FA_ICON_SHRIMP,
+		SPECIES_PERK_NAME = "Shelled",
+		SPECIES_PERK_DESC = "The back of a Snailperson is covered in an armored shell, which is effectively an unremovable backpack. \
+			Good for keeping your things from being stolen, but bad for needing to wear a MODsuit, or disguising.",
+	))
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_SKULL_CROSSBONES,
+		SPECIES_PERK_NAME = "Salty",
+		SPECIES_PERK_DESC = "Being evolved from Snails, Snailpeople are extremely susceptible to salt, which burns them.",
+	))
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_HAND_FIST,
+		SPECIES_PERK_NAME = "Squishy",
+		SPECIES_PERK_DESC = "Snailpeople are squishy and slimy, making their punches and kicks far less effective than other species.",
+	))
+	return to_add
 
 /datum/species/snail/handle_chemical(datum/reagent/chem, mob/living/carbon/human/affected, seconds_per_tick, times_fired)
 	. = ..()
@@ -93,4 +132,4 @@
 
 /obj/item/storage/backpack/snail/Initialize(mapload)
 	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, "snailshell")
+	ADD_TRAIT(src, TRAIT_NODROP, INNATE_TRAIT)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -359,7 +359,7 @@ ROUNDSTART_RACES ethereal
 #ROUNDSTART_RACES zombie
 #ROUNDSTART_RACES pod
 
-## Races that radial departures to what a species is, so while they technically can be roundstart it's probably not wise
+## Races that are radical departures to what a species is, so while they technically can be roundstart - it's probably not wise
 #ROUNDSTART_RACES android
 #ROUNDSTART_RACES golem
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -352,43 +352,16 @@ ROUNDSTART_RACES plasmaman
 ROUNDSTART_RACES ethereal
 #ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES abductor
-#ROUNDSTART_RACES synth
-
-## Including all the various golem subtypes that are better than humans in some ways, but worse in others
-#ROUNDSTART_RACES iron_golem
-#ROUNDSTART_RACES adamantine_golem
-#ROUNDSTART_RACES plasma_golem
-#ROUNDSTART_RACES diamond_golem
-#ROUNDSTART_RACES gold_golem
-#ROUNDSTART_RACES silver_golem
-#ROUNDSTART_RACES uranium_golem
-#ROUNDSTART_RACES plasteel_golem
-#ROUNDSTART_RACES titanium_golem
-#ROUNDSTART_RACES plastitanium_golem
-#ROUNDSTART_RACES alloy_golem
-#ROUNDSTART_RACES wood_golem
-#ROUNDSTART_RACES sand_golem
-#ROUNDSTART_RACES glass_golem
-#ROUNDSTART_RACES bluespace_golem
-#ROUNDSTART_RACES bananium_golem
-#ROUNDSTART_RACES runic_golem
-#ROUNDSTART_RACES cloth_golem
-#ROUNDSTART_RACES plastic_golem
-#ROUNDSTART_RACES bronze_golem
-#ROUNDSTART_RACES cardboard_golem
-#ROUNDSTART_RACES leather_golem
-#ROUNDSTART_RACES durathread_golem
-#ROUNDSTART_RACES bone_golem
-#ROUNDSTART_RACES snow_golem
-#ROUNDSTART_RACES metallic_hydrogen_golem
+#ROUNDSTART_RACES snail
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton
 #ROUNDSTART_RACES zombie
-#ROUNDSTART_RACES slime
 #ROUNDSTART_RACES pod
-#ROUNDSTART_RACES military_synth
-#ROUNDSTART_RACES agent
+
+## Races that radial departures to what a species is, so while they technically can be roundstart it's probably not wise
+#ROUNDSTART_RACES android
+#ROUNDSTART_RACES golem
 
 ##-------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## About The Pull Request

Adds lore, descriptions, and pref perk setups to Abductors, Androids, Jellypeople, Golems, Podpeople, and Snailpeople

# This PR does not imply nor implicate any intent to make any of the species roundstart species. 

Note: All the lore and descriptions created were intended to be extremely generic to work with "future lore", IE essentially just temp lore. Suggestions are welcome.

## Why It's Good For The Game

This kind of stuff is good to have setup in case rogue admins, station traits, or monthly events make these species roundstart. 

See: Monkies. Which have a fully setup pref page for Monkey Day. 

## Changelog

:cl: Melbert
qol: A few species (such as Jellypeople) now have proper(ish) preference menu setups
config: The in-repo species config has been updated. Well it's still the same by default, but it's now updated for newer species. 
/:cl:

