### PR TITLE
Jellyperson Hair Fix A: "No Hair For Anyone (except Slimepeople)"

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -130,7 +130,7 @@
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	limb_id = SPECIES_SLIMEPERSON
 	is_dimorphic = FALSE
-	head_flags = parent_type::head_flags | HEAD_HAIR | HEAD_FACIAL_HAIR
+	head_flags = HEAD_EYECOLOR | HEAD_EYESPRITES | HEAD_HAIR | HEAD_FACIAL_HAIR
 
 /obj/item/bodypart/chest/slime
 	biological_state = (BIO_FLESH|BIO_BLOODED)
@@ -159,7 +159,7 @@
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	limb_id = SPECIES_LUMINESCENT
 	is_dimorphic = TRUE
-	head_flags = HEAD_EYECOLOR
+	head_flags = HEAD_EYECOLOR | HEAD_EYESPRITES
 
 /obj/item/bodypart/chest/luminescent
 	biological_state = (BIO_FLESH|BIO_BLOODED)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -88,7 +88,7 @@
 	is_dimorphic = TRUE
 	dmg_overlay_type = null
 	burn_modifier = 0.5 // = 1/2x generic burn damage
-	head_flags = HEAD_EYECOLOR|HEAD_EYESPRITES
+	head_flags = HEAD_EYECOLOR | HEAD_EYESPRITES
 
 /obj/item/bodypart/chest/jelly
 	biological_state = (BIO_FLESH|BIO_BLOODED)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -88,7 +88,7 @@
 	is_dimorphic = TRUE
 	dmg_overlay_type = null
 	burn_modifier = 0.5 // = 1/2x generic burn damage
-	head_flags = HEAD_ALL_FEATURES
+	head_flags = HEAD_EYECOLOR|HEAD_EYESPRITES
 
 /obj/item/bodypart/chest/jelly
 	biological_state = (BIO_FLESH|BIO_BLOODED)
@@ -130,7 +130,7 @@
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	limb_id = SPECIES_SLIMEPERSON
 	is_dimorphic = FALSE
-	head_flags = HEAD_ALL_FEATURES
+	head_flags = parent_type::head_flags | HEAD_HAIR | HEAD_FACIAL_HAIR
 
 /obj/item/bodypart/chest/slime
 	biological_state = (BIO_FLESH|BIO_BLOODED)
@@ -159,7 +159,7 @@
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	limb_id = SPECIES_LUMINESCENT
 	is_dimorphic = TRUE
-	head_flags = HEAD_ALL_FEATURES
+	head_flags = HEAD_EYECOLOR
 
 /obj/item/bodypart/chest/luminescent
 	biological_state = (BIO_FLESH|BIO_BLOODED)


### PR DESCRIPTION
## About The Pull Request

#76074 Accidentally made all Slimepeople types have all head flags. Which they shouldn't have. 

This PR fixes Jellypeople, Luminescents, and Stargazers having hair when they shouldn't. 

This PR also fixes Slimepeople having some flags they shouldn't. 

## Changelog

:cl: Melbert
fix: Jellypeople and Luminescents and Stargazers no longer have hair. All jellyperson types no longer have eyesockets. 
/:cl:

