### PR TITLE
Give smoke machines the simple_rotation component

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -37,6 +37,7 @@
 	. = ..()
 	create_reagents(REAGENTS_BASE_VOLUME, INJECTABLE)
 	AddComponent(/datum/component/plumbing/simple_demand)
+	AddComponent(/datum/component/simple_rotation)
 	for(var/datum/stock_part/matter_bin/B in component_parts)
 		reagents.maximum_volume += REAGENTS_BASE_VOLUME * B.tier
 	if(is_operational)


### PR DESCRIPTION

## About The Pull Request

Smoke machines have a plumbing input, but as opposed to as far as I know all other plumbing machines they cannot easily be rotated. This is *really* awkward, and in some positions makes it a massive pain in the ass to position properly.
Giving it the `/datum/component/simple_rotation` component that all other such machines have fixes this.
## Why It's Good For The Game

It's really really awkward to orient where its plumbing input goes without this. Try put it against a wall with its plumbing end away from the wall, it sucks.
## Changelog
:cl:
qol: Smoke machines can actually be rotated with alt-click when unwrenched.
/:cl:
