### PR TITLE
Changeling IDs now have examine string

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -36,3 +36,9 @@
 )
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.
 #define WILDCARD_LIMIT_ADMIN list(WILDCARD_NAME_ALL = list(limit = -1, usage = list()))
+
+/**
+ * x1, y1, x2, y2 - Represents the bounding box for the ID card's non-transparent portion of its various icon_states.
+ * Used to crop the ID card's transparency away when chaching the icon for better use in tgui chat.
+ */
+#define ID_ICON_BORDERS 1, 9, 32, 24

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1,9 +1,3 @@
-/**
- * x1, y1, x2, y2 - Represents the bounding box for the ID card's non-transparent portion of its various icon_states.
- * Used to crop the ID card's transparency away when chaching the icon for better use in tgui chat.
- */
-#define ID_ICON_BORDERS 1, 9, 32, 24
-
 /// Fallback time if none of the config entries are set for USE_LOW_LIVING_HOUR_INTERN
 #define INTERN_THRESHOLD_FALLBACK_HOURS 15
 
@@ -1703,7 +1697,6 @@
 	icon_state = "ctf_green"
 
 #undef INTERN_THRESHOLD_FALLBACK_HOURS
-#undef ID_ICON_BORDERS
 #undef HOLOPAY_PROJECTION_INTERVAL
 
 #define INDEX_NAME_COLOR 1

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -127,7 +127,12 @@
 /obj/item/changeling/id/proc/get_cached_flat_icon()
 	if(!cached_flat_icon)
 		cached_flat_icon = getFlatIcon(src)
+		cached_flat_icon.Crop(ID_ICON_BORDERS)
 	return cached_flat_icon
+
+/obj/item/changeling/id/get_id_examine_strings(mob/user)
+	. = ..()
+	. += list("[icon2html(get_cached_flat_icon(), user, extra_classes = "bigicon")]")
 
 /obj/item/changeling/id/get_examine_string(mob/user, thats = FALSE)
 	return "[icon2html(get_cached_flat_icon(), user)] [thats? "That's ":""][get_examine_name(user)]" //displays all overlays in chat


### PR DESCRIPTION
## About The Pull Request

First examine block is roundstart examine, second one is as a disguised Changeling
![image](https://github.com/tgstation/tgstation/assets/53777086/ac90225f-372e-4ad7-9784-7f938fd030a0)

This PR adds the icon of the ID at the very bottom, something that was forgotten about when ID trimming was introduced.

## Why It's Good For The Game

Removes a tell from disguised changelings by seeing that they have an ID but no icon at the bottom of the examine list.

## Changelog

:cl:
fix: Changelings with a flesh ID now properly show the icon of the disguised ID in examine.
/:cl: