### PR TITLE
Fixes Venus Human Trap Tangle Ability

### DIFF
--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -205,8 +205,6 @@
 	button_icon_state = "Light1"
 	desc = "Grabs a target with a sticky vine, allowing you to pull it alongside you."
 	cooldown_time = 8 SECONDS
-	///how many vines can we handle
-	var/max_vines = 2
 	/// An assoc list of all the plant's vines (beam = leash)
 	var/list/datum/beam/vines = list()
 	/// How far away a plant can attach a vine to something
@@ -221,10 +219,12 @@
 /datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/Activate(atom/target_atom)
 	if(isturf(target_atom) || istype(target_atom, /obj/structure/spacevine))
 		return
-	if(length(vines) >= max_vines || get_dist(owner, target_atom) > vine_grab_distance)
+	if(get_dist(owner, target_atom) > vine_grab_distance)
+		owner.balloon_alert(owner, "too far!")
 		return
 	for(var/turf/blockage in get_line(owner, target_atom))
 		if(blockage.is_blocked_turf(exclude_mobs = TRUE))
+			owner.balloon_alert(owner, "something's in the way!")
 			return
 
 	var/datum/beam/new_vine = owner.Beam(target_atom, icon_state = "vine", time = vine_duration * (ismob(target_atom) ? 1 : 2), beam_type = /obj/effect/ebeam/vine, emissive = FALSE)

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -173,7 +173,7 @@
 	. = ..()
 	AddElement(/datum/element/lifesteal, 5)
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/vine_tangle = BB_TARGETED_ACTION,
+		/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle = BB_TARGETED_ACTION,
 	)
 	grant_actions_by_list(innate_actions)
 
@@ -199,7 +199,7 @@
 
 	adjustBruteLoss(vines_in_range ? -weed_heal : no_weed_damage) //every life tick take 20 damage if not near vines or heal 10 if near vines, 5 times out of weeds = u ded
 
-/datum/action/cooldown/vine_tangle
+/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle
 	name = "Tangle"
 	button_icon = 'icons/mob/spacevines.dmi'
 	button_icon_state = "Light1"
@@ -214,11 +214,11 @@
 	/// how long does a vine attached to something last (and its leash) (lasts twice as long on nonliving things)
 	var/vine_duration = 2 SECONDS
 
-/datum/action/cooldown/vine_tangle/Remove(mob/remove_from)
+/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/Remove(mob/remove_from)
 	QDEL_LIST(vines)
 	return ..()
 
-/datum/action/cooldown/vine_tangle/Activate(atom/target_atom)
+/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/Activate(atom/target_atom)
 	if(isturf(target_atom) || istype(target_atom, /obj/structure/spacevine))
 		return
 	if(length(vines) >= max_vines || get_dist(owner, target_atom) > vine_grab_distance)
@@ -245,7 +245,7 @@
  * Arguments:
  * * datum/beam/vine - The vine to be removed from the list.
  */
-/datum/action/cooldown/vine_tangle/proc/remove_vine(datum/beam/vine)
+/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/proc/remove_vine(datum/beam/vine)
 	SIGNAL_HANDLER
 
 	qdel(vines[vine])


### PR DESCRIPTION
## About The Pull Request

This makes the Venus Human Trap's dreaded "Tangle" ability work again! You can also now just click on people from a range to activate it too, instead of using the ability button.

It has been converted into a projectile attack mob ability. This (surprisingly) didn't require any work beyond extending the ability path. Some balloon alerts have been thrown in as well, to notify the user when they've tried to tangle something they can't.

The max_vines var has been axed, and you can only target one user. This is still an improvement over the current (zero) number of people you can target with this ability. I have no idea what this var was supposed to do because the ability has not worked since its implementation.
## Why It's Good For The Game

Closes #79848.
## Changelog
:cl: Rhials
fix: Venus Human Traps can once again entangle victims and drag them into their web.
/:cl:
