### PR TITLE
[NO GBP] Fixes input field & related lathe search bar

### DIFF
--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -102,31 +102,15 @@ export function Input(props: Props) {
   // The ref to the input field
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Used to upate value when onInput gets invoked after debounce or for an non expensive field directly.
-  let update: Boolean = true;
-
-  function updateAfterDebounce(
-    event: SyntheticEvent<HTMLInputElement>,
-    value: string,
-  ) {
-    if (!onInput) return;
-
-    onInput(event, value);
-
-    update = true;
-  }
-
   function handleInput(event: SyntheticEvent<HTMLInputElement>) {
     if (!onInput) return;
 
     const value = event.currentTarget?.value;
 
-    update = false;
     if (expensive) {
-      inputDebounce(() => updateAfterDebounce(event, value));
+      inputDebounce(() => onInput(event, value));
     } else {
       onInput(event, value);
-      update = true;
     }
   }
 
@@ -156,15 +140,12 @@ export function Input(props: Props) {
     const input = inputRef.current;
     if (!input) return;
 
-    if (update) {
-      const newValue = toInputValue(value);
+    const newValue = toInputValue(value);
 
-      if (input.value === newValue) return;
-
-      input.value = newValue;
-    }
+    if (input.value !== newValue) input.value = newValue;
 
     if (!autoFocus && !autoSelect) return;
+
     setTimeout(() => {
       input.focus();
 

--- a/tgui/packages/tgui/components/VirtualList.tsx
+++ b/tgui/packages/tgui/components/VirtualList.tsx
@@ -45,7 +45,7 @@ export const VirtualList = (props: PropsWithChildren) => {
 
       setPadding((children.length - newVisibleElements) * averageItemHeight);
     }
-  }, [containerRef, visibleElements, setVisibleElements, setPadding]);
+  }, [containerRef, visibleElements, children]);
 
   useEffect(() => {
     adjustExtents();


### PR DESCRIPTION
## About The Pull Request

There are 2 category of fixes

**1. Input field fixes**
  - Fixes #82023
  - Fixes #82175
 Right in my last PR #81968 I didn't test everything, my bad. Rather than using `useEffect()` twice [which now i discovered is responsible for the lag due to conflicting conditions for updating] we just check for our new updated value in 1 place. With this not only is the input field value updated with props as often as needed but also, they should display their saved value. 

**2.  Lathe search fixes**
 - Fixes https://github.com/tgstation/tgstation/pull/81968#issuecomment-1997014427. 
 
 So this bug is a combination of my mistake and `VirtualLists` which was introduced a while back. The issue is composed of 2 problems
  - The lathe search bar would not save your previous search query. Therefore when you reopened the UI it would not display your last search query but would still show you the results of your last search query
  - Virtual lists were not re-rendering when the number of children (in our case new search results) changed therefore it would display the view port of our previous query and clip the new results as it would not recompute the new visible area.
  
  Both of these combined together would create this mess
  

https://github.com/tgstation/tgstation/assets/110812394/ee34f316-104c-40c2-8fc4-733f877909ec

Now with text fields saving their text values & virtual lists rendering more often. We now get more accurate results like this

https://github.com/tgstation/tgstation/assets/110812394/9d8d6b54-c39e-4c24-8815-956933c42937



 
## Changelog
:cl:
fix: text fields which should save their value after hitting enter/closing the UI now actually does that
fix: lathe search bar now saves its previous search query after the UI is closed and also reloads search results correctly
/:cl:
