### PR TITLE
Corrects Suit Storage Unit charge rate 

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -46,11 +46,11 @@
 	recharge_speed = 0
 	repairs = 0
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		recharge_speed += capacitor.tier * 100
+		recharge_speed += capacitor.tier * STANDARD_CELL_CHARGE * 0.01
 	for(var/datum/stock_part/servo/servo in component_parts)
 		repairs += servo.tier - 1
 	for(var/obj/item/stock_parts/cell/cell in component_parts)
-		recharge_speed *= cell.maxcharge / 10000
+		recharge_speed *= cell.maxcharge / STANDARD_CELL_CHARGE
 
 /obj/machinery/recharge_station/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -46,11 +46,11 @@
 	recharge_speed = 0
 	repairs = 0
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		recharge_speed += capacitor.tier * STANDARD_CELL_CHARGE * 0.01
+		recharge_speed += capacitor.tier * 100
 	for(var/datum/stock_part/servo/servo in component_parts)
 		repairs += servo.tier - 1
 	for(var/obj/item/stock_parts/cell/cell in component_parts)
-		recharge_speed *= cell.maxcharge / STANDARD_CELL_CHARGE
+		recharge_speed *= cell.maxcharge / 10000
 
 /obj/machinery/recharge_station/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -53,11 +53,11 @@
 	/// Cooldown for occupant breakout messages via relaymove()
 	var/message_cooldown
 	/// How long it takes to break out of the SSU.
-	var/breakout_time = 300
+	var/breakout_time = 30 SECONDS
 	/// Power contributed by this machine to charge the mod suits cell without any capacitors
-	var/base_charge_rate = 200
+	var/base_charge_rate = 2 MEGA JOULES
 	/// Final charge rate which is base_charge_rate + contribution by capacitors
-	var/final_charge_rate = 250
+	var/final_charge_rate = 2.5 MEGA JOULES
 	/// is the card reader installed in this machine
 	var/card_reader_installed = FALSE
 	/// physical reference of the players id card to check for PERSONAL access level
@@ -287,7 +287,7 @@
 	. = ..()
 
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		final_charge_rate = base_charge_rate + (capacitor.tier * 50)
+		final_charge_rate = base_charge_rate + (capacitor.tier * 0.5 MEGA JOULES)
 
 	set_access()
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -55,9 +55,9 @@
 	/// How long it takes to break out of the SSU.
 	var/breakout_time = 30 SECONDS
 	/// Power contributed by this machine to charge the mod suits cell without any capacitors
-	var/base_charge_rate = 2 MEGA JOULES
+	var/base_charge_rate = 20 KILO JOULES
 	/// Final charge rate which is base_charge_rate + contribution by capacitors
-	var/final_charge_rate = 2.5 MEGA JOULES
+	var/final_charge_rate = 25 KILO JOULES
 	/// is the card reader installed in this machine
 	var/card_reader_installed = FALSE
 	/// physical reference of the players id card to check for PERSONAL access level
@@ -287,7 +287,7 @@
 	. = ..()
 
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		final_charge_rate = base_charge_rate + (capacitor.tier * 0.5 MEGA JOULES)
+		final_charge_rate = base_charge_rate + (capacitor.tier * 5 KILO JOULES)
 
 	set_access()
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -55,9 +55,9 @@
 	/// How long it takes to break out of the SSU.
 	var/breakout_time = 30 SECONDS
 	/// Power contributed by this machine to charge the mod suits cell without any capacitors
-	var/base_charge_rate = 20 KILO JOULES
+	var/base_charge_rate = 200 KILO WATTS
 	/// Final charge rate which is base_charge_rate + contribution by capacitors
-	var/final_charge_rate = 25 KILO JOULES
+	var/final_charge_rate = 250 KILO WATTS
 	/// is the card reader installed in this machine
 	var/card_reader_installed = FALSE
 	/// physical reference of the players id card to check for PERSONAL access level
@@ -287,7 +287,7 @@
 	. = ..()
 
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		final_charge_rate = base_charge_rate + (capacitor.tier * 5 KILO JOULES)
+		final_charge_rate = base_charge_rate + (capacitor.tier * 50 KILO WATTS)
 
 	set_access()
 


### PR DESCRIPTION
## About The Pull Request

Adjusts SSU charge rate according to the new conversion ratio. 

Betcha didn't know SSUs recharge suit and MOD cells? 

This number is actually supposed to be equal to the rate a recharger station does it.
I don't know if we have some macro for it. 

## Changelog

:cl: Melbert
fix: Fixed Suit Storage Unit cell charging rate
/:cl:

