### PR TITLE
Suit Storage Units / Inducers can charge MODsuits without necessitating them be screwdrivered opened 

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -565,7 +565,7 @@
 	if(cell_count <= 0)
 		return
 
-	var/charge_per_item = final_charge_rate * seconds_per_tick / cell_count
+	var/charge_per_item = (final_charge_rate * seconds_per_tick) / cell_count
 	for(var/obj/item/stock_parts/cell/cell as anything in cells_to_charge)
 		charge_cell(charge_per_item, cell)
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -553,15 +553,17 @@
 			dump_inventory_contents()
 
 /obj/machinery/suit_storage_unit/process(seconds_per_tick)
-	var/obj/item/stock_parts/cell/cell
-	if(suit && istype(suit))
-		cell = suit.cell
-	if(mod)
-		cell = mod.get_cell()
-	if(!cell || cell.charge == cell.maxcharge)
-		return
+	var/list/cells_to_charge = list()
+	for(var/obj/item/charging in list(mod, suit, helmet, mask, storage))
+		var/obj/item/stock_parts/cell/cell_charging = charging.get_cell()
+		if(!istype(cell_charging) || cell_charging.charge == cell_charging.maxcharge)
+			continue
 
-	charge_cell(final_charge_rate * seconds_per_tick, cell)
+		cells_to_charge += cell_charging
+
+	var/charge_per_item = final_charge_rate * seconds_per_tick / length(cells_to_charge)
+	for(var/obj/item/stock_parts/cell/cell as anything in cells_to_charge)
+		charge_cell(charge_per_item, cell)
 
 /obj/machinery/suit_storage_unit/proc/shock(mob/user, prb)
 	if(!prob(prb))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -561,7 +561,11 @@
 
 		cells_to_charge += cell_charging
 
-	var/charge_per_item = final_charge_rate * seconds_per_tick / length(cells_to_charge)
+	var/cell_count = length(cells_to_charge)
+	if(cell_count <= 0)
+		return
+
+	var/charge_per_item = final_charge_rate * seconds_per_tick / cell_count
 	for(var/obj/item/stock_parts/cell/cell as anything in cells_to_charge)
 		charge_cell(charge_per_item, cell)
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -410,11 +410,9 @@
 	return ..()
 
 /obj/item/mod/control/get_cell()
-	if(!open)
-		return
 	var/obj/item/stock_parts/cell/cell = get_charge_source()
 	if(!istype(cell))
-		return
+		return null
 	return cell
 
 /obj/item/mod/control/GetAccess()


### PR DESCRIPTION
## About The Pull Request

So MODsuits do this thing here with `get_cell` in that they don't return anything when they're closed 

![image](https://github.com/tgstation/tgstation/assets/51863163/416f8ef5-3bfc-4d2c-a12f-029f051d6692)

And I... can't tell why they do this. 

I looked through every use of `get_cell` and the only things affected by this are 
A. Suit Storage Units, which I believe have always been intended to charge MODsuits?
and
B. Inducers

So I removed the `open` check. Allowing both Inducers and Suit Storage Units to charge mods without needing you screwdriver their panel open first. 

I also took the opportunity to allow SSUs to charge multiple items at once (divvying charge accross all items) 

## Why It's Good For The Game

I asked Fikou and they said it was "probably not" intended that you need to screwdriver them open so yeah. 

I think I remember charging my MODs during the original test merges years back but I can't remember if I opened the suit first when I did or not. 

Either way, it's not super intuitive. Though it's already not very intuitive that SSUs charge things. 

## Changelog

:cl: Melbert
qol: Suit Storage Units charge MODsuits while their cell panel is closed or open, rather than only when screwed open
qol: Inducers can charge MODsuits while their cell panel is closed or open, rather than only when screwed open
qol: Suit Storage Units will charge all items within simultaneously (if possible)
/:cl:

