### PR TITLE
Makes lua file upload work with bigger files and standardizes a few file|null

### DIFF
--- a/code/modules/admin/verbs/lua/lua_editor.dm
+++ b/code/modules/admin/verbs/lua/lua_editor.dm
@@ -105,6 +105,11 @@
 		return
 	if(!check_rights_for(usr.client, R_DEBUG))
 		return
+	if(action == "runCodeFile")
+		params["code"] = file2text(input(usr, "Input File") as null|file)
+		if(isnull(params["code"]))
+			return
+		action = "runCode"
 	switch(action)
 		if("newState")
 			var/state_name = params["name"]

--- a/code/modules/wiremod/core/duplicator.dm
+++ b/code/modules/wiremod/core/duplicator.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(circuit_dupe_whitelisted_types, list(
 	var/txt
 	switch(option)
 		if("File")
-			txt = file2text(input(usr, "Input File") as file|null)
+			txt = file2text(input(usr, "Input File") as null|file)
 		if("Direct Input")
 			txt = input(usr, "Input JSON", "Input JSON") as text|null
 

--- a/tgui/packages/tgui/interfaces/LuaEditor/index.jsx
+++ b/tgui/packages/tgui/interfaces/LuaEditor/index.jsx
@@ -182,14 +182,7 @@ export class LuaEditor extends Component {
                   title="Input"
                   buttons={
                     <>
-                      <Button.File
-                        onSelectFiles={(file) =>
-                          this.setState({ scriptInput: file })
-                        }
-                        accept=".lua,.luau"
-                      >
-                        Import
-                      </Button.File>
+                      <Button onClick={() => act('runCodeFile')}>Import</Button>
                       <Button onClick={() => setModal('documentation')}>
                         Help
                       </Button>


### PR DESCRIPTION

## About The Pull Request
My lua scripts were hitting the topic byte limit, so this makes file upload of lua scripts able to bypass the topic limit.

## Why It's Good For The Game
Removes arbitrary restriction on how big a lua file can be in bytes.

## Changelog
:cl:
admin: Admins can now run lua files bigger than 36 KB by importing them directly.
/:cl:
