### PR TITLE
[NO GBP]Fixes static power usage not always drawing the remaining energy of an APC cell.

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -699,7 +699,7 @@
 	terminal?.add_load(grid_used)
 	var/cell_used = 0
 	if(amount > grid_used)
-		cell_used += cell.use(amount - grid_used)
+		cell_used += cell.use(amount - grid_used, force = TRUE)
 	return grid_used + cell_used
 
 /// Draws power from the connected grid. When there isn't enough surplus energy from the grid, draws the rest of the demand from its cell. Returns the energy used.


### PR DESCRIPTION

## About The Pull Request
Makes APC static power draw consume the remaining energy of the cell if there's not enough energy.
## Why It's Good For The Game
Prevents a niche issue where an area composed entirely of static power users with no dynamic users from running forever with no power supply.
## Changelog
:cl:
fix: Fixes static power usage from being able to not draw power.
/:cl:
