### PR TITLE
Combat mode  shooting don't hit carbon mobs when thay lying down. 

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -621,7 +621,7 @@
 			return FALSE
 		if(HAS_TRAIT(living_target, TRAIT_IMMOBILIZED) && HAS_TRAIT(living_target, TRAIT_FLOORED) && HAS_TRAIT(living_target, TRAIT_HANDS_BLOCKED))
 			return FALSE
-		if(!hit_prone_targets)
+		if(!hit_prone_targets || iscarbon(living_target))
 			var/mob/living/buckled_to = living_target.lowest_buckled_mob()
 			if(!buckled_to.density) // Will just be us if we're not buckled to another mob
 				return FALSE


### PR DESCRIPTION
## About The Pull Request

Projectile don't hit lying carbon mob if projectile shooted in combat mode not directly at mob.

## Why It's Good For The Game

Rigth now you could accidentally hit a carbon mob that was in a prone position even if you were not aiming at the mob, which logically is strange for carbon mobs that have a check for the prone position. This will balance this problem. The player can still shoot at mobs that logically do not have a prone position (such as beepsky and other bots) with the combat mod enabled and hit the annoying beepsky without aiming at him. This balance is ​​aimed only at mobs who, logically, have the opportunity to lie down.

:cl:
balance: carbon mobs can't be hitten by shooting in combat mode not directly on em. living/simple/basic mobs such as beepsky can still be broken by a shot in combat mode without necessarily aiming at the mob itself.
/:cl:

