### PR TITLE
Fix puzzlegrids not reporting their answer

### DIFF
--- a/code/datums/components/puzzgrid.dm
+++ b/code/datums/components/puzzgrid.dm
@@ -172,7 +172,7 @@
 
 	var/message = answers.Join("<p>-----</p>")
 
-	for (var/mob/mob as anything in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src))
+	for (var/mob/mob in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, parent))
 		to_chat(mob, message)
 
 /datum/component/puzzgrid/ui_data(mob/user)


### PR DESCRIPTION
## About The Pull Request

`src` is a a datum, so `get_hearers_in_view` fails

## Changelog

:cl: Melbert
fix: Puzzlegrids now report their answers properly
/:cl:


