### PR TITLE
Prevents Debug ID Card from Polluting Cargo Budget By Doing It Right

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -47,6 +47,9 @@
 
 #define NO_FREEBIES "commies go home"
 
+/// The special account ID for admins using debug cards.
+#define ADMIN_ACCOUNT_ID "ADMIN!"
+
 //Defines that set what kind of civilian bounties should be applied mid-round.
 #define CIV_JOB_BASIC 1
 #define CIV_JOB_ROBO 2

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -148,7 +148,7 @@
 
 		return FALSE
 
-	if(!idcard.can_be_used_in_payment())
+	if(!idcard.can_be_used_in_payment(user))
 		atom_parent.say("Departmental accounts have been blacklisted from personal expenses due to embezzlement.")
 		return FALSE
 

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -148,7 +148,7 @@
 
 		return FALSE
 
-	if(!idcard.registered_account.account_job)
+	if(!idcard.can_be_used_in_payment())
 		atom_parent.say("Departmental accounts have been blacklisted from personal expenses due to embezzlement.")
 		return FALSE
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -416,8 +416,8 @@
 		wildcard_access_list |= new_access
 
 /// Helper proc that determines if a card can be used in certain types of payment transactions.
-/obj/item/card/id/proc/can_be_used_in_payment()
-	if(QDELETED(src) || isnull(registered_account) || isnull(registered_account.account_job))
+/obj/item/card/id/proc/can_be_used_in_payment(mob/living/user)
+	if(QDELETED(src) || isnull(registered_account) || isnull(registered_account.account_job) || !isliving(user))
 		return FALSE
 
 	return TRUE
@@ -460,7 +460,7 @@
 	if(!COOLDOWN_FINISHED(src, last_holopay_projection))
 		balloon_alert(user, "still recharging")
 		return
-	if(!id_card.can_be_used_in_payment())
+	if(!id_card.can_be_used_in_payment(user))
 		balloon_alert(user, "no account")
 		to_chat(user, span_warning("You need a valid bank account to do this."))
 		return
@@ -1255,7 +1255,7 @@
 
 	return TRUE
 
-/obj/item/card/id/advanced/debug/can_be_used_in_payment()
+/obj/item/card/id/advanced/debug/can_be_used_in_payment(mob/living/user)
 	. = ..()
 	if(!. || isnull(user.client?.holder))
 		registered_account.bank_card_talk(span_warning("Only authorized representatives of Nanotrasen may use this card."), force = TRUE)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -415,6 +415,13 @@
 
 		wildcard_access_list |= new_access
 
+/// Helper proc that determines if a card can be used in certain types of payment transactions.
+/obj/item/card/id/proc/can_be_used_in_payment()
+	if(QDELETED(src) || isnull(registered_account) || isnull(registered_account.account_job))
+		return FALSE
+
+	return TRUE
+
 /obj/item/card/id/attack_self(mob/user)
 	if(Adjacent(user))
 		var/minor
@@ -1242,6 +1249,13 @@
 /obj/item/card/id/advanced/debug/alt_click_can_use_id(mob/living/user)
 	. = ..()
 	if(!. || isnull(user.client?.holder)) // admins only as a safety so people don't steal all the dollars
+		return FALSE
+
+	return TRUE
+
+/obj/item/card/id/advanced/debug/can_be_used_in_payment()
+	. = ..()
+	if(!. || isnull(user.client?.holder))
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -460,7 +460,7 @@
 	if(!COOLDOWN_FINISHED(src, last_holopay_projection))
 		balloon_alert(user, "still recharging")
 		return
-	if(!id_card.can_be_used_in_payment(user))
+	if(can_be_used_in_payment(user))
 		balloon_alert(user, "no account")
 		to_chat(user, span_warning("You need a valid bank account to do this."))
 		return

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -460,7 +460,7 @@
 	if(!COOLDOWN_FINISHED(src, last_holopay_projection))
 		balloon_alert(user, "still recharging")
 		return
-	if(!registered_account || !registered_account.account_job)
+	if(!id_card.can_be_used_in_payment())
 		balloon_alert(user, "no account")
 		to_chat(user, span_warning("You need a valid bank account to do this."))
 		return
@@ -1243,12 +1243,14 @@
 /obj/item/card/id/advanced/debug/Initialize(mapload)
 	. = ..()
 	registered_account = new(player_account = FALSE)
+	registered_account.account_id = ADMIN_ACCOUNT_ID // this is so bank_card_talk() can work.
 	registered_account.account_job = SSjob.GetJobType(/datum/job/admin)
-	registered_account.account_balance = 999999999 // MONEY
+	registered_account.account_balance += 999999 // MONEY! We add more money to the account every time we spawn because it's a debug item and infinite money whoopie
 
 /obj/item/card/id/advanced/debug/alt_click_can_use_id(mob/living/user)
 	. = ..()
-	if(!. || isnull(user.client?.holder)) // admins only as a safety so people don't steal all the dollars
+	if(!. || isnull(user.client?.holder)) // admins only as a safety so people don't steal all the dollars. spawn in a holochip if you want them to get some dosh
+		registered_account.bank_card_talk(span_warning("Only authorized representatives of Nanotrasen may use this card."), force = TRUE)
 		return FALSE
 
 	return TRUE
@@ -1256,6 +1258,7 @@
 /obj/item/card/id/advanced/debug/can_be_used_in_payment()
 	. = ..()
 	if(!. || isnull(user.client?.holder))
+		registered_account.bank_card_talk(span_warning("Only authorized representatives of Nanotrasen may use this card."), force = TRUE)
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -417,7 +417,7 @@
 
 /// Helper proc that determines if a card can be used in certain types of payment transactions.
 /obj/item/card/id/proc/can_be_used_in_payment(mob/living/user)
-	if(QDELETED(src) || isnull(registered_account) || isnull(registered_account.account_job) || !isliving(user))
+	if(QDELETED(src) || isnull(registered_account?.account_job) || !isliving(user))
 		return FALSE
 
 	return TRUE
@@ -461,7 +461,7 @@
 		balloon_alert(user, "still recharging")
 		return
 	if(can_be_used_in_payment(user))
-		balloon_alert(user, "no account")
+		balloon_alert(user, "no account!")
 		to_chat(user, span_warning("You need a valid bank account to do this."))
 		return
 	/// Determines where the holopay will be placed based on tile contents

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -631,9 +631,9 @@
 /// Helper proc. Can the user alt-click the ID?
 /obj/item/card/id/proc/alt_click_can_use_id(mob/living/user)
 	if(!isliving(user))
-		return
+		return FALSE
 	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
-		return
+		return FALSE
 
 	return TRUE
 
@@ -1227,7 +1227,7 @@
 
 /obj/item/card/id/advanced/debug
 	name = "\improper Debug ID"
-	desc = "A debug ID card. Has ALL the all access, you really shouldn't have this."
+	desc = "A debug ID card. Has ALL the all access and a boatload of money, you really shouldn't have this."
 	icon_state = "card_centcom"
 	assigned_icon_state = "assigned_centcom"
 	trim = /datum/id_trim/admin
@@ -1235,8 +1235,16 @@
 
 /obj/item/card/id/advanced/debug/Initialize(mapload)
 	. = ..()
-	registered_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	registered_account.account_job = SSjob.GetJobType(/datum/job/admin) // so we can actually use this account without being filtered as a "departmental" card
+	registered_account = new(player_account = FALSE)
+	registered_account.account_job = SSjob.GetJobType(/datum/job/admin)
+	registered_account.account_balance = 999999999 // MONEY
+
+/obj/item/card/id/advanced/debug/alt_click_can_use_id(mob/living/user)
+	. = ..()
+	if(!. || isnull(user.client?.holder)) // admins only as a safety so people don't steal all the dollars
+		return FALSE
+
+	return TRUE
 
 /obj/item/card/id/advanced/prisoner
 	name = "prisoner ID card"

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -256,7 +256,7 @@
 	if(!id_card)
 		to_chat(user, span_warning("You don't even have a id and you want to be an art patron?"))
 		return
-	if(!id_card.can_be_used_in_payment())
+	if(!id_card.can_be_used_in_payment(user))
 		to_chat(user, span_warning("No valid non-departmental account found."))
 		return
 	var/datum/bank_account/account = id_card.registered_account

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -256,7 +256,7 @@
 	if(!id_card)
 		to_chat(user, span_warning("You don't even have a id and you want to be an art patron?"))
 		return
-	if(!id_card.registered_account || !id_card.registered_account.account_job)
+	if(!id_card.can_be_used_in_payment())
 		to_chat(user, span_warning("No valid non-departmental account found."))
 		return
 	var/datum/bank_account/account = id_card.registered_account

--- a/code/modules/economy/holopay.dm
+++ b/code/modules/economy/holopay.dm
@@ -255,7 +255,7 @@
 	/// Account checks
 	var/obj/item/card/id/id_card
 	id_card = user.get_idcard(TRUE)
-	if(isnull(id_card) || id_card.can_be_used_in_payment())
+	if(isnull(id_card) || id_card.can_be_used_in_payment(user))
 		balloon_alert(user, "invalid account")
 		to_chat(user, span_warning("You don't have a valid account."))
 		return FALSE

--- a/code/modules/economy/holopay.dm
+++ b/code/modules/economy/holopay.dm
@@ -255,7 +255,7 @@
 	/// Account checks
 	var/obj/item/card/id/id_card
 	id_card = user.get_idcard(TRUE)
-	if(!id_card || !id_card.registered_account || !id_card.registered_account.account_job)
+	if(isnull(id_card) || id_card.can_be_used_in_payment())
 		balloon_alert(user, "invalid account")
 		to_chat(user, span_warning("You don't have a valid account."))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

Fixes #81755

Alright instead of piggybacking off the departmental/non-departmental distinction and prevent ourselves from constantly abusing the cargo budget in order to achieve the very-specific effect of not wanting players to abuse this card in certain contexts let's just leverage the framework and expand it so that we can snowflake for admin/`holder` use cases in stuff like debugging code on a local server while preventing some player from stealing it off a newbie admin and immediately wrecking the economy (although it is funny).
## Why It's Good For The Game

Probably a bad idea to continue to abuse the cargo budget like this since the only reason why it's structured that way is just for specific use-case exemptions in certain contexts - let's just do our own thing now :3
## Changelog
:cl:
admin: Advanced Debug Cards will still provide a whole lot of access, but the way the money on those cards work is now a bit different. Players shouldn't be able to use the money on those cards in any context though, don't fret about that. Just know that the money printer goes wrrrr
/:cl:
