### PR TITLE
[NO GBP] Fixes the "Drop Pod: Syndies" deathmatch modifier.

### DIFF
--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -363,6 +363,8 @@
 
 /datum/deathmatch_modifier/drop_pod/proc/populate_contents()
 	contents = typesof(/mob/living/basic/trooper/syndicate)
+	for(var/typepath in contents) //Make sure to set even weights for the keys or `pick_weight` won't work.
+		contents[typepath] = 1
 
 /datum/deathmatch_modifier/drop_pod/monsters
 	name = "Drop Pod: Monsters"


### PR DESCRIPTION
## About The Pull Request
I've had false memories of `pick_weight` working with assoc-value-less lists.

## Why It's Good For The Game
This will fix an issue with deathmatch modifiers.

## Changelog

:cl:
fix: Fixed the "Drop Pod: Syndies" deathmatch modifier.
/:cl:
