### PR TITLE
BCIs actions are usable in soft crit

### DIFF
--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -59,11 +59,19 @@
 /datum/action/innate/bci_action
 	name = "Action"
 	button_icon = 'icons/mob/actions/actions_items.dmi'
-	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "bci_power"
 
 	var/obj/item/organ/internal/cyberimp/bci/bci
 	var/obj/item/circuit_component/equipment_action/circuit_component
+
+/datum/action/innate/bci_action/IsAvailable(feedback = FALSE)
+	. = ..()
+	if(!.)
+		return
+	if(owner.stat > SOFT_CRIT) //softcrit and above
+		if (feedback)
+			owner.balloon_alert(owner, "unconscious!")
+		return FALSE
 
 /datum/action/innate/bci_action/New(obj/item/organ/internal/cyberimp/bci/_bci, obj/item/circuit_component/equipment_action/circuit_component)
 	..()


### PR DESCRIPTION

## About The Pull Request

bci actions are usable in softcrit too but not in hardcrit or dead

## Why It's Good For The Game

circuits are limited too hard making their use absolutely minimally useful, so lets alleviate that a very very tiny bit
this should help if you want like a BCI action that calls your circuit drone buddies to pick you up if crit

## Changelog
:cl:
balance: BCI actions are usable in soft crit too
/:cl:
