### PR TITLE
[no gbp] poll completion follow link points to current client mob

### DIFF
--- a/code/datums/candidate_poll.dm
+++ b/code/datums/candidate_poll.dm
@@ -138,9 +138,7 @@
 /datum/candidate_poll/proc/announce_chosen(list/poll_recipients)
 	if(!length(chosen_candidates))
 		return
-	for(var/mob/chosen as anything in chosen_candidates)
-		if(isnull(chosen))
-			continue
+	for(var/mob/chosen in chosen_candidates)
 		var/client/chosen_client = chosen.client
 		for(var/mob/poll_recipient as anything in poll_recipients)
 			to_chat(poll_recipient, span_ooc("[isobserver(poll_recipient) ? FOLLOW_LINK(poll_recipient, chosen_client.mob) : null][span_warning(" [full_capitalize(role)] Poll: ")][key_name(chosen_client, include_name = FALSE)] was selected."))

--- a/code/datums/candidate_poll.dm
+++ b/code/datums/candidate_poll.dm
@@ -138,8 +138,9 @@
 /datum/candidate_poll/proc/announce_chosen(list/poll_recipients)
 	if(!length(chosen_candidates))
 		return
-	for(var/mob/poll_recipient as anything in poll_recipients)
-		for(var/mob/chosen as anything in chosen_candidates)
-			if(isnull(chosen))
-				continue
-			to_chat(poll_recipient, span_ooc("[isobserver(poll_recipient) ? FOLLOW_LINK(poll_recipient, chosen) : null][span_warning(" [full_capitalize(role)] Poll: ")][key_name(chosen, include_name = FALSE)] was selected."))
+	for(var/mob/chosen as anything in chosen_candidates)
+		if(isnull(chosen))
+			continue
+		var/client/chosen_client = chosen.client
+		for(var/mob/poll_recipient as anything in poll_recipients)
+			to_chat(poll_recipient, span_ooc("[isobserver(poll_recipient) ? FOLLOW_LINK(poll_recipient, chosen_client.mob) : null][span_warning(" [full_capitalize(role)] Poll: ")][key_name(chosen_client, include_name = FALSE)] was selected."))


### PR DESCRIPTION

## About The Pull Request
Previously the follow link before the name didn't work because by the time you clicked it, the old mob it referenced was gone
## Changelog
:cl:
fix: the follow link upon poll completion should work properly now
/:cl:
