### PR TITLE
Validate all character slots on preference load

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -436,6 +436,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					what_did_we_reset[name] += "high priority job"
 				else
 					already_high = TRUE
+		if(already_high)
+			job_preferences = new_job_preferences
 
 		if(length(what_did_we_reset[name]))
 			save_character() // save the character if anything changed
@@ -446,7 +448,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			continue
 		to_chat(parent, span_notice("Your character profile for [character_name] had to be reset due to invalid data: [english_list(reset_things)]."))
 
-	load_character(default_slot) // load their character back up
+	load_character(old_slot) // load their character back up
 
 /datum/preferences/proc/set_job_preference_level(datum/job/job, level)
 	if (!job)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -236,6 +236,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		max_save_slots = old_max_save_slots
 		save_preferences()
 
+	validate_character_profiles()
+
 	return TRUE
 
 /datum/preferences/proc/save_preferences()


### PR DESCRIPTION
## About The Pull Request

See title.
Ensures that all character slots don't have invalid setups.
## Why It's Good For The Game

According to [this discord message](https://discord.com/channels/326822144233439242/326831214667235328/1221868487035846716) we do not perform character validation on loading preferences, only when attempting to update. This means we can have instances where players use outdated and banned quirk pairings. This prevents that from happening in the future and is also made expandable so that we can check for anything else in the future as it arises.
Fixes https://github.com/tgstation/tgstation/issues/65318

## Changelog

:cl:
balance: Client Preferences now validate character slots at load.
/:cl:
