### PR TITLE
New Neutral Quirk to indicate to Medical you're willing to be borged

### DIFF
--- a/code/datums/quirks/neutral_quirks/borg_ready.dm
+++ b/code/datums/quirks/neutral_quirks/borg_ready.dm
@@ -1,0 +1,14 @@
+/datum/quirk/item_quirk/borg_ready
+	name = "Cyborg Pre-screened dogtag"
+	desc = "Get pre-approved for NT's experimental Cyborg program, with a dog tag that lets medical staff know."
+	icon = FA_ICON_ROBOT
+	value = 0
+	gain_text = span_notice("You hear a distant echo of beeps and buzzes.")
+	lose_text = span_danger("The distant beeping halts.")
+	medical_record_text = "Patient appears ready to abandon the flesh." //considering this quirk's whole point is a dogtag for medical to see, this feels redundant and silly
+
+/datum/quirk/item_quirk/borg_ready/add_unique(client/client_source)
+	if(is_banned_from(quirk_holder.ckey, JOB_CYBORG))
+		return FALSE
+	var/obj/item/clothing/accessory/dogtag/borg_ready/borgtag = new(get_turf(quirk_holder))
+	give_item_to_holder(borgtag, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))

--- a/code/datums/quirks/neutral_quirks/borg_ready.dm
+++ b/code/datums/quirks/neutral_quirks/borg_ready.dm
@@ -5,7 +5,7 @@
 	value = 0
 	gain_text = span_notice("You hear a distant echo of beeps and buzzes.")
 	lose_text = span_danger("The distant beeping halts.")
-	medical_record_text = "Patient appears ready to abandon the flesh." //considering this quirk's whole point is a dogtag for medical to see, this feels redundant and silly
+	medical_record_text = "Patient is a registered brain donor for Robotics research."
 
 /datum/quirk/item_quirk/borg_ready/add_unique(client/client_source)
 	if(is_banned_from(quirk_holder.ckey, JOB_CYBORG))

--- a/code/datums/quirks/neutral_quirks/borg_ready.dm
+++ b/code/datums/quirks/neutral_quirks/borg_ready.dm
@@ -1,7 +1,7 @@
 /datum/quirk/item_quirk/borg_ready
 	name = "Cyborg Pre-screened dogtag"
 	desc = "Get pre-approved for NT's experimental Cyborg program, with a dog tag that lets medical staff know."
-	icon = FA_ICON_ROBOT
+	icon = FA_ICON_TAG
 	value = 0
 	gain_text = span_notice("You hear a distant echo of beeps and buzzes.")
 	lose_text = span_danger("The distant beeping halts.")

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -171,6 +171,10 @@
 	else
 		display = span_notice("The dogtag is all scratched up.")
 
+/obj/item/clothing/accessory/dogtag/borg_ready
+	name = "Pre-Approved Cyborg Cantidate dogtag"
+	display = "This employee has been screened for negative mental traits to an acceptable level of accuracy, and is approved for the NT Cyborg program as an alternative to medical resuscitation."
+
 /// Reskins for the pride pin accessory, mapped by display name to icon state
 GLOBAL_LIST_INIT(pride_pin_reskins, list(
 	"Rainbow Pride" = "pride",

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1679,6 +1679,7 @@
 #include "code\datums\quirks\negative_quirks\unstable.dm"
 #include "code\datums\quirks\negative_quirks\unusual.dm"
 #include "code\datums\quirks\neutral_quirks\bald.dm"
+#include "code\datums\quirks\neutral_quirks\borg_ready.dm"
 #include "code\datums\quirks\neutral_quirks\colorist.dm"
 #include "code\datums\quirks\neutral_quirks\deviant_tastes.dm"
 #include "code\datums\quirks\neutral_quirks\extrovert.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a quirk that gives the user a "Cyborg Pre-approved" dogtag upon gaining, or (more usually) spawning with,  the quirk. Wearing this dog tag is to be considered granting full permission to be borged.
## Why It's Good For The Game
Waiting for medical to spend 15 minutes running tend wounds on your dead body, not to mention having to deal with your organ damage if you've been dead for a while, kinda sucks. It sucks more when you're waiting and just watching your stuff walk out the door. And if you're a Plasma man, you might as well go take a nap. Meanwhile, the rules get a bit eh about when you're allowed to just start throwing bodies at robotics. Not everyone appreciates being shifted to an entirely new role as a cyborg, but some players don't mind. 

I appreciate all you do medical. But if my body is more than a five minute fix to being revived, just borg me fam. You got other people you could be working on.

This isn't supposed to be mandatory in the opposite direction, mind. I intend that medical can still revive people with the tag, at their own discretion. 
## Changelog
:cl:
add: Added a new Neutral Quirk to indicate to Medical you're willing to be borged
/:cl:
