### PR TITLE
Adds dynamic blob/obsession to ghost popups, removes third rail popup, tweaks supply pod popup

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -476,6 +476,11 @@
 	var/mob/living/carbon/human/blob_antag = pick_n_take(candidates)
 	assigned += blob_antag.mind
 	blob_antag.mind.special_role = antag_flag
+	notify_ghosts(
+		"[blob_antag] has become a blob host!",
+		source = blob_antag,
+		header = "So Bulbous...",
+	)
 	return ..()
 
 /// Midround Xenomorph Ruleset (From Ghosts)
@@ -845,6 +850,11 @@
 	obsessed.gain_trauma(/datum/brain_trauma/special/obsessed)
 	message_admins("[ADMIN_LOOKUPFLW(obsessed)] has been made Obsessed by the midround ruleset.")
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")
+	notify_ghosts(
+		"[obsessed] has developed an obsession with someone!",
+		source = obsessed,
+		header = "Love Can Bloom",
+	)
 	return TRUE
 
 /// Midround Space Changeling Ruleset (From Ghosts)

--- a/code/datums/components/energized.dm
+++ b/code/datums/components/energized.dm
@@ -110,11 +110,6 @@
 		return FALSE
 
 	// Finally the interesting part where they ACTUALLY get hit!
-	notify_ghosts(
-		"[future_tram_victim] has fallen in the path of an oncoming tram!",
-		source = future_tram_victim,
-		header = "Electrifying!",
-	)
 	do_sparks(4, FALSE, source)
 	playsound(parent, SFX_SPARKS, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	source.audible_message(span_danger("[parent] makes a loud electric crackle!"))

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -102,7 +102,8 @@
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
 	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
-	announce_to_ghosts(landing_marker)
+	var/mutable_appearance/target_appearance = mutable_appearance('icons/obj/supplypods_32x32.dmi', "LZ")
+	notify_ghosts("[control.name] has summoned a supply crate!", source = get_turf(landing_marker), header = "Cargo Inbound", alert_overlay = target_appearance)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand
 /datum/round_event/stray_cargo/proc/make_pod()

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -102,7 +102,7 @@
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
 	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
-	var/mutable_appearance/target_appearance = mutable_appearance('icons/obj/supplypods_32x32.dmi', "LZ")
+	var/static/mutable_appearance/target_appearance = mutable_appearance('icons/obj/supplypods_32x32.dmi', "LZ")
 	notify_ghosts("[control.name] has summoned a supply crate!", source = get_turf(landing_marker), header = "Cargo Inbound", alert_overlay = target_appearance)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand


### PR DESCRIPTION

## About The Pull Request

Three changes to ghost orbit popups. Let's check them one-by-one.

First off -- The obsession awakening and blob host midrounds now have a ghost popup when summoned via Dynamic. They already have them when summoned by a random event roll, so this is mostly just bringing the two different spawn methods in line with each other. None of the other midround dynamic picks (autotraitor, revs, etc) have had this added, because they're less focused on spectacle and require more mystery to function properly.

Second -- The electrified railings on the tram no longer notify ghosts every time someone gets shocked. Electrocute_act is called on anything that passes by it, and the popup would be thrown regardless of whether or not they've "fallen in the path of an oncoming tram" or not. Making it check if the electrocute_act actually successfully stunned a player, and that they're about to be hit, would probably require an unwieldy rewrite to the behavior that I'd rather not resort to. I brought this helper call into this world, and now I'm taking it out.

Lastly -- The supply pod random event can now be properly jumped to. Originally, it would track the landing indicator, which would delete almost immediately and leave an un-orbitable popup on your screen. Now you jump to the landing zone, regardless of when you click the toast popup.

This is really long PR body for such tiny changes please don't think this is anything more than it actually is.
## Why It's Good For The Game

Minor improvements to some ghost orbit popups, because Observers are players too!
## Changelog
:cl:
qol: Dynamic midrounds "Obsession Awakening" and "Blob Host" now have ghost orbit popups, so you can see them happening in real time.
qol: There is no longer a ghost orbit popup for players being shocked by an electrified tram rail.
qol: The Stray Cargo orbit popup no longer has a half-second window to orbit before it becomes useless.
/:cl:
