### PR TITLE
Blocks (most instances of) screen elements from entering base atom `/Click`

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -26,3 +26,5 @@
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"
 ///from base of mob/MouseWheelOn(): (/atom, delta_x, delta_y, params)
 #define COMSIG_MOUSE_SCROLL_ON "mousescroll_on"
+/// From /atom/movable/screen/click(): (atom/target, atom/location, control, params, mob/user)
+#define COMSIG_SCREEN_ELEMENT_CLICK "screen_element_click"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -1048,6 +1048,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	return TRUE
 
 /atom/movable/screen/alert/Click(location, control, params)
+	SHOULD_CALL_PARENT(TRUE)
+
+	..()
 	if(!usr || !usr.client)
 		return FALSE
 	if(usr != owner)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -35,6 +35,12 @@
 
 	/// If FALSE, this will not be cleared when calling /client/clear_screen()
 	var/clear_with_screen = TRUE
+	/// If TRUE, clicking the screen element will fall through and perform a default "Click" call
+	/// Obviously this requires your Click override, if any, to call parent on their own.
+	/// This is set to FALSE to default to dissade you from doing this.
+	/// Generally we don't want default Click stuff, which results in bugs like using Telekinesis on a screen element
+	/// or trying to point your gun at your screen.
+	var/default_click = FALSE
 
 /atom/movable/screen/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
@@ -45,6 +51,12 @@
 	master_ref = null
 	hud = null
 	return ..()
+
+/atom/movable/screen/Click(location, control, params)
+	if(flags_1 & INITIALIZED_1)
+		SEND_SIGNAL(src, COMSIG_SCREEN_ELEMENT_CLICK, location, control, params, usr)
+	if(default_click)
+		return ..()
 
 /atom/movable/screen/examine(mob/user)
 	return list()
@@ -653,9 +665,6 @@
 	name = "mood"
 	icon_state = "mood5"
 	screen_loc = ui_mood
-
-/atom/movable/screen/mood/attack_tk()
-	return
 
 /atom/movable/screen/splash
 	icon = 'icons/blanks/blank_title.png'

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -10,7 +10,7 @@
 	C.icon = H.ui_style
 	H.static_inventory += C
 	CL.screen += C
-	RegisterSignal(C, COMSIG_CLICK, PROC_REF(component_ui_interact))
+	RegisterSignal(C, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(component_ui_interact))
 
 #define COOKING TRUE
 #define CRAFTING FALSE

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -298,7 +298,7 @@
 	mood_screen_object.color = "#4b96c4"
 	hud.infodisplay += mood_screen_object
 	RegisterSignal(hud, COMSIG_QDELETING, PROC_REF(unmodify_hud))
-	RegisterSignal(mood_screen_object, COMSIG_CLICK, PROC_REF(hud_click))
+	RegisterSignal(mood_screen_object, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(hud_click))
 
 /// Removes the mood HUD object
 /datum/mood/proc/unmodify_hud(datum/source)

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	SHOULD_CALL_PARENT(TRUE)
 	lobby_buttons |= lobby_button
 	RegisterSignal(lobby_button, COMSIG_ATOM_UPDATE_ICON, PROC_REF(on_lobby_button_update_icon))
-	RegisterSignal(lobby_button, COMSIG_CLICK, PROC_REF(on_lobby_button_click))
+	RegisterSignal(lobby_button, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(on_lobby_button_click))
 	RegisterSignal(lobby_button, COMSIG_QDELETING, PROC_REF(on_lobby_button_destroyed))
 	lobby_button.update_appearance(UPDATE_ICON)
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -878,6 +878,9 @@
 	icon_state = "antalert"
 
 /atom/movable/screen/alert/status_effect/ants/Click()
+	. = ..()
+	if(!.)
+		return
 	var/mob/living/living = owner
 	if(!istype(living) || !living.can_resist() || living != owner)
 		return

--- a/code/datums/status_effects/debuffs/hooked.dm
+++ b/code/datums/status_effects/debuffs/hooked.dm
@@ -31,6 +31,9 @@
 	icon_state = "hooked"
 
 /atom/movable/screen/alert/status_effect/hooked/Click()
+	. = ..()
+	if(!.)
+		return
 	if(!owner.can_resist())
 		return
 	owner.balloon_alert(owner, "removing hook...")

--- a/code/game/objects/effects/cursor_catcher.dm
+++ b/code/game/objects/effects/cursor_catcher.dm
@@ -3,6 +3,7 @@
 	icon_state = "fullscreen_blocker" // Fullscreen semi transparent icon
 	plane = HUD_PLANE
 	mouse_opacity = MOUSE_OPACITY_ICON
+	default_click = TRUE
 	/// The mob whose cursor we are tracking.
 	var/mob/owner
 	/// Client view size of the scoping mob.

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -171,7 +171,7 @@
 	kinesis_beam = mod.wearer.Beam(grabbed_atom, "kinesis")
 	kinesis_catcher = mod.wearer.overlay_fullscreen("kinesis", /atom/movable/screen/fullscreen/cursor_catcher/kinesis, 0)
 	kinesis_catcher.assign_to_mob(mod.wearer)
-	RegisterSignal(kinesis_catcher, COMSIG_CLICK, PROC_REF(on_catcher_click))
+	RegisterSignal(kinesis_catcher, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(on_catcher_click))
 	soundloop.start()
 	START_PROCESSING(SSfastprocess, src)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #76495

This PR prevents (most) screen elements from running base `/atom/proc/Click` and `/mob/proc/ClickOn()` when clickend. 

(The only exception I found to it was the cursor catcher for scopes.) 

Why?
Most, if not everything in `ClickOn` is considered "in world" interacting. It abides by `incapacitated`, runs `faceAtom`, etc. 
This means, currently, you can "interact" with screen elements using in world elements. For example, TK-ing / pointing a gun at your mood face. 

Right now this affects very little, but there is a large potential for errors. All you have to do is forget a sanity check in `afterattack` and suddenly you have an item that can affect your screen objects. 
The only example I found was the `/item/godstaff`, which can color some of your screen elements. But there may be more. Like guns. 

Note: 
Many, many screen elements ALREADY do not fall down into atom click. They simply don't call parent. Which is totally fine.
I am just ensuring ALL* screen elements do not fall down into atom click. 

## Changelog

:cl: Melbert
fix: Blocks mobs from trying to "physically" interact with some of their hud elements, such as using Telekinesis or point a gun at your mood meter. 
/:cl:


