### PR TITLE
Fix 100k toggle move intent comsig runtimes

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -372,7 +372,7 @@
 /atom/movable/screen/mov_intent/proc/toggle(mob/living/user)
 	if(!istype(user))
 		return
-	user.toggle_move_intent(user)
+	user.toggle_move_intent()
 
 /atom/movable/screen/pull
 	name = "stop pulling"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -493,14 +493,14 @@
 	set instant = TRUE
 	if(isliving(mob))
 		var/mob/living/user_mob = mob
-		user_mob.toggle_move_intent(usr)
+		user_mob.toggle_move_intent()
 
 /**
  * Toggle the move intent of the mob
  *
  * triggers an update the move intent hud as well
  */
-/mob/living/proc/toggle_move_intent(mob/user)
+/mob/living/proc/toggle_move_intent()
 	if(move_intent == MOVE_INTENT_RUN)
 		move_intent = MOVE_INTENT_WALK
 	else
@@ -510,7 +510,7 @@
 			selector.update_appearance()
 	update_move_intent_slowdown()
 
-	SEND_SIGNAL(user, COMSIG_MOVE_INTENT_TOGGLED)
+	SEND_SIGNAL(src, COMSIG_MOVE_INTENT_TOGGLED)
 
 ///Moves a mob upwards in z level
 /mob/verb/up()


### PR DESCRIPTION
## About The Pull Request

`user` isn't passed in many situations in which `toggle_move_intent` is called and also it's useless to pass `user` because it should just be The Mob


