### PR TITLE
You can't ventcrawl with items in-hand anymore and have a click cooldown applied when exiting a vent.

### DIFF
--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -31,10 +31,14 @@
 			to_chat(src, span_warning("You can't vent crawl while buckled!"))
 		return
 	if(iscarbon(src) && required_nudity)
-		if(length(get_equipped_items(include_pockets = TRUE)) || get_num_held_items())
+		if(length(get_equipped_items(include_pockets = TRUE)))
 			if(provide_feedback)
 				to_chat(src, span_warning("You can't crawl around in the ventilation ducts with items!"))
 			return
+	if(get_num_held_items())
+		if(provide_feedback)
+			to_chat(src, span_warning("You can't crawl around in the ventilation ducts without all of your hands free!"))
+		return
 	if(ventcrawl_target.welded)
 		if(provide_feedback)
 			to_chat(src, span_warning("You can't crawl around a welded vent!"))
@@ -65,6 +69,7 @@
 			to_chat(src, span_warning("You can't crawl around a welded vent!"))
 			return
 		visible_message(span_notice("[src] scrambles out from the ventilation ducts!"), span_notice("You scramble out from the ventilation ducts."))
+		changeNext_move(CLICK_CD_MELEE)
 		forceMove(ventcrawl_target.loc)
 		REMOVE_TRAIT(src, TRAIT_MOVE_VENTCRAWLING, VENTCRAWLING_TRAIT)
 		update_pipe_vision()


### PR DESCRIPTION
## About The Pull Request

You can't ventcrawl with items in-hand anymore and have a click cooldown applied when exiting a vent.

## Why It's Good For The Game

Anyone with the ability to ventcrawl being able to pop out of a vent and instantly attack you with a ranged weapon they had ready to go sucks to play against and is immensely un-fun to be on the receiving end. Requiring some form of storage interaction to get out your weapon and a click cooldown on the act of getting out of a vent ensures you have time to react.

## Changelog
:cl:
balance: You can't ventcrawl with items in-hand anymore and have a click cooldown applied when exiting a vent.
/:cl: