### PR TITLE
Fix robocontrol access runtime

### DIFF
--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -35,7 +35,7 @@
 	for(var/mob/living/simple_animal/bot/simple_bot as anything in GLOB.bots_list)
 		if(!is_valid_z_level(current_turf, get_turf(simple_bot)) || !(simple_bot.bot_mode_flags & BOT_MODE_REMOTE_ENABLED)) //Only non-emagged bots on the same Z-level are detected!
 			continue
-		if(computer && !simple_bot.check_access(user)) // Only check Bots we can access)
+		if(computer && !simple_bot.allowed(user)) // Only check Bots we can access)
 			continue
 		var/list/newbot = list(
 			"name" = simple_bot.name,

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -35,7 +35,7 @@
 	for(var/mob/living/simple_animal/bot/simple_bot as anything in GLOB.bots_list)
 		if(!is_valid_z_level(current_turf, get_turf(simple_bot)) || !(simple_bot.bot_mode_flags & BOT_MODE_REMOTE_ENABLED)) //Only non-emagged bots on the same Z-level are detected!
 			continue
-		if(computer && !simple_bot.allowed(user)) // Only check Bots we can access)
+		if(!simple_bot.allowed(user) && !simple_bot.check_access(computer.computer_id_slot)) // Only check Bots we can access)
 			continue
 		var/list/newbot = list(
 			"name" = simple_bot.name,

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -35,7 +35,7 @@
 	for(var/mob/living/simple_animal/bot/simple_bot as anything in GLOB.bots_list)
 		if(!is_valid_z_level(current_turf, get_turf(simple_bot)) || !(simple_bot.bot_mode_flags & BOT_MODE_REMOTE_ENABLED)) //Only non-emagged bots on the same Z-level are detected!
 			continue
-		if(!simple_bot.allowed(user) && !simple_bot.check_access(computer.computer_id_slot)) // Only check Bots we can access)
+		if(!simple_bot.allowed(user) && !simple_bot.check_access(computer.computer_id_slot)) // Only check Bots we can access
 			continue
 		var/list/newbot = list(
 			"name" = simple_bot.name,


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/51863163/568fa916-d167-4038-b0e8-7b0870754bf9)

`check_access` expects an item, such as an ID card, to... check access. Not a mob. 

We can circumvent this entirely by using `allowed`.

But this has an averse effect in that `allowed` will only check the user's ID, not the ID in the mod PC. 

So we need to run a separate check of `check_access` for the computer ID card. 

## Changelog

:cl: Melbert
fix: Robocontrol should work better.
/:cl:

