### PR TITLE
Fix Kinetic Projectiles in non PKAs breaking

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -191,14 +191,13 @@
 	return ..()
 
 /obj/projectile/kinetic/prehit_pierce(atom/target)
-	if(is_type_in_typecache(target, kinetic_gun.ignored_mob_types))
+	if(is_type_in_typecache(target, kinetic_gun?.ignored_mob_types))
 		return PROJECTILE_PIERCE_PHASE
 	. = ..()
 	if(. == PROJECTILE_PIERCE_PHASE)
 		return
-	if(kinetic_gun)
-		for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in kinetic_gun.modkits)
-			modkit_upgrade.projectile_prehit(src, target, kinetic_gun)
+	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in kinetic_gun?.modkits)
+		modkit_upgrade.projectile_prehit(src, target, kinetic_gun)
 	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
 		name = "weakened [name]"
 		damage = damage * pressure_decrease


### PR DESCRIPTION
## About The Pull Request

Kinetic blasts are fired from things which are not PKAs sometimes which makes this runtime

![image](https://github.com/tgstation/tgstation/assets/51863163/53d3fe5f-7ab8-4e0d-ba81-36d148d671ae)

## Changelog

:cl: Melbert
fix: Non-PKA kinetic blasts should work better
/:cl:

