### PR TITLE
turret id panel thingamajig access works properly

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -976,10 +976,12 @@ DEFINE_BITFIELD(turret_flags, list(
 	if (issilicon(user))
 		return attack_hand(user)
 
-	if(!isidcard(attacking_item) && !istype(attacking_item, /obj/item/modular_computer/pda))
+	var/id = attacking_item.GetID()
+
+	if(isnull(id))
 		return
 
-	if (check_access(attacking_item))
+	if (check_access(id))
 		if(obj_flags & EMAGGED)
 			to_chat(user, span_warning("The turret control is unresponsive!"))
 			return

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -960,14 +960,14 @@ DEFINE_BITFIELD(turret_flags, list(
 		. += {"[span_notice("Ctrl-click [src] to [ enabled ? "disable" : "enable"] turrets.")]
 					[span_notice("Alt-click [src] to set turrets to [ lethal ? "stun" : "kill"].")]"}
 
-/obj/machinery/turretid/attackby(obj/item/I, mob/user, params)
+/obj/machinery/turretid/attackby(obj/item/attacking_item, mob/user, params)
 	if(machine_stat & BROKEN)
 		return
 
-	if(I.tool_behaviour == TOOL_MULTITOOL)
-		if(!multitool_check_buffer(user, I))
+	if(attacking_item.tool_behaviour == TOOL_MULTITOOL)
+		if(!multitool_check_buffer(user, attacking_item))
 			return
-		var/obj/item/multitool/M = I
+		var/obj/item/multitool/M = attacking_item
 		if(M.buffer && istype(M.buffer, /obj/machinery/porta_turret))
 			turrets |= WEAKREF(M.buffer)
 			to_chat(user, span_notice("You link \the [M.buffer] with \the [src]."))
@@ -976,16 +976,15 @@ DEFINE_BITFIELD(turret_flags, list(
 	if (issilicon(user))
 		return attack_hand(user)
 
-	if ( get_dist(src, user) == 0 ) // trying to unlock the interface
-		if (allowed(usr))
-			if(obj_flags & EMAGGED)
-				to_chat(user, span_warning("The turret control is unresponsive!"))
-				return
+	if (isidcard(attacking_item) && check_access(attacking_item))
+		if(obj_flags & EMAGGED)
+			to_chat(user, span_warning("The turret control is unresponsive!"))
+			return
 
-			locked = !locked
-			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the panel."))
-		else
-			to_chat(user, span_alert("Access denied."))
+		locked = !locked
+		to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the panel."))
+	else
+		to_chat(user, span_alert("Access denied."))
 
 /obj/machinery/turretid/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -976,7 +976,10 @@ DEFINE_BITFIELD(turret_flags, list(
 	if (issilicon(user))
 		return attack_hand(user)
 
-	if (isidcard(attacking_item) && check_access(attacking_item))
+	if(!isidcard(attacking_item) && !istype(attacking_item, /obj/item/modular_computer/pda))
+		return
+
+	if (check_access(attacking_item))
 		if(obj_flags & EMAGGED)
 			to_chat(user, span_warning("The turret control is unresponsive!"))
 			return


### PR DESCRIPTION

## About The Pull Request

it now checks access of the attacking item instead of you
also removes the ass range check anyway it messes up TK and its inconvenient and attackby should handle it anyway and if the ID card somehow has a greater reach variable it still works

## Why It's Good For The Game

fixes #81978

## Changelog
:cl:
fix: turret id panel checks the access of the attacking item instead
/:cl:
