### PR TITLE
makes an unused weather variable used and snow storms no longer glow

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -259,9 +259,10 @@
 		// This method of applying one overlay per z layer has some minor downsides, in that it could lead to improperly doubled effects if some have alpha
 		// I prefer it to creating 2 extra plane masters however, so it's a cost I'm willing to pay
 		// LU
-		var/mutable_appearance/glow_overlay = mutable_appearance('icons/effects/glow_weather.dmi', weather_state, overlay_layer, null, ABOVE_LIGHTING_PLANE, 100, offset_const = offset)
-		glow_overlay.color = weather_color
-		gen_overlay_cache += glow_overlay
+		if(use_glow)
+			var/mutable_appearance/glow_overlay = mutable_appearance('icons/effects/glow_weather.dmi', weather_state, overlay_layer, null, ABOVE_LIGHTING_PLANE, 100, offset_const = offset)
+			glow_overlay.color = weather_color
+			gen_overlay_cache += glow_overlay
 
 		var/mutable_appearance/weather_overlay = mutable_appearance('icons/effects/weather_effects.dmi', weather_state, overlay_layer, plane = overlay_plane, offset_const = offset)
 		weather_overlay.color = weather_color

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -11,6 +11,7 @@
 	weather_overlay = "snow_storm"
 	weather_duration_lower = 600
 	weather_duration_upper = 1500
+	use_glow = FALSE
 
 	end_duration = 100
 	end_message = "<span class='boldannounce'>The snowfall dies down, it should be safe to go outside again.</span>"


### PR DESCRIPTION

## About The Pull Request

use_glow variable is now actually checked (i think this is a fix?)
sets it to FALSE for snow storms cuz it looks cool

## Why It's Good For The Game

i think its more visually appealing for the no glow part
and also bug fix

i mean check this swag
![image](https://github.com/tgstation/tgstation/assets/70376633/3ae7cbf7-9664-4cc0-9920-37ae5b6cf8b7)


## Changelog
:cl:
fix: Certain weather types that arent supposed to be glowing no longer glow
image: Snow storms no longer glow
/:cl:
