### PR TITLE
Fixes stabilized red bypassing immutable slowdowns / Fixes being unable to construct fulltile objects on immutably slow things

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -314,8 +314,7 @@
 	pickup_sound = 'sound/items/handling/crowbar_pickup.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	block_sound = 'sound/weapons/sonic_jackhammer.ogg'
-	obj_flags = IMMUTABLE_SLOW
-	item_flags = SLOWS_WHILE_IN_HAND
+	item_flags = SLOWS_WHILE_IN_HAND | IMMUTABLE_SLOW
 	slowdown = 3
 	attack_speed = 1.2 SECONDS
 	/// The factor at which the recoil becomes less.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1531,14 +1531,32 @@
 ///Apply a proper movespeed modifier based on items we have equipped
 /mob/proc/update_equipment_speed_mods()
 	var/speedies = 0
+	var/immutable_speedies = 0
 	for(var/obj/item/thing in get_equipped_speed_mod_items())
-		speedies += thing.slowdown
-	if(speedies > 0 && HAS_TRAIT(src, TRAIT_SETTLER)) //if our movespeed mod is in the negatives, we don't modify it since that's a benefit
+		if(thing.item_flags & IMMUTABLE_SLOW)
+			immutable_speedies += thing.slowdown
+		else
+			speedies += thing.slowdown
+
+	//if our movespeed mod is in the negatives, we don't modify it since that's a benefit
+	if(speedies > 0 && HAS_TRAIT(src, TRAIT_SETTLER))
 		speedies *= 0.2
-	if(!speedies)
-		remove_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod)
+
+	if(immutable_speedies)
+		add_or_update_variable_movespeed_modifier(
+			/datum/movespeed_modifier/equipment_speedmod/immutable,
+			multiplicative_slowdown = immutable_speedies,
+		)
 	else
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod, multiplicative_slowdown = speedies)
+		remove_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod/immutable)
+
+	if(speedies)
+		add_or_update_variable_movespeed_modifier(
+			/datum/movespeed_modifier/equipment_speedmod,
+			multiplicative_slowdown = speedies,
+		)
+	else
+		remove_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod)
 
 ///Get all items in our possession that should affect our movespeed
 /mob/proc/get_equipped_speed_mod_items()

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -9,7 +9,7 @@
 	body_parts_covered = HEAD
 	heat_protection = HEAD
 	cold_protection = HEAD
-	obj_flags = IMMUTABLE_SLOW
+	item_flags = IMMUTABLE_SLOW
 
 /obj/item/clothing/suit/mod
 	name = "MOD chestplate"
@@ -28,7 +28,7 @@
 	body_parts_covered = CHEST|GROIN
 	heat_protection = CHEST|GROIN
 	cold_protection = CHEST|GROIN
-	obj_flags = IMMUTABLE_SLOW
+	item_flags = IMMUTABLE_SLOW
 
 /obj/item/clothing/gloves/mod
 	name = "MOD gauntlets"
@@ -41,7 +41,7 @@
 	body_parts_covered = HANDS|ARMS
 	heat_protection = HANDS|ARMS
 	cold_protection = HANDS|ARMS
-	obj_flags = IMMUTABLE_SLOW
+	item_flags = IMMUTABLE_SLOW
 
 /obj/item/clothing/shoes/mod
 	name = "MOD boots"
@@ -54,6 +54,5 @@
 	body_parts_covered = FEET|LEGS
 	heat_protection = FEET|LEGS
 	cold_protection = FEET|LEGS
-	obj_flags = IMMUTABLE_SLOW
-	item_flags = IGNORE_DIGITIGRADE
+	item_flags = IGNORE_DIGITIGRADE | IMMUTABLE_SLOW
 	can_be_tied = FALSE

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -30,9 +30,13 @@
 	movetypes = FLYING
 	variable = TRUE
 
+/// Movespeed modifier applied by worn equipment.
 /datum/movespeed_modifier/equipment_speedmod
 	variable = TRUE
 	blacklisted_movetypes = FLOATING
+
+/// Movespeed modifier applied by immutably slow worn equipment. Should never be ignored, because that's the point.
+/datum/movespeed_modifier/equipment_speedmod/immutable
 
 /datum/movespeed_modifier/grab_slowdown
 	id = MOVESPEED_ID_MOB_GRAB_STATE

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -138,7 +138,7 @@ Slimecrossing Armor
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	inhand_icon_state = null
 	flags_inv = NONE
-	obj_flags = IMMUTABLE_SLOW
+	item_flags = IMMUTABLE_SLOW
 	slowdown = 4
 	var/hit_reflect_chance = 40
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -917,7 +917,7 @@
 		return
 	if(isitem(C))
 		var/obj/item/I = C
-		if(I.slowdown <= 0 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.slowdown <= 0 || (I.item_flags & IMMUTABLE_SLOW))
 			to_chat(user, span_warning("The [C] can't be made any faster!"))
 			return ..()
 		I.slowdown = 0


### PR DESCRIPTION
## About The Pull Request

- Fixes Stabilized Red extract's equipment slowdown immunity bypassing item Immutable Slowdown

- Fixes(?) Settler equipment slowdown modifier applying to immutable slows

- Fixes Immutable Slow being considered an object flag when it was an item flag, causing objects to consider objects with it to be `BLOCKS_CONSTRUCTION_DIR` 

## Why It's Good For The Game

The description of Immutable Slows: 

`When players should not be able to change the slowdown of the item (Speed potions, etc)`

Stabilized Red extracts were changing the slowdown of the item, which is unintended. 
Likewise Settler was doing the same, but that one I'm a bit more iffy on. 

Either way I suppose if things should immutably be slow, they should immutably be slow. 

## Changelog

:cl: Melbert
fix: Stabilized Red extracts no longer bypass Immutably Slow items
fix: Settler equipment speed modifier no longer applied to Immutably Slow items
fix: Immutably Slow items no longer block construction of certain items 
/:cl:


