### PR TITLE
FIX: Makes Hatsune mi-go a (friendly) gold slime mob

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -41,6 +41,10 @@
 		new /mob/living/basic/migo/hatsune(get_turf(loc), mapload)
 		return INITIALIZE_HINT_QDEL
 
+	if(istype(src, /mob/living/basic/migo/hatsune))
+		var/static/list/death_loot = list(/obj/item/instrument/piano_synth)
+		AddElement(/datum/element/death_drops, death_loot)
+
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_NETHER, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 0)
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = -1.5, additional_status_callback = CALLBACK(src, PROC_REF(update_dodge_chance)))
 
@@ -52,15 +56,22 @@
 	. = ..()
 	if(stat != CONSCIOUS)
 		return
-	playsound(src, pick(migo_sounds), 50, TRUE)
+	if(!istype(src, /mob/living/basic/migo/hatsune))
+		playsound(src, pick(migo_sounds), 50, TRUE)
+	else
+		playsound(src, 'sound/creatures/tourist/tourist_talk_japanese1.ogg', 50, TRUE)
 
 /mob/living/basic/migo/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	..()
 	if(stat)
 		return
 	if(SPT_PROB(5, seconds_per_tick))
-		var/chosen_sound = pick(migo_sounds)
-		playsound(src, chosen_sound, 50, TRUE)
+		if(!istype(src, /mob/living/basic/migo/hatsune))
+			var/chosen_sound = pick(migo_sounds)
+			playsound(src, chosen_sound, 50, TRUE)
+		else
+			playsound(src, 'sound/creatures/tourist/tourist_talk_japanese1.ogg', 50, TRUE)
+
 
 /mob/living/basic/migo/Move(atom/newloc, dir, step_x, step_y)
 	if(!ckey && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
@@ -82,4 +93,6 @@
 	desc = parent_type::desc + " This one is wearing a bright blue wig."
 	icon_state = "mi-go-h"
 	icon_living = "mi-go-h"
-	gold_core_spawnable = NO_SPAWN
+
+	gold_core_spawnable = FRIENDLY_SPAWN
+	faction = list(FACTION_NEUTRAL)

--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -41,9 +41,9 @@
 		new /mob/living/basic/migo/hatsune(get_turf(loc), mapload)
 		return INITIALIZE_HINT_QDEL
 
-	if(istype(src, /mob/living/basic/migo/hatsune))
-		var/static/list/death_loot = list(/obj/item/instrument/piano_synth)
-		AddElement(/datum/element/death_drops, death_loot)
+	//if(istype(src, /mob/living/basic/migo/hatsune))
+		//var/static/list/death_loot = list(/obj/item/instrument/piano_synth)
+		//AddElement(/datum/element/death_drops, death_loot)
 
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_NETHER, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 0)
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = -1.5, additional_status_callback = CALLBACK(src, PROC_REF(update_dodge_chance)))
@@ -52,26 +52,21 @@
 /mob/living/basic/migo/proc/update_dodge_chance(health_ratio)
 	dodge_prob = LERP(50, 10, health_ratio)
 
+/mob/living/basic/migo/proc/make_migo_sound()
+	playsound(src, pick(migo_sounds), 50, TRUE)
+
 /mob/living/basic/migo/send_speech(message_raw, message_range, obj/source, bubble_type, list/spans, datum/language/message_language, list/message_mods, forced, tts_message, list/tts_filter)
 	. = ..()
 	if(stat != CONSCIOUS)
 		return
-	if(!istype(src, /mob/living/basic/migo/hatsune))
-		playsound(src, pick(migo_sounds), 50, TRUE)
-	else
-		playsound(src, 'sound/creatures/tourist/tourist_talk_japanese1.ogg', 50, TRUE)
+	make_migo_sound()
 
 /mob/living/basic/migo/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	..()
 	if(stat)
 		return
 	if(SPT_PROB(5, seconds_per_tick))
-		if(!istype(src, /mob/living/basic/migo/hatsune))
-			var/chosen_sound = pick(migo_sounds)
-			playsound(src, chosen_sound, 50, TRUE)
-		else
-			playsound(src, 'sound/creatures/tourist/tourist_talk_japanese1.ogg', 50, TRUE)
-
+		make_migo_sound()
 
 /mob/living/basic/migo/Move(atom/newloc, dir, step_x, step_y)
 	if(!ckey && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
@@ -94,5 +89,14 @@
 	icon_state = "mi-go-h"
 	icon_living = "mi-go-h"
 
+	gender = FEMALE
 	gold_core_spawnable = FRIENDLY_SPAWN
 	faction = list(FACTION_NEUTRAL)
+
+/mob/living/basic/migo/hatsune/make_migo_sound()
+	playsound(src, 'sound/creatures/tourist/tourist_talk_japanese1.ogg', 50, TRUE)
+
+/mob/living/basic/migo/hatsune/Initialize(mapload)
+	. = ..()
+	var/static/list/death_loot = list(/obj/item/instrument/piano_synth)
+	AddElement(/datum/element/death_drops, death_loot)

--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -41,10 +41,6 @@
 		new /mob/living/basic/migo/hatsune(get_turf(loc), mapload)
 		return INITIALIZE_HINT_QDEL
 
-	//if(istype(src, /mob/living/basic/migo/hatsune))
-		//var/static/list/death_loot = list(/obj/item/instrument/piano_synth)
-		//AddElement(/datum/element/death_drops, death_loot)
-
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_NETHER, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 0)
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = -1.5, additional_status_callback = CALLBACK(src, PROC_REF(update_dodge_chance)))
 


### PR DESCRIPTION
## About The Pull Request:

 The hatsune mi-go is now a friendly gold slime mob. This means it won't try and kill you. It also now doesn't make your ears hurt, and drops a keyboard synth on death (you monster.)

![migomigodance](https://github.com/tgstation/tgstation/assets/69398298/9dd6eb82-68d6-470c-9538-12298c3a6008)
## Why It's Good For The Game


So in making my resprited mi-go and subsequent speedmerge, I failed to realize that there are only 10 possible migo spawnpoints - 5 in snowdin gateway, 3 on ceres whiteship, and 2 on kilo whiteship. This means at most eight can exist on anyround, with a decent likelyhood of 0. This, combined with the fact the hatsune migo is banned from spawning outside of roundstart locations, along with the fact people seem to love the thing, made it feel _too_ rare, even for a shiny mob. You still have to roll the random odds with the life chem or friendly gold slime pools, but you should actually see them outside of two mutually exclusive space ruins and a gateway now. Also, they don't try and kill you now, because it would have been wrong to add a hostile creature to the friendly pool.

:cl:
fix:  Hatsune mi-go now is a friendly gold slime mob, and doesn't hurt your ears.
add: Hatsune mi-go drops a keyboard synth on death (you monster.)
/:cl:
