### PR TITLE
Removes the ability for the AI to track mobs in objects, as well as very transparent mobs.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1267,18 +1267,18 @@
 	//basic fast checks go first. When overriding this proc, I recommend calling ..() at the end.
 	if(SEND_SIGNAL(src, COMSIG_LIVING_CAN_TRACK, user) & COMPONENT_CANT_TRACK)
 		return FALSE
-	var/turf/T = get_turf(src)
-	if(!T)
+	if(!isnull(user) && src == user)
 		return FALSE
+	if(invisibility || alpha <= 50)//cloaked
+		return FALSE
+	if(!isturf(src.loc)) //The reason why we don't just use get_turf is because they could be in a closet, disposals, or a vehicle.
+		return FALSE
+	var/turf/T = src.loc
 	if(is_centcom_level(T.z)) //dont detect mobs on centcom
 		return FALSE
 	if(is_away_level(T.z))
 		return FALSE
 	if(onSyndieBase() && !(ROLE_SYNDICATE in user?.faction))
-		return FALSE
-	if(!isnull(user) && src == user)
-		return FALSE
-	if(invisibility || alpha == 0)//cloaked
 		return FALSE
 	// Now, are they viewable by a camera? (This is last because it's the most intensive check)
 	if(!GLOB.cameranet.checkCameraVis(src))


### PR DESCRIPTION

## About The Pull Request

You can no longer visually track something (See: AI tracking) if that object is inside something.
You are considered invisible by the tracking system if your alpha is less than 50, instead of just having 0 alpha.
Rearranges some tracking code so the less expensive stuff is called before the more expensive stuff.

## Why It's Good For The Game

I don't know if this is a bug or an intended feature, but as it stands the AI can track and find people inside lockers, disposals, vehicles, and other objects despite in most cases not being able to have a visual lock-on to the target. As an AI player, it feels game breaking to be able to track people in these states. This PR makes it so that you cannot be tracked while you are inside an object.

I also made it so that you are considered "invisible" by the tracking system if your alpha level is less than 50, instead of it just being 0. To get an idea how invisible 50 alpha is, here is a picture of a clown set to 50 alpha. Horrifying.

![image](https://github.com/tgstation/tgstation/assets/8602857/ce794bcb-ee95-4b84-84cb-afc171e88e81)

## Changelog

:cl: BurgerBB
balance: You can no longer visually track something (See: AI tracking) if that object is inside something. You are also considered invisible by tracking if your alpha level is less than 50.
/:cl:
