### PR TITLE
Strip Menu Suit Sensors

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -1,4 +1,4 @@
-///Called on user, from base of /datum/strippable_item/alternate_action() (atom/target)
+///Called on user, from base of /datum/strippable_item/perform_alternate_action() (atom/target, action_key)
 #define COMSIG_TRY_ALT_ACTION "try_alt_action"
 	#define COMPONENT_CANT_ALT_ACTION (1<<0)
 ///Called on /basic when updating its speed, from base of /mob/living/basic/update_basic_mob_varspeed(): ()

--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -132,7 +132,7 @@
 	SIGNAL_HANDLER
 	return is_shy(target) && COMPONENT_CANT_STRIP
 
-/datum/component/shy/proc/on_try_alt_action(datum/source, atom/target)
+/datum/component/shy/proc/on_try_alt_action(datum/source, atom/target, action_key)
 	SIGNAL_HANDLER
 	return is_shy(target) && COMPONENT_CANT_ALT_ACTION
 

--- a/code/datums/components/shy_in_room.dm
+++ b/code/datums/components/shy_in_room.dm
@@ -69,6 +69,6 @@
 	SIGNAL_HANDLER
 	return is_shy(target) && COMPONENT_CANT_STRIP
 
-/datum/component/shy_in_room/proc/on_try_alt_action(datum/source, atom/target)
+/datum/component/shy_in_room/proc/on_try_alt_action(datum/source, atom/target, action_key)
 	SIGNAL_HANDLER
 	return is_shy(target) && COMPONENT_CANT_ALT_ACTION

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -352,6 +352,10 @@
 		result["icon"] = icon2base64(icon(item.icon, item.icon_state))
 		result["name"] = item.name
 		result["alternate"] = item_data.get_alternate_actions(owner, user)
+		var/static/list/already_cried = list()
+		if(length(result["alternate"]) > 2 && !(type in already_cried))
+			stack_trace("Too many alternate actions for [type]! Only two are supported at the moment! This will look bad!")
+			already_cried += type
 
 		items[strippable_key] = result
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -160,16 +160,22 @@
 	SHOULD_NOT_SLEEP(TRUE)
 	return STRIPPABLE_OBSCURING_NONE
 
-/// Returns the ID of this item's strippable action.
-/// Return `null` if there is no alternate action.
-/// Any return value of this must be in StripMenu.
+/**
+ * Returns a list of alternate actions that can be performed on this strippable_item.
+ * All string keys in the list must be inside tgui\packages\tgui\interfaces\StripMenu.tsx
+ * You can also return null if there are no alternate actions.
+ */
 /datum/strippable_item/proc/get_alternate_actions(atom/source, mob/user)
 	RETURN_TYPE(/list)
 	return null
 
-/// Performs an alternative action on this strippable_item.
-/// `has_alternate_action` needs to be TRUE.
-/// Returns FALSE if blocked by signal, TRUE otherwise.
+/**
+ * Performs an alternate action on this strippable_item.
+ * - source: The source of the action.
+ * - user: The user performing the action.
+ * - action_key: The key of the alternate action to perform.
+ * Returns FALSE if unable to perform the action; whether it be due to the signal or some other factor.
+ */
 /datum/strippable_item/proc/perform_alternate_action(atom/source, mob/user, action_key)
 	SHOULD_CALL_PARENT(TRUE)
 	if(SEND_SIGNAL(user, COMSIG_TRY_ALT_ACTION, source, action_key) & COMPONENT_CANT_ALT_ACTION)

--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -6,13 +6,14 @@
 	key = STRIPPABLE_ITEM_BACK
 	item_slot = ITEM_SLOT_BACK
 
-/datum/strippable_item/mob_item_slot/back/get_alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/back/get_alternate_actions(atom/source, mob/user)
 	return get_strippable_alternate_action_internals(get_item(source), source)
 
-/datum/strippable_item/mob_item_slot/back/alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/back/perform_alternate_action(atom/source, mob/user, action_key)
 	if(!..())
 		return
-	strippable_alternate_action_internals(get_item(source), source, user)
+	if(action_key in get_strippable_alternate_action_internals(get_item(source), source))
+		strippable_alternate_action_internals(get_item(source), source, user)
 
 /datum/strippable_item/mob_item_slot/mask
 	key = STRIPPABLE_ITEM_MASK

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		"[SENSOR_COORDS]" = "Tracking",
 	)
 
-	var/new_mode = tgui_input_list(user, "Set To What", "Adjust Sensors", sensor_mode_text_to_num, senor_mode_num_to_text["[jumpsuit.sensor_mode]"])
+	var/new_mode = tgui_input_list(user, "Adjust suit sensors", "Adjust Sensors", sensor_mode_text_to_num, senor_mode_num_to_text["[jumpsuit.sensor_mode]"])
 	new_mode = sensor_mode_text_to_num[new_mode]
 	if(isnull(new_mode)) // also catches returning null
 		return
@@ -113,13 +113,13 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		source.balloon_alert(user, "can't reach!")
 		return
 
-	to_chat(source, span_notice("[user] is trying to adjust your [jumpsuit]'s sensor."))
-	if(!do_after(user, (jumpsuit.strip_delay * 0.5), source)) // takes the same amount of time as adjusting it
+	to_chat(source, span_notice("[user] is trying to adjust your [jumpsuit.name]'s sensor."))
+	if(!do_after(user, jumpsuit.strip_delay * 0.5, source)) // takes the same amount of time as adjusting it
 		source.balloon_alert(user, "failed!")
 		return
 	source.balloon_alert(user, "changed sensors")
 	jumpsuit.sensor_mode = new_mode
-	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit]'s sensor."))
+	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit.name]'s sensor."))
 	if(ishuman(source))
 		var/mob/living/carbon/human/humano = source
 		humano.update_suit_sensors()

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		return
 
 	if(!user.Adjacent(source))
-		source.ballon_alert(user, "can't reach!")
+		source.balloon_alert(user, "can't reach!")
 		return
 
 	to_chat(source, span_notice("[user] is trying to adjust your [jumpsuit]'s sensor."))

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	if(!do_after(user, (jumpsuit.strip_delay * 0.5), source)) // takes the same amount of time as adjusting it
 		source.balloon_alert(user, "failed!")
 		return
-	source.ballon_alert(user, "changed sensors")
+	source.balloon_alert(user, "changed sensors")
 	jumpsuit.sensor_mode = new_mode
 	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit]'s sensor."))
 	if(ishuman(source))

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -90,20 +90,34 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 /datum/strippable_item/mob_item_slot/jumpsuit/proc/do_adjust_sensor(atom/source, mob/user, obj/item/clothing/under/jumpsuit)
 	if(!jumpsuit.has_sensor)
 		return
-	var/static/list/sensor_modes = list(
+
+	var/static/list/sensor_mode_text_to_num = list(
 		"Off" = SENSOR_OFF,
 		"Living" = SENSOR_LIVING,
 		"Vitals" = SENSOR_VITALS,
 		"Tracking" = SENSOR_COORDS,
 	)
-	var/new_mode = tgui_input_list(user, "Set To What", "Adjust Sensors", sensor_modes, sensor_modes[jumpsuit.sensor_mode])
-	new_mode = sensor_modes[new_mode]
-	if(isnull(new_mode) || !user.Adjacent(source)) // also catches returning null
+	var/static/list/senor_mode_num_to_text = list( // keep this as the inverse of the above list
+		"[SENSOR_OFF]" = "Off",
+		"[SENSOR_LIVING]" = "Living",
+		"[SENSOR_VITALS]" = "Vitals",
+		"[SENSOR_COORDS]" = "Tracking",
+	)
+
+	var/new_mode = tgui_input_list(user, "Set To What", "Adjust Sensors", sensor_mode_text_to_num, senor_mode_num_to_text["[jumpsuit.sensor_mode]"])
+	new_mode = sensor_mode_text_to_num[new_mode]
+	if(isnull(new_mode)) // also catches returning null
+		return
+
+	if(!user.Adjacent(source))
+		source.ballon_alert(user, "can't reach!")
 		return
 
 	to_chat(source, span_notice("[user] is trying to adjust your [jumpsuit]'s sensor."))
 	if(!do_after(user, (jumpsuit.strip_delay * 0.5), source)) // takes the same amount of time as adjusting it
+		source.balloon_alert(user, "failed!")
 		return
+	source.ballon_alert(user, "changed sensors")
 	jumpsuit.sensor_mode = new_mode
 	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit]'s sensor."))
 	if(ishuman(source))

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -45,22 +45,39 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	key = STRIPPABLE_ITEM_JUMPSUIT
 	item_slot = ITEM_SLOT_ICLOTHING
 
-/datum/strippable_item/mob_item_slot/jumpsuit/get_alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/jumpsuit/get_alternate_actions(atom/source, mob/user)
 	var/obj/item/clothing/under/jumpsuit = get_item(source)
 	if (!istype(jumpsuit))
 		return null
-	return jumpsuit?.can_adjust ? "adjust_jumpsuit" : null
 
-/datum/strippable_item/mob_item_slot/jumpsuit/alternate_action(atom/source, mob/user)
+	var/list/actions = list()
+	if(jumpsuit.has_sensor)
+		actions += "adjust_sensor"
+	if(jumpsuit.can_adjust)
+		actions += "adjust_jumpsuit"
+
+	return actions
+
+/datum/strippable_item/mob_item_slot/jumpsuit/perform_alternate_action(atom/source, mob/user, action_key)
 	if (!..())
 		return
 	var/obj/item/clothing/under/jumpsuit = get_item(source)
 	if (!istype(jumpsuit))
 		return null
-	to_chat(source, "<span class='notice'>[user] is trying to adjust your [jumpsuit.name].")
+
+	switch(action_key)
+		if("adjust_jumpsuit")
+			do_adjust_jumpsuit(source, user, jumpsuit)
+		if("adjust_sensor")
+			do_adjust_sensor(source, user, jumpsuit)
+		else
+			stack_trace("Unknown action key: [action_key] for [type]")
+
+/datum/strippable_item/mob_item_slot/jumpsuit/proc/do_adjust_jumpsuit(atom/source, mob/user, obj/item/clothing/under/jumpsuit)
+	to_chat(source, span_notice("[user] is trying to adjust your [jumpsuit]."))
 	if (!do_after(user, (jumpsuit.strip_delay * 0.5), source))
 		return
-	to_chat(source, "<span class='notice'>[user] successfully adjusted your [jumpsuit.name].")
+	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit]."))
 	jumpsuit.toggle_jumpsuit_adjust()
 
 	if (!ismob(source))
@@ -69,6 +86,29 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	var/mob/mob_source = source
 	mob_source.update_worn_undersuit()
 	mob_source.update_body()
+
+/datum/strippable_item/mob_item_slot/jumpsuit/proc/do_adjust_sensor(atom/source, mob/user, obj/item/clothing/under/jumpsuit)
+	if(!jumpsuit.has_sensor)
+		return
+	var/static/list/sensor_modes = list(
+		"Off" = SENSOR_OFF,
+		"Living" = SENSOR_LIVING,
+		"Vitals" = SENSOR_VITALS,
+		"Tracking" = SENSOR_COORDS,
+	)
+	var/new_mode = tgui_input_list(user, "Set To What", "Adjust Sensors", sensor_modes, sensor_modes[jumpsuit.sensor_mode])
+	new_mode = sensor_modes[new_mode]
+	if(isnull(new_mode) || !user.Adjacent(source)) // also catches returning null
+		return
+
+	to_chat(source, span_notice("[user] is trying to adjust your [jumpsuit]'s sensor."))
+	if(!do_after(user, (jumpsuit.strip_delay * 0.5), source)) // takes the same amount of time as adjusting it
+		return
+	jumpsuit.sensor_mode = new_mode
+	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit]'s sensor."))
+	if(ishuman(source))
+		var/mob/living/carbon/human/humano = source
+		humano.update_suit_sensors()
 
 /datum/strippable_item/mob_item_slot/suit
 	key = STRIPPABLE_ITEM_SUIT
@@ -82,39 +122,44 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	key = STRIPPABLE_ITEM_FEET
 	item_slot = ITEM_SLOT_FEET
 
-/datum/strippable_item/mob_item_slot/feet/get_alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/feet/get_alternate_actions(atom/source, mob/user)
 	var/obj/item/clothing/shoes/shoes = get_item(source)
 	if (!istype(shoes) || !shoes.can_be_tied)
 		return null
 
 	switch (shoes.tied)
 		if (SHOES_UNTIED)
-			return "knot"
+			return list("knot")
 		if (SHOES_TIED)
-			return "untie"
+			return list("untie")
 		if (SHOES_KNOTTED)
-			return "unknot"
+			return list("unknot")
 
-/datum/strippable_item/mob_item_slot/feet/alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/feet/perform_alternate_action(atom/source, mob/user, action_key)
 	if(!..())
 		return
+
 	var/obj/item/clothing/shoes/shoes = get_item(source)
 	if (!istype(shoes))
 		return
-
-	shoes.handle_tying(user)
+	switch(action_key)
+		if("knot", "untie", "unknot")
+			shoes.handle_tying(user)
+		else
+			stack_trace("Unknown action key: [action_key] for [type]")
 
 /datum/strippable_item/mob_item_slot/suit_storage
 	key = STRIPPABLE_ITEM_SUIT_STORAGE
 	item_slot = ITEM_SLOT_SUITSTORE
 
-/datum/strippable_item/mob_item_slot/suit_storage/get_alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/suit_storage/get_alternate_actions(atom/source, mob/user)
 	return get_strippable_alternate_action_internals(get_item(source), source)
 
-/datum/strippable_item/mob_item_slot/suit_storage/alternate_action(atom/source, mob/user)
-	if (!..())
+/datum/strippable_item/mob_item_slot/suit_storage/perform_alternate_action(atom/source, mob/user, action_key)
+	if(!..())
 		return
-	strippable_alternate_action_internals(get_item(source), source, user)
+	if(action_key in get_strippable_alternate_action_internals(get_item(source), source))
+		strippable_alternate_action_internals(get_item(source), source, user)
 
 /datum/strippable_item/mob_item_slot/id
 	key = STRIPPABLE_ITEM_ID
@@ -124,13 +169,14 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	key = STRIPPABLE_ITEM_BELT
 	item_slot = ITEM_SLOT_BELT
 
-/datum/strippable_item/mob_item_slot/belt/get_alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/belt/get_alternate_actions(atom/source, mob/user)
 	return get_strippable_alternate_action_internals(get_item(source), source)
 
-/datum/strippable_item/mob_item_slot/belt/alternate_action(atom/source, mob/user)
+/datum/strippable_item/mob_item_slot/belt/perform_alternate_action(atom/source, mob/user, action_key)
 	if (!..())
 		return
-	strippable_alternate_action_internals(get_item(source), source, user)
+	if(action_key in get_strippable_alternate_action_internals(get_item(source), source))
+		strippable_alternate_action_internals(get_item(source), source, user)
 
 /datum/strippable_item/mob_item_slot/pocket
 	/// Which pocket we're referencing. Used for visible text.
@@ -187,9 +233,9 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	var/mob/living/carbon/carbon_source = source
 	if (carbon_source.can_breathe_internals() && istype(item, /obj/item/tank))
 		if(carbon_source.internal != item)
-			return "enable_internals"
+			return list("enable_internals")
 		else
-			return "disable_internals"
+			return list("disable_internals")
 
 /proc/strippable_alternate_action_internals(obj/item/item, atom/source, mob/user)
 	var/obj/item/tank/tank = item

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -288,9 +288,8 @@ export const StripMenu = (props) => {
                   const item = data.items[keyAtSpot];
                   const slot = SLOTS[keyAtSpot];
 
-                  let alternateActions: string[] | undefined;
-
                   let content: JSX.Element | undefined;
+                  let alternateActions: JSX.Element[] | undefined;
                   let tooltip: string | undefined;
 
                   if (item === null) {
@@ -307,14 +306,42 @@ export const StripMenu = (props) => {
                       />
                     );
 
-                    if (item.alternate) {
-                      alternateActions = [];
-                      for (const alternateKey of item.alternate || []) {
-                        alternateActions.push(alternateKey);
-                      }
-                    }
-
                     tooltip = item.name;
+                    if (item.alternate) {
+                      alternateActions = item.alternate.map(
+                        (alternateKey, idx) => {
+                          const alternateAction =
+                            ALTERNATE_ACTIONS[alternateKey];
+
+                          const alternateActionStyle = {
+                            background: 'rgba(0, 0, 0, 0.6)',
+                            position: 'absolute',
+                            overflow: 'hidden',
+                            margin: '0px',
+                            maxWidth: '22px', // yes I know its not 20 or 25; they look bad. 22px is perfect
+                            zIndex: '2',
+                            left: `${idx === 0 ? '0' : undefined}`,
+                            right: `${idx === 1 ? '0' : undefined}`,
+                            bottom: '0',
+                          };
+                          return (
+                            <Button
+                              key={alternateAction.text}
+                              onClick={() => {
+                                act('alt', {
+                                  key: keyAtSpot,
+                                  alternate_action: alternateKey,
+                                });
+                              }}
+                              tooltip={alternateAction.text}
+                              style={alternateActionStyle}
+                            >
+                              <Icon name={alternateAction.icon} />
+                            </Button>
+                          );
+                        },
+                      );
+                    }
                   } else if ('obscured' in item) {
                     content = (
                       <Icon
@@ -382,39 +409,7 @@ export const StripMenu = (props) => {
 
                           {slot.additionalComponent}
                         </Button>
-
-                        {alternateActions &&
-                          alternateActions.map((alternateKey, idx) => {
-                            const alternateAction =
-                              ALTERNATE_ACTIONS[alternateKey];
-
-                            const alternateActionStyle = {
-                              background: 'rgba(0, 0, 0, 0.6)',
-                              position: 'absolute',
-                              overflow: 'hidden',
-                              margin: '0px',
-                              maxWidth: '22px', // 22px is a good width
-                              zIndex: '2',
-                              left: `${idx === 0 ? '0' : undefined}`,
-                              right: `${idx === 1 ? '0' : undefined}`,
-                              bottom: '0',
-                            };
-                            return (
-                              <Button
-                                key={alternateAction.text}
-                                onClick={() => {
-                                  act('alt', {
-                                    key: keyAtSpot,
-                                    alternate_action: alternateKey,
-                                  });
-                                }}
-                                tooltip={alternateAction.text}
-                                style={alternateActionStyle}
-                              >
-                                <Icon name={alternateAction.icon} />
-                              </Button>
-                            );
-                          })}
+                        {alternateActions}
                       </Box>
                     </Stack.Item>
                   );

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -290,26 +290,26 @@ export const StripMenu = (props) => {
 
                   let alternateActions: string[] | undefined;
 
-                  let content;
-                  let tooltip;
+                  let content: JSX.Element | undefined;
+                  let tooltip: string | undefined;
 
                   if (item === null) {
                     tooltip = slot.displayName;
                   } else if ('name' in item) {
+                    content = (
+                      <Image
+                        src={`data:image/jpeg;base64,${item.icon}`}
+                        height="100%"
+                        width="100%"
+                        style={{
+                          verticalAlign: 'middle',
+                        }}
+                      />
+                    );
+
                     if (item.alternate) {
                       alternateActions = [];
-                      const alternateActionIconSize =
-                        100 / item.alternate.length;
                       for (const alternateKey of item.alternate || []) {
-                        const alternateAction = ALTERNATE_ACTIONS[alternateKey];
-                        <Image
-                          src={`data:image/jpeg;base64,${alternateAction.icon}`}
-                          height={`${alternateActionIconSize}%`}
-                          width={`${alternateActionIconSize}%`}
-                          style={{
-                            verticalAlign: 'middle',
-                          }}
-                        />;
                         alternateActions.push(alternateKey);
                       }
                     }
@@ -384,9 +384,21 @@ export const StripMenu = (props) => {
                         </Button>
 
                         {alternateActions &&
-                          alternateActions.map((alternateKey) => {
+                          alternateActions.map((alternateKey, idx) => {
                             const alternateAction =
                               ALTERNATE_ACTIONS[alternateKey];
+
+                            const alternateActionStyle = {
+                              background: 'rgba(0, 0, 0, 0.6)',
+                              position: 'absolute',
+                              overflow: 'hidden',
+                              margin: '0px',
+                              maxWidth: '22px', // 22px is a good width
+                              zIndex: '2',
+                              left: `${idx === 0 ? '0' : undefined}`,
+                              right: `${idx === 1 ? '0' : undefined}`,
+                              bottom: '0',
+                            };
                             return (
                               <Button
                                 key={alternateAction.text}
@@ -397,13 +409,7 @@ export const StripMenu = (props) => {
                                   });
                                 }}
                                 tooltip={alternateAction.text}
-                                style={{
-                                  background: 'rgba(0, 0, 0, 0.6)',
-                                  position: 'absolute',
-                                  bottom: '0',
-                                  right: '0',
-                                  zIndex: '2',
-                                }}
+                                style={alternateActionStyle}
                               >
                                 <Icon name={alternateAction.icon} />
                               </Button>

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -72,6 +72,11 @@ const ALTERNATE_ACTIONS: Record<string, AlternateAction> = {
     icon: 'tshirt',
     text: 'Adjust jumpsuit',
   },
+
+  adjust_sensor: {
+    icon: 'microchip',
+    text: 'Adjust sensors',
+  },
 };
 
 const SLOTS: Record<
@@ -236,7 +241,7 @@ type StripMenuItem =
       | {
           icon: string;
           name: string;
-          alternate?: string;
+          alternate?: string[];
         }
       | {
           obscured: ObscuringLevel;
@@ -283,7 +288,7 @@ export const StripMenu = (props) => {
                   const item = data.items[keyAtSpot];
                   const slot = SLOTS[keyAtSpot];
 
-                  let alternateAction: AlternateAction | undefined;
+                  let alternateActions: string[] | undefined;
 
                   let content;
                   let tooltip;
@@ -292,19 +297,22 @@ export const StripMenu = (props) => {
                     tooltip = slot.displayName;
                   } else if ('name' in item) {
                     if (item.alternate) {
-                      alternateAction = ALTERNATE_ACTIONS[item.alternate];
+                      alternateActions = [];
+                      const alternateActionIconSize =
+                        100 / item.alternate.length;
+                      for (const alternateKey of item.alternate || []) {
+                        const alternateAction = ALTERNATE_ACTIONS[alternateKey];
+                        <Image
+                          src={`data:image/jpeg;base64,${alternateAction.icon}`}
+                          height={`${alternateActionIconSize}%`}
+                          width={`${alternateActionIconSize}%`}
+                          style={{
+                            verticalAlign: 'middle',
+                          }}
+                        />;
+                        alternateActions.push(alternateKey);
+                      }
                     }
-
-                    content = (
-                      <Image
-                        src={`data:image/jpeg;base64,${item.icon}`}
-                        height="100%"
-                        width="100%"
-                        style={{
-                          verticalAlign: 'middle',
-                        }}
-                      />
-                    );
 
                     tooltip = item.name;
                   } else if ('obscured' in item) {
@@ -375,25 +383,32 @@ export const StripMenu = (props) => {
                           {slot.additionalComponent}
                         </Button>
 
-                        {alternateAction !== undefined && (
-                          <Button
-                            onClick={() => {
-                              act('alt', {
-                                key: keyAtSpot,
-                              });
-                            }}
-                            tooltip={alternateAction.text}
-                            style={{
-                              background: 'rgba(0, 0, 0, 0.6)',
-                              position: 'absolute',
-                              bottom: '0',
-                              right: '0',
-                              zIndex: '2',
-                            }}
-                          >
-                            <Icon name={alternateAction.icon} />
-                          </Button>
-                        )}
+                        {alternateActions &&
+                          alternateActions.map((alternateKey) => {
+                            const alternateAction =
+                              ALTERNATE_ACTIONS[alternateKey];
+                            return (
+                              <Button
+                                key={alternateAction.text}
+                                onClick={() => {
+                                  act('alt', {
+                                    key: keyAtSpot,
+                                    alternate_action: alternateKey,
+                                  });
+                                }}
+                                tooltip={alternateAction.text}
+                                style={{
+                                  background: 'rgba(0, 0, 0, 0.6)',
+                                  position: 'absolute',
+                                  bottom: '0',
+                                  right: '0',
+                                  zIndex: '2',
+                                }}
+                              >
+                                <Icon name={alternateAction.icon} />
+                              </Button>
+                            );
+                          })}
                       </Box>
                     </Stack.Item>
                   );


### PR DESCRIPTION
## About The Pull Request

Allows players to modify the suit sensors of someone else's jumpsuit without first requiring them to disrobe them.
![image](https://github.com/tgstation/tgstation/assets/12817816/9b6ca2a3-ed23-4b46-a18b-9c5283fe8957)

## Why It's Good For The Game
It's annoying for players, usually antags, who are attempting to kidnap someone and then disable their suit sensors they must first entirely disrobe them, change the sensors, and then put everything back onto them.

## Changelog

:cl:
balance: You can now adjust the suit sensors of another player in the strip menu. No longer must you first take it off.
/:cl:
