### PR TITLE
Fixes modular computer boot-up

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -491,7 +491,7 @@
 				to_chat(user, span_warning("You press the power button, but the computer fails to boot up, displaying variety of errors before shutting down again."))
 		return FALSE
 
-	if(use_energy()) // checks if the PC is powered
+	if(use_energy(base_active_power_usage)) // checks if the PC is powered
 		if(looping_sound)
 			soundloop.start()
 		enabled = TRUE

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -9,6 +9,8 @@
 
 	if(!internal_cell)
 		return FALSE
+	if(amount == 0)
+		return TRUE
 	if(internal_cell.use(amount))
 		return TRUE
 	if(!check_programs)

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -9,8 +9,6 @@
 
 	if(!internal_cell)
 		return FALSE
-	if(amount == 0)
-		return TRUE
 	if(internal_cell.use(amount))
 		return TRUE
 	if(!check_programs)


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where modular computers (specifically PDAs) will fail to start up if there is zero required application power draw.

PDA will now consume base active power usage during startup.

Related https://github.com/tgstation/tgstation/issues/82196
Fixes https://github.com/tgstation/tgstation/issues/82245
Fixes https://github.com/tgstation/tgstation/issues/82229

## Changelog

:cl: LT3
fix: Fixed modular computers failing to boot up using cell power (eg: contractor tablet)
/:cl: