### PR TITLE
Fixes Circuit Multi-Tools to work on Carbons holding / wearing anything at all

### DIFF
--- a/code/modules/wiremod/core/marker.dm
+++ b/code/modules/wiremod/core/marker.dm
@@ -79,7 +79,7 @@
 		item_choice.image = item_appearance
 		selectable_targets[REF(item)] = item_choice
 
-	var/picked_ref = show_radial_menu(user, src, selectable_targets, uniqueid = TRUE, radius = 38, custom_check = CALLBACK(src, PROC_REF(check_menu), user, target), tooltips = TRUE)
+	var/picked_ref = show_radial_menu(user, src, selectable_targets, radius = 38, custom_check = CALLBACK(src, PROC_REF(check_menu), user, target), tooltips = TRUE)
 	if(!picked_ref)
 		return
 


### PR DESCRIPTION

## About The Pull Request
Ever since https://github.com/tgstation/tgstation/pull/81215 I havent been able to scan anyone that was wearing or holding anything with a circuit multi tool because the options never popped up, the click was just unresponsive and nothing would happen.

Then I remembered that Ghommie posted a picture of it working when the pr was first made and went to look at any changes made in the commits afterwards

For some reason uniqueid set to true was what made the list not appear, and I cant find any side effects from removing that bit of code.
## Why It's Good For The Game

This works as intended.


https://github.com/tgstation/tgstation/assets/62126254/61a5435c-9d51-462b-927a-9b1fc1cffb0e
## Changelog
:cl:

fix: Circuit multitools can now correctly scan carbons who are wearing clothes or holding objects again.

/:cl:
