### PR TITLE
Adds new obj var for damage feedback, modular shields now tell you youre actually doing something when damaging them. Uncapitalizes Modular Shield Objects

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -698,8 +698,8 @@
 			hit_with_what_noun += plural_s(hit_with_what_noun) // hit with "their hands"
 
 	user.visible_message(
-		span_danger("[user] smashes [src] with [user.p_their()] [hit_with_what_noun][damage ? "." : ", without leaving a mark!"]"),
-		span_danger("You smash [src] with your [hit_with_what_noun][damage ? "." : ", without leaving a mark!"]"),
+		span_danger("[user] smashes [src] with [user.p_their()] [hit_with_what_noun][damage ? "." : ", [no_damage_feedback]"]!"),
+		span_danger("You smash [src] with your [hit_with_what_noun][damage ? "." : ", [no_damage_feedback]"]!"),
 		span_hear("You hear a [damage ? "smash" : "thud"]."),
 		COMBAT_MESSAGE_RANGE,
 	)

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -678,6 +678,7 @@
 	density = FALSE
 	alpha = 100
 	resistance_flags = INDESTRUCTIBLE //the shield itself is indestructible or atleast should be
+	no_damage_feedback = "weakening the generator sustaining it"
 
 	///The shield generator sustaining us
 	var/obj/machinery/modular_shield_generator/shield_generator

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -1,5 +1,5 @@
 /obj/machinery/modular_shield_generator
-	name = "Modular Shield Generator"
+	name = "modular shield generator"
 	desc = "A forcefield generator, it seems more stationary than its cousins. It cant handle G-force and will require frequent reboots when built on mobile craft."
 	icon = 'icons/obj/machines/modular_shield_generator.dmi'
 	icon_state = "gen_recovering_closed"
@@ -382,7 +382,7 @@
 ///The general code used for machines that want to connect to the network
 /obj/machinery/modular_shield/module
 
-	name = "Modular Shield Debugger" //Filler name and sprite for testing
+	name = "modular shield debugger" //Filler name and sprite for testing
 	desc = "This is filler for testing you shouldn`t see this."
 	icon = 'icons/obj/machines/mech_bay.dmi'
 	icon_state = "recharge_port"
@@ -506,7 +506,7 @@
 
 /obj/machinery/modular_shield/module/node
 
-	name = "Modular Shield Node"
+	name = "modular shield node"
 	desc = "A waist high mess of humming pipes and wires that extend the modular shield network."
 	icon = 'icons/obj/machines/modular_shield_generator.dmi'
 	icon_state = "node_off_closed"
@@ -587,7 +587,7 @@
 
 /obj/machinery/modular_shield/module/charger
 
-	name = "Modular Shield Charger"
+	name = "modular shield charger"
 	desc = "A machine that somehow fabricates hardlight using electrons."
 	icon = 'icons/obj/machines/modular_shield_generator.dmi'
 	icon_state = "charger_off_closed"
@@ -615,7 +615,7 @@
 
 /obj/machinery/modular_shield/module/relay
 
-	name = "Modular Shield Relay"
+	name = "modular shield relay"
 	desc = "It helps the shield generator project farther out."
 	icon = 'icons/obj/machines/modular_shield_generator.dmi'
 	icon_state = "relay_off_closed"
@@ -643,7 +643,7 @@
 
 /obj/machinery/modular_shield/module/well
 
-	name = "Modular Shield Well"
+	name = "modular shield well"
 	desc = "A device used to hold more hardlight for the modular shield generator."
 	icon = 'icons/obj/machines/modular_shield_generator.dmi'
 	icon_state = "well_off_closed"
@@ -672,7 +672,7 @@
 
 //The shield itself
 /obj/structure/emergency_shield/modular
-	name = "Modular energy shield"
+	name = "modular energy shield"
 	desc = "An energy shield with varying configurations."
 	color = "#00ffff"
 	density = FALSE

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -41,7 +41,7 @@
 		)
 	if(hitting_projectile.suppressed != SUPPRESSED_VERY)
 		visible_message(
-			span_danger("[src] is hit by \a [hitting_projectile][damage_sustained ? "" : ", without leaving a mark"]!"),
+			span_danger("[src] is hit by \a [hitting_projectile][damage_sustained ? "" : ", [no_damage_feedback]"]!"),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 		)
 
@@ -54,7 +54,7 @@
 	else
 		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
 	var/damage = take_damage(hulk_damage(), BRUTE, MELEE, 0, get_dir(src, user))
-	user.visible_message(span_danger("[user] smashes [src][damage ? "" : ", without leaving a mark"]!"), span_danger("You smash [src][damage ? "" : ", without leaving a mark"]!"), null, COMBAT_MESSAGE_RANGE)
+	user.visible_message(span_danger("[user] smashes [src][damage ? "" : ", [no_damage_feedback]"]!"), span_danger("You smash [src][damage ? "" : ", [no_damage_feedback]"]!"), null, COMBAT_MESSAGE_RANGE)
 	return TRUE
 
 /obj/blob_act(obj/structure/blob/B)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -7,6 +7,7 @@
 	/// Extra examine line to describe controls, such as right-clicking, left-clicking, etc.
 	var/desc_controls
 
+	/// The context returned when an attack against this object doesnt deal any traditional damage to the object.
 	var/no_damage_feedback = "without leaving a mark"
 	/// Icon to use as a 32x32 preview in crafting menus and such
 	var/icon_preview

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -7,6 +7,7 @@
 	/// Extra examine line to describe controls, such as right-clicking, left-clicking, etc.
 	var/desc_controls
 
+	var/no_damage_feedback = "without leaving a mark"
 	/// Icon to use as a 32x32 preview in crafting menus and such
 	var/icon_preview
 	var/icon_state_preview
@@ -80,8 +81,8 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 	if(attacking_item.demolition_mod < 1)
 		damage_verb = "ineffectively pierce"
 
-	user.visible_message(span_danger("[user] [damage_verb][plural_s(damage_verb)] [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]"), \
-		span_danger("You [damage_verb] [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]"), null, COMBAT_MESSAGE_RANGE)
+	user.visible_message(span_danger("[user] [damage_verb][plural_s(damage_verb)] [src] with [attacking_item][damage ? "." : ", [no_damage_feedback]"]!"), \
+		span_danger("You [damage_verb] [src] with [attacking_item][damage ? "." : ", [no_damage_feedback]"]!"), null, COMBAT_MESSAGE_RANGE)
 	log_combat(user, src, "attacked", attacking_item)
 
 /obj/assume_air(datum/gas_mixture/giver)


### PR DESCRIPTION

## About The Pull Request
Basically when a shield gets hit it calls upon its (ouchy) code from its parent (obj) and instead of overriding like 4 different procs that are used to attack objects (projectile/attack paw/hulksmash/normal melee) I added a no_damage_feedback variable to the obj parent that hulk/projectile/attackpaw/nonhulk melee now use when the object being hit isnt actually taking damage. Then I made it so when a shield gets hit it refers to the fact that you are indeed doing something, just that your damage is working differently than normal.



https://github.com/tgstation/tgstation/assets/62126254/b9c294b9-416a-4d1f-bf1b-54b9339a66ae



After I recorded this video I uncapitalized all modular shield generator assets since they are generic objects and dont have unique names, so they wont be capitalized mid attack text.
## Why It's Good For The Game

For starters, now people know they can actually break forcefields instead of smacking it twice then getting dissuaded because the obj code told them they are stupid for trying.

And I believe that the way I went about doing this opens up opportunities for more stagnant structures that are damaged in different ways (Like say IndieanaJones could make space dragon's portals take x amount of hits to go down so a hulk/durand cant just 2 shot without having to buff its health/armor values to such an extent that you can only break it with a hulk/durand)

As it currently stands, obj damage is not balanced, the crew are largely locked away from decent obj damage because being able to break structures = aa, simple mobs are given very large obj damage modifiers because they dont have access id cards. 

This pr should lower the bar for designing objects that operate a little bit differently in terms of receiving damage in order to accommodate for this, but are still objects and need to use it as a parent.
## Changelog
:cl:

fix: Modular shields now give correct feedback and no longer dissuade individuals from breaking them.

/:cl:
