### PR TITLE
Fixes grammatical error with splashing

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -148,7 +148,7 @@
 	if (ismob(target))
 		var/mob/target_mob = target
 		target_mob.show_message(
-			span_userdanger("[user] splash the contents of [src] onto you!"),
+			span_userdanger("[user] splashes the contents of [src] onto you!"),
 			MSG_VISUAL,
 			span_userdanger("You feel drenched!"),
 		)


### PR DESCRIPTION
## About The Pull Request

Changes `Joe Assistant splash the contents of the beaker onto you!` to instead read `Joe Assistant splashes the contents of the beaker onto you!`

## Changelog

:cl:
spellcheck: fixed grammatical error in chemical splashing
/:cl:
