### PR TITLE
Wisdom Cows contain unusual milk

### DIFF
--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -181,7 +181,7 @@
 		return
 	var/transferred = reagents.trans_to(milk_holder, rand(5,10))
 	if(transferred)
-		user.visible_message(span_notice("[user] milks [src] using \the [milk_holder]."), span_notice("You milk [src] using \the [milk_holder]."))
+		user.visible_message(span_notice("[user] milks [udder_mob] using \the [milk_holder]."), span_notice("You milk [udder_mob] using \the [milk_holder]."))
 	else
 		to_chat(user, span_warning("The udder is dry. Wait a bit longer..."))
 

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -7,17 +7,20 @@
 	description = "A cow appears to tell you wise words."
 	admin_setup = list(
 		/datum/event_admin_setup/set_location/wisdom_cow,
-		/datum/event_admin_setup/listed_options/wisdom_cow,
+		/datum/event_admin_setup/listed_options/wisdom_cow_wisdom,
 		/datum/event_admin_setup/input_number/wisdom_cow,
+		/datum/event_admin_setup/listed_options/wisdom_cow_milk,
 	)
 
 /datum/round_event/wisdomcow
 	///Location override that, if set causes the cow to spawn in a pre-determined locaction instead of randomly.
 	var/turf/spawn_location
-	///An override that, if set rigs the cow to spawn with a specific wisdow rather than a random one.
+	///An override that if set rigs the cow to spawn with a specific wisdow rather than a random one.
 	var/selected_wisdom
-	///An override that, if set modifies the amount of wisdow the cow will add/remove, if not set will default to 500.
+	///An override that if set modifies the amount of wisdow the cow will add/remove, if not set will default to 500.
 	var/selected_experience
+	///An override that if set modifies what you can milk out of the cow
+	var/datum/reagent/forced_reagent_type
 
 /datum/round_event/wisdomcow/announce(fake)
 	priority_announce("A wise cow has been spotted in the area. Be sure to ask for her advice.", "Nanotrasen Cow Ranching Agency")
@@ -28,7 +31,7 @@
 		targetloc = spawn_location
 	else
 		targetloc = get_safe_random_station_turf()
-	var/mob/living/basic/cow/wisdom/wise = new(targetloc, selected_wisdom, selected_experience)
+	var/mob/living/basic/cow/wisdom/wise = new(targetloc, selected_wisdom, selected_experience, forced_reagent_type)
 	do_smoke(1, holder = wise, location = targetloc)
 	announce_to_ghosts(wise)
 
@@ -38,14 +41,14 @@
 /datum/event_admin_setup/set_location/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
 	event.spawn_location = chosen_turf
 
-/datum/event_admin_setup/listed_options/wisdom_cow
+/datum/event_admin_setup/listed_options/wisdom_cow_wisdom
 	input_text = "Select a specific wisdom type?"
 	normal_run_option = "Random Wisdom"
 
-/datum/event_admin_setup/listed_options/wisdom_cow/get_list()
+/datum/event_admin_setup/listed_options/wisdom_cow_wisdom/get_list()
 	return subtypesof(/datum/skill)
 
-/datum/event_admin_setup/listed_options/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
+/datum/event_admin_setup/listed_options/wisdom_cow_wisdom/apply_to_event(datum/round_event/wisdomcow/event)
 	event.selected_wisdom = chosen
 
 /datum/event_admin_setup/input_number/wisdom_cow
@@ -56,5 +59,13 @@
 
 /datum/event_admin_setup/input_number/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
 	event.selected_experience = chosen_value
-	
-	
+
+/datum/event_admin_setup/listed_options/wisdom_cow_milk
+	input_text = "Select a kind of milk?"
+	normal_run_option = "Random Reagent"
+
+/datum/event_admin_setup/listed_options/wisdom_cow_milk/get_list()
+	return sort_list(subtypesof(/datum/reagent), /proc/cmp_typepaths_asc)
+
+/datum/event_admin_setup/listed_options/wisdom_cow_milk/apply_to_event(datum/round_event/scrubber_overflow/event)
+	event.forced_reagent_type = chosen

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -33,6 +33,8 @@
 	var/tame_message = "lets out a happy moo"
 	/// singular version for player cows
 	var/self_tame_message = "let out a happy moo"
+	/// What kind of juice do we produce?
+	var/milked_reagent = /datum/reagent/consumable/milk
 
 /mob/living/basic/cow/Initialize(mapload)
 	AddComponent(/datum/component/tippable, \
@@ -42,14 +44,14 @@
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_cow_tipped)))
 	AddElement(/datum/element/pet_bonus, "moos happily!")
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_COW, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
-	udder_component()
+	setup_udder()
 	setup_eating()
 	. = ..()
 	ai_controller.set_blackboard_key(BB_BASIC_FOODS, typecacheof(food_types))
 
 ///wrapper for the udder component addition so you can have uniquely uddered cow subtypes
-/mob/living/basic/cow/proc/udder_component()
-	AddComponent(/datum/component/udder)
+/mob/living/basic/cow/proc/setup_udder()
+	AddComponent(/datum/component/udder, reagent_produced_override = milked_reagent)
 
 /*
  * food related components and elements are set up here for a few reasons:

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
@@ -21,14 +21,12 @@
 	food_types = list(/obj/item/food/grown/galaxythistle)
 	tame_message = "nods with respect"
 	self_tame_message = "nod with respect"
+	milked_reagent = /datum/reagent/drug/mushroomhallucinogen
 
 /mob/living/basic/cow/moonicorn/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/venomous, /datum/reagent/pax, 5, injection_flags = INJECT_CHECK_PENETRATE_THICK | INJECT_CHECK_IGNORE_SPECIES)
 	AddElement(/datum/element/movement_turf_changer, /turf/open/floor/grass/fairy)
-
-/mob/living/basic/cow/moonicorn/udder_component()
-	AddComponent(/datum/component/udder, reagent_produced_override = /datum/reagent/drug/mushroomhallucinogen)
 
 /mob/living/basic/cow/moonicorn/setup_eating()
 	var/static/list/food_types

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
@@ -28,7 +28,7 @@
 	AddElement(/datum/element/movement_turf_changer, /turf/open/floor/grass/fairy)
 
 /mob/living/basic/cow/moonicorn/udder_component()
-	AddComponent(/datum/component/udder, /obj/item/udder, null, null, /datum/reagent/drug/mushroomhallucinogen)
+	AddComponent(/datum/component/udder, reagent_produced_override = /datum/reagent/drug/mushroomhallucinogen)
 
 /mob/living/basic/cow/moonicorn/setup_eating()
 	var/static/list/food_types

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -21,8 +21,9 @@
 /mob/living/basic/cow/wisdom/setup_eating()
 	return //cannot tame me! and I don't care about eatin' nothing, neither!
 
-/mob/living/basic/cow/wisdom/udder_component()
-	AddComponent(/datum/component/udder, reagent_produced_override = get_random_reagent_id())
+/mob/living/basic/cow/wisdom/setup_udder()
+	milked_reagent = get_random_reagent_id()
+	return ..()
 
 /datum/ai_controller/basic_controller/cow/wisdom
 	//don't give a targeting strategy

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -9,7 +9,8 @@
 	///How much experience this cow will grant.
 	var/granted_experience
 
-/mob/living/basic/cow/wisdom/Initialize(mapload, granted_wisdom, granted_experience = 500)
+/mob/living/basic/cow/wisdom/Initialize(mapload, granted_wisdom, granted_experience = 500, milked_reagent = null)
+	src.milked_reagent = milked_reagent
 	. = ..()
 	src.granted_wisdom = granted_wisdom
 	if(!granted_wisdom)
@@ -22,7 +23,8 @@
 	return //cannot tame me! and I don't care about eatin' nothing, neither!
 
 /mob/living/basic/cow/wisdom/setup_udder()
-	milked_reagent = get_random_reagent_id()
+	if (isnull(milked_reagent))
+		milked_reagent = get_random_reagent_id()
 	return ..()
 
 /datum/ai_controller/basic_controller/cow/wisdom

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -21,6 +21,9 @@
 /mob/living/basic/cow/wisdom/setup_eating()
 	return //cannot tame me! and I don't care about eatin' nothing, neither!
 
+/mob/living/basic/cow/wisdom/udder_component()
+	AddComponent(/datum/component/udder, reagent_produced_override = get_random_reagent_id())
+
 /datum/ai_controller/basic_controller/cow/wisdom
 	//don't give a targeting strategy
 	blackboard = list(


### PR DESCRIPTION
## About The Pull Request

Wisdom Cows can now be milked for a random reagent (excepting the randomly generated reagent blacklist).
Also I changed it to say `you milk the cow` instead of `you milk the udder` because the latter is stupid.

## Why It's Good For The Game

My experience is that people totally ignore this event when it occurs, which is _fine_ when we have so many events and they don't all need to be high impact but I think someone discovering that you can milk the cow for cognac or meth or something could add something to a round. 
I want people to bicker over ownership of the cow, basically.

If the reagent is annoying you can simply speak to the cow to receive its wisdom and it will disappear.

## Changelog

:cl:
add: Wise cows produce surprising milk.
spellcheck: You now milk the owner of an udder, not the udder.
/:cl:
