### PR TITLE
Minor AI control airlock runtime fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1442,7 +1442,7 @@
 
 /obj/machinery/door/airlock/hostile_lockdown(mob/origin)
 	// Must be powered and have working AI wire.
-	if(canAIControl(src) && !machine_stat)
+	if(canAIControl(origin) && !machine_stat)
 		locked = FALSE //For airlocks that were bolted open.
 		safe = FALSE //DOOR CRUSH
 		close()
@@ -1454,7 +1454,7 @@
 
 /obj/machinery/door/airlock/disable_lockdown()
 	// Must be powered and have working AI wire.
-	if(canAIControl(src) && !machine_stat)
+	if(canAIControl() && !machine_stat)
 		unbolt()
 		set_electrified(MACHINE_NOT_ELECTRIFIED)
 		open()


### PR DESCRIPTION
## About The Pull Request

`canAIControl` accepts 1 argument, `user` / "the AI who is controlling us". It doesn't accept `src`. (Why would it use `src`?)

## Changelog

Technically no player visible change, as the proc would runtime / return `null`, which is the same end result