### PR TITLE
[NO GBP]Grind & juice fixes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -988,7 +988,7 @@
 
 ///Juice item, converting nutriments into juice_typepath and transfering to target_holder if specified
 /obj/item/proc/juice(datum/reagents/target_holder, mob/user)
-	if(on_juice() == -1 || !reagents.total_volume)
+	if(on_juice() == -1 || !reagents?.total_volume)
 		return FALSE
 
 	if(ispath(juice_typepath))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -960,8 +960,8 @@
 
 	return SEND_SIGNAL(src, COMSIG_ITEM_MICROWAVE_ACT, microwave_source, microwaver, randomize_pixel_offset)
 
-
-/obj/item/proc/grind_requirements(obj/machinery/reagentgrinder/R) //Used to check for extra requirements for grinding an object
+//Used to check for extra requirements for blending(grinding or juicing) an object
+/obj/item/proc/blend_requirements(obj/machinery/reagentgrinder/R)
 	return TRUE
 
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
@@ -972,10 +972,12 @@
 /obj/item/proc/grind(datum/reagents/target_holder, mob/user)
 	if(on_grind() == -1)
 		return FALSE
-	if(target_holder)
+
+	if(length(grind_results))
 		target_holder.add_reagent_list(grind_results)
-		if(reagents)
-			reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+	if(reagents?.total_volume)
+		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+
 	return TRUE
 
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
@@ -986,12 +988,13 @@
 
 ///Juice item, converting nutriments into juice_typepath and transfering to target_holder if specified
 /obj/item/proc/juice(datum/reagents/target_holder, mob/user)
-	if(on_juice() == -1)
+	if(on_juice() == -1 || !reagents.total_volume)
 		return FALSE
-	if(reagents)
+
+	if(ispath(juice_typepath))
 		reagents.convert_reagent(/datum/reagent/consumable, juice_typepath, include_source_subtypes = TRUE)
-		if(target_holder)
-			reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+	reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+
 	return TRUE
 
 /obj/item/proc/set_force_string()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -145,7 +145,7 @@
 /obj/item/stack/set_custom_materials(list/materials, multiplier=1, is_update=FALSE)
 	return is_update ? ..() : set_mats_per_unit(materials, multiplier/(amount || 1))
 
-/obj/item/stack/grind_requirements()
+/obj/item/stack/blend_requirements()
 	if(is_cyborg)
 		to_chat(usr, span_warning("[src] is too integrated into your chassis and can't be ground up!"))
 		return

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -104,7 +104,7 @@
 
 	return new trash_type(location || drop_location())
 
-/obj/item/food/grown/grind_requirements()
+/obj/item/food/grown/blend_requirements()
 	if(dry_grind && !HAS_TRAIT(src, TRAIT_DRIED))
 		to_chat(usr, span_warning("[src] needs to be dry before it can be ground up!"))
 		return

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -174,12 +174,12 @@
 			continue
 
 		//Nothing would come from grinding or juicing
-		if(!length(ingredient.grind_results) && !ingredient.juice_typepath)
+		if(!length(ingredient.grind_results) && !ingredient.reagents.total_volume)
 			to_chat(user, span_warning("You cannot grind/juice [ingredient] into reagents!"))
 			continue
 
 		//Error messages should be in the objects' definitions
-		if(!ingredient.grind_requirements(src))
+		if(!ingredient.blend_requirements(src))
 			continue
 
 		filtered_list += ingredient
@@ -241,7 +241,7 @@
 		return ITEM_INTERACT_SUCCESS
 
 	//add item directly
-	else if(tool.grind_results || tool.juice_typepath)
+	else if(length(tool.grind_results) || tool.reagents?.total_volume)
 		if(tool.atom_storage) //anything that has internal storage would be too much recursion for us to handle
 			to_chat(user, span_notice("Drag this item onto [src] to dump its contents."))
 			return ITEM_INTERACT_BLOCKING
@@ -439,12 +439,11 @@
 				break
 
 			if(juicing)
-				if(ingredient.juice_typepath)
-					if(!ingredient.juice(beaker.reagents, user))
-						to_chat(user, span_danger("[src] shorts out as it tries to juice up [ingredient], and transfers it back to storage."))
-						continue
-					item_processed = TRUE
-			else if(ingredient.grind_results)
+				if(!ingredient.juice(beaker.reagents, user))
+					to_chat(user, span_danger("[src] shorts out as it tries to juice up [ingredient], and transfers it back to storage."))
+					continue
+				item_processed = TRUE
+			else if(length(ingredient.grind_results) || ingredient.reagents?.total_volume)
 				if(!ingredient.grind(beaker.reagents, user))
 					if(isstack(ingredient))
 						to_chat(user, span_notice("[src] attempts to grind as many pieces of [ingredient] as possible."))


### PR DESCRIPTION
## About The Pull Request
- Fixes #82266. Anything that has reagents can be either grinded or juiced
- If something doesn't have reagents but has grind results it can still be grinded but not juiced

## Changelog
:cl:
fix: anything that has reagents can be either grinded or juiced
fix: stuff that does not have reagents but has grind results can still be grinded but not juiced
/:cl:
