### PR TITLE
Makes the easter event spawning logic use a more curated list

### DIFF
--- a/code/modules/events/holiday/easter.dm
+++ b/code/modules/events/holiday/easter.dm
@@ -26,13 +26,22 @@
 
 
 /datum/round_event/rabbitrelease/start()
-	for(var/obj/effect/landmark/R in GLOB.landmarks_list)
-		if(R.name != "blobspawn")
-			if(prob(35))
-				if(isspaceturf(R.loc))
-					new /mob/living/basic/rabbit/easter/space(R.loc)
-				else
-					new /mob/living/basic/rabbit/easter(R.loc)
+
+	for(var/obj/effect/landmark/event_spawn/spawn_point as anything in GLOB.generic_event_spawns) //Common public bunnies
+		if(prob(35))
+			new /mob/living/basic/rabbit/easter(spawn_point.loc)
+		CHECK_TICK
+
+	for(var/obj/effect/landmark/event_spawn/spawn_point as anything in GLOB.generic_maintenance_landmarks) // The rare maint bunnies
+		if(prob(15))
+			new /mob/living/basic/rabbit/easter(spawn_point.loc)
+		CHECK_TICK
+
+	for(var/obj/effect/landmark/carpspawn/spawn_point in GLOB.landmarks_list) // The rare space bunnies
+		if(prob(15))
+			new /mob/living/basic/rabbit/easter/space(spawn_point.loc)
+		CHECK_TICK
+
 
 //Easter Baskets
 /obj/item/storage/basket/easter


### PR DESCRIPTION
## About The Pull Request

The easter rabbit event looped through every single landmark in the game, not checking for zlevel or purpose, just that they would not be called "blobspawn". This PR makes the logic more curated, using generic and maintenance event landmarks for normal bunnies, and carpspawn for space rabbits.

Also added check_tick  checks for a good measure.

There is a still a lot of them! I counted around 50 bunnies on average per test.

## Why It's Good For The Game

A more curated list is better than a list that checks for name strings. Ensures the rabbits spawn only on the station Z levels.

## Changelog

:cl:
code: Made the easter rabbits spawn on a more curated list.
/:cl:

