### PR TITLE
[NO GBP] Fix letting you actually beat up racks with objects. (oops)

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -868,7 +868,7 @@
 
 /obj/structure/rack/item_interaction(mob/living/user, obj/item/tool, list/modifiers, is_right_clicking)
 	. = ..()
-	if(. || tool.item_flags & ABSTRACT)
+	if(. || tool.item_flags & ABSTRACT || user.combat_mode)
 		return .
 	if(user.transferItemToLoc(tool, drop_location(), silent = FALSE))
 		return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -868,7 +868,7 @@
 
 /obj/structure/rack/item_interaction(mob/living/user, obj/item/tool, list/modifiers, is_right_clicking)
 	. = ..()
-	if(. || tool.item_flags & ABSTRACT || user.combat_mode)
+	if(. || (tool.item_flags & ABSTRACT) || user.combat_mode)
 		return .
 	if(user.transferItemToLoc(tool, drop_location(), silent = FALSE))
 		return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION

## About The Pull Request

I misjudged `item_interaction` as being a non-combat mode only proc.
https://github.com/tgstation/tgstation/blob/593f1eaee33d0016b473bd799e2b3beddd977304/code/game/atom/atom_tool_acts.dm#L2-L12
Which today I realized, well, it clearly isn't. With my changes, racks don't let you beat them with an object even though you're in combat mode.

Anyhow, this pr just makes it so it doesn't continue to the item placing part when in combat mode.
## Why It's Good For The Game

Fixes an issue I caused, not letting you attack racks with objects.
## Changelog
:cl:
fix: You can actually hit racks with objects when in combat mode again. Importantly, painting them with spraycans like that works again.
/:cl:
