### PR TITLE
fixes gas analyzers

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -172,8 +172,8 @@
  * Also used in other chat-based gas scans.
  */
 /proc/atmos_scan(mob/user, atom/target, silent=FALSE)
-	var/mixture = target.return_air()
-	if(mixture)
+	var/mixture = target.return_analyzable_air()
+	if(!mixture)
 		return FALSE
 
 	var/icon = target


### PR DESCRIPTION
## About The Pull Request

#82180 accidentally messed up air analyzers being able to read or send readouts to the chat.

## Why It's Good For The Game

air analyzer good

## Changelog

:cl:
fix: air analyzers work again
/:cl:
