### PR TITLE
prevent linear transports from picking up underfloor objects during movement

### DIFF
--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -138,7 +138,7 @@
 /obj/structure/transport/linear/proc/add_item_on_transport(datum/source, atom/movable/new_transport_contents)
 	SIGNAL_HANDLER
 	var/static/list/blacklisted_types = typecacheof(list(/obj/structure/fluff/tram_rail, /obj/effect/decal/cleanable, /obj/structure/transport/linear, /mob/camera))
-	if(is_type_in_typecache(new_transport_contents, blacklisted_types) || new_transport_contents.invisibility == INVISIBILITY_ABSTRACT) //prevents the tram from stealing things like landmarks
+	if(is_type_in_typecache(new_transport_contents, blacklisted_types) || new_transport_contents.invisibility == INVISIBILITY_ABSTRACT || HAS_TRAIT(new_transport_contents, TRAIT_UNDERFLOOR)) //prevents the tram from stealing things like landmarks
 		return FALSE
 	if(new_transport_contents in transport_contents)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

prevent linear transports from picking up underfloor objects during movement

as this checks the trait, this doesnt work during map load because underfloor objects tend to not have the trait before theyre picked up during init by transports but idk how to fix that

## Why It's Good For The Game

its a bug and bugs are bad

## Changelog
:cl:
fix: elevators may no longer pick up things from under the floor during movement
/:cl:
