### PR TITLE
[No GBP] Fixes slow slime feed

### DIFF
--- a/code/datums/status_effects/debuffs/slime/slime_leech.dm
+++ b/code/datums/status_effects/debuffs/slime/slime_leech.dm
@@ -87,7 +87,7 @@
 
 		to_chat(owner, span_userdanger(pick(pain_lines)))
 
-	our_slime.adjust_nutrition(-1 * 1.6 * totaldamage * seconds_between_ticks)
+	our_slime.adjust_nutrition(-1 * 1.8 * totaldamage) //damage is already modified by seconds_between_ticks
 
 	//Heal yourself.
 	our_slime.adjustBruteLoss(-1.5 * seconds_between_ticks)


### PR DESCRIPTION
## About The Pull Request

Slimes were supposed to gain the same amount of nutrition as the damage they dealt while feeding. However, I have accidentally multiplied this again by `seconds_between_ticks` a second time. This meant that locally slimes fed normally, but on the server they got about the third nutrition they were supposed to, probably due to having more ticks per second then my machine. This PR fixes that.

Also raised the nutrition gained by slimes by 20%, after careful testing, one monkey wasn't always enough.

## Why It's Good For The Game

 Fixes #82283

## Changelog

:cl:
fix: Slimes now feed faster, and should only need one monkey to reach their next lifestage.
/:cl:


