### PR TITLE
Ties power limit of anchored circuits to 20 * standard cell charge to make it consistent with power changes.

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -25,7 +25,7 @@
 	COOLDOWN_DECLARE(power_used_cooldown)
 
 	/// The maximum power that the shell can use in a minute before entering overheating and destroying itself.
-	var/max_power_use_in_minute = 20000
+	var/max_power_use_in_minute = (20000 KILO WATTS)
 
 /datum/component/shell/Initialize(unremovable_circuit_components, capacity, shell_flags, starting_circuit)
 	. = ..()

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -25,7 +25,7 @@
 	COOLDOWN_DECLARE(power_used_cooldown)
 
 	/// The maximum power that the shell can use in a minute before entering overheating and destroying itself.
-	var/max_power_use_in_minute = (20000 KILO WATTS)
+	var/max_power_use_in_minute = 20 * STANDARD_CELL_CHARGE
 
 /datum/component/shell/Initialize(unremovable_circuit_components, capacity, shell_flags, starting_circuit)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
It just makes the power requirement 20 * standard cell charge instead of 20000
## Why It's Good For The Game
This is too restrictive to make anything with.


https://github.com/tgstation/tgstation/assets/62126254/e39dcf27-8793-42b0-84a0-7f747e95efcc
## Changelog
:cl:
fix: anchored circuits no longer blow up after 2 components are used.
/:cl:
