### PR TITLE
Fixing cell power usage (Part 5)

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -66,7 +66,7 @@
 	recharge_speed = 0
 	repairs = 0
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		recharge_speed += (capacitor.tier * STANDARD_CELL_CHARGE * 0.01)
+		recharge_speed += (capacitor.tier * STANDARD_CELL_CHARGE * 0.1)
 	for(var/datum/stock_part/servo/servo in component_parts)
 		repairs += servo.tier - 1
 	for(var/obj/item/stock_parts/cell/cell in component_parts)

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -659,7 +659,7 @@
 	if (!cell)
 		return
 	if (!(. & EMP_PROTECT_SELF))
-		deductcharge(1000 / severity)
+		deductcharge(STANDARD_CELL_CHARGE / severity)
 	if (cell.charge >= cell_hit_cost)
 		var/scramble_time
 		scramble_mode()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -204,7 +204,7 @@
 	name = "cyborg energy sword"
 	sword_color_icon = "red"
 	/// The cell cost of hitting something.
-	var/hitcost = 50
+	var/hitcost = 50 KILO JOULES
 
 /obj/item/melee/energy/sword/cyborg/attack(mob/target, mob/living/silicon/robot/user)
 	if(!user.cell)
@@ -229,7 +229,7 @@
 	icon_state = "esaw"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	force = 18
-	hitcost = 75 // Costs more than a standard cyborg esword.
+	hitcost = 75 KILO JOULES // Costs more than a standard cyborg esword.
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	light_color = LIGHT_COLOR_LIGHT_CYAN

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -204,7 +204,7 @@
 	name = "cyborg energy sword"
 	sword_color_icon = "red"
 	/// The cell cost of hitting something.
-	var/hitcost = 50 KILO JOULES
+	var/hitcost = 0.05 * STANDARD_CELL_CHARGE
 
 /obj/item/melee/energy/sword/cyborg/attack(mob/target, mob/living/silicon/robot/user)
 	if(!user.cell)
@@ -229,7 +229,7 @@
 	icon_state = "esaw"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	force = 18
-	hitcost = 75 KILO JOULES // Costs more than a standard cyborg esword.
+	hitcost = 0.075 * STANDARD_CELL_CHARGE // Costs more than a standard cyborg esword.
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	light_color = LIGHT_COLOR_LIGHT_CYAN

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -13,7 +13,7 @@
 	icon = 'icons/mob/silicon/robot_items.dmi'
 
 /// Cost to use the stun arm
-#define CYBORG_STUN_CHARGE_COST (200 KILO JOULES)
+#define CYBORG_STUN_CHARGE_COST (0.2 * STANDARD_CELL_CHARGE)
 
 /obj/item/borg/stun
 	name = "electrically-charged arm"
@@ -185,7 +185,7 @@
 						span_danger("You shock [attacked_mob] to no effect."),
 					)
 			playsound(loc, 'sound/effects/sparks2.ogg', 50, TRUE, -1)
-			user.cell.use(500 KILO JOULES, force = TRUE)
+			user.cell.use(0.5 * STANDARD_CELL_CHARGE, force = TRUE)
 			COOLDOWN_START(src, shock_cooldown, HUG_SHOCK_COOLDOWN)
 		if(HUG_MODE_CRUSH)
 			if (!COOLDOWN_FINISHED(src, crush_cooldown))
@@ -202,7 +202,7 @@
 				)
 			playsound(loc, 'sound/weapons/smash.ogg', 50, TRUE, -1)
 			attacked_mob.adjustBruteLoss(15)
-			user.cell.use(300 KILO JOULES, force = TRUE)
+			user.cell.use(0.3 * STANDARD_CELL_CHARGE, force = TRUE)
 			COOLDOWN_START(src, crush_cooldown, HUG_CRUSH_COOLDOWN)
 
 /obj/item/borg/cyborghug/peacekeeper

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -12,12 +12,13 @@
 /obj/item/borg
 	icon = 'icons/mob/silicon/robot_items.dmi'
 
+/// Cost to use the stun arm
+#define CYBORG_STUN_CHARGE_COST (200 KILO JOULES)
+
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
 	var/stamina_damage = 60 //Same as normal batong
-	/// Cost to use the stun arm
-	var/charge_cost = 200
 	var/cooldown_check = 0
 	/// cooldown between attacks
 	var/cooldown = 4 SECONDS // same as baton
@@ -33,7 +34,7 @@
 			return FALSE
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/robot_user = user
-		if(!robot_user.cell.use(charge_cost))
+		if(!robot_user.cell.use(CYBORG_STUN_CHARGE_COST))
 			return
 
 	user.do_attack_animation(attacked_mob)
@@ -56,6 +57,8 @@
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 	cooldown_check = world.time + cooldown
 	log_combat(user, attacked_mob, "stunned", src, "(Combat mode: [user.combat_mode ? "On" : "Off"])")
+
+#undef CYBORG_STUN_CHARGE_COST
 
 /obj/item/borg/cyborghug
 	name = "hugging module"

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -185,7 +185,7 @@
 						span_danger("You shock [attacked_mob] to no effect."),
 					)
 			playsound(loc, 'sound/effects/sparks2.ogg', 50, TRUE, -1)
-			user.cell.charge -= 500
+			user.cell.use(500 KILO JOULES, force = TRUE)
 			COOLDOWN_START(src, shock_cooldown, HUG_SHOCK_COOLDOWN)
 		if(HUG_MODE_CRUSH)
 			if (!COOLDOWN_FINISHED(src, crush_cooldown))
@@ -202,7 +202,7 @@
 				)
 			playsound(loc, 'sound/weapons/smash.ogg', 50, TRUE, -1)
 			attacked_mob.adjustBruteLoss(15)
-			user.cell.charge -= 300
+			user.cell.use(300 KILO JOULES, force = TRUE)
 			COOLDOWN_START(src, crush_cooldown, HUG_CRUSH_COOLDOWN)
 
 /obj/item/borg/cyborghug/peacekeeper

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -200,7 +200,7 @@
 	if(!istype(power_cell))
 		return
 
-	if(power_cell.charge < 300)
+	if(power_cell.charge < 300 KILO JOULES)
 		to_chat(chap, span_notice("[GLOB.deity] does not accept pity amounts of power."))
 		return
 

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -200,7 +200,7 @@
 	if(!istype(power_cell))
 		return
 
-	if(power_cell.charge < 300 KILO JOULES)
+	if(power_cell.charge < 0.3 * STANDARD_CELL_CHARGE)
 		to_chat(chap, span_notice("[GLOB.deity] does not accept pity amounts of power."))
 		return
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -187,7 +187,7 @@
 	///check for phasing, if it is set to text (to describe how it is phasing: "flying", "phasing") it will let the mech walk through walls.
 	var/phasing = ""
 	///Power we use every time we phaze through something
-	var/phasing_energy_drain = 200
+	var/phasing_energy_drain = 200 KILO JOULES
 	///icon_state for flick() when phazing
 	var/phase_state = ""
 
@@ -554,8 +554,9 @@
 
 	if(internal_damage & MECHA_INT_SHORT_CIRCUIT && get_charge())
 		spark_system.start()
-		use_energy(min(10 * seconds_per_tick, cell.charge))
-		cell.maxcharge -= min(10 * seconds_per_tick, cell.maxcharge)
+		var/damage = 5 KILO WATTS * seconds_per_tick
+		use_energy(damage)
+		cell.maxcharge -= min(damage, cell.maxcharge)
 
 /obj/vehicle/sealed/mecha/proc/process_cabin_air(seconds_per_tick)
 	if(!(internal_damage & MECHA_INT_TEMP_CONTROL) && cabin_air && cabin_air.return_volume() > 0)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -187,7 +187,7 @@
 	///check for phasing, if it is set to text (to describe how it is phasing: "flying", "phasing") it will let the mech walk through walls.
 	var/phasing = ""
 	///Power we use every time we phaze through something
-	var/phasing_energy_drain = 200 KILO JOULES
+	var/phasing_energy_drain = 0.2 * STANDARD_CELL_CHARGE
 	///icon_state for flick() when phazing
 	var/phase_state = ""
 
@@ -554,9 +554,9 @@
 
 	if(internal_damage & MECHA_INT_SHORT_CIRCUIT && get_charge())
 		spark_system.start()
-		var/damage = 5 KILO WATTS * seconds_per_tick
-		use_energy(damage)
-		cell.maxcharge -= min(damage, cell.maxcharge)
+		var/damage_energy_consumption = 0.005 * STANDARD_CELL_CHARGE * seconds_per_tick
+		use_energy(damage_energy_consumption)
+		cell.maxcharge -= min(damage_energy_consumption, cell.maxcharge)
 
 /obj/vehicle/sealed/mecha/proc/process_cabin_air(seconds_per_tick)
 	if(!(internal_damage & MECHA_INT_TEMP_CONTROL) && cabin_air && cabin_air.return_volume() > 0)

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -271,7 +271,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_energy((max_integrity - atom_integrity) * 100 KILO JOULES))
+	if(!chassis.use_energy((max_integrity - atom_integrity) * 0.1 * STANDARD_CELL_CHARGE))
 		chassis.cell?.charge = 0
 		for(var/O in chassis.occupants)
 			var/mob/living/occupant = O

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -271,7 +271,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_energy((max_integrity - atom_integrity) * 100))
+	if(!chassis.use_energy((max_integrity - atom_integrity) * 100 KILO JOULES))
 		chassis.cell?.charge = 0
 		for(var/O in chassis.occupants)
 			var/mob/living/occupant = O

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -285,7 +285,7 @@
 	///Maximum fuel capacity of the generator, in units
 	var/max_fuel = 75 * SHEET_MATERIAL_AMOUNT
 	///Energy recharged per second
-	var/rechargerate = 10
+	var/rechargerate = 5 KILO WATTS
 
 /obj/item/mecha_parts/mecha_equipment/generator/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/mecha/mech_bay.dm
+++ b/code/modules/vehicles/mecha/mech_bay.dm
@@ -45,7 +45,7 @@
 	var/total_rating = 0
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
 		total_rating += capacitor.tier
-	recharge_power = total_rating * 12.5
+	recharge_power = total_rating * 12.5 KILO WATTS
 
 /obj/machinery/mech_bay_recharge_port/examine(mob/user)
 	. = ..()

--- a/code/modules/vehicles/mecha/mech_bay.dm
+++ b/code/modules/vehicles/mecha/mech_bay.dm
@@ -11,7 +11,7 @@
 	///Ref to charge console for seeing charge for this port, cyclical reference
 	var/obj/machinery/computer/mech_bay_power_console/recharge_console
 	///Power unit per second to charge by
-	var/recharge_power = 25
+	var/recharge_power = 25 KILO WATTS
 	///turf that will be checked when a mech wants to charge. directly one turf in the direction it is facing
 	var/turf/recharging_turf
 


### PR DESCRIPTION
## About The Pull Request
Continuation of #82227

Fixes these issues in https://github.com/tgstation/tgstation/issues/82196 and others that weren't noticed.
- Batton emp protection
- Cyborg stun arm
- Cyborg energy sword
- Cyborg hug attack
- Mechanical god religious sect charge check
- Mecha fixes
  - Phasing energy drain
  - Short circuit energy drain
  - Durand shield damage energy drain
  - Plasma engine recharge rate
- Mechbay recharge power rate
- Recharge station charge rate

Stuff that was already working & didn't require fixing.
- Plasma cutter energy shots
- Botany cell charging

## Changelog
:cl:
fix: Fixed cell energy usage for a bunch of stuff(Part 5). See PR 82296 for details
/:cl: