### PR TITLE
Enable mech logging by default

### DIFF
--- a/config/logging.txt
+++ b/config/logging.txt
@@ -39,7 +39,7 @@ LOG_GAME
 LOG_MANIFEST
 
 ## log mecha actions
-# LOG_MECHA
+LOG_MECHA
 
 ## log OOC channel
 LOG_OOC


### PR DESCRIPTION
## About The Pull Request

Enables mech logging by default- this wasn't enabled by default when it was first introduced 6 years ago. These logfiles are tiny(In 1 terry round: 2kb mecha, 350kb game.txt), there is no reason to not have this enabled by default. 

## Changelog
:cl:
config: mech logging is now on by default. Existing config setups will not mirror this change.
/:cl:
