### PR TITLE
Your heart now stops beating when you go under stasis, and must be started back up again after exiting it.

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -118,7 +118,7 @@
 	update_use_power(ACTIVE_POWER_USE)
 	if(ishuman(target))
 		var/mob/living/carbon/human/heart_stoppee = target
-		if(heart_stoppee.stat == DEAD || HAS_TRAIT(heart_stoppee, TRAIT_CRITICAL_CONDITION) || !heart_stoppee.can_heartattack() || (/datum/disease/heart_failure in heart_stoppee.diseases) || heart_stoppee.undergoing_cardiac_arrest()
+		if(heart_stoppee.stat == DEAD || HAS_TRAIT(heart_stoppee, TRAIT_CRITICAL_CONDITION) || !heart_stoppee.can_heartattack() || (/datum/disease/heart_failure in heart_stoppee.diseases) || heart_stoppee.undergoing_cardiac_arrest())
 			return
 		else
 			heart_stoppee.set_heartattack(TRUE)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -116,6 +116,13 @@
 	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 	target.extinguish_mob()
 	update_use_power(ACTIVE_POWER_USE)
+	if(ishuman(target))
+		var/mob/living/carbon/human/heart_stoppee = target
+		if(heart_stoppee.stat == DEAD || HAS_TRAIT(heart_stoppee, TRAIT_CRITICAL_CONDITION) || !heart_stoppee.can_heartattack() || (/datum/disease/heart_failure in heart_stoppee.diseases) || heart_stoppee.undergoing_cardiac_arrest()
+			return
+		else
+			heart_stoppee.set_heartattack(TRUE)
+	
 
 /obj/machinery/stasis/proc/thaw_them(mob/living/target)
 	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -118,7 +118,8 @@
 	update_use_power(ACTIVE_POWER_USE)
 	if(ishuman(target))
 		var/mob/living/carbon/human/heart_stoppee = target
-		if(heart_stoppee.stat == DEAD || HAS_TRAIT(heart_stoppee, TRAIT_CRITICAL_CONDITION) || !heart_stoppee.can_heartattack() || (/datum/disease/heart_failure in heart_stoppee.diseases) || heart_stoppee.undergoing_cardiac_arrest())
+		if(heart_stoppee.stat != DEAD)
+			heart_stoppee.set_heartattack(TRUE)
 			return
 		else
 			heart_stoppee.set_heartattack(TRUE)


### PR DESCRIPTION
## About The Pull Request

Your heart now stops beating when you go under stasis, and must be started back up again after exiting it.
Inspired by Barotrauma.

## Why It's Good For The Game

Stasis is currently a massive crutch for Medical and enables really, really, really easy treatment of just about every issue in the game, along with allowing players to reliably pause every single possible DOT effect in the game. Poisoned? On fire? Limbs infected? Just go sit on stasis until a doctor can fix it.

Stasis basically kills triage, which is lame, so I think it needs a nerf to not be the answer to everything, and especially to not be a self-service system that you can just hop on real quick to negate all consequences of your actions with no drawbacks.

By making it so your heart needs restarted by a doctor after coming off of stasis, it ensures it's a tool for medical doctors to utilize in treating patients per triage, not something for people barging into medical to treat themselves with.

## Changelog
:cl:
balance: Your heart now stops beating when you go under stasis, and must be started back up again after exiting it.
/:cl: