### PR TITLE
[No GBP] Slime stasis fixes

### DIFF
--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -2,7 +2,10 @@
 /mob/living/basic/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	..()
 
-	handle_nutrition(seconds_per_tick)
+	if(!HAS_TRAIT(src, TRAIT_STASIS)) //No hunger in stasis
+		handle_nutrition(seconds_per_tick)
+
+	handle_slime_stasis(seconds_per_tick)
 
 /mob/living/basic/slime/handle_environment(datum/gas_mixture/environment, seconds_per_tick, times_fired)
 	..()
@@ -10,6 +13,10 @@
 		apply_status_effect(/datum/status_effect/freon, SLIME_COLD)
 	else
 		remove_status_effect(/datum/status_effect/freon, SLIME_COLD)
+
+///Handles if a slime's environment would cause it to enter stasis. Ignores TRAIT_STASIS
+/mob/living/basic/slime/proc/handle_slime_stasis(seconds_per_tick)
+	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/bz_percentage = 0
 


### PR DESCRIPTION
## About The Pull Request

`handle_environment` is never called when the target was in stasis, so slimes stayed in stasis forever. This PR fixes that, albeit in an ugly way.
It also makes slimes actually not get hungry while in stasis.

## Why It's Good For The Game

Fixes #82300
I also claimed slimes can be safely kept in stasis, but I didn't actually put a stasis check before handle_nutrition. This is fixed now.

## Changelog


:cl:
fix: Slimes stop being in stasis when taken out of a BZ filled environment
fix: Slimes no longer become hungry while in stasis
/:cl:
