### PR TITLE
Let ethereals starve again

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -434,7 +434,7 @@
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR 0.8 KILO WATTS //factor at which ethereal's charge decreases per second
+#define ETHEREAL_CHARGE_FACTOR (0.8 KILO WATTS) //factor at which ethereal's charge decreases per second
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -434,7 +434,7 @@
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR (0.8 KILO WATTS) //factor at which ethereal's charge decreases per second
+#define ETHEREAL_DISCHARGE_RATE (0.8 KILO WATTS) // Rate at which ethereal stomach charge decreases
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -434,7 +434,7 @@
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
+#define ETHEREAL_CHARGE_FACTOR 0.8 KILO WATTS //factor at which ethereal's charge decreases per second
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.

--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -10,7 +10,7 @@
 
 /obj/item/organ/internal/stomach/ethereal/on_life(seconds_per_tick, times_fired)
 	. = ..()
-	adjust_charge(-ETHEREAL_CHARGE_FACTOR * seconds_per_tick)
+	adjust_charge(-ETHEREAL_DISCHARGE_RATE * seconds_per_tick)
 	handle_charge(owner, seconds_per_tick, times_fired)
 
 /obj/item/organ/internal/stomach/ethereal/on_mob_insert(mob/living/carbon/stomach_owner)


### PR DESCRIPTION

## About The Pull Request

Ethereals use energy as 'food', so of course #81579 had to touch them.
To bring them in line with the new standard, the Ethereal charge levels were updated to be in megajoules.
https://github.com/tgstation/tgstation/blob/466b3df0483162c3900e411c25dfe15c2320786e/code/__DEFINES/mobs.dm#L292-L299
https://github.com/tgstation/tgstation/blob/7fa8daad63f49a11e22ab64a984d29b35619852c/code/__DEFINES/mobs.dm#L285-L292
However! This forgot to update the rate at which Ethereals passively discharge.
https://github.com/tgstation/tgstation/blob/7fa8daad63f49a11e22ab64a984d29b35619852c/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm#L11-L14
https://github.com/tgstation/tgstation/blob/7fa8daad63f49a11e22ab64a984d29b35619852c/code/__DEFINES/mobs.dm#L437
Meaning it's effectively a thousand times less with the new charge levels.

So we simply update this define to be in kilowatts.
```dm
#define ETHEREAL_CHARGE_FACTOR (0.8 KILO WATTS) //factor at which ethereal's charge decreases per second
```
## Why It's Good For The Game

Fixes issue with ethereal hunger caused by #81579.
## Changelog
:cl:
fix: Ethereal starvation has been updated to the new joules/watts standard. Congratulations Ethereals! You can starve again!
/:cl:
