### PR TITLE
Makes Social Anxiety stuttering a lot less harsh

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -261,6 +261,8 @@
 #define SANITY_LEVEL_UNSTABLE 4
 #define SANITY_LEVEL_CRAZY 5
 #define SANITY_LEVEL_INSANE 6
+/// Equal to the highest sanity level
+#define SANITY_LEVEL_MAX SANITY_LEVEL_INSANE
 
 //Nutrition levels for humans
 #define NUTRITION_LEVEL_FAT 600

--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -15,9 +15,26 @@
 	RegisterSignal(quirk_holder, COMSIG_MOB_EYECONTACT, PROC_REF(eye_contact))
 	RegisterSignal(quirk_holder, COMSIG_MOB_EXAMINATE, PROC_REF(looks_at_floor))
 	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+	quirk_holder.apply_status_effect(/datum/status_effect/speech/stutter/anxiety, INFINITY)
 
 /datum/quirk/social_anxiety/remove()
 	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE, COMSIG_MOB_SAY))
+	quirk_holder.remove_status_effect(/datum/status_effect/speech/stutter/anxiety)
+
+/// Calculates how much to modifiy our effects based on our mood level
+/datum/quirk/social_anxiety/proc/calculate_mood_mod()
+	var/nearby_people = 0
+	for(var/mob/living/carbon/human/listener in oview(3, quirk_holder))
+		if(listener.client || listener.mind)
+			nearby_people++
+
+	var/mod = 1
+	if(quirk_holder.mob_mood)
+		mod = 1 + 0.02 * (50 - (max(50, quirk_holder.mob_mood.mood_level * (SANITY_LEVEL_MAX + 1 - quirk_holder.mob_mood.sanity_level)))) //low sanity levels are better, they max at 6
+	else
+		mod = 1 + 0.02 * (50 - (max(50, 0.1 * quirk_holder.nutrition)))
+
+	return mod * nearby_people * 12.5
 
 /datum/quirk/social_anxiety/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
@@ -27,48 +44,33 @@
 	if(HAS_TRAIT(source, TRAIT_SIGN_LANG)) // No modifiers for signers, so you're less anxious when you go non-verbal
 		return
 
-	var/moodmod
-	if(quirk_holder.mob_mood)
-		moodmod = (1+0.02*(50-(max(50, quirk_holder.mob_mood.mood_level*(7-quirk_holder.mob_mood.sanity_level))))) //low sanity levels are better, they max at 6
-	else
-		moodmod = (1+0.02*(50-(max(50, 0.1*quirk_holder.nutrition))))
-	var/nearby_people = 0
-	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
-		if(H.client)
-			nearby_people++
+	var/moodmod = calculate_mood_mod()
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message)
 		var/list/message_split = splittext(message, " ")
 		var/list/new_message = list()
-		var/mob/living/carbon/human/quirker = quirk_holder
 		for(var/word in message_split)
-			if(prob(max(5,(nearby_people*12.5*moodmod))) && word != message_split[1]) //Minimum 1/20 chance of filler
+			if(prob(max(5, moodmod)) && word != message_split[1]) //Minimum 1/20 chance of filler
 				new_message += pick("uh,","erm,","um,")
-				if(prob(min(5,(0.05*(nearby_people*12.5)*moodmod)))) //Max 1 in 20 chance of cutoff after a successful filler roll, for 50% odds in a 15 word sentence
-					quirker.set_silence_if_lower(6 SECONDS)
-					to_chat(quirker, span_danger("You feel self-conscious and stop talking. You need a moment to recover!"))
+				if(prob(min(5, moodmod))) //Max 1 in 20 chance of cutoff after a successful filler roll, for 50% odds in a 15 word sentence
+					quirk_holder.set_silence_if_lower(6 SECONDS)
+					to_chat(quirk_holder, span_danger("You feel self-conscious and stop talking. You need a moment to recover!"))
 					break
-			if(prob(max(5,(nearby_people*12.5*moodmod)))) //Minimum 1/20 chance of stutter
-				// Add a short stutter, THEN treat our word
-				quirker.adjust_stutter(0.5 SECONDS)
-				var/list/message_data = quirker.treat_message(word, capitalize_message = FALSE)
-				new_message += message_data["message"]
-			else
-				new_message += word
+			new_message += word
 
 		message = jointext(new_message, " ")
-	var/mob/living/carbon/human/quirker = quirk_holder
-	if(prob(min(50,(0.50*(nearby_people*12.5)*moodmod)))) //Max 50% chance of not talking
+
+	if(prob(min(50, (0.50 * moodmod)))) //Max 50% chance of not talking
 		if(dumb_thing)
-			to_chat(quirker, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
+			to_chat(quirk_holder, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
 			dumb_thing = FALSE //only once per life
 			if(prob(1))
-				new/obj/item/food/spaghetti/pastatomato(get_turf(quirker)) //now that's what I call spaghetti code
+				new/obj/item/food/spaghetti/pastatomato(get_turf(quirk_holder)) //now that's what I call spaghetti code
 		else
 			to_chat(quirk_holder, span_warning("You think that wouldn't add much to the conversation and decide not to say it."))
-			if(prob(min(25,(0.25*(nearby_people*12.75)*moodmod)))) //Max 25% chance of silence stacks after successful not talking roll
-				to_chat(quirker, span_danger("You retreat into yourself. You <i>really</i> don't feel up to talking."))
-				quirker.set_silence_if_lower(10 SECONDS)
+			if(prob(min(25, (0.25 * moodmod)))) //Max 25% chance of silence stacks after successful not talking roll
+				to_chat(quirk_holder, span_danger("You retreat into yourself. You <i>really</i> don't feel up to talking."))
+				quirk_holder.set_silence_if_lower(10 SECONDS)
 
 		speech_args[SPEECH_MESSAGE] = pick("Uh.","Erm.","Um.")
 	else

--- a/code/datums/status_effects/debuffs/speech_debuffs.dm
+++ b/code/datums/status_effects/debuffs/speech_debuffs.dm
@@ -3,8 +3,9 @@
 	alert_type = null
 	remove_on_fullheal = TRUE
 	tick_interval = -1
-
+	/// If TRUE, TTS will say the original message rather than what we changed it to
 	var/make_tts_message_original = FALSE
+	/// If set, this will be appended to the TTS filter of the message
 	var/tts_filter = ""
 
 /datum/status_effect/speech/on_creation(mob/living/new_owner, duration = 10 SECONDS)
@@ -96,16 +97,12 @@
 	four_char_chance = 4
 	three_char_chance = 10
 	two_char_chance = 100
-	tick_interval = 30 SECONDS
-	processing_speed = STATUS_EFFECT_NORMAL_PROCESS
 	remove_on_fullheal = FALSE
 
-/datum/status_effect/speech/stutter/anxiety/tick(seconds_between_ticks)
-	. = ..()
-	// Every so often the probability of stuttering updates based on how many people are nearby
-	// I could signalize this but it really seems like a waste, since it's RNG anyways. No one will notice.
+/datum/status_effect/speech/stutter/anxiety/handle_message(datum/source, list/message_args)
 	var/datum/quirk/social_anxiety/host_quirk = owner.get_quirk(/datum/quirk/social_anxiety)
-	stutter_prob = max(5, host_quirk?.calculate_mood_mod())
+	stutter_prob = clamp(host_quirk?.calculate_mood_mod() * 0.5, 5, 50)
+	return ..()
 
 /datum/status_effect/speech/stutter/derpspeech
 	id = "derp_stutter"

--- a/code/datums/status_effects/debuffs/speech_debuffs.dm
+++ b/code/datums/status_effects/debuffs/speech_debuffs.dm
@@ -2,6 +2,7 @@
 	id = null
 	alert_type = null
 	remove_on_fullheal = TRUE
+	tick_interval = -1
 
 	var/make_tts_message_original = FALSE
 	var/tts_filter = ""
@@ -41,7 +42,7 @@
 	for(var/i = 1, i <= length(phrase), i += length(original_char))
 		original_char = phrase[i]
 
-		final_phrase += apply_speech(original_char, original_char)
+		final_phrase += apply_speech(original_char)
 
 	message_args[TREAT_MESSAGE_ARG] = sanitize(final_phrase)
 
@@ -51,19 +52,25 @@
  *
  * Return the modified_char to be reapplied to the message.
  */
-/datum/status_effect/speech/proc/apply_speech(original_char, modified_char)
+/datum/status_effect/speech/proc/apply_speech(original_char)
 	stack_trace("[type] didn't implement apply_speech.")
 	return original_char
 
 /datum/status_effect/speech/stutter
 	id = "stutter"
-	/// The probability of adding a stutter to any character
-	var/stutter_prob = 80
-	/// Regex of characters we won't apply a stutter to
-	var/static/regex/no_stutter
-
 	make_tts_message_original = TRUE
 	tts_filter = "tremolo=f=10:d=0.8,rubberband=tempo=0.5"
+
+	/// The probability of adding a stutter to any character
+	var/stutter_prob = 80
+	/// The chance of a four character stutter
+	var/four_char_chance = 10
+	/// The chance of a three character stutter
+	var/three_char_chance = 20
+	/// The chance of a two character stutter
+	var/two_char_chance = 95
+	/// Regex of characters we won't apply a stutter to
+	var/static/regex/no_stutter
 
 /datum/status_effect/speech/stutter/on_creation(mob/living/new_owner, ...)
 	. = ..()
@@ -72,18 +79,33 @@
 	if(!no_stutter)
 		no_stutter = regex(@@[aeiouAEIOU ""''()[\]{}.!?,:;_`~-]@)
 
-/datum/status_effect/speech/stutter/apply_speech(original_char, modified_char)
+/datum/status_effect/speech/stutter/apply_speech(original_char)
 	if(prob(stutter_prob) && !no_stutter.Find(original_char))
-		if(prob(10))
-			modified_char = "[modified_char]-[modified_char]-[modified_char]-[modified_char]"
-		else if(prob(20))
-			modified_char = "[modified_char]-[modified_char]-[modified_char]"
-		else if(prob(95))
-			modified_char = "[modified_char]-[modified_char]"
-		else
-			modified_char = ""
+		if(prob(four_char_chance))
+			return "[original_char]-[original_char]-[original_char]-[original_char]"
+		if(prob(three_char_chance))
+			return "[original_char]-[original_char]-[original_char]"
+		if(prob(two_char_chance))
+			return "[original_char]-[original_char]"
 
-	return modified_char
+	return original_char
+
+/datum/status_effect/speech/stutter/anxiety
+	id = "anxiety_stutter"
+	stutter_prob = 5
+	four_char_chance = 4
+	three_char_chance = 10
+	two_char_chance = 100
+	tick_interval = 30 SECONDS
+	processing_speed = STATUS_EFFECT_NORMAL_PROCESS
+	remove_on_fullheal = FALSE
+
+/datum/status_effect/speech/stutter/anxiety/tick(seconds_between_ticks)
+	. = ..()
+	// Every so often the probability of stuttering updates based on how many people are nearby
+	// I could signalize this but it really seems like a waste, since it's RNG anyways. No one will notice.
+	var/datum/quirk/social_anxiety/host_quirk = owner.get_quirk(/datum/quirk/social_anxiety)
+	stutter_prob = max(5, host_quirk?.calculate_mood_mod())
 
 /datum/status_effect/speech/stutter/derpspeech
 	id = "derp_stutter"
@@ -160,8 +182,9 @@
 	string_replacements = speech_changes["string_replacements"]
 	string_additions = speech_changes["string_additions"]
 
-/datum/status_effect/speech/slurring/apply_speech(original_char, modified_char)
+/datum/status_effect/speech/slurring/apply_speech(original_char)
 
+	var/modified_char = original_char
 	var/lower_char = lowertext(modified_char)
 	if(prob(common_prob) && (lower_char in common_replacements))
 		var/to_replace = common_replacements[lower_char]


### PR DESCRIPTION
## About The Pull Request

Social Anxiety was doing a lot of jank things with stuttering so I replaced it

I added a new subtype of stuttering specifically for it which scales a lot better (IMO)

![image](https://github.com/tgstation/tgstation/assets/51863163/7f0ccc62-48eb-4e34-81d1-1131d3140979)

I haven't tested this with TTS but it should work the same as normal stuttering now

Also this effect will stack with normal stuttering, which is either the funniest thing ever or a complete disaster. You decide

## Why It's Good For The Game

I think some bugs arose from the way we (I) did social anxiety, especially in the wake of TTS so I'm here to resolve them

Now it should be a lot less full tilt, since we no longer use the same stuttering probabilities for "being hit by a bomb" as "one person is standing next to me". 

## Changelog

:cl: Melbert
qol: Socially Anxious people should be able to talk a bit more clearer while still maintaining the stuttering "charm"
/:cl:
