### PR TITLE
Uplinks now have auditory feedback upon purchasing something.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -125,6 +125,7 @@
 /datum/uplink_item/proc/purchase(mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	var/atom/spawned_item = spawn_item(item, user, uplink_handler, source)
 	log_uplink("[key_name(user)] purchased [src] for [cost] telecrystals from [source]'s uplink")
+	user.playsound_local(get_turf(user), 'sound/effects/kaching.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	if(purchase_log_vis && uplink_handler.purchase_log)
 		uplink_handler.purchase_log.LogPurchase(spawned_item, src, cost)
 	if(lock_other_purchases)


### PR DESCRIPTION
## About The Pull Request

Syndicate (and ERT) uplinks now make a 'ka-ching' sound for the user of the uplink only.

## Why It's Good For The Game

Uplink purchases have no feedback nor confirmation which i found kinda strange. Especially useful during massive time dilation to let the user know when the purchase was actually made, or just in case you accidentally mis-click the purchase button.

## Changelog

:cl:
add: Added the 'kaching' sound to uplink purchases to confirm a purchase was made for the user.
/:cl:
