### PR TITLE
random spawners now check if the destination turf is unblocked in a straight line

### DIFF
--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -94,18 +94,20 @@
 /obj/effect/spawner/random/proc/make_item(spawn_loc, type_path_to_make)
 	return new type_path_to_make(spawn_loc)
 
-///If the spawner has a spawn_scatter_radius set, this creates a list of nearby turfs available
+///If the spawner has a spawn_scatter_radius set, this creates a list of nearby turfs available that are in view and have an unblocked line to them.
 /obj/effect/spawner/random/proc/get_spawn_locations(radius)
 	var/list/scatter_locations = list()
 
-	if(radius >= 0)
-		for(var/turf/turf_in_view in view(radius, get_turf(src)))
-			if(isclosedturf(turf_in_view) || (isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view)))
-				continue
-			if(!has_unblocked_line(turf_in_view))
-				continue
+	if(!radius)
+		return scatter_locations
 
-			scatter_locations += turf_in_view
+	for(var/turf/turf_in_view in view(radius, get_turf(src)))
+		if(isclosedturf(turf_in_view) || (isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view)))
+			continue
+		if(!has_unblocked_line(turf_in_view))
+			continue
+
+		scatter_locations += turf_in_view
 
 	return scatter_locations
 

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -110,12 +110,11 @@
 	return scatter_locations
 
 /obj/effect/spawner/random/proc/has_unblocked_line(destination)
-	. = TRUE
-	var/turf/us = get_turf(src)
-	for(var/turf/potential_blockage as anything in get_line(us, destination))
+	for(var/turf/potential_blockage as anything in get_line(get_turf(src), destination))
 		if(!potential_blockage.is_blocked_turf(exclude_mobs = TRUE))
 			continue
 		return FALSE
+	return TRUE
 
 //finds the probabilities of items spawning from a loot spawner's loot pool
 /obj/item/loot_table_maker

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -102,9 +102,20 @@
 		for(var/turf/turf_in_view in view(radius, get_turf(src)))
 			if(isclosedturf(turf_in_view) || (isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view)))
 				continue
+			if(!has_unblocked_line(turf_in_view))
+				continue
+
 			scatter_locations += turf_in_view
 
 	return scatter_locations
+
+/obj/effect/spawner/random/proc/has_unblocked_line(destination)
+	. = TRUE
+	var/turf/us = get_turf(src)
+	for(var/turf/potential_blockage as anything in get_line(us, destination))
+		if(!potential_blockage.is_blocked_turf(exclude_mobs = TRUE))
+			continue
+		return FALSE
 
 //finds the probabilities of items spawning from a loot spawner's loot pool
 /obj/item/loot_table_maker

--- a/code/game/objects/effects/spawners/random/trash.dm
+++ b/code/game/objects/effects/spawners/random/trash.dm
@@ -134,13 +134,11 @@
 		/obj/effect/spawner/random/trash/cigbutt = 2,
 	)
 
-/obj/effect/spawner/random/trash/grime/make_item(turf/open/spawn_loc, mob/living/type_path_to_make)
-	if(!istype(type_path_to_make))
-		return ..()
-	if(!istype(spawn_loc))
-		return ..()
-	if(spawn_loc.initial_gas_mix != OPENTURF_DEFAULT_ATMOS && spawn_loc.initial_gas_mix != OPENTURF_DIRTY_ATMOS)
-		return
+/obj/effect/spawner/random/trash/grime/Initialize(mapload)
+	if(mapload)
+		var/turf/location = get_turf(loc)
+		if(location.initial_gas_mix != OPENTURF_DEFAULT_ATMOS && location.initial_gas_mix != OPENTURF_DIRTY_ATMOS)
+			loot -= /mob/living/basic/cockroach
 	return ..()
 
 /obj/effect/spawner/random/trash/moisture

--- a/code/game/objects/effects/spawners/random/trash.dm
+++ b/code/game/objects/effects/spawners/random/trash.dm
@@ -134,11 +134,13 @@
 		/obj/effect/spawner/random/trash/cigbutt = 2,
 	)
 
-/obj/effect/spawner/random/trash/grime/Initialize(mapload)
-	if(mapload)
-		var/turf/location = get_turf(loc)
-		if(location.initial_gas_mix != OPENTURF_DEFAULT_ATMOS && location.initial_gas_mix != OPENTURF_DIRTY_ATMOS)
-			loot -= /mob/living/basic/cockroach
+/obj/effect/spawner/random/trash/grime/make_item(turf/open/spawn_loc, mob/living/type_path_to_make)
+	if(!istype(type_path_to_make))
+		return ..()
+	if(!istype(spawn_loc))
+		return ..()
+	if(spawn_loc.initial_gas_mix != OPENTURF_DEFAULT_ATMOS && spawn_loc.initial_gas_mix != OPENTURF_DIRTY_ATMOS)
+		return
 	return ..()
 
 /obj/effect/spawner/random/trash/moisture


### PR DESCRIPTION
## About The Pull Request
random spawners now check if the destination turf is unblocked in a straight line

![image](https://github.com/tgstation/tgstation/assets/70376633/15fb4e23-95d1-473c-8bba-00b9497f0ca8)

(spammed grime spawner, nothing spawned behind glass)

## Why It's Good For The Game

bug

## Changelog
not player facing
