### PR TITLE
critters no longer spawn in windows

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -31,15 +31,15 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 	/turf/open/lava,
 	/turf/open/water,
 	/turf/open/openspace,
-	/turf/open/space/openspace
-	)))
+	/turf/open/space/openspace,
+)))
 
 #define isgroundlessturf(A) (is_type_in_typecache(A, GLOB.turfs_without_ground))
 
 GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 	/turf/open/openspace,
-	/turf/open/space/openspace
-	)))
+	/turf/open/space/openspace,
+)))
 
 #define isopenspaceturf(A) (is_type_in_typecache(A, GLOB.turfs_openspace))
 
@@ -79,7 +79,7 @@ GLOBAL_LIST_INIT(turfs_pass_meteor, typecacheof(list(
 	/turf/closed/mineral,
 	/turf/open/misc/asteroid,
 	/turf/open/openspace,
-	/turf/open/space
+	/turf/open/space,
 )))
 
 #define ispassmeteorturf(A) (is_type_in_typecache(A, GLOB.turfs_pass_meteor))

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -107,6 +107,8 @@
 	if(radius < 0)
 		return scatter_locations
 	for(var/turf/open/turf_in_view in view(radius, get_turf(src)))
+		if(isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view))
+			continue
 		if(turf_in_view.is_blocked_turf(exclude_mobs = TRUE))
 			continue
 		scatter_locations += turf_in_view

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -94,15 +94,29 @@
 /obj/effect/spawner/random/proc/make_item(spawn_loc, type_path_to_make)
 	return new type_path_to_make(spawn_loc)
 
-///If the spawner has a spawn_scatter_radius set, this creates a list of nearby turfs available
+/**
+ * Gets a list of all turfs within a certain radius of the spawner that is 'valid' to be spawned on.
+ * Returns the list of all valid turfs
+ * We make sure it is an open turf (or at least has something under it if multi-z) and has no dense things on it,
+ * such as tables and windows.
+ */
 /obj/effect/spawner/random/proc/get_spawn_locations(radius)
+	RETURN_TYPE(/list)
 	var/list/scatter_locations = list()
 
-	if(radius >= 0)
-		for(var/turf/turf_in_view in view(radius, get_turf(src)))
-			if(isclosedturf(turf_in_view) || (isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view)))
-				continue
-			scatter_locations += turf_in_view
+	if(radius < 0)
+		return scatter_locations
+	for(var/turf/open/turf_in_view in view(radius, get_turf(src)))
+		if(isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view))
+			continue
+		var/density_found = FALSE
+		for(var/atom/movable/found_movable in turf_in_view)
+			if(found_movable.density)
+				density_found = TRUE
+				break
+		if(density_found)
+			continue
+		scatter_locations += turf_in_view
 
 	return scatter_locations
 

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -107,14 +107,7 @@
 	if(radius < 0)
 		return scatter_locations
 	for(var/turf/open/turf_in_view in view(radius, get_turf(src)))
-		if(isgroundlessturf(turf_in_view) && !GET_TURF_BELOW(turf_in_view))
-			continue
-		var/density_found = FALSE
-		for(var/atom/movable/found_movable in turf_in_view)
-			if(found_movable.density)
-				density_found = TRUE
-				break
-		if(density_found)
+		if(turf_in_view.is_blocked_turf(exclude_mobs = TRUE))
 			continue
 		scatter_locations += turf_in_view
 

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -227,7 +227,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 
-/obj/effect/mob_spawn/cow/special(mob/living/spawned_mob)
+/obj/effect/mob_spawn/ghost_role/cow/special(mob/living/spawned_mob)
 	. = ..()
 	gender = FEMALE
 


### PR DESCRIPTION
## About The Pull Request

Sorta alt to https://github.com/tgstation/tgstation/pull/82325 but this should be merged anyways because it's the actual fix.

Makes spawners unable to spawn things in windows or anything else with something dense like a table. Not only does it have the problem that spawning in a window facing space/icemoon can cause random CI errors, but in general spawning something in a window makes it unreachable, or under a table where it's invisible.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/82312 but actual

## Changelog

:cl:
fix: Spawners can no longer spawn entities on tiles with something dense on it like windows and tables.
/:cl: