### PR TITLE
[No GBP] Fixes a slime speed config and ai controller null error in slime nutrition handling

### DIFF
--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -36,17 +36,17 @@
 		adjust_nutrition((life_stage == SLIME_LIFE_STAGE_ADULT ? -1 : -0.5) * seconds_per_tick)
 
 	if(nutrition < SLIME_STARVE_NUTRITION)
-		ai_controller.set_blackboard_key(BB_SLIME_HUNGER_LEVEL, SLIME_HUNGER_STARVING)
+		ai_controller?.set_blackboard_key(BB_SLIME_HUNGER_LEVEL, SLIME_HUNGER_STARVING)
 
 		if(SPT_PROB(0.5, seconds_per_tick) && LAZYLEN(ai_controller?.blackboard[BB_FRIENDS_LIST]))
 			var/your_fault = pick(ai_controller?.blackboard[BB_FRIENDS_LIST])
 			unfriend(your_fault)
 
 	else if(nutrition < SLIME_HUNGER_NUTRITION || (nutrition < SLIME_GROW_NUTRITION && SPT_PROB(25, seconds_per_tick)) )
-		ai_controller.set_blackboard_key(BB_SLIME_HUNGER_LEVEL, SLIME_HUNGER_HUNGRY)
+		ai_controller?.set_blackboard_key(BB_SLIME_HUNGER_LEVEL, SLIME_HUNGER_HUNGRY)
 
 	else
-		ai_controller.set_blackboard_key(BB_SLIME_HUNGER_LEVEL, SLIME_HUNGER_NONE)
+		ai_controller?.set_blackboard_key(BB_SLIME_HUNGER_LEVEL, SLIME_HUNGER_NONE)
 
 	if(nutrition == 0) //adjust nutrition ensures it can't go below 0
 		if(SPT_PROB(50, seconds_per_tick))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -43,7 +43,7 @@ WALK_DELAY 4
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/silicon/robot 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/alien 0
-##MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal/slime 0
+##MULTIPLICATIVE_MOVESPEED /mob/living/basic/slime 0
 MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 0
 MULTIPLICATIVE_MOVESPEED /mob/living/basic 0
 


### PR DESCRIPTION


## About The Pull Request

Someone has linked the runtimes logs of round 226376 to show off a runtime, and I took a look, and found some unrelated runtimes in slime code.

- The config file for slime slowdown was still using the simple_animal path. This has been fixed.
- Somehow, a grey slime has lost its AI controller, and when it got hungry, it runtimed. For now, a coalesce operator has been put in place. Later, an investigation is needed to figure out where did its AI controller go.

## Why It's Good For The Game

Runtimes bad.

## Changelog

:cl:
fix: Slime properly load their slowdown values from the config files.
fix: Slimes who lose their AI controller will no longer runtime when they get hungry.
/:cl:

