### PR TITLE
Detective revolver no longer can be turned into a flawless .357 revolver; In this house our gun explodes from excessive pressure

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -707,10 +707,6 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	if(!I.use_tool(src, user, 3 SECONDS))
 		return TRUE
 
-	if(blow_up(user))
-		user.visible_message(span_danger("[src] goes off!"), span_danger("[src] goes off in your face!"))
-		return
-
 	if(magazine.caliber == initial_caliber)
 		magazine.caliber = alternative_caliber
 		if(alternative_ammo_misfires)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -720,7 +720,6 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		fire_sound = initial_fire_sound
 		to_chat(user, span_notice("You reset [src]. Now it will fire [initial_caliber] rounds."))
 
-
 ///used for sawing guns, causes the gun to fire without the input of the user
 /obj/item/gun/ballistic/proc/blow_up(mob/user)
 	return chambered && process_fire(user, user, FALSE)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -683,7 +683,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 
 	if(do_after(user, 100, target = src))
 		misfire_probability = initial(misfire_probability)
-		balloon_alert(user, "fouling cleaned out.")
+		balloon_alert(user, "fouling cleaned out")
 		return TRUE
 
 /obj/item/gun/ballistic/wrench_act(mob/living/user, obj/item/I)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -679,11 +679,11 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		return
 
 	user.changeNext_move(CLICK_CD_MELEE)
-	balloon_alert(user, "cleaning.")
+	balloon_alert(user, "cleaning...")
 
 	if(do_after(user, 100, target = src))
 		misfire_probability = initial(misfire_probability)
-		balloon_alert(user, "fouling cleaned out!")
+		balloon_alert(user, "fouling cleaned out.")
 		return TRUE
 
 /obj/item/gun/ballistic/wrench_act(mob/living/user, obj/item/I)
@@ -702,7 +702,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		balloon_alert(user, "the bolt is in the way!")
 		return
 
-	to_chat(user, span_notice("You begin to tinker with [src]..."))
+	balloon_alert(user, "tinkering...")
 	I.play_tool_sound(src)
 	if(!I.use_tool(src, user, 3 SECONDS))
 		return TRUE

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -674,36 +674,33 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		return TRUE
 
 /obj/item/gun/ballistic/proc/guncleaning(mob/user, obj/item/A)
-	if(misfire_probability == 0)
+	if(misfire_probability == initial(misfire_probability))
 		balloon_alert(user, "it's already clean!")
 		return
 
 	user.changeNext_move(CLICK_CD_MELEE)
-	user.visible_message(span_notice("[user] begins to cleaning [src]."), span_notice("You begin to clean the internals of [src]."))
+	balloon_alert(user, "cleaning.")
 
 	if(do_after(user, 100, target = src))
-		var/original_misfire_value = initial(misfire_probability)
-		if(misfire_probability > original_misfire_value)
-			misfire_probability = original_misfire_value
-			user.visible_message(span_notice("[user] cleans [src] of any fouling."), span_notice("You clean [src], removing any fouling, preventing misfire."))
-			return TRUE
-
-/obj/item/gun/ballistic/wrench_act(mob/living/user, obj/item/I)
-	if(!user.is_holding(src))
-		to_chat(user, span_notice("You need to hold [src] to modify it."))
+		misfire_probability = initial(misfire_probability)
+		balloon_alert(user, "fouling cleaned out!")
 		return TRUE
 
+/obj/item/gun/ballistic/wrench_act(mob/living/user, obj/item/I)
 	if(!can_modify_ammo)
 		return
 
-	if(bolt_type == BOLT_TYPE_STANDARD)
-		if(get_ammo())
-			to_chat(user, span_notice("You can't get at the internals while the gun has a bullet in it!"))
-			return
+	if(!user.is_holding(src))
+		balloon_alert(user, "hold to modify!")
+		return TRUE
 
-		else if(!bolt_locked)
-			to_chat(user, span_notice("You can't get at the internals while the bolt is down!"))
-			return
+	if(get_ammo())
+		balloon_alert(user, "can't modify while loaded!")
+		return
+
+	if(!bolt_locked && bolt_type == BOLT_TYPE_LOCKING)
+		balloon_alert(user, "the bolt is in the way!")
+		return
 
 	to_chat(user, span_notice("You begin to tinker with [src]..."))
 	I.play_tool_sound(src)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/82324

Also cleans up a lot of the code around the issue itself.

## Why It's Good For The Game

You should not be able to modify this revolver while it is loaded whatsoever. I don't know when exactly this broke, but time has clearly not been kind to the feature. 

I think it was actually impossible to reach the self explosion on modifying the gun? The return I added probably prevented it outright. I guess that was broken the entire time. Honestly, I feel like that's going to be a maintainability issue to keep it working, so maybe we just do away with what we never had.

Maybe it was for the very, very unlikely possibility that you could theoretically load in a bullet DURING the do_after? I think I was just sleep deprived. Like right now.

## Changelog
:cl:
fix: Detective revolvers can no longer exist in a quantum state of both being chambered in .38 and .357, without risk of misfire. Detectives, cowboy enthusiasts and reckless federal agents across the Spinward Sector mourn the loss.
/:cl:
