### PR TITLE
Creates a node compatibility mode

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,7 +12,7 @@ export RUST_G_VERSION=3.1.0
 
 #node version
 export NODE_VERSION=14
-export NODE_VERSION_PRECISE=20.12.0
+export NODE_VERSION_LTS=20.12.0
 export NODE_VERSION_COMPAT=14.16.1
 
 # SpacemanDMM git tag

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,7 +12,8 @@ export RUST_G_VERSION=3.1.0
 
 #node version
 export NODE_VERSION=14
-export NODE_VERSION_PRECISE=14.16.1
+export NODE_VERSION_PRECISE=20.12.0
+export NODE_VERSION_COMPAT=14.16.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.8

--- a/tgui/.prettierignore
+++ b/tgui/.prettierignore
@@ -6,6 +6,7 @@
 /yarn.lock
 /.pnp.*
 
+.swcrc
 /docs
 /public
 /packages/tgui-polyfill

--- a/tools/bootstrap/node
+++ b/tools/bootstrap/node
@@ -16,7 +16,7 @@ if [ "$TG_BOOTSTRAP_CACHE" ]; then
 fi
 OldPWD="$PWD"
 cd "$Bootstrap/../.."
-. ./dependencies.sh  # sets NODE_VERSION_PRECISE
+. ./dependencies.sh  # sets NODE_VERSION_LTS
 cd "$OldPWD"
 NodeVersion="$NODE_VERSION_LTS"
 NodeFullVersion="node-v$NodeVersion-win-x64"

--- a/tools/bootstrap/node
+++ b/tools/bootstrap/node
@@ -18,7 +18,7 @@ OldPWD="$PWD"
 cd "$Bootstrap/../.."
 . ./dependencies.sh  # sets NODE_VERSION_PRECISE
 cd "$OldPWD"
-NodeVersion="$NODE_VERSION_PRECISE"
+NodeVersion="$NODE_VERSION_LTS"
 NodeFullVersion="node-v$NodeVersion-win-x64"
 NodeDir="$Cache/$NodeFullVersion"
 NodeExe="$NodeDir/node.exe"

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -40,7 +40,7 @@ if ($OSVersion -gt 6.1) {
 	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_COMPAT"
 }
 else {
-	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_LTS"
 }
 
 $NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -30,7 +30,19 @@ $Cache = "$BaseDir\.cache"
 if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
-$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
+
+# Get OS version
+$OSVersion = (Get-WmiObject -Class Win32_OperatingSystem).Version
+
+# Set Node version based on OS version
+if ($OSVersion -gt 6.1) {
+ # Windows 7 is version 6.1
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_COMPAT"
+}
+else {
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
+}
+
 $NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
 $NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"


### PR DESCRIPTION
## About The Pull Request
By default this will install node v20 LTS, but if a user is detected to be using win 7 it's node v14

This lets us run higher node versions (with presumably more stable and performant content) while allowing win 7 users to play

I should note that this is making clean tgui builds run at ~6.7sec which is about a 6.9% speed increase (nice) from the previous #80310
## Why It's Good For The Game
Better tools
## Changelog
N/A nothing player facing
