### PR TITLE
Mechbay & modsuit recharger tweaks

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -3,6 +3,7 @@
 	desc = "This device recharges energy dependent lifeforms, like cyborgs, ethereals and MODsuit users."
 	icon = 'icons/obj/machines/borg_charger.dmi'
 	icon_state = "borgcharger0"
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.1
 	density = FALSE
 	req_access = list(ACCESS_ROBOTICS)
 	state_open = TRUE
@@ -176,4 +177,8 @@
 /obj/machinery/recharge_station/proc/process_occupant(seconds_per_tick)
 	if(!occupant)
 		return
+
+	if(!use_energy(active_power_usage * seconds_per_tick))
+		return
+
 	SEND_SIGNAL(occupant, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, charge_cell, seconds_per_tick, repairs, sendmats)

--- a/code/modules/vehicles/mecha/mech_bay.dm
+++ b/code/modules/vehicles/mecha/mech_bay.dm
@@ -1,10 +1,11 @@
 /obj/machinery/mech_bay_recharge_port
 	name = "mech bay power port"
 	desc = "This port recharges a mech's internal power cell."
-	density = TRUE
-	dir = EAST
 	icon = 'icons/obj/machines/mech_bay.dmi'
 	icon_state = "recharge_port"
+	density = TRUE
+	dir = EAST
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.1
 	circuit = /obj/item/circuitboard/machine/mech_recharger
 	///Weakref to currently recharging mech on our recharging_turf
 	var/datum/weakref/recharging_mech_ref
@@ -64,9 +65,9 @@
 	if(!recharging_mech?.cell)
 		return
 	if(recharging_mech.cell.charge < recharging_mech.cell.maxcharge)
-		var/delta = min(recharge_power * seconds_per_tick, recharging_mech.cell.maxcharge - recharging_mech.cell.charge)
-		recharging_mech.give_power(delta)
-		use_energy(delta + active_power_usage)
+		if(!use_energy(active_power_usage * seconds_per_tick))
+			return
+		charge_cell(recharge_power * seconds_per_tick, recharging_mech.cell, grid_only = TRUE)
 	else
 		recharge_console.update_appearance()
 	if(recharging_mech.loc != recharging_turf)

--- a/tgui/packages/tgui/interfaces/MechBayPowerConsole.jsx
+++ b/tgui/packages/tgui/interfaces/MechBayPowerConsole.jsx
@@ -1,12 +1,12 @@
 import { useBackend } from '../backend';
 import {
-  AnimatedNumber,
   Button,
   LabeledList,
   NoticeBox,
   ProgressBar,
   Section,
 } from '../components';
+import { formatEnergy } from '../format';
 import { Window } from '../layouts';
 
 export const MechBayPowerConsole = (props) => {
@@ -58,8 +58,9 @@ export const MechBayPowerConsole = (props) => {
                       bad: [-Infinity, 0.3],
                     }}
                   >
-                    <AnimatedNumber value={cell.charge} />
-                    {' / ' + cell.maxcharge}
+                    {formatEnergy(cell.charge) +
+                      '/' +
+                      formatEnergy(cell.maxcharge)}
                   </ProgressBar>
                 )}
             </LabeledList.Item>


### PR DESCRIPTION
## About The Pull Request
- Both mechbay & modsuit rechargers now waste a small amount of energy as heat like it did before
- Fixes #82332. Mechbay recharger displays the energy of the mech in joules & charges the cell with the exact energy required directly from the grid thus not causing the room to blackout

## Changelog
:cl:
fix: Mechbay & modsuit rechargers waste a small amount of energy as heat
fix: Mechbay recharger console displays mech charge as joules & charges directly from the grid thus sparing the rooms apc cell from huge loads
/:cl:
