### PR TITLE
Fixed that miss colored '1' button on the safe and nuke keypad

### DIFF
--- a/tgui/packages/tgui/interfaces/LockedSafe.tsx
+++ b/tgui/packages/tgui/interfaces/LockedSafe.tsx
@@ -23,7 +23,7 @@ export const LockedSafe = (props) => {
             {input_code}
           </Flex.Item>
           <Flex.Item className="NuclearBomb__displayBox">
-            {!lock_code && 'No password set.'}
+            {!lock_code && 'Password?'}
             {!!lock_code && (!locked ? 'Unlocked' : 'Locked')}
           </Flex.Item>
           <Flex.Item ml="3px">

--- a/tgui/packages/tgui/interfaces/LockedSafe.tsx
+++ b/tgui/packages/tgui/interfaces/LockedSafe.tsx
@@ -27,7 +27,7 @@ export const LockedSafe = (props) => {
             {!!lock_code && (!locked ? 'Unlocked' : 'Locked')}
           </Flex.Item>
           <Flex.Item ml="3px">
-            <NukeKeypad />
+            <NukeKeypad keypadClassPrefix="LockedSafe" />
           </Flex.Item>
         </Flex>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/LockedSafe.tsx
+++ b/tgui/packages/tgui/interfaces/LockedSafe.tsx
@@ -1,7 +1,7 @@
 import { BooleanLike } from 'common/react';
 
 import { useBackend } from '../backend';
-import { Box, Flex } from '../components';
+import { Flex } from '../components';
 import { Window } from '../layouts';
 import { NukeKeypad } from './NuclearBomb';
 
@@ -16,22 +16,20 @@ export const LockedSafe = (props) => {
   const { act, data } = useBackend<Data>();
   const { input_code, locked, lock_code } = data;
   return (
-    <Window width={300} height={400} theme="ntos">
+    <Window width={195} height={430} theme="retro">
       <Window.Content>
-        <Box m="6px">
-          <Box mb="6px" className="NuclearBomb__displayBox">
+        <Flex direction="column" justify="center" width={'170px'} m="6px">
+          <Flex.Item className="NuclearBomb__displayBox">
             {input_code}
-          </Box>
-          <Box className="NuclearBomb__displayBox">
+          </Flex.Item>
+          <Flex.Item className="NuclearBomb__displayBox">
             {!lock_code && 'No password set.'}
             {!!lock_code && (!locked ? 'Unlocked' : 'Locked')}
-          </Box>
-          <Flex ml="3px">
-            <Flex.Item>
-              <NukeKeypad />
-            </Flex.Item>
-          </Flex>
-        </Box>
+          </Flex.Item>
+          <Flex.Item ml="3px">
+            <NukeKeypad />
+          </Flex.Item>
+        </Flex>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/NuclearBomb.jsx
+++ b/tgui/packages/tgui/interfaces/NuclearBomb.jsx
@@ -51,6 +51,8 @@ export const NukeKeypad = (props) => {
 export const NuclearBomb = (props) => {
   const { act, data } = useBackend();
   const { anchored, disk_present, status1, status2 } = data;
+  // Side note, why the width in the flex?  Otherwise the text
+  // box can scroll willy nilly
   return (
     <Window width={350} height={442} theme="retro">
       <Window.Content>

--- a/tgui/packages/tgui/interfaces/NuclearBomb.jsx
+++ b/tgui/packages/tgui/interfaces/NuclearBomb.jsx
@@ -1,7 +1,7 @@
 import { classes } from 'common/react';
 
 import { useBackend } from '../backend';
-import { Box, Button, Flex, Grid, Icon } from '../components';
+import { Box, Button, Flex, Icon } from '../components';
 import { Window } from '../layouts';
 
 // This ui is so many manual overrides and !important tags
@@ -11,22 +11,22 @@ import { Window } from '../layouts';
 export const NukeKeypad = (props) => {
   const { act } = useBackend();
   const keypadKeys = [
-    ['1', '4', '7', 'C'],
-    ['2', '5', '8', '0'],
-    ['3', '6', '9', 'E'],
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['7', '8', '9'],
+    ['C', '0', 'E'],
   ];
   return (
-    <Box width="185px">
-      <Grid width="1px">
-        {keypadKeys.map((keyColumn) => (
-          <Grid.Column key={keyColumn[0]}>
-            {keyColumn.map((key) => (
+    <Box className="NuclearBomb__Button--keypad" width="185px">
+      <Flex direction="column" justify="center">
+        {keypadKeys.map((keyRow) => (
+          <Flex direction="inline" key={keyRow[0]}>
+            {keyRow.map((key, index) => (
               <Button
                 fluid
                 bold
-                key={key}
+                key={index + '_' + key}
                 mb="6px"
-                content={key}
                 textAlign="center"
                 fontSize="40px"
                 lineHeight={1.25}
@@ -37,11 +37,13 @@ export const NukeKeypad = (props) => {
                   'NuclearBomb__Button--' + key,
                 ])}
                 onClick={() => act('keypad', { digit: key })}
-              />
+              >
+                {key}
+              </Button>
             ))}
-          </Grid.Column>
+          </Flex>
         ))}
-      </Grid>
+      </Flex>
     </Box>
   );
 };
@@ -52,29 +54,32 @@ export const NuclearBomb = (props) => {
   return (
     <Window width={350} height={442} theme="retro">
       <Window.Content>
-        <Box m="6px">
-          <Box mb="6px" className="NuclearBomb__displayBox">
-            {status1}
-          </Box>
-          <Flex mb={1.5}>
-            <Flex.Item grow={1}>
-              <Box className="NuclearBomb__displayBox">{status2}</Box>
+        <Flex direction="column" width={'340px'}>
+          <Flex direction="column" mb={1.5}>
+            <Flex.Item mb="6px" className="NuclearBomb__displayBox">
+              {status1}
             </Flex.Item>
-            <Flex.Item>
-              <Button
-                icon="eject"
-                fontSize="24px"
-                lineHeight={1}
-                textAlign="center"
-                width="43px"
-                ml="6px"
-                mr="3px"
-                mt="3px"
-                className="NuclearBomb__Button NuclearBomb__Button--keypad"
-                onClick={() => act('eject_disk')}
-              />
-            </Flex.Item>
+            <Flex>
+              <Flex.Item grow={1}>
+                <Box className="NuclearBomb__displayBox">{status2}</Box>
+              </Flex.Item>
+              <Flex.Item>
+                <Button
+                  icon="eject"
+                  fontSize="24px"
+                  lineHeight={1}
+                  textAlign="center"
+                  width="43px"
+                  ml="6px"
+                  mr="3px"
+                  mt="3px"
+                  className="NuclearBomb__Button NuclearBomb__Button--keypad"
+                  onClick={() => act('eject_disk')}
+                />
+              </Flex.Item>
+            </Flex>
           </Flex>
+
           <Flex ml="3px">
             <Flex.Item>
               <NukeKeypad />
@@ -109,7 +114,7 @@ export const NuclearBomb = (props) => {
               </Box>
             </Flex.Item>
           </Flex>
-        </Box>
+        </Flex>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/NuclearBomb.tsx
+++ b/tgui/packages/tgui/interfaces/NuclearBomb.tsx
@@ -4,11 +4,16 @@ import { useBackend } from '../backend';
 import { Box, Button, Flex, Icon } from '../components';
 import { Window } from '../layouts';
 
+type NukeKeypadPropsType = {
+  keypadClassPrefix: string;
+};
+
 // This ui is so many manual overrides and !important tags
 // and hand made width sets that changing pretty much anything
 // is going to require a lot of tweaking it get it looking correct again
 // I'm sorry, but it looks bangin
-export const NukeKeypad = (props) => {
+export const NukeKeypad = (props: NukeKeypadPropsType) => {
+  const { keypadClassPrefix } = props;
   const { act } = useBackend();
   const keypadKeys = [
     ['1', '2', '3'],
@@ -17,7 +22,7 @@ export const NukeKeypad = (props) => {
     ['C', '0', 'E'],
   ];
   return (
-    <Box className="NuclearBomb__Button--keypad" width="185px">
+    <Box className={keypadClassPrefix + '__Button--keypad'} width="185px">
       <Flex direction="column" justify="center">
         {keypadKeys.map((keyRow) => (
           <Flex direction="inline" key={keyRow[0]}>
@@ -32,9 +37,9 @@ export const NukeKeypad = (props) => {
                 lineHeight={1.25}
                 width="55px"
                 className={classes([
-                  'NuclearBomb__Button',
-                  'NuclearBomb__Button--keypad',
-                  'NuclearBomb__Button--' + key,
+                  keypadClassPrefix + '__Button',
+                  keypadClassPrefix + '__Button--keypad',
+                  keypadClassPrefix + '__Button--' + key,
                 ])}
                 onClick={() => act('keypad', { digit: key })}
               >
@@ -48,8 +53,15 @@ export const NukeKeypad = (props) => {
   );
 };
 
+type NuclearBombPropType = {
+  anchored: boolean;
+  disk_present: boolean;
+  status1: string;
+  status2: string;
+};
+
 export const NuclearBomb = (props) => {
-  const { act, data } = useBackend();
+  const { act, data } = useBackend<NuclearBombPropType>();
   const { anchored, disk_present, status1, status2 } = data;
   // Side note, why the width in the flex?  Otherwise the text
   // box can scroll willy nilly
@@ -84,7 +96,7 @@ export const NuclearBomb = (props) => {
 
           <Flex ml="3px">
             <Flex.Item>
-              <NukeKeypad />
+              <NukeKeypad keypadClassPrefix="NuclearBomb" />
             </Flex.Item>
             <Flex.Item ml="6px" width="129px">
               <Box>

--- a/tgui/packages/tgui/styles/interfaces/NuclearBomb.scss
+++ b/tgui/packages/tgui/styles/interfaces/NuclearBomb.scss
@@ -32,12 +32,6 @@ $background-beige: #e8e4c9;
   }
 }
 
-.NuclearBomb__Button--1 {
-  background-color: #d3cfb7 !important;
-  border-color: #d3cfb7 !important;
-  color: #a9a692 !important;
-}
-
 .NuclearBomb__Button--E {
   background-color: $color-caution !important;
   border-color: $color-caution !important;

--- a/tgui/packages/tgui/styles/interfaces/NuclearBomb.scss
+++ b/tgui/packages/tgui/styles/interfaces/NuclearBomb.scss
@@ -32,6 +32,12 @@ $background-beige: #e8e4c9;
   }
 }
 
+.NuclearBomb__Button--1 {
+  background-color: #d3cfb7 !important;
+  border-color: #d3cfb7 !important;
+  color: #a9a692 !important;
+}
+
 .NuclearBomb__Button--E {
   background-color: $color-caution !important;
   border-color: $color-caution !important;
@@ -55,4 +61,20 @@ $background-beige: #e8e4c9;
   background-size: 70%;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+.LockedSafe__Button {
+  @extend .NuclearBomb__Button !optional;
+}
+
+.LockedSafe__Button--keypad {
+  @extend .NuclearBomb__Button--keypad !optional;
+}
+
+.LockedSafe__Button--E {
+  @extend .NuclearBomb__Button--E !optional;
+}
+
+.LockedSafe__Button--C {
+  @extend .NuclearBomb__Button--C !optional;
 }


### PR DESCRIPTION

## About The Pull Request

Its been driving me crazy.  So I fixed it.  I also went a head and set the wall/captin safe to the "retro" template like the nuke button is so all the shadows come in right.  While I was at it I removed the obsoleted Grid control and just did it all with Flex.
## Why It's Good For The Game

The keypad is more consistent.
![2pxgJs0id3](https://github.com/tgstation/tgstation/assets/1102671/00ca2b9d-ba9f-4534-809d-d19bb40ae89a) | ![nBIAozJxok](https://github.com/tgstation/tgstation/assets/1102671/75bf9597-a396-455b-9157-28fb1bcbe856)
## Changelog
:cl:
fix: The '1' button is the right color
fix: Backgrounds look better on normal safes
:cl:
