### PR TITLE
(april fools) all humans+nonhumans are augmented with experimental reagent generating augments (unremovable)

### DIFF
--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -45,8 +45,11 @@
 
 
 ///signal called on parent being attacked with an item
-/datum/component/udder/proc/on_attackby(datum/source, obj/item/milking_tool, mob/user)
+/datum/component/udder/proc/on_attackby(datum/source, obj/item/milking_tool, mob/living/user)
 	SIGNAL_HANDLER
+
+	if(user.combat_mode)
+		return
 
 	var/mob/living/milked = parent
 	if(milked.stat == CONSCIOUS && istype(milking_tool, /obj/item/reagent_containers/cup))
@@ -204,3 +207,12 @@
 		reagents.add_reagent(/datum/reagent/medicine/salglu_solution, rand(2,5))
 	if(on_generate_callback)
 		on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)
+
+/obj/item/udder/carbon
+	name = "experimental reagent generating augment"
+
+/obj/item/udder/carbon/Initialize(mapload)
+	production_probability = rand(10,75)
+	reagent_produced_typepath = get_random_reagent_id()
+	size = rand(30,80)
+	return ..() //so volume changes and stuff

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -27,6 +27,7 @@
 	AddComponent(/datum/component/bloodysoles/feet, FOOTPRINT_SPRITE_SHOES)
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/human)
 	AddElement(/datum/element/strippable, GLOB.strippable_human_items, TYPE_PROC_REF(/mob/living/carbon/human/, should_strip))
+	AddComponent(/datum/component/udder, udder_type = /obj/item/udder/carbon)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 		COMSIG_LIVING_DISARM_PRESHOVE = PROC_REF(disarm_precollide),


### PR DESCRIPTION

## About The Pull Request

all subtypes of humans are given a experimental reagent generating augment
this augment is not removable
it generates a random reagent at a random pace and at a random max volume

## Why It's Good For The Game

nanotrasen experiment or something idk

## Changelog
:cl:
add: everyone is forcefully augmented with unremovable experimental reagent generating augments
/:cl:
