### PR TITLE
[April Fools] Restart votes are now weighted random

### DIFF
--- a/code/datums/votes/restart_vote.dm
+++ b/code/datums/votes/restart_vote.dm
@@ -8,6 +8,7 @@
 		CHOICE_CONTINUE,
 	)
 	message = "Vote to restart the ongoing round."
+	winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
 
 /// This proc checks to see if any admins are online for the purposes of this vote to see if it can pass. Returns TRUE if there are valid admins online (Has +SERVER and is not AFK), FALSE otherwise.
 /datum/vote/restart_vote/proc/admins_present()


### PR DESCRIPTION

## About The Pull Request

Restart votes are now weighted random, as God intended.

The server still won't restart if there's an admin online, though.

## Why It's Good For The Game

No vote should be a simple winner take all. Every vote should be randomly chosen based on votes. Even restart votes.

## Changelog
:cl:
balance: Restart votes are now weighted random.
/:cl:
