### PR TITLE
Makes radiaton and bomb good helmets have the FOV effect...... its not my fault

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -99,6 +99,11 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 
+/obj/item/clothing/head/utility/bomb_hood/Initialize(mapload)
+	. = ..()
+	if(flags_inv & HIDEFACE)
+		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+
 /datum/armor/utility_bomb_hood
 	melee = 20
 	laser = 20

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -169,6 +169,11 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 
+/obj/item/clothing/head/utility/radiation/Initialize(mapload)
+	. = ..()
+	if(flags_inv & HIDEFACE)
+		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+
 /datum/armor/utility_radiation
 	bio = 60
 	fire = 30


### PR DESCRIPTION

## About The Pull Request
Fixes Radiation hood having normal vision 

Closes #80917 
![image](https://github.com/tgstation/tgstation/assets/84478872/81e43edb-7b66-4403-b06d-fa4d256ebc48)
## Why It's Good For The Game
It isnt but it must be done in order to remove github issues
## Changelog
:cl:
fix: Fixes Radiation Hood not having FOV blockage
/:cl:
