### PR TITLE
renames the Head of Personnel job to better suit emergent play patterns

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -43,7 +43,7 @@
 #define JOB_PRISONER "Prisoner"
 //Command
 #define JOB_CAPTAIN "Captain"
-#define JOB_HEAD_OF_PERSONNEL "Head of Personnel"
+#define JOB_HEAD_OF_PERSONNEL "Second Captain"
 #define JOB_HEAD_OF_SECURITY "Head of Security"
 #define JOB_RESEARCH_DIRECTOR "Research Director"
 #define JOB_CHIEF_ENGINEER "Chief Engineer"
@@ -258,7 +258,7 @@ DEFINE_BITFIELD(job_flags, list(
 #define SUPERVISOR_CAPTAIN "the Captain"
 #define SUPERVISOR_CE "the Chief Engineer"
 #define SUPERVISOR_CMO "the Chief Medical Officer"
-#define SUPERVISOR_HOP "the Head of Personnel"
+#define SUPERVISOR_HOP "the Second Captain"
 #define SUPERVISOR_HOS "the Head of Security"
 #define SUPERVISOR_QM "the Quartermaster"
 #define SUPERVISOR_RD "the Research Director"


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

The actual play patterns of players in the Head of Personnel job have drifted over time to no longer suit the position's title. Renaming the job to better reflect what players expect of it will help reduce the barrier to entry for new players.

## Changelog

:cl: ATHATH
spellcheck: The Head of Personnel role has been renamed to better suit emergent play patterns.
/:cl:
