### PR TITLE
Clown anomalous crystals turn the dead into living clowns, rather than anyone who speaks in proximity

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -354,6 +354,8 @@
 			new_clown.dropItemToGround(to_strip)
 		new_clown.dress_up_as_job(SSjob.GetJobType(/datum/job/clown))
 		clowned_mob_refs += clown_ref
+	
+	return TRUE
 
 /// Transforms the area to look like a new one
 /obj/machinery/anomalous_crystal/theme_warp
@@ -432,6 +434,8 @@
 		//Free revives, but significantly limits your options for reviving except via the crystal
 		//except JK who cares about BADDNA anymore. this even heals suicides.
 		ADD_TRAIT(to_revive, TRAIT_BADDNA, MAGIC_TRAIT)
+	
+	return TRUE
 
 /obj/machinery/anomalous_crystal/helpers //Lets ghost spawn as helpful creatures that can only heal people slightly. Incredibly fragile and they can't converse with humans
 	observer_desc = "This crystal allows ghosts to turn into a fragile creature that can heal people."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -319,7 +319,7 @@
 	return TRUE
 
 /obj/machinery/anomalous_crystal/honk //Revives the dead, but strips and equips them as a clown
-	observer_desc = "This crystal revives targets around it as clowns Oh, that's horrible...."
+	observer_desc = "This crystal revives targets around it as clowns. Oh, that's horrible...."
 	activation_method = ACTIVATE_TOUCH
 	activation_sound = 'sound/items/bikehorn.ogg'
 	use_time = 3 SECONDS
@@ -329,28 +329,31 @@
 /obj/machinery/anomalous_crystal/honk/ActivationReaction(mob/user)
 	. = ..()
 	if(!.)
-		return
+		return FALSE
+	
 	for(var/atom/thing as anything in range(1, src))
 		if(isturf(thing))
 			new /obj/effect/decal/cleanable/confetti(thing)
 			continue
 
-		if(ishuman(thing))
-			var/mob/living/carbon/human/new_clown = thing
-			
-			if(new_clown.stat != DEAD)
-				continue
+		if(!ishuman(thing))
+			continue
 
-			new_clown.revive(ADMIN_HEAL_ALL, force_grab_ghost = TRUE)
-
-			var/clown_ref = REF(new_clown)
-			if(clown_ref in clowned_mob_refs) //one clowning per person
-				continue
+		var/mob/living/carbon/human/new_clown = thing
 			
-			for(var/obj/item/to_strip in new_clown.get_equipped_items())
-				new_clown.dropItemToGround(to_strip)
-			new_clown.dress_up_as_job(SSjob.GetJobType(/datum/job/clown))
-			clowned_mob_refs += clown_ref
+		if(new_clown.stat != DEAD)
+			continue
+
+		new_clown.revive(ADMIN_HEAL_ALL, force_grab_ghost = TRUE)
+
+		var/clown_ref = REF(new_clown)
+		if(clown_ref in clowned_mob_refs) //one clowning per person
+			continue
+			
+		for(var/obj/item/to_strip in new_clown.get_equipped_items())
+			new_clown.dropItemToGround(to_strip)
+		new_clown.dress_up_as_job(SSjob.GetJobType(/datum/job/clown))
+		clowned_mob_refs += clown_ref
 
 /// Transforms the area to look like a new one
 /obj/machinery/anomalous_crystal/theme_warp
@@ -409,21 +412,26 @@
 /obj/machinery/anomalous_crystal/dark_reprise/ActivationReaction(mob/user, method)
 	. = ..()
 	if(!.)
-		return
+		return FALSE
+
 	for(var/atom/thing as anything in range(1, src))
 		if(isturf(thing))
 			new /obj/effect/temp_visual/cult/sparks(thing)
 			continue
 
-		if(ishuman(thing))
-			var/mob/living/carbon/human/to_revive = thing
-			if(to_revive.stat != DEAD)
-				continue
-			to_revive.set_species(/datum/species/shadow, TRUE)
-			to_revive.revive(ADMIN_HEAL_ALL, force_grab_ghost = TRUE)
-			//Free revives, but significantly limits your options for reviving except via the crystal
-			//except JK who cares about BADDNA anymore. this even heals suicides.
-			ADD_TRAIT(to_revive, TRAIT_BADDNA, MAGIC_TRAIT)
+		if(!ishuman(thing))
+			continue
+		
+		var/mob/living/carbon/human/to_revive = thing
+		
+		if(to_revive.stat != DEAD)
+			continue
+		
+		to_revive.set_species(/datum/species/shadow, TRUE)
+		to_revive.revive(ADMIN_HEAL_ALL, force_grab_ghost = TRUE)
+		//Free revives, but significantly limits your options for reviving except via the crystal
+		//except JK who cares about BADDNA anymore. this even heals suicides.
+		ADD_TRAIT(to_revive, TRAIT_BADDNA, MAGIC_TRAIT)
 
 /obj/machinery/anomalous_crystal/helpers //Lets ghost spawn as helpful creatures that can only heal people slightly. Incredibly fragile and they can't converse with humans
 	observer_desc = "This crystal allows ghosts to turn into a fragile creature that can heal people."


### PR DESCRIPTION
## About The Pull Request

Rather than turning people into clowns if they speak within proximity of the crystal, the clown anomalous crystal instead transforms the dead into clowns, similar to the dark revival crystal.

This also adds logging for crystal activation.

## Why It's Good For The Game

We've had a significant number of admin issues with this crystal being abused to both grief and killbait people by turning them into clowns as of late. The crystal literally only exists to do this basically. And it is also grossly unlogged despite the fact that many of the effects could be cause for investigation.

Rather remove this crystal, I'm making it useful...with a catch.

## Changelog
:cl:
qol: Makes the clown anomalous crystal actually useful for once rather than an open griefing tool. It now revives the dead...as clowns!
admin: Adds logging for the anomalous crystal activation, including fingerprints.
/:cl:
