### PR TITLE
Make it easier to click on heretic influences

### DIFF
--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -8,11 +8,16 @@
 		/// Takes lmb_text and rmb_text.
 		list/screentip_texts
 
+		/// A custom callback to determine whether a user's clicks will be redirected or not (mob/user)
+		datum/callback/interact_check
+
 		turf/current_turf
+
 
 /datum/component/redirect_attack_hand_from_turf/Initialize(
 	adjust_for_pixel_shift = TRUE,
 	list/screentip_texts = null,
+	datum/callback/interact_check = null
 )
 	. = ..()
 
@@ -21,6 +26,7 @@
 
 	src.adjust_for_pixel_shift = adjust_for_pixel_shift
 	src.screentip_texts = screentip_texts
+	src.interact_check = interact_check
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	connect_to_new_turf()
@@ -95,6 +101,9 @@
 	var/atom/movable/movable_parent = parent
 	if (!movable_parent.can_interact(user))
 		return NONE
+	
+	if (!isnull(interact_check) && !interact_check.Invoke(user))
+		return NONE
 
 	INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, UnarmedAttack), parent, proximity_flag = TRUE, modifiers = modifiers)
 
@@ -113,6 +122,9 @@
 		return NONE
 
 	if (!isnull(held_item))
+		return NONE
+	
+	if (!isnull(interact_check) && !interact_check.Invoke(user))
 		return NONE
 
 	if (!isnull(screentip_texts["lmb_text"]))

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -219,6 +219,11 @@
 	on_turf.interaction_flags_atom |= INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
 	RegisterSignal(on_turf, COMSIG_TURF_CHANGE, PROC_REF(replace_our_turf))
 
+	AddComponent(/datum/component/redirect_attack_hand_from_turf, interact_check = CALLBACK(src, PROC_REF(verify_user_can_see)))
+
+/obj/effect/heretic_influence/proc/verify_user_can_see(mob/user)
+	return (user?.mind in minds)
+
 /obj/effect/heretic_influence/proc/replace_our_turf(datum/source, path, new_baseturfs, flags, post_change_callbacks)
 	SIGNAL_HANDLER
 	post_change_callbacks += CALLBACK(src, PROC_REF(replace_our_turf_two))
@@ -255,13 +260,16 @@
 		return
 
 	// Using a codex will give you two knowledge points for draining.
-	if(!being_drained && istype(weapon, /obj/item/codex_cicatrix))
-		var/obj/item/codex_cicatrix/codex = weapon
-		if(!codex.book_open)
-			codex.attack_self(user) // open booke
-		INVOKE_ASYNC(src, PROC_REF(drain_influence), user, 2)
+	if(drain_influence_with_codex(user, weapon))
 		return TRUE
 
+/obj/effect/heretic_influence/proc/drain_influence_with_codex(mob/user, obj/item/codex_cicatrix/codex)
+	if(!istype(codex) || being_drained)
+		return FALSE
+	if(!codex.book_open)
+		codex.attack_self(user) // open booke
+	INVOKE_ASYNC(src, PROC_REF(drain_influence), user, 2)
+	return TRUE
 
 /**
  * Begin to drain the influence, setting being_drained,

--- a/code/modules/antagonists/heretic/items/forbidden_book.dm
+++ b/code/modules/antagonists/heretic/items/forbidden_book.dm
@@ -55,7 +55,9 @@
 		return
 
 	if(isopenturf(target))
-		heretic_datum.try_draw_rune(user, target, drawing_time = 8 SECONDS)
+		var/obj/effect/heretic_influence/influence = locate(/obj/effect/heretic_influence) in target
+		if(!influence?.drain_influence_with_codex(user, src))
+			heretic_datum.try_draw_rune(user, target, drawing_time = 8 SECONDS)
 		return TRUE
 
 /// Plays a little animation that shows the book opening and closing.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so heretic influences are easier for heretics to click:
- Clicking a codex cicatrix on the turf of an influence will let you the drain said influence, rather than having to click directly on the sprite
- Any right click on the turf of an influence will be redirected to the influence. This really isn't as necessary as the first bit, but eh, why not, doesn't hurt.



https://github.com/tgstation/tgstation/assets/65794972/124393a4-337d-49af-9f67-3e865e151aeb



## Why It's Good For The Game

Way too easy to misclick the sprite due to the animation - last thing you want is to _accidentally start drawing a rune_ when you're trying to sneakily drain a reality butthole.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Makes it easier for heretics to click on influences without accidentally drawing a rune with their codex cicatrix because the animation shifted and made you click on the floor instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
