### PR TITLE
Makes deconstruction of computer & machine frames consistent

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -78,10 +78,11 @@
 
 	switch(state)
 		if(FRAME_STATE_EMPTY)
-			. += span_notice("It can be [EXAMINE_HINT("wrenched")] [anchored ? "loose" : "in place"].")
+			. += span_notice("It can be [EXAMINE_HINT("anchored")] [anchored ? "loose" : "in place"].")
 			if(anchored)
 				. += span_warning("It's missing a circuit board.")
-			. += span_notice("It can be [EXAMINE_HINT("welded")] or [EXAMINE_HINT("screwed")] apart.")
+			else
+				. += span_notice("It can be [EXAMINE_HINT("welded")] or [EXAMINE_HINT("screwed")] apart.")
 		if(FRAME_COMPUTER_STATE_BOARD_INSTALLED)
 			. += span_warning("An [circuit.name] is installed and should be [EXAMINE_HINT("screwed")] in place.")
 			. += span_notice("The circuit board can be [EXAMINE_HINT("pried")] out.")

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -63,6 +63,9 @@
 		return NONE
 	if(obj_flags & NO_DECONSTRUCTION)
 		return NONE
+	if(anchored && state == FRAME_STATE_EMPTY) //when using a screwdriver on an incomplete frame(missing components) no point checking for this
+		balloon_alert(user, "must be unanchored first!")
+		return ITEM_INTERACT_BLOCKING
 	if(!tool.tool_start_check(user, amount = (tool.tool_behaviour == TOOL_WELDER ? 1 : 0)))
 		return ITEM_INTERACT_BLOCKING
 

--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -24,12 +24,6 @@
 		dump_contents()
 	return ..()
 
-/obj/structure/frame/machine/try_dissassemble(mob/living/user, obj/item/tool, disassemble_time)
-	if(anchored && state == FRAME_STATE_EMPTY) //when using a screwdriver on an incomplete frame(missing components) no point checking for this
-		balloon_alert(user, "must be unanchored first!")
-		return FALSE
-	return ..()
-
 /obj/structure/frame/machine/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = NONE
 	if(isnull(held_item))
@@ -90,6 +84,8 @@
 	if(!circuit?.needs_anchored)
 		. += span_notice("It can be [EXAMINE_HINT("anchored")] [anchored ? "loose" : "in place"]")
 	if(state == FRAME_STATE_EMPTY)
+		if(!anchored)
+			. += span_notice("It can be [EXAMINE_HINT("welded")] or [EXAMINE_HINT("screwed")] apart.")
 		. += span_warning("It needs [EXAMINE_HINT("5 cable")] pieces to wire it.")
 		return
 	if(state == FRAME_STATE_WIRED)


### PR DESCRIPTION
## About The Pull Request
- Adds a missing examine for when the machine frame can be deconstructed
- Both the machine & computer frames needs to be unanchored before it can be deconstructed & adds examines to explain the same. Currently computer frames don't have the unanchor requirement which is inconsistent, but now both frames share the same code

## Changelog
:cl:
qol: adds missing examine for when machine frames can be deconstructed 
qol: both machine & computer frames must be unanchored before it can be deconstructed & adds examines to explain the same
/:cl:
