### PR TITLE
punch knockdown is now based off punch damage + armor (of victim) + other unarmed balance things

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1156,7 +1156,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		return
 	
-	if(!attacking_bodypart.attacking_bodypart.unarmed_stun_threshold) //this limb cannot knock down
+	if(!attacking_bodypart.unarmed_stun_threshold) //this limb cannot knock down
 		return
 
 	//The probability for landing a knockdown is also affected armor and an additional chance if the victim is staggered

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1155,6 +1155,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	if(HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		return
+	
+	if(!attacking_bodypart.attacking_bodypart.unarmed_stun_threshold) //this limb cannot knock down
+		return
 
 	//The probability for landing a knockdown is also affected armor and an additional chance if the victim is staggered
 	var/result = damage_plus_armor + (staggered ? attacking_bodypart.unarmed_damage_high / 100 * 20 : 0)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1143,24 +1143,28 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			target.force_say()
 		log_combat(user, target, grappled ? "grapple punched" : "kicked")
 		target.apply_damage(damage, attack_type, affecting, armor_block - limb_accuracy, attack_direction = attack_direction)
-		target.apply_damage(damage*1.5, STAMINA, affecting, armor_block - limb_accuracy)
-	else // Normal attacks do not gain the benefit of armor penetration.
-		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction)
-		target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
-		if(damage >= 9)
-			target.force_say()
-		log_combat(user, target, "punched")
+		return
+	
+	// Punches
+	// Normal attacks do not gain the benefit of armor penetration.
+	var/damage_plus_armor = target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction)
+	target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
+	if(damage >= 9)
+		target.force_say()
+	log_combat(user, target, "punched")
 
-	//If we rolled a punch high enough to hit our stun threshold, or our target is staggered and they have at least 40 damage+stamina loss, we knock them down
-	//This does not work against opponents who are knockdown immune, such as from wearing riot armor.
-	if(!HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
-		if((target.stat != DEAD) && prob(limb_accuracy) || (target.stat != DEAD) && staggered && (target.getStaminaLoss() + user.getBruteLoss()) >= 40)
-			target.visible_message(span_danger("[user] knocks [target] down!"), \
-							span_userdanger("You're knocked down by [user]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
-			to_chat(user, span_danger("You knock [target] down!"))
-			var/knockdown_duration = 4 SECONDS + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 //50 total damage = 4 second base stun + 4 second stun modifier = 8 second knockdown duration
-			target.apply_effect(knockdown_duration, EFFECT_KNOCKDOWN, armor_block)
-			log_combat(user, target, "got a stun punch with their previous punch")
+	if(HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
+		return
+
+	//The probability for landing a knockdown is also affected armor and an additional chance if the victim is staggered
+	var/result = damage_plus_armor + (staggered ? attacking_bodypart.unarmed_damage_high / 100 * 20 : 0)
+	if((target.stat != DEAD) && result >= attacking_bodypart.unarmed_stun_threshold)
+		target.visible_message(span_danger("[user] knocks [target] down!"), \
+						span_userdanger("You're knocked down by [user]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
+		to_chat(user, span_danger("You knock [target] down!"))
+		var/knockdown_duration = 4 SECONDS + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 //50 total damage = 4 second base stun + 4 second stun modifier = 8 second knockdown duration
+		target.apply_effect(knockdown_duration, EFFECT_KNOCKDOWN, armor_block)
+		log_combat(user, target, "got a stun punch with their previous punch")
 
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(user.body_position != STANDING_UP)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -178,8 +178,10 @@
 	var/unarmed_damage_low = 1
 	///Highest possible punch damage this bodypart can ive.
 	var/unarmed_damage_high = 1
-	///Determines the accuracy bonus, armor penetration and knockdown probability.
+	///Determines the accuracy bonus, armor penetration
 	var/unarmed_effectiveness = 10
+	/// If damage is above this number its a knockdown (In the case of 0 and below, no knockdown ever)
+	var/unarmed_stun_threshold = 0
 	/// How many pixels this bodypart will offset the top half of the mob, used for abnormally sized torsos and legs
 	var/top_offset = 0
 

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -132,8 +132,9 @@
 	can_be_disabled = TRUE
 	unarmed_attack_verb = "punch" /// The classic punch, wonderfully classic and completely random
 	grappled_attack_verb = "pummel"
-	unarmed_damage_low = 5
+	unarmed_damage_low = 1
 	unarmed_damage_high = 10
+	unarmed_stun_threshold = 10
 	body_zone = BODY_ZONE_L_ARM
 	/// Datum describing how to offset things worn on the hands of this arm, note that an x offset won't do anything here
 	var/datum/worn_feature_offset/worn_glove_offset
@@ -392,9 +393,10 @@
 	unarmed_attack_effect = ATTACK_EFFECT_KICK
 	body_zone = BODY_ZONE_L_LEG
 	unarmed_attack_verb = "kick" // The lovely kick, typically only accessable by attacking a grouded foe. 1.5 times better than the punch.
-	unarmed_damage_low = 7
+	unarmed_damage_low = 2
 	unarmed_damage_high = 15
 	unarmed_effectiveness = 15
+	unarmed_stun_threshold = 10
 	/// Datum describing how to offset things worn on the foot of this leg, note that an x offset won't do anything here
 	var/datum/worn_feature_offset/worn_foot_offset
 	/// Used by the bloodysoles component to make footprints

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -541,7 +541,7 @@
 	desc = "An advanced cybernetic arm, capable of greater feats of strength and durability."
 	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
 	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 5
+	unarmed_damage_low = 3
 	unarmed_damage_high = 13
 	unarmed_effectiveness = 20
 	max_damage = LIMB_MAX_HP_ADVANCED
@@ -552,7 +552,7 @@
 	desc = "An advanced cybernetic arm, capable of greater feats of strength and durability."
 	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
 	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 5
+	unarmed_damage_low = 3
 	unarmed_damage_high = 13
 	unarmed_effectiveness = 20
 	max_damage = LIMB_MAX_HP_ADVANCED

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -382,6 +382,7 @@
 	unarmed_damage_low = 6
 	unarmed_damage_high = 14
 	unarmed_effectiveness = 15
+	unarmed_stun_threshold = 14
 	burn_modifier = 1.25
 
 /obj/item/bodypart/arm/right/mushroom
@@ -389,6 +390,7 @@
 	unarmed_damage_low = 6
 	unarmed_damage_high = 14
 	unarmed_effectiveness = 15
+	unarmed_stun_threshold = 14
 	burn_modifier = 1.25
 
 /obj/item/bodypart/leg/left/mushroom
@@ -396,6 +398,7 @@
 	unarmed_damage_low = 9
 	unarmed_damage_high = 21
 	unarmed_effectiveness = 20
+	unarmed_stun_threshold = 14
 	burn_modifier = 1.25
 	speed_modifier = 0.75
 
@@ -404,6 +407,7 @@
 	unarmed_damage_low = 9
 	unarmed_damage_high = 21
 	unarmed_effectiveness = 20
+	unarmed_stun_threshold = 14
 	burn_modifier = 1.25
 	speed_modifier = 0.75
 
@@ -499,6 +503,7 @@
 	unarmed_damage_low = 5
 	unarmed_damage_high = 14
 	unarmed_effectiveness = 20
+	unarmed_stun_threshold = 11
 
 /obj/item/bodypart/arm/left/golem/Initialize(mapload)
 	held_hand_offset =  new(
@@ -532,6 +537,7 @@
 	unarmed_damage_low = 5
 	unarmed_damage_high = 14
 	unarmed_effectiveness = 20
+	unarmed_stun_threshold = 11
 
 /obj/item/bodypart/arm/right/golem/Initialize(mapload)
 	held_hand_offset =  new(
@@ -564,6 +570,7 @@
 	unarmed_damage_low = 7
 	unarmed_damage_high = 21
 	unarmed_effectiveness = 25
+	unarmed_stun_threshold = 11
 
 /obj/item/bodypart/leg/right/golem
 	icon = 'icons/mob/human/species/golems.dmi'
@@ -577,6 +584,7 @@
 	unarmed_damage_low = 7
 	unarmed_damage_high = 21
 	unarmed_effectiveness = 25
+	unarmed_stun_threshold = 11
 
 ///flesh
 


### PR DESCRIPTION
## About The Pull Request

punch knockdown is now based off punch damage (as it was before brawlening)
as in arms deal 1 to 10 damage and knock down if it deals 10 and above (this varies per limb type)
however, to add to the mix it also now accounts for armor
this means punch knockdowning people with MELEE armor on that limb of VI and above is highly unlikely
HOWEVER you can get augmented to make this more likely
AND ALSO you can make this not extremely unlikely by staggering (via shoves or otherwise) which to adds 20% of your attacking limbs max unarmed damage to the calculation to increase the odds

also reverts basic human arm damage to 1 min 10 max as it was before brawlening
and also basic human legs to 2 low to 15 max (also before that)
decreases advanced arm lower bound of damage by 2 to get that in line with the basic arms
you may no longer deal stamina damage to people by kicking them so you cant stunlock them (as it was before brawlening, no more baton combos)
you may no longer knockdown people by kicking them (youre on the floor bozo how does this happen)

## Why It's Good For The Game

the brawlening gave everyone extremely easy ways to enact stun combat on people
like shoving them and then punching them and theyre fucked if the high chance thing procs because theyre on the floor and slow because of that

or god forbid northstar gloves
or baton + kick
or mansus grasp + kick

this solves that by using more fair calculations while still keeping brawlenings staggering check relevant

## Changelog
:cl:
balance: punch knockdown chance is now based off resulting punch damage, accounting for armor of victim and staggering
balance: basic human arms have been restored to 1 to 10 damage (as it was before brawlening)
balance: you may no longer stunlock floored people by kicking their shins in
/:cl:
