### PR TITLE
Fixes issues with multitools on power objects

### DIFF
--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -247,11 +247,11 @@
 	if(user)
 		to_chat(user, span_notice("You set [src] to [setting_text]."))
 
-/obj/machinery/power/floodlight/cable_layer_change_checks(mob/living/user, obj/item/tool)
+/obj/machinery/power/floodlight/cable_layer_act(mob/living/user, obj/item/tool)
 	if(anchored)
 		balloon_alert(user, "unanchor first!")
-		return FALSE
-	return TRUE
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
 /obj/machinery/power/floodlight/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -67,7 +67,7 @@
 /// Called on multitool_act when we can change cable layers, override to add more conditions 
 /obj/machinery/power/proc/cable_layer_act(mob/living/user, obj/item/tool)
 	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
-	if(isnull(choice) || QDELETED(src))
+	if(isnull(choice) || QDELETED(src) || QDELETED(user) || QDELETED(tool) || !user.Adjacent(src) || !user.is_holding(tool))
 		return ITEM_INTERACT_BLOCKING
 
 	cable_layer = GLOB.cable_name_to_layer[choice]

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -56,7 +56,7 @@
 		. += span_notice("It's power line can be changed with a [EXAMINE_HINT("multitool")].")
 
 /obj/machinery/power/multitool_act(mob/living/user, obj/item/tool)
-	if(can_change_cable_layer)
+	if(!can_change_cable_layer)
 		return NONE
 
 	return cable_layer_act(user, tool)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -56,10 +56,8 @@
 		. += span_notice("It's power line can be changed with a [EXAMINE_HINT("multitool")].")
 
 /obj/machinery/power/multitool_act(mob/living/user, obj/item/tool)
-	if(!can_change_cable_layer)
-		return NONE
-
-	return cable_layer_act(user, tool)
+	if(can_change_cable_layer)
+		return cable_layer_act(user, tool)
 
 /obj/machinery/power/multitool_act_secondary(mob/living/user, obj/item/tool)
 	return multitool_act(user, tool)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -67,7 +67,7 @@
 /// Called on multitool_act when we can change cable layers, override to add more conditions 
 /obj/machinery/power/proc/cable_layer_act(mob/living/user, obj/item/tool)
 	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
-	if(isnull(choice))
+	if(isnull(choice) || QDELETED(src))
 		return ITEM_INTERACT_BLOCKING
 
 	cable_layer = GLOB.cable_name_to_layer[choice]

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -55,26 +55,24 @@
 			. += span_warning("It's disconnected from the [lowertext(GLOB.cable_layer_to_name["[cable_layer]"])].")
 		. += span_notice("It's power line can be changed with a [EXAMINE_HINT("multitool")].")
 
-///does the required checks to see if this machinery layer can be changed
-/obj/machinery/power/proc/cable_layer_change_checks(mob/living/user, obj/item/tool)
-	return can_change_cable_layer
-
 /obj/machinery/power/multitool_act(mob/living/user, obj/item/tool)
-	. = ITEM_INTERACT_BLOCKING
+	if(can_change_cable_layer)
+		return NONE
 
-	if(!can_change_cable_layer || !cable_layer_change_checks(user, tool))
-		return
+	return cable_layer_act(user, tool)
 
+/obj/machinery/power/multitool_act_secondary(mob/living/user, obj/item/tool)
+	return multitool_act(user, tool)
+
+/// Called on multitool_act when we can change cable layers, override to add more conditions 
+/obj/machinery/power/proc/cable_layer_act(mob/living/user, obj/item/tool)
 	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
 	if(isnull(choice))
-		return
+		return ITEM_INTERACT_BLOCKING
 
 	cable_layer = GLOB.cable_name_to_layer[choice]
 	balloon_alert(user, "now operating on the [choice]")
 	return ITEM_INTERACT_SUCCESS
-
-/obj/machinery/power/multitool_act_secondary(mob/living/user, obj/item/tool)
-	return multitool_act(user, tool)
 
 /obj/machinery/power/proc/add_avail(amount)
 	if(powernet)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -77,11 +77,13 @@
 	welded = TRUE
 	. = ..()
 
-/obj/machinery/power/emitter/cable_layer_change_checks(mob/living/user, obj/item/tool)
+/obj/machinery/power/emitter/cable_layer_act(mob/living/user, obj/item/tool)
+	if(panel_open)
+		return NONE
 	if(welded)
 		balloon_alert(user, "unweld first!")
-		return FALSE
-	return TRUE
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
 /obj/machinery/power/emitter/set_anchored(anchorvalue)
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -81,11 +81,11 @@
 /obj/machinery/power/smes/should_have_node()
 	return TRUE
 
-/obj/machinery/power/smes/cable_layer_change_checks(mob/living/user, obj/item/tool)
+/obj/machinery/power/smes/cable_layer_act(mob/living/user, obj/item/tool)
 	if(!QDELETED(terminal))
 		balloon_alert(user, "cut the terminal first!")
-		return FALSE
-	return TRUE
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
 /obj/machinery/power/smes/attackby(obj/item/item, mob/user, params)
 	//opening using screwdriver

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -34,11 +34,13 @@
 	. = ..()
 	set_wires(new /datum/wires/tesla_coil(src))
 
-/obj/machinery/power/energy_accumulator/tesla_coil/cable_layer_change_checks(mob/living/user, obj/item/tool)
+/obj/machinery/power/energy_accumulator/tesla_coil/cable_layer_act(mob/living/user, obj/item/tool)
+	if(panel_open)
+		return NONE
 	if(anchored)
 		balloon_alert(user, "unanchor first!")
-		return FALSE
-	return TRUE
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
 /obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
 	. = ..()

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -430,11 +430,11 @@
 	if(!all_parts_connected)
 		. += span_warning("The parts need to be linked via a [EXAMINE_HINT("multitool")]")
 
-/obj/machinery/power/turbine/core_rotor/cable_layer_change_checks(mob/living/user, obj/item/tool)
+/obj/machinery/power/turbine/core_rotor/cable_layer_act(mob/living/user, obj/item/tool)
 	if(!panel_open)
 		balloon_alert(user, "open panel first!")
-		return FALSE
-	return TRUE
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
 /obj/machinery/power/turbine/core_rotor/multitool_act(mob/living/user, obj/item/tool)
 	//allow cable layer changing


### PR DESCRIPTION

## About The Pull Request

So at some point the power object's `multitool_act(...)` proc was set to _always_ block, for what I could find to be no discernable reason.

### The Main Thing

https://github.com/tgstation/tgstation/blob/d38f9385b863e49f83455a227764d302629e2867/code/modules/power/power.dm#L62-L74
Now, of course, it shouldn't, because this cuts the entire chain short and thus blocks any other multitool interactions. Like opening the wires panel with a multitool, in this case. Even if `can_change_cable_layer` were to be false and thus the object would never actually care about having this interaction, it'd _still_ block it.

So we don't do that. But what _do_ we do?
I decided to just split off the actual cable changing part into its own proc, `cable_layer_act(...)`.
```dm
/obj/machinery/power/proc/cable_layer_act(mob/living/user, obj/item/tool)
	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
	if(isnull(choice))
		return ITEM_INTERACT_BLOCKING

	cable_layer = GLOB.cable_name_to_layer[choice]
	balloon_alert(user, "now operating on the [choice]")
	return ITEM_INTERACT_SUCCESS
```
Which is then called on `multitool_act(...)`, if `can_change_cable_layer` is true.
```dm
/obj/machinery/power/multitool_act(mob/living/user, obj/item/tool)
	if(can_change_cable_layer)
		return cable_layer_act(user, tool)
```
Which continues with the chain if we can't change layers by default, and otherwise lets `cable_layer_act(...)` work out whether we should block or continue.
Notably, we've removed the `cable_layer_change_checks(...)` proc from the equation, and just let inheritors override it to add their own preconditions and what flags they should return.
On its own this fixes the APC wire panel interactions, but also lets us just return `NONE` when we need to.
```dm
/obj/machinery/power/emitter/cable_layer_act(mob/living/user, obj/item/tool)
	if(panel_open)
		return NONE
	if(welded)
		balloon_alert(user, "unweld first!")
		return ITEM_INTERACT_BLOCKING
	return ..()
```

### The OTHER Things

While doing this I noticed there's actually very little sanity checks after we close our input list.
```dm
var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
if(isnull(choice))
	return ITEM_INTERACT_BLOCKING
```
We only care about whether we made a choice!
Testing this, lo and behold, this can cause runtimes if the power object gets qdeleted before you close the menu.
As a funny side, it _also_ doesn't care about whether you're on the other side of the station, while your multitool is on a different z-level, or just doesn't exist anymore.
So we just add a few basic sanity checks while we're at it.
```dm
var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
if(isnull(choice) || QDELETED(src) || QDELETED(user) || QDELETED(tool) || !user.Adjacent(src) || !user.is_holding(tool))
	return ITEM_INTERACT_BLOCKING
```
That's all. Having done some basic testing, I believe the behaviour is otherwise unaffected.
## Why It's Good For The Game

It's annoying to need to swap to an empty hand or wirecutters to interact with APC, emitter, or tesla coil wires.
This fixes that. (Fixes #81745.)
...and then a few other tidbits I realized existed.
## Changelog
:cl:
fix: Fix using a multitool on a power object with wires not actually opening the wires menu when it should.
fix: Fix a runtime from a power object being deleted before selecting what cable layer to put it at.
fix: Fix power object cable changing not caring about whether you were still adjacent, still holding your multitool, or whether it even still existed after the selection menu was closed.
/:cl:
