### PR TITLE
adds evil seedlings to Perennial Growth blacklist

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -517,7 +517,10 @@
 	description = "It may be harvested multiple times from the same plant."
 	icon = "cubes-stacked"
 	/// Don't allow replica pods to be multi harvested, please.
-	seed_blacklist = list(/obj/item/seeds/replicapod)
+	seed_blacklist = list(
+		/obj/item/seeds/replicapod,
+		/obj/item/seeds/seedling/evil,
+	)
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /*


### PR DESCRIPTION

## About The Pull Request
i dont play botany at all so i didnt know this trait existed. evil seedlings are pretty powerful beings and being able to mass produce an army of them wasnt my intention, it was always meant to be just one silly guy

## Why It's Good For The Game
it became apparent to me that armies of evil seedlings were being raised to wreak havoc upon the station, which can become really unbalanced and unfair considering how tanky one can be.

## Changelog
:cl:
balance: evil seedlings can no longer be mass produced
/:cl:
