### PR TITLE
stamcrit is no longer extended by any sort of stamina damage

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -145,8 +145,9 @@
 
 /mob/living/carbon/adjustStaminaLoss(amount, updating_stamina, forced, required_biotype = ALL)
 	. = ..()
-	if(amount > 0)
-		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
+	if(amount <= 0 || HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))
+		return
+	stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
 
 /**
  * If an organ exists in the slot requested, and we are capable of taking damage (we don't have [GODMODE] on), call the damage proc on that organ.


### PR DESCRIPTION
## About The Pull Request

stamcrit is no longer extended by any sort of stamina damage
eg like previously
you john doe would shoot john assistant with a disabler and they drop to stamcrit
you could afterwards keep shooting him once in a while and he wouldnt get up because that resets the timer

it doesnt do that now
mind you the timer for stam crit regen is 10 seconds so you should restrain this individual unless you want them to walk off

## Why It's Good For The Game

right now you can keep people forever be it with a pillow, stun baton, punch, etc
this is because receiving stamina damage resets your stamina recovery timer (10s)
the victim can stay this way forever until the assailant gets bored and goes away or if the victim powergames hard enough

with this PR the victim has a window of opportunity to run away or fight back so they cannot be stunlocked forever

## Changelog
:cl:
balance: stamina damage does not reset stamcrit recovery timer
/:cl:
