### PR TITLE
Adds Proof of Testing to PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,9 @@
 
 <!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
 
-## Proof of Testing
+## Optional:  Proof of Testing
 
-<!-- We want to make sure you tested this on a local machine before PRing it. If you have a good reason to not test it locally, put it here, but make sure it's really good. -->
+<!-- Maintainers are more likely to merge your PR if you provide proof of testing here. -->
 
 ## Changelog
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,10 @@
 
 <!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
 
+## Proof of Testing
+
+<!-- We want to make sure you tested this on a local machine before PRing it. If you have a good reason to not test it locally, put it here, but make sure it's really good. -->
+
 ## Changelog
 
 <!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


### PR DESCRIPTION
## About The Pull Request

Adds Proof of Testing to PULL_REQUEST_TEMPLATE.md

## Why It's Good For The Game

When people show photographic or video evidence of testing their work, 

## Optional: Proof of Testing

This is an example of where you'd put proof of testing of your change. As a placeholder, here's my new favorite DBD build.

![DeadByDaylight-Win64-Shipping_lVRTu7karf](https://github.com/tgstation/tgstation/assets/4081722/b4e74aa3-191e-4e59-ad1b-c283ec031dd4)


## Changelog

:cl:
spellcheck: Proof of Testing is now in the PR template by default.
/:cl: