### PR TITLE
Switches organ activation on legion regenerative core from HEAL_ALL to HEAL_DAMAGE

### DIFF
--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -31,7 +31,7 @@
 		trigger_organ_action(TRIGGER_FORCE_AVAILABLE)
 
 /obj/item/organ/internal/monster_core/regenerative_core/on_triggered_internal()
-	owner.revive(HEAL_ALL)
+	owner.revive(HEAL_DAMAGE)
 	qdel(src)
 
 /// Log applications and apply moodlet.


### PR DESCRIPTION
## About The Pull Request

What it says on the title. Implanted legion cores will instead HEAL_DAMAGE instead of a sudo aheal. 

## Why It's Good For The Game

Feel free to place your input on this.

Legion cores are obviously extremely easy of an item to obtain, and the ability to organ implant them is equally as easy provided you find someone whose willing to do the very basic surgery required. While inherently I don't find this entirely a bad thing, I'm in the opinion that practically free, easy to obtain, second chance aheals with no downsides should have a bit more requirement than what essentially is running north for a minute on lavaland and killing one of the easiest to kill fauna. I feel there's a little bit of an inconsistancy, especially when other aheal sources that are much harder to obtain (Godslayer Armor) turn you into a shadow if triggered and xenobiology obviously requires cross-breeding. I'm not going to remove or severely punish all aheal sources in the game.

Would this effect you, fighting a megafauna, getting your second chance? Not really. Nothing on lavaland inflicts wounds, blood loss, and other negative afflictions that would otherwise give you, the crewmember, the war of attrition where wounds do matter in a fight. I may be corrected, but I feel there is a direction of mining to slowly ensure that there's a few mechanical barriers to using some of the best healing in the game on station. Granted, this is still an extremely powerful item. I just aim to tone it down slightly onboard the station. ``HEAL_ALL`` heals everything, afterall. Whether it be organs, traumas, and limbs. The only thing going for it is that it requires someone to be alive to activate ``HEAL_ALL``

I don't think this item needs to some sort soft lock to it, but there will be a very negligable diffrence on lavaland, fighting fauna normally while making things like wounds and blood loss require a bit more

## Changelog

:cl:
balance: Implanted legion cores only heal damage instead of being a psuedo aheal. 
/:cl: