### PR TITLE
Makes Boxing Gloves Buyable

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -321,9 +321,3 @@
 	cost = PAYCHECK_COMMAND * 18
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/shotgun/doublebarrel)
-
-/datum/supply_pack/goody/boxing_gloves
-	name = "Boxing Gloves"
-	desc = "A set of boxing gloves, perfect for making others see your way."
-	cost = PAYCHECK_CREW
-	contains = list(/obj/item/clothing/gloves/boxing)

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -321,3 +321,9 @@
 	cost = PAYCHECK_COMMAND * 18
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/shotgun/doublebarrel)
+
+/datum/supply_pack/goody/boxing_gloves
+	name = "Boxing Gloves"
+	desc = "A set of boxing gloves, perfect for making others see your way."
+	cost = PAYCHECK_CREW
+	contains = list(/obj/item/clothing/gloves/boxing)

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -255,3 +255,13 @@
 		/obj/item/hatchet/cutterblade = 1,
 	)
 	crate_name = "paper cutters crate"
+
+/datum/supply_pack/misc/boxing_gloves
+	name = "Boxer Glove Set"
+	desc = "Contains multiple sets of gloves fit for anyone seeking to go one \
+		more round when they don't think they can anymore."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(
+		/obj/item/clothing/gloves/boxing,
+		/obj/item/clothing/gloves/boxing/blue,
+	)


### PR DESCRIPTION
## About The Pull Request

Makes it so there is a supply crate that contains a two sets of boxing gloves. I found it odd that there was no way to buy more boxing gloves.

## Why It's Good For The Game

I have arrived on the station multiple times when someone has taken every one of them and it is impossible to get more for gimmicks. Having the only way to obtain boxing gloves be on shuttles, rare mail, and roundstart seems like a bit of a waste since there are only at most ever 5 or 6 pairs of boxing gloves in any round.

Consider:
![image](https://github.com/tgstation/tgstation/assets/76832653/50d56984-5309-45e1-b191-7971ffa5c85c)


## Changelog

:cl:
add: Added boxer glove set supply crate
/:cl:
