### PR TITLE
Prevents npcs from making progress bars

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -230,7 +230,7 @@ GLOBAL_LIST_EMPTY(species_list)
 		delay *= user.cached_multiplicative_actions_slowdown
 
 	var/datum/progressbar/progbar
-	if(progress)
+	if(progress && user.client)
 		progbar = new(user, delay, target || user)
 
 	SEND_SIGNAL(user, COMSIG_DO_AFTER_BEGAN)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -230,8 +230,9 @@ GLOBAL_LIST_EMPTY(species_list)
 		delay *= user.cached_multiplicative_actions_slowdown
 
 	var/datum/progressbar/progbar
-	if(progress && user.client)
-		progbar = new(user, delay, target || user)
+	if(progress)
+		if(user.client)
+			progbar = new(user, delay, target || user)
 
 	SEND_SIGNAL(user, COMSIG_DO_AFTER_BEGAN)
 


### PR DESCRIPTION

## About The Pull Request
A lot of lavaland mobs constantly make progress bars. Discovered this while working on another PR. 

![image](https://github.com/tgstation/tgstation/assets/42397676/2fc57cff-7e7e-46ea-8956-83c4ba44c69b)

Put a breakpoint in progressbar/New to see what I mean.
## Why It's Good For The Game
They can't even see them. Why are we making these? In case someone swaps in? That seems a bit too rare to justify this
## Changelog
N/A literally nothing player facing
