### PR TITLE
Fixes root beer rounding down to 0 delay for laser carbines/disabler SMGs

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -9,11 +9,11 @@
 	var/autofire_stat = AUTOFIRE_STAT_IDLE
 	var/mouse_parameters
 	/// Time between individual shots.
-	var/autofire_shot_delay = 0.3 SECONDS 
+	var/autofire_shot_delay = 0.3 SECONDS
 	/// This seems hacky but there can be two MouseDown() without a MouseUp() in between if the user holds click and uses alt+tab, printscreen or similar.
-	var/mouse_status = AUTOFIRE_MOUSEUP 
+	var/mouse_status = AUTOFIRE_MOUSEUP
 	/// Should dual wielding be allowed?
-	var/allow_akimbo 
+	var/allow_akimbo
 
 	///windup autofire vars
 	///Whether the delay between shots increases over time, simulating a spooling weapon
@@ -259,7 +259,7 @@
 		current_windup_reduction = (current_windup_reduction + round(autofire_shot_delay * windup_autofire_reduction_multiplier))
 		timerid = addtimer(CALLBACK(src, PROC_REF(windup_reset), FALSE), windup_spindown, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE)
 	if(HAS_TRAIT(shooter, TRAIT_DOUBLE_TAP))
-		next_delay = round(next_delay * 0.5)
+		next_delay = round(next_delay * 0.5, SSprojectiles.wait)
 	COOLDOWN_START(src, next_shot_cd, next_delay)
 	if(SEND_SIGNAL(parent, COMSIG_AUTOFIRE_SHOT, target, shooter, allow_akimbo, mouse_parameters) & COMPONENT_AUTOFIRE_SHOT_SUCCESS)
 		return TRUE


### PR DESCRIPTION

## About The Pull Request

Title.
Closes https://github.com/tgstation/tgstation/issues/80921.

Uses SSprojectiles wait, via lemon's suggestion (https://discord.com/channels/326822144233439242/326831214667235328/1195468576514130010)
## Why It's Good For The Game

bug bad
## Changelog
:cl:
fix: Root beer no longer causes laser carbines and disabler smgs to fire infinitely fast.
/:cl:
