### PR TITLE
Mech mob deletion fix

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -269,12 +269,9 @@
 	AddElement(/datum/element/hostile_machine)
 
 /obj/vehicle/sealed/mecha/Destroy()
-	for(var/ejectee in occupants)
-		mob_exit(ejectee, silent = TRUE)
-
 	/// If the former occupants get polymorphed, mutated, chestburstered,
 	/// or otherwise replaced by another mob, that mob is no longer in .occupants
-	/// and gets deleted with the mech. We need to save them.
+	/// and gets deleted with the mech. However, they do remain in .contents
 	for(var/mob/buggy_ejectee in contents)
 		mob_exit(buggy_ejectee, silent = TRUE)
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -276,7 +276,7 @@
 	/// or otherwise replaced by another mob, that mob is no longer in .occupants
 	/// and gets deleted with the mech. We need to save them.
 	for(var/mob/buggy_ejectee in contents)
-		buggy_ejectee.forceMove(src.loc)
+		mob_exit(buggy_ejectee, silent = TRUE)
 
 	if(LAZYLEN(flat_equipment))
 		for(var/obj/item/mecha_parts/mecha_equipment/equip as anything in flat_equipment)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -272,6 +272,12 @@
 	for(var/ejectee in occupants)
 		mob_exit(ejectee, silent = TRUE)
 
+	/// If the former occupants get polymorphed, mutated, chestburstered,
+	/// or otherwise replaced by another mob, that mob is no longer in .occupants
+	/// and gets deleted with the mech. We need to save them.
+	for(var/mob/buggy_ejectee in contents)
+		buggy_ejectee.forceMove(src.loc)
+
 	if(LAZYLEN(flat_equipment))
 		for(var/obj/item/mecha_parts/mecha_equipment/equip as anything in flat_equipment)
 			equip.detach(loc)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -272,7 +272,8 @@
 	/// If the former occupants get polymorphed, mutated, chestburstered,
 	/// or otherwise replaced by another mob, that mob is no longer in .occupants
 	/// and gets deleted with the mech. However, they do remain in .contents
-	for(var/mob/buggy_ejectee in contents)
+	var/list/potential_occupants = contents ^ occupants
+	for(var/mob/buggy_ejectee in potential_occupants)
 		mob_exit(buggy_ejectee, silent = TRUE)
 
 	if(LAZYLEN(flat_equipment))

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -139,6 +139,8 @@
 			mob_container = AI
 			newloc = get_turf(AI.linked_core)
 			qdel(AI.linked_core)
+	else if(isliving(M))
+		mob_container = M
 	else
 		return ..()
 	var/mob/living/ejector = M


### PR DESCRIPTION

## About The Pull Request

If the occupant of a mech has their mob changed -- mutation, polymorph, admin fuckery -- or if a mob somehow enters a mech without becoming an occupant -- the above, or a chestburster in said mech pilot -- then they don't get added to the occupants, only the contents. All contents are hard-deleted if a mech is destroyed. This fixes that, and ejects any mobs inside mechs who are technically inside the mech but not an occupant.
## Why It's Good For The Game

Fixes #82395 and any similar case
## Changelog

Being inside a mech when it's destroyed should no longer delete you, even if you ended up in that mech in an odd way.
:cl: Bisar
fix: Mechs will no longer delete their living non-occupant contents when destroyed.
/:cl:
