### PR TITLE
`heal_and_revive` restarts hearts

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -894,8 +894,6 @@
 
 	return .
 
-
-
 /mob/living/carbon/fully_heal(heal_flags = HEAL_ALL)
 
 	// Should be handled via signal on embedded, or via heal on bodypart

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -888,7 +888,13 @@
 	if(!HAS_TRAIT(src, TRAIT_LIVERLESS_METABOLISM) && !isnull(dna?.species.mutantliver) && !get_organ_slot(ORGAN_SLOT_LIVER))
 		return FALSE
 
-	return ..()
+	. = ..()
+	if(.) // if revived successfully
+		set_heartattack(FALSE)
+
+	return .
+
+
 
 /mob/living/carbon/fully_heal(heal_flags = HEAL_ALL)
 


### PR DESCRIPTION
## About The Pull Request

The intent of this proc is to make sure the guy can survive after being revived and having your heart stopped kinda works against that

## Changelog

:cl: Melbert
fix: Heretic sac restarts your heart
/:cl:
