### PR TITLE
Fixes quirk being examined when observing

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -403,8 +403,8 @@
 					. += jointext(list("<a href='?src=[REF(src)];hud=s;add_citation=1;examine_time=[world.time]'>\[Add citation\]</a>",
 						"<a href='?src=[REF(src)];hud=s;add_crime=1;examine_time=[world.time]'>\[Add crime\]</a>",
 						"<a href='?src=[REF(src)];hud=s;add_note=1;examine_time=[world.time]'>\[Add note\]</a>"), "")
-	else if(isobserver(user))
-		. += span_info("<b>Quirks:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]")
+	if(isobserver(user))
+		. += span_info("\n<b>Quirks:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]")
 	. += "</span>"
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE, user, .)


### PR DESCRIPTION

## About The Pull Request

Examining a human as ghost now shows their quirks again. This was unintentionally removed with https://github.com/tgstation/tgstation/pull/80692



## Why It's Good For The Game

This was unintentionally removed. Bugfix good me thinks?

![image](https://github.com/tgstation/tgstation/assets/49160555/57a8d817-c9f4-4bf5-bc10-498be58ed23d)


## Changelog
:cl:
fix: Observers can now see people's quirks again
/:cl:
