### PR TITLE
Fixes access to borg panels

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -106,6 +106,7 @@
 	///Random serial number generated for each cyborg upon its initialization
 	var/ident = 0
 	var/locked = TRUE
+	req_one_access = list(ACCESS_ROBOTICS)
 
 	///Whether the robot has no charge left.
 	var/low_power_mode = FALSE


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/81681 removed the access requirement to unlock a borg, which of course meant anyone with any ID could fiddle with them.

## Why It's Good For The Game

back to sanity

## Changelog
:cl:Zergspower
fix: borg panel access now requires robotics access again
/:cl:
