### PR TITLE
Inducer fixes for Syndie and Borg

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -203,5 +203,5 @@
 	icon_state = "inducer-syndi"
 	inhand_icon_state = "inducer-syndi"
 	desc = "A tool for inductively charging internal power cells. This one has a suspicious colour scheme, and seems to be rigged to transfer charge at a much faster rate."
-	powertransfer = 2000
+	powertransfer = 2 * STANDARD_CELL_CHARGE
 	cell_type = /obj/item/stock_parts/cell/super

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -633,7 +633,6 @@
 
 /obj/item/inducer/cyborg
 	name = "Internal inducer"
-	powertransfer = 1500
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "inducer-engi"
 	cell_type = null


### PR DESCRIPTION
Borg and Syndies
## About The Pull Request

The borg and syndie inducers were basically inoperable, so this just fixes that

![image](https://github.com/tgstation/tgstation/assets/22140677/b0bc411a-ad38-456f-944b-5272e121a01f)
![image](https://github.com/tgstation/tgstation/assets/22140677/ebaab84f-36e7-4871-958b-eb47af335a3a)

Also i just noticed TG borgs have no  Messenger or ability to see the manifest???

## Why It's Good For The Game
## Changelog
:cl:Zergspower
fix: fixes Borg and Syndicate inducers not working
/:cl:
