### PR TITLE
Caps door shock damage to 80 unless grounding wire is cut

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -481,7 +481,7 @@
 		return FALSE //you lucked out, no shock for you
 	do_sparks(5, TRUE, src)
 	var/check_range = TRUE
-	if(electrocute_mob(user, get_area(src), src, 1, check_range))
+	if(electrocute_mob(user, get_area(src), src, 1, check_range, wires.is_cut(WIRE_SHOCK) ? 200 : 80))
 		COOLDOWN_START(src, shockCooldown, 1 SECONDS)
 		// Provides timed airlock shock immunity, to prevent overly cheesy deathtraps
 		ADD_TRAIT(user, TRAIT_AIRLOCK_SHOCKIMMUNE, REF(src))

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -477,7 +477,7 @@
 //siemens_coeff - layman's terms, conductivity
 //dist_check - set to only shock mobs within 1 of source (vendors, airlocks, etc.)
 //No animations will be performed by this proc.
-/proc/electrocute_mob(mob/living/carbon/victim, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE)
+/proc/electrocute_mob(mob/living/carbon/victim, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE, max_damage = 200)
 	if(!istype(victim) || ismecha(victim.loc))
 		return FALSE //feckin mechs are dumb
 
@@ -509,6 +509,8 @@
 	else
 		power_source = cell
 		shock_damage = cell_damage
+	//cap shock damage
+	shock_damage = min(shock_damage, max_damage)
 	var/drained_hp = victim.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
 	log_combat(source, victim, "electrocuted")
 


### PR DESCRIPTION

## About The Pull Request
Caps door shock damage to 80 unless grounding wire is cut.
If grounding wire is cut, shock reverts to normal cap of 190-200 damage

## Why It's Good For The Game
Let me paint you a picture.
Nuclear operatives have declared war.
You spend 20 minutes powergaming and prepping your anti-nukie strategy.
Saboteur borg has silently caused the supermatter to actively delam and hotwired it to the grid.
You touch a door.
You instantly die.

With this change, you still take significant damage, but you are now wise to their methods. You can now play around the possibility of any door being shocked.
80 damage is usually significant enough to knock into crit if you have some damage

## Changelog
:cl:
balance: Door shock damage capped to 80 unless grounding wire is cut
/:cl:
