### PR TITLE
Makes attempting to refresh the logs not just throw a runtime error

### DIFF
--- a/code/modules/logging/log_holder.dm
+++ b/code/modules/logging/log_holder.dm
@@ -107,7 +107,7 @@ GENERAL_PROTECT_DATUM(/datum/log_holder)
 		return
 
 	switch(action)
-		if("re-render")
+		if("refresh")
 			cache_ui_data()
 			SStgui.update_uis(src)
 			return TRUE

--- a/code/modules/logging/log_holder.dm
+++ b/code/modules/logging/log_holder.dm
@@ -111,7 +111,6 @@ GENERAL_PROTECT_DATUM(/datum/log_holder)
 			cache_ui_data()
 			SStgui.update_uis(src)
 			return TRUE
-
 		else
 			stack_trace("unknown ui_act action [action] for [type]")
 


### PR DESCRIPTION

## About The Pull Request

Really all this seems to be is a mismatch between the tgui and dm side of the menu.
https://github.com/tgstation/tgstation/blob/3c71b14df0957749f31fb2e678130daf4cfb3250/tgui/packages/tgui/interfaces/LogViewer.tsx#L71
https://github.com/tgstation/tgstation/blob/3c71b14df0957749f31fb2e678130daf4cfb3250/code/modules/logging/log_holder.dm#L110-L113
Making these line up by renaming `re-render` to `refresh` seems to make it work just fine, and not just throw an error.
## Why It's Good For The Game

Life tends to be better when refreshing to see new runtimes doesn't just add its own lovely little runtimes.
![image](https://github.com/tgstation/tgstation/assets/42909981/79bee3db-5c28-409b-9ff5-3a315fb4ed1c)
![image](https://github.com/tgstation/tgstation/assets/42909981/82a25038-ba7a-430a-bb79-f59d5f4b262b)
And then not show them til you re-open the window cause it doesn't refresh.
## Changelog
:cl:
admin: Refresh button on the View Round Logs menu actually works, instead of just adding a runtime to the logs (and not updating them).
/:cl:
