### PR TITLE
Updates cyborg cells created from borgifier to the SI standard

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -20,7 +20,7 @@
 	/// How long until the next mob can be processed
 	var/cooldown_timer
 	/// The created cyborg's cell chage
-	var/robot_cell_charge = 5000
+	var/robot_cell_charge = 5 MEGA JOULES
 	/// The visual countdown effect
 	var/obj/effect/countdown/transformer/countdown
 	/// Who the master AI is that created this factory

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -20,7 +20,7 @@
 	/// How long until the next mob can be processed
 	var/cooldown_timer
 	/// The created cyborg's cell chage
-	var/robot_cell_charge = 5 MEGA JOULES
+	var/robot_cell_charge = STANDARD_CELL_CHARGE * 5
 	/// The visual countdown effect
 	var/obj/effect/countdown/transformer/countdown
 	/// Who the master AI is that created this factory


### PR DESCRIPTION

## About The Pull Request

Unchanged value in transformer.dm resulted in borg charge draining to zero immediately after forced conversion in the borgifer.  Changing the value of robot cell charge to 5 MJs to fix this.
## Why It's Good For The Game

Fixes #82426
## Changelog
:cl:
fix: changed value of cell charge from 5000 to 5 megajoules
/:cl:
