### PR TITLE
Fix "Aheal" for ears deafness

### DIFF
--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -239,6 +239,12 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		for(var/obj/item/organ/organ as anything in organs)
 			organ.set_organ_damage(0)
 		set_heartattack(FALSE)
+
+		// Ears have aditional vаr "deaf", need to update it too
+		var/obj/item/organ/internal/ears/ears = get_organ_slot(ORGAN_SLOT_EARS)
+		if(ears)
+			ears.adjustEarDamage(0, -120) // full heal ears deafness
+
 		return
 
 	// Default organ fixing handling
@@ -273,7 +279,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(!ears)
 		ears = new()
 		ears.Insert(src)
-	ears.set_organ_damage(0)
+	ears.adjustEarDamage(-50, -120) // actually do: set_organ_damage(0) and deaf = 0
 
 /obj/item/organ/proc/handle_failing_organs(seconds_per_tick)
 	return

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -243,7 +243,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		// Ears have aditional vаr "deaf", need to update it too
 		var/obj/item/organ/internal/ears/ears = get_organ_slot(ORGAN_SLOT_EARS)
 		if(ears)
-			ears.adjustEarDamage(0, -120) // full heal ears deafness
+			ears.adjustEarDamage(0, -INFINITY) // full heal ears deafness
 
 		return
 
@@ -279,7 +279,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(!ears)
 		ears = new()
 		ears.Insert(src)
-	ears.adjustEarDamage(-50, -120) // actually do: set_organ_damage(0) and deaf = 0
+	ears.adjustEarDamage(-INFINITY, -INFINITY) // actually do: set_organ_damage(0) and deaf = 0
 
 /obj/item/organ/proc/handle_failing_organs(seconds_per_tick)
 	return

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -242,8 +242,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 		// Ears have aditional vаr "deaf", need to update it too
 		var/obj/item/organ/internal/ears/ears = get_organ_slot(ORGAN_SLOT_EARS)
-		if(ears)
-			ears.adjustEarDamage(0, -INFINITY) // full heal ears deafness
+		ears?.adjustEarDamage(0, -INFINITY) // full heal ears deafness
 
 		return
 


### PR DESCRIPTION

## About The Pull Request
Make the admin button "Aheal" and Magic Wand of Healing (resurrection) actually full heal carbon's Ears.

File _ears.dm contains timer variable "deaf" that should be updated to 0 after complete healing.

But I think this must be properly code-refactored because looks like it's just duplicates(?) standart variable "damage" for organ type.

## Why It's Good For The Game
Aheal - means FULLY HEAL.

## Changelog

:cl:
fix: aheal now properly heals ears deafness
/:cl:
