### PR TITLE
Adds more medipens to the medipen refiller

### DIFF
--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -14,9 +14,10 @@
 		/obj/item/reagent_containers/hypospray/medipen/oxandrolone = /datum/reagent/medicine/oxandrolone,
 		/obj/item/reagent_containers/hypospray/medipen/salacid = /datum/reagent/medicine/sal_acid,
 		/obj/item/reagent_containers/hypospray/medipen/penacid = /datum/reagent/medicine/pen_acid,
+		/obj/item/reagent_containers/hypospray/medipen/mutadone = /datum/reagent/medicine/mutadone,
+		/obj/item/reagent_containers/hypospray/medipen/methamphetamine = /datum/reagent/drug/methamphetamine,
 		/obj/item/reagent_containers/hypospray/medipen/survival = /datum/reagent/medicine/c2/libital,
 		/obj/item/reagent_containers/hypospray/medipen/survival/luxury = /datum/reagent/medicine/c2/penthrite,
-		/obj/item/reagent_containers/hypospray/medipen/methamphetamine = /datum/reagent/drug/methamphetamine,
 	)
 
 /obj/machinery/medipen_refiller/Initialize(mapload)

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -18,6 +18,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/methamphetamine = /datum/reagent/drug/methamphetamine,
 		/obj/item/reagent_containers/hypospray/medipen/survival = /datum/reagent/medicine/c2/libital,
 		/obj/item/reagent_containers/hypospray/medipen/survival/luxury = /datum/reagent/medicine/c2/penthrite,
+		/obj/item/reagent_containers/hypospray/medipen/invisibility = /datum/reagent/drug/saturnx,
 	)
 
 /obj/machinery/medipen_refiller/Initialize(mapload)

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -14,6 +14,8 @@
 		/obj/item/reagent_containers/hypospray/medipen/oxandrolone = /datum/reagent/medicine/oxandrolone,
 		/obj/item/reagent_containers/hypospray/medipen/salacid = /datum/reagent/medicine/sal_acid,
 		/obj/item/reagent_containers/hypospray/medipen/penacid = /datum/reagent/medicine/pen_acid,
+		/obj/item/reagent_containers/hypospray/medipen/survival = /datum/reagent/medicine/c2/libital,
+		/obj/item/reagent_containers/hypospray/medipen/survival/luxury = /datum/reagent/medicine/c2/penthrite,
 	)
 
 /obj/machinery/medipen_refiller/Initialize(mapload)

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -16,6 +16,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/penacid = /datum/reagent/medicine/pen_acid,
 		/obj/item/reagent_containers/hypospray/medipen/survival = /datum/reagent/medicine/c2/libital,
 		/obj/item/reagent_containers/hypospray/medipen/survival/luxury = /datum/reagent/medicine/c2/penthrite,
+		/obj/item/reagent_containers/hypospray/medipen/methamphetamine = /datum/reagent/drug/methamphetamine,
 	)
 
 /obj/machinery/medipen_refiller/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Adds mining pens and meth pens as things you can refill from the medipen refiller
Regular pen requires Libital
Luxury pen requires Penthrite
Meth pens requires meth
Mutadone pens requires mutadone
Invisibility pens requires saturnX

## Why It's Good For The Game

This is a criminally underused machine that is already hidden by being behind research and construction in the department least likely to build machines, giving them a pretty minor but cool interaction with Mining that could save them some mining points if they put the work in sounds cool.

Regular medipen takes Libital but it also gains epinephrine, aiuri and leporazine, which is fine because these are all just as easy to get than Libital anyways (except for Epinephrine, but it's not a major player here, even in epipens it's used for the formal more) and has the low pressure requirement making it not worthwhile for doctors to abuse.
Luxury medipens takes Penthrite, so even if it makes omnizine and some others, the penthrite alone, being hard to make, requiring Lavaland geysers, AND having the low-pressure on top of it, makes it nice for miners to have. Chemists who goes out of their way to do plunging stuff on lavaland, bluespaces it up, and make a well optimized factory, on top of having to get some pens to refill, makes it a long and worthwhile process for a good item.

For the meth pens, it was added as a nukie only item, and I don't really see why you shouldn't be able to refill them.
Mutadone medipens is just straight up mutadone with nothing extra added on top, so I don't see why it shouldn't be refillable.

## Changelog

:cl:
add: A bunch of new medipens you can refill with the medipen refiller (survival/luxury/mutadone/saturnx/meth)
/:cl: