### PR TITLE
Medipens can't have reagents removed from them anymore.

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -122,7 +122,7 @@
 	has_variable_transfer_amount = FALSE
 	volume = 15
 	ignore_flags = 1 //so you can medipen through spacesuits
-	reagent_flags = DRAWABLE
+	reagent_flags = NONE
 	flags_1 = null
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/medicine/coagulant = 2)
 	custom_price = PAYCHECK_CREW

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -312,7 +312,6 @@
 	base_icon_state = "gorillapen"
 	volume = 5
 	ignore_flags = 0
-	reagent_flags = NONE
 	list_reagents = list(/datum/reagent/magillitis = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/pumpup


### PR DESCRIPTION
## About The Pull Request

This will be needed for https://github.com/tgstation/tgstation/pull/82449 because this removes the machine's ability to make infinite chems.
Basically in https://github.com/tgstation/tgstation/pull/29139 they removed medipen's ability to have reagents injected into them, but never removed the ability to take reagents out.
You could take a syringe, remove all chemicals from a medipen, put the main ingredient in a medipen refiller, then refill. You could do this right now on live servers with an epipen for infinite formaldehyde.

This doesn't affect the hypospray.

## Why It's Good For The Game

Removes a way of infinitely making reagents with a medipen refiller and also removes a dumb mechanic.
You could take all chemicals out of an EHMS autoinjector, which removes the visual and feedback tell to the target that they've been injected, and even with 0 chemicals they get the disease anyways.
You could buy medipens as a miner, take the chemicals out, and put them in a syringe or pill that you can inject yourself instantly with.
You can take otherwise hard-to-get chemicals like fungal TB's 2-use cure injector, and make 40 cure pills instead.

## Changelog

:cl:
fix: You can no longer take chemicals out of medipens with a syringe.
/:cl: