### PR TITLE
[NO GBP]Cells will only consider 0.1% of their charge when shocking a user.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -285,7 +285,7 @@
 	SSexplosions.high_mov_atom += src
 
 /obj/item/stock_parts/cell/proc/get_electrocute_damage()
-	return ELECTROCUTE_DAMAGE(charge)
+	return ELECTROCUTE_DAMAGE(charge / (0.001 * STANDARD_CELL_CHARGE))
 
 /obj/item/stock_parts/cell/get_part_rating()
 	return maxcharge * 10 + charge

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -285,7 +285,7 @@
 	SSexplosions.high_mov_atom += src
 
 /obj/item/stock_parts/cell/proc/get_electrocute_damage()
-	return ELECTROCUTE_DAMAGE(charge / (0.001 * STANDARD_CELL_CHARGE))
+	return ELECTROCUTE_DAMAGE(charge / max(0.001 * STANDARD_CELL_CHARGE, 1)) // Wouldn't want it to consider more energy than whatever is actually in the cell if for some strange reason someone set the STANDARD_CELL_CHARGE to below 1kJ.
 
 /obj/item/stock_parts/cell/get_part_rating()
 	return maxcharge * 10 + charge


### PR DESCRIPTION

## About The Pull Request
Makes cells only consider 0.1% of their charge when calculating the damage for shocking someone. This makes the minimum damage 20, and goes up to 22 (previous behaviour, even though that's a shockingly small difference) with a 50 MJ cell, which is the highest capacity crew can get. This makes it inversely scale with the standard cell charge define, so if that gets changed, cells will use a different composition of their charge to consider.
## Why It's Good For The Game
Airlocks instantly critting people when shocked regardless of what's in the grid wasn't previous behaviour.
## Changelog
:cl:
balance: Cells will only consider 0.1% of their charge for calculating shock damage.
/:cl:
