### PR TITLE
re-adds list of components for admins to remove

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -299,15 +299,6 @@
 	return islist(components) ? components : list(components)
 
 /**
- * Gets all components with no typepath provided.
- */
-/datum/proc/GetAllComponentTypes()
-	var/list/components = list()
-	for(var/component_type in _datum_components)
-		components += component_type
-	return components
-
-/**
  * Creates an instance of `new_type` in the datum and attaches to it as parent
  *
  * Sends the [COMSIG_COMPONENT_ADDED] signal to the datum

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -299,6 +299,15 @@
 	return islist(components) ? components : list(components)
 
 /**
+ * Gets all components with no typepath provided.
+ */
+/datum/proc/GetAllComponentTypes()
+	var/list/components = list()
+	for(var/component_type in _datum_components)
+		components += component_type
+	return components
+
+/**
  * Creates an instance of `new_type` in the datum and attaches to it as parent
  *
  * Sends the [COMSIG_COMPONENT_ADDED] signal to the datum

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -98,7 +98,7 @@
 		if(!check_rights(NONE))
 			return
 		var/mass_remove = href_list[VV_HK_MASS_REMOVECOMPONENT]
-		var/list/components = target.GetAllComponentTypes()
+		var/list/components = target._datum_components.Copy()
 		var/list/names = list()
 		names += "---Components---"
 		if(length(components))

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -98,9 +98,7 @@
 		if(!check_rights(NONE))
 			return
 		var/mass_remove = href_list[VV_HK_MASS_REMOVECOMPONENT]
-		var/list/components = list()
-		for(var/datum/component/component in target.GetComponents(/datum/component))
-			components += component.type
+		var/list/components = target.GetAllComponentTypes()
 		var/list/names = list()
 		names += "---Components---"
 		if(length(components))


### PR DESCRIPTION
## About The Pull Request

The list of components on a mob when admins try to remove one didn't actually show them, now it does.
![image](https://github.com/tgstation/tgstation/assets/53777086/a6102c3a-df30-4e9c-b7fd-29a4d8ddaa89)

## Why It's Good For The Game

Messing with components/elements on mobs are such a pain, in this case was broken entirely.
![admin-toolings](https://github.com/tgstation/tgstation/assets/53777086/3d190c66-34e4-4424-824b-37f95e88b003)

## Changelog

:cl:
admin: Removing components button now lists components to remove
/:cl: