### PR TITLE
Atmos Tech Clothing QOL and Advanced Extinguisher Tweak

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -124,6 +124,7 @@
 	tanktype = /obj/structure/reagent_dispensers/foamtank
 	sprite_name = "foam_extinguisher"
 	precision = TRUE
+	max_water = 100
 
 /obj/item/extinguisher/advanced/empty
 	starting_water = FALSE

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -425,6 +425,7 @@
 		/obj/item/t_scanner,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
+		/obj/item/extinguisher,
 	)
 
 /datum/armor/atmos_overalls


### PR DESCRIPTION
Changes Advanced Extinguisher capacity to 100u foam
Adds the ability for atmos technicians to store extinguishers in the suit storage slot on atmospherics overalls
## About The Pull Request

Allows for atmos technicians to store extinguishers on their shiftstart overalls without using backpack space or wearing the atmos firesuit, and helps set the Advanced Extinguisher apart from the regular ones in every cabinet.
## Why It's Good For The Game
QOL change for atmos technicians via a minor change to their shiftstart overalls, giving them the ability to actually act as firefighters better by actually carrying an extinguisher on them without wasting backpack space. It also just makes more sense than them NOT being able to. Also makes the advanced extinguisher slightly more useful to help encourage techs to carry it with them instead of just sprinting for the closest conventional extinguisher when a fire breaks out.
## Changelog
:cl:
qol: Atmospherics Overalls now can store fire extinguishers in the suit storage slot
balance: Increased Advanced Extinguisher capacity to 100u
/:cl:
