### PR TITLE
Neutered symptoms no longer activate

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -160,7 +160,8 @@
 
 	for(var/s in symptoms)
 		var/datum/symptom/symptom_datum = s
-		symptom_datum.Activate(src)
+		if(!symptom_datum.neutered)
+			symptom_datum.Activate(src)
 
 
 // Tell symptoms stage changed

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -35,6 +35,10 @@
 		symptom_delay_max = 45
 
 /datum/symptom/narcolepsy/Activate(datum/disease/advance/A)
+	. = ..()
+	if(!.)
+		return
+
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
 		if(1)


### PR DESCRIPTION
## About The Pull Request

Stops activation of all neutered symptoms in a advanced disease.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/68944

## Changelog

:cl:
fix: Narcolepsy is no longer activated while neutered.
/:cl:
