### PR TITLE
cyborgs know door, APC, and other wires (not cyborg wires)

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -3,7 +3,7 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	add_traits(list(TRAIT_CAN_STRIP, TRAIT_FORCED_STANDING), INNATE_TRAIT)
+	add_traits(list(TRAIT_CAN_STRIP, TRAIT_FORCED_STANDING, TRAIT_KNOW_ENGI_WIRES), INNATE_TRAIT)
 	AddComponent(/datum/component/tippable, \
 		tip_time = 3 SECONDS, \
 		untip_time = 2 SECONDS, \


### PR DESCRIPTION

## About The Pull Request

This gives cyborgs a trait at roundstart that makes them know the wires around the station, just like engineers.
## Why It's Good For The Game

Cyborgs should know the wires just as well as the engineers; simple as that.
## Changelog

Cyborgs know which door wires they're looking at now.
:cl: Bisar
qol: Cyborgs now understand door and APC wires at a glance, among others
/:cl:
