### PR TITLE
Fixes the color matrix editor

### DIFF
--- a/tgui/packages/tgui/interfaces/ColorMatrixEditor.tsx
+++ b/tgui/packages/tgui/interfaces/ColorMatrixEditor.tsx
@@ -13,7 +13,7 @@ import { Window } from '../layouts';
 
 type Data = {
   mapRef: string;
-  currentColor: string[];
+  currentColor: number[];
 };
 
 const PREFIXES = ['r', 'g', 'b', 'a', 'c'] as const;
@@ -49,7 +49,7 @@ export const ColorMatrixEditor = (props) => {
                                 format={(value) => toFixed(value, 2)}
                                 onDrag={(value) => {
                                   let retColor = currentColor;
-                                  retColor[row * 4 + col] = `${value}`;
+                                  retColor[row * 4 + col] = value;
                                   act('transition_color', {
                                     color: retColor,
                                   });


### PR DESCRIPTION

## About The Pull Request

It was sending back stringified numbers as inputs. This came from a typescript cleanup pr from sync (#82000) and was ultimately caused by a... I think misunderstanding of how the color list works (#67967)

## Why It's Good For The Game

Works like a charm now, which is good cause I use it a lot

## Changelog
:cl:
fix: The color matrix editor now works properly again
/:cl:
