### PR TITLE
Stabilized Cerulean extract now copies owner diseases.

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -748,6 +748,8 @@
 		C.real_name = O.real_name
 		O.dna.transfer_identity(C)
 		C.updateappearance(mutcolor_update=1)
+		for(var/datum/disease/D in O.diseases)
+			D.infect(C)
 	return ..()
 
 /datum/status_effect/stabilized/cerulean/tick(seconds_between_ticks)


### PR DESCRIPTION
## About The Pull Request

Stabilized Cerulean extract now copies owner diseases.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/81675

## Changelog

:cl:
fix: Stabilized Cerulean extract now copies owner diseases.
/:cl:
