### PR TITLE
Fix slime `check_item_passthrough` effect

### DIFF
--- a/code/modules/mob/living/basic/slime/defense.dm
+++ b/code/modules/mob/living/basic/slime/defense.dm
@@ -31,7 +31,7 @@
 		return
 
 	//Checks if the item passes through the slime first. Safe items can be used simply
-	if(check_item_passthrough(attacking_item))
+	if(check_item_passthrough(attacking_item, user))
 		return
 
 	try_discipline_slime(attacking_item)


### PR DESCRIPTION
## About The Pull Request

This proc expects a user but is not passed one. 

## Changelog

:cl: Melbert
fix: Items will properly pass through slime on occasion
/:cl:

