### PR TITLE
Maint Mania dust runtime fix

### DIFF
--- a/_maps/deathmatch/maint_mania.dmm
+++ b/_maps/deathmatch/maint_mania.dmm
@@ -46,11 +46,6 @@
 "hB" = (
 /turf/closed/indestructible/fakedoor,
 /area/deathmatch)
-"hN" = (
-/obj/structure/lattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/template_noop,
-/area/template_noop)
 "ih" = (
 /obj/item/reagent_containers/pill/maintenance,
 /turf/open/indestructible,
@@ -512,7 +507,7 @@ FL
 FL
 ur
 ur
-hN
+ur
 ur
 ur
 ur


### PR DESCRIPTION

## About The Pull Request

This removes some dust from a space tile that was throwing stack_traces every time the Maint Mania map was loaded up.
## Why It's Good For The Game

Less clutter while looking for an entirely unrelated runtime regarding deathmatch.
## Changelog
:cl: Rhials
fix: Sweeps a tile of dust off of the Maint Mania deathmatch map, which was causing errors.
/:cl:
