### PR TITLE
Removes an erroneously placed light from Hilbert's Facility

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -136,14 +136,6 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
-"dS" = (
-/obj/machinery/light/floor{
-	brightness = 2;
-	bulb_colour = "#deefff";
-	bulb_power = 0.6
-	},
-/turf/closed/mineral/asteroid,
-/area/ruin/space)
 "el" = (
 /obj/item/disk/cargo/bluespace_pod{
 	pixel_y = 8
@@ -3449,7 +3441,7 @@ Dk
 Dk
 Dk
 Dk
-dS
+Dk
 Dk
 Dk
 Dk


### PR DESCRIPTION

## About The Pull Request

Gets rid of this floor light under a rock.

![image](https://github.com/tgstation/tgstation/assets/28870487/bfcb2863-a3cf-42c3-b778-67819e3ee3aa)

Weird!
## Why It's Good For The Game

I don't think that light should be there honestly.
## Changelog
:cl: Rhials
fix: Removes a floor light under the asteroid surrounding the HIlbert's facility.
/:cl:
