### PR TITLE
`/datum/element/skill_reward` attempting to drop "itself" fix

### DIFF
--- a/code/datums/elements/skill_reward.dm
+++ b/code/datums/elements/skill_reward.dm
@@ -24,14 +24,15 @@
 	if(!LAZYACCESS(modifiers, CTRL_CLICK) && !check_equippable(user)) //Allows other players to drag it around at least.
 		to_chat(user, span_warning("You feel completely and utterly unworthy to even touch \the [source]."))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
+	return NONE
 
 ///We check if the item can be equipped, otherwise we drop it.
 /datum/element/skill_reward/proc/drop_if_unworthy(datum/source, mob/living/user)
 	SIGNAL_HANDLER
-	if(check_equippable(user) | !(source in user.get_equipped_items(include_pockets = TRUE, include_accessories = TRUE)))
-		return
+	if(check_equippable(user) || !(source in user.get_equipped_items(include_pockets = TRUE, include_accessories = TRUE)))
+		return NONE
 	to_chat(user, span_warning("You feel completely and utterly unworthy to even touch \the [source]."))
-	user.dropItemToGround(src, TRUE)
+	user.dropItemToGround(source, TRUE)
 	return COMPONENT_EQUIPPED_FAILED
 
 /datum/element/skill_reward/proc/check_equippable(mob/living/user)


### PR DESCRIPTION
## About The Pull Request

`src` vs `source` moment. 

Plus some minor code cleaup. 

## Changelog

:cl: Melbert
fix: Skill rewards should properly be dropped out of unworthy player's hands
/:cl:


