### PR TITLE
Fix captive xeno roundend report runtime

### DIFF
--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -111,7 +111,7 @@
 
 	parts += "<span class='header'>The [name] were:</span> <br>"
 
-	if(check_captivity(progenitor))
+	if(check_captivity(progenitor.current))
 		parts += span_greentext("The progenitor of this hive was [progenitor.key], as [progenitor], who successfully escaped captivity!") + "<br>"
 	else
 		parts += span_redtext("The progenitor of this hive was [progenitor.key], as [progenitor], who failed to escape captivity") + "<br>"

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -111,7 +111,7 @@
 
 	parts += "<span class='header'>The [name] were:</span> <br>"
 
-	if(check_captivity(progenitor.current))
+	if(check_captivity(progenitor.current) == CAPTIVE_XENO_PASS)
 		parts += span_greentext("The progenitor of this hive was [progenitor.key], as [progenitor], who successfully escaped captivity!") + "<br>"
 	else
 		parts += span_redtext("The progenitor of this hive was [progenitor.key], as [progenitor], who failed to escape captivity") + "<br>"


### PR DESCRIPTION
## About The Pull Request

`check_captivity` accepts a mob, not a mind

![image](https://github.com/tgstation/tgstation/assets/51863163/77952d56-8142-4bbc-8042-028dcb39a989)

Which leads me to believe this always returned `null` and always failed.

But checking further and this proc does not return a truthy or falsy value at all, meaning even if this runtime didn't happen, it still wouldn't function correctly. So I made it check for `CAPTIVE_XENO_PASS`.

## Changelog

:cl: Melbert
fix: Captive Xeno end round report should make a tad more sense
/:cl:
