### PR TITLE
makes broken chameleon kit items immune to being EMP'd to unbreak them

### DIFF
--- a/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
+++ b/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
@@ -3,6 +3,7 @@
 do { \
 	var/datum/action/item_action/chameleon/change/_action = locate() in item.actions; \
 	_action?.emp_randomise(INFINITY); \
+	item.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF); \
 } while(FALSE)
 
 // Cham jumpsuit


### PR DESCRIPTION

## About The Pull Request

Broken chameleon kits can be EMP'd to un-break them. This fixes that and makes them permanently broken.
## Why It's Good For The Game

Patching a possible exploit
Fixes #82454 
## Changelog

Broken chameleon kits can't be unbroken by an EMP.
:cl:
fix: Broken chameleon kits can't be unbroken by an EMP.
/:cl:
