### PR TITLE
Hats no longer cover mouths

### DIFF
--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -37,7 +37,7 @@
 			if(covered_locations & HEAD || face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
 				return FALSE
 		if(BODY_ZONE_PRECISE_MOUTH)
-			if(covered_locations & HEAD || face_covered & HIDEFACE || eyesmouth_covered & MASKCOVERSMOUTH || eyesmouth_covered & HEADCOVERSMOUTH)
+			if(face_covered & HIDEFACE || eyesmouth_covered & MASKCOVERSMOUTH || eyesmouth_covered & HEADCOVERSMOUTH)
 				return FALSE
 		if(BODY_ZONE_CHEST)
 			if(covered_locations & CHEST)

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -37,7 +37,7 @@
 			if(face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
 				return FALSE
 		if(BODY_ZONE_PRECISE_MOUTH)
-			if((face_covered & HIDEFACE) || (eyesmouth_covered & (MASKCOVERSMOUTH|HEADCOVERSMOUTH))
+			if((face_covered & HIDEFACE) || (eyesmouth_covered & (MASKCOVERSMOUTH|HEADCOVERSMOUTH)))
 				return FALSE
 		if(BODY_ZONE_CHEST)
 			if(covered_locations & CHEST)

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -37,7 +37,7 @@
 			if(face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
 				return FALSE
 		if(BODY_ZONE_PRECISE_MOUTH)
-			if(face_covered & HIDEFACE || eyesmouth_covered & MASKCOVERSMOUTH || eyesmouth_covered & HEADCOVERSMOUTH)
+			if((face_covered & HIDEFACE) || (eyesmouth_covered & (MASKCOVERSMOUTH|HEADCOVERSMOUTH))
 				return FALSE
 		if(BODY_ZONE_CHEST)
 			if(covered_locations & CHEST)

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -34,7 +34,7 @@
 			if(covered_locations & HEAD)
 				return FALSE
 		if(BODY_ZONE_PRECISE_EYES)
-			if(face_covered & HIDEEYES || eyesmouth_covered & (MASKCOVERSEYES|HEADCOVERSEYES|GLASSESCOVERSEYES))
+			if((face_covered & HIDEEYES) || (eyesmouth_covered & (MASKCOVERSEYES|HEADCOVERSEYES|GLASSESCOVERSEYES)))
 				return FALSE
 		if(BODY_ZONE_PRECISE_MOUTH)
 			if((face_covered & HIDEFACE) || (eyesmouth_covered & (MASKCOVERSMOUTH|HEADCOVERSMOUTH)))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -34,7 +34,7 @@
 			if(covered_locations & HEAD)
 				return FALSE
 		if(BODY_ZONE_PRECISE_EYES)
-			if(face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
+			if(face_covered & HIDEEYES || eyesmouth_covered & (MASKCOVERSEYES|HEADCOVERSEYES|GLASSESCOVERSEYES))
 				return FALSE
 		if(BODY_ZONE_PRECISE_MOUTH)
 			if((face_covered & HIDEFACE) || (eyesmouth_covered & (MASKCOVERSMOUTH|HEADCOVERSMOUTH)))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -34,7 +34,7 @@
 			if(covered_locations & HEAD)
 				return FALSE
 		if(BODY_ZONE_PRECISE_EYES)
-			if(covered_locations & HEAD || face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
+			if(face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
 				return FALSE
 		if(BODY_ZONE_PRECISE_MOUTH)
 			if(face_covered & HIDEFACE || eyesmouth_covered & MASKCOVERSMOUTH || eyesmouth_covered & HEADCOVERSMOUTH)


### PR DESCRIPTION
## About The Pull Request
Hats that don't explicitly cover your mouth, no longer say they do, for the purposes of `get_location_accessible`. I believe this is only used for surgeries (eg tongue transplant) or razors (cutting someone's beard). It makes no sense that a typical, fully above the ears hat would prevent these types of actions.
## Why It's Good For The Game
Consistency, having a clear view of someone's face but not being able to interact with it is silly.
## Changelog
:cl: Fluffles
fix: Hats/glasses/masks should hopefully behave more predictably for the purposes of eye/mouth surgery.
/:cl:
