### PR TITLE
[no gbp] you may no longer get nullspaced by deathmatch

### DIFF
--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -13,6 +13,9 @@
 	var/automatic_gameend_time = 8 MINUTES
 	/// List of allowed loadouts for this map, otherwise defaults to all loadouts
 	var/list/allowed_loadouts = list()
+	/// whether we are currently being loaded by a lobby
+	var/template_in_use = FALSE
+		
 
 /datum/lazy_template/deathmatch/ragecage
 	name = "Ragecage"


### PR DESCRIPTION

## About The Pull Request

you may no longer start loading a map that is already being loaded by another lobby
thats like a bad idea if you put some thought into the implications

## Why It's Good For The Game

closes #82466
closes #82460

## Changelog
:cl:
fix: deathmatch can no longer occassionally send people to nullspace
/:cl:
