### PR TITLE
pulsing mech overclock wire only turns it on

### DIFF
--- a/code/datums/wires/mecha.dm
+++ b/code/datums/wires/mecha.dm
@@ -41,7 +41,7 @@
 		if(WIRE_LIGHT)
 			mecha.set_light_on(!mecha.light_on)
 		if(WIRE_OVERCLOCK)
-			mecha.toggle_overclock()
+			mecha.toggle_overclock(TRUE)
 
 /datum/wires/mecha/on_cut(wire, mend, source)
 	var/obj/vehicle/sealed/mecha/mecha = holder


### PR DESCRIPTION

## About The Pull Request
pulsing the overclock wire only turns it on, not toggle
cut and mend to turn off

## Why It's Good For The Game

mechas shouldnt be able to solo most of the station in one go and get away blazing fast too because someone has a BCI or voice analyzer on their wire

this makes mechas require more downtime aside from welding

## Changelog
:cl:
balance: you can only turn on mecha overclock by pulsing the overclock wire, cut and mend to turn off overclock
/:cl:
