### PR TITLE
Fix table top deconstruction

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -211,7 +211,7 @@
 		return FALSE
 	to_chat(user, span_notice("You start disassembling [src]..."))
 	if(tool.use_tool(src, user, 2 SECONDS, volume=50))
-		deconstruct_top()
+		deconstruct(TRUE)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/table/wrench_act_secondary(mob/living/user, obj/item/tool)
@@ -220,6 +220,7 @@
 	to_chat(user, span_notice("You start deconstructing [src]..."))
 	if(tool.use_tool(src, user, 4 SECONDS, volume=50))
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+		frame = null
 		deconstruct(TRUE)
 	return ITEM_INTERACT_SUCCESS
 
@@ -299,26 +300,16 @@
 
 /obj/structure/table/atom_deconstruct(disassembled = TRUE)
 	var/turf/target_turf = get_turf(src)
-	// Drop the materials for our top.
-	drop_top_mats(target_turf)
-	// And remember to drop our frame materials too.
-	new framestack(target_turf, framestackamount)
-
-/obj/structure/table/proc/deconstruct_top()
-	var/obj/table_frame = new frame(loc)
-	if(obj_flags & NO_DECONSTRUCTION)
-		table_frame.obj_flags |= NO_DECONSTRUCTION
-	else // Mimic deconstruction logic, only drop our materials without NO_DECONSTRUCTION
-		var/turf/target_turf = get_turf(src)
-		drop_top_mats(target_turf)
-	qdel(src)
-
-/obj/structure/table/proc/drop_top_mats(turf/target_turf)
 	if(buildstack)
 		new buildstack(target_turf, buildstackamount)
 	else
 		for(var/datum/material/mat in custom_materials)
 			new mat.sheet_type(target_turf, FLOOR(custom_materials[mat] / SHEET_MATERIAL_AMOUNT, 1))
+
+	if(frame)
+		new frame(target_turf)
+	else
+		new framestack(get_turf(src), framestackamount)
 
 /obj/structure/table/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -211,7 +211,7 @@
 		return FALSE
 	to_chat(user, span_notice("You start disassembling [src]..."))
 	if(tool.use_tool(src, user, 2 SECONDS, volume=50))
-		deconstruct(TRUE)
+		deconstruct_top()
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/table/wrench_act_secondary(mob/living/user, obj/item/tool)
@@ -299,12 +299,26 @@
 
 /obj/structure/table/atom_deconstruct(disassembled = TRUE)
 	var/turf/target_turf = get_turf(src)
+	// Drop the materials for our top.
+	drop_top_mats(target_turf)
+	// And remember to drop our frame materials too.
+	new framestack(target_turf, framestackamount)
+
+/obj/structure/table/proc/deconstruct_top()
+	var/obj/table_frame = new frame(loc)
+	if(obj_flags & NO_DECONSTRUCTION)
+		table_frame.obj_flags |= NO_DECONSTRUCTION
+	else // Mimic deconstruction logic, only drop our materials without NO_DECONSTRUCTION
+		var/turf/target_turf = get_turf(src)
+		drop_top_mats(target_turf)
+	qdel(src)
+
+/obj/structure/table/proc/drop_top_mats(turf/target_turf)
 	if(buildstack)
 		new buildstack(target_turf, buildstackamount)
 	else
 		for(var/datum/material/mat in custom_materials)
 			new mat.sheet_type(target_turf, FLOOR(custom_materials[mat] / SHEET_MATERIAL_AMOUNT, 1))
-		new framestack(target_turf, framestackamount)
 
 /obj/structure/table/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)


### PR DESCRIPTION
## About The Pull Request

Edited: updated changelog, adjusted description for new implementation as per comments. Read comments for further info.

So previously, tables would let you use a wrench to fully deconstruct them, or a screwdriver to take off only their top.
This, however, broke in two different ways in #82280, when their deconstruction logic got changed.

First off, deconstructed tables would only drop the materials for their top and not their frame.
For this, the primary culprit seems to be on line 307:
https://github.com/tgstation/tgstation/blob/c34d56a45b0461f5e0fad3cc75e81580c3357119/code/game/objects/structures/tables_racks.dm#L300-L307
Where `new framestack(target_turf, framestackamount)` accidentally got an extra indent, and ended up in the less common half of the if-else chain.
Just moving this outside of the if-else chain again fixes it.

However, that makes both screwdriver and wrench deconstruction drop the framestack material.
So we instead make it drop a frame if available, and drop the framestack otherwise.
```dm
	if(frame)
		new frame(target_turf)
	else
		new framestack(get_turf(src), framestackamount)
```
And then simply set the frame to null when wrenching the table.

This fixes our problems without going against the point of the deconstruction refactor.

<details>
  <summary>Old Implementation</summary>
  
So previously, tables would let you use a wrench to fully deconstruct them, or a screwdriver to take off only their top.
This, however, broke in two different ways in #82280, when their deconstruction logic got changed.

First off, deconstructed tables would only drop the materials for their top and not their frame.
For this, the primary culprit seems to be on line 307:
https://github.com/tgstation/tgstation/blob/c34d56a45b0461f5e0fad3cc75e81580c3357119/code/game/objects/structures/tables_racks.dm#L300-L307
Where `new framestack(target_turf, framestackamount)` accidentally got an extra indent, and ended up in the less common half of the if-else chain.
Just moving this outside of the if-else chain again fixes it.

Secondly, tables had their own special deconstruction logic, which got 'standardized'.
Issue. This was special to accommodate for having two different deconstruction logics: full or top only.
With `deconstruct(...)` no longer being overridable, I feel it's awkward to attempt to proxy that information to the new `atom_deconstruct(...)`
So we introduce a new method, `deconstruct_top`, for the screwdriver to use, which handles deconstructing only the top.
```dm
/obj/structure/table/proc/deconstruct_top()
	var/obj/table_frame = new frame(loc)
	if(obj_flags & NO_DECONSTRUCTION)
		table_frame.obj_flags |= NO_DECONSTRUCTION
	else // Mimic deconstruction logic, only drop our materials without NO_DECONSTRUCTION
		var/turf/target_turf = get_turf(src)
		drop_top_mats(target_turf)
	qdel(src)
```
Mimicking the `NO_DECONSTRUCTION` logic of normal deconstruction, and copying over the flag onto its frames if need be.
This fixes screwdriver deconstruction.
  
</details>

## Why It's Good For The Game

Fixes #82503.
We can now deconstruct the table top separately again, AND get the right materials back too.

## Changelog
:cl: 00-Steven, SyncIt21
fix: Wrench table deconstruction gives the right materials again.
fix: Screwdriver table deconstruction only deconstructs the top again.
/:cl:
