### PR TITLE
Fixes some grammar on vorpal scythe execute

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -154,7 +154,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 	if(do_after(user,  15 SECONDS * death_knell_speed_mod, target = potential_reaping))
 		playsound(get_turf(potential_reaping), 'sound/weapons/bladeslice.ogg', 250, TRUE)
 		reaped_head.dismember()
-		user.visible_message(span_danger("[user] swings \the [src] down, slicing [potential_reaping]'s [head_name] clean off! You think \the [src] may have grown stronger!"), span_notice("As you perform the death knell on [potential_reaping], \the [src] gains power! For a time..."))
+		user.visible_message(span_danger("[user] swings [src] down, slicing [potential_reaping]'s [head_name] clean off! You think [src] may have grown stronger!"), span_notice("As you perform the death knell on [potential_reaping], [src] gains power! For a time..."))
 		if(potential_empowerment == SCYTHE_SATED) //We don't want actual player heads to go wandering off, but it'll be funny if a bunch of monkeyhuman heads started floating around
 			reaped_head.AddComponent(/datum/component/haunted_item, \
 				haunt_color = "#7be595", \

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -154,7 +154,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 	if(do_after(user,  15 SECONDS * death_knell_speed_mod, target = potential_reaping))
 		playsound(get_turf(potential_reaping), 'sound/weapons/bladeslice.ogg', 250, TRUE)
 		reaped_head.dismember()
-		user.visible_message(span_danger("[user] swings the [src] down, slicing [potential_reaping]'s [head_name] clean off! You think the [src] may have grown stronger!"), span_notice("As you perform the death knell on [potential_reaping], the [src] gains power! For a time..."))
+		user.visible_message(span_danger("[user] swings \the [src] down, slicing [potential_reaping]'s [head_name] clean off! You think \the [src] may have grown stronger!"), span_notice("As you perform the death knell on [potential_reaping], \the [src] gains power! For a time..."))
 		if(potential_empowerment == SCYTHE_SATED) //We don't want actual player heads to go wandering off, but it'll be funny if a bunch of monkeyhuman heads started floating around
 			reaped_head.AddComponent(/datum/component/haunted_item, \
 				haunt_color = "#7be595", \


### PR DESCRIPTION
## About The Pull Request

Easy PR on the tin, we were calling "the [src]" in a number of places on the vorpal scythe execute causing it to say "the the vorpal scythe"

## Why It's Good For The Game

5 second grammar fix basically

## Changelog


:cl:
fix: Vorpal Scythe execute messages now read correctly.
/:cl:

