### PR TITLE
Update lead acid batteries charge values

### DIFF
--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -29,8 +29,8 @@
 	icon = 'icons/obj/maintenance_loot.dmi'
 	icon_state = "lead_battery"
 	throwforce = 10
-	maxcharge = 20000 //decent max charge
-	chargerate = 1400 //charging is about 30% less efficient than lithium batteries.
+	maxcharge = STANDARD_CELL_CHARGE * 20 //decent max charge
+	chargerate = STANDARD_CELL_CHARGE * 0.7 //charging is about 30% less efficient than lithium batteries.
 	charge_light_type = null
 	connector_type = "leadacid"
 	rating = 2 //Kind of a mid-tier battery


### PR DESCRIPTION

## About The Pull Request

So during the whole power consistency update thing, it seems lead acid batteries were entirely forgotten about.
Which, well, is easy, because they never actually used `STANDARD_CELL_CHARGE`.
https://github.com/tgstation/tgstation/blob/c34d56a45b0461f5e0fad3cc75e81580c3357119/code/game/objects/items/maintenance_loot.dm#L32-L33
Looking into it, the previous value for `STANDARD_CELL_CHARGE` seemed to have been 1000, so we convert it directly:
```dm
maxcharge = STANDARD_CELL_CHARGE * 20
chargerate = STANDARD_CELL_CHARGE * 1.4
```
But, comparing this to the normal power cells, it seems their charge rates got _halved_ during the update.
So, we do that too.
```dm
maxcharge = STANDARD_CELL_CHARGE * 20
chargerate = STANDARD_CELL_CHARGE * 0.7
```
And that fixes it.
## Why It's Good For The Game

Fixes lead acid batteries still using the old power amounts, and not being relative to `STANDARD_CELL_CHARGE`.
## Changelog
:cl:
fix: Lead acid batteries have had their power values fixed.
/:cl:
