### PR TITLE
Ody sleeper new UI

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -17,7 +17,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper
 	name = "mounted sleeper"
-	desc = "Equipment for medical exosuits. A mounted sleeper that stabilizes patients and can inject reagents in the exosuit's reserves."
+	desc = "Equipment for medical exosuits. A mounted sleeper that stabilizes patients and can inject reagents from a equiped exosuit syringe gun."
 	icon_state = "mecha_sleeper"
 	energy_drain = 20
 	range = MECHA_MELEE
@@ -70,7 +70,7 @@
 	data["has_brain_damage"] = patient.get_organ_loss(ORGAN_SLOT_BRAIN) != 0
 	data["has_traumas"] = length(patient.get_traumas()) != 0
 	data["contained_reagents"] = get_reagent_data(patient.reagents.reagent_list)
-	
+
 	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun) in chassis
 	data["injectible_reagents"] = get_reagent_data(SG.reagents.reagent_list)
 	return data

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -26,13 +26,18 @@
 	var/mob/living/carbon/patient
 	/// amount of chems to inject into patient from other hands syringe gun
 	var/inject_amount = 10
-	/// List of avalible chemst to inject
-	var/list/injectible_reagents = list()
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/Destroy()
 	for(var/atom/movable/content as anything in src)
 		content.forceMove(get_turf(src))
 	return ..()
+
+/obj/item/mecha_parts/mecha_equipment/medical/proc/get_reagent_data(var/list/datum/reagent/reagent_list)
+	var/list/contained_reagents = list()
+	if(length(reagent_list))
+		for(var/datum/reagent/reagent as anything in reagent_list)
+			contained_reagents += list(list("name" = reagent.name, "volume" = round(reagent.volume, 0.01))) // list in a list because Byond merges the first list...
+	return contained_reagents
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/get_snowflake_data()
 	var/list/data = list("snowflake_id" = MECHA_SNOWFLAKE_ID_SLEEPER)
@@ -64,19 +69,10 @@
 	)
 	data["has_brain_damage"] = patient.get_organ_loss(ORGAN_SLOT_BRAIN) != 0
 	data["has_traumas"] = length(patient.get_traumas()) != 0
-	var/list/contained_reagents = list()
-	if(length(patient.reagents.reagent_list))
-		for(var/datum/reagent/reagent as anything in patient.reagents.reagent_list)
-			contained_reagents += list(list("name" = reagent.name, "volume" = round(reagent.volume, 0.01))) // list in a list because Byond merges the first list...
-	data["contained_reagents"] = contained_reagents
+	data["contained_reagents"] = get_reagent_data(patient.reagents.reagent_list)
 	
-	injectible_reagents = list()
 	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun) in chassis
-	if(SG && SG.reagents && islist(SG.reagents.reagent_list))
-		for(var/datum/reagent/R in SG.reagents.reagent_list)
-			if(R.volume > 0)
-				injectible_reagents += list(list("name" = R.name, "volume" = round(R.volume, 0.01)))
-	data["injectible_reagents"] = injectible_reagents
+	data["injectible_reagents"] = get_reagent_data(SG.reagents.reagent_list)
 	return data
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/handle_ui_act(action, list/params)
@@ -84,10 +80,6 @@
 		if("eject")
 			go_out()
 			return TRUE
-		if("view_stats")
-			usr << browse(get_patient_stats(),"window=msleeper")
-			onclose(usr, "msleeper")
-			return FALSE
 		else
 			var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate() in chassis
 			for(var/datum/reagent/R in SG.reagents.reagent_list)
@@ -144,91 +136,6 @@
 		return
 	STOP_PROCESSING(SSobj, src)
 	return ..()
-
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/Topic(href,href_list)
-	. = ..()
-	if(.)
-		return
-	if(!(usr in chassis.occupants))
-		return
-	if(href_list["inject"])
-		var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate() in chassis
-		var/datum/reagent/R = locate(href_list["inject"]) in SG.reagents.reagent_list
-		if(istype(R))
-			inject_reagent(R, SG)
-
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/get_patient_stats()
-	if(!patient)
-		return
-	return {"<html>
-				<head>
-				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
-				<title>[patient] statistics</title>
-				<script language='javascript' type='text/javascript'>
-				[js_byjax]
-				</script>
-				<style>
-				h3 {margin-bottom:2px;font-size:14px;}
-				#lossinfo, #reagents, #injectwith {padding-left:15px;}
-				</style>
-				</head>
-				<body>
-				<h3>Health statistics</h3>
-				<div id="lossinfo">
-				[get_patient_dam()]
-				</div>
-				<h3>Reagents in bloodstream</h3>
-				<div id="reagents">
-				[get_patient_reagents()]
-				</div>
-				<div id="injectwith">
-				[get_available_reagents()]
-				</div>
-				</body>
-				</html>"}
-
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/get_patient_dam()
-	var/t1
-	switch(patient.stat)
-		if(0)
-			t1 = "Conscious"
-		if(1)
-			t1 = "Unconscious"
-		if(2)
-			t1 = "*dead*"
-		else
-			t1 = "Unknown"
-	var/core_temp = ""
-	if(ishuman(patient))
-		var/mob/living/carbon/human/humi = patient
-		core_temp = {"<font color="[humi.coretemperature > 300 ? "#3d5bc3" : "#c51e1e"]"><b>Body Temperature:</b> [humi.bodytemperature-T0C]&deg;C ([humi.bodytemperature*1.8-459.67]&deg;F)</font><br />"}
-	return {"<font color="[patient.health > 50 ? "#3d5bc3" : "#c51e1e"]"><b>Health:</b> [patient.stat > 1 ? "[t1]" : "[patient.health]% ([t1])"]</font><br />
-				[core_temp]
-				<font color="[patient.bodytemperature > 300 ? "#3d5bc3" : "#c51e1e"]"><b>Body Temperature:</b> [patient.bodytemperature-T0C]&deg;C ([patient.bodytemperature*1.8-459.67]&deg;F)</font><br />
-				<font color="[patient.getBruteLoss() < 60 ? "#3d5bc3" : "#c51e1e"]"><b>Brute Damage:</b> [patient.getBruteLoss()]%</font><br />
-				<font color="[patient.getOxyLoss() < 60 ? "#3d5bc3" : "#c51e1e"]"><b>Respiratory Damage:</b> [patient.getOxyLoss()]%</font><br />
-				<font color="[patient.getToxLoss() < 60 ? "#3d5bc3" : "#c51e1e"]"><b>Toxin Content:</b> [patient.getToxLoss()]%</font><br />
-				<font color="[patient.getFireLoss() < 60 ? "#3d5bc3" : "#c51e1e"]"><b>Burn Severity:</b> [patient.getFireLoss()]%</font><br />
-				[span_danger("[patient.get_organ_loss(ORGAN_SLOT_BRAIN) ? "Significant brain damage detected." : ""]")]<br />
-				[span_danger("[length(patient.get_traumas()) ? "Brain Traumas detected." : ""]")]<br />
-				"}
-
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/get_patient_reagents()
-	if(patient.reagents)
-		for(var/datum/reagent/R in patient.reagents.reagent_list)
-			if(R.volume > 0)
-				. += "[R]: [round(R.volume,0.01)]<br />"
-	return . || "None"
-
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/get_available_reagents()
-	var/output
-	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun) in chassis
-	if(SG && SG.reagents && islist(SG.reagents.reagent_list))
-		for(var/datum/reagent/R in SG.reagents.reagent_list)
-			if(R.volume > 0)
-				output += "<a href=\"?src=[REF(src)];inject=[REF(R)]\">Inject [R.name]</a><br />"
-	return output
-
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/inject_reagent(datum/reagent/R, obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG)
 	if(!R || !patient || !SG || !(SG in chassis.flat_equipment))
@@ -336,11 +243,7 @@
 		"total_reagents" = reagents.maximum_volume,
 		"analyzed_reagents" = analyzed_reagents,
 	)
-	var/list/contained_reagents = list()
-	if(length(reagents.reagent_list))
-		for(var/datum/reagent/reagent as anything in reagents.reagent_list)
-			contained_reagents += list(list("name" = reagent.name, "volume" = round(reagent.volume, 0.01))) // list in a list because Byond merges the first list...
-	data["contained_reagents"] = contained_reagents
+	data["contained_reagents"] = get_reagent_data(reagents.reagent_list)
 	return data
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/handle_ui_act(action, list/params)

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -32,7 +32,7 @@
 		content.forceMove(get_turf(src))
 	return ..()
 
-/obj/item/mecha_parts/mecha_equipment/medical/proc/get_reagent_data(var/list/datum/reagent/reagent_list)
+/obj/item/mecha_parts/mecha_equipment/medical/proc/get_reagent_data(list/datum/reagent/reagent_list)
 	var/list/contained_reagents = list()
 	if(length(reagent_list))
 		for(var/datum/reagent/reagent as anything in reagent_list)

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -17,7 +17,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper
 	name = "mounted sleeper"
-	desc = "Equipment for medical exosuits. A mounted sleeper that stabilizes patients and can inject reagents from a equiped exosuit syringe gun."
+	desc = "Equipment for medical exosuits. A mounted sleeper that stabilizes patients and can inject reagents from a equipped exosuit syringe gun."
 	icon_state = "mecha_sleeper"
 	energy_drain = 20
 	range = MECHA_MELEE

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -80,12 +80,13 @@
 		if("eject")
 			go_out()
 			return TRUE
-		else
-			var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate() in chassis
-			for(var/datum/reagent/R in SG.reagents.reagent_list)
-				if(action == ("inject_reagent_" + R.name))
-					inject_reagent(R, SG)
-					return
+	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/shooter = locate() in chassis
+	for(var/datum/reagent/medication in shooter.reagents.reagent_list)
+		if(action == ("inject_reagent_" + medication.name))
+			inject_reagent(medication, shooter)
+			break // or maybe return TRUE? i'm not certain
+				
+	return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/action(mob/source, atom/atomtarget, list/modifiers)
 	if(!action_checks(atomtarget))

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -71,8 +71,8 @@
 	data["has_traumas"] = length(patient.get_traumas()) != 0
 	data["contained_reagents"] = get_reagent_data(patient.reagents.reagent_list)
 
-	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/SG = locate(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun) in chassis
-	data["injectible_reagents"] = get_reagent_data(SG.reagents.reagent_list)
+	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/shooter = locate(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun) in chassis
+	data["injectible_reagents"] = get_reagent_data(shooter.reagents.reagent_list)
 	return data
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/handle_ui_act(action, list/params)

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -434,40 +434,52 @@ const SnowflakeSleeper = (props) => {
           value={patient.patient_health}
         />
       </LabeledList.Item>
-      <LabeledList.Item label={'State'}>
+      <LabeledList.Item className="candystripe" label={'State'}>
         {patient.patient_state}
       </LabeledList.Item>
-      <LabeledList.Item label={'Temperature'}>
+      <LabeledList.Item className="candystripe" label={'Temperature'}>
         {patient.core_temp} C
       </LabeledList.Item>
-      <LabeledList.Item label={'Brute Damage'}>
+      <LabeledList.Item className="candystripe" label={'Brute Damage'}>
         {patient.brute_loss}
       </LabeledList.Item>
-      <LabeledList.Item label={'Burn Severity'}>
+      <LabeledList.Item className="candystripe" label={'Burn Severity'}>
         {patient.burn_loss}
       </LabeledList.Item>
-      <LabeledList.Item label={'Toxin Content'}>
+      <LabeledList.Item className="candystripe" label={'Toxin Content'}>
         {patient.toxin_loss}
       </LabeledList.Item>
-      <LabeledList.Item label={'Respiratory Damage'}>
+      <LabeledList.Item className="candystripe" label={'Respiratory Damage'}>
         {patient.oxygen_loss}
       </LabeledList.Item>
       {!!has_brain_damage && (
-        <LabeledList.Item label={'Detected'}>Brain Damage</LabeledList.Item>
+        <LabeledList.Item className="candystripe" label={'Detected'}>
+          Brain Damage
+        </LabeledList.Item>
       )}
       {!!has_traumas && (
-        <LabeledList.Item label={'Detected'}>Traumatic Damage</LabeledList.Item>
+        <LabeledList.Item className="candystripe" label={'Detected'}>
+          Traumatic Damage
+        </LabeledList.Item>
       )}
       <LabeledList.Item label={'Reagent Details'}>
         {contained_reagents.map((reagent) => (
-          <LabeledList.Item key={reagent.name} label={reagent.name}>
+          <LabeledList.Item
+            key={reagent.name}
+            className="candystripe"
+            label={reagent.name}
+          >
             <LabeledList.Item label={`${reagent.volume}u`} />
           </LabeledList.Item>
         ))}
       </LabeledList.Item>
       <LabeledList.Item label={'Reagent Injection'}>
         {injectible_reagents.map((reagent) => (
-          <LabeledList.Item key={reagent.name} label={reagent.name}>
+          <LabeledList.Item
+            className="candystripe"
+            key={reagent.name}
+            label={reagent.name}
+          >
             <LabeledList.Item label={`${reagent.volume}u`}>
               <Button
                 onClick={() =>

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -434,7 +434,7 @@ const SnowflakeSleeper = (props) => {
           value={patient.patient_health}
         />
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'State'}>
+      <LabeledList.Item className="candystripe" label="State">
         {patient.patient_state}
       </LabeledList.Item>
       <LabeledList.Item className="candystripe" label={'Temperature'}>

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -452,14 +452,12 @@ const SnowflakeSleeper = (props) => {
       <LabeledList.Item label={'Respiratory Damage'}>
         {patient.oxygen_loss}
       </LabeledList.Item>
-      {(has_brain_damage && (
+      {has_brain_damage && (
         <LabeledList.Item label={'Detected'}>Brain Damage</LabeledList.Item>
-      )) ||
-        undefined}
-      {(has_traumas && (
+      )}
+      {has_traumas && (
         <LabeledList.Item label={'Detected'}>Traumatic Damage</LabeledList.Item>
-      )) ||
-        undefined}
+      )}
       <LabeledList.Item label={'Reagent Details'}>
         {contained_reagents.map((reagent) => (
           <LabeledList.Item key={reagent.name} label={reagent.name}>

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -228,8 +228,8 @@ const ModuleDetailsBasic = (props) => {
           label="Integrity"
           buttons={
             <Button
-              content={'Repair'}
-              icon={'wrench'}
+              content="Repair"
+              icon="wrench"
               onClick={() =>
                 act('equip_act', {
                   ref: ref,
@@ -363,7 +363,7 @@ const SnowflakeWeaponBallistic = (props) => {
           !disabledreload &&
           projectiles_cache > 0 && (
             <Button
-              icon={'redo'}
+              icon="redo"
               disabled={projectiles >= max_magazine}
               onClick={() =>
                 act('equip_act', {
@@ -424,7 +424,7 @@ const SnowflakeSleeper = (props) => {
       >
         {patient.patient_name}
       </LabeledList.Item>
-      <LabeledList.Item label={'Health'}>
+      <LabeledList.Item label="Health">
         <ProgressBar
           ranges={{
             good: [0.75, Infinity],
@@ -434,35 +434,35 @@ const SnowflakeSleeper = (props) => {
           value={patient.patient_health}
         />
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'State'}>
+      <LabeledList.Item className="candystripe" label="State">
         {patient.patient_state}
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'Temperature'}>
+      <LabeledList.Item className="candystripe" label="Temperature">
         {patient.core_temp} C
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'Brute Damage'}>
+      <LabeledList.Item className="candystripe" label="Brute Damage">
         {patient.brute_loss}
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'Burn Severity'}>
+      <LabeledList.Item className="candystripe" label="Burn Severity">
         {patient.burn_loss}
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'Toxin Content'}>
+      <LabeledList.Item className="candystripe" label="Toxin Content">
         {patient.toxin_loss}
       </LabeledList.Item>
-      <LabeledList.Item className="candystripe" label={'Respiratory Damage'}>
+      <LabeledList.Item className="candystripe" label="Respiratory Damage">
         {patient.oxygen_loss}
       </LabeledList.Item>
       {!!has_brain_damage && (
-        <LabeledList.Item className="candystripe" label={'Detected'}>
+        <LabeledList.Item className="candystripe" label="Detected">
           Brain Damage
         </LabeledList.Item>
       )}
       {!!has_traumas && (
-        <LabeledList.Item className="candystripe" label={'Detected'}>
+        <LabeledList.Item className="candystripe" label="Detected">
           Traumatic Damage
         </LabeledList.Item>
       )}
-      <LabeledList.Item label={'Reagent Details'}>
+      <LabeledList.Item label="Reagent Details">
         {contained_reagents.map((reagent) => (
           <LabeledList.Item
             key={reagent.name}
@@ -473,7 +473,7 @@ const SnowflakeSleeper = (props) => {
           </LabeledList.Item>
         ))}
       </LabeledList.Item>
-      <LabeledList.Item label={'Reagent Injection'}>
+      <LabeledList.Item label="Reagent Injection">
         {injectible_reagents.map((reagent) => (
           <LabeledList.Item
             className="candystripe"
@@ -525,17 +525,17 @@ const SnowflakeSyringe = (props) => {
   } = props.module.snowflake;
   return (
     <>
-      <LabeledList.Item label={'Syringes'}>
+      <LabeledList.Item label="Syringes">
         <ProgressBar value={syringe / max_syringe}>
           {`${syringe} of ${max_syringe}`}
         </ProgressBar>
       </LabeledList.Item>
-      <LabeledList.Item label={'Reagents'}>
+      <LabeledList.Item label="Reagents">
         <ProgressBar value={reagents / total_reagents}>
           {`${reagents} of ${total_reagents} units`}
         </ProgressBar>
       </LabeledList.Item>
-      <LabeledList.Item label={'Mode'}>
+      <LabeledList.Item label="Mode">
         <Button
           content={mode}
           onClick={() =>
@@ -696,8 +696,8 @@ const SnowflakeAirTank = (props) => {
             label="Integrity"
             buttons={
               <Button
-                content={'Repair'}
-                icon={'wrench'}
+                content="Repair"
+                icon="wrench"
                 onClick={() =>
                   act('equip_act', {
                     ref: ref,
@@ -985,8 +985,8 @@ const SnowflakeExtinguisher = (props) => {
         label="Water"
         buttons={
           <Button
-            content={'Refill'}
-            icon={'fill'}
+            content="Refill"
+            icon="fill"
             onClick={() =>
               act('equip_act', {
                 ref: ref,
@@ -1002,10 +1002,10 @@ const SnowflakeExtinguisher = (props) => {
       </LabeledList.Item>
       <LabeledList.Item label="Extinguisher">
         <Button
-          content={'Activate'}
-          color={'red'}
+          content="Activate"
+          color="red"
           disabled={reagents < reagents_required}
-          icon={'fire-extinguisher'}
+          icon="fire-extinguisher"
           onClick={() =>
             act('equip_act', {
               ref: ref,
@@ -1069,9 +1069,9 @@ const SnowflakeLawClaw = (props) => {
       label="Handcuff Suspects"
       buttons={
         <Button
-          content={'Toggle'}
+          content="Toggle"
           color={autocuff ? 'green' : 'blue'}
-          icon={'handcuffs'}
+          icon="handcuffs"
           onClick={() =>
             act('equip_act', {
               ref: ref,

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -485,17 +485,6 @@ const SnowflakeSleeper = (props) => {
           </LabeledList.Item>
         ))}
       </LabeledList.Item>
-      <LabeledList.Item label={'Detailed Vitals'}>
-        <Button
-          content={'View'}
-          onClick={() =>
-            act('equip_act', {
-              ref: ref,
-              gear_action: 'view_stats',
-            })
-          }
-        />
-      </LabeledList.Item>
     </>
   );
 };

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -396,7 +396,13 @@ const SnowflakeWeaponBallistic = (props) => {
 const SnowflakeSleeper = (props) => {
   const { act, data } = useBackend<MainData>();
   const { ref } = props.module;
-  const { patient } = props.module.snowflake;
+  const {
+    patient,
+    contained_reagents,
+    injectible_reagents,
+    has_brain_damage,
+    has_traumas,
+  } = props.module.snowflake;
   return !patient ? (
     <LabeledList.Item label="Patient">None</LabeledList.Item>
   ) : (
@@ -416,21 +422,68 @@ const SnowflakeSleeper = (props) => {
           />
         }
       >
-        {patient.patientname}
+        {patient.patient_name}
       </LabeledList.Item>
       <LabeledList.Item label={'Health'}>
-        {patient.is_dead ? (
-          <Box color="red">Patient dead</Box>
-        ) : (
-          <ProgressBar
-            ranges={{
-              good: [0.75, Infinity],
-              average: [0.25, 0.75],
-              bad: [-Infinity, 0.25],
-            }}
-            value={patient.patient_health}
-          />
-        )}
+        <ProgressBar
+          ranges={{
+            good: [0.75, Infinity],
+            average: [0.25, 0.75],
+            bad: [-Infinity, 0.25],
+          }}
+          value={patient.patient_health}
+        />
+      </LabeledList.Item>
+      <LabeledList.Item label={'State'}>
+        {patient.patient_state}
+      </LabeledList.Item>
+      <LabeledList.Item label={'Temperature'}>
+        {patient.core_temp} C
+      </LabeledList.Item>
+      <LabeledList.Item label={'Brute Damage'}>
+        {patient.brute_loss}
+      </LabeledList.Item>
+      <LabeledList.Item label={'Burn Severity'}>
+        {patient.burn_loss}
+      </LabeledList.Item>
+      <LabeledList.Item label={'Toxin Content'}>
+        {patient.toxin_loss}
+      </LabeledList.Item>
+      <LabeledList.Item label={'Respiratory Damage'}>
+        {patient.oxygen_loss}
+      </LabeledList.Item>
+      {(has_brain_damage && (
+        <LabeledList.Item label={'Detected'}>Brain Damage</LabeledList.Item>
+      )) ||
+        undefined}
+      {(has_traumas && (
+        <LabeledList.Item label={'Detected'}>Traumatic Damage</LabeledList.Item>
+      )) ||
+        undefined}
+      <LabeledList.Item label={'Reagent Details'}>
+        {contained_reagents.map((reagent) => (
+          <LabeledList.Item key={reagent.name} label={reagent.name}>
+            <LabeledList.Item label={`${reagent.volume}u`} />
+          </LabeledList.Item>
+        ))}
+      </LabeledList.Item>
+      <LabeledList.Item label={'Reagent Injection'}>
+        {injectible_reagents.map((reagent) => (
+          <LabeledList.Item key={reagent.name} label={reagent.name}>
+            <LabeledList.Item label={`${reagent.volume}u`}>
+              <Button
+                onClick={() =>
+                  act('equip_act', {
+                    ref: ref,
+                    gear_action: `inject_reagent_${reagent.name}`,
+                  })
+                }
+              >
+                Inject
+              </Button>
+            </LabeledList.Item>
+          </LabeledList.Item>
+        ))}
       </LabeledList.Item>
       <LabeledList.Item label={'Detailed Vitals'}>
         <Button

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -452,10 +452,10 @@ const SnowflakeSleeper = (props) => {
       <LabeledList.Item label={'Respiratory Damage'}>
         {patient.oxygen_loss}
       </LabeledList.Item>
-      {has_brain_damage && (
+      {!!has_brain_damage && (
         <LabeledList.Item label={'Detected'}>Brain Damage</LabeledList.Item>
       )}
-      {has_traumas && (
+      {!!has_traumas && (
         <LabeledList.Item label={'Detected'}>Traumatic Damage</LabeledList.Item>
       )}
       <LabeledList.Item label={'Reagent Details'}>


### PR DESCRIPTION
## About The Pull Request

Removes the old reagent manager menu, and replaces it with a modern tsx one.
Old:
![Screenshot 2024-04-06 130418](https://github.com/tgstation/tgstation/assets/163439532/71cb46a8-ad3d-4c74-a1de-19c41b07a461)

New:
![Screenshot 2024-04-06 130427](https://github.com/tgstation/tgstation/assets/163439532/008722b5-0473-4cdb-99ec-2eeba3886eeb)

+Candy Stripes:
![image](https://github.com/tgstation/tgstation/assets/163439532/c0f0681d-a298-44a6-a57d-bdb212040524)


## Why It's Good For The Game

Old menu doesn't look good. Fixes some issues old menu had.

## Changelog

:cl:
fix: fixes ody sleeper UI not updating to new chems to inject.
fix: fixes ody sleeper not telling user why they can't pick up a person.
code: gives a common method for giving reagent list data to .tsx
/:cl:
