### PR TITLE
randomized virus symptom stats

### DIFF
--- a/code/datums/diseases/advance/symptoms/chills.dm
+++ b/code/datums/diseases/advance/symptoms/chills.dm
@@ -31,10 +31,10 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 5) //dangerous cold
-		power = 1.5
+		power = 1.5 + GLOB.symptom_randomness[type]["power"]
 		unsafe = TRUE
 	if(A.totalStageSpeed() >= 10)
-		power = 2.5
+		power = 2.5 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/chills/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -112,7 +112,7 @@ Bonus
 	if(A.totalStageSpeed() >= 8)
 		paralysis = TRUE
 	if(A.totalTransmittable() >= 8)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/asphyxiation/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -36,7 +36,7 @@
 	if(advanced_disease.totalResistance() >= 6)
 		brain_damage = TRUE
 	if(advanced_disease.totalTransmittable() >= 6)
-		power = 1.5
+		power = 1.5 + GLOB.symptom_randomness[type]["power"]
 	if(advanced_disease.totalStealth() >= 4)
 		suppress_warning = TRUE
 

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -42,9 +42,9 @@
 	if(active_disease.totalTransmittable() >= 7)
 		spread_range = 2
 	if(active_disease.totalResistance() >= 11) //strong enough to drop items
-		power = 1.5
+		power = 1.5 + GLOB.symptom_randomness[type]["power"]
 	if(active_disease.totalResistance() >= 15) //strong enough to stun (occasionally)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 	if(active_disease.totalStageSpeed() >= 6) //cough more often
 		symptom_delay_max = 10
 

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -31,7 +31,7 @@
 	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
 	if(A.totalTransmittable() >= 6) //druggy
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/dizzy/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -32,10 +32,10 @@
 	if(!.)
 		return
 	if(A.totalResistance() >= 5) //dangerous fever
-		power = 1.5
+		power = 1.5 + GLOB.symptom_randomness[type]["power"]
 		unsafe = TRUE
 	if(A.totalResistance() >= 10)
-		power = 2.5
+		power = 2.5 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/fever/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -33,9 +33,9 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 4)
-		power = 1.5
+		power = 1.5 + GLOB.symptom_randomness[type]["power"]
 	if(A.totalStageSpeed() >= 8)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
 	if(A.totalTransmittable() >= 8) //burning skin spreads the virus through smoke
@@ -112,7 +112,7 @@ Bonus
 	if(!.)
 		return
 	if(A.totalResistance() >= 9) //intense but sporadic effect
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 		symptom_delay_min = 50
 		symptom_delay_max = 140
 	if(A.totalStageSpeed() >= 8) //serious boom when wet

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -34,7 +34,7 @@
 		fake_healthy = TRUE
 		base_message_chance = 50
 	if(A.totalStageSpeed() >= 7) //stronger hallucinations
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/hallucigen/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -32,11 +32,11 @@
 	if(A.totalStealth() >= 4)
 		base_message_chance = 50
 	if(A.totalStageSpeed() >= 6) //severe pain
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 	if(A.totalStageSpeed() >= 9) //cluster headaches
 		symptom_delay_min = 30
 		symptom_delay_max = 60
-		power = 3
+		power = 3 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/headache/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -71,7 +71,7 @@
 	if(A.totalTransmittable() >= 6)
 		nearspace_penalty = 1
 	if(A.totalStageSpeed() >= 6)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/heal/starlight/proc/CanTileHealDirectional(turf/turf_to_check, direction)
 	if(direction == UP)
@@ -200,7 +200,7 @@
 	if(A.totalStageSpeed() >= 6)
 		food_conversion = TRUE
 	if(A.totalResistance() >= 7)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/heal/chem/Heal(mob/living/M, datum/disease/advance/A, actual_power)
 	for(var/datum/reagent/R in M.reagents.reagent_list) //Not just toxins!
@@ -281,7 +281,7 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 8)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/heal/darkness/CanHeal(datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
@@ -343,7 +343,7 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 7)
-		power = 1.5
+		power = 1.5 + GLOB.symptom_randomness[type]["power"]
 	if(A.totalResistance() >= 4)
 		stabilize = TRUE
 	if(A.totalStealth() >= 2)
@@ -440,7 +440,7 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 7)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 	if(A.totalResistance() >= 5)
 		absorption_coeff = 0.25
 
@@ -515,7 +515,7 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 7)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 	if(A.totalTransmittable() >= 6)
 		temp_rate = 4
 
@@ -626,7 +626,7 @@
 	if(!.)
 		return
 	if(A.totalResistance() >= 7)
-		power = 2
+		power = 2 + GLOB.symptom_randomness[type]["power"]
 
 /datum/symptom/heal/radiation/CanHeal(datum/disease/advance/A)
 	return HAS_TRAIT(A.affected_mob, TRAIT_IRRADIATED) ? power : 0

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -45,6 +45,8 @@ GLOBAL_LIST_EMPTY(symptom_randomness)
 	//intialize new random symptom behavior
 	if(isnull(GLOB.symptom_randomness[type]))
 		GLOB.symptom_randomness[type] = list("stealth" = randomize_stats(), "resistance" = randomize_stats(), "stage_speed" = randomize_stats(), "transmittable" = randomize_stats(), "power" = randomize_stats() / 2)
+		if(power + GLOB.symptom_randomness[type]["power"] < 0.5)
+			GLOB.symptom_randomness[type]["power"] = 0
 	//inherit random symptom behavior
 	stealth += GLOB.symptom_randomness[type]["stealth"]
 	resistance += GLOB.symptom_randomness[type]["resistance"]

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -1,4 +1,5 @@
 // Symptoms are the effects that engineered advanced diseases do.
+GLOBAL_LIST_EMPTY(symptom_randomness)
 
 /datum/symptom
 	var/name = "8-bitten bugs"
@@ -41,12 +42,30 @@
 	var/required_organ
 
 /datum/symptom/New()
+	//intialize new random symptom behavior
+	if(isnull(GLOB.symptom_randomness[type]))
+		GLOB.symptom_randomness[type] = list("stealth" = randomize_stats(), "resistance" = randomize_stats(), "stage_speed" = randomize_stats(), "transmittable" = randomize_stats(), "power" = randomize_stats() / 2)
+	//inherit random symptom behavior
+	stealth += GLOB.symptom_randomness[type]["stealth"]
+	resistance += GLOB.symptom_randomness[type]["resistance"]
+	stage_speed += GLOB.symptom_randomness[type]["stage_speed"]
+	transmittable += GLOB.symptom_randomness[type]["transmittable"]
+	power += GLOB.symptom_randomness[type]["power"]
+
 	var/list/S = SSdisease.list_symptoms
 	for(var/i = 1; i <= S.len; i++)
 		if(type == S[i])
 			id = "[i]"
 			return
 	CRASH("We couldn't assign an ID!")
+
+/datum/symptom/proc/randomize_stats()
+	if(prob(50))
+		return 0
+	if(prob(50))
+		return prob(15) + 1
+	else
+		return -prob(15) - 1
 
 ///Called when processing of the advance disease that holds this symptom infects a host and upon each Refresh() of that advance disease.
 /datum/symptom/proc/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(symptom_randomness)
 	if(isnull(GLOB.symptom_randomness[type]))
 		GLOB.symptom_randomness[type] = list("stealth" = randomize_stats(), "resistance" = randomize_stats(), "stage_speed" = randomize_stats(), "transmittable" = randomize_stats(), "power" = randomize_stats() / 2)
 		if(power + GLOB.symptom_randomness[type]["power"] < 0.5)
-			GLOB.symptom_randomness[type]["power"] = 0
+			GLOB.symptom_randomness[type]["power"] = max(0, (GLOB.symptom_randomness[type]["power"]))
 	//inherit random symptom behavior
 	stealth += GLOB.symptom_randomness[type]["stealth"]
 	resistance += GLOB.symptom_randomness[type]["resistance"]

--- a/code/modules/unit_tests/confusion.dm
+++ b/code/modules/unit_tests/confusion.dm
@@ -2,6 +2,8 @@
 /datum/unit_test/confusion_symptom/Run()
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 	var/datum/disease/advance/confusion/disease = allocate(/datum/disease/advance/confusion)
+	// Ignore randomization
+	GLOB.symptom_randomness[/datum/disease/advance/confusion] = list("stealth" = 0, "resistance" = 0, "stage_speed" = 0, "transmittable" = 0, "power" = 0)
 	var/datum/symptom/confusion/confusion = disease.symptoms[1]
 	disease.processing = TRUE
 	disease.update_stage(5)

--- a/code/modules/unit_tests/confusion.dm
+++ b/code/modules/unit_tests/confusion.dm
@@ -1,9 +1,9 @@
 // Checks that the confusion symptom correctly gives, and removes, confusion
 /datum/unit_test/confusion_symptom/Run()
-	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
-	var/datum/disease/advance/confusion/disease = allocate(/datum/disease/advance/confusion)
 	// Ignore randomization
 	GLOB.symptom_randomness[/datum/disease/advance/confusion] = list("stealth" = 0, "resistance" = 0, "stage_speed" = 0, "transmittable" = 0, "power" = 0)
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+	var/datum/disease/advance/confusion/disease = allocate(/datum/disease/advance/confusion)
 	var/datum/symptom/confusion/confusion = disease.symptoms[1]
 	disease.processing = TRUE
 	disease.update_stage(5)


### PR DESCRIPTION
## About The Pull Request

Every round symptom stats are randomized.

## Why It's Good For The Game

This should make virology a bit better by creating more variety, and rewarding someone to get all the symptoms. Because you will be able to better leverage stats since they can be random and create better viruses.

## Changelog

:cl:
balance: Randomizes symptom stats every round.
/:cl:
