### PR TITLE
Coffee machines carry over reagents from the beans

### DIFF
--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -401,7 +401,7 @@
 	if(!silent)
 		playsound(src, 'sound/machines/coffeemaker_brew.ogg', 20, vary = TRUE)
 	toggle_steam()
-	use_power(active_power_usage * time * 0.1) // .1 needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules
+	use_energy(active_power_usage * time / (1 SECONDS)) // .1 needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules
 	addtimer(CALLBACK(src, PROC_REF(stop_operating)), time / speed)
 
 /obj/machinery/coffeemaker/proc/stop_operating()

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -401,7 +401,7 @@
 	if(!silent)
 		playsound(src, 'sound/machines/coffeemaker_brew.ogg', 20, vary = TRUE)
 	toggle_steam()
-	use_energy(active_power_usage * time / (1 SECONDS)) // .1 needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules
+	use_power(active_power_usage * time * 0.1) // .1 needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules
 	addtimer(CALLBACK(src, PROC_REF(stop_operating)), time / speed)
 
 /obj/machinery/coffeemaker/proc/stop_operating()
@@ -715,9 +715,30 @@
 	if(!try_brew())
 		return
 	operate_for(brew_time)
-	coffeepot.reagents.add_reagent_list(list(/datum/reagent/consumable/coffee = 120))
-	coffee.Cut(1,2) //remove the first item from the list
+
+	// create a reference bean reagent list
+	var/list/reference_bean_reagents = list()
+	var/obj/item/food/grown/coffee/reference_bean = new /obj/item/food/grown/coffee(src)
+	for(var/datum/reagent/ref_bean_reagent in reference_bean.reagents.reagent_list)
+		reference_bean_reagents += ref_bean_reagent.name
+
+	// add all the reagents from the coffee beans to the coffeepot (ommit the ones from the reference bean)
+	var/list/reagent_delta = list()
+	var/obj/item/food/grown/coffee/bean = coffee[coffee_amount]
+	for(var/datum/reagent/substance in bean.reagents.reagent_list)
+		if(!(reference_bean_reagents.Find(substance.name)))	// we only add the reagent if it's a non-standard for coffee beans
+			reagent_delta += list(substance.type = substance.volume)
+	coffeepot.reagents.add_reagent_list(reagent_delta)
+
+	// remove the coffee beans from the machine
+	coffee.Cut(1,2)
 	coffee_amount--
+
+	// fill the rest of the pot with coffee
+	if(coffeepot.reagents.total_volume < 120)
+		var/extra_coffee_amount = 120 - coffeepot.reagents.total_volume
+		coffeepot.reagents.add_reagent_list(list(/datum/reagent/consumable/coffee = extra_coffee_amount))
+
 	update_appearance(UPDATE_OVERLAYS)
 
 #undef BEAN_CAPACITY

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -719,13 +719,13 @@
 	// create a reference bean reagent list
 	var/list/reference_bean_reagents = list()
 	var/obj/item/food/grown/coffee/reference_bean = new /obj/item/food/grown/coffee(src)
-	for(var/datum/reagent/ref_bean_reagent in reference_bean.reagents.reagent_list)
+	for(var/datum/reagent/ref_bean_reagent as anything in reference_bean.reagents.reagent_list)
 		reference_bean_reagents += ref_bean_reagent.name
-
+qdel(reference_bean)
 	// add all the reagents from the coffee beans to the coffeepot (ommit the ones from the reference bean)
 	var/list/reagent_delta = list()
 	var/obj/item/food/grown/coffee/bean = coffee[coffee_amount]
-	for(var/datum/reagent/substance in bean.reagents.reagent_list)
+	for(var/datum/reagent/substance as anything in bean.reagents.reagent_list)
 		if(!(reference_bean_reagents.Find(substance.name)))	// we only add the reagent if it's a non-standard for coffee beans
 			reagent_delta += list(substance.type = substance.volume)
 	coffeepot.reagents.add_reagent_list(reagent_delta)
@@ -737,7 +737,7 @@
 	// fill the rest of the pot with coffee
 	if(coffeepot.reagents.total_volume < 120)
 		var/extra_coffee_amount = 120 - coffeepot.reagents.total_volume
-		coffeepot.reagents.add_reagent_list(list(/datum/reagent/consumable/coffee = extra_coffee_amount))
+		coffeepot.reagents.add_reagent(/datum/reagent/consumable/coffee, extra_coffee_amount)
 
 	update_appearance(UPDATE_OVERLAYS)
 

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -721,7 +721,7 @@
 	var/obj/item/food/grown/coffee/reference_bean = new /obj/item/food/grown/coffee(src)
 	for(var/datum/reagent/ref_bean_reagent as anything in reference_bean.reagents.reagent_list)
 		reference_bean_reagents += ref_bean_reagent.name
-qdel(reference_bean)
+
 	// add all the reagents from the coffee beans to the coffeepot (ommit the ones from the reference bean)
 	var/list/reagent_delta = list()
 	var/obj/item/food/grown/coffee/bean = coffee[coffee_amount]
@@ -730,6 +730,8 @@ qdel(reference_bean)
 			reagent_delta += list(substance.type = substance.volume)
 	coffeepot.reagents.add_reagent_list(reagent_delta)
 
+	qdel(reference_bean)
+	
 	// remove the coffee beans from the machine
 	coffee.Cut(1,2)
 	coffee_amount--


### PR DESCRIPTION
## About The Pull Request

I can't believe that this wasn't included in the original PR #70991. 
From now on, if there might be any unusual substances inside coffee beans, their reagents will be carried over to the coffee made by the machine. This is one of those niche unused mechanics that no one knows about but the coders hope to see one day in a intricate plot situation.
<sub><sup>please please please I hope so much for someone to use this</sup></sub>

Obviously a indispensable gampleay feature.


https://github.com/tgstation/tgstation/assets/57324037/e3c243d7-03fd-47bc-9bdb-fac50c5bba0b


## Why It's Good For The Game

Provides the coffee machine with features that it should have had fromm the beginning.

## Changelog

:cl:
add: Coffee machines can now carry over reagents from the beans to the coffee (surely no one will inject poison into them)
/:cl:

