### PR TITLE
Fixes standard RPEDs not working on machines

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -953,9 +953,6 @@
 	if(!istype(replacer_tool))
 		return FALSE
 
-	if(!replacer_tool.works_from_distance)
-		return FALSE
-
 	var/shouldplaysound = FALSE
 	if(!component_parts)
 		return FALSE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1142,8 +1142,6 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 /obj/machinery/vending/exchange_parts(mob/user, obj/item/storage/part_replacer/replacer)
 	if(!istype(replacer))
 		return FALSE
-	if(!replacer.works_from_distance)
-		return FALSE
 	if(!component_parts || !refill_canister)
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Previously, `exchange_parts(...)` would cancel if both the `NO_DECONSTRUCTION` flag was set and you couldn't use your part replacer from a distance.
https://github.com/tgstation/tgstation/blob/1583cf0cc968cd9f5da2398035feb8d70d58bcf2/code/game/machinery/_machinery.dm#L958-L959
Our recent removal of `NO_DECONSTRUCTION`, however, has left this to _only_ be the latter.
https://github.com/tgstation/tgstation/blob/f0ed4ba4ce6b114509c10ee2f36ab0af6d7c81d2/code/game/machinery/_machinery.dm#L956-L957
Buuuuut this makes it unconditionally cancel for normal RPEDs, instead of only blocking them if `NO_DECONSTRUCTION` was set.

As `NO_DECONSTRUCTION` is very much no longer relevant for this purpose, we simply remove the ranged RPED check altogether.
This fixes our issue.
## Why It's Good For The Game

Fixes #82525.
## Changelog
:cl:
fix: Standard RPEDs work on machines again.
/:cl:
