### PR TITLE
LateInitialize is not allowed to call parent anymore

### DIFF
--- a/code/game/atom/atoms_initializing_EXPENSIVE.dm
+++ b/code/game/atom/atoms_initializing_EXPENSIVE.dm
@@ -162,3 +162,5 @@
  */
 /atom/proc/LateInitialize()
 	set waitfor = FALSE
+	SHOULD_CALL_PARENT(FALSE)
+	CRASH("[src] ([type]) called LateInitialize but has nothing on it!")

--- a/code/game/atom/atoms_initializing_EXPENSIVE.dm
+++ b/code/game/atom/atoms_initializing_EXPENSIVE.dm
@@ -163,4 +163,4 @@
 /atom/proc/LateInitialize()
 	set waitfor = FALSE
 	SHOULD_CALL_PARENT(FALSE)
-	CRASH("[src] ([type]) called LateInitialize but has nothing on it!")
+	stack_trace("[src] ([type]) called LateInitialize but has nothing on it!")

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -196,6 +196,12 @@
 
 	return ..()
 
+/**
+ * Called in LateInitialize meant to be the machine replacement to it
+ * This sets up power for the machine and requires parent be called,
+ * ensuring power works on all machines unless exempted with NO_POWER_USE.
+ * This is the proc to override if you want to do anything in LateInitialize.
+ */
 /obj/machinery/proc/post_machine_initialize()
 	SHOULD_CALL_PARENT(TRUE)
 	power_change()

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -184,12 +184,8 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/LateInitialize()
-	. = ..()
-	power_change()
-	if(use_power == NO_POWER_USE)
-		return
-	update_current_power_usage()
-	setup_area_power_relationship()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	post_machine_initialize()
 
 /obj/machinery/Destroy(force)
 	SSmachines.unregister_machine(src)
@@ -199,6 +195,14 @@
 	unset_static_power()
 
 	return ..()
+
+/obj/machinery/proc/post_machine_initialize()
+	SHOULD_CALL_PARENT(TRUE)
+	power_change()
+	if(use_power == NO_POWER_USE)
+		return
+	update_current_power_usage()
+	setup_area_power_relationship()
 
 /**
  * proc to call when the machine starts to require power after a duration of not requiring power

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -66,7 +66,7 @@
 
 /**
  * Autonaming camera
- * Automatically names itself after the area it's in during LateInitialize,
+ * Automatically names itself after the area it's in during post_machine_initialize,
  * good for mappers who don't want to manually name them all.
  */
 /obj/machinery/camera/autoname
@@ -76,7 +76,7 @@
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/camera/autoname/LateInitialize()
+/obj/machinery/camera/autoname/post_machine_initialize()
 	. = ..()
 	var/static/list/autonames_in_areas = list()
 	var/area/camera_area = get_area(src)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -60,7 +60,7 @@
 		pad_ref = WEAKREF(I.buffer)
 		return TRUE
 
-/obj/machinery/computer/piratepad_control/civilian/LateInitialize()
+/obj/machinery/computer/piratepad_control/civilian/post_machine_initialize()
 	. = ..()
 	if(cargo_hold_id)
 		for(var/obj/machinery/piratepad/civilian/C as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/piratepad/civilian))

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -235,7 +235,7 @@
 	// Set the default tgui state
 	set_default_state()
 
-/obj/machinery/computer/scan_consolenew/LateInitialize()
+/obj/machinery/computer/scan_consolenew/post_machine_initialize()
 	. = ..()
 	// Link machine with research techweb. Used for discovering and accessing
 	// already discovered mutations

--- a/code/game/machinery/computer/mechlaunchpad.dm
+++ b/code/game/machinery/computer/mechlaunchpad.dm
@@ -34,7 +34,8 @@
 	SIGNAL_HANDLER
 	connected_mechpad = null
 
-/obj/machinery/computer/mechpad/LateInitialize()
+/obj/machinery/computer/mechpad/post_machine_initialize()
+	. = ..()
 	for(var/obj/machinery/mechpad/pad as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/mechpad))
 		if(pad == connected_mechpad)
 			continue

--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -20,7 +20,7 @@
 	find_table()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/computer/operating/LateInitialize()
+/obj/machinery/computer/operating/post_machine_initialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !linked_techweb)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(linked_techweb, src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -2152,7 +2152,7 @@
 
 	return ..()
 
-/obj/machinery/door/airlock/external/LateInitialize()
+/obj/machinery/door/airlock/external/post_machine_initialize()
 	. = ..()
 	if(space_dir)
 		unres_sides |= space_dir

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -91,7 +91,7 @@
 	RegisterSignal(src, COMSIG_MACHINERY_POWER_LOST, PROC_REF(on_power_loss))
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/door/firedoor/LateInitialize()
+/obj/machinery/door/firedoor/post_machine_initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_MERGER_ADDING, PROC_REF(merger_adding))
 	RegisterSignal(src, COMSIG_MERGER_REMOVING, PROC_REF(merger_removing))

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -16,7 +16,8 @@
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/door_buttons/LateInitialize()
+/obj/machinery/door_buttons/post_machine_initialize()
+	. = ..()
 	find_objects_by_tag()
 
 /obj/machinery/door_buttons/emag_act(mob/user, obj/item/card/emag/emag_card)

--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -34,7 +34,7 @@
 
 	var/processing = FALSE
 
-/obj/machinery/airlock_controller/LateInitialize()
+/obj/machinery/airlock_controller/post_machine_initialize()
 	. = ..()
 
 	var/obj/machinery/door/interior_door = GLOB.objects_by_id_tag[interior_door_tag]

--- a/code/game/machinery/incident_display.dm
+++ b/code/game/machinery/incident_display.dm
@@ -80,7 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/incident_display/tram, 32)
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/incident_display/LateInitialize()
+/obj/machinery/incident_display/post_machine_initialize()
 	. = ..()
 	GLOB.map_delamination_counters += src
 	update_delam_count(SSpersistence.rounds_since_engine_exploded, SSpersistence.delam_highscore)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -35,7 +35,7 @@
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/recycler/LateInitialize()
+/obj/machinery/recycler/post_machine_initialize()
 	. = ..()
 	update_appearance(UPDATE_ICON)
 	req_one_access = SSid_access.get_region_access_list(list(REGION_ALL_STATION, REGION_CENTCOM))

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -74,7 +74,8 @@
 	GLOB.telecomms_list += src
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/computer/message_monitor/LateInitialize()
+/obj/machinery/computer/message_monitor/post_machine_initialize()
+	. = ..()
 	//Is the server isn't linked to a server, and there's a server available, default it to the first one in the list.
 	if(!linkedServer)
 		for(var/obj/machinery/telecomms/message_server/message_server in GLOB.telecomms_list)
@@ -280,12 +281,11 @@
 	name = "monitor decryption key"
 
 /obj/item/paper/monitorkey/Initialize(mapload, obj/machinery/telecomms/message_server/server)
-	..()
+	. = ..()
 	if (server)
 		print(server)
 		return INITIALIZE_HINT_NORMAL
-	else
-		return INITIALIZE_HINT_LATELOAD
+	return INITIALIZE_HINT_LATELOAD
 
 /**
  * Handles printing the monitor key for a given server onto this piece of paper.

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -105,9 +105,8 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 	if(mapload && autolinkers.len)
 		return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/telecomms/LateInitialize()
-	..()
-
+/obj/machinery/telecomms/post_machine_initialize()
+	. = ..()
 	for(var/obj/machinery/telecomms/telecomms_machine in GLOB.telecomms_list)
 		if (long_range_link || IN_GIVEN_RANGE(src, telecomms_machine, 20))
 			add_automatic_link(telecomms_machine)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -501,7 +501,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	return ..()
 
 /obj/effect/landmark/start/hangover/LateInitialize()
-	. = ..()
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_BIRTHDAY))
 		party_debris += new /obj/effect/decal/cleanable/confetti(get_turf(src)) //a birthday celebration can also be a hangover
 		var/list/bonus_confetti = GLOB.alldirs
@@ -582,7 +581,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/landmark/navigate_destination/LateInitialize()
-	. = ..()
 	if(!location)
 		var/obj/machinery/door/airlock/A = locate(/obj/machinery/door/airlock) in loc
 		location = A ? format_text(A.name) : get_area_name(src, format_text = TRUE)

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -323,7 +323,7 @@
 		SSqueuelinks.add_to_queue(src, id, late_initialize_pop ? 0 : queue_size)
 		return late_initialize_pop ? INITIALIZE_HINT_LATELOAD : .
 
-/obj/machinery/puzzle/LateInitialize()
+/obj/machinery/puzzle/post_machine_initialize()
 	. = ..()
 	if(late_initialize_pop && id && SSqueuelinks.queues[id])
 		SSqueuelinks.pop_link(id)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -191,7 +191,6 @@
 
 // Late init so that we can wait for air to exist in lazyloaded templates
 /obj/structure/bonfire/prelit/LateInitialize()
-	. = ..()
 	start_burning()
 
 #undef BONFIRE_FIRE_STACK_STRENGTH

--- a/code/game/objects/structures/broken_flooring.dm
+++ b/code/game/objects/structures/broken_flooring.dm
@@ -16,7 +16,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/broken_flooring/LateInitialize()
-	. = ..()
 	var/turf/turf = get_turf(src)
 	if(!isplatingturf(turf) && !always_floorplane) // Render as trash if not on plating
 		plane = GAME_PLANE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -163,7 +163,6 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	update_appearance()
 
 /obj/structure/closet/LateInitialize()
-	. = ..()
 	if(!opened && is_maploaded)
 		take_contents()
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -46,20 +46,20 @@
 	var/static/list/crate_paint_jobs
 	if(isnull(crate_paint_jobs))
 		crate_paint_jobs = list(
-		"Internals" = list("icon_state" = "o2crate"),
-		"Medical" = list("icon_state" = "medical"),
-		"Medical Plus" = list("icon_state" = "medicalcrate"),
-		"Radiation" = list("icon_state" = "radiation"),
-		"Hydrophonics" = list("icon_state" = "hydrocrate"),
-		"Science" = list("icon_state" = "scicrate"),
-		"Robotics" = list("icon_state" = "robo"),
-		"Solar" = list("icon_state" = "engi_e_crate"),
-		"Engineering" = list("icon_state" = "engi_crate"),
-		"Atmospherics" = list("icon_state" = "atmos"),
-		"Cargo" = list("icon_state" = "cargo"),
-		"Mining" = list("icon_state" = "mining"),
-		"Command" = list("icon_state" = "centcom")
-	)
+			"Internals" = list("icon_state" = "o2crate"),
+			"Medical" = list("icon_state" = "medical"),
+			"Medical Plus" = list("icon_state" = "medicalcrate"),
+			"Radiation" = list("icon_state" = "radiation"),
+			"Hydrophonics" = list("icon_state" = "hydrocrate"),
+			"Science" = list("icon_state" = "scicrate"),
+			"Robotics" = list("icon_state" = "robo"),
+			"Solar" = list("icon_state" = "engi_e_crate"),
+			"Engineering" = list("icon_state" = "engi_crate"),
+			"Atmospherics" = list("icon_state" = "atmos"),
+			"Cargo" = list("icon_state" = "cargo"),
+			"Mining" = list("icon_state" = "mining"),
+			"Command" = list("icon_state" = "centcom"),
+		)
 	if(paint_jobs)
 		paint_jobs = crate_paint_jobs
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,13 +190,11 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	/// Minimum temperature of the internal air mixture
 	var/minimum_temperature = T0C - 60
 
-
 /obj/structure/bodycontainer/morgue/Initialize(mapload)
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/bodycontainer/morgue/LateInitialize()
-	. = ..()
 	var/datum/gas_mixture/external_air = loc.return_air()
 	if(external_air)
 		internal_air = external_air.copy()

--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -35,8 +35,7 @@
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/structure/plaque/static_plaque/tram/LateInitialize(mapload)
-	. = ..()
+/obj/structure/plaque/static_plaque/tram/LateInitialize()
 	link_tram()
 	set_tram_serial()
 

--- a/code/game/turfs/open/floor/glass.dm
+++ b/code/game/turfs/open/floor/glass.dm
@@ -33,7 +33,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /turf/open/floor/glass/LateInitialize()
-	. = ..()
 	AddElement(/datum/element/turf_z_transparency)
 	setup_glow()
 

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -32,7 +32,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /turf/open/openspace/LateInitialize()
-	. = ..()
 	AddElement(/datum/element/turf_z_transparency)
 
 /turf/open/openspace/ChangeTurf(path, list/new_baseturfs, flags)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -273,7 +273,6 @@ GLOBAL_LIST_EMPTY(starlight)
 	return INITIALIZE_HINT_LATELOAD
 
 /turf/open/space/openspace/LateInitialize()
-	. = ..()
 	AddElement(/datum/element/turf_z_transparency)
 
 /turf/open/space/openspace/Destroy()

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -198,11 +198,8 @@
 		pad.teleport_target = location
 		to_chat(user, span_notice("Location marked as test subject release point."))
 
-/obj/machinery/abductor/console/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/abductor/console/LateInitialize()
+/obj/machinery/abductor/console/post_machine_initialize()
+	. = ..()
 	if(!team_number)
 		return
 

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -232,7 +232,7 @@
 		pad_ref = WEAKREF(I.buffer)
 		return TRUE
 
-/obj/machinery/computer/piratepad_control/LateInitialize()
+/obj/machinery/computer/piratepad_control/post_machine_initialize()
 	. = ..()
 	if(cargo_hold_id)
 		for(var/obj/machinery/piratepad/P as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/piratepad))

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -81,7 +81,7 @@
 	fire = 100
 	acid = 70
 
-/obj/machinery/atmospherics/LateInitialize()
+/obj/machinery/atmospherics/post_machine_initialize()
 	. = ..()
 	update_name()
 

--- a/code/modules/atmospherics/machinery/bluespace_vendor.dm
+++ b/code/modules/atmospherics/machinery/bluespace_vendor.dm
@@ -71,7 +71,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/bluespace_vendor, 30)
 	AddComponent(/datum/component/payment, tank_cost, SSeconomy.get_dep_account(ACCOUNT_ENG), PAYMENT_ANGRY)
 	find_and_hang_on_wall( FALSE)
 
-/obj/machinery/bluespace_vendor/LateInitialize()
+/obj/machinery/bluespace_vendor/post_machine_initialize()
 	. = ..()
 	if(!map_spawned)
 		return

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -104,7 +104,7 @@
 
 // We late initialize here so all stationary tanks have time to set up their
 // initial gas mixes and signal registrations.
-/obj/machinery/atmospherics/components/tank/LateInitialize()
+/obj/machinery/atmospherics/components/tank/post_machine_initialize()
 	. = ..()
 	GetMergeGroup(merger_id, merger_typecache)
 

--- a/code/modules/bitrunning/objects/byteforge.dm
+++ b/code/modules/bitrunning/objects/byteforge.dm
@@ -14,7 +14,7 @@
 
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/byteforge/LateInitialize()
+/obj/machinery/byteforge/post_machine_initialize()
 	. = ..()
 
 	setup_particles()

--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -24,12 +24,7 @@
 	/// Static list of outfits to select from
 	var/list/cached_outfits = list()
 
-/obj/machinery/netpod/Initialize(mapload)
-	. = ..()
-
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/netpod/LateInitialize()
+/obj/machinery/netpod/post_machine_initialize()
 	. = ..()
 
 	disconnect_damage = BASE_DISCONNECT_DAMAGE

--- a/code/modules/bitrunning/objects/quantum_console.dm
+++ b/code/modules/bitrunning/objects/quantum_console.dm
@@ -12,11 +12,8 @@
 	. = ..()
 	desc = "Even in the distant year [CURRENT_STATION_YEAR], Nanostrasen is still using REST APIs. How grim."
 
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/computer/quantum_console/LateInitialize()
+/obj/machinery/computer/quantum_console/post_machine_initialize()
 	. = ..()
-
 	find_server()
 
 /obj/machinery/computer/quantum_console/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/bitrunning/server/_parent.dm
+++ b/code/modules/bitrunning/server/_parent.dm
@@ -49,12 +49,7 @@
 	/// Cooldown between being able to toggle broadcasting
 	COOLDOWN_DECLARE(broadcast_toggle_cd)
 
-/obj/machinery/quantum_server/Initialize(mapload)
-	. = ..()
-
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/quantum_server/LateInitialize()
+/obj/machinery/quantum_server/post_machine_initialize()
 	. = ..()
 
 	radio = new(src)

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -221,7 +221,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/item/ctf_flag/LateInitialize()
-	. = ..()
 	ctf_game = GLOB.ctf_games[game_id] //Flags don't create ctf games by themselves since you can get ctf flags from christmas trees.
 
 /obj/item/ctf_flag/Destroy()

--- a/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
@@ -12,9 +12,8 @@
 /obj/machinery/ctf/spawner/medisim/Initialize(mapload)
 	. = ..()
 	ctf_game.setup_rules(victory_rejoin_text = "Teams have been cleared. The next game is starting automatically. Rejoin a team if you wish!", auto_restart = TRUE)
-	return INITIALIZE_HINT_LATELOAD //Start CTF needs to run after both medisim spawners have initalized.
 
-/obj/machinery/ctf/spawner/medisim/LateInitialize()
+/obj/machinery/ctf/spawner/medisim/post_machine_initialize()
 	. = ..()
 	ctf_game.start_ctf()
 

--- a/code/modules/experisci/destructive_scanner.dm
+++ b/code/modules/experisci/destructive_scanner.dm
@@ -12,12 +12,8 @@
 	layer = MOB_LAYER
 	var/scanning = FALSE
 
-/obj/machinery/destructive_scanner/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
 // Late load to ensure the component initialization occurs after the machines are initialized
-/obj/machinery/destructive_scanner/LateInitialize()
+/obj/machinery/destructive_scanner/post_machine_initialize()
 	. = ..()
 
 	var/static/list/destructive_signals = list(

--- a/code/modules/experisci/handheld_scanner.dm
+++ b/code/modules/experisci/handheld_scanner.dm
@@ -18,7 +18,6 @@
 
 // Late initialize to allow for the rnd servers to initialize first
 /obj/item/experi_scanner/LateInitialize()
-	. = ..()
 	var/static/list/handheld_signals = list(
 		COMSIG_ITEM_PRE_ATTACK = TYPE_PROC_REF(/datum/component/experiment_handler, try_run_handheld_experiment),
 		COMSIG_ITEM_AFTERATTACK = TYPE_PROC_REF(/datum/component/experiment_handler, ignored_handheld_experiment_attempt),

--- a/code/modules/explorer_drone/scanner_array.dm
+++ b/code/modules/explorer_drone/scanner_array.dm
@@ -181,11 +181,7 @@ GLOBAL_LIST_INIT(scan_conditions,init_scan_conditions())
 	failed_popup = TRUE
 	SStgui.update_uis(src)
 
-/obj/machinery/computer/exoscanner_control/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/computer/exoscanner_control/LateInitialize()
+/obj/machinery/computer/exoscanner_control/post_machine_initialize()
 	. = ..()
 	AddComponent(/datum/component/experiment_handler, \
 		allowed_experiments = list(/datum/experiment/exploration_scan), \

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -84,11 +84,8 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	//creates the timer that determines if another program can be manually loaded
 	COOLDOWN_DECLARE(holodeck_cooldown)
 
-/obj/machinery/computer/holodeck/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/computer/holodeck/LateInitialize()//from here linked is populated and the program list is generated. its also set to load the offline program
+/obj/machinery/computer/holodeck/post_machine_initialize() //from here linked is populated and the program list is generated. its also set to load the offline program
+	. = ..()
 	linked = GLOB.areas_by_type[mapped_start_area]
 	if(!linked)
 		log_mapping("[src] at [AREACOORD(src)] has no matching holodeck area.")

--- a/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
@@ -185,7 +185,6 @@
 		return INITIALIZE_HINT_LATELOAD
 
 /obj/item/keycard/cafeteria/LateInitialize()
-	. = ..()
 	if(SSqueuelinks.queues[CAFE_KEYCARD_TOILETS])
 		SSqueuelinks.pop_link(CAFE_KEYCARD_TOILETS)
 

--- a/code/modules/mapping/mail_sorting_helpers.dm
+++ b/code/modules/mapping/mail_sorting_helpers.dm
@@ -3,10 +3,6 @@
 	late = TRUE
 	var/sort_type = SORT_TYPE_WASTE
 
-/obj/effect/mapping_helpers/mail_sorting/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
 /obj/effect/mapping_helpers/mail_sorting/LateInitialize()
 	var/obj/structure/disposalpipe/sorting/mail/mail_sorter = locate(/obj/structure/disposalpipe/sorting/mail) in loc
 	if(mail_sorter)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -138,7 +138,6 @@
 		payload(airlock)
 
 /obj/effect/mapping_helpers/airlock/LateInitialize()
-	. = ..()
 	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in loc
 	if(!airlock)
 		qdel(src)
@@ -283,7 +282,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/mapping_helpers/airalarm/LateInitialize()
-	. = ..()
 	var/obj/machinery/airalarm/target = locate(/obj/machinery/airalarm) in loc
 
 	if(isnull(target))
@@ -442,7 +440,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/mapping_helpers/apc/LateInitialize()
-	. = ..()
 	var/obj/machinery/power/apc/target = locate(/obj/machinery/power/apc) in loc
 
 	if(isnull(target))
@@ -1106,8 +1103,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
  */
 /obj/effect/mapping_helpers/trapdoor_placer
 	name = "trapdoor placer"
-	late = TRUE
 	icon_state = "trapdoor"
+	late = TRUE
 
 /obj/effect/mapping_helpers/trapdoor_placer/LateInitialize()
 	var/turf/component_target = get_turf(src)
@@ -1187,12 +1184,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	name = "broken floor"
 	icon = 'icons/turf/damaged.dmi'
 	icon_state = "damaged1"
-	late = TRUE
 	layer = ABOVE_NORMAL_TURF_LAYER
-
-/obj/effect/mapping_helpers/broken_floor/Initialize(mapload)
-	.=..()
-	return INITIALIZE_HINT_LATELOAD
+	late = TRUE
 
 /obj/effect/mapping_helpers/broken_floor/LateInitialize()
 	var/turf/open/floor/floor = get_turf(src)
@@ -1203,12 +1196,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	name = "burnt floor"
 	icon = 'icons/turf/damaged.dmi'
 	icon_state = "floorscorched1"
-	late = TRUE
 	layer = ABOVE_NORMAL_TURF_LAYER
-
-/obj/effect/mapping_helpers/burnt_floor/Initialize(mapload)
-	.=..()
-	return INITIALIZE_HINT_LATELOAD
+	late = TRUE
 
 /obj/effect/mapping_helpers/burnt_floor/LateInitialize()
 	var/turf/open/floor/floor = get_turf(src)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1260,7 +1260,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/mapping_helpers/damaged_window/LateInitialize()
-	. = ..()
 	var/obj/structure/window/target = locate(/obj/structure/window) in loc
 
 	if(isnull(target))

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1293,7 +1293,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/effect/mapping_helpers/requests_console/LateInitialize(mapload)
+/obj/effect/mapping_helpers/requests_console/LateInitialize()
 	var/obj/machinery/airalarm/target = locate(/obj/machinery/requests_console) in loc
 	if(isnull(target))
 		var/area/target_area = get_area(target)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1226,7 +1226,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/mapping_helpers/broken_machine/LateInitialize()
-	. = ..()
 	var/obj/machinery/target = locate(/obj/machinery) in loc
 
 	if(isnull(target))
@@ -1429,7 +1428,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		return INITIALIZE_HINT_QDEL
 
 /obj/effect/mapping_helpers/basic_mob_flags/LateInitialize()
-	. = ..()
 	var/had_any_mobs = FALSE
 	for(var/mob/living/basic/basic_mobs in loc)
 		had_any_mobs = TRUE

--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -38,7 +38,7 @@
 
 	register_context()
 
-/obj/machinery/bouldertech/LateInitialize()
+/obj/machinery/bouldertech/post_machine_initialize()
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -162,7 +162,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /mob/living/basic/bot/medbot/LateInitialize()
-	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !linked_techweb)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(linked_techweb, src)
 

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -144,7 +144,7 @@
 	update_appearance(UPDATE_ICON)
 	// Rest of the chat program setup is done in LateInit
 
-/obj/machinery/modular_computer/preset/cargochat/cargo/LateInitialize()
+/obj/machinery/modular_computer/preset/cargochat/cargo/post_machine_initialize()
 	. = ..()
 	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
 	chatprogram.username = "cargo_requests_operator"

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -118,9 +118,8 @@
 	RegisterSignal(src, COMSIG_HIT_BY_SABOTEUR, PROC_REF(on_saboteur))
 	AddElement(/datum/element/atmos_sensitive, mapload)
 	find_and_hang_on_wall(custom_drop_callback = CALLBACK(src, PROC_REF(knock_down)))
-	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/light/LateInitialize()
+/obj/machinery/light/post_machine_initialize()
 	. = ..()
 #ifndef MAP_TEST
 	switch(fitting)

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -43,7 +43,7 @@
 	register_context()
 
 
-/obj/machinery/power/turbine/LateInitialize()
+/obj/machinery/power/turbine/post_machine_initialize()
 	. = ..()
 	activate_parts()
 

--- a/code/modules/power/turbine/turbine_computer.dm
+++ b/code/modules/power/turbine/turbine_computer.dm
@@ -9,11 +9,7 @@
 	///Easy way to connect a computer and a turbine roundstart by setting an id on both this and the core_rotor
 	var/mapping_id
 
-/obj/machinery/computer/turbine_computer/Initialize(mapload)
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/computer/turbine_computer/LateInitialize()
+/obj/machinery/computer/turbine_computer/post_machine_initialize()
 	. = ..()
 	locate_machinery()
 

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -114,9 +114,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	update_move_direction()
 	LAZYADD(GLOB.conveyors_by_id[id], src)
-	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/conveyor/LateInitialize()
+/obj/machinery/conveyor/post_machine_initialize()
 	. = ..()
 	build_neighbors()
 

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -44,6 +44,22 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	AddElement(/datum/element/give_turf_traits, give_turf_traits)
 	register_context()
 
+	if(new_dir)
+		setDir(new_dir)
+	if(new_id)
+		id = new_id
+	neighbors = list()
+	///Leaving onto conveyor detection won't work at this point, but that's alright since it's an optimization anyway
+	///Should be fine without it
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXITED = PROC_REF(conveyable_exit),
+		COMSIG_ATOM_ENTERED = PROC_REF(conveyable_enter),
+		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(conveyable_enter)
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+	update_move_direction()
+	LAZYADD(GLOB.conveyors_by_id[id], src)
+
 /obj/machinery/conveyor/examine(mob/user)
 	. = ..()
 	if(inverted)
@@ -95,25 +111,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /obj/machinery/conveyor/auto/inverted
 	icon_state = "conveyor_map_inverted"
 	flipped = TRUE
-
-// create a conveyor
-/obj/machinery/conveyor/Initialize(mapload, new_dir, new_id)
-	..()
-	if(new_dir)
-		setDir(new_dir)
-	if(new_id)
-		id = new_id
-	neighbors = list()
-	///Leaving onto conveyor detection won't work at this point, but that's alright since it's an optimization anyway
-	///Should be fine without it
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_EXITED = PROC_REF(conveyable_exit),
-		COMSIG_ATOM_ENTERED = PROC_REF(conveyable_enter),
-		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(conveyable_enter)
-	)
-	AddElement(/datum/element/connect_loc, loc_connections)
-	update_move_direction()
-	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/post_machine_initialize()
 	. = ..()

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -37,7 +37,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	//Direction -> if we have a conveyor belt in that direction
 	var/list/neighbors
 
-/obj/machinery/conveyor/Initialize(mapload)
+/obj/machinery/conveyor/Initialize(mapload, new_dir, new_id)
 	. = ..()
 	AddElement(/datum/element/footstep_override, priority = STEP_SOUND_CONVEYOR_PRIORITY)
 	var/static/list/give_turf_traits = list(TRAIT_TURF_IGNORE_SLOWDOWN)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -10,6 +10,7 @@
 	resistance_flags = FIRE_PROOF
 	interaction_flags_machine = INTERACT_MACHINE_OPEN | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON
 	obj_flags = CAN_BE_HIT
+	use_power = NO_POWER_USE
 
 	/// The internal air reservoir of the disposal
 	var/datum/gas_mixture/air_contents
@@ -99,7 +100,8 @@
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
 
-/obj/machinery/disposal/LateInitialize()
+/obj/machinery/disposal/post_machine_initialize()
+	. = ..()
 	//this will get a copy of the air turf and take a SEND PRESSURE amount of air from it
 	var/atom/L = loc
 	var/datum/gas_mixture/env = new

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -45,7 +45,7 @@ Nothing else in the console has ID requirements.
 		return reagent.name
 	return ID
 
-/obj/machinery/computer/rdconsole/LateInitialize()
+/obj/machinery/computer/rdconsole/post_machine_initialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !stored_research)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(stored_research, src)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -24,7 +24,7 @@
 	set_wires(new /datum/wires/rnd(src))
 	register_context()
 
-/obj/machinery/rnd/LateInitialize()
+/obj/machinery/rnd/post_machine_initialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !stored_research)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(stored_research, src)

--- a/code/modules/research/server_control.dm
+++ b/code/modules/research/server_control.dm
@@ -9,7 +9,7 @@
 	///Connected techweb node the server is connected to.
 	var/datum/techweb/stored_research
 
-/obj/machinery/computer/rdservercontrol/LateInitialize()
+/obj/machinery/computer/rdservercontrol/post_machine_initialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !stored_research)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(stored_research, src)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -58,7 +58,7 @@
 
 	stored_slimes = list()
 
-/obj/machinery/computer/camera_advanced/xenobio/LateInitialize(mapload)
+/obj/machinery/computer/camera_advanced/xenobio/post_machine_initialize()
 	. = ..()
 	for(var/obj/machinery/monkey_recycler/recycler in GLOB.monkey_recyclers)
 		if(get_area(recycler.loc) == get_area(loc))

--- a/code/modules/transport/elevator/elev_indicator.dm
+++ b/code/modules/transport/elevator/elev_indicator.dm
@@ -36,11 +36,7 @@
 	/// The elevator's current floor relative to its lowest floor being 1
 	var/current_lift_floor = 1
 
-/obj/machinery/lift_indicator/Initialize(mapload)
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/lift_indicator/LateInitialize()
+/obj/machinery/lift_indicator/post_machine_initialize()
 	. = ..()
 
 	for(var/datum/transport_controller/linear/possible_match as anything in SStransport.transports_by_type[TRANSPORT_TYPE_ELEVATOR])

--- a/code/modules/transport/elevator/elev_panel.dm
+++ b/code/modules/transport/elevator/elev_panel.dm
@@ -60,19 +60,15 @@
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 	AddElement(/datum/element/contextual_screentip_bare_hands, lmb_text = "Send Elevator")
 
-	// Machinery returns lateload by default via parent,
-	// this is just here for redundancy's sake.
-	. = INITIALIZE_HINT_LATELOAD
-
 	maploaded = mapload
-	// Maploaded panels link in LateInitialize...
+	// Maploaded panels link in post_machine_initialize...
 	if(mapload)
 		return
 
 	// And non-mapload panels link in Initialize
 	link_with_lift(log_error = FALSE)
 
-/obj/machinery/elevator_control_panel/LateInitialize()
+/obj/machinery/elevator_control_panel/post_machine_initialize()
 	. = ..()
 	// If we weren't maploaded, we probably already linked (or tried to link) in Initialize().
 	if(!maploaded)

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -715,12 +715,11 @@
 	register_context()
 	if(!id_tag)
 		id_tag = assign_random_name()
-	return INITIALIZE_HINT_LATELOAD
 
 /**
  * Mapped or built tram cabinet isn't located on a transport module.
  */
-/obj/machinery/transport/tram_controller/LateInitialize(mapload)
+/obj/machinery/transport/tram_controller/post_machine_initialize()
 	. = ..()
 	SStransport.hello(src, name, id_tag)
 	find_controller()

--- a/code/modules/transport/tram/tram_controls.dm
+++ b/code/modules/transport/tram/tram_controls.dm
@@ -54,7 +54,7 @@
 	var/obj/item/circuitboard/computer/tram_controls/my_circuit = circuit
 	split_mode = my_circuit.split_mode
 
-/obj/machinery/computer/tram_controls/LateInitialize()
+/obj/machinery/computer/tram_controls/post_machine_initialize()
 	. = ..()
 	if(!id_tag)
 		id_tag = assign_random_name()

--- a/code/modules/transport/tram/tram_displays.dm
+++ b/code/modules/transport/tram/tram_displays.dm
@@ -51,7 +51,6 @@
 		TRAMSTATION_LINE_1,
 	)
 	set_light(l_dir = REVERSE_DIR(dir))
-	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/transport/destination_sign/Destroy()
 	SStransport.displays -= src
@@ -61,7 +60,7 @@
 	. = ..()
 	set_light(l_dir = REVERSE_DIR(dir))
 
-/obj/machinery/transport/destination_sign/indicator/LateInitialize(mapload)
+/obj/machinery/transport/destination_sign/indicator/post_machine_initialize()
 	. = ..()
 	link_tram()
 

--- a/code/modules/transport/tram/tram_doors.dm
+++ b/code/modules/transport/tram/tram_doors.dm
@@ -184,7 +184,7 @@
 	RemoveElement(/datum/element/atmos_sensitive, mapload)
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/door/airlock/tram/LateInitialize(mapload)
+/obj/machinery/door/airlock/tram/post_machine_initialize()
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(open))
 	SStransport.doors += src

--- a/code/modules/transport/tram/tram_machinery.dm
+++ b/code/modules/transport/tram/tram_machinery.dm
@@ -37,7 +37,7 @@
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/item/assembly/control/transport/call_button/LateInitialize(mapload)
+/obj/item/assembly/control/transport/call_button/LateInitialize()
 	if(!id_tag)
 		id_tag = assign_random_name()
 	SStransport.hello(src, name, id_tag)

--- a/code/modules/transport/tram/tram_machinery.dm
+++ b/code/modules/transport/tram/tram_machinery.dm
@@ -38,7 +38,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/item/assembly/control/transport/call_button/LateInitialize(mapload)
-	. = ..()
 	if(!id_tag)
 		id_tag = assign_random_name()
 	SStransport.hello(src, name, id_tag)

--- a/code/modules/transport/tram/tram_power.dm
+++ b/code/modules/transport/tram/tram_power.dm
@@ -15,11 +15,7 @@
 	/// The tram platform we're connected to and providing power
 	var/obj/effect/landmark/transport/nav_beacon/tram/platform/connected_platform
 
-/obj/machinery/transport/power_rectifier/Initialize(mapload)
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/transport/power_rectifier/LateInitialize(mapload)
+/obj/machinery/transport/power_rectifier/post_machine_initialize()
 	. = ..()
 	RegisterSignal(SStransport, COMSIG_TRANSPORT_ACTIVE, PROC_REF(power_tram))
 	find_platform()

--- a/code/modules/transport/tram/tram_signals.dm
+++ b/code/modules/transport/tram/tram_signals.dm
@@ -107,9 +107,8 @@
 	RegisterSignal(SStransport, COMSIG_COMMS_STATUS, PROC_REF(comms_change))
 	SStransport.crossing_signals += src
 	register_context()
-	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/transport/crossing_signal/LateInitialize(mapload)
+/obj/machinery/transport/crossing_signal/post_machine_initialize()
 	. = ..()
 	link_tram()
 	link_sensor()
@@ -510,10 +509,8 @@
 /obj/machinery/transport/guideway_sensor/Initialize(mapload)
 	. = ..()
 	SStransport.sensors += src
-	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/transport/guideway_sensor/LateInitialize(mapload)
-	. = ..()
+/obj/machinery/transport/guideway_sensor/post_machine_initialize()
 	pair_sensor()
 	RegisterSignal(SStransport, COMSIG_TRANSPORT_ACTIVE, PROC_REF(wake_up))
 

--- a/code/modules/transport/tram/tram_signals.dm
+++ b/code/modules/transport/tram/tram_signals.dm
@@ -511,6 +511,7 @@
 	SStransport.sensors += src
 
 /obj/machinery/transport/guideway_sensor/post_machine_initialize()
+	. = ..()
 	pair_sensor()
 	RegisterSignal(SStransport, COMSIG_TRANSPORT_ACTIVE, PROC_REF(wake_up))
 

--- a/code/modules/transport/tram/tram_structures.dm
+++ b/code/modules/transport/tram/tram_structures.dm
@@ -486,7 +486,6 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/tram/spoiler/LateInitialize()
-	. = ..()
 	RegisterSignal(SStransport, COMSIG_TRANSPORT_ACTIVE, PROC_REF(set_spoiler))
 
 /obj/structure/tram/spoiler/add_context(atom/source, list/context, obj/item/held_item, mob/user)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -96,7 +96,6 @@
 		return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/transport/linear/LateInitialize()
-	. = ..()
 	//after everything is initialized the transport controller can order everything
 	transport_controller_datum.order_platforms_by_z_level()
 

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -55,7 +55,7 @@
 	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	return ..()
 
-/obj/machinery/mecha_part_fabricator/LateInitialize()
+/obj/machinery/mecha_part_fabricator/post_machine_initialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !stored_research)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(stored_research, src)

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	materials = AddComponent(/datum/component/remote_materials, mapload)
 
-/obj/machinery/component_printer/LateInitialize()
+/obj/machinery/component_printer/post_machine_initialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !techweb)
 		CONNECT_TO_RND_SERVER_ROUNDSTART(techweb, src)


### PR DESCRIPTION
## About The Pull Request

I've seen a few cases in the past where LateInitialize is done cause of the init return value being set to do so for no real reason, I thought I should try to avoid that by ensuring LateInitialize isn't ever called without overriding.

This fixes a ton of machine's LateInitialize not calling parent (mechpad, door buttons, message monitor, a lot of tram machines, abductor console, holodeck computer & disposal bin), avoiding having to set itself up to be connected to power. If they were intended to not connect to power, they should be using ``NO_POWER_USE`` instead.

Also removes a ton of returns to LateInit when it's already getting it from parent regardless (many cases of that in machine code).

## Why It's Good For The Game

I think this is better for coding standard reasons as well as just making sure we're not calling this proc on things that does absolutely nothing with them. A machine not using power can be seen evidently not using power with ``NO_POWER_USE``, not so much if it's LateInitialize not calling parent.

## Changelog

:cl:
fix: Mech pads, door buttons, message monitors, tram machines, abductor consoles & holodeck computers now use power.
/:cl: