### PR TITLE
Adds Healthdoll to Basic Dexterous Mobs

### DIFF
--- a/code/_onclick/hud/generic_dextrous.dm
+++ b/code/_onclick/hud/generic_dextrous.dm
@@ -43,6 +43,9 @@
 	using.icon = ui_style
 	static_inventory += using
 
+	healthdoll = new /atom/movable/screen/healthdoll/living(null, src)
+	infodisplay += healthdoll
+
 	mymob.canon_client?.clear_screen()
 
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))


### PR DESCRIPTION
## About The Pull Request

This PR adds a health doll to the hud used by basic and simple mobs to the dexterous basic mob HUD. I'd reckon the only reason it wasn't initially there in the first place is by mistake.

This also apparently adds the damage borders around the screen as the mob takes damage, which is a useful gauge for knowing when you're about to die.

![image](https://github.com/tgstation/tgstation/assets/47086570/d5c45f32-2326-4c65-bf67-77b10c0c153e)

## Why It's Good For The Game

Basic QoL change to provide basic dexterous mobs with the same level of health info that we provide everything else.

## Changelog
:cl:
qol: Basic dexterous mobs now have a health doll and screen damage indication like other basic mobs.
/:cl: