### PR TITLE
[NO GBP] Post-round blob zombies no longer offer themselves to ghosts

### DIFF
--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -87,7 +87,7 @@
 
 /mob/living/basic/blob_minion/zombie/controlled/consume_corpse(mob/living/carbon/human/new_corpse)
 	. = ..()
-	if (!isnull(client))
+	if (!isnull(client) || SSticker.current_state == GAME_STATE_FINISHED)
 		return
 	AddComponent(\
 		/datum/component/ghost_direct_control,\


### PR DESCRIPTION

## About The Pull Request

This should properly fix the post-blob-win audio/notif spam for real this time.

I wanted to preserve the effect as much as possible, so they just don't poll for ghosts when the round is already over.
## Why It's Good For The Game

Closes #80998 for real this time.
## Changelog
:cl: Rhials
fix: The tide of post-round blob zombies when a blob wins will no longer break the speakers in your headset.
/:cl:
