### PR TITLE
You can no longer aggressive grab medbots

### DIFF
--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -14,7 +14,7 @@
 	light_power = 0.8
 	light_color = "#99ccff"
 	pass_flags = PASSMOB | PASSFLAPS
-	status_flags = (CANPUSH | CANSTUN)
+	status_flags = CANSTUN
 	ai_controller = /datum/ai_controller/basic_controller/bot/medbot
 
 	req_one_access = list(ACCESS_ROBOTICS, ACCESS_MEDICAL)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/82475
Medbots had CANPUSH in their flags, which allows them to be aggressive grabbed, which allows them to be thrown.
We don't want that because it turns them into all-access keycards.

As far as me (and ben10) could ascertain, it didn't have this flag enabled for any particular reason.

## Changelog

:cl:
fix: Medbots can no longer be used as especially large golden ID cards
/:cl:
