### PR TITLE
Baisc Bot "Commission Emote" Tweak

### DIFF
--- a/code/modules/mob/living/basic/bots/bot_ai.dm
+++ b/code/modules/mob/living/basic/bots/bot_ai.dm
@@ -2,9 +2,8 @@
 	blackboard = list(
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_SALUTE_MESSAGES = list(
-			"salutes",
+			"performs an elaborate salute for",
 			"nods in appreciation towards",
-			"fist bumps",
 		),
 		BB_UNREACHABLE_LIST_COOLDOWN = 45 SECONDS,
 	)
@@ -205,7 +204,7 @@
 
 /datum/ai_behavior/find_and_set/valid_authority
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
-	action_cooldown = 30 SECONDS
+	action_cooldown = BOT_COMMISSIONED_SALUTE_DELAY
 
 /datum/ai_behavior/find_and_set/valid_authority/search_tactic(datum/ai_controller/controller, locate_path, search_range)
 	for(var/mob/living/nearby_mob in oview(search_range, controller.pawn))
@@ -231,7 +230,7 @@
 	if(our_hat)
 		salute_list += "tips [our_hat] at "
 
-	bot_pawn.manual_emote(pick(salute_list) + " [controller.blackboard[target_key]]")
+	bot_pawn.manual_emote(pick(salute_list) + " [controller.blackboard[target_key]]!")
 	finish_action(controller, TRUE, target_key)
 	return
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -380,7 +380,7 @@
 		COOLDOWN_START(src, next_salute_check, BOT_COMMISSIONED_SALUTE_DELAY)
 		for(var/mob/living/simple_animal/bot/B in view(5, src))
 			if(!HAS_TRAIT(B, TRAIT_COMMISSIONED) && B.bot_mode_flags & BOT_MODE_ON)
-				visible_message("<b>[B]</b> performs an elaborate salute for [src]!")
+				manual_emote("performs an elaborate salute for [src]!")
 				break
 
 	switch(mode) //High-priority overrides are processed first. Bots can do nothing else while under direct command.


### PR DESCRIPTION
## About The Pull Request

1. Simple bots use Manual Emotes like Basic Bots
2. Re-ups the CD for emoting to commission bots to 60 seconds, as it was originally with Simple Bots
3. Punctuates the manual emotes
4. Deletes the fist bump message

## Why It's Good For The Game

1. Consistency. 
2. These messages get a little... a lot spammy when walking around the halls, especially if Robotics has made a few additional bots. The original implementation had a CD of 60 seconds, which the AI behavior halved. Upping it back up for consistency + less spam. 
3. Looks a little less shoddy. 
4. It's a cute message, but it's completely out of character for what the bots are supposed to be "doing". They're "saluting" their "commissioned officer", not meeting up with the bros. Also they don't have fists! I understand saluting with their "robot appendage" but they don't punch people!

## Changelog

:cl: Melbert
qol: Basic Bots will use their "salute" emotes less often. 
del: Basic bot fists. 
/:cl:


