### PR TITLE
Atmos resin can cool the floor down directly.

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -430,6 +430,7 @@
 		return
 
 	location.ClearWet()
+	location.temperature = T20C
 	if(location.air)
 		var/datum/gas_mixture/air = location.air
 		air.temperature = T20C


### PR DESCRIPTION

## About The Pull Request
Makes atmos resin set the floor's temperature to 293.15 Kelvin.
## Why It's Good For The Game
The floor can heat the air up. If someone were to extinguish a tritium fire or something ridiculous with halon, then an awkward situation will arise where the halon cools the air down, but when someone breaks the resin open, the floor heats the air back up, triggering the resin to spawn again and again, which can cause quite awkward problems.
## Changelog
:cl:
balance: Atmos resin can directly cool the floor.
/:cl:
