### PR TITLE
Add balloon alerts to plunging

### DIFF
--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -91,9 +91,9 @@
 	return ..()
 
 /obj/machinery/medipen_refiller/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
-	to_chat(user, span_notice("You start furiously plunging [name]."))
+	user.balloon_alert_to_viewers("furiously plunging...", "plunging medipen refiller...")
 	if(do_after(user, 3 SECONDS, target = src))
-		to_chat(user, span_notice("You finish plunging the [name]."))
+		user.balloon_alert_to_viewers("finished plunging")
 		reagents.expose(get_turf(src), TOUCH)
 		reagents.clear_reagents()
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -177,7 +177,7 @@
 		to_chat(user, span_notice("You cannot pump [vent] if it's welded shut!"))
 		return
 
-	to_chat(user, span_notice("You begin pumping [vent] with your plunger."))
+	user.balloon_alert_to_viewers("plunging vent...", "plunging clogged vent...")
 	if(do_after(user, 6 SECONDS, target = vent))
 		to_chat(user, span_notice("You finish pumping [vent]."))
 		clear_signals()

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -179,7 +179,7 @@
 
 	user.balloon_alert_to_viewers("plunging vent...", "plunging clogged vent...")
 	if(do_after(user, 6 SECONDS, target = vent))
-		to_chat(user, span_notice("You finish pumping [vent]."))
+		user.balloon_alert_to_viewers("finished plunging")
 		clear_signals()
 		kill()
 

--- a/code/modules/fishing/aquarium/aquarium.dm
+++ b/code/modules/fishing/aquarium/aquarium.dm
@@ -179,9 +179,9 @@
 /obj/structure/aquarium/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
 	if(!panel_open)
 		return
-	to_chat(user, span_notice("You start plunging [name]."))
+	user.balloon_alert_to_viewers("plunging...")
 	if(do_after(user, 3 SECONDS, target = src))
-		to_chat(user, span_notice("You finish plunging the [name]."))
+		user.balloon_alert_to_viewers("finished plunging")
 		reagents.expose(get_turf(src), TOUCH) //splash on the floor
 		reagents.clear_reagents()
 

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -35,9 +35,9 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/plumbing/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
-	to_chat(user, span_notice("You start furiously plunging [name]."))
+	user.balloon_alert_to_viewers("furiously plunging...", "plunging medipen refiller...")
 	if(do_after(user, 3 SECONDS, target = src))
-		to_chat(user, span_notice("You finish plunging the [name]."))
+		user.balloon_alert_to_viewers("finished plunging")
 		reagents.expose(get_turf(src), TOUCH) //splash on the floor
 		reagents.clear_reagents()
 

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -35,7 +35,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/plumbing/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
-	user.balloon_alert_to_viewers("furiously plunging...", "plunging medipen refiller...")
+	user.balloon_alert_to_viewers("furiously plunging...")
 	if(do_after(user, 3 SECONDS, target = src))
 		user.balloon_alert_to_viewers("finished plunging")
 		reagents.expose(get_turf(src), TOUCH) //splash on the floor

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -23,7 +23,7 @@
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/iv_drip/plumbing/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
-	user.balloon_alert_to_viewers("furiously plunging...", "plunging medipen refiller...")
+	user.balloon_alert_to_viewers("furiously plunging...", "plunging iv drip...")
 	if(do_after(user, 3 SECONDS, target = src))
 		user.balloon_alert_to_viewers("finished plunging")
 		reagents.expose(get_turf(src), TOUCH) //splash on the floor

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -23,9 +23,9 @@
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/iv_drip/plumbing/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
-	to_chat(user, span_notice("You start furiously plunging [name]."))
+	user.balloon_alert_to_viewers("furiously plunging...", "plunging medipen refiller...")
 	if(do_after(user, 3 SECONDS, target = src))
-		to_chat(user, span_notice("You finish plunging the [name]."))
+		user.balloon_alert_to_viewers("finished plunging")
 		reagents.expose(get_turf(src), TOUCH) //splash on the floor
 		reagents.clear_reagents()
 


### PR DESCRIPTION

## About The Pull Request

Makes all plunging actions (pretty much anything using `plunger_act`) have a visible balloon alert.

## Why It's Good For The Game

Makes sense that others would easily notice you plunging the shit out of something.

Also, more people might finally learn that you can plunge the vent clogs instead of welding them.

## Changelog
:cl:
qol: Added balloon alerts whenever you start plunging something (i.e )
/:cl:
