### PR TITLE
Fixes incorrect operator usage in mecha code

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -272,7 +272,7 @@
 	/// If the former occupants get polymorphed, mutated, chestburstered,
 	/// or otherwise replaced by another mob, that mob is no longer in .occupants
 	/// and gets deleted with the mech. However, they do remain in .contents
-	var/list/potential_occupants = contents ^ occupants
+	var/list/potential_occupants = contents | occupants
 	for(var/mob/buggy_ejectee in potential_occupants)
 		mob_exit(buggy_ejectee, silent = TRUE)
 


### PR DESCRIPTION
## About The Pull Request

I completely screwed up and told the original PR author of #82415 (9922d2f2377c3ab571d34c857174c45f5521a5ae) to use the `XOR` operator instead of the `OR` operator (I wasn't thinking right for some reason when I was reading the ref), anyways this PR just fixes that because I misled the contributor into doing something that wasn't correct and actually would BREAK functionality instead.