### PR TITLE
Fixes spurious runtime on Icemoon caused by turf calling unimplemented LateInitialize()

### DIFF
--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -188,7 +188,8 @@
 		return
 	if(T.turf_flags & NO_RUINS && protect_ruin)
 		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
-		return INITIALIZE_HINT_NORMAL
+		if(isopenspaceturf(replacement_turf)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
+			return INITIALIZE_HINT_NORMAL
 	if(!ismineralturf(T) || !drill_below)
 		return
 	var/turf/closed/mineral/M = T

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -188,8 +188,9 @@
 		return
 	if(T.turf_flags & NO_RUINS && protect_ruin)
 		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
-		if(isopenspaceturf(replacement_turf)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
+		if(!isopenspaceturf(replacement_turf)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
 			return INITIALIZE_HINT_NORMAL
+		return
 	if(!ismineralturf(T) || !drill_below)
 		return
 	var/turf/closed/mineral/M = T

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -188,7 +188,7 @@
 		return
 	if(T.turf_flags & NO_RUINS && protect_ruin)
 		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
-		return
+		return INITIALIZE_HINT_NORMAL
 	if(!ismineralturf(T) || !drill_below)
 		return
 	var/turf/closed/mineral/M = T


### PR DESCRIPTION
## About The Pull Request

As of https://github.com/tgstation/tgstation/pull/82540 this runtime was happening,

![image](https://github.com/tgstation/tgstation/assets/13398309/4d838fda-c157-4e33-ae64-77eafca1806f)

`/turf/open/openspace/icemoon/` can be changed to `/turf/open/misc/asteroid/snow/icemoon/do_not_chasm` before `Initialize()` returns, which resulted in it `INITIALIZE_HINT_LATELOAD` getting returned on a turf that does not have an implementation of that proc.

This should fix that.

## Why It's Good For The Game

Fixes CI error


