### PR TITLE
Add signals to run `update_sight()` whenever vision traits are changed.

### DIFF
--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -65,6 +65,20 @@
 
 	RegisterSignal(src, COMSIG_MOVABLE_EDIT_UNIQUE_IMMERSE_OVERLAY, PROC_REF(edit_immerse_overlay))
 
+	RegisterSignals(src, list(
+		SIGNAL_ADDTRAIT(TRAIT_XRAY_VISION),
+		SIGNAL_REMOVETRAIT(TRAIT_XRAY_VISION),
+
+		SIGNAL_ADDTRAIT(TRAIT_THERMAL_VISION),
+		SIGNAL_REMOVETRAIT(TRAIT_THERMAL_VISION),
+
+		SIGNAL_ADDTRAIT(TRAIT_MESON_VISION),
+		SIGNAL_REMOVETRAIT(TRAIT_MESON_VISION),
+
+		SIGNAL_ADDTRAIT(TRAIT_TRUE_NIGHT_VISION),
+		SIGNAL_REMOVETRAIT(TRAIT_TRUE_NIGHT_VISION)
+	), PROC_REF(vision_changed))
+
 /// Called when [TRAIT_KNOCKEDOUT] is added to the mob.
 /mob/living/proc/on_knockedout_trait_gain(datum/source)
 	SIGNAL_HANDLER
@@ -273,3 +287,8 @@
 /mob/living/proc/undense_changed(datum/source)
 	SIGNAL_HANDLER
 	update_density()
+
+/// Called when a vision trait ([TRAIT_XRAY_VISION], [TRAIT_THERMAL_VISION], [TRAIT_MESON_VISION], [TRAIT_TRUE_NIGHT_VISION]) is gained or lost
+/mob/living/proc/vision_changed(datum/source)
+	SIGNAL_HANDLER
+	update_sight()


### PR DESCRIPTION

## About The Pull Request

tbh `update_sight` should be refactored a bit to have more code in living rather than carbon, but kinda out-of-scope for this, and I'm not entirely sure on how I'd do that at the moment.

## Why It's Good For The Game

Just makes sense, honestly. Plus, helpful whenever admins might VV these traits onto someone or something like that.

## Changelog
:cl:
code: Added hooks for whenever a vision trait is added or removed from a mob.
/:cl:
