### PR TITLE
[NO GBP] Fixes spurious runtime caused by icemoon (again)

### DIFF
--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -187,9 +187,8 @@
 	if(!T)
 		return
 	if(T.turf_flags & NO_RUINS && protect_ruin)
-		var/is_openspace = isopenspaceturf(replacement_turf) // because we're about to change this to something that potentially does not have the 'replacement_turf' var
 		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
-		if(!is_openspace) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
+		if(!isopenspaceturf(src)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
 			return INITIALIZE_HINT_NORMAL
 		return
 	if(!ismineralturf(T) || !drill_below)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -187,8 +187,9 @@
 	if(!T)
 		return
 	if(T.turf_flags & NO_RUINS && protect_ruin)
+		var/is_openspace = isopenspaceturf(replacement_turf) // because we're about to change this to something that potentially does not have the 'replacement_turf' var
 		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
-		if(!isopenspaceturf(replacement_turf)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
+		if(!is_openspace) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
 			return INITIALIZE_HINT_NORMAL
 		return
 	if(!ismineralturf(T) || !drill_below)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -187,8 +187,8 @@
 	if(!T)
 		return
 	if(T.turf_flags & NO_RUINS && protect_ruin)
-		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
-		if(!isopenspaceturf(src)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
+		var/turf/newturf = ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
+		if(!isopenspaceturf(newturf)) // only openspace turfs should be returning INITIALIZE_HINT_LATELOAD
 			return INITIALIZE_HINT_NORMAL
 		return
 	if(!ismineralturf(T) || !drill_below)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/82572 I tried to fix this but there was an unaccounted race condition which just caused a separate runtime...

![firefox_GxGibAO281](https://github.com/tgstation/tgstation/assets/13398309/f251aecc-ef17-4bae-a741-5aade40de423)

Since the type is being changed mid-execution `replacement_turf` will become out of scope. My bad--this should fix it now for good.