### PR TITLE
bug fixes and code refactor for AI, malf or otherwise

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -12,7 +12,8 @@
 	var/datum/ai_laws/laws
 	var/obj/item/circuitboard/aicore/circuit
 	var/obj/item/mmi/core_mmi
-	var/mob/living/silicon/ai/remote_ai = null // only used in cases of AIs piloting mechs or shunted malf AIs, possible later use cases
+	/// only used in cases of AIs piloting mechs or shunted malf AIs, possible later use cases
+	var/mob/living/silicon/ai/remote_ai = null
 
 /obj/structure/ai_core/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -68,9 +68,9 @@
 	return ..()
 
 /obj/structure/ai_core/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
-	if(istype(remote_ai))
-		to_chat(remote_ai, span_danger("Your core is under attack!"))
 	. = ..()
+	if(. > 0 && istype(remote_ai))
+		to_chat(remote_ai, span_danger("Your core is under attack!"))
 	
 
 /obj/structure/ai_core/deactivated
@@ -309,7 +309,7 @@
 					balloon_alert(user, "removed [AI_CORE_BRAIN(core_mmi)]")
 					if(remote_ai)
 						remote_ai.break_core_link()
-						if(!(IS_MALF_AI(remote_ai)))
+						if(!IS_MALF_AI(remote_ai))
 							//don't pull back shunted malf AIs
 							remote_ai.death(gibbed = TRUE, drop_mmi = FALSE)
 							///the drop_mmi param determines whether the MMI is dropped at their current location

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -309,14 +309,14 @@
 					tool.play_tool_sound(src)
 					balloon_alert(user, "removed [AI_CORE_BRAIN(core_mmi)]")
 					if(remote_ai)
-						remote_ai.break_core_link()
-						if(!IS_MALF_AI(remote_ai))
+						var/mob/living/silicon/ai/remoted_ai = remote_ai
+						remoted_ai.break_core_link()
+						if(!IS_MALF_AI(remoted_ai))
 							//don't pull back shunted malf AIs
-							remote_ai.death(gibbed = TRUE, drop_mmi = FALSE)
+							remoted_ai.death(gibbed = TRUE, drop_mmi = FALSE)
 							///the drop_mmi param determines whether the MMI is dropped at their current location
 							///which in this case would be somewhere else, so we drop their MMI at the core instead
-							remote_ai.make_mmi_drop_and_transfer(core_mmi, src)
-						remote_ai = null
+							remoted_ai.make_mmi_drop_and_transfer(core_mmi, src)
 					core_mmi.forceMove(loc) //if they're malf, just drops a blank MMI, or if it's an incomplete shell
 					return					//it drops the mmi that was put in before it was finished
 

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -159,6 +159,9 @@
 
 	to_chat(malf_ai, "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!")
 
+	if(malf_ai.malf_picker)
+		stack_trace("Attempted to give malf AI malf picker to \[[owner]\], who already has a malf picker.")
+		return
 	malf_ai.add_malf_picker()
 
 

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -160,7 +160,6 @@
 	to_chat(malf_ai, "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!")
 
 	if(malf_ai.malf_picker)
-		stack_trace("Attempted to give malf AI malf picker to \[[owner]\], who already has a malf picker.")
 		return
 	malf_ai.add_malf_picker()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1041,7 +1041,7 @@
 		else //combat software AIs use a different UI
 			malf_picker.update_static_data_for_all_viewers()
 	if(apc.malfai) // another malf hacked this one; counter-hack!
-		apc.malfai(to_chat, span_warning("An adversarial subroutine has counter-hacked [apc]!"))
+		to_chat(apc.malfai, span_warning("An adversarial subroutine has counter-hacked [apc]!"))
 		apc.malfai.hacked_apcs -= apc
 	apc.malfai = src
 	apc.malfhack = TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -53,6 +53,7 @@
 	var/shunted = FALSE //1 if the AI is currently shunted. Used to differentiate between shunted and ghosted/braindead
 	var/obj/machinery/ai_voicechanger/ai_voicechanger = null // reference to machine that holds the voicechanger
 	var/malfhacking = FALSE // More or less a copy of the above var, so that malf AIs can hack and still get new cyborgs -- NeoFite
+	var/list/hacked_apcs = list() // List of hacked APCs
 	var/malf_cooldown = 0 //Cooldown var for malf modules, stores a worldtime + cooldown
 
 	var/obj/machinery/power/apc/malfhack
@@ -1043,6 +1044,7 @@
 	apc.coverlocked = TRUE
 	apc.flicker_hacked_icon()
 	apc.set_hacked_hud()
+	hacked_apcs += apc
 	playsound(get_turf(src), 'sound/machines/ding.ogg', 50, TRUE, ignore_walls = FALSE)
 	to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -53,7 +53,8 @@
 	var/shunted = FALSE //1 if the AI is currently shunted. Used to differentiate between shunted and ghosted/braindead
 	var/obj/machinery/ai_voicechanger/ai_voicechanger = null // reference to machine that holds the voicechanger
 	var/malfhacking = FALSE // More or less a copy of the above var, so that malf AIs can hack and still get new cyborgs -- NeoFite
-	var/list/hacked_apcs = list() // List of hacked APCs
+	/// List of hacked APCs
+	var/list/hacked_apcs = list() 
 	var/malf_cooldown = 0 //Cooldown var for malf modules, stores a worldtime + cooldown
 
 	var/obj/machinery/power/apc/malfhack

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1040,7 +1040,9 @@
 			malf_ai_datum.update_static_data_for_all_viewers()
 		else //combat software AIs use a different UI
 			malf_picker.update_static_data_for_all_viewers()
-
+	if(apc.malfai) // another malf hacked this one; counter-hack!
+		apc.malfai("An adversarial subroutine has counter-hacked [apc]!")
+		apc.malfai.hacked_apcs -= apc
 	apc.malfai = src
 	apc.malfhack = TRUE
 	apc.locked = TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -59,7 +59,6 @@
 	var/obj/machinery/power/apc/malfhack
 	var/explosive = FALSE //does the AI explode when it dies?
 
-	var/mob/living/silicon/ai/parent
 	var/camera_light_on = FALSE
 	var/list/obj/machinery/camera/lit_cameras = list()
 
@@ -451,6 +450,10 @@
 	if(make_mmi_drop_and_transfer(ai_core.core_mmi, the_core = ai_core))
 		qdel(src)
 	return ai_core
+
+/mob/living/silicon/ai/proc/break_core_link()
+	to_chat(src, span_danger("Your core has been destroyed!"))
+	linked_core = null
 
 /mob/living/silicon/ai/proc/make_mmi_drop_and_transfer(obj/item/mmi/the_mmi, the_core)
 	var/mmi_type
@@ -1038,7 +1041,7 @@
 		else //combat software AIs use a different UI
 			malf_picker.update_static_data_for_all_viewers()
 
-	apc.malfai = parent || src
+	apc.malfai = src
 	apc.malfhack = TRUE
 	apc.locked = TRUE
 	apc.coverlocked = TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -964,6 +964,9 @@
 	module_picker.ui_interact(owner)
 
 /mob/living/silicon/ai/proc/add_malf_picker()
+	if (malf_picker)
+		stack_trace("Attempted to give malf AI malf picker to \[[src]\], who already has a malf picker.")
+		return
 	to_chat(src, "In the top left corner of the screen you will find the Malfunction Modules button, where you can purchase various abilities, from upgraded surveillance to station ending doomsday devices.")
 	to_chat(src, "You are also capable of hacking APCs, which grants you more points to spend on your Malfunction powers. The drawback is that a hacked APC will give you away if spotted by the crew. Hacking an APC takes 60 seconds.")
 	view_core() //A BYOND bug requires you to be viewing your core before your verbs update

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1041,7 +1041,7 @@
 		else //combat software AIs use a different UI
 			malf_picker.update_static_data_for_all_viewers()
 	if(apc.malfai) // another malf hacked this one; counter-hack!
-		apc.malfai("An adversarial subroutine has counter-hacked [apc]!")
+		apc.malfai(to_chat, span_warning("An adversarial subroutine has counter-hacked [apc]!"))
 		apc.malfai.hacked_apcs -= apc
 	apc.malfai = src
 	apc.malfhack = TRUE

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -2,6 +2,7 @@
 /mob/living/silicon/ai/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/ai_module))
 		var/obj/item/ai_module/MOD = W
+		disconnect_shell()
 		if(!mind) //A player mind is required for law procs to run antag checks.
 			to_chat(user, span_warning("[src] is entirely unresponsive!"))
 			return
@@ -137,7 +138,7 @@
 		return ITEM_INTERACT_SUCCESS
 	balloon_alert(src, "neural network being disconnected...")
 	balloon_alert(user, "disconnecting neural network...")
-	if(!tool.use_tool(src, user, (stat == DEAD ? 40 SECONDS : 5 SECONDS)))
+	if(!tool.use_tool(src, user, (stat == DEAD ? 5 SECONDS : 40 SECONDS)))
 		return ITEM_INTERACT_SUCCESS
 	if(IS_MALF_AI(src))
 		to_chat(user, span_userdanger("The voltage inside the wires rises dramatically!"))

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -1,18 +1,3 @@
-/mob/living/silicon/ai/say(
-	message,
-	bubble_type,
-	list/spans = list(),
-	sanitize = TRUE,
-	datum/language/language,
-	ignore_spam = FALSE,
-	forced,
-	filterproof = FALSE,
-	message_range = 7,
-	datum/saymode/saymode,
-	list/message_mods = list(),
-)
-	return ..()
-
 /mob/living/silicon/ai/compose_track_href(atom/movable/speaker, namepart)
 	var/mob/M = speaker.GetSource()
 	if(M)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -11,8 +11,6 @@
 	datum/saymode/saymode,
 	list/message_mods = list(),
 )
-	if(istype(parent) && parent.stat != DEAD) //If there is a defined "parent" AI, it is actually an AI, and it is alive, anything the AI tries to say is said by the parent instead.
-		return parent.say(arglist(args))
 	return ..()
 
 /mob/living/silicon/ai/compose_track_href(atom/movable/speaker, namepart)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/ai/death(gibbed)
+/mob/living/silicon/ai/death(gibbed, drop_mmi = TRUE)
 	if(stat == DEAD)
 		return
 
@@ -33,7 +33,7 @@
 
 	ShutOffDoomsdayDevice()
 
-	if(gibbed)
+	if(gibbed && drop_mmi)
 		make_mmi_drop_and_transfer()
 
 	if(explosive)

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -110,13 +110,17 @@
 		return TRUE
 	if(!HAS_SILICON_ACCESS(user))
 		return TRUE
+	. = TRUE
 	var/mob/living/silicon/ai/AI = user
 	var/mob/living/silicon/robot/robot = user
-	if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
-		if(!loud)
-			balloon_alert(user, "it's disabled!")
-		return FALSE
-	return TRUE
+	if(istype(AI) || istype(robot))
+		if(istype(malfai) && (malfai != AI || !(robot in malfai.connected_robots)))
+			. = FALSE 
+		if(aidisabled)
+			. = FALSE
+	if (!. && !loud)
+		balloon_alert(user, "it's disabled!")
+	return .
 
 /obj/machinery/power/apc/proc/set_broken()
 	if(machine_stat & BROKEN)

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -114,10 +114,10 @@
 	var/mob/living/silicon/ai/AI = user
 	var/mob/living/silicon/robot/robot = user
 	if(istype(AI) || istype(robot))
-		if(istype(malfai) && (malfai != AI || !(robot in malfai.connected_robots)))
-			. = FALSE 
 		if(aidisabled)
 			. = FALSE
+		else if(istype(malfai) && (malfai != AI || !(robot in malfai.connected_robots)))
+			. = FALSE 
 	if (!. && !loud)
 		balloon_alert(user, "it's disabled!")
 	return .

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -229,6 +229,7 @@
 /obj/machinery/power/apc/Destroy()
 	if(malfai && operating)
 		malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10, 0, 1000)
+		malfai.hacked_apcs -= src
 	disconnect_from_area()
 	QDEL_NULL(alarm_manager)
 	if(occupier)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -227,9 +227,11 @@
 	find_and_hang_on_wall()
 
 /obj/machinery/power/apc/Destroy()
-	if(malfai && operating)
-		malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10, 0, 1000)
+	if(malfai)
+		if(operating)
+			malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10, 0, 1000)
 		malfai.hacked_apcs -= src
+		malfai = null
 	disconnect_from_area()
 	QDEL_NULL(alarm_manager)
 	if(occupier)

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -38,7 +38,7 @@
 		return
 	malf.ShutOffDoomsdayDevice()
 	occupier = malf
-	if (istype(malf.loc, /turf)) // create a deactivated AI core if the AI isn't coming from an emergency mech shunt
+	if (isturf(malf.loc)) // create a deactivated AI core if the AI isn't coming from an emergency mech shunt
 		malf.linked_core = new /obj/structure/ai_core/deactivated
 		malf.linked_core.remote_ai = malf // note that we do not set the deactivated core's core_mmi.brainmob
 	malf.forceMove(src) // move INTO the APC, not to its tile

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -12,14 +12,14 @@
 /obj/machinery/power/apc/proc/malfhack(mob/living/silicon/ai/malf)
 	if(!istype(malf))
 		return
-	if(!get_malf_status(malf))
+	if(get_malf_status(malf) =! APC_AI_HACK_NO_SHUNT || get_malf_status(malf) =! APC_AI_NO_HACK)
 		return
 	if(malf.malfhacking)
 		to_chat(malf, span_warning("You are already hacking an APC!"))
 		return
 	to_chat(malf, span_notice("Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process."))
 	malf.malfhack = src
-	malf.malfhacking = addtimer(CALLBACK(malf, TYPE_PROC_REF(/mob/living/silicon/ai/, malfhacked), src), 30, TIMER_STOPPABLE)
+	malf.malfhacking = addtimer(CALLBACK(malf, TYPE_PROC_REF(/mob/living/silicon/ai/, malfhacked), src), 600, TIMER_STOPPABLE)
 
 	var/atom/movable/screen/alert/hackingapc/hacking_apc
 	hacking_apc = malf.throw_alert(ALERT_HACKING_APC, /atom/movable/screen/alert/hackingapc)

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -1,7 +1,7 @@
 /obj/machinery/power/apc/proc/get_malf_status(mob/living/silicon/ai/malf)
 	if(!istype(malf) || !malf.malf_picker)
 		return APC_AI_NO_MALF
-	if(malfai != (malf.parent || malf))
+	if(malfai != malf)
 		return APC_AI_NO_HACK
 	if(occupier == malf)
 		return APC_AI_HACK_SHUNT_HERE
@@ -12,7 +12,7 @@
 /obj/machinery/power/apc/proc/malfhack(mob/living/silicon/ai/malf)
 	if(!istype(malf))
 		return
-	if(get_malf_status(malf) != 1)
+	if(!get_malf_status(malf))
 		return
 	if(malf.malfhacking)
 		to_chat(malf, span_warning("You are already hacking an APC!"))

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -12,7 +12,7 @@
 /obj/machinery/power/apc/proc/malfhack(mob/living/silicon/ai/malf)
 	if(!istype(malf))
 		return
-	if(get_malf_status(malf) =! APC_AI_HACK_NO_SHUNT || get_malf_status(malf) =! APC_AI_NO_HACK)
+	if(get_malf_status(malf) != APC_AI_HACK_NO_SHUNT || get_malf_status(malf) != APC_AI_NO_HACK)
 		return
 	if(malf.malfhacking)
 		to_chat(malf, span_warning("You are already hacking an APC!"))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -328,7 +328,7 @@
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
 			var/mob/living/silicon/ai/ai = occupant
-			if(!ai.linked_core) // we probably shouldnt gib AIs with a core
+			if(!ai.linked_core && !ai.can_shunt) // we probably shouldnt gib AIs with a core
 				unlucky_ai = occupant
 				ai.investigate_log("has been gibbed by having their mech destroyed.", INVESTIGATE_DEATHS)
 				ai.gib(DROP_ALL_REMAINS) //No wreck, no AI to recover

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -272,9 +272,9 @@
 	/// If the former occupants get polymorphed, mutated, chestburstered,
 	/// or otherwise replaced by another mob, that mob is no longer in .occupants
 	/// and gets deleted with the mech. However, they do remain in .contents
-	var/list/potential_occupants = contents ^ occupants
+	var/list/potential_occupants = contents | occupants
 	for(var/mob/buggy_ejectee in potential_occupants)
-		mob_exit(buggy_ejectee, silent = TRUE)
+		mob_exit(buggy_ejectee, silent = TRUE, forced = TRUE)
 
 	if(LAZYLEN(flat_equipment))
 		for(var/obj/item/mecha_parts/mecha_equipment/equip as anything in flat_equipment)
@@ -328,7 +328,7 @@
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
 			var/mob/living/silicon/ai/ai = occupant
-			if(!ai.linked_core && !ai.can_shunt) // we probably shouldnt gib AIs with a core
+			if(!ai.linked_core && !ai.can_shunt) // we probably shouldnt gib AIs with a core or shunting abilities
 				unlucky_ai = occupant
 				ai.investigate_log("has been gibbed by having their mech destroyed.", INVESTIGATE_DEATHS)
 				ai.gib(DROP_ALL_REMAINS) //No wreck, no AI to recover

--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -67,6 +67,7 @@
 
 		if(AI_MECH_HACK) //Called by AIs on the mech
 			AI.linked_core = new /obj/structure/ai_core/deactivated(AI.loc)
+			AI.linked_core.remote_ai = AI
 			if(AI.can_dominate_mechs && LAZYLEN(occupants)) //Oh, I am sorry, were you using that?
 				to_chat(AI, span_warning("Occupants detected! Forced ejection initiated!"))
 				to_chat(occupants, span_danger("You have been forcibly ejected!"))
@@ -101,6 +102,7 @@
 	AI.eyeobj?.RegisterSignal(src, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/mob/camera/ai_eye, update_visibility))
 	AI.controlled_equipment = src
 	AI.remote_control = src
+	AI.ShutOffDoomsdayDevice()
 	to_chat(AI, AI.can_dominate_mechs ? span_greenannounce("Takeover of [name] complete! You are now loaded onto the onboard computer. Do not attempt to leave the station sector!") :\
 		span_notice("You have been uploaded to a mech's onboard computer."))
 	to_chat(AI, "<span class='reallybig boldnotice'>Use Middle-Mouse or the action button in your HUD to toggle equipment safety. Clicks with safety enabled will pass AI commands.</span>")

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -119,13 +119,16 @@
 		//stop listening to this signal, as the static update is now handled by the eyeobj's setLoc
 		AI.eyeobj?.UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 		AI.eyeobj?.forceMove(newloc) //kick the eye out as well
-		if(forced)//This should only happen if there are multiple AIs in a round, and at least one is Malf.
+		if(forced)
 			AI.controlled_equipment = null
 			AI.remote_control = null
 			if(!AI.linked_core) //if the victim AI has no core
 				if (!AI.can_shunt || !length(AI.hacked_apcs))
 					AI.investigate_log("has been gibbed by being forced out of their mech.", INVESTIGATE_DEATHS)
-					AI.gib(DROP_ALL_REMAINS)  //If one Malf decides to steal a mech from another AI (even other Malfs!), and they have no hacked APCs or core, they are destroyed
+					/// If an AI with no core (and no shunting abilities) gets forced out of their mech
+					/// (in a way that isn't handled by the normal handling of their mech being destroyed)
+					/// we gib 'em here, too.
+					AI.gib(DROP_ALL_REMAINS)
 					AI = null
 					mecha_flags &= ~SILICON_PILOT
 					return

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -196,9 +196,14 @@
 			to_chat(AI, span_userdanger("Inactive core destroyed. Unable to return."))
 			if(!AI.can_shunt || !AI.hacked_apcs.len)
 				to_chat(AI, span_warning("[AI.can_shunt ? "No hacked APCs available." : "No shunting capabilities."]"))
-				return FALSE
+				return
 			var/confirm = tgui_alert(AI, "Shunt to a random APC? You won't have anywhere else to go!", "Confirm Emergency Shunt", list("Yes", "No"))
 			if(confirm == "Yes")
+				/// Mechs with open cockpits can have the pilot shot by projectiles, or EMPs may destroy the AI inside
+				/// Alternatively, destroying the mech will shunt the AI if they can shunt, or a deadeye wizard can hit
+				/// them with a teleportation bolt
+				if (AI.stat == DEAD || AI.loc != src)
+					return
 				mob_exit(AI, forced = TRUE)
 			return
 	to_chat(user, span_notice("You begin the ejection procedure. Equipment is disabled during this process. Hold still to finish ejecting."))

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -123,7 +123,7 @@
 			AI.controlled_equipment = null
 			AI.remote_control = null
 			if(!AI.linked_core) //if the victim AI has no core
-				if (!AI.can_shunt || !(LAZYLEN(AI.hacked_apcs)))
+				if (!AI.can_shunt || !length(AI.hacked_apcs))
 					AI.investigate_log("has been gibbed by being forced out of their mech.", INVESTIGATE_DEATHS)
 					AI.gib(DROP_ALL_REMAINS)  //If one Malf decides to steal a mech from another AI (even other Malfs!), and they have no hacked APCs or core, they are destroyed
 					AI = null
@@ -195,7 +195,7 @@
 		if(!AI.linked_core)
 			to_chat(AI, span_userdanger("Inactive core destroyed. Unable to return."))
 			if(!AI.can_shunt || !AI.hacked_apcs.len)
-				to_chat(AI, span_warning(AI.can_shunt ? "No hacked APCs available." : "No shunting capabilities."))
+				to_chat(AI, span_warning("[AI.can_shunt ? "No hacked APCs available." : "No shunting capabilities."]"))
 				return FALSE
 			var/confirm = tgui_alert(AI, "Shunt to a random APC? You won't have anywhere else to go!", "Confirm Emergency Shunt", list("Yes", "No"))
 			if(confirm == "Yes")

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -56,5 +56,4 @@ map multiz_debug
 endmap
 
 map runtimestation
-default
 endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -56,4 +56,5 @@ map multiz_debug
 endmap
 
 map runtimestation
+default
 endmap


### PR DESCRIPTION
## About The Pull Request

I was trying to fix a bug with ejecting from mechs as malf AI and the more I looked the worse it seemed to get? So I'm putting in this PR with the intent to refactor AI code to not be a Byzantine nightmare of new objects referencing each other incompletely or with buggy behavior.
Finished PR for #82579 because I didn't want to clutter the comments with commits of me trying to fix shit with git restore and revert
## Why It's Good For The Game

Fixes #81877 
Fixes #82524
Mech dominating now just works off (and integrates with) similar code for APC shunting
The cores left behind by AIs shunting or controlling mechs now properly reference the AI instead of only the other way around
Some of these refactors slightly change how malf works; I think most of it was unintended behavior in the first place, let me know in review if not
## Changelog

The code for AIs remoting out of their shell has been refactored.
:cl:
fix: Mech domination now properly integrates with shunting.
fix: Combat upgraded AIs no longer get two buggy malf ability pickers if they also become malfunctioning
refactor: Refactored most of the functionality around malf AI shunting, mech control
/:cl:
