### PR TITLE
[NO GBP] Power outage operation fixes for chem master

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -514,6 +514,7 @@
 	//use power
 	if(!use_energy(active_power_usage))
 		is_printing = FALSE
+		update_appearance(UPDATE_OVERLAYS)
 		return
 
 	//print the stuff

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -400,7 +400,7 @@
 		return FALSE
 
 	//use energy
-	if(!use_energy(active_power_usage))
+	if(!use_energy(active_power_usage, force = FALSE))
 		return FALSE
 
 	//do the operation
@@ -512,7 +512,7 @@
 		return
 
 	//use power
-	if(!use_energy(active_power_usage))
+	if(!use_energy(active_power_usage, force = FALSE))
 		is_printing = FALSE
 		update_appearance(UPDATE_OVERLAYS)
 		return

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -513,6 +513,7 @@
 
 	//use power
 	if(!use_energy(active_power_usage))
+		is_printing = FALSE
 		return
 
 	//print the stuff


### PR DESCRIPTION
## About The Pull Request
- If the chem master runs out of power mid printing, it will properly stop the printing process and its animation
- When transferring reagents it correctly checks if we have enough power without forcing it

## Changelog
:cl:
fix: chem master properly shuts down if it loses power mid printing and won't transfer reagents for the same 
/:cl:
