### PR TITLE
[No GBP] Removes cogbar from some stealthy actions

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -276,8 +276,8 @@
 	source.log_message("had [item] put on them by [key_name(user)].", LOG_VICTIM, color="orange", log_globally=FALSE)
 
 /// A utility function for `/datum/strippable_item`s to start unequipping an item from a mob.
-/proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay)
-	if (!do_after(user, strip_delay || item.strip_delay, source, interaction_key = REF(item)))
+/proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay, hidden = FALSE)
+	if (!do_after(user, strip_delay || item.strip_delay, source, interaction_key = REF(item), hidden = hidden))
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -24,37 +24,43 @@
 /obj/structure/bed/nest/wrench_act_secondary(mob/living/user, obj/item/weapon)
 	return ITEM_INTERACT_BLOCKING
 
+
 /obj/structure/bed/nest/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)
-	if(has_buckled_mobs())
-		for(var/buck in buckled_mobs) //breaking a nest releases all the buckled mobs, because the nest isn't holding them down anymore
-			var/mob/living/M = buck
+	if(!has_buckled_mobs())
+		return
+		
+	var/mob/living/captive = buckled_mobs[1]
+	if(isnull(captive))
+		return
 
-			if(user.get_organ_by_type(/obj/item/organ/internal/alien/plasmavessel))
-				unbuckle_mob(M)
-				add_fingerprint(user)
-				return
+	if(user.get_organ_by_type(/obj/item/organ/internal/alien/plasmavessel))
+		unbuckle_mob(captive)
+		add_fingerprint(user)
+		return
 
-			if(M != user)
-				M.visible_message(span_notice("[user.name] pulls [M.name] free from the sticky nest!"),\
-					span_notice("[user.name] pulls you free from the gelatinous resin."),\
-					span_hear("You hear squelching..."))
-			else
-				M.visible_message(span_warning("[M.name] struggles to break free from the gelatinous resin!"),\
-					span_notice("You struggle to break free from the gelatinous resin... (Stay still for about a minute and a half.)"),\
-					span_hear("You hear squelching..."))
-				if(!do_after(M, 100 SECONDS, target = src))
-					if(M?.buckled)
-						to_chat(M, span_warning("You fail to unbuckle yourself!"))
-					return
-				if(!M.buckled)
-					return
-				M.visible_message(span_warning("[M.name] breaks free from the gelatinous resin!"),\
-					span_notice("You break free from the gelatinous resin!"),\
-					span_hear("You hear squelching..."))
+	if(captive != user)
+		captive.visible_message(span_notice("[user.name] pulls [captive.name] free from the sticky nest!"),
+			span_notice("[user.name] pulls you free from the gelatinous resin."),
+			span_hear("You hear squelching..."))
+		unbuckle_mob(captive)
+		add_fingerprint(user)
+		return
+	
+	captive.visible_message(span_warning("[captive.name] struggles to break free from the gelatinous resin!"),
+		span_notice("You struggle to break free from the gelatinous resin... (Stay still for about a minute and a half.)"),
+		span_hear("You hear squelching..."))
 
+	if(!do_after(captive, 100 SECONDS, target = src, hidden = TRUE))
+		if(captive.buckled)
+			to_chat(captive, span_warning("You fail to unbuckle yourself!"))
+		return
 
-			unbuckle_mob(M)
-			add_fingerprint(user)
+	captive.visible_message(span_warning("[captive.name] breaks free from the gelatinous resin!"),
+		span_notice("You break free from the gelatinous resin!"),
+		span_hear("You hear squelching..."))
+
+	unbuckle_mob(captive)
+	add_fingerprint(user)
 
 /obj/structure/bed/nest/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
 	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.incapacitated() || M.buckled )

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -25,25 +25,21 @@
 	return ITEM_INTERACT_BLOCKING
 
 
-/obj/structure/bed/nest/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)
-	if(!has_buckled_mobs())
-		return
-		
-	var/mob/living/captive = buckled_mobs[1]
-	if(isnull(captive))
+/obj/structure/bed/nest/user_unbuckle_mob(mob/living/captive, mob/living/hero)
+	if(!length(buckled_mobs))
 		return
 
-	if(user.get_organ_by_type(/obj/item/organ/internal/alien/plasmavessel))
+	if(hero.get_organ_by_type(/obj/item/organ/internal/alien/plasmavessel))
 		unbuckle_mob(captive)
-		add_fingerprint(user)
+		add_fingerprint(hero)
 		return
 
-	if(captive != user)
-		captive.visible_message(span_notice("[user.name] pulls [captive.name] free from the sticky nest!"),
-			span_notice("[user.name] pulls you free from the gelatinous resin."),
+	if(captive != hero)
+		captive.visible_message(span_notice("[hero.name] pulls [captive.name] free from the sticky nest!"),
+			span_notice("[hero.name] pulls you free from the gelatinous resin."),
 			span_hear("You hear squelching..."))
 		unbuckle_mob(captive)
-		add_fingerprint(user)
+		add_fingerprint(hero)
 		return
 	
 	captive.visible_message(span_warning("[captive.name] struggles to break free from the gelatinous resin!"),
@@ -60,7 +56,7 @@
 		span_hear("You hear squelching..."))
 
 	unbuckle_mob(captive)
-	add_fingerprint(user)
+	add_fingerprint(hero)
 
 /obj/structure/bed/nest/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
 	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.incapacitated() || M.buckled )

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -143,7 +143,7 @@
 		span_notice("You struggle to break free from [src], exacerbating your wounds! (Stay still for two minutes.)"),\
 		span_hear("You hear a wet squishing noise.."))
 		buckled_mob.adjustBruteLoss(30)
-		if(!do_after(buckled_mob, 2 MINUTES, target = src))
+		if(!do_after(buckled_mob, 2 MINUTES, target = src, hidden = TRUE))
 			if(buckled_mob?.buckled)
 				to_chat(buckled_mob, span_warning("You fail to free yourself!"))
 			return

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -174,8 +174,7 @@
 				adjust_laces(SHOES_UNTIED, user)
 
 	else // if they're someone else's shoes, go knot-wards
-		var/mob/living/L = user
-		if(istype(L) && L.body_position == STANDING_UP)
+		if(istype(living_user) && living_user.body_position == STANDING_UP)
 			to_chat(user, span_warning("You must be on the floor to interact with [src]!"))
 			return
 		if(tied == SHOES_KNOTTED)
@@ -190,7 +189,7 @@
 		if(HAS_TRAIT(user, TRAIT_CLUMSY)) // based clowns trained their whole lives for this
 			mod_time *= 0.75
 
-		if(do_after(user, mod_time, target = our_guy, extra_checks = CALLBACK(src, PROC_REF(still_shoed), our_guy)))
+		if(do_after(user, mod_time, target = our_guy, extra_checks = CALLBACK(src, PROC_REF(still_shoed), our_guy), hidden = TRUE))
 			to_chat(user, span_notice("You [tied ? "untie" : "knot"] the laces on [loc]'s [src.name]."))
 			if(tied == SHOES_UNTIED)
 				adjust_laces(SHOES_KNOTTED, user)
@@ -200,12 +199,12 @@
 			user.visible_message(span_danger("[our_guy] stamps on [user]'s hand, mid-shoelace [tied ? "knotting" : "untying"]!"), span_userdanger("Ow! [our_guy] stamps on your hand!"), list(our_guy))
 			to_chat(our_guy, span_userdanger("You stamp on [user]'s hand! What the- [user.p_they()] [user.p_were()] [tied ? "knotting" : "untying"] your shoelaces!"))
 			user.emote("scream")
-			if(istype(L))
-				var/obj/item/bodypart/ouchie = L.get_bodypart(pick(GLOB.arm_zones))
+			if(istype(living_user))
+				var/obj/item/bodypart/ouchie = living_user.get_bodypart(pick(GLOB.arm_zones))
 				if(ouchie)
 					ouchie.receive_damage(brute = 10)
-				L.adjustStaminaLoss(40)
-				L.Paralyze(10)
+				living_user.adjustStaminaLoss(40)
+				living_user.Paralyze(10)
 
 ///checking to make sure we're still on the person we're supposed to be, for lacing do_after's
 /obj/item/clothing/shoes/proc/still_shoed(mob/living/carbon/our_guy)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -276,34 +276,40 @@
 		cuff_resist(I)
 
 
-/mob/living/carbon/proc/cuff_resist(obj/item/I, breakouttime = 1 MINUTES, cuff_break = 0)
-	if((cuff_break != INSTANT_CUFFBREAK) && (SEND_SIGNAL(src, COMSIG_MOB_REMOVING_CUFFS, I) & COMSIG_MOB_BLOCK_CUFF_REMOVAL))
+/**
+ * Helper to break the cuffs from hands
+ * @param {obj/item} cuffs - The cuffs to break
+ * @param {number} breakouttime - The time it takes to break the cuffs. Use SECONDS/MINUTES defines
+ * @param {number} cuff_break - Speed multiplier, 0 is default, see _DEFINES\combat.dm
+ */
+/mob/living/carbon/proc/cuff_resist(obj/item/cuffs, breakouttime = 1 MINUTES, cuff_break = 0)
+	if((cuff_break != INSTANT_CUFFBREAK) && (SEND_SIGNAL(src, COMSIG_MOB_REMOVING_CUFFS, cuffs) & COMSIG_MOB_BLOCK_CUFF_REMOVAL))
 		return //The blocking object should sent a fluff-appropriate to_chat about cuff removal being blocked
-	if(I.item_flags & BEING_REMOVED)
-		to_chat(src, span_warning("You're already attempting to remove [I]!"))
+	if(cuffs.item_flags & BEING_REMOVED)
+		to_chat(src, span_warning("You're already attempting to remove [cuffs]!"))
 		return
-	I.item_flags |= BEING_REMOVED
-	breakouttime = I.breakouttime
+	cuffs.item_flags |= BEING_REMOVED
+	breakouttime = cuffs.breakouttime
 	if(!cuff_break)
-		visible_message(span_warning("[src] attempts to remove [I]!"))
-		to_chat(src, span_notice("You attempt to remove [I]... (This will take around [DisplayTimeText(breakouttime)] and you need to stand still.)"))
-		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM))
-			. = clear_cuffs(I, cuff_break)
+		visible_message(span_warning("[src] attempts to remove [cuffs]!"))
+		to_chat(src, span_notice("You attempt to remove [cuffs]... (This will take around [DisplayTimeText(breakouttime)] and you need to stand still.)"))
+		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM, hidden = TRUE))
+			. = clear_cuffs(cuffs, cuff_break)
 		else
-			to_chat(src, span_warning("You fail to remove [I]!"))
+			to_chat(src, span_warning("You fail to remove [cuffs]!"))
 
 	else if(cuff_break == FAST_CUFFBREAK)
-		breakouttime = 50
-		visible_message(span_warning("[src] is trying to break [I]!"))
-		to_chat(src, span_notice("You attempt to break [I]... (This will take around 5 seconds and you need to stand still.)"))
+		breakouttime = 5 SECONDS
+		visible_message(span_warning("[src] is trying to break [cuffs]!"))
+		to_chat(src, span_notice("You attempt to break [cuffs]... (This will take around 5 seconds and you need to stand still.)"))
 		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM))
-			. = clear_cuffs(I, cuff_break)
+			. = clear_cuffs(cuffs, cuff_break)
 		else
-			to_chat(src, span_warning("You fail to break [I]!"))
+			to_chat(src, span_warning("You fail to break [cuffs]!"))
 
 	else if(cuff_break == INSTANT_CUFFBREAK)
-		. = clear_cuffs(I, cuff_break)
-	I.item_flags &= ~BEING_REMOVED
+		. = clear_cuffs(cuffs, cuff_break)
+	cuffs.item_flags &= ~BEING_REMOVED
 
 /mob/living/carbon/proc/uncuff()
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -234,25 +234,34 @@
 			return TRUE
 	return FALSE
 
+
 /mob/living/carbon/resist_buckle()
-	if(HAS_TRAIT(src, TRAIT_RESTRAINED))
-		changeNext_move(CLICK_CD_BREAKOUT)
-		last_special = world.time + CLICK_CD_BREAKOUT
-		var/buckle_cd = 60 SECONDS
-		if(handcuffed)
-			var/obj/item/restraints/O = src.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-			buckle_cd = O.breakouttime
-		visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"), \
-					span_notice("You attempt to unbuckle yourself... (This will take around [round(buckle_cd/600,1)] minute\s, and you need to stay still.)"))
-		if(do_after(src, buckle_cd, target = src, timed_action_flags = IGNORE_HELD_ITEM))
-			if(!buckled)
-				return
-			buckled.user_unbuckle_mob(src,src)
-		else
-			if(src && buckled)
-				to_chat(src, span_warning("You fail to unbuckle yourself!"))
-	else
-		buckled.user_unbuckle_mob(src,src)
+	if(!HAS_TRAIT(src, TRAIT_RESTRAINED))
+		buckled.user_buckle_mob(src, src)
+		return
+
+	changeNext_move(CLICK_CD_BREAKOUT)
+	last_special = world.time + CLICK_CD_BREAKOUT
+	var/buckle_cd = 1 MINUTES
+
+	if(handcuffed)
+		var/obj/item/restraints/cuffs = src.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
+		buckle_cd = cuffs.breakouttime
+
+	visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"), 
+				span_notice("You attempt to unbuckle yourself... \
+				(This will take around [DisplayTimeText(buckle_cd)] and you must stay still.)"))
+
+	if(!do_after(src, buckle_cd, target = src, timed_action_flags = IGNORE_HELD_ITEM, hidden = TRUE))
+		if(buckled)
+			to_chat(src, span_warning("You fail to unbuckle yourself!"))
+		return
+	
+	if(QDELETED(src) || isnull(buckled))
+		return
+
+	buckled.user_unbuckle_mob(src, src)
+
 
 /mob/living/carbon/resist_fire()
 	return !!apply_status_effect(/datum/status_effect/stop_drop_roll)

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	source.log_message("is being pickpocketed of [item] by [key_name(user)] ([pocket_side])", LOG_VICTIM, color="orange", log_globally=FALSE)
 	item.add_fingerprint(src)
 
-	var/result = start_unequip_mob(item, source, user, POCKET_STRIP_DELAY)
+	var/result = start_unequip_mob(item, user, source, strip_delay = POCKET_STRIP_DELAY, hidden = TRUE)
 
 	if (!result)
 		warn_owner(source)

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	source.log_message("is being pickpocketed of [item] by [key_name(user)] ([pocket_side])", LOG_VICTIM, color="orange", log_globally=FALSE)
 	item.add_fingerprint(src)
 
-	var/result = start_unequip_mob(item, user, source, strip_delay = POCKET_STRIP_DELAY, hidden = TRUE)
+	var/result = start_unequip_mob(item, source, user, strip_delay = POCKET_STRIP_DELAY, hidden = TRUE)
 
 	if (!result)
 		warn_owner(source)


### PR DESCRIPTION
## About The Pull Request
Issue brought some missed hidden actions to my attention. 

I left cogbars in for _breaking_ handcuffs because resisting is sort of a gray area. On one hand, you don't want someone to see you doing it; on the other, there is a visible warning that you started doing it. So, meet in the the middle, breaking handcuffs is still visible while resisting isn't.
## Why It's Good For The Game
Closes #82583
Cogbars are not intended to ruin stealth
## Changelog
:cl:
fix: Deviants buffed: Rogue shoelacing, pickpocketing and restraint resisting no longer give cogbar icons.
/:cl:
