### PR TITLE
Fixes SS13.register_signal throwing unclear errors when called on deleted datums

### DIFF
--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -78,7 +78,7 @@ function SS13.await(thing_to_call, proc_to_call, ...)
 end
 
 function SS13.register_signal(datum, signal, func)
-	if not SS13.istype(datum, "/datum") then
+	if not SS13.istype(datum, "/datum") or not SS13.is_valid(datum) then
 		return
 	end
 	local datumWeakRef = dm.global_proc("WEAKREF", datum)

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -78,7 +78,11 @@ function SS13.await(thing_to_call, proc_to_call, ...)
 end
 
 function SS13.register_signal(datum, signal, func)
-	if not SS13.istype(datum, "/datum") or not SS13.is_valid(datum) then
+	if not SS13.istype(datum, "/datum") then
+		return
+	end
+	if not SS13.is_valid(datum) then
+		error("Tried to register a signal on a deleted datum!", 2)
 		return
 	end
 	local datumWeakRef = dm.global_proc("WEAKREF", datum)


### PR DESCRIPTION

## About The Pull Request
See title

## Why It's Good For The Game
More descriptive error message

## Changelog
:cl:
fix: LUA: Registering a signal on a deleted datum will throw a more descriptive error message.
/:cl:
