### PR TITLE
turns martial arts gloves into a component

### DIFF
--- a/code/datums/components/martial_art_giver.dm
+++ b/code/datums/components/martial_art_giver.dm
@@ -40,7 +40,6 @@
 	style.teach(source, TRUE)
 
 /datum/component/martial_art_giver/proc/forget(mob/source)
-	SIGNAL_HANDLER
 	if(isnull(style))
 		return
 	style.fully_remove(source)

--- a/code/datums/components/martial_art_giver.dm
+++ b/code/datums/components/martial_art_giver.dm
@@ -35,7 +35,6 @@
 	UnregisterSignal(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF))
 
 /datum/component/martial_art_giver/proc/teach(mob/source)
-	SIGNAL_HANDLER
 	if(isnull(style))
 		return
 	style.teach(source, TRUE)

--- a/code/datums/components/martial_art_giver.dm
+++ b/code/datums/components/martial_art_giver.dm
@@ -1,0 +1,47 @@
+/// when equipped and unequipped this item gives a martial art
+/datum/component/martial_art_giver
+	/// the style we give
+	var/datum/martial_art/style
+
+/datum/component/martial_art_giver/Initialize(style_type)
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	style = new style_type()
+	style.allow_temp_override = FALSE
+
+/datum/component/martial_art_giver/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(equipped))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(dropped))
+
+/datum/component/martial_art_giver/UnregisterFromParent(datum/source)
+	UnregisterSignal(parent, list(COMSIG_ITEM_POST_EQUIPPED, COMSIG_ITEM_POST_UNEQUIP))
+	var/obj/item/parent_item = parent
+	if(ismob(parent_item?.loc))
+		UnregisterSignal(parent, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF))
+	QDEL_NULL(style)
+
+/datum/component/martial_art_giver/proc/equipped(obj/item/source, mob/user, slot)
+	SIGNAL_HANDLER
+	if(!(source.slot_flags & slot))
+		return
+	RegisterSignals(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED), PROC_REF(teach))
+	RegisterSignal(user, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF, PROC_REF(forget))
+	teach(user)
+
+/datum/component/martial_art_giver/proc/dropped(obj/item/source, mob/user)
+	SIGNAL_HANDLER
+	forget(user)
+	UnregisterSignal(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF))
+
+/datum/component/martial_art_giver/proc/teach(mob/source)
+	SIGNAL_HANDLER
+	if(isnull(style))
+		return
+	style.teach(source, TRUE)
+
+/datum/component/martial_art_giver/proc/forget(mob/source)
+	SIGNAL_HANDLER
+	if(isnull(style))
+		return
+	style.fully_remove(source)

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -74,7 +74,6 @@
 	return ..()
 
 /obj/item/clothing/gloves/boxing
-	var/datum/martial_art/boxing/style
 
 /obj/item/clothing/gloves/boxing/Initialize(mapload)
 	. = ..()
@@ -85,18 +84,4 @@
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
-	style = new()
-	style.allow_temp_override = FALSE
-
-/obj/item/clothing/gloves/boxing/Destroy()
-	QDEL_NULL(style)
-	return ..()
-
-/obj/item/clothing/gloves/boxing/equipped(mob/user, slot)
-	. = ..()
-	if(slot & ITEM_SLOT_GLOVES)
-		style.teach(user, TRUE)
-
-/obj/item/clothing/gloves/boxing/dropped(mob/user)
-	. = ..()
-	style.fully_remove(user)
+	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/boxing)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -209,25 +209,10 @@
 
 /obj/item/clothing/gloves/krav_maga
 	clothing_traits = list(TRAIT_FAST_CUFFING)
-	var/datum/martial_art/krav_maga/style
 
 /obj/item/clothing/gloves/krav_maga/Initialize(mapload)
 	. = ..()
-	style = new()
-	style.allow_temp_override = FALSE
-
-/obj/item/clothing/gloves/krav_maga/Destroy()
-	QDEL_NULL(style)
-	return ..()
-
-/obj/item/clothing/gloves/krav_maga/equipped(mob/user, slot)
-	. = ..()
-	if(slot & ITEM_SLOT_GLOVES)
-		style.teach(user, TRUE)
-
-/obj/item/clothing/gloves/krav_maga/dropped(mob/user)
-	. = ..()
-	style.fully_remove(user)
+	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/krav_maga)
 
 /obj/item/clothing/gloves/krav_maga/sec//more obviously named, given to sec
 	name = "krav maga gloves"

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -333,40 +333,10 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
-	var/datum/martial_art/the_sleeping_carp/style
 
 /obj/item/clothing/gloves/the_sleeping_carp/Initialize(mapload)
 	. = ..()
-	style = new()
-	style.allow_temp_override = FALSE
-
-/obj/item/clothing/gloves/the_sleeping_carp/Destroy()
-	QDEL_NULL(style)
-	return ..()
-
-/obj/item/clothing/gloves/the_sleeping_carp/equipped(mob/user, slot)
-	. = ..()
-	if(slot & ITEM_SLOT_GLOVES)
-		RegisterSignals(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED), PROC_REF(teach_carp))
-		RegisterSignal(user, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF, PROC_REF(forget_carp))
-		teach_carp(user)
-
-/obj/item/clothing/gloves/the_sleeping_carp/dropped(mob/user)
-	. = ..()
-	UnregisterSignal(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF))
-	forget_carp(user)
-
-/obj/item/clothing/gloves/the_sleeping_carp/proc/teach_carp(mob/source)
-	SIGNAL_HANDLER
-	if(isnull(style))
-		return
-	style.teach(source, TRUE)
-
-/obj/item/clothing/gloves/the_sleeping_carp/proc/forget_carp(mob/source)
-	SIGNAL_HANDLER
-	if(isnull(style))
-		return
-	style.fully_remove(source)
+	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/the_sleeping_carp)
 
 #undef STRONG_PUNCH_COMBO
 #undef LAUNCH_KICK_COMBO

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -325,7 +325,7 @@
 
 /obj/item/clothing/gloves/the_sleeping_carp
 	name = "carp gloves"
-	desc = "This gloves are capable of making people use The Sleeping Carp."
+	desc = "These gloves are capable of making people use The Sleeping Carp."
 	icon_state = "black"
 	greyscale_colors = COLOR_BLACK
 	cold_protection = HANDS
@@ -347,12 +347,26 @@
 /obj/item/clothing/gloves/the_sleeping_carp/equipped(mob/user, slot)
 	. = ..()
 	if(slot & ITEM_SLOT_GLOVES)
-		style.teach(user, TRUE)
+		RegisterSignals(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED), PROC_REF(teach_carp))
+		RegisterSignal(user, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF, PROC_REF(forget_carp))
+		teach_carp(user)
 
 /obj/item/clothing/gloves/the_sleeping_carp/dropped(mob/user)
 	. = ..()
-	if(!isnull(style))
-		style.fully_remove(user)
+	UnregisterSignal(user, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED, COMSIG_MOB_MIND_TRANSFERRED_OUT_OF))
+	forget_carp(user)
+
+/obj/item/clothing/gloves/the_sleeping_carp/proc/teach_carp(mob/source)
+	SIGNAL_HANDLER
+	if(isnull(style))
+		return
+	style.teach(source, TRUE)
+
+/obj/item/clothing/gloves/the_sleeping_carp/proc/forget_carp(mob/source)
+	SIGNAL_HANDLER
+	if(isnull(style))
+		return
+	style.fully_remove(source)
 
 #undef STRONG_PUNCH_COMBO
 #undef LAUNCH_KICK_COMBO

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -490,22 +490,7 @@ If you make a derivative work from this code, you must include this notification
 
 /obj/item/storage/belt/champion/wrestling
 	name = "Wrestling Belt"
-	var/datum/martial_art/wrestling/style
 
 /obj/item/storage/belt/champion/wrestling/Initialize(mapload)
 	. = ..()
-	style = new()
-	style.allow_temp_override = FALSE
-
-/obj/item/storage/belt/champion/wrestling/Destroy()
-	QDEL_NULL(style)
-	return ..()
-
-/obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot)
-	. = ..()
-	if(slot & ITEM_SLOT_BELT)
-		style.teach(user, TRUE)
-
-/obj/item/storage/belt/champion/wrestling/dropped(mob/user)
-	. = ..()
-	style.fully_remove(user)
+	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/wrestling)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1124,6 +1124,7 @@
 #include "code\datums\components\manual_breathing.dm"
 #include "code\datums\components\manual_heart.dm"
 #include "code\datums\components\marionette.dm"
+#include "code\datums\components\martial_art_giver.dm"
 #include "code\datums\components\mind_linker.dm"
 #include "code\datums\components\mirv.dm"
 #include "code\datums\components\mob_chain.dm"


### PR DESCRIPTION

## About The Pull Request

sleeping carp gloves also work on mind init

this means for the sake of deathmatch you dont have to put them off and on

## Why It's Good For The Game

fixes #82321

## Changelog
:cl:
fix: you no longer need to put your sleeping carp gloves off and on in Deathmatch to get the martial art
/:cl:
