### PR TITLE
Removes avatar earpiece [no gbp]

### DIFF
--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -43,6 +43,7 @@
 	var/datum/outfit/to_wear = new outfit_path()
 
 	to_wear.belt = /obj/item/bitrunning_host_monitor
+	to_wear.ears = null
 	to_wear.glasses = null
 	to_wear.gloves = null
 	to_wear.l_pocket = null


### PR DESCRIPTION

## About The Pull Request
There's no comms in the digital plane anyway so this is only stopping them from exploiting binary comms
## Why It's Good For The Game
Exploit fix
Fixes #82604
## Changelog
:cl:
fix: Bit avatars no longer have access to free binary comms with the AI outfit
/:cl:
