### PR TITLE
[NO GBP] Fixes deconstruction of closets & crates under a special case

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -580,7 +580,11 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	else
 		return open(user)
 
-/obj/structure/closet/atom_deconstruct(disassembled = TRUE)
+/obj/structure/closet/handle_deconstruct(disassembled)
+	dump_contents()
+	if(obj_flags & NO_DEBRIS_AFTER_DECONSTRUCTION)
+		return
+
 	if(ispath(material_drop) && material_drop_amount)
 		new material_drop(loc, material_drop_amount)
 	if (secure)
@@ -592,7 +596,6 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			electronics.accesses = req_access
 	if(card_reader_installed)
 		new /obj/item/stock_parts/card_reader(drop_location())
-	dump_contents()
 
 /obj/structure/closet/atom_break(damage_flag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
So if a closet/crate has the `NO_DEBRIS_AFTER_DECONSTRUCTION` set on it and if someone/something is still inside, then after deconstruction they get deleted rather than getting dumped out first.

Could cause potential hard delete of mobs & stuff. We don't want to deal with that

## Changelog
:cl:
fix: closets & crates will dump all contents out first before deleting itself regardless of `NO_DEBRIS_AFTER_DECONSTRUCTION` thus not for e.g. hard deleting mobs inside it
/:cl:
