### PR TITLE
Oven tray checks for ovens

### DIFF
--- a/code/modules/food_and_drinks/machinery/oven.dm
+++ b/code/modules/food_and_drinks/machinery/oven.dm
@@ -101,9 +101,9 @@
 
 
 /obj/machinery/oven/attackby(obj/item/item, mob/user, params)
-	if(!open || used_tray || !item.atom_storage)
+	if(!open || used_tray || !istype(item, /obj/item/plate/oven_tray))
 		return ..()
-		
+
 	if(user.transferItemToLoc(item, src, silent = FALSE))
 		to_chat(user, span_notice("You put [item] in [src]."))
 		add_tray_to_oven(item, user)
@@ -253,7 +253,7 @@
 
 	if(isnull(item.atom_storage))
 		return
-	
+
 	if(is_right_clicking)
 		var/obj/item/storage/tray = item
 

--- a/code/modules/food_and_drinks/machinery/oven.dm
+++ b/code/modules/food_and_drinks/machinery/oven.dm
@@ -99,7 +99,6 @@
 	update_appearance()
 	use_energy(active_power_usage)
 
-
 /obj/machinery/oven/attackby(obj/item/item, mob/user, params)
 	if(!open || used_tray || !istype(item, /obj/item/plate/oven_tray))
 		return ..()


### PR DESCRIPTION
## About The Pull Request
- Fixes #82610

Only oven trays have this proc not serving trays or other stuff
![Screenshot (408)](https://github.com/tgstation/tgstation/assets/110812394/4867cc14-9df3-4398-9d2d-f8e38b5f0da9)

Also oven trays have a null atom storage which prevents it from being put back in the oven after taking it out. So we remove that check

## Changelog
:cl:
fix: you can put back the oven tray after you take it out
fix: only oven trays are allowed in ovens preventing baked food runtimes
/:cl:
