### PR TITLE
Operating computers clears its display procedures upon patient loss from table

### DIFF
--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -103,6 +103,7 @@
 
 	data["table"] = table
 	data["patient"] = list()
+	data["procedures"] = list()
 	if(!table.patient)
 		return data
 	var/mob/living/carbon/patient = table.patient
@@ -136,7 +137,6 @@
 	data["patient"]["fireLoss"] = patient.getFireLoss()
 	data["patient"]["toxLoss"] = patient.getToxLoss()
 	data["patient"]["oxyLoss"] = patient.getOxyLoss()
-	data["procedures"] = list()
 	if(patient.surgeries.len)
 		for(var/datum/surgery/procedure in patient.surgeries)
 			var/datum/surgery_step/surgery_step = procedure.get_surgery_step()
@@ -158,8 +158,6 @@
 				"alt_chems_needed" = alt_chems_needed
 			))
 	return data
-
-
 
 /obj/machinery/computer/operating/ui_act(action, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
- Fixes #82580

We have to update the ui data if the patient leaves the table

## Changelog
:cl:
fix: Operating computers clears its ui display procedures if patient is moved out of the operating table in any way
/:cl:
