### PR TITLE
Advanced camera consoles correctly deactivates when something happens to it or the user

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -588,12 +588,14 @@
 	set_panel_open(!panel_open)
 
 /obj/machinery/can_interact(mob/user)
+	if(QDELETED(user))
+		return FALSE
+
 	if((machine_stat & (NOPOWER|BROKEN)) && !(interaction_flags_machine & INTERACT_MACHINE_OFFLINE)) // Check if the machine is broken, and if we can still interact with it if so
 		return FALSE
 
 	if(SEND_SIGNAL(user, COMSIG_TRY_USE_MACHINE, src) & COMPONENT_CANT_USE_MACHINE_INTERACT)
 		return FALSE
-
 
 	if(isAdminGhostAI(user))
 		return TRUE //the Gods have unlimited power and do not care for things such as range or blindness

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -125,8 +125,6 @@
 /obj/machinery/computer/camera_advanced/on_set_is_operational(old_value)
 	if(!is_operational)
 		unset_machine(current_user)
-	else if(!QDELETED(current_user))
-		begin_processing()
 
 /obj/machinery/computer/camera_advanced/proc/unset_machine(mob/M)
 	if(M == current_user)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -4,6 +4,8 @@
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
 	light_color = COLOR_SOFT_RED
+	processing_flags = START_PROCESSING_MANUALLY
+
 	var/list/z_lock = list() // Lock use to these z levels
 	var/lock_override = NONE
 	var/mob/camera/ai_eye/remote/eyeobj
@@ -50,6 +52,20 @@
 	if(move_down_action)
 		actions += new move_down_action(src)
 
+/obj/machinery/computer/camera_advanced/Destroy()
+	if(!QDELETED(current_user))
+		unset_machine(current_user)
+	if(eyeobj)
+		QDEL_NULL(eyeobj)
+	QDEL_LIST(actions)
+	current_user = null
+	return ..()
+
+/obj/machinery/computer/camera_advanced/process()
+	if(!can_use(current_user) || (issilicon(current_user) && !current_user.has_unlimited_silicon_privilege))
+		unset_machine(current_user)
+		return PROCESS_KILL
+
 /obj/machinery/computer/camera_advanced/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	for(var/i in networks)
 		networks -= i
@@ -85,7 +101,7 @@
 	eyeobj.setLoc(eyeobj.loc)
 	if(should_supress_view_changes)
 		user.client.view_size.supress()
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_eye))
+	begin_processing()
 
 /obj/machinery/computer/camera_advanced/remove_eye_control(mob/living/user)
 	if(isnull(user?.client))
@@ -104,25 +120,18 @@
 	eyeobj.eye_user = null
 	user.remote_control = null
 	current_user = null
-	unset_machine(user)
 	playsound(src, 'sound/machines/terminal_off.ogg', 25, FALSE)
-	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 
-/obj/machinery/computer/camera_advanced/proc/check_eye(mob/user)
-	SIGNAL_HANDLER
-	if(!can_use(user) || (issilicon(user) && !user.has_unlimited_silicon_privilege))
-		unset_machine(user)
-
-/obj/machinery/computer/camera_advanced/Destroy()
-	if(eyeobj)
-		QDEL_NULL(eyeobj)
-	QDEL_LIST(actions)
-	current_user = null
-	return ..()
+/obj/machinery/computer/camera_advanced/on_set_is_operational(old_value)
+	if(!is_operational)
+		unset_machine(current_user)
+	else if(!QDELETED(current_user))
+		begin_processing()
 
 /obj/machinery/computer/camera_advanced/proc/unset_machine(mob/M)
 	if(M == current_user)
 		remove_eye_control(M)
+		end_processing()
 
 /obj/machinery/computer/camera_advanced/proc/can_use(mob/living/user)
 	return can_interact(user)


### PR DESCRIPTION
## About The Pull Request
- Fixes #82520

1. The eye deactivates when the machine is destroyed/deleted
2. The eye deactivates when the machine loses power
3. The computer constantly moniters the users status inside `process()` and will deactivate when anything happens to them. Its not enough to just hook onto to the mobs `COMSIG_MOVABLE_MOVED` signal. Literarly anything can happen to them so we have to check constantly for any changes

## Changelog
:cl:
fix: advanced camera consoles correctly deactivate when something happens(no proximity, no power etc) to its user
/:cl:

