### PR TITLE
Fixes to battle arcade

### DIFF
--- a/code/game/machinery/computer/arcade/battle_gear.dm
+++ b/code/game/machinery/computer/arcade/battle_gear.dm
@@ -2,7 +2,7 @@
 	///The name of the gear, used in shops.
 	var/name = "Gear"
 	///The slot this gear fits into
-	var/slot = WEAPON_SLOT
+	var/slot
 	///The world the player has to be at in order to buy this item.
 	var/world_available
 	///The stat given by the gear
@@ -95,7 +95,7 @@
 	bonus_modifier = 4
 
 /datum/battle_arcade_gear/tier_7/armor
-	name = "Celestial Armor"
+	name = "Ethereal Armor"
 	slot = ARMOR_SLOT
 	bonus_modifier = 4
 
@@ -103,11 +103,24 @@
 	world_available = BATTLE_WORLD_EIGHT
 
 /datum/battle_arcade_gear/tier_8/weapon
+	name = "Gungnir"
+	slot = WEAPON_SLOT
+	bonus_modifier = 4.5
+
+/datum/battle_arcade_gear/tier_8/armor
+	name = "Celestial Armor"
+	slot = ARMOR_SLOT
+	bonus_modifier = 4.5
+
+/datum/battle_arcade_gear/tier_9
+	world_available = BATTLE_WORLD_NINE
+
+/datum/battle_arcade_gear/tier_9/weapon
 	name = "Mjolnir"
 	slot = WEAPON_SLOT
 	bonus_modifier = 5
 
-/datum/battle_arcade_gear/tier_8/armor
-	name = "Ethereal Armor"
+/datum/battle_arcade_gear/tier_9/armor
+	name = "Void Armor"
 	slot = ARMOR_SLOT
 	bonus_modifier = 5


### PR DESCRIPTION
## About The Pull Request

Added gear for world nine, removed the "Gear" gear that did nothing.
Made counterattacks to kill an enemy properly kill the enemy.
I renamed some gear items to fit the theme of the area they are unlocked in just as a small thing.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/82613

## Changelog

:cl:
fix: Battle arcade's higher levels no longer gives you a "Gear" gear, and counterattacks can now properly kill enemies.
/:cl: