### PR TITLE
Fix buckled alert unbuckling not working properly

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -237,7 +237,7 @@
 
 /mob/living/carbon/resist_buckle()
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED))
-		buckled.user_buckle_mob(src, src)
+		buckled.user_unbuckle_mob(src, src)
 		return
 
 	changeNext_move(CLICK_CD_BREAKOUT)


### PR DESCRIPTION
## About The Pull Request

So funny thing, while trying to reproduce a different issue on the current master, I coincidentally let my local instance start without reading, latejoined on the shuttle, and I noticed it wasn't letting me unbuckle as easily.

Looking into this a bit later, it seems as if it's a line #82593 accidentally changed while moving around the `/mob/living/carbon/resist_buckle()` proc's flow.
https://github.com/tgstation/tgstation/blob/fe26373572e41415ec12e2b0785f0c6dc2567577/code/modules/mob/living/carbon/carbon.dm#L238-L241
While before it was
```dm
/mob/living/carbon/resist_buckle()
	if(HAS_TRAIT(src, TRAIT_RESTRAINED))
		(...)
	else
		buckled.user_unbuckle_mob(src,src)
```
Just changing this to `buckled.user_unbuckle_mob(src, src)` fixes this.
## Why It's Good For The Game

Fixes buckled alert unbuckling not working properly.
Fixes #82627.

## Changelog
:cl:
fix: Clicking the buckled alert unbuckles you again.
/:cl:
