### PR TITLE
Security photobooths have their own ID

### DIFF
--- a/code/game/machinery/photobooth.dm
+++ b/code/game/machinery/photobooth.dm
@@ -38,6 +38,7 @@
 	req_one_access = list(ACCESS_SECURITY)
 	color = COLOR_LIGHT_GRAYISH_RED
 	add_height_chart = TRUE
+	button_id = "photobooth_machine_security"
 
 /obj/machinery/photobooth/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Prevents the HoP's photobooth button from connecting to the security photobooth via having the same ID.

## Why It's Good For The Game

I forgot to add this when I made the security photobooth but it's important that by default without any varedits, the HoP and security photobooths stay separate.

## Changelog

:cl:
fix: The HoP's photobooth button is now consistently connected to the HoP's photobooth.
/:cl: