### PR TITLE
Human AI camera consoles can now be repackaged

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -334,3 +334,12 @@
 		to_chat(owner, span_notice("You move downwards."))
 	else
 		to_chat(owner, span_notice("You couldn't move downwards!"))
+
+/obj/machinery/computer/camera_advanced/human_ai/screwdriver_act(mob/living/user, obj/item/tool)
+	balloon_alert(user, "repackaging...")
+	if(!do_after(user, 5 SECONDS, src))
+		return TRUE
+	tool.play_tool_sound(src, 40)
+	new /obj/item/secure_camera_console_pod(get_turf(src))
+	qdel(src)
+	return TRUE

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -338,7 +338,7 @@
 /obj/machinery/computer/camera_advanced/human_ai/screwdriver_act(mob/living/user, obj/item/tool)
 	balloon_alert(user, "repackaging...")
 	if(!do_after(user, 5 SECONDS, src))
-		return TRUE
+		return ITEM_INTERACT_BLOCKING
 	tool.play_tool_sound(src, 40)
 	new /obj/item/secure_camera_console_pod(get_turf(src))
 	qdel(src)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -342,4 +342,4 @@
 	tool.play_tool_sound(src, 40)
 	new /obj/item/secure_camera_console_pod(get_turf(src))
 	qdel(src)
-	return TRUE
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -149,7 +149,7 @@
 
 /obj/item/secure_camera_console_pod
 	name = "advanced camera control pod"
-	desc = "Calls down a secure camera console to use for all your AI stuff, may only be activated in the SAT."
+	desc = "A pre-packaged camera console used for all your AI stuff, programmed to only active in the SAT."
 	icon = 'icons/obj/devices/remote.dmi'
 	icon_state = "botpad_controller"
 	inhand_icon_state = "radio"
@@ -163,9 +163,9 @@
 	if(!is_type_in_typecache(current_area, allowed_areas))
 		user.balloon_alert(user, "not in the sat!")
 		return
-	podspawn(list(
-		"target" = get_turf(src),
-		"style" = STYLE_BLUESPACE,
-		"spawn" = /obj/machinery/computer/camera_advanced,
-	))
+	user.balloon_alert(user, "unpacking...")
+	if(!do_after(user, 5 SECONDS, src))
+		return
+	playsound(src, 'sound/items/drill_use.ogg', 40, TRUE)
+	new /obj/machinery/computer/camera_advanced/human_ai(get_turf(src))
 	qdel(src)

--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -148,7 +148,7 @@
 	return ..()
 
 /obj/item/secure_camera_console_pod
-	name = "advanced camera control pod"
+	name = "pre-packaged advanced camera control"
 	desc = "A pre-packaged camera console used for all your AI stuff, programmed to only active in the SAT."
 	icon = 'icons/obj/devices/remote.dmi'
 	icon_state = "botpad_controller"


### PR DESCRIPTION
## About The Pull Request

Human AI's advanced camera console currently uses the base console which has no circuit, meaning it's impossible to unscrew it. Instead of giving it their own circuit, I thought it would be better to rework it into something that gets packed and unpacked, similar to the bible w/ Altar of the Gods.
I thought this would be the best way to handle it in case the human AI wants to move their board over, while still keeping that limit of remaining in the AI sat, and making it still make sense (if it was a board, there's no reason for it to NOT work outside of the SAT).

## Why It's Good For The Game

The advanced camera console can be moved without compromise on the intended restrictions.

## Changelog

:cl:
qol: The Human AI's advanced security console can be repackaged with a screwdriver if you wish to move it.
/:cl: