### PR TITLE
Reverts parts of #82602 (nodeath checks)

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/death(gibbed)
-	if(stat == DEAD || HAS_TRAIT(src, TRAIT_NODEATH) && !gibbed)
+	if(stat == DEAD)
 		return
 
 	losebreath = 0

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_EMPTY(dead_players_during_shift)
 		new /obj/effect/decal/remains/human(loc)
 
 /mob/living/carbon/human/death(gibbed)
-	if(stat == DEAD || HAS_TRAIT(src, TRAIT_NODEATH) && !gibbed)
+	if(stat == DEAD)
 		return
 	stop_sound_channel(CHANNEL_HEARTBEAT)
 	var/obj/item/organ/internal/heart/human_heart = get_organ_slot(ORGAN_SLOT_HEART)


### PR DESCRIPTION
## About The Pull Request

Reverts the nodeath checks of #82602

I opened a review thinking these checks were sus and the PR author said they would remove them, but it was merged before that happened. 

TL;DR 

1. I just noticed this now but it only affects carbons / humans it doesn't even cover living or any other subtypes
2. Kinda sus. Some code intentionally skips checking nodeath (I guess? Like removing the brain for example) so we would need a larger audit of this rather than haphazardly throwing it in. 