### PR TITLE
[READY] MASSIVE CRAYON BUFF (GAME-CHANGING) (MUST MERGE)

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -512,7 +512,7 @@
 	if(istagger)
 		wait_time *= 0.5
 
-	if(!instant && !do_after(user, wait_time, target = target))
+	if(!instant && !do_after(user, wait_time, target = target, max_interact_count = 4))
 		return
 
 	if(!use_charges(user, cost))


### PR DESCRIPTION
## About The Pull Request

You can now type up to 4 letters on a tile at once, one for each corner of the tile, an ability lost when max interactions was added.
![image](https://github.com/tgstation/tgstation/assets/53777086/9f9a2b80-5777-4490-acee-33e3df2d4c5a)

## Why It's Good For The Game

Currently if you're typing on the floor with a crayon, you either spend a million years going letter by letter, or do the alternative of typing every second letter to write on 3 tiles at once, and repeat, which is stupid that we even have to do that.

## Changelog

:cl:
qol: Crayons can now draw up to 4 letters at a time per tile.
/:cl: