### PR TITLE
Adds the proc we're overriding to RegisterSignals's override stacktrace

### DIFF
--- a/code/datums/signals.dm
+++ b/code/datums/signals.dm
@@ -38,7 +38,7 @@
 
 	if(exists)
 		if(!override)
-			var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]"
+			var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Existing Proc: [exists] New Proc: [proctype]"
 			log_signal(override_message)
 			stack_trace(override_message)
 		return


### PR DESCRIPTION

## About The Pull Request

We get it for quite literally free, no reason not to dump it. 
I always find myself checking in the debugger, which says something about what'll happen when I don't have that again.