### PR TITLE
[no gbp] Space Ruin bioscramblers shouldn't chase people around

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -29,22 +29,29 @@
 		nearby.bioscramble(name)
 
 /obj/effect/anomaly/bioscrambler/move_anomaly()
+	update_target()
+	if (isnull(pursuit_target))
+		return ..()
+	var/turf/step_turf = get_step(src, get_dir(src, pursuit_target.resolve()))
+	if (!HAS_TRAIT(step_turf, TRAIT_CONTAINMENT_FIELD))
+		Move(step_turf)
+
+/// Select a new target if we need one
+/obj/effect/anomaly/bioscrambler/proc/update_target()
 	var/mob/living/current_target = pursuit_target?.resolve()
 	if (QDELETED(current_target))
 		pursuit_target = null
-	if (isnull(pursuit_target) || prob(20))
-		var/mob/living/new_target = find_nearest_target()
-		if (isnull(new_target))
-			pursuit_target = null
-		else if (new_target != current_target)
-			current_target = new_target
-			pursuit_target = WEAKREF(new_target)
-			new_target.ominous_nosebleed()
-	if (isnull(pursuit_target))
+	if (!isnull(pursuit_target) && prob(80))
 		return
-	var/turf/step_turf = get_step(src, get_dir(src, current_target))
-	if (!HAS_TRAIT(step_turf, TRAIT_CONTAINMENT_FIELD))
-		Move(step_turf)
+	var/mob/living/new_target = find_nearest_target()
+	if (isnull(new_target))
+		pursuit_target = null
+		return
+	if (new_target == current_target)
+		return
+	current_target = new_target
+	pursuit_target = WEAKREF(new_target)
+	new_target.ominous_nosebleed()
 
 /// Returns the closest conscious carbon on our z level or null if there somehow isn't one
 /obj/effect/anomaly/bioscrambler/proc/find_nearest_target()
@@ -53,8 +60,8 @@
 	for(var/mob/living/carbon/target in GLOB.player_list)
 		if (target.z != z)
 			continue
-		if (target.status_effects & GODMODE)
-			continue	
+		if (target.status_flags & GODMODE)
+			continue
 		if (target.stat >= UNCONSCIOUS)
 			continue // Don't just haunt a corpse
 		var/distance_from_target = get_dist(src, target)
@@ -64,3 +71,9 @@
 		closest_target = target
 
 	return closest_target
+
+/// A bioscrambler anomaly subtype which does not pursue people, for purposes of a space ruin
+/obj/effect/anomaly/bioscrambler/docile
+
+/obj/effect/anomaly/bioscrambler/docile/update_target()
+	return

--- a/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
@@ -17,7 +17,7 @@
 		/obj/effect/anomaly/flux,
 		/obj/effect/anomaly/bluespace,
 		/obj/effect/anomaly/hallucination,
-		/obj/effect/anomaly/bioscrambler
+		/obj/effect/anomaly/bioscrambler/docile
 	)
 
 	///Do we anchor the anomaly? Set to true if you don't want anomalies drifting away (like if theyre in space or something)


### PR DESCRIPTION
## About The Pull Request

See title
They wouldn't lock on to people on the station from a space ruin, but would to whoever entered their z level the second it was entered.
Also fixes bug where I changed `status_flags` to `status_effects` for some reason which isn't where you look for godmode

## Why It's Good For The Game

We have a space ruin whcih several (coreless) anomalies spawn on, the bioscrambler was put as an option because it was already immortal. It's weird though to zone into the ruin and immediately have every anomaly in there lock onto you, the best intended effect is probably for these ones specifically not to be bloodthirsty.
We kind of only care about that behaviour on the station.

## Changelog

:cl:
fix: Anomalous Research ruin Bioscrambler anomalies won't home in on targets
fix: Bioscrambler won't randomly drop its target for no reason
/:cl:
