### PR TITLE
Quirks, which give items, now have quirk_item arg specified as obj/item, instead of being just a var

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -167,7 +167,7 @@
  * * default_location - If the item isn't possible to equip in a valid slot, this is a description of where the item was spawned.
  * * notify_player - If TRUE, adds strings to where_items_spawned list to be output to the player in [/datum/quirk/item_quirk/post_add()]
  */
-/datum/quirk/item_quirk/proc/give_item_to_holder(quirk_item, list/valid_slots, flavour_text = null, default_location = "at your feet", notify_player = TRUE)
+/datum/quirk/item_quirk/proc/give_item_to_holder(obj/item/quirk_item, list/valid_slots, flavour_text = null, default_location = "at your feet", notify_player = TRUE)
 	if(ispath(quirk_item))
 		quirk_item = new quirk_item(get_turf(quirk_holder))
 


### PR DESCRIPTION
## About The Pull Request
quirk_item is now /obj/item, since it will allow for calling procs or getting variables from this item

It's required for non-modular translation to call for item's name to remove articles

## Why It's Good For The Game
It's always an item, and if it's a path, it's already checked for it. Better usage in the future.