### PR TITLE
Fixes a critical spelling mistake

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -172,7 +172,7 @@
 		display = span_notice("The dogtag is all scratched up.")
 
 /obj/item/clothing/accessory/dogtag/borg_ready
-	name = "Pre-Approved Cyborg Cantidate dogtag"
+	name = "Pre-Approved Cyborg Candidate dogtag"
 	display = "This employee has been screened for negative mental traits to an acceptable level of accuracy, and is approved for the NT Cyborg program as an alternative to medical resuscitation."
 
 /// Reskins for the pride pin accessory, mapped by display name to icon state


### PR DESCRIPTION
## About The Pull Request

See title

## Why It's Good For The Game

Spell word good is good.

## Changelog
:cl:
spellcheck: Pre-Approved Cyborg Candidates are no longer "Cantidates"
/:cl:
