### PR TITLE
[nogbp] fixes minebots bombing each other

### DIFF
--- a/code/modules/mob/living/basic/minebots/minebot_abilities.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_abilities.dm
@@ -63,7 +63,10 @@
 	var/wind_up_timer = 1 SECONDS
 
 /datum/action/cooldown/mob_cooldown/missile_launcher/IsAvailable(feedback = TRUE)
-	if(is_mining_level(owner.z))
+	. = ..()
+	if(!.)
+		return FALSE
+	if(lavaland_equipment_pressure_check(get_turf(owner)))
 		return TRUE
 	if(feedback)
 		owner.balloon_alert(owner, "cant be used here!")
@@ -101,7 +104,10 @@
 	click_to_activate = FALSE
 
 /datum/action/cooldown/mob_cooldown/drop_landmine/IsAvailable(feedback = TRUE)
-	if(is_mining_level(owner.z))
+	. = ..()
+	if(!.)
+		return FALSE
+	if(lavaland_equipment_pressure_check(get_turf(owner)))
 		return TRUE
 	if(feedback)
 		owner.balloon_alert(owner, "cant be used here!")
@@ -175,5 +181,10 @@
 
 /obj/effect/mine/minebot/can_trigger(atom/movable/on_who)
 	if(REF(on_who) in ignore_list)
+		return FALSE
+	if(!isliving(on_who))
+		return ..()
+	var/mob/living/stepped_mob = on_who
+	if(FACTION_NEUTRAL in stepped_mob.faction)
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -15,10 +15,10 @@
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/simple_find_target,
+		/datum/ai_planning_subtree/launch_missiles,
 		/datum/ai_planning_subtree/pet_planning,
 		/datum/ai_planning_subtree/befriend_miners,
 		/datum/ai_planning_subtree/defend_node,
-		/datum/ai_planning_subtree/launch_missiles,
 		/datum/ai_planning_subtree/minebot_maintain_distance,
 		/datum/ai_planning_subtree/basic_ranged_attack_subtree/minebot,
 		/datum/ai_planning_subtree/find_and_hunt_target/hunt_ores/minebot,

--- a/code/modules/mob/living/basic/minebots/minebot_upgrades.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_upgrades.dm
@@ -78,7 +78,7 @@
 /obj/effect/overlay/minebot_top_shield
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
-	vis_flags = VIS_INHERIT_DIR
+	vis_flags = VIS_INHERIT_DIR | VIS_INHERIT_PLANE
 	icon = 'icons/mob/silicon/aibots.dmi'
 	icon_state = "minebot_shield_top_layer"
 	layer = ABOVE_ALL_MOB_LAYER
@@ -86,7 +86,7 @@
 /obj/effect/overlay/minebot_bottom_shield
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
-	vis_flags = VIS_INHERIT_DIR
+	vis_flags = VIS_INHERIT_DIR | VIS_INHERIT_PLANE
 	icon = 'icons/mob/silicon/aibots.dmi'
 	icon_state = "minebot_shield_bottom_layer"
 	layer = BELOW_MOB_LAYER


### PR DESCRIPTION
## About The Pull Request
minebots will no longer be able to explode each other through landmines. also fixes regenerative shield overlays appearing pitch black in lower z levels. 

## Why It's Good For The Game
fixes #82396

## Changelog
:cl:
fix: minebots no longer bomb each other (and other miners) through landmines
fix: minebot shields will no longer lose color in lower z levels
/:cl:
