### PR TITLE
Machinery Destroy() side effect clean up

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -65,6 +65,7 @@
 	AddElement(/datum/element/atmos_sensitive, mapload)
 
 /obj/machinery/door/window/Destroy()
+	set_density(FALSE)
 	electronics = null
 	air_update_turf(TRUE, FALSE)
 	return ..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -65,12 +65,8 @@
 	AddElement(/datum/element/atmos_sensitive, mapload)
 
 /obj/machinery/door/window/Destroy()
-	set_density(FALSE)
-	if(atom_integrity == 0)
-		playsound(src, SFX_SHATTER, 70, TRUE)
 	electronics = null
-	var/turf/floor = get_turf(src)
-	floor.air_update_turf(TRUE, FALSE)
+	air_update_turf(TRUE, FALSE)
 	return ..()
 
 /obj/machinery/door/window/update_icon_state()
@@ -300,10 +296,11 @@
 		if(BURN)
 			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
 
-
 /obj/machinery/door/window/on_deconstruction(disassembled)
 	if(disassembled)
 		return
+
+	playsound(src, SFX_SHATTER, 70, TRUE)
 
 	for(var/i in 1 to shards)
 		drop_debris(new /obj/item/shard(src))

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -14,10 +14,6 @@
 	. = ..()
 	wires = new /datum/wires/mass_driver(src)
 
-/obj/machinery/mass_driver/Destroy()
-	QDEL_NULL(wires)
-	. = ..()
-
 /obj/machinery/mass_driver/chapelgun
 	name = "holy driver"
 	id = MASSDRIVER_CHAPEL
@@ -35,6 +31,7 @@
 	for(var/obj/machinery/computer/pod/control as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/pod))
 		if(control.id == id)
 			control.connected = null
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/machinery/mass_driver/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -68,10 +68,18 @@
 			coinvalues["[cointype]"] = C.get_item_credit_value()
 			qdel(C) //Sigh
 
-/obj/machinery/computer/slot_machine/Destroy()
+/obj/machinery/computer/slot_machine/atom_break(damage_flag)
+	. = ..()
+	if(!.)
+		return
 	if(balance)
 		give_payout(balance)
-	return ..()
+
+/obj/machinery/computer/slot_machine/on_deconstruction(disassembled)
+	if(balance)
+		give_payout(balance)
+
+
 
 /obj/machinery/computer/slot_machine/process(seconds_per_tick)
 	. = ..() //Sanity checks.

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -68,18 +68,9 @@
 			coinvalues["[cointype]"] = C.get_item_credit_value()
 			qdel(C) //Sigh
 
-/obj/machinery/computer/slot_machine/atom_break(damage_flag)
-	. = ..()
-	if(!.)
-		return
-	if(balance)
-		give_payout(balance)
-
 /obj/machinery/computer/slot_machine/on_deconstruction(disassembled)
 	if(balance)
 		give_payout(balance)
-
-
 
 /obj/machinery/computer/slot_machine/process(seconds_per_tick)
 	. = ..() //Sanity checks.

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -22,9 +22,6 @@
 	. = ..()
 	AddElement(/datum/element/elevation, pixel_shift = 6)
 
-/obj/machinery/stasis/Destroy()
-	. = ..()
-
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()
 	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -22,7 +22,9 @@
 
 /obj/machinery/meter/Destroy()
 	SSair.stop_processing_machine(src)
-	target = null
+	if(!isnull(target))
+		UnregisterSignal(target, COMSIG_QDELETING)
+		target = null
 	return ..()
 
 /obj/machinery/meter/Initialize(mapload, new_piping_layer)
@@ -45,7 +47,13 @@
 			candidate = pipe
 	if(candidate)
 		target = candidate
+		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(drop_meter))
 		setAttachLayer(candidate.piping_layer)
+
+///Called when the parent pipe is removed
+/obj/machinery/meter/proc/drop_meter()
+	SIGNAL_HANDLER
+	deconstruct(FALSE)
 
 /obj/machinery/meter/proc/setAttachLayer(new_layer)
 	target_layer = new_layer
@@ -135,7 +143,8 @@
 	return TRUE
 
 /obj/machinery/meter/on_deconstruction(disassembled)
-	new /obj/item/pipe_meter(loc)
+	var/obj/item/pipe_meter/meter_object = new /obj/item/pipe_meter(get_turf(src))
+	transfer_fingerprints_to(meter_object)
 
 /obj/machinery/meter/interact(mob/user)
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -34,8 +34,7 @@
 	if(hide)
 		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 
-/obj/machinery/atmospherics/pipe/Destroy()
-	QDEL_NULL(parent)
+/obj/machinery/atmospherics/pipe/on_deconstruction(disassembled)
 
 	releaseAirToTurf()
 
@@ -46,6 +45,11 @@
 		var/obj/item/pipe_meter/meter_object = new (local_turf)
 		meter.transfer_fingerprints_to(meter_object)
 		qdel(meter)
+
+	return ..()
+
+/obj/machinery/atmospherics/pipe/Destroy()
+	QDEL_NULL(parent)
 	return ..()
 
 //-----------------

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -35,16 +35,7 @@
 		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 
 /obj/machinery/atmospherics/pipe/on_deconstruction(disassembled)
-
 	releaseAirToTurf()
-
-	var/turf/local_turf = loc
-	for(var/obj/machinery/meter/meter in local_turf)
-		if(meter.target != src)
-			continue
-		var/obj/item/pipe_meter/meter_object = new (local_turf)
-		meter.transfer_fingerprints_to(meter_object)
-		qdel(meter)
 
 	return ..()
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -46,13 +46,16 @@
 	AddElement(/datum/element/climbable, climb_time = 3 SECONDS, climb_stun = 3 SECONDS)
 	AddElement(/datum/element/elevation, pixel_shift = 8)
 
+/obj/machinery/portable_atmospherics/on_deconstruction(disassembled)
+	if(nob_crystal_inserted)
+		new /obj/item/hypernoblium_crystal(src)
+
+	return ..()
+
 /obj/machinery/portable_atmospherics/Destroy()
 	disconnect()
 	air_contents = null
 	SSair.stop_processing_machine(src)
-
-	if(nob_crystal_inserted)
-		new /obj/item/hypernoblium_crystal(src)
 
 	return ..()
 

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -12,7 +12,7 @@
 
 	volume = 1000
 
-/obj/machinery/portable_atmospherics/pump/Destroy()
+/obj/machinery/portable_atmospherics/pump/on_deconstruction(disassembled)
 	var/turf/local_turf = get_turf(src)
 	local_turf.assume_air(air_contents)
 	return ..()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -31,9 +31,9 @@
 		/datum/gas/halon,
 	)
 
-/obj/machinery/portable_atmospherics/scrubber/Destroy()
-	var/turf/T = get_turf(src)
-	T.assume_air(air_contents)
+/obj/machinery/portable_atmospherics/pump/on_deconstruction(disassembled)
+	var/turf/local_turf = get_turf(src)
+	local_turf.assume_air(air_contents)
 	return ..()
 
 /obj/machinery/portable_atmospherics/scrubber/update_icon_state()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -31,7 +31,7 @@
 		/datum/gas/halon,
 	)
 
-/obj/machinery/portable_atmospherics/pump/on_deconstruction(disassembled)
+/obj/machinery/portable_atmospherics/scrubber/on_deconstruction(disassembled)
 	var/turf/local_turf = get_turf(src)
 	local_turf.assume_air(air_contents)
 	return ..()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -98,7 +98,7 @@
 	var/obj/S = sheet_path
 	sheet_name = initial(S.name)
 
-/obj/machinery/power/port_gen/pacman/Destroy()
+/obj/machinery/power/port_gen/pacman/on_deconstruction(disassembled)
 	DropFuel()
 	return ..()
 

--- a/code/modules/vending/runic_vendor.dm
+++ b/code/modules/vending/runic_vendor.dm
@@ -60,8 +60,7 @@
 
 	return .
 
-
-/obj/machinery/vending/runic_vendor/Destroy()
+/obj/machinery/vending/runic_vendor/on_deconstruction(disassembled)
 	visible_message(span_warning("[src] flickers and disappears!"))
 	playsound(src,'sound/weapons/resonator_blast.ogg',25,TRUE)
 	return ..()

--- a/code/modules/vending/runic_vendor.dm
+++ b/code/modules/vending/runic_vendor.dm
@@ -9,6 +9,7 @@
 	vend_reply = "Please, stand still near the vending machine for your special package!"
 	resistance_flags = FIRE_PROOF
 	light_mask = "RunicVendor-light-mask"
+	obj_flags = parent_type::obj_flags | NO_DEBRIS_AFTER_DECONSTRUCTION
 	/// How long the vendor stays up before it decays.
 	var/time_to_decay = 30 SECONDS
 	/// Area around the vendor that will pushback nearby mobs.
@@ -60,14 +61,16 @@
 
 	return .
 
-/obj/machinery/vending/runic_vendor/on_deconstruction(disassembled)
+/obj/machinery/vending/runic_vendor/handle_deconstruct(disassembled)
+	SHOULD_NOT_OVERRIDE(TRUE)
+
 	visible_message(span_warning("[src] flickers and disappears!"))
 	playsound(src,'sound/weapons/resonator_blast.ogg',25,TRUE)
 	return ..()
 
 /obj/machinery/vending/runic_vendor/proc/runic_explosion()
 	explosion(src, light_impact_range = 2)
-	qdel(src)
+	deconstruct(FALSE)
 
 /obj/machinery/vending/runic_vendor/proc/runic_pulse()
 	var/pulse_locs = spiral_range_turfs(pulse_distance, get_turf(src))
@@ -81,10 +84,9 @@
 			mob_to_be_pulsed_back.throw_at(target, 4, 4)
 
 /obj/machinery/vending/runic_vendor/screwdriver_act(mob/living/user, obj/item/I)
-	explosion(src, light_impact_range = 2)
-	qdel(src)
+	runic_explosion()
 
 /obj/machinery/vending/runic_vendor/proc/decay()
-	qdel(src)
+	deconstruct(FALSE)
 
 #undef PULSE_DISTANCE_RANGE


### PR DESCRIPTION
## About The Pull Request

I have combed over implementations of `Destroy()` for `obj/machinery`, and noticed quite a few was spawning items or playing sounds.

**Slot machines**:
Moved payout to on_deconstruction()

**Windoors**:
Break sound moved to on_deconstruction().
I have also slightly cleaned up Destroy(), the windoor calls air_update_turf directly, as that proc already retrieves the turf it is on.
 
**Atmospheric pipe**:
Releases air and deconstructs meter objects on_deconstruction().

**Portable atmospheric devices**:
Drop hyper noblium crystal on on_destruction().

**Pump, Scrubbers**:
Releases air on_deconstruction().

**PACMAN power generator**:
Spawns dropped fuel on_deconstruction().

**Runic vendor**:
Moved vanishing effects to on_deconstruction().

I did not change Destroy side effects in the following instances:

-  side effects are critical for the round (e.g. doomsday device, nuke, blackbox recorder dropping the tape, gulag item reclaimer [less critical but still])
- might spawn messages and noises, but moving them to on_deconstruct would put linked items into an unusable state if deleted directly (e.g. express order console, cyborg lockdown console, tram paired sensors)
- would potentially delete mobs we don't want deleted (e.g. disposals, slime camera console)

Out of 220 Destroy defines, I found only 8 side effects that could not be moved to other procs, so `machinery\Destroy()` has almost always been used properly! I really hope `structure` will be as well made.

Other changes:

- Stasis beds had a completely empty destroy, removed
- Mass drivers had two destroy procs, merged

## Why It's Good For The Game

The Destroy() proc should only contain reference clean ups, barring edge cases that would harm playability.

## Changelog

Nothing player facing.
