### PR TITLE
fixes the strip menu being able to change locked sensors

### DIFF
--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	mob_source.update_body()
 
 /datum/strippable_item/mob_item_slot/jumpsuit/proc/do_adjust_sensor(atom/source, mob/user, obj/item/clothing/under/jumpsuit)
-	if(!jumpsuit.has_sensor)
+	if(jumpsuit.has_sensor != HAS_SENSORS)
 		return
 
 	var/static/list/sensor_mode_text_to_num = list(

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		return null
 
 	var/list/actions = list()
-	if(jumpsuit.has_sensor)
+	if(jumpsuit.has_sensor == HAS_SENSORS)
 		actions += "adjust_sensor"
 	if(jumpsuit.can_adjust)
 		actions += "adjust_jumpsuit"


### PR DESCRIPTION

## About The Pull Request

the strip menu sensor change doesn't check for sensors being locked (eg prisoner jumpsuit) so you can just have someone turn them off which isn't intentional i dont think

## Why It's Good For The Game

naked prisoner breakouts are good for the game

## Changelog
:cl:
fix: strip menu sensors change respects locked sensors
/:cl:
