### PR TITLE
Monkey eyes fix and noticable organ display refactor; AI monkeys no longer catatonic

### DIFF
--- a/code/__DEFINES/pronouns.dm
+++ b/code/__DEFINES/pronouns.dm
@@ -19,22 +19,22 @@
 
 /// A list for all the pronoun procs, if you need to iterate or search through it or something.
 #define ALL_PRONOUNS list( \
-"%PRONOUN_they" = "p_they", \
-"%PRONOUN_They" = "p_They", \
-"%PRONOUN_their" = "p_their", \
-"%PRONOUN_Their" = "p_Their", \
-"%PRONOUN_theirs" = "p_theirs", \
-"%PRONOUN_Theirs" = "p_Theirs", \
-"%PRONOUN_them" = "p_them", \
-"%PRONOUN_Them" = "p_Them", \
-"%PRONOUN_have" = "p_have", \
-"%PRONOUN_are" = "p_are", \
-"%PRONOUN_were" = "p_were", \
-"%PRONOUN_do" = "p_do", \
-"%PRONOUN_theyve" = "p_theyve", \
-"%PRONOUN_Theyve" = "p_Theyve", \
-"%PRONOUN_theyre" = "p_theyre", \
-"%PRONOUN_Theyre" = "p_Theyre", \
-"%PRONOUN_s" = "p_s", \
-"%PRONOUN_es" = "p_es" \
+"%PRONOUN_they" = TYPE_PROC_REF(/datum, p_they), \
+"%PRONOUN_They" = TYPE_PROC_REF(/datum, p_They), \
+"%PRONOUN_their" = TYPE_PROC_REF(/datum, p_their), \
+"%PRONOUN_Their" = TYPE_PROC_REF(/datum, p_Their), \
+"%PRONOUN_theirs" = TYPE_PROC_REF(/datum, p_theirs), \
+"%PRONOUN_Theirs" = TYPE_PROC_REF(/datum, p_Theirs), \
+"%PRONOUN_them" = TYPE_PROC_REF(/datum, p_them), \
+"%PRONOUN_Them" = TYPE_PROC_REF(/datum, p_Them), \
+"%PRONOUN_have" = TYPE_PROC_REF(/datum, p_have), \
+"%PRONOUN_are" = TYPE_PROC_REF(/datum, p_are), \
+"%PRONOUN_were" = TYPE_PROC_REF(/datum, p_were), \
+"%PRONOUN_do" = TYPE_PROC_REF(/datum, p_do), \
+"%PRONOUN_theyve" = TYPE_PROC_REF(/datum, p_theyve), \
+"%PRONOUN_Theyve" = TYPE_PROC_REF(/datum, p_Theyve), \
+"%PRONOUN_theyre" = TYPE_PROC_REF(/datum, p_theyre), \
+"%PRONOUN_Theyre" = TYPE_PROC_REF(/datum, p_Theyre), \
+"%PRONOUN_s" = TYPE_PROC_REF(/datum, p_s), \
+"%PRONOUN_es" = TYPE_PROC_REF(/datum, p_es) \
 )

--- a/code/__DEFINES/pronouns.dm
+++ b/code/__DEFINES/pronouns.dm
@@ -19,22 +19,22 @@
 
 /// A list for all the pronoun procs, if you need to iterate or search through it or something.
 #define ALL_PRONOUNS list( \
-"%PRONOUN_they" = TYPE_PROC_REF(/datum, p_they), \
-"%PRONOUN_They" = TYPE_PROC_REF(/datum, p_They), \
-"%PRONOUN_their" = TYPE_PROC_REF(/datum, p_their), \
-"%PRONOUN_Their" = TYPE_PROC_REF(/datum, p_Their), \
-"%PRONOUN_theirs" = TYPE_PROC_REF(/datum, p_theirs), \
-"%PRONOUN_Theirs" = TYPE_PROC_REF(/datum, p_Theirs), \
-"%PRONOUN_them" = TYPE_PROC_REF(/datum, p_them), \
-"%PRONOUN_Them" = TYPE_PROC_REF(/datum, p_Them), \
-"%PRONOUN_have" = TYPE_PROC_REF(/datum, p_have), \
-"%PRONOUN_are" = TYPE_PROC_REF(/datum, p_are), \
-"%PRONOUN_were" = TYPE_PROC_REF(/datum, p_were), \
-"%PRONOUN_do" = TYPE_PROC_REF(/datum, p_do), \
-"%PRONOUN_theyve" = TYPE_PROC_REF(/datum, p_theyve), \
-"%PRONOUN_Theyve" = TYPE_PROC_REF(/datum, p_Theyve), \
-"%PRONOUN_theyre" = TYPE_PROC_REF(/datum, p_theyre), \
-"%PRONOUN_Theyre" = TYPE_PROC_REF(/datum, p_Theyre), \
-"%PRONOUN_s" = TYPE_PROC_REF(/datum, p_s), \
-"%PRONOUN_es" = TYPE_PROC_REF(/datum, p_es) \
+	"%PRONOUN_they" = TYPE_PROC_REF(/datum, p_they), \
+	"%PRONOUN_They" = TYPE_PROC_REF(/datum, p_They), \
+	"%PRONOUN_their" = TYPE_PROC_REF(/datum, p_their), \
+	"%PRONOUN_Their" = TYPE_PROC_REF(/datum, p_Their), \
+	"%PRONOUN_theirs" = TYPE_PROC_REF(/datum, p_theirs), \
+	"%PRONOUN_Theirs" = TYPE_PROC_REF(/datum, p_Theirs), \
+	"%PRONOUN_them" = TYPE_PROC_REF(/datum, p_them), \
+	"%PRONOUN_Them" = TYPE_PROC_REF(/datum, p_Them), \
+	"%PRONOUN_have" = TYPE_PROC_REF(/datum, p_have), \
+	"%PRONOUN_are" = TYPE_PROC_REF(/datum, p_are), \
+	"%PRONOUN_were" = TYPE_PROC_REF(/datum, p_were), \
+	"%PRONOUN_do" = TYPE_PROC_REF(/datum, p_do), \
+	"%PRONOUN_theyve" = TYPE_PROC_REF(/datum, p_theyve), \
+	"%PRONOUN_Theyve" = TYPE_PROC_REF(/datum, p_Theyve), \
+	"%PRONOUN_theyre" = TYPE_PROC_REF(/datum, p_theyre), \
+	"%PRONOUN_Theyre" = TYPE_PROC_REF(/datum, p_Theyre), \
+	"%PRONOUN_s" = TYPE_PROC_REF(/datum, p_s), \
+	"%PRONOUN_es" = TYPE_PROC_REF(/datum, p_es) \
 )

--- a/code/__DEFINES/pronouns.dm
+++ b/code/__DEFINES/pronouns.dm
@@ -1,0 +1,40 @@
+/// she, he, they, it "%PRONOUN_they" = "p_they"
+/// She, He, They, It "%PRONOUN_They" = "p_They"
+/// her, his, their, its "%PRONOUN_their" = "p_their"
+/// Her, His, Their, Its "%PRONOUN_Their" = "p_Their"
+/// hers, his, theirs, its "%PRONOUN_theirs" = "p_theirs"
+/// Hers, His, Theirs, Its "%PRONOUN_Theirs" = "p_Theirs"
+/// her, him, them, it "%PRONOUN_them" = "p_them"
+/// Her, Him, Them, It "%PRONOUN_Them" = "p_Them"
+/// has, have "%PRONOUN_have" = "p_have"
+/// is, are "%PRONOUN_are" = "p_are"
+/// was, were "%PRONOUN_were" = "p_were"
+/// does, do "%PRONOUN_do" = "p_do"
+/// she has, he has, they have, it has "%PRONOUN_theyve" = "p_theyve"
+/// She has, He has, They have, It has "%PRONOUN_Theyve" = "p_Theyve"
+/// she is, he is, they are, it is "%PRONOUN_theyre" = "p_theyre"
+/// She is, He is, They are, It is "%PRONOUN_Theyre" = "p_Theyre"
+/// s, null (she looks, they look) "%PRONOUN_s" = "p_s"
+/// es, null (she goes, they go) "%PRONOUN_es" = "p_es"
+
+/// A list for all the pronoun procs, if you need to iterate or search through it or something.
+#define ALL_PRONOUNS list( \
+"%PRONOUN_they" = "p_they", \
+"%PRONOUN_They" = "p_They", \
+"%PRONOUN_their" = "p_their", \
+"%PRONOUN_Their" = "p_Their", \
+"%PRONOUN_theirs" = "p_theirs", \
+"%PRONOUN_Theirs" = "p_Theirs", \
+"%PRONOUN_them" = "p_them", \
+"%PRONOUN_Them" = "p_Them", \
+"%PRONOUN_have" = "p_have", \
+"%PRONOUN_are" = "p_are", \
+"%PRONOUN_were" = "p_were", \
+"%PRONOUN_do" = "p_do", \
+"%PRONOUN_theyve" = "p_theyve", \
+"%PRONOUN_Theyve" = "p_Theyve", \
+"%PRONOUN_theyre" = "p_theyre", \
+"%PRONOUN_Theyre" = "p_Theyre", \
+"%PRONOUN_s" = "p_s", \
+"%PRONOUN_es" = "p_es" \
+)

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -1,5 +1,12 @@
+#define GET_TARGET_PRONOUN(target, pronoun) call(target, ALL_PRONOUNS[pronoun])(null)
+#define GET_GENERIC_PRONOUN(pronoun) call(/datum/, ALL_PRONOUNS[pronoun])(null)
+/// Only call this in the context of REPLACE_PRONOUNS
+#define PRONOUN_REGEX regex("%PRONOUN(_(they|They|their|Their|theirs|Theirs|them|Them|have|are|were|do|theyve|Theyve|theyre|Theyre|s|es))")
+
+
 //pronoun procs, for getting pronouns without using the text macros that only work in certain positions
 //datums don't have gender, but most of their subtypes do!
+
 /datum/proc/p_they(temp_gender)
 	return "it"
 
@@ -68,6 +75,16 @@
 					return "es"
 				else
 					return "s"
+
+/// A proc to replace pronouns in a string with the appropriate pronouns for a target atom.
+/// Uses associative list access from a __DEFINE list, since associative access is slightly
+/// faster
+/datum/proc/REPLACE_PRONOUNS(target_string, target_atom = src)
+	var/regex/pronouns_to_sub = PRONOUN_REGEX
+	while(pronouns_to_sub.Find(target_string))
+		target_string = pronouns_to_sub.Replace(target_string, GET_TARGET_PRONOUN(target_atom, pronouns_to_sub.match))
+	return target_string
+
 
 //like clients, which do have gender.
 /client/p_they(temp_gender)

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -1,8 +1,4 @@
-#define GET_TARGET_PRONOUN(target, pronoun) call(target, ALL_PRONOUNS[pronoun])(null)
-#define GET_GENERIC_PRONOUN(pronoun) call(/datum/, ALL_PRONOUNS[pronoun])(null)
-/// Only call this in the context of REPLACE_PRONOUNS
-#define PRONOUN_REGEX regex("%PRONOUN(_(they|They|their|Their|theirs|Theirs|them|Them|have|are|were|do|theyve|Theyve|theyre|Theyre|s|es))")
-
+#define GET_TARGET_PRONOUN(target, pronoun, gender) call(target, ALL_PRONOUNS[pronoun])(gender)
 
 //pronoun procs, for getting pronouns without using the text macros that only work in certain positions
 //datums don't have gender, but most of their subtypes do!
@@ -79,10 +75,20 @@
 /// A proc to replace pronouns in a string with the appropriate pronouns for a target atom.
 /// Uses associative list access from a __DEFINE list, since associative access is slightly
 /// faster
-/datum/proc/REPLACE_PRONOUNS(target_string, target_atom = src)
-	var/regex/pronouns_to_sub = PRONOUN_REGEX
-	while(pronouns_to_sub.Find(target_string))
-		target_string = pronouns_to_sub.Replace(target_string, GET_TARGET_PRONOUN(target_atom, pronouns_to_sub.match))
+/datum/proc/REPLACE_PRONOUNS(target_string, atom/targeted_atom, targeted_gender = null)
+	/// If someone specifies targeted_gender we choose that,
+	/// otherwise we go off the gender of our object
+	var/gender
+	if(targeted_gender)
+		if(!istext(targeted_gender) || !(targeted_gender in list(MALE, FEMALE, PLURAL, NEUTER)))
+			stack_trace("REPLACE_PRONOUNS called with improper parameters.")
+			return
+		gender = targeted_gender
+	else
+		gender = targeted_atom.gender
+	var/regex/pronoun_regex = regex("%PRONOUN(_(they|They|their|Their|theirs|Theirs|them|Them|have|are|were|do|theyve|Theyve|theyre|Theyre|s|es))")
+	while(pronoun_regex.Find(target_string))
+		target_string = pronoun_regex.Replace(target_string, GET_TARGET_PRONOUN(targeted_atom, pronoun_regex.match, gender))
 	return target_string
 
 

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -45,7 +45,7 @@ have ways of interacting with a specific mob and control it.
 
 /datum/ai_controller/monkey/New(atom/new_pawn)
 	var/static/list/control_examine = list(
-		ORGAN_SLOT_EYES = span_monkey("eyes have a primal look in them."),
+		ORGAN_SLOT_EYES = span_monkey("%PRONOUN_They stare%PRONOUN_s around with wild, primal eyes."),
 	)
 	AddElement(/datum/element/ai_control_examine, control_examine)
 	return ..()

--- a/code/datums/elements/ai_control_examine.dm
+++ b/code/datums/elements/ai_control_examine.dm
@@ -50,8 +50,3 @@
 	var/examine_text = noticable_organ_examines[organ_slot]
 	var/body_zone = organ_slot != ORGAN_SLOT_BRAIN ? noticable_organ.zone : null
 	noticable_organ.AddElement(/datum/element/noticable_organ/ai_control, examine_text, body_zone)
-	/// The proc for actually enabling the examine is in the noticable_organ element
-	/// and only gets added on an implant signal; AI controllers don't get put on until
-	/// the body is set up during init, so they miss out on the initial signal; erego,
-	/// we give em this one.
-	SEND_SIGNAL(noticable_organ, COMSIG_ORGAN_IMPLANTED, human_pawn)

--- a/code/datums/elements/ai_control_examine.dm
+++ b/code/datums/elements/ai_control_examine.dm
@@ -46,7 +46,12 @@
 	if(noticable_organ_examines[possibly_noticable.slot])
 		make_organ_noticable(possibly_noticable.slot, possibly_noticable)
 
-/datum/element/ai_control_examine/proc/make_organ_noticable(organ_slot, obj/item/organ/noticable_organ)
+/datum/element/ai_control_examine/proc/make_organ_noticable(organ_slot, obj/item/organ/noticable_organ, mob/living/carbon/human/human_pawn)
 	var/examine_text = noticable_organ_examines[organ_slot]
 	var/body_zone = organ_slot != ORGAN_SLOT_BRAIN ? noticable_organ.zone : null
 	noticable_organ.AddElement(/datum/element/noticable_organ/ai_control, examine_text, body_zone)
+	/// The proc for actually enabling the examine is in the noticable_organ element
+	/// and only gets added on an implant signal; AI controllers don't get put on until
+	/// the body is set up during init, so they miss out on the initial signal; erego,
+	/// we give em this one.
+	SEND_SIGNAL(noticable_organ, COMSIG_ORGAN_IMPLANTED, human_pawn)

--- a/code/datums/elements/noticable_organ.dm
+++ b/code/datums/elements/noticable_organ.dm
@@ -12,7 +12,7 @@
 	/// Which body zone has to be exposed. If none is set, this is always noticable.
 	var/body_zone
 
-/datum/element/noticable_organ/Attach(datum/target, infused_desc, body_zone)
+/datum/element/noticable_organ/Attach(obj/item/organ/target, infused_desc, body_zone)
 	. = ..()
 
 	if(!isorgan(target))
@@ -21,8 +21,10 @@
 	src.infused_desc = infused_desc
 	src.body_zone = body_zone
 
-	RegisterSignal(target, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_implanted))
+	RegisterSignal(target, COMSIG_ORGAN_IMPLANTED, PROC_REF(enable_description))
 	RegisterSignal(target, COMSIG_ORGAN_REMOVED, PROC_REF(on_removed))
+	if(target.owner)
+		enable_description(target, target.owner)
 
 /datum/element/noticable_organ/Detach(obj/item/organ/target)
 	UnregisterSignal(target, list(COMSIG_ORGAN_IMPLANTED, COMSIG_ORGAN_REMOVED))
@@ -36,7 +38,7 @@
 		return FALSE
 	return TRUE
 
-/datum/element/noticable_organ/proc/on_implanted(obj/item/organ/target, mob/living/carbon/receiver)
+/datum/element/noticable_organ/proc/enable_description(obj/item/organ/target, mob/living/carbon/receiver)
 	SIGNAL_HANDLER
 
 	RegisterSignal(receiver, COMSIG_ATOM_EXAMINE, PROC_REF(on_receiver_examine))
@@ -52,10 +54,8 @@
 	if(!should_show_text(examined))
 		return
 
-	var/examine_text = infused_desc
-	/// Helper proc to iterate over whatever message and replace
-	/// pronouns where necessary
-	examine_text = REPLACE_PRONOUNS(examine_text, examined)
+	var/examine_text = 	REPLACE_PRONOUNS(infused_desc, examined)
+
 
 	examine_list += examine_text
 

--- a/code/datums/elements/noticable_organ.dm
+++ b/code/datums/elements/noticable_organ.dm
@@ -54,7 +54,7 @@
 	if(!should_show_text(examined))
 		return
 
-	var/examine_text = 	REPLACE_PRONOUNS(infused_desc, examined)
+	var/examine_text = REPLACE_PRONOUNS(infused_desc, examined)
 
 
 	examine_list += examine_text

--- a/code/datums/elements/noticable_organ.dm
+++ b/code/datums/elements/noticable_organ.dm
@@ -6,12 +6,10 @@
 /datum/element/noticable_organ
 	element_flags = ELEMENT_BESPOKE
 	argument_hash_start_idx = 2
-	/// whether we wrap the examine text in a notice span.
-	var/add_span = TRUE
-	/// "[they]|[their] [desc here]", shows on examining someone with an infused organ.
-	/// Uses a possessive pronoun (His/Her/Their) if a body zone is given, or a singular pronoun (He/She/They) otherwise.
+
+	///Shows on examining someone with an infused organ.
 	var/infused_desc
-	/// Which body zone has to be exposed. If none is set, this is always noticable, and the description pronoun becomes singular instead of possesive.
+	/// Which body zone has to be exposed. If none is set, this is always noticable.
 	var/body_zone
 
 /datum/element/noticable_organ/Attach(datum/target, infused_desc, body_zone)
@@ -53,16 +51,19 @@
 
 	if(!should_show_text(examined))
 		return
-	var/examine_text = replacetext(replacetext("[body_zone ? examined.p_Their() : examined.p_They()] [infused_desc]", "%PRONOUN_ES", examined.p_es()), "%PRONOUN_S", examined.p_s())
-	if(add_span)
-		examine_text = span_notice(examine_text)
+
+	var/examine_text = infused_desc
+	/// Helper proc to iterate over whatever message and replace
+	/// pronouns where necessary
+	examine_text = REPLACE_PRONOUNS(examine_text, examined)
+
 	examine_list += examine_text
 
 /**
  * Subtype of noticable organs for AI control, that will make a few more ai status checks before forking over the examine.
  */
 /datum/element/noticable_organ/ai_control
-	add_span = FALSE
+
 
 /datum/element/noticable_organ/ai_control/should_show_text(mob/living/carbon/examined)
 	. = ..()

--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -27,7 +27,7 @@
 
 /obj/item/organ/internal/lungs/carp/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "neck has odd gills.", BODY_ZONE_HEAD)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their neck has odd gills.", BODY_ZONE_HEAD)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/carp)
 	ADD_TRAIT(src, TRAIT_SPACEBREATHING, REF(src))
 
@@ -45,7 +45,7 @@
 
 /obj/item/organ/internal/tongue/carp/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "teeth are big and sharp.", BODY_ZONE_PRECISE_MOUTH)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their teeth are big and sharp.", BODY_ZONE_PRECISE_MOUTH)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/carp)
 
 /obj/item/organ/internal/tongue/carp/on_mob_insert(mob/living/carbon/tongue_owner, special, movement_flags)
@@ -113,7 +113,7 @@
 /obj/item/organ/internal/brain/carp/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/carp)
-	AddElement(/datum/element/noticable_organ, "seem%PRONOUN_S unable to stay still.")
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_They seem%PRONOUN_S unable to stay still.")
 
 /obj/item/organ/internal/brain/carp/on_mob_insert(mob/living/carbon/brain_owner)
 	. = ..()
@@ -151,7 +151,7 @@
 
 /obj/item/organ/internal/heart/carp/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "skin has small patches of scales growing on it.", BODY_ZONE_CHEST)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their skin has small patches of scales growing on it.", BODY_ZONE_CHEST)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/carp)
 
 #undef CARP_ORGAN_COLOR

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -31,7 +31,7 @@
 
 /obj/item/organ/internal/eyes/night_vision/goliath/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "eyes are blood red and stone-like.", BODY_ZONE_PRECISE_EYES)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their eyes are blood red and stone-like.", BODY_ZONE_PRECISE_EYES)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/goliath)
 
 ///goliath lungs! You can breathe lavaland air mix but can't breath pure O2 from a tank anymore.
@@ -46,7 +46,7 @@
 
 /obj/item/organ/internal/lungs/lavaland/goliath/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "back is covered in small tendrils.", BODY_ZONE_CHEST)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their back is covered in small tendrils.", BODY_ZONE_CHEST)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/goliath)
 
 ///goliath brain. you can't use gloves but one of your arms becomes a tendril hammer that can be used to mine!
@@ -63,7 +63,7 @@
 
 /obj/item/organ/internal/brain/goliath/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "arm is just a mass of plate and tendrils.", BODY_ZONE_CHEST)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their arm is just a mass of plate and tendrils.", BODY_ZONE_CHEST)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/goliath)
 
 /obj/item/organ/internal/brain/goliath/on_mob_insert(mob/living/carbon/brain_owner)
@@ -170,7 +170,7 @@
 
 /obj/item/organ/internal/heart/goliath/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "skin has visible hard plates growing from within.", BODY_ZONE_CHEST)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their skin has visible hard plates growing from within.", BODY_ZONE_CHEST)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/goliath)
 	AddElement(/datum/element/update_icon_blocker)
 

--- a/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
@@ -31,7 +31,7 @@ Fluoride Stare: After someone says 5 words, blah blah blah...
 /obj/item/organ/internal/heart/gondola/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/gondola)
-	AddElement(/datum/element/noticable_organ, "radiate%PRONOUN_S an aura of serenity.")
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_They radiate%PRONOUN_S an aura of serenity.")
 
 /obj/item/organ/internal/heart/gondola/Insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()
@@ -60,7 +60,7 @@ Fluoride Stare: After someone says 5 words, blah blah blah...
 
 /obj/item/organ/internal/tongue/gondola/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "mouth is permanently affixed into a relaxed smile.", BODY_ZONE_PRECISE_MOUTH)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their mouth is permanently affixed into a relaxed smile.", BODY_ZONE_PRECISE_MOUTH)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/gondola)
 
 /obj/item/organ/internal/tongue/gondola/Insert(mob/living/carbon/tongue_owner, special, movement_flags)
@@ -83,8 +83,8 @@ Fluoride Stare: After someone says 5 words, blah blah blah...
 /obj/item/organ/internal/liver/gondola/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/gondola)
-	AddElement(/datum/element/noticable_organ, "left arm has small needles breaching the skin all over it.", BODY_ZONE_L_ARM)
-	AddElement(/datum/element/noticable_organ, "right arm has small needles breaching the skin all over it.", BODY_ZONE_R_ARM)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their left arm has small needles breaching the skin all over it.", BODY_ZONE_L_ARM)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their right arm has small needles breaching the skin all over it.", BODY_ZONE_R_ARM)
 
 /obj/item/organ/internal/liver/gondola/Insert(mob/living/carbon/liver_owner, special, movement_flags)
 	. = ..()

--- a/code/game/machinery/dna_infuser/organ_sets/rat_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/rat_organs.dm
@@ -29,7 +29,7 @@
 
 /obj/item/organ/internal/eyes/night_vision/rat/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "eyes have deep, shifty black pupils, surrounded by a sickening yellow sclera.", BODY_ZONE_PRECISE_EYES)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their eyes have deep, shifty black pupils, surrounded by a sickening yellow sclera.", BODY_ZONE_PRECISE_EYES)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/rat)
 
 ///increases hunger, disgust recovers quicker, expands what is defined as "food"
@@ -47,7 +47,7 @@
 /obj/item/organ/internal/stomach/rat/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/rat)
-	AddElement(/datum/element/noticable_organ, "mouth is drooling excessively.", BODY_ZONE_PRECISE_MOUTH)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their mouth is drooling excessively.", BODY_ZONE_PRECISE_MOUTH)
 
 /// makes you smaller, walk over tables, and take 1.5x damage
 /obj/item/organ/internal/heart/rat
@@ -61,7 +61,7 @@
 /obj/item/organ/internal/heart/rat/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/rat)
-	AddElement(/datum/element/noticable_organ, "hunch%PRONOUN_ES over unnaturally!")
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_They hunch%PRONOUN_ES over unnaturally!")
 
 /obj/item/organ/internal/heart/rat/on_mob_insert(mob/living/carbon/receiver)
 	. = ..()
@@ -98,7 +98,7 @@
 
 /obj/item/organ/internal/tongue/rat/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "teeth are oddly shaped and yellowing.", BODY_ZONE_PRECISE_MOUTH)
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their teeth are oddly shaped and yellowing.", BODY_ZONE_PRECISE_MOUTH)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/rat)
 
 /obj/item/organ/internal/tongue/rat/modify_speech(datum/source, list/speech_args)

--- a/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
@@ -63,7 +63,7 @@
 
 /obj/item/organ/internal/heart/roach/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "has hardened, somewhat translucent skin.")
+	AddElement(/datum/element/noticable_organ, "%PRONOUN_They %PRONOUN_have hardened, somewhat translucent skin.")
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/roach)
 	roach_shell = new()
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -322,7 +322,8 @@
 				if(HAS_TRAIT(src, TRAIT_DUMB))
 					msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
 		if(get_organ_by_type(/obj/item/organ/internal/brain))
-			if(!key)
+			if (ai_controller)
+			else if(!key)
 				msg += "[span_deadsay("[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.")]\n"
 			else if(!client)
 				msg += "[span_deadsay("[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.")]\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -321,9 +321,8 @@
 			if(CONSCIOUS)
 				if(HAS_TRAIT(src, TRAIT_DUMB))
 					msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
-		if(get_organ_by_type(/obj/item/organ/internal/brain))
-			if (ai_controller)
-			else if(!key)
+		if(get_organ_by_type(/obj/item/organ/internal/brain) && isnull(ai_controller))
+			if(!key)
 				msg += "[span_deadsay("[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.")]\n"
 			else if(!client)
 				msg += "[span_deadsay("[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.")]\n"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -181,6 +181,7 @@
 #include "code\__DEFINES\procpath.dm"
 #include "code\__DEFINES\profile.dm"
 #include "code\__DEFINES\projectiles.dm"
+#include "code\__DEFINES\pronouns.dm"
 #include "code\__DEFINES\qdel.dm"
 #include "code\__DEFINES\quirks.dm"
 #include "code\__DEFINES\radiation.dm"


### PR DESCRIPTION

## About The Pull Request

It turns out monkeys being catatonic got broken 2 years ago in a PR that was meant to fix something else; also, it turns out monkeys are supposed to have primal eyes when turned into humans, and that got broken too. I fixed both of those things, and while I was at it I did a refactor to make it easier to give noticable organs (or anything else that you'd want correct pronoun and verb tenses) easier to implement.

1) AI controlled mobs now properly display their noticable organs when appropriate
2) Added some macros and a helper proc for replacing appropriate pronouns and verb tenses in text
3) The noticable organ HTML is no longer broken, so you can pass text with spans into it, if you want the text to be pretty or big or whatever
4) Monkeys are no longer catatonic if they have an active AI controller; this goes for any carbon actually but I think monkeys are the only one with AI controllers at the moment
## Why It's Good For The Game

Fixes the logic for displaying organs on AI controller mobs (currently monkeys)
Makes it easier to add these kind of organs for carbons, AI controlled or not, in the future

Look! An actual use-case for split editor:
![image](https://github.com/tgstation/tgstation/assets/49173900/8cd0d69e-8091-4431-9418-6bd29e1713b5)
## Changelog

Humanized monkeys now have their primal eyes again; monkeys with active AI are no longer catatonic.
:cl: Bisar
fix: AI controlled monkeys are no longer catatonic, and they have primal eyes again when turned into humans.
spellcheck: Noticable organs now have more modular grammar, and their current grammar is fixed.
refactor: Refactored the code for displaying the messages for noticable organs.
config: Added a documented define of all our pronouns
/:cl:
