### PR TITLE
Medipens cant be deepfried anymore

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/reagent_containers/condiment,
 	/obj/item/reagent_containers/cup,
 	/obj/item/reagent_containers/syringe,
+	/obj/item/reagent_containers/hypospray/medipen, //letting medipens become edible opens them to being injected/drained with IV drip & saltshakers
 )))
 
 /obj/machinery/deepfryer


### PR DESCRIPTION
## About The Pull Request

Saltshakers and IV drips have special checks that allows edible things through, and deepfrying medipens turns them edible, therefore opening the exploit that you can deepfry a medipen to drain and inject chemcials into it.
This sucks, and I don't want to get rid of this cool feature for everyone else, so I'm just gonna go the cheap way and blacklist medipens from being deepfried at all.
It's too much of a hassle and I don't want to have to constantly bug smash new ways to inject/drain from edible foods just so medipens can't be exploited as an instant piercing chem transfer.

## Why It's Good For The Game

Explained in the about me already, this is lame!

Closes https://github.com/tgstation/tgstation/issues/82631, closes https://github.com/tgstation/tgstation/issues/79178

## Changelog

:cl:
fix: Medipens can no longer be deepfried, closing an exploit that allowed people to drain/inject chems into it with saltshakers and IV drips.
/:cl: