### PR TITLE
fixes bots having all access

### DIFF
--- a/code/modules/mob/living/basic/bots/bot_ai.dm
+++ b/code/modules/mob/living/basic/bots/bot_ai.dm
@@ -34,6 +34,13 @@
 	if(. & AI_CONTROLLER_INCOMPATIBLE)
 		return
 	RegisterSignal(new_pawn, COMSIG_BOT_RESET, PROC_REF(reset_bot))
+	RegisterSignal(new_pawn, COMSIG_AI_BLACKBOARD_KEY_CLEARED(BB_BOT_SUMMON_TARGET), PROC_REF(clear_summon))
+
+/datum/ai_controller/basic_controller/bot/proc/clear_summon()
+	SIGNAL_HANDLER
+
+	var/mob/living/basic/bot/bot_pawn = pawn
+	bot_pawn.bot_reset()
 
 /datum/ai_controller/basic_controller/bot/able_to_run()
 	var/mob/living/basic/bot/bot_pawn = pawn

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -7,14 +7,13 @@
 	icon_state = "medibot0"
 	base_icon_state = "medibot"
 	density = FALSE
-	anchored = FALSE
 	health = 20
 	maxHealth = 20
 	speed = 2
 	light_power = 0.8
 	light_color = "#99ccff"
 	pass_flags = PASSMOB | PASSFLAPS
-	status_flags = CANSTUN
+	status_flags = (CANPUSH | CANSTUN)
 	ai_controller = /datum/ai_controller/basic_controller/bot/medbot
 
 	req_one_access = list(ACCESS_ROBOTICS, ACCESS_MEDICAL)


### PR DESCRIPTION
## About The Pull Request
a recent change to silicon access meant all bots, simple and basic had all access from roundstart

## Why It's Good For The Game
fixes bots having all access
Fixes https://github.com/tgstation/tgstation/issues/82671

## Changelog
:cl:
fix: basic bots no longer start with all access
/:cl:
