### PR TITLE
[no gbp] Loot panel subsystem initializes now

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -185,7 +185,6 @@
 #define INIT_ORDER_MINOR_MAPPING -40
 #define INIT_ORDER_PATH -50
 #define INIT_ORDER_EXPLOSIONS -69
-#define INIT_ORDER_LOOT -70
 #define INIT_ORDER_STATPANELS -97
 #define INIT_ORDER_BAN_CACHE -98
 #define INIT_ORDER_INIT_PROFILER -99 //Near the end, logs the costs of initialize

--- a/code/modules/lootpanel/ss_looting.dm
+++ b/code/modules/lootpanel/ss_looting.dm
@@ -10,6 +10,8 @@ SUBSYSTEM_DEF(looting)
 	/// Actively processing items
 	var/list/datum/lootpanel/processing = list()
 
+/datum/controller/subsystem/looting/Initialize()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/looting/stat_entry(msg)
 	msg = "P:[length(backlog)]"
@@ -32,7 +34,7 @@ SUBSYSTEM_DEF(looting)
 
 		if(!panel.process_images())
 			backlog += panel
-			
+
 		if(MC_TICK_CHECK)
 			return
 

--- a/code/modules/lootpanel/ss_looting.dm
+++ b/code/modules/lootpanel/ss_looting.dm
@@ -2,16 +2,15 @@
 /// Queues image generation for search objects without icons
 SUBSYSTEM_DEF(looting)
 	name = "Loot Icon Generation"
-	init_order = INIT_ORDER_LOOT
+	flags = SS_NO_INIT
 	priority = FIRE_PRIORITY_PROCESS
+	runlevels = RUNLEVEL_LOBBY|RUNLEVELS_DEFAULT
 	wait = 0.5 SECONDS
 	/// Backlog of items. Gets put into processing
 	var/list/datum/lootpanel/backlog = list()
 	/// Actively processing items
 	var/list/datum/lootpanel/processing = list()
 
-/datum/controller/subsystem/looting/Initialize()
-	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/looting/stat_entry(msg)
 	msg = "P:[length(backlog)]"


### PR DESCRIPTION

## About The Pull Request
Confusing error message at loading screen

![image](https://github.com/tgstation/tgstation/assets/42397676/850e5f97-f319-4f4d-b49a-ff90bb527aa8)
## Why It's Good For The Game
Less confusing
## Changelog
:cl:
fix: CentCom dispatched a team of interns to fix the loot panel's loading message. It should now load properly. It did before too, but now the message is fixed.
/:cl:
