### PR TITLE
Anomaly Releaser logging and fixes

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -21,8 +21,6 @@
 	var/drops_core = TRUE
 	///Do we keep on living forever?
 	var/immortal = FALSE
-	///Do we stay in one place?
-	var/immobile = FALSE
 	///Chance per second that we will move
 	var/move_chance = ANOMALY_MOVECHANCE
 
@@ -122,4 +120,5 @@
 	if(!has_core)
 		drops_core = FALSE
 		QDEL_NULL(aSignal)
-	immobile = anchor
+	if (anchor)
+		move_chance = 0

--- a/code/game/objects/effects/anomalies/anomalies_dimensional.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional.dm
@@ -4,7 +4,7 @@
 	icon_state = "dimensional"
 	aSignal = /obj/item/assembly/signaler/anomaly/dimensional
 	immortal = TRUE
-	immobile = TRUE
+	move_chance = 0
 	/// Range of effect, if left alone anomaly will convert a 2(range)+1 squared area.
 	var/range = 3
 	/// List of turfs this anomaly will try to transform before relocating

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -4,7 +4,7 @@
 	icon_state = "ectoplasm"
 	aSignal = /obj/item/assembly/signaler/anomaly/ectoplasm
 	lifespan = ANOMALY_COUNTDOWN_TIMER + 2 SECONDS //This one takes slightly longer, because it can run away.
-	immobile = TRUE //prevents it from moving around so ghosts can actually move it with decent accuracy
+	move_chance = 0 //prevents it from moving around so ghosts can actually move it with decent accuracy
 
 	///Blocks the anomaly from updating ghost count. Used in case an admin wants to rig the anomaly to be a certain size or intensity.
 	var/override_ghosts = FALSE

--- a/code/game/objects/items/devices/anomaly_releaser.dm
+++ b/code/game/objects/items/devices/anomaly_releaser.dm
@@ -28,6 +28,9 @@
 	if(!do_after(user, 3 SECONDS, target))
 		return
 
+	if(used)
+		return
+
 	var/obj/item/assembly/signaler/anomaly/core = target
 
 	if(!core.anomaly_type)
@@ -35,6 +38,7 @@
 
 	var/obj/effect/anomaly/anomaly = new core.anomaly_type(get_turf(core))
 	anomaly.stabilize()
+	log_combat(user, anomaly, "released", object = src, addition = "in [get_area(target)].")
 
 	if(infinite)
 		return


### PR DESCRIPTION
## About The Pull Request

I literally do not think I have heard of anyone using this extremely niche space ruin item a single time.
_**However**_ if they did it wasn't logged, so now it is.

Additionally I found a bunch of bugs while testing it:
- You could queue inputs on a bunch of cores and activate all of them at once because it didn't check if had been expended by a concurrent do_after.
- It made normally immobile anomalies mobile.
- I broke immobility in general in a recent PR, but also it's redundant with a different var I added.

I fixed all of these.

## Why It's Good For The Game

For the one round that will happen in tg history where someone reactivates a Vortex Anomaly Core on the escape shuttle, it should log who did it.

## Changelog

:cl:
admin: Reactivating an anomaly core via the anomaly releaser is now logged.
fix: Fixes various bugs related to dimensional/spectral anomalies moving when they should not.
/:cl:
