### PR TITLE
Makes the AI Controller subsystem use spatial grid instead of looping clients

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -307,6 +307,11 @@
 #define SSWARDROBE_STOCK 1
 #define SSWARDROBE_INSPECT 2
 
+// AI Controllers Subsystem subtasks
+#define SSAI_CONTROLLERS_ACTIVE 1
+#define SSAI_CONTROLLERS_IDLE 2
+#define SSAI_CONTROLLERS_DEIDLE 3
+
 // Wardrobe cache metadata indexes
 #define WARDROBE_CACHE_COUNT 1
 #define WARDROBE_CACHE_LAST_INSPECT 2

--- a/code/controllers/subsystem/ai_controllers.dm
+++ b/code/controllers/subsystem/ai_controllers.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(ai_controllers)
 	var/list/active_list = ai_controllers_by_status[AI_STATUS_ON]
 	var/list/inactive_list = ai_controllers_by_status[AI_STATUS_OFF]
 	var/list/idle_list = ai_controllers_by_status[AI_STATUS_IDLE]
-	msg = "Active AIs:[length(active_list)]/[round(cost_on,1)]%|Inactive:[length(inactive_list)]|Idle:[length(idle_list)]/[round(cost_idle,1)]%"
+	msg = "Active AIs:[length(active_list)]/[round(cost_on,1)]%|Inactive:[length(inactive_list)]|Idle:[length(idle_list)]/[round(cost_idle,1)]%|Idle Cost:[round(cost_to_idle,1)]%"
 	return ..()
 
 /datum/controller/subsystem/ai_controllers/fire(resumed)

--- a/code/controllers/subsystem/ai_controllers.dm
+++ b/code/controllers/subsystem/ai_controllers.dm
@@ -1,7 +1,7 @@
 /// The subsystem used to tick [/datum/ai_controllers] instances. Handling the re-checking of plans.
 SUBSYSTEM_DEF(ai_controllers)
 	name = "AI Controller Ticker"
-	flags = SS_POST_FIRE_TIMING
+	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
 	priority = FIRE_PRIORITY_NPC
 	init_order = INIT_ORDER_AI_CONTROLLERS
 	wait = 0.5 SECONDS //Plan every half second if required, not great not terrible.


### PR DESCRIPTION
## About The Pull Request

Makes the AI Controller subsystem use spatial grid instead of looping clients. I also applied some more of our usual subsystem speedup tech to the subsystem(breaking processing into parts, caching for faster list access, etc.) since we need to squeeze as much performance out of this as possible.

## Why It's Good For The Game

performance...good?

## Changelog
:cl:
fix: Makes the AI Controller subsystem use spatial grid instead of looping clients
/:cl:
