### PR TITLE
Add sanity check to spawnEvent()

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -84,8 +84,8 @@ SUBSYSTEM_DEF(events)
 		else
 			event_roster[event_to_check] = event_to_check.weight
 
-	var/datum/round_event_control/event_to_run = pick_weight(event_roster)
-	if(!isnull(event_to_run))
+	if(length(event_roster) > 0)
+		var/datum/round_event_control/event_to_run = pick_weight(event_roster)
 		TriggerEvent(event_to_run)
 
 ///Does the last pre-flight checks for the passed event, and runs it if the event is ready.

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -85,7 +85,8 @@ SUBSYSTEM_DEF(events)
 			event_roster[event_to_check] = event_to_check.weight
 
 	var/datum/round_event_control/event_to_run = pick_weight(event_roster)
-	TriggerEvent(event_to_run)
+	if(!isnull(event_to_run))
+		TriggerEvent(event_to_run)
 
 ///Does the last pre-flight checks for the passed event, and runs it if the event is ready.
 /datum/controller/subsystem/events/proc/TriggerEvent(datum/round_event_control/event_to_trigger)


### PR DESCRIPTION

## About The Pull Request

a 0-length event_roster leads to null being passed to TriggerEvent, which eventually causes a runtime.

Should I add logging for this as well?
