### PR TITLE
Dimensional anomalies are immobile again

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -78,7 +78,7 @@
 	return ..()
 
 /obj/effect/anomaly/proc/anomalyEffect(seconds_per_tick)
-	if(SPT_PROB(move_chance, seconds_per_tick))
+	if(!immobile && SPT_PROB(move_chance, seconds_per_tick))
 		move_anomaly()
 
 /// Move in a direction


### PR DESCRIPTION

## About The Pull Request

A check for the "immobile" arg in the anomaly move loop got dropped in #82555. This restores the check.

This means dimensional anomalies no longer wander around the place.
## Why It's Good For The Game

Dimensional anomalies should NOT be walking around.
## Changelog
:cl:
fix: immobile anomalies (like the dimensional anomaly) are now actually immobile.
/:cl:
