### PR TITLE
Gets rid of UNIT_TESTS compiler warning

### DIFF
--- a/code/modules/unit_tests/lootpanel.dm
+++ b/code/modules/unit_tests/lootpanel.dm
@@ -32,5 +32,4 @@
 	TEST_ASSERT_EQUAL(length(panel.contents), 2, "Panel shouldnt dupe searchables if reopened")
 
 	mock_client.mob = null
-	if(!isnull(new_box)) // this is effectively a do-nothing just so we can get the compiler to shut up, `allocate()` will ensure it gets qdel'd
-		new_box = null
+	pass(new_box)

--- a/code/modules/unit_tests/lootpanel.dm
+++ b/code/modules/unit_tests/lootpanel.dm
@@ -31,4 +31,5 @@
 	panel.populate_contents()
 	TEST_ASSERT_EQUAL(length(panel.contents), 2, "Panel shouldnt dupe searchables if reopened")
 
+	new_box = null // this is effectively a do-nothing just so we can get the compiler to shut up, `allocate()` will ensure it gets qdel'd
 	mock_client.mob = null

--- a/code/modules/unit_tests/lootpanel.dm
+++ b/code/modules/unit_tests/lootpanel.dm
@@ -21,7 +21,7 @@
 	TEST_ASSERT_EQUAL(length(panel.contents), 1, "Contents should update on searchobj deleted")
 	TEST_ASSERT_EQUAL(length(panel.to_image), 1, "to_image should update on searchobj deleted")
 
-	var/obj/item/storage/toolbox/new_box = allocate(/obj/item/storage/toolbox, one_over)
+	allocate(/obj/item/storage/toolbox, one_over)
 	TEST_ASSERT_EQUAL(length(panel.contents), 1, "Contents shouldn't update, we're dumb")
 	TEST_ASSERT_EQUAL(length(panel.to_image), 1, "to_image shouldn't update, we're dumb")
 
@@ -32,4 +32,4 @@
 	TEST_ASSERT_EQUAL(length(panel.contents), 2, "Panel shouldnt dupe searchables if reopened")
 
 	mock_client.mob = null
-	pass(new_box)
+

--- a/code/modules/unit_tests/lootpanel.dm
+++ b/code/modules/unit_tests/lootpanel.dm
@@ -31,5 +31,6 @@
 	panel.populate_contents()
 	TEST_ASSERT_EQUAL(length(panel.contents), 2, "Panel shouldnt dupe searchables if reopened")
 
-	new_box = null // this is effectively a do-nothing just so we can get the compiler to shut up, `allocate()` will ensure it gets qdel'd
 	mock_client.mob = null
+	if(!isnull(new_box)) // this is effectively a do-nothing just so we can get the compiler to shut up, `allocate()` will ensure it gets qdel'd
+		new_box = null


### PR DESCRIPTION
## About The Pull Request

Basically every single CI Run is throwing the following warning:
```txt
code/modules/unit_tests/lootpanel.dm:24:warning (unused_var): new_box: variable defined but not used
```

You may find an example here: https://github.com/tgstation/tgstation/actions/runs/8698627681/job/23855921813#step:9:24

This is pretty silly but I don't really know why we even have this variable (I assume there's something far more complicated underneath the surface based on what the unit test is asserting), but assuming it is important let's just insert a do-nothing procedure to get rid of the compiler warning while ensuring the unit test is actually operating as it should.

I also don't really like the fact that this is a warning instead of an error but let's tackle this problem one step at a time by at least getting rid of the compiler warning in a quick advance PR while I dwell on this issue (is there a way to get the Dreamchecker linter to look at the unit test files? it's caught perfectly fine in the langserver)

