### PR TITLE
Higher capacity SMES variant for low maintenance areas; miners can access their maintenance area on mining base, gulag no longer saps all power from the main base

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -755,7 +755,7 @@
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/listeningstation)
 "NO" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},

--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -357,7 +357,7 @@
 /area/ruin/space/has_grav/waystation/cargobay)
 "gE" = (
 /obj/structure/sign/poster/contraband/missing_gloves/directional/north,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -464,7 +464,7 @@
 /area/ruin/space)
 "iT" = (
 /obj/machinery/light/dim/directional/north,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/waystation/power)

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -24951,7 +24951,7 @@
 /area/station/ai_monitored/security/armory)
 "jBA" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/machinery/camera/directional/north{
 	c_tag = "AI Chamber - SMES";
 	network = list("aicore")
@@ -27020,7 +27020,7 @@
 /area/station/hallway/primary/central/fore)
 "kiQ" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/equipment)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -62743,7 +62743,7 @@
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "pKa" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "AI Chamber - Fore";

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16610,7 +16610,7 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/security)
 "eYH" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55922,7 +55922,7 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel/funeral)
 "tVC" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/flasher/directional/north{

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2832,7 +2832,7 @@
 /area/mine/laborcamp/production)
 "ps" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
@@ -3145,6 +3145,17 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"rr" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Mining External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lavaland_services_north"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/mine/maintenance/service)
 "rv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark/smooth_edge{
@@ -3418,7 +3429,7 @@
 	name = "Mining Station Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "ti" = (
@@ -3671,7 +3682,7 @@
 	name = "Mining Station Maintenance"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "vd" = (
@@ -4110,7 +4121,7 @@
 	name = "Mining Station Maintenance"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/mine/maintenance/service/comms)
 "xJ" = (
@@ -4962,7 +4973,7 @@
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "Ee" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
@@ -7121,6 +7132,17 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"Rx" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining External Airlock"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lavaland_services_north"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/mine/maintenance/service)
 "RB" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -7476,7 +7498,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "TW" = (
@@ -7979,6 +8001,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /turf/open/floor/plating,
 /area/mine/storage)
+"Xb" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/toy/plush/shark{
+	desc = "A plushie depicting a somewhat cartoonish shark. The tag calls it a 'hákarl', noting that it was made by an obscure furniture manufacturer in old Scandinavia. This one seems to have some cable wiring sticking out of its mouth."
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Xd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -29775,7 +29806,7 @@ Xw
 aj
 aj
 aj
-cU
+Xb
 aj
 aj
 aj
@@ -38994,7 +39025,7 @@ pU
 Dx
 cm
 FL
-cm
+Rx
 Ao
 Ao
 aW
@@ -39251,7 +39282,7 @@ pU
 aD
 cV
 fi
-cV
+rr
 Jh
 cr
 JS

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -12179,7 +12179,7 @@
 /obj/machinery/camera/motion/directional/north{
 	c_tag = "Minisat North"
 	},
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/service)
@@ -61910,7 +61910,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "pUB" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/service)
@@ -79799,7 +79799,7 @@
 /area/station/maintenance/solars/starboard/fore)
 "uDR" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -22971,7 +22971,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "hhf" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1935,7 +1935,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/armory)
 "tP" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/electric_shock/directional/north,

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -753,7 +753,7 @@
 	},
 /area/shuttle/ruin/caravan/pirate)
 "We" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -376,7 +376,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/ruin/caravan/syndicate3)
 "Oe" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -349,6 +349,9 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/techfab/department/engineering
 
+/obj/item/circuitboard/machine/smes/super
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/super/empty)
+
 /obj/item/circuitboard/machine/thermomachine
 	name = "Thermomachine"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -437,6 +437,16 @@
 	update_appearance()
 	log_smes()
 
+// Variant of SMES that starts with super power cells for higher longevity
+/obj/machinery/power/smes/super
+	name = "super capacity power storage unit"
+	desc = "A super-capacity superconducting magnetic energy storage (SMES) unit. Relatively rare, and typically installed in long-range outposts where minimal maintenance is expected."
+	circuit = /obj/item/circuitboard/machine/smes/super
+	capacity = 100 * STANDARD_CELL_CHARGE
+
+/obj/machinery/power/smes/super/full
+	charge = 100 * STANDARD_CELL_CHARGE
+
 /obj/machinery/power/smes/full
 	charge = 50 * STANDARD_CELL_CHARGE
 


### PR DESCRIPTION

## About The Pull Request

Creates a higher capacity version of the SMES unit that spawns in with super capacity cells, as well as a full version. Places the full version into all the AI sats (which all have independent grids for the most part), some remote space ruins and the mining base. These SMES units are intended for areas where players aren't expected or cannot reasonably be expected to constantly monitor power usage within the length of a standard round.

Miners can access their power stations, telecommunications box and atmospheric station on the mining base. They're really the only people who care, after all.

The gulag's SMES (also now upgraded) no longer saps power from the main base due to having its input terminal rigged to the main base power grid, and thus demanding all power from the grid greedily. To revert this in-game is a single power cable placed back east of the SMES unit.

## Why It's Good For The Game

The power changes made some of the once largely low-maintenance areas much more likely to run out of power more quickly than you would expect. These aren't areas expected to be maintained or monitored by engineering (probably because they're not easily accessed), and they're just kind of troublesome to deal with on a round-to-round basis.

Mining had this problem triple-fold. It had significant drain with no convenient method of installing power generation at all, miners couldn't access what power generation there was without using their 'skeleton key' to open the way (only engineers could, and they aren't expected to come down to mining at all), and even then, there was the gulag SMES just eating all the power anyway. I'm pretty sure that SMES unit was the biggest culprit of them all, but I think this conveniently future proofs these issues for the time being.

## Changelog
:cl:
add: Adds a higher capacity SMES unit to lower maintenance areas and maps.
fix: Miners can actually access and fix their engineering issues on the lavaland base via the engineering section of the base.
fix: The gulag SMES unit is no longer needlessly draining the entire power grid of the main mining base.
/:cl:
