### PR TITLE
Admin Forced Mob Rename and Preference Update

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -136,6 +136,7 @@
 
 // /mob/living
 #define VV_HK_GIVE_SPEECH_IMPEDIMENT "impede_speech"
+#define VV_HK_ADMIN_RENAME "admin_rename"
 #define VV_HK_ADD_MOOD "addmood"
 #define VV_HK_REMOVE_MOOD "removemood"
 #define VV_HK_GIVE_HALLUCINATION "give_hallucination"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1979,7 +1979,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			return
 
 		fully_replace_character_name(real_name, new_name)
-		var/replace_preferences = !!client && (tgui_alert(usr, "Would you like to update the client's preference with the new name?", "Pref Overwrite", list("Yes", "No")) == "Yes")
+		var/replace_preferences = !isnull(client) && (tgui_alert(usr, "Would you like to update the client's preference with the new name?", "Pref Overwrite", list("Yes", "No")) == "Yes")
 		if(replace_preferences)
 			client.prefs.write_preference(GLOB.preference_entries[/datum/preference/name/real_name], new_name)
 


### PR DESCRIPTION
## About The Pull Request

Admins can now rename a mob using the drop down menu.
If the mob has a client attached they can also overwrite their preferences.
## Why It's Good For The Game

Better admin tooling for bad player names.
Was also requested by @Mothblocks 

## Changelog

:cl:
admin: New dropdown to force change a mob's name and the attached client's preferences.
/:cl:
