### PR TITLE
Adds text to lootpanel items [no gbp]

### DIFF
--- a/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
@@ -10,15 +10,23 @@ export function IconDisplay(props: Props) {
     item: { icon, icon_state },
   } = props;
 
-  const fallback = <Icon name="spinner" size={2.4} spin color="gray" />;
+  const fallback = <Icon name="spinner" size={2.2} spin color="gray" />;
 
   if (!icon) {
     return fallback;
   }
 
   if (icon_state) {
-    return <DmIcon fallback={fallback} icon={icon} icon_state={icon_state} />;
+    return (
+      <DmIcon
+        fallback={fallback}
+        icon={icon}
+        icon_state={icon_state}
+        height={3}
+        width={3}
+      />
+    );
   }
 
-  return <Image fixErrors src={icon} />;
+  return <Image fixErrors src={icon} height={3} width={3} />;
 }

--- a/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
@@ -1,4 +1,4 @@
-import { capitalizeAll } from 'common/string';
+import { capitalizeAll, capitalizeFirst } from 'common/string';
 
 import { useBackend } from '../../backend';
 import { Tooltip } from '../../components';
@@ -25,28 +25,35 @@ export function LootBox(props: Props) {
     item = props.item;
   }
 
+  const name = !item.name
+    ? '???'
+    : capitalizeFirst(item.name.split(' ')[0]).slice(0, 5);
+
   return (
     <Tooltip content={capitalizeAll(item.name)}>
-      <div
-        className="SearchItem"
-        onClick={(event) =>
-          act('grab', {
-            ctrl: event.ctrlKey,
-            ref: item.ref,
-            shift: event.shiftKey,
-          })
-        }
-        onContextMenu={(event) => {
-          event.preventDefault();
-          act('grab', {
-            middle: true,
-            ref: item.ref,
-            shift: true,
-          });
-        }}
-      >
-        <IconDisplay item={item} />
-        {amount > 1 && <div className="SearchItem--amount">{amount}</div>}
+      <div className="SearchItem">
+        <div
+          className="SearchItem--box"
+          onClick={(event) =>
+            act('grab', {
+              ctrl: event.ctrlKey,
+              ref: item.ref,
+              shift: event.shiftKey,
+            })
+          }
+          onContextMenu={(event) => {
+            event.preventDefault();
+            act('grab', {
+              middle: true,
+              ref: item.ref,
+              shift: true,
+            });
+          }}
+        >
+          <IconDisplay item={item} />
+          {amount > 1 && <div className="SearchItem--amount">{amount}</div>}
+        </div>
+        <span className="SearchItem--text">{name}</span>
       </div>
     </Tooltip>
   );

--- a/tgui/packages/tgui/interfaces/LootPanel/index.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/index.tsx
@@ -24,7 +24,7 @@ export function LootPanel(props) {
   const total = contents.length ? contents.length - 1 : 0;
 
   return (
-    <Window height={250} width={190} title={`Contents: ${total}`}>
+    <Window height={275} width={190} title={`Contents: ${total}`}>
       <Window.Content
         onKeyDown={(event) => {
           if (event.key === KEY.Escape) {

--- a/tgui/packages/tgui/styles/components/SearchItem.scss
+++ b/tgui/packages/tgui/styles/components/SearchItem.scss
@@ -2,21 +2,34 @@
 
 .SearchItem {
   align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.SearchItem--box {
   background: black;
   border: thin solid #212121;
   display: flex;
-  height: 3rem;
+  align-items: center;
   justify-content: center;
+  height: 3rem;
   position: relative;
   width: 3rem;
-  margin-bottom: 0;
 }
 
 .SearchItem--amount {
-  bottom: -1rem;
+  bottom: -4px;
   color: colors.$teal;
   font-family: 'Roboto', sans-serif;
   font-size: 1.5rem;
   position: absolute;
-  right: -4px;
+  right: -6px;
+}
+
+.SearchItem--text {
+  color: colors.$label;
+  font-family: 'Roboto', sans-serif;
+  font-size: 1rem;
+  z-index: 1;
 }


### PR DESCRIPTION

## About The Pull Request
Just some qol, this captures a small portion of the item name and fixes some icon clipping issues

I clipped it at 5 because monke
![Screenshot 2024-04-17 034211](https://github.com/tgstation/tgstation/assets/42397676/64d9ce18-3722-4382-a58d-f58eb6b9f26c)

![gXR2XjslzR](https://github.com/tgstation/tgstation/assets/42397676/3fc93110-e35e-434a-b63b-89aa669090e7)
## Why It's Good For The Game
Handy if youre in a rush and won't upgrade byond to fix the issue
## Changelog
:cl:
fix: Lootpanel additions: Condensed item names for the quick of draw
/:cl:
