### PR TITLE
RCD upgrades have names and icon states

### DIFF
--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -290,27 +290,39 @@
 	var/upgrade
 
 /obj/item/rcd_upgrade/frames
+	name = "RCD advanced upgrade: frames"
 	desc = "It contains the design for machine frames and computer frames."
+	icon_state = "datadisk6"
 	upgrade = RCD_UPGRADE_FRAMES
 
 /obj/item/rcd_upgrade/simple_circuits
+	name = "RCD advanced upgrade: simple circuits"
 	desc = "It contains the design for firelock, air alarm, fire alarm, apc circuits and crap power cells."
+	icon_state = "datadisk4"
 	upgrade = RCD_UPGRADE_SIMPLE_CIRCUITS
 
 /obj/item/rcd_upgrade/anti_interrupt
+	name = "RCD advanced upgrade: anti disruption"
 	desc = "It contains the upgrades necessary to prevent interruption of RCD construction and deconstruction."
+	icon_state = "datadisk2"
 	upgrade = RCD_UPGRADE_ANTI_INTERRUPT
 
 /obj/item/rcd_upgrade/cooling
+	name = "RCD advanced upgrade: enhanced cooling"
 	desc = "It contains the upgrades necessary to allow more frequent use of the RCD."
+	icon_state = "datadisk7"
 	upgrade = RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 
 /obj/item/rcd_upgrade/silo_link
+	name = "RCD advanced upgrade: silo link"
 	desc = "It contains direct silo connection RCD upgrade."
+	icon_state = "datadisk8"
 	upgrade = RCD_UPGRADE_SILO_LINK
 
 /obj/item/rcd_upgrade/furnishing
+	name = "RCD advanced upgrade: furnishings"
 	desc = "It contains the design for chairs, stools, tables, and glass tables."
+	icon_state = "datadisk5"
 	upgrade = RCD_UPGRADE_FURNISHING
 
 /datum/action/item_action/rcd_scan

--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -705,7 +705,9 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/upgrade_flags
 
 /obj/item/rpd_upgrade/unwrench
+	name = "RPD advanced upgrade: wrench mode"
 	desc = "Adds reverse wrench mode to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button."
+	icon_state = "datadisk1"
 	upgrade_flags = RPD_UPGRADE_UNWRENCH
 
 #undef ATMOS_CATEGORY


### PR DESCRIPTION
## About The Pull Request

Adds names and icon states to RCD/RPD upgrades

## Why It's Good For The Game

I don't have a pile of 6 disks on the lathe that all look identical and the RCD going YOU HAVE THAT ONE INSTALLED ALREADY, TRY AGAIN IDIOT as I fall into further despair

## Changelog

:cl: LT3
qol: The various RCD upgrade disks no longer look identical
/:cl: