### PR TITLE
Lava/Plasma River tiles now immerse you in them

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -40,6 +40,8 @@
 	var/mask_state = "lava-lightmask"
 	/// The type for the preset fishing spot of this type of turf.
 	var/fish_source_type = /datum/fish_source/lavaland
+	/// The color we use for our immersion overlay
+	var/immerse_overlay_color = "#a15e1b"
 
 /turf/open/lava/Initialize(mapload)
 	. = ..()
@@ -48,7 +50,7 @@
 	refresh_light()
 	if(!smoothing_flags)
 		update_appearance()
-
+	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
 
 /turf/open/lava/Destroy()
 	for(var/mob/living/leaving_mob in contents)
@@ -337,6 +339,7 @@
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_FLOOR_LAVA
 	canSmoothWith = SMOOTH_GROUP_FLOOR_LAVA
 	underfloor_accessibility = 2 //This avoids strangeness when routing pipes / wires along catwalks over lava
+	immerse_overlay_color = "#F98511"
 
 /turf/open/lava/smooth/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
@@ -360,6 +363,7 @@
 	immunity_trait = TRAIT_SNOWSTORM_IMMUNE
 	immunity_resistance_flags = FREEZE_PROOF
 	lava_temperature = 100
+	immerse_overlay_color = "#CD4C9F"
 
 /turf/open/lava/plasma/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This adds the "immerse" element to lava tiles. 

![lava tests but smaller file](https://github.com/tgstation/tgstation/assets/28870487/a03555bf-6d2a-46d9-a437-da49a636a61a)

It's a tad hard to see because you're super on-fire, but it still looks nice.
## Why It's Good For The Game

Eye candy, pretty...
## Changelog
:cl: Rhials
qol: Lava and plasma rivers now immerse you in them.
/:cl:
