### PR TITLE
immortal heart attack fix

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -787,7 +787,7 @@
  * Returns TRUE if heart status was changed (heart attack -> no heart attack, or visa versa)
  */
 /mob/living/carbon/proc/set_heartattack(status)
-	if(!can_heartattack())
+	if(!can_heartattack() && status)
 		return FALSE
 
 	var/obj/item/organ/internal/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -787,7 +787,7 @@
  * Returns TRUE if heart status was changed (heart attack -> no heart attack, or visa versa)
  */
 /mob/living/carbon/proc/set_heartattack(status)
-	if(!can_heartattack() && status)
+	if(status && !can_heartattack())
 		return FALSE
 
 	var/obj/item/organ/internal/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)


### PR DESCRIPTION

## About The Pull Request

cybernetic hearts no longer permanently break when you die, as they would try to restart after you get revived but then the proc to stop the heart attack would get early returned because the heart is immune to heart attacks

## Why It's Good For The Game

having to explode to revive because of surplus heart seems like a bug

## Changelog
:cl:
fix: being revived with a cyber-heart now properly restarts the cyber heart
/:cl:
