### PR TITLE
Add information to the DNR message if you're an antagonist with revival abilities

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -392,6 +392,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, span_warning("You're already stuck out of your body!"))
 		return FALSE
 
+	var/helpful_message = "Are you sure you want to prevent (almost) all means of resuscitation? This cannot be undone."
+	if(IS_CULTIST(src))
+		helpful_message += " Cultists will be unable to revive you."
+	if(IS_CHANGELING(src))
+		helpful_message += " Reviving stasis will not revive you."
+	if(istype(get_organ_by_type(src, ORGAN_SLOT_HEART), /obj/item/organ/internal/heart/nightmare))
+		helpful_message += " Your heart will not revive you."
+
+	var/response = tgui_alert(usr, helpful_message, "Are you sure you want to stay dead?", list("DNR","Save Me"))
+	if(response != "DNR")
+		return
+
 	var/response = tgui_alert(usr, "Are you sure you want to prevent (almost) all means of resuscitation? This cannot be undone.", "Are you sure you want to stay dead?", list("DNR","Save Me"))
 	if(response != "DNR")
 		return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -397,8 +397,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		helpful_message += " Cultists will be unable to revive you."
 	if(IS_CHANGELING(src))
 		helpful_message += " Reviving stasis will not revive you."
-	if(istype(body.get_organ_by_type(ORGAN_SLOT_HEART), /obj/item/organ/internal/heart/nightmare))
-		helpful_message += " Your heart will not revive you."
+	if(mind) /// We shouldn't get this far into the verb if they don't have a mind but existence is mysterious
+		if(istype(mind.current))
+			var/obj/item/organ/internal/heart = mind.current.get_organ_slot(ORGAN_SLOT_HEART)
+			if(istype(heart, /obj/item/organ/internal/heart/ethereal) || istype(heart, /obj/item/organ/internal/heart/nightmare))
+				helpful_message += " Your heart will not revive you."
 
 	var/response = tgui_alert(usr, helpful_message, "Are you sure you want to stay dead?", list("DNR","Save Me"))
 	if(response != "DNR")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -397,7 +397,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		helpful_message += " Cultists will be unable to revive you."
 	if(IS_CHANGELING(src))
 		helpful_message += " Reviving stasis will not revive you."
-	if(mind) /// We shouldn't get this far into the verb if they don't have a mind but existence is mysterious
+	if(mind) /// We shouldn't get this far into the proc if they don't have a mind but existence is mysterious
 		if(istype(mind.current))
 			var/obj/item/organ/internal/heart = mind.current.get_organ_slot(ORGAN_SLOT_HEART)
 			if(istype(heart, /obj/item/organ/internal/heart/ethereal) || istype(heart, /obj/item/organ/internal/heart/nightmare))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -404,10 +404,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(response != "DNR")
 		return
 
-	var/response = tgui_alert(usr, "Are you sure you want to prevent (almost) all means of resuscitation? This cannot be undone.", "Are you sure you want to stay dead?", list("DNR","Save Me"))
-	if(response != "DNR")
-		return
-
 	can_reenter_corpse = FALSE
 	var/mob/living/current_mob = mind.current
 	if(istype(current_mob))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -397,7 +397,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		helpful_message += " Cultists will be unable to revive you."
 	if(IS_CHANGELING(src))
 		helpful_message += " Reviving stasis will not revive you."
-	if(istype(get_organ_by_type(src, ORGAN_SLOT_HEART), /obj/item/organ/internal/heart/nightmare))
+	if(istype(body.get_organ_by_type(ORGAN_SLOT_HEART), /obj/item/organ/internal/heart/nightmare))
 		helpful_message += " Your heart will not revive you."
 
 	var/response = tgui_alert(usr, helpful_message, "Are you sure you want to stay dead?", list("DNR","Save Me"))


### PR DESCRIPTION

## About The Pull Request

I recently set DNR as a changeling to try to trick the roboticist and Captain looming over my handcuffed body (I so would have gotten away if it weren't for space lag trust me I'm very robust) to not try and revive me. I didn't realize this would completely lock me out of my body that had a revival stasis ready. 

That was a real kick in the butt. 

So, I made this PR with the intent that those with revival abilities (currently, cultists, nightmares, ethereals, and changelings) are explicitly made aware that their specific abilities will not revive them.
## Why It's Good For The Game

Keeps malding in the realm of getting donked in-game instead of misunderstanding OOC messages that are meant to be informative.
## Changelog
:cl: Bisar
qol: Set DNR will now make it more explicit that certain antagonist abilities won't revive you, if you possess them.
/:cl:
