### PR TITLE
Carps migrating through the station no longer idle so they don't get stuck after spawning until someone walks by.

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -134,6 +134,8 @@
 
 /// Gives the carp a list of weakrefs of destinations to try and travel between when it has nothing better to do
 /mob/living/basic/carp/proc/migrate_to(list/datum/weakref/migration_points)
+	ai_controller.can_idle = FALSE
+	ai_controller.set_ai_status(AI_STATUS_ON) // We need htem to actually walk to the station
 	var/list/actual_points = list()
 	for(var/datum/weakref/point_ref as anything in migration_points)
 		var/turf/point_resolved = point_ref.resolve()


### PR DESCRIPTION
## About The Pull Request

Carps migrating through the station no longer idle so they don't get stuck after spawning until someone walks by.

## Why It's Good For The Game

Bugfix for Carp Migrations.

## Changelog
:cl:
fix: Carps migrating through the station no longer idle so they don't get stuck after spawning until someone walks by.
/:cl:
