### PR TITLE
Fixes the RnD console by adding a removed import

### DIFF
--- a/tgui/packages/tgui/interfaces/Techweb.jsx
+++ b/tgui/packages/tgui/interfaces/Techweb.jsx
@@ -1,4 +1,4 @@
-import { sortBy } from 'common/collections';
+import { map, sortBy } from 'common/collections';
 import { useState } from 'react';
 
 import { useBackend, useLocalState } from '../backend';


### PR DESCRIPTION

## About The Pull Request
The 'map' import was removed from this file by #82417 but it's still used in place in code. This re-adds the import

## Why It's Good For The Game
Fixes RnD consoles

## Changelog
:cl:
fix: Fixed RnD consoles not being able to be opened.
/:cl:
