### PR TITLE
Fixes Alien Numerical Identifier Transfer System

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -122,17 +122,31 @@ Des: Removes all infected images from the alien.
 		span_alertalien("[src] begins to twist and contort!"),
 		span_noticealien("You begin to evolve!"),
 	)
+
 	new_xeno.setDir(dir)
-	if(numba && unique_name)
-		new_xeno.numba = numba
-		new_xeno.set_name()
-	if(!alien_name_regex.Find(name))
-		new_xeno.name = name
-		new_xeno.real_name = real_name
+	new_xeno.change_name(name, real_name, numba)
+
 	if(mind)
 		mind.name = new_xeno.real_name
 		mind.transfer_to(new_xeno)
+
 	qdel(src)
+
+/// Changes the name of the xeno we are evolving into in order to keep the same numerical identifier the old xeno had.
+/mob/living/carbon/alien/proc/change_name(old_name, old_real_name, old_number)
+	if(!alien_name_regex.Find(old_name)) // check to make sure there's no admins doing funny stuff with naming these aliens
+		new_xeno.name = old_name
+		new_xeno.real_name = old_real_name
+		return
+
+	if(!unique_name)
+		return
+
+	if(old_number != 0)
+		numba = old_number
+		name = initial(name) // prevent chicanery like two different numerical identifiers tied to the same mob
+
+	set_name()
 
 /mob/living/carbon/alien/can_hold_items(obj/item/I)
 	return (I && (I.item_flags & XENOMORPH_HOLDABLE || ISADVANCEDTOOLUSER(src)) && ..())

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -135,8 +135,8 @@ Des: Removes all infected images from the alien.
 /// Changes the name of the xeno we are evolving into in order to keep the same numerical identifier the old xeno had.
 /mob/living/carbon/alien/proc/change_name(old_name, old_real_name, old_number)
 	if(!alien_name_regex.Find(old_name)) // check to make sure there's no admins doing funny stuff with naming these aliens
-		new_xeno.name = old_name
-		new_xeno.real_name = old_real_name
+		name = old_name
+		real_name = old_real_name
 		return
 
 	if(!unique_name)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1815,7 +1815,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	user.put_in_hands(holder)
 
 /mob/living/proc/set_name()
-	if(!numba)
+	if(numba == 0)
 		numba = rand(1, 1000)
 	name = "[name] ([numba])"
 	real_name = name


### PR DESCRIPTION

## About The Pull Request

Fixes #82756

I'm not sure what the root cause of the issue is or why it broke so recently (this has been a thing since #49150) but I went and cleaned up the code and ensured that we always reset the `name` to the `initial()` value we have for it if we determine that we need to transfer over the `numba` from the old xenomorph. This is done by a new proc which is a lot less convoluted from the old system (always respecting var-edited names and stuff like that) that should make it flow a lot better and make it more hardy against double-addition of the `numba` to the name.
## Why It's Good For The Game

Having two numbers in your name is weird, should only have one.

[x] I tested this PR
## Changelog
:cl:
fix: Evolved aliens should no longer have two numbers in their name.
/:cl:
