### PR TITLE
Lathes compute their local storage size correctly

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -22,10 +22,6 @@
 	var/drop_direction = 0
 
 /obj/machinery/rnd/production/Initialize(mapload)
-	. = ..()
-
-	cached_designs = list()
-
 	materials = AddComponent(
 		/datum/component/remote_materials, \
 		mapload, \
@@ -33,6 +29,10 @@
 			COMSIG_MATCONTAINER_ITEM_CONSUMED = TYPE_PROC_REF(/obj/machinery/rnd/production, local_material_insert)
 		) \
 	)
+
+	. = ..()
+
+	cached_designs = list()
 
 	RegisterSignal(src, COMSIG_SILO_ITEM_CONSUMED, TYPE_PROC_REF(/obj/machinery/rnd/production, silo_material_insert))
 
@@ -182,11 +182,10 @@
 /obj/machinery/rnd/production/RefreshParts()
 	. = ..()
 
-	if(materials)
-		var/total_storage = 0
-		for(var/datum/stock_part/matter_bin/bin in component_parts)
-			total_storage += bin.tier * 37.5 * SHEET_MATERIAL_AMOUNT
-		materials.set_local_size(total_storage)
+	var/total_storage = 0
+	for(var/datum/stock_part/matter_bin/bin in component_parts)
+		total_storage += bin.tier * 37.5 * SHEET_MATERIAL_AMOUNT
+	materials.set_local_size(total_storage)
 
 	efficiency_coeff = compute_efficiency()
 


### PR DESCRIPTION
## About The Pull Request
Basically we have to add the material container before we call parent Initialize(which calls `RefreshParts()`), else the container  doesn't get initialized early and we skip over computing storage sizes

## Changelog
:cl:
fix: off station & round start lathes with local storage don't have infinite storage size.
/:cl:
