### PR TITLE
Fixes dropdown displaytext not working for numeric values

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
@@ -43,16 +43,17 @@ export function FeatureDropdownInput(props: DropdownInputProps) {
     };
   });
 
+  let display_text = value;
+  if (display_names) {
+    display_text = display_names[value];
+  }
+
   return (
     <Dropdown
       buttons={buttons}
       disabled={disabled}
       onSelected={handleSetValue}
-      displayText={
-        display_names
-          ? display_names[value] && capitalizeFirst(display_names[value])
-          : value && capitalizeFirst(value)
-      }
+      displayText={capitalizeFirst(display_text)}
       options={dropdownOptions}
       selected={value}
       width="100%"
@@ -94,14 +95,15 @@ export function FeatureIconnedDropdownInput(props: IconnedDropdownInputProps) {
     };
   });
 
+  let display_text = value;
+  if (display_names) {
+    display_text = display_names[value];
+  }
+
   return (
     <Dropdown
       buttons
-      displayText={
-        display_names
-          ? display_names[value] && capitalizeFirst(display_names[value])
-          : value && capitalizeFirst(value)
-      }
+      displayText={capitalizeFirst(display_text)}
       onSelected={handleSetValue}
       options={dropdownOptions}
       selected={value}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
@@ -48,7 +48,11 @@ export function FeatureDropdownInput(props: DropdownInputProps) {
       buttons={buttons}
       disabled={disabled}
       onSelected={handleSetValue}
-      displayText={value && capitalizeFirst(value)}
+      displayText={
+        display_names
+          ? display_names[value] && capitalizeFirst(display_names[value])
+          : value && capitalizeFirst(value)
+      }
       options={dropdownOptions}
       selected={value}
       width="100%"
@@ -93,7 +97,11 @@ export function FeatureIconnedDropdownInput(props: IconnedDropdownInputProps) {
   return (
     <Dropdown
       buttons
-      displayText={value && capitalizeFirst(value)}
+      displayText={
+        display_names
+          ? display_names[value] && capitalizeFirst(display_names[value])
+          : value && capitalizeFirst(value)
+      }
       onSelected={handleSetValue}
       options={dropdownOptions}
       selected={value}


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/82697 broke the prefs menu downstream; we have a couple of dropdown choices that are numeric but that make use of `display_names` to map those choices to appropriate strings.

The code was assuming that `value` would always be a string when calling `capitalizeFirst(value)`. Basically it should be doing `display_names[value]` when `display_names` are present.

## Why It's Good For The Game

Fixes an oversight/bug.

## Changelog

:cl:
fix: dropdowns that use display_names as an alias for numeric values will no longer cause tgui bluescreens
/:cl:

