### PR TITLE
Moving on WALK INTENT regen stamina per passing tiles.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -998,6 +998,10 @@
 
 	. = ..()
 
+	if(move_intent == MOVE_INTENT_WALK)
+		if(staminaloss > 0)
+			adjustStaminaLoss(-stamina_regen_per_walk)
+
 	if(moving_diagonally != FIRST_DIAG_STEP && isliving(pulledby))
 		var/mob/living/L = pulledby
 		L.set_pull_offsets(src, pulledby.grab_state)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -223,3 +223,6 @@
 
 	/// What our current gravity state is. Used to avoid duplicate animates and such
 	var/gravity_state = null
+
+	/// How many stamina will mob regen when walking.
+	var/stamina_regen_per_walk = 2


### PR DESCRIPTION
## About The Pull Request

Similar to PR that takes stamina when living move on RUN INTENT but vice reversa:
 Moving on WALK INTENT heal stamina damage per passing turfs(2 stamina per tile) 

## Why It's Good For The Game

Gives more interaction with stamina damage. If you take a lot of stamina damage, you'll have two options: switch to a walk intent to regain your stamina and re-enter the fight (but you'll be slowed by the walk intent), or use a run intent to get out of dangerous(but you will be in danger of getting more stamina damage). Adds more "logic" to the characters - tired? stop running.

## Changelog

:cl:
balance: Walk intent now regen stamina damage per tile passed.
/:cl: