### PR TITLE
Plumbing & chem reaction chamber patches

### DIFF
--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -51,22 +51,17 @@
 	if(!is_operational)
 		return
 
-	//half the power for getting reagents in
-	var/power_usage = active_power_usage * 0.5
-
 	if(!emptying || reagents.is_reacting)
 		//adjust temperature of final solution
 		var/temp_diff = target_temperature - reagents.chem_temp
 		if(abs(temp_diff) > 0.01) //if we are not close enough keep going
 			reagents.adjust_thermal_energy(temp_diff * HEATER_COEFFICIENT * seconds_per_tick * SPECIFIC_HEAT_DEFAULT * reagents.total_volume) //keep constant with chem heater
 
+			//use energy
+			use_energy(active_power_usage * seconds_per_tick)
+
 		//do other stuff with final solution
 		handle_reagents(seconds_per_tick)
-
-		//full power for doing reactions
-		power_usage *= 2
-
-	use_energy(power_usage * seconds_per_tick)
 
 ///For subtypes that want to do additional reagent handling
 /obj/machinery/plumbing/reaction_chamber/proc/handle_reagents(seconds_per_tick)

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -53,13 +53,9 @@
 
 	if(!emptying || reagents.is_reacting)
 		//adjust temperature of final solution
-		var/temp_diff = target_temperature - reagents.chem_temp
-		if(abs(temp_diff) > 0.01) //if we are not close enough keep going
-			//heat reagents
-			reagents.adjust_thermal_energy(temp_diff * HEATER_COEFFICIENT * seconds_per_tick * reagents.heat_capacity())
-
-			//use energy
-			use_energy(active_power_usage * seconds_per_tick)
+		var/energy = (target_temperature - reagents.chem_temp) * HEATER_COEFFICIENT * seconds_per_tick * reagents.heat_capacity()
+		reagents.adjust_thermal_energy(energy)
+		use_energy(active_power_usage + abs(ROUND_UP(energy) / 120))
 
 		//do other stuff with final solution
 		handle_reagents(seconds_per_tick)

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -48,14 +48,15 @@
 	return NONE
 
 /obj/machinery/plumbing/reaction_chamber/process(seconds_per_tick)
-	if(!is_operational)
+	if(!is_operational || !reagents.total_volume)
 		return
 
 	if(!emptying || reagents.is_reacting)
 		//adjust temperature of final solution
 		var/temp_diff = target_temperature - reagents.chem_temp
 		if(abs(temp_diff) > 0.01) //if we are not close enough keep going
-			reagents.adjust_thermal_energy(temp_diff * HEATER_COEFFICIENT * seconds_per_tick * SPECIFIC_HEAT_DEFAULT * reagents.total_volume) //keep constant with chem heater
+			//heat reagents
+			reagents.adjust_thermal_energy(temp_diff * HEATER_COEFFICIENT * seconds_per_tick * reagents.heat_capacity())
 
 			//use energy
 			use_energy(active_power_usage * seconds_per_tick)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -178,12 +178,13 @@
 	PRIVATE_PROC(TRUE)
 
 	//must be on and beaker must have something inside to heat
-	if(!on || (machine_stat & NOPOWER) || QDELETED(beaker) || !beaker.reagents.total_volume)
+	if(!on || !is_operational || QDELETED(beaker) || !beaker.reagents.total_volume)
 		return FALSE
 
 	//heat the beaker and use some power. we want to use only a small amount of power since this proc gets called frequently
-	beaker.reagents.adjust_thermal_energy((target_temperature - beaker.reagents.chem_temp) * heater_coefficient * seconds_per_tick * beaker.reagents.heat_capacity())
-	use_energy(active_power_usage * seconds_per_tick)
+	var/energy = (target_temperature - beaker.reagents.chem_temp) * heater_coefficient * seconds_per_tick * beaker.reagents.heat_capacity()
+	beaker.reagents.adjust_thermal_energy(energy)
+	use_energy(active_power_usage + abs(ROUND_UP(energy) / 120))
 	return TRUE
 
 /obj/machinery/chem_heater/proc/on_reaction_step(datum/reagents/holder, num_reactions, seconds_per_tick)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -108,16 +108,25 @@
 	return NONE
 
 /obj/machinery/chem_heater/wrench_act(mob/living/user, obj/item/tool)
+	if(user.combat_mode)
+		return NONE
+
 	. = ITEM_INTERACT_BLOCKING
 	if(default_unfasten_wrench(user, tool) == SUCCESSFUL_UNFASTEN)
 		return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/chem_heater/screwdriver_act(mob/living/user, obj/item/tool)
+	if(user.combat_mode)
+		return NONE
+
 	. = ITEM_INTERACT_BLOCKING
 	if(default_deconstruction_screwdriver(user, "mixer0b", "[base_icon_state][beaker ? 1 : 0]b", tool))
 		return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/chem_heater/crowbar_act(mob/living/user, obj/item/tool)
+	if(user.combat_mode)
+		return NONE
+
 	. = ITEM_INTERACT_BLOCKING
 	if(default_deconstruction_crowbar(tool))
 		return ITEM_INTERACT_SUCCESS

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -31,8 +31,12 @@
 		QDEL_NULL(beaker)
 	return ..()
 
-/obj/machinery/chem_heater/on_deconstruction(disassembled)
-	beaker?.forceMove(drop_location())
+/obj/machinery/chem_heater/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == beaker)
+		UnregisterSignal(beaker.reagents, COMSIG_REAGENTS_REACTION_STEP)
+		beaker = null
+		update_appearance()
 
 /obj/machinery/chem_heater/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	if(isnull(held_item) || (held_item.item_flags & ABSTRACT) || (held_item.flags_1 & HOLOGRAM_1))
@@ -58,7 +62,6 @@
 
 	return NONE
 
-
 /obj/machinery/chem_heater/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
@@ -80,25 +83,17 @@
 	icon_state = "[base_icon_state][beaker ? 1 : 0]b"
 	return ..()
 
-/obj/machinery/chem_heater/Exited(atom/movable/gone, direction)
-	. = ..()
-	if(gone == beaker)
-		UnregisterSignal(beaker.reagents, COMSIG_REAGENTS_REACTION_STEP)
-		beaker = null
-		update_appearance()
-
 /obj/machinery/chem_heater/RefreshParts()
 	. = ..()
 	heater_coefficient = 0.1
 	for(var/datum/stock_part/micro_laser/micro_laser in component_parts)
 		heater_coefficient *= micro_laser.tier
 
-
 /obj/machinery/chem_heater/item_interaction(mob/living/user, obj/item/held_item, list/modifiers)
-	if((held_item.item_flags & ABSTRACT) || (held_item.flags_1 & HOLOGRAM_1))
+	if(user.combat_mode || (held_item.item_flags & ABSTRACT) || (held_item.flags_1 & HOLOGRAM_1) || !user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH))
 		return NONE
 
-	if(QDELETED(beaker))
+	if(!QDELETED(beaker))
 		if(istype(held_item, /obj/item/reagent_containers/dropper) || istype(held_item, /obj/item/reagent_containers/syringe))
 			var/obj/item/reagent_containers/injector = held_item
 			injector.afterattack(beaker, user, proximity_flag = TRUE)
@@ -178,8 +173,8 @@
 		return FALSE
 
 	//heat the beaker and use some power. we want to use only a small amount of power since this proc gets called frequently
-	beaker.reagents.adjust_thermal_energy((target_temperature - beaker.reagents.chem_temp) * heater_coefficient * seconds_per_tick * SPECIFIC_HEAT_DEFAULT * beaker.reagents.total_volume)
-	use_energy(active_power_usage * seconds_per_tick * 0.3)
+	beaker.reagents.adjust_thermal_energy((target_temperature - beaker.reagents.chem_temp) * heater_coefficient * seconds_per_tick * beaker.reagents.heat_capacity())
+	use_energy(active_power_usage * seconds_per_tick)
 	return TRUE
 
 /obj/machinery/chem_heater/proc/on_reaction_step(datum/reagents/holder, num_reactions, seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request
1. Both Plumbing & Chem reaction chamber will use the beakers `heat_capacity()` proc instead of the formulae `SPECIFIC_HEAT_DEFAULT * reagents.total_volume`. This yields the exact same results as before but will mean in the future if individual reagents heat capacities are changed then the heating effects will be accurately reflected here. It also uses that amount of power for heating
2. Plumbing rection chamber will not use energy when its either 'emptying' or when no reagents are present in its internal buffer
3. You can hit the chem reaction chamber with items like beakers, screwdrivers, crowbars and what not 

## Changelog
:cl:
fix: plumbing & chem reaction chamber heating effects accurately reflect the beakers heat capacity & power usage
fix: plumbing reaction will not use power when emptying or when there are no reagents to heat
fix: you can hit the chem reaction chamber with items like beakers, screwdrivers, crowbars and what not 
/:cl:
