### PR TITLE
Fix oven tray runtime

### DIFF
--- a/code/modules/food_and_drinks/machinery/oven.dm
+++ b/code/modules/food_and_drinks/machinery/oven.dm
@@ -264,7 +264,7 @@
 	if(isnull(item.atom_storage))
 		return NONE
 
-	if(length(contents >= max_items))
+	if(length(contents) >= max_items)
 		balloon_alert(user, "it's full!")
 		return ITEM_INTERACT_BLOCKING
 


### PR DESCRIPTION

## About The Pull Request
Fixes a lil typo from the interaction refactors that broke the ability to load oven trays from containers
## Why It's Good For The Game
squamsh bug
## Changelog
:cl:
fix: loading oven trays from serving trays and other containers works again
/:cl:
