### PR TITLE
Slightly reduces stun chance and increases ripping limb off time for 

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -37,7 +37,7 @@
 	faction = list(FACTION_MONKEY, FACTION_JUNGLE)
 	butcher_results = list(/obj/item/food/meat/slab/gorilla = 4, /obj/effect/gibspawner/generic/animal = 1)
 	/// How likely our meaty fist is to stun someone
-	var/paralyze_chance = 20
+	var/paralyze_chance = 18
 	/// A counter for when we can scream again
 	var/oogas = 0
 	/// Types of things we want to find and eat
@@ -61,7 +61,7 @@
 	AddElement(/datum/element/basic_eating, heal_amt = 10, food_types = gorilla_food)
 	AddElement(
 		/datum/element/amputating_limbs, \
-		surgery_time = 0 SECONDS, \
+		surgery_time = 2 SECONDS, \
 		surgery_verb = "punches",\
 	)
 	AddComponent(/datum/component/personal_crafting)


### PR DESCRIPTION



About The Pull Request
Makes gorillas have a cooldown to rip people's limbs off.
Makes gorillas have a lesser stun chance to allow people a chance.


Why It's Good For The Game
Gorillas should not be able to rip a person's limb off in 0 seconds. Yes,, they may be strong, but seriously? Maybe a hulked gorilla can do it, if we ever add that. Reducing stun time is optional, not required, the main part is the gorilla ripping off part.


Changelog

-Gorillas spend time ripping limbs off.
-Gorillas have reduced stun time

(accidently removed this shit.. uh... oops, first PR.)
