### PR TITLE
[NO GBP]Inversely scale mechanical favor with STANDARD_CELL_CHARGE.

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -200,11 +200,11 @@
 	if(!istype(power_cell))
 		return
 
-	if(power_cell.charge < 0.3 * STANDARD_CELL_CHARGE)
+	if(power_cell.charge() < 0.3 * STANDARD_CELL_CHARGE)
 		to_chat(chap, span_notice("[GLOB.deity] does not accept pity amounts of power."))
 		return
 
-	adjust_favor(round(power_cell.charge/300), chap)
+	adjust_favor(round(power_cell.charge() / (0.3 * STANDARD_CELL_CHARGE)), chap)
 	to_chat(chap, span_notice("You offer [power_cell]'s power to [GLOB.deity], pleasing them."))
 	qdel(power_cell)
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Makes the mechanical sect cell sacrifice favor adjustment inversely scale with STANDARD_CELL_CHARGE. This reduces it by a factor of 1,000.
## Why It's Good For The Game
So they don't get 1,000 times the favor as intended from a cell.
## Changelog
:cl:
fix: Fixes mechanical sect gaining 1,000 times the favor from a cell sacrifice.
/:cl:
