### PR TITLE
Makes lavaland stone tiles prevent immersion

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -262,7 +262,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 
 	var/static/list/give_turf_traits
 	if(!give_turf_traits)
-		give_turf_traits = string_list(list(TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED))
+		give_turf_traits = string_list(list(TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED, TRAIT_IMMERSE_STOPPED))
 	AddElement(/datum/element/give_turf_traits, give_turf_traits)
 
 /obj/structure/stone_tile/singularity_pull()


### PR DESCRIPTION

## About The Pull Request
Adds the same trait that lavaproof rods have to the stone tiles, so things can continue being visually outside of the lava
## Why It's Good For The Game
this shit looks goofy
![324271923-9c1e353d-70ff-4321-839c-8bac2fd03c01](https://github.com/tgstation/tgstation/assets/25628932/d120458d-8f65-418c-a0c8-7d1f939a472b)
## Changelog
:cl: FlufflesTheDog
fix: Stone tiles (and things on them) no longer get immersed in lava
/:cl:
