### PR TITLE
Catlike Grace works with Freerunning

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -75,6 +75,7 @@
 				addtimer(CALLBACK(src, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/landed_on_feet), levels * 3 SECONDS)
 			else
 				Knockdown(levels * 4 SECONDS)
+				emote("spin")
 
 			visible_message(
 				span_notice("[src] makes a hard landing on [impacted_turf] but remains unharmed from the fall[graceful_landing ? " and stays on [p_their()] feet" : " by tucking in rolling into the landing"]."),

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -69,14 +69,17 @@
 		var/obj/item/organ/external/wings/gliders = get_organ_by_type(/obj/item/organ/external/wings)
 		if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed
 			var/graceful_landing = HAS_TRAIT(src, TRAIT_CATLIKE_GRACE)
-			if(!graceful_landing)
+
+			if(graceful_landing)
+				add_movespeed_modifier(/datum/movespeed_modifier/landed_on_feet)
+				addtimer(CALLBACK(src, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/landed_on_feet), levels * 3 SECONDS)
+			else
 				Knockdown(levels * 4 SECONDS)
+
 			visible_message(
 				span_notice("[src] makes a hard landing on [impacted_turf] but remains unharmed from the fall[graceful_landing ? " and stays on [p_their()] feet" : " by tucking in rolling into the landing"]."),
 				span_notice("You brace for the fall. You make a hard landing on [impacted_turf], but remain unharmed[graceful_landing ? " while landing on your feet" : " by tucking in and rolling into the landing"]."),
 			)
-			add_movespeed_modifier(/datum/movespeed_modifier/landed_on_feet)
-			addtimer(CALLBACK(src, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/landed_on_feet), levels * 2 SECONDS)
 			return . | ZIMPACT_NO_MESSAGE
 
 	var/incoming_damage = (levels * 5) ** 1.5

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -68,13 +68,15 @@
 	if(levels <= 1 && can_help_themselves)
 		var/obj/item/organ/external/wings/gliders = get_organ_by_type(/obj/item/organ/external/wings)
 		if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed
-			var/graceful_landing = HAS_TRAIT(src, TRAIT_CATLIKE_GRACE) ? TRUE : FALSE
+			var/graceful_landing = HAS_TRAIT(src, TRAIT_CATLIKE_GRACE)
 			if(!graceful_landing)
 				Knockdown(levels * 4 SECONDS)
 			visible_message(
-				span_notice("[src] makes a hard landing on [impacted_turf] but remains unharmed from the fall[graceful_landing ? " and stays on [p_their()] feet" : null]."),
-				span_notice("You brace for the fall. You make a hard landing on [impacted_turf], but remain unharmed[graceful_landing ? " and stay on your feet" : null]."),
+				span_notice("[src] makes a hard landing on [impacted_turf] but remains unharmed from the fall[graceful_landing ? " and stays on [p_their()] feet" : " by tucking in rolling into the landing"]."),
+				span_notice("You brace for the fall. You make a hard landing on [impacted_turf], but remain unharmed[graceful_landing ? " while landing on your feet" : " by tucking in and rolling into the landing"]."),
 			)
+			add_movespeed_modifier(/datum/movespeed_modifier/landed_on_feet)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/landed_on_feet), levels * 2 SECONDS)
 			return . | ZIMPACT_NO_MESSAGE
 
 	var/incoming_damage = (levels * 5) ** 1.5

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -68,11 +68,13 @@
 	if(levels <= 1 && can_help_themselves)
 		var/obj/item/organ/external/wings/gliders = get_organ_by_type(/obj/item/organ/external/wings)
 		if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed
+			var/graceful_landing = HAS_TRAIT(src, TRAIT_CATLIKE_GRACE) ? TRUE : FALSE
+			if(!graceful_landing)
+				Knockdown(levels * 4 SECONDS)
 			visible_message(
-				span_notice("[src] makes a hard landing on [impacted_turf] but remains unharmed from the fall."),
-				span_notice("You brace for the fall. You make a hard landing on [impacted_turf], but remain unharmed."),
+				span_notice("[src] makes a hard landing on [impacted_turf] but remains unharmed from the fall[graceful_landing ? " and stays on [p_their()] feet" : null]."),
+				span_notice("You brace for the fall. You make a hard landing on [impacted_turf], but remain unharmed[graceful_landing ? " and stay on your feet" : null]."),
 			)
-			Knockdown(levels * 4 SECONDS)
 			return . | ZIMPACT_NO_MESSAGE
 
 	var/incoming_damage = (levels * 5) ** 1.5


### PR DESCRIPTION

## About The Pull Request

If you have Catlike Grace when Freerunning takes effect, you do not suffer a knockdown. fixes https://github.com/tgstation/tgstation/issues/82818

## Why It's Good For The Game

Taking a quirk to do something worse than if you didn't have it at all is probably not the best outcome. Some may argue that not taking damage from a fall is actually a good thing, but in my experience the catlike grace bonus is a much better outcome.

If for whatever reason you now have both, they're no longer at odds.

Obviously, Freerunning only cares about dropping from a single level. If you take a tumble down into the depths of the ice moon, you're still landing on your feet and taking a ridiculous, bone shattering amount of damage.

Also I asked @MrMelbert if the PR was okay and he said 'so long as the PR is good' so hopefully this is up to snuff.

## Changelog
:cl:
fix: If you are a freerunner, you don't end up faceplanting despite having catlike grace.
/:cl:
