### PR TITLE
Removes the stun from longfall modules activating.

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -506,8 +506,16 @@
 	if(!drain_power(use_energy_cost * levels))
 		return NONE
 	new /obj/effect/temp_visual/mook_dust(fell_on)
+
+	/// Boolean that tracks whether we fell more than one z-level. If TRUE, we stagger our wearer.
+	var/extreme_fall = FALSE
+
+	if(levels >= 2)
+		extreme_fall = TRUE
+		mod.wearer.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * levels, 10 SECONDS)
+
 	mod.wearer.visible_message(
-		span_notice("[mod.wearer] lands on [fell_on] safely."),
+		span_notice("[mod.wearer] lands on [fell_on] safely[extreme_fall ? ", but barely manages to stay on [p_their()] feet." : ", and quite stylishly on [p_their()] feet" ]."),
 		span_notice("[src] protects you from the damage!"),
 	)
 	return ZIMPACT_CANCEL_DAMAGE|ZIMPACT_NO_MESSAGE|ZIMPACT_NO_SPIN

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -506,7 +506,6 @@
 	if(!drain_power(use_energy_cost * levels))
 		return NONE
 	new /obj/effect/temp_visual/mook_dust(fell_on)
-	mod.wearer.Stun(levels * 1 SECONDS)
 	mod.wearer.visible_message(
 		span_notice("[mod.wearer] lands on [fell_on] safely."),
 		span_notice("[src] protects you from the damage!"),


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. When you fall with the longfall module active, you do not get stunned. If you fall from more than one z-level, however, you will be staggered from the fall, with a length based on the number of levels fallen.

## Why It's Good For The Game

I noticed that while using these as a felinid that I actually was stunned utilizing them. dropping the equipment I was carrying and being rooted in place for a bit. And I thought to myself 'wait, hang on, by taking this thing out, out I'm actually WAY better off than if I kept them in, what gives?'

They just got powercreeped, unfortunately. Freerunner and being a catgirl is stronger than this very niche module, because they're equipment independent and also not a hard stun (I know faceplanting with freerunner is still a bit of a stun, but you can still move and potentially avoid losing equipment by falling while prone). 

And maybe it functions a lot stronger in situations where those two traits just don't apply (or apply in a very negative fashion in the case of felinids), I don't see why they shouldn't be superior to those traits. You have to have a modsuit, and you need to be on a map that makes use of multi-z. And additionally be in gravity. Typically, I would think equipment benefits should be stronger than innate/roundstart features.

Most of the time, it is easier and more beneficial to be in constant flight while using a modsuit than to prepare for longfalling.

So let's just make it better overall. I don't know how many people would even use it, but I know I will and I love tossing myself into the void below.

## Changelog
:cl:
balance: Longfall modules no logner stun you when they activate.
balance: Falling from a height greater than one z-level while using the longfall module will still stagger you.
/:cl:
