### PR TITLE
[NO GBP] Critical fixes for cyborg omnitools

### DIFF
--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -139,7 +139,7 @@
 		for(var/obj/item/borg/cyborg_omnitool/medical/omnitool in user.held_items)
 			if(omnitool.tool_behaviour == TOOL_CAUTERY)
 				has_cautery = TRUE
-		if(has_cautery)
+		if(!has_cautery)
 			patient.balloon_alert(user, "need a cautery in an inactive slot to stop the surgery!")
 			return
 	else if(!close_tool || close_tool.tool_behaviour != required_tool_type)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -319,9 +319,10 @@
 
 /obj/item/borg/cyborg_omnitool/medical/reference_item_for_parameters()
 	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = tool_behaviour == (TOOL_SCALPEL && TOOL_SAW)
+	if(tool_behaviour == (TOOL_SCALPEL && TOOL_SAW))
+		butchering.butchering_enabled = TRUE
 	RemoveElement(/datum/element/eyestab)
-	RemoveComponentSource(/datum/component/surgery_initiator)
+	qdel(GetComponent(/datum/component/surgery_initiator))
 	item_flags = SURGICAL_TOOL
 	switch(tool_behaviour)
 		if(TOOL_SCALPEL)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -319,8 +319,7 @@
 
 /obj/item/borg/cyborg_omnitool/medical/reference_item_for_parameters()
 	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	if(tool_behaviour == (TOOL_SCALPEL && TOOL_SAW))
-		butchering.butchering_enabled = TRUE
+	butchering.butchering_enabled = (tool_behaviour == TOOL_SCALPEL || tool_behaviour == TOOL_SAW)
 	RemoveElement(/datum/element/eyestab)
 	qdel(GetComponent(/datum/component/surgery_initiator))
 	item_flags = SURGICAL_TOOL

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -48,7 +48,7 @@
 /datum/surgery_step/repair_bone_hairline
 	name = "repair hairline fracture (bonesetter/bone gel/tape)"
 	implements = list(
-		/obj/item/bonesetter = 100,
+		TOOL_BONESET = 100,
 		/obj/item/stack/medical/bone_gel = 100,
 		/obj/item/stack/sticky_tape/surgical = 100,
 		/obj/item/stack/sticky_tape/super = 50,
@@ -98,7 +98,7 @@
 /datum/surgery_step/reset_compound_fracture
 	name = "reset bone (bonesetter)"
 	implements = list(
-		/obj/item/bonesetter = 100,
+		TOOL_BONESET = 100,
 		/obj/item/stack/sticky_tape/surgical = 60,
 		/obj/item/stack/sticky_tape/super = 40,
 		/obj/item/stack/sticky_tape = 20)


### PR DESCRIPTION
## About The Pull Request
Fixes several critical fixes for cyborg omnitools, surgical omnitools in peculiar. Which is:
1. bonesetter omnitool can do compound fracture surgery now
2. omnitool butchering not properly disabled works (why didn't that runtime. fucking dreammaker)
3. omnitool surgery_initiator not properly disabled
4. cautery in offhand not working

Fixes #82805
Fixes #82868

Honestly I have now regretted for doing this kind of implementation at the start. with how shoddily coded it is.
Planning to refactor cyborg omnitools, admin omnitool and ayys omnitool (all have the same base of implementation) to be less snowflakey. but that's for the future. and will take some time. This is a bandaid fix for now
## Why It's Good For The Game
this is cbt
## Changelog
:cl:
fix: fixed cyborg bonesetter not working for compound fractures
fix: butchering not disabling in cyborg omnitool
fix: fixes a bug where if you select the omnitool it would be stuck in surgery initiator mode
fix: cautery in off hand for cyborg omnitools not working
/:cl:
