### PR TITLE
Tuberculosis makes you cough more, Nicotine Withdrawal makes you cough less

### DIFF
--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -18,11 +18,12 @@
 	if(!.)
 		return
 
+	if(SPT_PROB(stage * 2, seconds_per_tick))
+		affected_mob.emote("cough")
+		to_chat(affected_mob, span_danger("Your chest hurts."))
+
 	switch(stage)
 		if(2)
-			if(SPT_PROB(1, seconds_per_tick))
-				affected_mob.emote("cough")
-				to_chat(affected_mob, span_danger("Your chest hurts."))
 			if(SPT_PROB(1, seconds_per_tick))
 				to_chat(affected_mob, span_danger("Your stomach violently rumbles!"))
 			if(SPT_PROB(2.5, seconds_per_tick))

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -183,7 +183,7 @@
 
 /datum/addiction/medicine/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
-	if(SPT_PROB(10, seconds_per_tick))
+	if(SPT_PROB(1, seconds_per_tick))
 		affected_carbon.emote("cough")
 
 /datum/addiction/medicine/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
@@ -216,6 +216,9 @@
 
 /datum/addiction/medicine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
+	if(SPT_PROB(2, seconds_per_tick))
+		affected_carbon.emote("cough")
+
 	var/datum/hallucination/fake_health_doll/hallucination = health_doll_ref?.resolve()
 	if(QDELETED(hallucination))
 		health_doll_ref = null
@@ -235,13 +238,13 @@
 
 /datum/addiction/medicine/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
+	if(SPT_PROB(5, seconds_per_tick))
+		affected_carbon.emote("cough")
+		return
+
 	var/datum/hallucination/fake_health_doll/hallucination = health_doll_ref?.resolve()
 	if(!QDELETED(hallucination) && SPT_PROB(5, seconds_per_tick))
 		hallucination.increment_fake_damage()
-		return
-
-	if(SPT_PROB(15, seconds_per_tick))
-		affected_carbon.emote("cough")
 		return
 
 	if(SPT_PROB(65, seconds_per_tick))
@@ -283,11 +286,11 @@
 /datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
 	affected_carbon.set_jitter_if_lower(20 SECONDS * seconds_per_tick)
-	if(SPT_PROB(10, seconds_per_tick))
+	if(SPT_PROB(2, seconds_per_tick))
 		affected_carbon.emote("cough")
 
 /datum/addiction/nicotine/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
 	affected_carbon.set_jitter_if_lower(30 SECONDS * seconds_per_tick)
-	if(SPT_PROB(15, seconds_per_tick))
+	if(SPT_PROB(5, seconds_per_tick))
 		affected_carbon.emote("cough")

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -240,7 +240,6 @@
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_carbon.emote("cough")
-		return
 
 	var/datum/hallucination/fake_health_doll/hallucination = health_doll_ref?.resolve()
 	if(!QDELETED(hallucination) && SPT_PROB(5, seconds_per_tick))


### PR DESCRIPTION
## About The Pull Request

- Tuberculosis makes you cough more, and is no longer restricted to stage two 
- Nicotine Addiction Withdrawal makes you cough less often
- Medicine Addiction Withdrawal makes you cough less often but now carries across all stages

## Why It's Good For The Game

Nicotine Addiction currently makes you cough 10x more often than Tuberculosis, the lung disease. Kinda nonsensical right? 

This makes smoking a single cigar (which instantly makes you addicted because lol) pretty insufferable to be around, and while this makes sense OOC it's a roleplaying game and being actively avoided in a roleplaying game is not fun

So tweaking the values should make it a bit more sensible

Initial values looked like `TB: 1% chance per second` vs `Nicotine: 10% chance per second` 🥴 

## Changelog

:cl: Melbert
qol: Tuberculosis makes you cough more
qol: Nicotine Addiciton makes you cough less
qol: Medicine Addiction maybe makes you cough more, maybe makes you cough less
/:cl:
