### PR TITLE
Fake handcuffs no longer apply click cooldown on resist

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -225,6 +225,8 @@
 	var/current_skin
 	///// List of options to reskin.
 	var/list/unique_reskin
+	/// Do we apply a click cooldown when resisting this object if it is restraining them?
+	var/breakout_cooldown = TRUE
 
 /obj/item/Initialize(mapload)
 	if(attack_verb_continuous)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -226,7 +226,7 @@
 	///// List of options to reskin.
 	var/list/unique_reskin
 	/// Do we apply a click cooldown when resisting this object if it is restraining them?
-	var/breakout_cooldown = TRUE
+	var/resist_cooldown = CLICK_CD_BREAKOUT
 
 /obj/item/Initialize(mapload)
 	if(attack_verb_continuous)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -175,6 +175,7 @@
 	desc = "Fake handcuffs meant for gag purposes."
 	breakouttime = 1 SECONDS
 	restraint_strength = HANDCUFFS_TYPE_WEAK
+	breakout_cooldown = FALSE
 
 /**
  * # Cable restraints
@@ -356,6 +357,7 @@
 	name = "fake zipties"
 	desc = "Fake zipties meant for gag purposes."
 	breakouttime = 1 SECONDS
+	breakout_cooldown = FALSE
 
 /obj/item/restraints/handcuffs/cable/zipties/fake/used
 	desc = "A pair of broken fake zipties."

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -175,7 +175,7 @@
 	desc = "Fake handcuffs meant for gag purposes."
 	breakouttime = 1 SECONDS
 	restraint_strength = HANDCUFFS_TYPE_WEAK
-	breakout_cooldown = FALSE
+	resist_cooldown = CLICK_CD_SLOW
 
 /**
  * # Cable restraints
@@ -357,7 +357,7 @@
 	name = "fake zipties"
 	desc = "Fake zipties meant for gag purposes."
 	breakouttime = 1 SECONDS
-	breakout_cooldown = FALSE
+	resist_cooldown = CLICK_CD_SLOW
 
 /obj/item/restraints/handcuffs/cable/zipties/fake/used
 	desc = "A pair of broken fake zipties."

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -248,7 +248,7 @@
 		var/obj/item/restraints/cuffs = src.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
 		buckle_cd = cuffs.breakouttime
 
-	visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"), 
+	visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"),
 				span_notice("You attempt to unbuckle yourself... \
 				(This will take around [DisplayTimeText(buckle_cd)] and you must stay still.)"))
 
@@ -256,7 +256,7 @@
 		if(buckled)
 			to_chat(src, span_warning("You fail to unbuckle yourself!"))
 		return
-	
+
 	if(QDELETED(src) || isnull(buckled))
 		return
 
@@ -276,7 +276,7 @@
 		I = legcuffed
 		type = 2
 	if(I)
-		if(type == 1)
+		if(type == 1 && I.breakout_cooldown)
 			changeNext_move(CLICK_CD_BREAKOUT)
 			last_special = world.time + CLICK_CD_BREAKOUT
 		if(type == 2)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -276,9 +276,9 @@
 		I = legcuffed
 		type = 2
 	if(I)
-		if(type == 1 && I.breakout_cooldown)
-			changeNext_move(CLICK_CD_BREAKOUT)
-			last_special = world.time + CLICK_CD_BREAKOUT
+		if(type == 1)
+			changeNext_move(I.resist_cooldown)
+			last_special = world.time + I.resist_cooldown
 		if(type == 2)
 			changeNext_move(CLICK_CD_RANGE)
 			last_special = world.time + CLICK_CD_RANGE


### PR DESCRIPTION

## About The Pull Request

Fake handcuffs/zipties do not apply a click cooldown upon resisting.

I'm not super happy with the solution to this (adding another item-level var) but I told myself I'd fix this, and wasn't about to give up after my handcuff-level solution didn't work.

Which calls into question -- Why does the breakout proc use item typecasting over the restraint type? Is this necessary for anything to function? I was too afraid to change it and accidentally break something else.
## Why It's Good For The Game

Closes #82711.

Makes fake handcuffs a properly harmless joke item.
## Changelog
:cl: Rhials
fix: Fake handcuffs/Zipties no longer block clicks for a few seconds after being resisted out of.
/:cl:
