### PR TITLE
Fix playing card memory

### DIFF
--- a/code/datums/memory/general_memories.dm
+++ b/code/datums/memory/general_memories.dm
@@ -643,7 +643,7 @@
 
 /datum/memory/playing_cards/get_starts()
 	return list(
-		"[formatted_players_list] are waiting for [protagonist_name] to start the [game]",
+		"[formatted_players_list] waiting for [protagonist_name] to start the [game]",
 		"The [game] has been setup by [deuteragonist_name]",
 		"[deuteragonist_name] starts shuffling the deck for the [game]",
 	)
@@ -668,7 +668,7 @@
 
 /datum/memory/playing_card_pickup/get_starts()
 	return list(
-		"[protagonist_name] tosses the [antagonist_name] at [deuteragonist_name] spilling cards all over the floor",
+		"[protagonist_name] tossing the [antagonist_name] at [deuteragonist_name] spilling cards all over the floor",
 		"A [antagonist_name] thrown by [protagonist_name] splatters across [deuteragonist_name] face",
 	)
 

--- a/code/modules/cards/deck/deck.dm
+++ b/code/modules/cards/deck/deck.dm
@@ -117,15 +117,17 @@
 
 	if(length(card_players) >= 2) // need at least 2 people to play a cardgame, duh!
 		for(var/mob/living/carbon/player in card_players)
-			var/other_players = english_list(card_players - player)
+			var/other_players = card_players - player
 			var/obj/item/toy/held_card_item = card_players[player]
 
 			player.add_mood_event("playing_cards", /datum/mood_event/playing_cards)
-			player.add_mob_memory(/datum/memory/playing_cards, \
+			player.add_mob_memory( \
+				/datum/memory/playing_cards, \
 				deuteragonist = dealer, \
 				game = cardgame_desc, \
 				protagonist_held_card = held_card_item, \
-				other_players = other_players)
+				other_players = other_players, \
+			)
 
 /obj/item/toy/cards/deck/attack_hand(mob/living/user, list/modifiers, flip_card = FALSE)
 	if(!ishuman(user) || !user.can_perform_action(src, NEED_DEXTERITY|FORBID_TELEKINESIS_REACH))


### PR DESCRIPTION
## About The Pull Request

`/datum/memory/playing_cards` accepts a list of other players, which it uses to format into an english list. 

But where it is applied, it takes a list of players, formats it into an english list, and passes it in. Oops.

Also fixed some verbage for how the memories look in-story-form. 

## Changelog

:cl: Melbert
fix: Playing Cards memory now reads better
/:cl:

