### PR TITLE
ChemMaster 3000 printing speed based on servo tier

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -1,3 +1,5 @@
+#define MAX_CONTAINER_PRINT_AMOUNT 50
+
 /obj/machinery/chem_master
 	name = "ChemMaster 3000"
 	desc = "Used to separate chemicals and distribute them in a variety of forms."
@@ -26,8 +28,6 @@
 	var/printing_progress
 	/// Number of containers to be printed
 	var/printing_total
-	/// The amount of containers that can be printed in 1 cycle
-	var/printing_amount = 50
 	/// The time it takes to print a container
 	var/printing_speed = 0.75 SECONDS
 
@@ -296,7 +296,7 @@
 	.["isPrinting"] = is_printing
 	.["printingProgress"] = printing_progress
 	.["printingTotal"] = printing_total
-	.["maxPrintable"] = printing_amount
+	.["maxPrintable"] = MAX_CONTAINER_PRINT_AMOUNT
 
 	//contents of source beaker
 	var/list/beaker_data = null
@@ -472,7 +472,7 @@
 			item_count = text2num(item_count)
 			if(isnull(item_count) || item_count <= 0)
 				return FALSE
-			item_count = min(item_count, printing_amount)
+			item_count = min(item_count, MAX_CONTAINER_PRINT_AMOUNT)
 			var/volume_in_each = round(reagents.total_volume / item_count, CHEMICAL_VOLUME_ROUNDING)
 
 			// Generate item name
@@ -547,3 +547,5 @@
 	if(!length(containers))
 		containers = list(CAT_CONDIMENTS = GLOB.reagent_containers[CAT_CONDIMENTS])
 	return containers
+
+#undef MAX_CONTAINER_PRINT_AMOUNT

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -267,6 +267,7 @@
 /obj/machinery/chem_master/ui_static_data(mob/user)
 	var/list/data = list()
 
+	data["maxPrintable"] = MAX_CONTAINER_PRINT_AMOUNT
 	data["categories"] = list()
 	for(var/category in printable_containers)
 		//make the category
@@ -296,7 +297,6 @@
 	.["isPrinting"] = is_printing
 	.["printingProgress"] = printing_progress
 	.["printingTotal"] = printing_total
-	.["maxPrintable"] = MAX_CONTAINER_PRINT_AMOUNT
 
 	//contents of source beaker
 	var/list/beaker_data = null


### PR DESCRIPTION
## About The Pull Request

Reverts the maximum number of containers (pills/patches/etc.) the ChemMaster 3000 can print back to 50. (Recently changed to 12.5 per tier in https://github.com/tgstation/tgstation/pull/82002) Instead, the servo tier determines the speed the batch is printed at.

![image](https://github.com/tgstation/tgstation/assets/83487515/d58a2325-55ff-4087-b73b-9d08ebdf98e5)

![image](https://github.com/tgstation/tgstation/assets/83487515/5d078957-dbc4-483f-8e38-62a815370f66)

## Why It's Good For The Game

Refilling the buffer and pressing print for every 13 pills is pointless busywork when there is already a delay now implemented per pill printed.

## Changelog

:cl: LT3
balance: ChemMaster can again print a maximum of 50 pills/patches per run
balance: Higher tier servos increase ChemMaster printing speed
/:cl: