### PR TITLE
Adminhelp length check

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -211,9 +211,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
  */
 /datum/admin_help/New(msg_raw, client/C, is_bwoink, urgent = FALSE)
 	//check message length
-	if(length(msg_raw) > MAX_MESSAGE_LEN)
+	var/message_length = length(msg_raw)
+	if(message_length > MAX_MESSAGE_LEN)
 		if(C)
-			to_chat(C, span_redtext("Failed to send your adminhelp. The maximum length of a message is [MAX_MESSAGE_LEN] characters, please reduce the length and try again. You attempted to send the following message:\n[sanitize(msg_raw)]"))
+			to_chat(C, span_redtext("Failed to send your adminhelp. Your message is [message_length] characters which exceeds the maximum length of [MAX_MESSAGE_LEN], please reduce the length and try again. You attempted to send the following message:\n[sanitize(msg_raw)]"))
 		message_admins("[C ? C.ckey : "An unknown client"] attempted to send an adminhelp that was too long.")
 		qdel(src)
 		return

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -210,6 +210,14 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
  * * is_bwoink - Boolean operator, TRUE if this ticket was started by an admin PM
  */
 /datum/admin_help/New(msg_raw, client/C, is_bwoink, urgent = FALSE)
+	//check message length
+	if(length(msg_raw) > MAX_MESSAGE_LEN)
+		if(C)
+			to_chat(C, span_redtext("Failed to send your adminhelp. The maximum length of a message is [MAX_MESSAGE_LEN] characters, please reduce the length and try again. You attempted to send the following message:\n[sanitize(msg_raw)]"))
+		message_admins("[C ? C.ckey : "An unknown client"] attempted to send an adminhelp that was too long.")
+		qdel(src)
+		return
+
 	//clean the input msg
 	var/msg = sanitize(copytext_char(msg_raw, 1, MAX_MESSAGE_LEN))
 	if(!msg || !C || !C.mob)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/82350 by checking the length of an ahelp before creation. If it exceeds the maximum length, it is returned to the player so they can copy/paste and fix without losing the message, similar to OOC messages.

## Why It's Good For The Game

People don't lose portions of ahelps to the void

## Changelog

:cl: LT3
fix: Players now receive an error when trying to send an adminhelp that exceeds the maximum character limit instead of being truncated silently
/:cl: