### PR TITLE
Fixes plasma flower modsuit cores having an extremely small amount of power

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -382,8 +382,8 @@
 	light_power = 1.5
 	// Slightly better than the normal plasma core.
 	// Not super sure if this should just be the same, but will see.
-	maxcharge = 15000
-	charge = 15000
+	maxcharge = 15 * STANDARD_CELL_CHARGE
+	charge = 15 * STANDARD_CELL_CHARGE
 	/// The mob to be spawned by the core
 	var/mob/living/spawned_mob_type = /mob/living/basic/butterfly/lavaland/temporary
 	/// Max number of mobs it can spawn


### PR DESCRIPTION

## About The Pull Request

The var was still using the old values.

## Why It's Good For The Game

15 kj instantly depletes your power supply upon taking a step. Oof.

## Changelog
:cl:
fix: The plasma flower modsuit core now actually contains a reasonable quantity of power.
/:cl:
