### PR TITLE
Revert of a Revert | ListInputModal

### DIFF
--- a/code/modules/asset_cache/assets/tgui.dm
+++ b/code/modules/asset_cache/assets/tgui.dm
@@ -1,21 +1,31 @@
 #ifdef TGS
-#define KLN FALSE
-#else
-#define KLN TRUE
-#endif
-
 /datum/asset/simple/tgui
-	keep_local_name = KLN
+	keep_local_name = FALSE
 	assets = list(
 		"tgui.bundle.js" = "tgui/public/tgui.bundle.js",
 		"tgui.bundle.css" = "tgui/public/tgui.bundle.css",
 	)
 
 /datum/asset/simple/tgui_panel
-	keep_local_name = KLN
+	keep_local_name = FALSE
 	assets = list(
 		"tgui-panel.bundle.js" = "tgui/public/tgui-panel.bundle.js",
 		"tgui-panel.bundle.css" = "tgui/public/tgui-panel.bundle.css",
 	)
 
-#undef KLN
+#else
+/datum/asset/simple/tgui
+	keep_local_name = TRUE
+	assets = list(
+		"tgui.bundle.js" = file("tgui/public/tgui.bundle.js"),
+		"tgui.bundle.css" = file("tgui/public/tgui.bundle.css"),
+	)
+
+/datum/asset/simple/tgui_panel
+	keep_local_name = TRUE
+	assets = list(
+		"tgui-panel.bundle.js" = file("tgui/public/tgui-panel.bundle.js"),
+		"tgui-panel.bundle.css" = file("tgui/public/tgui-panel.bundle.css"),
+	)
+
+#endif

--- a/code/modules/asset_cache/assets/tgui.dm
+++ b/code/modules/asset_cache/assets/tgui.dm
@@ -1,3 +1,7 @@
+// If you use a file(...) object, instead of caching the asset it will be loaded from disk every time it's requested.
+// This is useful for development, but not recommended for production.
+// And if TGS is defined, we're being run in a production environment.
+
 #ifdef TGS
 /datum/asset/simple/tgui
 	keep_local_name = FALSE

--- a/code/modules/asset_cache/assets/tgui.dm
+++ b/code/modules/asset_cache/assets/tgui.dm
@@ -1,13 +1,21 @@
+#ifdef TGS
+#define KLN FALSE
+#else
+#define KLN TRUE
+#endif
+
 /datum/asset/simple/tgui
-	keep_local_name = TRUE
+	keep_local_name = KLN
 	assets = list(
 		"tgui.bundle.js" = "tgui/public/tgui.bundle.js",
 		"tgui.bundle.css" = "tgui/public/tgui.bundle.css",
 	)
 
 /datum/asset/simple/tgui_panel
-	keep_local_name = TRUE
+	keep_local_name = KLN
 	assets = list(
 		"tgui-panel.bundle.js" = "tgui/public/tgui-panel.bundle.js",
 		"tgui-panel.bundle.css" = "tgui/public/tgui-panel.bundle.css",
 	)
+
+#undef KLN

--- a/code/modules/asset_cache/assets/tgui.dm
+++ b/code/modules/asset_cache/assets/tgui.dm
@@ -1,13 +1,13 @@
 /datum/asset/simple/tgui
 	keep_local_name = TRUE
 	assets = list(
-		"tgui.bundle.js" = file("tgui/public/tgui.bundle.js"),
-		"tgui.bundle.css" = file("tgui/public/tgui.bundle.css"),
+		"tgui.bundle.js" = "tgui/public/tgui.bundle.js",
+		"tgui.bundle.css" = "tgui/public/tgui.bundle.css",
 	)
 
 /datum/asset/simple/tgui_panel
 	keep_local_name = TRUE
 	assets = list(
-		"tgui-panel.bundle.js" = file("tgui/public/tgui-panel.bundle.js"),
-		"tgui-panel.bundle.css" = file("tgui/public/tgui-panel.bundle.css"),
+		"tgui-panel.bundle.js" = "tgui/public/tgui-panel.bundle.js",
+		"tgui-panel.bundle.css" = "tgui/public/tgui-panel.bundle.css",
 	)

--- a/code/modules/tgui_input/list.dm
+++ b/code/modules/tgui_input/list.dm
@@ -111,7 +111,7 @@
 /datum/tgui_list_input/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "ListInputModal")
+		ui = new(user, src, "ListInputWindow")
 		ui.open()
 
 /datum/tgui_list_input/ui_close(mob/user)

--- a/tgui/packages/tgui/interfaces/ListInputWindow/index.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputWindow/index.tsx
@@ -1,0 +1,44 @@
+import { useBackend } from '../../backend';
+import { Window } from '../../layouts';
+import { Loader } from '../common/Loader';
+import { ListInputModal } from './ListInputModal';
+
+type ListInputData = {
+  init_value: string;
+  items: string[];
+  large_buttons: boolean;
+  message: string;
+  timeout: number;
+  title: string;
+};
+
+export const ListInputWindow = () => {
+  const { act, data } = useBackend<ListInputData>();
+  const {
+    items = [],
+    message = '',
+    init_value,
+    large_buttons,
+    timeout,
+    title,
+  } = data;
+
+  // Dynamically changes the window height based on the message.
+  const windowHeight =
+    325 + Math.ceil(message.length / 3) + (large_buttons ? 5 : 0);
+
+  return (
+    <Window title={title} width={325} height={windowHeight}>
+      {timeout && <Loader value={timeout} />}
+      <Window.Content>
+        <ListInputModal
+          items={items}
+          default_item={init_value}
+          message={message}
+          on_selected={(entry) => act('submit', { entry })}
+          on_cancel={() => act('cancel')}
+        />
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/common/InputButtons.tsx
+++ b/tgui/packages/tgui/interfaces/common/InputButtons.tsx
@@ -8,19 +8,36 @@ type InputButtonsData = {
 
 type InputButtonsProps = {
   input: string | number | string[];
+  on_submit?: () => void;
+  on_cancel?: () => void;
   message?: string;
 };
 
 export const InputButtons = (props: InputButtonsProps) => {
   const { act, data } = useBackend<InputButtonsData>();
   const { large_buttons, swapped_buttons } = data;
-  const { input, message } = props;
+  const { input, message, on_submit, on_cancel } = props;
+
+  let on_submit_actual = on_submit;
+  if (!on_submit_actual) {
+    on_submit_actual = () => {
+      act('submit', { entry: input });
+    };
+  }
+
+  let on_cancel_actual = on_cancel;
+  if (!on_cancel_actual) {
+    on_cancel_actual = () => {
+      act('cancel');
+    };
+  }
+
   const submitButton = (
     <Button
       color="good"
       fluid={!!large_buttons}
       height={!!large_buttons && 2}
-      onClick={() => act('submit', { entry: input })}
+      onClick={on_submit_actual}
       m={0.5}
       pl={2}
       pr={2}
@@ -37,7 +54,7 @@ export const InputButtons = (props: InputButtonsProps) => {
       color="bad"
       fluid={!!large_buttons}
       height={!!large_buttons && 2}
-      onClick={() => act('cancel')}
+      onClick={on_cancel_actual}
       m={0.5}
       pl={2}
       pr={2}


### PR DESCRIPTION
This reverts commit 9acf5bd821b37e4d8dad1c850497eeef79c0e7d8.

MSO determined that because we use `file(...)` instead of a string instead of an asset being locked to its initial state via a cache object we are sending it as it is on disk every time. which means that when a new server deployment updates the tgui it will send this new tgui code even if the currently running DM code does not support it.