### PR TITLE
Fixes some rando failures off the ignore list of projectiles

### DIFF
--- a/code/datums/components/mirv.dm
+++ b/code/datums/components/mirv.dm
@@ -39,5 +39,5 @@
 			P.range = override_projectile_range
 		P.preparePixelProjectile(shootat_turf, target)
 		P.firer = firer // don't hit ourself that would be really annoying
-		P.impacted = list(target = TRUE) // don't hit the target we hit already with the flak
+		P.impacted = list(WEAKREF(target) = TRUE) // don't hit the target we hit already with the flak
 		P.fire()

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -277,7 +277,7 @@
 	P.original = target
 	P.fired_from = parent
 	P.firer = parent // don't hit ourself that would be really annoying
-	P.impacted = list(parent = TRUE) // don't hit the target we hit already with the flak
+	P.impacted = list(WEAKREF(parent) = TRUE) // don't hit the target we hit already with the flak
 	P.suppressed = SUPPRESSED_VERY // set the projectiles to make no message so we can do our own aggregate message
 	P.preparePixelProjectile(target, parent)
 	RegisterSignal(P, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(pellet_hit))

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -491,7 +491,7 @@
 	blown_kiss.original = target
 	blown_kiss.fired_from = user
 	blown_kiss.firer = user // don't hit ourself that would be really annoying
-	blown_kiss.impacted = list(user = TRUE) // just to make sure we don't hit the wearer
+	blown_kiss.impacted = list(WEAKREF(user) = TRUE) // just to make sure we don't hit the wearer
 	blown_kiss.preparePixelProjectile(target, user)
 	blown_kiss.fire()
 	qdel(src)
@@ -517,7 +517,7 @@
 	blown_kiss.original = taker
 	blown_kiss.fired_from = offerer
 	blown_kiss.firer = offerer // don't hit ourself that would be really annoying
-	blown_kiss.impacted = list(offerer = TRUE) // just to make sure we don't hit the wearer
+	blown_kiss.impacted = list(WEAKREF(offerer) = TRUE) // just to make sure we don't hit the wearer
 	blown_kiss.preparePixelProjectile(taker, offerer)
 	blown_kiss.suppressed = SUPPRESSED_VERY // this also means it's a direct offer
 	blown_kiss.fire()

--- a/code/modules/clothing/shoes/gunboots.dm
+++ b/code/modules/clothing/shoes/gunboots.dm
@@ -59,7 +59,7 @@
 	shot.original = target
 	shot.fired_from = src
 	shot.firer = wearer // don't hit ourself that would be really annoying
-	shot.impacted = list(wearer = TRUE)
+	shot.impacted = list(WEAKREF(wearer) = TRUE)
 	shot.def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG) // they're fired from boots after all
 	shot.preparePixelProjectile(target, wearer)
 	if(!shot.suppressed)

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -234,7 +234,7 @@
 	cast_projectile.original = target
 	cast_projectile.fired_from = src
 	cast_projectile.firer = user
-	cast_projectile.impacted = list(user = TRUE)
+	cast_projectile.impacted = list(WEAKREF(user) = TRUE)
 	cast_projectile.preparePixelProjectile(target, user)
 	cast_projectile.fire()
 	COOLDOWN_START(src, casting_cd, 1 SECONDS)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -457,7 +457,7 @@
 	if(!trajectory)
 		qdel(src)
 		return FALSE
-	if(impacted[WEAKREF(A)]) // NEVER doublehit
+	if(impacted[A.weak_reference]) // NEVER doublehit
 		return FALSE
 	var/datum/point/point_cache = trajectory.copy_to()
 	var/turf/T = get_turf(A)
@@ -587,7 +587,7 @@
 //Returns true if the target atom is on our current turf and above the right layer
 //If direct target is true it's the originally clicked target.
 /obj/projectile/proc/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
-	if(QDELETED(target) || impacted[WEAKREF(target)])
+	if(QDELETED(target) || impacted[target.weak_reference])
 		return FALSE
 	if(!ignore_loc && (loc != target.loc) && !(can_hit_turfs && direct_target && loc == target))
 		return FALSE
@@ -675,7 +675,7 @@
  * Used to not even attempt to Bump() or fail to Cross() anything we already hit.
  */
 /obj/projectile/CanPassThrough(atom/blocker, movement_dir, blocker_opinion)
-	return ..() || impacted[WEAKREF(blocker)]
+	return ..() || impacted[blocker.weak_reference]
 
 /**
  * Projectile moved:

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -457,7 +457,7 @@
 	if(!trajectory)
 		qdel(src)
 		return FALSE
-	if(impacted[A]) // NEVER doublehit
+	if(impacted[WEAKREF(A)]) // NEVER doublehit
 		return FALSE
 	var/datum/point/point_cache = trajectory.copy_to()
 	var/turf/T = get_turf(A)
@@ -510,7 +510,7 @@
 	if(QDELETED(src) || !T || !target)
 		return
 	// 2.
-	impacted[target] = TRUE //hash lookup > in for performance in hit-checking
+	impacted[WEAKREF(target)] = TRUE //hash lookup > in for performance in hit-checking
 	// 3.
 	var/mode = prehit_pierce(target)
 	if(mode == PROJECTILE_DELETE_WITHOUT_HITTING)
@@ -587,7 +587,7 @@
 //Returns true if the target atom is on our current turf and above the right layer
 //If direct target is true it's the originally clicked target.
 /obj/projectile/proc/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
-	if(QDELETED(target) || impacted[target])
+	if(QDELETED(target) || impacted[WEAKREF(target)])
 		return FALSE
 	if(!ignore_loc && (loc != target.loc) && !(can_hit_turfs && direct_target && loc == target))
 		return FALSE
@@ -675,7 +675,7 @@
  * Used to not even attempt to Bump() or fail to Cross() anything we already hit.
  */
 /obj/projectile/CanPassThrough(atom/blocker, movement_dir, blocker_opinion)
-	return impacted[blocker] ? TRUE : ..()
+	return ..() || impacted[WEAKREF(blocker)]
 
 /**
  * Projectile moved:
@@ -1188,8 +1188,7 @@
 	bullet.starting = startloc
 	var/list/ignore = list()
 	for (var/atom/thing as anything in ignore_targets)
-		ignore[thing] = TRUE
-	bullet.impacted += ignore
+		bullet.impacted[WEAKREF(thing)] = TRUE
 	bullet.firer = firer || src
 	bullet.fired_from = src
 	bullet.yo = target.y - startloc.y


### PR DESCRIPTION

## About The Pull Request

Let's swap the ignored list to weakrefs instead of hard refs. Should reduce hard deletes

## Why It's Good For The Game

We should not be holding a list of refs without cleaning them. It is GENERALLY safe to assume that projectiles have short lifetimes, but it's not guarenteed anywhere, and it's better to ensure they never hang a ref we can't clear.

Prompted by a rando failure in dark wizards off #82851 
