### PR TITLE
Bepis techs can be found in bitrunning crates, removed from vendors

### DIFF
--- a/code/modules/bitrunning/objects/loot_crate.dm
+++ b/code/modules/bitrunning/objects/loot_crate.dm
@@ -7,6 +7,7 @@
 #define ORE_MULTIPLIER_URANIUM 0.4
 #define ORE_MULTIPLIER_DIAMOND 0.3
 #define ORE_MULTIPLIER_BLUESPACE_CRYSTAL 0.2
+#define BEPIS_CHANCE_PER_REWARD_TIER 5
 
 /obj/structure/closet/crate/secure/bitrunning // Base class. Do not spawn this.
 	name = "base class cache"
@@ -64,7 +65,7 @@
 		new /obj/item/stack/ore/diamond(src, calculate_loot(reward_points, rewards_multiplier, ORE_MULTIPLIER_DIAMOND))
 		new /obj/item/stack/ore/bluespace_crystal(src, calculate_loot(reward_points, rewards_multiplier, ORE_MULTIPLIER_BLUESPACE_CRYSTAL))
 
-	if(reward_points > 1 && LAZYLEN(SSresearch.techweb_nodes_experimental) && prob(min(100, reward_points * 10)))
+	if(reward_points > 1 && LAZYLEN(SSresearch.techweb_nodes_experimental) && prob(min(100, reward_points * BEPIS_CHANCE_PER_REWARD_TIER)))
 		new /obj/item/disk/design_disk/bepis/remove_tech(src)
 
 /// Handles generating random numbers & calculating loot totals
@@ -96,3 +97,4 @@
 #undef ORE_MULTIPLIER_URANIUM
 #undef ORE_MULTIPLIER_DIAMOND
 #undef ORE_MULTIPLIER_BLUESPACE_CRYSTAL
+#undef BEPIS_CHANCE_PER_REWARD_TIER

--- a/code/modules/bitrunning/objects/loot_crate.dm
+++ b/code/modules/bitrunning/objects/loot_crate.dm
@@ -64,6 +64,9 @@
 		new /obj/item/stack/ore/diamond(src, calculate_loot(reward_points, rewards_multiplier, ORE_MULTIPLIER_DIAMOND))
 		new /obj/item/stack/ore/bluespace_crystal(src, calculate_loot(reward_points, rewards_multiplier, ORE_MULTIPLIER_BLUESPACE_CRYSTAL))
 
+	if(reward_points > 1 && LAZYLEN(SSresearch.techweb_nodes_experimental) && prob(min(100, reward_points * 10)))
+		new /obj/item/disk/design_disk/bepis/remove_tech(src)
+
 /// Handles generating random numbers & calculating loot totals
 /obj/structure/closet/crate/secure/bitrunning/decrypted/proc/calculate_loot(reward_points, rewards_multiplier, ore_multiplier)
 	var/base = rewards_multiplier + reward_points

--- a/code/modules/bitrunning/objects/loot_crate.dm
+++ b/code/modules/bitrunning/objects/loot_crate.dm
@@ -7,7 +7,6 @@
 #define ORE_MULTIPLIER_URANIUM 0.4
 #define ORE_MULTIPLIER_DIAMOND 0.3
 #define ORE_MULTIPLIER_BLUESPACE_CRYSTAL 0.2
-#define BEPIS_CHANCE_PER_REWARD_TIER 5
 
 /obj/structure/closet/crate/secure/bitrunning // Base class. Do not spawn this.
 	name = "base class cache"
@@ -65,9 +64,6 @@
 		new /obj/item/stack/ore/diamond(src, calculate_loot(reward_points, rewards_multiplier, ORE_MULTIPLIER_DIAMOND))
 		new /obj/item/stack/ore/bluespace_crystal(src, calculate_loot(reward_points, rewards_multiplier, ORE_MULTIPLIER_BLUESPACE_CRYSTAL))
 
-	if(reward_points > 1 && LAZYLEN(SSresearch.techweb_nodes_experimental) && prob(min(100, reward_points * BEPIS_CHANCE_PER_REWARD_TIER)))
-		new /obj/item/disk/design_disk/bepis/remove_tech(src)
-
 /// Handles generating random numbers & calculating loot totals
 /obj/structure/closet/crate/secure/bitrunning/decrypted/proc/calculate_loot(reward_points, rewards_multiplier, ore_multiplier)
 	var/base = rewards_multiplier + reward_points
@@ -97,4 +93,3 @@
 #undef ORE_MULTIPLIER_URANIUM
 #undef ORE_MULTIPLIER_DIAMOND
 #undef ORE_MULTIPLIER_BLUESPACE_CRYSTAL
-#undef BEPIS_CHANCE_PER_REWARD_TIER

--- a/code/modules/bitrunning/orders/bepis.dm
+++ b/code/modules/bitrunning/orders/bepis.dm
@@ -17,7 +17,3 @@
 /datum/orderable_item/bepis/sprayoncan
 	item_path = /obj/item/toy/sprayoncan
 	cost_per_order = 750
-
-/datum/orderable_item/bepis/pristine
-	item_path = /obj/item/disk/design_disk/bepis/remove_tech
-	cost_per_order = 1000

--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -44,6 +44,8 @@
 	var/start_time
 	/// This map is specifically for unit tests. Shouldn't display in game
 	var/test_only = FALSE
+	/// Has this domain been beaten with high enough score to spawn a tech disk?
+	var/disk_reward_spawned = FALSE
 
 /// Sends a point to any loot signals on the map
 /datum/lazy_template/virtual_domain/proc/add_points(points_to_add)


### PR DESCRIPTION
## About The Pull Request

This PR adds Bepis disks to the main rewards of the Bitrunning crate in addition to the minerals and domain specific rewards. It also removes it from the Bepis vending machine. 

Once per domain, if its difficult was Medium or higher, and the completion score was A or S, and if there are still any leftover locked Bepis tech nodes, a Bepis disk will spawn.

<details>
  <summary>Original PR text</summary>
If domain has a reward value greater than one, it has 10% chance per reward value to drop. No disk is gained if they ran out of techs to unlock. Most of the domains have a reward value of three, so by the law of great numbers they probably get one disk per every three domains run, which should be one disk every 20-30 minutes. At least, if I am correct that domain runs take about five to ten minutes, and the server cooldown is three minutes. If I am incorrect, I can edit the drop chance as needed, of course.

Edit: As I have underestimated how fast Bitrunners can be, I have decreased the chance to be 5% per reward tier.
</details> 

## Why It's Good For The Game

- Bepis disks are expensive, and bitrunners need to spend almost all their NP on gear and abilities
- Downloading secret research data, is flavourful, fitting for invading the forgotten nooks of cyberspace.
- This will allow Bepis tech to be actually used in rounds

## Changelog

:cl:
balance: Bitrunners can now earn Bepis disks, once per medium domain or above, if they scored at least an A.
del: Bitrunners can not buy Bepis disks from their vendors.
/:cl:

