### PR TITLE
you can use a photo with blueprints on it to read wires

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -262,7 +262,7 @@
 		if(user.is_holding_item_of_type(/obj/item/blueprints))
 			return TRUE
 		for(var/obj/item/photo/photo in user.held_items)
-			if(!photo.picture.has_blueprints)
+			if(!photo.picture || !photo.picture.has_blueprints)
 				continue
 			return TRUE
 

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -258,8 +258,13 @@
 		return TRUE
 
 	// Station blueprints do that too, but only if the wires are not randomized.
-	if(user.is_holding_item_of_type(/obj/item/blueprints) && !randomize)
-		return TRUE
+	if(!randomize)
+		if(user.is_holding_item_of_type(/obj/item/blueprints))
+			return TRUE
+		for(var/obj/item/photo/photo in user.held_items)
+			if(!photo.picture.has_blueprints)
+				continue
+			return TRUE
 
 	return FALSE
 


### PR DESCRIPTION

## About The Pull Request
like how you can get the objective by taking a photo of the station blueprints, now you can view wires with a photo of them

## Why It's Good For The Game
lets the chief engineer help out his fellas if he wants to and provides plausible deniability for traitors that want a picture of the blueprints

## Changelog
:cl:
add: you can use a photo with blueprints on it to read wires
/:cl:
