### PR TITLE
fixes jps mobs occasioanlly pathing forever

### DIFF
--- a/code/datums/ai/movement/_ai_movement.dm
+++ b/code/datums/ai/movement/_ai_movement.dm
@@ -72,7 +72,8 @@
 /datum/ai_movement/proc/post_move(datum/move_loop/source, succeeded)
 	SIGNAL_HANDLER
 	var/datum/ai_controller/controller = source.extra_info
-	if(succeeded != MOVELOOP_FAILURE)
-		reset_pathing_failures(controller)
-		return
-	increment_pathing_failures(controller)
+	switch(succeeded)
+		if(MOVELOOP_SUCCESS)
+			reset_pathing_failures(controller)
+		if(MOVELOOP_FAILURE)
+			increment_pathing_failures(controller)


### PR DESCRIPTION

## About The Pull Request
if MOVELOOP_NOT_READY gets passed once through the signal (which can be often), the failure increments gets reset back to 0 and starts counting again. this can cause the increments to never reach the max failure threshold so itll keep checking forever. i saw some mobs get stuck trying to reach an unreachable target because of this

## Why It's Good For The Game
fixes mobs getting stuck trying to reach something unreachable

## Changelog
:cl:
fix: fixes mobs getting stuck trying to reach something unreachable
/:cl:
