### PR TITLE
[NO GBP] Overwatch Intelligence Agents No Longer Get Their Own Uplink

### DIFF
--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -120,10 +120,7 @@
 	head = /obj/item/clothing/head/helmet/space/plasmaman/syndie
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	glasses = /obj/item/clothing/glasses/overwatch
-	suit = /obj/item/clothing/suit/jacket/letterman_syndie
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
-	command_radio = TRUE
-	tc = 0
 
 /datum/outfit/syndicate/reinforcement/gorlex
 	name = "Syndicate Operative - Gorlex Reinforcement"
@@ -212,3 +209,4 @@
 	shoes = /obj/item/clothing/shoes/sandal
 	command_radio = TRUE
 	tc = 0
+	uplink_type = null


### PR DESCRIPTION

## About The Pull Request

Overwatch operatives no longer get an uplink with TC in it.

While they failed to break out of the nukie base (GOOD!) they were able to call in more of each other, which led to a grey-goo scenario of self-replicating discount overwatch operatives (KINDA BAD BUT ALSO KIND OF FUNNY).

![image](https://github.com/tgstation/tgstation/assets/28870487/28683e31-dc98-496f-9ef8-e05516444c17)

![image](https://github.com/tgstation/tgstation/assets/28870487/7be759b3-2d91-47bc-8a2b-9efc94e7bad9)

I really really really hate having to fix this bug because it ended up being fucking hilarious but it cannot happen again.

(Also some minor inheritance gripes with the plasmeme outfit, don't worry about it).

I also might make the turfs indestructible/have a better baseturf so accidental explosive discharges can't break the floor and space everyone in the nukie base areas in another PR. 
## Why It's Good For The Game

Self-replicating helpdesk assistants, a terrifying concept.
## Changelog
:cl: Rhials
fix: Overwatch Intelligence Agents no longer get their own uplinks, leading to a self-replicating grey goo scenario. 
/:cl:
