### PR TITLE
Starts Shaft Miners equipped with the Kheiral Cuffs.

### DIFF
--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -45,7 +45,7 @@
 	)
 	belt = /obj/item/modular_computer/pda/shaftminer
 	ears = /obj/item/radio/headset/headset_cargo/mining
-	gloves = /obj/item/clothing/gloves/color/black
+	gloves = /obj/item/kheiral_cuffs
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	l_pocket = /obj/item/reagent_containers/hypospray/medipen/survival
 	r_pocket = /obj/item/storage/bag/ore //causes issues if spawned in backpack


### PR DESCRIPTION
## About The Pull Request

Starts Shaft Miners equipped with the Kheiral Cuffs.

## Why It's Good For The Game

In the old mining, the station figured out all the miners were dead because they ran out of mats and they didn't restock. This doesn't occur in new mining, where ore vents and boulders ensure a permanent steady stream of materials for the crew to never think about the miners again.

This results in an extremely unfun experience for new miners who don't know the Kheiral Cuffs should be their first purchase and immediate equip. As such, I've made them spawn on miners by default.

## Changelog
:cl:
balance: Starts Shaft Miners equipped with the Kheiral Cuffs.
/:cl:
