### PR TITLE
Fix the materials box dropping its contents on creation

### DIFF
--- a/code/game/objects/items/storage/boxes/engineering_boxes.dm
+++ b/code/game/objects/items/storage/boxes/engineering_boxes.dm
@@ -24,10 +24,7 @@
 
 /obj/item/storage/box/material/Initialize(mapload)
 	. = ..()
-	atom_storage.allow_big_nesting = TRUE
-	atom_storage.max_slots = 99
-	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
-	atom_storage.max_total_storage = 99
+	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC //This needs to be set here too because the parent type overrides it again
 
 /obj/item/storage/box/material/PopulateContents() //less uranium because radioactive
 	var/static/items_inside = list(
@@ -51,6 +48,11 @@
 		/obj/item/stack/sheet/plastic/fifty=1,
 		/obj/item/stack/sheet/runed_metal/fifty=1,
 		)
+	//This needs to be done here and not in Initialize() because the stacks get merged and fall out when their weight updates if this is set after PopulateContents()
+	atom_storage.allow_big_nesting = TRUE
+	atom_storage.max_slots = 99
+	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
+	atom_storage.max_total_storage = 99
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/box/debugtools


### PR DESCRIPTION
## About The Pull Request
This fixes the materials box (part of the debug box/admin outfit) dropping its contents everywhere. The issue is that these stacks will merge during `PopulateContents` as part of the parent call to `/obj/item/storage/Initialize` before `/obj/item/storage/box/material/Initialize` has a chance to change the size of the box.
## Why It's Good For The Game
Fixes #82705
## Changelog
:cl: VexingRaven
fix: The debug box no longer spills its contents everywhere
/:cl:
