### PR TITLE
Fix malf AI being unable to trigger because AIs are considered ghost roles

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -297,25 +297,29 @@
 	cost = 10
 	required_type = /mob/living/silicon/ai
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/malf_ai)
+	// AIs are technically considered "Ghost roles" as far as candidate selection are concerned
+	// So we need to allow it here. We filter of actual ghost role AIs (charlie) via trim_candidates ourselves
+	restrict_ghost_roles = FALSE
 
 /datum/dynamic_ruleset/midround/malf/trim_candidates()
 	..()
-	candidates = living_players
-	for(var/mob/living/player in candidates)
-		if(!isAI(player))
-			candidates -= player
+	candidates = list()
+	for(var/mob/living/silicon/ai/player in living_players)
+		if(!is_station_level(player.z))
 			continue
-
-		if(is_centcom_level(player.z))
-			candidates -= player
+		if(isnull(player.mind))
 			continue
+		if(player.mind.special_role || length(player.mind.antag_datums))
+			continue
+		candidates += player
 
-		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
-			candidates -= player
+/datum/dynamic_ruleset/midround/malf/ready(forced)
+	if(!check_candidates())
+		log_dynamic("FAIL: No valid AI found for the Malfunctioning AI ruleset.")
+		return FALSE
+	return ..()
 
 /datum/dynamic_ruleset/midround/malf/execute()
-	if(!candidates || !candidates.len)
-		return FALSE
 	var/mob/living/silicon/ai/new_malf_ai = pick_n_take(candidates)
 	assigned += new_malf_ai.mind
 	var/datum/antagonist/malf_ai/malf_antag_datum = new


### PR DESCRIPTION
## About The Pull Request

Fix #82891 

PR #82030 added this job flag check to dynamic candidate trimming

https://github.com/tgstation/tgstation/blob/cd29b123eff035fff7da10d21f8d55e1c898670f/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm#L77-L79

Problem: AIs do not have `JOB_CREW_MEMBER`!

This meant that all AI mobs were trimmed out of the candidate list for midround malf, so no it always failed

This PR fixes this by flipping `restrict_ghost_roles` to `FALSE` for midround malf and then tightening up some of the checks to ensure off station AIs don't roll malf. 

## Changelog

:cl: Melbert
fix: Midround malf can roll again
/:cl:
