### PR TITLE
Fix plasma cutters (the hacky way)

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -208,7 +208,7 @@
 	if(user.Adjacent(src))
 		attack_hand(user)
 
-/turf/closed/mineral/proc/gets_drilled(mob/user, give_exp = FALSE)
+/turf/closed/mineral/proc/gets_drilled(mob/user, give_exp = FALSE) as /turf
 	if(istype(user))
 		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, give_exp)
 	if(mineralType && (mineralAmt > 0))
@@ -234,6 +234,7 @@
 	addtimer(CALLBACK(src, PROC_REF(AfterChange), flags, old_type), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
 	mined.update_visuals()
+	return mined
 
 /turf/closed/mineral/attack_alien(mob/living/carbon/alien/user, list/modifiers)
 	balloon_alert(user, "digging...")

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1186,7 +1186,6 @@
 	var/turf/startloc = get_turf(src)
 	var/obj/projectile/bullet = new projectile_type(startloc)
 	bullet.starting = startloc
-	var/list/ignore = list()
 	for (var/atom/thing as anything in ignore_targets)
 		bullet.impacted[WEAKREF(thing)] = TRUE
 	bullet.firer = firer || src

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -15,7 +15,8 @@
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
-		M.gets_drilled(firer, FALSE)
+		var/turf/below = M.gets_drilled(firer, FALSE)
+		impacted[WEAKREF(below)] = TRUE
 		if(mine_range)
 			mine_range--
 			range++


### PR DESCRIPTION
## About The Pull Request

Fixes #82886

Changing impacted to weakrefs (#82855) caused some interesting behavior with turfs, because when a turf is changed its gets a new weakref. Meaning we end up hitting the same turf twice (where before we would ignore it, due to holding a real reference to it). 

I fixed it with a hack, by manually inserting the new turf's new weakref into the impacted list, but this might be worth fixing at a turf level, dunno

## Changelog

:cl: Melbert
fix: Plasma cutters work again
/:cl:

