### PR TITLE
Turf weakref persists in changeturf / Fix plasma cutters 

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -91,6 +91,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 	var/list/old_baseturfs = baseturfs
 	var/old_type = type
+	var/datum/weakref/old_ref = weak_reference
+	weak_reference = null
 
 	var/list/post_change_callbacks = list()
 	SEND_SIGNAL(src, COMSIG_TURF_CHANGE, path, new_baseturfs, flags, post_change_callbacks)
@@ -136,6 +138,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	dynamic_lumcount = old_dynamic_lumcount
 
 	lattice_underneath = old_lattice_underneath
+
+	new_turf.weak_reference = old_ref
 
 	if(SSlighting.initialized)
 		// Space tiles should never have lighting objects

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1186,7 +1186,6 @@
 	var/turf/startloc = get_turf(src)
 	var/obj/projectile/bullet = new projectile_type(startloc)
 	bullet.starting = startloc
-	var/list/ignore = list()
 	for (var/atom/thing as anything in ignore_targets)
 		bullet.impacted[WEAKREF(thing)] = TRUE
 	bullet.firer = firer || src


### PR DESCRIPTION
## About The Pull Request

Turf references don't change so logically, turf weakrefs wouldn't change if the turf changes. 

By not doing this this can cause bugs: See #82886 . (This Fixes #82886) 

(Projectiles hold a list of weakrefs to atoms hit to determine what they have already hit. 

Because turf weakrefs reset, we could "hit" the same turf twice if it destroyed the turf. 

Old behavior - this was fine but now that they're weakrefs, we get two weakref datums in the list that point to the same ref.)

Less hacky alternative to #82901 . (Closes #82901) 

## Changelog

:cl: Melbert
fix: Plasma cutters work again
/:cl: