### PR TITLE
fix roleless poll ignores not working

### DIFF
--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -85,7 +85,7 @@ SUBSYSTEM_DEF(polling)
 		// Opt-out for admins whom are currently adminned.
 		if(role && (!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && candidate_mob.client.holder)
 			continue
-		if(role && !is_eligible(candidate_mob, role, check_jobban, ignore_category))
+		if(!is_eligible(candidate_mob, role, check_jobban, ignore_category))
 			continue
 
 		if(start_signed_up)

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -79,11 +79,11 @@ SUBSYSTEM_DEF(polling)
 	for(var/mob/candidate_mob as anything in group)
 		if(!candidate_mob.client)
 			continue
-		// Universal opt-out for all players if it's for a role.
-		if(role && (!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles)))
+		// Universal opt-out for all players.
+		if(!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles))
 			continue
 		// Opt-out for admins whom are currently adminned.
-		if(role && (!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && candidate_mob.client.holder)
+		if((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && candidate_mob.client.holder)
 			continue
 		if(!is_eligible(candidate_mob, role, check_jobban, ignore_category))
 			continue


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/82890

In some cases an alert poll had no role, like the monkey helmet, and because of that it skipped the eligibility check
## Changelog
:cl:
fix: All alert polls ignore option works
/:cl:
