### PR TITLE
Adds tinyfans to the arrival shuttles

### DIFF
--- a/_maps/shuttles/arrival_birdshot.dmm
+++ b/_maps/shuttles/arrival_birdshot.dmm
@@ -62,6 +62,11 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
+"x" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "B" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -69,6 +74,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "J" = (
@@ -128,20 +134,20 @@
 
 (1,1,1) = {"
 a
-Q
-Q
-Q
-Q
-Q
+x
+x
+x
+x
+x
 a
 "}
 (2,1,1) = {"
 a
-Q
+x
 f
 n
 R
-Q
+x
 a
 "}
 (3,1,1) = {"
@@ -172,22 +178,22 @@ B
 F
 "}
 (6,1,1) = {"
-Q
+x
 U
 B
 U
 B
 U
-Q
+x
 "}
 (7,1,1) = {"
-Q
+x
 U
 B
 U
 B
 U
-Q
+x
 "}
 (8,1,1) = {"
 V
@@ -204,7 +210,7 @@ Q
 L
 q
 w
-Q
+x
 a
 "}
 (10,1,1) = {"
@@ -217,22 +223,22 @@ q
 V
 "}
 (11,1,1) = {"
-Q
+x
 U
 B
 U
 B
 U
-Q
+x
 "}
 (12,1,1) = {"
-Q
+x
 U
 B
 U
 B
 U
-Q
+x
 "}
 (13,1,1) = {"
 F

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -9,10 +9,12 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -39,6 +39,7 @@
 /area/shuttle/arrival)
 "ah" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "ai" = (
@@ -156,6 +157,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron/white,
 /area/shuttle/arrival)
 "ap" = (

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -38,6 +38,7 @@
 /area/shuttle/arrival)
 "k" = (
 /obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "l" = (
@@ -55,6 +56,7 @@
 /area/shuttle/arrival)
 "o" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "p" = (

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -16,6 +16,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "ae" = (
@@ -99,6 +100,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "ap" = (
@@ -298,6 +300,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
+"lA" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "rV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -349,7 +356,7 @@ aX
 aW
 aQ
 aY
-af
+lA
 "}
 (5,1,1) = {"
 ae
@@ -367,7 +374,7 @@ rV
 ay
 aV
 aN
-af
+lA
 "}
 (7,1,1) = {"
 af
@@ -376,7 +383,7 @@ rV
 az
 aV
 aN
-af
+lA
 "}
 (8,1,1) = {"
 af
@@ -385,7 +392,7 @@ rV
 ab
 aV
 aN
-af
+lA
 "}
 (9,1,1) = {"
 ac
@@ -435,9 +442,9 @@ ag
 (14,1,1) = {"
 ag
 ac
-af
-af
-af
+lA
+lA
+lA
 ac
 ag
 "}

--- a/_maps/shuttles/arrival_northstar.dmm
+++ b/_maps/shuttles/arrival_northstar.dmm
@@ -12,6 +12,7 @@
 /obj/machinery/door/airlock/survival_pod/glass{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (
@@ -183,6 +184,7 @@
 /area/shuttle/arrival)
 "Z" = (
 /obj/effect/spawner/structure/window/survival_pod,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -9,10 +9,12 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (
@@ -53,6 +55,7 @@
 	name = "Ship Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "n" = (


### PR DESCRIPTION
## About The Pull Request
This PR adds tinyfans all arrivals shuttles

## Why It's Good For The Game
Sometimes arrivals shuttle gets depressurized due the state of the arrivals wings and air going out of doors this means if a new player joins the game they are immediatly met with the suffocation indictator while a veteran might know his way around it a new player would not this gives them a little more breathing space in to whats supposed to be a non griefable area

:cl:
qol: Arrivals shuttle is now more player friendly
/:cl:
