### PR TITLE
Replaces all main map pacmans with random pre_loaded spawners

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -9500,7 +9500,7 @@
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "eip" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -15251,7 +15251,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
 	},
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
 "gub" = (
@@ -18183,7 +18183,7 @@
 "hnY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5874,7 +5874,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/random/directional/south,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bwl" = (
@@ -6974,7 +6974,7 @@
 "bID" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "bIG" = (
@@ -12698,7 +12698,7 @@
 "ddC" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -18149,7 +18149,7 @@
 /area/station/service/cafeteria)
 "exM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -19028,7 +19028,7 @@
 /area/station/service/abandoned_gambling_den)
 "eJG" = (
 /obj/effect/turf_decal/delivery/red,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
@@ -21901,7 +21901,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "ftw" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/textured,
@@ -29908,7 +29908,7 @@
 /area/station/science/lobby)
 "htg" = (
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "hth" = (
@@ -39907,7 +39907,7 @@
 /area/station/maintenance/solars/port/fore)
 "jRk" = (
 /obj/machinery/light_switch/directional/north,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -41344,7 +41344,7 @@
 "kjk" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/bot_red,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
@@ -46464,7 +46464,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "lAA" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lAH" = (
@@ -53197,7 +53197,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "nmQ" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/machinery/power/terminal{
 	dir = 8
@@ -69484,7 +69484,7 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "rrL" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "rrU" = (
@@ -73157,7 +73157,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "slZ" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
@@ -92025,7 +92025,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "wZu" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
@@ -92859,7 +92859,7 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "xiG" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "xiJ" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -635,7 +635,7 @@
 /area/station/hallway/secondary/entry)
 "alK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -40285,7 +40285,7 @@
 	},
 /area/station/security/brig/entrance)
 "mqO" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "mqR" = (
@@ -64056,7 +64056,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -75824,7 +75824,7 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "xjO" = (
-/obj/machinery/power/port_gen/pacman{
+/obj/effect/spawner/random/structure/pacman_random{
 	anchored = 1
 	},
 /turf/open/floor/iron/smooth,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14270,7 +14270,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "fje" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "fjn" = (
@@ -14477,7 +14477,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "flN" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "flQ" = (
@@ -31043,7 +31043,7 @@
 /area/station/engineering/atmos)
 "ldO" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -32716,7 +32716,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "lOZ" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lPa" = (
@@ -35982,7 +35982,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mVp" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -41302,7 +41302,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "oOZ" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "oPc" = (
@@ -43394,7 +43394,7 @@
 "pCk" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pCl" = (
@@ -44974,7 +44974,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "qfL" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qfM" = (
@@ -50346,7 +50346,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rYc" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -51613,7 +51613,7 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/lobby)
 "sxn" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "sxo" = (
@@ -57072,7 +57072,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "urE" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "urG" = (
@@ -59810,7 +59810,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vmE" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "vmI" = (
@@ -61588,7 +61588,7 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "vQR" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -65313,7 +65313,7 @@
 /area/station/service/hydroponics)
 "xgE" = (
 /obj/machinery/status_display/evac/directional/north,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -65876,7 +65876,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "xsd" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -9157,7 +9157,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -14338,7 +14338,7 @@
 "dFq" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -20341,7 +20341,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/spawner/random/structure/pacman_random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -51913,7 +51913,7 @@
 	},
 /obj/machinery/power/terminal,
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "nou" = (
@@ -76089,7 +76089,7 @@
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "tDE" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/lobby)
 "tDG" = (
@@ -79268,7 +79268,7 @@
 "uwP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
 "uwQ" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -16912,7 +16912,7 @@
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
 "eSU" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "eTl" = (
@@ -33622,7 +33622,7 @@
 /turf/open/openspace,
 /area/station/maintenance/department/medical)
 "kSp" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "kSA" = (
@@ -45733,7 +45733,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "plz" = (
-/obj/machinery/power/port_gen/pacman{
+/obj/effect/spawner/random/structure/pacman_random{
 	anchored = 1
 	},
 /obj/structure/cable,
@@ -60154,7 +60154,7 @@
 /area/station/science/robotics/lab)
 "ukY" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/structure/pacman_random,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "ulb" = (

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -144,6 +144,15 @@
 		/obj/structure/closet/secure_closet/personal/cabinet,
 	)
 
+/obj/effect/spawner/random/structure/pacman_random
+	name = "Pacman spawner"
+	loot = list(
+		/obj/machinery/power/port_gen/pacman = 5,
+		/obj/machinery/power/port_gen/pacman/pre_loaded = 2,
+		/obj/machinery/power/port_gen/pacman/pre_loaded/half_stacked = 2,
+		/obj/machinery/power/port_gen/pacman/pre_loaded/full = 1,
+	)
+
 /obj/effect/spawner/random/structure/closet_maintenance
 	name = "maintenance closet spawner"
 	icon_state = "locker"

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -280,3 +280,9 @@
 
 /obj/machinery/power/port_gen/pacman/pre_loaded
 	sheets = 15
+
+/obj/machinery/power/port_gen/pacman/pre_loaded/half_stacked
+	sheets = 25
+
+/obj/machinery/power/port_gen/pacman/pre_loaded/full
+	sheets = 50


### PR DESCRIPTION
## About The Pull Request
This PR adds a effect spawner for pacmans to make them either spawn empty pre-loaded with 15 sheets, 25 sheets, or 50 sheets,

## Why It's Good For The Game
Some maps just place 30 pre-loaded plasma gens on the station while having 15 sheets plasma in every pacman is fun this adds a more of a chance based thing to pacmans being pre-loaded or not and make cargo runs maint runs more static then a raw amount of money because its x station

## Changelog

:cl:
balance: Pacman now have a random amount of sheets or spawn empty
/:cl:
