### PR TITLE
A birdshot atmos improvement, and fixes the engineering microwave.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -7520,14 +7520,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs/auxiliary)
 "dqV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dqX" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -10261,6 +10259,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "exE" = (
@@ -15800,9 +15802,9 @@
 /area/station/hallway/secondary/command)
 "gCP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gCR" = (
@@ -18458,8 +18460,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "hsL" = (
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "hsO" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window,
@@ -20263,12 +20269,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "hZf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hZP" = (
 /obj/structure/cable,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -20833,11 +20839,13 @@
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/central/fore)
 "ijP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2O to Pure"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ijV" = (
 /turf/open/misc/asteroid,
@@ -35420,14 +35428,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "mKK" = (
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
-	dir = 4;
-	name = "Plasma to Pure";
-	color = "#BF40BF";
-	piping_layer = 3;
-	icon_state = "pump_map-3"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mKV" = (
 /obj/effect/turf_decal/siding/blue{
@@ -36131,15 +36135,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/storage)
 "mXx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2O to Pure"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "mXD" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -38475,6 +38476,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/corner,
 /area/station/science/xenobiology)
+"nID" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nIJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42257,11 +42265,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "oTY" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "oTZ" = (
 /obj/structure/table,
@@ -43232,13 +43243,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"piW" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "piZ" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -43257,6 +43261,9 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
+"pjk" = (
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pjn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/dna_scannernew,
@@ -46694,13 +46701,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"qep" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "qeq" = (
 /obj/structure/fluff/broken_canister_frame,
 /turf/open/misc/asteroid,
@@ -49058,13 +49058,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
-"qKz" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qKE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49190,6 +49183,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/engine_smes)
+"qME" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qMG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -50920,7 +50920,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
 	},
@@ -51792,6 +51791,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rxu" = (
@@ -60244,10 +60244,6 @@
 	pixel_x = -7;
 	pixel_y = 11
 	},
-/obj/item/clothing/head/cone{
-	pixel_x = -7;
-	pixel_y = 9
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tSh" = (
@@ -61683,6 +61679,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white/small,
 /area/station/medical/cryo)
+"ulf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ull" = (
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron,
@@ -67702,12 +67705,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "vUh" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
+	dir = 4;
+	name = "Plasma to Pure";
+	color = "#BF40BF";
+	piping_layer = 3;
+	icon_state = "pump_map-3"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "vUq" = (
 /obj/machinery/restaurant_portal/bar,
 /obj/machinery/firealarm/directional/west,
@@ -85800,8 +85806,8 @@ tYT
 dDB
 dDB
 jul
-mXx
-piW
+oTY
+qME
 dDB
 dDB
 tYT
@@ -85819,7 +85825,7 @@ tYT
 tYT
 dDB
 dDB
-qKz
+hsL
 pJT
 rqV
 dDB
@@ -86058,7 +86064,7 @@ wBo
 vmL
 apj
 kwH
-qep
+nID
 vmL
 ybO
 tYT
@@ -86076,10 +86082,10 @@ aJq
 tYT
 ybO
 vmL
-oTY
+hZf
 kwH
 lLE
-vUh
+dqV
 ybO
 aJq
 aJq
@@ -86571,8 +86577,8 @@ qBD
 gKs
 hXt
 mXm
-ijP
-mKK
+mXx
+vUh
 bJN
 hYC
 pwv
@@ -86827,9 +86833,9 @@ jwC
 vDD
 gKs
 ydI
-dqV
+ijP
 ivT
-hZf
+gCP
 sWE
 hYC
 gjP
@@ -86847,9 +86853,9 @@ tSi
 vnz
 hYC
 dYY
-dqV
+ijP
+ulf
 gCP
-hZf
 nkp
 kvb
 gBh
@@ -87342,7 +87348,7 @@ vtw
 gKs
 mFZ
 exE
-hsL
+pjk
 wWP
 dlk
 qUN
@@ -87600,7 +87606,7 @@ gKs
 pIB
 wNi
 tFB
-rxs
+mKK
 tnH
 vcR
 fxV

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1991,13 +1991,6 @@
 	dir = 1
 	},
 /area/station/engineering/supermatter/room)
-"aUZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2O to Pure"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "aVT" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -2988,11 +2981,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "brC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
+	dir = 4;
+	name = "Plasma to Pure";
+	color = "#BF40BF";
+	piping_layer = 3;
+	icon_state = "pump_map-3"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "brD" = (
 /obj/machinery/airalarm/directional/west,
@@ -8452,7 +8448,7 @@
 "dMg" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Neurotoxin Outlet Pump"
+	name = "Helium Outlet Pump"
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
@@ -8860,6 +8856,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
+"dVg" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dVW" = (
 /obj/structure/chair{
 	dir = 8
@@ -14792,13 +14795,6 @@
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/iron/freezer,
 /area/station/command/corporate_suite)
-"giu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "giU" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
@@ -15813,12 +15809,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "gCP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gCR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -20851,14 +20849,11 @@
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/central/fore)
 "ijP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 1
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ijV" = (
 /turf/open/misc/asteroid,
@@ -21666,9 +21661,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ivX" = (
@@ -35441,14 +35434,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "mKK" = (
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
-	dir = 4;
-	name = "Plasma to Pure";
-	color = "#BF40BF";
-	piping_layer = 3;
-	icon_state = "pump_map-3"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "mKV" = (
 /obj/effect/turf_decal/siding/blue{
@@ -36152,11 +36142,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/storage)
 "mXx" = (
-/obj/effect/turf_decal/sand/plating,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
+	dir = 6
 	},
-/turf/open/floor/plating/airless,
+/turf/open/space/basic,
 /area/space/nearstation)
 "mXD" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -39810,13 +39800,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
-"ogk" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "ogr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42282,8 +42265,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "oTY" = (
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "oTZ" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -53577,6 +53564,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"rVh" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "rVj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/cold/directional/north,
@@ -59366,6 +59363,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
 /area/station/service/theater)
+"tEe" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2O to Pure"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "tEg" = (
 /obj/structure/transport/linear/tram,
 /obj/effect/turf_decal/stripes/white/line{
@@ -66292,8 +66296,7 @@
 "vzK" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
-	dir = 4;
-	name = "neurotoxin tank output inlet"
+	dir = 4
 	},
 /turf/open/floor/engine/helium,
 /area/station/ai_monitored/turret_protected/ai)
@@ -67714,12 +67717,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "vUh" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vUq" = (
 /obj/machinery/restaurant_portal/bar,
 /obj/machinery/firealarm/directional/west,
@@ -85812,7 +85811,7 @@ tYT
 dDB
 dDB
 jul
-ijP
+rVh
 hsL
 dDB
 dDB
@@ -85831,7 +85830,7 @@ tYT
 tYT
 dDB
 dDB
-gCP
+mXx
 pJT
 rqV
 dDB
@@ -86070,7 +86069,7 @@ wBo
 vmL
 apj
 kwH
-vUh
+oTY
 vmL
 ybO
 tYT
@@ -86088,10 +86087,10 @@ aJq
 tYT
 ybO
 vmL
-mXx
+ijP
 kwH
 lLE
-ogk
+dVg
 ybO
 aJq
 aJq
@@ -86325,9 +86324,9 @@ drw
 gvB
 wBo
 ybO
-brC
-brC
-brC
+mKK
+mKK
+mKK
 ybO
 ybO
 aJq
@@ -86345,9 +86344,9 @@ aJq
 aJq
 ybO
 ybO
-brC
-brC
-brC
+mKK
+mKK
+mKK
 pfx
 ybO
 akZ
@@ -86583,8 +86582,8 @@ qBD
 gKs
 hXt
 mXm
-aUZ
-mKK
+tEe
+brC
 bJN
 hYC
 pwv
@@ -86840,7 +86839,7 @@ vDD
 gKs
 ydI
 dqV
-ivT
+gCP
 hZf
 sWE
 hYC
@@ -86860,7 +86859,7 @@ vnz
 hYC
 dYY
 dqV
-giu
+ivT
 hZf
 nkp
 kvb
@@ -87354,7 +87353,7 @@ vtw
 gKs
 mFZ
 exE
-oTY
+vUh
 wWP
 dlk
 qUN

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -632,8 +632,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "api" = (
@@ -647,17 +647,11 @@
 /area/station/science/server)
 "apj" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "apk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_red{
@@ -1720,6 +1714,7 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "aOx" = (
@@ -1996,6 +1991,13 @@
 	dir = 1
 	},
 /area/station/engineering/supermatter/room)
+"aUZ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2O to Pure"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "aVT" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -2566,10 +2568,10 @@
 /turf/open/floor/iron/small,
 /area/station/security/office)
 "bkI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bkO" = (
@@ -2987,13 +2989,7 @@
 /area/station/maintenance/starboard/greater)
 "brC" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3514,8 +3510,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bDO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2 to Pure"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -3733,6 +3730,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/status_display/evac/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bJZ" = (
@@ -4846,7 +4844,7 @@
 "chb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -7532,7 +7530,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dqX" = (
@@ -9088,6 +9088,7 @@
 /area/station/medical/medbay/aft)
 "dYY" = (
 /obj/machinery/light/cold/dim/directional/north,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "dZa" = (
@@ -9159,6 +9160,10 @@
 /area/station/maintenance/department/medical/central)
 "dZX" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 4;
+	name = "Air to Pure"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "dZZ" = (
@@ -13350,8 +13355,9 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "fJt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8;
+	initialize_directions = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -14786,6 +14792,13 @@
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/iron/freezer,
 /area/station/command/corporate_suite)
+"giu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "giU" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
@@ -15800,12 +15813,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "gCP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 6
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space/nearstation)
 "gCR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -18459,18 +18472,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "hsL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
-	dir = 6
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 5
 	},
 /turf/open/space/basic,
-/area/station/engineering/atmos/space_catwalk)
+/area/space/nearstation)
 "hsO" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window,
@@ -20277,9 +20284,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hZP" = (
@@ -20846,14 +20851,15 @@
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/central/fore)
 "ijP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space/nearstation)
 "ijV" = (
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/engine)
@@ -21660,7 +21666,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -24484,14 +24490,14 @@
 /area/station/commons/storage/tools)
 "jul" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 10
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -27411,7 +27417,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
-	dir = 9
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
@@ -27930,7 +27936,7 @@
 /area/station/science/robotics/augments)
 "kwH" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -29476,10 +29482,8 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/engine_smes)
 "kXf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "kXj" = (
@@ -31846,10 +31850,10 @@
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/primary/central/fore)
 "lGq" = (
+/obj/structure/fluff/broken_canister_frame,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/structure/fluff/broken_canister_frame,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lGr" = (
@@ -32220,14 +32224,11 @@
 /area/station/hallway/primary/fore)
 "lLE" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+	dir = 10
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -33667,7 +33668,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mgt" = (
@@ -35117,14 +35120,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/head/cone{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -7;
-	pixel_y = 11
-	},
+/obj/structure/tank_holder/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mFG" = (
@@ -35445,17 +35441,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "mKK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
+	dir = 4;
+	name = "Plasma to Pure";
+	color = "#BF40BF";
+	piping_layer = 3;
+	icon_state = "pump_map-3"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "mKV" = (
 /obj/effect/turf_decal/siding/blue{
@@ -36146,16 +36139,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mXm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2O to Pure"
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
-	dir = 4;
-	name = "Plasma to Pure";
-	color = "#BF40BF"
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer5{
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 4;
 	name = "CO2 to Pure"
 	},
@@ -36168,14 +36152,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/storage)
 "mXx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mXD" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -39602,6 +39584,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/space_heater,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "obe" = (
@@ -39827,6 +39810,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
+"ogk" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ogr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42292,8 +42282,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "oTY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/tank_holder/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oTZ" = (
@@ -45217,8 +45205,9 @@
 /area/station/maintenance/port/fore)
 "pJT" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -47581,16 +47570,19 @@
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central/aft)
 "qqr" = (
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer5{
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 4;
-	name = "Air to Pure"
+	name = "O2 to pure"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 4;
-	name = "N2 to Pure"
+	name = "O2 to pure"
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 4;
+	name = "O2 to pure"
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 4;
 	name = "O2 to Pure"
 	},
@@ -48364,7 +48356,8 @@
 "qAQ" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
-	dir = 8
+	dir = 8;
+	name = "neurotoxin tank output inlet"
 	},
 /turf/open/floor/engine/n2o,
 /area/station/ai_monitored/turret_protected/ai)
@@ -51341,14 +51334,17 @@
 /area/station/maintenance/starboard/fore)
 "rqV" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -51807,10 +51803,6 @@
 "rxs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 8;
-	initialize_directions = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -53611,8 +53603,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -55071,8 +55063,9 @@
 /area/station/security/checkpoint/customs/auxiliary)
 "sqB" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8;
+	initialize_directions = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -58249,7 +58242,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "tnH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tnO" = (
@@ -60256,6 +60252,14 @@
 "tSg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/light_switch/directional/east,
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tSh" = (
@@ -61730,12 +61734,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "South Ports to Wastes"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -66288,7 +66292,8 @@
 "vzK" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
-	dir = 4
+	dir = 4;
+	name = "neurotoxin tank output inlet"
 	},
 /turf/open/floor/engine/helium,
 /area/station/ai_monitored/turret_protected/ai)
@@ -67432,7 +67437,9 @@
 /area/station/maintenance/starboard/central)
 "vPY" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vQk" = (
@@ -67707,12 +67714,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "vUh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "vUq" = (
 /obj/machinery/restaurant_portal/bar,
 /obj/machinery/firealarm/directional/west,
@@ -68880,7 +68887,9 @@
 /area/station/service/chapel)
 "wlS" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wlU" = (
@@ -70721,10 +70730,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 1
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wNv" = (
@@ -71436,7 +71445,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wWR" = (
@@ -75780,10 +75788,10 @@
 /area/station/maintenance/starboard/aft)
 "xXl" = (
 /obj/structure/table/reinforced,
-/obj/structure/showcase/machinery/microwave{
-	pixel_y = 7
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "xXr" = (
@@ -85567,7 +85575,7 @@ dDB
 dDB
 dDB
 jhz
-hsL
+xQZ
 kpe
 dDB
 dDB
@@ -85804,8 +85812,8 @@ tYT
 dDB
 dDB
 jul
-blb
-blb
+ijP
+hsL
 dDB
 dDB
 tYT
@@ -85823,7 +85831,7 @@ tYT
 tYT
 dDB
 dDB
-blb
+gCP
 pJT
 rqV
 dDB
@@ -86061,8 +86069,8 @@ giq
 wBo
 vmL
 apj
-vmL
-vmL
+kwH
+vUh
 vmL
 ybO
 tYT
@@ -86080,10 +86088,10 @@ aJq
 tYT
 ybO
 vmL
-vmL
+mXx
 kwH
 lLE
-vmL
+ogk
 ybO
 aJq
 aJq
@@ -86317,9 +86325,9 @@ drw
 gvB
 wBo
 ybO
-mKK
-cwf
-cwf
+brC
+brC
+brC
 ybO
 ybO
 aJq
@@ -86337,10 +86345,10 @@ aJq
 aJq
 ybO
 ybO
-cwf
-pfx
 brC
-ybO
+brC
+brC
+pfx
 ybO
 akZ
 akZ
@@ -86575,8 +86583,8 @@ qBD
 gKs
 hXt
 mXm
-hXt
-hXt
+aUZ
+mKK
 bJN
 hYC
 pwv
@@ -86831,9 +86839,9 @@ jwC
 vDD
 gKs
 ydI
-ijP
+dqV
 ivT
-gCP
+hZf
 sWE
 hYC
 gjP
@@ -86852,7 +86860,7 @@ vnz
 hYC
 dYY
 dqV
-ivT
+giu
 hZf
 nkp
 kvb
@@ -87108,7 +87116,7 @@ bSm
 qxz
 mRA
 hvZ
-mXx
+xHT
 fJt
 vPY
 wPt
@@ -87346,7 +87354,7 @@ vtw
 gKs
 mFZ
 exE
-tFB
+oTY
 wWP
 dlk
 qUN
@@ -87603,8 +87611,8 @@ ihj
 gKs
 pIB
 wNi
-bPU
-yii
+tFB
+rxs
 tnH
 vcR
 fxV
@@ -87860,8 +87868,8 @@ fEr
 pUK
 vjK
 rVA
-vUh
-oTY
+bPU
+yii
 kXf
 hvo
 kQr

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2981,14 +2981,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "brC" = (
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
-	dir = 4;
-	name = "Plasma to Pure";
-	color = "#BF40BF";
-	piping_layer = 3;
-	icon_state = "pump_map-3"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "brD" = (
 /obj/machinery/airalarm/directional/west,
@@ -8448,7 +8445,7 @@
 "dMg" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Helium Outlet Pump"
+	name = "Neurotoxin Outlet Pump"
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
@@ -8856,13 +8853,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
-"dVg" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "dVW" = (
 /obj/structure/chair{
 	dir = 8
@@ -15812,9 +15802,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gCR" = (
@@ -18470,12 +18458,8 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "hsL" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hsO" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window,
@@ -20849,12 +20833,12 @@
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/central/fore)
 "ijP" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2O to Pure"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "ijV" = (
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/engine)
@@ -21661,7 +21645,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ivX" = (
@@ -35434,11 +35420,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "mKK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer1{
+	dir = 4;
+	name = "Plasma to Pure";
+	color = "#BF40BF";
+	piping_layer = 3;
+	icon_state = "pump_map-3"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "mKV" = (
 /obj/effect/turf_decal/siding/blue{
@@ -36143,8 +36132,11 @@
 /area/station/medical/storage)
 "mXx" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -42266,7 +42258,7 @@
 /area/station/science/genetics)
 "oTY" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -43240,6 +43232,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"piW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "piZ" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -46695,6 +46694,13 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"qep" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qeq" = (
 /obj/structure/fluff/broken_canister_frame,
 /turf/open/misc/asteroid,
@@ -47561,18 +47567,6 @@
 	dir = 4;
 	name = "O2 to pure"
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
-	dir = 4;
-	name = "O2 to pure"
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
-	dir = 4;
-	name = "O2 to pure"
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
-	dir = 4;
-	name = "O2 to Pure"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qqx" = (
@@ -48344,7 +48338,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
 	dir = 8;
-	name = "neurotoxin tank output inlet"
+	name = "N2O tank output inlet"
 	},
 /turf/open/floor/engine/n2o,
 /area/station/ai_monitored/turret_protected/ai)
@@ -49064,6 +49058,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
+"qKz" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qKE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53564,16 +53565,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"rVh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "rVj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/cold/directional/north,
@@ -59363,13 +59354,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
 /area/station/service/theater)
-"tEe" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2O to Pure"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "tEg" = (
 /obj/structure/transport/linear/tram,
 /obj/effect/turf_decal/stripes/white/line{
@@ -66296,7 +66280,8 @@
 "vzK" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
-	dir = 4
+	dir = 4;
+	chamber_id = "helium"
 	},
 /turf/open/floor/engine/helium,
 /area/station/ai_monitored/turret_protected/ai)
@@ -67717,8 +67702,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "vUh" = (
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "vUq" = (
 /obj/machinery/restaurant_portal/bar,
 /obj/machinery/firealarm/directional/west,
@@ -85811,8 +85800,8 @@ tYT
 dDB
 dDB
 jul
-rVh
-hsL
+mXx
+piW
 dDB
 dDB
 tYT
@@ -85830,7 +85819,7 @@ tYT
 tYT
 dDB
 dDB
-mXx
+qKz
 pJT
 rqV
 dDB
@@ -86069,7 +86058,7 @@ wBo
 vmL
 apj
 kwH
-oTY
+qep
 vmL
 ybO
 tYT
@@ -86087,10 +86076,10 @@ aJq
 tYT
 ybO
 vmL
-ijP
+oTY
 kwH
 lLE
-dVg
+vUh
 ybO
 aJq
 aJq
@@ -86324,9 +86313,9 @@ drw
 gvB
 wBo
 ybO
-mKK
-mKK
-mKK
+brC
+brC
+brC
 ybO
 ybO
 aJq
@@ -86344,9 +86333,9 @@ aJq
 aJq
 ybO
 ybO
-mKK
-mKK
-mKK
+brC
+brC
+brC
 pfx
 ybO
 akZ
@@ -86582,8 +86571,8 @@ qBD
 gKs
 hXt
 mXm
-tEe
-brC
+ijP
+mKK
 bJN
 hYC
 pwv
@@ -86839,7 +86828,7 @@ vDD
 gKs
 ydI
 dqV
-gCP
+ivT
 hZf
 sWE
 hYC
@@ -86859,7 +86848,7 @@ vnz
 hYC
 dYY
 dqV
-ivT
+gCP
 hZf
 nkp
 kvb
@@ -87353,7 +87342,7 @@ vtw
 gKs
 mFZ
 exE
-vUh
+hsL
 wWP
 dlk
 qUN


### PR DESCRIPTION
## About The Pull Request
I have changed the layout of the pumps going into atmos from the tanks to make it easier to use.
![image](https://github.com/tgstation/tgstation/assets/64122807/ec95eab6-b7ac-4927-b3d9-70f7c58e5dc8)
![image](https://github.com/tgstation/tgstation/assets/64122807/571bb2f3-49c8-4b4b-9d9d-405a8d5a06eb)
I also fixed the engineering microwave.
I also adjusted the name for the pumps and vents in the AI chamber. 


This is my first PR!
## Why It's Good For The Game

This change allow people to easily set up a pump to fill up a can with the gas they want. Before this it was impossible to fill up an n2o can and a plasma can without making a big mess or having them mix together.

The microwave in engi being able to work is also a good quality of life change for the poor engineers that want to cook a donk pocket in their department.

The change of names for the vents and pumps in the AI chamber is for consistency sake. n2o is not helium!
## Changelog
:cl:
qol: Made birdshot atmos easier to use.
fix: The Birdshot engineering department is no longer using a second hand broken microwave.
/:cl:
