### PR TITLE
Eigenstasium Fix

### DIFF
--- a/code/datums/eigenstate.dm
+++ b/code/datums/eigenstate.dm
@@ -119,8 +119,7 @@ GLOBAL_DATUM_INIT(eigenstate_manager, /datum/eigenstate_manager, new)
 		spark_time = world.time
 	//Calls a special proc for the atom if needed (closets use bust_open())
 	SEND_SIGNAL(eigen_target, COMSIG_EIGENSTATE_ACTIVATE)
-	if(!subtle)
-		return COMPONENT_CLOSET_INSERT_INTERRUPT
+	return COMPONENT_CLOSET_INSERT_INTERRUPT
 
 ///Prevents tool use on the item
 /datum/eigenstate_manager/proc/tool_interact(atom/source, mob/user, obj/item/item)

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -29,12 +29,6 @@
 	var/obj/effect/overlay/holo_pad_hologram/eigenstate
 	///The point you're returning to after the reagent is removed
 	var/turf/open/location_return = null
-	///List of all lockers on a turf
-	var/num_of_closets = 0
-	///Number of closets counted so far from a turf
-	var/closets_counted = 0
-	///The turf we last exposed this reagent to
-	var/turf/open/location_exposed = null
 
 /datum/reagent/eigenstate/on_new(list/data)
 	. = ..()
@@ -113,40 +107,6 @@
 	do_sparks(5, FALSE, living_mob)
 
 //FOR ADDICTION-LIKE EFFECTS, SEE datum/status_effect/eigenstasium
-
-///For sprays & smoke puffs
-/datum/reagent/eigenstate/expose_obj(obj/exposed_obj, reac_volume)
-	SHOULD_CALL_PARENT(FALSE)
-
-	if(!istype(exposed_obj, /obj/structure/closet))
-		return
-
-	//objects like sprays expose objects on a turf 1 at a time instead of calling expose_turf()
-	//so we wait for the last object on that turf to be sprayed down & then link them altogether
-	//this assumes all objects we have counted so far are on the same turf cause that is the requirment.
-
-	var/turf/open/location = get_turf(exposed_obj)
-	if(!isnull(location_exposed))
-		if(location != location_exposed)
-			num_of_closets = 0
-			closets_counted = 0
-			location_exposed = null
-			return
-	else
-		location_exposed = location
-
-	//count total number of closets on the turf and wait for this number to arrive in this proc
-	if(!num_of_closets)
-		for(var/obj/structure/closet/closet in location_exposed)
-			num_of_closets += 1
-
-	//count each closet as it comes. once we are sure this is the last closet accounted for we link everything
-	closets_counted += 1
-	if(closets_counted == num_of_closets)
-		num_of_closets = 0
-		closets_counted = 0
-		location_exposed = null
-		expose_turf(get_turf(exposed_obj))
 
 ///Lets you link lockers together
 /datum/reagent/eigenstate/expose_turf(turf/exposed_turf, reac_volume)


### PR DESCRIPTION
## About The Pull Request
- Fixes #82921. Closets that are not linked by the closet anomaly station trait will be tainted blue, show sparks & do all that jazz once again. In other words they are not subtle
- Closes #82353. Duplicate of the above. Sprays work since the above issue is fixed

## Changelog
:cl:
fix: Eigenstasium exposed & Anomaly station trait affected closets work again. Eigenstasium closets are tainted blue
/:cl:
