### PR TITLE
Adds a notice to PDAs that their batteries can be removed 

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -397,6 +397,9 @@
 			. += "Its identification card slot is currently occupied."
 		. += span_info("Alt-click [src] to eject the identification card.")
 
+	if(internal_cell)
+		. += span_info("Right-click it with a screwdriver to eject the [internal_cell]")
+
 /obj/item/modular_computer/examine_more(mob/user)
 	. = ..()
 	. += "Storage capacity: [used_capacity]/[max_capacity]GQ"


### PR DESCRIPTION
## About The Pull Request

This adds a span notice on examine to PDAs containing a power cell that the cell can be removed by right clicking

Discussed this morning in coder general:
* Lots of functions have been moved to PDAs, but their batteries deplete obnoxiously quickly
* Dedicated PDA chargers are not wanted per Mothblocks, and would be map clutter
* Existing rechargers cannot be made more available because they recharge guns, but are the only 'obvious' way to recharge PDAs.
* PDA batteries can actually be removed and externally recharged - but there is nothing in game telling players this.
* There is also nothing on the wiki telling players this.
* Left click w/ screwdriver = nothing, but right click removes cell is completely non-intuitive and inconsistent with all other tool use.

## Why It's Good For The Game

Actually telling players about an interaction is good and the description of this PR is already longer than the code change.

## Changelog
:cl: 
fix: On examine PDAs will now inform players that the power cell can be removed for recharging or replacement, and how to do so.
/:cl:
