### PR TITLE
Use defines for spellbook categories

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -1,44 +1,45 @@
+#define SPELLBOOK_CATEGORY_ASSISTANCE "Assistance"
 // Wizard spells that assist the caster in some way
 /datum/spellbook_entry/summonitem
 	name = "Summon Item"
 	desc = "Recalls a previously marked item to your hand from anywhere in the universe."
 	spell_type = /datum/action/cooldown/spell/summonitem
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	cost = 1
 
 /datum/spellbook_entry/charge
 	name = "Charge"
 	desc = "This spell can be used to recharge a variety of things in your hands, from magical artifacts to electrical components. A creative wizard can even use it to grant magical power to a fellow magic user."
 	spell_type = /datum/action/cooldown/spell/charge
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	cost = 1
 
 /datum/spellbook_entry/shapeshift
 	name = "Wild Shapeshift"
 	desc = "Take on the shape of another for a time to use their natural abilities. Once you've made your choice it cannot be changed."
 	spell_type = /datum/action/cooldown/spell/shapeshift/wizard
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	cost = 1
 
 /datum/spellbook_entry/tap
 	name = "Soul Tap"
 	desc = "Fuel your spells using your own soul!"
 	spell_type = /datum/action/cooldown/spell/tap
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	cost = 1
 
 /datum/spellbook_entry/item/staffanimation
 	name = "Staff of Animation"
 	desc = "An arcane staff capable of shooting bolts of eldritch energy which cause inanimate objects to come to life. This magic doesn't affect machines."
 	item_path = /obj/item/gun/magic/staff/animate
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 
 /datum/spellbook_entry/item/soulstones
 	name = "Soulstone Shard Kit"
 	desc = "Soul Stone Shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. \
 		The spell Artificer allows you to create arcane machines for the captured souls to pilot."
 	item_path = /obj/item/storage/belt/soulstone/full
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 
 /datum/spellbook_entry/item/soulstones/try_equip_item(mob/living/carbon/human/user, obj/item/to_equip)
 	var/was_equipped = user.equip_to_slot_if_possible(to_equip, ITEM_SLOT_BELT, disable_warning = TRUE)
@@ -56,13 +57,13 @@
 	name = "A Necromantic Stone"
 	desc = "A Necromantic stone is able to resurrect three dead individuals as skeletal thralls for you to command."
 	item_path = /obj/item/necromantic_stone
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 
 /datum/spellbook_entry/item/contract
 	name = "Contract of Apprenticeship"
 	desc = "A magical contract binding an apprentice wizard to your service, using it will summon them to your side."
 	item_path = /obj/item/antag_spawner/contract
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	refundable = TRUE
 
 /datum/spellbook_entry/item/guardian
@@ -70,7 +71,7 @@
 	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to your body. There are multiple types of guardian available, but all of them will transfer some amount of damage to you. \
 	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
 	item_path = /obj/item/guardian_creator/wizard
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 
 /datum/spellbook_entry/item/bloodbottle
 	name = "Bottle of Blood"
@@ -80,7 +81,7 @@
 		in their killing, and you yourself may become a victim."
 	item_path = /obj/item/antag_spawner/slaughter_demon
 	limit = 3
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	refundable = TRUE
 
 /datum/spellbook_entry/item/hugbottle
@@ -95,7 +96,7 @@
 	item_path = /obj/item/antag_spawner/slaughter_demon/laughter
 	cost = 1 //non-destructive; it's just a jape, sibling!
 	limit = 3
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
 	refundable = TRUE
 
 /datum/spellbook_entry/item/vendormancer
@@ -105,4 +106,6 @@
 		throw around to squash oponents or be directly detonated. When out of \
 		charges a long channel will restore the charges."
 	item_path = /obj/item/runic_vendor_scepter
-	category = "Assistance"
+	category = SPELLBOOK_CATEGORY_ASSISTANCE
+
+#undef SPELLBOOK_CATEGORY_ASSISTANCE

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -1,49 +1,50 @@
+#define SPELLBOOK_CATEGORY_DEFENSIVE "Defensive"
 // Defensive wizard spells
 /datum/spellbook_entry/magicm
 	name = "Magic Missile"
 	desc = "Fires several, slow moving, magic projectiles at nearby targets."
 	spell_type = /datum/action/cooldown/spell/aoe/magic_missile
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/disabletech
 	name = "Disable Tech"
 	desc = "Disables all weapons, cameras and most other technology in range."
 	spell_type = /datum/action/cooldown/spell/emp/disable_tech
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/repulse
 	name = "Repulse"
 	desc = "Throws everything around the user away."
 	spell_type = /datum/action/cooldown/spell/aoe/repulse/wizard
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/lightning_packet
 	name = "Thrown Lightning"
 	desc = "Forged from eldrich energies, a packet of pure power, \
 		known as a spell packet will appear in your hand, that when thrown will stun the target."
 	spell_type = /datum/action/cooldown/spell/conjure_item/spellpacket
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/timestop
 	name = "Time Stop"
 	desc = "Stops time for everyone except for you, allowing you to move freely \
 		while your enemies and even projectiles are frozen."
 	spell_type = /datum/action/cooldown/spell/timestop
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/smoke
 	name = "Smoke"
 	desc = "Spawns a cloud of choking smoke at your location."
 	spell_type = /datum/action/cooldown/spell/smoke
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/forcewall
 	name = "Force Wall"
 	desc = "Create a magical barrier that only you can pass through."
 	spell_type = /datum/action/cooldown/spell/forcewall
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/lichdom
@@ -53,28 +54,28 @@
 		no matter the circumstances. Be wary - with each revival, your body will become weaker, and \
 		it will become easier for others to find your item of power."
 	spell_type =  /datum/action/cooldown/spell/lichdom
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	no_coexistance_typecache = list(/datum/action/cooldown/spell/splattercasting)
 
 /datum/spellbook_entry/chuunibyou
 	name = "Chuuni Invocations"
 	desc = "Makes all your spells shout invocations, and the invocations become... stupid. You heal slightly after casting a spell."
 	spell_type =  /datum/action/cooldown/spell/chuuni_invocations
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/spacetime_dist
 	name = "Spacetime Distortion"
 	desc = "Entangle the strings of space-time in an area around you, \
 		randomizing the layout and making proper movement impossible. The strings vibrate..."
 	spell_type = /datum/action/cooldown/spell/spacetime_dist
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/the_traps
 	name = "The Traps!"
 	desc = "Summon a number of traps around you. They will damage and enrage any enemies that step on them."
 	spell_type = /datum/action/cooldown/spell/conjure/the_traps
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/bees
@@ -82,7 +83,7 @@
 	desc = "This spell magically kicks a transdimensional beehive, \
 		instantly summoning a swarm of bees to your location. These bees are NOT friendly to anyone."
 	spell_type = /datum/action/cooldown/spell/conjure/bee
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/duffelbag
 	name = "Bestow Cursed Duffel Bag"
@@ -91,7 +92,7 @@
 		if it is not fed regularly, and regardless of whether or not it's been fed, \
 		it will slow the person wearing it down significantly."
 	spell_type = /datum/action/cooldown/spell/touch/duffelbag
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/item/staffhealing
@@ -99,26 +100,26 @@
 	desc = "An altruistic staff that can heal the lame and raise the dead."
 	item_path = /obj/item/gun/magic/staff/healing
 	cost = 1
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/item/lockerstaff
 	name = "Staff of the Locker"
 	desc = "A staff that shoots lockers. It eats anyone it hits on its way, leaving a welded locker with your victims behind."
 	item_path = /obj/item/gun/magic/staff/locker
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/item/scryingorb
 	name = "Scrying Orb"
 	desc = "An incandescent orb of crackling energy. Using it will allow you to release your ghost while alive, allowing you to spy upon the station and talk to the deceased. In addition, buying it will permanently grant you X-ray vision."
 	item_path = /obj/item/scrying
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/item/wands
 	name = "Wand Assortment"
 	desc = "A collection of wands that allow for a wide variety of utility. \
 		Wands have a limited number of charges, so be conservative with their use. Comes in a handy belt."
 	item_path = /obj/item/storage/belt/wands/full
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/item/wands/try_equip_item(mob/living/carbon/human/user, obj/item/to_equip)
 	var/was_equipped = user.equip_to_slot_if_possible(to_equip, ITEM_SLOT_BELT, disable_warning = TRUE)
@@ -130,7 +131,7 @@
 		while providing more protection against attacks and the void of space. \
 		Also grants a battlemage shield."
 	item_path = /obj/item/mod/control/pre_equipped/enchanted
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 
 /datum/spellbook_entry/item/armor/try_equip_item(mob/living/carbon/human/user, obj/item/to_equip)
 	var/obj/item/mod/control/mod = to_equip
@@ -151,5 +152,7 @@
 	name = "Battlemage Armour Charges"
 	desc = "A powerful defensive rune, it will grant eight additional charges to a battlemage shield."
 	item_path = /obj/item/wizard_armour_charge
-	category = "Defensive"
+	category = SPELLBOOK_CATEGORY_DEFENSIVE
 	cost = 1
+
+#undef SPELLBOOK_CATEGORY_DEFENSIVE

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
@@ -1,47 +1,48 @@
+#define SPELLBOOK_CATEGORY_MOBILITY "Mobility"
 // Wizard spells that aid mobiilty(or stealth?)
 /datum/spellbook_entry/mindswap
 	name = "Mindswap"
 	desc = "Allows you to switch bodies with a target next to you. You will both fall asleep when this happens, and it will be quite obvious that you are the target's body if someone watches you do it."
 	spell_type = /datum/action/cooldown/spell/pointed/mind_transfer
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 
 /datum/spellbook_entry/knock
 	name = "Knock"
 	desc = "Opens nearby doors and closets."
 	spell_type = /datum/action/cooldown/spell/aoe/knock
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 	cost = 1
 
 /datum/spellbook_entry/blink
 	name = "Blink"
 	desc = "Randomly teleports you a short distance."
 	spell_type = /datum/action/cooldown/spell/teleport/radius_turf/blink
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 
 /datum/spellbook_entry/teleport
 	name = "Teleport"
 	desc = "Teleports you to an area of your selection."
 	spell_type = /datum/action/cooldown/spell/teleport/area_teleport/wizard
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 
 /datum/spellbook_entry/jaunt
 	name = "Ethereal Jaunt"
 	desc = "Turns your form ethereal, temporarily making you invisible and able to pass through walls."
 	spell_type = /datum/action/cooldown/spell/jaunt/ethereal_jaunt
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 
 /datum/spellbook_entry/swap
 	name = "Swap"
 	desc = "Switch places with any living target within nine tiles. Right click to mark a secondary target. You will always swap to your primary target."
 	spell_type = /datum/action/cooldown/spell/pointed/swap
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 	cost = 1
 
 /datum/spellbook_entry/item/warpwhistle
 	name = "Warp Whistle"
 	desc = "A strange whistle that will transport you to a distant safe place on the station. There is a window of vulnerability at the beginning of every use."
 	item_path = /obj/item/warp_whistle
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 	cost = 1
 
 /datum/spellbook_entry/item/staffdoor
@@ -49,11 +50,13 @@
 	desc = "A particular staff that can mold solid walls into ornate doors. Useful for getting around in the absence of other transportation. Does not work on glass."
 	item_path = /obj/item/gun/magic/staff/door
 	cost = 1
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
 
 /datum/spellbook_entry/item/teleport_rod
 	name = /obj/item/teleport_rod::name
 	desc = /obj/item/teleport_rod::desc
 	item_path = /obj/item/teleport_rod
 	cost = 2 // Puts it at 3 cost if you go for safety instant summons, but teleporting anywhere on screen is pretty good.
-	category = "Mobility"
+	category = SPELLBOOK_CATEGORY_MOBILITY
+
+#undef SPELLBOOK_CATEGORY_MOBILITY

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
@@ -1,27 +1,28 @@
+#define SPELLBOOK_CATEGORY_OFFENSIVE "Offensive"
 // Offensive wizard spells
 /datum/spellbook_entry/fireball
 	name = "Fireball"
 	desc = "Fires an explosive fireball at a target. Considered a classic among all wizards."
 	spell_type = /datum/action/cooldown/spell/pointed/projectile/fireball
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/spell_cards
 	name = "Spell Cards"
 	desc = "Blazing hot rapid-fire homing cards. Send your foes to the shadow realm with their mystical power!"
 	spell_type = /datum/action/cooldown/spell/pointed/projectile/spell_cards
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/rod_form
 	name = "Rod Form"
 	desc = "Take on the form of an immovable rod, destroying all in your path. Purchasing this spell multiple times will also increase the rod's damage and travel range."
 	spell_type = /datum/action/cooldown/spell/rod_form
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/disintegrate
 	name = "Smite"
 	desc = "Charges your hand with an unholy energy that can be used to cause a touched victim to violently explode."
 	spell_type = /datum/action/cooldown/spell/touch/smite
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/summon_simians
 	name = "Summon Simians"
@@ -29,45 +30,45 @@
 		summons primal monkeys and lesser gorillas that will promptly flip out and attack everything in sight. Fun! \
 		Their lesser, easily manipulable minds will be convinced you are one of their allies, but only for a minute. Unless you also are a monkey."
 	spell_type = /datum/action/cooldown/spell/conjure/simian
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/blind
 	name = "Blind"
 	desc = "Temporarily blinds a single target."
 	spell_type = /datum/action/cooldown/spell/pointed/blind
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/mutate
 	name = "Mutate"
 	desc = "Causes you to turn into a hulk and gain laser vision for a short while."
 	spell_type = /datum/action/cooldown/spell/apply_mutations/mutate
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/fleshtostone
 	name = "Flesh to Stone"
 	desc = "Charges your hand with the power to turn victims into inert statues for a long period of time."
 	spell_type = /datum/action/cooldown/spell/touch/flesh_to_stone
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/teslablast
 	name = "Tesla Blast"
 	desc = "Charge up a tesla arc and release it at a random nearby target! You can move freely while it charges. The arc jumps between targets and can knock them down."
 	spell_type = /datum/action/cooldown/spell/charged/beam/tesla
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/lightningbolt
 	name = "Lightning Bolt"
 	desc = "Fire a lightning bolt at your foes! It will jump between targets, but can't knock them down."
 	spell_type = /datum/action/cooldown/spell/pointed/projectile/lightningbolt
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 	cost = 1
 
 /datum/spellbook_entry/infinite_guns
 	name = "Lesser Summon Guns"
 	desc = "Why reload when you have infinite guns? Summons an unending stream of bolt action rifles that deal little damage, but will knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Arcane Barrage."
 	spell_type = /datum/action/cooldown/spell/conjure_item/infinite_guns/gun
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 	cost = 3
 	no_coexistance_typecache = list(/datum/action/cooldown/spell/conjure_item/infinite_guns/arcane_barrage)
 
@@ -75,7 +76,7 @@
 	name = "Arcane Barrage"
 	desc = "Fire a torrent of arcane energy at your foes with this (powerful) spell. Deals much more damage than Lesser Summon Guns, but won't knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Lesser Summon Gun."
 	spell_type = /datum/action/cooldown/spell/conjure_item/infinite_guns/arcane_barrage
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 	cost = 3
 	no_coexistance_typecache = list(/datum/action/cooldown/spell/conjure_item/infinite_guns/gun)
 
@@ -83,68 +84,70 @@
 	name = "Barnyard Curse"
 	desc = "This spell dooms an unlucky soul to possess the speech and facial attributes of a barnyard animal."
 	spell_type = /datum/action/cooldown/spell/pointed/barnyardcurse
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/splattercasting
 	name = "Splattercasting"
 	desc = "Dramatically lowers the cooldown on all spells, but each one will cost blood, as well as it naturally \
 		draining from you over time. You can replenish it from your victims, specifically their necks."
 	spell_type =  /datum/action/cooldown/spell/splattercasting
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 	no_coexistance_typecache = list(/datum/action/cooldown/spell/lichdom)
 
 /datum/spellbook_entry/sanguine_strike
 	name = "Exsanguinating Strike"
 	desc = "Sanguine spell that enchants your next weapon strike to deal more damage, heal you for damage dealt, and refill blood."
 	spell_type =  /datum/action/cooldown/spell/sanguine_strike
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/scream_for_me
 	name = "Scream For Me"
 	desc = "Sadistic sanguine spell that inflicts numerous severe blood wounds all over the victim's body."
 	spell_type =  /datum/action/cooldown/spell/touch/scream_for_me
 	cost = 1
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/item/staffchaos
 	name = "Staff of Chaos"
 	desc = "A caprious tool that can fire all sorts of magic without any rhyme or reason. Using it on people you care about is not recommended."
 	item_path = /obj/item/gun/magic/staff/chaos
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/item/staffchange
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
 	item_path = /obj/item/gun/magic/staff/change
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/item/mjolnir
 	name = "Mjolnir"
 	desc = "A mighty hammer on loan from Thor, God of Thunder. It crackles with barely contained power."
 	item_path = /obj/item/mjollnir
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/item/singularity_hammer
 	name = "Singularity Hammer"
 	desc = "A hammer that creates an intensely powerful field of gravity where it strikes, pulling everything nearby to the point of impact."
 	item_path = /obj/item/singularityhammer
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/item/spellblade
 	name = "Spellblade"
 	desc = "A sword capable of firing blasts of energy which rip targets limb from limb."
 	item_path = /obj/item/gun/magic/staff/spellblade
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 
 /datum/spellbook_entry/item/highfrequencyblade
 	name = "High Frequency Blade"
 	desc = "An incredibly swift enchanted blade resonating at a frequency high enough to be able to slice through anything."
 	item_path = /obj/item/highfrequencyblade/wizard
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
 	cost = 3
 
 /datum/spellbook_entry/item/frog_contract
 	name = "Frog Contract"
 	desc = "Sign a pact with the frogs to have your own destructive pet guardian!"
 	item_path = /obj/item/frog_contract
-	category = "Offensive"
+	category = SPELLBOOK_CATEGORY_OFFENSIVE
+
+#undef SPELLBOOK_CATEGORY_OFFENSIVE


### PR DESCRIPTION

## About The Pull Request
Spellbook entries' categories now use defines

## Why It's Good For The Game
Prettier
Less of a chance for misspelling a category
Renaming a category is easier (for localized downstreams especially less strain)