### PR TITLE
Makes pod doors re-constructible

### DIFF
--- a/code/__DEFINES/construction/structures.dm
+++ b/code/__DEFINES/construction/structures.dm
@@ -48,9 +48,11 @@
 #define AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS 1
 #define AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER 2
 
-//blast door (de)construction states
+///The blast door is missing wires, first step of construction.
 #define BLASTDOOR_NEEDS_WIRES 0
+///The blast door needs electronics, second step of construction.
 #define BLASTDOOR_NEEDS_ELECTRONICS 1
+///The blast door is fully constructed.
 #define BLASTDOOR_FINISHED 2
 
 //floodlights because apparently we use defines now

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -35,6 +35,72 @@
 /obj/machinery/door/poddoor/get_save_vars()
 	return ..() + NAMEOF(src, id)
 
+/obj/machinery/door/poddoor/examine(mob/user)
+	. = ..()
+	if(panel_open)
+		if(deconstruction == BLASTDOOR_FINISHED)
+			. += span_notice("The maintenance panel is opened and the electronics could be <b>pried</b> out.")
+			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b>.")
+		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
+			. += span_notice("The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.")
+		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)
+			. += span_notice("The <i>wires</i> have been removed and it's ready to be <b>sliced apart</b>.")
+
+/obj/machinery/door/poddoor/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(isnull(held_item))
+		return NONE
+	if(deconstruction == BLASTDOOR_NEEDS_WIRES && istype(held_item, /obj/item/stack/cable_coil))
+		context[SCREENTIP_CONTEXT_LMB] = "Wire assembly"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS && istype(held_item, /obj/item/electronics/airlock))
+		context[SCREENTIP_CONTEXT_LMB] = "Add electronics"
+		return CONTEXTUAL_SCREENTIP_SET
+	//we do not check for special effects like if they can actually perform the action because they will be told they can't do it when they try,
+	//with feedback on what they have to do in order to do so.
+	switch(held_item.tool_behaviour)
+		if(TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = "Open panel"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_MULTITOOL)
+			context[SCREENTIP_CONTEXT_LMB] = "Calibrate ID"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_CROWBAR)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove electronics"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_WIRECUTTER)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove wires"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_WELDER)
+			context[SCREENTIP_CONTEXT_LMB] = "Disassemble"
+			return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/door/poddoor/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(deconstruction == BLASTDOOR_NEEDS_WIRES && istype(tool, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/coil = tool
+		var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
+		var/amount_needed = recipe.reqs[/obj/item/stack/cable_coil]
+		if(coil.get_amount() < amount_needed)
+			balloon_alert(user, "not enough cable!")
+			return ITEM_INTERACT_SUCCESS
+		balloon_alert(user, "adding cables...")
+		if(!do_after(user, 5 SECONDS, src))
+			return ITEM_INTERACT_SUCCESS
+		coil.use(amount_needed)
+		deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
+		balloon_alert(user, "cables added")
+		return ITEM_INTERACT_SUCCESS
+
+	if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS && istype(tool, /obj/item/electronics/airlock))
+		balloon_alert(user, "adding electronics...")
+		if(!do_after(user, 10 SECONDS, src))
+			return ITEM_INTERACT_SUCCESS
+		qdel(tool)
+		balloon_alert(user, "electronics added")
+		deconstruction = BLASTDOOR_FINISHED
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
 /obj/machinery/door/poddoor/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if (density)
@@ -49,7 +115,8 @@
 		balloon_alert(user, "open the door first!")
 		return ITEM_INTERACT_SUCCESS
 	if (!panel_open)
-		return
+		balloon_alert(user, "open the panel first!")
+		return ITEM_INTERACT_SUCCESS
 	if (deconstruction != BLASTDOOR_FINISHED)
 		return
 	var/change_id = tgui_input_number(user, "Set the door controllers ID (Current: [id])", "Door Controller ID", isnum(id) ? id : null, 100)
@@ -69,7 +136,8 @@
 		balloon_alert(user, "open the door first!")
 		return ITEM_INTERACT_SUCCESS
 	if (!panel_open)
-		return
+		balloon_alert(user, "open the panel first!")
+		return ITEM_INTERACT_SUCCESS
 	if (deconstruction != BLASTDOOR_FINISHED)
 		return
 	balloon_alert(user, "removing airlock electronics...")
@@ -86,7 +154,8 @@
 		balloon_alert(user, "open the door first!")
 		return ITEM_INTERACT_SUCCESS
 	if (!panel_open)
-		return
+		balloon_alert(user, "open the panel first!")
+		return ITEM_INTERACT_SUCCESS
 	if (deconstruction != BLASTDOOR_NEEDS_ELECTRONICS)
 		return
 	balloon_alert(user, "removing internal cables...")
@@ -104,7 +173,8 @@
 		balloon_alert(user, "open the door first!")
 		return ITEM_INTERACT_SUCCESS
 	if (!panel_open)
-		return
+		balloon_alert(user, "open the panel first!")
+		return ITEM_INTERACT_SUCCESS
 	if (deconstruction != BLASTDOOR_NEEDS_WIRES)
 		return
 	balloon_alert(user, "tearing apart...") //You're tearing me apart, Lisa!
@@ -115,17 +185,6 @@
 		user.balloon_alert(user, "torn apart")
 		qdel(src)
 	return ITEM_INTERACT_SUCCESS
-
-/obj/machinery/door/poddoor/examine(mob/user)
-	. = ..()
-	if(panel_open)
-		if(deconstruction == BLASTDOOR_FINISHED)
-			. += span_notice("The maintenance panel is opened and the electronics could be <b>pried</b> out.")
-			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b>.")
-		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
-			. += span_notice("The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.")
-		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)
-			. += span_notice("The <i>wires</i> have been removed and it's ready to be <b>sliced apart</b>.")
 
 /obj/machinery/door/poddoor/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	id = "[port.shuttle_id]_[id]"

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -16,6 +16,9 @@
 	density = FALSE
 	opacity = FALSE
 
+/obj/machinery/door/poddoor/shutters/preopen/deconstructed
+	deconstruction = BLASTDOOR_NEEDS_WIRES
+
 /obj/machinery/door/poddoor/shutters/indestructible
 	name = "hardened shutters"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -256,6 +256,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("AI core", /obj/structure/ai_core, 4, time = 5 SECONDS, one_per_turf = TRUE, check_density = FALSE, category = CAT_ROBOT),
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 5 SECONDS, check_density = FALSE, category = CAT_CHEMISTRY),
 	new/datum/stack_recipe("Large Gas Tank", /obj/structure/tank_frame, 4, time=1 SECONDS, one_per_turf=TRUE, check_density = FALSE, category = CAT_ATMOSPHERIC),
+	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = CAT_STRUCTURE, category = CAT_ATMOSPHERIC),
 	null,
 	new /datum/stack_recipe_list("airlock assemblies", list( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_DOORS),

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("AI core", /obj/structure/ai_core, 4, time = 5 SECONDS, one_per_turf = TRUE, check_density = FALSE, category = CAT_ROBOT),
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 5 SECONDS, check_density = FALSE, category = CAT_CHEMISTRY),
 	new/datum/stack_recipe("Large Gas Tank", /obj/structure/tank_frame, 4, time=1 SECONDS, one_per_turf=TRUE, check_density = FALSE, category = CAT_ATMOSPHERIC),
-	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = TRUE, category = CAT_DOORS),
+	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = FALSE, category = CAT_DOORS),
 	null,
 	new /datum/stack_recipe_list("airlock assemblies", list( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_DOORS),

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("AI core", /obj/structure/ai_core, 4, time = 5 SECONDS, one_per_turf = TRUE, check_density = FALSE, category = CAT_ROBOT),
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 5 SECONDS, check_density = FALSE, category = CAT_CHEMISTRY),
 	new/datum/stack_recipe("Large Gas Tank", /obj/structure/tank_frame, 4, time=1 SECONDS, one_per_turf=TRUE, check_density = FALSE, category = CAT_ATMOSPHERIC),
-	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = CAT_STRUCTURE, category = CAT_DOORS),
+	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = TRUE, category = CAT_DOORS),
 	null,
 	new /datum/stack_recipe_list("airlock assemblies", list( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_DOORS),

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("AI core", /obj/structure/ai_core, 4, time = 5 SECONDS, one_per_turf = TRUE, check_density = FALSE, category = CAT_ROBOT),
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 5 SECONDS, check_density = FALSE, category = CAT_CHEMISTRY),
 	new/datum/stack_recipe("Large Gas Tank", /obj/structure/tank_frame, 4, time=1 SECONDS, one_per_turf=TRUE, check_density = FALSE, category = CAT_ATMOSPHERIC),
-	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = CAT_STRUCTURE, category = CAT_ATMOSPHERIC),
+	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, one_per_turf = TRUE, check_density = CAT_STRUCTURE, category = CAT_DOORS),
 	null,
 	new /datum/stack_recipe_list("airlock assemblies", list( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_DOORS),


### PR DESCRIPTION
## About The Pull Request

Adds the ability to reconstruct pod doors once deconstruction has been started, and adds a pre-deconstructed pod door to the list of plasteel crafting recipes.

Also adds context tips and some minor extra feedback during deconstruction steps.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/68800
Door construction like airlocks are all possible this slap-crafting rather than stuffing all of it in the crafting menu, I thought it would be nice to have pod doors available there as well.

## Changelog

:cl:
fix: You can now re-construct pod doors that had deconstruction started.
qol: You can now make pod door assemblies using plasteel in-hand.
/:cl: