### PR TITLE
Fix laser_pointer/inifity_range having the wrong diode

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -70,7 +70,7 @@
 
 /obj/item/laser_pointer/infinite_range/Initialize(mapload)
 	. = ..()
-	diode = new /obj/item/stock_parts/servo/femto
+	diode = new /obj/item/stock_parts/micro_laser/quadultra
 
 /obj/item/laser_pointer/screwdriver_act(mob/living/user, obj/item/tool)
 	if(diode)


### PR DESCRIPTION

## About The Pull Request
Fixes an issue where diode in infinity_range laser pointer was servo, not a micro-laser

## Changelog
:cl:
fix: Infinite-range laser pointer (for "AI" Big Brother) now has a correct diode. If you accidentaly remove it then you can put it back!
/:cl:
