### PR TITLE
QM is excluded from command-excluded objectives

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -236,7 +236,8 @@
 		JOB_HEAD_OF_SECURITY,
 		JOB_HEAD_OF_PERSONNEL,
 		JOB_CHIEF_ENGINEER,
-		JOB_CHIEF_MEDICAL_OFFICER
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_QUARTERMASTER,
 	)
 	exists_on_map = TRUE
 	difficulty = 3
@@ -279,7 +280,8 @@
 		JOB_HEAD_OF_SECURITY,
 		JOB_HEAD_OF_PERSONNEL,
 		JOB_CHIEF_ENGINEER,
-		JOB_CHIEF_MEDICAL_OFFICER
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_QUARTERMASTER,
 	)
 	exists_on_map = TRUE
 	difficulty = 4
@@ -629,7 +631,15 @@
 /datum/objective_item/steal/traitor/rpd
 	name = "rapid pipe dispenser"
 	targetitem = /obj/item/pipe_dispenser
-	excludefromjob = list(JOB_ATMOSPHERIC_TECHNICIAN, JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_SCIENTIST, JOB_RESEARCH_DIRECTOR, JOB_GENETICIST, JOB_ROBOTICIST)
+	excludefromjob = list(
+		JOB_ATMOSPHERIC_TECHNICIAN,
+		JOB_STATION_ENGINEER,
+		JOB_CHIEF_ENGINEER,
+		JOB_SCIENTIST,
+		JOB_RESEARCH_DIRECTOR,
+		JOB_GENETICIST,
+		JOB_ROBOTICIST,
+	)
 	item_owner = list(JOB_CHIEF_ENGINEER)
 	exists_on_map = TRUE
 	difficulty = 1
@@ -641,7 +651,19 @@
 /datum/objective_item/steal/traitor/donut_box
 	name = "a box of prized donuts"
 	targetitem = /obj/item/storage/fancy/donut_box
-	excludefromjob = list(JOB_CAPTAIN, JOB_CHIEF_ENGINEER, JOB_HEAD_OF_PERSONNEL, JOB_HEAD_OF_SECURITY, JOB_QUARTERMASTER, JOB_CHIEF_MEDICAL_OFFICER, JOB_RESEARCH_DIRECTOR, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_LAWYER, JOB_DETECTIVE)
+	excludefromjob = list(
+		JOB_CAPTAIN,
+		JOB_CHIEF_ENGINEER,
+		JOB_HEAD_OF_PERSONNEL,
+		JOB_HEAD_OF_SECURITY,
+		JOB_QUARTERMASTER,
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_RESEARCH_DIRECTOR,
+		JOB_SECURITY_OFFICER,
+		JOB_WARDEN,
+		JOB_LAWYER,
+		JOB_DETECTIVE,
+	)
 	exists_on_map = TRUE
 	difficulty = 1
 	steal_hint = "Everyone has a box of donuts - you may most commonly find them on the Bridge, within Security, or in any department's break room."


### PR DESCRIPTION
## About The Pull Request

QM will not longer be tasked with stealing telescopic batons and the captain's spare ID like all other command members are.

## Why It's Good For The Game

I just found it and thought it might've been unintentional since QM spawns with a baton and is in line for acting captain.

## Changelog

:cl:
fix: QM is now excluded from getting tasked with stealing telescopic batons and the captain's spare ID, like all other command personnel are.
/:cl: