### PR TITLE
Fixes DNA sequence scanner showing mutated genes

### DIFF
--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -19,7 +19,7 @@
 	var/list/discovered = list() //hit a dna console to update the scanners database
 	var/list/buffer
 	var/ready = TRUE
-	var/cooldown = 200
+	var/cooldown = (20 SECONDS)
 	/// genetic makeup data that's scanned
 	var/list/genetic_makeup_buffer = list()
 
@@ -104,7 +104,7 @@
 	buffer = LAZYLISTDUPLICATE(target.dna.mutation_index)
 	var/list/active_mutations = list()
 	for(var/datum/mutation/human/mutation in target.dna.mutations)
-		LAZYOR(buffer, mutation.type)
+		LAZYSET(buffer, mutation.type, GET_SEQUENCE(mutation.type))
 		active_mutations.Add(mutation.type)
 
 	to_chat(user, span_notice("Subject [target.name]'s DNA sequence has been saved to buffer."))


### PR DESCRIPTION
## About The Pull Request

Using a genetic sequence scanner now properly stores the right sequence to mutated genes, letting them actually be read later.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/82928

## Changelog

:cl:
fix: Genetic sequence scanners now show the sequence to mutated genes from scanned individuals.
/:cl: