### PR TITLE
[gbp no update] fix: ethereal alt attack verb is "sear"

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -36,7 +36,7 @@
 	limb_id = SPECIES_ETHEREAL
 	dmg_overlay_type = null
 	attack_type = BURN //burn bish
-	unarmed_attack_verbs = list("burn", "singe")
+	unarmed_attack_verbs = list("burn", "sear")
 	grappled_attack_verb = "scorch"
 	unarmed_attack_sound = 'sound/weapons/etherealhit.ogg'
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
@@ -54,7 +54,7 @@
 	limb_id = SPECIES_ETHEREAL
 	dmg_overlay_type = null
 	attack_type = BURN // bish buzz
-	unarmed_attack_verbs = list("burn")
+	unarmed_attack_verbs = list("burn", "sear")
 	grappled_attack_verb = "scorch"
 	unarmed_attack_sound = 'sound/weapons/etherealhit.ogg'
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'


### PR DESCRIPTION
forgot to add the alt attack verb to the r ight arm

also, unfortunately have to change "singe" because it ends in E and bodypart unarmed attacks get "ed" appended to them

## Changelog
:cl:
fix: Ethereal unarmed attacks "sear" instead of "singe", which was buggy
/:cl:
