### PR TITLE
Bumps Hypnagogic to v3.1.0

### DIFF
--- a/cutter_templates/bitmask/restore.toml
+++ b/cutter_templates/bitmask/restore.toml
@@ -1,0 +1,20 @@
+# Bitmask restoration!
+# Allows for easy mass extraction of template pngs and their configs from a dmi
+# Use this if you have a dmi and you want a cutter config you can edit easily
+# Of note, while it tries its best it is nowhere near perfect. We don't parity check against the existing dmi
+# And we also do not account for overrided states very well
+# Always double check (and be aware that dmi is weird so you may get diffs of 1 rgb value when doin this)
+mode = "BitmaskSliceReconstruct"
+# List of icon states to pull out (by default)
+extract = ["0", "3", "12", "15", "255"]
+
+# Map of name -> state that will be encoded into a positions list later
+# Lets you extract particular states and use them to fill in for states later
+# Useful to carry over odd snowflake states
+#[bespoke]
+
+# Map of key -> value to set on the created config
+# Lets you set arbitrary values on the created config, mostly useful for batch processing
+# IMPORTANT NOTE: We sort of assume you'll setup a default template here (since this is for batch processing),
+# so if things work odd that's likely why
+#[set]

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -30,4 +30,4 @@ export AUXLUA_VERSION=1.4.4
 export CUTTER_REPO=spacestation13/hypnagogic
 
 #hypnagogic git tag
-export CUTTER_VERSION=v3.0.1
+export CUTTER_VERSION=v3.1.0

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -35,7 +35,6 @@ Juke.setup({ file: import.meta.url }).then((code) => {
 });
 
 const DME_NAME = 'tgstation';
-const CUTTER_SUFFIX = '.png.toml'
 
 // Stores the contents of dependencies.sh as a key value pair
 // Best way I could figure to get ahold of this stuff
@@ -148,20 +147,34 @@ export const IconCutterTarget = new Juke.Target({
   dependsOn: () => [
     CutterTarget,
   ],
-  inputs: [
-    'icons/**/*.png',
-    `icons/**/*${CUTTER_SUFFIX}`,
-    `cutter_templates/**/*${CUTTER_SUFFIX}`,
-    cutter_path,
-  ],
+  inputs: ({ get }) => {
+    const standard_inputs = [
+      `icons/**/*.png.toml`,
+      `icons/**/*.dmi.toml`,
+      `cutter_templates/**/*.toml`,
+      cutter_path,
+    ]
+    // Alright we're gonna search out any existing toml files and convert
+    // them to their matching .dmi or .png file
+    const existing_configs = [
+      ...Juke.glob(`icons/**/*.png.toml`),
+      ...Juke.glob(`icons/**/*.dmi.toml`),
+    ];
+    return [
+      ...standard_inputs,
+      ...existing_configs.map((file) => file.replace('.toml', '')),
+    ]
+  },
   outputs: ({ get }) => {
     if(get(ForceRecutParameter))
       return [];
     const folders = [
-      ...Juke.glob(`icons/**/*${CUTTER_SUFFIX}`),
+      ...Juke.glob(`icons/**/*.png.toml`),
+      ...Juke.glob(`icons/**/*.dmi.toml`),
     ];
     return folders
-      .map((file) => file.replace(`${CUTTER_SUFFIX}`, '.dmi'));
+      .map((file) => file.replace(`.png.toml`, '.dmi'))
+      .map((file) => file.replace(`.dmi.toml`, '.png'));
   },
   executes: async () => {
     await Juke.exec(cutter_path, [


### PR DESCRIPTION
## About The Pull Request

Bumps the cutter to my latest [version](https://github.com/spacestation13/hypnagogic/releases/tag/v3.1.0)

See there for the full CL but in short:

### Fixes/Polish

Error handling actually works now (it prints instead of crashing the program)

Pretty colors in CLI when running it

![image](https://github.com/tgstation/tgstation/assets/58055496/3bb1ce3c-055e-4b3d-ba94-dad262517a94)

Release files are more portable (Windows version requires less cruft bs dlls, and the linux version targets musl instead of glibc, making it far less platform dependent)

### Features

The cutter supports a new mode called Reconstruction, which takes a target dmi and does a good faith effort to convert it back to input png and toml files. This only works for default bitmasking, and it doesn't ALWAYS work, but it's really powerful. 
It's what I used to make my initial cutter pr here. See [here](https://github.com/spacestation13/hypnagogic/blob/v3.1.0/examples/bitmask-slice-restore.toml) for more detail.
