### PR TITLE
Adds the Telescopic Baton to the HoS's backpack.

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -55,6 +55,7 @@
 	suit_store = /obj/item/gun/energy/e_gun
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
+		/obj/item/melee/baton/telescopic = 1,
 		)
 	belt = /obj/item/modular_computer/pda/heads/hos
 	ears = /obj/item/radio/headset/heads/hos/alt


### PR DESCRIPTION

## About The Pull Request

This PR adds the Telescopic Baton to the backpack of the Head of Security, just like it does for every other Head of Staff.

## Why It's Good For The Game

These batons are useful for being compact while allowing heads to still have a powerful self defense tool without a need to constantly recharge it.
However, this is given to every station head except the head of security, the one most likely to get into fights with a need for self defense.
Sure, the stun baton is better against multiple people, but that still does not explain why a more advanced baton that is better in 1v1s, which are common when engaging suspects, is only obtainable by a HoS by either asking/trading with a head of staff who is much less likely to ever use it, or confiscating it off of one in the event they are found out as a traitor.
Furthermore, this would give the HoS a backup option if their limited charge tools run out of said charges, while not taking up a huge amount of storage space.
In general, this is even listed in the wiki as a security item, so I don't see why the HoS does not get one, nor why giving them one would be a problem.

## Changelog
:cl: BramvanZijp
balance: The Head of Security is now issued a Telescopic Baton like all other heads.
/:cl:
