### PR TITLE
Fixes computers deconstructing themselves twice

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -117,7 +117,9 @@
 	new_frame.set_anchored(TRUE)
 	new_frame.circuit = circuit
 	// Circuit removal code is handled in /obj/machinery/Exited()
+	component_parts -= circuit
 	circuit.forceMove(new_frame)
+
 	if((machine_stat & BROKEN) || !disassembled)
 		var/atom/drop_loc = drop_location()
 		playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 70, TRUE)
@@ -127,7 +129,6 @@
 	else
 		new_frame.state = FRAME_COMPUTER_STATE_GLASSED
 	new_frame.update_appearance(UPDATE_ICON_STATE)
-
 
 /obj/machinery/computer/ui_interact(mob/user, datum/tgui/ui)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
## About The Pull Request
- Closes #82944

That PR was a bandage fix to the actual problem on computer deconstruction. `/obj/machinery/computer/spawn_frame()` moves the circuit board out of the computer as such
https://github.com/tgstation/tgstation/blob/a57d02bf4695f6501e20ab7650f0d4fe36cac489/code/game/machinery/computer/_computer.dm#L120
But it does not first remove it from `component_parts` as a result `/obj/machinery/Exited()` still sees that circuit board is inside the machines component parts and since this machine only gets deleted at the last step of deconstruction, the `QDELETED(src)` check doesn't help either & so it sees the circuit board removal as an abnormal condition & attempts to call `deconstruct(FALSE)` again while the machine is still getting deconstructed!!. It's an recursive condition
https://github.com/tgstation/tgstation/blob/a57d02bf4695f6501e20ab7650f0d4fe36cac489/code/game/machinery/_machinery.dm#L918-L921

To prevent this loop we have to first remove the circuitboard from the component parts so that ` if(gone in component_parts)` fails & does not call `deconstruct(FALSE)` while deconstruction is taking place

## Changelog
:cl:
fix: computers don't deconstruct themselves twice so machines like slotmachine don't spawn excess chips upon deconstruction
/:cl:
