### PR TITLE
Fixes syndicate infiltrator having "weak spots"

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -587,7 +587,7 @@
 /area/shuttle/syndicate/medical)
 "fB" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/shuttle/syndicate/airlock)
 "gt" = (
 /obj/item/storage/box/handcuffs{
@@ -1096,7 +1096,7 @@
 	},
 /area/shuttle/syndicate/eva)
 "Xy" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/shuttle/syndicate/airlock)
 "YN" = (
 /turf/open/floor/iron/dark/smooth_corner{


### PR DESCRIPTION
## About The Pull Request
This pr adresses 2 walls which used the normal variant instead of rwalls

## Why It's Good For The Game
Makes it a little harder for people to grief the syndicate infiltrator while they are trying to get the disk.

## Changelog

:cl:
fix: The syndicate infiltrator has no weak spots anymore
/:cl:
