### PR TITLE
Changeling clothes can now be removed by monkeys

### DIFF
--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -19,6 +19,9 @@
 		return
 	. = ..()
 
+/obj/item/clothing/glasses/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
+
 /obj/item/clothing/under/changeling
 	name = "flesh"
 	item_flags = DROPDEL
@@ -30,6 +33,9 @@
 		qdel(src)
 		return
 	. = ..()
+
+/obj/item/clothing/under/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
 
 /obj/item/clothing/suit/changeling
 	name = "flesh"
@@ -44,6 +50,9 @@
 		return
 	. = ..()
 
+/obj/item/clothing/suit/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
+
 /obj/item/clothing/head/changeling
 	name = "flesh"
 	icon_state = null
@@ -57,6 +66,9 @@
 		return
 	. = ..()
 
+/obj/item/clothing/head/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
+
 /obj/item/clothing/shoes/changeling
 	name = "flesh"
 	item_flags = DROPDEL
@@ -68,6 +80,9 @@
 		qdel(src)
 		return
 	. = ..()
+
+/obj/item/clothing/shoes/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
 
 /obj/item/clothing/gloves/changeling
 	name = "flesh"
@@ -81,6 +96,9 @@
 		return
 	. = ..()
 
+/obj/item/clothing/gloves/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
+
 /obj/item/clothing/mask/changeling
 	name = "flesh"
 	item_flags = DROPDEL
@@ -92,6 +110,9 @@
 		qdel(src)
 		return
 	. = ..()
+
+/obj/item/clothing/mask/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
 
 /obj/item/changeling
 	name = "flesh"
@@ -105,6 +126,9 @@
 		qdel(src)
 		return
 	. = ..()
+
+/obj/item/changeling/attack_paw(mob/user, list/modifiers)
+	attack_hand(user, modifiers)
 
 /obj/item/changeling/id
 	slot_flags = ITEM_SLOT_ID


### PR DESCRIPTION
## About The Pull Request

It feels like Changeling clothes can be an element/component instead, but for now this fixes a bug where if you turn into a monkey after transforming into someone, unless you have Clever mutation to use attack hand then you could not take off your nodrop clothes.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/59182

## Changelog

:cl:
fix: Monkey changelings that are disguised as someone can now take off their flesh clothes.
/:cl: