### PR TITLE
Debug uplinks shows all categories and doesnt lock

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -266,7 +266,7 @@
 
 /datum/component/uplink/ui_assets(mob/user)
 	return list(
-		get_asset_datum(/datum/asset/json/uplink)
+		get_asset_datum(/datum/asset/json/uplink),
 	)
 
 /datum/component/uplink/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -71,7 +71,7 @@
 	/// If this uplink item is only available to certain roles. Roles are dependent on the frequency chip or stored ID.
 	var/list/restricted_roles = list()
 	/// The species able to purchase this uplink item.
-	var/restricted_species = list()
+	var/list/restricted_species = list()
 	/// The minimum amount of progression needed for this item to be added to uplinks.
 	var/progression_minimum = 0
 	/// Whether this purchase is visible in the purchase log.

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -137,13 +137,15 @@ export class Uplink extends Component<{}, UplinkState> {
     uplinkData.items = uplinkData.items.filter((value) => {
       if (
         value.restricted_roles.length > 0 &&
-        !value.restricted_roles.includes(uplinkRole)
+        !value.restricted_roles.includes(uplinkRole) &&
+        !data.debug
       ) {
         return false;
       }
       if (
         value.restricted_species.length > 0 &&
-        !value.restricted_species.includes(uplinkSpecies)
+        !value.restricted_species.includes(uplinkSpecies) &&
+        !data.debug
       ) {
         return false;
       }
@@ -455,7 +457,7 @@ export class Uplink extends Component<{}, UplinkState> {
                         }
                       }}
                     />
-                    {(shop_locked && (
+                    {(shop_locked && !data.debug && (
                       <Dimmer>
                         <Box
                           color="red"


### PR DESCRIPTION
## About The Pull Request

Using debug uplinks once again shows you all categories of role/species restricted items. I also made it not show the shop as being locked since they are meant to always be able to buy things per;
https://github.com/tgstation/tgstation/blob/fae4ec5aa1fdd51364b2ffdd49d54ab22c2dc38f/code/modules/antagonists/traitor/uplink_handler.dm#L90-L110

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66743

## Changelog

:cl:
admin: Debug uplinks now shows all categories and won't lock upon buying items like his grace and the syndicate balloon.
/:cl: