### PR TITLE
Fixes a way to get a very long gold number

### DIFF
--- a/code/game/machinery/computer/arcade/battle.dm
+++ b/code/game/machinery/computer/arcade/battle.dm
@@ -531,7 +531,8 @@
 						return
 					player_turn = TRUE
 					ui_panel = UI_PANEL_WORLD_MAP
-					player_gold /= 2
+					if(player_gold)
+						player_gold = max(round(player_gold /= 2, 1), 0)
 					return TRUE
 			//they pressed something but it wasn't in the menu, we'll be nice and give them back their turn anyway.
 			player_turn = TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes this
![image](https://github.com/tgstation/tgstation/assets/53777086/091991e4-6470-4ffb-a9b7-a2899adc594d)

Which occurs when you spam flee, since it unrestrictedly halves your gold. 

## Why It's Good For The Game

another arcade issue gone.

## Changelog

:cl:
fix: Constantly fleeing in Battle Arcade will no longer give you a very large amount of decimals due to halving your gold every time.
/:cl: