### PR TITLE
[NO GBP]Fixes hypercharged slime core cells and circuit gun cells starting with an insignificant amount of charge.

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -93,8 +93,8 @@ Slimecrossing Items
 	icon_state = "yellow slime extract"
 	rating = 7
 	custom_materials = null
-	maxcharge = 50000
-	chargerate = 2500
+	maxcharge = 50 * STANDARD_CELL_CHARGE
+	chargerate = 2.5 * STANDARD_CELL_RATE
 	charge_light_type = null
 	connector_type = "slimecore"
 

--- a/code/modules/wiremod/shell/gun.dm
+++ b/code/modules/wiremod/shell/gun.dm
@@ -30,7 +30,7 @@
 	range = 7
 
 /obj/item/stock_parts/cell/emproof/wiremod_gun
-	maxcharge = 100
+	maxcharge = 0.1 * STANDARD_CELL_CHARGE
 
 /obj/item/gun/energy/wiremod_gun/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
Scales the hypercharged slime core and wiremod gun cell maximum charge and charge rate by the STANDARD_CELL_CHARGE and STANDARD_CELL_RATE defines. Fixes their scale.

Closes #82907

## Changelog
:cl:
fix: Fixes hypercharged slime core cells and circuit guns having 1,000 times less energy than intended.
/:cl:
