### PR TITLE
make SSevents `frequeny_lower` and `frequency_upper` configurable, fix runtimes when no events were drafted to trigger

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -473,7 +473,7 @@
  * You should only pass integers in.
  */
 /proc/pick_weight(list/list_to_pick)
-	if(!length(list_to_pick))
+	if(length(list_to_pick) == 0)
 		return null
 
 	var/total = 0
@@ -485,7 +485,7 @@
 	total = rand(1, total)
 	for(var/item in list_to_pick)
 		var/item_weight = list_to_pick[item]
-		if(!item_weight)
+		if(item_weight == 0)
 			continue
 
 		total -= item_weight

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -417,7 +417,7 @@
 **/
 /proc/list_clear_nulls(list/list_to_clear)
 	return (list_to_clear.RemoveAll(null) > 0)
-	
+
 
 /**
  * Removes any empty weakrefs from the list
@@ -473,17 +473,23 @@
  * You should only pass integers in.
  */
 /proc/pick_weight(list/list_to_pick)
+	if(!length(list_to_pick))
+		return null
+
 	var/total = 0
-	var/item
-	for(item in list_to_pick)
+	for(var/item in list_to_pick)
 		if(!list_to_pick[item])
 			list_to_pick[item] = 0
 		total += list_to_pick[item]
 
 	total = rand(1, total)
-	for(item in list_to_pick)
-		total -= list_to_pick[item]
-		if(total <= 0 && list_to_pick[item])
+	for(var/item in list_to_pick)
+		var/item_weight = list_to_pick[item]
+		if(!item_weight)
+			continue
+
+		total -= item_weight
+		if(total <= 0)
 			return item
 
 	return null

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -347,6 +347,16 @@
 	min_val = 0
 	integer = FALSE
 
+/datum/config_entry/number/events_frequency_lower
+	default = 2.5 MINUTES
+	min_val = 0
+	protection = CONFIG_ENTRY_LOCKED
+
+/datum/config_entry/number/events_frequency_upper
+	default = 7 MINUTES
+	min_val = 0
+	protection = CONFIG_ENTRY_LOCKED
+
 /datum/config_entry/number/mice_roundstart
 	default = 10
 	min_val = 0

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -23,6 +23,10 @@ SUBSYSTEM_DEF(events)
 		if(!event.typepath || !event.valid_for_map())
 			continue //don't want this one! leave it for the garbage collector
 		control += event //add it to the list of all events (controls)
+
+	frequency_lower = CONFIG_GET(number/events_frequency_lower)
+	frequency_upper = CONFIG_GET(number/events_frequency_upper)
+
 	reschedule()
 	// Instantiate our holidays list if it hasn't been already
 	if(isnull(GLOB.holidays))
@@ -85,7 +89,8 @@ SUBSYSTEM_DEF(events)
 			event_roster[event_to_check] = event_to_check.weight
 
 	var/datum/round_event_control/event_to_run = pick_weight(event_roster)
-	TriggerEvent(event_to_run)
+	if(event_to_run)
+		TriggerEvent(event_to_run)
 
 ///Does the last pre-flight checks for the passed event, and runs it if the event is ready.
 /datum/controller/subsystem/events/proc/TriggerEvent(datum/round_event_control/event_to_trigger)
@@ -103,8 +108,8 @@ SUBSYSTEM_DEF(events)
 
 ///Sets the event frequency bounds back to their initial value.
 /datum/controller/subsystem/events/proc/resetFrequency()
-	frequency_lower = initial(frequency_lower)
-	frequency_upper = initial(frequency_upper)
+	frequency_lower = CONFIG_GET(number/events_frequency_lower)
+	frequency_upper = CONFIG_GET(number/events_frequency_upper)
 
 /**
  * HOLIDAYS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -147,6 +147,13 @@ EVENTS_MIN_TIME_MUL 1
 ## Set to 0 to make dangerous events avaliable for all populations.
 EVENTS_MIN_PLAYERS_MUL 1
 
+## The lower bound, in deciseconds, for how soon another random event can be scheduled.
+## Defaults to 1500 deciseconds or 2.5 minutes
+EVENTS_FREQUENCY_LOWER 1500
+
+## The upper bound, in deciseconds, for how soon another random event can be scheduled.
+## Defaults to 4200 deciseconds or 7 minutes
+EVENTS_FREQUENCY_UPPER 4200
 
 ## AI ###
 


### PR DESCRIPTION
## About The Pull Request

Make events frequency configurable.
Fix runtime when no events were drafted to be picked from.

## Why It's Good For The Game

No runtimes good. 
No need to change frequency in code.

:cl:
fix: fix runtime when no events were drafted to be picked from
config: make events frequency configurable
/:cl:
