### PR TITLE
Reading a photo with blueprints now requires squinting

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -264,9 +264,10 @@
 	if(!randomize)
 		if(user.is_holding_item_of_type(/obj/item/blueprints))
 			return TRUE
-		for(var/obj/item/photo/photo in user.held_items)
-			if(LAZYACCESS(studied_photos, REF(user)) == REF(photo))
-				return TRUE
+		if(!isnull(user.mind))
+			for(var/obj/item/photo/photo in user.held_items)
+				if(LAZYACCESS(studied_photos, REF(user.mind)) == REF(photo))
+					return TRUE
 
 	return FALSE
 
@@ -281,13 +282,20 @@
 /datum/wires/proc/always_reveal_wire(color)
 	return FALSE
 
+#define STUDY_INTERACTION_KEY "studying_photo"
+
 /**
  * Attempts to study a photo for blueprints.
  */
 /datum/wires/proc/try_study_photo(mob/user)
 	if(randomize)
 		return
-
+	if(isnull(user.mind))
+		return
+	if(DOING_INTERACTION(user, STUDY_INTERACTION_KEY))
+		return
+	if(LAZYACCESS(studied_photos, REF(user.mind)))
+		return
 	for(var/obj/item/photo/photo in user.held_items)
 		if(!photo.picture?.has_blueprints)
 			continue
@@ -299,9 +307,11 @@
 		else
 			to_chat(user, span_notice("<i>You glance at [photo], looking for wires in the pictured blueprints.</i>"))
 
-		if(do_after(user, study_length, holder, hidden = TRUE))
-			LAZYSET(studied_photos, REF(user), REF(photo))
+		if(do_after(user, study_length, holder, interaction_key = STUDY_INTERACTION_KEY, hidden = TRUE))
+			LAZYSET(studied_photos, REF(user.mind), REF(photo))
 		return
+
+#undef STUDY_INTERACTION_KEY
 
 /datum/wires/ui_host()
 	return holder

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -292,8 +292,13 @@
 		if(!photo.picture?.has_blueprints)
 			continue
 
-		to_chat(user, span_notice("<i>You squint at [photo], looking for wires hidden in the pictured blueprints.</i>"))
-		var/study_length = 1 SECONDS * (min(photo.picture.psize_x, photo.picture.psize_y) / 32)
+		var/study_length = 1 SECONDS * floor(min(photo.picture.psize_x, photo.picture.psize_y) / 32)
+		if(study_length >= 4 SECONDS)
+			to_chat(user, span_notice("<i>You squint [photo]... Hey, there's blueprints in the frame! Really wish the photo was zoomed in, though. \
+				It's rather difficult to make out the wires.</i>"))
+		else
+			to_chat(user, span_notice("<i>You glance at [photo], looking for wires in the pictured blueprints.</i>"))
+
 		if(do_after(user, study_length, holder, hidden = TRUE))
 			LAZYSET(studied_photos, REF(user), REF(photo))
 		return
@@ -314,7 +319,7 @@
 	if (!ui)
 		ui = new(user, src, "Wires", "[holder.name] Wires")
 		ui.open()
-		try_study_photo(user)
+	try_study_photo(user)
 
 /datum/wires/ui_data(mob/user)
 	var/list/data = list()

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -41,6 +41,7 @@
 	/// If every instance of these wires should be random. Prevents wires from showing up in station blueprints.
 	var/randomize = FALSE
 
+	/// Lazy assoc list of refs to mobs to refs to photos they have studied for wires
 	var/list/studied_photos
 
 /datum/wires/New(atom/holder)
@@ -264,7 +265,7 @@
 		if(user.is_holding_item_of_type(/obj/item/blueprints))
 			return TRUE
 		for(var/obj/item/photo/photo in user.held_items)
-			if(LAZYACCESS(studied_photos, REF(photo)))
+			if(LAZYACCESS(studied_photos, REF(user)) == REF(photo))
 				return TRUE
 
 	return FALSE
@@ -294,7 +295,7 @@
 		to_chat(user, span_notice("<i>You squint at [photo], looking for wires hidden in the pictured blueprints.</i>"))
 		var/study_length = 1 SECONDS * (min(photo.picture.psize_x, photo.picture.psize_y) / 32)
 		if(do_after(user, study_length, holder, hidden = TRUE))
-			LAZYSET(studied_photos, REF(photo), TRUE)
+			LAZYSET(studied_photos, REF(user), REF(photo))
 		return
 
 /datum/wires/ui_host()


### PR DESCRIPTION
## About The Pull Request

To see the wires in a photo of blueprints you first must squint at them. 

## Why It's Good For The Game

Realism, a picture of blueprints taken from across the room makes it difficult to see what's up

## Changelog

:cl: Melbert
balance: To see wires in photos of blueprints, you first must squint at the photo. 
/:cl:

