### PR TITLE
Pacifists can no longer endlessly spam rocket launcher backblasts

### DIFF
--- a/code/datums/elements/backblast.dm
+++ b/code/datums/elements/backblast.dm
@@ -38,10 +38,8 @@
 
 /// For firing an actual backblast pellet
 /datum/element/backblast/proc/pew(obj/item/gun/weapon, mob/living/user, atom/target)
-	if(istype(user))
-		var/mob/living/pacifist_check = user
-		if(HAS_TRAIT(pacifist_check, TRAIT_PACIFISM))
-			return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
 
 	var/turf/origin = get_turf(weapon)
 	var/backblast_angle = get_angle(target, origin)

--- a/code/datums/elements/backblast.dm
+++ b/code/datums/elements/backblast.dm
@@ -38,6 +38,11 @@
 
 /// For firing an actual backblast pellet
 /datum/element/backblast/proc/pew(obj/item/gun/weapon, mob/living/user, atom/target)
+	if(istype(user))
+		var/mob/living/pacifist_check = user
+		if(HAS_TRAIT(pacifist_check, TRAIT_PACIFISM))
+			return
+
 	var/turf/origin = get_turf(weapon)
 	var/backblast_angle = get_angle(target, origin)
 	explosion(weapon, devastation_range = dev_range, heavy_impact_range = heavy_range, light_impact_range = light_range, flame_range = flame_range, adminlog = FALSE, protect_epicenter = TRUE, explosion_direction = backblast_angle, explosion_arc = blast_angle)


### PR DESCRIPTION

## About The Pull Request
Fixes: #82990 

Backblasts from a rocket launcher are often the last thing an untrained person thinks of when they fire a rocket launcher. I did not consider the moral stance of pacifists who nevertheless try to shoot rocket launchers when I implemented rocket launcher backblast, because currently pacifists trying to shoot a loaded rocket launcher can spam backblast as much as they want, even if they aren't able to actually shoot.

This PR filters out pacifists before they trigger the backblast, to make sure only actual live shots deliver the hellpayload to their allies behind them.
## Why It's Good For The Game
A magical reverse flamethrower with no ammo limit (because at no point is the rocket in the chamber actually expended when a pacifist fails to fire it) is bad. A weapon as destructive as that left solely in the hands of pacifists is even worse.
## Changelog
:cl: Ryll/Shaps
fix: Pacifists can no longer endlessly spam the backblast functionality of loaded rocket launchers that they cannot actually fire
/:cl:
