### PR TITLE
Stamp papers quickly with a right click

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -441,8 +441,8 @@
 	// Handle stamping items.
 	if(writing_stats["interaction_mode"] == MODE_STAMPING)
 		if(!user.can_read(src) || user.is_blind())
-			//The paper's stampable window area is assumed approx 400x500
-			add_stamp(writing_stats["stamp_class"], rand(0, 400), rand(0, 500), rand(0, 360), writing_stats["stamp_icon_state"])
+			//The paper's stampable window area is assumed approx 300x400
+			add_stamp(writing_stats["stamp_class"], rand(0, 300), rand(0, 400), rand(0, 360), writing_stats["stamp_icon_state"])
 			user.visible_message(span_notice("[user] blindly stamps [src] with \the [attacking_item]!"))
 			to_chat(user, span_notice("You stamp [src] with \the [attacking_item] the best you can!"))
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
@@ -459,15 +459,17 @@
 	var/list/writing_stats = tool.get_writing_implement_details()
 
 	if(!length(writing_stats))
-		return
-	if(writing_stats["interaction_mode"] == MODE_STAMPING)
-		if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
-			return
-		else
-			add_stamp(writing_stats["stamp_class"], rand(0, 300), rand(0, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
-			user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
-			to_chat(user, span_notice("You stamp [src] quickly with \the [tool]"))
-			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
+		return NONE
+	if(writing_stats["interaction_mode"] != MODE_STAMPING)
+		return NONE
+	if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
+		return NONE
+
+	add_stamp(writing_stats["stamp_class"], rand(0, 300), rand(0, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
+	user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
+	balloon_alert(user, "Paper Stamped")
+	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
+
 	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.
 /**
  * Attempts to ui_interact the paper to the given user, with some sanity checking

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -467,7 +467,6 @@
 
 	add_stamp(writing_stats["stamp_class"], rand(1, 300), rand(1, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
 	user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
-	balloon_alert(user, "paper stamped")
 	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 
 	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -466,7 +466,10 @@
 		return NONE
 
 	add_stamp(writing_stats["stamp_class"], rand(1, 300), rand(1, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
-	user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
+	user.visible_message(
+		span_notice("[user] quickly stamps [src] with [tool] without looking."),
+		span_notice("You quickly stamp [src] with [tool] without looking."),
+	)
 	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 
 	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -455,16 +455,18 @@
 	return ..()
 
 /// Secondary right click interaction to quickly stamp things
-/obj/item/paper/attackby_secondary(obj/item/weapon, mob/user, params)
-	var/writing_stats = weapon.get_writing_implement_details()
+/obj/item/paper/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	var/list/writing_stats = tool.get_writing_implement_details()
 
+	if(!length(writing_stats))
+		return
 	if(writing_stats["interaction_mode"] == MODE_STAMPING)
 		if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
 			return
 		else
 			add_stamp(writing_stats["stamp_class"], rand(0, 400), rand(0, 500), stamp_icon_state = writing_stats["stamp_icon_state"])
-			user.visible_message(span_notice("[user] quickly stamps [src] with \the [weapon]"))
-			to_chat(user, span_notice("You stamp [src] quickly with \the [weapon]"))
+			user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
+			to_chat(user, span_notice("You stamp [src] quickly with \the [tool]"))
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 	return ..()
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -468,7 +468,7 @@
 			user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
 			to_chat(user, span_notice("You stamp [src] quickly with \the [tool]"))
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
-	return ITEM_INTERACT_BLOCKING
+	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.
 /**
  * Attempts to ui_interact the paper to the given user, with some sanity checking
  * to make sure the camera still exists via the weakref and that this paper is still

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -454,6 +454,20 @@
 	ui_interact(user)
 	return ..()
 
+/// Secondary right click interaction to quickly stamp things
+/obj/item/paper/attackby_secondary(obj/item/weapon, mob/user, params)
+	var/writing_stats = weapon.get_writing_implement_details()
+
+	if(writing_stats["interaction_mode"] == MODE_STAMPING)
+		if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
+			return
+		else
+			add_stamp(writing_stats["stamp_class"], rand(0,400), rand(0, 500), stamp_icon_state = writing_stats["stamp_icon_state"])
+			user.visible_message(span_notice("[user] quickly stamps [src] with \the [weapon]"))
+			to_chat(user, span_notice("You stamp [src] quickly with \the [weapon]"))
+			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
+	return ..()
+
 /**
  * Attempts to ui_interact the paper to the given user, with some sanity checking
  * to make sure the camera still exists via the weakref and that this paper is still

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -462,7 +462,7 @@
 		if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
 			return
 		else
-			add_stamp(writing_stats["stamp_class"], rand(0,400), rand(0, 500), stamp_icon_state = writing_stats["stamp_icon_state"])
+			add_stamp(writing_stats["stamp_class"], rand(0, 400), rand(0, 500), stamp_icon_state = writing_stats["stamp_icon_state"])
 			user.visible_message(span_notice("[user] quickly stamps [src] with \the [weapon]"))
 			to_chat(user, span_notice("You stamp [src] quickly with \the [weapon]"))
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -467,7 +467,7 @@
 
 	add_stamp(writing_stats["stamp_class"], rand(1, 300), rand(1, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
 	user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
-	balloon_alert(user, "Paper Stamped")
+	balloon_alert(user, "paper stamped")
 	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 
 	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -465,7 +465,7 @@
 	if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
 		return NONE
 
-	add_stamp(writing_stats["stamp_class"], rand(0, 300), rand(0, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
+	add_stamp(writing_stats["stamp_class"], rand(1, 300), rand(1, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
 	user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
 	balloon_alert(user, "Paper Stamped")
 	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -464,12 +464,11 @@
 		if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
 			return
 		else
-			add_stamp(writing_stats["stamp_class"], rand(0, 400), rand(0, 500), stamp_icon_state = writing_stats["stamp_icon_state"])
+			add_stamp(writing_stats["stamp_class"], rand(0, 300), rand(0, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
 			user.visible_message(span_notice("[user] quickly stamps [src] with \the [tool]"))
 			to_chat(user, span_notice("You stamp [src] quickly with \the [tool]"))
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
-	return ..()
-
+	return ITEM_INTERACT_BLOCKING
 /**
  * Attempts to ui_interact the paper to the given user, with some sanity checking
  * to make sure the camera still exists via the weakref and that this paper is still


### PR DESCRIPTION
## About The Pull Request

Right clicking a paper with a stamp will quickly place down the stamp

## Why It's Good For The Game

![fast](https://github.com/tgstation/tgstation/assets/95130227/de3eab11-e8bf-4266-aab6-97c8434663d7)


## Changelog
:cl:
qol: You can now quickly stamp papers with a right click
/:cl: