### PR TITLE
Spies can now use other spies' uplinks.

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -251,6 +251,9 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// Checks if the given mob is a malf ai.
 #define IS_MALF_AI(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/malf_ai))
 
+/// Checks if the given mob is a spy!
+#define IS_SPY(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/spy))
+
 /// List of human antagonist types which don't spawn directly on the space station
 GLOBAL_LIST_INIT(human_invader_antagonists, list(
 	/datum/antagonist/abductor,

--- a/code/modules/antagonists/spy/spy_uplink.dm
+++ b/code/modules/antagonists/spy/spy_uplink.dm
@@ -56,7 +56,7 @@
 /datum/component/spy_uplink/proc/on_attack_self(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(user.mind.has_antag_datum(/datum/antagonist/spy))
+	if(IS_SPY(user))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, ui_interact), user)
 	return NONE
 
@@ -65,7 +65,7 @@
 
 	if(!ismovable(target))
 		return NONE
-	if(!user.mind.has_antag_datum(/datum/antagonist/spy))
+	if(!IS_SPY(user))
 		return NONE
 	if(!try_steal(target, user))
 		return NONE

--- a/code/modules/antagonists/spy/spy_uplink.dm
+++ b/code/modules/antagonists/spy/spy_uplink.dm
@@ -56,7 +56,7 @@
 /datum/component/spy_uplink/proc/on_attack_self(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(is_our_spy(user))
+	if(user.mind.has_antag_datum(/datum/antagonist/spy))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, ui_interact), user)
 	return NONE
 
@@ -65,7 +65,7 @@
 
 	if(!ismovable(target))
 		return NONE
-	if(!is_our_spy(user))
+	if(!user.mind.has_antag_datum(/datum/antagonist/spy))
 		return NONE
 	if(!try_steal(target, user))
 		return NONE


### PR DESCRIPTION
## About The Pull Request

Spies can now use other spies' uplinks.

## Why It's Good For The Game

Every other antagonist in the game has a recovery method for their main gimmick or has their main gimmick baked into their mind and thus cannot be taken from them. This sucks ass for spies because they have zero recovery so they're left with the broken ass freeform objectives that don't green or redtext that maintainers and admins told me were bad for Families but are suddenly okay here I guess.

Spies being able to jack and use other spies' PDAs means you can now recover your primary gimmick by tracking down other spies, which improves spy gameplay and also discourages sharing loot.

## Changelog
:cl:
balance: Spies can now use other spies' uplinks.
/:cl:
