### PR TITLE
[NO GBP] Multiz deck revert

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -301,8 +301,8 @@
  * * given_layer - the piping_layer we are checking
  */
 /obj/machinery/atmospherics/proc/connection_check(obj/machinery/atmospherics/target, given_layer)
-	//check if the target & src connect in the same direction
-	if(!((initialize_directions & get_dir(src, target)) && (target.initialize_directions & get_dir(target, src))))
+	//if target is not multiz then we have to check if the target & src connect in the same direction
+	if(!istype(target, /obj/machinery/atmospherics/pipe/multiz) && !((initialize_directions & get_dir(src, target)) && (target.initialize_directions & get_dir(target, src))))
 		return FALSE
 
 	//both target & src can't be connected either way


### PR DESCRIPTION
## About The Pull Request

I've probably did unnecessary things in my old PR and it made a little problem for larvas. Now I revert my mistakes so they can feel great again.

Partially reverts #81452, fixes https://github.com/tgstation/tgstation/pull/82996

## Why It's Good For The Game

Larvas can change Z levels using multiz-deck again. Is good or at least I hope so.

## Changelog

:cl: mogeoko
fix: Ventcrawling mobs can change Z-level using multiz-decks again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
