### PR TITLE
Fire ant colonies created by burning actually contain fire ants

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -413,8 +413,6 @@
 
 /obj/effect/decal/cleanable/ants/fire_act(exposed_temperature, exposed_volume)
 	var/obj/effect/decal/cleanable/ants/fire/fire_ants = new(loc)
-	fire_ants.reagents.clear_reagents()
-	reagents.trans_to(fire_ants, fire_ants.reagents.maximum_volume)
 	qdel(src)
 
 /obj/effect/decal/cleanable/ants/fire

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -412,7 +412,7 @@
 	. += emissive_appearance(icon, "[icon_state]_light", src, alpha = src.alpha)
 
 /obj/effect/decal/cleanable/ants/fire_act(exposed_temperature, exposed_volume)
-	var/obj/effect/decal/cleanable/ants/fire/fire_ants = new(loc)
+	new /obj/effect/decal/cleanable/ants/fire(loc)
 	qdel(src)
 
 /obj/effect/decal/cleanable/ants/fire


### PR DESCRIPTION

## About The Pull Request
Fire ant colonies created by burning regular ants now give you fire ants when scooped up
There were 2 lines of code clearing the ants' reagent when they're burned. They're not needed because ants use `decal_reagent`
Tested and it works without these 2 lines
![fireants](https://github.com/tgstation/tgstation/assets/113535457/aee4ec28-a767-4dfe-b870-2a222848ae3a)
## Why It's Good For The Game
Fixes #82864 
## Changelog
:cl:
fix: Fire ant colonies created by burning regular ants will now contain fire ants as their reagent
/:cl:
