### PR TITLE
you may not shovestun batoned people

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -700,7 +700,7 @@
 	. |= SHOVE_CAN_STAGGER
 	if(IsKnockdown() && !IsParalyzed())
 		if(HAS_TRAIT_FROM(src, TRAIT_IWASBATONED, REF(shover))) // so we can do a balloon alert
-			balloon_alert(shover, "tired from baton use to kick onto side!")
+			balloon_alert(shover, "can't kick after batonning!")
 			return
 		. |= SHOVE_CAN_KICK_SIDE
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -699,6 +699,9 @@
 	. = ..()
 	. |= SHOVE_CAN_STAGGER
 	if(IsKnockdown() && !IsParalyzed())
+		if(HAS_TRAIT_FROM(src, TRAIT_IWASBATONED, REF(shover))) // so we can do a balloon alert
+			balloon_alert(shover, "tired from baton use to kick onto side!")
+			return
 		. |= SHOVE_CAN_KICK_SIDE
 
 #undef SHAKE_ANIMATION_OFFSET

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -705,7 +705,7 @@
 			log_combat(src, target, "shoved", "knocking them down[weapon ? " with [weapon]" : ""]")
 			return
 
-	if(shove_flags & SHOVE_CAN_KICK_SIDE) //KICK HIM IN THE NUTS
+	if((shove_flags & SHOVE_CAN_KICK_SIDE) && !HAS_TRAIT(target, TRAIT_IWASBATONED)) //KICK HIM IN THE NUTS
 		target.Paralyze(SHOVE_CHAIN_PARALYZE)
 		target.visible_message(span_danger("[name] kicks [target.name] onto [target.p_their()] side!"),
 						span_userdanger("You're kicked onto your side by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -705,7 +705,7 @@
 			log_combat(src, target, "shoved", "knocking them down[weapon ? " with [weapon]" : ""]")
 			return
 
-	if((shove_flags & SHOVE_CAN_KICK_SIDE)) //KICK HIM IN THE NUTS
+	if(shove_flags & SHOVE_CAN_KICK_SIDE) //KICK HIM IN THE NUTS
 		target.Paralyze(SHOVE_CHAIN_PARALYZE)
 		target.visible_message(span_danger("[name] kicks [target.name] onto [target.p_their()] side!"),
 						span_userdanger("You're kicked onto your side by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -705,7 +705,7 @@
 			log_combat(src, target, "shoved", "knocking them down[weapon ? " with [weapon]" : ""]")
 			return
 
-	if((shove_flags & SHOVE_CAN_KICK_SIDE) && !HAS_TRAIT(target, TRAIT_IWASBATONED)) //KICK HIM IN THE NUTS
+	if((shove_flags & SHOVE_CAN_KICK_SIDE) && !HAS_TRAIT_FROM(target, TRAIT_IWASBATONED, REF(src))) //KICK HIM IN THE NUTS
 		target.Paralyze(SHOVE_CHAIN_PARALYZE)
 		target.visible_message(span_danger("[name] kicks [target.name] onto [target.p_their()] side!"),
 						span_userdanger("You're kicked onto your side by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -705,7 +705,7 @@
 			log_combat(src, target, "shoved", "knocking them down[weapon ? " with [weapon]" : ""]")
 			return
 
-	if((shove_flags & SHOVE_CAN_KICK_SIDE) && !HAS_TRAIT_FROM(target, TRAIT_IWASBATONED, REF(src))) //KICK HIM IN THE NUTS
+	if((shove_flags & SHOVE_CAN_KICK_SIDE)) //KICK HIM IN THE NUTS
 		target.Paralyze(SHOVE_CHAIN_PARALYZE)
 		target.visible_message(span_danger("[name] kicks [target.name] onto [target.p_their()] side!"),
 						span_userdanger("You're kicked onto your side by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)


### PR DESCRIPTION
## About The Pull Request

**_you_** may not shovestun people that were batoned 4 seconds ago or less
(others still can go gang up on people or something)


https://github.com/tgstation/tgstation/assets/70376633/709801a9-3c45-4859-a2f6-c7c28bc715d6



## Why It's Good For The Game

batons have a delay to not instantly stamcrit someone and baton+shoving someone to achieve vaguely the same thing seems like going around that

also that is just not fun to play against and its pretty cheap

with this change you will have gang up on people (socializing??? in my RP game???) to stunlock or just wait for the cooldown to expire to stamcrit the victim which is miles better than an almost instant paralyze

## Changelog
:cl:
balance: the person that batons another person may not shovestun that person for 4 seconds
/:cl:
