### PR TITLE
Detective buff: Fixes detective's candy dispenser

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -113,6 +113,10 @@
 	/// If TRUE, shows the contents of the storage in open_storage
 	var/display_contents = TRUE
 
+	/// Switch this off if you want to handle click_alt in the parent atom
+	var/click_alt_open = TRUE
+
+
 /datum/storage/New(
 	atom/parent,
 	max_slots = src.max_slots,
@@ -198,7 +202,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
 	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(on_preattack))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(mass_empty))
-	RegisterSignals(parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY), PROC_REF(open_storage_on_signal))
+	RegisterSignals(parent, list(COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY), PROC_REF(open_storage_on_signal))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY_SECONDARY, PROC_REF(open_storage_attackby_secondary))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(close_distance))
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(update_actions))
@@ -208,6 +212,9 @@
 	RegisterSignal(parent, COMSIG_OBJ_DECONSTRUCT, PROC_REF(on_deconstruct))
 	RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	RegisterSignal(parent, COMSIG_ATOM_CONTENTS_WEIGHT_CLASS_CHANGED, PROC_REF(contents_changed_w_class))
+
+	if(click_alt_open)
+		RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_click_alt))
 
 /**
  * Sets where items are physically being stored in the case it shouldn't be on the parent.
@@ -918,6 +925,14 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	INVOKE_ASYNC(src, PROC_REF(open_storage), to_show)
 	if(display_contents)
 		return COMPONENT_NO_AFTERATTACK
+
+
+/// Alt click on the storage item. Default: Open the storage.
+/datum/storage/proc/on_click_alt(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	return open_storage_on_signal(source, user)
+
 
 /// Opens the storage to the mob, showing them the contents to their UI.
 /datum/storage/proc/open_storage(mob/to_show)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -212,9 +212,7 @@
 	RegisterSignal(parent, COMSIG_OBJ_DECONSTRUCT, PROC_REF(on_deconstruct))
 	RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	RegisterSignal(parent, COMSIG_ATOM_CONTENTS_WEIGHT_CLASS_CHANGED, PROC_REF(contents_changed_w_class))
-
-	if(click_alt_open)
-		RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_click_alt))
+	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_click_alt))
 
 /**
  * Sets where items are physically being stored in the case it shouldn't be on the parent.
@@ -931,7 +929,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_click_alt(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	return open_storage_on_signal(source, user)
+	if(!click_alt_open)
+		return
+
+	open_storage_on_signal(source, user)
 
 
 /// Opens the storage to the mob, showing them the contents to their UI.

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -932,7 +932,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(!click_alt_open)
 		return
 
-	open_storage_on_signal(source, user)
+	return open_storage_on_signal(source, user)
 
 
 /// Opens the storage to the mob, showing them the contents to their UI.

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -45,6 +45,7 @@
 
 /datum/storage/pockets/small/fedora/detective
 	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
+	click_alt_open = FALSE
 
 /datum/storage/pockets/chefhat
 	attack_hand_interact = TRUE

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -216,6 +216,7 @@
 
 /// Now to solve where all these keep coming from
 /obj/item/clothing/head/fedora/det_hat/proc/on_clicked_alt(datum/source, mob/user)
+	SIGNAL_HANDLER
 	if(!COOLDOWN_FINISHED(src, candy_cooldown))
 		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
 		return COMSIG_MOB_CANCEL_CLICKON

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -182,6 +182,7 @@
 	/// Cooldown for retrieving precious candy corn with rmb
 	COOLDOWN_DECLARE(candy_cooldown)
 
+
 /datum/armor/fedora_det_hat
 	melee = 25
 	bullet = 5
@@ -191,15 +192,16 @@
 	acid = 50
 	wound = 5
 
+
 /obj/item/clothing/head/fedora/det_hat/Initialize(mapload)
 	. = ..()
 
 	create_storage(storage_type = /datum/storage/pockets/small/fedora/detective)
 
-	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(on_clicked_alt))
 	register_context()
 
 	new flask_path(src)
+
 
 /obj/item/clothing/head/fedora/det_hat/examine(mob/user)
 	. = ..()
@@ -215,18 +217,17 @@
 
 
 /// Now to solve where all these keep coming from
-/obj/item/clothing/head/fedora/det_hat/proc/on_clicked_alt(datum/source, mob/user)
-	SIGNAL_HANDLER
+/obj/item/clothing/head/fedora/det_hat/click_alt(mob/user)
 	if(!COOLDOWN_FINISHED(src, candy_cooldown))
 		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
-		return COMSIG_MOB_CANCEL_CLICKON
+		return CLICK_ACTION_BLOCKING
 
 	var/obj/item/food/candy_corn/sweets = new /obj/item/food/candy_corn(src)
 	user.put_in_hands(sweets)
 	to_chat(user, span_notice("You slip a candy corn from your hat."))
 	COOLDOWN_START(src, candy_cooldown, CANDY_CD_TIME)
 
-	return COMSIG_MOB_CANCEL_CLICKON
+	return CLICK_ACTION_SUCCESS
 
 
 #undef CANDY_CD_TIME

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -166,6 +166,8 @@
 	desc = "An opulent hat that functions as a radio to God. Or as a lightning rod, depending on who you ask."
 	icon_state = "bishopmitre"
 
+#define CANDY_CD_TIME 2 MINUTES
+
 //Detective
 /obj/item/clothing/head/fedora/det_hat
 	name = "detective's fedora"
@@ -174,11 +176,11 @@
 	icon_state = "detective"
 	inhand_icon_state = "det_hat"
 	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
-	/// Cooldown for retrieving precious candy corn on alt click
-	var/candy_cooldown = 0
 	dog_fashion = /datum/dog_fashion/head/detective
-	///Path for the flask that spawns inside their hat roundstart
+	/// Path for the flask that spawns inside their hat roundstart
 	var/flask_path = /obj/item/reagent_containers/cup/glass/flask/det
+	/// Cooldown for retrieving precious candy corn with rmb
+	COOLDOWN_DECLARE(candy_cooldown)
 
 /datum/armor/fedora_det_hat
 	melee = 25
@@ -194,22 +196,39 @@
 
 	create_storage(storage_type = /datum/storage/pockets/small/fedora/detective)
 
+	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(on_clicked_alt))
+	register_context()
+
 	new flask_path(src)
 
 /obj/item/clothing/head/fedora/det_hat/examine(mob/user)
 	. = ..()
 	. += span_notice("Alt-click to take a candy corn.")
 
-/obj/item/clothing/head/fedora/det_hat/click_alt(mob/user)
-	if(candy_cooldown >= world.time)
-		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
-		return CLICK_ACTION_BLOCKING
 
-	var/obj/item/food/candy_corn/CC = new /obj/item/food/candy_corn(src)
-	user.put_in_hands(CC)
+/obj/item/clothing/head/fedora/det_hat/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Candy Time"
+
+	return CONTEXTUAL_SCREENTIP_SET
+
+
+/// Now to solve where all these keep coming from
+/obj/item/clothing/head/fedora/det_hat/proc/on_clicked_alt(datum/source, mob/user)
+	if(!COOLDOWN_FINISHED(src, candy_cooldown))
+		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
+		return COMSIG_MOB_CANCEL_CLICKON
+
+	var/obj/item/food/candy_corn/sweets = new /obj/item/food/candy_corn(src)
+	user.put_in_hands(sweets)
 	to_chat(user, span_notice("You slip a candy corn from your hat."))
-	candy_cooldown = world.time+1200
-	return CLICK_ACTION_SUCCESS
+	COOLDOWN_START(src, candy_cooldown, CANDY_CD_TIME)
+
+	return COMSIG_MOB_CANCEL_CLICKON
+
+
+#undef CANDY_CD_TIME
 
 /obj/item/clothing/head/fedora/det_hat/minor
 	flask_path = /obj/item/reagent_containers/cup/glass/flask/det/minor


### PR DESCRIPTION

## About The Pull Request
Alt click was broken on detective's hat. Couldn't draw candy corn, oh no!

This issue is somewhat rightly caused from the alt click refactor, as its aim was to prevent double interactions from one click. In this case, both withdrawing morsels and opening storage at the same time

Added cooldown defines and screen tips
## Why It's Good For The Game
Candy corn.
Fixes #82950
## Changelog
:cl:
fix: Candy corn is once again available to detective fedoras
/:cl:
