### PR TITLE
13 year old singularity bug fixed

### DIFF
--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -286,7 +286,7 @@
 			if (STAGE_ONE)
 				steps = 1
 			if (STAGE_TWO)
-				steps = 3//Yes this is right
+				steps = 2
 			if (STAGE_THREE)
 				steps = 3
 			if (STAGE_FOUR)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -340,7 +340,7 @@
 			if(STAGE_ONE)
 				steps = 1
 			if(STAGE_TWO)
-				steps = 3//Yes this is right
+				steps = 2
 			if(STAGE_THREE)
 				steps = 3
 			if(STAGE_FOUR)


### PR DESCRIPTION

## About The Pull Request
Stage 2 singularities have the wrong step size, allowing them to eat the containment field if they happen to be right next to it. 
(For instance, if they are contained in a 3x3 or 4x4 field)
2 lines of code, and that's fixed.
## Why It's Good For The Game
BEFORE

https://github.com/tgstation/tgstation/assets/23534908/821f43f6-85ca-482b-a905-614f2b1c8359

AFTER

https://github.com/tgstation/tgstation/assets/23534908/4580d23a-41f0-4485-8454-4e991aa38344
## The Source
This was introduced in a googlecode commit in 2011:
https://github.com/tgstation/tgstation/blob/337be2c3bcc7a739ffc927ccce9d6aa2b43c114c/code/modules/power/singularity/singularity.dm#L269
No, mport2004, I *don't* think this is right.

## Changelog
:cl:
fix: Stage 2 singularities should no longer escape containment
/:cl:
