### PR TITLE
Mount Chainsaw Arm is Now Properly Mechanic

### DIFF
--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -126,6 +126,8 @@
 		display_pain(target, "You feel a strange sensation from your new [parse_zone(target_zone)].", TRUE)
 		if(istype(tool, /obj/item/chainsaw))
 			qdel(tool)
+			bodypart_to_attach.bodytype |= BODYTYPE_ROBOTIC
+			bodypart_to_attach.bodytype &= ~BODYTYPE_ORGANIC
 			var/obj/item/chainsaw/mounted_chainsaw/new_arm = new(target)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return


### PR DESCRIPTION

## About The Pull Request
Mounted Chainsaw arm is now considered to be robotic, so you heal it as if it were a robot limb instead of an organic limb.

## Why It's Good For The Game
A chainsaw arm should be repaired with cables/welder, instead of being repaired with chems or sutures/mesh.

## Changelog
:cl:
fix: Mounted Chainsaw arm is now properly mechanic.
/:cl:
