### PR TITLE
Fixes lua breaking when registering signals on turfs

### DIFF
--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -135,7 +135,7 @@ function SS13.unregister_signal(datum, signal, callback)
 		if not SS13.istype(datum, "/datum/weakref") then
 			handler_callback:call_proc("UnregisterSignal", datum, signal)
 		else
-			local actualDatum = callbackWeakRef:call_proc("hard_resolve")
+			local actualDatum = datum:call_proc("hard_resolve")
 			-- Turfs don't remove their signals on deletion.
 			if SS13.is_valid(actualDatum) or SS13.istype(actualDatum, "/turf") then
 				handler_callback:call_proc("UnregisterSignal", actualDatum, signal)

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -134,6 +134,12 @@ function SS13.unregister_signal(datum, signal, callback)
 		local callbackWeakRef = dm.global_proc("WEAKREF", handler_callback)
 		if not SS13.istype(datum, "/datum/weakref") then
 			handler_callback:call_proc("UnregisterSignal", datum, signal)
+		else
+			local actualDatum = callbackWeakRef:call_proc("hard_resolve")
+			-- Turfs don't remove their signals on deletion.
+			if SS13.is_valid(actualDatum) or SS13.istype(actualDatum, "/turf") then
+				handler_callback:call_proc("UnregisterSignal", actualDatum, signal)
+			end
 		end
 		SS13.stop_tracking(handler_callback)
 	end

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -100,7 +100,8 @@ function SS13.register_signal(datum, signal, func)
 	callback:call_proc("RegisterSignal", datum, signal, "Invoke")
 	local path = { "__SS13_signal_handlers", datumWeakRef, signal, callbackWeakRef, "func" }
 	callback.vars.arguments = { path }
-	if not __SS13_signal_handlers[datumWeakRef]._cleanup then
+	-- Turfs don't remove their signals on deletion.
+	if not __SS13_signal_handlers[datumWeakRef]._cleanup and not SS13.istype(datum, "/turf") then
 		local cleanupCallback = SS13.new("/datum/callback", SS13.state, "call_function_return_first")
 		local cleanupPath = { "__SS13_signal_handlers", datumWeakRef, "_cleanup"}
 		cleanupCallback.vars.arguments = { cleanupPath }
@@ -136,8 +137,7 @@ function SS13.unregister_signal(datum, signal, callback)
 			handler_callback:call_proc("UnregisterSignal", datum, signal)
 		else
 			local actualDatum = datum:call_proc("hard_resolve")
-			-- Turfs don't remove their signals on deletion.
-			if SS13.is_valid(actualDatum) or SS13.istype(actualDatum, "/turf") then
+			if SS13.is_valid(actualDatum) then
 				handler_callback:call_proc("UnregisterSignal", actualDatum, signal)
 			end
 		end

--- a/lua/handler_group.lua
+++ b/lua/handler_group.lua
@@ -14,7 +14,7 @@ function HandlerGroup:register_signal(datum, signal, func)
 	if not callback then
 		return
 	end
-	table.insert(self.registered, { datum = datum, signal = signal, callback = callback  })
+	table.insert(self.registered, { datum = dm.global_proc("WEAKREF", datum), signal = signal, callback = callback  })
 end
 
 -- Clears all the signals that have been registered on this HandlerGroup


### PR DESCRIPTION

## About The Pull Request
Signals don't get removed on turfs when they're deleted. This fixes that so that it is reflected in lua as well.

## Why It's Good For The Game
Lua bugfixes

## Changelog
:cl:
fix: Fixed lua scripts breaking when turfs with registered signals get deleted.
/:cl:
