### PR TITLE
Fix missing crafting flags

### DIFF
--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -47,6 +47,7 @@
 	src.res_amount = res_amount
 	src.max_res_amount = max_res_amount
 	src.time = time
+	src.crafting_flags = crafting_flags
 	src.placement_checks = placement_checks
 	src.trait_booster = trait_booster
 	src.trait_modifier = trait_modifier


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/83023

## Changelog
:cl:
fix: Materials are now correctly applied to crafted items (chairs, toilets, etc)
/:cl:
