### PR TITLE
Cargo scanner no longer kidnaps people

### DIFF
--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -428,7 +428,7 @@
 
 /datum/export/pirate/ransom/sell_object(mob/living/carbon/human/sold_item, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
 	. = ..()
-	if(. == EXPORT_NOT_SOLD)
+	if(. == EXPORT_NOT_SOLD || dry_run)
 		return
 	var/turf/picked_turf = pick(GLOB.holdingfacility)
 	sold_item.forceMove(picked_turf)
@@ -439,7 +439,7 @@
 	sold_item.flash_act()
 	sold_item.adjust_confusion(10 SECONDS)
 	sold_item.adjust_dizzy(10 SECONDS)
-	addtimer(src, CALLBACK(src, PROC_REF(send_back_to_station), sold_item), COME_BACK_FROM_CAPTURE_TIME)
+	addtimer(CALLBACK(src, PROC_REF(send_back_to_station), sold_item), COME_BACK_FROM_CAPTURE_TIME)
 	to_chat(sold_item, span_hypnophrase("A million voices echo in your head... <i>\"Yaarrr, thanks for the booty, landlubber. \
 		You will be ransomed back to your station, so it's only a matter of time before we ship you back...</i>"))
 


### PR DESCRIPTION

## About The Pull Request
Fixes #83022 
The universal cargo scanner calls `sell_object(dry_run = TRUE)` to determine the price without actually selling anything, but an early return for this case was not included when the proc was overridden for the `/datum/export/pirate` type, allowing anybody with a cargo scanner to participate in illegal human trafficking.

The automatic return timer had incorrect args causing a runtime error which I've also fixed, humans are returned after 6 minutes.

Kidnapping code desperately needs a unification because now there are 3 ways to end up in the holding facility (progression traitor kidnapping side objective, traitor contractor, pirates) and they all have copy pasted code but some is different for no reason. This pirate code does not handle your belongings and you can take anything out of the holding facility or get your stuff stolen while in there, unlike the other 2 methods which hold your belongings for safe return later.
## Why It's Good For The Game
Fixes a very funny but very lame oversight and also allows for the safe return of our friends kidnapped by pirates.
## Changelog
:cl:
fix: If kidnapped and ransomed by pirates, you will now properly return to the station automatically after 6 minutes.
fix: You can no longer be kidnapped and held for ransom by cargo technicians posing as pirates.
/:cl:
