### PR TITLE
Fix vote `can_be_initiated` mutating the active choices

### DIFF
--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -21,14 +21,22 @@
 
 /datum/vote/map_vote/create_vote()
 	. = ..()
-	check_population(should_key_choices = FALSE)
-	if(length(choices) == 1) // Only one choice, no need to vote. Let's just auto-rotate it to the only remaining map because it would just happen anyways.
-		var/de_facto_winner = choices[1]
-		var/datum/map_config/change_me_out = global.config.maplist[de_facto_winner]
-		SSmapping.changemap(change_me_out)
-		to_chat(world, span_boldannounce("The map vote has been skipped because there is only one map left to vote for. The map has been changed to [change_me_out.map_name]."))
-		SSmapping.map_voted = TRUE // voted by not voting, very sad.
+	if(!.)
 		return FALSE
+
+	choices -= get_choices_invalid_for_population()
+	if(length(choices) == 1) // Only one choice, no need to vote. Let's just auto-rotate it to the only remaining map because it would just happen anyways.
+		var/datum/map_config/change_me_out = global.config.maplist[choices[1]]
+		finalize_vote(choices[1])// voted by not voting, very sad.
+		to_chat(world, span_boldannounce("The map vote has been skipped because there is only one map left to vote for. \
+			The map has been changed to [change_me_out.map_name]."))
+		return FALSE
+	if(length(choices) == 0)
+		to_chat(world, span_boldannounce("A map vote was called, but there are no maps to vote for! \
+			Players, complain to the admins. Admins, complain to the coders."))
+		return FALSE
+
+	return TRUE
 
 /datum/vote/map_vote/toggle_votable()
 	CONFIG_SET(flag/allow_vote_map, !CONFIG_GET(flag/allow_vote_map))
@@ -42,38 +50,33 @@
 		return .
 	if(forced)
 		return VOTE_AVAILABLE
-	var/number_of_choices = length(check_population())
-	if(number_of_choices < 2)
-		return "There [number_of_choices == 1 ? "is only one map" : "are no maps"] to choose from."
+	var/num_choices = length(default_choices - get_choices_invalid_for_population())
+	if(num_choices <= 1)
+		return "There [num_choices == 1 ? "is only one map" : "are no maps"] to choose from."
 	if(SSmapping.map_vote_rocked)
 		return VOTE_AVAILABLE
 	if(SSmapping.map_voted)
 		return "The next map has already been selected."
 	return VOTE_AVAILABLE
 
-/// Before we create a vote, remove all maps from our choices that are outside of our population range.
-/// Note that this can result in zero remaining choices for our vote, which is not ideal (but ultimately okay).
-/// Argument should_key_choices is TRUE, pass as FALSE in a context where choices are already keyed in a list.
-/datum/vote/map_vote/proc/check_population(should_key_choices = TRUE)
-	if(should_key_choices)
-		for(var/key in default_choices)
-			choices[key] = 0
-
+/// Returns a list of all map options that are invalid for the current population.
+/datum/vote/map_vote/proc/get_choices_invalid_for_population()
 	var/filter_threshold = 0
 	if(SSticker.HasRoundStarted())
 		filter_threshold = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE)
 	else
 		filter_threshold = GLOB.clients.len
 
-	for(var/map in choices)
+	var/list/invalid_choices = list()
+	for(var/map in default_choices)
 		var/datum/map_config/possible_config = config.maplist[map]
 		if(possible_config.config_min_users > 0 && filter_threshold < possible_config.config_min_users)
-			choices -= map
+			invalid_choices += map
 
 		else if(possible_config.config_max_users > 0 && filter_threshold > possible_config.config_max_users)
-			choices -= map
+			invalid_choices += map
 
-	return choices
+	return invalid_choices
 
 /datum/vote/map_vote/get_vote_result(list/non_voters)
 	// Even if we have default no vote off,


### PR DESCRIPTION
## About The Pull Request

Closes #83020

This proc, called *every single ui_data tick*, was mutating the vote's list of choices. Grahhh impure procs grahhh

https://github.com/tgstation/tgstation/blob/f112369547a7da6fdafd69c1d43baf0fc6f76f77/code/datums/votes/map_vote.dm#L57-L60

Weirdly, I have no idea how this *ever* worked, even prior to my PR, because I didn't touch this or any consuming code. It was called in the same place, same args, etc. prior to my PR. So I have no idea. 

## Changelog

:cl: Melbert
fix: Map vote should work better
/:cl:
