### PR TITLE
Blood Brothers should start with objectives

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -135,10 +135,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 
 /datum/dynamic_ruleset/roundstart/traitorbro/execute()
 	for (var/datum/mind/mind in assigned)
-		var/datum/team/brother_team/team = new
-		team.add_member(mind)
-		team.forge_brother_objectives()
-		mind.add_antag_datum(/datum/antagonist/brother, team)
+		new /datum/team/brother_team(mind)
 		GLOB.pre_setup_antags -= mind
 
 	return TRUE

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -167,13 +167,15 @@
 	member_name = "blood brother"
 	var/brothers_left = 2
 
-/datum/team/brother_team/New()
+/datum/team/brother_team/New(starting_members)
 	. = ..()
 	if (prob(10))
 		brothers_left += 1
 
 /datum/team/brother_team/add_member(datum/mind/new_member)
 	. = ..()
+	if (!length(objectives))
+		forge_brother_objectives()
 	if (!new_member.has_antag_datum(/datum/antagonist/brother))
 		add_brother(new_member.current)
 
@@ -217,7 +219,7 @@
 	add_objective(new /datum/objective/convert_brother)
 
 	var/is_hijacker = prob(10)
-	for(var/i = 1 to max(1, CONFIG_GET(number/brother_objectives_amount) + (members.len > 2) - is_hijacker))
+	for(var/i = 1 to max(1, CONFIG_GET(number/brother_objectives_amount) + (brothers_left > 2) - is_hijacker))
 		forge_single_objective()
 	if(is_hijacker)
 		if(!locate(/datum/objective/hijack) in objectives)


### PR DESCRIPTION
## About The Pull Request

Fixes #82064
Fixes a couple of different bugs with Blood Brothers.

- Delegates creating the objectives to the team rather than the ruleset, so ones created via the traitor panel will also have objectives.
- Creates the objectives after the team has a member mind, so it doesn't runtime when trying to give that mob the equipment needed to steal a supermatter sliver.
- Creates the objectives before the first Blood Brother is assigned the antag datum, so that they will correctly be given the starting objectives.
- Check the maximum number of brothers that can be recruited when deciding how many objectives to generate rather than the current number of members (which would always be 1).

## Changelog

:cl:
fix: Blood Brothers should spawn knowing what their objectives are.
fix: Teams of 3 Blood Brothers will once more have an additional objective.
/:cl:
