### PR TITLE
[testmerge] Split up a key parallax proc for profiler purposes

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -248,11 +248,11 @@
 			update_parallax_do_animation(parallax_layer, change_x, change_y, glide_rate)
 
 
-/datum/hud/proc/update_parallax_do_animation(/atom/movable/screen/parallax_layer/parallax_layer, change_x, change_y, glide_rate)
+/datum/hud/proc/update_parallax_do_animation(atom/movable/screen/parallax_layer/parallax_layer, change_x, change_y, glide_rate)
 	parallax_layer.transform = matrix(1,0,change_x, 0,1,change_y)
 	animate(parallax_layer, transform=matrix(), time = glide_rate)
 
-/datum/hud/proc/update_parallax_set_screen_loc(/atom/movable/screen/parallax_layer/parallax_layer)
+/datum/hud/proc/update_parallax_set_screen_loc(atom/movable/screen/parallax_layer/parallax_layer)
 	parallax_layer.screen_loc = "CENTER-7:[round(parallax_layer.offset_x, 1)],CENTER-7:[round(parallax_layer.offset_y, 1)]"
 
 /atom/movable/proc/update_parallax_contents()

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -240,13 +240,20 @@
 		parallax_layer.offset_x -= change_x
 		parallax_layer.offset_y -= change_y
 
-		parallax_layer.screen_loc = "CENTER-7:[round(parallax_layer.offset_x, 1)],CENTER-7:[round(parallax_layer.offset_y, 1)]"
+		update_parallax_set_screen_loc(parallax_layer)
 
 		// We're going to use a transform to "glide" that last movement out, so it looks nicer
 		// Don't do any animates if we're not actually moving enough distance yeah? thanks lad
 		if(run_parralax && (largest_change * our_speed > 1))
-			parallax_layer.transform = matrix(1,0,change_x, 0,1,change_y)
-			animate(parallax_layer, transform=matrix(), time = glide_rate)
+			update_parallax_do_animation(parallax_layer, change_x, change_y, glide_rate)
+
+
+/datum/hud/proc/update_parallax_do_animation(/atom/movable/screen/parallax_layer/parallax_layer, change_x, change_y, glide_rate)
+	parallax_layer.transform = matrix(1,0,change_x, 0,1,change_y)
+	animate(parallax_layer, transform=matrix(), time = glide_rate)
+
+/datum/hud/proc/update_parallax_set_screen_loc(/atom/movable/screen/parallax_layer/parallax_layer)
+	parallax_layer.screen_loc = "CENTER-7:[round(parallax_layer.offset_x, 1)],CENTER-7:[round(parallax_layer.offset_y, 1)]"
 
 /atom/movable/proc/update_parallax_contents()
 	for(var/mob/client_mob as anything in client_mobs_in_contents)


### PR DESCRIPTION
Need to see what the cost of assigning to screen_loc is, because i know doing so triggers a appearance refresh, but mainly want to see what the cost (and occurrence rate) of the animations are.

This is ssinput call chain code, so its high priority and steals from everything else.
