### PR TITLE
Adminmod now has radiation protect module

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -596,6 +596,7 @@
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/emp_shield/advanced,
 		/obj/item/mod/module/welding,
+		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/stealth/ninja,
 		/obj/item/mod/module/quick_carry/advanced,
 		/obj/item/mod/module/magboot/advanced,


### PR DESCRIPTION

## About The Pull Request
Adminmod now has radprotect module 
## Why It's Good For The Game
It’s kind of annoying to heal yourself every minute when you’re experimenting with a tritium or a supermatter on a local server, so radprotect module fixes this issue
## Changelog
:cl:
qol: Admin modsuit now has a radiation protect module
/:cl:
