### PR TITLE
Fixes auxtools hanging on server shutdown.

### DIFF
--- a/code/controllers/subsystem/lua.dm
+++ b/code/controllers/subsystem/lua.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(lua)
 	world.SetConfig("env", "LUAU_PATH", jointext(lua_path, ";"))
 
 /datum/controller/subsystem/lua/Shutdown()
-	AUXTOOLS_SHUTDOWN(AUXLUA)
+	AUXTOOLS_FULL_SHUTDOWN(AUXLUA)
 
 /datum/controller/subsystem/lua/proc/queue_resume(datum/lua_state/state, index, arguments)
 	if(!initialized)


### PR DESCRIPTION

## About The Pull Request
Does a full shutdown of auxlua when the lua subsystem shuts down. This should unpin the dll file.

Compare `AUXTOOLS_SHUTDOWN` code with `AUXTOOLS_FULL_SHUTDOWN`, let me know if I'm mistaken:

### AUXTOOLS_SHUTDOWN

https://github.com/willox/auxtools/blob/bc5b2cf019f0f9b18f46b560a0f730d709171b55/auxtools/src/lib.rs#L346

### AUXTOOLS_FULL_SHUTDOWN

https://github.com/willox/auxtools/blob/bc5b2cf019f0f9b18f46b560a0f730d709171b55/auxtools/src/lib.rs#L365

## Why It's Good For The Game
Fixes auxlua keeping the dll pinned when the server is in a process of shutting down.
