### PR TITLE
Fixes traditional equipment having no name for its crate

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -169,6 +169,7 @@
 					/obj/item/clothing/mask/whistle,
 					/obj/item/conversion_kit,
 				)
+	crate_name = "traditional equipment crate"
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE
 
 /// Armory packs


### PR DESCRIPTION
## About The Pull Request

This pr fixes the missing name when you order traditional equipment then just appearing the name

## Why It's Good For The Game

So people know what kind of crate it is at sight

## Changelog

:cl:
fix: fixes traditional equipment crate name
/:cl:

