### PR TITLE
Resting knockdown disarm immunity exploit fix

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2400,10 +2400,10 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /// Proc to append behavior to the condition of being floored. Called when the condition starts.
 /mob/living/proc/on_floored_start()
+	on_fall()
 	if(body_position == STANDING_UP) //force them on the ground
 		set_body_position(LYING_DOWN)
 		set_lying_angle(pick(90, 270))
-		on_fall()
 
 
 /// Proc to append behavior to the condition of being floored. Called when the condition ends.


### PR DESCRIPTION
## About The Pull Request

This fix makes it so the effect of you falling is always applied if you receive the knockdown effect. Currently, you can make yourself immune to being disarmed by shoves or any other effect that applies knockdown by laying down. We've all seen the tactically crawling desword user using this to avoid being disarmed. This fixes that.

No GBP because I got GBP for a separate PR that I tagged wrong
## Why It's Good For The Game

Lying down in the middle of a hand-to-hand fight flies in the face of common sense. I'm working on another PR to rebalance being prone in melee combat, but this itself is a simple fix of what seems to be a long-standing exploit.
## Changelog

Receiving the effects of a knockdown will now always disarm you, instead of only when you're not laying down.
:cl: Bisar
balance: Knockdown effects will know consistently disarm, instead of failing to disarm if you're already lying down.
/:cl:
