### PR TITLE
The ghost orbit UI now auto-updates

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -159,3 +159,6 @@
 	#define HANDLE_BLOOD_NO_NUTRITION_DRAIN (1<<1)
 	/// Return to skip oxyloss and similar effecst from blood level
 	#define HANDLE_BLOOD_NO_EFFECTS (1<<2)
+
+/// Called when a human's sec HUD is is set, from /mob/living/carbon/human/proc/sec_hud_set_ID()
+#define COMSIG_HUMAN_SECHUD_SET_ID "human_sechud_set_id"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -244,3 +244,8 @@
 
 /// from /mob/proc/key_down(): (key, client/client, full_key)
 #define COMSIG_MOB_KEYDOWN "mob_key_down"
+
+/// Called whenever the mob's mind gains an antagonist, after the antagonist list has updated: (datum/antagonist/antagonist)
+#define COMSIG_MOB_ANTAGONIST_GAINED "mob_antagonist_gained"
+/// Called whenever the mob's mind loses an antagonist, after the antagonist list has updated: (datum/antagonist/antagonist)
+#define COMSIG_MOB_ANTAGONIST_REMOVED "mob_antagonist_removed"

--- a/code/datums/elements/point_of_interest.dm
+++ b/code/datums/elements/point_of_interest.dm
@@ -1,6 +1,20 @@
-/// Designates the atom as a "point of interest", meaning it can be directly orbited
+/// Designates the atom as a "point of interest", meaning it can be directly orbited.
+/// Also handles updating the ghost orbit menu whenever the PoI has a change that might appear on the menu.
 /datum/element/point_of_interest
 	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+	var/should_update = FALSE
+	var/static/list/update_signals = list(
+		COMSIG_ATOM_ORBIT_BEGIN,
+		COMSIG_ATOM_ORBIT_STOP,
+		COMSIG_MOB_STATCHANGE,
+		COMSIG_MOB_ANTAGONIST_GAINED,
+		COMSIG_MOB_ANTAGONIST_REMOVED,
+		COMSIG_HUMAN_SECHUD_SET_ID,
+		SIGNAL_ADDTRAIT(TRAIT_UNKNOWN)
+	) + COMSIG_LIVING_ADJUST_STANDARD_DAMAGE_TYPES
+
+/datum/element/point_of_interest/New()
+	START_PROCESSING(SSdcs, src)
 
 /datum/element/point_of_interest/Attach(datum/target)
 	if (!isatom(target))
@@ -13,8 +27,21 @@
 		return ELEMENT_INCOMPATIBLE
 
 	SSpoints_of_interest.on_poi_element_added(target)
+	RegisterSignals(target, update_signals, PROC_REF(flag_updated))
+	flag_updated()
 	return ..()
 
 /datum/element/point_of_interest/Detach(datum/target)
 	SSpoints_of_interest.on_poi_element_removed(target)
+	UnregisterSignal(target, update_signals)
+	flag_updated()
 	return ..()
+
+/datum/element/point_of_interest/process(seconds_per_tick)
+	if(should_update)
+		INVOKE_ASYNC(GLOB.orbit_menu, TYPE_PROC_REF(/datum/orbit_menu, update_static_data_for_all_viewers))
+		should_update = FALSE
+
+/datum/element/point_of_interest/proc/flag_updated()
+	SIGNAL_HANDLER
+	should_update = TRUE

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -279,6 +279,7 @@ Security HUDs! Basic mode shows only the job.
 		sechud_icon_state = "hudno_id"
 	holder.icon_state = sechud_icon_state
 	sec_hud_set_security_status()
+	SEND_SIGNAL(src, COMSIG_HUMAN_SECHUD_SET_ID)
 
 /mob/living/proc/sec_hud_set_implants()
 	var/image/holder

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -270,6 +270,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 		owner.current.add_to_current_living_antags()
 
 	SEND_SIGNAL(owner, COMSIG_ANTAGONIST_GAINED, src)
+	SEND_SIGNAL(owner.current, COMSIG_MOB_ANTAGONIST_GAINED, src)
 
 /**
  * Proc that checks the sent mob aganst the banlistfor this antagonist.
@@ -326,6 +327,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 	if(team)
 		team.remove_member(owner)
 	SEND_SIGNAL(owner, COMSIG_ANTAGONIST_REMOVED, src)
+	if(owner.current)
+		SEND_SIGNAL(owner.current, COMSIG_MOB_ANTAGONIST_REMOVED, src)
 
 	// Remove HUDs that they should no longer see
 	var/mob/living/current = owner.current

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -13,6 +13,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "Orbit")
+		ui.set_autoupdate(FALSE) // /datum/element/point_of_interest handles updating the static data whenever it actually changes, and we have no non-static data to autoupdate.
 		ui.open()
 
 /datum/orbit_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)


### PR DESCRIPTION
## About The Pull Request

Pretty simple, this makes the ghost orbit UI autoupdate. Works by having `/datum/element/point_of_interest` register various signals that would likely affect the various things the orbit menu keeps track of, and sets a `should_update` flag. The element now processes (in `SSdcs`, which means about every second or so), and it will asynchronously invoke `GLOB.orbit_menu.update_static_data_for_all_viewers()` if `should_update` is true.

The processing is somewhat necessary, as some of the registered signals are sent _before_ the relevant change to the PoI's state is actually set, meaning that it wouldn't actually appear on the orbit menu until the *next* auto-update. Plus, if multiple updates happen in between `SSdcs` processes, it'd only update once.

Also, three new signals: `COMSIG_HUMAN_SECHUD_SET_ID` (can't think of a better, non-polling way to run whenever a mob's visible name or ID changes), `COMSIG_MOB_ANTAGONIST_GAINED` and `COMSIG_MOB_ANTAGONIST_REMOVED` (because some antag datums are visible on the orbit menu, and it'd be dumb for the PoI to keep track of minds when the orbit menu doesn't really give a shit about them)

## Why It's Good For The Game

QoL feature that gets rid of the need to manually refresh the orbit menu.

## Changelog
:cl:
qol: The ghost orbit menu now auto-updates, no more need to manually refresh it.
/:cl:
