### PR TITLE
Revert weighted random map votes

### DIFF
--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -2,8 +2,8 @@
 	name = "Map"
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_SINGLE
-	winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
-	display_statistics = FALSE
+	winner_method = VOTE_WINNER_METHOD_SIMPLE
+	display_statistics = TRUE
 
 /datum/vote/map_vote/New()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Reverts the change to make map votes weighted random and to hide the vote counts. Power to the people, democracy wins again, etc.

## Why It's Good For The Game

Weighted random was, _ostensibly,_ set to the default map voting style because Northstar wasn't getting voted for, and then the vote counts were removed because people were getting upset when weighted random chose the map with the least votes. Now, after the changes, Northstar _still_ doesn't get run (on US servers) because the server pop is never high enough because weighted random and server config have trapped the servers on Birdshot and Icebox, two of the most-hated maps in the game.

This PR reverts those changes, so that, _hopefully,_ the servers can recover from the problems they've caused.

## Changelog

:cl:
fix: reverts map vote changes
/:cl: