### PR TITLE
temporarily soulless bodies dont appear as soulless on medhud

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -207,7 +207,7 @@ Medical HUD! Basic mode needs suit sensors on.
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
 	else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
-		if(can_defib_client())
+		if(HAS_TRAIT(src, TRAIT_MIND_TEMPORARILY_GONE) || can_defib_client())
 			holder.icon_state = "huddefib"
 		else
 			holder.icon_state = "huddead"


### PR DESCRIPTION

## About The Pull Request

temporarily soulless bodies dont appear as soulless on medhud

like if you were playing deathmatch or something

## Why It's Good For The Game

getting revived is good

## Changelog
:cl:
qol: temporarily soulless (deathmatch, etc) bodies dont appear as soulless on medhud
/:cl:
