### PR TITLE
Fixes a meter in Birdshot's atmosperics

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -49319,7 +49319,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer2{
 	dir = 6
 	},
-/obj/machinery/meter,
+/obj/machinery/meter/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "qQg" = (


### PR DESCRIPTION

## About The Pull Request
Changes a meter in Birdshot's atmospherics from layer 3 to layer 2, so that it matches up with the distribution pipe its intended to monitor.
## Why It's Good For The Game
The meter will work better when its on the matching pipe layer.
## Changelog
:cl:
fix: A meter attached to distribution pipes in Birdshot's atmospherics has been moved to the matching pipe layer.
/:cl:
