### PR TITLE
Command bar typing indicators (client side html version)

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -121,6 +121,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		no_tgui_adminhelp(input(src, "Enter your ahelp", "Ahelp") as null|message)
 		return
 
+	if(href_list["commandbar_typing"])
+		handle_commandbar_typing(href_list)
+
 	switch(href_list["_src_"])
 		if("holder")
 			hsrc = holder
@@ -253,6 +256,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	tgui_panel = new(src, "browseroutput")
 
 	tgui_say = new(src, "tgui_say")
+
+	initialize_commandbar_spy()
 
 	set_right_click_menu_mode(TRUE)
 

--- a/code/modules/client/verbs/typing.dm
+++ b/code/modules/client/verbs/typing.dm
@@ -1,0 +1,68 @@
+#define IC_VERBS list("say", "me", "whisper")
+
+/client/var/commandbar_thinking = FALSE
+/client/var/commandbar_typing = FALSE
+
+/client/proc/initialize_commandbar_spy()
+	src << output('html/typing_indicator.html', "commandbar_spy")
+
+/client/proc/handle_commandbar_typing(href_list)
+	if (!typing_indicators) //check pref
+		return
+	if (length(href_list["verb"]) < 1 || !(lowertext(href_list["verb"]) in IC_VERBS) || text2num(href_list["argument_length"]) < 1)
+		if (commandbar_typing)
+			commandbar_typing = FALSE
+			stop_typing()
+
+		if (commandbar_thinking)
+			commandbar_thinking = FALSE
+			stop_thinking()
+		return
+
+	if (!commandbar_thinking)
+		commandbar_thinking = TRUE
+		start_thinking()
+
+	if (!commandbar_typing)
+		commandbar_typing = TRUE
+		start_typing()
+
+
+/** Sets the mob as "thinking" - with indicator and the TRAIT_THINKING_IN_CHARACTER trait */
+/client/proc/start_thinking()
+	if(!typing_indicators)
+		return FALSE
+	/// Special exemptions
+	if(isabductor(mob))
+		return FALSE
+	ADD_TRAIT(mob, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
+	mob.create_thinking_indicator()
+
+/** Removes typing/thinking indicators and flags the mob as not thinking */
+/client/proc/stop_thinking()
+	mob?.remove_all_indicators()
+
+/**
+ * Handles the user typing. After a brief period of inactivity,
+ * signals the client mob to revert to the "thinking" icon.
+ */
+/client/proc/start_typing()
+	var/mob/client_mob = mob
+	client_mob.remove_thinking_indicator()
+	if(!typing_indicators || !HAS_TRAIT(client_mob, TRAIT_THINKING_IN_CHARACTER))
+		return FALSE
+	client_mob.create_typing_indicator()
+	addtimer(CALLBACK(src, PROC_REF(stop_typing)), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+
+/**
+ * Callback to remove the typing indicator after a brief period of inactivity.
+ * If the user was typing IC, the thinking indicator is shown.
+ */
+/client/proc/stop_typing()
+	if(isnull(mob))
+		return FALSE
+	var/mob/client_mob = mob
+	client_mob.remove_typing_indicator()
+	if(!typing_indicators || !HAS_TRAIT(client_mob, TRAIT_THINKING_IN_CHARACTER))
+		return FALSE
+	client_mob.create_thinking_indicator()

--- a/code/modules/client/verbs/typing.dm
+++ b/code/modules/client/verbs/typing.dm
@@ -66,3 +66,5 @@
 	if(!typing_indicators || !HAS_TRAIT(client_mob, TRAIT_THINKING_IN_CHARACTER))
 		return FALSE
 	client_mob.create_thinking_indicator()
+
+#undef IC_VERBS

--- a/code/modules/client/verbs/typing.dm
+++ b/code/modules/client/verbs/typing.dm
@@ -9,7 +9,7 @@
 /client/proc/handle_commandbar_typing(href_list)
 	if (!typing_indicators) //check pref
 		return
-	if (length(href_list["verb"]) < 1 || !(lowertext(href_list["verb"]) in IC_VERBS) || text2num(href_list["argument_length"]) < 1)
+	if (length(href_list["verb"]) < 1 || !(LOWER_TEXT(href_list["verb"]) in IC_VERBS) || text2num(href_list["argument_length"]) < 1)
 		if (commandbar_typing)
 			commandbar_typing = FALSE
 			stop_typing()

--- a/code/modules/tgui_input/say_modal/typing.dm
+++ b/code/modules/tgui_input/say_modal/typing.dm
@@ -38,42 +38,31 @@
 
 /** Sets the mob as "thinking" - with indicator and the TRAIT_THINKING_IN_CHARACTER trait */
 /datum/tgui_say/proc/start_thinking()
-	if(!window_open || !client.typing_indicators)
+	if(!window_open)
 		return FALSE
-	/// Special exemptions
-	if(isabductor(client.mob))
-		return FALSE
-	ADD_TRAIT(client.mob, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
-	client.mob.create_thinking_indicator()
+	return client.start_thinking()
 
 /** Removes typing/thinking indicators and flags the mob as not thinking */
 /datum/tgui_say/proc/stop_thinking()
-	client.mob?.remove_all_indicators()
+	return client.stop_thinking()
 
 /**
  * Handles the user typing. After a brief period of inactivity,
  * signals the client mob to revert to the "thinking" icon.
  */
 /datum/tgui_say/proc/start_typing()
-	var/mob/client_mob = client.mob
-	client_mob.remove_thinking_indicator()
-	if(!window_open || !client.typing_indicators || !HAS_TRAIT(client_mob, TRAIT_THINKING_IN_CHARACTER))
+	if(!window_open)
 		return FALSE
-	client_mob.create_typing_indicator()
-	addtimer(CALLBACK(src, PROC_REF(stop_typing)), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+	return client.start_typing()
 
 /**
- * Callback to remove the typing indicator after a brief period of inactivity.
+ * Remove the typing indicator after a brief period of inactivity or during say events.
  * If the user was typing IC, the thinking indicator is shown.
  */
 /datum/tgui_say/proc/stop_typing()
-	if(isnull(client?.mob))
+	if(!window_open)
 		return FALSE
-	var/mob/client_mob = client.mob
-	client_mob.remove_typing_indicator()
-	if(!window_open || !client.typing_indicators || !HAS_TRAIT(client_mob, TRAIT_THINKING_IN_CHARACTER))
-		return FALSE
-	client_mob.create_thinking_indicator()
+	client.stop_typing()
 
 /// Overrides for overlay creation
 /mob/living/create_thinking_indicator()

--- a/html/typing_indicator.html
+++ b/html/typing_indicator.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	</head>
+	<body>
+		<script>
+			lastseentypedtext = "";
+			function getoutput() {
+				setTimeout(getoutput, 1000);
+				window.location = "byond://winget?callback=checkoutput&id=:Input&property=text";
+			}
+			function checkoutput(props) {
+				if (typeof props !== 'object')
+					return;
+
+				if (typeof props.text !== 'string' && !(props.text instanceof String))
+					return;
+
+				var text = props.text;
+
+				if (text == lastseentypedtext)
+					return;
+
+				lastseentypedtext = text;
+
+				var words = text.split(" ");
+				var verb = words[0];
+				var argument = "";
+				var argument_length = -1;
+
+				if (words.length >= 2) {
+					words.splice(0, 1)
+					argument = words.join(" ");
+					argument_length = argument.length;
+				}
+
+				if (argument_length > 0 && argument[0] == "\"")
+					argument_length -= 1;
+
+				window.location = "byond://?commandbar_typing=1&verb="+encodeURIComponent(verb)+"&argument_length="+argument_length;
+			}
+			setTimeout(getoutput, 2000);
+		</script>
+	</body>
+</html>

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -94,6 +94,15 @@ window "mainwindow"
 		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
+	elem "commandbar_spy"
+		type = BROWSER
+		is-default = false
+		pos = 0,0
+		size = 200x200
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		is-visible = false
+		saved-params = ""
 
 window "mapwindow"
 	elem "mapwindow"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3726,6 +3726,7 @@
 #include "code\modules\client\verbs\ooc.dm"
 #include "code\modules\client\verbs\ping.dm"
 #include "code\modules\client\verbs\suicide.dm"
+#include "code\modules\client\verbs\typing.dm"
 #include "code\modules\client\verbs\who.dm"
 #include "code\modules\clothing\clothing.dm"
 #include "code\modules\clothing\belts\polymorph_belt.dm"


### PR DESCRIPTION
This uses a browser skin element to spy on the command bar and report back to the server what verb is currently in it and how many characters it has. it skips reporting if the text hasn't changed since the last report. 

im intentionally not providing the full text in the command bar to the server, while designing the system so new verbs can be given typing indicators by editing DM code, not html code. 

The report rate is once a second but this could be lowered or tweaked.

Both the tgui say window being open and this system being active because the command bar starts with `say "` is undefined behavior, mostly the first one to end the indicator will just freeze indicators for the other one until it too ends its current indicator session.

The system waits until something besides the `"` is in the argument to say.

It is enabled for verbs `say`, `me`, and `whisper`.

I don't actually know if this is the case for tgui say. this is a one line tweak anyways so let me know if this should be changed.

[(This pr closes a bounty)](https://tgstation13.org/phpBB/viewtopic.php?p=726634#p726634)

:cl: MrStonedOne & Lilah Novi
add: Say commands typed in the command bar now trigger typing indicators 
/:cl:

