### PR TITLE
Lootpanel: Requires 515.1635+

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1633"
+byond: "515.1637"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/code/modules/lootpanel/search_object.dm
+++ b/code/modules/lootpanel/search_object.dm
@@ -50,6 +50,7 @@
 	var/build = owner.byond_build
 	var/version = owner.byond_version
 	if(build < 515 || (build == 515 && version < 1635))
+		icon = "n/a"
 		return
 
 	icon = "[item.icon]"
@@ -64,10 +65,7 @@
 
 /// Generates the icon for the search object. This is the expensive part.
 /datum/search_object/proc/generate_icon(client/owner)
-	if(ismob(item) || length(item.overlays) > 2)
-		icon = costly_icon2html(item, owner, sourceonly = TRUE)
-	else // our pre 515.1635 fallback for normal items
-		icon = icon2html(item, owner, sourceonly = TRUE)
+	icon = costly_icon2html(item, owner, sourceonly = TRUE)
 
 
 /// Parent item has been altered, search object no longer valid

--- a/config/config.txt
+++ b/config/config.txt
@@ -381,7 +381,7 @@ AUTOADMIN_RANK Game Master
 #CLIENT_WARN_VERSION 515
 #CLIENT_WARN_BUILD 1635
 #CLIENT_WARN_POPUP
-#CLIENT_WARN_MESSAGE Byond released 515 as the stable release. This comes bundled with a host of niceties, including .
+#CLIENT_WARN_MESSAGE Byond released 515 as the stable release. This comes bundled with a host of niceties, including image generation for UIs and :: operators.
 CLIENT_ERROR_VERSION 515
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
 ## The minimum build needed for joining the server.

--- a/config/config.txt
+++ b/config/config.txt
@@ -378,14 +378,14 @@ AUTOADMIN_RANK Game Master
 ## These trigger for any version below (non-inclusive) the given version, so 510 triggers on 509 or lower.
 ## These messages will be followed by one stating the clients current version and the required version for clarity.
 ## If CLIENT_WARN_POPUP is uncommented a popup window with the message will be displayed instead
-#CLIENT_WARN_VERSION 511
-#CLIENT_WARN_BUILD 1421
+#CLIENT_WARN_VERSION 515
+#CLIENT_WARN_BUILD 1635
 #CLIENT_WARN_POPUP
-#CLIENT_WARN_MESSAGE Byond released 511 as the stable release. You can set the framerate your client runs at, which makes the game feel very different and cool. Shortly after its release we will end up using 511 client features and you will be forced to update.
-CLIENT_ERROR_VERSION 511
+#CLIENT_WARN_MESSAGE Byond released 515 as the stable release. This comes bundled with a host of niceties, including .
+CLIENT_ERROR_VERSION 515
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
-## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
-CLIENT_ERROR_BUILD 1421
+## The minimum build needed for joining the server.
+CLIENT_ERROR_BUILD 1590
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=515
-export BYOND_MINOR=1633
+export BYOND_MINOR=1637
 
 #rust_g git tag
 export RUST_G_VERSION=3.1.0

--- a/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
@@ -16,6 +16,10 @@ export function IconDisplay(props: Props) {
     return fallback;
   }
 
+  if (icon === 'n/a') {
+    return <Icon name="dumpster-fire" size={2} color="gray" />;
+  }
+
   if (icon_state) {
     return (
       <DmIcon


### PR DESCRIPTION

## About The Pull Request
Per request of MSO, drops the fallback icon generation for clients under 515.1635. Lootpanel warns about this anyways and you had ample time.

![image](https://github.com/tgstation/tgstation/assets/42397676/b7064b28-13b9-4cd1-ad99-33f3e665209b)

Saves some time from SSlooting.
## Why It's Good For The Game
Pushes players to use a better client
Saves some server cost from older clients
## Changelog
:cl:
fix: Lootpanel now requires 515.1635 to generate most icons. TG support for 514 ended May 1. Update your client to fix the icons.
/:cl:
