### PR TITLE
Stasis bed TLC: Emag effects, toggleable and upgradable blood filtering

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -1,7 +1,8 @@
 #define STASIS_TOGGLE_COOLDOWN 50
 /obj/machinery/stasis
 	name = "lifeform stasis unit"
-	desc = "A not so comfortable looking bed with some nozzles at the top and bottom. It will keep someone in stasis."
+	desc = "A not so comfortable looking bed with some nozzles at the top and bottom. It will keep someone in stasis, and if toggled into \
+	high support mode, filter any harmful substances out of their body."
 	icon = 'icons/obj/machines/stasis.dmi'
 	icon_state = "stasis"
 	base_icon_state = "stasis"
@@ -14,8 +15,9 @@
 	payment_department = ACCOUNT_MED
 	interaction_flags_click = ALLOW_SILICON_REACH
 	var/stasis_enabled = TRUE
+	var/filtering_enabled = FALSE
 	var/last_stasis_sound = FALSE
-	var/stasis_can_toggle = 0
+	var/can_toggle = 0
 	var/mattress_state = "stasis_on"
 	var/obj/effect/overlay/vis/mattress_on
 
@@ -25,7 +27,11 @@
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()
-	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")
+	. += span_notice("Alt-click to [filtering_enabled ? "turn off" : "turn on"] the auxilary filtering function. A ridiculously small-print \
+		warning label beside the switch reads: \"CONSULT ENGINEERING DEPARTMENT REGARDING SUFFICIENT POWER ALLOCATION. WARNING: XENOBIOLOGY PERSONNEL STATISTICALLY AT HIGHER RISK FOR \
+		METABOLIC SIDE EFFECTS RELATED TO SLIME LIFE-FORM EXPERIMENTATION. USE OF THIS MEDICAL APPARATUS WAIVES ANY LIABILITY FOR ORGAN, CIRCULATORY, OR MILD(tm) PIERCING DAMAGE.\"")
+	if(filtering_enabled)
+		. += span_notice("Thousands of micro-needles jut up from the mattress.[prob(10) ? " They look thirsty...?" : ""]")
 
 /obj/machinery/stasis/proc/play_power_sound()
 	var/_running = stasis_running()
@@ -38,10 +44,10 @@
 		last_stasis_sound = _running
 
 /obj/machinery/stasis/click_alt(mob/user)
-	if(world.time < stasis_can_toggle)
+	if(world.time < can_toggle)
 		return CLICK_ACTION_BLOCKING
 	stasis_enabled = !stasis_enabled
-	stasis_can_toggle = world.time + STASIS_TOGGLE_COOLDOWN
+	can_toggle = world.time + STASIS_TOGGLE_COOLDOWN
 	playsound(src, 'sound/machines/click.ogg', 60, TRUE)
 	user.visible_message(span_notice("\The [src] [stasis_enabled ? "powers on" : "shuts down"]."), \
 				span_notice("You [stasis_enabled ? "power on" : "shut down"] \the [src]."), \
@@ -49,6 +55,29 @@
 	play_power_sound()
 	update_appearance()
 	return CLICK_ACTION_SUCCESS
+
+/// Toggle the filtering function on or off. This makes a bunch of scary-ass needles poke out of the bed.
+/// In exchange for having a passive function on hand to filter people's blood, it causes a little bit of damage.
+/// This damage only occurs upon initial activation, either through filtering starting by you being buckled or
+/// someone activating filtering on the bed you're buckled in already. Malicious doctors or silicons could toggle
+/// this over and over while you're helplessly buckled to the bed, though the effect of you being mutilated with
+/// needles will be obvious to onlookers.
+/obj/machinery/stasis/CtrlClick(mob/user)
+	. = ..()
+	if(world.time < can_toggle)
+		return CLICK_ACTION_BLOCKING
+	filtering_enabled = !filtering_enabled
+	can_toggle = world.time + STASIS_TOGGLE_COOLDOWN
+	playsound(src, 'sound/machines/click.ogg', 60, TRUE)
+	user.visible_message(span_notice("\The [src] filtering function [filtering_enabled ? "powers on. Thousands of micro-needles jut up from the mattress." : "shuts down. The micro-needles shunt back into the mattress invisibly."]."), \
+				span_notice("You [filtering_enabled ? "power on" : "shut down"] \the [src] filtering function. [filtering_enabled ? "Thousands of micro-needles jut up from the mattress." : "The micro-needles collapse back into the mattress, invisible"]."), \
+				span_hear("You hear [filtering_enabled ? " the unnerving sound of sharpened metal sliding against metal." : " a clunk of something metal"]."))
+	play_filtering_sound()
+	update_appearance()
+	if(occupant && filtering_enabled)
+		filter_jab(occupant, user)
+	return CLICK_ACTION_SUCCESS
+
 
 /obj/machinery/stasis/Exited(atom/movable/gone, direction)
 	if(gone == occupant)
@@ -112,13 +141,26 @@
 	target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
 	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 	target.extinguish_mob()
-	update_use_power(ACTIVE_POWER_USE)
+	/// Double power usage if we have filtering enabled.
+	update_use_power(ACTIVE_POWER_USE * (filtering_enabled ? 2 : 1))
+
+/obj/machinery/stasis/proc/filter_jab(mob/living/target, mob/user)
+
+	target.log_message("has been jabbed with the needles of a stasis bed by [key_name(user)]", LOG_ATTACK)
+
+/obj/machinery/stasis/proc/passive_filter(mob/living/target)
+
 
 /obj/machinery/stasis/proc/thaw_them(mob/living/target)
 	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
 	REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 	if(target == occupant)
 		update_use_power(IDLE_POWER_USE)
+
+/obj/machinery/stasis/user_buckle_mob(mob/living/L, mob/user, check_loc = TRUE)
+	. = ..()
+	if(. && filtering_enabled)
+		filter_jab(L, user)
 
 /obj/machinery/stasis/post_buckle_mob(mob/living/L)
 	if(!can_be_occupant(L))
@@ -142,6 +184,8 @@
 	if(stasis_running())
 		if(!HAS_TRAIT(L_occupant, TRAIT_STASIS))
 			chill_out(L_occupant)
+		if(filtering_enabled)
+			passive_filter(L_occupant)
 	else if(HAS_TRAIT(L_occupant, TRAIT_STASIS))
 		thaw_them(L_occupant)
 


### PR DESCRIPTION

## About The Pull Request

This is to tackle a couple of things. The stasis bed is one of the fundamental aspects of medbay, but there are no options to sabotage it besides turning it off. This PR adds a little something to do that; emagging a stasis bed will make anyone buckled into it incapacitated and forced to speak at a whisper so they can only call for help from people nearby.

Emagging also has an effect on the second part of this PR: blood filtering for stasis beds. It works as follows:

You are able to toggle a blood filtering option on for stasis beds. This causes anyone buckled into it (or already buckled in it) to take 5 brute damage and spatter a little blood. If it's emagged, you take 20 brute damage from this instead. This only happens upon initial buckling or initial activation. Sly subverted silicons or malicious doctors can repeatedly toggle this setting, though the cooldown means that it's usually faster to just hit you in the head with a saw a lot.

From there, depending on your upgrade tier, the stasis bed will either:
Gradually filter reagents from your blood, or if at higher tiers, it will avoid filtering out medical reagents in your blood.

The amount of reagents the bed filters when enabled in this mode is determined by its filtering_efficiency, which is itself determined first by its servo tier, then modified by its capacitor tier. This maxes out at 8 units of each reagent filtered out at the highest level.

But if it's emagged? Something else happens: While you're incapacitated and forced to a whisper, the stasis bed will ONLY filter out medicine from your blood, and it will also gradually drain your blood. The rate of this is determined by the tier of the parts, as well, so it pays for any emaggers to wait until later in the round to emag the fully upgraded stasis beds.

If you try to get your blood filtered as a jellyperson, it will drain your blood as if it were emagged, but otherwise drain toxic reagent out of you, if you wanted to commit a convoluted suicide for some reason... or if a bored antagonist bucklecuffs you to it.
## Why It's Good For The Game

We have a few ways to filter toxins from people right now. All of them take forever and are a bit of a pain in the ass. This is an option for lazy doctors to filter toxins, the same way that the cryo tube is an option for lazy doctors to treat patients. Right now we do have the potassium+water jank, but that's glitchy tribal knowledge and probably not an intended medical treatment.

The emagging is to offer another sly avenue for antagonists to fuck with medbay, or to set up a ripper clinic in maintenance full of emagged stasis beds just waiting for some helpless victims.
## Changelog

Stasis beds now have an upgradable blood filtering toggle, and are now able to be emagged.
:cl: Bisar
add: Added emag interactions to stasis beds.
add: Added optional and upgradable function to sleeper beds for filtering blood. Jellypeople are advised against using it.
/:cl:
