### PR TITLE
Fixes inducers breaking when trying to charge a PDA/Modular Computer

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -173,7 +173,7 @@
 
 	if(istype(item, /obj/item/inducer))
 		var/obj/item/inducer/inducer = item
-		INVOKE_ASYNC(inducer, TYPE_PROC_REF(/obj/item, attack_atom), attached_circuit|parent, attacker, list())
+		INVOKE_ASYNC(inducer, TYPE_PROC_REF(/obj/item, attack_atom), attached_circuit || parent, attacker, list())
 		return COMPONENT_NO_AFTERATTACK
 
 	if(attached_circuit)

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -173,7 +173,7 @@
 
 	if(istype(item, /obj/item/inducer))
 		var/obj/item/inducer/inducer = item
-		INVOKE_ASYNC(inducer, TYPE_PROC_REF(/obj/item, attack_atom), attached_circuit, attacker, list())
+		INVOKE_ASYNC(inducer, TYPE_PROC_REF(/obj/item, attack_atom), attached_circuit|parent, attacker, list())
 		return COMPONENT_NO_AFTERATTACK
 
 	if(attached_circuit)


### PR DESCRIPTION

## About The Pull Request
Fixes #83035 - attached_circuit is not guaranteed to exist & we should just pass the parent in that case. 
## Why It's Good For The Game
Inducers no longer break permanently due to this issue.
## Changelog
:cl: ShizCalev
fix: Inducers no longer break completely after trying to charge a PDA with them. 
/:cl:
