### PR TITLE
Fixes runtime when an APC has a functional external power supply but no power cell inserted

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -704,6 +704,8 @@
 /obj/machinery/power/apc/proc/draw_energy(amount)
 	var/grid_used = min(terminal?.surplus(), amount)
 	terminal?.add_load(grid_used)
+	if(QDELETED(cell))
+		return grid_used
 	var/cell_used = 0
 	if(amount > grid_used)
 		cell_used += cell.use(amount - grid_used, force = TRUE)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -62,7 +62,7 @@
 /obj/machinery/power/multitool_act_secondary(mob/living/user, obj/item/tool)
 	return multitool_act(user, tool)
 
-/// Called on multitool_act when we can change cable layers, override to add more conditions 
+/// Called on multitool_act when we can change cable layers, override to add more conditions
 /obj/machinery/power/proc/cable_layer_act(mob/living/user, obj/item/tool)
 	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
 	if(isnull(choice) || QDELETED(src) || QDELETED(user) || QDELETED(tool) || !user.Adjacent(src) || !user.is_holding(tool))
@@ -176,7 +176,7 @@
 	var/surplus = local_apc.surplus()
 	var/grid_used = min(surplus, amount)
 	var/apc_used = 0
-	if((amount > grid_used) && !ignore_apc) // Use from the APC's cell if there isn't enough energy from the grid.
+	if((amount > grid_used) && !ignore_apc && !QDELETED(local_apc.cell)) // Use from the APC's cell if there isn't enough energy from the grid.
 		apc_used = local_apc.cell.use(amount - grid_used, force = force)
 
 	if(!force && (amount < grid_used + apc_used)) // If we aren't forcing it and there isn't enough energy to supply demand, return nothing.
@@ -206,7 +206,7 @@
 	var/obj/machinery/power/apc/my_apc = my_area.apc
 	if(isnull(my_apc))
 		return FALSE
-	return my_apc.cell.use(amount, force = force)
+	return my_apc.cell?.use(amount, force = force)
 
 /**
  * Attempts to draw power directly from the APC's Powernet rather than the APC's battery. For high-draw machines, like the cell charger

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -204,9 +204,9 @@
 		return amount
 
 	var/obj/machinery/power/apc/my_apc = my_area.apc
-	if(isnull(my_apc))
+	if(isnull(my_apc) || QDELETED(my_apc.cell))
 		return FALSE
-	return my_apc.cell?.use(amount, force = force)
+	return my_apc.cell.use(amount, force = force)
 
 /**
  * Attempts to draw power directly from the APC's Powernet rather than the APC's battery. For high-draw machines, like the cell charger


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/6209658/059c5647-55c2-4509-8cce-7bcb565f6070)

![image](https://github.com/tgstation/tgstation/assets/6209658/5f7c0335-fda1-4db7-b24e-99c9fbb5169c)

```
[2024-05-03 02:26:28.713] RUNTIME: runtime error: Cannot execute null.use().
 - proc name: draw energy (/obj/machinery/power/apc/proc/draw_energy)
 -   source file: code/modules/power/apc/apc_main.dm,709
 -   usr: null
 -   src: the Brig Entrance APC (/obj/machinery/power/apc/auto_name/directional/north)
 -   src.loc: the floor (66,117,2) (/turf/open/floor/iron)
 -   call stack:
 - the Brig Entrance APC (/obj/machinery/power/apc/auto_name/directional/north): draw energy(2565)
 - the Brig Entrance APC (/obj/machinery/power/apc/auto_name/directional/north): early process(2)
 - Machines (/datum/controller/subsystem/machines): fire(0)
 - Machines (/datum/controller/subsystem/machines): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```

```
[2024-05-03 02:08:31.047] RUNTIME: runtime error: Cannot execute null.use().
 - proc name: use energy (/obj/machinery/proc/use_energy)
 -   source file: code/modules/power/power.dm,180
 -   usr: null
 -   src: the disposal unit (/obj/machinery/disposal/bin/tagger)
 -   src.loc: the floor (51,156,2) (/turf/open/floor/iron)
 -   call stack:
 - the disposal unit (/obj/machinery/disposal/bin/tagger): use energy(100, 1, 0, 1)
 - the disposal unit (/obj/machinery/disposal/bin/tagger): process(2)
 - Machines (/datum/controller/subsystem/machines): fire(1)
 - Machines (/datum/controller/subsystem/machines): ignite(1)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```

Don't think this one has an issue report, but it's all over in the runtime log. 

Fixes #83106