### PR TITLE
blueprints status on photographs is no longer persistent

### DIFF
--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -72,7 +72,6 @@
 	.["caption"] = caption
 	.["pixel_size_x"] = psize_x
 	.["pixel_size_y"] = psize_y
-	.["blueprints"] = has_blueprints
 	.["logpath"] = logpath
 
 	SET_SERIALIZATION_SEMVER(semvers, "1.0.0")
@@ -93,8 +92,6 @@
 	id = input["id"]
 	psize_x = input["pixel_size_x"]
 	psize_y = input["pixel_size_y"]
-	if(input["blueprints"])
-		has_blueprints = input["blueprints"]
 	if(input["caption"])
 		caption = input["caption"]
 	if(input["desc"])


### PR DESCRIPTION
## About The Pull Request
Bro it's a different station with different wires!
Closes #83092

## Changelog
:cl:
del: You can no longer use another station's blueprint photo to look at wires or do the traitor objective with.
/:cl:
