### PR TITLE
Human AI get some more cyberware to feel more 'artificial'.

### DIFF
--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -121,10 +121,18 @@
 	if(visualsOnly)
 		return
 	if(!equipped.get_quirk(/datum/quirk/body_purist))
-		var/obj/item/organ/internal/tongue/robot/cybernetic = new()
-		cybernetic.Insert(equipped, special = TRUE, movement_flags = DELETE_IF_REPLACED)
+		var/obj/item/organ/internal/tongue/robot/cybernetic_tongue = new()
+		var/obj/item/organ/internal/cyberimp/eyes/hud/medical/cybernetic_med_hud = new()
+		var/obj/item/organ/internal/cyberimp/chest/nutriment/cybernetic_food_pump = new()
+		cybernetic_tongue.Insert(equipped, special = TRUE, movement_flags = DELETE_IF_REPLACED)
+		cybernetic_med_hud.Insert(equipped, special = TRUE, movement_flags = DELETE_IF_REPLACED)
+		cybernetic_food_pump.Insert(equipped, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		//you only get respect if you go all the way, man.
 		ADD_TRAIT(equipped, TRAIT_COMMISSIONED, INNATE_TRAIT)
+		equipped.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/advanced, special = TRUE)
+		equipped.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/advanced, special = TRUE)
+		equipped.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/advanced, special = TRUE)
+		equipped.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/advanced, special = TRUE)
 	equipped.faction |= list(FACTION_SILICON, FACTION_TURRET)
 
 	var/static/list/allowed_areas = typecacheof(list(/area/station/ai_monitored))


### PR DESCRIPTION

## About The Pull Request

Gives the Human AI advanced robotic limbs, a Medcial HUD eye implant, and a nutrient pump (the basic kind, not the advanced kind).

## Why It's Good For The Game

I think Human AIs being some weird blend of cyborg and man is cool and helps sell the concept a bit more. Cool cybernetic limbs are mostly harmless as a roundstart benefit for the human AI due to their isolation.

They're not expected to ever leave, however, so I feel like they need some means of helping them maintain their nutrition that isn't effectively begging someone to come deliver them a sandwich in the sat or forcing them to come on-board the station somehow. We don't really want them to leave, so maybe they shouldn't have to worry too much about food (the implant only takes effect if they're starving, however, so it isn't a perfect solution), They also lack a few qualities of actual silicons that are beneficial towards doing their jobs, so hopefully the medical hud assists with that.

## Changelog
:cl:
add: Human AI's get some additional cybernetics to help make them a bit more...robotic.
/:cl:
