### PR TITLE
Fix space heaters always saying Auto when panel is closed

### DIFF
--- a/tgui/packages/tgui/interfaces/SpaceHeater.jsx
+++ b/tgui/packages/tgui/interfaces/SpaceHeater.jsx
@@ -1,3 +1,5 @@
+import { capitalize } from 'common/string';
+
 import { useBackend } from '../backend';
 import {
   Box,
@@ -96,7 +98,7 @@ export const SpaceHeater = (props) => {
                 data.targetTemp + '°C'}
             </LabeledList.Item>
             <LabeledList.Item label="Mode">
-              {(!data.open && 'Auto') || (
+              {!data.open && capitalize(data.mode) || (
                 <>
                   <Button
                     icon="thermometer-half"

--- a/tgui/packages/tgui/interfaces/SpaceHeater.jsx
+++ b/tgui/packages/tgui/interfaces/SpaceHeater.jsx
@@ -98,7 +98,7 @@ export const SpaceHeater = (props) => {
                 data.targetTemp + '°C'}
             </LabeledList.Item>
             <LabeledList.Item label="Mode">
-              {!data.open && capitalize(data.mode) || (
+              {(!data.open && capitalize(data.mode)) || (
                 <>
                   <Button
                     icon="thermometer-half"


### PR DESCRIPTION

## About The Pull Request

Currently, space heaters with their panel closed will always say they are in Auto mode, even if that's not true. This PR changes it to display the correct mode when the panel is closed.

Before:
![image](https://github.com/tgstation/tgstation/assets/44654353/d1d40493-8580-440f-b2ca-e047861b62a9)
After:
![image](https://github.com/tgstation/tgstation/assets/44654353/d29e93ff-160a-43e0-8699-1f578816ddfc)


## Why It's Good For The Game

It's annoying that space heaters lie about their current mode. The UI should correctly identify the current mode of the heater, even if the panel is closed.

## Changelog
:cl:
fix: space heaters now display the correct mode when the maintenance panel is closed
/:cl:
