### PR TITLE
Laser decharge sound uses pitch instead of frequency

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -44,10 +44,11 @@
 	// Ignore this on oversized/infinite cells or ammo without cost
 	if(shot_cost_percent > 0)
 		// The total amount of shots the fully charged energy gun can fire before running out
-		var/max_shots = round(100/shot_cost_percent)
+		var/max_shots = round(100/shot_cost_percent) - 1
 		// How many shots left before the energy gun's current battery runs out of energy
-		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent)
+		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent) - 1
 		pitch_to_use = LERP(1, 0.3, (1 - (shots_left/max_shots)) ** 2)
+		to_chat(world, "test [(1 - (shots_left/max_shots)) ** 2]")
 
 	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
 	playing_sound.pitch = pitch_to_use

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -48,7 +48,6 @@
 		// How many shots left before the energy gun's current battery runs out of energy
 		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent) - 1
 		pitch_to_use = LERP(1, 0.3, (1 - (shots_left/max_shots)) ** 2)
-		to_chat(world, "test [(1 - (shots_left/max_shots)) ** 2]")
 
 	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
 	playing_sound.pitch = pitch_to_use

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -55,7 +55,7 @@
 	if(suppressed)
 		playsound(src, playing_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
 	else
-		playsound(src, playing_sound, fire_sound_volume, FALSE)
+		playsound(src, playing_sound, fire_sound_volume, vary_fire_sound)
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -36,7 +36,7 @@
 
 /obj/item/gun/energy/fire_sounds()
 	// What frequency the energy gun's sound will make
-	var/frequency_to_use
+	var/pitch_to_use
 
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	// What percentage of the full battery a shot will expend
@@ -47,12 +47,15 @@
 		var/max_shots = round(100/shot_cost_percent)
 		// How many shots left before the energy gun's current battery runs out of energy
 		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent)
-		frequency_to_use = sin((90/max_shots) * shots_left)
+		pitch_to_use = LERP(1, 0.4, (1 - (shots_left/max_shots)) ** 2) // We could go as low as 0.25 but it starts sounding pretty bad
+
+	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
+	playing_sound.pitch = pitch_to_use
 
 	if(suppressed)
-		playsound(src, suppressed_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0, frequency = frequency_to_use)
+		playsound(src, playing_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
 	else
-		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound, frequency = frequency_to_use)
+		playsound(src, playing_sound, fire_sound_volume, FALSE)
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -47,7 +47,7 @@
 		var/max_shots = round(100/shot_cost_percent)
 		// How many shots left before the energy gun's current battery runs out of energy
 		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent)
-		pitch_to_use = LERP(1, 0.4, (1 - (shots_left/max_shots)) ** 2) // We could go as low as 0.25 but it starts sounding pretty bad
+		pitch_to_use = LERP(1, 0.3, (1 - (shots_left/max_shots)) ** 2)
 
 	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
 	playing_sound.pitch = pitch_to_use


### PR DESCRIPTION
## About The Pull Request

Now that we require Byond 515 we can make use of the sound pitch var instead of frequency.
The advantage of this is that we can make a sound lower or higher pitched without also changing its duration.

Before:

https://github.com/tgstation/tgstation/assets/7483112/ff61c130-788b-432e-93e8-56c6b6df42d4

After:

https://github.com/tgstation/tgstation/assets/7483112/c1c3d1d5-97fd-468e-9724-61fb6f9f3026


In some extreme cases with frequency, the sound would become incredibly long. This no longer occurs.

## Why It's Good For The Game

I think it sounds better.

## Changelog

:cl:
sound: Lasers adjust their pitch as they run out of charge, rather than frequency
/:cl:
