### PR TITLE
janitor keyring now spawns in all janitor's backpacks instead of only the first one's

### DIFF
--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -41,6 +41,7 @@
 	belt = /obj/item/modular_computer/pda/janitor
 	ears = /obj/item/radio/headset/headset_srv
 	skillchips = list(/obj/item/skillchip/job/janitor)
+	backpack_contents = list(/obj/item/access_key)
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/human_equipper, visuals_only)
 	. = ..()

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -48,11 +48,6 @@
 		backpack_contents += list(/obj/item/gun/ballistic/revolver)
 		r_pocket = /obj/item/ammo_box/a357
 
-	var/static/access_key_given = FALSE
-	if(!access_key_given && !visuals_only)
-		access_key_given = TRUE
-		backpack_contents += list(/obj/item/access_key)
-
 /datum/outfit/job/janitor/get_types_to_preload()
 	. = ..()
 	if(check_holidays(GARBAGEDAY))

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -449,6 +449,7 @@
 		/obj/item/storage/bag/trash = 2,
 		/obj/item/plunger = 2,
 		/obj/item/wirebrush = 2,
+		/obj/item/access_key = 2,
 		/obj/item/radio/headset/headset_srv = 2,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -449,7 +449,6 @@
 		/obj/item/storage/bag/trash = 2,
 		/obj/item/plunger = 2,
 		/obj/item/wirebrush = 2,
-		/obj/item/access_key = 2,
 		/obj/item/radio/headset/headset_srv = 2,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that all janitors spawn with the keyring, instead of just the first one.

So the janitor keyring was added roughly a year ago. I like it a lot but the one aspect that I never quite got was how the spawning worked. Currently, the janitor keyring spawns for the first janitor only. Any additional janitors will not get a keyring. The reasoning for doing so is as follows: (Per Adds the Janitor access keyring #73768 PR):
_"I also wanted to limit how easy this is to greytide/steal, currently only the first Janitor spawns with the key. I thought it would be too easy to exploit otherwise, or essentially stolen roundstart if there were no Janitors."_

Although I understand the idea, I feel like the potential issue was overblown. There are significantly easier ways to tide than a keyring that:

1. Requires a head of staff to head to their office and grant keyring access. (Most heads of staff do not know how to do this, or that you can even do this)
2. Requires you to fumble with the keys at each door for several seconds, which makes an incredibly distinct and unique sound.
3. Expires after ten minutes.

This isn't to mention other jobs that either start off with significant access (paramedic) or jobs that spawn with the tools to tide easily (engineering).

If the keyring is being used for tiding, the head of staff can revoke access or have security/department personnel deal with whoever is abusing access ICly.

## Why It's Good For The Game

Allows multiple janitors to respond to emergency mess calls.
The second (or more) janitors aren't permanently lacking an important tool of the job the whole shift.

## Changelog
:cl:
add: Janitorial keyrings are now part of every janitor's toolkit instead of just the first one.
/:cl:
