### PR TITLE
Fixes some missing poll_ghost_candidates sanity checking for ghost role based events

### DIFF
--- a/code/modules/events/ghost_role/abductor.dm
+++ b/code/modules/events/ghost_role/abductor.dm
@@ -16,7 +16,7 @@
 /datum/round_event/ghost_role/abductor/spawn_role()
 	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_ABDUCTOR, role = ROLE_ABDUCTOR, alert_pic = /obj/item/melee/baton/abductor, role_name_text = role_name, amount_to_pick = 2)
 
-	if(candidates.len < 2)
+	if(isnull(candidates) || candidates.len < 2)
 		return NOT_ENOUGH_PLAYERS
 
 	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_ABDUCTOR_SHIPS)

--- a/code/modules/events/ghost_role/abductor.dm
+++ b/code/modules/events/ghost_role/abductor.dm
@@ -16,7 +16,7 @@
 /datum/round_event/ghost_role/abductor/spawn_role()
 	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_ABDUCTOR, role = ROLE_ABDUCTOR, alert_pic = /obj/item/melee/baton/abductor, role_name_text = role_name, amount_to_pick = 2)
 
-	if(isnull(candidates) || candidates.len < 2)
+	if(length(candidates) < 2)
 		return NOT_ENOUGH_PLAYERS
 
 	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_ABDUCTOR_SHIPS)

--- a/code/modules/events/ghost_role/alien_infestation.dm
+++ b/code/modules/events/ghost_role/alien_infestation.dm
@@ -64,7 +64,7 @@
 
 	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_ALIEN, role = ROLE_ALIEN, alert_pic = /mob/living/carbon/alien/larva, role_name_text = role_name)
 
-	if(isnull(candidates))
+	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 
 	while(spawncount > 0 && vents.len && candidates.len)

--- a/code/modules/events/ghost_role/alien_infestation.dm
+++ b/code/modules/events/ghost_role/alien_infestation.dm
@@ -64,7 +64,7 @@
 
 	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_ALIEN, role = ROLE_ALIEN, alert_pic = /mob/living/carbon/alien/larva, role_name_text = role_name)
 
-	if(!candidates.len)
+	if(isnull(candidates))
 		return NOT_ENOUGH_PLAYERS
 
 	while(spawncount > 0 && vents.len && candidates.len)

--- a/code/modules/events/ghost_role/sentience.dm
+++ b/code/modules/events/ghost_role/sentience.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 
 /datum/round_event/ghost_role/sentience/spawn_role()
 	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, alert_pic = /obj/item/slimepotion/slime/sentience, role_name_text = role_name)
-	if(isnull(candidates))
+	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 
 	// find our chosen mob to breathe life into

--- a/code/modules/events/ghost_role/sentience.dm
+++ b/code/modules/events/ghost_role/sentience.dm
@@ -49,8 +49,9 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 	priority_announce(sentience_report,"[command_name()] Medium-Priority Update")
 
 /datum/round_event/ghost_role/sentience/spawn_role()
-	var/list/mob/dead/observer/candidates
-	candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, alert_pic = /obj/item/slimepotion/slime/sentience, role_name_text = role_name)
+	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, alert_pic = /obj/item/slimepotion/slime/sentience, role_name_text = role_name)
+	if(!LAZYLEN(candidates))
+		return NOT_ENOUGH_PLAYERS
 
 	// find our chosen mob to breathe life into
 	// Mobs have to be simple animals, mindless, on station, and NOT holograms.

--- a/code/modules/events/ghost_role/sentience.dm
+++ b/code/modules/events/ghost_role/sentience.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 
 /datum/round_event/ghost_role/sentience/spawn_role()
 	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, alert_pic = /obj/item/slimepotion/slime/sentience, role_name_text = role_name)
-	if(!LAZYLEN(candidates))
+	if(isnull(candidates))
 		return NOT_ENOUGH_PLAYERS
 
 	// find our chosen mob to breathe life into

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -70,23 +70,25 @@
 /datum/round_event_control/santa
 	name = "Visit by Santa"
 	holidayID = CHRISTMAS
-	typepath = /datum/round_event/santa
+	typepath = /datum/round_event/ghost_role/santa
 	weight = 20
 	max_occurrences = 1
 	earliest_start = 30 MINUTES
 	category = EVENT_CATEGORY_HOLIDAY
 	description = "Spawns santa, who shall roam the station, handing out gifts."
 
-/datum/round_event/santa
+/datum/round_event/ghost_role/santa
+	role_name = "Santa"
 	var/mob/living/carbon/human/santa //who is our santa?
 
-/datum/round_event/santa/announce(fake)
+/datum/round_event/ghost_role/santa/announce(fake)
 	priority_announce("Santa is coming to town!", "Unknown Transmission")
 
-/datum/round_event/santa/start()
+/datum/round_event/ghost_role/santa/start()
 	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Santa is coming to town! Do you want to be [span_notice("Santa")]?", poll_time = 15 SECONDS, alert_pic = /obj/item/clothing/head/costume/santa, role_name_text = "santa", amount_to_pick = 1)
-	if(chosen_one)
-		santa = new /mob/living/carbon/human(pick(GLOB.blobstart))
-		santa.key = chosen_one.key
-		var/datum/antagonist/santa/A = new
-		santa.mind.add_antag_datum(A)
+	if(isnull(chosen_one))
+		return NOT_ENOUGH_PLAYERS
+	santa = new /mob/living/carbon/human(pick(GLOB.blobstart))
+	santa.key = chosen_one.key
+	var/datum/antagonist/santa/A = new
+	santa.mind.add_antag_datum(A)


### PR DESCRIPTION
poll_ghost_candidates can return null if nobody signs up, these weren't properly checking for that case. 

Also moved the Santa ghost role over to the proper subtype (not sure if it was outright broken, but it'll now properly update the Santa's role and trigger automatically.)

```
[14:41:54] Runtime in code/modules/events/ghost_role/sentience.dm, line 77: Cannot read null.vars
proc name: spawn role (/datum/round_event/ghost_role/sentience/spawn_role)
src: /datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience)
call stack:
/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): spawn role()
/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): try spawning()
/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): start()
/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): process(2)
Events (/datum/controller/subsystem/events): fire(0)
Events (/datum/controller/subsystem/events): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```