### PR TITLE
Fixes masspurbation erroring out when trying to give/remove cat tails from incompatible subspecies of humans

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -126,9 +126,6 @@
 		var/datum/species/human/felinid/cat_species = soon_to_be_felinid.dna.species
 		cat_species.original_felinid = FALSE
 	else
-		var/obj/item/organ/internal/ears/cat/kitty_ears = new
-		var/obj/item/organ/external/tail/cat/kitty_tail = new
-
 		// This removes the spines if they exist
 		var/obj/item/organ/external/spines/current_spines = soon_to_be_felinid.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
 		if(current_spines)
@@ -139,8 +136,12 @@
 		// Humans get converted directly to felinids, and the key is handled in on_species_gain.
 		// Now when we get mob.dna.features[feature_key], it returns None, which is why the tail is invisible.
 		// stored_feature_id is only set once (the first time an organ is inserted), so this should be safe.
+		var/obj/item/organ/internal/ears/cat/kitty_ears = new
 		kitty_ears.Insert(soon_to_be_felinid, special = TRUE, movement_flags = DELETE_IF_REPLACED)
-		kitty_tail.Insert(soon_to_be_felinid, special = TRUE, movement_flags = DELETE_IF_REPLACED)
+		if(should_external_organ_apply_to(/obj/item/organ/external/tail/cat, soon_to_be_felinid)) //only give them a tail if they actually have sprites for it / are a compatible subspecies.
+			var/obj/item/organ/external/tail/cat/kitty_tail = new
+			kitty_tail.Insert(soon_to_be_felinid, special = TRUE, movement_flags = DELETE_IF_REPLACED)
+
 	if(!silent)
 		to_chat(soon_to_be_felinid, span_boldnotice("Something is nya~t right."))
 		playsound(get_turf(soon_to_be_felinid), 'sound/effects/meow1.ogg', 50, TRUE, -1)
@@ -161,6 +162,8 @@
 			qdel(old_tail)
 			// Locate does not work on assoc lists, so we do it by hand
 			for(var/external_organ in target_species.external_organs)
+				if(!should_external_organ_apply_to(external_organ, purrbated_human))
+					continue
 				if(ispath(external_organ, /obj/item/organ/external/tail))
 					var/obj/item/organ/external/tail/new_tail = new external_organ()
 					new_tail.Insert(purrbated_human, special = TRUE, movement_flags = DELETE_IF_REPLACED)


### PR DESCRIPTION
```
[2024-05-06 22:43:46.320] RUNTIME: runtime error: adding a /obj/item/organ/external/tail/monkey to a /mob/living/carbon/human/species/monkey when it shouldn't be!
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: code/__HELPERS/stack_trace.dm,4
 -   usr: the monkey (828) (as Gratian H... (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (120,86,2) (/turf/open/floor/iron)
 -   call stack:
 -  stack trace("adding a /obj/item/organ/exter...", "code/modules/surgery/organs/ex...", 69)
 - the monkey tail (/obj/item/organ/external/tail/monkey): mob insert(the monkey (412) (/mob/living/carbon/human/species/monkey), 1, 1)
 - the monkey tail (/obj/item/organ/external/tail/monkey): Insert(the monkey (412) (/mob/living/carbon/human/species/monkey), 1, 1)
 - the monkey tail (/obj/item/organ/external/tail/monkey): Insert(the monkey (412) (/mob/living/carbon/human/species/monkey), 1, 1)
 - the monkey tail (/obj/item/organ/external/tail/monkey): Insert(the monkey (412) (/mob/living/carbon/human/species/monkey), 1, 1)
 - purrbation remove(the monkey (412) (/mob/living/carbon/human/species/monkey), 0)
 - mass remove purrbation()
 - /datum/secrets_menu (/datum/secrets_menu): ui act("massremovepurrbation", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/admin_state (/datum/ui_state/admin_state))
 - /datum/tgui (/datum/tgui): on act message("massremovepurrbation", /list (/list), /datum/ui_state/admin_state (/datum/ui_state/admin_state))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - 
[2024-05-06 22:44:02.813] RUNTIME: runtime error: adding a /obj/item/organ/external/tail/monkey to a /mob/living/carbon/human when it shouldn't be!
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: code/__HELPERS/stack_trace.dm,4
 -   usr: the monkey (828) (as Gratian H... (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (120,86,2) (/turf/open/floor/iron)
 -   call stack:
 -  stack trace("adding a /obj/item/organ/exter...", "code/modules/surgery/organs/ex...", 69)
 - the monkey tail (/obj/item/organ/external/tail/monkey): mob insert(the monkey (665) (/mob/living/carbon/human), 1, 1)
 - the monkey tail (/obj/item/organ/external/tail/monkey): Insert(the monkey (665) (/mob/living/carbon/human), 1, 1)
 - the monkey tail (/obj/item/organ/external/tail/monkey): Insert(the monkey (665) (/mob/living/carbon/human), 1, 1)
 - the monkey tail (/obj/item/organ/external/tail/monkey): Insert(the monkey (665) (/mob/living/carbon/human), 1, 1)
 - purrbation remove(the monkey (665) (/mob/living/carbon/human), 0)
 - mass remove purrbation()
 - /datum/secrets_menu (/datum/secrets_menu): ui act("massremovepurrbation", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/admin_state (/datum/ui_state/admin_state))
 - /datum/tgui (/datum/tgui): on act message("massremovepurrbation", /list (/list), /datum/ui_state/admin_state (/datum/ui_state/admin_state))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - 
```