### PR TITLE
Fixes logging runtime when admins trigger summon events

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -617,7 +617,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 					E.announce_chance = 0
 		E.processing = TRUE
 	if(holder)
-		log_admin("[key_name(holder)] used secret [action]")
+		log_admin("[key_name(holder)] used secret: [action].")
 #undef THUNDERDOME_TEMPLATE_FILE
 #undef HIGHLANDER_DELAY_TEXT
 

--- a/code/modules/spells/spell_types/right_and_wrong.dm
+++ b/code/modules/spells/spell_types/right_and_wrong.dm
@@ -230,9 +230,12 @@ GLOBAL_LIST_INIT(summoned_magic_objectives, list(
 
 		SSevents.reschedule()
 		if(user)
-			to_chat(user, span_warning("You have intensified summon events, causing them to occur more often!"))
-			message_admins("[ADMIN_LOOKUPFLW(user)] intensified summon events!")
-			user.log_message("intensified events!", LOG_GAME)
+			message_admins("[ADMIN_LOOKUPFLW(user)] [ismob(user) ? "":"admin triggered "]intensified summon events!")
+			if(ismob(user))
+				to_chat(user, span_warning("You have intensified summon events, causing them to occur more often!"))
+				user.log_message("intensified events!", LOG_GAME)
+			else //admin triggered
+				log_admin("[key_name(user)] intensified summon events.")
 		else
 			log_game("Summon Events was intensified!")
 
@@ -245,9 +248,12 @@ GLOBAL_LIST_INIT(summoned_magic_objectives, list(
 		SSevents.toggleWizardmode()
 		SSevents.reschedule()
 		if(user)
-			to_chat(user, span_warning("You have cast summon events!"))
-			message_admins("[ADMIN_LOOKUPFLW(user)] summoned events!")
-			user.log_message("summoned events!", LOG_GAME)
+			message_admins("[ADMIN_LOOKUPFLW(user)] [ismob(user) ? "summoned":"admin triggered summon"] events!")
+			if(ismob(user))
+				to_chat(user, span_warning("You have cast summon events!"))
+				user.log_message("summoned events!", LOG_GAME)
+			else //admin triggered
+				log_admin("[key_name(user)] summoned events.")
 		else
 			message_admins("Summon Events was triggered!")
 			log_game("Summon Events was triggered!")


### PR DESCRIPTION
Admin secrets panel passes a client to this proc, which only had handling for being passed a mob. 

```
[17:23:21] Runtime in code/modules/spells/spell_types/right_and_wrong.dm, line 250: undefined proc or verb /client/log message(). 
proc name: summon events (/proc/summon_events)
usr: ShizCalev/(Gratian Hunter)
usr.loc: (Engineering SMES (115,96,2))
src: null
call stack:
summon events(ShizCalev (/client))
/datum/secrets_menu (/datum/secrets_menu): ui act("events", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/admin_state (/datum/ui_state/admin_state))
/datum/tgui (/datum/tgui): on act message("events", /list (/list), /datum/ui_state/admin_state (/datum/ui_state/admin_state))
/datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
```