### PR TITLE
Fixes the stomach pump surgery not actually causing vomit nor decreasing reagent contents

### DIFF
--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -55,7 +55,7 @@
 		display_results(
 			user,
 			target,
-			span_warning("You screw up, brusing [target_human]'s chest!"),
+			span_warning("You screw up, bruising [target_human]'s chest!"),
 			span_warning("[user] screws up, brusing [target_human]'s chest!"),
 			span_warning("[user] screws up!"),
 		)

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -46,7 +46,7 @@
 			span_notice("[user] forces [target_human] to vomit, cleansing their stomach of some chemicals!"),
 			span_notice("[user] forces [target_human] to vomit!"),
 		)
-		target_human.vomit(20, FALSE, TRUE, 1, TRUE, FALSE, purge_ratio = 0.67) //higher purge ratio than regular vomiting
+		target_human.vomit((MOB_VOMIT_MESSAGE | MOB_VOMIT_STUN), lost_nutrition = 20, purge_ratio = 0.67) //higher purge ratio than regular vomiting
 	return ..()
 
 /datum/surgery_step/stomach_pump/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION

## About The Pull Request

So while playing I had to get a bunch of unstable mutagen out of a corpse's stomach before reviving it, and thus I tried to stomach pump it.
This, however, never decreased the amount in the stomach, nor did it actually create any vomit like it's supposed to.

Looking into it, the issue seems to be with this line:
https://github.com/tgstation/tgstation/blob/0c562fd74299f8ce92a81c0a932b8ec4862189af/code/modules/surgery/stomachpump.dm#L49
Which doesn't line up with the parameters `vomit(...)` takes:
https://github.com/tgstation/tgstation/blob/0c562fd74299f8ce92a81c0a932b8ec4862189af/code/modules/mob/living/carbon/carbon.dm#L417
`vomit_type = FALSE` isn't very helpful.

This mismatch seems to be due to the `vomit(...)` proc getting changed quite a while ago, but in the process forgetting to update stomach pump to use it.
Based on what I found looking into this, I replaced it with the following:
```dm
target_human.vomit((MOB_VOMIT_MESSAGE | MOB_VOMIT_STUN), lost_nutrition = 20, purge_ratio = 0.67)
```
Where we don't use `VOMIT_CATEGORY_DEFAULT` as that includes `MOB_VOMIT_HARM`, and we already have our own harm condition.

This fixes our issue.

Oh, we also fix a minor spelling issue, "brusing" to "bruising".
## Why It's Good For The Game

Makes stomach pumping actually work.
## Changelog
:cl:
fix: The stomach pump surgery actually works again.
spellcheck: "brusing" to "bruising" in the message you get when failing the stomach pump surgery.
/:cl:
