### PR TITLE
Fixes Cursed Items wizard event

### DIFF
--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -32,30 +32,30 @@
 		VOICE_MODULATORS,
 		WIZARD_MIMICRY,
 	)
-	var/list/loadout[SLOTS_AMT]
+	var/list/loadout = list()
 	var/ruins_spaceworthiness = FALSE
 	var/ruins_wizard_loadout = FALSE
 
 	switch(item_set)
 		if(BIG_FAT_DOOBIE)
-			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/cigarette/rollie/trippy
+			loadout += /obj/item/clothing/mask/cigarette/rollie/trippy
 			ruins_spaceworthiness = TRUE
 		if(BOXING)
-			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/luchador
-			loadout[ITEM_SLOT_GLOVES] = /obj/item/clothing/gloves/boxing
+			loadout += /obj/item/clothing/mask/luchador
+			loadout += /obj/item/clothing/gloves/boxing
 			ruins_spaceworthiness = TRUE
 		if(CATGIRLS_2015)
-			loadout[ITEM_SLOT_HEAD] = /obj/item/clothing/head/costume/kitty
-			ruins_spaceworthiness = TRUE
-			ruins_wizard_loadout = TRUE
+			loadout += /obj/item/clothing/head/costume/kitty
+			ruins_spaceworthiness += TRUE
+			ruins_wizard_loadout += TRUE
 		if(CURSED_SWORDS)
-			loadout[ITEM_SLOT_HANDS] = /obj/item/katana/cursed
+			loadout += /obj/item/katana/cursed
 		if(VOICE_MODULATORS)
-			loadout[ITEM_SLOT_MASK] = /obj/item/clothing/mask/chameleon
+			loadout += /obj/item/clothing/mask/chameleon
 		if(WIZARD_MIMICRY)
-			loadout[ITEM_SLOT_OCLOTHING] = /obj/item/clothing/suit/wizrobe
-			loadout[ITEM_SLOT_FEET] = /obj/item/clothing/shoes/sandal/magic
-			loadout[ITEM_SLOT_HEAD] = /obj/item/clothing/head/wizard
+			loadout += /obj/item/clothing/suit/wizrobe
+			loadout += /obj/item/clothing/shoes/sandal/magic
+			loadout += /obj/item/clothing/head/wizard
 			ruins_spaceworthiness = TRUE
 
 	var/list/mob/living/carbon/human/victims = list()
@@ -67,18 +67,18 @@
 			continue
 		if(item_set == CATGIRLS_2015) //Wizard code means never having to say you're sorry
 			target.gender = FEMALE
-		for(var/iterable in 1 to loadout.len)
-			if(!loadout[iterable])
-				continue
+		for(var/item_to_equip in loadout)
+			var/obj/item/new_item = new item_to_equip
+			var/slot_to_equip_to = ITEM_SLOT_HANDS
+			if(isclothing(new_item))
+				var/obj/item/clothing/clothing_item = new_item
+				slot_to_equip_to = clothing_item.slot_flags
 
-			var/obj/item/item_type = loadout[iterable]
-			var/obj/item/thing = new item_type //dumb but required because of byond throwing a fit anytime new gets too close to a list
-
-			target.dropItemToGround(target.get_item_by_slot(iterable), TRUE)
-			target.equip_to_slot_or_del(thing, iterable, indirect_action = TRUE)
-			ADD_TRAIT(thing, TRAIT_NODROP, CURSED_ITEM_TRAIT(thing))
-			thing.item_flags |= DROPDEL
-			thing.name = "cursed " + thing.name
+			target.dropItemToGround(target.get_item_by_slot(slot_to_equip_to), TRUE)
+			target.equip_to_slot_or_del(new_item, slot_to_equip_to, indirect_action = TRUE)
+			ADD_TRAIT(new_item, TRAIT_NODROP, CURSED_ITEM_TRAIT(new_item))
+			new_item.item_flags |= DROPDEL
+			new_item.name = "cursed " + new_item.name
 
 		victims += target
 


### PR DESCRIPTION
Slot flags got changed from set 1 through 20 numbers to bitflags, this was runtiming since it was still trying to use the old hard-set slot numbers.

```
[2024-05-07 00:50:31.612] RUNTIME: runtime error: list index out of bounds
 - proc name: start (/datum/round_event/wizard/cursed_items/start)
 -   source file: code/modules/events/wizard/curseditems.dm,44
 -   usr: null
 -   src: /datum/round_event/wizard/curs... (/datum/round_event/wizard/cursed_items)
 -   call stack:
 - /datum/round_event/wizard/curs... (/datum/round_event/wizard/cursed_items): start()
 - /datum/round_event/wizard/curs... (/datum/round_event/wizard/cursed_items): process(2)
 - Events (/datum/controller/subsystem/events): fire(0)
 - Events (/datum/controller/subsystem/events): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```

:cl: ShizCalev
fix: Cursed Items wizard event actually works again.
/:cl:

