### PR TITLE
Quick equip no longer throws balloon alerts

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -443,11 +443,12 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  * * mob/user - (optional) the user who is inserting the item.
  * * override - see item_insertion_feedback()
  * * force - bypass locked storage up to a certain level. See [code/__DEFINES/storage.dm]
+ * * messages - if TRUE, we will create balloon alerts for the user.
  */
-/datum/storage/proc/attempt_insert(obj/item/to_insert, mob/user, override = FALSE, force = STORAGE_NOT_LOCKED)
+/datum/storage/proc/attempt_insert(obj/item/to_insert, mob/user, override = FALSE, force = STORAGE_NOT_LOCKED, messages = TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 
-	if(!can_insert(to_insert, user, force = force))
+	if(!can_insert(to_insert, user, messages = messages, force = force))
 		return FALSE
 
 	SEND_SIGNAL(parent, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)

--- a/code/datums/storage/subtypes/bag_of_holding.dm
+++ b/code/datums/storage/subtypes/bag_of_holding.dm
@@ -4,7 +4,7 @@
 	max_slots = 30
 	allow_big_nesting = TRUE
 
-/datum/storage/bag_of_holding/attempt_insert(obj/item/to_insert, mob/user, override, force)
+/datum/storage/bag_of_holding/attempt_insert(obj/item/to_insert, mob/user, override, force, messages)
 	var/list/obj/item/storage/backpack/holding/matching = typecache_filter_list(to_insert.get_all_contents(), typecacheof(/obj/item/storage/backpack/holding))
 	matching -= parent
 	matching -= real_location

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -4,7 +4,7 @@
 	max_total_storage = 50
 	rustle_sound = FALSE
 
-/datum/storage/pockets/attempt_insert(obj/item/to_insert, mob/user, override, force)
+/datum/storage/pockets/attempt_insert(obj/item/to_insert, mob/user, override, force, messages)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -456,31 +456,32 @@
 	return obscured
 
 
-/obj/item/proc/equip_to_best_slot(mob/M)
-	if(M.equip_to_appropriate_slot(src))
-		M.update_held_items()
+/// Tries to equip an item, store it in open storage, or in next best storage
+/obj/item/proc/equip_to_best_slot(mob/user)
+	if(user.equip_to_appropriate_slot(src))
+		user.update_held_items()
 		return TRUE
 	else
 		if(equip_delay_self)
 			return
 
-	if(M.active_storage?.attempt_insert(src, M))
+	if(user.active_storage?.attempt_insert(src, user, messages = FALSE))
 		return TRUE
 
 	var/list/obj/item/possible = list(
-		M.get_inactive_held_item(),
-		M.get_item_by_slot(ITEM_SLOT_BELT),
-		M.get_item_by_slot(ITEM_SLOT_DEX_STORAGE),
-		M.get_item_by_slot(ITEM_SLOT_BACK),
+		user.get_inactive_held_item(),
+		user.get_item_by_slot(ITEM_SLOT_BELT),
+		user.get_item_by_slot(ITEM_SLOT_DEX_STORAGE),
+		user.get_item_by_slot(ITEM_SLOT_BACK),
 	)
-	for(var/i in possible)
-		if(!i)
+	for(var/thing in possible)
+		if(isnull(thing))
 			continue
-		var/obj/item/I = i
-		if(I.atom_storage?.attempt_insert(src, M))
+		var/obj/item/gear = thing
+		if(gear.atom_storage?.attempt_insert(src, user, messages = FALSE))
 			return TRUE
 
-	to_chat(M, span_warning("You are unable to equip that!"))
+	to_chat(user, span_warning("You are unable to equip that!"))
 	return FALSE
 
 


### PR DESCRIPTION

## About The Pull Request
Pressing E to quick equip would throw balloon alerts when it iterates over storage that's full
Especially noticeable on round start engies because their toolbelt gets checked
## Why It's Good For The Game
Less noise
## Changelog
:cl:
fix: The quick equip 'E' hotkey shouldn't warn if one of your bags is full anymore
/:cl:
