### PR TITLE
Fix conveyor switches not working for cyborgs

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -446,17 +446,33 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	else
 		position = CONVEYOR_OFF
 
-/// Called when a user clicks on this switch with an open hand.
-/obj/machinery/conveyor_switch/attack_hand(mob/living/user, list/modifiers)
+/obj/machinery/conveyor_switch/proc/on_user_activation(mob/user, direction)
 	add_fingerprint(user)
-	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		update_position(CONVEYOR_BACKWARDS)
-	else
-		update_position(CONVEYOR_FORWARD)
+	update_position(direction)
 	update_appearance()
 	update_linked_conveyors()
 	update_linked_switches()
-	return TRUE
+
+/// Called when a user clicks on this switch with an open hand.
+/obj/machinery/conveyor_switch/attack_hand(mob/user, list/modifiers)
+	. = ..()
+	on_user_activation(user, CONVEYOR_FORWARD)
+
+/obj/machinery/conveyor_switch/attack_hand_secondary(mob/user, list/modifiers)
+	on_user_activation(user, CONVEYOR_BACKWARDS)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/machinery/conveyor_switch/attack_ai(mob/user)
+	return attack_hand(user)
+
+/obj/machinery/conveyor_switch/attack_ai_secondary(mob/user, list/modifiers)
+	return attack_hand_secondary(user, modifiers)
+
+/obj/machinery/conveyor_switch/attack_robot(mob/user)
+	return attack_hand(user)
+
+/obj/machinery/conveyor_switch/attack_robot_secondary(mob/user, list/modifiers)
+	return attack_hand_secondary(user, modifiers)
 
 /obj/machinery/conveyor_switch/attackby(obj/item/attacking_item, mob/user, params)
 	if(is_wire_tool(attacking_item))


### PR DESCRIPTION

## About The Pull Request
Makes conveyor switches work for cyborgs again

## Why It's Good For The Game
The left/right click update broke it. Fixes #83078 

## Changelog
:cl:
fix: conveyor switches work for cyborgs again
/:cl:
