### PR TITLE
Add alt-click usage context to toggle_icon component

### DIFF
--- a/code/datums/components/toggle_suit.dm
+++ b/code/datums/components/toggle_suit.dm
@@ -15,6 +15,7 @@
 		return COMPONENT_INCOMPATIBLE
 
 	var/atom/atom_parent = parent
+	atom_parent.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 
 	src.toggle_noun = toggle_noun
 	src.base_icon_state = atom_parent.base_icon_state || atom_parent.icon_state
@@ -22,9 +23,10 @@
 /datum/component/toggle_icon/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_click_alt))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_adding_context))
 
 /datum/component/toggle_icon/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_EXAMINE, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))
 
 /*
  * Signal proc for COMSIG_CLICK_ALT.
@@ -68,6 +70,21 @@
 	SIGNAL_HANDLER
 
 	examine_list += span_notice("Alt-click on [source] to toggle the [toggle_noun].")
+
+/*
+ * Signal proc for COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM.
+ * Adds usage context for toggling the parent open or closed.
+ *
+ * source - the atom context is requested from (parent)
+ * context - the list of usage contexts set
+ * held_item - the item held by the requesting mob
+ * user - the mob requesting context
+ */
+/datum/component/toggle_icon/proc/on_adding_context(atom/source, list/context, obj/item/held_item, mob/user)
+	SIGNAL_HANDLER
+
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Toggle [toggle_noun]"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /*
  * Actually do the toggle of the icon.


### PR DESCRIPTION

## About The Pull Request

There is not much to this.
We make `toggle_icon` register an additional signal `COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM` upon which we set the alt-click usage context, and just add the `HAS_CONTEXTUAL_SCREENTIPS_1` flag to the parent ourselves as we don't want the other effects of `register_context()`.
## Why It's Good For The Game

Having working screentips is helpful.
## Changelog
:cl:
qol: Added alt-click usage context to toggle_icon component
/:cl:
