### PR TITLE
Adds slight animation to entering a portal / teleporter

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -73,22 +73,24 @@
 		com.target_ref = null
 		visible_message(span_alert("Cannot authenticate locked on coordinates. Please reinstate coordinate matrix."))
 		return
-	if (ismovable(M))
-		if(do_teleport(M, target, channel = TELEPORT_CHANNEL_BLUESPACE))
-			use_energy(active_power_usage)
-			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
-				if(ishuman(M))//don't remove people from the round randomly you jerks
-					var/mob/living/carbon/human/human = M
-					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
-						var/datum/species/species_to_transform = /datum/species/fly
-						if(check_holidays(MOTH_WEEK))
-							species_to_transform = /datum/species/moth
-						if(human.dna && human.dna.species.id != initial(species_to_transform.id))
-							to_chat(M, span_hear("You hear a buzzing in your ears."))
-							human.set_species(species_to_transform)
-							human.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)
-			calibrated = FALSE
-	return
+	if(!ismovable(M))
+		return
+	var/turf/start_turf = get_turf(M)
+	if(!do_teleport(M, target, channel = TELEPORT_CHANNEL_BLUESPACE))
+		return
+	use_energy(active_power_usage)
+	new /obj/effect/temp_visual/portal_animation(start_turf, src, M)
+	if(!calibrated && ishuman(M) && prob(30 - ((accuracy) * 10))) //oh dear a problem
+		var/mob/living/carbon/human/human = M
+		if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
+			var/datum/species/species_to_transform = /datum/species/fly
+			if(check_holidays(MOTH_WEEK))
+				species_to_transform = /datum/species/moth
+			if(human.dna && human.dna.species.id != initial(species_to_transform.id))
+				to_chat(M, span_hear("You hear a buzzing in your ears."))
+				human.set_species(species_to_transform)
+				human.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)
+	calibrated = FALSE
 
 /obj/machinery/teleport/hub/update_icon_state()
 	icon_state = "[base_icon_state][panel_open ? "-o" : (is_ready() ? 1 : 0)]"

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -140,10 +140,12 @@
 		no_effect = TRUE
 	else
 		last_effect = world.time
+	var/turf/start_turf = get_turf(M)
 	if(do_teleport(M, real_target, innate_accuracy_penalty, no_effects = no_effect, channel = teleport_channel, forced = force_teleport))
 		if(isprojectile(M))
 			var/obj/projectile/P = M
 			P.ignore_source_check = TRUE
+		new /obj/effect/temp_visual/portal_animation(start_turf, src, M)
 		return TRUE
 	return FALSE
 
@@ -206,3 +208,22 @@
 	. = ..()
 	if (. && !isdead(M))
 		qdel(src)
+
+/**
+ * Animation used for transitioning atoms which are teleporting somewhere via a portal
+ *
+ * To use, pass it the atom doing the teleporting and the atom that is being teleported in init.
+ */
+/obj/effect/temp_visual/portal_animation
+	duration = 0.25 SECONDS
+
+/obj/effect/temp_visual/portal_animation/Initialize(mapload, atom/portal, atom/movable/teleporting)
+	. = ..()
+	if(isnull(portal) || isnull(teleporting))
+		return
+
+	appearance = teleporting.appearance
+	dir = teleporting.dir
+	layer = portal.layer + 0.01
+	alpha = teleporting.alpha
+	animate(src, pixel_x = (portal.x * 32) - (x * 32), pixel_y = (portal.y * 32) - (y * 32), alpha = 0, time = duration)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/assets/51863163/ba4e1d58-8caf-4248-a50a-69ff3e1ecf2e

Nothing new for exiting, just for entering. 

Also doesn't affect actual travel time, it's still instantaneous.

## Why It's Good For The Game

Provides some minor visual feedback when someone's entering a teleporter or portal, rather than them just disappearing into sparks. 

## Changelog

:cl: Melbert
qol: There is now a slight animation to entering a portal or teleporter. 
/:cl:

