### PR TITLE
Removes another rogue cable under a disconnected SMES on Ice Box

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -58486,11 +58486,6 @@
 /obj/structure/fake_stairs/wood/directional/north,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"rPu" = (
-/obj/structure/cable,
-/obj/machinery/power/smes/engineering,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "rPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -257545,7 +257540,7 @@ dvS
 pwd
 glI
 tsR
-rPu
+gZR
 lUC
 tXV
 kvX


### PR DESCRIPTION
## About The Pull Request
I'm still surprised this didn't come up in the tests here, but here you go, now it's fixed properly. https://github.com/tgstation/tgstation/pull/83059 forgot to notice that there was actually two rogue wires, not just one!

## Why It's Good For The Game
Less CI failures == happier maintainers

## Changelog

:cl: GoldenAlpharex
fix: Removed another rogue cable from underneath a disconnected SMES.
/:cl: