### PR TITLE
Fixes flap and wing emotes not updating wing sprites (for functional wings)

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -126,14 +126,14 @@
 	key_third_person = "flaps"
 	message = "flaps their wings."
 	hands_use_check = TRUE
-	var/wing_time = 20
+	var/wing_time = 0.5 SECONDS
 
 /datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(. && ishuman(user))
-		var/mob/living/carbon/human/H = user
+		var/mob/living/carbon/human/human_user = user
 		var/open = FALSE
-		var/obj/item/organ/external/wings/functional/wings = H.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
+		var/obj/item/organ/external/wings/functional/wings = human_user.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
 
 		// open/close functional wings
 		if(istype(wings))
@@ -144,9 +144,8 @@
 				wings.open_wings()
 			addtimer(CALLBACK(wings,  open ? TYPE_PROC_REF(/obj/item/organ/external/wings/functional, open_wings) : TYPE_PROC_REF(/obj/item/organ/external/wings/functional, close_wings)), wing_time)
 
-		// play moth flutter noise if moth wing
-		if(istype(wings, /obj/item/organ/external/wings/moth))
-			playsound(H, 'sound/voice/moth/moth_flutter.ogg', 50, TRUE)
+		// play a flapping noise if the wing has this implemented
+		wings.make_flap_sound(human_user)
 
 /datum/emote/living/flap/aflap
 	key = "aflap"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -126,7 +126,7 @@
 	key_third_person = "flaps"
 	message = "flaps their wings."
 	hands_use_check = TRUE
-	var/wing_time = 0.5 SECONDS
+	var/wing_time = 0.25 SECONDS
 
 /datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -126,7 +126,7 @@
 	key_third_person = "flaps"
 	message = "flaps their wings."
 	hands_use_check = TRUE
-	var/wing_time = 0.25 SECONDS
+	var/wing_time = 0.35 SECONDS
 
 /datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -187,6 +187,9 @@
 	desc = "Powered by pure edgy-teenager-notebook-scribblings. Just kidding. But seriously, how do these keep you flying?!"
 	sprite_accessory_override = /datum/sprite_accessory/wings/skeleton
 
+/obj/item/organ/external/wings/functional/moth/make_flap_sound(mob/living/carbon/wing_owner)
+	playsound(wing_owner, 'sound/voice/moth/moth_flutter.ogg', 50, TRUE)
+
 ///mothra wings, which relate to moths.
 /obj/item/organ/external/wings/functional/moth/mothra
 	name = "mothra wings"

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -112,19 +112,20 @@
 		human.remove_traits(list(TRAIT_NO_FLOATING_ANIM, TRAIT_MOVE_FLYING), SPECIES_FLIGHT_TRAIT)
 		passtable_off(human, SPECIES_FLIGHT_TRAIT)
 		close_wings()
-	human.update_body_parts()
 
 ///SPREAD OUR WINGS AND FLLLLLYYYYYY
 /obj/item/organ/external/wings/functional/proc/open_wings()
 	var/datum/bodypart_overlay/mutant/wings/functional/overlay = bodypart_overlay
 	overlay.open_wings()
 	wings_open = TRUE
+	owner.update_body_parts()
 
 ///close our wings
 /obj/item/organ/external/wings/functional/proc/close_wings()
 	var/datum/bodypart_overlay/mutant/wings/functional/overlay = bodypart_overlay
 	wings_open = FALSE
 	overlay.close_wings()
+	owner.update_body_parts()
 
 	if(isturf(owner?.loc))
 		var/turf/location = loc

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -25,6 +25,9 @@
 	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOVABLE_PRE_MOVE))
 	REMOVE_TRAIT(organ_owner, TRAIT_FREE_FLOAT_MOVEMENT, REF(src))
 
+/obj/item/organ/external/wings/moth/make_flap_sound(mob/living/carbon/wing_owner)
+	playsound(wing_owner, 'sound/voice/moth/moth_flutter.ogg', 50, TRUE)
+
 /obj/item/organ/external/wings/moth/can_soften_fall()
 	return !burnt
 

--- a/code/modules/surgery/organs/external/wings/wings.dm
+++ b/code/modules/surgery/organs/external/wings/wings.dm
@@ -13,6 +13,10 @@
 /obj/item/organ/external/wings/proc/can_soften_fall()
 	return TRUE
 
+///Implement as needed to play a sound effect on *flap emote
+/obj/item/organ/external/wings/proc/make_flap_sound(mob/living/carbon/wing_owner)
+	return
+
 ///Bodypart overlay of default wings. Does not have any wing functionality
 /datum/bodypart_overlay/mutant/wings
 	layers = ALL_EXTERNAL_OVERLAYS


### PR DESCRIPTION
## About The Pull Request

Pretty straightforward, the wing sprites were not updating on the mob after calling `open_wings()`/`close_wings()`. Additionally I reduced the time between opening/closing for the flap emote to 0.35 seconds. It matches up more with the sound effect that way, and in my opinion look a bit more like a proper flap should. 2 seconds was really long.

And finally functional moth wings will make the moth flap sound too! As they should.


---

More codey stuff:

I slightly refactored the way sounds play to be more object oriented adding a new proc for it: `/obj/item/organ/external/wings/make_flap_sound()`. This will make it easier for people to add different sound effects for other types of wings beyond just moth ones, should they so desire.

## Why It's Good For The Game

Moths can rejoice in more ways to express yourselves!

<details><summary>Flap emote</summary>

![dreamseeker_KhEzxJaA4A](https://github.com/tgstation/tgstation/assets/13398309/d5b2ad6d-be62-4629-9c7f-4bb0523d8da3)

</details>

<details><summary>Wing emote</summary>

![dreamseeker_kuV1sMxHOB](https://github.com/tgstation/tgstation/assets/13398309/78f339d5-b28f-4cb6-885c-e16e649a89e3)

</details>

## Changelog

:cl:
fix: moths with functional/flight potion wings get an animation when they *flap once again, and it makes a sound
/:cl: