### PR TITLE
Blocks admin actions on photo albums

### DIFF
--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -15,6 +15,8 @@
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	var/persistence_id
 
+GENERAL_PROTECT_DATUM(/obj/item/storage/photo_album)
+
 /obj/item/storage/photo_album/Initialize(mapload)
 	. = ..()
 	if (!SSpersistence.initialized)


### PR DESCRIPTION
Admins apparently think deleting 2 years of a player's memories over a single """exploit""" (that was the result of explicit code to allow it to happen, ie, not an exploit) is acceptable and until i setup a way to backup and restore photo_albums.json they can't be allowed to fuck with it. 