### PR TITLE
Joining a deathmatch lobby sets players to ready by default

### DIFF
--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -223,7 +223,7 @@
 /datum/deathmatch_lobby/proc/add_player(mob/mob, loadout, host = FALSE)
 	if (observers[mob.ckey])
 		CRASH("Tried to add [mob.ckey] as a player while being an observer.")
-	players[mob.ckey] = list("mob" = mob, "host" = host, "ready" = TRUE, "loadout" = loadout)
+	players[mob.ckey] = list("mob" = mob, "host" = host, "ready" = !host, "loadout" = loadout)
 
 /datum/deathmatch_lobby/proc/remove_ckey_from_play(ckey)
 	var/is_likely_player = (ckey in players)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -223,7 +223,7 @@
 /datum/deathmatch_lobby/proc/add_player(mob/mob, loadout, host = FALSE)
 	if (observers[mob.ckey])
 		CRASH("Tried to add [mob.ckey] as a player while being an observer.")
-	players[mob.ckey] = list("mob" = mob, "host" = host, "ready" = FALSE, "loadout" = loadout)
+	players[mob.ckey] = list("mob" = mob, "host" = host, "ready" = TRUE, "loadout" = loadout)
 
 /datum/deathmatch_lobby/proc/remove_ckey_from_play(ckey)
 	var/is_likely_player = (ckey in players)


### PR DESCRIPTION
## About The Pull Request

Sets the default value of ready to TRUE when joining a deathmatch lobby. Hosts still start unready.

## Why It's Good For The Game

Waiting for every player to ready up for this gamemode is silly given how frequent and short the rounds often are. The case where someone wants to join the lobby but not be ready to play immediately seems to be pretty rare. That being said, hosts are still unready by default for the sake of controlling when their lobby starts.

## Changelog

:cl:
qol: Joining a deathmatch minigame lobby sets you to ready by default. Hosts still start unready.
/:cl:
