### PR TITLE
Confirm Order button now active when cargo shuttle is at Central

### DIFF
--- a/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
@@ -17,7 +17,7 @@ export function CargoCart(props) {
   const { act, data } = useBackend<CargoData>();
   const { requestonly, away, cart = [], docked, location } = data;
 
-  const sendable = !away && !!docked;
+  const sendable = !!away && !!docked;
 
   return (
     <Stack fill vertical>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, the cargo console's Confirm Order button is active when the supply shuttle is shipside. This PR flips it, so it's active at Central.

## Why It's Good For The Game

Makes more sense to confirm the order when you're actually going to have the shuttle coming to the station.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The "Confirm Order" button on Cargo consoles is now active when the cargo shuttle is at Central Command instead of at the station.
/:cl: