### PR TITLE
Fixes sabre alt-click

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -823,6 +823,7 @@
 	atom_storage.rustle_sound = FALSE
 	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
 	atom_storage.set_holdable(/obj/item/melee/sabre)
+	atom_storage.click_alt_open = FALSE
 
 /obj/item/storage/belt/sabre/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Alt click wouldnt draw the sabre bc of dual click actions
## Why It's Good For The Game
Fixes #83159
## Changelog
:cl:
fix: Alt click will draw the captain's sabre again
/:cl:
