### PR TITLE
Coroner, Chief Engineer, Bitrunner are no longer exempt from certain Traitor objectives

### DIFF
--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -76,6 +76,7 @@
 	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		// Cargo
+		/datum/job/bitrunner,
 		/datum/job/shaft_miner,
 		// Service
 		/datum/job/chaplain,

--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -44,6 +44,7 @@
 		/datum/job/paramedic,
 		/datum/job/psychologist,
 		/datum/job/chemist,
+		/datum/job/coroner,
 		// Service
 		/datum/job/clown,
 		/datum/job/botanist,
@@ -99,6 +100,7 @@
 		/datum/job/chief_medical_officer,
 		/datum/job/research_director,
 		/datum/job/quartermaster,
+		/datum/job/chief_engineer,
 	)
 
 /datum/traitor_objective/destroy_heirloom/captain

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -80,6 +80,7 @@
 
 	target_jobs = list(
 		// Cargo
+		/datum/job/bitrunner,
 		/datum/job/shaft_miner,
 		// Medical
 		/datum/job/paramedic,

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -48,6 +48,7 @@
 		/datum/job/chemist,
 		/datum/job/doctor,
 		/datum/job/psychologist,
+		/datum/job/coroner,
 		// Science
 		/datum/job/geneticist,
 		/datum/job/roboticist,


### PR DESCRIPTION
## About The Pull Request
While reading traitor objective code for a project, I noticed that both the Coroner and CE are not listed as potential targets for the 'Destroy Heirloom' objectives. Looking into it, I noticed that the Coroner was also not listed for the kidnapping objective. This fixes that.
## Why It's Good For The Game
Coroner should not be immune to traitory
And the CE should not be exempt from having their heirloom potentially destroyed
## Changelog
:cl:
fix: The Coroner and Bitrunner can now be selected as a target for kidnapping and heirloom destruction objectives.
fix: The Chief Engineer is now a valid target for heirloom destruction objectives.
/:cl:
