### PR TITLE
The armoury contraband locker guns have a chance to be rigged.

### DIFF
--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -43,14 +43,14 @@
 	name = "armory loot spawner"
 	icon_state = "pistol"
 	loot = list(
-		/obj/item/gun/ballistic/automatic/pistol/contraband = 8,
-		/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
-		/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
-		/obj/item/grenade/clusterbuster/teargas = 2,
-		/obj/item/grenade/clusterbuster = 2,
+		/obj/item/gun/ballistic/automatic/pistol/contraband = 80,
+		/obj/item/gun/ballistic/shotgun/automatic/combat = 50,
+		/obj/item/storage/box/syndie_kit/throwing_weapons = 30,
+		/obj/item/grenade/clusterbuster/teargas = 20,
+		/obj/item/grenade/clusterbuster = 20,
 		/obj/item/gun/ballistic/automatic/pistol/deagle/contraband,
-		/obj/item/gun/ballistic/revolver/mateba = 0.9,
-		/obj/item/gun/ballistic/revolver/reverse/mateba = 0.1,
+		/obj/item/gun/ballistic/revolver/mateba = 9,
+		/obj/item/gun/ballistic/revolver/reverse/mateba = 1,
 	)
 
 /obj/effect/spawner/random/contraband/narcotics

--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -43,13 +43,14 @@
 	name = "armory loot spawner"
 	icon_state = "pistol"
 	loot = list(
-		/obj/item/gun/ballistic/automatic/pistol = 8,
+		/obj/item/gun/ballistic/automatic/pistol/contraband = 8,
 		/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 		/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
 		/obj/item/grenade/clusterbuster/teargas = 2,
 		/obj/item/grenade/clusterbuster = 2,
-		/obj/item/gun/ballistic/automatic/pistol/deagle,
-		/obj/item/gun/ballistic/revolver/mateba,
+		/obj/item/gun/ballistic/automatic/pistol/deagle/contraband,
+		/obj/item/gun/ballistic/revolver/mateba = 0.9,
+		/obj/item/gun/ballistic/revolver/reverse/mateba = 0.1,
 	)
 
 /obj/effect/spawner/random/contraband/narcotics

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -30,6 +30,19 @@
 /obj/item/gun/ballistic/automatic/pistol/fire_mag
 	spawn_magazine_type = /obj/item/ammo_box/magazine/m9mm/fire
 
+/obj/item/gun/ballistic/automatic/pistol/contraband
+
+/obj/item/gun/ballistic/automatic/pistol/contraband/Initialize(mapload)
+	if(prob(10))
+		pin = pick(
+		list(
+			/obj/item/firing_pin/clown,
+			/obj/item/firing_pin/clown/ultra,
+			/obj/item/firing_pin/clown/ultra/selfdestruct,
+		))
+	. = ..()
+
+
 /obj/item/gun/ballistic/automatic/pistol/suppressed/Initialize(mapload)
 	. = ..()
 	var/obj/item/suppressor/S = new(src)
@@ -82,6 +95,18 @@
 	rack_sound = 'sound/weapons/gun/pistol/rack.ogg'
 	lock_back_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
+
+/obj/item/gun/ballistic/automatic/pistol/deagle/contraband
+
+/obj/item/gun/ballistic/automatic/pistol/deagle/contraband/Initialize(mapload)
+	if(prob(10))
+		pin = pick(
+		list(
+			/obj/item/firing_pin/clown,
+			/obj/item/firing_pin/clown/ultra,
+			/obj/item/firing_pin/clown/ultra/selfdestruct,
+		))
+	. = ..()
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold
 	desc = "A gold plated Desert Eagle folded over a million times by superior martian gunsmiths. Uses .50 AE ammo."

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -41,6 +41,7 @@
 			/obj/item/firing_pin/clown/ultra/selfdestruct,
 		))
 	. = ..()
+	pin.pin_removable = FALSE
 
 
 /obj/item/gun/ballistic/automatic/pistol/suppressed/Initialize(mapload)
@@ -107,6 +108,7 @@
 			/obj/item/firing_pin/clown/ultra/selfdestruct,
 		))
 	. = ..()
+	pin.pin_removable = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold
 	desc = "A gold plated Desert Eagle folded over a million times by superior martian gunsmiths. Uses .50 AE ammo."

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -311,3 +311,10 @@
 		user.emote("scream")
 		user.drop_all_held_items()
 		user.Paralyze(80)
+
+/obj/item/gun/ballistic/revolver/reverse/mateba
+	name = /obj/item/gun/ballistic/revolver/syndicate::name
+	desc = /obj/item/gun/ballistic/revolver/syndicate::desc
+	clumsy_check = FALSE
+	icon_state = "mateba"
+

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -313,8 +313,8 @@
 		user.Paralyze(80)
 
 /obj/item/gun/ballistic/revolver/reverse/mateba
-	name = /obj/item/gun/ballistic/revolver/syndicate::name
-	desc = /obj/item/gun/ballistic/revolver/syndicate::desc
+	name = /obj/item/gun/ballistic/revolver/mateba::name
+	desc = /obj/item/gun/ballistic/revolver/mateba::desc
 	clumsy_check = FALSE
 	icon_state = "mateba"
 


### PR DESCRIPTION
## About The Pull Request
Gives a 10% chance for the handguns in the armoury to be rigged. The makarov and desert eagle will have a clown pin, ultra clown pin or the explosive ultra clown pin when rigged, randomly and uniformly weighted. The pins can not be removed, even the normal ones, so there is only one way to find out. The Unica 6 will be reversed, shooting you instead when rigged.
## Why It's Good For The Game
People are too trustworthy of the gear they use in the contraband locker. By giving them a chance to be rigged and backfire on them, people will treat these guns like contraband and not toys. If someone was treating them like a toy, they could receive a nice introduction of the syndicate.
## Changelog
:cl:
balance: There are reports of malfunctioning guns being confiscated.
/:cl:
