### PR TITLE
Replace potassium + water poison purging with zanier explosion purging

### DIFF
--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -281,7 +281,7 @@
  * * modifier - a flat additive numeric to the size of the explosion - set this if you want a minimum range
  * * strengthdiv - the divisional factor of the explosion, a larger number means a smaller range - This is the part that modifies an explosion's range with volume (i.e. it divides it by this number)
  */
-/datum/chemical_reaction/proc/default_explode(datum/reagents/holder, created_volume, modifier = 0, strengthdiv = 10)
+/datum/chemical_reaction/proc/default_explode(datum/reagents/holder, created_volume, modifier = 0, strengthdiv = 10, clear_mob_reagents)
 	var/power = modifier + round(created_volume/strengthdiv, 1)
 	if(power > 0)
 		var/turf/T = get_turf(holder.my_atom)
@@ -300,8 +300,13 @@
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(power , T, 0, 0)
 		e.start(holder.my_atom)
-	holder.clear_reagents()
-
+	if (ismob(holder.my_atom))
+		if (clear_mob_reagents)
+		/// Only clear reagents if they use a special explosive reaction to do it; it shouldn't apply
+		/// to any explosion inside a person
+			holder.clear_reagents()
+	else
+		holder.clear_reagents()
 /*
  *Creates a flash effect only - less expensive than explode()
  *

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -113,15 +113,11 @@
 		/// But medics who work hard enough can make this
 		/// to clear reagents instantly (for a price...)
 		clear_mob_reagents = TRUE
-	if(ismob(holder.my_atom))
-		/// Minimum explosion range of 1 if inside a mob
+		if(ismob(holder.my_atom))
+		/// Minimum explosion mod of 1.5 if inside a mob
 		/// to make this a trade-off for medics who want
 		/// a quick instant purge of all chems for someone
-		/// We check to see if the volume is over five so we
-		/// don't default to +1 explosion for miners who fucked up and
-		/// penstacked because the volume means they'll get
-		/// donked by it regardless
-		modifier = (created_volume > 5 ? 0 : 1)
+			modifier = (created_volume > 5 ? 0 : 1.5)
 	..()
 
 


### PR DESCRIPTION
## About The Pull Request

Right now doctors who don't want to use the blood filter surgery (or the purging chems) can simply filter someone's blood by exploiting reagent explosions clearing their containers via an explosion so small that it does no damage (<20 unit each of potassium and ice 1 K away from the melting point of water). I'm making this pull request to replace it with something similar in spirit, but it's the logical conclusion of using an explosion inside someone's body to cure them of poison.

Instead, either penthrite and epinephrine (with omnizine as a catalyst) will clear their blood of reagents, or penthrite and atropine (though this one will typically gib people who don't have explosive resistance). I think it keeps in line with the spirit of the malpractice masquerading as medicine that SS13 doctors are known for, while offering people an instant chem purge option for the possible situations of a patient who just has a ludicrous amount of whatever inside of them. If they don't want to have to blow a few of their patients limbs off (or dress them up in bomb resistant gear), they can go the slow and careful route of using the blood filter.

Specifically:
A patient without explosive resistance will take 123 brute damage from the epi+pen+omni purging minimum. Explosive armor will mitigate this damage, of course. They'll typically lose limbs unless they have high wounding resistance or resistance to delimbing.
This won't vent the room if you do the minimum reaction amount.

The penthrite + atropine explosion has been untouched by me besides being made to specifically purge chems. It'll blow a hole in the station and probably gib your patient (and critically wound you) unless you're both decked out in bomb resistant gear. I added chem purging to this one because blowing a hole in the station to purge chems is a hilarious concept.

**This will have no additional effect on miners who penstack. You'll get blown up either way, and the explosion will not be more powerful, and you'll still lose all your chems.**
## Why It's Good For The Game

Potassium water purging renders poisons completely moot. If you get filled full of 500 units of whatever deadly concoction, you should be an extenuating circumstance that calls for extreme measures, which is either an extended blood filter surgery, a body swap, or a sick-ass explosion.
## Changelog

Chemistry explosions no longer unilaterally purge all reagents in mobs; this has been relegated to penthrite + epinephrine + omnizine, or penthrite + atropine (extremely dangerous)
:cl: Bisar
balance: Explosive chem purging now only applies to penthrite + epinephrine + omnizine, or the extremely dangerous penthrite + atropine.
fix: Chem explosions no longer purge mob reagents across the board; unless they gib you, but then you have another problem.
/:cl:
