### PR TITLE
fix glass style /hooch being duped

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/glass_styles/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/glass_styles/alcohol.dm
@@ -107,8 +107,8 @@
 	desc = "It's as strong as it smells."
 	icon_state = "absinthe"
 
-/datum/glass_style/drinking_glass/hooch
-	required_drink_type = /datum/reagent/consumable/ethanol/hooch
+/datum/glass_style/drinking_glass/ale
+	required_drink_type = /datum/reagent/consumable/ethanol/ale
 	name = "glass of ale"
 	desc = "A freezing pint of delicious Ale."
 	icon_state = "aleglass"


### PR DESCRIPTION

## About The Pull Request
/datum/glass_style/drinking_glass/hooch was being added 2 times, so I just replaced the one with "aleglass" sprite to be /ale
## Why It's Good For The Game
fix dupe
## Changelog
:cl:
fix: Ale now has a drinking_glass style
/:cl:
