### PR TITLE
Fix the RMB action on the cigarettes pack and add a new QoL

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -236,11 +236,11 @@
 	atom_storage.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
 	register_context()
 
-/obj/item/storage/fancy/cigarettes/attack(mob/living/M, mob/living/user, params)
+/obj/item/storage/fancy/cigarettes/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	. = ..()
-	if(M != user) // you can quickly put a cigarette in your mouth only
+	if(interacting_with != user) // you can quickly put a cigarette in your mouth only
 		return ..()
-	quick_remove_item(/obj/item/clothing/mask/cigarette, user, equip = 1)
+	quick_remove_item(/obj/item/clothing/mask/cigarette, user, equip_to_mouth = TRUE)
 
 /obj/item/storage/fancy/cigarettes/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
@@ -256,14 +256,14 @@
 	return CLICK_ACTION_SUCCESS
 
 /// Removes an item or puts it in mouth from the packet, if any
-/obj/item/storage/fancy/cigarettes/proc/quick_remove_item(obj/item/grabbies, mob/user, equip = 0)
+/obj/item/storage/fancy/cigarettes/proc/quick_remove_item(obj/item/grabbies, mob/user, equip_to_mouth =  FALSE)
 	var/obj/item/finger = locate(grabbies) in contents
 	if(finger)
-		if(!equip)
+		if(!equip_to_mouth)
 			atom_storage.remove_single(user, finger, drop_location())
 			user.put_in_hands(finger)
 			return
-		if(user.equip_to_slot_if_possible(finger, ITEM_SLOT_MASK, 0, 1, 1))
+		if(user.equip_to_slot_if_possible(finger, ITEM_SLOT_MASK, qdel_on_fail = FALSE, disable_warning = TRUE))
 			finger.forceMove(user)
 			return
 		balloon_alert(user, "mouth is covered!")

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -236,9 +236,16 @@
 	atom_storage.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
 	register_context()
 
+/obj/item/storage/fancy/cigarettes/attack(mob/living/M, mob/living/user, params)
+	. = ..()
+	if(M != user) // you can quickly put a cigarette in your mouth only
+		return ..()
+	quick_remove_item(/obj/item/clothing/mask/cigarette, user, equip = 1)
+
 /obj/item/storage/fancy/cigarettes/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
 	quick_remove_item(/obj/item/clothing/mask/cigarette, user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/storage/fancy/cigarettes/click_alt(mob/user)
 	var/obj/item/lighter = locate(/obj/item/lighter) in contents
@@ -248,12 +255,18 @@
 		quick_remove_item(/obj/item/clothing/mask/cigarette, user)
 	return CLICK_ACTION_SUCCESS
 
-/// Removes an item from the packet if there is one
-/obj/item/storage/fancy/cigarettes/proc/quick_remove_item(obj/item/grabbies, mob/user)
+/// Removes an item or puts it in mouth from the packet, if any
+/obj/item/storage/fancy/cigarettes/proc/quick_remove_item(obj/item/grabbies, mob/user, equip = 0)
 	var/obj/item/finger = locate(grabbies) in contents
 	if(finger)
-		atom_storage.remove_single(user, finger, drop_location())
-		user.put_in_hands(finger)
+		if(!equip)
+			atom_storage.remove_single(user, finger, drop_location())
+			user.put_in_hands(finger)
+			return
+		if(user.equip_to_slot_if_possible(finger, ITEM_SLOT_MASK, 0, 1, 1))
+			finger.forceMove(user)
+			return
+		balloon_alert(user, "mouth is covered!")
 
 /obj/item/storage/fancy/cigarettes/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fix the movement of a pack of cigarettes under an spaceman when they interacts with it with the right mouse button. 
Also adds a new way to quickly insert cigarettes in the mouth, just hitting a pack of cigarettes on yourself. Here how it works:

https://github.com/tgstation/tgstation/assets/126676387/9f1442b0-173b-4f2e-a95e-e42fd9269642
## Why It's Good For The Game
It fixes the bug and adds a new quick and convenient way to put a cigarette in your mouth. That's good, isn't it?
## Changelog
:cl:
qol: Now you can put a cigarette in your mouth just by hitting the pack of cigarettes on yourself.
fix: The cigarette pack no longer moves under the spaceman when they interacts with it with the RMB
/:cl:
