### PR TITLE
Fixes arcade spawners in Interdyne Spinward Research Base

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -852,7 +852,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "JM" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/random/entertainment/arcade{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,


### PR DESCRIPTION

## About The Pull Request
Replaces the two 'arcade cabinet which shouldn't exist' with arcade machine spawners.
## Why It's Good For The Game
The arcade cabinet which shouldn't exist shouldn't exist, hence the name. It's the base type for the real arcade machines. The spawner should be used instead.
## Changelog
:cl:
fix: The random arcade machines in the 'Interdyne Spinward Research Base's now function.
/:cl:
