### PR TITLE
Rat Kings can no longer create grime and miasma while ventcrawling

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -15,10 +15,16 @@
 	button_icon_state = "coffer"
 	shared_cooldown = NONE
 
-/datum/action/cooldown/mob_cooldown/domain/proc/domain()
-	if(owner.movement_type & VENTCRAWLING)
-		owner.balloon_alert(owner, "can't use while ventcrawling!")
+/datum/action/cooldown/mob_cooldown/domain/IsAvailable(feedback = FALSE)
+	. = ..()
+	if (!.)
 		return FALSE
+	if (owner.movement_type & VENTCRAWLING)
+		if (feedback)
+			owner.balloon_alert(owner, "can't use while ventcrawling!")
+		return FALSE
+
+/datum/action/cooldown/mob_cooldown/domain/proc/domain()
 	var/turf/location = get_turf(owner)
 	location.atmos_spawn_air("[GAS_MIASMA]=4;[TURF_TEMPERATURE(T20C)]")
 	switch (rand(1,10))
@@ -72,6 +78,15 @@
 		/datum/pet_command/point_targeting/attack/glockroach
 	)
 
+/datum/action/cooldown/mob_cooldown/riot/IsAvailable(feedback = FALSE)
+	. = ..()
+	if (!.)
+		return FALSE
+	if (owner.movement_type & VENTCRAWLING)
+		if (feedback)
+			owner.balloon_alert(owner, "can't use while ventcrawling!")
+		return FALSE
+
 /datum/action/cooldown/mob_cooldown/riot/Activate(atom/target)
 	StartCooldown(10 SECONDS)
 	riot()
@@ -85,9 +100,6 @@
  * * Spawn a single mouse if below the mouse cap.
  */
 /datum/action/cooldown/mob_cooldown/riot/proc/riot()
-	if(owner.movement_type & VENTCRAWLING)
-		owner.balloon_alert(owner, "can't use while ventcrawling!")
-		return FALSE
 	var/uplifted_mice = FALSE
 	for (var/mob/living/basic/mouse/nearby_mouse in oview(owner, range))
 		uplifted_mice = convert_mouse(nearby_mouse) || uplifted_mice

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -85,6 +85,9 @@
  * * Spawn a single mouse if below the mouse cap.
  */
 /datum/action/cooldown/mob_cooldown/riot/proc/riot()
+	if(owner.movement_type & VENTCRAWLING)
+		owner.balloon_alert(owner, "can't use while ventcrawling!")
+		return FALSE
 	var/uplifted_mice = FALSE
 	for (var/mob/living/basic/mouse/nearby_mouse in oview(owner, range))
 		uplifted_mice = convert_mouse(nearby_mouse) || uplifted_mice

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -16,6 +16,9 @@
 	shared_cooldown = NONE
 
 /datum/action/cooldown/mob_cooldown/domain/proc/domain()
+	if(owner.movement_type & VENTCRAWLING)
+		owner.balloon_alert(owner, "can't use while ventcrawling!")
+		return FALSE
 	var/turf/location = get_turf(owner)
 	location.atmos_spawn_air("[GAS_MIASMA]=4;[TURF_TEMPERATURE(T20C)]")
 	switch (rand(1,10))


### PR DESCRIPTION

## About The Pull Request
Blocks Rat Kings from using "Rat King's Domain" (the spell that spawns dirt/vomit/oil and creates miasma) while ventcrawling.

Also blocks Rat Kings from summoning mice while in pipes; as far as I can tell, this is just an oversight, as it previously created a mouse stuck inside of the pipe without the normal chat message.
## Why It's Good For The Game
Rat Kings are supposed to build a lair of filth, a rat king visiting every department in the distro pipes while spamming motor oil is boring, lame, lacks any contextual sense that a rat inside a pipe could dirty the floor above it, and doesn't really have any counterplay besides begging atmos to up the temperature (which they realistically probably will never do because it's a rat king not a xeno or a ling).

Ling spells are blocked while crawling so there's precedent for it.
## Changelog
:cl: PapaMichael
fix: Rat Kings can no longer trap mice inside of pipes by creating them while ventcrawling.
balance: Rat Kings can no longer create grime and miasma while ventcrawling.
/:cl:
