### PR TITLE
Fixes kinetic accelerator fire sound div 0 runtime

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -42,7 +42,7 @@
 	// What percentage of the full battery a shot will expend
 	var/shot_cost_percent = round(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100)
 	// Ignore this on oversized/infinite cells or ammo without cost
-	if(shot_cost_percent > 0)
+	if(shot_cost_percent >= 0)
 		// The total amount of shots the fully charged energy gun can fire before running out
 		var/max_shots = round(100/shot_cost_percent) - 1
 		// How many shots left before the energy gun's current battery runs out of energy

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -36,13 +36,13 @@
 
 /obj/item/gun/energy/fire_sounds()
 	// What frequency the energy gun's sound will make
-	var/pitch_to_use
+	var/pitch_to_use = 1
 
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	// What percentage of the full battery a shot will expend
 	var/shot_cost_percent = round(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100)
 	// Ignore this on oversized/infinite cells or ammo without cost
-	if(shot_cost_percent >= 0)
+	if(shot_cost_percent > 0 && shot_cost_percent < 100)
 		// The total amount of shots the fully charged energy gun can fire before running out
 		var/max_shots = round(100/shot_cost_percent) - 1
 		// How many shots left before the energy gun's current battery runs out of energy


### PR DESCRIPTION
```
 [17:34:10] Division by zero
Thrown by fire_sounds (/obj/item/gun/energy/fire_sounds) at code/modules/projectiles/guns/energy.dm, line 50

User: Xiryang Zhol (/mob/living/carbon/human)
User Location: the volcanic floor (/turf/open/misc/asteroid/basalt/lava_land_surface) (78, 184, 3)
Source: the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator)
Source Location: Xiryang Zhol (/mob/living/carbon/human)
Stacktrace:
1	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): fire sounds()
2	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): shoot live shot(Xiryang Zhol (/mob/living/carbon/human), 0, the legion (/mob/living/basic/legion_brood), 1)
3	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): shoot live shot(Xiryang Zhol (/mob/living/carbon/human), 0, the legion (/mob/living/basic/legion_brood), 1)
4	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): process fire(the legion (/mob/living/basic/legion_brood), Xiryang Zhol (/mob/living/carbon/human), 1, "icon-x=18;icon-y=17;left=1;but...", "", 0)
5	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): process fire(the legion (/mob/living/basic/legion_brood), Xiryang Zhol (/mob/living/carbon/human), 1, "icon-x=18;icon-y=17;left=1;but...", "", 0)
6	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): fire gun(the legion (/mob/living/basic/legion_brood), Xiryang Zhol (/mob/living/carbon/human), 1, "icon-x=18;icon-y=17;left=1;but...")
7	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): afterattack(the legion (/mob/living/basic/legion_brood), Xiryang Zhol (/mob/living/carbon/human), 1, "icon-x=18;icon-y=17;left=1;but...")
8	the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): melee attack chain(Xiryang Zhol (/mob/living/carbon/human), the legion (/mob/living/basic/legion_brood), "icon-x=18;icon-y=17;left=1;but...")
9	Xiryang Zhol (/mob/living/carbon/human): ClickOn(the legion (/mob/living/basic/legion_brood), "icon-x=18;icon-y=17;left=1;but...")
10	the legion (/mob/living/basic/legion_brood): Click(the volcanic floor (78,183,3) (/turf/open/misc/asteroid/basalt/lava_land_surface), "mapwindow.map", "icon-x=18;icon-y=17;left=1;but...")
```