### PR TITLE
Fixes random decal in space on Tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -53702,6 +53702,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"rYE" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "rYL" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -54233,7 +54236,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron/airless,
 /area/space)
 "siZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70366,6 +70369,10 @@
 /obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/left)
+"xRm" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "xRn" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
@@ -130810,8 +130817,8 @@ vXM
 vXM
 vXM
 vXM
-vXM
-vXM
+xRm
+rYE
 vXM
 vXM
 vXM
@@ -131066,9 +131073,9 @@ vXM
 vXM
 vXM
 vXM
-vXM
-vXM
-vXM
+xRm
+rYE
+rYE
 vXM
 vXM
 vXM
@@ -131323,9 +131330,9 @@ vXM
 vXM
 vXM
 vXM
-vXM
+xRm
 siX
-vXM
+xRm
 vXM
 vXM
 vXM
@@ -131581,7 +131588,7 @@ vXM
 vXM
 vXM
 vXM
-vXM
+xRm
 vXM
 vXM
 vXM


### PR DESCRIPTION
By adding random tiles in space around it. It's funny.
## About The Pull Request

There was a random tile decal in space that I fixed by adding random tiles and lattices around it so that the decal makes sense. I thought it'd be a funnier way than just simply removing the errant decal.

![StrongDMM_D0y2Sy3U2w](https://github.com/tgstation/tgstation/assets/65363339/716165e3-5ff0-4b30-90ab-1fd8f05ca41b)
![StrongDMM_YOcoE66JUa](https://github.com/tgstation/tgstation/assets/65363339/2f99ece0-2603-4eef-896a-959b00c0912e)


## Why It's Good For The Game

:) fun little thing in space.

## Changelog

:cl:
fix: Fixes random decal in space on Tramstation
/:cl:

Maintainers can request that I just remove the decal instead, I guess. I don't care all that much at the end of the day.
