### PR TITLE
Enables right click, alt click, ctrl click for alt-click item window

### DIFF
--- a/code/modules/lootpanel/ui.dm
+++ b/code/modules/lootpanel/ui.dm
@@ -36,6 +36,11 @@
 		modifiers += "middle=1;"
 	if(params["shift"])
 		modifiers += "shift=1;"
+	if(params["alt"])
+		modifiers += "alt=1;"
+	if(params["right"])
+		modifiers += "right=1;"
+
 
 	user.ClickOn(thing, modifiers)
 

--- a/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
@@ -36,6 +36,7 @@ export function LootBox(props: Props) {
           className="SearchItem--box"
           onClick={(event) =>
             act('grab', {
+              alt: event.altKey,
               ctrl: event.ctrlKey,
               ref: item.ref,
               shift: event.shiftKey,
@@ -44,9 +45,8 @@ export function LootBox(props: Props) {
           onContextMenu={(event) => {
             event.preventDefault();
             act('grab', {
-              middle: true,
+              right: true,
               ref: item.ref,
-              shift: true,
             });
           }}
         >


### PR DESCRIPTION

## About The Pull Request

This fix enables most of the clicks that have been disabled in the alt click menu up to this point. However, I did have to cut out the pointing thing it would do for right clicking. The only thing you aren't able to do with the new alt-click menu at this point is dragging items onto each other, pointing, and the shift-click context menu. Maybe we'll leave that for another PR, because I think I'd have to rewrite core components of TGUI for that?
## Why It's Good For The Game

Lets you perform almost all of the alternative and right click functions on things you have alt-clicked the tiles for. I believe this outweighs the benefits of pointing at stuff on a tile instead.
## Changelog

The alt-click item panel now lets you perform most of the alternative click options.
:cl: Bisar
qol: Most of the alternate click modes (right click, control clicking, shift clicking, etc) have been enabled in the alt-click item menu.
fix: You will no longer point at things you right-click in the alt-click item menu.
/:cl:
