### PR TITLE
Shift-clicking an offer for an item will examine the item

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -391,6 +391,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/give/highfive
 	additional_desc_text = "Click this alert to slap it."
 	screentip_override_text = "High Five"
+	examinable = FALSE
 	/// Tracks active "to slow"ing so we can't spam click
 	var/too_slowing_this_guy = FALSE
 
@@ -451,6 +452,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give/hand
 	screentip_override_text = "Take Hand"
+	examinable = FALSE
 
 /atom/movable/screen/alert/give/hand/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	additional_desc_text = "Click this alert to take it and let [offerer.p_them()] pull you around!"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -301,11 +301,24 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	/// The offer we're linked to, yes this is suspiciously like a status effect alert
 	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
-	var/additional_desc_text = "Click this alert to take it."
+	var/additional_desc_text = "Click this alert to take it, or shift click it to examiante it."
+	/// Text to override what appears in screentips for the alert
+	var/screentip_override_text
+	/// Whether the offered item can be examined by shift-clicking the alert
+	var/examinable = TRUE
+
+/atom/movable/screen/alert/give/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	register_context()
 
 /atom/movable/screen/alert/give/Destroy()
 	offer = null
 	return ..()
+
+/atom/movable/screen/alert/give/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_LMB] = screentip_override_text || "Take [offer.offered_item.name]"
+	context[SCREENTIP_CONTEXT_SHIFT_LMB] = "Examine"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /**
  * Handles assigning most of the variables for the alert that pops up when an item is offered
@@ -357,6 +370,15 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	handle_transfer()
 
+/atom/movable/screen/alert/give/alert_examine(mob/clicker)
+	if(!examinable)
+		return ..()
+
+	var/name_bold = span_boldnotice(name)
+	var/desc_info = span_info("[offer.owner] is offering you the following item (click the alert to take it!):")
+	var/examine_info = jointext(offer.offered_item.examine(clicker), "\n")
+	to_chat(clicker, examine_block("[name_bold]\n[desc_info]\n<hr>[examine_info]"))
+
 /// An overrideable proc used simply to hand over the item when claimed, this is a proc so that high-fives can override them since nothing is actually transferred
 /atom/movable/screen/alert/give/proc/handle_transfer()
 	var/mob/living/carbon/taker = owner
@@ -367,6 +389,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give/highfive
 	additional_desc_text = "Click this alert to slap it."
+	screentip_override_text = "High Five"
 	/// Tracks active "to slow"ing so we can't spam click
 	var/too_slowing_this_guy = FALSE
 
@@ -424,6 +447,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	if(QDELETED(offer.offered_item))
 		examine_list += span_warning("[source]'s arm appears tensed up, as if [source.p_they()] plan on pulling it back suddenly...")
+
+/atom/movable/screen/alert/give/hand
+	screentip_override_text = "Take Hand"
 
 /atom/movable/screen/alert/give/hand/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	additional_desc_text = "Click this alert to take it and let [offerer.p_them()] pull you around!"
@@ -1057,7 +1083,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
-		to_chat(usr, span_boldnotice("[name]</span> - <span class='info'>[desc]"))
+		alert_examine(usr)
 		return FALSE
 	var/datum/our_master = master_ref?.resolve()
 	if(our_master && click_master)
@@ -1071,3 +1097,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	master_ref = null
 	owner = null
 	screen_loc = ""
+
+/// Called when someone tries to examine the alert.
+/atom/movable/screen/alert/proc/alert_examine(mob/clicker)
+	var/name_bold = span_boldnotice(name)
+	var/desc_info = span_info(desc)
+	to_chat(clicker, examine_block("[name_bold]\n[desc_info]"))

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -370,14 +370,15 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	handle_transfer()
 
-/atom/movable/screen/alert/give/alert_examine(mob/clicker)
+/atom/movable/screen/alert/give/examine(mob/user)
 	if(!examinable)
 		return ..()
 
-	var/name_bold = span_boldnotice(name)
-	var/desc_info = span_info("[offer.owner] is offering you the following item (click the alert to take it!):")
-	var/examine_info = jointext(offer.offered_item.examine(clicker), "\n")
-	to_chat(clicker, examine_block("[name_bold]\n[desc_info]\n<hr>[examine_info]"))
+	return list(
+		span_boldnotice(name),
+		span_info("[offer.owner] is offering you the following item (click the alert to take it!):"),
+		"<hr>[jointext(offer.offered_item.examine(user), "\n")]",
+	)
 
 /// An overrideable proc used simply to hand over the item when claimed, this is a proc so that high-fives can override them since nothing is actually transferred
 /atom/movable/screen/alert/give/proc/handle_transfer()
@@ -1083,7 +1084,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
-		alert_examine(usr)
+		to_chat(usr, examine_block(jointext(examine(usr), "\n")))
 		return FALSE
 	var/datum/our_master = master_ref?.resolve()
 	if(our_master && click_master)
@@ -1098,8 +1099,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	owner = null
 	screen_loc = ""
 
-/// Called when someone tries to examine the alert.
-/atom/movable/screen/alert/proc/alert_examine(mob/clicker)
-	var/name_bold = span_boldnotice(name)
-	var/desc_info = span_info(desc)
-	to_chat(clicker, examine_block("[name_bold]\n[desc_info]"))
+/atom/movable/screen/alert/examine(mob/user)
+	return list(
+		span_boldnotice(name),
+		span_info(desc),
+	)


### PR DESCRIPTION
## About The Pull Request

- When you are offered an item, you can shift-click the alert to examine the item in the person's hands. 
- Plus screen tips for offers. 
- Plus examine boxing alert examine text.

![image](https://github.com/tgstation/tgstation/assets/51863163/1b67b13e-46c2-44d0-a11d-427b1fc67bfb)

## Why It's Good For The Game

Simple thing. I figure people can get use out of it by, say, presenting their ID for inspection, holding a paper out for someone to read, checking how much ammo is in a gun someone hands you, etc etc. 

## Changelog

:cl: Melbert
qol: When you are offered something, you can shift-click the alert to examine the item rather than take it.
qol: Examine blocks for screen alert examining. 
qol: Screentips for offer alerts.  
/:cl:

