### PR TITLE
allows the SC/FISHER to shoot floor lights

### DIFF
--- a/code/modules/projectiles/projectile/special/saboteur.dm
+++ b/code/modules/projectiles/projectile/special/saboteur.dm
@@ -7,6 +7,7 @@
 	range = 21
 	projectile_phasing = PASSTABLE | PASSMOB | PASSMACHINE | PASSSTRUCTURE
 	hitscan = TRUE
+	hit_threshhold = LOW_OBJ_LAYER // required to be able to hit floor lights
 	var/disrupt_duration = 15 SECONDS
 
 /obj/projectile/energy/fisher/on_hit(atom/target, blocked, pierce_hit)


### PR DESCRIPTION
## About The Pull Request
Lowers the hit threshold layer of SC/FISHER bolts from `PROJECTILE_HIT_THRESHHOLD_LAYER` (2.75) to `LOW_OBJ_LAYER` (2.5), allowing you to shoot floor lights with it.

## Why It's Good For The Game
floor lights count as lightbulbs and therefore you should be able to explode them with the gun that explodes lightbulbs

## Changelog

:cl:
fix: The SC/FISHER can now shoot floor lights.
/:cl:
