### PR TITLE
Fixes some bitrunning related issues [no gbp]

### DIFF
--- a/code/modules/bitrunning/antagonists/_parent.dm
+++ b/code/modules/bitrunning/antagonists/_parent.dm
@@ -60,13 +60,36 @@
 
 	return TRUE
 
+
 /// Sets up the agent so that they look like cyber police && don't have an account ID
-/datum/antagonist/bitrunning_glitch/proc/convert_agent(mob/living/carbon/human/player, datum/outfit/agent_outfit)
+/datum/antagonist/bitrunning_glitch/proc/convert_agent()
+	if(!ishuman(owner.current))
+		return
+
+	var/mob/living/carbon/human/player = owner.current
+
 	player.set_service_style()
-	player.equipOutfit(agent_outfit)
-	player.fully_replace_character_name(player.name, pick(GLOB.cyberauth_names))
+	player.equipOutfit(preview_outfit)
+
+	var/chosen_name = pick(GLOB.cyberauth_names)
+
+	player.fully_replace_character_name(player.name, chosen_name)
+	fix_agent_id()
+
+
+/// Resets the agent's ID and name. Needed so this doesn't show as "unknown"
+/datum/antagonist/bitrunning_glitch/proc/fix_agent_id()
+	if(!ishuman(owner.current))
+		return
+
+	var/mob/living/carbon/human/player = owner.current
 
 	var/obj/item/card/id/outfit_id = player.wear_id
-	if(outfit_id)
-		outfit_id.registered_account = new()
-		outfit_id.registered_account.replaceable = FALSE
+	if(isnull(outfit_id))
+		return
+
+	outfit_id.registered_account = new()
+	outfit_id.registered_account.replaceable = FALSE
+	outfit_id.registered_account.account_id = null
+	outfit_id.registered_name = player.name
+	outfit_id.update_label()

--- a/code/modules/bitrunning/antagonists/_parent.dm
+++ b/code/modules/bitrunning/antagonists/_parent.dm
@@ -70,10 +70,7 @@
 
 	player.set_service_style()
 	player.equipOutfit(preview_outfit)
-
-	var/chosen_name = pick(GLOB.cyberauth_names)
-
-	player.fully_replace_character_name(player.name, chosen_name)
+	player.fully_replace_character_name(player.name, pick(GLOB.cyberauth_names))
 	fix_agent_id()
 
 

--- a/code/modules/bitrunning/antagonists/cyber_police.dm
+++ b/code/modules/bitrunning/antagonists/cyber_police.dm
@@ -9,11 +9,10 @@
 		stack_trace("humans only for this position")
 		return
 
-	var/mob/living/player = owner.current
-	convert_agent(player, /datum/outfit/cyber_police)
+	convert_agent()
 
 	var/datum/martial_art/the_sleeping_carp/carp = new()
-	carp.teach(player)
+	carp.teach(owner.current)
 
 /datum/outfit/cyber_police
 	name = ROLE_CYBER_POLICE

--- a/code/modules/bitrunning/antagonists/cyber_tac.dm
+++ b/code/modules/bitrunning/antagonists/cyber_tac.dm
@@ -11,7 +11,7 @@
 		stack_trace("humans only for this position")
 		return
 
-	convert_agent(owner.current, /datum/outfit/cyber_police/tactical)
+	convert_agent()
 
 /datum/outfit/cyber_police/tactical
 	name = ROLE_CYBER_TAC

--- a/code/modules/bitrunning/server/threats.dm
+++ b/code/modules/bitrunning/server/threats.dm
@@ -76,7 +76,7 @@
 		checked_target = mutation_target,
 		ignore_category = POLL_IGNORE_GLITCH,
 		alert_pic = mutation_target,
-		role_name_text = "Bitrunning Malfunction: [role_name]",
+		role_name_text = "Malfunction: [role_name]",
 	)
 	spawn_glitch(chosen_role, mutation_target, chosen_one)
 	return mutation_target

--- a/code/modules/bitrunning/server/util.dm
+++ b/code/modules/bitrunning/server/util.dm
@@ -63,9 +63,10 @@
 
 	return initial(selected.key)
 
+
 /// Removes all blacklisted items from a mob and returns them to base state
 /obj/machinery/quantum_server/proc/reset_equipment(mob/living/carbon/human/person)
-	for(var/item in person.get_contents())
+	for(var/obj/item in person.get_equipped_items(include_pockets = TRUE, include_accessories = TRUE))
 		qdel(item)
 
 	var/datum/antagonist/bitrunning_glitch/antag_datum = locate() in person.mind?.antag_datums
@@ -73,6 +74,9 @@
 		return
 
 	person.equipOutfit(antag_datum.preview_outfit)
+
+	antag_datum.fix_agent_id()
+
 
 /// Severs any connected users
 /obj/machinery/quantum_server/proc/sever_connections()


### PR DESCRIPTION

## About The Pull Request
Properly allows bitrunning antagonists to come station side

A few issues were resolved:
- Event title was too lengthy, it's been renamed
- IDs were not being named properly for cyber police. Cybertac would appear as "unknown"
- Runtime at examining cyber police ID because it had an erroneous account
- Teleporting station side would delete your organs and leave you a broken husk of a mob
## Why It's Good For The Game
Fixes #83181
## Changelog
:cl:
fix: Bitrunning antagonists no longer gib on teleport
fix: Cyber tac now have a visible name / ID
fix: Renamed the bitrunning malfunction event to just "Malfunction: x"
/:cl:
