### PR TITLE
Node Bootstrap: Cast OS version to int so compat code works

### DIFF
--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -32,7 +32,7 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 }
 
 # Get OS version
-$OSMajor = (Get-WmiObject -Class Win32_OperatingSystem).Version.Split(".")[0]
+[int]$OSMajor = (Get-WmiObject -Class Win32_OperatingSystem).Version.Split(".")[0]
 
 # Set Node version based on OS version
 if ($OSMajor -lt 10) {


### PR DESCRIPTION
This wasn't working for me because `OSMajor` was set to a string, not a number, so it failed the if check. 

Making this change made it work