### PR TITLE
Update reactions.dm so that water isn't consumed needlessly

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -110,7 +110,7 @@
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
-			consumed = 0
+			. = REACTING
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
 			location.water_vapor_gas_act()
 			consumed = MOLES_GAS_VISIBLE

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -110,7 +110,6 @@
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
-				consumed = MOLES_GAS_VISIBLE
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
 			location.water_vapor_gas_act()
 			consumed = MOLES_GAS_VISIBLE

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -109,7 +109,7 @@
 	var/consumed = 0
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
-			if(location?.freeze_turf())
+			location?.freeze_turf()
 			return REACTING
 	
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -110,7 +110,8 @@
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
-			. = REACTING
+			return REACTING
+	
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
 			location.water_vapor_gas_act()
 			consumed = MOLES_GAS_VISIBLE

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -110,6 +110,7 @@
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
+			consumed = 0
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
 			location.water_vapor_gas_act()
 			consumed = MOLES_GAS_VISIBLE


### PR DESCRIPTION
## About The Pull Request
The reaction information regarding water vapor condensation was inaccurate due to what appears to be a bit of copypasted code when reactions were changed over a bit for excitability.  Water vapor was being consumed wrongly when below freezing temperature. This also indirectly influences electrolysis by making it more efficient (since there's no longer moles vanishing out of existence constantly at safe electrolyzing temperatures.)
## Why It's Good For The Game
Vanishing gases bad. Me want hydrogen.
## Changelog

:cl:

fix: Water vapor is no longer anomalously lost at below freezing temperatures due to condensation. 

:cl: