### PR TITLE
Fixes tram malfuction event not ending properly

### DIFF
--- a/code/modules/transport/_transport_machinery.dm
+++ b/code/modules/transport/_transport_machinery.dm
@@ -95,7 +95,7 @@
 
 /obj/machinery/transport/proc/clear_repair_signals()
 	UnregisterSignal(src, repair_signals)
-	QDEL_LAZYLIST(repair_signals)
+	LAZYNULL(repair_signals)
 
 /obj/machinery/transport/examine(mob/user)
 	. = ..()
@@ -128,8 +128,8 @@
 	playsound(src, 'sound/machines/synth_yes.ogg', 75, use_reverb = TRUE)
 	machine.balloon_alert(user, "success!")
 	UnregisterSignal(src, repair_signals)
-	QDEL_LAZYLIST(repair_signals)
-	QDEL_LAZYLIST(methods_to_fix)
+	LAZYNULL(repair_signals)
+	methods_to_fix = list()
 	malfunctioning = FALSE
 	set_machine_stat(machine_stat & ~EMAGGED)
 	set_is_operational(TRUE)


### PR DESCRIPTION
these lists only contains text, not anything qdeletable. 
```
[18:10:26] Runtime in code/controllers/subsystem/garbage.dm, line 349: bad del
proc name: qdel (/proc/qdel)
src: null
call stack:
qdel(null, 0)
the tram controller (/obj/machinery/transport/tram_controller): clear repair signals()
/datum/transport_controller/li... (/datum/transport_controller/linear/tram): end malf event()
/datum/round_event/tram_malfun... (/datum/round_event/tram_malfunction): end()
/datum/round_event/tram_malfun... (/datum/round_event/tram_malfunction): process(2)
Events (/datum/controller/subsystem/events): fire(0)
Events (/datum/controller/subsystem/events): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```