### PR TITLE
Fixes brain deletion not being lethal

### DIFF
--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -82,10 +82,11 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/Destroy()
 	if(bodypart_owner && !owner && !QDELETED(bodypart_owner))
 		bodypart_remove(bodypart_owner)
-	else if(owner)
-		// The special flag is important, because otherwise mobs can die
-		// while undergoing transformation into different mobs.
+	else if(owner && QDESTROYING(owner))
+		// The mob is being deleted, don't update the mob
 		Remove(owner, special=TRUE)
+	else if(owner)
+		Remove(owner)
 	else
 		STOP_PROCESSING(SSobj, src)
 	return ..()


### PR DESCRIPTION
Oversight on my part. I stuck c4 on a lizards brain and it didnt kill them.

The deletion chain is somewhat awkward for humans. When deleting a human, it deletes the organs but also removes them, which causes all kinds of wacky effects on a deleting mob which is not great. 

This is more akin to a band aid, but I need to take some time and focus to sort through all the removal procs and make them qdel friendly

:cl:
fix: Deleting someones brain kills them again
/:cl: