### PR TITLE
Fixes energy lost as heat for some machines

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -130,18 +130,16 @@
 		charge_rate *= capacitor.tier
 
 /obj/machinery/cell_charger/process(seconds_per_tick)
-	if(!charging || !anchored || (machine_stat & (BROKEN|NOPOWER)))
-		return
-
-	if(charging.percent() >= 100)
+	if(!charging || charging.percent() >= 100 || !anchored || !is_operational)
 		return
 
 	var/main_draw = charge_rate * seconds_per_tick
 	if(!main_draw)
 		return
 
-	//use a small bit for the charger itself, but power usage scales up with the part tier
-	use_energy(main_draw * 0.01)
-	charge_cell(main_draw, charging, grid_only = TRUE)
+	//charge cell, account for heat loss from work done
+	var/charge_given = charge_cell(main_draw, charging, grid_only = TRUE)
+	if(charge_given)
+		use_energy((charge_given + active_power_usage) * 0.01)
 
 	update_appearance()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -60,7 +60,12 @@
 /obj/machinery/recharge_station/proc/charge_target_cell(obj/item/stock_parts/cell/target, seconds_per_tick)
 	PRIVATE_PROC(TRUE)
 
-	return charge_cell(recharge_speed * seconds_per_tick, target, grid_only = TRUE)
+	//charge the cell, account for heat loss from work done
+	var/charge_given = charge_cell(recharge_speed * seconds_per_tick, target, grid_only = TRUE)
+	if(charge_given)
+		use_energy((charge_given + active_power_usage) * 0.01)
+
+	return charge_given
 
 /obj/machinery/recharge_station/RefreshParts()
 	. = ..()
@@ -176,9 +181,6 @@
 
 /obj/machinery/recharge_station/proc/process_occupant(seconds_per_tick)
 	if(!occupant)
-		return
-
-	if(!use_energy(active_power_usage * seconds_per_tick, force = FALSE))
 		return
 
 	SEND_SIGNAL(occupant, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, charge_cell, seconds_per_tick, repairs, sendmats)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -93,12 +93,6 @@
 	else //Turned on
 		begin_processing()
 
-
-/obj/machinery/recharge_station/process(seconds_per_tick)
-	if(occupant)
-		process_occupant(seconds_per_tick)
-	return 1
-
 /obj/machinery/recharge_station/relaymove(mob/living/user, direction)
 	if(user.stat)
 		return
@@ -179,8 +173,8 @@
 	icon_state = "borgcharger[state_open ? 0 : (occupant ? 1 : 2)]"
 	return ..()
 
-/obj/machinery/recharge_station/proc/process_occupant(seconds_per_tick)
-	if(!occupant)
+/obj/machinery/recharge_station/process(seconds_per_tick)
+	if(QDELETED(occupant) || !is_operational)
 		return
 
 	SEND_SIGNAL(occupant, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, charge_cell, seconds_per_tick, repairs, sendmats)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -950,13 +950,14 @@
 
 /mob/living/silicon/robot/proc/charge(datum/source, datum/callback/charge_cell, seconds_per_tick, repairs, sendmats)
 	SIGNAL_HANDLER
-	charge_cell.Invoke(cell, seconds_per_tick)
+
 	if(model)
-		model.respawn_consumable(src, cell.use(cell.chargerate * 0.005))
+		model.respawn_consumable(src, cell.use(cell.charge * 0.005))
 		if(sendmats)
 			model.restock_consumable()
 	if(repairs)
 		heal_bodypart_damage(repairs, repairs)
+	charge_cell.Invoke(cell, seconds_per_tick)
 
 /mob/living/silicon/robot/proc/set_connected_ai(new_ai)
 	if(connected_ai == new_ai)

--- a/code/modules/vehicles/mecha/mech_bay.dm
+++ b/code/modules/vehicles/mecha/mech_bay.dm
@@ -64,10 +64,11 @@
 			recharge_console.update_appearance()
 	if(!recharging_mech?.cell)
 		return
-	if(recharging_mech.cell.charge < recharging_mech.cell.maxcharge)
-		if(!use_energy(active_power_usage * seconds_per_tick, force = FALSE))
-			return
-		charge_cell(recharge_power * seconds_per_tick, recharging_mech.cell, grid_only = TRUE)
+	if(recharging_mech.cell.used_charge())
+		//charge cell, account for heat loss given from work done
+		var/charge_given = charge_cell(recharge_power * seconds_per_tick, recharging_mech.cell, grid_only = TRUE)
+		if(charge_given)
+			use_energy((charge_given + active_power_usage) * 0.01)
 	else
 		recharge_console.update_appearance()
 	if(recharging_mech.loc != recharging_turf)


### PR DESCRIPTION
## About The Pull Request
By fixes i mean the energy lost as heat is now directly proportional to the amount of power these machines draw from the grid via `charge_cell()` proc. The machines affected are as follows
- Cell charger
- Mechbay charger
- Recharge stations + cyborg charging fix(Fixes #82626)

The idea is simple. As the cell nears its charging completion it draws less power from the grid to complete that last mile (for e.g. if the cell is 0% charged the cell charger attempts to draw 100% of the cells max charge from the grid but if the cell is already 99% charged it will only attempt to draw 1% of the required power from the grid) and so it only makes sense that the heat energy lost is also less & vice versa.

In other words the heat energy lost is directly proportional to the amount of work done (via `charge_cell()` proc) so you get conservation of energy & bug fixes which especially benifits borgs & mod suits at the recharge station as it will attempt to first pump in whatever energy is available from the grid and then compute energy lost as heat from it & not the other way around.

For borgs we attempt to first charge its modules & then charge the cell so you get an fully charged cell at the end

## Changelog
:cl:
fix: cell chargers, mechbay port chargers & recharge stations heat lost is directly proportional to energy drawn from the grid to charge their respective cells
fix: cyborgs should charge more frequently & to their max capacity at recharge stations
/:cl:
