### PR TITLE
Makes it so cargo security doesnt get stuck in mining station.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2027,10 +2027,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
 "lN" = (
@@ -7197,7 +7198,6 @@
 "RW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
@@ -7207,6 +7207,7 @@
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
 "RY" = (


### PR DESCRIPTION
By default, cargo security officers have "Mining" access (e.g. the mining dock) but not mining station access.
This combined with the fact the mining station dock on lavaland are emergency access going in, but mining station access going out, can easily end up with a cargo security officer getting stuck down there.

Why its good for the game:
Being stuck in lavaland due to access jank is not fun.
## Changelog
:cl: Webcomicartist
fix: The lavaland mining shuttle doors no longer trap cargo security on lavaland due to access weirdness.
/:cl:
