### PR TITLE
Allows status effects with alerts to display their duration (on the alert), adds it to a select handful

### DIFF
--- a/code/datums/status_effects/_status_effect.dm
+++ b/code/datums/status_effects/_status_effect.dm
@@ -13,7 +13,7 @@
 	/// -1 = will prevent ticks, and if duration is also unlimited (-1), stop processing wholesale.
 	var/tick_interval = 1 SECONDS
 	/// The mob affected by the status effect.
-	var/mob/living/owner
+	VAR_FINAL/mob/living/owner
 	/// How many of the effect can be on one mob, and/or what happens when you try to add a duplicate.
 	var/status_type = STATUS_EFFECT_UNIQUE
 	/// If TRUE, we call [proc/on_remove] when owner is deleted. Otherwise, we call [proc/be_replaced].
@@ -22,7 +22,9 @@
 	/// Status effect "name"s and "description"s are shown to the owner here.
 	var/alert_type = /atom/movable/screen/alert/status_effect
 	/// The alert itself, created in [proc/on_creation] (if alert_type is specified).
-	var/atom/movable/screen/alert/status_effect/linked_alert
+	VAR_FINAL/atom/movable/screen/alert/status_effect/linked_alert
+	/// If TRUE, and we have an alert, we will show a duration on the alert
+	var/show_duration = FALSE
 	/// Used to define if the status effect should be using SSfastprocess or SSprocessing
 	var/processing_speed = STATUS_EFFECT_FAST_PROCESS
 	/// Do we self-terminate when a fullheal is called?
@@ -30,7 +32,7 @@
 	/// If remove_on_fullheal is TRUE, what flag do we need to be removed?
 	var/heal_flag_necessary = HEAL_STATUS
 	/// A particle effect, for things like embers - Should be set on update_particles()
-	var/obj/effect/abstract/particle_holder/particle_effect
+	VAR_FINAL/obj/effect/abstract/particle_holder/particle_effect
 
 /datum/status_effect/New(list/arguments)
 	on_creation(arglist(arguments))
@@ -57,6 +59,7 @@
 		var/atom/movable/screen/alert/status_effect/new_alert = owner.throw_alert(id, alert_type)
 		new_alert.attached_effect = src //so the alert can reference us, if it needs to
 		linked_alert = new_alert //so we can reference the alert, if we need to
+		update_shown_duration()
 
 	if(duration > world.time || tick_interval > world.time) //don't process if we don't care
 		switch(processing_speed)
@@ -86,14 +89,22 @@
 		QDEL_NULL(particle_effect)
 	return ..()
 
+/datum/status_effect/proc/update_shown_duration()
+	if(!linked_alert || !show_duration)
+		return
+
+	linked_alert.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align:center'>[round((duration - world.time)/10, 1)]s</span>")
+
 // Status effect process. Handles adjusting its duration and ticks.
 // If you're adding processed effects, put them in [proc/tick]
 // instead of extending / overriding the process() proc.
 /datum/status_effect/process(seconds_per_tick)
 	SHOULD_NOT_OVERRIDE(TRUE)
+
 	if(QDELETED(owner))
 		qdel(src)
 		return
+
 	if(tick_interval != -1 && tick_interval < world.time)
 		var/tick_length = initial(tick_interval)
 		tick(tick_length / (1 SECONDS))
@@ -101,8 +112,12 @@
 		if(QDELING(src))
 			// tick deleted us, no need to continue
 			return
-	if(duration != -1 && duration < world.time)
-		qdel(src)
+
+	if(duration != -1)
+		if(duration < world.time)
+			qdel(src)
+			return
+		update_shown_duration()
 
 /// Called whenever the effect is applied in on_created
 /// Returning FALSE will cause it to delete itself during creation instead.
@@ -185,24 +200,25 @@
 		qdel(src)
 		return TRUE
 
+	update_shown_duration()
 	return FALSE
 
 /**
  * Updates the particles for the status effects
  * Should be handled by subtypes!
  */
-
 /datum/status_effect/proc/update_particles()
 	SHOULD_CALL_PARENT(FALSE)
+	return
 
 /// Alert base type for status effect alerts
 /atom/movable/screen/alert/status_effect
 	name = "Curse of Mundanity"
 	desc = "You don't feel any different..."
+	maptext_y = 2
 	/// The status effect we're linked to
 	var/datum/status_effect/attached_effect
 
 /atom/movable/screen/alert/status_effect/Destroy()
 	attached_effect = null //Don't keep a ref now
 	return ..()
-

--- a/code/datums/status_effects/_status_effect.dm
+++ b/code/datums/status_effects/_status_effect.dm
@@ -89,7 +89,9 @@
 		QDEL_NULL(particle_effect)
 	return ..()
 
+/// Updates the status effect alert's maptext (if possible)
 /datum/status_effect/proc/update_shown_duration()
+	PRIVATE_PROC(TRUE)
 	if(!linked_alert || !show_duration)
 		return
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -114,6 +114,7 @@
 	id = "fleshmend"
 	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/fleshmend
+	show_duration = TRUE
 
 /datum/status_effect/fleshmend/on_apply()
 	. = ..()
@@ -379,6 +380,7 @@
 	duration = 1 MINUTES
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /atom/movable/screen/alert/status_effect/regenerative_core
+	show_duration = TRUE
 
 /datum/status_effect/regenerative_core/on_apply()
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, STATUS_EFFECT_TRAIT)
@@ -398,6 +400,7 @@
 	id = "Lightning Orb"
 	duration = 30 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/lightningorb
+	show_duration = TRUE
 
 /datum/status_effect/lightningorb/on_apply()
 	. = ..()
@@ -460,6 +463,7 @@
 	id = "speed_boost"
 	duration = 2 SECONDS
 	status_type = STATUS_EFFECT_REPLACE
+	show_duration = TRUE
 
 /datum/status_effect/speed_boost/on_creation(mob/living/new_owner, set_duration)
 	if(isnum(set_duration))

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -663,6 +663,7 @@
 	duration = 150
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /atom/movable/screen/alert/status_effect/convulsing
+	show_duration = TRUE
 
 /datum/status_effect/convulsing/on_creation(mob/living/zappy_boy)
 	. = ..()

--- a/code/datums/status_effects/food_effects.dm
+++ b/code/datums/status_effects/food_effects.dm
@@ -4,6 +4,7 @@
 	duration = 5 MINUTES // Same as food mood buffs
 	status_type = STATUS_EFFECT_REPLACE // Only one food buff allowed
 	alert_type = /atom/movable/screen/alert/status_effect/food
+	show_duration = TRUE
 	/// Buff power
 	var/strength
 

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -3,6 +3,7 @@
 	id = "golem_status"
 	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/golem_status
+	show_duration = TRUE
 	/// Icon state prefix for overlay to display on golem limbs
 	var/overlay_state_prefix
 	/// Name of the mineral we ate to get this

--- a/code/modules/antagonists/heretic/magic/realignment.dm
+++ b/code/modules/antagonists/heretic/magic/realignment.dm
@@ -53,6 +53,7 @@
 	duration = 8 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/realignment
 	tick_interval = 0.2 SECONDS
+	show_duration = TRUE
 
 /datum/status_effect/realignment/get_examine_text()
 	return span_notice("[owner.p_Theyre()] glowing a soft white.")

--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -6,6 +6,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 15 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/crucible_soul
+	show_duration = TRUE
 	var/turf/location
 
 /datum/status_effect/crucible_soul/on_apply()
@@ -30,6 +31,7 @@
 	id = "Blessing of Dusk and Dawn"
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 60 SECONDS
+	show_duration = TRUE
 	alert_type =/atom/movable/screen/alert/status_effect/duskndawn
 
 /datum/status_effect/duskndawn/on_apply()
@@ -47,6 +49,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 60 SECONDS
 	tick_interval = 1 SECONDS
+	show_duration = TRUE
 	alert_type = /atom/movable/screen/alert/status_effect/marshal
 
 /datum/status_effect/marshal/on_apply()
@@ -299,6 +302,7 @@
 	id = "Moon Grasp Hide Identity"
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 15 SECONDS
+	show_duration = TRUE
 	alert_type = /atom/movable/screen/alert/status_effect/moon_grasp_hide
 
 /datum/status_effect/moon_grasp_hide/on_apply()

--- a/code/modules/antagonists/wizard/equipment/teleport_rod.dm
+++ b/code/modules/antagonists/wizard/equipment/teleport_rod.dm
@@ -144,6 +144,7 @@
 	duration = 6 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/teleport_flux
 	remove_on_fullheal = TRUE // staff of healing ~synergy~
+	show_duration = TRUE
 
 	/// Amount of damage to deal when teleporting in flux
 	var/tp_damage = 15

--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -45,6 +45,7 @@
 	id = "lobster_rush"
 	duration = 3 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/lobster_rush
+	show_duration = TRUE
 	var/spawned_last_move = FALSE
 
 /atom/movable/screen/alert/status_effect/lobster_rush

--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
@@ -39,6 +39,7 @@
 	id = "wumbo_inflated"
 	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/inflated
+	show_duration = TRUE
 
 /atom/movable/screen/alert/status_effect/inflated
 	name = "WUMBO"

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -7,6 +7,7 @@
 	id = "rainbow_protection"
 	duration = 100
 	alert_type = /atom/movable/screen/alert/status_effect/rainbow_protection
+	show_duration = TRUE
 	var/originalcolor
 
 /datum/status_effect/rainbow_protection/on_apply()
@@ -37,6 +38,7 @@
 	id = "slimeskin"
 	duration = 300
 	alert_type = /atom/movable/screen/alert/status_effect/slimeskin
+	show_duration = TRUE
 	var/originalcolor
 
 /datum/status_effect/slimeskin/on_apply()


### PR DESCRIPTION
## About The Pull Request

Plainly: Expands the status effect API so their alerts can showcase duration remaining. 

https://github.com/tgstation/tgstation/assets/51863163/02eaad84-ebb7-4af9-9895-977c6e71acc4

## Why It's Good For The Game

I figure there are some status effects out there which really want the player to know how long the duration is. 

And right now, for 95% of them, you have to code dive to find out. This is rather punishing for players who... don't code dive. 

At the same time, there are effects which *do* tell you how long they last, which leaves it up to the player to intuit when it'll run out. This can get a bit silly during lag, and again, punishes new players. 

That's not to say I think every status effect should report how much duration is left: **For very common effects, like sleeping, it should be left up to the player to guess.** Otherwise we lose a lot of paranoia and feeling of helplessness. (Also keep in mind this only applies to status effects with alerts associated.)

Hence why I only added it, largely, to the more "gamified" buffs and debuffs - Things from (generally) one or two sources and with a static duration, (or things which already informed the player how long they last).  

Notable ones include Fleshmend, Convulsing (from emag defib), Regen core.

## Changelog

:cl: Melbert
qol: Some alerts, such as Fleshmend's, show their remaining duration on their icon.
/:cl:

