### PR TITLE
Mech RCD rework

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -533,7 +533,7 @@
 	has_ammobar = FALSE
 	resistance_flags = FIRE_PROOF | INDESTRUCTIBLE // should NOT be destroyed unless the equipment is destroyed
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON | DROPDEL // already qdeleted in the equipment's Destroy() but you can never be too sure
-	delay_mod = 0.5
+	delay_mod = 2.5
 
 /obj/item/construction/rcd/exosuit/ui_status(mob/user, datum/ui_state/state)
 	if(ismecha(owner))

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -533,7 +533,7 @@
 	has_ammobar = FALSE
 	resistance_flags = FIRE_PROOF | INDESTRUCTIBLE // should NOT be destroyed unless the equipment is destroyed
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON | DROPDEL // already qdeleted in the equipment's Destroy() but you can never be too sure
-	delay_mod = 2.5
+	delay_mod = 1.75
 
 /obj/item/construction/rcd/exosuit/ui_status(mob/user, datum/ui_state/state)
 	if(ismecha(owner))

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -223,7 +223,7 @@
 	range = MECHA_MELEE|MECHA_RANGED
 	item_flags = NO_MAT_REDEMPTION
 	///Maximum range the RCD can construct at.
-	var/rcd_range = 3
+	var/rcd_range = 5
 	///Whether or not to deconstruct instead.
 	var/deconstruct_active = FALSE
 	///The type of internal RCD this equipment uses.


### PR DESCRIPTION
## About The Pull Request
The mech RCD will now build at 5 tiles range (from 3), but build structures 1.5 slower than a normal RCD, 3 times slower than it used to be (2 times faster than a normal RCD)
This will make the mech RCD used for big construction projects, but not in combat.
## Why It's Good For The Game
Mech RCD shouldn't be able to Fortnite all over the crew and build structures WHILE WALKING and GETTING SHOT at 2 times the speed of a normal RCD.
I don't think fortnite-like gameplay is good for SS13, being able to build a box around your mech and get out for repairs/changing cells is absurd and destroys any weaknesses a mech has.
## Changelog
:cl: grungussuss
balance: The mech RCD has been reworked to build 3 times slower but at 2 tiles further.
/:cl:
