### PR TITLE
Creates a heatmap for atmos processing

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -69,6 +69,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(flags & CHANGETURF_SKIP)
 		return new path(src)
 
+	var/old_TEMP_atmos_heat = TEMP_atmos_heat
 	var/old_lighting_object = lighting_object
 	var/old_lighting_corner_NE = lighting_corner_NE
 	var/old_lighting_corner_SE = lighting_corner_SE
@@ -134,6 +135,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	lighting_corner_SE = old_lighting_corner_SE
 	lighting_corner_SW = old_lighting_corner_SW
 	lighting_corner_NW = old_lighting_corner_NW
+	TEMP_atmos_heat = old_TEMP_atmos_heat
 
 	dynamic_lumcount = old_dynamic_lumcount
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -105,6 +105,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	/// Never directly access this, use get_explosive_block() instead
 	var/inherent_explosive_resistance = -1
 
+	/// Incremented by the amount of cost each `process_cell` is called by.
+	var/TEMP_atmos_heat = 0
+
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list(NAMEOF_STATIC(src, x), NAMEOF_STATIC(src, y), NAMEOF_STATIC(src, z))
 	if(var_name in banned_edits)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -249,7 +249,11 @@
 /turf/proc/process_cell(fire_count)
 	SSair.remove_from_active(src)
 
+GLOBAL_VAR_INIT(TEMP_atmos_heat_max, 0)
+
 /turf/open/process_cell(fire_count)
+	var/cost_offset = world.tick_usage
+
 	if(archived_cycle < fire_count) //archive self if not already done
 		LINDA_CYCLE_ARCHIVE(src)
 
@@ -364,6 +368,8 @@
 
 	significant_share_ticker = cached_ticker //Save our changes
 	temperature_expose(our_air, our_air.temperature)
+	TEMP_atmos_heat += world.tick_usage - cost_offset
+	GLOB.TEMP_atmos_heat_max = max(GLOB.TEMP_atmos_heat_max, TEMP_atmos_heat)
 
 //////////////////////////SPACEWIND/////////////////////////////
 


### PR DESCRIPTION

## About The Pull Request
Adds two verbs, one which generates a list of turfs and their total atmos processing and saves it to a json file, the other generating a heatmap for every turf in the game for the calling client.

This may help me get down to the bottom of what's causing so much atmos processing in rounds:
![image](https://github.com/tgstation/tgstation/assets/37270891/8a5b1199-aac8-431d-a9e0-b13a7df4bfeb)
