### PR TITLE
Fixes cultist blood rites runtime

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -799,7 +799,8 @@
 		human_bloodbag.updatehealth()
 	playsound(get_turf(human_bloodbag), 'sound/magic/staff_healing.ogg', 25)
 	new /obj/effect/temp_visual/cult/sparks(get_turf(human_bloodbag))
-	user.Beam(human_bloodbag, icon_state="sendbeam", time = 15)
+	if (user != human_bloodbag) //Dont create beam from the user to the user
+		user.Beam(human_bloodbag, icon_state="sendbeam", time = 15)
 	return TRUE
 
 /**


### PR DESCRIPTION
## About The Pull Request
Fixes #82443
Fixes a runtime when using bloodrites on yourself. It was trying to create a beam from the user to the user, and the beam datum cant handle that.

## Why It's Good For The Game
Bugfix

## Changelog

:cl: Seven
fix: Fixed a runtime when using the cultist blood rites on yourself.
/:cl:

