### PR TITLE
Fixes minor runtime when borgs get qdeleted

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -319,7 +319,7 @@
 	update_appearance(UPDATE_OVERLAYS)
 
 /mob/living/silicon/robot/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
-	if(same_z_layer)
+	if(same_z_layer || QDELING(src))
 		return ..()
 	cut_overlay(eye_lights)
 	SET_PLANE_EXPLICIT(eye_lights, PLANE_TO_TRUE(eye_lights.plane), src)


### PR DESCRIPTION
no need to worry about their eye overlay when they're being deleted.
```
[15:52:42] Runtime in code/modules/mob/living/silicon/robot/robot.dm, line 325: /list {len = 1}l.vars
proc name: on changed z level (/mob/living/silicon/robot/on_changed_z_level)
usr: *no key*/(Default Cyborg-955)
src: Default Cyborg-955 (/mob/living/silicon/robot)
src.loc: null
call stack:
Default Cyborg-955 (/mob/living/silicon/robot): on changed z level(the floor (120,88,2) (/turf/open/floor/iron), null, 0, null)
Default Cyborg-955 (/mob/living/silicon/robot): Moved(the floor (120,88,2) (/turf/open/floor/iron), 0, 1, null, 1)
Default Cyborg-955 (/mob/living/silicon/robot): Moved(the floor (120,88,2) (/turf/open/floor/iron), 0, 1, null, 1)
Default Cyborg-955 (/mob/living/silicon/robot): Moved(the floor (120,88,2) (/turf/open/floor/iron), 0, 1, null, 1)
Default Cyborg-955 (/mob/living/silicon/robot): doMove(null)
Default Cyborg-955 (/mob/living/silicon/robot): moveToNullspace()
Default Cyborg-955 (/mob/living/silicon/robot): Destroy(0)
Default Cyborg-955 (/mob/living/silicon/robot): Destroy(0)
Default Cyborg-955 (/mob/living/silicon/robot): Destroy(0)
Default Cyborg-955 (/mob/living/silicon/robot): Destroy(0)
Default Cyborg-955 (/mob/living/silicon/robot): Destroy(0)
qdel(Default Cyborg-955 (/mob/living/silicon/robot), 0)
/datum/callback (/datum/callback): Invoke()
world: push usr(Default Cyborg-955 (/mob/living/silicon/robot), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```