### PR TITLE
Fixes destroyed solar panels dropping overlays

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -42,6 +42,8 @@
 
 /obj/machinery/power/solar/Destroy()
 	unset_control() //remove from control computer
+	QDEL_NULL(panel)
+	QDEL_NULL(panel_edge)
 	return ..()
 
 /obj/machinery/power/solar/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)


### PR DESCRIPTION
## About The Pull Request
Fixes #82301
It feels like im missing something here so if this isnt the right way to fix this (deleting the overlays on the solar panels Destroy() ) please tell me.

## Why It's Good For The Game
Bugfix

## Changelog

:cl: Seven
fix: Destroyed solar panels no longer drop their overlays
/:cl:
