### PR TITLE
[TM ONLY] Hijacked Revision Date for v3 TGS Api

### DIFF
--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -36,6 +36,7 @@
 	var/instance_name
 	var/originmastercommit
 	var/commit
+	var/revision_date
 	var/list/cached_custom_tgs_chat_commands
 	var/warned_revison = FALSE
 	var/warned_custom_commands = FALSE
@@ -66,8 +67,14 @@
 	var/list/logs = TGS_FILE2LIST(".git/logs/HEAD")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")
-		if (logs.len >= 2)
+		if (logs.len >= 5)
 			commit = logs[2]
+			var/unix_timestamp = text2num(logs[5])
+			if(isnum(unix_timestamp))
+				unix_timestamp += world.timezone * 3600
+				unix_timestamp -= 946684800
+				unix_timestamp *= 10
+				revision_date = "[time2text(unix_timestamp, "YYYY-MM-DDThh:mm:ss", 0)]+00:00"
 		else
 			TGS_ERROR_LOG("Error parsing commit logs")
 
@@ -184,6 +191,7 @@
 	var/datum/tgs_revision_information/ri = new
 	ri.commit = commit
 	ri.origin_commit = originmastercommit
+	ri.timestamp = revision_date
 	return ri
 
 /datum/tgs_api/v3210/EndProcess()

--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -36,7 +36,6 @@
 	var/instance_name
 	var/originmastercommit
 	var/commit
-	var/revision_date
 	var/list/cached_custom_tgs_chat_commands
 	var/warned_revison = FALSE
 	var/warned_custom_commands = FALSE
@@ -67,14 +66,8 @@
 	var/list/logs = TGS_FILE2LIST(".git/logs/HEAD")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")
-		if (logs.len >= 5)
+		if (logs.len >= 2)
 			commit = logs[2]
-			var/unix_timestamp = text2num(logs[5])
-			if(isnum(unix_timestamp))
-				unix_timestamp += world.timezone * 3600
-				unix_timestamp -= 946684800
-				unix_timestamp *= 10
-				revision_date = "[time2text(unix_timestamp, "YYYY-MM-DDThh:mm:ss", 0)]+00:00"
 		else
 			TGS_ERROR_LOG("Error parsing commit logs")
 
@@ -191,7 +184,6 @@
 	var/datum/tgs_revision_information/ri = new
 	ri.commit = commit
 	ri.origin_commit = originmastercommit
-	ri.timestamp = revision_date
 	return ri
 
 /datum/tgs_api/v3210/EndProcess()

--- a/code/modules/tgs_override/revision_date_hijack_v3210.dm
+++ b/code/modules/tgs_override/revision_date_hijack_v3210.dm
@@ -1,0 +1,32 @@
+#ifndef TGS_V3_API
+#error Codebase no longer compiled for TGSv3210. Remove hijack implementation
+#endif
+
+#define TGS_FILE2LIST(filename) (splittext(trim_left(trim_right(file2text(filename))), "\n"))
+
+/datum/tgs_api/v3210/var/revision_date
+/datum/tgs_api/v3210/OnWorldNew(minimum_required_security_level)
+	. = ..()
+	if(. == FALSE)
+		return
+
+	var/list/logs = TGS_FILE2LIST(".git/logs/HEAD")
+	if(length(logs) >= 5)
+		var/unix_timestamp = text2num(logs[5])
+		if(isnum(unix_timestamp))
+			unix_timestamp += world.timezone * 3600
+			unix_timestamp -= 946684800
+			unix_timestamp *= 10
+			revision_date = "[time2text(unix_timestamp, "YYYY-MM-DDThh:mm:ss", 0)]+00:00"
+		else
+			TGS_ERROR_LOG("Failed to parse timestamp from commit logs")
+
+	return .
+
+/datum/tgs_api/v3210/Revision()
+	var/datum/tgs_revision_information/revision_info = ..()
+	if(!isnull(revision_date))
+		revision_info.timestamp = revision_date
+	return revision_info
+
+#undef TGS_FILE2LIST

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5886,6 +5886,7 @@
 #include "code\modules\tgchat\message.dm"
 #include "code\modules\tgchat\to_chat.dm"
 #include "code\modules\tgs\includes.dm"
+#include "code\modules\tgs_override\revision_date_hijack_v3210.dm"
 #include "code\modules\tgui\external.dm"
 #include "code\modules\tgui\states.dm"
 #include "code\modules\tgui\status_composers.dm"


### PR DESCRIPTION
Adds revision date generation for the v3 TGS Api.
Because of float precision it usually be within +-8 minutes.
This is better than not having it at all and is something I need for CompileMon
