### PR TITLE
Makes qdel hard del if the implementation for the server is OpenDream

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -13,6 +13,11 @@
 // Qdel should assume this object won't gc, and hard delete it posthaste.
 #define QDEL_HINT_HARDDEL_NOW 4
 
+#ifdef OPENDREAM
+#define DEFAULT_QDEL_HINT QDEL_HINT_HARDDEL_NOW
+#else
+#define DEFAULT_QDEL_HINT QDEL_HINT_QUEUE
+#endif
 
 #ifdef REFERENCE_TRACKING
 /** If REFERENCE_TRACKING is enabled, qdel will call this object's find_references() verb.

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -142,7 +142,11 @@
 	_clear_signal_refs()
 	//END: ECS SHIT
 
+#ifdef OPENDREAM // OpenDream has C# style garbage collection (because it's written in C#), so we can just let it fall off naturally.
+	return QDEL_HINT_HARDDEL_NOW
+#else
 	return QDEL_HINT_QUEUE
+#endif
 
 ///Only override this if you know what you're doing. You do not know what you're doing
 ///This is a threat

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -142,7 +142,7 @@
 	_clear_signal_refs()
 	//END: ECS SHIT
 
-#ifdef OPENDREAM // OpenDream has C# style garbage collection (because it's written in C#), so we can just let it fall off naturally.
+#ifdef OPENDREAM // OpenDream does things better than byond.
 	return QDEL_HINT_HARDDEL_NOW
 #else
 	return QDEL_HINT_QUEUE

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -142,11 +142,7 @@
 	_clear_signal_refs()
 	//END: ECS SHIT
 
-#ifdef OPENDREAM // OpenDream does things better than byond.
-	return QDEL_HINT_HARDDEL_NOW
-#else
-	return QDEL_HINT_QUEUE
-#endif
+	return DEFAULT_QDEL_HINT
 
 ///Only override this if you know what you're doing. You do not know what you're doing
 ///This is a threat

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -89,4 +89,4 @@
 	// off an enormous amount of procs, signals, etc, that this temporary effect object
 	// never needs or affects.
 	loc = null
-	return QDEL_HINT_QUEUE
+	return DEFAULT_QDEL_HINT

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -36,7 +36,7 @@
 /obj/effect/spawner/Destroy(force)
 	SHOULD_CALL_PARENT(FALSE)
 	moveToNullspace()
-	return QDEL_HINT_QUEUE
+	return DEFAULT_QDEL_HINT
 
 /obj/effect/spawner/forceMove(atom/destination)
 	if(destination && QDELETED(src)) // throw a warning if we try to forceMove a qdeleted spawner to somewhere other than nullspace

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -63,7 +63,7 @@
 	// may result.
 	if(force)
 		..()
-		return QDEL_HINT_QUEUE
+		return DEFAULT_QDEL_HINT
 	else
 		return QDEL_HINT_LETMELIVE
 


### PR DESCRIPTION
## About The Pull Request

Makes the default return value for Destroy HARDDEL_NOW if the server implementation is OpenDream

## Why It's Good For The Game

It's much more efficient than byond's del system, notably because it is written in C# and uses C# GC which is a lazy clear instead of an instant clear.
