### PR TITLE
OpenDream fast del() support

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -376,6 +376,13 @@ SUBSYSTEM_DEF(garbage)
 	if(isnull(to_delete))
 		return
 
+#ifdef OPENDREAM
+	// go brrr
+	// but HARDDEL_NOW breaks shit, lol
+	if(hint == QDEL_HINT_QUEUE)
+		hint = QDEL_HINT_HARDDEL
+#endif
+
 	switch(hint)
 		if (QDEL_HINT_QUEUE) //qdel should queue the object for deletion.
 			SSgarbage.Queue(to_delete)


### PR DESCRIPTION
## About The Pull Request

Skips GC on OpenDream

## Why It's Good For The Game

OpenDream's implementation makes del() super fast and not to be feared. Save a ton of bytecode processing by ridding the queue logic.

## Changelog

Not really.