### PR TITLE
Fixes wings working in space

### DIFF
--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -50,7 +50,7 @@
 
 ///Called on_life(). Handle flight code and check if we're still flying
 /obj/item/organ/external/wings/functional/proc/handle_flight(mob/living/carbon/human/human)
-	if(human.movement_type & ~FLYING)
+	if(!(human.movement_type & FLYING))
 		return FALSE
 	if(!can_fly(human))
 		toggle_flight(human)

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -113,6 +113,8 @@
 		passtable_off(human, SPECIES_FLIGHT_TRAIT)
 		close_wings()
 
+	human.refresh_gravity()
+
 ///SPREAD OUR WINGS AND FLLLLLYYYYYY
 /obj/item/organ/external/wings/functional/proc/open_wings()
 	var/datum/bodypart_overlay/mutant/wings/functional/overlay = bodypart_overlay


### PR DESCRIPTION
## About The Pull Request
Fixes #82035
Fixes #82184
Wings no longer are able to function in space if you activated them in an environment they can function in.
This surfaced another bug where the wings would stop flying but would leave the mob in a weird state where they weren't flying but were still negating gravity, calling refresh_gravity fixed this, if this is a bad way to do this let me know.

## Why It's Good For The Game
Bugfix, wings not working in space is an intentional balance consideration.

## Changelog
:cl: Seven
fix: Wings no longer work in space if you activated them beforehand.
/:cl:

