### PR TITLE
Restores Balance to the Candle Economy

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -238,7 +238,7 @@
 		to_chat(user, span_notice("The candle needs to be lit to be offered!"))
 		return
 	to_chat(user, span_notice("[GLOB.deity] is pleased with your sacrifice."))
-	adjust_favor(50, user) //it's not a lot but hey there's a pacifist favor option at least
+	adjust_favor(40, user) //it's not a lot but hey there's a pacifist favor option at least
 	qdel(offering)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Reduces the favour gain of candled from 50 to 40. This prevents infinite free favour farming by buying 5 candles for 200 and selling them for 250.

## Why It's Good For The Game

Letting people generate free infinite resources from nothing is both lame and a violation of the laws of thermodynamics, at least walking to the biogenerator to make candles requires a minimal level of effort/interaction.

## Changelog
:cl:
fix: Pyre chaplains can no longer generate infinite favour for free by buying and selling candles. Candles now offer for 40 favour, down from 50.
/:cl:
