### PR TITLE
Fixes Space Phase softlock

### DIFF
--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -69,6 +69,11 @@
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(update_status_on_signal))
 	if(iscarbon(jaunter))
 		jaunter.drop_all_held_items()
+		// Sanity check to ensure we didn't lose our focus as a result.
+		if(!HAS_TRAIT(jaunter, TRAIT_ALLOW_HERETIC_CASTING))
+			REMOVE_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
+			exit_jaunt(jaunter, our_turf)
+			return FALSE
 		// Give them some space hands to prevent them from doing things
 		var/obj/item/space_crawl/left_hand = new(jaunter)
 		var/obj/item/space_crawl/right_hand = new(jaunter)
@@ -77,6 +82,7 @@
 		jaunter.put_in_hands(left_hand)
 		jaunter.put_in_hands(right_hand)
 
+	RegisterSignal(jaunter, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), PROC_REF(on_focus_lost))
 	our_turf.visible_message(span_warning("[jaunter] sinks into [our_turf]!"))
 	playsound(our_turf, 'sound/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	new /obj/effect/temp_visual/space_explosion(our_turf)
@@ -88,8 +94,8 @@
 /**
  * Attempts to Exit the passed space or misc turf.
  */
-/datum/action/cooldown/spell/jaunt/space_crawl/proc/try_exit_jaunt(turf/our_turf, mob/living/jaunter)
-	if(HAS_TRAIT_FROM(jaunter, TRAIT_NO_TRANSFORM, REF(src)))
+/datum/action/cooldown/spell/jaunt/space_crawl/proc/try_exit_jaunt(turf/our_turf, mob/living/jaunter, force = FALSE)
+	if(!force && HAS_TRAIT_FROM(jaunter, TRAIT_NO_TRANSFORM, REF(src)))
 		to_chat(jaunter, span_warning("You cannot exit yet!!"))
 		return FALSE
 
@@ -101,6 +107,7 @@
 
 /datum/action/cooldown/spell/jaunt/space_crawl/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	UnregisterSignal(jaunt, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(unjaunter, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING))
 	playsound(get_turf(unjaunter), 'sound/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	new /obj/effect/temp_visual/space_explosion(get_turf(unjaunter))
 	if(iscarbon(unjaunter))
@@ -108,6 +115,12 @@
 			unjaunter.temporarilyRemoveItemFromInventory(space_hand, force = TRUE)
 			qdel(space_hand)
 	return ..()
+
+/// Signal proc for [SIGNAL_REMOVETRAIT] via [TRAIT_ALLOW_HERETIC_CASTING], losing our focus midcast will throw us out.
+/datum/action/cooldown/spell/jaunt/space_crawl/proc/on_focus_lost(mob/living/source)
+	SIGNAL_HANDLER
+	var/turf/our_turf = get_turf(source)
+	try_exit_jaunt(our_turf, source, TRUE)
 
 /// Spacecrawl "hands", prevent the user from holding items in spacecrawl
 /obj/item/space_crawl

--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -83,6 +83,7 @@
 		jaunter.put_in_hands(right_hand)
 
 	RegisterSignal(jaunter, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), PROC_REF(on_focus_lost))
+	RegisterSignal(jaunter, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 	our_turf.visible_message(span_warning("[jaunter] sinks into [our_turf]!"))
 	playsound(our_turf, 'sound/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	new /obj/effect/temp_visual/space_explosion(our_turf)
@@ -107,7 +108,7 @@
 
 /datum/action/cooldown/spell/jaunt/space_crawl/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	UnregisterSignal(jaunt, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(unjaunter, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING))
+	UnregisterSignal(unjaunter, list(SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), COMSIG_MOB_STATCHANGE))
 	playsound(get_turf(unjaunter), 'sound/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	new /obj/effect/temp_visual/space_explosion(get_turf(unjaunter))
 	if(iscarbon(unjaunter))
@@ -121,6 +122,13 @@
 	SIGNAL_HANDLER
 	var/turf/our_turf = get_turf(source)
 	try_exit_jaunt(our_turf, source, TRUE)
+
+/// Signal proc for [COMSIG_MOB_STATCHANGE], to throw us out of the jaunt if we lose consciousness.
+/datum/action/cooldown/spell/jaunt/space_crawl/proc/on_stat_change(mob/living/source, new_stat, old_stat)
+	SIGNAL_HANDLER
+	if(new_stat != CONSCIOUS)
+		var/turf/our_turf = get_turf(source)
+		try_exit_jaunt(our_turf, source, TRUE)
 
 /// Spacecrawl "hands", prevent the user from holding items in spacecrawl
 /obj/item/space_crawl


### PR DESCRIPTION
## About The Pull Request

It's very easy to get softlock if you try to use a codex as a focus for Space Phase - you'll drop the codex, resulting in you having no focus, and you can't re-cast Space Phase in order to exit the jaunt, requiring admin intervention in order to escape.

This just makes it so you're ejected from the phase if you ever lose your focus mid-cast, or if you lose consciousness (crit, dying, etc)

## Why It's Good For The Game

Because softlocks are bad and unfun.

## Changelog
:cl:
fix: You will now be ejected from Space Phase if you lose your focus or lose consciousness somehow during the jaunt.
/:cl:
