### PR TITLE
Fixes cyborg omnitool combat behaviour.

### DIFF
--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -236,10 +236,16 @@
 	if(isnull(reference))
 		sharpness = NONE
 		force = initial(force)
+		wound_bonus = 0
+		bare_wound_bonus = 0
+		armour_penetration = 0
 		hitsound = initial(hitsound)
 		usesound = initial(usesound)
 	else
 		force = initial(reference.force)
+		wound_bonus = reference::wound_bonus
+		bare_wound_bonus = reference::bare_wound_bonus
+		armour_penetration = reference::armour_penetration
 		sharpness = initial(reference.sharpness)
 		hitsound = initial(reference.hitsound)
 		usesound = initial(reference.usesound)
@@ -372,10 +378,10 @@
 	RemoveElement(/datum/element/eyestab)
 	switch(tool_behaviour)
 		if(TOOL_SCREWDRIVER)
-			reference = /obj/item/crowbar
+			reference = /obj/item/screwdriver
 			AddElement(/datum/element/eyestab)
 		if(TOOL_CROWBAR)
-			reference = /obj/item/surgicaldrill
+			reference = /obj/item/crowbar
 		if(TOOL_WRENCH)
 			reference = /obj/item/wrench
 		if(TOOL_WIRECUTTER)


### PR DESCRIPTION

## About The Pull Request
Fixes engineering cyborg omnitool from choosing the wrong reference for the screwdriver and crowbar. Also fixes cyborg omnitool not transferring the wound_bonus, bare_wound_bonus, and armour_penetration.
## Why It's Good For The Game
So they behave naturally.
## Changelog
:cl:
fix: Fixes engineering cyborg screwdriver not being pointy. Fixes engineering cyborg crowbar from being pointy.
fix: Fixes cyborg omnitools not using the correct wound bonus and armour penetration values.
/:cl:
