### PR TITLE
Adds extra signals for storage add/remove, + minor signal doc

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_storage.dm
+++ b/code/__DEFINES/dcs/signals/signals_storage.dm
@@ -9,4 +9,4 @@
 #define COMSIG_STORAGE_STORED_ITEM "storage_storing_item"
 
 /// Sent to the STORAGE when an ITEM is REMOVED. (obj/item, atom, silent)
-#define COMSIG_STORAGE_REMOVED_ITEM "stoarge_removing_item"
+#define COMSIG_STORAGE_REMOVED_ITEM "storage_removing_item"

--- a/code/__DEFINES/dcs/signals/signals_storage.dm
+++ b/code/__DEFINES/dcs/signals/signals_storage.dm
@@ -5,6 +5,12 @@
 /// Sent after dumping into some other storage object: (atom/dest_object, mob/user)
 #define COMSIG_STORAGE_DUMP_POST_TRANSFER "storage_dump_into_storage"
 
+/// Fired off the storage's PARENT when an ITEM is STORED INSIDE. (obj/item, mob, force)
+#define COMSIG_ATOM_STORED_ITEM "atom_storing_item"
+
+/// Fired off the storage's PARENT when an ITEM is REMOVED. (obj/item, atom, silent)
+#define COMSIG_ATOM_REMOVED_ITEM "atom_removing_item"
+
 /// Sent to the STORAGE when an ITEM is STORED INSIDE. (obj/item, mob, force)
 #define COMSIG_STORAGE_STORED_ITEM "storage_storing_item"
 

--- a/code/__DEFINES/dcs/signals/signals_storage.dm
+++ b/code/__DEFINES/dcs/signals/signals_storage.dm
@@ -5,5 +5,8 @@
 /// Sent after dumping into some other storage object: (atom/dest_object, mob/user)
 #define COMSIG_STORAGE_DUMP_POST_TRANSFER "storage_dump_into_storage"
 
-/// Sent to the STORAGE when an ITEM is STORED INSIDE.
+/// Sent to the STORAGE when an ITEM is STORED INSIDE. (obj/item, mob, force)
 #define COMSIG_STORAGE_STORED_ITEM "storage_storing_item"
+
+/// Sent to the STORAGE when an ITEM is REMOVED. (obj/item, atom, silent)
+#define COMSIG_STORAGE_REMOVED_ITEM "stoarge_removing_item"

--- a/code/datums/components/bloody_spreader.dm
+++ b/code/datums/components/bloody_spreader.dm
@@ -17,7 +17,7 @@
 			signals_to_add += list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_ATOM, COMSIG_ITEM_HIT_REACT, COMSIG_ITEM_ATTACK_SELF, COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED)
 		var/atom/atom_parent = parent
 		if(atom_parent.atom_storage)
-			signals_to_add += list(COMSIG_STORAGE_STORED_ITEM)
+			signals_to_add += list(COMSIG_ATOM_STORED_ITEM)
 		else if(isstructure(parent))
 			signals_to_add += list(COMSIG_ATOM_ATTACK_HAND)
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -452,7 +452,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	SEND_SIGNAL(parent, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
 	SEND_SIGNAL(src, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
-	parent.on_storage_insert(src, to_insert, user, force)
 	to_insert.forceMove(real_location)
 	item_insertion_feedback(user, to_insert, override)
 	parent.update_appearance()

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -451,6 +451,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	SEND_SIGNAL(parent, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
+	SEND_SIGNAL(src, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
 	parent.on_storage_insert(src, to_insert, user, force)
 	to_insert.forceMove(real_location)
 	item_insertion_feedback(user, to_insert, override)
@@ -544,11 +545,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(animated)
 		animate_parent()
 
-	SEND_SIGNAL(parent, COMSIG_STORAGE_REMOVED_ITEM, thing, remove_to_loc, silent)
-	parent.on_storage_remove(src, thing, remove_to_loc, silent)
-
 	refresh_views()
 	parent.update_appearance()
+
+	SEND_SIGNAL(parent, COMSIG_ATOM_REMOVED_ITEM, thing, remove_to_loc, silent)
+	SEND_SIGNAL(src, COMSIG_STORAGE_REMOVED_ITEM, thing, remove_to_loc, silent)
 	return TRUE
 
 /**

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -527,6 +527,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/attempt_remove(obj/item/thing, atom/remove_to_loc, silent = FALSE)
 	SHOULD_NOT_SLEEP(TRUE)
 
+	SEND_SIGNAL(parent, COMSIG_STORAGE_REMOVED_ITEM, thing, remove_to_loc, silent)
+
 	if(istype(thing) && ismob(parent.loc))
 		var/mob/mob_parent = parent.loc
 		thing.dropped(mob_parent, /*silent = */TRUE)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -451,6 +451,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	SEND_SIGNAL(parent, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
+	parent.on_storage_insert(src, to_insert, user, force)
 	to_insert.forceMove(real_location)
 	item_insertion_feedback(user, to_insert, override)
 	parent.update_appearance()
@@ -527,8 +528,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/attempt_remove(obj/item/thing, atom/remove_to_loc, silent = FALSE)
 	SHOULD_NOT_SLEEP(TRUE)
 
-	SEND_SIGNAL(parent, COMSIG_STORAGE_REMOVED_ITEM, thing, remove_to_loc, silent)
-
 	if(istype(thing) && ismob(parent.loc))
 		var/mob/mob_parent = parent.loc
 		thing.dropped(mob_parent, /*silent = */TRUE)
@@ -544,6 +543,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(animated)
 		animate_parent()
+
+	SEND_SIGNAL(parent, COMSIG_STORAGE_REMOVED_ITEM, thing, remove_to_loc, silent)
+	parent.on_storage_remove(src, thing, remove_to_loc, silent)
 
 	refresh_views()
 	parent.update_appearance()

--- a/code/datums/storage/subtypes/cards.dm
+++ b/code/datums/storage/subtypes/cards.dm
@@ -15,19 +15,6 @@
 	. = ..()
 	set_holdable(/obj/item/tcgcard)
 
-/datum/storage/tcg/attempt_remove(obj/item/thing, atom/remove_to_loc, silent = FALSE)
-	. = ..()
-	if(!.)
-		return
-
-	var/obj/item/tcgcard_deck/deck = parent
-	var/obj/item/tcgcard/card = thing
-	card.flipped = deck.flipped
-	card.update_appearance(UPDATE_ICON_STATE)
-
-	if(length(real_location.contents) == 0)
-		qdel(parent)
-
 /datum/storage/tcg/show_contents(mob/to_show)
 	// sometimes, show contents is called when the mob is already seeing the contents of the deck, to refresh the view.
 	// to avoid spam, we only show the message if they weren't already seeing the contents.

--- a/code/game/atom/atom_storage.dm
+++ b/code/game/atom/atom_storage.dm
@@ -41,11 +41,3 @@
 			atom_storage.set_holdable(cloning.can_hold, cloning.cant_hold)
 
 	return atom_storage
-
-/// Called from /datum/storage/attempt_insert(), or when an item is placed in our atom storage.
-/atom/proc/on_storage_insert(datum/storage/storage_datum, obj/item/to_insert, mob/user, force = STORAGE_NOT_LOCKED)
-	return
-
-/// Called from /datum/storage/attempt_remove(), or when an item is removed from our atom storage.
-/atom/proc/on_storage_remove(datum/storage/storage_datum, obj/item/thing, atom/remove_to_loc, silent = FALSE)
-	return

--- a/code/game/atom/atom_storage.dm
+++ b/code/game/atom/atom_storage.dm
@@ -41,3 +41,11 @@
 			atom_storage.set_holdable(cloning.can_hold, cloning.cant_hold)
 
 	return atom_storage
+
+/// Called from /datum/storage/attempt_insert(), or when an item is placed in our atom storage.
+/atom/proc/on_storage_insert(datum/storage/storage_datum, obj/item/to_insert, mob/user, force = STORAGE_NOT_LOCKED)
+	return
+
+/// Called from /datum/storage/attempt_remove(), or when an item is removed from our atom storage.
+/atom/proc/on_storage_remove(datum/storage/storage_datum, obj/item/thing, atom/remove_to_loc, silent = FALSE)
+	return

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -196,6 +196,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 /obj/item/tcgcard_deck/Initialize(mapload)
 	. = ..()
 	create_storage(storage_type = /datum/storage/tcg)
+	RegisterSignal(atom_storage, COMSIG_STORAGE_REMOVED_ITEM, PROC_REF(on_item_removed))
 
 /obj/item/tcgcard_deck/update_icon_state()
 	if(!flipped)
@@ -314,9 +315,13 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		nu_card.update_icon_state()
 	update_icon_state()
 
-/obj/item/tcgcard_deck/on_storage_remove(datum/storage/storage_datum, obj/item/thing, atom/remove_to_loc, silent = FALSE)
+/**
+ * Signal handler for COMSIG_STORAGE_REMOVED_ITEM. Qdels src if contents are empty, flips the removed card if needed.
+ */
+/obj/item/tcgcard_deck/proc/on_item_removed(datum/storage/storage_datum, obj/item/thing, atom/remove_to_loc, silent = FALSE)
+	SIGNAL_HANDLER
 
-	if (istype(thing, /obj/item/tcgcard))
+	if (!istype(thing, /obj/item/tcgcard))
 		return
 	var/obj/item/tcgcard/card = thing
 	card.flipped = flipped

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -195,7 +195,14 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 
 /obj/item/tcgcard_deck/Initialize(mapload)
 	. = ..()
-	create_storage(storage_type = /datum/storage/tcg)
+	var/datum/storage/storage_datum = create_storage(storage_type = /datum/storage/tcg)
+	RegisterSignal(storage_datum, COMSIG_STORAGE_REMOVED_ITEM, PROC_REF(card_removed_from_storage))
+
+/obj/item/tcgcard_deck/Destroy()
+	if (atom_storage)
+		UnregisterSignal(atom_storage, COMSIG_STORAGE_REMOVED_ITEM)
+
+	return ..()
 
 /obj/item/tcgcard_deck/update_icon_state()
 	if(!flipped)
@@ -313,6 +320,18 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		nu_card.flipped = flipped
 		nu_card.update_icon_state()
 	update_icon_state()
+/**
+ * Signal handler for COMSIG_STORAGE_REMOVED_ITEM. Flips the card to our flipped state, and qdels src if our storage is empty.
+ */
+/obj/item/tcgcard_deck/proc/card_removed_from_storage(datum/storage/tcg/signal_source, obj/item/thing, atom/remove_to_loc, silent)
+	SIGNAL_HANDLER
+
+	var/obj/item/tcgcard/card = thing
+	card.flipped = flipped
+	card.update_appearance(UPDATE_ICON_STATE)
+
+	if(length(signal_source.real_location.contents) == 0)
+		qdel(src)
 
 /obj/item/cardpack
 	name = "Trading Card Pack: Coder"

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -198,11 +198,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	var/datum/storage/storage_datum = create_storage(storage_type = /datum/storage/tcg)
 	RegisterSignal(storage_datum, COMSIG_STORAGE_REMOVED_ITEM, PROC_REF(card_removed_from_storage))
 
-/obj/item/tcgcard_deck/Destroy()
-	if (atom_storage)
-		UnregisterSignal(atom_storage, COMSIG_STORAGE_REMOVED_ITEM)
-
-	return ..()
 
 /obj/item/tcgcard_deck/update_icon_state()
 	if(!flipped)
@@ -330,7 +325,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	card.flipped = flipped
 	card.update_appearance(UPDATE_ICON_STATE)
 
-	if(length(signal_source.real_location.contents) == 0)
+	if(length(contents) == 0)
 		qdel(src)
 
 /obj/item/cardpack

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -193,6 +193,10 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	var/static/radial_shuffle = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_shuffle")
 	var/static/radial_pickup = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_pickup")
 
+/obj/item/tcgcard_deck/Initialize(mapload)
+	. = ..()
+	create_storage(storage_type = /datum/storage/tcg)
+
 /obj/item/tcgcard_deck/update_icon_state()
 	if(!flipped)
 		icon_state = "[base_icon_state]_up"

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -193,12 +193,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	var/static/radial_shuffle = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_shuffle")
 	var/static/radial_pickup = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_pickup")
 
-/obj/item/tcgcard_deck/Initialize(mapload)
-	. = ..()
-	var/datum/storage/storage_datum = create_storage(storage_type = /datum/storage/tcg)
-	RegisterSignal(storage_datum, COMSIG_STORAGE_REMOVED_ITEM, PROC_REF(card_removed_from_storage))
-
-
 /obj/item/tcgcard_deck/update_icon_state()
 	if(!flipped)
 		icon_state = "[base_icon_state]_up"
@@ -315,12 +309,11 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		nu_card.flipped = flipped
 		nu_card.update_icon_state()
 	update_icon_state()
-/**
- * Signal handler for COMSIG_STORAGE_REMOVED_ITEM. Flips the card to our flipped state, and qdels src if our storage is empty.
- */
-/obj/item/tcgcard_deck/proc/card_removed_from_storage(datum/storage/tcg/signal_source, obj/item/thing, atom/remove_to_loc, silent)
-	SIGNAL_HANDLER
 
+/obj/item/tcgcard_deck/on_storage_remove(datum/storage/storage_datum, obj/item/thing, atom/remove_to_loc, silent = FALSE)
+
+	if (istype(thing, /obj/item/tcgcard))
+		return
 	var/obj/item/tcgcard/card = thing
 	card.flipped = flipped
 	card.update_appearance(UPDATE_ICON_STATE)


### PR DESCRIPTION
## About The Pull Request

Title.

Converts TCG decks to use signals instead of a proc override, as is better practice.
## Why It's Good For The Game

It's generally better practice to not snowflake behavior like this onto the storage itself, instead using signals/procs.
Also, its good to have parity between add/remove in signals.
## Changelog
:cl:
code: New signals for atom storage remove and insert
/:cl:
