### PR TITLE
Nerfs moon smile

### DIFF
--- a/code/modules/antagonists/heretic/magic/moon_smile.dm
+++ b/code/modules/antagonists/heretic/magic/moon_smile.dm
@@ -1,7 +1,7 @@
 /datum/action/cooldown/spell/pointed/moon_smile
 	name = "Smile of the moon"
 	desc = "Lets you turn the gaze of the moon on someone \
-			temporarily blinding, muting, deafening and knocking down a single target."
+			temporarily blinding, muting, deafening and knocking down a single target if their sanity is low enough."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
@@ -37,16 +37,19 @@
 
 	playsound(cast_on, 'sound/hallucinations/i_see_you1.ogg', 50, 1)
 	to_chat(cast_on, span_warning("Your eyes cry out in pain, your ears bleed and your lips seal! THE MOON SMILES UPON YOU!"))
-	cast_on.adjust_temp_blindness(moon_smile_duration + 5 SECONDS)
-	cast_on.set_eye_blur_if_lower(moon_smile_duration + 7 SECONDS)
+	cast_on.adjust_temp_blindness(moon_smile_duration + 1 SECONDS)
+	cast_on.set_eye_blur_if_lower(moon_smile_duration + 2 SECONDS)
 
 	var/obj/item/organ/internal/ears/ears = cast_on.get_organ_slot(ORGAN_SLOT_EARS)
 	//adjustEarDamage takes deafness duration parameter in one unit per two seconds, instead of the normal time, so we divide by two seconds
-	ears?.adjustEarDamage(0, (moon_smile_duration + 2 SECONDS) / (2 SECONDS))
+	ears?.adjustEarDamage(0, (moon_smile_duration + 1 SECONDS) / (2 SECONDS))
 
-	cast_on.adjust_silence(moon_smile_duration + 5 SECONDS)
-	cast_on.AdjustKnockdown(2 SECONDS)
+	cast_on.adjust_silence(moon_smile_duration + 1 SECONDS)
 	cast_on.add_mood_event("moon_smile", /datum/mood_event/moon_smile)
+
+	// Only knocksdown if the target has a low enough sanity
+	if(cast_on.mob_mood.sanity < 40)
+		cast_on.AdjustKnockdown(2 SECONDS)
 	//Lowers sanity
 	cast_on.mob_mood.set_sanity(cast_on.mob_mood.sanity - 20)
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
This pull request makes the Moon Smile spell a worse alpha strike by lowering the minimum duration of most of the effects and making the knockdown only occur if the targets sanity is low enough. Currently its knocking down at less than 40 sanity though this threshold can be lowered if desired.
## Why It's Good For The Game
In its current state this spell is wayyyy too strong for how quickly you get it and I've heard a lot of frustration expressed about it. This PR attempts to tackle this by decreasing the minimum duration of its effects and locking the knockdown to lower sanity levels making it better in extended combat like the intent of the ability always was.
## Changelog
:cl:
balance: Moon Smile only does a knockdown if the targets sanity is low enough and the minimum duration of its abilities have been decreased
/:cl:
