### PR TITLE
Fixes division by zero math error in energy fire sound proc (aka proto-kinetic accelerators make their fire sound again)

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -44,9 +44,9 @@
 	// Ignore this on oversized/infinite cells or ammo without cost
 	if(shot_cost_percent > 0)
 		// The total amount of shots the fully charged energy gun can fire before running out
-		var/max_shots = round(100/shot_cost_percent) - 1
+		var/max_shots = round(100/shot_cost_percent)
 		// How many shots left before the energy gun's current battery runs out of energy
-		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent) - 1
+		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent)
 		pitch_to_use = LERP(1, 0.3, (1 - (shots_left/max_shots)) ** 2)
 
 	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)


### PR DESCRIPTION
## About The Pull Request

I'm not really sure what the -1 was initially there for but there are some weapons like the proto-kinetic accelerator that only have one shot and they were not being accounted for in that formula, resulting in a division by zero error.

![image](https://github.com/tgstation/tgstation/assets/13398309/93ad278c-60e6-447a-b85d-dbd21f8b23e5)

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: proto-kinetic accelerators and other energy weapons that only have one shot will now play their sound again.
/:cl:
