### PR TITLE
Standardises name of The Lizard's Gas (Lava)

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -30,7 +30,7 @@
 	suffix = "lavaland_biodome_clown_planet.dmm"
 
 /datum/map_template/ruin/lavaland/lizgas
-	name = "The Lizard's Gas(Lava)"
+	name = "Lava-Ruin The Lizard's Gas"
 	id = "lizgas2"
 	description = "A recently opened gas station from the Lizard's Gas franchise."
 	suffix = "lavaland_surface_gas.dmm"


### PR DESCRIPTION

## About The Pull Request
Renames the ruin to include the required prefix "Lava-Ruin". Removes the now unnecessary suffix.
## Why It's Good For The Game
## Changelog
The names have this prefix system for easier string-searching. If they don't have the prefixes, they're harder to find and sort.
:cl:
fix: adds missing prefix to name of The Lizard's Gas Lava land ruin.
/:cl:
