### PR TITLE
Cancel CI on new commit

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -23,6 +23,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4
@@ -133,6 +134,7 @@ jobs:
     name: Compile Maps
     needs: [collect_data]
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4
@@ -156,6 +158,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Collect data for other tasks
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
@@ -185,6 +188,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
     needs: [collect_data]
+
     strategy:
       fail-fast: false
       matrix:
@@ -223,6 +227,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') && (always() && (!failure() && !cancelled())) )
     needs: [run_all_tests, run_alternate_tests]
     name: Compare Screenshot Tests
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -261,6 +266,7 @@ jobs:
     name: Windows Build
     needs: [collect_data]
     runs-on: windows-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -13,14 +13,17 @@ on:
   merge_group:
     branches:
     - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_linters:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
     runs-on: ubuntu-22.04
-    concurrency:
-      group: run_linters-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v4
       - name: Restore SpacemanDMM cache
@@ -130,9 +133,7 @@ jobs:
     name: Compile Maps
     needs: [collect_data]
     runs-on: ubuntu-22.04
-    concurrency:
-      group: compile_all_maps-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v4
       - name: Restore BYOND cache
@@ -159,9 +160,7 @@ jobs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
       max_required_byond_client: ${{ steps.max_required_byond_client.outputs.max_required_byond_client }}
-    concurrency:
-      group: find_all_maps-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v4
       - name: Find Maps
@@ -190,9 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         map: ${{ fromJSON(needs.collect_data.outputs.maps).paths }}
-    concurrency:
-      group: run_all_tests-${{ github.head_ref || github.run_id }}-${{ matrix.map }}
-      cancel-in-progress: true
+
     uses: ./.github/workflows/run_integration_tests.yml
     with:
       map: ${{ matrix.map }}
@@ -206,9 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         setup: ${{ fromJSON(needs.collect_data.outputs.alternate_tests) }}
-    concurrency:
-      group: run_all_tests-${{ github.head_ref || github.run_id }}-${{ matrix.setup.major }}.${{ matrix.setup.minor }}-${{ matrix.setup.map }}
-      cancel-in-progress: true
+
     uses: ./.github/workflows/run_integration_tests.yml
     with:
       map: ${{ matrix.setup.map }}
@@ -266,9 +261,7 @@ jobs:
     name: Windows Build
     needs: [collect_data]
     runs-on: windows-latest
-    concurrency:
-      group: test_windows-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v4
       - name: Restore Yarn cache

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -220,6 +220,7 @@ jobs:
     name: Check Alternate Tests
     needs: [run_alternate_tests]
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - run: echo Alternate tests passed.
 

--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -9,6 +9,7 @@ jobs:
   assign-users:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -16,9 +16,11 @@ on:
       max_required_byond_client:
         required: true
         type: string
+
 jobs:
   run_integration_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       mysql:
         image: mysql:latest


### PR DESCRIPTION
## About The Pull Request
This sets concurrency at the workflow level, which should provide a more concise way to eject if a new commit is entered

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

I've also added timeouts that are between 5-15 minutes per test. Default is 360 minutes without this
