### PR TITLE
Fixes a bunch of hearts becoming errors when being eaten

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -153,6 +153,7 @@
 	. = ..()
 	AddElement(/datum/element/noticable_organ, "%PRONOUN_Their skin has small patches of scales growing on it.", BODY_ZONE_CHEST)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/carp)
+	AddElement(/datum/element/update_icon_blocker)
 
 #undef CARP_ORGAN_COLOR
 #undef CARP_SCLERA_COLOR

--- a/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
@@ -32,6 +32,7 @@ Fluoride Stare: After someone says 5 words, blah blah blah...
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/gondola)
 	AddElement(/datum/element/noticable_organ, "%PRONOUN_They radiate%PRONOUN_s an aura of serenity.")
+	AddElement(/datum/element/update_icon_blocker)
 
 /obj/item/organ/internal/heart/gondola/Insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()

--- a/code/game/machinery/dna_infuser/organ_sets/rat_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/rat_organs.dm
@@ -62,6 +62,7 @@
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/rat)
 	AddElement(/datum/element/noticable_organ, "%PRONOUN_They hunch%PRONOUN_es over unnaturally!")
+	AddElement(/datum/element/update_icon_blocker)
 
 /obj/item/organ/internal/heart/rat/on_mob_insert(mob/living/carbon/receiver)
 	. = ..()

--- a/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
@@ -65,6 +65,7 @@
 	. = ..()
 	AddElement(/datum/element/noticable_organ, "%PRONOUN_They %PRONOUN_have hardened, somewhat translucent skin.")
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/roach)
+	AddElement(/datum/element/update_icon_blocker)
 	roach_shell = new()
 
 /obj/item/organ/internal/heart/roach/Destroy()


### PR DESCRIPTION

## About The Pull Request
Fixes a bunch of hearts so they no longer turn into errors when you take a bite out of them... for whatever reason.
Fixes #83147 

## Why It's Good For The Game
Immersion: ruined

## Changelog
:cl:
fix: Fixes a bunch of hearts turning into errors when you try to eat them
/:cl:
