### PR TITLE
Mobs spawners won't spawn more mobs than they are supposed to

### DIFF
--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -19,7 +19,7 @@
 	var/spawn_distance_exclude
 	COOLDOWN_DECLARE(spawn_delay)
 
-/datum/component/spawner/Initialize(spawn_types = list(), spawn_time = 30 SECONDS, max_spawned = 5, max_spawn_per_attempt = 2 , faction = list(FACTION_MINING), spawn_text = null, spawn_distance = 1, spawn_distance_exclude = 0)
+/datum/component/spawner/Initialize(spawn_types = list(), spawn_time = 30 SECONDS, max_spawned = 5, max_spawn_per_attempt = 1 , faction = list(FACTION_MINING), spawn_text = null, spawn_distance = 1, spawn_distance_exclude = 0)
 	if (!islist(spawn_types))
 		CRASH("invalid spawn_types to spawn specified for spawner component!")
 	src.spawn_time = spawn_time
@@ -52,14 +52,16 @@
 	if(!COOLDOWN_FINISHED(src, spawn_delay))
 		return
 	validate_references()
-	if(length(spawned_things) >= max_spawned)
+	var/spawned_total = length(spawned_things)
+	if(spawned_total >= max_spawned)
 		return
 	var/atom/spawner = parent
 	COOLDOWN_START(src, spawn_delay, spawn_time)
 	var/chosen_mob_type = pick(spawn_types)
 	var/adjusted_spawn_count = 1
-	if (max_spawn_per_attempt > 1)
-		adjusted_spawn_count = rand(1, max_spawn_per_attempt)
+	var/max_spawn_this_attempt = min(max_spawn_per_attempt, max_spawned - spawned_total)
+	if (max_spawn_this_attempt > 1)
+		adjusted_spawn_count = rand(1, max_spawn_this_attempt)
 	for(var/i in 1 to adjusted_spawn_count)
 		var/atom/created
 		var/turf/picked_spot


### PR DESCRIPTION
## About The Pull Request

At some point we added a new parameter to spawners which randomised the number of mobs they could spawn up to a maximum. 
For some reason the default value here was set to "2", meaning that every mob spawner in the game would be spawning an average of 1.5 mobs per update instead of 1.
As the place it was _intended_ for (mining vents) already provides a value in the constructor, I just set the default back to 1.

Additionally, this randomised value did not actually obey the "maximum mobs" parameter of the component and could spawn mobs above what was supposed to be the cap of mobs created by the spawner.

This PR fixes those things.

## Changelog

:cl:
fix: Mob spawners (such as lavaland tendrils) won't spawn more mobs than they are supposed to, faster than they should.
/:cl:
