### PR TITLE
Legion mob nerfs

### DIFF
--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -19,8 +19,8 @@
 	friendly_verb_simple = "chatter near"
 	maxHealth = 1
 	health = 1
-	melee_damage_lower = 8
-	melee_damage_upper = 8
+	melee_damage_lower = 12
+	melee_damage_upper = 12
 	obj_damage = 0
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"

--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -19,8 +19,8 @@
 	friendly_verb_simple = "chatter near"
 	maxHealth = 1
 	health = 1
-	melee_damage_lower = 12
-	melee_damage_upper = 12
+	melee_damage_lower = 8
+	melee_damage_upper = 8
 	obj_damage = 0
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
@@ -38,6 +38,7 @@
 	AddElement(/datum/element/simple_flying)
 	AddComponent(/datum/component/swarming)
 	AddComponent(/datum/component/clickbox, icon_state = "sphere", max_scale = 2)
+	AddComponent(/datum/component/basic_mob_attack_telegraph)
 	addtimer(CALLBACK(src, PROC_REF(death)), 10 SECONDS)
 
 /mob/living/basic/legion_brood/death(gibbed)

--- a/code/modules/mob/living/basic/lavaland/legion/spawn_legions.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/spawn_legions.dm
@@ -7,7 +7,7 @@
 	background_icon_state = "bg_demon"
 	overlay_icon_state = "bg_demon_border"
 	click_to_activate = TRUE
-	cooldown_time = 2 SECONDS
+	cooldown_time = 4 SECONDS
 	melee_cooldown_time = 0
 	shared_cooldown = NONE
 	/// If a mob is not clicked directly, inherit targeting data from this blackboard key and setting it upon this target key
@@ -16,6 +16,15 @@
 	var/spawn_type = /mob/living/basic/legion_brood
 	/// How far can we fire?
 	var/max_range = 7
+
+/datum/action/cooldown/mob_cooldown/skull_launcher/IsAvailable(feedback)
+	. = ..()
+	if (!.)
+		return
+	if (!isturf(owner.loc))
+		owner.balloon_alert(owner, "no room!")
+		return FALSE
+	return TRUE
 
 /datum/action/cooldown/mob_cooldown/skull_launcher/Activate(atom/target)
 	var/turf/target_turf = get_turf(target)


### PR DESCRIPTION
## About The Pull Request

This PR does a handful of things to make the hostile "Legion" mob less dangerous.
Firstly: They will spawn extra mobs half as often.
Secondly: Those mobs have the "attack forecast" component also used by Goliaths and some other mining mobs.

Also now Legions can't spawn skulls while they're inside pipes or bags, because that doesn't make any sense.

## Why It's Good For The Game

When converted to basic mobs these guys became _far_ more deadly than they were supposed to be, to the point where even approaching a Legion tendril was basically suicide. 
This was compounded by an issue which would sometimes cause 33% more Legions to be present at the tendril than were supposed to spawn there, but they'd still be fairly scary with just 3 of them.

There were a couple of causes of this which this PR does something to address:
- Simple mob AI was simply a lot more sluggish than Basic Mobs. Legions now react faster and more reliably _actually_ spawn skulls at every available opportunity whereas previously despite having the same cooldown they wouldn't always bother.
- Similarly, the skulls themselves were slower to pick a target and slower to attack, whereas Basic Mob skulls will melee you the instant they detect that you are in range.
- This also means three (or four with the spawner bug) Legions dropping adds on you the second they see _you_, with no guarantee that you have yet seen them. The damage starts to become quite hard to avoid, and 4x Legion skulls (with another four spawning in two seconds) dealing 12 damage each would crit you very quickly.
- Our click CD means it's not even possible to punch four skulls in two seconds even if you managed to time it perfectly.

So to solve this: Spawn fewer of them, they do less damage, and you can step away from their attacks (this gets pretty hard when you're surrounded, but that is by design).

Eventually I am probably going to play like 20 rounds of miner, look at all of the mining mobs we have on each map, and then completely redraw what their roles are in a way that probably changes what this mob does quite significantly... but I'm not going to do it yet. This should do for now.

## Changelog

:cl:
balance: The melee attacks from small mobs spawned by Legions can now be dodged.
balance: Legions spawn their mobs less often.
fix: Legions cannot spawn mobs while inside pipes or closets.
/:cl:
