### PR TITLE
malf AI fixes

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -255,10 +255,8 @@
 	return CLICK_ACTION_SUCCESS
 
 /obj/machinery/power/apc/attack_ai_secondary(mob/living/silicon/user, list/modifiers)
-	if(!can_use(user, loud = TRUE))
-		return
-
-	togglelock(user)
+	if(can_use(user, loud = TRUE))
+		togglelock(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /* AI Turrets */

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -111,13 +111,11 @@
 	if(!HAS_SILICON_ACCESS(user))
 		return TRUE
 	. = TRUE
-	var/mob/living/silicon/ai/AI = user
-	var/mob/living/silicon/robot/robot = user
-	if(istype(AI) || istype(robot))
+	if(isAI(user) || iscyborg(user))
 		if(aidisabled)
 			. = FALSE
-		else if(istype(malfai) && (malfai != AI || !(robot in malfai.connected_robots)))
-			. = FALSE 
+		else if(istype(malfai) && !(malfai == user || (user in malfai.connected_robots)))
+			. = FALSE
 	if (!. && !loud)
 		balloon_alert(user, "it's disabled!")
 	return .

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -484,7 +484,7 @@
 	else if(machine_stat & (BROKEN|MAINT))
 		balloon_alert(user, "nothing happens!")
 	else
-		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack && !remote_control_user)
+		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && ((!malfhack && !remote_control_user) || (malfhack && (malfai == user || (user in malfai.connected_robots)))))
 			locked = !locked
 			balloon_alert(user, locked ? "locked" : "unlocked")
 			update_appearance()


### PR DESCRIPTION
Fixes #83254

:cl: ShizCalev
fix: Malf AI can now properly interact with APCs under their control
fix: Malf AI & their slaved cyborgs won't be told that access is denied when trying to right-click lock/unlock APCs.
/:cl:

