### PR TITLE
Research Directors are now strong (the Athletics trait, that is). Suplexing a rod is an incredible workout.

### DIFF
--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -253,8 +253,8 @@
 	new /obj/effect/anomaly/flux(drop_location())
 
 	var/is_heavy_gravity = strongman.has_gravity() > STANDARD_GRAVITY //If for some reason you have to suplex the rod in heavy gravity, you get the double experience here as well, why not
-
-	strongman.mind?.adjust_experience(/datum/skill/athletics, is_heavy_gravity ? 2000 : 1000) //You'll probably instantly become an expert athlete from this alone
+	var/experience_gained = 100 * num_sentient_mobs_hit * (is_heavy_gravity ? 2 : 1) // We gain more expeirence the more people the rod has taken out. The deadlier the rod, the stronger we become. At 25 mobs, we instantly become a legendary athlete.
+	strongman.mind?.adjust_experience(/datum/skill/athletics, experience_gained)
 	strongman.apply_status_effect(/datum/status_effect/exercised) //time for a nap, you earned it
 
 	qdel(src)

--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -247,10 +247,16 @@
 	strongman.client?.give_award(/datum/award/achievement/jobs/feat_of_strength, strongman)
 	strongman.visible_message(
 		span_boldwarning("[strongman] suplexes [src] into the ground!"),
-		span_warning("You suplex [src] into the ground!")
+		span_warning("As you suplex [src] into the ground, your body ripples with power!")
 		)
 	new /obj/structure/festivus/anchored(drop_location())
 	new /obj/effect/anomaly/flux(drop_location())
+
+	var/is_heavy_gravity = strongman.has_gravity() > STANDARD_GRAVITY //If for some reason you have to suplex the rod in heavy gravity, you get the double experience here as well, why not
+
+	strongman.mind?.adjust_experience(/datum/skill/athletics, is_heavy_gravity ? 2000 : 1000) //You'll probably instantly become an expert athlete from this alone
+	strongman.apply_status_effect(/datum/status_effect/exercised) //time for a nap, you earned it
+
 	qdel(src)
 	return TRUE
 

--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -253,7 +253,7 @@
 	new /obj/effect/anomaly/flux(drop_location())
 
 	var/is_heavy_gravity = strongman.has_gravity() > STANDARD_GRAVITY //If for some reason you have to suplex the rod in heavy gravity, you get the double experience here as well, why not
-	var/experience_gained = 100 * num_sentient_mobs_hit * (is_heavy_gravity ? 2 : 1) // We gain more expeirence the more people the rod has taken out. The deadlier the rod, the stronger we become. At 25 mobs, we instantly become a legendary athlete.
+	var/experience_gained = 100 * num_sentient_mobs_hit * (is_heavy_gravity ? 2 : 1) // We gain more expeirence the more sentient mobs the rod has taken out. The deadlier the rod, the stronger we become. At 25 sentient mobs, we instantly become a legendary athlete.
 	strongman.mind?.adjust_experience(/datum/skill/athletics, experience_gained)
 	strongman.apply_status_effect(/datum/status_effect/exercised) //time for a nap, you earned it
 

--- a/code/modules/library/skill_learning/generic_skillchips/rod_suplex.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/rod_suplex.dm
@@ -1,12 +1,12 @@
 /obj/item/skillchip/research_director
 	name = "R.D.S.P.L.X. skillchip"
 	desc = "Knowledge of how to solve the ancient conumdrum; what happens when an unstoppable force meets an immovable object."
-	auto_traits = list(TRAIT_ROD_SUPLEX)
+	auto_traits = list(TRAIT_ROD_SUPLEX, TRAIT_STRENGTH)
 	skill_name = "True Strength"
 	skill_description = "The knowledge and strength to resolve the most ancient conumdrum; what happens when an unstoppable force meets an immovable object."
 	skill_icon = "dumbbell"
-	activate_message = "<span class='notice'>You realise if you apply the correct force, at the correct angle, it is possible to make the immovable permanently movable.</span>"
-	deactivate_message = "<span class='notice'>You forget how to permanently anchor a paradoxical object.</span>"
+	activate_message = "<span class='notice'>You realise if you apply the correct force, at the correct angle, it is possible to make the immovable permanently movable. And... damn, you look huge.</span>"
+	deactivate_message = "<span class='notice'>You forget how to permanently anchor a paradoxical object. Also, you should really hit the gym...</span>"
 	chip_category = SKILLCHIP_CATEGORY_GENERAL
 	skillchip_flags = NONE
 	slot_use = 1

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -335,6 +335,8 @@
 		fitness_modifier *= 2
 	if (HAS_TRAIT(src, TRAIT_STRENGTH))
 		fitness_modifier *= 1.5
+	if (HAS_TRAIT(src, TRAIT_ROD_SUPLEX))
+		fitness_modifier *= 2 // To be able to suplex a rod, you must possess an incredible amount of power
 	if (HAS_TRAIT(src, TRAIT_EASILY_WOUNDED))
 		fitness_modifier /= 2
 	if (HAS_TRAIT(src, TRAIT_GAMER))


### PR DESCRIPTION
## About The Pull Request

Grants the Research Director TRAIT_STRENGTH via their skill chip. This trait is only relevant to athletics-related activities. They still need to actually do the workout before they see any results.

Fitness bros will overestimate the RD's power level due to their ability to suplex an immovable rod.

Suplexing a rod grants an incredible amount of athletics skill, increased by how many people the rod has taken out. The frequency of this happening is bound to be pretty small, but it's a nice in-round reward for accomplishing the task (and maybe blowing up a department as a result), and also potentially a large number of casualties on top of that.

## Why It's Good For The Game

The athletics changes didn't acknowledge that there is already someone on the station that is, for some reason, unnaturally stronger than everyone else. The Research Director. So now, fitness bros think they're naturally swole. Mind over matter, I guess?

I just think it'd be funny if by suplexing the rod once, you gain incredible physical power and then need to take a nap because boy that sure was an explosive amount of strength you had to apply. Since this only happens with looping rods, I don't imagine it will disrupt fitness as a skill too much.

## Changelog
:cl:
add: The Research Director is now actually strong.
add: Fitness bros will determine the Research Director to be stronger than they actually are, without even working out. How does he do it?
balance: Suplexing a rod grants a large burst of athletics experience.
add: The more sentient casualties of the rod, the more experience suplexing that rod grants. Absorb the souls of the weak and feeble.
/:cl:
