### PR TITLE
reinforced windoors stay open for another 2 seconds.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -116,7 +116,7 @@
 	if(check_access(null))
 		sleep(5 SECONDS)
 	else //secure doors close faster
-		sleep(2 SECONDS)
+		sleep(4 SECONDS)
 	if(!density && autoclose) //did someone change state while we slept?
 		close()
 


### PR DESCRIPTION

## About The Pull Request

reinforced windoors stay open for another 2 seconds.

## Why It's Good For The Game

the current time is too fast, it is very frustrating and nobody likes it.

## Changelog

:cl:
qol: reinforced windoors stay open for another 2 seconds.
/:cl:

