### PR TITLE
`*Me` invoked via verb defaults to visible | audible, rather than just audible

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -663,13 +663,15 @@
 	return copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
 
 /datum/emote/living/custom/proc/get_custom_emote_type_from_user()
-	var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
+	var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable", "Both")
 
 	switch(type)
 		if("Visible")
 			return EMOTE_VISIBLE
 		if("Hearable")
 			return EMOTE_AUDIBLE
+		if("Both")
+			return EMOTE_VISIBLE | EMOTE_AUDIBLE
 		else
 			tgui_alert(usr,"Unable to use this emote, must be either hearable or visible.")
 			return FALSE

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -42,6 +42,7 @@
 /mob/verb/me_verb(message as text)
 	set name = "Me"
 	set category = "IC"
+	set desc = "Perform a custom emote. Leave blank to pick between an audible or a visible emote (Defaults to visible)."
 
 	if(GLOB.say_disabled) //This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
@@ -49,7 +50,7 @@
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 
-	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "me", 1, message, TRUE), SSspeech_controller)
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "me", EMOTE_VISIBLE, message, TRUE), SSspeech_controller)
 
 /mob/try_speak(message, ignore_spam = FALSE, forced = null, filterproof = FALSE)
 	var/list/filter_result

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -50,7 +50,7 @@
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 
-	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "me", EMOTE_VISIBLE, message, TRUE), SSspeech_controller)
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "me", EMOTE_VISIBLE|EMOTE_AUDIBLE, message, TRUE), SSspeech_controller)
 
 /mob/try_speak(message, ignore_spam = FALSE, forced = null, filterproof = FALSE)
 	var/list/filter_result


### PR DESCRIPTION
## About The Pull Request

`*me` emotes invoked via the verb (or TGUI say) now default to visible | audible, rather than just audible

Also adds a description on how to set your `*me` emotes to the verb. (Doesn't work for TGUI say unfortunately)

## Why It's Good For The Game

I don't know why these are set to audible by default, that's just kinda weird considering 95% of custom emotes are not audible

Both is best of both worlds, ensures deaf and blind people can see their own custom emotes at the very least. 

## Changelog

:cl: Melbert
qol: Custom emotes now default to both visible and audible rather than just audible
qol: Invoking the custom emote verb now explains how to set your custom emote to visible or audible
/:cl:

