### PR TITLE
Changelings can't transform people into species they cannot absorb

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -99,6 +99,9 @@
 		return
 	if(!new_selected_dna || changeling.chosen_sting || selected_dna) // selected other sting or other DNA while sleeping
 		return
+	if(TRAIT_NO_DNA_COPY in new_selected_dna.dna.species.inherent_traits)
+		user.balloon_alert(user, "dna incompatible!")
+		return
 	selected_dna = new_selected_dna
 	return ..()
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -77,6 +77,8 @@
 	VAR_FINAL/datum/changeling_profile/selected_dna
 	/// Duration of the sting
 	var/sting_duration = 8 MINUTES
+	/// Set this to false via VV to allow golem, plasmaman, or monkey changelings to turn other people into golems, plasmamen, or monkeys
+	var/verify_valid_species = TRUE
 
 /datum/action/changeling/sting/transformation/Grant(mob/grant_to)
 	. = ..()
@@ -99,7 +101,7 @@
 		return
 	if(!new_selected_dna || changeling.chosen_sting || selected_dna) // selected other sting or other DNA while sleeping
 		return
-	if(TRAIT_NO_DNA_COPY in new_selected_dna.dna.species.inherent_traits)
+	if(verify_valid_species && (TRAIT_NO_DNA_COPY in new_selected_dna.dna.species.inherent_traits))
 		user.balloon_alert(user, "dna incompatible!")
 		return
 	selected_dna = new_selected_dna


### PR DESCRIPTION
## About The Pull Request

This PR makes a change to the Transform Sting ability to prevent you from turning people into species that have unabsorbable DNA.
Now you may ask "Jacquerel, how do you even have a DNA profile of a species with unabsorbable DNA in the first place?"
The answer is that we do not do any species checks when assigning roundstart antagonists, or when admins try to make someone into a Changeling.

The upshot of this is that while you can't copy the DNA of a plasmaman and then wander around turning random people into plasmamen (instantly setting them on fire and suffocating them), you can **start** the round as a Plasmaman, apply _your own_ DNA to people, and have them experience those consequences.

We _could_ change this so that people queueing as Plasmaman who also are assigned to be Changelings use their forced human profile... but I think that's more boring than this solution (and might lead to very slightly more metagaming).
This way _also_ adds a little bit of protection for the cases of admins giving the changeling antag datum to Golems, Monkeys, Skeletons, Androids, or the like.

Just in case admins _want_ to turn people into burning skeletons with transform sting, I have added a variable on the ability which you can toggle to disable the check.

## Changelog

:cl:
balance: If you can't absorb a species' DNA as a changeling, you also can't use transform sting to turn someone into that species.
/:cl:
