### PR TITLE
Cargo ripley starts at full charge.

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -265,8 +265,6 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 
 /obj/vehicle/sealed/mecha/ripley/cargo/Initialize(mapload)
 	. = ..()
-	if(cell)
-		cell.charge = FLOOR(cell.charge * 0.25, 1) //Starts at very low charge
 
 	//Attach hydraulic clamp ONLY
 	var/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/HC = new


### PR DESCRIPTION

## About The Pull Request
Cargo ripley starts at 100% charge instead of 25% charge.
## Why It's Good For The Game
Because charging a cell actually requires a significant amount of energy now, the roundstart ripley starting almost uncharged causes quite a significant roundstart load since it's next to the recharger. This makes it start fully charged so the roundstart power rush is less extreme.
## Changelog
:cl:
balance: Cargo ripley's cell starts fully charged.
/:cl:
