### PR TITLE
Fixes The description of Pulse Of Entropy to display the correct reagents.

### DIFF
--- a/code/modules/antagonists/heretic/knife_effect.dm
+++ b/code/modules/antagonists/heretic/knife_effect.dm
@@ -1,8 +1,8 @@
 // "Floating ghost blade" effect for blade heretics
 /obj/effect/floating_blade
 	name = "knife"
-	icon = 'icons/effects/eldritch.dmi'
-	icon_state = "Dio_Knife"
+	icon = 'icons/obj/service/kitchen.dmi'
+	icon_state = "knife"
 	layer = LOW_MOB_LAYER
 	/// The color the knife glows around it.
 	var/glow_color = "#ececff"
@@ -11,4 +11,4 @@
 	. = ..()
 	AddElement(/datum/element/movetype_handler)
 	ADD_TRAIT(src, TRAIT_MOVE_FLYING, INNATE_TRAIT)
-	add_filter("Dio_Knife", 2, list("type" = "outline", "color" = glow_color, "size" = 1))
+	add_filter("knife", 2, list("type" = "outline", "color" = glow_color, "size" = 1))

--- a/code/modules/antagonists/heretic/knife_effect.dm
+++ b/code/modules/antagonists/heretic/knife_effect.dm
@@ -1,8 +1,8 @@
 // "Floating ghost blade" effect for blade heretics
 /obj/effect/floating_blade
 	name = "knife"
-	icon = 'icons/obj/service/kitchen.dmi'
-	icon_state = "knife"
+	icon = 'icons/effects/eldritch.dmi'
+	icon_state = "Dio_Knife"
 	layer = LOW_MOB_LAYER
 	/// The color the knife glows around it.
 	var/glow_color = "#ececff"
@@ -11,4 +11,4 @@
 	. = ..()
 	AddElement(/datum/element/movetype_handler)
 	ADD_TRAIT(src, TRAIT_MOVE_FLYING, INNATE_TRAIT)
-	add_filter("knife", 2, list("type" = "outline", "color" = glow_color, "size" = 1))
+	add_filter("Dio_Knife", 2, list("type" = "outline", "color" = glow_color, "size" = 1))

--- a/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
@@ -20,7 +20,7 @@
 
 /datum/heretic_knowledge/entropy_pulse
 	name = "Pulse of Entropy"
-	desc = "Allows you to transmute 10 iron sheets to fill the surrounding vicinity of the rune with rust."
+	desc = "Allows you to transmute 10 iron sheets and a garbage item to fill the surrounding vicinity of the rune with rust."
 	gain_text = "Reality begins to whisper to me. To give it its entropic end."
 	required_atoms = list(
 		/obj/item/stack/sheet/iron = 10,


### PR DESCRIPTION
## About The Pull Request

Fixes a typo on the description of Pulse of Entropy

## Why It's Good For The Game

When i made my pr to rework rust heretic, i kinda forgot to update the description on the recipe for Pulse of Entropy to include the garbage item, this fixes that.

## Changelog

:cl:

spellcheck: Pulse of entropy description now displays the correct reagents for the ritual
/:cl:

