### PR TITLE
carps now properly stop floating when you kill them

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -20,7 +20,6 @@
 	icon_gib = "carp_gib"
 	gold_core_spawnable = HOSTILE_SPAWN
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
-	movement_type = FLYING
 	health = 25
 	maxHealth = 25
 	pressure_resistance = 200

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -28,7 +28,6 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 0.5, OXY = 1)
 	combat_mode = TRUE
 	speed = 0
-	movement_type = FLYING
 	attack_verb_continuous = "chomps"
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/magic/demon_attack1.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -29,7 +29,6 @@ Difficulty: Medium
 	health_doll_icon = "miner"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	light_color = COLOR_LIGHT_GRAYISH_RED
-	movement_type = GROUND
 	speak_emote = list("roars")
 	speed = 3
 	move_to_delay = 3


### PR DESCRIPTION

## About The Pull Request
they forced their movement type to FLYING when all this stuff is supposed to be handled by the simple flying element, so even though they would lose the flying trait they would keep doing the flying animation and had movement type flying (would go over chasms and shit)
as a side note - ground movement probably shouldnt exist (nothing really checks for it and you get goofy shit like GROUND|FLYING all the time) but i cant be assed to remove it because of how it interacts with speed modifiers

## Why It's Good For The Game
Got damned!

## Changelog
:cl:
fix: carps now properly stop floating when you kill them
/:cl:
