### PR TITLE
Ore vents now have countermeasures against walling them off from all sides.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_spawner.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_spawner.dm
@@ -2,5 +2,8 @@
 /// called when a spawner spawns a mob
 #define COMSIG_SPAWNER_SPAWNED "spawner_spawned"
 
+/// Called when a spawner spawns a mob in a turf peel, but we need to use the default case.
+#define COMSIG_SPAWNER_SPAWNED_DEFAULT "spawner_spawned_default"
+
 /// called when a ghost clicks a spawner role: (mob/living)
 #define COMSIG_GHOSTROLE_SPAWNED "ghostrole_spawned"

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -468,5 +468,8 @@
 		if(possible_spawn in inner)
 			continue
 		peel += possible_spawn
+
+	if(!length(peel))
+		return center //Offer the center only as a default case when we don't have a valid circle.
 	return peel
 

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -72,6 +72,8 @@
 			picked_spot = pick(turf_peel(spawn_distance, spawn_distance_exclude, spawner.loc, view_based = TRUE))
 			if(!picked_spot)
 				picked_spot = pick(circle_range_turfs(spawner.loc, spawn_distance))
+			if(picked_spot == spawner.loc)
+				SEND_SIGNAL(spawner, COMSIG_SPAWNER_SPAWNED_DEFAULT)
 			created = new chosen_mob_type(picked_spot)
 		else if (spawn_distance >= 1)
 			picked_spot = pick(circle_range_turfs(spawner.loc, spawn_distance))

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -82,6 +82,8 @@
 		icon_state = icon_state_tapped
 		update_appearance(UPDATE_ICON_STATE)
 		add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER))
+
+	RegisterSignal(src, COMSIG_SPAWNER_SPAWNED_DEFAULT, PROC_REF(anti_cheese))
 	return ..()
 
 /obj/structure/ore_vent/Destroy()
@@ -406,6 +408,13 @@
 	if(apply_cooldown)
 		COOLDOWN_START(src, manual_vent_cooldown, 10 SECONDS)
 	return new_rock
+
+/**
+ * When the ore vent cannot spawn a mob due to being blocked from all sides, we cause some MILD, MILD explosions.
+ * Explosion matches a gibtonite light explosion, as a way to clear neartby solid structures, with a high likelyhood of breaking the NODE drone.
+ */
+/obj/structure/ore_vent/proc/anti_cheese()
+	explosion(src, heavy_impact_range = 1, light_impact_range = 3, flame_range = 0, flash_range = 0, adminlog = FALSE)
 
 //comes with the station, and is already tapped.
 /obj/structure/ore_vent/starter_resources

--- a/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
+++ b/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
@@ -17,7 +17,7 @@
 	icon_living = "mining_node_active"
 	icon_dead = "mining_node_active"
 
-	maxHealth = 300
+	maxHealth = 300 // We adjust the max health based on the vent size in the arrive() proc.
 	health = 300
 	density = TRUE
 	pass_flags = PASSTABLE|PASSGRILLE|PASSMOB
@@ -74,6 +74,8 @@
 
 /mob/living/basic/node_drone/proc/arrive(obj/structure/ore_vent/parent_vent)
 	attached_vent = parent_vent
+	maxHealth = 300 + ((attached_vent.boulder_size/BOULDER_SIZE_SMALL) * 100)
+	health = maxHealth
 	flying_state = FLY_IN_STATE
 	update_appearance(UPDATE_ICON_STATE)
 	pixel_z = 400

--- a/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
+++ b/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
@@ -17,8 +17,8 @@
 	icon_living = "mining_node_active"
 	icon_dead = "mining_node_active"
 
-	maxHealth = 500
-	health = 500
+	maxHealth = 300
+	health = 300
 	density = TRUE
 	pass_flags = PASSTABLE|PASSGRILLE|PASSMOB
 	mob_size = MOB_SIZE_LARGE


### PR DESCRIPTION
## About The Pull Request

This PR fixes some balance and practicality issues with the spawner component that has affected vent mining and the associated wave defense.

* The turf_peel() proc now checks to see if it's pulling no turf from the inside or outside of it's peel, in which case it now has a default case where it returns it's center turf instead.
* As a consequence of this, the center turf is where mobs will spawn if an ore vent is unable to find any space where it can spawn any new hostile mobs.

Upon testing this, it worked fairly well, but ultimately node drones were capable of tanking enough hits for long enough that typically they could still survive a small vent's onslaught. As a precaution, I've made two additional changes.

* Node drones have had their maximum health dropped slightly, from 500 health to 300 health.
* As a secondary precaution, if a spawner using the turf peel method cannot spawn correctly, it will send a signal, which ore vents are now registered to. When called on an ore vent, it has new behavior to clear the offending nearby turfs and create a pathway to allow nearby mobs to get access to the vent.
* (**This is an explosion**.)

## Why It's Good For The Game

Fixes an unreported on the repo but repeatedly pinged issue regarding ore vent waves where players could often wall off or blockoff an ore vent in such a way that it allows vents to be functionally immortal by quickly walling off the vent using sandstone doors. This should help to prevent players cheesing the intended gameplay mechanic, as well as keep up the challenge to arcmining wave defense without some additional nuance.

I may have gone a little overboard with the health tweaks as well, but considering that even with the explosions, I was able to survive the repeated explosions on the vent, I think this should work quite well all things considered. Still, open to feedback there.

## Changelog

:cl:
balance: Ore vents, if blocked off from all four sides while being defended, now cause a mild gas explosion, resulting in a mild dissuasive explosion.
fix: NODE drones spawned from ore vent defense have lower maximum health.
/:cl:

