### PR TITLE
Fix MetaStation service hallway door bypass

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19251,6 +19251,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "hcv" = (


### PR DESCRIPTION

## About The Pull Request
This PR fixes a one-click all access oversight for MetaStation's service hallway. An additional reinforced window has been added between the plastic flaps and the door, thus preventing the character from opening it while lying down.

https://github.com/tgstation/tgstation/assets/80724828/47102cdc-a7f1-42e2-888c-940f47bc51c9

https://github.com/tgstation/tgstation/assets/80724828/e4fa1b2e-5602-40f4-820c-20fa8d704ef2

## Why It's Good For The Game
The service hallway should not be accessible just by lying down and clicking once.

## Changelog
:cl:
fix: [Metastation] Service hallway door being bypassed by lying down
/:cl:
