### PR TITLE
adds sgt.araneus to birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -76062,6 +76062,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/mob/living/basic/spider/giant/sgt_araneus,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
 "yaG" = (


### PR DESCRIPTION

## About The Pull Request
All other stations have a pet for the hos, why doesn't birdshot?
## Why It's Good For The Game
HoS should have a pet like on other maps
## Changelog
:cl:
fix: HoS on birdshot now has a pet like on all other maps
/:cl:
