### PR TITLE
Adds logging for Legion Tumour interactions

### DIFF
--- a/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
@@ -149,7 +149,6 @@
 	if (QDELETED(src) || QDELETED(owner))
 		return
 	owner.log_message("has been turned into a Legion by their tumour.", LOG_VICTIM)
-	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion.")
 	owner.visible_message(span_boldwarning("Black tendrils burst from [owner]'s flesh, covering them in amorphous flesh!"))
 	var/mob/living/basic/mining/legion/new_legion = new spawn_type(owner.loc)
 	new_legion.consume(owner)

--- a/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
@@ -83,7 +83,7 @@
 	if (!ishuman(target))
 		return FALSE
 
-	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion")
+	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion.")
 	target.visible_message(span_boldwarning("[user] splatters [target] with [src]... and it springs into horrible life!"))
 	var/mob/living/basic/legion_brood/skull = new(target.loc)
 	skull.melee_attack(target)
@@ -149,7 +149,7 @@
 	if (QDELETED(src) || QDELETED(owner))
 		return
 	owner.log_message("has been turned into a Legion by their tumour.", LOG_VICTIM)
-	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion")
+	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion.")
 	owner.visible_message(span_boldwarning("Black tendrils burst from [owner]'s flesh, covering them in amorphous flesh!"))
 	var/mob/living/basic/mining/legion/new_legion = new spawn_type(owner.loc)
 	new_legion.consume(owner)

--- a/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
@@ -55,6 +55,10 @@
 	stage = 0
 	elapsed_time = 0
 
+/obj/item/organ/internal/legion_tumour/on_mob_insert(mob/living/carbon/organ_owner, special, movement_flags)
+	. = ..()
+	owner.log_message("has received [src] which will eventually turn them into a Legion.", LOG_VICTIM)
+
 /obj/item/organ/internal/legion_tumour/attack(mob/living/target, mob/living/user, params)
 	if (try_apply(target, user))
 		qdel(src)
@@ -79,6 +83,7 @@
 	if (!ishuman(target))
 		return FALSE
 
+	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion")
 	target.visible_message(span_boldwarning("[user] splatters [target] with [src]... and it springs into horrible life!"))
 	var/mob/living/basic/legion_brood/skull = new(target.loc)
 	skull.melee_attack(target)
@@ -143,6 +148,8 @@
 /obj/item/organ/internal/legion_tumour/proc/infest()
 	if (QDELETED(src) || QDELETED(owner))
 		return
+	owner.log_message("has been turned into a Legion by their tumour.", LOG_VICTIM)
+	log_combat(user, target, "used a Legion Tumour on", src, "as they are in crit, this will turn them into a Legion")
 	owner.visible_message(span_boldwarning("Black tendrils burst from [owner]'s flesh, covering them in amorphous flesh!"))
 	var/mob/living/basic/mining/legion/new_legion = new spawn_type(owner.loc)
 	new_legion.consume(owner)


### PR DESCRIPTION
## About The Pull Request

Adds logs to three events:
- Receiving a Legion Tumour organ (logs victim).
- Being transformed by having a Legion Tumour organ for too long (logs victim).
- A Critically Wounded person being clicked with a Legion Tumour and turned into a Legion (logs attacker and victim).

## Why It's Good For The Game

It hasn't happened _often_ but I've seen these various interactions confuse admins (or players) every so often and it's good to log things that aren't obvious (and many things which are).
This usually comes up in the case of someone getting one from a Bioscrambler and then later experiencing a surprise transformation.

## Changelog

:cl:
admin: Various bad things that can happen as a result of Legion organs are now logged
/:cl:
