### PR TITLE
Advanced Health Analysers can detect certain organs

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -26,6 +26,8 @@
 #define ORGAN_HIDDEN (1<<9)
 /// Has the organ already been inserted inside someone
 #define ORGAN_VIRGIN (1<<10)
+/// ALWAYS show this when scanned by advanced scanners, even if it is totally healthy
+#define ORGAN_PROMINENT (1<<11)
 
 /// Helper to figure out if a limb is organic
 #define IS_ORGANIC_LIMB(limb) (limb.bodytype & BODYTYPE_ORGANIC)

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -279,7 +279,7 @@
 				<td style='width:12em;'><font color='#ff0000'><b>Status</b></font></td>"
 
 			for(var/obj/item/organ/organ as anything in humantarget.organs)
-				var/status = organ.get_status_text()
+				var/status = organ.get_status_text(advanced)
 				if (status != "")
 					render = TRUE
 					toReport += "<tr><td><font color='#cc3333'>[organ.name]:</font></td>\

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -3,7 +3,7 @@
 	desc = "A nausea-inducing hunk of twisting flesh and metal."
 	icon = 'icons/obj/antags/abductor.dmi'
 	icon_state = "gland"
-	organ_flags = ORGAN_ROBOTIC // weird?
+	organ_flags = ORGAN_ROBOTIC | ORGAN_PROMINENT // weird?
 	/// Shows name of the gland as well as a description of what it does upon examination by abductor scientists and observers.
 	var/abductor_hint = "baseline placebo referencer"
 

--- a/code/modules/antagonists/heretic/items/corrupted_organs.dm
+++ b/code/modules/antagonists/heretic/items/corrupted_organs.dm
@@ -2,6 +2,7 @@
 /obj/item/organ/internal/eyes/corrupt
 	name = "corrupt orbs"
 	desc = "These eyes have seen something they shouldn't have."
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	/// The override images we are applying
 	var/list/hallucinations
 
@@ -39,6 +40,7 @@
 /obj/item/organ/internal/tongue/corrupt
 	name = "corrupt tongue"
 	desc = "This one tells only lies."
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 
 /obj/item/organ/internal/tongue/corrupt/Initialize(mapload)
 	. = ..()
@@ -65,6 +67,7 @@
 /obj/item/organ/internal/liver/corrupt
 	name = "corrupt liver"
 	desc = "After what you've seen you could really go for a drink."
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	/// How much extra ingredients to add?
 	var/amount_added = 5
 	/// What extra ingredients can we add?
@@ -108,6 +111,7 @@
 /obj/item/organ/internal/stomach/corrupt
 	name = "corrupt stomach"
 	desc = "This parasite demands an unwholesome diet in order to be satisfied."
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	/// Do we have an unholy thirst?
 	var/thirst_satiated = FALSE
 	/// Timer for when we get thirsty again
@@ -173,6 +177,7 @@
 /obj/item/organ/internal/heart/corrupt
 	name = "corrupt heart"
 	desc = "What corruption is this spreading along with the blood?"
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	/// How long until the next heart?
 	COOLDOWN_DECLARE(hand_cooldown)
 
@@ -192,6 +197,7 @@
 /obj/item/organ/internal/lungs/corrupt
 	name = "corrupt lungs"
 	desc = "Some things SHOULD be drowned in tar."
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	/// How likely are we not to cough every time we take a breath?
 	var/cough_chance = 15
 	/// How much gas to emit?
@@ -226,6 +232,7 @@
 /obj/item/organ/internal/appendix/corrupt
 	name = "corrupt appendix"
 	desc = "What kind of dark, cosmic force is even going to bother to corrupt an appendix?"
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	/// How likely are we to spawn worms?
 	var/worm_chance = 2
 

--- a/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_tumour.dm
@@ -7,6 +7,7 @@
 	icon_state = "legion_remains"
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_PARASITE_EGG
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_VIRGIN | ORGAN_PROMINENT
 	decay_factor = STANDARD_ORGAN_DECAY * 3 // About 5 minutes outside of a host
 	/// What stage of growth the corruption has reached.
 	var/stage = 0

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -318,18 +318,23 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		replacement.set_organ_damage(damage)
 
 /// Called by medical scanners to get a simple summary of how healthy the organ is. Returns an empty string if things are fine.
-/obj/item/organ/proc/get_status_text()
-	var/status = ""
-	if(owner.has_reagent(/datum/reagent/inverse/technetium))
-		status = "<font color='#E42426'>[round((damage/maxHealth)*100, 1)]% damaged.</font>"
-	else if(organ_flags & ORGAN_FAILING)
-		status = "<font color='#cc3333'>Non-Functional</font>"
-	else if(damage > high_threshold)
-		status = "<font color='#ff9933'>Severely Damaged</font>"
-	else if (damage > low_threshold)
-		status = "<font color='#ffcc33'>Mildly Damaged</font>"
+/obj/item/organ/proc/get_status_text(advanced)
+	if(advanced && (organ_flags & ORGAN_PROMINENT))
+		return "<font color='#cc3333'>Harmful Foreign Body</font>"
 
-	return status
+	if(owner.has_reagent(/datum/reagent/inverse/technetium))
+		return "<font color='#E42426'>[round((damage/maxHealth)*100, 1)]% damaged.</font>"
+
+	if(organ_flags & ORGAN_FAILING)
+		return "<font color='#cc3333'>Non-Functional</font>"
+
+	if(damage > high_threshold)
+		return "<font color='#ff9933'>Severely Damaged</font>"
+
+	if (damage > low_threshold)
+		return "<font color='#ffcc33'>Mildly Damaged</font>"
+
+	return ""
 
 /// Tries to replace the existing organ on the passed mob with this one, with special handling for replacing a brain without ghosting target
 /obj/item/organ/proc/replace_into(mob/living/carbon/new_owner)

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -87,7 +87,7 @@
 		ADD_TRAIT(organ_owner, TRAIT_DISEASELIKE_SEVERITY_MEDIUM, type)
 		organ_owner.med_hud_set_status()
 
-/obj/item/organ/internal/appendix/get_status_text()
+/obj/item/organ/internal/appendix/get_status_text(advanced)
 	if((!(organ_flags & ORGAN_FAILING)) && inflamation_stage)
 		return "<font color='#ff9933'>Inflamed</font>"
 	else


### PR DESCRIPTION
## About The Pull Request

This PR makes certain organs appear in the output of the Advanced Health Analyzer, even if they are at 100% health.
![image](https://github.com/tgstation/tgstation/assets/7483112/0a0f143e-e29b-4107-9f96-612278709548)

The organs this applies to are:
- Legion Tumours
- Heretic Organs which you get when you are sacrificed
- Abductor Organs (but it doesn't specify what they do)

It doesn't apply to xenomorph or changeling eggs, or romerol tumours, as those are supposed to be "stealthy".

## Why It's Good For The Game

Basically I just saw someone ask for this to be possible and thought it sounded like a reasonable idea; none of these three things are intended to be particularly stealthy and it seemed like reasonably nice medical quality of life not to have to do exploratory surgery to detect their presence.
It should be reasonably obvious to a medical practitioner with the correct tools that something is wrong here.

## Changelog

:cl:
balance: Certain unhealthy organs can be detected via the advanced health scanner
/:cl:
