### PR TITLE
Adds more ingredients to the chef's grocery console.

### DIFF
--- a/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
@@ -142,5 +142,5 @@
 
 /datum/orderable_item/milk_eggs/moonfish
 	name = "Moonfish"
-	item_path = /obj/item/food/meat/slab/moonfish
+	item_path = /obj/item/food/fishmeat/moonfish
 	cost_per_order = 30

--- a/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
@@ -134,3 +134,13 @@
 	name = "Mothic Pantry Pack"
 	item_path = /obj/item/storage/box/mothic_cans_sauces
 	cost_per_order = 120
+
+/datum/orderable_item/milk_eggs/armorfish
+	name = "Cleaned Armorfish"
+	item_path = /obj/item/food/fishmeat/armorfish
+	cost_per_order = 30
+
+/datum/orderable_item/milk_eggs/moonfish
+	name = "Moonfish"
+	item_path = /obj/item/food/meat/slab/moonfish
+	cost_per_order = 30

--- a/code/game/machinery/computer/orders/order_items/cook/order_reagents.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_reagents.dm
@@ -95,3 +95,13 @@
 	name = "Grounding Solution"
 	item_path = /obj/item/reagent_containers/condiment/grounding_solution
 	cost_per_order = 30
+
+/datum/orderable_item/reagents/honey
+	name = "Honey"
+	item_path = /obj/item/reagent_containers/condiment/honey
+	cost_per_order = 125 //its high quality honey :)
+
+/datum/orderable_item/reagents/mayonnaise
+	name = "Mayonnaise"
+	item_path = /obj/item/reagent_containers/condiment/mayonnaise
+	cost_per_order = 30

--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -150,3 +150,30 @@
 /datum/orderable_item/veggies/oat
 	name = "Oat"
 	item_path = /obj/item/food/grown/oat
+
+/datum/orderable_item/veggies/trumpet
+	name = "Spaceman's Trumpet"
+	item_path = /obj/item/food/grown/trumpet
+	cost_per_order = 25
+
+/datum/orderable_item/veggies/banana
+	name = "Banana"
+	item_path = /obj/item/food/grown/banana
+
+/datum/orderable_item/veggies/ghostchili
+	name = "Ghost Chili"
+	item_path = /obj/item/food/grown/ghost_chili
+	cost_per_order = 25
+
+/datum/orderable_item/veggies/lemon
+	name = "Lemon"
+	item_path = /obj/item/food/grown/citrus/lemon
+
+/datum/orderable_item/veggies/lime
+	name = "Lime"
+	item_path = /obj/item/food/grown/citrus/lime
+
+/datum/orderable_item/veggies/toechtauese
+	name = "Töchtaüse berries"
+	item_path = /obj/item/food/grown/toechtauese
+	cost_per_order = 15

--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -146,3 +146,7 @@
 	name = "Sweet Potato"
 	item_path = /obj/item/food/grown/potato/sweet
 	cost_per_order = 25
+
+/datum/orderable_item/veggies/oat
+	name = "Oat"
+	item_path = /obj/item/food/grown/oat

--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -89,3 +89,60 @@
 	name = "Pickled Voltvine"
 	item_path = /obj/item/food/pickled_voltvine
 	cost_per_order = 5
+
+/datum/orderable_item/veggies/chili
+	name = "Chili"
+	item_path = /obj/item/food/grown/chili
+
+/datum/orderable_item/veggies/berries
+	name = "Berries"
+	item_path = /obj/item/food/grown/berries
+
+/datum/orderable_item/veggies/pineapple
+	name = "Pineapple"
+	item_path = /obj/item/food/grown/pineapple
+
+/datum/orderable_item/veggies/peas
+	name = "Peas"
+	item_path = /obj/item/food/grown/peas
+
+/datum/orderable_item/veggies/korta_nut //nanotrasen does not devote as much of their resources to pathetic lizard crops
+	name = "Korta Nut"
+	item_path = /obj/item/food/grown/korta_nut
+	cost_per_order = 15
+
+/datum/orderable_item/veggies/parsnip
+	name = "Parsnip"
+	item_path = /obj/item/food/grown/parsnip
+
+/datum/orderable_item/veggies/redbeet
+	name = "Red Beet"
+	item_path = /obj/item/food/grown/redbeet
+
+/datum/orderable_item/veggies/orange
+	name = "Orange"
+	item_path = /obj/item/food/grown/citrus/orange
+
+/datum/orderable_item/veggies/vanillapod
+	name = "Vanilla"
+	item_path = /obj/item/food/grown/vanillapod
+	cost_per_order = 25 //food items that are treated as mutations in game should be more expensive. groceries shouldnt include ACTUAL mutations but i think real foods are ok
+
+/datum/orderable_item/veggies/sweetkorta
+	name = "Sweet Korta Nut"
+	item_path = /obj/item/food/grown/korta_nut/sweet
+	cost_per_order = 30
+
+/datum/orderable_item/veggies/redonion
+	name = "Red Onion"
+	item_path = /obj/item/food/grown/onion/red
+	cost_per_order = 25
+
+/datum/orderable_item/veggies/peanut
+	name = "Peanut"
+	item_path = /obj/item/food/grown/peanut
+
+/datum/orderable_item/veggies/sweetpotato
+	name = "Sweet Potato"
+	item_path = /obj/item/food/grown/potato/sweet
+	cost_per_order = 25


### PR DESCRIPTION
## About The Pull Request

As title. The chef's grocery console now has twenty four!!! new orderable options that are commonly used in cooking.

## Why It's Good For The Game

Chefs can spend more of their time playing as a chef and less of their time not playing as a chef

## Changelog
:cl:
add: Nanotrasen has made strides in their frontier sector food networks, increasing the selection of produce available to chefs.
/:cl:
