### PR TITLE
Increases move resistance on NODE Drones, adds handling for when the drone is seperated from the node

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -214,6 +214,7 @@
 		node = new /mob/living/basic/node_drone(loc)
 		node.arrive(src)
 		RegisterSignal(node, COMSIG_QDELETING, PROC_REF(handle_wave_conclusion))
+		RegisterSignal(node, COMSIG_MOVABLE_MOVED, PROC_REF(handle_wave_conclusion))
 	particles = new /particles/smoke/ash()
 	for(var/i in 1 to 5) // Clears the surroundings of the ore vent before starting wave defense.
 		for(var/turf/closed/mineral/rock in oview(i))
@@ -266,8 +267,18 @@
 	SEND_SIGNAL(src, COMSIG_VENT_WAVE_CONCLUDED)
 	COOLDOWN_RESET(src, wave_cooldown)
 	particles = null
-	if(!QDELETED(node)) ///The Node Drone has survived the wave defense, and the ore vent is tapped.
-		tapped = TRUE
+
+	if(!QDELETED(node))
+		if(get_turf(node) != get_turf(src))
+			visible_message(span_danger("The [node] detaches from the [src], and the vent closes back up!"))
+			icon_state = initial(icon_state)
+			update_appearance(UPDATE_ICON_STATE)
+			UnregisterSignal(node, COMSIG_MOVABLE_MOVED)
+			node.pre_escape(success = FALSE)
+			node = null
+			return //Start over!
+
+		tapped = TRUE //The Node Drone has survived the wave defense, and the ore vent is tapped.
 		SSore_generation.processed_vents += src
 		balloon_alert_to_viewers("vent tapped!")
 		icon_state = icon_state_tapped

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	if(!isturf(thing.loc)) // no extracting stuff inside other stuff
 		return
 	if(thing.anchored || (thing.move_resist > max_force_fulton))
-		to_chat(user, span_warning("[thing] is too heavy for the [src] to lift!"))
+		balloon_alert(user, "too heavy!")
 		return
 
 	balloon_alert_to_viewers("attaching...")

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -78,6 +78,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	if(!isturf(thing.loc)) // no extracting stuff inside other stuff
 		return
 	if(thing.anchored || (thing.move_resist > max_force_fulton))
+		to_chat(user, span_warning("[thing] is too heavy for the [src] to lift!"))
 		return
 
 	balloon_alert_to_viewers("attaching...")

--- a/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon.dm
+++ b/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon.dm
@@ -18,9 +18,9 @@
 	attack_verb_simple = "slice"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	move_force = MOVE_FORCE_EXTREMELY_STRONG
-	move_resist = MOVE_FORCE_EXTREMELY_STRONG
-	pull_force = MOVE_FORCE_EXTREMELY_STRONG
+	move_force = MOVE_FORCE_VERY_STRONG
+	move_resist = MOVE_FORCE_VERY_STRONG
+	pull_force = MOVE_FORCE_VERY_STRONG
 	crusher_loot = /obj/item/crusher_trophy/ice_demon_cube
 	ai_controller = /datum/ai_controller/basic_controller/ice_demon
 	death_message = "fades as the energies that tied it to this world dissipate."

--- a/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon.dm
+++ b/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon.dm
@@ -18,9 +18,9 @@
 	attack_verb_simple = "slice"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	move_force = MOVE_FORCE_VERY_STRONG
-	move_resist = MOVE_FORCE_VERY_STRONG
-	pull_force = MOVE_FORCE_VERY_STRONG
+	move_force = MOVE_FORCE_EXTREMELY_STRONG
+	move_resist = MOVE_FORCE_EXTREMELY_STRONG
+	pull_force = MOVE_FORCE_EXTREMELY_STRONG
 	crusher_loot = /obj/item/crusher_trophy/ice_demon_cube
 	ai_controller = /datum/ai_controller/basic_controller/ice_demon
 	death_message = "fades as the energies that tied it to this world dissipate."

--- a/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
+++ b/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
@@ -85,14 +85,17 @@
 /**
  * Called when wave defense is completed. Visually flicks the escape sprite and then deletes the mob.
  */
-/mob/living/basic/node_drone/proc/escape()
+/mob/living/basic/node_drone/proc/escape(success)
 	var/funny_ending = FALSE
 	flying_state = FLY_OUT_STATE
 	update_appearance(UPDATE_ICON_STATE)
 	if(prob(1))
 		say("I have to go now, my planet needs me.")
 		funny_ending = TRUE
-	visible_message(span_notice("The drone flies away to safety as the vent is secured."))
+	if(success)
+		visible_message(span_notice("The drone flies away to safety as the vent is secured."))
+	else
+		visible_message(span_danger("The drone flies away after failing to open the vent!"))
 	animate(src, pixel_z = 400, time = 2 SECONDS, easing = QUAD_EASING|EASE_IN, flags = ANIMATION_PARALLEL)
 	sleep(2 SECONDS)
 	if(funny_ending)
@@ -101,14 +104,15 @@
 	qdel(src)
 
 
-/mob/living/basic/node_drone/proc/pre_escape()
+/mob/living/basic/node_drone/proc/pre_escape(success = TRUE)
+	if(buckled)
+		buckled.unbuckle_mob(src)
 	if(attached_vent)
-		attached_vent.unbuckle_mob(src)
 		attached_vent = null
 	if(!escaping)
 		escaping = TRUE
 		flick("mining_node_escape", src)
-		addtimer(CALLBACK(src, PROC_REF(escape)), 1.9 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(escape), success), 1.9 SECONDS)
 		return
 
 /// The node drone AI controller

--- a/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
+++ b/code/modules/mob/living/basic/lavaland/node_drone/node_drone.dm
@@ -26,7 +26,9 @@
 	faction = list(FACTION_STATION, FACTION_NEUTRAL)
 	light_range = 4
 	basic_mob_flags = DEL_ON_DEATH
-
+	move_force = MOVE_FORCE_VERY_STRONG
+	move_resist = MOVE_FORCE_VERY_STRONG
+	pull_force = MOVE_FORCE_VERY_STRONG
 	speak_emote = list("chirps")
 	response_help_continuous = "pets"
 	response_help_simple = "pet"


### PR DESCRIPTION
## About The Pull Request

NODE Drones now have higher move resistance (MOVE_FORCE_EXTREMELY_STRONG), preventing them from being bumped off the node, pulled away, or lifted away by a fulton extraction kit.

As an extra layer of assurance, the NODE Drone will depart from the site if it is moved off of its vent.

## Why It's Good For The Game

Closes #83164.

I'm pretty sure these things shouldn't really be ever moving off of their vents.
## Changelog
:cl: Rhials
fix: You can no longer force NODE Drones off of ore vents. That includes using fulton packs!
fix: When a NODE Drone is forcibly separated from its vent, it will fly away.
/:cl:
