### PR TITLE
Fixed lights doing processing when they shouldn't need to.

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -293,6 +293,7 @@
 
 /obj/machinery/light/process(seconds_per_tick)
 	if(has_power())
+		// If the cell is done mooching station power, and reagents don't need processing, stop processing
 		if(is_full_charge() && !reagents)
 			return PROCESS_KILL
 		if(cell)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -292,7 +292,6 @@
 	return TRUE
 
 /obj/machinery/light/process(seconds_per_tick)
-	var/got_power = has_power()
 	if(has_power())
 		if(is_full_charge() && !reagents)
 			return PROCESS_KILL

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -286,11 +286,17 @@
 		var/delay = rand(BROKEN_SPARKS_MIN, BROKEN_SPARKS_MAX)
 		addtimer(CALLBACK(src, PROC_REF(broken_sparks)), delay, TIMER_UNIQUE | TIMER_NO_HASH_WAIT)
 
+/obj/machinery/light/proc/is_full_charge()
+	if(cell)
+		return cell.charge == cell.maxcharge
+	return TRUE
+
 /obj/machinery/light/process(seconds_per_tick)
-	if(has_power()) //If the light is being powered by the station.
+	var/got_power = has_power()
+	if(has_power())
+		if(is_full_charge() && !reagents)
+			return PROCESS_KILL
 		if(cell)
-			if(cell.charge == cell.maxcharge && !reagents) //If the cell is done mooching station power, and reagents don't need processing, stop processing
-				return PROCESS_KILL
 			charge_cell(LIGHT_EMERGENCY_POWER_USE * seconds_per_tick, cell = cell) //Recharge emergency power automatically while not using it
 	if(reagents) //with most reagents coming out at 300, and with most meaningful reactions coming at 370+, this rate gives a few seconds of time to place it in and get out of dodge regardless of input.
 		reagents.adjust_thermal_energy(8 * reagents.total_volume * SPECIFIC_HEAT_DEFAULT * seconds_per_tick)


### PR DESCRIPTION

## About The Pull Request
Lights would do processing if they spawned with a mock cell, since it would never pass the conditional to see if the cell was full and stop processing since the cell didn't exist. This fixes that by making it so that having no cell equates to having a full one.

This is expected since whenever any charge is supposed to be used by the cell, it will generate the cell which will have full charge.

## Why It's Good For The Game
Fixes a potential performance hog. Metastation dropped from 2800 processing machinery to 1900 after implementing this change.

## Changelog

No player facing changes
