### PR TITLE
Syndicate AI fixes

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -481,9 +481,10 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 			continue
 		if(ai.control_disabled)
 			continue
-		if(skip_syndicate && (ROLE_SYNDICATE in ai.faction))
+		var/syndie_ai = istype(ai, /mob/living/silicon/ai/weak_syndie)
+		if(skip_syndicate && syndie_ai)
 			continue
-		if(only_syndicate && !(ROLE_SYNDICATE in ai.faction))
+		if(only_syndicate && !syndie_ai)
 			continue
 		if(check_mind)
 			if(!ai.mind)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -474,12 +474,16 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 		. += borg
 
 //Returns a list of AI's
-/proc/active_ais(check_mind=FALSE, z = null)
+/proc/active_ais(check_mind=FALSE, z = null, skip_syndicate, only_syndicate)
 	. = list()
 	for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
 		if(ai.stat == DEAD)
 			continue
 		if(ai.control_disabled)
+			continue
+		if(skip_syndicate && (ROLE_SYNDICATE in ai.faction))
+			continue
+		if(only_syndicate && !(ROLE_SYNDICATE in ai.faction))
 			continue
 		if(check_mind)
 			if(!ai.mind)
@@ -507,8 +511,8 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 			. = pick(borgs)
 	return .
 
-/proc/select_active_ai(mob/user, z = null)
-	var/list/ais = active_ais(FALSE, z)
+/proc/select_active_ai(mob/user, z = null, skip_syndicate, only_syndicate)
+	var/list/ais = active_ais(FALSE, z, skip_syndicate, only_syndicate)
 	if(ais.len)
 		if(user)
 			. = input(user,"AI signals detected:", "AI Selection", ais[1]) in sort_list(ais)

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -35,10 +35,11 @@
 		if(WIRE_AI) // Pulse to pick a new AI.
 			if(!R.emagged)
 				var/new_ai
+				var/is_a_syndi_borg = (ROLE_SYNDICATE in R.faction)
 				if(user)
-					new_ai = select_active_ai(user, R.z)
+					new_ai = select_active_ai(user, R.z, !is_a_syndi_borg, is_a_syndi_borg)
 				else
-					new_ai = select_active_ai(R, R.z)
+					new_ai = select_active_ai(R, R.z, !is_a_syndi_borg, is_a_syndi_borg)
 				R.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
 				if(new_ai && (new_ai != R.connected_ai))
 					R.set_connected_ai(new_ai)

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -48,7 +48,7 @@
 		return INITIALIZE_HINT_QDEL
 
 /obj/machinery/computer/upload/ai/interact(mob/user)
-	current = select_active_ai(user, z)
+	current = select_active_ai(user, z, TRUE)
 
 	if (!current)
 		to_chat(user, span_alert("No active AIs detected!"))

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -250,7 +250,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_generic_objective()
 	if(prob(KILL_PROB))
-		var/list/active_ais = active_ais()
+		var/list/active_ais = active_ais(skip_syndicate = TRUE)
 		if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
 			var/datum/objective/destroy/destroy_objective = new()
 			destroy_objective.owner = owner


### PR DESCRIPTION
Fixes #83291 

:cl: ShizCalev
fix: Syndicate AI can no longer be selected via the station law upload console.
fix: Non-syndicate borgs can no longer accidentally be slaved to syndicate AI by pulsing their AI wires. 
fix: Syndicate borgs can no longer be slaved to the station AI by pulsing their AI wires.
fix: Syndicate operatives onboard the station can no longer end up with an objective to destroy their own syndicate AI. 
/:cl:
