### PR TITLE
Unreverts the fixes from #82713; the mining station once again no longer rapidly loses power

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -650,7 +650,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/toy/plush/shark{
-	name = "Snappy"
 	desc = "A plushie depicting a somewhat cartoonish shark. The tag calls it a 'hákarl', noting that it was made by an obscure furniture manufacturer in old Scandinavia. This one seems to have some cable wiring sticking out of its mouth."
 	},
 /turf/open/lava/smooth/lava_land_surface,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -645,6 +645,16 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ey" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/toy/plush/shark{
+	name = "Snappy"
+	desc = "A plushie depicting a somewhat cartoonish shark. The tag calls it a 'hákarl', noting that it was made by an obscure furniture manufacturer in old Scandinavia. This one seems to have some cable wiring sticking out of its mouth."
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ez" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -2869,7 +2879,7 @@
 /area/mine/laborcamp/production)
 "ps" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
@@ -5038,7 +5048,7 @@
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "Ee" = (
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
@@ -29901,7 +29911,7 @@ Xw
 aj
 aj
 aj
-cU
+ey
 aj
 aj
 aj


### PR DESCRIPTION

## About The Pull Request

#82537 unfortunately reverted my fixes in #82713 because of how old that PR was when it was merged. So this restores those fixes.

## Why It's Good For The Game

The bane of map prs that stay up for a really long time is that this happens a lot more than you would think.

## Changelog
:cl:
fix: Miners can actually access and fix their engineering issues on the lavaland base via the engineering section of the base. AGAIN.
fix: The gulag SMES unit is no longer needlessly draining the entire power grid of the main mining base. AGAIN.
/:cl:
