### PR TITLE
Sentience balloon can now assign antag to affected mobs

### DIFF
--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -38,6 +38,7 @@
 	desc = "When this pops, things are gonna get more aware around here."
 	var/group_name = "a bunch of giant spiders"
 	var/effect_range = 3
+	var/antag_type = null
 
 /obj/effect/fun_balloon/sentience/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -73,6 +74,14 @@
 		if("effect_range")
 			effect_range = params["updated_range"]
 
+		if("select_antag")
+			// var/list/antagonists = list()
+			var/list/paths = subtypesof(/datum/antagonist)
+			// for(var/path in paths)
+			// 	var/datum/antagonist/O = path
+			// 	antagonists[initial(O.name)] = path
+			antag_type = input(usr,"Select antag", "Antagonist selection") as null|anything in sort_list(paths)
+
 		if("pop")
 			if(!popped)
 				popped = TRUE
@@ -105,6 +114,9 @@
 		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(body)])")
 		body.ghostize(FALSE)
 		body.key = C.key
+		if (antag_type != null)
+			body.mind.add_antag_datum(antag_type)
+			continue
 		new /obj/effect/temp_visual/gravpush(get_turf(body))
 
 // ----------- Emergency Shuttle Balloon

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -39,6 +39,7 @@
 	var/group_name = "a bunch of giant spiders"
 	var/effect_range = 3
 	var/antag_type = null
+	var/make_antag = FALSE
 
 /obj/effect/fun_balloon/sentience/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -50,6 +51,7 @@
 	var/list/data = list()
 	data["group_name"] = group_name
 	data["range"] = effect_range
+	data["antag"] = make_antag
 	return data
 
 /obj/effect/fun_balloon/sentience/ui_state(mob/user)
@@ -77,6 +79,7 @@
 		if("select_antag")
 			var/list/paths = subtypesof(/datum/antagonist)
 			antag_type = input(usr,"Select antag", "Antagonist selection") as null|anything in sort_list(paths)
+			make_antag = TRUE
 
 		if("pop")
 			if(!popped)
@@ -110,7 +113,7 @@
 		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(body)])")
 		body.ghostize(FALSE)
 		body.key = C.key
-		if (antag_type != null)
+		if (make_antag)
 			body.mind.add_antag_datum(antag_type)
 			continue
 		new /obj/effect/temp_visual/gravpush(get_turf(body))

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -75,11 +75,7 @@
 			effect_range = params["updated_range"]
 
 		if("select_antag")
-			// var/list/antagonists = list()
 			var/list/paths = subtypesof(/datum/antagonist)
-			// for(var/path in paths)
-			// 	var/datum/antagonist/O = path
-			// 	antagonists[initial(O.name)] = path
 			antag_type = input(usr,"Select antag", "Antagonist selection") as null|anything in sort_list(paths)
 
 		if("pop")

--- a/tgui/packages/tgui/interfaces/SentienceFunBalloon.jsx
+++ b/tgui/packages/tgui/interfaces/SentienceFunBalloon.jsx
@@ -11,7 +11,7 @@ import { Window } from '../layouts';
 
 export const SentienceFunBalloon = (props) => {
   const { act, data } = useBackend();
-  const { group_name, range } = data;
+  const { group_name, range, antag } = data;
   return (
     <Window title={'Sentience Fun Balloon'} width={400} height={200}>
       <Window.Content>
@@ -45,10 +45,10 @@ export const SentienceFunBalloon = (props) => {
                 />
               </LabeledList.Item>
               <LabeledList.Item label="Make group into antagonists?">
-                <Button
-                  icon={data.on ? 'user-secret' : 'times'}
-                  content={data.on ? 'Yes' : 'No'}
-                  selected={data.on}
+                <Button.Checkbox
+                  icon={data.antag ? 'user-secret' : 'times'}
+                  content={data.antag ? 'Yes' : 'No'}
+                  selected={data.antag}
                   onClick={() => act('select_antag')}
                 />
               </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/SentienceFunBalloon.jsx
+++ b/tgui/packages/tgui/interfaces/SentienceFunBalloon.jsx
@@ -13,7 +13,7 @@ export const SentienceFunBalloon = (props) => {
   const { act, data } = useBackend();
   const { group_name, range } = data;
   return (
-    <Window title={'Sentience Fun Balloon'} width={400} height={175}>
+    <Window title={'Sentience Fun Balloon'} width={400} height={200}>
       <Window.Content>
         <Stack vertical>
           <Section title="Configure balloon effect:">
@@ -42,6 +42,14 @@ export const SentienceFunBalloon = (props) => {
                       updated_range: value,
                     })
                   }
+                />
+              </LabeledList.Item>
+              <LabeledList.Item label="Make group into antagonists?">
+                <Button
+                  icon={data.on ? 'user-secret' : 'times'}
+                  content={data.on ? 'Yes' : 'No'}
+                  selected={data.on}
+                  onClick={() => act('select_antag')}
                 />
               </LabeledList.Item>
             </LabeledList>


### PR DESCRIPTION
## About The Pull Request
![изображение](https://github.com/tgstation/tgstation/assets/53361823/732725fe-7c87-48dd-a0d0-bab990e54cef)
![изображение](https://github.com/tgstation/tgstation/assets/53361823/4b78a0ae-05e2-40ea-9f48-574fb9ba1140)

there's probably a better way to show the list of antags
## Why It's Good For The Game
I wanna give out antag datum to things I spawn, doing it one by one is annoying
## Changelog
:cl:
admin: sentience balloon can now assign antag to affected mobs
/:cl:
