### PR TITLE
Makes wound noises drop off more quickly, requires higher severity for conspicuous messaging

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -215,13 +215,13 @@
 		var/msg = span_danger("[victim]'s [limb.plaintext_zone] [occur_text]!")
 		var/vis_dist = COMBAT_MESSAGE_RANGE
 
-		if(severity > WOUND_SEVERITY_MODERATE)
+		if(severity > WOUND_SEVERITY_SEVERE)
 			msg = "<b>[msg]</b>"
 			vis_dist = DEFAULT_MESSAGE_RANGE
 
 		victim.visible_message(msg, span_userdanger("Your [limb.plaintext_zone] [occur_text]!"), vision_distance = vis_dist)
 		if(sound_effect)
-			playsound(L.owner, sound_effect, sound_volume + (20 * severity), TRUE)
+			playsound(L.owner, sound_effect, sound_volume + (20 * severity), TRUE, falloff_exponent = SOUND_FALLOFF_EXPONENT + 2,  ignore_walls = FALSE, falloff_distance = 0)
 
 	wound_injury(old_wound, attack_direction = attack_direction)
 	if(!demoted)


### PR DESCRIPTION

## About The Pull Request

Wounds are louder than the attacks that cause them. As well, if you are using a weapon that is meant to be silent or stealthy, the sound of your victim spraying blood ends up being louder than the silenced pistol you're using. This pull request changes wound sounds to drop off more quickly and not penetrate walls (attack sounds already penetrate walls in almost all cases already), and also increases the severity needed for a wound to be broadcast to anyone in view, instead of only to combat message range.
## Why It's Good For The Game

It doesn't make sense for the sound of the wound you inflict to be louder than the weapon you're using. This mostly applies to silenced or stealthy weapons.
## Changelog
:cl: Bisar
balance: A wound being inflicted doesn't get broadcasted to everyone in view until a higher severity now.
sound: Wound sounds drop off more quickly, and no longer travel through walls. This has no effect on attack sounds.
/:cl:
