### PR TITLE
add RUN_SERVER.bat, uplink smokes & tweak emp price

### DIFF
--- a/RUN_SERVER.bat
+++ b/RUN_SERVER.bat
@@ -1,0 +1,3 @@
+@echo off
+call "%~dp0\tools\build\build.bat" server %*
+pause

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -440,6 +440,13 @@
 		new /obj/item/grenade/empgrenade(src)
 	new /obj/item/implanter/emp(src)
 
+/obj/item/storage/box/syndie_kit/smoke
+	name = "smoke kit"
+
+/obj/item/storage/box/syndie_kit/smoke/PopulateContents()
+	for(var/i in 1 to 4)
+		new /obj/item/grenade/smokebomb(src)
+
 /obj/item/storage/box/syndie_kit/mail_counterfeit
 	name = "mail counterfeit kit"
 	desc = "A box full of mail counterfeit devices. Nothing stops the mail."

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -50,12 +50,18 @@
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \
 			security's energy weapons and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 2
+	cost = 3
 
 /datum/uplink_item/explosives/emp/New()
 	..()
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
 		cost *= 3
+
+/datum/uplink_item/explosives/smoke
+	name = "Smoke Grenades"
+	desc = "A box that contains four smoke grenades. Useful for vanishing and ninja fans with katana."
+	item = /obj/item/storage/box/syndie_kit/smoke
+	cost = 3
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"


### PR DESCRIPTION
## About The Pull Request

Adding RUN_SERVER.bat is useful for starting the server, smoke kit by 3 TC, tweak emp kit price 2 -> 3 TC

## Why It's Good For The Game

Smokes can be a good addition for stealth implant, vanishing, slicing with a katana. 5 emp grenades and an implant for three uses is considered too cheap, for which the price is raised by 1 TC

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/tgstation/tgstation/assets/60922927/5451cf16-8310-43d2-9ea9-ee57a5d05b8e)
![image](https://github.com/tgstation/tgstation/assets/60922927/89b56042-2b25-4f5e-bfd4-b5d088c56abd)
![image](https://github.com/tgstation/tgstation/assets/60922927/56d0c084-6c46-4e58-8931-c30d623858ee)

</details>

## Changelog

:cl:
add: Added RUN_SERVER.bat for maintainers
add: Added smoke kit with four grenades to uplink by 3 TC
balance: tweak EMP kit price to 3 TC (from 2 TC)
/:cl:
