### PR TITLE
add smoke kit to uplink

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -440,6 +440,13 @@
 		new /obj/item/grenade/empgrenade(src)
 	new /obj/item/implanter/emp(src)
 
+/obj/item/storage/box/syndie_kit/smoke
+	name = "smoke kit"
+
+/obj/item/storage/box/syndie_kit/smoke/PopulateContents()
+	for(var/i in 1 to 4)
+		new /obj/item/grenade/smokebomb(src)
+
 /obj/item/storage/box/syndie_kit/mail_counterfeit
 	name = "mail counterfeit kit"
 	desc = "A box full of mail counterfeit devices. Nothing stops the mail."

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -444,7 +444,7 @@
 	name = "smoke kit"
 
 /obj/item/storage/box/syndie_kit/smoke/PopulateContents()
-	for(var/i in 1 to 4)
+	for(var/i in 1 to 5)
 		new /obj/item/grenade/smokebomb(src)
 
 /obj/item/storage/box/syndie_kit/mail_counterfeit

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -59,7 +59,7 @@
 
 /datum/uplink_item/explosives/smoke
 	name = "Smoke Grenades"
-	desc = "A box that contains four smoke grenades. Useful for vanishing and ninja fans with katana."
+	desc = "A box that contains five smoke grenades. Useful for vanishing and ninja fans with katana."
 	item = /obj/item/storage/box/syndie_kit/smoke
 	cost = 2
 

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -61,7 +61,7 @@
 	name = "Smoke Grenades"
 	desc = "A box that contains four smoke grenades. Useful for vanishing and ninja fans with katana."
 	item = /obj/item/storage/box/syndie_kit/smoke
-	cost = 3
+	cost = 2
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -57,6 +57,12 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
 		cost *= 3
 
+/datum/uplink_item/explosives/smoke
+	name = "Smoke Grenades"
+	desc = "A box that contains four smoke grenades. Useful for vanishing and ninja fans with katana."
+	item = /obj/item/storage/box/syndie_kit/smoke
+	cost = 3
+
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"
 	desc = "A pizza box with a bomb cunningly attached to the lid. The timer needs to be set by opening the box; afterwards, \


### PR DESCRIPTION
## About The Pull Request

Add smoke kit (5 grenades) by 2 TC

## Why It's Good For The Game

Smokes can be a good addition for stealth implant, vanishing and slicing with a katana

## Proof of Testing

<details>
<summary>Screenshots/Videos OLD</summary>
  
![image](https://github.com/tgstation/tgstation/assets/60922927/89b56042-2b25-4f5e-bfd4-b5d088c56abd)
![image](https://github.com/tgstation/tgstation/assets/60922927/56d0c084-6c46-4e58-8931-c30d623858ee)

</details>

## Changelog


:cl:
add: Added smoke kit (5 grenades) with four grenades to uplink by 2 TC
/:cl:

