### PR TITLE
tweak emp kit price

### DIFF
--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -50,7 +50,7 @@
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \
 			security's energy weapons and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 2
+	cost = 3
 
 /datum/uplink_item/explosives/emp/New()
 	..()


### PR DESCRIPTION
## About The Pull Request

tweak emp kit price 2 -> 3 TC

## Why It's Good For The Game

5 emp grenades and an implant for three uses is considered too cheap, for which the price is raised by 1 TC

## Changelog

:cl:
balance: tweak EMP kit price to 3 TC (from 2 TC)
/:cl:

