### PR TITLE
fixes Booze-O-Mat and ShadyCigs Deluxe selling to minors

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1417,7 +1417,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 		if(isliving(usr))
 			living_user = usr
 			card_used = living_user.get_idcard(TRUE)
-		else if(age_restrictions && item_record.age_restricted && (!card_used.registered_age || card_used.registered_age < AGE_MINOR))
+		if(age_restrictions && item_record.age_restricted && (!card_used.registered_age || card_used.registered_age < AGE_MINOR))
 			speak("You are not of legal age to purchase [item_record.name].")
 			if(!(usr in GLOB.narcd_underages))
 				if (isnull(sec_radio))


### PR DESCRIPTION

## About The Pull Request
now they block the purchase and alert security like they used to
![image](https://github.com/tgstation/tgstation/assets/94711066/f1370e73-9acc-44eb-94dc-87273fe42b4f)
## Why It's Good For The Game
fixes #82653
## Changelog
:cl:
fix: underage drinkers beware: the Booze-O-Mat and ShadyCigs Deluxe check your age again
/:cl:
