### PR TITLE
Reduces free medieval holodeck claymore from 4(!) to 6 hit weapon

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -418,8 +418,8 @@
 
 /obj/item/claymore/weak
 	desc = "This one is rusted."
-	force = 30
-	armour_penetration = 15
+	force = 24
+	armour_penetration = 10
 
 /obj/item/claymore/weak/ceremonial
 	desc = "A rusted claymore, once at the heart of a powerful scottish clan struck down and oppressed by tyrants, it has been passed down the ages as a symbol of defiance."


### PR DESCRIPTION

## About The Pull Request
Did you know the medieval holodeck has two free claymores with 30 force? Me neither. And I will not have to.

## Why It's Good For The Game
Hey AI, I need my free 4-hit weapon. I'm totally not a changeling or anything.

Oh and it's not like there are non-human antags on Terry, or antag players that actually play station roles when they didn't get their antag.

## Changelog
:cl:
balance: reduced claymore/weak force from 30 to 24 and armor penetration from 15 to 10
/:cl:
