### PR TITLE
Fixes deathmatch modifier menu

### DIFF
--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -363,8 +363,8 @@
 	data["map"]["min_players"] = map.min_players
 	data["map"]["max_players"] = map.max_players
 
-	data["mod_menu_open"] = FALSE
-	data["modifiers"] = has_auth ? list() : get_modifier_list(is_host, mod_menu_open)
+	data["mod_menu_open"] = mod_menu_open
+	data["modifiers"] = has_auth ? get_modifier_list(is_host, mod_menu_open) : list()
 	data["observers"] = get_observer_list()
 	data["players"] = get_player_list()
 	data["playing"] = playing


### PR DESCRIPTION

## About The Pull Request

Title.

I dont understand this code very well, but I feel like passing in a static FALSE into mod_menu_open isnt intentional? Also, I have a feeling this ternary was flipped, since non-hosts would get getting the lsit of modifiers while the host gets nothing.
## Why It's Good For The Game

BUGS BAD
## Changelog
:cl:
fix: The deathmatch modifier menu works now
/:cl:
