### PR TITLE
Fixed spies having a duplicate elite syndicate modsuit

### DIFF
--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -59,14 +59,14 @@
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
 	item = /obj/item/storage/backpack/duffelbag/clown/syndie
-	purchasable_from = ALL
+	purchasable_from = ~(UPLINK_SPY)
 	progression_minimum = 70 MINUTES
 
 /datum/uplink_item/badass/costumes/tactical_naptime
 	name = "Sleepy Time Pajama Bundle"
 	desc = "Even soldiers need to get a good nights rest. Comes with blood-red pajamas, a blankie, a hot mug of cocoa and a fuzzy friend."
 	item = /obj/item/storage/box/syndie_kit/sleepytime
-	purchasable_from = ALL
+	purchasable_from = ~(UPLINK_SPY)
 	progression_minimum = 90 MINUTES
 	cost = 4
 	limited_stock = 1
@@ -77,14 +77,14 @@
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
 			Please note that this kit did NOT pass quality control."
 	purchasable_from = ALL
-	progression_minimum = 90 MINUTES
+	progression_minimum = ~(UPLINK_SPY)
 	item = /obj/item/storage/box/syndie_kit/chameleon/broken
 
 /datum/uplink_item/badass/costumes/centcom_official
 	name = "CentCom Official Costume"
 	desc = "Ask the crew to \"inspect\" their nuclear disk and weapons system, and then when they decline, pull out a fully automatic rifle and gun down the Captain. \
 			Radio headset does not include encryption key. No gun included."
-	purchasable_from = ALL
+	purchasable_from = ~(UPLINK_SPY)
 	progression_minimum = 110 MINUTES
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
 

--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -59,14 +59,14 @@
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
 	item = /obj/item/storage/backpack/duffelbag/clown/syndie
-	purchasable_from = ~(UPLINK_SPY)
+	purchasable_from = ALL
 	progression_minimum = 70 MINUTES
 
 /datum/uplink_item/badass/costumes/tactical_naptime
 	name = "Sleepy Time Pajama Bundle"
 	desc = "Even soldiers need to get a good nights rest. Comes with blood-red pajamas, a blankie, a hot mug of cocoa and a fuzzy friend."
 	item = /obj/item/storage/box/syndie_kit/sleepytime
-	purchasable_from = ~(UPLINK_SPY)
+	purchasable_from = ALL
 	progression_minimum = 90 MINUTES
 	cost = 4
 	limited_stock = 1
@@ -77,14 +77,14 @@
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
 			Please note that this kit did NOT pass quality control."
 	purchasable_from = ALL
-	progression_minimum = ~(UPLINK_SPY)
+	progression_minimum = 90 MINUTES
 	item = /obj/item/storage/box/syndie_kit/chameleon/broken
 
 /datum/uplink_item/badass/costumes/centcom_official
 	name = "CentCom Official Costume"
 	desc = "Ask the crew to \"inspect\" their nuclear disk and weapons system, and then when they decline, pull out a fully automatic rifle and gun down the Captain. \
 			Radio headset does not include encryption key. No gun included."
-	purchasable_from = ~(UPLINK_SPY)
+	purchasable_from = ALL
 	progression_minimum = 110 MINUTES
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
 

--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -70,6 +70,6 @@
 			provides the user with superior armor and mobility compared to the standard Syndicate MODsuit."
 	item = /obj/item/mod/control/pre_equipped/traitor_elite
 	// This one costs more than the nuke op counterpart
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS | UPLINK_SPY)
 	progression_minimum = 90 MINUTES
 	cost = 16


### PR DESCRIPTION

## About The Pull Request
As the title says.
These are the uplink items exclusive to traitor uplinks. Spies already get a variant of the hardsuit based on the nukie variant of this uplink item.

## Why It's Good For The Game
An uplink should have access to one or the other, not both.

## Changelog
:cl:
fix: Fixed spies having a slightly increased chance of getting a different cost model for the elite syndicate hardsuit
/:cl:
