### PR TITLE
buff cerulean major activation

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -105,14 +105,14 @@
 				M.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			to_chat(user, span_notice("You spit out a monkey cube."))
-			return 120
+			return 12 SECONDS
 		if(SLIME_ACTIVATE_MAJOR)
 			to_chat(user, span_notice("Your [name] starts pulsing..."))
 			if(do_after(user, 4 SECONDS, target = user))
 				var/mob/living/basic/slime/new_slime = new(get_turf(user), /datum/slime_type/grey)
 				playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 				to_chat(user, span_notice("You spit out [new_slime]."))
-				return 350
+				return 35 SECONDS
 			else
 				return 0
 
@@ -133,7 +133,7 @@
 				spawned_mob.faction |= FACTION_NEUTRAL
 				playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 				user.visible_message(span_warning("[user] spits out [spawned_mob]!"), span_notice("You spit out [spawned_mob]!"))
-				return 300
+				return 30 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			user.visible_message(span_warning("[user] starts shaking violently!"),span_warning("Your [name] starts pulsing violently..."))
@@ -145,7 +145,7 @@
 					spawned_mob.faction |= FACTION_SLIME
 				playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 				user.visible_message(span_warning("[user] spits out [spawned_mob]!"), span_warning("You spit out [spawned_mob]!"))
-				return 600
+				return 60 SECONDS
 
 /obj/item/slime_extract/silver
 	name = "silver slime extract"
@@ -165,7 +165,7 @@
 				food_item.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [food_item]!"), span_notice("You spit out [food_item]!"))
-			return 200
+			return 20 SECONDS
 		if(SLIME_ACTIVATE_MAJOR)
 			var/drink_type = get_random_drink()
 			var/obj/O = new drink_type
@@ -173,7 +173,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 200
+			return 20 SECONDS
 
 /obj/item/slime_extract/metal
 	name = "metal slime extract"
@@ -189,7 +189,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/obj/item/stack/sheet/iron/O = new(null, 5)
@@ -197,7 +197,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 200
+			return 20 SECONDS
 
 /obj/item/slime_extract/purple
 	name = "purple slime extract"
@@ -211,12 +211,12 @@
 			user.adjust_nutrition(50)
 			user.blood_volume += 50
 			to_chat(user, span_notice("You activate [src], and your body is refilled with fresh slime jelly!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			to_chat(user, span_notice("You activate [src], and it releases regenerative chemicals!"))
 			user.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,10)
-			return 600
+			return 60 SECONDS
 
 /obj/item/slime_extract/darkpurple
 	name = "dark purple slime extract"
@@ -232,14 +232,14 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/turf/open/T = get_turf(user)
 			if(istype(T))
 				T.atmos_spawn_air("[GAS_PLASMA]=20")
 			to_chat(user, span_warning("You activate [src], and a cloud of plasma bursts out of your skin!"))
-			return 900
+			return 90 SECONDS
 
 /obj/item/slime_extract/orange
 	name = "orange slime extract"
@@ -252,14 +252,14 @@
 		if(SLIME_ACTIVATE_MINOR)
 			to_chat(user, span_notice("You activate [src]. You start feeling hot!"))
 			user.reagents.add_reagent(/datum/reagent/consumable/capsaicin,10)
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			user.reagents.add_reagent(/datum/reagent/phosphorus,5)//
 			user.reagents.add_reagent(/datum/reagent/potassium,5) // = smoke, along with any reagents inside mr. slime
 			user.reagents.add_reagent(/datum/reagent/consumable/sugar,5)     //
 			to_chat(user, span_warning("You activate [src], and a cloud of smoke bursts out of your skin!"))
-			return 450
+			return 45 SECONDS
 
 /obj/item/slime_extract/yellow
 	name = "yellow slime extract"
@@ -282,7 +282,7 @@
 			if(do_after(user, 2.5 SECONDS, target = user))
 				empulse(user, 1, 2)
 				user.visible_message(span_warning("[user]'s skin flashes!"), span_warning("Your skin flashes as you emit an electromagnetic pulse!"))
-				return 600
+				return 60 SECONDS
 
 /obj/item/slime_extract/red
 	name = "red slime extract"
@@ -295,14 +295,14 @@
 		if(SLIME_ACTIVATE_MINOR)
 			to_chat(user, span_notice("You activate [src]. You start feeling fast!"))
 			user.reagents.add_reagent(/datum/reagent/medicine/ephedrine,5)
-			return 450
+			return 45 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			user.visible_message(span_warning("[user]'s skin flashes red for a moment..."), span_warning("Your skin flashes red as you emit rage-inducing pheromones..."))
 			for(var/mob/living/basic/slime/slime in viewers(get_turf(user), null))
 				slime.ai_controller?.set_blackboard_key(BB_SLIME_RABID, TRUE)
 				slime.visible_message(span_danger("The [slime] is driven into a frenzy!"))
-			return 600
+			return 60 SECONDS
 
 /obj/item/slime_extract/blue
 	name = "blue slime extract"
@@ -316,12 +316,12 @@
 			to_chat(user, span_notice("You activate [src]. Your genome feels more stable!"))
 			user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
 			user.reagents.add_reagent(/datum/reagent/medicine/potass_iodide, 10)
-			return 250
+			return 25 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			user.reagents.create_foam(/datum/effect_system/fluid_spread/foam, 20, log = TRUE)
 			user.visible_message(span_danger("Foam spews out from [user]'s skin!"), span_warning("You activate [src], and foam bursts out of your skin!"))
-			return 600
+			return 60 SECONDS
 
 /obj/item/slime_extract/darkblue
 	name = "dark blue slime extract"
@@ -337,14 +337,14 @@
 			user.adjust_wet_stacks(20)
 			user.reagents.add_reagent(/datum/reagent/consumable/frostoil,6)
 			user.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,7)
-			return 100
+			return 10 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/turf/open/T = get_turf(user)
 			if(istype(T))
 				T.atmos_spawn_air("[GAS_N2]=40;[TURF_TEMPERATURE(2.7)]")
 			to_chat(user, span_warning("You activate [src], and icy air bursts out of your skin!"))
-			return 900
+			return 90 SECONDS
 
 /obj/item/slime_extract/pink
 	name = "pink slime extract"
@@ -365,14 +365,14 @@
 			else
 				user.gender = MALE
 				user.visible_message(span_boldnotice("[user] suddenly looks more masculine!"), span_boldwarning("You suddenly feel more masculine!"))
-			return 100
+			return 10 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			user.visible_message(span_warning("[user]'s skin starts flashing hypnotically..."), span_notice("Your skin starts forming odd patterns, pacifying creatures around you."))
 			for(var/mob/living/carbon/C in viewers(user, null))
 				if(C != user)
 					C.reagents.add_reagent(/datum/reagent/pax,2)
-			return 600
+			return 60 SECONDS
 
 /obj/item/slime_extract/green
 	name = "green slime extract"
@@ -412,7 +412,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/obj/item/slimepotion/slime/sentience/O = new(null, 1)
@@ -420,7 +420,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 450
+			return 45 SECONDS
 
 /obj/item/slime_extract/black
 	name = "black slime extract"
@@ -433,7 +433,7 @@
 		if(SLIME_ACTIVATE_MINOR)
 			to_chat(user, span_userdanger("You feel something <i>wrong</i> inside you..."))
 			user.ForceContractDisease(new /datum/disease/transformation/slime(), FALSE, TRUE)
-			return 100
+			return 10 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			to_chat(user, span_warning("You feel your own light turning dark..."))
@@ -455,7 +455,7 @@
 			to_chat(user, span_warning("You vomit slippery oil."))
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			new /obj/effect/decal/cleanable/oil/slippery(get_turf(user))
-			return 450
+			return 45 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			user.visible_message(span_warning("[user]'s skin starts pulsing and glowing ominously..."), span_userdanger("You feel unstable..."))
@@ -483,7 +483,7 @@
 			to_chat(user, span_notice("You feel your skin harden and become more resistant."))
 			user.physiology.damage_resistance += 25
 			addtimer(CALLBACK(src, PROC_REF(reset_armor), user), 120 SECONDS)
-			return 450
+			return 45 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			to_chat(user, span_warning("You feel your body rapidly hardening..."))
@@ -514,7 +514,7 @@
 			if(do_after(user, 2.5 SECONDS, target = user))
 				to_chat(user, span_warning("You teleport!"))
 				do_teleport(user, get_turf(user), 6, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
-				return 300
+				return 30 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			if(!teleport_ready)
@@ -530,7 +530,7 @@
 					var/turf/T = locate(teleport_x, teleport_y, teleport_z)
 					to_chat(user, span_notice("You snap back to your anchor point!"))
 					do_teleport(user, T,  asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
-					return 450
+					return 45 SECONDS
 
 
 /obj/item/slime_extract/pyrite
@@ -548,7 +548,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/blacklisted_cans = list(/obj/item/toy/crayon/spraycan/borg, /obj/item/toy/crayon/spraycan/infinite)
@@ -558,7 +558,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 250
+			return 25 SECONDS
 
 /obj/item/slime_extract/cerulean
 	name = "cerulean slime extract"
@@ -571,14 +571,17 @@
 		if(SLIME_ACTIVATE_MINOR)
 			user.reagents.add_reagent(/datum/reagent/medicine/salbutamol,15)
 			to_chat(user, span_notice("You feel like you don't need to breathe!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
-			var/turf/open/T = get_turf(user)
-			if(istype(T))
-				T.atmos_spawn_air("[GAS_O2]=11;[GAS_N2]=41;[TURF_TEMPERATURE(T20C)]")
-				to_chat(user, span_warning("You activate [src], and fresh air bursts out of your skin!"))
-				return 600
+			var/list/connected_turfs = detect_room(origin = get_turf(src), max_size = 25)
+			var/datum/gas_mixture/base_mix = SSair.parse_gas_string(OPENTURF_DEFAULT_ATMOS)
+			for(var/turf/open/turf_fix in connected_turfs)
+				if(turf_fix.blocks_air)
+					continue
+				turf_fix.copy_air(base_mix)
+			to_chat(user, span_warning("You activate [src], and fresh air bursts out of your skin!"))
+			return 60 SECONDS
 
 /obj/item/slime_extract/sepia
 	name = "sepia slime extract"
@@ -594,13 +597,13 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 150
+			return 15 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			to_chat(user, span_warning("You feel time slow down..."))
 			if(do_after(user, 3 SECONDS, target = user))
 				new /obj/effect/timestop(get_turf(user), 2, 50, list(user))
-				return 900
+				return 90 SECONDS
 
 /obj/item/slime_extract/rainbow
 	name = "rainbow slime extract"
@@ -616,7 +619,7 @@
 			user.updateappearance(mutcolor_update=1)
 			species.update_glow(user)
 			to_chat(user, span_notice("You feel different..."))
-			return 100
+			return 10 SECONDS
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/chosen = pick(subtypesof(/obj/item/slime_extract))
@@ -625,7 +628,7 @@
 				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
-			return 150
+			return 15 SECONDS
 
 ////Slime-derived potions///
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that cerulean extract will now fix a significant amount of atmos rather than injecting a small amount of air into a single tile.

Also codewise I replaced all the DECISECOND returns with SECONDS returns (should change nothing other than cleaner to look at)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This ability is a meme.
The wiki states: `Spawns a large amount of breathable air around the user.`
But does not specify that "a large amount" is like 11 moles of oxygen and 41 moles of nitrogen.
This should make the power feel like it's actually worthwhile and not just a slap in the face at thinking you can help out the station.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Luminescents can now use cerulean major activation go fix a pretty large amount of atmos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
