### PR TITLE
Adds a new deathmatch modifier that enables quirks

### DIFF
--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -544,3 +544,13 @@
 
 /datum/deathmatch_modifier/hear_global_chat/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
 	player.add_traits(list(TRAIT_SIXTHSENSE, TRAIT_XRAY_HEARING), DEATHMATCH_TRAIT)
+
+/datum/deathmatch_modifier/apply_quirks
+	name = "Quirks enabled"
+	description = "Applies selected quirks to all players"
+
+/datum/deathmatch_modifier/apply_quirks/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
+	if (!player.client)
+		return
+
+	SSquirks.AssignQuirks(player, player.client)


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Quirks can be pretty silly, especially the negative ones, and its kinda a shame we dont apply them in deathmatch. This fixes that! You can now finally play DM in a wheelchair to show off how robust you are to your friends.
## Changelog
:cl:
add: Adds a new deathmatch modifier that enables quirks
/:cl:
