### PR TITLE
[No GBP] Slime people will not be eaten be slimes

### DIFF
--- a/code/modules/mob/living/basic/slime/ai/behaviours.dm
+++ b/code/modules/mob/living/basic/slime/ai/behaviours.dm
@@ -32,6 +32,10 @@
 	if(REF(dinner) in hunter.faction) //Don't eat our friends...
 		return
 
+	var/static/list/slime_faction = list(FACTION_SLIME)
+	if(faction_check(slime_faction, dinner.faction)) //Don't try to eat slimy things, no matter how hungry we are. Anyone else can be betrayed.
+		return
+
 	if(!hunter.can_feed_on(dinner, check_adjacent = FALSE)) //Are they tasty to slimes?
 		return
 


### PR DESCRIPTION

## About The Pull Request

This PR readds a missing faction check that got lost during basic mob conversion. Partially at least, previous, it ensured that FACTION_NEUTRAL was a one way faction, protecting slimes from other things, while keeping all the other factions via a check that fully reimplemented `faction_check` in a less efficient way. Rather then reimplementing this behaviour, I have just made them check for the FACTION_SLIME, similarly how regal rats skip converting already converted frogs and cockroaches.

So in short, slimes once again will not attack slime people, but everything else is fair game once they get hungry (except for people who are in their friend list).

I am not fully happy with this solution, but I would rather not make a new list by subtracting FACTION_NEUTRAL every time they check someone.

## Why It's Good For The Game

One of the unique features of slime people was that slimes consider them friends and family. This PR brings this back this feature I forgot to reimplement.

Fixes #83324

## Changelog

:cl:
fix: Slimes will no longer consider feeding upon slime people
/:cl:

