### PR TITLE
reverts the description of the nuke op reinforcement beacon

### DIFF
--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -139,7 +139,7 @@
 	icon_state = "self_delivery"
 	inhand_icon_state = "self_delivery"
 	company_source = "S.E.L.F."
-	company_message = span_bold("Request status: Recieved. Package status: Delivered. Notes: To assure optimal value, use supplied Interdyne-brand autosurgeons to change implantment status.")
+	company_message = span_bold("Request status: Received. Package status: Delivered. Notes: To assure optimal value, use supplied Interdyne-brand autosurgeons to change implantment status.")
 
 /obj/item/choice_beacon/augments/generate_display_names()
 	var/static/list/augment_list

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -95,7 +95,7 @@
  */
 /obj/item/antag_spawner/nuke_ops
 	name = "syndicate operative beacon"
-	desc = "MI13 designed one-use radio for calling immediate backup. Have no regards for safety of whom it summons - they are all inferior clones from Interdyne's genebanks anyway."
+	desc = "A single-use beacon designed to quickly launch reinforcement operatives into the field."
 	icon = 'icons/obj/devices/voice.dmi'
 	icon_state = "nukietalkie"
 	/// The name of the special role given to the recruit


### PR DESCRIPTION
## About The Pull Request
Changes the description of the reinforcement beacon from "MI13 designed one-use radio for calling immediate backup. Have no regards for safety of whom it summons - they are all inferior clones from Interdyne's genebanks anyway." back to what it used to be- "A single-use beacon designed to quickly launch reinforcement operatives into the field."

## Why It's Good For The Game
This change was brought in a sprite PR that had no justification for its code changes. I don't like this lore change, it seems needlessly "edgy", and I designed the reinforcements to be flavorful workers from different companies that are part of the Syndicate as you can see by all their different random outfits, them being "inferior clones from genebanks" is a weird contrast to that and doesn't sit well with me. And the random MI13 drop is eh.

## Changelog
:cl:
spellcheck: the nuke op reinforcement beacon no longer talks about clones
/:cl:
