### PR TITLE
Viewing Reticence Stats no longer causes NtOS error

### DIFF
--- a/code/modules/vehicles/mecha/combat/reticence.dm
+++ b/code/modules/vehicles/mecha/combat/reticence.dm
@@ -37,7 +37,7 @@
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced,
 		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/rcd,
 		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full, /obj/item/mecha_parts/mecha_equipment/thrusters/ion),
-		MECHA_POWER = /obj/item/mecha_parts/mecha_equipment/generator,
+		MECHA_POWER = list(/obj/item/mecha_parts/mecha_equipment/generator),
 		MECHA_ARMOR = list(),
 	)
 


### PR DESCRIPTION

## About The Pull Request
These changes correctly place Reticence's default power module into a `list()` object, preventing an NtOS error when using the "View Stats" button inside the mech. This resolves a bug in the UI, which had prevented players from viewing their Reticence mech's stats, and modifying its loaded modules therein.

Closes #82374

Before:
![reticence-before](https://github.com/tgstation/tgstation/assets/5588048/9c90e7f2-13b6-49bb-af9b-6ad68834bfd4)


After:
![reticence-after](https://github.com/tgstation/tgstation/assets/5588048/96862f04-cc00-4d6f-bdeb-c34193794ab5)
## Why It's Good For The Game
Syndicate Mimes can now scream (inaudibly) for joy, as they'll be able to inspect and modify their mech as was intended.
## Changelog
:cl:
fix: Viewing Reticence's stats no longer causes an NtOS UI error
/:cl:
