### PR TITLE
fixes riding mobs through space

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -97,7 +97,7 @@
 	return ..()
 
 /datum/component/riding/creature/driver_move(atom/movable/movable_parent, mob/living/user, direction)
-	if(!COOLDOWN_FINISHED(src, vehicle_move_cooldown))
+	if(!COOLDOWN_FINISHED(src, vehicle_move_cooldown) || !Process_Spacemove())
 		return COMPONENT_DRIVER_BLOCK_MOVE
 	if(!keycheck(user))
 		if(ispath(keytype, /obj/item))


### PR DESCRIPTION

## About The Pull Request
this fixes being able to ride all mobs through space, apart from things which actually can like carps

## Why It's Good For The Game
fixes being able to ride all mobs through space

## Changelog
:cl:
fix:  fixes being able to ride all mobs through space
/:cl:
