### PR TITLE
Fix Crew Monitor scrolling breaking once focused

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -175,7 +175,6 @@ const CrewTable = () => {
 
   return (
     <Section
-      scrollable
       title={
         <>
           <Button onClick={cycleSortBy}>{SORT_NAMES[sortBy]}</Button>


### PR DESCRIPTION

## About The Pull Request

Due to the nested scrollable section that grows to fill once focused you can no longer scroll the outer window using the wheel. Very annoying especially for us sillycones.

This PR removes the inner scrollbar that never scrolls anyway, but is happy to eat your inputs.

![LqSBlgPuxe](https://github.com/tgstation/tgstation/assets/64715958/b1ff6534-1175-4c12-a893-d5925c1a0deb)

## Why It's Good For The Game

Functional UI good. QOL good.

## Changelog
:cl:
qol: Crew Monitor UI now scrolls properly even after clicking the inner list.
/:cl:
