### PR TITLE
Correct spelling for moonlight amulet

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -469,7 +469,7 @@
 	mood_change = -3
 	timeout = 5 MINUTES
 
-/datum/mood_event/amulette_insanity
+/datum/mood_event/amulet_insanity
 	description = "I sEe THe LiGHt, It mUsT BE stOPPed"
 	mood_change = -6
 	timeout = 5 MINUTES

--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -52,9 +52,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 
-// The amulette conversion tool used by moon heretics
-/obj/item/clothing/neck/heretic_focus/moon_amulette
-	name = "Moonlight Amulette"
+// The amulet conversion tool used by moon heretics
+/obj/item/clothing/neck/heretic_focus/moon_amulet
+	name = "Moonlight Amulet"
 	desc = "A piece of the mind, the soul and the moon. Gazing into it makes your head spin and hear whispers of laughter and joy."
 	icon = 'icons/obj/antags/eldritch.dmi'
 	icon_state = "moon_amulette"
@@ -62,11 +62,11 @@
 	// How much damage does this item do to the targets sanity?
 	var/sanity_damage = 20
 
-/obj/item/clothing/neck/heretic_focus/moon_amulette/attack(mob/living/target, mob/living/user, params)
+/obj/item/clothing/neck/heretic_focus/moon_amulet/attack(mob/living/target, mob/living/user, params)
 	var/mob/living/carbon/human/hit = target
 	if(!IS_HERETIC_OR_MONSTER(user))
 		user.balloon_alert(user, "you feel a presence watching you")
-		user.add_mood_event("Moon Amulette Insanity", /datum/mood_event/amulette_insanity)
+		user.add_mood_event("Moon Amulet Insanity", /datum/mood_event/amulet_insanity)
 		user.mob_mood.set_sanity(user.mob_mood.sanity - 50)
 		return
 	if(hit.can_block_magic())
@@ -75,7 +75,7 @@
 		return
 	if(hit.mob_mood.sanity_level < SANITY_LEVEL_UNSTABLE)
 		user.balloon_alert(user, "their mind is too strong!")
-		hit.add_mood_event("Moon Amulette Insanity", /datum/mood_event/amulette_insanity)
+		hit.add_mood_event("Moon Amulet Insanity", /datum/mood_event/amulet_insanity)
 		hit.mob_mood.set_sanity(hit.mob_mood.sanity - sanity_damage)
 	else
 		user.balloon_alert(user, "their mind bends to see the truth!")

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -13,7 +13,7 @@
  * Mark of Moon
  * Ritual of Knowledge
  * Lunar Parade
- * Moonlight Amulette
+ * Moonlight Amulet
  * > Sidepaths:
  *   Curse of Paralasys
  *   Unfathomable Curio
@@ -103,15 +103,15 @@
 	desc = "Grants you Lunar Parade, a spell that - after a short charge - sends a carnival forward \
 		when hitting someone they are forced to join the parade and suffer hallucinations."
 	gain_text = "The music like a reflection of the soul compelled them, like moths to a flame they followed"
-	next_knowledge = list(/datum/heretic_knowledge/moon_amulette)
+	next_knowledge = list(/datum/heretic_knowledge/moon_amulet)
 	spell_to_add = /datum/action/cooldown/spell/pointed/projectile/moon_parade
 	cost = 1
 	route = PATH_MOON
 
 
-/datum/heretic_knowledge/moon_amulette
-	name = "Moonlight Amulette"
-	desc = "Allows you to transmute 2 sheets of glass, a heart and a tie to create a Moonlight Amulette. \
+/datum/heretic_knowledge/moon_amulet
+	name = "Moonlight Amulet"
+	desc = "Allows you to transmute 2 sheets of glass, a heart and a tie to create a Moonlight Amulet. \
 			If the item is used on someone with low sanity they go berserk attacking everyone, \
 			if their sanity isn't low enough it decreases their mood."
 	gain_text = "At the head of the parade he stood, the moon condensed into one mass, a reflection of the soul."
@@ -127,7 +127,7 @@
 		/obj/item/stack/sheet/glass = 2,
 		/obj/item/clothing/neck/tie = 1,
 	)
-	result_atoms = list(/obj/item/clothing/neck/heretic_focus/moon_amulette)
+	result_atoms = list(/obj/item/clothing/neck/heretic_focus/moon_amulet)
 	cost = 1
 	route = PATH_MOON
 
@@ -171,7 +171,7 @@
 		Bring 3 corpses with more than 50 brain damage to a transmutation rune to complete the ritual. \
 		When completed, you become a harbinger of madness gaining and aura of passive sanity decrease, \
 		confusion increase and, if their sanity is low enough, brain damage and blindness. \
-		1/5th of the crew will turn into acolytes and follow your command, they will all recieve moonlight amulettes."
+		1/5th of the crew will turn into acolytes and follow your command, they will all receive moonlight amulets."
 	gain_text = "We dived down towards the crowd, his soul splitting off in search of greater venture \
 		for where the Ringleader had started the parade, I shall continue it unto the suns demise \
 		WITNESS MY ASCENSION, THE MOON SMILES ONCE MORE AND FOREVER MORE IT SHALL!"
@@ -229,7 +229,7 @@
 			continue
 		var/datum/antagonist/lunatic/lunatic = crewmate.mind.add_antag_datum(/datum/antagonist/lunatic)
 		lunatic.set_master(user.mind, user)
-		var/obj/item/clothing/neck/heretic_focus/moon_amulette/amulet = new(crewmate_turf)
+		var/obj/item/clothing/neck/heretic_focus/moon_amulet/amulet = new(crewmate_turf)
 		var/static/list/slots = list(
 			"neck" = ITEM_SLOT_NECK,
 			"hands" = ITEM_SLOT_HANDS,

--- a/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_ash_moon.dm
@@ -25,7 +25,7 @@
 	gain_text = "The flesh of humanity is weak. Make them bleed. Show them their fragility."
 	next_knowledge = list(
 		/datum/heretic_knowledge/mad_mask,
-		/datum/heretic_knowledge/moon_amulette,
+		/datum/heretic_knowledge/moon_amulet,
 	)
 	required_atoms = list(
 		/obj/item/bodypart/leg/left = 1,

--- a/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_lock_moon.dm
@@ -23,7 +23,7 @@
 	gain_text = "The mansus holds many a curio, some are not meant for the mortal eye."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/burglar_finesse,
-		/datum/heretic_knowledge/moon_amulette,
+		/datum/heretic_knowledge/moon_amulet,
 	)
 	required_atoms = list(
 		/obj/item/organ/internal/lungs = 1,
@@ -48,7 +48,7 @@
 				They yearn for mortal eyes again, and I shall grant that wish."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/burglar_finesse,
-		/datum/heretic_knowledge/moon_amulette,
+		/datum/heretic_knowledge/moon_amulet,
 	)
 	required_atoms = list(/obj/item/canvas = 1)
 	result_atoms = list(/obj/item/canvas)


### PR DESCRIPTION

## About The Pull Request

Changes all instances of "amulette" to "amulet" (except for icon_state instances of the misspelling).

## Why It's Good For The Game

Spelling

## Changelog
:cl:
spellcheck: Corrects spelling of "amulette" to "amulet"
/:cl:
