### PR TITLE
Makes monkey powder reaction instant

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -577,6 +577,7 @@
 
 /datum/chemical_reaction/monkey
 	required_reagents = list(/datum/reagent/monkey_powder = 50, /datum/reagent/water = 1)
+	reaction_flags = REACTION_INSTANT
 	mix_message = "<span class='danger'>Expands into a brown mass before shaping itself into a monkey!.</span>"
 
 /datum/chemical_reaction/monkey/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)


### PR DESCRIPTION
## About The Pull Request
- Fixes #83347

This issue title is misleading because the actual problem is with the monkey reaction

Because this reaction is currently not instant it will only require `CHEMICAL_QUANTIZATION_LEVEL`(0.0001)u of reagents to be present for the reaction to occur. This means even though the actual requirements are 50u power & 1u water in reality you only need 0.005u(50 * 0.0001) powder & 0.0001u(1 * 0.0001) water for the reaction to occur.

This is expected behaviour for non instant reactions because we still want reactions to occur but yield less products when less required reagent amounts are present but it's not ideal for monkey reactions

## Changelog
:cl:
fix: Monkey power reactions are instant and won't occur when exact reagent requirements (50u power & 1u water) or above aren't met. Stops players from cheesing monkeys from plumbing factories
/:cl:
