### PR TITLE
Increases oculine metabolism and adds a chem threshold

### DIFF
--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -13,7 +13,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/service/hydroponics/growing_vegetables.dmi'
 	mutatelist = list(/obj/item/seeds/carrot/parsnip)
-	reagents_add = list(/datum/reagent/medicine/oculine = 0.25, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
+	reagents_add = list(/datum/reagent/medicine/oculine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/food/grown/carrot
 	seed = /obj/item/seeds/carrot

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -704,6 +704,7 @@
 		return
 	improve_eyesight(affected_mob, eyes)
 
+
 /datum/reagent/medicine/oculine/proc/improve_eyesight(mob/living/carbon/affected_mob, obj/item/organ/internal/eyes/eyes)
 	delta_light = creation_purity*10
 	eyes.lighting_cutoff += delta_light
@@ -753,6 +754,11 @@
 	if(!eyes)
 		return
 	restore_eyesight(affected_mob, eyes)
+
+/datum/reagent/medicine/oculine/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	if(affected_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 1.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+		. = UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/inacusiate
 	name = "Inacusiate"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -684,6 +684,7 @@
 	reagent_state = LIQUID
 	color = "#404040" //oculine is dark grey, inacusiate is light grey
 	metabolization_rate = 1 * REAGENTS_METABOLISM
+	overdose_threshold = 30
 	taste_description = "earthy bitterness"
 	purity = REAGENT_STANDARD_PURITY
 	ph = 10

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -683,7 +683,7 @@
 	description = "Quickly restores eye damage, cures nearsightedness, and has a chance to restore vision to the blind."
 	reagent_state = LIQUID
 	color = "#404040" //oculine is dark grey, inacusiate is light grey
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "earthy bitterness"
 	purity = REAGENT_STANDARD_PURITY
 	ph = 10


### PR DESCRIPTION
## About The Pull Request
This pr increases the metabolism rate from 0.25 to 1 for oculine and adds a 30u threshold and changes the amount of oculine a carrot contains from 100 potency from 25 units to 10 units(still very reasonable amount since you usually farm in batches of 10)

## Why It's Good For The Game
Oculine at the moment gives you soft night vision lets me give you a comparision

This is without Oculine in system
![image](https://github.com/tgstation/tgstation/assets/24854897/a33161bd-3c44-45ea-8274-33d7d866b9ec)

This is with Oculine in system
![image](https://github.com/tgstation/tgstation/assets/24854897/8a157edc-4a92-4ba0-8cbc-d6c21c43a613)


Currently how it is you make 90 units beaker and it lasts you a hour trough the round its pretty easy to make
Which is kinda ridicilous because at that point it just becomes chug a beaker and have bootleg NV this PR
Will make the chem a little more situational it still will lost long enough to benefit in a combat scenario
just not enough to chug a beaker and not care about for it the rest of the round

## Changelog

:cl:
balance: Adds a threshold to oculine and increases metabolism, and reduces the amount of oculine in a carrot
/:cl:
