### PR TITLE
Removes a shit clown name and adds a better clown name instead

### DIFF
--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -28,8 +28,8 @@ Delicious Dan
 Dinkster
 Dinky Doodle
 Doctor Greenthumb
-Doink
 Doctor Rockso
+Doink
 Early Worm
 Eggy
 Emotional Oatmeal

--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -29,6 +29,7 @@ Dinkster
 Dinky Doodle
 Doctor Greenthumb
 Doink
+Doctor Rockso
 Early Worm
 Eggy
 Emotional Oatmeal
@@ -118,7 +119,6 @@ Unimaginable Nut
 Valid Vincent
 Weather Report
 Widderwise
-Doctor Rockso
 Yesterdays Beef
 Yobbo
 Ziggy Yoyo

--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -118,7 +118,7 @@ Unimaginable Nut
 Valid Vincent
 Weather Report
 Widderwise
-Yanye Kest
+Doctor Rockso
 Yesterdays Beef
 Yobbo
 Ziggy Yoyo


### PR DESCRIPTION
## About The Pull Request

Removes a shit clown name and adds a better clown name instead

## Why It's Good For The Game

Disgraced nazi artist has been replaced with a professional clown who's an expert in cocaine. Someone brought up we didn't have this in the clown name pool.

## Changelog
:cl:
spellcheck: Removes a shit clown name and adds a better clown name instead
/:cl: