### PR TITLE
Mapped in airlocks without access requirements don't create electronics with erroring tgui

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1531,7 +1531,7 @@
 			if(length(req_one_access))
 				ae.one_access = 1
 				ae.accesses = req_one_access
-			else
+			else if(length(req_access))
 				ae.accesses = req_access
 		else
 			ae = electronics


### PR DESCRIPTION

## About The Pull Request

So a friend of mine mentioned that whenever they tried to deconstruct a roundstart door, it'd always create nonfunctional airlock electronics for which you can't open the tgui window.
I couldn't reproduce it, so we compared which doors we were deconstructing, and lo and behold, it was specifically public airlocks causing the issue.

More specifically, when an airlock is deconstructed, it copies its access over onto the airlock electronics.
https://github.com/tgstation/tgstation/blob/5394ba20edd5bbf71ed1c212260a596fd8cb2517/code/game/machinery/doors/airlock.dm#L1528-L1535
Now, the actual issue is that airlocks can have null access, while airlock electronics initialize it as an empty list and error out if it isn't a list.

So all we do is make it only copy over access if there is in fact access to be copied over, and just let it default to its empty list otherwise.
```dm
 	else if(length(req_access)) 
 		ae.accesses = req_access 
 ```
 This stops it from being set to null, and lets you actually edit the electronics' access again.
## Why It's Good For The Game

Fixes inability to reconstruct deconstructed airlocks without access requirements with different settings.
## Changelog
:cl:
fix: Airlocks without access requirements no longer create airlock electronics with a broken menu.
/:cl:
