### PR TITLE
tgui: Converts some uselocal -> usestate

### DIFF
--- a/tgui/packages/tgui/interfaces/Biogenerator.tsx
+++ b/tgui/packages/tgui/interfaces/Biogenerator.tsx
@@ -1,7 +1,8 @@
 import { BooleanLike } from 'common/react';
 import { classes } from 'common/react';
+import { useState } from 'react';
 
-import { useBackend, useLocalState } from '../backend';
+import { useBackend } from '../backend';
 import {
   Box,
   Button,
@@ -59,8 +60,7 @@ export const Biogenerator = (props) => {
     efficiency,
     categories,
   } = data;
-  const [selectedCategory, setSelectedCategory] = useLocalState<string>(
-    'category',
+  const [selectedCategory, setSelectedCategory] = useState(
     data.categories[0]?.name,
   );
   const items =
@@ -184,8 +184,7 @@ export const Biogenerator = (props) => {
 const ItemList = (props) => {
   const { act } = useBackend();
   const items = props.items.map((item) => {
-    const [amount, setAmount] = useLocalState(
-      'amount' + item.name,
+    const [amount, setAmount] = useState(
       item.is_reagent ? Math.min(Math.max(props.space, 1), 10) : 1,
     );
     const disabled =

--- a/tgui/packages/tgui/interfaces/MessageMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/MessageMonitor.tsx
@@ -1,6 +1,7 @@
 import { BooleanLike } from 'common/react';
+import { Dispatch, SetStateAction, useState } from 'react';
 
-import { useBackend, useLocalState } from '../backend';
+import { useBackend } from '../backend';
 import {
   Box,
   Button,
@@ -160,13 +161,12 @@ const HackedScreen = (props) => {
   );
 };
 
-const MainScreenAuth = (props) => {
+const MainScreenAuth = (props: AuthScreenProps) => {
+  const { auth_password, setPassword } = props;
+
   const { act, data } = useBackend<Data>();
-  const { status, is_malf, password } = data;
-  const [auth_password, setPassword] = useLocalState(
-    'input_password',
-    password,
-  );
+  const { status, is_malf } = data;
+
   return (
     <>
       <Stack.Item>
@@ -260,13 +260,15 @@ const MainScreenAuth = (props) => {
   );
 };
 
-const MainScreenNotAuth = (props) => {
+type AuthScreenProps = {
+  auth_password: string;
+  setPassword: Dispatch<SetStateAction<string>>;
+};
+
+const MainScreenNotAuth = (props: AuthScreenProps) => {
+  const { auth_password, setPassword } = props;
   const { act, data } = useBackend<Data>();
-  const { status, is_malf, password } = data;
-  const [auth_password, setPassword] = useLocalState(
-    'input_password',
-    password,
-  );
+  const { status, is_malf } = data;
 
   return (
     <>
@@ -319,11 +321,24 @@ const MainScreenNotAuth = (props) => {
 };
 
 const MainScreen = (props) => {
-  const { act, data } = useBackend<Data>();
-  const { auth } = data;
+  const { data } = useBackend<Data>();
+  const { auth, password } = data;
+
+  const [auth_password, setPassword] = useState(password);
+
   return (
     <Stack fill vertical>
-      {auth ? <MainScreenAuth /> : <MainScreenNotAuth />}
+      {auth ? (
+        <MainScreenAuth
+          auth_password={auth_password}
+          setPassword={setPassword}
+        />
+      ) : (
+        <MainScreenNotAuth
+          auth_password={auth_password}
+          setPassword={setPassword}
+        />
+      )}
     </Stack>
   );
 };

--- a/tgui/packages/tgui/interfaces/PaiInterface/Available.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/Available.tsx
@@ -15,7 +15,7 @@ import { PaiData } from './types';
 /**
  * Renders a list of available software and the ram with which to download it
  */
-export const AvailableDisplay = () => {
+export function AvailableDisplay(props) {
   const { data } = useBackend<PaiData>();
   const { available } = data;
 
@@ -38,10 +38,10 @@ export const AvailableDisplay = () => {
       </Table>
     </Section>
   );
-};
+}
 
 /** Displays the remaining RAM left as a progressbar. */
-const MemoryDisplay = (props) => {
+function MemoryDisplay(props) {
   const { data } = useBackend<PaiData>();
   const { ram } = data;
 
@@ -62,13 +62,16 @@ const MemoryDisplay = (props) => {
                 bad: [0, 33],
               }}
               value={ram}
-            />
+              width={5}
+            >
+              {ram}
+            </ProgressBar>
           </Table.Cell>
         </Table.Row>
       </Table>
     </Tooltip>
   );
-};
+}
 
 type ListItemProps = {
   cost: number;
@@ -76,12 +79,13 @@ type ListItemProps = {
 };
 
 /** A row for an individual software listing. */
-const ListItem = (props: ListItemProps) => {
+function ListItem(props: ListItemProps) {
   const { act, data } = useBackend<PaiData>();
   const { installed, ram } = data;
   const { cost, name } = props;
 
   const purchased = installed.includes(name);
+  const tooExpensive = ram < cost;
 
   return (
     <Tooltip content={SOFTWARE_DESC[name]} position="bottom-start">
@@ -90,7 +94,7 @@ const ListItem = (props: ListItemProps) => {
           <Box color="label">{name}</Box>
         </Table.Cell>
         <Table.Cell collapsing>
-          <Box color={ram < cost && 'bad'} textAlign="right">
+          <Box color={tooExpensive && 'bad'} textAlign="right">
             {!purchased && cost}{' '}
             <Icon
               color={purchased || ram >= cost ? 'purple' : 'bad'}
@@ -101,13 +105,12 @@ const ListItem = (props: ListItemProps) => {
         <Table.Cell collapsing>
           <Button
             icon="download"
-            width={2}
             mb={0.5}
-            disabled={ram < cost || purchased}
+            disabled={tooExpensive || purchased}
             onClick={() => act('buy', { selection: name })}
           />
         </Table.Cell>
       </Table.Row>
     </Tooltip>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/PaiInterface/Directives.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/Directives.tsx
@@ -6,7 +6,7 @@ import { DIRECTIVE_COMPREHENSION, DIRECTIVE_ORDER } from './constants';
 import { PaiData } from './types';
 
 /** Shows the hardcoded PAI info along with any supplied orders. */
-export const DirectiveDisplay = (props) => {
+export function DirectiveDisplay(props) {
   const { data } = useBackend<PaiData>();
   const { directives = [], master_name } = data;
   const displayedLaw = directives?.length
@@ -43,4 +43,4 @@ export const DirectiveDisplay = (props) => {
       </Stack.Item>
     </Stack>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/PaiInterface/Installed.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/Installed.tsx
@@ -1,4 +1,5 @@
-import { useBackend, useLocalState } from 'tgui/backend';
+import { useState } from 'react';
+import { useBackend } from 'tgui/backend';
 import { Button, NoticeBox, Section, Stack } from 'tgui/components';
 
 import { DOOR_JACK, HOST_SCAN, PHOTO_MODE, SOFTWARE_DESC } from './constants';
@@ -10,57 +11,46 @@ import { PaiData } from './types';
  * software info.
  */
 export const InstalledDisplay = (props) => {
-  return (
-    <Stack fill vertical>
-      <Stack.Item grow>
-        <InstalledSoftware />
-      </Stack.Item>
-      <Stack.Item grow={2}>
-        <InstalledInfo />
-      </Stack.Item>
-    </Stack>
-  );
-};
-
-/** Iterates over installed software to render buttons. */
-const InstalledSoftware = (props) => {
   const { data } = useBackend<PaiData>();
   const { installed = [] } = data;
-  const [currentSelection, setCurrentSelection] = useLocalState('software', '');
 
-  return (
-    <Section fill scrollable title="Installed Software">
-      {!installed.length ? (
-        <NoticeBox>Nothing installed!</NoticeBox>
-      ) : (
-        installed.map((software, index) => {
-          return (
-            <Button key={index} onClick={() => setCurrentSelection(software)}>
-              {software}
-            </Button>
-          );
-        })
-      )}
-    </Section>
-  );
-};
+  const [currentSelection, setCurrentSelection] = useState('');
 
-/** Software info for buttons clicked. */
-const InstalledInfo = (props) => {
-  const [currentSelection] = useLocalState('software', '');
   const title = !currentSelection ? 'Select a Program' : currentSelection;
 
   return (
-    <Section fill scrollable title={title}>
-      {currentSelection && (
-        <Stack fill vertical>
-          <Stack.Item>{SOFTWARE_DESC[currentSelection]}</Stack.Item>
-          <Stack.Item grow>
-            <SoftwareButtons />
-          </Stack.Item>
-        </Stack>
-      )}
-    </Section>
+    <Stack fill vertical>
+      <Stack.Item grow>
+        <Section fill scrollable title={title}>
+          {currentSelection && (
+            <Stack fill vertical>
+              <Stack.Item>{SOFTWARE_DESC[currentSelection]}</Stack.Item>
+              <Stack.Item grow>
+                <SoftwareButtons currentSelection={currentSelection} />
+              </Stack.Item>
+            </Stack>
+          )}
+        </Section>
+      </Stack.Item>
+      <Stack.Item grow={2}>
+        <Section fill scrollable title="Installed Software">
+          {!installed.length ? (
+            <NoticeBox>Nothing installed!</NoticeBox>
+          ) : (
+            installed.map((software, index) => {
+              return (
+                <Button
+                  key={index}
+                  onClick={() => setCurrentSelection(software)}
+                >
+                  {software}
+                </Button>
+              );
+            })
+          )}
+        </Section>
+      </Stack.Item>
+    </Stack>
   );
 };
 
@@ -68,10 +58,11 @@ const InstalledInfo = (props) => {
  * Once a software is selected, generates custom buttons or a default
  * power toggle.
  */
-const SoftwareButtons = (props) => {
+const SoftwareButtons = (props: { currentSelection: string }) => {
+  const { currentSelection } = props;
+
   const { act, data } = useBackend<PaiData>();
   const { door_jack, languages, master_name } = data;
-  const [currentSelection] = useLocalState('software', '');
 
   switch (currentSelection) {
     case 'Door Jack':

--- a/tgui/packages/tgui/interfaces/PaiInterface/Installed.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/Installed.tsx
@@ -10,7 +10,7 @@ import { PaiData } from './types';
  * another section that displays the selected installed
  * software info.
  */
-export const InstalledDisplay = (props) => {
+export function InstalledDisplay(props) {
   const { data } = useBackend<PaiData>();
   const { installed = [] } = data;
 
@@ -52,13 +52,17 @@ export const InstalledDisplay = (props) => {
       </Stack.Item>
     </Stack>
   );
+}
+
+type SoftwareButtonsProps = {
+  currentSelection: string;
 };
 
 /**
  * Once a software is selected, generates custom buttons or a default
  * power toggle.
  */
-const SoftwareButtons = (props: { currentSelection: string }) => {
+function SoftwareButtons(props: SoftwareButtonsProps) {
   const { currentSelection } = props;
 
   const { act, data } = useBackend<PaiData>();
@@ -161,4 +165,4 @@ const SoftwareButtons = (props: { currentSelection: string }) => {
         </Button>
       );
   }
-};
+}

--- a/tgui/packages/tgui/interfaces/PaiInterface/System.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/System.tsx
@@ -4,7 +4,7 @@ import { Box, Button, LabeledList, Section, Stack } from 'tgui/components';
 import { ICON_MAP } from './constants';
 import { PaiData } from './types';
 
-export const SystemDisplay = (props) => {
+export function SystemDisplay(props) {
   return (
     <Stack fill vertical>
       <Stack.Item grow={3}>
@@ -15,10 +15,10 @@ export const SystemDisplay = (props) => {
       </Stack.Item>
     </Stack>
   );
-};
+}
 
 /** Renders some ASCII art. Changes to red on emag. */
-const SystemWallpaper = (props) => {
+function SystemWallpaper(props) {
   const { data } = useBackend<PaiData>();
   const { emagged } = data;
 
@@ -58,12 +58,12 @@ const SystemWallpaper = (props) => {
       </pre>
     </Section>
   );
-};
+}
 
 /** Displays master info.
  * You can check their DNA and change your image here.
  */
-const SystemInfo = (props) => {
+function SystemInfo(props) {
   const { act, data } = useBackend<PaiData>();
   const { image, master_dna, master_name } = data;
 
@@ -101,4 +101,4 @@ const SystemInfo = (props) => {
       </LabeledList>
     </Section>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/PaiInterface/index.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/index.tsx
@@ -1,4 +1,4 @@
-import { useLocalState } from 'tgui/backend';
+import { useState } from 'react';
 import { Stack, Tabs } from 'tgui/components';
 import { Window } from 'tgui/layouts';
 
@@ -9,7 +9,7 @@ import { InstalledDisplay } from './Installed';
 import { SystemDisplay } from './System';
 
 export const PaiInterface = (props) => {
-  const [tab] = useLocalState('tab', PAI_TAB.System);
+  const [tab, setTab] = useState(PAI_TAB.System);
 
   return (
     <Window title="pAI Software Interface v2.5" width={380} height={480}>
@@ -22,51 +22,39 @@ export const PaiInterface = (props) => {
             {tab === PAI_TAB.Available && <AvailableDisplay />}
           </Stack.Item>
           <Stack.Item>
-            <TabDisplay />
+            <Tabs fluid>
+              <Tabs.Tab
+                icon="list"
+                onClick={() => setTab(PAI_TAB.System)}
+                selected={tab === PAI_TAB.System}
+              >
+                System
+              </Tabs.Tab>
+              <Tabs.Tab
+                icon="list"
+                onClick={() => setTab(PAI_TAB.Directive)}
+                selected={tab === PAI_TAB.Directive}
+              >
+                Directives
+              </Tabs.Tab>
+              <Tabs.Tab
+                icon="list"
+                onClick={() => setTab(PAI_TAB.Installed)}
+                selected={tab === PAI_TAB.Installed}
+              >
+                Installed
+              </Tabs.Tab>
+              <Tabs.Tab
+                icon="list"
+                onClick={() => setTab(PAI_TAB.Available)}
+                selected={tab === PAI_TAB.Available}
+              >
+                Download
+              </Tabs.Tab>
+            </Tabs>
           </Stack.Item>
         </Stack>
       </Window.Content>
     </Window>
-  );
-};
-
-/**
- * Tabs at bottom of screen. YES THIS IS INTENTIONAL. It's a phone screen
- * and the buttons are on the bottom. Android!
- */
-const TabDisplay = (props) => {
-  const [tab, setTab] = useLocalState('tab', PAI_TAB.System);
-
-  return (
-    <Tabs fluid>
-      <Tabs.Tab
-        icon="list"
-        onClick={() => setTab(PAI_TAB.System)}
-        selected={tab === PAI_TAB.System}
-      >
-        System
-      </Tabs.Tab>
-      <Tabs.Tab
-        icon="list"
-        onClick={() => setTab(PAI_TAB.Directive)}
-        selected={tab === PAI_TAB.Directive}
-      >
-        Directives
-      </Tabs.Tab>
-      <Tabs.Tab
-        icon="list"
-        onClick={() => setTab(PAI_TAB.Installed)}
-        selected={tab === PAI_TAB.Installed}
-      >
-        Installed
-      </Tabs.Tab>
-      <Tabs.Tab
-        icon="list"
-        onClick={() => setTab(PAI_TAB.Available)}
-        selected={tab === PAI_TAB.Available}
-      >
-        Download
-      </Tabs.Tab>
-    </Tabs>
   );
 };

--- a/tgui/packages/tgui/interfaces/PaiInterface/index.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/index.tsx
@@ -8,7 +8,7 @@ import { DirectiveDisplay } from './Directives';
 import { InstalledDisplay } from './Installed';
 import { SystemDisplay } from './System';
 
-export const PaiInterface = (props) => {
+export function PaiInterface(props) {
   const [tab, setTab] = useState(PAI_TAB.System);
 
   return (
@@ -57,4 +57,4 @@ export const PaiInterface = (props) => {
       </Window.Content>
     </Window>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/PaiInterface/types.ts
+++ b/tgui/packages/tgui/interfaces/PaiInterface/types.ts
@@ -1,7 +1,7 @@
 import { BooleanLike } from 'common/react';
 
 export type PaiData = {
-  available: ReadonlyArray<{ name: string; value: number }>;
+  available: Record<string, number>;
   directives: string;
   door_jack: string | null;
   emagged: BooleanLike;

--- a/tgui/packages/tgui/interfaces/Pandemic/Specimen.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Specimen.tsx
@@ -1,4 +1,5 @@
-import { useBackend, useLocalState } from 'tgui/backend';
+import { useState } from 'react';
+import { useBackend } from 'tgui/backend';
 import { Button, NoticeBox, Section, Stack, Tabs } from 'tgui/components';
 
 import { SymptomDisplay } from './Symptom';
@@ -6,13 +7,53 @@ import { Data } from './types';
 import { VirusDisplay } from './Virus';
 
 export const SpecimenDisplay = (props) => {
-  const { data } = useBackend<Data>();
-  const { viruses = [] } = data;
-  const [tab, setTab] = useLocalState('tab', 0);
+  const { act, data } = useBackend<Data>();
+  const { is_ready, viruses = [] } = data;
+
+  const [tab, setTab] = useState(0);
   const virus = viruses[tab];
 
   return (
-    <Section fill scrollable title="Specimen" buttons={<Buttons />}>
+    <Section
+      fill
+      scrollable
+      title="Specimen"
+      buttons={
+        <Stack>
+          {viruses.length > 1 && (
+            <Stack.Item>
+              <Tabs>
+                {viruses.map((virus, index) => {
+                  return (
+                    <Tabs.Tab
+                      selected={tab === index}
+                      onClick={() => setTab(index)}
+                      key={index}
+                    >
+                      {virus.name}
+                    </Tabs.Tab>
+                  );
+                })}
+              </Tabs>
+            </Stack.Item>
+          )}
+          <Stack.Item>
+            <Button
+              icon="flask"
+              disabled={!is_ready || !virus}
+              tooltip={virus ? '' : 'No virus culture found.'}
+              onClick={() =>
+                act('create_culture_bottle', {
+                  index: virus.index,
+                })
+              }
+            >
+              Create Culture Bottle
+            </Button>
+          </Stack.Item>
+        </Stack>
+      }
+    >
       {!virus ? (
         <NoticeBox success>Nothing detected.</NoticeBox>
       ) : (
@@ -26,47 +67,5 @@ export const SpecimenDisplay = (props) => {
         </Stack>
       )}
     </Section>
-  );
-};
-
-const Buttons = (props) => {
-  const { act, data } = useBackend<Data>();
-  const { is_ready, viruses = [] } = data;
-  const [tab, setTab] = useLocalState('tab', 0);
-  const virus = viruses[tab];
-
-  return (
-    <Stack>
-      {viruses.length > 1 && (
-        <Stack.Item>
-          <Tabs>
-            {viruses.map((virus, index) => {
-              return (
-                <Tabs.Tab
-                  selected={tab === index}
-                  onClick={() => setTab(index)}
-                  key={index}
-                >
-                  {virus.name}
-                </Tabs.Tab>
-              );
-            })}
-          </Tabs>
-        </Stack.Item>
-      )}
-      <Stack.Item>
-        <Button
-          icon="flask"
-          content="Create culture bottle"
-          disabled={!is_ready || !virus}
-          tooltip={virus ? '' : 'No virus culture found.'}
-          onClick={() =>
-            act('create_culture_bottle', {
-              index: virus.index,
-            })
-          }
-        />
-      </Stack.Item>
-    </Stack>
   );
 };

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
@@ -1,4 +1,6 @@
-import { useBackend, useLocalState } from '../../backend';
+import { useContext } from 'react';
+
+import { useBackend } from '../../backend';
 import {
   Box,
   Button,
@@ -9,6 +11,7 @@ import {
   NumberInput,
   Stack,
 } from '../../components';
+import { ParticleContext } from '.';
 import {
   EntryCoordProps,
   EntryFloatProps,
@@ -26,14 +29,14 @@ import {
 import { editKeyOf, editWeightOf, setGradientSpace } from './helpers';
 
 export const EntryFloat = (props: EntryFloatProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, float } = props;
   return (
     <LabeledList.Item label={name}>
       <Button
         icon={'question'}
-        onClick={() => setdesc(var_name)}
+        onClick={() => setDesc(var_name)}
         tooltip={'View details'}
       />
       <NumberInput
@@ -54,14 +57,14 @@ export const EntryFloat = (props: EntryFloatProps) => {
 };
 
 export const EntryCoord = (props: EntryCoordProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, coord } = props;
   return (
     <LabeledList.Item label={name}>
       <Button
         icon={'question'}
-        onClick={() => setdesc(var_name)}
+        onClick={() => setDesc(var_name)}
         tooltip={'View details'}
       />
       <NumberInput
@@ -108,8 +111,8 @@ export const EntryCoord = (props: EntryCoordProps) => {
 };
 
 export const EntryGradient = (props: EntryGradientProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, gradient } = props;
   const isLooping = gradient?.find((x) => x === 'loop');
   const space_type = gradient?.includes('space')
@@ -123,7 +126,7 @@ export const EntryGradient = (props: EntryGradientProps) => {
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>
@@ -209,8 +212,8 @@ export const EntryGradient = (props: EntryGradientProps) => {
 };
 
 export const EntryTransform = (props: EntryTransformProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const len = props.transform?.length ? props.transform.length : 0;
   const selected =
     len < 7
@@ -225,7 +228,7 @@ export const EntryTransform = (props: EntryTransformProps) => {
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>
@@ -263,8 +266,8 @@ export const EntryTransform = (props: EntryTransformProps) => {
 };
 
 export const EntryIcon = (props: EntryIconStateProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, icon_state } = props;
   return (
     <LabeledList.Item label={name}>
@@ -272,7 +275,7 @@ export const EntryIcon = (props: EntryIconStateProps) => {
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>
@@ -337,8 +340,8 @@ export const EntryIcon = (props: EntryIconStateProps) => {
 };
 
 export const EntryIconState = (props: EntryIconStateProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, icon_state } = props;
   const newValue =
     typeof icon_state === 'string'
@@ -350,7 +353,7 @@ export const EntryIconState = (props: EntryIconStateProps) => {
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/jsx-no-undef */
-import { useBackend, useLocalState } from '../../backend';
+import { useContext } from 'react';
+
+import { useBackend } from '../../backend';
 import {
   Button,
   ColorBox,
@@ -8,6 +10,7 @@ import {
   NumberInput,
   Stack,
 } from '../../components';
+import { ParticleContext } from '.';
 import {
   EntryGeneratorNumbersListProps,
   FloatGeneratorColorProps,
@@ -20,8 +23,8 @@ import { GeneratorListEntry } from './Generators';
 import { isStringArray } from './helpers';
 
 export const FloatGenerator = (props: FloatGeneratorProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, float } = props;
   return (
     <LabeledList.Item label={name}>
@@ -29,7 +32,7 @@ export const FloatGenerator = (props: FloatGeneratorProps) => {
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>
@@ -73,8 +76,8 @@ export const FloatGenerator = (props: FloatGeneratorProps) => {
 };
 
 export const FloatGeneratorColor = (props: FloatGeneratorColorProps) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, float } = props;
   return (
     <LabeledList.Item label={name}>
@@ -82,7 +85,7 @@ export const FloatGeneratorColor = (props: FloatGeneratorColorProps) => {
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>
@@ -129,8 +132,8 @@ export const FloatGeneratorColor = (props: FloatGeneratorColorProps) => {
 export const EntryGeneratorNumbersList = (
   props: EntryGeneratorNumbersListProps,
 ) => {
-  const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { act } = useBackend<ParticleUIData>();
+  const { setDesc } = useContext(ParticleContext);
   const { name, var_name, allow_z, input } = props;
   return (
     <LabeledList.Item label={name}>
@@ -138,7 +141,7 @@ export const EntryGeneratorNumbersList = (
         <Stack.Item>
           <Button
             icon={'question'}
-            onClick={() => setdesc(var_name)}
+            onClick={() => setDesc(var_name)}
             tooltip={'View details'}
           />
         </Stack.Item>

--- a/tgui/packages/tgui/interfaces/ParticleEdit/Tutorial.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/Tutorial.tsx
@@ -1,5 +1,6 @@
+import { useContext } from 'react';
+
 import { resolveAsset } from '../../assets';
-import { useLocalState } from '../../backend';
 import {
   Box,
   Button,
@@ -9,9 +10,10 @@ import {
   Section,
   Stack,
 } from '../../components';
+import { ParticleContext } from '.';
 
 export const ShowDesc = (props) => {
-  const [desc, setdesc] = useLocalState('desc', '');
+  const { desc, setDesc } = useContext(ParticleContext);
   return (
     <Modal
       width={'60em'}
@@ -21,29 +23,29 @@ export const ShowDesc = (props) => {
         title={'Var Details'}
         buttons={
           VarExplanation[desc].dataunit ? (
-            <Button content="Dismiss" onClick={() => setdesc('')} />
+            <Button content="Dismiss" onClick={() => setDesc('')} />
           ) : (
             <>
               <Button
                 content="Motion basics"
                 selected={desc === 'motion'}
-                onClick={() => setdesc('motion')}
+                onClick={() => setDesc('motion')}
               />
               <Button
                 content="Rand types"
                 selected={desc === 'randtypes'}
-                onClick={() => setdesc('randtypes')}
+                onClick={() => setDesc('randtypes')}
               />
               <Button
                 content="Generator types"
                 selected={desc === 'gentypes'}
-                onClick={() => setdesc('gentypes')}
+                onClick={() => setDesc('gentypes')}
               />
               <Button
                 icon="x"
                 tooltip={'Dismiss'}
                 color={'red'}
-                onClick={() => setdesc('')}
+                onClick={() => setDesc('')}
               />
             </>
           )

--- a/tgui/packages/tgui/interfaces/ParticleEdit/index.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/index.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/jsx-no-undef */
-import { useBackend, useLocalState } from '../../backend';
+import { createContext, Dispatch, SetStateAction, useState } from 'react';
+
+import { useBackend } from '../../backend';
 import { Button, LabeledList, Section } from '../../components';
 import { Window } from '../../layouts';
 import { ParticleUIData } from './data';
@@ -18,9 +20,16 @@ import {
 } from './EntriesGenerators';
 import { ShowDesc } from './Tutorial';
 
+type ParticleEditContext = {
+  desc: string;
+  setDesc: Dispatch<SetStateAction<string>>;
+};
+
+export const ParticleContext = createContext({} as ParticleEditContext);
+
 export const ParticleEdit = (props) => {
   const { act, data } = useBackend<ParticleUIData>();
-  const [desc, setdesc] = useLocalState('desc', '');
+  const [desc, setDesc] = useState('');
 
   const {
     width,
@@ -52,137 +61,151 @@ export const ParticleEdit = (props) => {
   } = data.particle_data;
 
   return (
-    <Window title={data.target_name + "'s particles"} width={940} height={890}>
-      {desc ? <ShowDesc /> : null}
-      <Window.Content scrollable>
-        <LabeledList>
-          <Section
-            title={'Affects entire set'}
-            buttons={
-              <>
-                <Button
-                  icon={'question'}
-                  onClick={() => setdesc('generator')}
-                  tooltip={'Generator information'}
-                />
-                <Button
-                  icon={'sync'}
-                  onClick={() => act('new_type')}
-                  tooltip={'Change type'}
-                />
-                <Button
-                  icon={'x'}
-                  color={'red'}
-                  onClick={() => act('delete_and_close')}
-                  tooltip={'Delete and close UI'}
-                />
-              </>
-            }
-          >
-            <EntryFloat name={'Width'} var_name={'width'} float={width} />
-            <EntryFloat name={'Height'} var_name={'height'} float={height} />
-            <EntryFloat name={'Count'} var_name={'count'} float={count} />
-            <EntryFloat
-              name={'Spawning'}
-              var_name={'spawning'}
-              float={spawning}
-            />
-            <EntryCoord
-              name={'Bound corner 1'}
-              var_name={'bound1'}
-              coord={bound1}
-            />
-            <EntryCoord
-              name={'Bound corner 2'}
-              var_name={'bound2'}
-              coord={bound2}
-            />
-            <EntryCoord name={'Gravity'} var_name={'gravity'} coord={gravity} />
-            <EntryGradient
-              name={'Gradient'}
-              var_name={'gradient'}
-              gradient={gradient}
-            />
-            <EntryTransform
-              name={'Transform'}
-              var_name={'transform'}
-              transform={transform}
-            />
-          </Section>
-          <Section title={'Evaluated on particle creation'}>
-            <EntryIcon name={'Icon'} var_name={'icon'} icon_state={icon} />
-            <EntryIconState
-              name={'Icon State'}
-              var_name={'icon_state'}
-              icon_state={icon_state}
-            />
-            <FloatGenerator
-              name={'Lifespan'}
-              var_name={'lifespan'}
-              float={lifespan}
-            />
-            <FloatGenerator name={'Fade out'} var_name={'fade'} float={fade} />
-            <FloatGenerator
-              name={'Fade in'}
-              var_name={'fadein'}
-              float={fadein}
-            />
-            <FloatGeneratorColor
-              name={'Color'}
-              var_name={'color'}
-              float={color}
-            />
-            <FloatGenerator
-              name={'Color change'}
-              var_name={'color_change'}
-              float={color_change}
-            />
-            <EntryGeneratorNumbersList
-              name={'Position'}
-              var_name={'position'}
-              allow_z
-              input={position}
-            />
-            <EntryGeneratorNumbersList
-              name={'Velocity'}
-              var_name={'velocity'}
-              allow_z
-              input={velocity}
-            />
-            <EntryGeneratorNumbersList
-              name={'Scale'}
-              var_name={'scale'}
-              allow_z={false}
-              input={scale}
-            />
-            <EntryGeneratorNumbersList
-              name={'Grow'}
-              var_name={'grow'}
-              allow_z={false}
-              input={grow}
-            />
-            <FloatGenerator
-              name={'Rotation'}
-              var_name={'rotation'}
-              float={rotation}
-            />
-            <FloatGenerator name={'Spin'} var_name={'spin'} float={spin} />
-            <FloatGenerator
-              name={'Friction'}
-              var_name={'friction'}
-              float={friction}
-            />
-          </Section>
-          <Section title={'Evaluated every tick'}>
-            <EntryGeneratorNumbersList
-              name={'Drift'}
-              var_name={'drift'}
-              allow_z
-              input={drift}
-            />
-          </Section>
-        </LabeledList>
-      </Window.Content>
-    </Window>
+    <ParticleContext.Provider value={{ desc, setDesc }}>
+      <Window
+        title={data.target_name + "'s particles"}
+        width={940}
+        height={890}
+      >
+        {desc ? <ShowDesc /> : null}
+        <Window.Content scrollable>
+          <LabeledList>
+            <Section
+              title={'Affects entire set'}
+              buttons={
+                <>
+                  <Button
+                    icon={'question'}
+                    onClick={() => setDesc('generator')}
+                    tooltip={'Generator information'}
+                  />
+                  <Button
+                    icon={'sync'}
+                    onClick={() => act('new_type')}
+                    tooltip={'Change type'}
+                  />
+                  <Button
+                    icon={'x'}
+                    color={'red'}
+                    onClick={() => act('delete_and_close')}
+                    tooltip={'Delete and close UI'}
+                  />
+                </>
+              }
+            >
+              <EntryFloat name={'Width'} var_name={'width'} float={width} />
+              <EntryFloat name={'Height'} var_name={'height'} float={height} />
+              <EntryFloat name={'Count'} var_name={'count'} float={count} />
+              <EntryFloat
+                name={'Spawning'}
+                var_name={'spawning'}
+                float={spawning}
+              />
+              <EntryCoord
+                name={'Bound corner 1'}
+                var_name={'bound1'}
+                coord={bound1}
+              />
+              <EntryCoord
+                name={'Bound corner 2'}
+                var_name={'bound2'}
+                coord={bound2}
+              />
+              <EntryCoord
+                name={'Gravity'}
+                var_name={'gravity'}
+                coord={gravity}
+              />
+              <EntryGradient
+                name={'Gradient'}
+                var_name={'gradient'}
+                gradient={gradient}
+              />
+              <EntryTransform
+                name={'Transform'}
+                var_name={'transform'}
+                transform={transform}
+              />
+            </Section>
+            <Section title={'Evaluated on particle creation'}>
+              <EntryIcon name={'Icon'} var_name={'icon'} icon_state={icon} />
+              <EntryIconState
+                name={'Icon State'}
+                var_name={'icon_state'}
+                icon_state={icon_state}
+              />
+              <FloatGenerator
+                name={'Lifespan'}
+                var_name={'lifespan'}
+                float={lifespan}
+              />
+              <FloatGenerator
+                name={'Fade out'}
+                var_name={'fade'}
+                float={fade}
+              />
+              <FloatGenerator
+                name={'Fade in'}
+                var_name={'fadein'}
+                float={fadein}
+              />
+              <FloatGeneratorColor
+                name={'Color'}
+                var_name={'color'}
+                float={color}
+              />
+              <FloatGenerator
+                name={'Color change'}
+                var_name={'color_change'}
+                float={color_change}
+              />
+              <EntryGeneratorNumbersList
+                name={'Position'}
+                var_name={'position'}
+                allow_z
+                input={position}
+              />
+              <EntryGeneratorNumbersList
+                name={'Velocity'}
+                var_name={'velocity'}
+                allow_z
+                input={velocity}
+              />
+              <EntryGeneratorNumbersList
+                name={'Scale'}
+                var_name={'scale'}
+                allow_z={false}
+                input={scale}
+              />
+              <EntryGeneratorNumbersList
+                name={'Grow'}
+                var_name={'grow'}
+                allow_z={false}
+                input={grow}
+              />
+              <FloatGenerator
+                name={'Rotation'}
+                var_name={'rotation'}
+                float={rotation}
+              />
+              <FloatGenerator name={'Spin'} var_name={'spin'} float={spin} />
+              <FloatGenerator
+                name={'Friction'}
+                var_name={'friction'}
+                float={friction}
+              />
+            </Section>
+            <Section title={'Evaluated every tick'}>
+              <EntryGeneratorNumbersList
+                name={'Drift'}
+                var_name={'drift'}
+                allow_z
+                input={drift}
+              />
+            </Section>
+          </LabeledList>
+        </Window.Content>
+      </Window>
+    </ParticleContext.Provider>
   );
 };

--- a/tgui/packages/tgui/interfaces/RequestsConsole/AnnouncementTab.tsx
+++ b/tgui/packages/tgui/interfaces/RequestsConsole/AnnouncementTab.tsx
@@ -1,11 +1,13 @@
-import { useBackend, useLocalState } from '../../backend';
+import { useState } from 'react';
+
+import { useBackend } from '../../backend';
 import { Button, NoticeBox, Section, TextArea } from '../../components';
 import { RequestsData } from './types';
 
 export const AnnouncementTab = (props) => {
   const { act, data } = useBackend<RequestsData>();
   const { authentication_data, is_admin_ghost_ai } = data;
-  const [messageText, setMessageText] = useLocalState('messageText', '');
+  const [messageText, setMessageText] = useState('');
   return (
     <Section>
       <TextArea


### PR DESCRIPTION
## About The Pull Request
Title. Had some extra time, converted some UIs to use usestate/usecontext rather than uselocalstate.

PAI available software interface was adjusted a little.

<details>
<summary>pictures</summary>

before
![Screenshot 2024-05-20 155616](https://github.com/tgstation/tgstation/assets/42397676/ea5e66bc-1257-4fad-ac8c-6ed40df70563)

after
![Screenshot 2024-05-20 155927](https://github.com/tgstation/tgstation/assets/42397676/2b86f44c-27e9-4bc4-9503-dd3d5a41e4a4)

![image](https://github.com/tgstation/tgstation/assets/42397676/4f745a4d-14c8-429f-91ca-9e06e505c7fc)

</details>

## Why It's Good For The Game
Uselocalstate is deprecated in favor of using plain react hooks.
## Changelog
:cl:
fix: Slightly cleaned up PAI software downloads interface
/:cl:
