### PR TITLE
Fix airlock assembly renaming examine grammar issue

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -61,9 +61,6 @@
 
 /obj/structure/door_assembly/examine(mob/user)
 	. = ..()
-	var/doorname = ""
-	if(created_name)
-		doorname = ", written on it is '[created_name]'"
 	switch(state)
 		if(AIRLOCK_ASSEMBLY_NEEDS_WIRES)
 			if(anchored)
@@ -80,8 +77,8 @@
 		. += span_notice("There are <i>empty</i> slots for mineral covers.")
 	else if(!glass && !noglass)
 		. += span_notice("There are <i>empty</i> slots for glass windows.")
-	if(doorname)
-		. += span_notice("There is a small <i>paper</i> placard on the assembly labelled \"[doorname]\".")
+	if(created_name)
+		. += span_notice("There is a small <i>paper</i> placard on the assembly, written on it is '[created_name]'.")
 
 /obj/structure/door_assembly/attackby(obj/item/W, mob/living/user, params)
 	if(istype(W, /obj/item/pen) && !user.combat_mode)


### PR DESCRIPTION

## About The Pull Request

At some point the examine line about what the resulting airlock will be named got split off into a separate statement, but in the process some things got crossed and it doubled up on the final half of the line.
Currently, an airlock might state:

> There is a small <i>paper</i> placard on the assembly labelled ", written on it is 'Public Garden'".

So we cut out the ` labelled \"[doorname]\"` part and go back to just having the `, written on it is '[created_name]'` part.

> There is a small <i>paper</i> placard on the assembly, written on it is 'Public Garden'.
## Why It's Good For The Game

Comprehensible examine for airlock assemblies.
## Changelog
:cl:
spellcheck: Examining a renamed airlock assembly no longer says it has a paper placard that is "labelled with written on it is".
/:cl:
