### PR TITLE
Changes the adjust_visor interaction text to be more neutral

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -480,7 +480,7 @@ BLIND     // can't see anything
 
 	visor_toggling()
 
-	to_chat(user, span_notice("You push [src] [up ? "out of the way" : "back to its original position"]."))
+	to_chat(user, span_notice("You push [src] [up ? "out of the way" : "back into place"]."))
 
 	update_item_action_buttons()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -480,7 +480,7 @@ BLIND     // can't see anything
 
 	visor_toggling()
 
-	to_chat(user, span_notice("You adjust [src] [up ? "up" : "down"]."))
+	to_chat(user, span_notice("You push [src] [up ? "out of the way" : "back to its original position"]."))
 
 	update_item_action_buttons()
 


### PR DESCRIPTION

## About The Pull Request
Following #79784, things such as welding helmets and breath masks used the same code for adjusting them. When adjusting it, it would either print "You adjust [the object] up" if you are adjusting it to its non-normal state, or "You adjust [the object] down". So, when you adjust the welding helmet's visor up, it prints the former and makes sense. Masks, however, were a different story. When you adjust the mask down, it would print "You adjust the mask up" to chat, which doesn't make sense. This just changes the text to be more neutral in terms of direction.
## Why It's Good For The Game
I don't adjust the breath mask up when I drop it down to my chest
## Changelog
:cl:
spellcheck: The message displayed when adjusting a mask no longer incorrectly states the way in which the mask has moved.
/:cl:
