### PR TITLE
Airlock electronics created by deconstructing roundstart airlocks inherit their cycling id properly.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1528,6 +1528,8 @@
 		var/obj/item/electronics/airlock/ae
 		if(!electronics)
 			ae = new/obj/item/electronics/airlock(loc)
+			if(closeOtherId)
+				ae.passed_cycle_id = closeOtherId
 			if(length(req_one_access))
 				ae.one_access = 1
 				ae.accesses = req_one_access


### PR DESCRIPTION

## About The Pull Request

When you deconstruct a roundstart airlock, it has to create new airlock electronics matching its settings.
It, however, fails to do this for the airlock cycling ID, meaning you have to reset it manually each time you deconstruct a cycling airlock for the first time.
So we just set the electronics' `passed_cycle_id` to the airlock's `closeOtherId`, and this fixes our issue.
## Why It's Good For The Game

Fixes deconstructing roundstart airlocks with a cycle ID not actually giving you electronics with that cycle ID.
## Changelog
:cl:
fix: Airlock electronics created by deconstructing roundstart airlocks inherit their cycling id properly.
/:cl:
