### PR TITLE
Turns bat knockback into an element and adds it to cleric maces

### DIFF
--- a/code/datums/elements/attack_knockback.dm
+++ b/code/datums/elements/attack_knockback.dm
@@ -1,0 +1,28 @@
+/**
+ * Knocks the target back one tile when melee hitting!
+ *
+ * Used in bats and maces
+ */
+/datum/element/attack_knockback
+
+/datum/element/attack_knockback/Attach(datum/target)
+	. = ..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ITEM_ATTACK, PROC_REF(on_item_attack))
+
+/datum/element/attack_knockback/Detach(datum/source, ...)
+	. = ..()
+
+	UnregisterSignal(source, COMSIG_ITEM_ATTACK)
+
+/datum/element/attack_knockback/proc/on_item_attack(obj/item/bat, mob/living/target, mob/living/user)
+	SIGNAL_HANDLER
+
+	// we obtain the relative direction from the bat itself to the target
+	var/relative_direction = get_cardinal_dir(bat, target)
+	var/atom/throw_target = get_edge_target_turf(target, relative_direction)
+	if(QDELETED(target) || target.anchored)
+		return
+	var/whack_speed = (prob(60) ? 1 : 4)
+	target.throw_at(throw_target, rand(1, 2), whack_speed, user, gentle = TRUE) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)

--- a/code/datums/elements/attack_knockback.dm
+++ b/code/datums/elements/attack_knockback.dm
@@ -4,11 +4,28 @@
  * Used in bats and maces
  */
 /datum/element/attack_knockback
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// Picks a number from this list, throws this far away
+	var/list/throw_range = list(1)
+	/// Picks a number from this list, throws at this speed
+	var/list/throw_speed = list(1, 4)
+	/// If the throw is violent or not
+	var/gentle = TRUE
+	/// Callback for a proc right before confirming the attack. If it returns FALSE, cancel
+	var/datum/callback/pre_hit_callback
 
-/datum/element/attack_knockback/Attach(datum/target)
+/datum/element/attack_knockback/Attach(datum/target, throw_range, throw_speed, datum/callback/pre_hit_callback)
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
+
+	if(throw_range)
+		src.throw_range = throw_range
+	if(throw_speed)
+		src.throw_speed = throw_speed
+	src.pre_hit_callback = pre_hit_callback
+
 	RegisterSignal(target, COMSIG_ITEM_POST_ATTACK, PROC_REF(on_item_attack))
 
 /datum/element/attack_knockback/Detach(datum/source, ...)
@@ -24,5 +41,8 @@
 	var/atom/throw_target = get_edge_target_turf(target, relative_direction)
 	if(QDELETED(target) || target.anchored)
 		return
-	var/whack_speed = (prob(60) ? 1 : 4)
-	target.throw_at(throw_target, rand(1, 2), whack_speed, user, gentle = TRUE) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)
+
+	if(pre_hit_callback && !pre_hit_callback.Invoke(user))
+		return
+
+	target.throw_at(throw_target, pick(throw_range), pick(throw_speed), user, gentle = src.gentle) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)

--- a/code/datums/elements/attack_knockback.dm
+++ b/code/datums/elements/attack_knockback.dm
@@ -42,7 +42,7 @@
 	if(QDELETED(target) || target.anchored)
 		return
 
-	if(pre_hit_callback && !pre_hit_callback.Invoke(user))
+	if(pre_hit_callback && !pre_hit_callback.Invoke())
 		return
 
 	target.throw_at(throw_target, pick(throw_range), pick(throw_speed), user, gentle = src.gentle) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)

--- a/code/datums/elements/attack_knockback.dm
+++ b/code/datums/elements/attack_knockback.dm
@@ -9,7 +9,7 @@
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
-	RegisterSignal(target, COMSIG_ITEM_ATTACK, PROC_REF(on_item_attack))
+	RegisterSignal(target, COMSIG_ITEM_POST_ATTACK, PROC_REF(on_item_attack))
 
 /datum/element/attack_knockback/Detach(datum/source, ...)
 	. = ..()

--- a/code/datums/elements/attack_knockback.dm
+++ b/code/datums/elements/attack_knockback.dm
@@ -29,10 +29,9 @@
 	RegisterSignal(target, COMSIG_ITEM_POST_ATTACK, PROC_REF(on_item_attack))
 
 /datum/element/attack_knockback/Detach(datum/source, ...)
-	. = ..()
-
 	QDEL_NULL(pre_hit_callback)
 	UnregisterSignal(source, COMSIG_ITEM_ATTACK)
+	. = ..()
 
 /datum/element/attack_knockback/proc/on_item_attack(obj/item/bat, mob/living/target, mob/living/user)
 	SIGNAL_HANDLER

--- a/code/datums/elements/attack_knockback.dm
+++ b/code/datums/elements/attack_knockback.dm
@@ -31,6 +31,7 @@
 /datum/element/attack_knockback/Detach(datum/source, ...)
 	. = ..()
 
+	QDEL_NULL(pre_hit_callback)
 	UnregisterSignal(source, COMSIG_ITEM_ATTACK)
 
 /datum/element/attack_knockback/proc/on_item_attack(obj/item/bat, mob/living/target, mob/living/user)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -483,6 +483,12 @@
 	attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
 	attack_verb_simple = list("smack", "strike", "crack", "beat")
 
+// They dont call it the grandfather of the baseball bat for nothing
+/obj/item/melee/cleric_mace/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/kneecapping)
+	AddElement(/datum/element/attack_knockback)
+
 /obj/item/melee/cleric_mace/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	if(attack_type == PROJECTILE_ATTACK || attack_type == LEAP_ATTACK)
 		final_block_chance = 0 //Don't bring a...mace to a gunfight, and also you aren't going to really block someone full body tackling you with a mace

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -715,6 +715,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		desc = pick("You've got red on you.", "You gotta know what a crumpet is to understand cricket.")
 
 	AddElement(/datum/element/kneecapping)
+	AddElement(/datum/element/attack_knockback)
 
 /obj/item/melee/baseball_bat/attack_self(mob/user)
 	if(!homerun_able)
@@ -730,23 +731,19 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	return ..()
 
 /obj/item/melee/baseball_bat/attack(mob/living/target, mob/living/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) || !homerun_ready)
+		return
 	// we obtain the relative direction from the bat itself to the target
 	var/relative_direction = get_cardinal_dir(src, target)
 	var/atom/throw_target = get_edge_target_turf(target, relative_direction)
-	. = ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		return
-	if(homerun_ready)
-		user.visible_message(span_userdanger("It's a home run!"))
-		if(!QDELETED(target))
-			target.throw_at(throw_target, rand(8,10), 14, user)
-		SSexplosions.medturf += throw_target
-		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, TRUE)
-		homerun_ready = FALSE
-		return
-	else if(!QDELETED(target) && !target.anchored)
-		var/whack_speed = (prob(60) ? 1 : 4)
-		target.throw_at(throw_target, rand(1, 2), whack_speed, user, gentle = TRUE) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)
+	user.visible_message(span_userdanger("It's a home run!"))
+	SSexplosions.medturf += throw_target
+	playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, TRUE)
+	homerun_ready = FALSE
+	if(!QDELETED(target))
+		target.throw_at(throw_target, rand(8,10), 14, user)
+	return
 
 /obj/item/melee/baseball_bat/Destroy(force)
 	for(var/target in thrown_datums)

--- a/code/game/objects/items/wizard_weapons.dm
+++ b/code/game/objects/items/wizard_weapons.dm
@@ -99,10 +99,18 @@
 		icon_wielded = "[base_icon_state]1", \
 		attacksound = SFX_SPARKS, \
 	)
+	AddElement(/datum/element/attack_knockback, \
+		throw_range = 200, \
+		throw_speed = 4, \
+		pre_hit_callback = CALLBACK(src, PROC_REF(is_wielded_wrapper)), \
+	)
 
 /obj/item/mjollnir/update_icon_state()
 	icon_state = "[base_icon_state]0"
 	return ..()
+
+/obj/item/mjollnir/proc/is_wielded_wrapper()
+	return HAS_TRAIT(src, TRAIT_WIELDED)
 
 /obj/item/mjollnir/proc/shock(mob/living/target)
 	target.Stun(1.5 SECONDS)
@@ -113,8 +121,6 @@
 	target.visible_message(span_danger("[target.name] is shocked by [src]!"), \
 		span_userdanger("You feel a powerful shock course through your body sending you flying!"), \
 		span_hear("You hear a heavy electrical crack!"))
-	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
-	target.throw_at(throw_target, 200, 4)
 
 /obj/item/mjollnir/attack(mob/living/target_mob, mob/user)
 	..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1369,6 +1369,7 @@
 #include "code\datums\elements\atmos_requirements.dm"
 #include "code\datums\elements\atmos_sensitive.dm"
 #include "code\datums\elements\attack_equip.dm"
+#include "code\datums\elements\attack_knockback.dm"
 #include "code\datums\elements\attack_zone_randomiser.dm"
 #include "code\datums\elements\backblast.dm"
 #include "code\datums\elements\bane.dm"


### PR DESCRIPTION

## About The Pull Request

Turns bat knockback into an element and adds it to cleric maces.

To farm GBP, I also turned the knockback into a standard element.

## Why It's Good For The Game

Cleric maces are pretty poop. Ruin-only, bulky, and with only slightly above average damage, there's little point to hauling one around most of the time as opposed to a welding tool or something. I saw the description referenced the baseball bat, but it doesn't actually the bat's knockback gimmick, which I think would be pretty damn useful for it to be 1. less useless and 2. more useful for the space explorers that will find it.

> To farm GBP, I also turned the knockback into a standard element.

Now it can be added to other things yayyyyyyyyy

## Changelog

:cl:
refactor: Turns baseball bat knockback into an element
add: and adds it to cleric maces
/:cl:

