### PR TITLE
Fixes some grammar in wall sign descriptions

### DIFF
--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -8,7 +8,7 @@
 /obj/structure/sign/departments/med
 	name = "\improper Medbay sign"
 	sign_change_name = "Department - Medbay"
-	desc = "A sign labeling an area of medical department."
+	desc = "A sign labelling an area of the medical department."
 	icon_state = "med"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/med, 32)
@@ -23,7 +23,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/med_alt, 32)
 /obj/structure/sign/departments/medbay
 	name = "\improper Medbay sign"
 	sign_change_name = "Generic Medical"
-	desc = "The Intergalactic symbol of Medical institutions. You'll probably get help here."
+	desc = "The intergalactic symbol of medical institutions. You'll probably get help here."
 	icon_state = "bluecross"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/medbay, 32)
@@ -84,7 +84,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/virology, 32)
 /obj/structure/sign/departments/morgue
 	name = "\improper Morgue sign"
 	sign_change_name = "Department - Medbay: Morgue"
-	desc = "A sign labelling an area where station stores its ever-piling bodies."
+	desc = "A sign labelling an area where the station stores its ever-piling bodies."
 	icon_state = "morgue"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/morgue, 32)

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -199,7 +199,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/gas_mask, 32)
 /obj/structure/sign/warning/chem_diamond
 	name = "\improper REACTIVE CHEMICALS sign"
 	sign_change_name = "Warning - Hazardous Chemicals sign"
-	desc = "A sign that warns of potentially reactive chemicals nearby, be they explosive, flamable, or acidic."
+	desc = "A sign that warns of potentially reactive chemicals nearby, be they explosive, flammable, or acidic."
 	icon_state = "chemdiamond"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/chem_diamond, 32)


### PR DESCRIPTION

## About The Pull Request
Fixes some grammar errors in some of the department wall signs, mostly adding "the" to the sign descriptions and tweaking a few misplaced capitals.
## Why It's Good For The Game
A minor grammar mistake has been eliminated. (Grammar is nice.)
## Changelog
:cl:
spellcheck: A handful of grammar errors in some department signs has been fixed.
/:cl:
