### PR TITLE
Fix smoker quirk preferences

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_INIT(possible_junkie_addictions, setup_junkie_addictions(list(
 )))
 
 ///Options for the Smoker quirk to choose from
-GLOBAL_LIST_INIT(possible_smoker_addictions, setup_junkie_addictions(list(
+GLOBAL_LIST_INIT(possible_smoker_addictions, setup_smoker_addictions(list(
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/storage/fancy/cigarettes/cigpack_midori,
 	/obj/item/storage/fancy/cigarettes/cigpack_uplift,

--- a/code/modules/client/preferences/addict.dm
+++ b/code/modules/client/preferences/addict.dm
@@ -4,6 +4,12 @@
 		. -= addiction
 		.[addiction::name] = addiction
 
+/proc/setup_smoker_addictions(list/possible_addictions)
+	. = possible_addictions
+	for(var/obj/item/storage/addiction as anything in .)
+		. -= addiction
+		.[format_text(addiction::name)] = addiction // Format text to remove \improper used in cigarette packs
+
 /datum/preference/choiced/junkie
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "junkie"


### PR DESCRIPTION

## About The Pull Request

So the smoker quirk would always reset back to "Random" whichever preferences you selected, just in the menu.
Looking into why this was happening, it seemed to be failing at the point where it deserializes and sanitizes your selected value, specifically at the point where it'd compare it to the list of possible preferences.

This seemed to be because the value it got back from tgui had removed the `\improper` text macro, while the value in the list was saved with that text macro.
It's not actually useful here, so we remove it using `format_text(...)` when setting up the list, and this makes it work again.

We also split it off from the previous used proc used for setting up the list:
```dm
/proc/setup_junkie_addictions(list/possible_addictions)
	. = possible_addictions
	for(var/datum/reagent/addiction as anything in .)
		. -= addiction
		.[addiction::name] = addiction
```
Because the smoker list doesn't actually use reagents. I'm surprised this successfully got the name values for the non-reagents in the first place.
## Why It's Good For The Game
Fixes #83277.
Fixes #82538.
## Changelog
:cl:
fix: Smoker quirk users can select a favourite brand again.
/:cl:
