### PR TITLE
Fixes vendors displaying a broken character when dropping cigarette boxes onto the floor.

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1458,7 +1458,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	if(usr.CanReach(src) && usr.put_in_hands(vended_item))
 		to_chat(usr, span_notice("You take [item_record.name] out of the slot."))
 	else
-		to_chat(usr, span_warning("[capitalize(item_record.name)] falls onto the floor!"))
+		to_chat(usr, span_warning("[capitalize(format_text(item_record.name))] falls onto the floor!"))
 	SSblackbox.record_feedback("nested tally", "vending_machine_usage", 1, list("[type]", "[item_record.product_path]"))
 	vend_ready = TRUE
 
@@ -1846,7 +1846,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	if(user.CanReach(src) && user.put_in_hands(dispensed_item))
 		to_chat(user, span_notice("You take [dispensed_item.name] out of the slot."))
 	else
-		to_chat(user, span_warning("[capitalize(dispensed_item.name)] falls onto the floor!"))
+		to_chat(user, span_warning("[capitalize(format_text(dispensed_item.name))] falls onto the floor!"))
 	return TRUE
 
 /obj/machinery/vending/custom/unbreakable


### PR DESCRIPTION

## About The Pull Request

Vendors dispensing cigarette boxes onto the floor would cause a broken character to appear at the beginning of the line.
Looking into it, this seemed to be due to an attempt at capitalizing the item names, which interacts with the `\improper` text macro to cause this issue.
Calling `format_text(...)` beforehand resolves this issue.

Look in the linked issue for more details.
## Why It's Good For The Game

Fixes #82618.
## Changelog
:cl:
spellcheck: When a vendor tells you something dropped onto the floor, the line no longer starts with a broken character in the case of cigarette boxes.
/:cl:
