### PR TITLE
makes food hud burger icon have a sharp outline

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -784,7 +784,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 	food_image = image(icon = food_icon, icon_state = food_icon_state, pixel_x = -5)
 	food_image.plane = plane
 	food_image.appearance_flags |= KEEP_APART // To be unaffected by filters applied to src
-	food_image.add_filter("simple_outline", 2, outline_filter(1, COLOR_BLACK))
+	food_image.add_filter("simple_outline", 2, outline_filter(1, COLOR_BLACK, OUTLINE_SHARP))
 	underlays += food_image // To be below filters applied to src
 
 	SetInvisibility(INVISIBILITY_ABSTRACT, name) // Start invisible, update later


### PR DESCRIPTION

## About The Pull Request
instead of
![image](https://github.com/tgstation/tgstation/assets/23585223/fa013f8d-d402-4714-8f85-986273643f86)
will look more like this
![image](https://github.com/MrMelbert/tgstation/assets/23585223/8fe754c8-5242-4e8d-be6f-90897c8eae5d)
also i would like to make it not protrude from the middle of your hud it looks ugly but idk where to put it @Mothblocks 

## Why It's Good For The Game
anti aliasing smells

## Changelog
:cl:
image: makes food hud burger icon have a sharp outline
/:cl:
