### PR TITLE
Fixes a minor plurality typo with latejoin AIs

### DIFF
--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -83,7 +83,7 @@
 /datum/job/human_ai/announce_job(mob/living/joining_mob)
 	. = ..()
 	if(SSticker.HasRoundStarted())
-		minor_announce("Due to a research mishaps, [joining_mob] has been sent to be your replacement AI at [AREACOORD(joining_mob)]. Please treat them with respect.")
+		minor_announce("Due to a research mishap, [joining_mob] has been sent to be your replacement AI at [AREACOORD(joining_mob)]. Please treat them with respect.")
 
 /datum/job/human_ai/get_radio_information()
 	return "<b>Prefix your message with :b to speak with cyborgs.</b>"


### PR DESCRIPTION

## About The Pull Request

Removes an S from the message `Due to a research mishaps, [station AI] has been sent to be your replacement AI at [location]. Please treat them with respect.`
## Why It's Good For The Game

Latejoin AIs don't have a goofy typo in them now. whoag.
## Changelog
:cl:
spellcheck: Fixes a typo with latejoin AIs
/:cl:
