### PR TITLE
Going bananas - Fixes a 1% chance spurious CI runtime

### DIFF
--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -36,11 +36,7 @@
 	. = ..()
 	if(prob(1))
 		AddComponent(/datum/component/boomerang, boomerang_throw_range = throw_range + 4, thrower_easy_catch_enabled = TRUE)
-
-/obj/item/food/grown/banana/examine_more(mob/user)
-	. = ..()
-	if(GetComponent(/datum/component/boomerang))
-		. += "The curve on this one looks particularly acute."
+		addtimer(VARSET_CALLBACK(src, desc, " The curve on this one looks particularly acute."), 0.1 SECONDS) // delay because orderable items shouldn't have a dynamic desc
 
 ///Clowns will always like bananas.
 /obj/item/food/grown/banana/proc/check_liked(mob/living/carbon/human/consumer)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -36,7 +36,11 @@
 	. = ..()
 	if(prob(1))
 		AddComponent(/datum/component/boomerang, boomerang_throw_range = throw_range + 4, thrower_easy_catch_enabled = TRUE)
-		desc += " The curve on this one looks particularly acute."
+
+/obj/item/food/grown/banana/examine_more(mob/user)
+	. = ..()
+	if(GetComponent(/datum/component/boomerang))
+		. += "The curve on this one looks particularly acute."
 
 ///Clowns will always like bananas.
 /obj/item/food/grown/banana/proc/check_liked(mob/living/carbon/human/consumer)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	if(prob(1))
 		AddComponent(/datum/component/boomerang, boomerang_throw_range = throw_range + 4, thrower_easy_catch_enabled = TRUE)
-		addtimer(VARSET_CALLBACK(src, desc, " The curve on this one looks particularly acute."), 0.1 SECONDS) // delay because orderable items shouldn't have a dynamic desc
+		addtimer(VARSET_CALLBACK(src, desc, desc + " The curve on this one looks particularly acute."), 0.1 SECONDS) // delay because orderable items shouldn't have a dynamic desc
 
 ///Clowns will always like bananas.
 /obj/item/food/grown/banana/proc/check_liked(mob/living/carbon/human/consumer)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/83353
Fixes https://github.com/NovaSector/NovaSector/issues/2594
Alternative to / closes #83391

![firefox_qqmUK0lnjP](https://github.com/tgstation/tgstation/assets/13398309/c5bfd3e7-9abe-4c3d-96a2-1adf0282de4c)

So there is currently a 1% chance CI fails in a given run, because bananas. Every 1 in 100 banana is useable as a boomerang, and when that is the case it gets its desc updated.

I thought about adding it to examine_more but it makes it less obvious that way that the banana is special, since I doubt people really examine bananas twice. So instead it just waits a hot minute before updating the desc.

<details><summary>Does in fact still work</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/369d0cdd-5847-4cb9-a95a-ffa7ade87888)

</details>

If there's a better solution I'm all ears but this runtime was annoying me.

## Why It's Good For The Game

Less CI fails

## Changelog


Nothing player-facing