### PR TITLE
Infected AI (Traitor Final Objective) no longer plays the Malf Antag sound effect

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -276,7 +276,7 @@
 	name = "Infected AI"
 	employer = "Infected AI"
 	can_assign_self_objectives = FALSE
-	malf_sound = ""
+	malf_sound = null
 	///The player, to who is this AI slaved
 	var/datum/mind/boss
 

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -20,6 +20,8 @@
 	var/should_give_codewords = TRUE
 	///since the module purchasing is built into the antag info, we need to keep track of its compact mode here
 	var/module_picker_compactmode = FALSE
+	///malf on_gain sound effect. Set here so Infected AI can override
+	var/malf_sound = 'sound/ambience/antag/malf.ogg'
 
 /datum/antagonist/malf_ai/New(give_objectives = TRUE)
 	. = ..()
@@ -39,7 +41,8 @@
 	malfunction_flavor = strings(MALFUNCTION_FLAVOR_FILE, employer)
 
 	add_law_zero()
-	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/malf.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+	if(malf_sound)
+		owner.current.playsound_local(get_turf(owner.current), malf_sound, 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	owner.current.grant_language(/datum/language/codespeak, source = LANGUAGE_MALF)
 
 	var/datum/atom_hud/data/hackyhud = GLOB.huds[DATA_HUD_MALF_APC]
@@ -272,6 +275,7 @@
 /datum/antagonist/malf_ai/infected
 	name = "Infected AI"
 	employer = "Infected AI"
+	malf_sound = ''
 	///The player, to who is this AI slaved
 	var/datum/mind/boss
 

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -276,7 +276,7 @@
 	name = "Infected AI"
 	employer = "Infected AI"
 	can_assign_self_objectives = FALSE
-	malf_sound = ''
+	malf_sound = ""
 	///The player, to who is this AI slaved
 	var/datum/mind/boss
 

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -275,6 +275,7 @@
 /datum/antagonist/malf_ai/infected
 	name = "Infected AI"
 	employer = "Infected AI"
+	can_assign_self_objectives = FALSE
 	malf_sound = ''
 	///The player, to who is this AI slaved
 	var/datum/mind/boss


### PR DESCRIPTION
## About The Pull Request
Does as title says. Infected AI *could* be given a new sound effect but I'll leave that to someone in the future.

Also removes the ability for Infected AIs to set their own custom objectives
## Why It's Good For The Game
Getting Malf AI usually means you can ignore laws. AIs really should be checking their Law 0 before deciding to do their own flavor of chaos but Infected AI having the same sound effect is an unnecessary extra chance to mix the two up.
## Changelog
:cl:
qol: Traitor-created Infected AIs no longer hear the Malf AI antag sound alert.
/:cl:
