### PR TITLE
Fixes race condition with alien weeds

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -279,7 +279,7 @@
 	//destroy any non-node weeds on turf
 	var/obj/structure/alien/weeds/check_weed = locate(/obj/structure/alien/weeds) in loc
 	if(check_weed && check_weed != src)
-		qdel(check_weed)
+		QDEL_IN(check_weed, 0) // Weeds might not be finished initializing yet (as in create_and_destroy).
 
 	//start the cooldown
 	COOLDOWN_START(src, growtime, rand(minimum_growtime, maximum_growtime))

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -276,10 +276,12 @@
 	//we are the parent node
 	parent_node = src
 
+// we do this in LateInitialize() because weeds on the same loc may not be done initializing yet (as in create_and_destroy)
+/obj/structure/alien/weeds/node/LateInitialize()
 	//destroy any non-node weeds on turf
 	var/obj/structure/alien/weeds/check_weed = locate(/obj/structure/alien/weeds) in loc
 	if(check_weed && check_weed != src)
-		QDEL_IN(check_weed, 0) // Weeds might not be finished initializing yet (as in create_and_destroy).
+		qdel(check_weed)
 
 	//start the cooldown
 	COOLDOWN_START(src, growtime, rand(minimum_growtime, maximum_growtime))

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -276,6 +276,8 @@
 	//we are the parent node
 	parent_node = src
 
+	return INITIALIZE_HINT_LATELOAD
+
 // we do this in LateInitialize() because weeds on the same loc may not be done initializing yet (as in create_and_destroy)
 /obj/structure/alien/weeds/node/LateInitialize()
 	//destroy any non-node weeds on turf


### PR DESCRIPTION
## About The Pull Request

Tin. Another annoying spurious runtime that is caused by create_and_destroy spawning weed nodes (which delete the weed at their loc). It was doing this before the weed finished initializing sometimes.

Fixes https://github.com/NovaSector/NovaSector/issues/2494

Tested with 10 back to back CI runs, runtime did not occur.