### PR TITLE
Converts parallax to pixel offsets, saves a bunch of cpu time, makes things nicer on clients too

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -237,8 +237,8 @@ GLOBAL_LIST_EMPTY(parallax_count)
 		SET_COST("read speed var")
 		var/change_x
 		var/change_y
-		var/old_x = parallax_layer.pixel_x
-		var/old_y = parallax_layer.pixel_y
+		var/old_x = parallax_layer.offset_x
+		var/old_y = parallax_layer.offset_y
 		SET_COST("create change vars")
 		if(parallax_layer.absolute)
 			SET_COST("check absolute")
@@ -258,36 +258,45 @@ GLOBAL_LIST_EMPTY(parallax_count)
 			// It doesn't use change because we really don't want to animate this
 			if(old_x - change_x > 240)
 				SET_COST("tile check x > 240")
-				parallax_layer.pixel_x -= 480
+				parallax_layer.offset_x -= 480
+				parallax_layer.pixel_x = parallax_layer.offset_x
 				SET_COST("tile offset x - 480")
 			else if(old_x - change_x < -240)
 				SET_COST("tile check x < -240")
-				parallax_layer.pixel_x += 480
+				parallax_layer.offset_x += 480
+				parallax_layer.pixel_x = parallax_layer.offset_x
 				SET_COST("tile offset x + 480")
 			else
 				SET_COST("tile check failed")
 			if(old_y - change_y > 240)
 				SET_COST("tile check y > 240")
-				parallax_layer.pixel_y -= 480
+				parallax_layer.offset_y -= 480
+				parallax_layer.pixel_y = parallax_layer.offset_y
 				SET_COST("tile offset y - 480")
 			else if(old_y - change_y < -240)
 				SET_COST("tile check y < -240")
-				parallax_layer.pixel_y += 480
+				parallax_layer.offset_y += 480
+				parallax_layer.pixel_y = parallax_layer.offset_y
 				SET_COST("tile offset y + 480")
 			else
 				SET_COST("tile check failed")
+
+		parallax_layer.offset_x -= change_x
+		SET_COST("offset x")
+		parallax_layer.offset_y -= change_y
+		SET_COST("offset y")
 		// Now that we have our offsets, let's do our positioning
 		// We're going to use an animate to "glide" that last movement out, so it looks nicer
 		// Don't do any animates if we're not actually moving enough distance yeah? thanks lad
 		if(run_parralax && (largest_change * our_speed > 1))
 			SET_COST("check run parallax")
-			animate(parallax_layer, pixel_x = parallax_layer.pixel_x - change_x, pixel_y = parallax_layer.pixel_y - change_y, time = glide_rate)
+			animate(parallax_layer, pixel_x = parallax_layer.offset_x, pixel_y = parallax_layer.offset_y, time = glide_rate)
 			SET_COST("animate pixel offsets")
 		else
 			SET_COST("check run parallax")
-			parallax_layer.pixel_x -= change_x
+			parallax_layer.pixel_x = parallax_layer.offset_x
 			SET_COST("offset pixel x")
-			parallax_layer.pixel_y -= change_y
+			parallax_layer.pixel_y = parallax_layer.offset_x
 			SET_COST("offset pixel y")
 
 	SET_COST("finish iterate layers")

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -48,7 +48,7 @@
 /datum/hud/proc/remove_parallax(mob/viewmob)
 	var/mob/screenmob = viewmob || mymob
 	var/client/C = screenmob.client
-	C.screen -= (C.parallax_layers_cached)
+	C.screen -= (C.parallax_rock)
 	for(var/atom/movable/screen/plane_master/plane_master as anything in screenmob.hud_used.get_true_plane_masters(PLANE_SPACE))
 		if(screenmob != mymob)
 			C.screen -= locate(/atom/movable/screen/plane_master/parallax_white) in C.screen
@@ -108,89 +108,67 @@
 	update_parallax(screen_mob)
 
 // This sets which way the current shuttle is moving (returns true if the shuttle has stopped moving so the caller can append their animation)
-/datum/hud/proc/set_parallax_movedir(new_parallax_movedir = 0, skip_windups, mob/viewmob)
+/datum/hud/proc/set_parallax_movedir(new_parallax_movedir = NONE, skip_windups, mob/viewmob)
 	. = FALSE
 	var/mob/screenmob = viewmob || mymob
 	var/client/C = screenmob.client
 	if(new_parallax_movedir == C.parallax_movedir)
 		return
-	var/animatedir = new_parallax_movedir
-	if(new_parallax_movedir == FALSE)
-		var/animate_time = 0
-		for(var/atom/movable/screen/parallax_layer/layer as anything in C.parallax_layers)
-			layer.icon_state = initial(layer.icon_state)
-			layer.update_o(C.view)
-			var/T = PARALLAX_LOOP_TIME / layer.speed
-			if (T > animate_time)
-				animate_time = T
-		C.dont_animate_parallax = world.time + min(animate_time, PARALLAX_LOOP_TIME)
-		animatedir = C.parallax_movedir
 
-	var/target_x = 0
-	var/target_y = 0
-	switch(animatedir)
+	var/animation_dir = new_parallax_movedir || C.parallax_movedir
+	var/matrix/new_transform
+	switch(animation_dir)
 		if(NORTH)
-			target_y = 480
+			new_transform = matrix(1, 0, 0, 0, 1, 480)
 		if(SOUTH)
-			target_y = -480
+			new_transform = matrix(1, 0, 0, 0, 1,-480)
 		if(EAST)
-			target_x = 480
+			new_transform = matrix(1, 0, 480, 0, 1, 0)
 		if(WEST)
-			target_x = -480
+			new_transform = matrix(1, 0,-480, 0, 1, 0)
 
-	var/shortesttimer
-	if(!skip_windups)
-		for(var/atom/movable/screen/parallax_layer/layer as anything in C.parallax_layers)
-			var/T = PARALLAX_LOOP_TIME / layer.speed
-			if (isnull(shortesttimer))
-				shortesttimer = T
-			if (T < shortesttimer)
-				shortesttimer = T
-			layer.pixel_x = target_x
-			layer.pixel_y = target_y
-			animate(layer, pixel_x = 0, pixel_y = 0, time = T, easing = QUAD_EASING | (new_parallax_movedir ? EASE_IN : EASE_OUT), flags = ANIMATION_END_NOW)
-			#warn this should just be a looping animate
-			if (new_parallax_movedir)
-				layer.pixel_x = target_x
-				layer.pixel_y = target_y
-				animate(pixel_x = 0, pixel_y = 0, time = T) //queue up another animate so lag doesn't create a shutter
-
-	C.parallax_movedir = new_parallax_movedir
-	if (C.parallax_animate_timer)
-		deltimer(C.parallax_animate_timer)
-	var/datum/callback/CB = CALLBACK(src, PROC_REF(update_parallax_motionblur), C, animatedir, new_parallax_movedir, target_x, target_y)
-	if(skip_windups)
-		CB.Invoke()
-	else
-		C.parallax_animate_timer = addtimer(CB, min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_CLIENT_TIME|TIMER_STOPPABLE)
-
-
-/datum/hud/proc/update_parallax_motionblur(client/C, animatedir, new_parallax_movedir, target_x, target_y)
-	if(!C)
-		return
-	C.parallax_animate_timer = FALSE
+	var/longest_timer = 0
+	for(var/key in C.parallax_animate_timers)
+		deltimer(C.parallax_animate_timers[key])
+	C.parallax_animate_timers = list()
 	for(var/atom/movable/screen/parallax_layer/layer as anything in C.parallax_layers)
-		if (!new_parallax_movedir)
-			animate(layer)
+		var/scaled_time = PARALLAX_LOOP_TIME / layer.speed
+		if(new_parallax_movedir == NONE) // If we're stopping, we need to stop on the same dime, yeah?
+			scaled_time = PARALLAX_LOOP_TIME
+		longest_timer = max(longest_timer, scaled_time)
+
+		if(skip_windups)
+			update_parallax_motionblur(C, layer, new_parallax_movedir, new_transform)
 			continue
 
-		var/newstate = initial(layer.icon_state)
-		var/T = PARALLAX_LOOP_TIME / layer.speed
+		layer.transform = new_transform
+		animate(layer, transform = matrix(), time = scaled_time, easing = QUAD_EASING | (new_parallax_movedir ? EASE_IN : EASE_OUT))
+		if (new_parallax_movedir == NONE)
+			continue
+		//queue up another animate so lag doesn't create a shutter
+		animate(transform = new_transform, time = 0)
+		animate(transform = matrix(), time = scaled_time / 2)
+		C.parallax_animate_timers[layer] = addtimer(CALLBACK(src, PROC_REF(update_parallax_motionblur), C, layer, new_parallax_movedir, new_transform), scaled_time, TIMER_CLIENT_TIME|TIMER_STOPPABLE)
 
-		if (newstate in icon_states(layer.icon))
-			layer.icon_state = newstate
-			layer.update_o(C.view)
+	C.dont_animate_parallax = world.time + min(longest_timer, PARALLAX_LOOP_TIME)
+	C.parallax_movedir = new_parallax_movedir
 
-		layer.pixel_x = target_x
-		layer.pixel_y = target_y
+/datum/hud/proc/update_parallax_motionblur(client/C, atom/movable/screen/parallax_layer/layer, new_parallax_movedir, matrix/new_transform)
+	if(!C)
+		return
+	C.parallax_animate_timers -= layer
 
-		animate(layer, pixel_x = target_x, pixel_y = target_y, time = 0, loop = -1, flags = ANIMATION_END_NOW)
-		animate(pixel_x = 0, pixel_y = 0, time = T)
+	// If we are moving in a direction, we used the QUAD_EASING function with EASE_IN
+	// This means our position function is x^2. This is always LESS then the linear we're using here
+	// But if we just used the same time delay, our rate of change would mismatch. f'(1) = 2x for quad easing, rather then the 1 we get for linear
+	// (This is because of how derivatives work right?)
+	// Because of this, while our actual rate of change from before was PARALLAX_LOOP_TIME, our percieved rate of change was PARALLAX_LOOP_TIME / 2 (lower == faster).
+	// Let's account for that here
+	var/scaled_time = (PARALLAX_LOOP_TIME / layer.speed) / 2
+	animate(layer, transform = new_transform, time = 0, loop = -1, flags = ANIMATION_END_NOW)
+	animate(transform = matrix(), time = scaled_time)
 
-GLOBAL_LIST_EMPTY(parallax_cost)
-GLOBAL_LIST_EMPTY(parallax_count)
 /datum/hud/proc/update_parallax(mob/viewmob)
-	INIT_COST(GLOB.parallax_cost, GLOB.parallax_count)
 	var/mob/screenmob = viewmob || mymob
 	var/client/C = screenmob.client
 	var/turf/posobj = get_turf(C.eye)
@@ -198,108 +176,68 @@ GLOBAL_LIST_EMPTY(parallax_count)
 		return
 
 	var/area/areaobj = posobj.loc
-	SET_COST("initial setup")
 	// Update the movement direction of the parallax if necessary (for shuttles)
 	set_parallax_movedir(areaobj.parallax_movedir, FALSE, screenmob)
-	SET_COST("set movedir")
 
 	var/force = FALSE
 	if(!C.previous_turf || (C.previous_turf.z != posobj.z))
 		C.previous_turf = posobj
 		force = TRUE
-	SET_COST("pull previous turf")
 
 	//Doing it this way prevents parallax layers from "jumping" when you change Z-Levels.
 	var/offset_x = posobj.x - C.previous_turf.x
 	var/offset_y = posobj.y - C.previous_turf.y
-	SET_COST("calc offsets")
 
 	if(!offset_x && !offset_y && !force)
 		return
 
-	SET_COST("check offsets")
 	var/glide_rate = round(world.icon_size / screenmob.glide_size * world.tick_lag, world.tick_lag)
-	SET_COST("build glide rate")
 	C.previous_turf = posobj
-	SET_COST("set previous turf")
 
 	var/largest_change = max(abs(offset_x), abs(offset_y))
-	SET_COST("calc largest change")
 	var/max_allowed_dist = (glide_rate / world.tick_lag) + 1
-	SET_COST("calc max allowed dist")
 	// If we aren't already moving/don't allow parallax, have made some movement, and that movement was smaller then our "glide" size, animate
 	var/run_parralax = (C.do_parallax_animations && glide_rate && !areaobj.parallax_movedir && C.dont_animate_parallax <= world.time && largest_change <= max_allowed_dist)
-	SET_COST("calc run parallax")
 
 	for(var/atom/movable/screen/parallax_layer/parallax_layer as anything in C.parallax_layers)
-		SET_COST("iterate layers")
 		var/our_speed = parallax_layer.speed
-		SET_COST("read speed var")
 		var/change_x
 		var/change_y
 		var/old_x = parallax_layer.offset_x
 		var/old_y = parallax_layer.offset_y
-		SET_COST("create change vars")
 		if(parallax_layer.absolute)
-			SET_COST("check absolute")
 			// We use change here so the typically large absolute objects (just lavaland for now) don't jitter so much
 			change_x = (posobj.x - SSparallax.planet_x_offset) * our_speed + old_x
-			SET_COST("abs calc delta x")
 			change_y = (posobj.y - SSparallax.planet_y_offset) * our_speed + old_y
-			SET_COST("abs calc delta y")
 		else
-			SET_COST("check absolute")
 			change_x = offset_x * our_speed
-			SET_COST("calc delta x")
 			change_y = offset_y * our_speed
-			SET_COST("calc delta y")
 
 			// This is how we tile parralax sprites
 			// It doesn't use change because we really don't want to animate this
 			if(old_x - change_x > 240)
-				SET_COST("tile check x > 240")
 				parallax_layer.offset_x -= 480
-				parallax_layer.pixel_x = parallax_layer.offset_x
-				SET_COST("tile offset x - 480")
+				parallax_layer.pixel_w = parallax_layer.offset_x
 			else if(old_x - change_x < -240)
-				SET_COST("tile check x < -240")
 				parallax_layer.offset_x += 480
-				parallax_layer.pixel_x = parallax_layer.offset_x
-				SET_COST("tile offset x + 480")
-			else
-				SET_COST("tile check failed")
+				parallax_layer.pixel_w = parallax_layer.offset_x
 			if(old_y - change_y > 240)
-				SET_COST("tile check y > 240")
 				parallax_layer.offset_y -= 480
-				parallax_layer.pixel_y = parallax_layer.offset_y
-				SET_COST("tile offset y - 480")
+				parallax_layer.pixel_z = parallax_layer.offset_y
 			else if(old_y - change_y < -240)
-				SET_COST("tile check y < -240")
 				parallax_layer.offset_y += 480
-				parallax_layer.pixel_y = parallax_layer.offset_y
-				SET_COST("tile offset y + 480")
-			else
-				SET_COST("tile check failed")
+				parallax_layer.pixel_z = parallax_layer.offset_y
 
 		parallax_layer.offset_x -= change_x
-		SET_COST("offset x")
 		parallax_layer.offset_y -= change_y
-		SET_COST("offset y")
 		// Now that we have our offsets, let's do our positioning
 		// We're going to use an animate to "glide" that last movement out, so it looks nicer
 		// Don't do any animates if we're not actually moving enough distance yeah? thanks lad
 		if(run_parralax && (largest_change * our_speed > 1))
-			SET_COST("check run parallax")
-			animate(parallax_layer, pixel_x = parallax_layer.offset_x, pixel_y = parallax_layer.offset_y, time = glide_rate)
-			SET_COST("animate pixel offsets")
+			animate(parallax_layer, pixel_w = round(parallax_layer.offset_x, 1), pixel_z = round(parallax_layer.offset_y, 1), time = glide_rate, flags = ANIMATION_CONTINUE)
 		else
-			SET_COST("check run parallax")
-			parallax_layer.pixel_x = parallax_layer.offset_x
-			SET_COST("offset pixel x")
-			parallax_layer.pixel_y = parallax_layer.offset_x
-			SET_COST("offset pixel y")
-
-	SET_COST("finish iterate layers")
+			parallax_layer.pixel_w = round(parallax_layer.offset_x, 1)
+			parallax_layer.pixel_z = round(parallax_layer.offset_y, 1)
 
 /atom/movable/proc/update_parallax_contents()
 	for(var/mob/client_mob as anything in client_mobs_in_contents)
@@ -328,9 +266,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 	var/offset_x = 0
 	var/offset_y = 0
 	var/absolute = FALSE
+	appearance_flags = APPEARANCE_UI | KEEP_TOGETHER
 	blend_mode = BLEND_ADD
 	plane = PLANE_SPACE_PARALLAX
-	screen_loc = "CENTER-7,CENTER-7"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner, template = FALSE)
@@ -364,16 +302,17 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 
 	// Turn the view size into a grid of correctly scaled overlays
 	var/list/viewscales = getviewsize(view)
-	var/countx = CEILING((viewscales[1] / 2) * parallax_scaler, 1) + 1
-	var/county = CEILING((viewscales[2] / 2) * parallax_scaler, 1) + 1
+	// This could be half the size but we need to provide space for parallax movement on mob movement, and movement on scroll from shuttles, so like this instead
+	var/countx = (CEILING((viewscales[1] / 2) * parallax_scaler, 1) + 1)
+	var/county = (CEILING((viewscales[2] / 2) * parallax_scaler, 1) + 1)
 	var/list/new_overlays = new
 	for(var/x in -countx to countx)
 		for(var/y in -county to county)
 			if(x == 0 && y == 0)
 				continue
 			var/mutable_appearance/texture_overlay = mutable_appearance(icon, icon_state)
-			texture_overlay.pixel_x += 480 * x
-			texture_overlay.pixel_y += 480 * y
+			texture_overlay.pixel_w += 480 * x
+			texture_overlay.pixel_z += 480 * y
 			new_overlays += texture_overlay
 	cut_overlays()
 	add_overlay(new_overlays)

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -11,6 +11,10 @@
 	for(var/atom/movable/screen/plane_master/parallax as anything in get_true_plane_masters(PLANE_SPACE_PARALLAX))
 		parallax.unhide_plane(screenmob)
 
+	if(!C.parallax_rock)
+		C.parallax_rock = new(null, src)
+		C.screen += C.parallax_rock
+
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()
 		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, src)
@@ -25,7 +29,7 @@
 	if (length(C.parallax_layers) > C.parallax_layers_max)
 		C.parallax_layers.len = C.parallax_layers_max
 
-	C.screen |= (C.parallax_layers)
+	C.parallax_rock.vis_contents = C.parallax_layers
 	// We could do not do parallax for anything except the main plane group
 	// This could be changed, but it would require refactoring this whole thing
 	// And adding non client particular hooks for all the inputs, and I do not have the time I'm sorry :(
@@ -113,73 +117,74 @@
 	var/animatedir = new_parallax_movedir
 	if(new_parallax_movedir == FALSE)
 		var/animate_time = 0
-		for(var/thing in C.parallax_layers)
-			var/atom/movable/screen/parallax_layer/L = thing
-			L.icon_state = initial(L.icon_state)
-			L.update_o(C.view)
-			var/T = PARALLAX_LOOP_TIME / L.speed
+		for(var/atom/movable/screen/parallax_layer/layer as anything in C.parallax_layers)
+			layer.icon_state = initial(layer.icon_state)
+			layer.update_o(C.view)
+			var/T = PARALLAX_LOOP_TIME / layer.speed
 			if (T > animate_time)
 				animate_time = T
 		C.dont_animate_parallax = world.time + min(animate_time, PARALLAX_LOOP_TIME)
 		animatedir = C.parallax_movedir
 
-	var/matrix/newtransform
+	var/target_x = 0
+	var/target_y = 0
 	switch(animatedir)
 		if(NORTH)
-			newtransform = matrix(1, 0, 0, 0, 1, 480)
+			target_y = 480
 		if(SOUTH)
-			newtransform = matrix(1, 0, 0, 0, 1,-480)
+			target_y = -480
 		if(EAST)
-			newtransform = matrix(1, 0, 480, 0, 1, 0)
+			target_x = 480
 		if(WEST)
-			newtransform = matrix(1, 0,-480, 0, 1, 0)
+			target_x = -480
 
 	var/shortesttimer
 	if(!skip_windups)
-		for(var/thing in C.parallax_layers)
-			var/atom/movable/screen/parallax_layer/L = thing
-
-			var/T = PARALLAX_LOOP_TIME / L.speed
+		for(var/atom/movable/screen/parallax_layer/layer as anything in C.parallax_layers)
+			var/T = PARALLAX_LOOP_TIME / layer.speed
 			if (isnull(shortesttimer))
 				shortesttimer = T
 			if (T < shortesttimer)
 				shortesttimer = T
-			L.transform = newtransform
-			animate(L, transform = matrix(), time = T, easing = QUAD_EASING | (new_parallax_movedir ? EASE_IN : EASE_OUT), flags = ANIMATION_END_NOW)
+			layer.pixel_x = target_x
+			layer.pixel_y = target_y
+			animate(layer, pixel_x = 0, pixel_y = 0, time = T, easing = QUAD_EASING | (new_parallax_movedir ? EASE_IN : EASE_OUT), flags = ANIMATION_END_NOW)
+			#warn this should just be a looping animate
 			if (new_parallax_movedir)
-				L.transform = newtransform
-				animate(transform = matrix(), time = T) //queue up another animate so lag doesn't create a shutter
+				layer.pixel_x = target_x
+				layer.pixel_y = target_y
+				animate(pixel_x = 0, pixel_y = 0, time = T) //queue up another animate so lag doesn't create a shutter
 
 	C.parallax_movedir = new_parallax_movedir
 	if (C.parallax_animate_timer)
 		deltimer(C.parallax_animate_timer)
-	var/datum/callback/CB = CALLBACK(src, PROC_REF(update_parallax_motionblur), C, animatedir, new_parallax_movedir, newtransform)
+	var/datum/callback/CB = CALLBACK(src, PROC_REF(update_parallax_motionblur), C, animatedir, new_parallax_movedir, target_x, target_y)
 	if(skip_windups)
 		CB.Invoke()
 	else
 		C.parallax_animate_timer = addtimer(CB, min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_CLIENT_TIME|TIMER_STOPPABLE)
 
 
-/datum/hud/proc/update_parallax_motionblur(client/C, animatedir, new_parallax_movedir, matrix/newtransform)
+/datum/hud/proc/update_parallax_motionblur(client/C, animatedir, new_parallax_movedir, target_x, target_y)
 	if(!C)
 		return
 	C.parallax_animate_timer = FALSE
-	for(var/thing in C.parallax_layers)
-		var/atom/movable/screen/parallax_layer/L = thing
+	for(var/atom/movable/screen/parallax_layer/layer as anything in C.parallax_layers)
 		if (!new_parallax_movedir)
-			animate(L)
+			animate(layer)
 			continue
 
-		var/newstate = initial(L.icon_state)
-		var/T = PARALLAX_LOOP_TIME / L.speed
+		var/newstate = initial(layer.icon_state)
+		var/T = PARALLAX_LOOP_TIME / layer.speed
 
-		if (newstate in icon_states(L.icon))
-			L.icon_state = newstate
-			L.update_o(C.view)
+		if (newstate in icon_states(layer.icon))
+			layer.icon_state = newstate
+			layer.update_o(C.view)
 
-		L.transform = newtransform
+		layer.pixel_x = target_x
+		layer.pixel_y = target_y
 
-		animate(L, transform = L.transform, time = 0, loop = -1, flags = ANIMATION_END_NOW)
+		animate(layer, pixel_x = 0, pixel_y = 0, time = 0, loop = -1, flags = ANIMATION_END_NOW)
 		animate(transform = matrix(), time = T)
 
 GLOBAL_LIST_EMPTY(parallax_cost)
@@ -232,13 +237,15 @@ GLOBAL_LIST_EMPTY(parallax_count)
 		SET_COST("read speed var")
 		var/change_x
 		var/change_y
+		var/old_x = parallax_layer.pixel_x
+		var/old_y = parallax_layer.pixel_y
 		SET_COST("create change vars")
 		if(parallax_layer.absolute)
 			SET_COST("check absolute")
 			// We use change here so the typically large absolute objects (just lavaland for now) don't jitter so much
-			change_x = (posobj.x - SSparallax.planet_x_offset) * our_speed + parallax_layer.offset_x
+			change_x = (posobj.x - SSparallax.planet_x_offset) * our_speed + old_x
 			SET_COST("abs calc delta x")
-			change_y = (posobj.y - SSparallax.planet_y_offset) * our_speed + parallax_layer.offset_y
+			change_y = (posobj.y - SSparallax.planet_y_offset) * our_speed + old_y
 			SET_COST("abs calc delta y")
 		else
 			SET_COST("check absolute")
@@ -249,45 +256,40 @@ GLOBAL_LIST_EMPTY(parallax_count)
 
 			// This is how we tile parralax sprites
 			// It doesn't use change because we really don't want to animate this
-			if(parallax_layer.offset_x - change_x > 240)
+			if(old_x - change_x > 240)
 				SET_COST("tile check x > 240")
-				parallax_layer.offset_x -= 480
+				parallax_layer.pixel_x -= 480
 				SET_COST("tile offset x - 480")
-			else if(parallax_layer.offset_x - change_x < -240)
+			else if(old_x - change_x < -240)
 				SET_COST("tile check x < -240")
-				parallax_layer.offset_x += 480
+				parallax_layer.pixel_x += 480
 				SET_COST("tile offset x + 480")
 			else
 				SET_COST("tile check failed")
-			if(parallax_layer.offset_y - change_y > 240)
+			if(old_y - change_y > 240)
 				SET_COST("tile check y > 240")
-				parallax_layer.offset_y -= 480
+				parallax_layer.pixel_y -= 480
 				SET_COST("tile offset y - 480")
-			else if(parallax_layer.offset_y - change_y < -240)
+			else if(old_y - change_y < -240)
 				SET_COST("tile check y < -240")
-				parallax_layer.offset_y += 480
+				parallax_layer.pixel_y += 480
 				SET_COST("tile offset y + 480")
 			else
 				SET_COST("tile check failed")
 		// Now that we have our offsets, let's do our positioning
-		parallax_layer.offset_x -= change_x
-		SET_COST("offset by detlta X")
-		parallax_layer.offset_y -= change_y
-		SET_COST("offset by delta y")
-
-		parallax_layer.screen_loc = "CENTER-7:[round(parallax_layer.offset_x, 1)],CENTER-7:[round(parallax_layer.offset_y, 1)]"
-		SET_COST("set screen loc")
-
-		// We're going to use a transform to "glide" that last movement out, so it looks nicer
+		// We're going to use an animate to "glide" that last movement out, so it looks nicer
 		// Don't do any animates if we're not actually moving enough distance yeah? thanks lad
 		if(run_parralax && (largest_change * our_speed > 1))
-			SET_COST("check for animation")
-			parallax_layer.transform = matrix(1,0,change_x, 0,1,change_y)
-			SET_COST("set transform backwards")
-			animate(parallax_layer, transform=matrix(), time = glide_rate)
-			SET_COST("animate transform to null")
+			SET_COST("check run parallax")
+			animate(parallax_layer, pixel_x = parallax_layer.pixel_x - change_x, pixel_y = parallax_layer.pixel_y - change_y, time = glide_rate)
+			SET_COST("animate pixel offsets")
 		else
-			SET_COST("check for animation failed")
+			SET_COST("check run parallax")
+			parallax_layer.pixel_x -= change_x
+			SET_COST("offset pixel x")
+			parallax_layer.pixel_y -= change_y
+			SET_COST("offset pixel y")
+
 	SET_COST("finish iterate layers")
 
 /atom/movable/proc/update_parallax_contents()
@@ -299,6 +301,15 @@ GLOBAL_LIST_EMPTY(parallax_count)
 	if(client?.eye && hud_used && length(client.parallax_layers))
 		var/area/areaobj = get_area(client.eye)
 		hud_used.set_parallax_movedir(areaobj.parallax_movedir, TRUE)
+
+// Root object for parallax, all parallax layers are drawn onto this
+INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_home)
+/atom/movable/screen/parallax_home
+	icon = null
+	blend_mode = BLEND_ADD
+	plane = PLANE_SPACE_PARALLAX
+	screen_loc = "CENTER-7,CENTER-7"
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 // We need parallax to always pass its args down into initialize, so we immediate init it
 INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -13,7 +13,7 @@
 
 	if(!C.parallax_rock)
 		C.parallax_rock = new(null, src)
-		C.screen += C.parallax_rock
+	C.screen |= C.parallax_rock
 
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -184,8 +184,8 @@
 		layer.pixel_x = target_x
 		layer.pixel_y = target_y
 
-		animate(layer, pixel_x = 0, pixel_y = 0, time = 0, loop = -1, flags = ANIMATION_END_NOW)
-		animate(transform = matrix(), time = T)
+		animate(layer, pixel_x = target_x, pixel_y = target_y, time = 0, loop = -1, flags = ANIMATION_END_NOW)
+		animate(pixel_x = 0, pixel_y = 0, time = T)
 
 GLOBAL_LIST_EMPTY(parallax_cost)
 GLOBAL_LIST_EMPTY(parallax_count)
@@ -363,7 +363,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 			if(x == 0 && y == 0)
 				continue
 			var/mutable_appearance/texture_overlay = mutable_appearance(icon, icon_state)
-			texture_overlay.transform = matrix(1, 0, x*480, 0, 1, y*480)
+			texture_overlay.pixel_x += 480 * x
+			texture_overlay.pixel_y += 480 * y
 			new_overlays += texture_overlay
 	cut_overlays()
 	add_overlay(new_overlays)

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -234,7 +234,7 @@
 		// We're going to use an animate to "glide" that last movement out, so it looks nicer
 		// Don't do any animates if we're not actually moving enough distance yeah? thanks lad
 		if(run_parralax && (largest_change * our_speed > 1))
-			animate(parallax_layer, pixel_w = round(parallax_layer.offset_x, 1), pixel_z = round(parallax_layer.offset_y, 1), time = glide_rate, flags = ANIMATION_CONTINUE)
+			animate(parallax_layer, pixel_w = round(parallax_layer.offset_x, 1), pixel_z = round(parallax_layer.offset_y, 1), time = glide_rate)
 		else
 			parallax_layer.pixel_w = round(parallax_layer.offset_x, 1)
 			parallax_layer.pixel_z = round(parallax_layer.offset_y, 1)

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -162,7 +162,7 @@
 	// This means our position function is x^2. This is always LESS then the linear we're using here
 	// But if we just used the same time delay, our rate of change would mismatch. f'(1) = 2x for quad easing, rather then the 1 we get for linear
 	// (This is because of how derivatives work right?)
-	// Because of this, while our actual rate of change from before was PARALLAX_LOOP_TIME, our percieved rate of change was PARALLAX_LOOP_TIME / 2 (lower == faster).
+	// Because of this, while our actual rate of change from before was PARALLAX_LOOP_TIME, our perceived rate of change was PARALLAX_LOOP_TIME / 2 (lower == faster).
 	// Let's account for that here
 	var/scaled_time = (PARALLAX_LOOP_TIME / layer.speed) / 2
 	animate(layer, transform = new_transform, time = 0, loop = -1, flags = ANIMATION_END_NOW)

--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -11,7 +11,7 @@
 	for(var/atom/movable/screen/plane_master/parallax as anything in get_true_plane_masters(PLANE_SPACE_PARALLAX))
 		parallax.unhide_plane(screenmob)
 
-	if(!C.parallax_rock)
+	if(isnull(C.parallax_rock))
 		C.parallax_rock = new(null, src)
 	C.screen |= C.parallax_rock
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -197,6 +197,7 @@
 
 	var/list/parallax_layers
 	var/list/parallax_layers_cached
+	var/atom/movable/screen/parallax_home/parallax_rock
 	///this is the last recorded client eye by SSparallax/fire()
 	var/atom/movable/movingmob
 	var/turf/previous_turf

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -207,8 +207,8 @@
 	var/parallax_movedir = 0
 	/// How many parallax layers to show our client
 	var/parallax_layers_max = 4
-	/// Timer for the area directional animation
-	var/parallax_animate_timer
+	/// Timers for the area directional animation, one for each layer
+	var/list/parallax_animate_timers
 	/// Do we want to do parallax animations at all?
 	/// Exists to prevent laptop fires
 	var/do_parallax_animations = TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -617,6 +617,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	QDEL_NULL(void)
 	QDEL_NULL(tooltips)
 	QDEL_NULL(loot_panel)
+	QDEL_NULL(parallax_rock)
+	QDEL_LIST(parallax_layers_cached)
+	parallax_layers = null
 	seen_messages = null
 	Master.UpdateTickRate()
 	..() //Even though we're going to be hard deleted there are still some things that want to know the destroy is happening


### PR DESCRIPTION
## About The Pull Request

Right now parallax is like a quarter of SSinput, which is BAD. It's so high mostly because of the animates we need to do, but also due to the cost of setting screen_loc.

![image](https://github.com/tgstation/tgstation/assets/58055496/8e4ec4b7-2101-4dca-91b8-4db9e79de7c4)

This sucks. The default step is to reduce the poll rate of the effect, but I don't want to do that because it SUCKS. Sooooo how can we optimize.

Well, if we stop thinking in terms of screen_loc, which is a string (tree shit) and also unanimatable, and start working in pixel offsets, this'd be a way cheaper.

We can make that happen by sticking all our parallax layers on one rock screen object. Then they have relative positions and can be pixel offset (I have stolen this concept wholesale from Ter)

This works unreasonably well, roughly a 65% cost reduction. S good shit.

![image](https://github.com/tgstation/tgstation/assets/58055496/1e6c4455-a13b-44c3-bf59-71ef26cac9fd)

While I'm here...

[uses KEEP_TOGETHER to reduce clientside load, makes the flying animation better.](https://github.com/tgstation/tgstation/commit/52610398e2dc221c80d1f629e9c9f8fb59498977)

We were individually rendering all like fucking 24 480x480 overlays on all 5 parallax layers, which means we had to apply our transform to EACH ONE. This has GOTTA suck shit for clients, so let's... not? Should help.

The existing flying animation makes me depressed. it has some very visible stutter, and jumps around a lot.

We can deal with the starting stutter by avoiding starting a new animation on the layer until the old one is finished. This is what was SUPPOSED to be happening, but because we fired one timer for all the layers, they'd desync and jump in ugly ways.

This means we need to use one timer per layer, which does induce more cost then I'd like. IDK how I feel about this to be honest.

I try and reduce ending weirdness by unscaling time at the end, so different aspects don't slow down at different rates.

Speed on the parallax animation was weird, it'd spike up, then dip down in flight. 
This was because the percieved rate of change from the quad easing was closer to 2x the existing. 
I've handled this by halving the animation time in the loop

Oh also there's no sense calling the update animation proc if we are coming to a stop, and thus have no follow up animation.


## Changelog

:cl: LemonInTheDark
refactor: I have reworked how parallax and its animations (space travel) work. Please report any bugs lads!
/:cl:
