### PR TITLE
northstar kitchen customer teleport oversight fix

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -8875,7 +8875,8 @@
 	},
 /area/station/command/teleporter)
 "cix" = (
-/obj/machinery/restaurant_portal/restaurant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "ciz" = (
@@ -56198,11 +56199,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
 "osX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/hedge,
-/turf/open/floor/carpet/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/restaurant_portal/bar,
+/turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "ote" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -62464,6 +62463,7 @@
 /area/station/science/auxlab)
 "qaY" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "qbh" = (
@@ -81916,9 +81916,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
 "ved" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "veA" = (
@@ -91798,6 +91798,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "xCR" = (
@@ -247246,11 +247247,11 @@ fjo
 mso
 dFd
 awt
-cix
+gjf
 gjf
 gjf
 qoa
-gjf
+jDe
 jDe
 qoW
 tTc
@@ -247504,7 +247505,6 @@ mso
 dFd
 awt
 gjf
-gjf
 ulB
 ulB
 ulB
@@ -247512,6 +247512,7 @@ jDe
 bMs
 kpa
 jzE
+gjf
 gjf
 ddx
 rBC
@@ -247761,7 +247762,6 @@ mso
 laJ
 jWT
 tRT
-gjf
 nXq
 xEL
 oAm
@@ -247769,6 +247769,7 @@ jDe
 dId
 jAl
 jHT
+gjf
 gjf
 ddx
 rBC
@@ -248018,13 +248019,13 @@ gWg
 iOh
 awt
 gjf
-gjf
 mQg
 rBC
 pzK
 jDe
 gjf
 wtg
+gjf
 gjf
 gjf
 uCW
@@ -248275,7 +248276,6 @@ qcd
 ccF
 awt
 gjf
-xCM
 mQg
 rBC
 pzK
@@ -248284,6 +248284,7 @@ gjf
 vXY
 vRj
 ldV
+osX
 jHJ
 hVt
 hVt
@@ -248532,7 +248533,6 @@ qcd
 nsn
 rSS
 xDS
-xDS
 sln
 jAl
 pWr
@@ -248540,6 +248540,7 @@ jDe
 bMs
 kpa
 jzE
+gjf
 vRj
 vWQ
 vWQ
@@ -248788,17 +248789,17 @@ fjo
 qcd
 ceh
 dMj
-gjf
-xDS
+cix
 ulB
 ulB
 ulB
-jDe
+xCM
 dId
 jAl
 jHT
+gjf
 xDS
-xna
+xDS
 xna
 xna
 xna
@@ -249045,9 +249046,8 @@ fjo
 qcd
 fOu
 awt
-gjf
-xDS
-xDS
+cix
+cix
 xDS
 xDS
 ved
@@ -249055,7 +249055,8 @@ xDS
 xDS
 xDS
 xDS
-osX
+xDS
+gjf
 vZg
 dIx
 dIx
@@ -249304,10 +249305,10 @@ dFd
 awt
 gjf
 gjf
-gjf
+vXY
 xDS
 qaY
-jDe
+gjf
 gjf
 wtg
 gjf
@@ -249563,11 +249564,11 @@ rZS
 nla
 mQF
 xDS
-gjf
 jDe
 bMs
 kpa
 jzE
+gjf
 tFS
 nNJ
 ycW
@@ -249820,11 +249821,11 @@ ubR
 mhE
 rwh
 xDS
-gjf
 jDe
 dId
 jAl
 jHT
+gjf
 gjf
 nNJ
 dxv
@@ -250078,7 +250079,7 @@ ubR
 nYE
 xDS
 jDe
-jDe
+gjf
 iwU
 psq
 eEr


### PR DESCRIPTION

## About The Pull Request
Previously the kitchen restaurant teleport was too far from the counter so bots wouldn't see seating at the kitchen counter, I moved it closer
## Why It's Good For The Game
oversight fix
## Changelog
:cl: grungussuss
fix: changed layout of Northstar dining hall so customer bots can reach the kitchen counter
/:cl:
