### PR TITLE
Fixed clip on tie screentips

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -60,9 +60,8 @@
 
 /obj/item/clothing/neck/tie/Initialize(mapload)
 	. = ..()
-	if(clip_on)
-		return
-	update_appearance(UPDATE_ICON)
+	if(!clip_on)
+		update_appearance(UPDATE_ICON)
 	register_context()
 
 /obj/item/clothing/neck/tie/examine(mob/user)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -107,7 +107,7 @@
 /obj/item/clothing/neck/tie/alt_click_secondary(mob/user)
 	. = ..()
 	if(!user.can_perform_action(src, NEED_DEXTERITY))
-		return	
+		return
 	alternate_worn_layer = alternate_worn_layer == initial(alternate_worn_layer) ? NONE : initial(alternate_worn_layer)
 	user.update_clothing(ITEM_SLOT_NECK)
 	balloon_alert(user, "wearing [alternate_worn_layer == initial(alternate_worn_layer) ? "below" : "above"] suits")
@@ -132,7 +132,7 @@
 	. = ..()
 	context[SCREENTIP_CONTEXT_ALT_RMB] = "Wear [alternate_worn_layer == initial(alternate_worn_layer) ? "above" : "below"] suit"
 	if(clip_on)
-		return
+		return CONTEXTUAL_SCREENTIP_SET
 	if(is_tied)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Untie"
 	else


### PR DESCRIPTION
## About The Pull Request
Noticed in a related issue

Clip ons get their screentips back
![image](https://github.com/tgstation/tgstation/assets/42397676/c56bacdb-e07b-493f-89d7-61d188d5f0cb)
## Why It's Good For The Game
Fixes #83359

Looks like a regression caused clip on neck ties to not get screentips even though they had context for them with <kbd>alt</kbd><kbd>RMB</kbd>
## Changelog
:cl:
fix: Fixed screentips not appearing on clip on neckties
/:cl:
