### PR TITLE
[no gbp] can no longer cheese blindness with lootpanel range

### DIFF
--- a/code/_onclick/click_alt.dm
+++ b/code/_onclick/click_alt.dm
@@ -11,7 +11,10 @@
 		return
 
 	// Is it visible (and we're not wearing it (our clothes are invisible))?
-	if(!(src in viewers(7, target)) && !CanReach(target))
+	if(!CAN_I_SEE(target))
+		return
+
+	if(is_blind() && !IN_GIVEN_RANGE(src, target, 1))
 		return
 
 	var/turf/tile = get_turf(target)

--- a/code/modules/lootpanel/_lootpanel.dm
+++ b/code/modules/lootpanel/_lootpanel.dm
@@ -49,6 +49,7 @@
 	var/list/data = list()
 
 	data["contents"] = get_contents()
+	data["is_blind"] = !!user.is_blind()
 	data["searching"] = length(to_image)
 
 	return data

--- a/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
@@ -1,9 +1,14 @@
+import { BooleanLike } from 'common/react';
 import { capitalizeAll, capitalizeFirst } from 'common/string';
 
 import { useBackend } from '../../backend';
 import { Tooltip } from '../../components';
 import { IconDisplay } from './IconDisplay';
 import { SearchGroup, SearchItem } from './types';
+
+type Data = {
+  is_blind: BooleanLike;
+};
 
 type Props =
   | {
@@ -14,7 +19,8 @@ type Props =
     };
 
 export function LootBox(props: Props) {
-  const { act } = useBackend();
+  const { act, data } = useBackend<Data>();
+  const { is_blind } = data;
 
   let amount = 0;
   let item: SearchItem;
@@ -29,32 +35,35 @@ export function LootBox(props: Props) {
     ? '???'
     : capitalizeFirst(item.name.split(' ')[0]).slice(0, 5);
 
-  return (
-    <Tooltip content={capitalizeAll(item.name)}>
-      <div className="SearchItem">
-        <div
-          className="SearchItem--box"
-          onClick={(event) =>
-            act('grab', {
-              alt: event.altKey,
-              ctrl: event.ctrlKey,
-              ref: item.ref,
-              shift: event.shiftKey,
-            })
-          }
-          onContextMenu={(event) => {
-            event.preventDefault();
-            act('grab', {
-              right: true,
-              ref: item.ref,
-            });
-          }}
-        >
-          <IconDisplay item={item} />
-          {amount > 1 && <div className="SearchItem--amount">{amount}</div>}
-        </div>
-        <span className="SearchItem--text">{name}</span>
+  // So we can conditionally wrap tooltip
+  const content = (
+    <div className="SearchItem">
+      <div
+        className="SearchItem--box"
+        onClick={(event) =>
+          act('grab', {
+            alt: event.altKey,
+            ctrl: event.ctrlKey,
+            ref: item.ref,
+            shift: event.shiftKey,
+          })
+        }
+        onContextMenu={(event) => {
+          event.preventDefault();
+          act('grab', {
+            right: true,
+            ref: item.ref,
+          });
+        }}
+      >
+        <IconDisplay item={item} />
+        {amount > 1 && <div className="SearchItem--amount">{amount}</div>}
       </div>
-    </Tooltip>
+      {!is_blind && <span className="SearchItem--text">{name}</span>}
+    </div>
   );
+
+  if (is_blind) return content;
+
+  return <Tooltip content={capitalizeAll(item.name)}>{content}</Tooltip>;
 }


### PR DESCRIPTION

## About The Pull Request
`in viewers` does not take into account blindness so you can open the lootpanel at range as a blind person to see item names, icons etc

This limits their alt click range to 1 tile away and removes the names/tooltips from the items in the ui
## Why It's Good For The Game
Realism and since this is a blindness nerf (as if they need one) I won't be mad this gets closed
## Changelog
:cl:
fix: You can no longer open the loot panel at range as a blind person and cheese item names
/:cl:
