### PR TITLE
Epinephrine will properly freeze multiple allergic reagents

### DIFF
--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -55,14 +55,19 @@
 		return
 
 	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
+	//Just halts the progression, I'd suggest you run to medbay asap to get it fixed
+	if(carbon_quirk_holder.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
+		for(var/allergy in allergies)
+			var/datum/reagent/instantiated_med = carbon_quirk_holder.reagents.has_reagent(allergy)
+			if(!instantiated_med)
+				continue
+			instantiated_med.reagent_removal_skip_list |= ALLERGIC_REMOVAL_SKIP
+		return //block damage so long as epinephrine exists
+
 	for(var/allergy in allergies)
 		var/datum/reagent/instantiated_med = carbon_quirk_holder.reagents.has_reagent(allergy)
 		if(!instantiated_med)
 			continue
-		//Just halts the progression, I'd suggest you run to medbay asap to get it fixed
-		if(carbon_quirk_holder.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
-			instantiated_med.reagent_removal_skip_list |= ALLERGIC_REMOVAL_SKIP
-			return //intentionally stops the entire proc so we avoid the organ damage after the loop
 		instantiated_med.reagent_removal_skip_list -= ALLERGIC_REMOVAL_SKIP
 		carbon_quirk_holder.adjustToxLoss(3 * seconds_per_tick)
 		carbon_quirk_holder.reagents.add_reagent(/datum/reagent/toxin/histamine, 3 * seconds_per_tick)


### PR DESCRIPTION

## About The Pull Request
Thanks to an early return, epinephrine was only freezing the metabolism of a single allergic reagent at a time; refactored the relevant code to rectify this.
## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/83393
## Changelog
:cl: PapaMichael
fix: Epinephrine will prevent metabolism of all allergic reagents (instead of just one), if taken with multiple chemicals that one is allergic to.
/:cl:
