### PR TITLE
Mindless ghosts can become harvesters

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -502,7 +502,11 @@
 		newstruct.master = stoner
 		var/datum/action/innate/seek_master/seek_master = new
 		seek_master.Grant(newstruct)
-	target.mind?.transfer_to(newstruct, force_key_move = TRUE)
+
+	if (isnull(target.mind))
+		newstruct.key = target.key
+	else
+		target.mind.transfer_to(newstruct, force_key_move = TRUE)
 	var/atom/movable/screen/alert/bloodsense/sense_alert
 	if(newstruct.mind && !IS_CULTIST(newstruct) && ((stoner && IS_CULTIST(stoner)) || cultoverride) && SSticker.HasRoundStarted())
 		newstruct.mind.add_antag_datum(/datum/antagonist/cult/construct)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -234,7 +234,7 @@
 	addtimer(CALLBACK(src, PROC_REF(narsie_spawn_animation_end)), 3.5 SECONDS)
 
 /obj/narsie/proc/narsie_spawn_animation_end()
-	var/datum/component/singularity/singularity_component = singularity.resolve()
+	var/datum/component/singularity/singularity_component = singularity?.resolve()
 	singularity_component?.roaming = TRUE
 
 /**


### PR DESCRIPTION
## About The Pull Request

Fixes #83374
Fixes #82445
#81665 changed Narsie to transfer minds rather than assigning keys to constructs.
This only works some amount of the time because observers don't have minds.
Dying in certain ways (such as: when playing as a construct) also seems to destroy the mind.
Now we transfer the mind if one exists, otherwise we assign the key (which creates a mind).

## Changelog

:cl:
fix: Ghosts can more reliably become a harvester.
/:cl:
