### PR TITLE
Large monsters break out of the Paddy very quickly

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -580,10 +580,13 @@
 		. = ..()
 		var/mob/living/mobtarget = target
 		if(mobtarget.move_resist == MOVE_FORCE_OVERPOWERING) //No megafauna or bolted AIs, please.
-			to_chat(source, "[span_warning("[src] is unable to lift [mobtarget].")]")
+			balloon_alert(source, "too strong!")
+			return
+		if (mobtarget.mob_size > MOB_SIZE_HUMAN)
+			balloon_alert(source, "too big!")
 			return
 		if(secmech.cargo_hold.contents.len >= secmech.cargo_hold.cargo_capacity)
-			to_chat(source, "[icon2html(src, source)][span_warning("Not enough room in cargo compartment!")]")
+			balloon_alert(source, "no room!")
 			return
 
 		playsound(chassis, clampsound, 50, FALSE, -6)

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -582,9 +582,6 @@
 		if(mobtarget.move_resist == MOVE_FORCE_OVERPOWERING) //No megafauna or bolted AIs, please.
 			balloon_alert(source, "too strong!")
 			return
-		if (mobtarget.mob_size > MOB_SIZE_HUMAN)
-			balloon_alert(source, "too big!")
-			return
 		if(secmech.cargo_hold.contents.len >= secmech.cargo_hold.cargo_capacity)
 			balloon_alert(source, "no room!")
 			return

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -396,8 +396,14 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/seccage/container_resist_act(mob/living/user)
-	to_chat(user, span_notice("You begin attempting a breakout. (This will take around 45 seconds and [chassis] need to remain stationary.)"))
-	if(!do_after(user, 1 MINUTES, target = chassis))
+
+	var/breakout_time = 1 MINUTES
+
+	if (user.mob_size > MOB_SIZE_HUMAN)
+		breakout_time = 6 SECONDS
+
+	to_chat(user, span_notice("You begin attempting a breakout. (This will take around [DisplayTimeText(breakout_time)] and [chassis] need to remain stationary.)"))
+	if(!do_after(user, breakout_time, target = chassis))
 		return
 	to_chat(user, span_notice("You break out of the [src]."))
 	playsound(chassis, 'sound/items/crowbar.ogg', 100, TRUE)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -396,13 +396,12 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/seccage/container_resist_act(mob/living/user)
-
 	var/breakout_time = 1 MINUTES
 
 	if (user.mob_size > MOB_SIZE_HUMAN)
 		breakout_time = 6 SECONDS
 
-	to_chat(user, span_notice("You begin attempting a breakout. (This will take around [DisplayTimeText(breakout_time)] and [chassis] need to remain stationary.)"))
+	to_chat(user, span_notice("You begin attempting a breakout. (This will take around [DisplayTimeText(breakout_time)] and [chassis] needs to remain stationary.)"))
 	if(!do_after(user, breakout_time, target = chassis))
 		return
 	to_chat(user, span_notice("You break out of the [src]."))


### PR DESCRIPTION
## About The Pull Request

Fixes #83292 by making mobs larger than Humans break out of the mech jail cell 10x faster than humans.
Also I made the error output into balloon alerts.

## Why It's Good For The Game

This is a security mech designed for interacting with crew; it doesn't _need_ the ability to arrest alien queens or space dragons and we didn't really design any of these antagonists with the idea that you can stuff them inside a mech that looks smaller than they are.

Resultingly; now they don't stay stuck in it for very long if you are not paying attention.

## Changelog

:cl:
balance: Mobs significantly larger than humans, such as Space Dragons and Xenomorph Queens, breakout of being arrested by a mech significantly faster.
/:cl:
