### PR TITLE
You can put multitools in the destructive analyser

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -107,7 +107,6 @@
 	return screwdriver_act(user, tool)
 
 /obj/machinery/rnd/multitool_act(mob/living/user, obj/item/multitool/tool)
-	. = ITEM_INTERACT_BLOCKING
 	if(panel_open)
 		wires.interact(user)
 		return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION

## About The Pull Request

Fixes #83273
We shouldn't exit out of interactions here if neither of those interactions are available because we want to be able to put it in the machine.

## Changelog

:cl:
fix: The destructive analyser once more hungers for multitools
/:cl:
