### PR TITLE
Vines can't pull anchored objects, can pull you off tables

### DIFF
--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -216,15 +216,19 @@
 	QDEL_LIST(vines)
 	return ..()
 
-/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/Activate(atom/target_atom)
-	if(isturf(target_atom) || istype(target_atom, /obj/structure/spacevine))
+/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/Activate(atom/movable/target_atom)
+	if(!ismovable(target_atom) || istype(target_atom, /obj/structure/spacevine))
+		return
+	if(target_atom.anchored)
+		owner.balloon_alert(owner, "can't pull!")
 		return
 	if(get_dist(owner, target_atom) > vine_grab_distance)
 		owner.balloon_alert(owner, "too far!")
 		return
-	for(var/turf/blockage in get_line(owner, target_atom))
+	var/list/target_turfs = get_line(owner, target_atom) - list(get_turf(owner), get_turf(target_atom))
+	for(var/turf/blockage in target_turfs)
 		if(blockage.is_blocked_turf(exclude_mobs = TRUE))
-			owner.balloon_alert(owner, "something's in the way!")
+			owner.balloon_alert(owner, "path blocked!")
 			return
 
 	var/datum/beam/new_vine = owner.Beam(target_atom, icon_state = "vine", time = vine_duration * (ismob(target_atom) ? 1 : 2), beam_type = /obj/effect/ebeam/vine, emissive = FALSE)


### PR DESCRIPTION
## About The Pull Request

Fixes #83072 by preventing the ability from targeting anchored atoms.
Also fixes the logic to only check for obstacles interposed between us and the target, not ones sharing the tile.

## Why It's Good For The Game

This is how the ability was already supposed to work

## Changelog

:cl:
fix: Venus Man Traps cannot use vines to drag around machines or objects that are bolted, welded, rooted to, or otherwise are part of the ground
fix: Standing on a table will not prevent you from being grappled by a Venus Man Trap
/:cl:
