### PR TITLE
Makes computer console circuits more consistent

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -508,7 +508,7 @@
 				to_chat(user, span_notice("You press the power button and start up \the [src]."))
 			if(open_ui)
 				update_tablet_open_uis(user)
-			SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_TURNED_ON, user)
+		SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_TURNED_ON, user)
 		return TRUE
 	else // Unpowered
 		if(user)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -484,6 +484,16 @@
 	playsound(src, 'sound/machines/card_slide.ogg', 50)
 
 /obj/item/modular_computer/proc/turn_on(mob/user, open_ui = TRUE)
+	if(!user) // Some things (circuits) can turn on the computer without a user
+		if(use_energy(base_active_power_usage))
+			if(looping_sound)
+				soundloop.start()
+			enabled = TRUE
+			update_appearance()
+			return TRUE
+		else
+			return FALSE
+
 	var/issynth = HAS_SILICON_ACCESS(user) // Robots and AIs get different activation messages.
 	if(atom_integrity <= integrity_failure * max_integrity)
 		if(user)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -484,17 +484,10 @@
 	playsound(src, 'sound/machines/card_slide.ogg', 50)
 
 /obj/item/modular_computer/proc/turn_on(mob/user, open_ui = TRUE)
-	if(!user) // Some things (circuits) can turn on the computer without a user
-		if(use_energy(base_active_power_usage))
-			if(looping_sound)
-				soundloop.start()
-			enabled = TRUE
-			update_appearance()
-			return TRUE
-		else
-			return FALSE
+	var/issynth = FALSE // Robots and AIs get different activation messages.
+	if(user)
+		issynth = HAS_SILICON_ACCESS(user)
 
-	var/issynth = HAS_SILICON_ACCESS(user) // Robots and AIs get different activation messages.
 	if(atom_integrity <= integrity_failure * max_integrity)
 		if(user)
 			if(issynth)
@@ -515,7 +508,7 @@
 				to_chat(user, span_notice("You press the power button and start up \the [src]."))
 			if(open_ui)
 				update_tablet_open_uis(user)
-		SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_TURNED_ON, user)
+			SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_TURNED_ON, user)
 		return TRUE
 	else // Unpowered
 		if(user)

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -5,7 +5,9 @@
 	var/obj/item/modular_computer/computer
 	///Turns the PC on/off
 	var/datum/port/input/on_off
-	///When set, will print a piece of paper with the value as text.
+	///Determines the text to be printed
+	var/datum/port/input/print_text
+	/// Print when triggered
 	var/datum/port/input/print
 
 	///Sent when turned on
@@ -54,7 +56,8 @@
 
 /obj/item/circuit_component/modpc/populate_ports()
 	on_off = add_input_port("Turn On/Off", PORT_TYPE_SIGNAL)
-	print = add_input_port("Print Text", PORT_TYPE_STRING)
+	print_text = add_input_port("Print Text", PORT_TYPE_STRING)
+	print = add_input_port("Print", PORT_TYPE_SIGNAL)
 
 	is_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
 	is_on = add_output_port("Shut Down", PORT_TYPE_SIGNAL)
@@ -62,7 +65,7 @@
 /obj/item/circuit_component/modpc/pre_input_received(datum/port/input/port)
 	if(isnull(computer))
 		return
-	if(COMPONENT_TRIGGERED_BY(print, port))
+	if(COMPONENT_TRIGGERED_BY(print_text, port))
 		print.set_value(html_encode(trim(print.value, MAX_PAPER_LENGTH)))
 
 /obj/item/circuit_component/modpc/input_received(datum/port/input/port)
@@ -79,7 +82,7 @@
 		return
 
 	if(COMPONENT_TRIGGERED_BY(print, port))
-		computer.print_text(print.value)
+		computer.print_text(print_text.value)
 
 	if(lights)
 		if(COMPONENT_TRIGGERED_BY(lights, port))

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -18,6 +18,7 @@
 	var/datum/port/input/red
 	var/datum/port/input/green
 	var/datum/port/input/blue
+	var/datum/port/input/set_color
 
 /obj/item/circuit_component/modpc/register_shell(atom/movable/shell)
 	. = ..()
@@ -43,6 +44,7 @@
 		red = add_input_port("Red", PORT_TYPE_NUMBER)
 		green = add_input_port("Green", PORT_TYPE_NUMBER)
 		blue = add_input_port("Blue", PORT_TYPE_NUMBER)
+		set_color = add_input_port("Set Color", PORT_TYPE_SIGNAL, trigger = PROC_REF(set_lights))
 
 /obj/item/circuit_component/modpc/unregister_shell(atom/movable/shell)
 	if(computer)
@@ -62,12 +64,6 @@
 		return
 	if(COMPONENT_TRIGGERED_BY(print, port))
 		print.set_value(html_encode(trim(print.value, MAX_PAPER_LENGTH)))
-	else if(COMPONENT_TRIGGERED_BY(red, port))
-		red.set_value(clamp(red.value, 0, 255))
-	else if(COMPONENT_TRIGGERED_BY(blue, port))
-		blue.set_value(clamp(blue.value, 0, 255))
-	else if(COMPONENT_TRIGGERED_BY(green, port))
-		green.set_value(clamp(green.value, 0, 255))
 
 /obj/item/circuit_component/modpc/input_received(datum/port/input/port)
 	if(isnull(computer))
@@ -88,8 +84,12 @@
 	if(lights)
 		if(COMPONENT_TRIGGERED_BY(lights, port))
 			computer.toggle_flashlight()
-		if(COMPONENT_TRIGGERED_BY(red, port) || COMPONENT_TRIGGERED_BY(green, port) || COMPONENT_TRIGGERED_BY(blue, port))
-			computer.set_flashlight_color(rgb(red.value || 0, green.value || 0, blue.value || 0))
+
+/obj/item/circuit_component/modpc/proc/set_lights(datum/source)
+	red.set_value(clamp(red.value, 0, 255))
+	blue.set_value(clamp(blue.value, 0, 255))
+	green.set_value(clamp(green.value, 0, 255))
+	computer.set_flashlight_color(rgb(red.value || 0, green.value || 0, blue.value || 0))
 
 /obj/item/circuit_component/modpc/proc/computer_on(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -69,7 +69,8 @@
 		print.set_value(html_encode(trim(print.value, MAX_PAPER_LENGTH)))
 
 /obj/item/circuit_component/modpc/proc/print_text(datum/source)
-	computer.print_text(print_text.value)
+	if(computer.enabled)
+		computer.print_text(print_text.value)
 
 /obj/item/circuit_component/modpc/proc/toggle_power(datum/source)
 	if(computer.enabled)

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -60,7 +60,7 @@
 	print = add_input_port("Print", PORT_TYPE_SIGNAL, trigger = PROC_REF(print_text))
 
 	is_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
-	is_on = add_output_port("Shut Down", PORT_TYPE_SIGNAL)
+	is_off = add_output_port("Shut Down", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/modpc/pre_input_received(datum/port/input/port)
 	if(isnull(computer))

--- a/code/modules/modular_computers/computers/item/computer_circuit.dm
+++ b/code/modules/modular_computers/computers/item/computer_circuit.dm
@@ -42,11 +42,11 @@
 	 * I hope you're cool with me doing it here.
 	 */
 	if(computer.has_light && isnull(lights))
-		lights = add_input_port("Toggle Lights", PORT_TYPE_SIGNAL)
+		lights = add_input_port("Toggle Lights", PORT_TYPE_SIGNAL, trigger = PROC_REF(toggle_flashlight))
 		red = add_input_port("Red", PORT_TYPE_NUMBER)
 		green = add_input_port("Green", PORT_TYPE_NUMBER)
 		blue = add_input_port("Blue", PORT_TYPE_NUMBER)
-		set_color = add_input_port("Set Color", PORT_TYPE_SIGNAL, trigger = PROC_REF(set_lights))
+		set_color = add_input_port("Set Color", PORT_TYPE_SIGNAL, trigger = PROC_REF(set_flashlight_color))
 
 /obj/item/circuit_component/modpc/unregister_shell(atom/movable/shell)
 	if(computer)
@@ -55,9 +55,9 @@
 	return ..()
 
 /obj/item/circuit_component/modpc/populate_ports()
-	on_off = add_input_port("Turn On/Off", PORT_TYPE_SIGNAL)
+	on_off = add_input_port("Turn On/Off", PORT_TYPE_SIGNAL, trigger = PROC_REF(toggle_power))
 	print_text = add_input_port("Print Text", PORT_TYPE_STRING)
-	print = add_input_port("Print", PORT_TYPE_SIGNAL)
+	print = add_input_port("Print", PORT_TYPE_SIGNAL, trigger = PROC_REF(print_text))
 
 	is_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
 	is_on = add_output_port("Shut Down", PORT_TYPE_SIGNAL)
@@ -68,27 +68,19 @@
 	if(COMPONENT_TRIGGERED_BY(print_text, port))
 		print.set_value(html_encode(trim(print.value, MAX_PAPER_LENGTH)))
 
-/obj/item/circuit_component/modpc/input_received(datum/port/input/port)
-	if(isnull(computer))
-		return
-	if(COMPONENT_TRIGGERED_BY(on_off, port))
-		if(computer.enabled)
-			INVOKE_ASYNC(computer, TYPE_PROC_REF(/obj/item/modular_computer, shutdown_computer))
-		else
-			INVOKE_ASYNC(computer, TYPE_PROC_REF(/obj/item/modular_computer, turn_on))
-		return
+/obj/item/circuit_component/modpc/proc/print_text(datum/source)
+	computer.print_text(print_text.value)
 
-	if(!computer.enabled)
-		return
+/obj/item/circuit_component/modpc/proc/toggle_power(datum/source)
+	if(computer.enabled)
+		INVOKE_ASYNC(computer, TYPE_PROC_REF(/obj/item/modular_computer, shutdown_computer))
+	else
+		INVOKE_ASYNC(computer, TYPE_PROC_REF(/obj/item/modular_computer, turn_on))
 
-	if(COMPONENT_TRIGGERED_BY(print, port))
-		computer.print_text(print_text.value)
+/obj/item/circuit_component/modpc/proc/toggle_flashlight(datum/source)
+	computer.toggle_flashlight()
 
-	if(lights)
-		if(COMPONENT_TRIGGERED_BY(lights, port))
-			computer.toggle_flashlight()
-
-/obj/item/circuit_component/modpc/proc/set_lights(datum/source)
+/obj/item/circuit_component/modpc/proc/set_flashlight_color(datum/source)
 	red.set_value(clamp(red.value, 0, 255))
 	blue.set_value(clamp(blue.value, 0, 255))
 	green.set_value(clamp(green.value, 0, 255))


### PR DESCRIPTION

## About The Pull Request
This PR makes the computer console's print feature work on a signal instead of wasting paper every string update, changes the flashlight color change to do the same, fixes the on/off signal not turning the console on, and fixes the signal for the console turning off not functioning.

## Why It's Good For The Game
Besides the bug fixes, this makes the console components more consistent with every other circuit component. The refactor is to prevent worrying about nulls for colors or errors because of early returns.

## Changelog
:cl:
fix: computers with no lights can now turn on using the on/off signal
fix: RGB lights on PDA circuits now use a signal
fix: the is_off signal now works on consoles
fix: printing text on a console component now uses a signal
refactor: each input signal in console circuits now have their own proc
/:cl:
