### PR TITLE
Fix dorm 1's lock in Ice Box Station

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5990,6 +5990,19 @@
 	dir = 5
 	},
 /area/station/maintenance/port/aft)
+"bLa" = (
+/obj/structure/bed,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/random/bedsheet,
+/obj/machinery/button/door/directional/east{
+	id = "Dorm1";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/item/pillow/random,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "bLc" = (
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
@@ -49673,7 +49686,7 @@
 /area/station/hallway/primary/central)
 "oTh" = (
 /obj/machinery/door/airlock{
-	id_tag = "Dorm2";
+	id_tag = "Dorm1";
 	name = "Dorm 1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -242567,7 +242580,7 @@ ygB
 mJO
 oCF
 ygB
-mJO
+bLa
 oCF
 ygB
 lBD


### PR DESCRIPTION

## About The Pull Request
Currently, the dorm 1 button and door are set to use dorm 2's IDs.

This PR fixes an erroneously set ID tag for the Dorm 1's lock and door bolts.

https://github.com/tgstation/tgstation/assets/80724828/a906f724-1608-49d7-b9ed-8ff98b6e0519

## Why It's Good For The Game
Fixes dorm 1 so it behaves as an actual functional dorm room.

## Changelog
:cl:
fix: [Ice Box Station] Dorm 1's door no longer shares ID with dorm 2's door
/:cl:
