### PR TITLE
Fixes Rust Victims being permanently exiled to the puke-zone.

### DIFF
--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -98,6 +98,8 @@
 	UnregisterSignal(source, COMSIG_ATOM_EXITED)
 	for(var/obj/effect/glowing_rune/rune_to_remove in source)
 		qdel(rune_to_remove)
+	for(var/mob/living/victim in source)
+		victim.remove_status_effect(/datum/status_effect/rust_corruption)
 
 /datum/element/rust/heretic/proc/on_entered(turf/source, atom/movable/entered, ...)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

closes : https://github.com/tgstation/tgstation/issues/83375


## Why It's Good For The Game

Deleting Heretic rust you are standing on now properly deletes the status effect.

## Changelog

:cl:

fix: Rust debuffs now gets properly removed if you derust a tile you  are standing on.
/:cl:

