### PR TITLE
Steal the Captain MOD and spare ID now show up regardless of previously completed objectives.

### DIFF
--- a/code/modules/antagonists/traitor/objectives/steal.dm
+++ b/code/modules/antagonists/traitor/objectives/steal.dm
@@ -131,11 +131,6 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		/datum/objective_item/steal/traitor/captain_spare,
 	)
 
-/datum/traitor_objective/steal_item/most_risky/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	if(!handler.get_completion_count(/datum/traitor_objective/steal_item/very_risky))
-		return FALSE
-	return ..()
-
 /datum/traitor_objective/steal_item/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	for(var/datum/traitor_objective/steal_item/objective as anything in possible_duplicates)
 		possible_items -= objective.target_item.type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the need of a previously completed objective to obtain Most_risky type objectives.
## Why It's Good For The Game

![Melon approval](https://github.com/tgstation/tgstation/assets/102721711/8b172447-2327-44dd-967b-9ac97c6b0ac0)

These objectives were essentially soft locked behind the steal the revolver objective, given no other traitor objective follows this pattern, i don't understand why we should keep such a snowflakey thing into the game; Progtot already has very little high end objectives, let's not soft lock what little are there.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: Most_Risky steal objectives now always show up whether you have completed a previous objective or not
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
