### PR TITLE
Admins can reroll random events into something else

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -65,8 +65,9 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/proc/reschedule()
 	scheduled = world.time + rand(frequency_lower, max(frequency_lower,frequency_upper))
 
-//selects a random event based on whether it can occur and it's 'weight'(probability)
-/datum/controller/subsystem/events/proc/spawnEvent()
+///selects a random event based on whether it can occur and it's 'weight'(probability)
+/// * excluded_event - The event path we will be foregoing, if present.
+/datum/controller/subsystem/events/proc/spawnEvent(datum/round_event_control/excluded_event)
 	set waitfor = FALSE //for the admin prompt
 	if(!CONFIG_GET(flag/allow_random_events))
 		return
@@ -77,6 +78,8 @@ SUBSYSTEM_DEF(events)
 	var/list/event_roster = list()
 
 	for(var/datum/round_event_control/event_to_check in control)
+		if(excluded_event && event_to_check.typepath == excluded_event.typepath) //If an event has been rerolled we won't just roll the same one again.
+			continue
 		if(!event_to_check.can_spawn_event(players_amt))
 			continue
 		if(event_to_check.weight < 0) //for round-start events etc.

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -65,8 +65,12 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/proc/reschedule()
 	scheduled = world.time + rand(frequency_lower, max(frequency_lower,frequency_upper))
 
-///selects a random event based on whether it can occur and it's 'weight'(probability)
-/// * excluded_event - The event path we will be foregoing, if present.
+/**
+ * Selects a random event based on whether it can occur and it's 'weight'(probability)
+ *
+ * Arguments:
+ * * excluded_event - The event path we will be foregoing, if present.
+ */
 /datum/controller/subsystem/events/proc/spawnEvent(datum/round_event_control/excluded_event)
 	set waitfor = FALSE //for the admin prompt
 	if(!CONFIG_GET(flag/allow_random_events))

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -72,14 +72,14 @@
 // Admin-created events override this.
 /datum/round_event_control/proc/can_spawn_event(players_amt, allow_magic = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	//__check_serialization_semverif(occurrences >= max_occurrences)
-	//	return FALSE
-	//if(earliest_start >= world.time-SSticker.round_start_time)
-	//	return FALSE
-	//if(!allow_magic && wizardevent != SSevents.wizardmode)
-	//	return FALSE
-//	if(players_amt < min_players)
-//		return FALSE
+	if(occurrences >= max_occurrences)
+		return FALSE
+	if(earliest_start >= world.time-SSticker.round_start_time)
+		return FALSE
+	if(!allow_magic && wizardevent != SSevents.wizardmode)
+		return FALSE
+	if(players_amt < min_players)
+		return FALSE
 	if(holidayID && !check_holidays(holidayID))
 		return FALSE
 	if(EMERGENCY_ESCAPED_OR_ENDGAMED)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -72,14 +72,14 @@
 // Admin-created events override this.
 /datum/round_event_control/proc/can_spawn_event(players_amt, allow_magic = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	if(occurrences >= max_occurrences)
-		return FALSE
-	if(earliest_start >= world.time-SSticker.round_start_time)
-		return FALSE
-	if(!allow_magic && wizardevent != SSevents.wizardmode)
-		return FALSE
-	if(players_amt < min_players)
-		return FALSE
+	//__check_serialization_semverif(occurrences >= max_occurrences)
+	//	return FALSE
+	//if(earliest_start >= world.time-SSticker.round_start_time)
+	//	return FALSE
+	//if(!allow_magic && wizardevent != SSevents.wizardmode)
+	//	return FALSE
+//	if(players_amt < min_players)
+//		return FALSE
 	if(holidayID && !check_holidays(holidayID))
 		return FALSE
 	if(EMERGENCY_ESCAPED_OR_ENDGAMED)
@@ -103,11 +103,12 @@
 
 	// We sleep HERE, in pre-event setup (because there's no sense doing it in run_event() since the event is already running!) for the given amount of time to make an admin has enough time to cancel an event un-fitting of the present round.
 	if(alert_observers)
-		message_admins("Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
+		message_admins("Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>) (<a href='?src=[REF(src)];different_event=1'>SOMETHING ELSE</a>)")
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)
 		var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 		if(!can_spawn_event(players_amt))
-			message_admins("Second pre-condition check for [name] failed, skipping...")
+			message_admins("Second pre-condition check for [name] failed, rerolling...")
+			SSevents.spawnEvent(excluded_event = src)
 			return EVENT_INTERRUPTED
 
 	if(!triggering)
@@ -125,6 +126,15 @@
 		message_admins("[key_name_admin(usr)] cancelled event [name].")
 		log_admin_private("[key_name(usr)] cancelled event [name].")
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
+	if(href_list["different_event"])
+		if(!triggering)
+			to_chat(usr, span_admin("Too late to change events now!"))
+			return
+		triggering = FALSE
+		message_admins("[key_name_admin(usr)] chose to have event [name] rolled into a different event.")
+		log_admin_private("[key_name(usr)] rerolled event [name].")
+		SSblackbox.record_feedback("tally", "event_admin_rerolled", 1, typepath)
+		SSevents.spawnEvent(excluded_event = src)
 
 /*
 Runs the event


### PR DESCRIPTION

## About The Pull Request

Random events can now be rerolled by admins, much like how they can reroll dynamic rulesets. During the ten-second warning window, you can choose "Something Else" to have a (randomly selected) different event run in its stead. You still get the 10-second delay when this new one is picked, meaning you can keep rerolling until you get something interesting.

The option to just cancel a random event remains.
## Why It's Good For The Game

Cancelling a random event sets back the random event clock, meaning you have to wait a few minutes for another one to roll. Now you can just reroll dangerous events into something calmer (or y'know, calm events into something more dangerous).
## Changelog
:cl: Rhials
admin: Admins can now reroll random events into something else.
/:cl:
