### PR TITLE
Cleans up some admin-related stuff in client `Destroy()` and `adminGreet()`

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -286,6 +286,8 @@ ADMIN_VERB(create_or_modify_area, R_DEBUG, "Create Or Modify Area", "Create of m
 
 	return TRUE
 
+/// Sends a message to adminchat when anyone with a holder logs in or logs out.
+/// Is dependent on admin preferences and configuration settings, which means that this proc can fire without sending a message.
 /client/proc/adminGreet(logout = FALSE)
 	if(!SSticker.HasRoundStarted())
 		return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -286,14 +286,15 @@ ADMIN_VERB(create_or_modify_area, R_DEBUG, "Create Or Modify Area", "Create of m
 
 	return TRUE
 
-/client/proc/adminGreet(logout)
-	if(SSticker.HasRoundStarted())
-		var/string
-		if(logout && CONFIG_GET(flag/announce_admin_logout))
-			string = pick(
-				"Admin logout: [key_name(src)]")
-		else if(!logout && CONFIG_GET(flag/announce_admin_login) && (prefs.toggles & ANNOUNCE_LOGIN))
-			string = pick(
-				"Admin login: [key_name(src)]")
-		if(string)
-			message_admins("[string]")
+/client/proc/adminGreet(logout = FALSE)
+	if(!SSticker.HasRoundStarted())
+		return
+
+	if(logout && CONFIG_GET(flag/announce_admin_logout))
+		message_admins("Admin logout: [key_name(src)]")
+		return
+
+	if(!logout && CONFIG_GET(flag/announce_admin_login) && (prefs.toggles & ANNOUNCE_LOGIN))
+		message_admins("Admin login: [key_name(src)]")
+		return
+

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1230,6 +1230,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(length(GLOB.admins) > 0 || !SSticker.IsRoundInProgress()) // We only want to report this stuff if we are currently playing.
 		return
 
+	var/list/message_to_send = list()
 	var/static/list/cheesy_messages = null
 
 	if (isnull(cheesy_messages))
@@ -1248,7 +1249,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			"Why does nobody love me? :(",
 		)
 
-	send2adminchat("Server", "[pick(cheesy_messages)] (No admins online)")
+	message_to_send += pick(cheesy_messages)
+	message_to_send += "(No admins online)"
+
+	send2adminchat("Server", jointext(message_to_send, " "))
 
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -588,26 +588,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(credits)
 		QDEL_LIST(credits)
 	if(holder)
-		adminGreet(1)
 		holder.owner = null
 		GLOB.admins -= src
-		if (!GLOB.admins.len && SSticker.IsRoundInProgress()) //Only report this stuff if we are currently playing.
-			var/cheesy_message = pick(
-				"I have no admins online!",\
-				"I'm all alone :(",\
-				"I'm feeling lonely :(",\
-				"I'm so lonely :(",\
-				"Why does nobody love me? :(",\
-				"I want a man :(",\
-				"Where has everyone gone?",\
-				"I need a hug :(",\
-				"Someone come hold me :(",\
-				"I need someone on me :(",\
-				"What happened? Where has everyone gone?",\
-				"Forever alone :("\
-			)
+		handle_admin_logout()
 
-			send2adminchat("Server", "[cheesy_message] (No admins online)")
 	QDEL_LIST_ASSOC_VAL(char_render_holders)
 
 	SSambience.remove_ambience_client(src)
@@ -1239,6 +1223,29 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				continue
 
 		screen -= object
+
+/// Handles any "fluff" or supplementary procedures related to an admin logout event. Should not have anything critically related cleaning up an admin's logout.
+/client/proc/handle_admin_logout()
+	adminGreet(logout = TRUE)
+	if(length(GLOB.admins) > 0 || !SSticker.IsRoundInProgress()) // We only want to report this stuff if we are currently playing.
+		return
+
+	var/cheesy_message = pick(
+		"Forever alone :(",
+		"I have no admins online!",
+		"I need a hug :(",
+		"I need someone on me :(",
+		"I want a man :(",
+		"I'm all alone :(",
+		"I'm feeling lonely :(",
+		"I'm so lonely :(",
+		"Someone come hold me :(",
+		"What happened? Where has everyone gone?",
+		"Where has everyone gone?",
+		"Why does nobody love me? :(",
+	)
+
+	send2adminchat("Server", "[cheesy_message] (No admins online)")
 
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1230,7 +1230,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(length(GLOB.admins) > 0 || !SSticker.IsRoundInProgress()) // We only want to report this stuff if we are currently playing.
 		return
 
-	var/cheesy_message = pick(
+	var/cheesy_message = pick(list(
 		"Forever alone :(",
 		"I have no admins online!",
 		"I need a hug :(",
@@ -1243,7 +1243,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		"What happened? Where has everyone gone?",
 		"Where has everyone gone?",
 		"Why does nobody love me? :(",
-	)
+	))
 
 	send2adminchat("Server", "[cheesy_message] (No admins online)")
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1230,22 +1230,25 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(length(GLOB.admins) > 0 || !SSticker.IsRoundInProgress()) // We only want to report this stuff if we are currently playing.
 		return
 
-	var/cheesy_message = pick(list(
-		"Forever alone :(",
-		"I have no admins online!",
-		"I need a hug :(",
-		"I need someone on me :(",
-		"I want a man :(",
-		"I'm all alone :(",
-		"I'm feeling lonely :(",
-		"I'm so lonely :(",
-		"Someone come hold me :(",
-		"What happened? Where has everyone gone?",
-		"Where has everyone gone?",
-		"Why does nobody love me? :(",
-	))
+	var/static/list/cheesy_messages = null
 
-	send2adminchat("Server", "[cheesy_message] (No admins online)")
+	if (isnull(cheesy_messages))
+		cheesy_messages = list(
+			"Forever alone :(",
+			"I have no admins online!",
+			"I need a hug :(",
+			"I need someone on me :(",
+			"I want a man :(",
+			"I'm all alone :(",
+			"I'm feeling lonely :(",
+			"I'm so lonely :(",
+			"Someone come hold me :(",
+			"What happened? Where has everyone gone?",
+			"Where has everyone gone?",
+			"Why does nobody love me? :(",
+		)
+
+	send2adminchat("Server", "[pick(cheesy_messages)] (No admins online)")
 
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE


### PR DESCRIPTION
## About The Pull Request

It made me really mad to see a huge list in the middle of client/Destroy for something that doesn't even run for 95% of users so I split it out into another proc so the fingerprint of the very important `Destroy()` stuff could be as minimal as possible without a big `pick()` so the server can send the "I need a man 🥺" message could be punted off to where no-one would care for it. It was already doing the async TGS operation so it doesn't matter anyways as far as proc overhead in my books.

I also fixed up the code for `adminGreet()` as well because that was being really weird with not having proper booleans and running `pick()` on things with literally one value (as well as excess stringification)... it wasn't good so I just cleaned all that up too. Ideally this all means we take up a little less CPU time but the aim of this PR is to just clean it all up for modern coding standards. alphabetized lists and early returns galore.

## Why It's Good For The Game

Code is better to read and less idented, and better yet it's no longer necessary to read all the softie messages in the middle of `Destroy()`

## Changelog

Irrelevant

