### PR TITLE
Make borg items not shift around depending on what is equipped

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -197,41 +197,7 @@
 	if(!R.client)
 		return
 
-	if(R.shown_robot_modules && screenmob.hud_used.hud_shown)
-		//Modules display is shown
-		screenmob.client.screen += module_store_icon //"store" icon
-
-		if(!R.model.modules)
-			to_chat(usr, span_warning("Selected model has no modules to select!"))
-			return
-
-		if(!R.robot_modules_background)
-			return
-
-		var/list/usable_modules = R.model.get_usable_modules()
-
-		var/display_rows = max(CEILING(length(usable_modules) / 8, 1),1)
-		R.robot_modules_background.screen_loc = "CENTER-4:16,SOUTH+1:7 to CENTER+3:16,SOUTH+[display_rows]:7"
-		screenmob.client.screen += R.robot_modules_background
-
-		for(var/i in 1 to length(usable_modules))
-			var/atom/movable/A = usable_modules[i]
-			if(A in R.held_items)
-				//Module is not currently active
-				continue
-
-			// Arrange in a grid x=-4 to 3 and y=1 to display_rows
-			var/x = (i-1)%8 - 4
-			var/y = floor((i-1)/8)+1
-
-			screenmob.client.screen += A
-			if(x < 0)
-				A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
-			else
-				A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
-			SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
-
-	else
+	if(!R.shown_robot_modules || !screenmob.hud_used.hud_shown)
 		//Modules display is hidden
 		screenmob.client.screen -= module_store_icon //"store" icon
 
@@ -240,6 +206,41 @@
 			screenmob.client.screen -= A
 		R.shown_robot_modules = 0
 		screenmob.client.screen -= R.robot_modules_background
+		return
+
+	//Modules display is shown
+	screenmob.client.screen += module_store_icon //"store" icon
+
+	if(!R.model.modules)
+		to_chat(usr, span_warning("Selected model has no modules to select!"))
+		return
+
+	if(!R.robot_modules_background)
+		return
+
+	var/list/usable_modules = R.model.get_usable_modules()
+
+	var/display_rows = max(CEILING(length(usable_modules) / 8, 1),1)
+	R.robot_modules_background.screen_loc = "CENTER-4:16,SOUTH+1:7 to CENTER+3:16,SOUTH+[display_rows]:7"
+	screenmob.client.screen += R.robot_modules_background
+
+	for(var/i in 1 to length(usable_modules))
+		var/atom/movable/A = usable_modules[i]
+		if(A in R.held_items)
+			//Module is not currently active
+			continue
+
+		// Arrange in a grid x=-4 to 3 and y=1 to display_rows
+		var/x = (i - 1) % 8 - 4
+		var/y = floor((i - 1) / 8) + 1
+
+		screenmob.client.screen += A
+		if(x < 0)
+			A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
+		else
+			A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
+		SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
+
 
 /datum/hud/robot/persistent_inventory_update(mob/viewer)
 	if(!mymob)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -214,23 +214,22 @@
 		R.robot_modules_background.screen_loc = "CENTER-4:16,SOUTH+1:7 to CENTER+3:16,SOUTH+[display_rows]:7"
 		screenmob.client.screen += R.robot_modules_background
 
-		var/x = -4 //Start at CENTER-4,SOUTH+1
-		var/y = 1
-
-		for(var/atom/movable/A in usable_modules)
-			if(!(A in R.held_items))
+		for(var/i in 1 to length(usable_modules))
+			var/atom/movable/A = usable_modules[i]
+			if(A in R.held_items)
 				//Module is not currently active
-				screenmob.client.screen += A
-				if(x < 0)
-					A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
-				else
-					A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
-				SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
+				continue
 
-			x++
-			if(x == 4)
-				x = -4
-				y++
+			// Arrange in a grid x=-4 to 3 and y=1 to display_rows
+			var/x = (i-1)%8 - 4
+			var/y = floor((i-1)/8)+1
+
+			screenmob.client.screen += A
+			if(x < 0)
+				A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
+			else
+				A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
+			SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
 
 	else
 		//Modules display is hidden

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -230,16 +230,16 @@
 			//Module is currently active
 			continue
 
-	// Arrange in a grid x=-4 to 3 and y=1 to display_rows
-	var/x = (i - 1) % 8 - 4
-	var/y = floor((i - 1) / 8) + 1
+		// Arrange in a grid x=-4 to 3 and y=1 to display_rows
+		var/x = (i - 1) % 8 - 4
+		var/y = floor((i - 1) / 8) + 1
 
-	screenmob.client.screen += A
-	if(x < 0)
-		A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
-	else
-		A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
-	SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
+		screenmob.client.screen += A
+		if(x < 0)
+			A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
+		else
+			A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
+		SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
 
 
 /datum/hud/robot/persistent_inventory_update(mob/viewer)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -208,21 +208,24 @@
 		if(!R.robot_modules_background)
 			return
 
-		var/display_rows = max(CEILING(length(R.model.get_inactive_modules()) / 8, 1),1)
+		var/list/usable_modules = R.model.get_usable_modules()
+
+		var/display_rows = max(CEILING(length(usable_modules) / 8, 1),1)
 		R.robot_modules_background.screen_loc = "CENTER-4:16,SOUTH+1:7 to CENTER+3:16,SOUTH+[display_rows]:7"
 		screenmob.client.screen += R.robot_modules_background
 
 		var/x = -4 //Start at CENTER-4,SOUTH+1
 		var/y = 1
 
-		for(var/atom/movable/A in R.model.get_inactive_modules())
-			//Module is not currently active
-			screenmob.client.screen += A
-			if(x < 0)
-				A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
-			else
-				A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
-			SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
+		for(var/atom/movable/A in usable_modules)
+			if(!(A in R.held_items))
+				//Module is not currently active
+				screenmob.client.screen += A
+				if(x < 0)
+					A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
+				else
+					A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
+				SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
 
 			x++
 			if(x == 4)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -224,22 +224,22 @@
 	R.robot_modules_background.screen_loc = "CENTER-4:16,SOUTH+1:7 to CENTER+3:16,SOUTH+[display_rows]:7"
 	screenmob.client.screen += R.robot_modules_background
 
-		for(var/i in 1 to length(usable_modules))
-			var/atom/movable/A = usable_modules[i]
-			if(A in R.held_items)
-				//Module is currently active
-				continue
+	for(var/i in 1 to length(usable_modules))
+		var/atom/movable/A = usable_modules[i]
+		if(A in R.held_items)
+			//Module is currently active
+			continue
 
-		// Arrange in a grid x=-4 to 3 and y=1 to display_rows
-		var/x = (i - 1) % 8 - 4
-		var/y = floor((i - 1) / 8) + 1
+	// Arrange in a grid x=-4 to 3 and y=1 to display_rows
+	var/x = (i - 1) % 8 - 4
+	var/y = floor((i - 1) / 8) + 1
 
-		screenmob.client.screen += A
-		if(x < 0)
-			A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
-		else
-			A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
-		SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
+	screenmob.client.screen += A
+	if(x < 0)
+		A.screen_loc = "CENTER[x]:16,SOUTH+[y]:7"
+	else
+		A.screen_loc = "CENTER+[x]:16,SOUTH+[y]:7"
+	SET_PLANE_IMPLICIT(A, ABOVE_HUD_PLANE)
 
 
 /datum/hud/robot/persistent_inventory_update(mob/viewer)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -217,7 +217,7 @@
 		for(var/i in 1 to length(usable_modules))
 			var/atom/movable/A = usable_modules[i]
 			if(A in R.held_items)
-				//Module is not currently active
+				//Module is currently active
 				continue
 
 			// Arrange in a grid x=-4 to 3 and y=1 to display_rows


### PR DESCRIPTION

## About The Pull Request

Stops items from shifting around the borg inventory depending on what is equipped. One of the most annoying things about playing borg for me is this.
## Why It's Good For The Game
Smoother borg inventory management

[2024-05-23 21-06-06.webm](https://github.com/tgstation/tgstation/assets/6713261/36b04fb8-47a5-4bd8-afb3-105b680805af)
## Changelog
:cl:
qol: Made borg inventory not shift around depending on equipped items
/:cl:
