### PR TITLE
Fix echolocation lag ft. an actual fix

### DIFF
--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -4,11 +4,11 @@
 	/// Time between echolocations. IMPORTANT!! The effective time in local and the effective time in live are very different. The second is noticeably slower,
 	var/cooldown_time = 1 SECONDS
 	/// Time for the image to start fading out.
-	var/image_expiry_time = 1.4 SECONDS
+	var/image_expiry_time = 0.7 SECONDS
 	/// Time for the image to fade in.
-	var/fade_in_time = 0.4 SECONDS
+	var/fade_in_time = 0.2 SECONDS
 	/// Time for the image to fade out and delete itself.
-	var/fade_out_time = 0.4 SECONDS
+	var/fade_out_time = 0.3 SECONDS
 	/// Are images static? If yes, spawns them on the turf and makes them not change location. Otherwise they change location and pixel shift with the original.
 	var/images_are_static = TRUE
 	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images.
@@ -105,7 +105,7 @@
 	for(var/mob/living/viewer in filtered)
 		if(blocking_trait && HAS_TRAIT(viewer, blocking_trait))
 			continue
-		if(HAS_TRAIT_FROM(viewer, TRAIT_ECHOLOCATION_RECEIVER, echo_group))
+		if(HAS_TRAIT_FROM(viewer, TRAIT_ECHOLOCATION_RECEIVER, echo_group) && isnull(receivers[viewer]))
 			receivers[viewer] = list()
 	for(var/atom/filtered_atom as anything in filtered)
 		show_image(saved_appearances["[filtered_atom.icon]-[filtered_atom.icon_state]"] || generate_appearance(filtered_atom), filtered_atom, current_time)
@@ -175,6 +175,7 @@
 		for(var/atom/rendered_atom as anything in receivers[echolocate_receiver])
 			if(receivers[echolocate_receiver][rendered_atom]["time"] <= from_when && echolocate_receiver.client)
 				echolocate_receiver.client.images -= receivers[echolocate_receiver][rendered_atom]["image"]
+				receivers[echolocate_receiver] -= rendered_atom
 		if(!length(receivers[echolocate_receiver]))
 			receivers -= echolocate_receiver
 


### PR DESCRIPTION

## About The Pull Request
Fixes the actual underlying issue that makes images pile up when the cooldown is lower than the fade time. 
Also, adjusts the fade time to compensate for the new 1 second cooldown, because otherwise you literally don't get an echolocation effect. Things just never vanish.
Fixes #83385
## Why It's Good For The Game
well-
current behavior:

https://github.com/tgstation/tgstation/assets/25628932/98efda07-5396-4f8c-8460-69231bbfc32e
## Changelog
:cl: Fluffles
fix: echolocation is less laggy. and works.
/:cl:
