### PR TITLE
disable client auth checks because byond is down

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -39,6 +39,7 @@
 		////////////////
 	/// hides the byond verb panel as we use our own custom version
 	show_verb_panel = FALSE
+	authenticate = FALSE //byond is down, allow signed in clients to auth via certificate
 	///Contains admin info. Null if client is not an admin.
 	var/datum/admins/holder = null
 	///Needs to implement InterceptClickOn(user,params,atom) proc


### PR DESCRIPTION
should allow clients to auth via cached certificates without contacting byond. ~~likely won't do anything.~~ **lol it fucking works!**

## About The Pull Request
## Why It's Good For The Game
People being able to connect to the servers is good for the game.

