### PR TITLE
Fully deletes improvised shotgun shells from the game.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -108,10 +108,6 @@
 	stamina = 6
 	embedding = null
 
-/obj/projectile/bullet/pellet/shotgun_improvised/on_range()
-	do_sparks(1, TRUE, src)
-	..()
-
 // Mech Scattershot
 
 /obj/projectile/bullet/scattershot

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -108,15 +108,6 @@
 	stamina = 6
 	embedding = null
 
-/obj/projectile/bullet/pellet/shotgun_improvised
-	damage = 5
-	wound_bonus = -5
-	demolition_mod = 3 //Very good at acts of vandalism
-
-/obj/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
-	. = ..()
-	range = rand(3, 8)
-
 /obj/projectile/bullet/pellet/shotgun_improvised/on_range()
 	do_sparks(1, TRUE, src)
 	..()


### PR DESCRIPTION

## About The Pull Request
For whatever reason, these were partially deleted but the projectile was left in. Since the thing that spawns these projectiles is 100% gone from the game and can't even be spawned by admins there's no reason to keep this vestigial code.
## Why It's Good For The Game
Why waste lines of code and storage space on something that is now gone? It's just clutter.
## Changelog
:cl:
no player facing change
/:cl:
