### PR TITLE
Pillow now consumes stamina in both unwielded and wielded states

### DIFF
--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -51,9 +51,10 @@
 	if(!iscarbon(target_mob))
 		return
 	if(bricked || HAS_TRAIT(src, TRAIT_WIELDED))
-		user.apply_damage(5, STAMINA) // when hitting with such force we should prolly be getting tired too
+		user.apply_damage(20, STAMINA) // when hitting with such force we should prolly be getting tired too
 		hit_sound = 'sound/items/pillow_hit2.ogg'
 	else
+		user.apply_damage(10, STAMINA) //Had to be done so one person cannot keep multiple people stam critted
 		hit_sound = 'sound/items/pillow_hit.ogg'
 	last_fighter = user
 	playsound(user, hit_sound, 80) //the basic 50 vol is barely audible

--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -51,7 +51,7 @@
 	if(!iscarbon(target_mob))
 		return
 	if(bricked || HAS_TRAIT(src, TRAIT_WIELDED))
-		user.apply_damage(15, STAMINA) // when hitting with such force we should prolly be getting tired too
+		user.apply_damage(15, STAMINA) // when hitting with such force we should prolly be getting tired too. Note wielded self dmg should always be higher as to not make it a straight upgrade from unwielded
 		hit_sound = 'sound/items/pillow_hit2.ogg'
 	else
 		user.apply_damage(10, STAMINA) //Had to be done so one person cannot keep multiple people stam critted

--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -51,7 +51,7 @@
 	if(!iscarbon(target_mob))
 		return
 	if(bricked || HAS_TRAIT(src, TRAIT_WIELDED))
-		user.apply_damage(20, STAMINA) // when hitting with such force we should prolly be getting tired too
+		user.apply_damage(15, STAMINA) // when hitting with such force we should prolly be getting tired too
 		hit_sound = 'sound/items/pillow_hit2.ogg'
 	else
 		user.apply_damage(10, STAMINA) //Had to be done so one person cannot keep multiple people stam critted

--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -51,11 +51,10 @@
 	if(!iscarbon(target_mob))
 		return
 	if(bricked || HAS_TRAIT(src, TRAIT_WIELDED))
-		user.apply_damage(15, STAMINA) // when hitting with such force we should prolly be getting tired too. Note wielded self dmg should always be higher as to not make it a straight upgrade from unwielded
 		hit_sound = 'sound/items/pillow_hit2.ogg'
 	else
-		user.apply_damage(10, STAMINA) //Had to be done so one person cannot keep multiple people stam critted
 		hit_sound = 'sound/items/pillow_hit.ogg'
+	user.apply_damage(5, STAMINA) //Had to be done so one person cannot keep multiple people stam critted
 	last_fighter = user
 	playsound(user, hit_sound, 80) //the basic 50 vol is barely audible
 


### PR DESCRIPTION
## About The Pull Request
There was some issue about players being kept in stamcrit via stamina damage refreshing the timer. @Watermelon914 has confirmed that refresh mechanic is ok but only with stamina weapon with limited charges, pillow does not have charges in its unwielded state so I have added some. Now there is a limited amount of hits you can make before being stam crit yourself. Self damage for wielded state have also been increased to create a trade off between dealing more damage and how much self damage you take. 
## Why It's Good For The Game
## Changelog
:cl:
balance: Attack with a pillow now consumes 5 stamina regardless of wielded or not.
/:cl:
