### PR TITLE
Removes virus symptom neutering

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -158,10 +158,8 @@
 				symptom_datum.next_activation = world.time + (rand(symptom_datum.symptom_delay_min SECONDS, symptom_datum.symptom_delay_max SECONDS) * DISEASE_SYMPTOM_FREQUENCY_MODIFIER)
 			symptom_datum.on_stage_change(src)
 
-	for(var/s in symptoms)
-		var/datum/symptom/symptom_datum = s
-		if(!symptom_datum.neutered)
-			symptom_datum.Activate(src)
+	for(var/datum/symptom/symptom_datum as anything in symptoms)
+		symptom_datum.Activate(src)
 
 
 // Tell symptoms stage changed
@@ -257,8 +255,7 @@
 		properties["stealth"] += S.stealth
 		properties["stage_rate"] += S.stage_speed
 		properties["transmittable"] += S.transmittable
-		if(!S.neutered)
-			properties["severity"] += S.severity // severity is based on the sum of all non-neutered symptoms' severity
+		properties["severity"] += S.severity
 	if(properties["severity"] > 0)
 		properties["severity"] += round((properties["resistance"] / 12), 1)
 		properties["severity"] += round((properties["stage_rate"] / 11), 1)
@@ -370,16 +367,6 @@
 			RemoveSymptom(S)
 			Refresh(TRUE)
 
-// Randomly neuter a symptom.
-/datum/disease/advance/proc/Neuter(ignore_mutable = FALSE)
-	if(!mutable && !ignore_mutable)
-		return
-	if(length(symptoms))
-		var/datum/symptom/S = pick(symptoms)
-		if(S)
-			NeuterSymptom(S)
-			Refresh(TRUE)
-
 // Name the disease.
 /datum/disease/advance/proc/AssignName(name = "Unknown")
 	var/datum/disease/advance/A = SSdisease.archive_diseases[GetDiseaseID()]
@@ -389,11 +376,8 @@
 /datum/disease/advance/GetDiseaseID()
 	if(!id)
 		var/list/L = list()
-		for(var/datum/symptom/S in symptoms)
-			if(S.neutered)
-				L += "[S.id]N"
-			else
-				L += S.id
+		for(var/datum/symptom/symptom as anything in symptoms)
+			L += symptom.id
 		L = sort_list(L) // Sort the list so it doesn't matter which order the symptoms are in.
 		var/result = jointext(L, ":")
 		id = result
@@ -415,13 +399,6 @@
 /datum/disease/advance/proc/RemoveSymptom(datum/symptom/S)
 	symptoms -= S
 	S.OnRemove(src)
-
-// Neuter a symptom, so it will only affect stats
-/datum/disease/advance/proc/NeuterSymptom(datum/symptom/S)
-	if(!S.neutered)
-		S.neutered = TRUE
-		S.name += " (neutered)"
-		S.OnRemove(src)
 
 /*
 

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -32,8 +32,6 @@
 	var/symptom_delay_max = 1
 	///Can be used to multiply virus effects
 	var/power = 1
-	///A neutered symptom has no effect, and only affects statistics.
-	var/neutered = FALSE
 	var/list/thresholds
 	///If this symptom can appear from /datum/disease/advance/GenerateSymptoms()
 	var/naturally_occuring = TRUE
@@ -50,19 +48,13 @@
 
 ///Called when processing of the advance disease that holds this symptom infects a host and upon each Refresh() of that advance disease.
 /datum/symptom/proc/Start(datum/disease/advance/A)
-	if(neutered)
-		return FALSE
 	return TRUE
 
 ///Called when the advance disease is going to be deleted or when the advance disease stops processing.
 /datum/symptom/proc/End(datum/disease/advance/A)
-	if(neutered)
-		return FALSE
 	return TRUE
 
 /datum/symptom/proc/Activate(datum/disease/advance/advanced_disease)
-	if(neutered)
-		return FALSE
 	if(required_organ)
 		if(!advanced_disease.has_required_infectious_organ(advanced_disease.affected_mob, required_organ))
 			return FALSE
@@ -74,15 +66,12 @@
 		return TRUE
 
 /datum/symptom/proc/on_stage_change(datum/disease/advance/A)
-	if(neutered)
-		return FALSE
 	return TRUE
 
 /datum/symptom/proc/Copy()
 	var/datum/symptom/new_symp = new type
 	new_symp.name = name
 	new_symp.id = id
-	new_symp.neutered = neutered
 	return new_symp
 
 /datum/symptom/proc/generate_threshold_desc()
@@ -111,7 +100,6 @@
 	data["stage_speed"] = stage_speed
 	data["transmission"] = transmittable
 	data["level"] = level
-	data["neutered"] = neutered
 	data["threshold_desc"] = threshold_descs
 	return data
 

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -767,8 +767,7 @@
 		/obj/item/reagent_containers/cup/bottle/mutagen = 1,
 		/obj/item/reagent_containers/cup/bottle/sugar = 1,
 		/obj/item/reagent_containers/cup/bottle/plasma = 1,
-		/obj/item/reagent_containers/cup/bottle/synaptizine = 1,
-		/obj/item/reagent_containers/cup/bottle/formaldehyde = 1)
+		/obj/item/reagent_containers/cup/bottle/synaptizine = 1)
 
 // ----------------------------
 // Disk """fridge"""

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -303,19 +303,6 @@
 		if(D)
 			D.Devolve()
 
-/datum/chemical_reaction/mix_virus/neuter_virus
-	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1)
-	required_catalysts = list(/datum/reagent/blood = 1)
-
-/datum/chemical_reaction/mix_virus/neuter_virus/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
-	if(B?.data)
-		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
-		if(D)
-			D.Neuter()
-
-
-
 ////////////////////////////////// foam and foam precursor ///////////////////////////////////////////////////
 
 


### PR DESCRIPTION
## About The Pull Request
Removes virus neutering. This mechanic allows you to neuter symptoms to optimize stats without having to actually having those symptoms do anything

## Why It's Good For The Game
Virology has disease stats that influence how viruses behave. Do you want to buff your viruses resistance? Headaches gives +4 resistance, but makes your virus less desirable. So neuter it and take all the positives without having to compromise in the slightest!

I'm not saying we need to add deadly symptoms, but just... add nothing? I don't think the mix-and matching is also particularly engaging (I'll get on removing the thresholds...)

Virology is already barely designed, but this mechanic exists only to entirely circumvent the decision making process behind mixing and matching your diseases. It had the upside of giving the virologist more to do 7 years ago, but that's no longer a concern and we can instead work towards making virology interesting in a different way

## Changelog
:cl:
del: Removes virus symptom neutering
/:cl:
