### PR TITLE
Removes miasma and gibs diseases

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -45,8 +45,6 @@
 				RegisterSignal(parent, COMSIG_GLASS_DRANK, PROC_REF(try_infect_drink))
 			if(isorgan(parent))
 				RegisterSignal(parent, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_organ_insertion))
-		else if(istype(parent, /obj/effect/decal/cleanable/blood/gibs))
-			RegisterSignal(parent, COMSIG_GIBS_STREAK, PROC_REF(try_infect_streak))
 
 /datum/component/infective/proc/on_organ_insertion(obj/item/organ/target, mob/living/carbon/receiver)
 	SIGNAL_HANDLER
@@ -180,6 +178,5 @@
 		COMSIG_ITEM_EQUIPPED,
 		COMSIG_GLASS_DRANK,
 		COMSIG_ORGAN_IMPLANTED,
-		COMSIG_GIBS_STREAK,
 	))
 	qdel(GetComponent(/datum/component/connect_loc_behalf))

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -111,8 +111,6 @@
 	drydesc = "They look bloody and gruesome while some terrible smell fills the air."
 	decal_reagent = /datum/reagent/consumable/liquidgibs
 	reagent_amount = 5
-	///Information about the diseases our streaking spawns
-	var/list/streak_diseases
 
 /obj/effect/decal/cleanable/blood/gibs/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
@@ -120,7 +118,6 @@
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, PROC_REF(on_pipe_eject))
 
 /obj/effect/decal/cleanable/blood/gibs/Destroy()
-	LAZYNULL(streak_diseases)
 	return ..()
 
 /obj/effect/decal/cleanable/blood/gibs/replace_decal(obj/effect/decal/cleanable/C)
@@ -147,8 +144,7 @@
 	streak(dirs)
 
 /obj/effect/decal/cleanable/blood/gibs/proc/streak(list/directions, mapload=FALSE)
-	LAZYINITLIST(streak_diseases)
-	SEND_SIGNAL(src, COMSIG_GIBS_STREAK, directions, streak_diseases)
+	SEND_SIGNAL(src, COMSIG_GIBS_STREAK, directions)
 	var/direction = pick(directions)
 	var/delay = 2
 	var/range = pick(0, 200; 1, 150; 2, 50; 3, 17; 50) //the 3% chance of 50 steps is intentional and played for laughs.
@@ -170,7 +166,7 @@
 	SIGNAL_HANDLER
 	if(NeverShouldHaveComeHere(loc))
 		return
-	new /obj/effect/decal/cleanable/blood/splatter(loc, streak_diseases)
+	new /obj/effect/decal/cleanable/blood/splatter(loc)
 
 /obj/effect/decal/cleanable/blood/gibs/up
 	icon_state = "gibup1"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -317,11 +317,6 @@
 	// Clear moodlet if no miasma at all.
 		clear_mood_event("smell")
 	else
-		// Miasma sickness
-		if(prob(1 * miasma_pp))
-			var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(max_symptoms = 2, max_level = 3)
-			miasma_disease.name = "Unknown"
-			ForceContractDisease(miasma_disease, make_copy = TRUE, del_on_fail = TRUE)
 		// Miasma side-effects.
 		if (HAS_TRAIT(src, TRAIT_ANOSMIA)) //We can't feel miasma without sense of smell
 			return

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -462,14 +462,7 @@
 /obj/item/organ/internal/lungs/proc/too_much_miasma(mob/living/carbon/breather, datum/gas_mixture/breath, miasma_pp, old_miasma_pp)
 	// Inhale Miasma. Exhale nothing.
 	breathe_gas_volume(breath, /datum/gas/miasma)
-	// Miasma sickness
-	if(prob(0.5 * miasma_pp))
-		var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(max_symptoms = min(round(max(miasma_pp / 2, 1), 1), 6), max_level = min(round(max(miasma_pp, 1), 1), 8))
-		// tl;dr the first argument chooses the smaller of miasma_pp/2 or 6(typical max virus symptoms), the second chooses the smaller of miasma_pp or 8(max virus symptom level)
-		// Each argument has a minimum of 1 and rounds to the nearest value. Feel free to change the pp scaling I couldn't decide on good numbers for it.
-		if(breather.CanContractDisease(miasma_disease))
-			miasma_disease.name = "Unknown"
-			breather.AirborneContractDisease(miasma_disease, TRUE)
+
 	// Miasma side effects
 	if (HAS_TRAIT(breather, TRAIT_ANOSMIA)) //Anosmia quirk holder cannot smell miasma, but can get diseases from it.
 		return


### PR DESCRIPTION
## About The Pull Request
Removes miasma generating random viruses (in two locations for some reason)
Also removes diseases being generated by gibs, which is responsible for a lot of disease spam

## Why It's Good For The Game
New diseases are spread through events and virology (and some other minor sources). Miasma and gibs are a source of random viruses that dilutes player response to diseases. It's frankly exhausting curing the disease outbreak, just to see 10 others pop-up. Hopefully we can reduce the madness a bit and place more focus on individual diseases

## Changelog
:cl:
del: Miasma and gibs no longer generates random diseases
/:cl:

Something like lung rot could be cool though, but out of scope for the current PR