### PR TITLE
Adds symptom weights

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -266,6 +266,7 @@
 		properties["severity"] = round((properties["severity"] / 2), 1)
 		properties["severity"] *= (symptoms.len / VIRUS_SYMPTOM_LIMIT) //fewer symptoms, less severity
 		properties["severity"] = clamp(properties["severity"], 1, 7)
+	properties["capacity"] = get_symptom_weights()
 
 // Assign the properties that are in the list.
 /datum/disease/advance/proc/assign_properties()
@@ -341,7 +342,7 @@
 // Will generate a random cure, the more resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/generate_cure()
 	if(properties?.len)
-		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
+		var/res = clamp(properties["resistance"] - (symptoms.len * 0.5), 1, advance_cures.len)
 		if(res == oldres)
 			return
 		cures = list(pick(advance_cures[res]))
@@ -402,11 +403,9 @@
 
 // Add a symptom, if it is over the limit we take a random symptom away and add the new one.
 /datum/disease/advance/proc/AddSymptom(datum/symptom/S)
-
 	if(HasSymptom(S))
 		return
-
-	if(symptoms.len >= VIRUS_SYMPTOM_LIMIT)
+	while(get_symptom_weights() >= VIRUS_SYMPTOM_LIMIT)
 		RemoveSymptom(pick(symptoms))
 	symptoms += S
 	S.OnAdd(src)
@@ -422,6 +421,12 @@
 		S.neutered = TRUE
 		S.name += " (neutered)"
 		S.OnRemove(src)
+
+/// How much of the symptom capacity is currently being used?
+/datum/disease/advance/proc/get_symptom_weights()
+	. = 0
+	for(var/datum/symptom/symptom as anything in symptoms)
+		. += symptom.weight
 
 /*
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -405,7 +405,7 @@
 /datum/disease/advance/proc/AddSymptom(datum/symptom/S)
 	if(HasSymptom(S))
 		return
-	while(get_symptom_weights() >= VIRUS_SYMPTOM_LIMIT)
+	while(get_symptom_weights() > VIRUS_SYMPTOM_LIMIT + S.weight)
 		RemoveSymptom(pick(symptoms))
 	symptoms += S
 	S.OnAdd(src)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -10,6 +10,7 @@
 	name = "Cough"
 	desc = "The virus irritates the throat of the host, causing occasional coughing. Each cough will try to infect bystanders who are within 1 tile of the host with the virus."
 	illness = "Jest Infection"
+	weight = 2
 	stealth = -1
 	resistance = 3
 	stage_speed = 1

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -10,6 +10,7 @@
 	name = "Sneezing"
 	desc = "The virus causes irritation of the nasal cavity, making the host sneeze occasionally. Sneezes from this symptom will spread the virus in a 4 meter cone in front of the host."
 	illness = "Bard Flu"
+	weight = 2
 	stealth = -2
 	resistance = 3
 	stage_speed = 0

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -39,6 +39,8 @@
 	var/naturally_occuring = TRUE
 	///If the symptom requires an organ for the effects to function, robotic organs are immune to disease unless inorganic biology symptom is present
 	var/required_organ
+	/// How much space does this symptom use?
+	var/weight = 1
 
 /datum/symptom/New()
 	var/list/S = SSdisease.list_symptoms
@@ -106,6 +108,7 @@
 	var/list/data = list()
 	data["name"] = name
 	data["desc"] = desc
+	data["weight"] = weight
 	data["stealth"] = stealth
 	data["resistance"] = resistance
 	data["stage_speed"] = stage_speed

--- a/tgui/packages/tgui/interfaces/Pandemic/Symptom.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Symptom.tsx
@@ -70,7 +70,7 @@ const Thresholds = (props) => {
 /** Displays the numerical trait modifiers for a virus symptom */
 const Traits = (props) => {
   const {
-    symptom: { level, resistance, stage_speed, stealth, transmission },
+    symptom: { level, weight, resistance, stage_speed, stealth, transmission },
   } = props;
 
   return (
@@ -79,6 +79,11 @@ const Traits = (props) => {
         <Tooltip content="Rarity of the symptom.">
           <LabeledList.Item color={getColor(level)} label="Level">
             {level}
+          </LabeledList.Item>
+        </Tooltip>
+        <Tooltip content="The space the symptom takes.">
+          <LabeledList.Item color={getColor(weight)} label="Weight">
+            {weight}
           </LabeledList.Item>
         </Tooltip>
         <Tooltip content="Decides the cure complexity.">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds symptom weights. Sneeze and cough have double weighing

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Sneezing and coughing are very commonly used symptoms in order to mass spread diseases. They're usually a given since it gives everyone your virus. 

By increasing their weighting, mass spreaders are limited to less symptoms. Reduces station-wipe potential of lethal diseases and nerfs positive viruses by requiring people to actually go to medbay and get them (even if its just the pill table). 

We can make viruses less symptom heavy now that we don't have to worry about the virologists' enjoyment, making it less horrible to deal with. Instead of combusting, freezing, becoming blind, starving and your skin melting, you now wont starve (unless you got infected through fluids, but that's a lot more direct and avoidable so probably fine)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Sneezing and coughing symptoms have double the weighting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
