### PR TITLE
Halves advanced disease symptom cap from 6 to 3

### DIFF
--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -1,5 +1,5 @@
 #define DISEASE_LIMIT 1
-#define VIRUS_SYMPTOM_LIMIT 6
+#define VIRUS_SYMPTOM_LIMIT 3
 
 //Visibility Flags
 #define HIDDEN_SCANNER (1<<0)


### PR DESCRIPTION

## About The Pull Request
Reduces the symptom cap from 6 to 3

## Why It's Good For The Game
Symptom overstacking is a big problem of what causes virology to be overly negative or positive. Virology was originally limited to 3-4 symptoms, which was raised overtime as more symptoms got added. I think moving it back truly makes virology not super shitty to deal with.

I realize this severely limits what you can do with virology, but we no longer have to worry about keeping the virologist happy. This makes diseases a lot more enjoyable for the average crewman, even if less people feel motivated to touch virology. I think it's overal okay if it's touched less

This also makes it significantly harder to hit thresholds. I'll remove it afterwards if we get that far

Here's a roadmap for what's next: https://hackmd.io/@O4g2O7RHRN-GPst4jkW46A/r1HpGZp7R, but obviously no promises and I can die or get distracted at any point. Virology will be a little side-project you can do in the meantime, and that's okay. I think full removal would've given more certainty to everyone, but these were the requests MSO laid out

## Changelog
:cl:
balance: Halves the disease symptom cap
/:cl:
