### PR TITLE
Restrict AI floor bolt external manipulation

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -64,7 +64,7 @@
 	. = ..()
 	if(user.combat_mode)
 		return
-	if(stat != DEAD && !incapacitated() && client)
+	if(stat != DEAD && !incapacitated() && (client || deployed_shell?.client))
 		// alive and well AIs control their floor bolts
 		balloon_alert(user, "the AI's bolt motors resist.")
 		return ITEM_INTERACT_SUCCESS

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -64,6 +64,10 @@
 	. = ..()
 	if(user.combat_mode)
 		return
+	if(stat != DEAD && !incapacitated() && client)
+		// alive and well AIs control their floor bolts
+		balloon_alert(user, "the AI's bolt motors resist.")
+		return ITEM_INTERACT_SUCCESS
 	balloon_alert(user, "[!is_anchored ? "tightening" : "loosening"] bolts...")
 	balloon_alert(src, "bolts being [!is_anchored ? "tightened" : "loosened"]...")
 	if(!tool.use_tool(src, user, 4 SECONDS))


### PR DESCRIPTION

## About The Pull Request

My delayed reaction to #68451

**When an AI is alive, on main power, and not SSD its bolts cannot be raised or lowered externally thus returning some small amount of autonomy to everyone's favorite brain in a box.** 

I tested to be sure this change does not interfere with (de)construction or other tool actions besides their "must be anchored" requirements. Should maintainers wish I can adjust the check to allow external lowering, but not raising, of the bolts anytime to satisfy those scenarios.

I decided to include "is on backup power (incapacitated)" in the check as a middle ground so when moving an AI from a bombed sat or the like anyone who is now used to being able to wrench for a rescue is not caught off guard since AI gets a harsh penalty for moving bolts on backup power (most likely overlooked in the original PR). This also means if you really want to move an active AI Core against its will you still have a path forward aside from _convincing_ the AI to raise them voluntarily.

## Why It's Good For The Game

IMO this sort of check should have been included in the original changes, or at least made to post the anchor status message to the AI's chat rather than a balloon they are likely to miss. An incapacitated AI is much more likely to be watching their core.

In the grand scheme this changes very little for anyone out to get an AI since they will most likely just card or smash it to death anyway. It's mostly just good for a little silicon piece of mind.

## Changelog
:cl:
balance: When an AI is alive, on main power, and not SSD its bolts cannot be raised or lowered externally.
/:cl:
