### PR TITLE
Adds a random martial arts modifier to deathmatch + Adds a blacklisted map framework to modifiers

### DIFF
--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -491,12 +491,10 @@
 				return TRUE
 			var/datum/deathmatch_modifier/chosen_modifier = GLOB.deathmatch_game.modifiers[modpath]
 			if(modpath in modifiers)
-				chosen_modifier.unselect(src)
-				modifiers -= modpath
+				unselect_modifier(chosen_modifier)
 				return TRUE
 			if(chosen_modifier.selectable(src))
-				chosen_modifier.on_select(src)
-				modifiers += modpath
+				select_modifier(chosen_modifier)
 				return TRUE
 
 		if ("admin") // Admin functions
@@ -511,6 +509,15 @@
 
 	return FALSE
 
+/// Selects the passed modifier.
+/datum/deathmatch_lobby/proc/select_modifier(datum/deathmatch_modifier/modifier)
+	modifier.on_select(src)
+	modifiers += modifier.type
+
+/// Deselects the passed modifier.
+/datum/deathmatch_lobby/proc/unselect_modifier(datum/deathmatch_modifier/modifier)
+	modifier.unselect(src)
+	modifiers -= modifier.type
 
 /datum/deathmatch_lobby/ui_close(mob/user)
 	. = ..()

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -580,11 +580,10 @@
 		/datum/martial_art/the_sleeping_carp = 30,
 		// uncommon
 		/datum/martial_art/boxing/evil = 20,
-		// rare
-		/datum/martial_art/psychotic_brawling = 10, // a complete meme. sometimes you just get hardstunned. sometimes you punch someone across the room
 		// LEGENDARY
 		/datum/martial_art/plasma_fist = 5,
 		/datum/martial_art/wrestling = 5, // wrestling is kinda strong ngl
+		/datum/martial_art/psychotic_brawling = 5, // a complete meme. sometimes you just get hardstunned. sometimes you punch someone across the room
 	)
 
 /datum/deathmatch_modifier/martial_artistry/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -593,7 +593,7 @@
 	var/datum/martial_art/instantiated_art = new picked_art_path()
 
 	if (istype(instantiated_art, /datum/martial_art/boxing))
-		player.mind.adjust_experience(/datum/skill/athletics, SKILL_EXP_MASTER)
+		player.mind.adjust_experience(/datum/skill/athletics, SKILL_EXP_LEGENDARY)
 
 	instantiated_art.teach(player)
 

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -1,14 +1,16 @@
 ///Deathmatch modifiers are little options the host can choose to spice the match a bit.
 /datum/deathmatch_modifier
-	///The name of the modifier
+	/// The name of the modifier
 	var/name = "Unnamed Modifier"
-	///A small description/tooltip shown in the UI
+	/// A small description/tooltip shown in the UI
 	var/description = "What the heck does this do?"
-	///The color of the button shown in the UI
+	/// The color of the button shown in the UI
 	var/color = "blue"
-	///A list of modifiers this is incompatible with.
-	var/list/blacklisted_modifiers
-	///Is this trait exempted from the "Random Modifiers" modifier.
+	/// A lazylist of modifier typepaths this is incompatible with.
+	var/list/datum/deathmatch_modifier/blacklisted_modifiers
+	/// A lazylist of map typepaths this is incomptable with.
+	var/list/datum/lazy_template/deathmatch/blacklisted_maps
+	/// Is this trait exempted from the "Random Modifiers" modifier.
 	var/random_exempted = FALSE
 
 ///Whether or not this modifier can be selected, for both host and player-selected modifiers.
@@ -18,10 +20,19 @@
 		return FALSE
 	if(length(lobby.modifiers & blacklisted_modifiers))
 		return FALSE
+	if (map_incompatible(lobby.map))
+		return FALSE
 	for(var/modpath in lobby.modifiers)
 		if(src in GLOB.deathmatch_game.modifiers[modpath].blacklisted_modifiers)
 			return FALSE
 	return TRUE
+
+/// Returns TRUE if map.type is in our blacklisted maps, FALSE otherwise.
+/datum/deathmatch_modifier/proc/map_incompatible(datum/lazy_template/deathmatch/map)
+	if (map?.type in blacklisted_maps)
+		return TRUE
+
+	return FALSE
 
 ///Called when selecting the deathmatch modifier.
 /datum/deathmatch_modifier/proc/on_select(datum/deathmatch_lobby/lobby)
@@ -31,9 +42,12 @@
 /datum/deathmatch_modifier/proc/unselect(datum/deathmatch_lobby/lobby)
 	return
 
-///Called when the host chooses to change map.
+///Called when the host chooses to change map. Returns FALSE if the new map is incompatible, TRUE otherwise.
 /datum/deathmatch_modifier/proc/on_map_changed(datum/deathmatch_lobby/lobby)
-	return
+	if (map_incompatible(lobby.map))
+		lobby.unselect_modifier(src)
+		return FALSE
+	return TRUE
 
 ///Called as the game is about to start.
 /datum/deathmatch_modifier/proc/on_start_game(datum/deathmatch_lobby/lobby)
@@ -554,3 +568,30 @@
 		return
 
 	SSquirks.AssignQuirks(player, player.client)
+
+/datum/deathmatch_modifier/martial_artistry
+	name = "Random martial arts"
+	description = "Everyone learns a random martial art!"
+	blacklisted_maps = list(/datum/lazy_template/deathmatch/meatower)
+	var/static/list/weighted_martial_arts = list(
+		// common
+		/datum/martial_art/cqc = 30,
+		/datum/martial_art/the_sleeping_carp = 30,
+		// uncommon
+		/datum/martial_art/boxing/evil = 20,
+		/datum/martial_art/wrestling = 20,
+		// rare
+		/datum/martial_art/psychotic_brawling = 10,
+		/datum/martial_art/mushpunch = 10,
+		// LEGENDARY
+		/datum/martial_art/plasma_fist = 5,
+	)
+
+/datum/deathmatch_modifier/martial_artistry/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
+	. = ..()
+
+	var/datum/martial_art/picked_art_path = pick_weight(weighted_martial_arts)
+	var/datum/martial_art/instantiated_art = new picked_art_path()
+	instantiated_art.teach(player)
+
+	to_chat(player, span_revenboldnotice("Your martial art is [uppertext(instantiated_art.name)]!"))

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -547,7 +547,7 @@
 
 /datum/deathmatch_modifier/any_loadout/on_map_changed(datum/deathmatch_lobby/lobby)
 	if(lobby.loadouts == GLOB.deathmatch_game.loadouts) //This arena already allows any loadout for some reason.
-		lobby.modifiers -= type
+		lobby.unselect_modifier(src)
 	else
 		lobby.loadouts = GLOB.deathmatch_game.loadouts
 

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -573,6 +573,7 @@
 	name = "Random martial arts"
 	description = "Everyone learns a random martial art!"
 	blacklisted_maps = list(/datum/lazy_template/deathmatch/meatower)
+	// krav maga excluded because its too common and too simple, mushpunch excluded because its horrible and not even funny
 	var/static/list/weighted_martial_arts = list(
 		// common
 		/datum/martial_art/cqc = 30,
@@ -580,11 +581,10 @@
 		// uncommon
 		/datum/martial_art/boxing/evil = 20,
 		// rare
-		/datum/martial_art/wrestling = 10, // wrestling is kinda strong ngl
-		/datum/martial_art/psychotic_brawling = 10,
-		/datum/martial_art/mushpunch = 10,
+		/datum/martial_art/psychotic_brawling = 10, // a complete meme. sometimes you just get hardstunned. sometimes you punch someone across the room
 		// LEGENDARY
 		/datum/martial_art/plasma_fist = 5,
+		/datum/martial_art/wrestling = 5, // wrestling is kinda strong ngl
 	)
 
 /datum/deathmatch_modifier/martial_artistry/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
@@ -592,6 +592,10 @@
 
 	var/datum/martial_art/picked_art_path = pick_weight(weighted_martial_arts)
 	var/datum/martial_art/instantiated_art = new picked_art_path()
+
+	if (istype(instantiated_art, /datum/martial_art/boxing))
+		player.mind.adjust_experience(/datum/skill/athletics, SKILL_EXP_MASTER)
+
 	instantiated_art.teach(player)
 
 	to_chat(player, span_revenboldnotice("Your martial art is [uppertext(instantiated_art.name)]!"))

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -579,8 +579,8 @@
 		/datum/martial_art/the_sleeping_carp = 30,
 		// uncommon
 		/datum/martial_art/boxing/evil = 20,
-		/datum/martial_art/wrestling = 20,
 		// rare
+		/datum/martial_art/wrestling = 10, // wrestling is kinda strong ngl
 		/datum/martial_art/psychotic_brawling = 10,
 		/datum/martial_art/mushpunch = 10,
 		// LEGENDARY


### PR DESCRIPTION
## About The Pull Request

Title.

Uses pickweight, to ensure rare martial arts stay rare. 

Common:

* Carp
* CQC

Uncommon:
* EVIL boxing

LEGENDARY:
* Wrestling
* UNNERFED PLASMA FIST
* Psychotic brawling (bath salts, rare because its a meme)

Does not work on meat tower.
## Why It's Good For The Game

Variety is good! Also, theres only one way to get martial arts in DM and thats meat tower. There is ALSO very little way to get evil boxing, mushpunch, plasmafist, etc. This allows people to go absolutely nuts in death match, and I think thats a good thing.
## Changelog
:cl:
add: New deathmatch modifier: "Random martial arts"
/:cl:
