### PR TITLE
Adds additional type logging to nested feedback for all printed parts.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -353,6 +353,7 @@
 	created.pixel_x = created.base_pixel_x + rand(-6, 6)
 	created.pixel_y = created.base_pixel_y + rand(-6, 6)
 	created.forceMove(target)
+	SSblackbox.record_feedback("nested tally", "lathe_printed_items", 1, list("[type]", "[created.type]"))
 
 	if(is_stack)
 		items_remaining = 0

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -414,6 +414,7 @@
 
 	created.pixel_x = created.base_pixel_x + rand(-6, 6)
 	created.pixel_y = created.base_pixel_y + rand(-6, 6)
+	SSblackbox.record_feedback("nested tally", "lathe_printed_items", 1, list("[type]", "[created.type]"))
 
 	if(is_stack)
 		items_remaining = 0

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -260,22 +260,23 @@
  *
  * Returns FALSE is the machine cannot dispense the part on the appropriate turf.
  * Return TRUE if the part was successfully dispensed.
- * * D - Design datum to attempt to dispense.
+ * * dispensed_design - Design datum to attempt to dispense.
  */
-/obj/machinery/mecha_part_fabricator/proc/dispense_built_part(datum/design/D)
-	var/obj/item/I = new D.build_path(src)
+/obj/machinery/mecha_part_fabricator/proc/dispense_built_part(datum/design/dispensed_design)
+	var/obj/item/built_part = new dispensed_design.build_path(src)
+	SSblackbox.record_feedback("nested tally", "lathe_printed_items", 1, list("[type]", "[built_part.type]"))
 
 	being_built = null
 
 	var/turf/exit = get_step(src,(dir))
 	if(exit.density)
 		say("Error! The part outlet is obstructed.")
-		desc = "It's trying to dispense the fabricated [D.name], but the part outlet is obstructed."
-		stored_part = I
+		desc = "It's trying to dispense the fabricated [dispensed_design.name], but the part outlet is obstructed."
+		stored_part = built_part
 		return FALSE
 
-	say("The fabrication of [I] is now complete.")
-	I.forceMove(exit)
+	say("The fabrication of [built_part] is now complete.")
+	built_part.forceMove(exit)
 
 	top_job_id += 1
 


### PR DESCRIPTION

## About The Pull Request

What it says on the tin, this adds logging to nested_logging for autolathes, protolathes, and the mech fabricator.

Also quickly renames a variable name within the mech fabricator because this thing hasn't been updated in awhile and it was egregious to me.

## Why It's Good For The Game

I wanted to throw together a quick superset chart of what items are printed most often and how often, and was shocked to learn that it wasn't logged in this way.

It was recorded somewhat within the silo log, but this is MUCH easier to use all thing considered, so it's an easy fix.

## Changelog

No front facing changes.

