### PR TITLE
Saves profiler snapshots every 5 minutes

### DIFF
--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -56,12 +56,12 @@ SUBSYSTEM_DEF(profiler)
 
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
-	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(world.time * 0.1)].json")
+	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(world.time * 0.1, 10)].json")
 	if(fexists(prof_file))
 		fdel(prof_file)
 	if(!length(current_sendmaps_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, sendmaps profiling stopped manually before dump.")
-	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(world.time * 0.1)].json")
+	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(world.time * 0.1, 10)].json")
 	if(fexists(sendmaps_file))
 		fdel(sendmaps_file)
 

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -1,5 +1,5 @@
-#define PROFILER_FILENAME "profiler.json"
-#define SENDMAPS_FILENAME "sendmaps.json"
+#define PROFILER_FILENAME "profiler"
+#define SENDMAPS_FILENAME "sendmaps"
 
 SUBSYSTEM_DEF(profiler)
 	name = "Profiler"
@@ -58,12 +58,12 @@ SUBSYSTEM_DEF(profiler)
 
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
-	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(time_counter * wait * 0.1)]")
+	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(time_counter * wait * 0.1)].json")
 	if(fexists(prof_file))
 		fdel(prof_file)
 	if(!length(current_sendmaps_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, sendmaps profiling stopped manually before dump.")
-	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(time_counter * wait * 0.1)]")
+	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(time_counter * wait * 0.1)].json")
 	if(fexists(sendmaps_file))
 		fdel(sendmaps_file)
 

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -1,6 +1,3 @@
-#define PROFILER_FILENAME "profiler"
-#define SENDMAPS_FILENAME "sendmaps"
-
 SUBSYSTEM_DEF(profiler)
 	name = "Profiler"
 	init_order = INIT_ORDER_PROFILER
@@ -56,12 +53,12 @@ SUBSYSTEM_DEF(profiler)
 
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
-	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(world.time * 0.1, 10)].json")
+	var/prof_file = file("[GLOB.log_directory]/profiler/profiler-[round(world.time * 0.1, 10)].json")
 	if(fexists(prof_file))
 		fdel(prof_file)
 	if(!length(current_sendmaps_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, sendmaps profiling stopped manually before dump.")
-	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(world.time * 0.1, 10)].json")
+	var/sendmaps_file = file("[GLOB.log_directory]/profiler/sendmaps-[round(world.time * 0.1, 10)].json")
 	if(fexists(sendmaps_file))
 		fdel(sendmaps_file)
 
@@ -70,5 +67,3 @@ SUBSYSTEM_DEF(profiler)
 	WRITE_FILE(sendmaps_file, current_sendmaps_data)
 	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
-#undef PROFILER_FILENAME
-#undef SENDMAPS_FILENAME

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -5,9 +5,11 @@ SUBSYSTEM_DEF(profiler)
 	name = "Profiler"
 	init_order = INIT_ORDER_PROFILER
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
-	wait = 3000
+	wait = 300 SECONDS
 	var/fetch_cost = 0
 	var/write_cost = 0
+
+	var/time_counter = 0
 
 /datum/controller/subsystem/profiler/stat_entry(msg)
 	msg += "F:[round(fetch_cost,1)]ms"
@@ -56,16 +58,17 @@ SUBSYSTEM_DEF(profiler)
 
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
-	var/prof_file = file("[GLOB.log_directory]/[PROFILER_FILENAME]")
+	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(time_counter * wait * 0.1)]")
 	if(fexists(prof_file))
 		fdel(prof_file)
 	if(!length(current_sendmaps_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, sendmaps profiling stopped manually before dump.")
-	var/sendmaps_file = file("[GLOB.log_directory]/[SENDMAPS_FILENAME]")
+	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(time_counter * wait * 0.1)]")
 	if(fexists(sendmaps_file))
 		fdel(sendmaps_file)
 
 	timer = TICK_USAGE_REAL
+	time_counter++
 	WRITE_FILE(prof_file, current_profile_data)
 	WRITE_FILE(sendmaps_file, current_sendmaps_data)
 	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -9,8 +9,6 @@ SUBSYSTEM_DEF(profiler)
 	var/fetch_cost = 0
 	var/write_cost = 0
 
-	var/time_counter = 0
-
 /datum/controller/subsystem/profiler/stat_entry(msg)
 	msg += "F:[round(fetch_cost,1)]ms"
 	msg += "|W:[round(write_cost,1)]ms"
@@ -58,17 +56,16 @@ SUBSYSTEM_DEF(profiler)
 
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
-	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(time_counter * wait * 0.1)].json")
+	var/prof_file = file("[GLOB.log_directory]/profiler/[PROFILER_FILENAME]-[round(world.time * 0.1)].json")
 	if(fexists(prof_file))
 		fdel(prof_file)
 	if(!length(current_sendmaps_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, sendmaps profiling stopped manually before dump.")
-	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(time_counter * wait * 0.1)].json")
+	var/sendmaps_file = file("[GLOB.log_directory]/profiler/[SENDMAPS_FILENAME]-[round(world.time * 0.1)].json")
 	if(fexists(sendmaps_file))
 		fdel(sendmaps_file)
 
 	timer = TICK_USAGE_REAL
-	time_counter++
 	WRITE_FILE(prof_file, current_profile_data)
 	WRITE_FILE(sendmaps_file, current_sendmaps_data)
 	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))


### PR DESCRIPTION

## About The Pull Request
As the title says. Each saved snapshot will be named 
- `profiler-[TIME IN SECONDS].json`
- `sendmaps-[TIME IN SECONDS].json`

For example, `profiler-0.json`, `profiler-300.json`, `profiler-600.json` would correspond to a profile at the start of the round, a profile 300 seconds into a round and a profile 600 seconds into a round.

The timings depend on world.time, so it's probably not a good idea to rely on these timings to stay consistent.

## Why It's Good For The Game
Allows us to track performance of procs over time. Could allow us to spot any sort of anomalies or performance sinks.

CC: @MrStonedOne @bobbah @LemonInTheDark 
