### PR TITLE
Mail now only cares about the (real) name to open

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -14,8 +14,8 @@
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	/// Destination tagging for the mail sorter.
 	var/sort_tag = 0
-	/// Weak reference to who this mail is for and who can open it.
-	var/datum/weakref/recipient_ref
+	/// The real name that this mail is associated with, anyone with that real name can open it
+	var/associated_real_name
 	/// How many goodies this mail contains.
 	var/goodie_count = 1
 	/// Goodies which can be given to anyone. The base weight is 50. For there to be a 50/50 chance of getting a department item, they need 50 weight as well.
@@ -166,9 +166,9 @@
 	. += span_info("Distribute by hand or via destination tagger using the certified NT disposal system.")
 
 /// Accepts a mind to initialize goodies for a piece of mail.
-/obj/item/mail/proc/initialize_for_recipient(datum/mind/recipient)
-	name = "[initial(name)] for [recipient.name] ([recipient.assigned_role.title])"
-	recipient_ref = WEAKREF(recipient)
+/obj/item/mail/proc/initialize_for_recipient(mob/living/carbon/human/recipient)
+	associated_real_name = recipient.real_name
+	name = "[initial(name)] for [associated_real_name] ([recipient.mind.assigned_role.title])"
 
 	var/mob/living/body = recipient.current
 	var/list/goodies = generic_goodies
@@ -283,7 +283,7 @@
 		if(!(human.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
 
-		mail_recipients += human.mind
+		mail_recipients += human
 
 	for(var/i in 1 to mail_count)
 		var/obj/item/mail/new_mail

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -270,11 +270,11 @@
 /// Fills this mail crate with N pieces of mail, where N is the lower of the amount var passed, and the maximum capacity of this crate. If N is larger than the number of alive human players, the excess will be junkmail.
 /obj/structure/closet/crate/mail/proc/populate(amount)
 	var/mail_count = min(amount, storage_capacity)
-	// Fills the
 	var/list/mail_recipients = list()
 
 	for(var/mob/living/carbon/human/human in GLOB.player_list)
-		if(human.stat == DEAD || !human.mind)
+		// People who suicided are usually not very interesting to look for on the player side
+		if(HAS_TRAIT(human, TRAIT_SUICIDED) || !human.mind)
 			continue
 		// Skip wizards, nuke ops, cyborgs; Centcom does not send them mail
 		if(!(human.mind.assigned_role.job_flags & JOB_CREW_MEMBER))

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -289,7 +289,7 @@
 		else
 			new_mail = new /obj/item/mail/envelope(src)
 
-		var/datum/mind/recipient = pick_n_take(mail_recipients)
+		var/mob/living/carbon/human/recipient = pick_n_take(mail_recipients)
 		if(recipient)
 			new_mail.initialize_for_recipient(recipient)
 		else
@@ -349,7 +349,7 @@
 	atom_storage.set_holdable(list(
 		/obj/item/mail,
 		/obj/item/delivery/small,
-		/obj/item/paper
+		/obj/item/paper,
 	))
 
 /obj/item/paper/fluff/junkmail_redpill
@@ -553,8 +553,8 @@
 		else
 			shady_mail.name = mail_type
 	else
-		var/recipient_mob = mail_recipients[index].current
-		shady_mail.initialize_for_recipient(recipient_mob)
+		var/datum/mind/recipient_mind = mail_recipients[index]
+		shady_mail.initialize_for_recipient(recipient_mind.current)
 
 	atom_storage.hide_contents(user)
 	user.temporarilyRemoveItemFromInventory(src, force = TRUE)

--- a/code/modules/unit_tests/traitor_mail_content_check.dm
+++ b/code/modules/unit_tests/traitor_mail_content_check.dm
@@ -6,5 +6,5 @@
 	person.mind_initialize()
 	var/obj/item/mail/traitor/test_mail = allocate(/obj/item/mail/traitor)
 	person.mind.set_assigned_role(SSjob.GetJobType(/datum/job/captain))
-	test_mail.initialize_for_recipient(person.mind)
+	test_mail.initialize_for_recipient(person)
 	TEST_ASSERT_EQUAL(test_mail.contents.len, 0, "/obj/item/mail/traitor should not have items after initialize_for_recipient proc!")


### PR DESCRIPTION
## About The Pull Request

Fixes #73194

Instead of checking for a specific mind when opening, mail now only cares about your real name. In meaningful terms this means that paradox clones and changelings can open "their" mail, and I suppose if two people happen to name themselves the EXACT same thing they can open eachothers mail. The job of the intended recipient is still on there, but there are no checks to make sure you have that job or anything.
I also made it so dead people can receive mail, but not suicided people. My reasoning is that dead people are still part of the round, and maybe a cargo tech looking for them would be interesting, but suicided people are not really fun to interact with.

## Why It's Good For The Game

As funny as it is, mail keeps getting abused because it is an easily accessible mind datum check. This will make it so that paradox clones, changelings, and things of that ilk can avoid antag checks.

## Changelog

:cl: Seven
balance: Mail doesn't care about specific minds anymore, as long as your real name is whats on the envelope you will be able to open it. As a result paradox clones and changelings can now open mail "intended" for them.
balance: Dead people can now receive mail, but not if they committed suicide
/:cl:
