### PR TITLE
Probital and disgust vomit are knockdowns, not stuns

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1540,7 +1540,7 @@
 /datum/reagent/medicine/metafactor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
-		affected_mob.vomit(VOMIT_CATEGORY_DEFAULT)
+		affected_mob.vomit(VOMIT_CATEGORY_KNOCKDOWN)
 
 /datum/reagent/medicine/silibinin
 	name = "Silibinin"

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -216,7 +216,7 @@
 			if(SPT_PROB(pukeprob, seconds_per_tick)) //iT hAndLeS mOrE ThaN PukInG
 				disgusted.adjust_confusion(2.5 SECONDS)
 				disgusted.adjust_stutter(2 SECONDS)
-				disgusted.vomit(VOMIT_CATEGORY_DEFAULT, distance = 0)
+				disgusted.vomit(VOMIT_CATEGORY_KNOCKDOWN, distance = 0)
 			disgusted.set_dizzy_if_lower(10 SECONDS)
 		if(disgust >= DISGUST_LEVEL_DISGUSTED)
 			if(SPT_PROB(13, seconds_per_tick))


### PR DESCRIPTION

## About The Pull Request

Disgust vomit knocks you down rather than stunning you.

Mitogen Metabolism Factor knocks you down rather than stunning you.

## Why It's Good For The Game

> Disgust vomit knocks you down rather than stunning you.

With the recent update to rust causing disgust on tiles, you end up vomiting, getting stunned, accruing even more disgust on the tile, vomiting again. An endless cycle of misery. Vomits should suck, but I don't think they should stunlock.

> Mitogen Metabolism Factor knocks you down rather than stunning you.

Similarly, Mitogen Metabolism Factor makes you vomit when overdosed. This is normally fine, but fermichem always finds a way to ruin things - it can be made via inverse Probital and is a guaranteed chain-stunner for far too little effort.


Easy, cheap, hard-to-escape stunlocks are bad.

## Changelog

:cl:
qol: Disgust vomit knocks you down rather than stunning you.
del: Mitogen Metabolism Factor knocks you down rather than stunning you.
/:cl:

