### PR TITLE
Resolves beam rifle overtime issues

### DIFF
--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -71,6 +71,8 @@
 	var/current_zoom_x = 0
 	var/current_zoom_y = 0
 
+	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/trace = null
+
 /obj/item/gun/energy/beam_rifle/apply_fantasy_bonuses(bonus)
 	. = ..()
 	delay = modify_fantasy_variable("delay", delay, -bonus * 2)
@@ -192,16 +194,19 @@
 	if(diff < AIMING_BEAM_ANGLE_CHANGE_THRESHOLD && !force_update)
 		return
 	aiming_lastangle = lastangle
-	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
-	P.gun = src
-	P.wall_pierce_amount = wall_pierce_amount
-	P.structure_pierce_amount = structure_piercing
-	P.do_pierce = projectile_setting_pierce
+	// ONLY ONE at once (since fire can sleep)
+	if(trace)
+		QDEL_NULL(trace)
+	trace = new
+	trace.gun = src
+	trace.wall_pierce_amount = wall_pierce_amount
+	trace.structure_pierce_amount = structure_piercing
+	trace.do_pierce = projectile_setting_pierce
 	if(aiming_time)
 		var/percent = ((100/aiming_time)*aiming_time_left)
-		P.color = rgb(255 * percent,255 * ((100 - percent) / 100),0)
+		trace.color = rgb(255 * percent,255 * ((100 - percent) / 100),0)
 	else
-		P.color = rgb(0, 255, 0)
+		trace.color = rgb(0, 255, 0)
 	var/turf/curloc = get_turf(src)
 
 	var/atom/target_atom = current_user.client.mouse_object_ref?.resolve()
@@ -211,8 +216,9 @@
 			return
 		targloc = get_turf_in_angle(lastangle, curloc, 10)
 	var/mouse_modifiers = params2list(current_user.client.mouseParams)
-	P.preparePixelProjectile(targloc, current_user, mouse_modifiers, 0)
-	P.fire(lastangle)
+	trace.preparePixelProjectile(targloc, current_user, mouse_modifiers, 0)
+	trace.fire(lastangle)
+	trace = null
 
 /obj/item/gun/energy/beam_rifle/process()
 	if(!aiming)
@@ -259,6 +265,7 @@
 	aiming_time_left = aiming_time
 	aiming = FALSE
 	QDEL_LIST(current_tracers)
+	QDEL_NULL(trace)
 	stop_zooming(user)
 
 /obj/item/gun/energy/beam_rifle/proc/set_user(mob/user)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -814,6 +814,8 @@
 	RegisterSignal(src, COMSIG_ATOM_ATTACK_HAND, PROC_REF(attempt_parry))
 	if(hitscan)
 		process_hitscan()
+		if(QDELETED(src))
+			return
 	if(!(datum_flags & DF_ISPROCESSING))
 		START_PROCESSING(SSprojectiles, src)
 	pixel_move(pixel_speed_multiplier, FALSE) //move it now!
@@ -908,6 +910,9 @@
 				qdel(src)
 			return //Kill!
 		pixel_move(1, TRUE)
+		// No kevinz I do not care that this is a hitscan weapon, it is not allowed to travel 100 turfs in a tick
+		if(CHECK_TICK && QDELETED(src))
+			return
 
 /obj/projectile/proc/pixel_move(trajectory_multiplier, hitscanning = FALSE)
 	if(!loc || !trajectory)


### PR DESCRIPTION
## About The Pull Request

Ok so like, beam rifles send out tracer rounds right
We send out tracer rounds once every few seconds and if the mob or mouse moves.
The problem is those tracer rounds are hitscan, and hitscan projectiles don't like, wait to move.
So if I just drag my mouse a bunch I'm causin a bunch of hitscan attempts.

This might be ok, but what happens if I do it in space (the place with 100s of turfs empty of things to hit).
Anyway let's do some tick checking in hitscan's while loop so it can't eat seconds of cpu time uncontested

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/58055496/527b9bd1-4031-4a01-b4db-9e044270aa9b)

https://github.com/tgstation/tgstation/assets/58055496/2ce870f5-b65d-46e5-8dc3-11646c789290