### PR TITLE
Warden can now only use krav maga in security areas

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -243,3 +243,33 @@
 	bio = 90
 	fire = 80
 	acid = 50
+
+///Subtype of krav maga. Only used for the warden.
+/datum/martial_art/krav_maga/warden
+	name = "Krav Maga"
+	///List of all areas that Krav Maga will work in, defaults to Security.
+	var/list/warden_areas = list(/area/station/security)
+
+/// Refreshes the valid areas from the cook's mapping config, adding areas in config to the list of possible areas.
+/datum/martial_art/krav_maga/warden/proc/refresh_valid_areas()
+	var/list/additional_warden_areas = CHECK_MAP_JOB_CHANGE(JOB_WARDEN, "additional_warden_areas")
+	if(!additional_warden_areas)
+		return
+
+	if(!islist(additional_warden_areas))
+		stack_trace("Incorrect Krav Maga area format from mapping configs. Expected /list, got: \[[additional_warden_areas.type]\]")
+		return
+
+	for(var/path_as_text in additional_warden_areas)
+		var/path = text2path(path_as_text)
+		if(!ispath(path, /area))
+			stack_trace("Invalid path in mapping config for warden Krav Maga: \[[path_as_text]\]")
+			continue
+
+		warden_areas |= path
+
+/// Limits where the warden's krav maga can be used to only whitelisted areas.
+/datum/martial_art/krav_maga/warden/can_use(mob/living/martial_artist)
+	if(!is_type_in_list(get_area(martial_artist), warden_areas))
+		return FALSE
+	return ..()

--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -100,7 +100,6 @@
 	new /obj/item/clothing/suit/armor/vest/warden/alt(src)
 	new /obj/item/clothing/under/rank/security/warden/formal(src)
 	new /obj/item/clothing/under/rank/security/warden/skirt(src)
-	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -69,3 +69,5 @@
 
 	box = /obj/item/storage/box/survival/security
 	implants = list(/obj/item/implant/mindshield)
+
+	skillchips = list(/obj/item/skillchip/job/warden)

--- a/code/modules/library/skill_learning/job_skillchips/warden.dm
+++ b/code/modules/library/skill_learning/job_skillchips/warden.dm
@@ -1,0 +1,23 @@
+/obj/item/skillchip/job/warden
+	name = "JUST1C3 skillchip"
+	desc = "This biochip radiates justice, which fills you with confidence, with this wedged in your brain you be able to enforce justice."
+	skill_name = "Krav Maga"
+	skill_description = "A specialised form of self defence, developed by skilled wardens that will make the brig their playground."
+	skill_icon = "handcuffs"
+	activate_message = "<span class='notice'>You can visualize how to defend your brig with martial arts.</span>"
+	deactivate_message = "<span class='notice'>You forget how to control your muscles to execute kicks, slams and restraints while in a Security environment.</span>"
+	/// The Warden Krav Maga given by the skillchip.
+	var/datum/martial_art/krav_maga/warden/style
+
+/obj/item/skillchip/job/warden/Initialize(mapload)
+	. = ..()
+	style = new
+	style.refresh_valid_areas()
+
+/obj/item/skillchip/job/warden/on_activate(mob/living/carbon/user, silent = FALSE)
+	. = ..()
+	style.teach(user, make_temporary = TRUE)
+
+/obj/item/skillchip/job/warden/on_deactivate(mob/living/carbon/user, silent = FALSE)
+	style.fully_remove(user)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4389,6 +4389,7 @@
 #include "code\modules\library\skill_learning\job_skillchips\psychologist.dm"
 #include "code\modules\library\skill_learning\job_skillchips\roboticist.dm"
 #include "code\modules\library\skill_learning\job_skillchips\station_engineer.dm"
+#include "code\modules\library\skill_learning\job_skillchips\warden.dm"
 #include "code\modules\lighting\lighting_area.dm"
 #include "code\modules\lighting\lighting_atom.dm"
 #include "code\modules\lighting\lighting_corner.dm"


### PR DESCRIPTION
## About The Pull Request
This pr lets you use krav maga only in security areas it also makes it a skillchip warden starts it so other people cant powergame with it by stealing it from the warden(which its intended for and brig areas)

## Why It's Good For The Game
Gives warden a more flavor then just a better officer because they have gloves this will encourage them to stay in brig and perform their duties

## Changelog


:cl:
balance: Warden can only use krav maga in security areas now
/:cl:

