### PR TITLE
Fixes Minebots ordered through cargo being stuck in idle mode

### DIFF
--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -1,6 +1,6 @@
 /mob/living/basic/mining_drone
 	name = "\improper Nanotrasen minebot"
-	desc = "The instructions printed on the side read: This is a small robot used to support miners, can be set to search and collect loose ore, or to help fend off wildlife. Insert any type of ore into it to make it start listening to your commands!"
+	desc = "The instructions printed on the side read: This is a small robot used to support miners, can be set to search and collect loose ore, or to help fend off wildlife."
 	gender = NEUTER
 	icon = 'icons/mob/silicon/aibots.dmi'
 	icon_state = "mining_drone"
@@ -107,6 +107,8 @@
 
 	for(var/obj/item/borg/upgrade/modkit/modkit as anything in stored_gun.modkits)
 		. += span_notice("There is \a [modkit] installed, using <b>[modkit.cost]%</b> capacity.")
+	if(ai_controller && ai_controller.ai_status == AI_STATUS_IDLE)
+		. += "The [src] appears to be in <b>sleep mode</b>. You can return it to normal function by <b>tapping</b> it."
 
 
 /mob/living/basic/mining_drone/welder_act(mob/living/user, obj/item/welder)
@@ -132,7 +134,10 @@
 
 /mob/living/basic/mining_drone/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	if(!user.combat_mode)
-		ui_interact(user)
+		if(ai_controller && ai_controller.ai_status == AI_STATUS_IDLE)
+			ai_controller.set_ai_status(AI_STATUS_ON)
+		if(LAZYACCESS(modifiers, LEFT_CLICK))
+			ui_interact(user) //Lets Right Click be specifically for re-enabling their AI, while Left Click simply does both.
 		return
 	return ..()
 

--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -108,7 +108,7 @@
 	for(var/obj/item/borg/upgrade/modkit/modkit as anything in stored_gun.modkits)
 		. += span_notice("There is \a [modkit] installed, using <b>[modkit.cost]%</b> capacity.")
 	if(ai_controller && ai_controller.ai_status == AI_STATUS_IDLE)
-		. += "The [src] appears to be in <b>sleep mode</b>. You can return it to normal function by <b>tapping</b> it."
+		. += "The [src] appears to be in <b>sleep mode</b>. You can restore normal functions by <b>tapping</b> it."
 
 
 /mob/living/basic/mining_drone/welder_act(mob/living/user, obj/item/welder)
@@ -136,7 +136,7 @@
 	if(!user.combat_mode)
 		if(ai_controller && ai_controller.ai_status == AI_STATUS_IDLE)
 			ai_controller.set_ai_status(AI_STATUS_ON)
-		if(LAZYACCESS(modifiers, LEFT_CLICK)) //Lets Right Click be specifically for re-enabling their AI, while Left Click simply does both.
+		if(LAZYACCESS(modifiers, LEFT_CLICK)) //Lets Right Click be specifically for re-enabling their AI (and avoiding the UI popup), while Left Click simply does both.
 			ui_interact(user)
 		return
 	return ..()

--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -136,8 +136,8 @@
 	if(!user.combat_mode)
 		if(ai_controller && ai_controller.ai_status == AI_STATUS_IDLE)
 			ai_controller.set_ai_status(AI_STATUS_ON)
-		if(LAZYACCESS(modifiers, LEFT_CLICK))
-			ui_interact(user) //Lets Right Click be specifically for re-enabling their AI, while Left Click simply does both.
+		if(LAZYACCESS(modifiers, LEFT_CLICK)) //Lets Right Click be specifically for re-enabling their AI, while Left Click simply does both.
+			ui_interact(user)
 		return
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
- Presumably due to being spawned off-station on (I believe) the centcomm Z-level, Minebots ordered via points and that are delivered by the shuttle are stuck with their AI in the idle state. Rather than override a bunch of base-level AI code, I made clicking on them set their status to active. Right-clicking will set this without opening the bot's UI, while left-clicking will do both. Examine text now gives users a hint about this.

- Removed text about feeding the mining bot ore to befriend it, as this functionality was removed in an earlier PR.
## Why It's Good For The Game
Bugfix.
## Changelog
:cl:
fix: Minebots purchased via mining points are no longer stuck in idle mode. Clicking on them will activate their AI.
spellcheck: Removed the examine text about feeding ore to minebots; this functionality was removed already.
/:cl:
