### PR TITLE
Removes logging each lua function called on the dm side of things.

### DIFF
--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -112,7 +112,6 @@ GLOBAL_PROTECT(lua_usr)
 			new_function_path += path_element
 		function = new_function_path
 	var/msg = "[key_name(usr)] called the lua function \"[function]\" with arguments: [english_list(call_args)]"
-	log_lua(msg)
 
 	var/tmp_usr = GLOB.lua_usr
 	GLOB.lua_usr = usr

--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -111,7 +111,6 @@ GLOBAL_PROTECT(lua_usr)
 		for(var/path_element in function)
 			new_function_path += path_element
 		function = new_function_path
-	var/msg = "[key_name(usr)] called the lua function \"[function]\" with arguments: [english_list(call_args)]"
 
 	var/tmp_usr = GLOB.lua_usr
 	GLOB.lua_usr = usr


### PR DESCRIPTION

## About The Pull Request
As the title says. This should significantly improve the performance of running lua scripts.

## Why It's Good For The Game
There is a lot of performance overhead in logging each individual function called by a lua script as can be seen in the following screenshot:
This is a test done on a local server where I run the `zombie_controller.lua` script that can be found on the auxlua-cookbook repository with a lot of AI zombies spawned in.
![image](https://github.com/tgstation/tgstation/assets/37270891/fb8ee2d8-0b4c-49d7-823a-a552cde6cb10)
![image](https://github.com/tgstation/tgstation/assets/37270891/186c2cb0-82f9-4914-bd29-df19e1c0dbe1)

Logging these calls is not necessary as it doesn't provide any real information to anyone looking for bad actors. Lua scripts are already logged when ran and they can be examined to spot if the script being run is done so in bad faith.
