### PR TITLE
Rewords Adrenaline glands changeling ability

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
 	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 30 chemicals."
-	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
+	helptext = "Removes all non stamina stuns instantly while increasing stamina regeneration and speed, adds a short-term baton knockdown immunity and stamina regeneration. Can be used while unconscious. Continued use poisons the body."
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
 	dna_cost = 2

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
 	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 30 chemicals."
-	helptext = "Removes all non stamina stuns instantly while increasing stamina regeneration and speed, adds a short-term baton knockdown immunity and stamina regeneration. Can be used while unconscious. Continued use poisons the body."
+	helptext = "Removes all non stamina stuns instantly while increasing stamina regeneration and movement speed, adds a short-term baton knockdown immunity and stamina regeneration. Can be used while unconscious. Continued use poisons the body."
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
 	dna_cost = 2


### PR DESCRIPTION
## About The Pull Request
This pr rewords the changeling adrenaline ability to what it auctally does, since it wasn't updated since the chem rework this is an alternative to #83474

## Why It's Good For The Game
So new players don't get false advertisement what the ability auctally does(glorified ephedrine with a paraylize removal)

:cl:
qol: makes changeling adrenaline description more clear to players
/:cl: