### PR TITLE
Allows the fermenting (wooden) barrel to be emptied and to be wrenched + add contextual helpers to help visualize its interactions

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -10,7 +10,9 @@
 	anchored = FALSE
 	pressure_resistance = 2 * ONE_ATMOSPHERE
 	max_integrity = 300
+	/// Is the barrel currently opened?
 	var/open = FALSE
+	/// Can the barrel be opened?
 	var/can_open = TRUE
 	/// The amount of reagents that can be created from the contained products, used for validation
 	var/potential_volume = 0
@@ -20,7 +22,9 @@
 	var/sound_volume = 25
 	/// The sound of fermentation
 	var/datum/looping_sound/boiling/soundloop
+	/// Sound played when the lid is opened.
 	var/lid_open_sound = 'sound/items/handling/cardboardbox_pickup.ogg'
+	/// Sound played when the lid is closed.
 	var/lid_close_sound = 'sound/effects/footstep/woodclaw2.ogg'
 
 /obj/structure/fermenting_barrel/Initialize(mapload)
@@ -28,6 +32,7 @@
 	create_reagents(600, DRAINABLE)
 	soundloop = new(src, fermenting)
 	soundloop.volume = sound_volume
+	register_context()
 
 	RegisterSignals(src, list(
 		SIGNAL_ADDTRAIT(TRAIT_WAS_RENAMED),
@@ -46,6 +51,7 @@
 		var/fruit_count = contents.len
 		if(fruit_count)
 			. += span_notice("It contains [fruit_count] fruit\s ready to be fermented.")
+			. += span_notice("[EXAMINE_HINT("Right-click")] to take them out of [src].")
 		. += span_notice("It is currently open, letting you fill it with fruits or reagents.")
 	else
 		. += span_notice("It is currently closed, letting it ferment fruits or draw reagents from its tap.")
@@ -85,6 +91,26 @@
 		stop_fermentation()
 	update_appearance(UPDATE_ICON)
 
+/obj/structure/fermenting_barrel/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return .
+
+	if(!open)
+		return .
+
+	if(!length(contents))
+		balloon_alert(user, "empty!")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	dump_contents()
+	balloon_alert(user, "emptied [src]")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/structure/fermenting_barrel/wrench_act(mob/living/user, obj/item/tool)
+	if(default_unfasten_wrench(user, tool) == SUCCESSFUL_UNFASTEN)
+		return ITEM_INTERACT_SUCCESS
+
 /obj/structure/fermenting_barrel/update_icon_state()
 	icon_state = open ? "barrel_open" : "barrel"
 	return ..()
@@ -97,6 +123,28 @@
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_WAS_RENAMED) || HAS_TRAIT(src, TRAIT_HAS_LABEL))
 		. += mutable_appearance(icon, "[base_icon_state]_overlay_label")
+
+/obj/structure/fermenting_barrel/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = open ? "Close" : "Open"
+
+		if(open && length(contents))
+			context[SCREENTIP_CONTEXT_RMB] = "Empty"
+
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(held_item.tool_behaviour == TOOL_WRENCH)
+		context[SCREENTIP_CONTEXT_LMB] = anchored ? "Unanchor" : "Anchor"
+
+	else if(open && (istype(held_item, /obj/item/food/grown) || istype(held_item, /obj/item/storage/bag/plants)))
+		context[SCREENTIP_CONTEXT_LMB] = "Add to barrel"
+
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/structure/fermenting_barrel/dump_contents()
+	var/atom/drop_point = drop_location()
+	for(var/obj/item/food/grown/fruit as anything in contents)
+		fruit.forceMove(drop_point)
 
 /// Adds the fruit to the barrel to queue the fermentation
 /obj/structure/fermenting_barrel/proc/insert_fruit(mob/user, obj/item/food/grown/fruit, obj/item/storage/bag/plants/bag = null)


### PR DESCRIPTION
## About The Pull Request
Wooden barrels can now be wrenched down to be anchored, which should make them a lot more convenient if you want to avoid people constantly pushing them around.

They can also now be emptied by right-clicking with an empty hand, to help with accidents that do unfortunately happen, like when you add an additional fruit that you didn't mean to add to the barrel on accident.

I also figured I'd improve its readability by giving it contextual helpers, and I'm quite pleased with the results.

## Why It's Good For The Game
More QoL functionalities is always good. More controls visibility is just better for accessibility.

## Changelog

:cl: GoldenAlpharex
qol: Fermenting (wooden) barrels can now be emptied when opened by right-clicking with an empty hand!
qol: Fermenting (wooden) barrels can now be anchored/unanchored using wrenches!
qol: Fermenting (wooden) barrels now have contextual helpers, to show what you need to do at a glance to interact with them.
code: Documented a few of the fermenting barrel's variables.
/:cl: