### PR TITLE
Transforms the chat feedback of cutting down logs and pulling cotton into balloon alerts, and simplifies their merging code

### DIFF
--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -38,8 +38,8 @@
 	if(seed)
 		cotton_count += round(seed.potency / 25)
 
-	user.balloon_alert(user, "pulled [cotton_count] piece\s of [cotton_name]!")
-	new cotton_type(user.loc, cotton_count)
+	user.balloon_alert(user, "pulled [cotton_count] piece\s")
+	new cotton_type(user.drop_location(), cotton_count)
 	qdel(src)
 
 

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -34,26 +34,14 @@
 	var/cotton_name = "raw cotton"
 
 /obj/item/grown/cotton/attack_self(mob/user)
-	user.show_message(span_notice("You pull some [cotton_name] out of the [name]!"), MSG_VISUAL)
-	var/seed_modifier = 0
+	var/cotton_count = 1
 	if(seed)
-		seed_modifier = round(seed.potency / 25)
-	var/obj/item/stack/cotton = new cotton_type(user.loc, 1 + seed_modifier)
-	var/old_cotton_amount = cotton.amount
-	for(var/obj/item/stack/potential_stack in user.loc)
-		if(QDELETED(potential_stack))
-			continue
-		if(potential_stack == cotton)
-			continue
-		if(!istype(potential_stack, cotton_type))
-			continue
-		if(potential_stack.amount >= potential_stack.max_amount)
-			continue
-		potential_stack.attackby(cotton, user)
+		cotton_count += round(seed.potency / 25)
 
-	if(cotton.amount > old_cotton_amount)
-		to_chat(user, span_notice("You add the newly-formed [cotton_name] to the stack. It now contains [cotton.amount] [cotton_name]."))
+	user.balloon_alert(user, "pulled [cotton_count] piece\s of [cotton_name]!")
+	new cotton_type(user.loc, cotton_count)
 	qdel(src)
+
 
 //reinforced mutated variant
 /obj/item/seeds/cotton/durathread

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -84,7 +84,7 @@
 		if(seed)
 			plank_count += round(seed.potency / 25)
 
-		user.balloon_alert(user, "made [plank_count] [plank_name]!")
+		user.balloon_alert(user, "made [plank_count] [plank_name]")
 		new plank_type(user.loc, plank_count)
 		qdel(src)
 		return
@@ -92,7 +92,7 @@
 	if(CheckAccepted(attacking_item))
 		var/obj/item/food/grown/leaf = attacking_item
 		if(HAS_TRAIT(leaf, TRAIT_DRIED))
-			user.show_message(span_notice("You wrap [attacking_item] around the log, turning it into a torch!"))
+			user.balloon_alert(user, "torch crafted")
 			var/obj/item/flashlight/flare/torch/new_torch = new /obj/item/flashlight/flare/torch(user.loc)
 			user.dropItemToGround(attacking_item)
 			user.put_in_active_hand(new_torch)
@@ -100,7 +100,7 @@
 			qdel(src)
 			return
 		else
-			balloon_alert(user, "dry [attacking_item] first!")
+			balloon_alert(user, "dry it first!")
 	else
 		return ..()
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -78,33 +78,29 @@
 
 	return NONE
 
-/obj/item/grown/log/attackby(obj/item/W, mob/user, params)
-	if(W.get_sharpness())
-		user.show_message(span_notice("You make [plank_name] out of \the [src]!"), MSG_VISUAL)
-		var/seed_modifier = 0
+/obj/item/grown/log/attackby(obj/item/attacking_item, mob/user, params)
+	if(attacking_item.get_sharpness())
+		var/plank_count = 1
 		if(seed)
-			seed_modifier = round(seed.potency / 25)
-		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier, FALSE)
-		var/old_plank_amount = plank.amount
-		for (var/obj/item/stack/ST in user.loc)
-			if (ST != plank && istype(ST, plank_type) && ST.amount < ST.max_amount)
-				ST.attackby(plank, user) //we try to transfer all old unfinished stacks to the new stack we created.
-		if (plank.amount > old_plank_amount)
-			to_chat(user, span_notice("You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name]."))
-		qdel(src)
+			plank_count += round(seed.potency / 25)
 
-	if(CheckAccepted(W))
-		var/obj/item/food/grown/leaf = W
+		user.balloon_alert(user, "made [plank_count] [plank_name]!")
+		new plank_type(user.loc, plank_count)
+		qdel(src)
+		return
+
+	if(CheckAccepted(attacking_item))
+		var/obj/item/food/grown/leaf = attacking_item
 		if(HAS_TRAIT(leaf, TRAIT_DRIED))
-			user.show_message(span_notice("You wrap \the [W] around the log, turning it into a torch!"))
-			var/obj/item/flashlight/flare/torch/T = new /obj/item/flashlight/flare/torch(user.loc)
-			usr.dropItemToGround(W)
-			usr.put_in_active_hand(T)
+			user.show_message(span_notice("You wrap [attacking_item] around the log, turning it into a torch!"))
+			var/obj/item/flashlight/flare/torch/new_torch = new /obj/item/flashlight/flare/torch(user.loc)
+			user.dropItemToGround(attacking_item)
+			user.put_in_active_hand(new_torch)
 			qdel(leaf)
 			qdel(src)
 			return
 		else
-			to_chat(usr, span_warning("You must dry this first!"))
+			balloon_alert(user, "dry [attacking_item] first!")
 	else
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request
Anyone that's ever played botany knows that cutting down tower cap logs simply nukes your chat, it used to spam it with ***three*** messages for each log that's been turned into planks.

*Not anymore!*

Now, it simply shows you a balloon alert to inform you of how many planks you've created. Not only that, but it also cleans up the code that was being used there, instead letting the stacks attempt to merge on their own, rather than having their own implementation, which is what led to cotton bundles to cause runtimes from trying to merge things manually after accidentally having the spawned raw cotton being merged automatically.

It also has the benefit of no longer causing the final stack of items to move all over the place every time you cut a log, instead it stays in place until it's full, and *only then* does a new one appear at a random position on the tile, making it a lot less annoying when cutting logs whilst standing on the same tile as them.

## Why It's Good For The Game
Less chat spam is *always* good. You don't *need* a live update to the count of planks in your plank stack, you can just shift-click it to examine it to know. Much, much neater that way.

## Changelog

:cl: GoldenAlpharex
qol: Grown logs no longer spam your chat when cut into planks, instead displaying balloon alerts informing you of how many planks were made!
qol: Cotton and Durathread bundles no longer spam your chat either, and display a balloon alert instead.
fix: Cotton and Durathread bundles no longer runtime when creating raw cotton/durathread from the created stack having been merged with an existing one.
/:cl: