### PR TITLE
Fix issues resulting from an elevated object being created inside of a non-turf atom

### DIFF
--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -18,8 +18,9 @@
 	if(ismovable(target))
 		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 
-	var/turf/turf = get_turf(target)
-	if(turf)
+	var/atom/atom_target = target
+	if(isturf(atom_target.loc))
+		var/turf/turf = atom_target.loc
 		if(!HAS_TRAIT(turf, TRAIT_TURF_HAS_ELEVATED_OBJ(pixel_shift)))
 			RegisterSignal(turf, COMSIG_TURF_RESET_ELEVATION, PROC_REF(check_elevation))
 			RegisterSignal(turf, COMSIG_TURF_CHANGE, PROC_REF(pre_change_turf))


### PR DESCRIPTION
## About The Pull Request

If an elevated object is initialized inside of a non-turf atom, it'll still make the turf it is on elevated. Permanently. Which is weird.

## Why It's Good For The Game

Randomly elevated turfs are bad. Bugs bad.

## Changelog
:cl:
fix: Fix a rare issue where a turf would remain permanently "elevated" if an elevated object was initialized inside of a non-turf object.
/:cl:
