### PR TITLE
[no GBP] Corrupt organs check patient for Holy Water, not surgeon

### DIFF
--- a/code/datums/elements/corrupted_organ.dm
+++ b/code/datums/elements/corrupted_organ.dm
@@ -27,7 +27,7 @@
 	return ..()
 
 /// When we're taken out of someone, do something spooky
-/datum/element/corrupted_organ/proc/on_removed(atom/organ, mob/living/carbon/loser)
+/datum/element/corrupted_organ/proc/on_removed(atom/organ, mob/living/remover, mob/living/carbon/loser)
 	SIGNAL_HANDLER
 	if (loser.has_reagent(/datum/reagent/water/holywater) || loser.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) || prob(20))
 		return


### PR DESCRIPTION
## About The Pull Request

Was looking into #83493 and I have no idea how that happens but I _did_ notice this unrelated runtime and logic error.
Due to the args being incorrect, we were checking the status of the surgeon performing the operation rather than the person the organ was being removed from.

## Changelog

:cl:
fix: When removing a corrupted organ from a patient, the patient will now be checked for Holy Water or magic resistance, rather than the person performing the surgery.
/:cl:
