### PR TITLE
Fixes missing access helper, incorrect disposal variant on Northstar medbay

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -31357,6 +31357,7 @@
 	name = "Medbay Lockdown Shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ihQ" = (
@@ -50672,7 +50673,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/disposal/bin/tagger,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mZT" = (


### PR DESCRIPTION

## About The Pull Request
Fixes #83469

![image](https://github.com/tgstation/tgstation/assets/7019927/86b1fbfe-6a36-4170-b5c2-2eabd45cb762)

![image](https://github.com/tgstation/tgstation/assets/7019927/dff50356-799a-4aa5-97a4-2885be2aad23)

## Why It's Good For The Game
~~I need GBP~~ People not being trapped in Medbay until a doctor lets them out is good, also wrong variants of things isn't a huge issue but it's not supposed to be there, so I might as well fix it

## Changelog
:cl: Vekter
fix: Fixed a missing access helper in Northstar Medbay. Assistants should no longer be trapped post-mending.
fix: Replaced an incorrect disposal variant in Northstar's Medbay.
/:cl:
