### PR TITLE
Check if drone is inside an object, and call the object's relaymove() proc and return

### DIFF
--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -110,5 +110,10 @@
 	if(!direction)
 		return
 
+	if(ismovable(shell.loc)) //Inside an object, tell it we moved
+		var/atom/loc_atom = shell.loc
+		loc_atom.relaymove(shell, direction)
+		return
+
 	if(shell.Process_Spacemove(direction))
 		shell.Move(get_step(shell, direction), direction)


### PR DESCRIPTION

## About The Pull Request
This PR adds an additional check for drones when they're inside a container, and properly calls the inherited proc `relaymove()`

## Why It's Good For The Game
This fixes bugs related to objects that can store living mobs, and properly calls the `relaymove()` related functions needed when leaving/exiting said object.

https://github.com/tgstation/tgstation/assets/80724828/b5adeb49-9205-4e70-aeef-ad0428ee5e54

https://github.com/tgstation/tgstation/assets/80724828/615e2a01-802f-44e8-8750-b39bd11aad70

## Changelog
:cl:
fix: Drones stored inside objects will call the stored object's relaymove() and return upon move
/:cl:
