### PR TITLE
Make Watcher Wreath Bounties Completable

### DIFF
--- a/code/modules/cargo/bounties/mining.dm
+++ b/code/modules/cargo/bounties/mining.dm
@@ -46,16 +46,17 @@
 /datum/bounty/item/mining/watcher_wreath
 	name = "Watcher Wreaths"
 	description = "Station 14's Research Director thinks they're onto a break-through on the cultural icons of some pagan beliefs. Ship them a few watcher wreaths for analysis."
+	include_subtypes = FALSE
 	reward = CARGO_CRATE_VALUE * 15
 	required_count = 3
-	wanted_types = list(/obj/item/clothing/neck/wreath = FALSE)
+	wanted_types = list(/obj/item/clothing/neck/wreath = TRUE)
 
 /datum/bounty/item/mining/icewing_wreath
 	name = "Icewing Wreath"
 	description = "We're getting some....weird messages from Station 14's Research Director. And most of what they said was incoherent. But they apparently want an icewing wreath. Could you send them one?"
 	reward = CARGO_CRATE_VALUE * 30
 	required_count = 1
-	wanted_types = list(/obj/item/clothing/neck/wreath/icewing = FALSE)
+	wanted_types = list(/obj/item/clothing/neck/wreath/icewing = TRUE)
 
 /datum/bounty/item/mining/bone_dagger
 	name = "Bone Daggers"


### PR DESCRIPTION

## About The Pull Request
Initial PR here: https://github.com/NovaSector/NovaSector/pull/2694

This is a proposed fix for an issue reported downstream on https://github.com/NovaSector/NovaSector/issues/2198 and requested to be put upstream where watcher wreath bounties were not accepting the items they state they want. The root of the issue seemed to be the FALSE flags attached to the wanted_types. include_subtypes can be used for what might have been the intended effect of having only ice wreaths for the ice bounty and normal wreaths for the normal bounty.

## Why It's Good For The Game
This bug would prevent someone from being able to do any bounties until the 5 minute timer to refresh the bounty options passed. Less wait time on undoable tasks means more time spent interacting with the round.

## Changelog
:cl:
fix: fixed watcher wreath bounties being incompletable
/:cl:
