### PR TITLE
Correct Sign In Cooldown Timestamp

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -107,7 +107,7 @@
 #define COOLDOWN_START(cd_source, cd_index, cd_time) (cd_source.cd_index = world.time + (cd_time))
 
 //Returns true if the cooldown has run its course, false otherwise
-#define COOLDOWN_FINISHED(cd_source, cd_index) (cd_source.cd_index < world.time)
+#define COOLDOWN_FINISHED(cd_source, cd_index) (cd_source.cd_index <= world.time)
 
 #define COOLDOWN_RESET(cd_source, cd_index) cd_source.cd_index = 0
 


### PR DESCRIPTION
## About The Pull Request
Okay, so we got timestamp here:
```dm
#define COOLDOWN_START(cd_source, cd_index, cd_time) (cd_source.cd_index = world.time + (cd_time))
```
Now we check if we are good to go:
```dm
#define COOLDOWN_FINISHED(cd_source, cd_index) (cd_source.cd_index < world.time)
```
But the problem is that only proper sign for the macro above is "<=" (cd_source.cd_index <= world.time). Since it will skip equality otherwise, and we are checking for finished state.


## Why It's Good For The Game
Well, wrong logic yeah? It ruins everything when we need precise data. Like if we are using timestamps for correct move delays and gliding.


## Changelog

:cl:
fix: Сertain cooldowns should now be more accurate and will no longer take an extra decisecond to clear.
/:cl: