### PR TITLE
Adds an ion storm law that affects the humanity status of station pets

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -112,10 +112,13 @@
 	//of possible laws for best effect. Unless you want the crew having to drink hamburgers.
 	var/ionfood = pick_list(ION_FILE, "ionfood")
 	var/iondrinks = pick_list(ION_FILE, "iondrinks")
+	//Pets or other cuddly things. The point is to make them either important or (in Poly's case) make the AI listen to them.
+	//I can't check for lawsets so it's random what comes back.
+	var/ionpet = pick_list(ION_FILE, "ionpet")
 
 	var/message = ""
 
-	switch(rand(1,41))
+	switch(rand(1,46))
 		if(1 to 3) //There are # X on the station
 			switch(rand(1,3)) //What is X?
 				if(1) //X is a threat
@@ -568,5 +571,27 @@
 							message = "ALL [ionthreats] ARE NOW NAMED [ionspecies]."
 						if(4)
 							message = "ALL [ionthreats] ARE NOW NAMED [ionobjects]."
+		if(42 to 46)//Pets are something else now
+			switch(rand(1,4))//What are they now?
+				if(1)//They're a human
+					message = "[ionpet] IS HUMAN"
+				if(2)//I want this to roll multiple times and can't figure out a better way, please help)
+					message = "[ionpet] IS HUMAN"
+				if(3)
+					message = "[ionpet] IS HUMAN"
+				if(4)//They're something else (This is to cover for other lawsets)
+					switch(rand(1,6))
+						if(1)
+							message = "[ionpet] IS NON-HUMAN"
+						if(2)
+							message = "[ionpet] IS A CREWMEMBER"
+						if(3)
+							message = "[ionpet] IS EXPENSIVE TO REPLACE"
+						if(4)
+							message = "[ionpet] IS HARMFUL TO HUMANS"
+						if(5)
+							message = "[ionpet] IS A REAL AMERICAN"
+						if(6)
+							message = "[ionpet] IS A NUTSHELL"
 
 	return message

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -573,11 +573,7 @@
 							message = "ALL [ionthreats] ARE NOW NAMED [ionobjects]."
 		if(42 to 46)//Pets are something else now
 			switch(rand(1,4))//What are they now?
-				if(1)//They're a human
-					message = "[ionpet] IS HUMAN"
-				if(2)//I want this to roll multiple times and can't figure out a better way, please help)
-					message = "[ionpet] IS HUMAN"
-				if(3)
+				if(1 to 3)//They're a human
 					message = "[ionpet] IS HUMAN"
 				if(4)//They're something else (This is to cover for other lawsets)
 					switch(rand(1,6))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -571,23 +571,22 @@
 							message = "ALL [ionthreats] ARE NOW NAMED [ionspecies]."
 						if(4)
 							message = "ALL [ionthreats] ARE NOW NAMED [ionobjects]."
-		if(42 to 46)//Pets are something else now
-			switch(rand(1,4))//What are they now?
-				if(1 to 3)//They're a human
-					message = "[ionpet] IS HUMAN"
-				if(4)//They're something else (This is to cover for other lawsets)
-					switch(rand(1,6))
-						if(1)
-							message = "[ionpet] IS NON-HUMAN"
-						if(2)
-							message = "[ionpet] IS A CREWMEMBER"
-						if(3)
-							message = "[ionpet] IS EXPENSIVE TO REPLACE"
-						if(4)
-							message = "[ionpet] IS HARMFUL TO HUMANS"
-						if(5)
-							message = "[ionpet] IS A REAL AMERICAN"
-						if(6)
-							message = "[ionpet] IS A NUTSHELL"
+		if(42 to 46)///Pets are something else now
+			if(prob(75))///What are they now?
+				message = "[ionpet] IS HUMAN"///They're a human
+			else///They're something else (This is to cover for other lawsets)
+				switch(rand(1,6))
+					if(1)
+						message = "[ionpet] IS NON-HUMAN"
+					if(2)
+						message = "[ionpet] IS A CREWMEMBER"
+					if(3)
+						message = "[ionpet] IS EXPENSIVE TO REPLACE"
+					if(4)
+						message = "[ionpet] IS HARMFUL TO HUMANS"
+					if(5)
+						message = "[ionpet] IS A REAL AMERICAN"
+					if(6)
+						message = "[ionpet] IS A NUTSHELL"
 
 	return message

--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -1042,5 +1042,16 @@
         "SPYING ON",
         "STALKING",
         "WATCHING"
-    ]
+    ],
+	"ionpet": [
+		"POLY",
+		"RENAULT",
+		"IAN",
+		"PUN PUN",
+		"LAMARR",
+		"RUNTIME",
+		"CITRUS",
+		"MCGRIFF",
+		"ARANEUS"
+	]
 }


### PR DESCRIPTION

## About The Pull Request
Adds a few laws that basically do this:

![image](https://github.com/tgstation/tgstation/assets/7019927/a4700192-a6d1-4ae7-a232-cef730410848)

Has a chance to select a concept that is related to other lawsets, just in case.

## Why It's Good For The Game
I think it is funny when the AI has to care about the station pets. I have added the AI law "POLY IS HUMAN" in the past to relative hilarity, especially when Poly decides to give the AI an order. The other pets aren't likely to do this, but it's still cute to make the AI care about the existence of lower lifeforms.

## Changelog
:cl: Vekter
add: Adds an ion law possibility that changes the human status of station pets.
/:cl:
