### PR TITLE
Fix tips for metal foam.

### DIFF
--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -129,9 +129,10 @@
 
 /turf/open/floor/plating/foam
 	name = "metal foam plating"
-	desc = "Thin, fragile flooring created with metal foam."
+	desc = "Thin, fragile flooring created with metal foam. Designed to be easily replacable by tiling when applied to in a combat stance."
 	icon_state = "foam_plating"
 	upgradable = FALSE
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/foam/burn_tile()
 	return //jetfuel can't melt steel foam


### PR DESCRIPTION

## About The Pull Request
### Old: 
![image](https://github.com/tgstation/tgstation/assets/96586172/554f4470-95d7-420d-9333-cef49c5af1b9)
### New:
![image](https://github.com/tgstation/tgstation/assets/96586172/865f40a7-7502-435f-a2e0-dc7a7cef851a)

closes https://github.com/tgstation/tgstation/issues/83526
## Why It's Good For The Game
false tips are bad, let's make learning the game easier by sharing game mechanics via descriptions.
## Changelog
:cl: grungussus
fix: fixed metal foam plating description and add more user friendly explanation on how to replace tiling.
/:cl:
