### PR TITLE
Fix a tiny typo in ion law generation

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -314,7 +314,7 @@
 						if(2) //It is Y of threats
 							message = "THE [ioncrew1] [ionthinksof] [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats]"
 						if(3) //It is Y of jobs
-							message = "THE [ioncrew1][ionthinksof] [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew2]"
+							message = "THE [ioncrew1] [ionthinksof] [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew2]"
 						if(4) //It is Y of abstracts
 							message = "THE [ioncrew1] [ionthinksof] [ionabstract]"
 


### PR DESCRIPTION

## About The Pull Request

Saw this in the wild and fixed what I believe was the cause: `!@!$&: THE MEDICAL DOCTORSIS IN NEED OF THREE NAKED CHAPLAINS` (Round ID: 229577)

## Why It's Good For The Game

Spellcheck good.

## Changelog
:cl:
spellcheck: Fixed a missing space typo in ion law logic.
/:cl:
