### PR TITLE
DNA vault balancing

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -19,10 +19,10 @@
 
 /datum/station_goal/dna_vault/New()
 	..()
-	animal_count = rand(15,20) //might be too few given ~15 roundstart stationside ones
+	animal_count = rand(10,15) //might be too few given ~15 roundstart stationside ones
 	human_count = rand(round(0.75 * SSticker.totalPlayersReady) , SSticker.totalPlayersReady) // 75%+ roundstart population.
 	var/non_standard_plants = non_standard_plants_count()
-	plant_count = rand(round(0.5 * non_standard_plants),round(0.7 * non_standard_plants))
+	plant_count = rand(round(0.2 * non_standard_plants),round(0.4 * non_standard_plants))
 
 /datum/station_goal/dna_vault/proc/non_standard_plants_count()
 	. = 0


### PR DESCRIPTION

## About The Pull Request
Reduced amount of animal and plant DNA needed for the DNA vault objective.
## Why It's Good For The Game
This objective getting completed is incredibly rare, BSA is a fun station objective and gets completed often, The DNA vault is too tedious and hopefully this will counteract that a little bit before some kind of rework comes in to fix the underlying issue of the objective being quite boring.
## Changelog
:cl: grungussuss
balance: The DNA vault now requires less animal and plant DNA to be completed
/:cl:
