### PR TITLE
Caramel can now only be cooked in a soup pot.

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -107,6 +107,8 @@
 	required_temp = 413.15
 	optimal_temp = 600
 	mob_react = FALSE
+	required_container = /obj/item/reagent_containers/cup/soup_pot
+	required_container_accepts_subtypes = TRUE
 
 /datum/chemical_reaction/food/caramel_burned
 	results = list(/datum/reagent/carbon = 1)
@@ -115,6 +117,8 @@
 	optimal_temp = 1000
 	rate_up_lim = 10
 	mob_react = FALSE
+	required_container = /obj/item/reagent_containers/cup/soup_pot
+	required_container_accepts_subtypes = TRUE
 
 /datum/chemical_reaction/food/cheesewheel
 	required_reagents = list(/datum/reagent/consumable/milk = 40)


### PR DESCRIPTION
## About The Pull Request

Caramel can now only be cooked in a soup pot.

## Why It's Good For The Game

Caramel is supposed to be made by chefs for their food, not by chemists trying to negate the need for a chef.

## Changelog
:cl:
balance: Caramel can now only be cooked in a soup pot.
/:cl: