### PR TITLE
Buff Meteor shield satellites

### DIFF
--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -107,7 +107,7 @@
 			continue
 		if(space_los(meteor_to_destroy))
 			var/turf/beam_from = get_turf(src)
-			beam_from.Beam(get_turf(meteor_to_destroy), icon_state="sat_beam", time = 5)
+			beam_from.Beam(get_turf(meteor_to_destroy), icon_state="sat_beam", time = 3)
 			if(meteor_to_destroy.shield_defense(src))
 				qdel(meteor_to_destroy)
 


### PR DESCRIPTION

## About The Pull Request
Decreased cooldown of shield satellite destroy ability from 5 seconds to 3, making them destroy meteors 1.(6) times faster.
## Why It's Good For The Game
For how tedious this objective is, it will only stop about 2 or 3 meteors during a meteor storm, barely doing anything to really protect the station, no one wants to set up 20 meteor shields to protect the station, it should be more rewarding to actually do a station objective.
## Changelog
:cl: grungussuss
balance: The targeting software in meteor shield satellites has improved, granting them increased power to destroy meteors.
/:cl:
