### PR TITLE
Admin fix_air verb also fixes the turfs' temperatures.

### DIFF
--- a/code/modules/admin/verbs/fix_air.dm
+++ b/code/modules/admin/verbs/fix_air.dm
@@ -9,4 +9,5 @@ ADMIN_VERB_AND_CONTEXT_MENU(fix_air, R_ADMIN, "Fix Air", "Fixes air in a specifi
 			continue
 		var/datum/gas_mixture/GM = SSair.parse_gas_string(valid_range_turf.initial_gas_mix, /datum/gas_mixture/turf)
 		valid_range_turf.copy_air(GM)
+		valid_range_turf.temperature = valid_range_turf::temperature
 		valid_range_turf.update_visuals()

--- a/code/modules/admin/verbs/fix_air.dm
+++ b/code/modules/admin/verbs/fix_air.dm
@@ -9,5 +9,5 @@ ADMIN_VERB_AND_CONTEXT_MENU(fix_air, R_ADMIN, "Fix Air", "Fixes air in a specifi
 			continue
 		var/datum/gas_mixture/GM = SSair.parse_gas_string(valid_range_turf.initial_gas_mix, /datum/gas_mixture/turf)
 		valid_range_turf.copy_air(GM)
-		valid_range_turf.temperature = valid_range_turf::temperature
+		valid_range_turf.temperature = initial(valid_range_turf.temperature)
 		valid_range_turf.update_visuals()


### PR DESCRIPTION

## About The Pull Request
Makes the turfs' temperatures be set to their initial values when fix_air is used on them.
## Why It's Good For The Game
Prevents the turfs from heating the air back up after an admin uses fix_air on a very hot room.
## Changelog
:cl:
admin: fix_air will also fix the turfs' temperatures.
/:cl:
