### PR TITLE
Called Gripper gloves - have nothing to do with gripping

### DIFF
--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/gloves/tackler
-	name = "gripper gloves"
-	desc = "Special gloves that manipulate the blood vessels in the wearer's hands, granting them the ability to launch headfirst into walls."
+	name = "Enhanced Retrieval gloves"
+	desc = "Special gloves that manipulate the blood vessels in the wearer's hands, granting them the ability to launch headfirst into walls and tackle fleeing criminals in a single bound."
 	icon_state = "tackle"
 	inhand_icon_state = null
 	cold_protection = HANDS

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/gloves/tackler
-	name = "Enhanced Retrieval gloves"
+	name = "enhanced retrieval gloves"
 	desc = "Special gloves that manipulate the blood vessels in the wearer's hands, granting them the ability to launch headfirst into walls and tackle fleeing criminals in a single bound."
 	icon_state = "tackle"
 	inhand_icon_state = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames the gripping gloves to Enhanced Retrieval gloves

## Why It's Good For The Game
These gloves in fact do nothing for your grip, they actually only let you tackle things, alternate name suggestions are welcome.

## Changelog


:cl: oranges
spellcheck: Gripper gloves are now Enhanced Retrieval gloves
/:cl:
