### PR TITLE
Fix being able to add too many symptoms to a virus

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -405,7 +405,7 @@
 /datum/disease/advance/proc/AddSymptom(datum/symptom/S)
 	if(HasSymptom(S))
 		return
-	while(get_symptom_weights() > VIRUS_SYMPTOM_LIMIT + S.weight)
+	while(get_symptom_weights() + S.weight > VIRUS_SYMPTOM_LIMIT)
 		RemoveSymptom(pick(symptoms))
 	symptoms += S
 	S.OnAdd(src)


### PR DESCRIPTION

## About The Pull Request
Makes sure viruses respect the weighted 6 symptom cap. 8 symptom viruses are not something this world is prepared for.
Fixes https://github.com/NovaSector/NovaSector/issues/2727
## Why It's Good For The Game
fix bug
## Changelog
:cl:
fix: viruses can no longer potentially have 8 symptoms
/:cl:
