### PR TITLE
Fixes runtime with serializing photo metadata

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -206,7 +206,7 @@
 
 ///Serializes into JSON. Does not encode type.
 /datum/proc/serialize_json(list/options)
-	. = serialize_list(options)
+	. = serialize_list(options, list())
 	if(!islist(.))
 		. = null
 	else

--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -177,7 +177,7 @@
 		fdel(jsonpath)
 	else
 		json = list()
-	json[id] = serialize_list()
+	json[id] = serialize_list(semvers = list())
 	WRITE_FILE(jsonpath, json_encode(json))
 
 /datum/picture/proc/Copy(greyscale = FALSE, cropx = 0, cropy = 0)


### PR DESCRIPTION
## About The Pull Request

So while working on an entirely unrelated thing, I noticed runtimes appearing in my logs after taking a picture.
Specifically a bad index runtime for the 77th line here:
https://github.com/tgstation/tgstation/blob/2f6920105e097479ae1f2fdf2823e2e8fdc59f3b/code/modules/photography/_pictures.dm#L66-L78
And the 199th line here:
https://github.com/tgstation/tgstation/blob/2f6920105e097479ae1f2fdf2823e2e8fdc59f3b/code/datums/datum.dm#L193-L200
This seemed to be caused by the fact `serialize_list(...)` is called with a null `semvers` parameter, which then causes it to try to add to a null list.

I asked about this in code general on the main discord, and got told just putting an empty list in when `serialize_list(...)` is called should be fine.
This resolves the runtime.
## Why It's Good For The Game

Better to not have two runtimes added to the logs whenever someone takes a picture.
Fixes #80514.