### PR TITLE
Remove a bunch of unnecessary periods from photo descriptions containing living entities.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -268,20 +268,17 @@
 				return
 
 /mob/living/get_photo_description(obj/item/camera/camera)
-	var/list/mob_details = list()
 	var/list/holding = list()
 	var/len = length(held_items)
 	if(len)
-		for(var/obj/item/I in held_items)
+		for(var/obj/item/held_item in held_items)
 			if(!holding.len)
-				holding += "[p_They()] [p_are()] holding \a [I]"
-			else if(held_items.Find(I) == len)
-				holding += ", and \a [I]."
+				holding += "[p_They()] [p_are()] holding \a [held_item]"
+			else if(held_items.Find(held_item) == len)
+				holding += ", and \a [held_item]"
 			else
-				holding += ", \a [I]"
-	holding += "."
-	mob_details += "You can also see [src] on the photo[health < (maxHealth * 0.75) ? ", looking a bit hurt":""][holding ? ". [holding.Join("")]":"."]."
-	return mob_details.Join("")
+				holding += ", \a [held_item]"
+	return "You can also see [src] on the photo[health < (maxHealth * 0.75) ? ", looking a bit hurt":""][holding.len ? ". [holding.Join("")].":"."]"
 
 //Called when we bump onto an obj
 /mob/living/proc/ObjBump(obj/O)

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -226,7 +226,7 @@
 		if(person.is_face_visible())
 			names += "[person.name]"
 
-	var/datum/picture/picture = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, names, get_icon, null, psize_x, psize_y, blueprints, can_see_ghosts = see_ghosts)
+	var/datum/picture/picture = new("picture", desc.Join("<br>"), mobs_spotted, dead_spotted, names, get_icon, null, psize_x, psize_y, blueprints, can_see_ghosts = see_ghosts)
 	after_picture(user, picture)
 	SEND_SIGNAL(src, COMSIG_CAMERA_IMAGE_CAPTURED, target, user, picture)
 	blending = FALSE


### PR DESCRIPTION
## About The Pull Request

Looking at a picture I noticed the description was a bit off, so I did some testing:
![image](https://github.com/tgstation/tgstation/assets/42909981/828664eb-d619-4000-8fcf-a847b8746556)
Lo and behold, wow it really does just slap periods on everywhere huh?

So I just went through the code for getting mob photo descriptions and shuffled around where and when the periods are placed til it no longer did that:
![image](https://github.com/tgstation/tgstation/assets/42909981/ed926ea6-5d4e-42d7-ab49-a9c6fd517bb1)
Also replaced a single letter variable while I was at it.

### EDIT:
Also added newlines between them, for good measure.
![image](https://github.com/tgstation/tgstation/assets/42909981/814b778b-6aac-4e9a-be90-8a2ed78fed08)

## Why It's Good For The Game

Think it's better for there to not be excess periods. ..

### EDIT:
The added newlines also make it, well, more readable.

## Changelog
:cl:
spellcheck: Photo descriptions containing living entities no longer have a pile of unnecessary periods. .. Which they used to have between describing different entities. ..  Also removed that additional space they had too sometimes..
qol: Photo descriptions containing living entities have these sub-descriptions split into newlines for ease of reading.
/:cl:
