### PR TITLE
Fixes css issue in orbit menu [no gbp]

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -13,7 +13,7 @@ type IconSettings = {
 
 const normalIcon: IconSettings = {
   dmi: 'icons/mob/huds/hud.dmi',
-  transform: 'scale(2.3) translateX(8px) translateY(1px)',
+  transform: 'scale(2.3) translateX(9px) translateY(1px)',
 };
 
 const antagIcon: IconSettings = {

--- a/tgui/packages/tgui/styles/interfaces/Orbit.scss
+++ b/tgui/packages/tgui/styles/interfaces/Orbit.scss
@@ -1,12 +1,6 @@
 .JobIcon {
-  align-items: center;
   background: black;
-  display: flex;
-  height: 20px;
-  justify-content: center;
-  margin-right: -1px;
-  padding-left: 2px;
-  overflow: hidden;
+  padding: 1px 1px 0 1px;
 }
 
 .OrbitItem__selected {


### PR DESCRIPTION

## About The Pull Request
Getting the icon positioned properly came at a cost
That cost was it being secretly scrollable

This fixes the css with little/no change to icon look
![Screenshot 2024-05-29 172856](https://github.com/tgstation/tgstation/assets/42397676/4fa46762-2cda-48c1-ae97-c474c82521fd)

Note:
I am using the black bg to give the icons a little bit of contrast
## Why It's Good For The Game
Fixes #83492
## Changelog
:cl:
fix: Orbit UI icons are no longer scrollable..
/:cl:
