### PR TITLE
[NO GBP] fixes positive viruses being hidden

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -272,7 +272,7 @@
 /datum/disease/advance/proc/assign_properties()
 
 	if(properties?.len)
-		if(properties["stealth"] >= properties["severity"])
+		if(properties["stealth"] >= properties["severity"] && properties["severity"] > 0)
 			visibility_flags |= HIDDEN_SCANNER
 		else
 			visibility_flags &= ~HIDDEN_SCANNER


### PR DESCRIPTION
## About The Pull Request

#83459 made stealth a function of being equal to or higher than severity which made a lot of previously visible positive viruses hidden. Unintended behavior, fixes it.

## Why It's Good For The Game

fix good, most people without HUDs can't see these anyway. It's almost a QOL thing to just be able to ask a doctor "hey do I have a positive virus" since if it's perfectly positive, there's nothing really gained by people not knowing (you, enemies, and friends alike.)

## Changelog

:cl:
fix: positive viruses are no longer hidden.
/:cl: