### PR TITLE
[Bounty] Juicing and distilling only consumes nutriment and vitamin

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1016,7 +1016,8 @@
 		return FALSE
 
 	if(ispath(juice_typepath))
-		reagents.convert_reagent(/datum/reagent/consumable, juice_typepath, include_source_subtypes = TRUE)
+		reagents.convert_reagent(/datum/reagent/consumable/nutriment, juice_typepath, include_source_subtypes = FALSE)
+		reagents.convert_reagent(/datum/reagent/consumable/nutriment/vitamin, juice_typepath, include_source_subtypes = FALSE)
 	reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 
 	return TRUE

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -118,7 +118,7 @@
 	var/quality_max = DRINK_FANTASTIC
 	var/quality = round(LERP(quality_min, quality_max, purity_above_base))
 	for(var/datum/reagent/reagent in reagents.reagent_list)
-		if(!istype(reagent, /datum/reagent/consumable))
+		if(reagent.type != /datum/reagent/consumable/nutriment && reagent.type != /datum/reagent/consumable/nutriment/vitamin)
 			continue
 		if(distill_reagent)
 			var/data = list()

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -208,7 +208,7 @@
 	icon_harvest = "lanternfruit-harvest"
 	genes = list(/datum/plant_gene/trait/glow/yellow)
 	mutatelist = null
-	reagents_add = list(/datum/reagent/sulfur = 0.07, /datum/reagent/consumable/sugar = 0.07, /datum/reagent/consumable/liquidelectricity = 0.07)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/sulfur = 0.07, /datum/reagent/consumable/sugar = 0.07, /datum/reagent/consumable/liquidelectricity = 0.07)
 	graft_gene = /datum/plant_gene/trait/glow/yellow
 
 /obj/item/food/grown/lanternfruit

--- a/code/modules/hydroponics/grown/sugarcane.dm
+++ b/code/modules/hydroponics/grown/sugarcane.dm
@@ -14,7 +14,7 @@
 	yield = 4
 	instability = 15
 	growthstages = 2
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/sugar = 0.25)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.25)
 	mutatelist = list(/obj/item/seeds/bamboo, /obj/item/seeds/sugarcane/saltcane)
 
 /obj/item/food/grown/sugarcane
@@ -66,7 +66,7 @@
 	plantname = "Saltcane"
 	product = /obj/item/food/grown/sugarcane/saltcane
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/salt = 0.25)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/salt = 0.25)
 	mutatelist = null
 
 /obj/item/food/grown/sugarcane/saltcane

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -311,7 +311,7 @@
 	product = /obj/item/food/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/service/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02)
 
 /obj/item/seeds/lavaland/porcini
 	name = "pack of porcini mycelium"


### PR DESCRIPTION
## About The Pull Request
This PR closes a bounty (https://tgstation13.org/phpBB/viewtopic.php?t=36203), but is also a change I'm personally interested in.
Distilling and juicing now explicitly checks for nutriment and vitamin and ignores any other reagents, as per the bounty requirements, meaning potentially useful chems like oils don't get removed.
## Why It's Good For The Game
More possibilities for cooking and ghetto chemistry, makes more sense because something like Frost Oil probably shouldn't turn into juice.
## Changelog
:cl:
balance: Juicing and distilling plants only consumes nutriment and vitamin
balance: Lanternfruit and polypore mushrooms now contain nutriment
balance: Increased the amount of nutriment in sugarcane and saltcane
/:cl:
