### PR TITLE
Makes the Clown Stamp give out clown cells

### DIFF
--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -88,6 +88,11 @@
 	icon_state = "stamp-clown"
 	dye_color = DYE_CLOWN
 
+/obj/item/stamp/clown/Initialize(mapload)
+	. = ..()
+
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CLOWN, CELL_VIRUS_TABLE_GENERIC, rand(2,3), 0)
+
 /obj/item/stamp/mime
 	name = "mime's rubber stamp"
 	icon_state = "stamp-mime"


### PR DESCRIPTION

## About The Pull Request

This PR makes it so swabbing the clown's stamp also gives clown cells for Cytology.

## Why It's Good For The Game
Right now for these cell lines you either need to swab the clown's shoes, clothes or mask - items that many clowns won't be too happy to part with, even if for a few seconds. Furthermore it means you only get 3 tries to get the cell line you want, alongside having a chance of having all of the cell lines rather than just two (making the process a lot more harder if i does happen). 

Letting the stamp give out cells both makes getting a single petri dish faster ("Clown give me the stamp" "K") but also means if you're going for one specific cell line you have more chances to get it, making the whole process of getting experimental clowns faster and more reliable overall.

## Changelog
:cl:
qol: Swabbing the clown's stamp also gives clown cells.
:cl:
