### PR TITLE
Adds a cyborg support bundle for nuke ops

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -709,6 +709,18 @@
 /obj/item/storage/backpack/duffelbag/syndie/ammo/mauler
 	desc = "A large duffel bag, packed to the brim with various exosuit ammo."
 
+/obj/item/storage/backpack/dufflebag/syndie/cyborg_support
+	desc = "A large duffle bag, packed to the brim of supplies to support cyborgs units"
+
+/obj/item/storage/backpack/dufflebag/syndie/cyborg_support/Populatecontents()
+	new /obj/item/storage/belt/utility/syndicate(src)
+	new /obj/item/clothing/glasses/hud/diagnostic/night(src)
+	new /obj/item/stock_parts/cell/bluespace(src)
+	new /obj/item/card/emag(src)
+	new /obj/item/encryptionkey/binary(src)
+	new /obj/item/borg_restart_board(src)
+	new /obj/item/stack/cable_coil(src)
+
 /obj/item/storage/backpack/duffelbag/syndie/ammo/mauler/PopulateContents()
 	new /obj/item/mecha_ammo/lmg(src)
 	new /obj/item/mecha_ammo/lmg(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -710,7 +710,7 @@
 	desc = "A large duffel bag, packed to the brim with various exosuit ammo."
 
 /obj/item/storage/backpack/dufflebag/syndie/cyborg_support
-	desc = "A large duffle bag, packed to the brim of supplies to support cyborgs units"
+	desc = "A large duffle bag, packed to the brim with supplies to support cyborg units."
 
 /obj/item/storage/backpack/dufflebag/syndie/cyborg_support/PopulateContents()
 	new /obj/item/storage/belt/utility/syndicate(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -712,7 +712,7 @@
 /obj/item/storage/backpack/dufflebag/syndie/cyborg_support
 	desc = "A large duffle bag, packed to the brim of supplies to support cyborgs units"
 
-/obj/item/storage/backpack/dufflebag/syndie/cyborg_support/Populatecontents()
+/obj/item/storage/backpack/dufflebag/syndie/cyborg_support/PopulateContents()
 	new /obj/item/storage/belt/utility/syndicate(src)
 	new /obj/item/clothing/glasses/hud/diagnostic/night(src)
 	new /obj/item/stock_parts/cell/bluespace(src)

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -540,6 +540,13 @@
 	cost = 18
 	purchasable_from = UPLINK_NUKE_OPS
 
+/datum/uplink/bundles_tc/cyborg_support
+	name = "Cyborg support Kit bag"
+	desc = "A duffle bag containing a full toolbelt including a inducer an spare battery, with a emergency reboot module and a emagg."
+	item = /obj/item/storage/backpack/dufflebag/syndie/cyborg_support
+	cost = 12
+	purchasable_from = UPLINK_NUKE_OPS
+
 // Mech related gear
 
 /datum/uplink_category/mech

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -540,7 +540,7 @@
 	cost = 18
 	purchasable_from = UPLINK_NUKE_OPS
 
-/datum/uplink/bundles_tc/cyborg_support
+/datum/uplink_item/bundles_tc/cyborg_support
 	name = "Cyborg support Kit bag"
 	desc = "A duffle bag containing a full toolbelt including a inducer an spare battery, with a emergency reboot module and a emagg."
 	item = /obj/item/storage/backpack/dufflebag/syndie/cyborg_support

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -541,7 +541,7 @@
 	purchasable_from = UPLINK_NUKE_OPS
 
 /datum/uplink_item/bundles_tc/cyborg_support
-	name = "Cyborg support Kit bag"
+	name = "Cyborg Support Kit"
 	desc = "A duffle bag containing a full toolbelt including a inducer an spare battery, with a emergency reboot module and a emagg."
 	item = /obj/item/storage/backpack/dufflebag/syndie/cyborg_support
 	cost = 12

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -542,7 +542,7 @@
 
 /datum/uplink_item/bundles_tc/cyborg_support
 	name = "Cyborg Support Kit"
-	desc = "A duffle bag containing a full toolbelt including a inducer an spare battery, with a emergency reboot module and a emagg."
+	desc = "A duffle bag containing a full toolbelt (inducer included), an extra bluespace cell, a reboot module, and a cryptographic sequencer, just in case your silicons get turned against you."
 	item = /obj/item/storage/backpack/dufflebag/syndie/cyborg_support
 	cost = 12
 	purchasable_from = UPLINK_NUKE_OPS

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -542,7 +542,7 @@
 
 /datum/uplink_item/bundles_tc/cyborg_support
 	name = "Cyborg Support Kit"
-	desc = "A duffle bag containing a full toolbelt (inducer included), an extra bluespace cell, a reboot module, and a cryptographic sequencer, just in case your silicons get turned against you."
+	desc = "A duffle bag containing a full toolbelt (inducer included), an extra bluespace cell, a reboot module, a pair of diagnostic night vision goggles and a cryptographic sequencer, just in case your silicons get turned against you."
 	item = /obj/item/storage/backpack/dufflebag/syndie/cyborg_support
 	cost = 12
 	purchasable_from = UPLINK_NUKE_OPS


### PR DESCRIPTION
## About The Pull Request
This pr adds a bundle for nuke ops that they can use for their cyborgs(or more oriental played to sabotage/stealth cyborg infiltration by subverting the AI borgs etc it contains the following.
(Binary key 4Tc, Emagg 4 TC, Dia NV hud to see your borg health with, a full toolbelt that contains a inducer, a emergency borg restart module to reboot dead borgs with after repairing, a spare bluespace battery and some cable)

## Why It's Good For The Game
This adds a kit for nuke ops to support their expensive heavy TC and fragile cyborg with the means to repair them when they die and subvert them back to their side when they get subverted by the crew for 12 tc

## Changelog

:cl:
add: Adds a cyborg support kit to nuke ops, containing binary, emagg, Dia NV, toolbelt, inducer, spare battery, reboot module
/:cl: