### PR TITLE
Fix imaginary friend trauma and message range

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -66,6 +66,7 @@
 
 	friend.key = ghost.key
 	friend.attach_to_owner(owner)
+	friend.setup_appearance()
 	friend_initialized = TRUE
 	friend.log_message("became [key_name(owner)]'s split personality.", LOG_GAME)
 	message_admins("[ADMIN_LOOKUPFLW(friend)] became [ADMIN_LOOKUPFLW(owner)]'s split personality.")

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -233,7 +233,6 @@
 		spans |= SPAN_SINGING
 
 	var/eavesdrop_range = 0
-	var/eavesdropped_message = ""
 
 	if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
 		message = message_mods[MODE_CUSTOM_SAY_EMOTE]
@@ -243,9 +242,7 @@
 			log_talk(message, LOG_WHISPER, tag="imaginary friend", forced_by = forced, custom_say_emote = message_mods[MODE_CUSTOM_SAY_EMOTE])
 			spans |= SPAN_ITALICS
 			eavesdrop_range = EAVESDROP_EXTRA_RANGE
-			// "This proc is dangerously laggy, avoid it or die"
-			// What other option do I have here? I guess I'll die
-			eavesdropped_message = stars(message)
+			range = WHISPER_RANGE
 		else
 			log_talk(message, LOG_SAY, tag="imaginary friend", forced_by = forced, custom_say_emote = message_mods[MODE_CUSTOM_SAY_EMOTE])
 
@@ -257,11 +254,7 @@
 	Hear(rendered, src, language, message, null, spans, message_mods) // We always hear what we say
 	var/group = owner.imaginary_group - src // The people in our group don't, so we have to exclude ourselves not to hear twice
 	for(var/mob/person in group)
-		if(eavesdrop_range && get_dist(src, person) > WHISPER_RANGE + eavesdrop_range && !HAS_TRAIT(person, TRAIT_GOOD_HEARING))
-			var/new_rendered = "[span_name("[name]")] [say_quote(say_emphasis(eavesdropped_message), spans, message_mods)]"
-			person.Hear(new_rendered, src, language, eavesdropped_message, null, spans, message_mods)
-		else
-			person.Hear(rendered, src, language, message, null, spans, message_mods)
+		person.Hear(null, src, language, message, null, spans, message_mods, range)
 
 	// Speech bubble, but only for those who have runechat off
 	var/list/speech_bubble_recipients = list()

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -65,6 +65,7 @@
 		return
 
 	friend.key = ghost.key
+	friend.attach_to_owner(owner)
 	friend_initialized = TRUE
 	friend.log_message("became [key_name(owner)]'s split personality.", LOG_GAME)
 	message_admins("[ADMIN_LOOKUPFLW(friend)] became [ADMIN_LOOKUPFLW(owner)]'s split personality.")

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -43,7 +43,7 @@
 	get_ghost()
 
 /datum/brain_trauma/special/imaginary_friend/proc/make_friend()
-	friend = new(get_turf(owner), owner)
+	friend = new(get_turf(owner))
 
 /// Tries a poll for the imaginary friend
 /datum/brain_trauma/special/imaginary_friend/proc/get_ghost()


### PR DESCRIPTION

## About The Pull Request

So during a previous pr, attaching the imaginary friend to a host and setting up its preferences were moved from initialization to two separate procs. The _smite_ was then updated to account for this, but in the process the brain trauma version was left behind- it even still tried to add a nonexistent parameter when making a new imaginary friend.

We first fix this by having those two procs be called during `add_friend(...)`, after finding and assigning a ghost.
```dm
/datum/brain_trauma/special/imaginary_friend/proc/add_friend(mob/dead/observer/ghost)
	if(isnull(ghost))
		qdel(src)
		return

	friend.key = ghost.key
	friend.attach_to_owner(owner) //new
	friend.setup_appearance() //new
	friend_initialized = TRUE
	friend.log_message("became [key_name(owner)]'s split personality.", LOG_GAME)
	message_admins("[ADMIN_LOOKUPFLW(friend)] became [ADMIN_LOOKUPFLW(owner)]'s split personality.")
```
This solves our first issue, where this not being called made every brain trauma imaginary friend get banished to gay baby jail where they do not have an appearance, cannot move from their spot, cannot be heard, and emit runtimes constantly.

Testing this brings us to our second issue, where the host couldn't actually hear their imaginary friend unless they were at most one tile away, and would get their message starred if not on the exact same tile.
Looking into it, this seemed to be because `Hear(...)` now had a `message_range = 0` parameter which we don't actually set here.

Upshot! This seems to let us gut the whisper starring code on our side and just proxy the right message range to `Hear(...)`.
So we gut our code a bit and do just that, and this fixes it.
## Why It's Good For The Game

Fixes #81138.
Fixes imaginary friend brain trauma being non-functional and emitting runtimes like hell.
Fixes imaginary friends not being audible to their host beyond a one tile distance.
## Changelog
:cl:
fix: Imaginary friend brain trauma works again.
fix: Imaginary friends can be heard by their hosts from more than a tile away again.
/:cl:
