### PR TITLE
Revert "Blade creation ritual returns lost blades"

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -46,8 +46,6 @@
 	var/high_value_sacrifices = 0
 	/// Lazy assoc list of [refs to humans] to [image previews of the human]. Humans that we have as sacrifice targets.
 	var/list/mob/living/carbon/human/sac_targets
-	/// List of all sickly blades linked with heretic mind.
-	var/list/obj/item/melee/sickly_blade/blades_list
 	/// List of all sacrifice target's names, used for end of round report
 	var/list/all_sac_targets = list()
 	/// Whether we're drawing a rune or not
@@ -86,9 +84,6 @@
 
 /datum/antagonist/heretic/Destroy()
 	LAZYNULL(sac_targets)
-	for(var/obj/item/melee/sickly_blade/blade as anything in blades_list)
-		blade.owner = null
-	LAZYNULL(blades_list)
 	return ..()
 
 /datum/antagonist/heretic/ui_data(mob/user)

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -225,8 +225,6 @@
 	var/limit = 1
 	/// A list of weakrefs to all items we've created.
 	var/list/datum/weakref/created_items
-	/// if we have all the blades then we don’t want to tear our hands off
-	var/valid_blades = FALSE
 
 /datum/heretic_knowledge/limited_amount/Destroy(force)
 	LAZYCLEARLIST(created_items)
@@ -239,14 +237,8 @@
 			LAZYREMOVE(created_items, ref)
 
 	if(LAZYLEN(created_items) >= limit)
-		for(var/obj/item/melee/sickly_blade/is_blade_ritual as anything in result_atoms)
-			valid_blades = blades_limit_check(user)
-			break
-		if(valid_blades)
-			return TRUE
-		else
-			loc.balloon_alert(user, "ritual failed, at limit!")
-			return FALSE
+		loc.balloon_alert(user, "ritual failed, at limit!")
+		return FALSE
 
 	return TRUE
 
@@ -254,35 +246,7 @@
 	for(var/result in result_atoms)
 		var/atom/created_thing = new result(loc)
 		LAZYADD(created_items, WEAKREF(created_thing))
-		if(istype(created_thing, /obj/item/melee/sickly_blade))
-			add_to_list_sickly_blade(user, created_thing)
 	return TRUE
-
-/datum/heretic_knowledge/limited_amount/proc/add_to_list_sickly_blade(mob/living/heretic, obj/item/melee/sickly_blade/created_blade)
-	var/obj/item/melee/sickly_blade/blade_check = created_blade
-	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(heretic)
-	if(!isnull(our_heretic))
-		blade_check.owner = our_heretic
-		LAZYADD(our_heretic.blades_list, blade_check)
-
-/datum/heretic_knowledge/limited_amount/proc/blades_limit_check(mob/living/heretic)
-	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(heretic)
-	var/success_check = FALSE
-	for(var/obj/item/melee/sickly_blade/blades_in_list as anything in our_heretic.blades_list)
-		if(get_turf(heretic) == get_turf(blades_in_list))
-			continue
-		success_check = TRUE
-		LAZYREMOVE(our_heretic.blades_list, blades_in_list)
-		var/mob/living/living_target = recursive_loc_check(src, /mob/living)
-		if(living_target)
-			living_target.apply_damage(15)
-			var/obj/item/bodypart/thief_hand = living_target.get_bodypart(BODY_ZONE_L_ARM)
-			if(!isnull(thief_hand))
-				thief_hand.dismember(BRUTE)
-			to_chat(living_target, span_boldwarning("You feel severe pain in your hand as if otherworldly powers tore it from inside. [blades_in_list] collapse and disappeared.. maybe it never existed?"))
-		qdel(blades_in_list)
-		break
-	return success_check
 
 /**
  * A knowledge subtype for limited_amount knowledge

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -23,14 +23,6 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	var/after_use_message = ""
-	//set owner to find where blade linked
-	var/datum/antagonist/heretic/owner
-
-/obj/item/melee/sickly_blade/Destroy()
-	if(!isnull(owner))
-		LAZYREMOVE(owner.blades_list, src)
-		owner = null
-	return ..()
 
 /obj/item/melee/sickly_blade/attack(mob/living/M, mob/living/user)
 	if(!IS_HERETIC_OR_MONSTER(user))

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -293,4 +293,3 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	body.do_jitter_animation()
 	body.visible_message(span_danger("An awful ripping sound is heard as [ripped_thing]'s [exterior_text] is ripped straight out, wrapping around [le_book || "the book"], turning into an eldritch shade of blue!"))
 	return ..()
-


### PR DESCRIPTION
Reverts tgstation/tgstation#82592

The point of the limit on blades is to punish heretics for handling them carelessly, allowing them to undo that for free is lame. 

Maybe someone can re-add this as a separate ritual which has its own requirements, maybe a knowledge requirement. 

🆑
del: Heretics can no longer return their stolen blades, that's the point of the limit
/:cl: