### PR TITLE
tgui: changes typescript module resolution to recommended setting

### DIFF
--- a/tgui/tsconfig.json
+++ b/tgui/tsconfig.json
@@ -14,7 +14,7 @@
       "ScriptHost"
     ],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## About The Pull Request
Swaps moduleResolution to the recommended setting. Should have no averse effects anywhere.

Current moduleResolution: "Node" gives this tooltip message:
`Node: Deprecated, use "Node10" in TypeScript 5.0+ instead`

This PR:
moduleResolution: "Bundler"
`Bundler: This is the recommended setting in TypeScript 5.0+ for applications that use a bundler` (aka us)

More info https://www.typescriptlang.org/tsconfig/#moduleResolution
## Why It's Good For The Game
If you're wondering what this PR is even for, I'd like to centralize tg components eventually so we can distribute them as a npm package. This lets me use the aliased imports from that package, so if we do make that change it's one line:

![image](https://github.com/tgstation/tgstation/assets/42397676/1dbb0180-01ea-42fb-b8c2-dc83c3b2bd1a)

In return we get to delete the entire tgui components folder, their style sheets, the common package, and maybe more. I have tested this using my (future PR) tgui library and it works.



