### PR TITLE
Poster and Sign Linting Preparations for Wallening - Granular Thought Process

### DIFF
--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -29,25 +29,25 @@
 #define REVERSE_DIR(dir) ( ((dir & 85) << 1) | ((dir & 170) >> 1) )
 
 /// Directional offset to place a wall item on the north side of a wall turf.
-#define NORTH_DIRECTIONAL_HELPER(path, offset)\
+#define NORTH_MAPPING_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/north {\
 	dir = NORTH; \
 	pixel_y = offset; \
 }
 /// Directional offset to place a wall item on the south side of a wall turf.
-#define SOUTH_DIRECTIONAL_HELPER(path, offset)\
+#define SOUTH_MAPPING_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/south {\
 	dir = SOUTH; \
 	pixel_y = -offset; \
 }
 /// Directional offset to place a wall item on the east side of a wall turf.
-#define EAST_DIRECTIONAL_HELPER(path, offset)\
+#define EAST_MAPPING_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/east {\
 	dir = EAST; \
 	pixel_x = offset; \
 }
 /// Directional offset to place a wall item on the west side of a wall turf.
-#define WEST_DIRECTIONAL_HELPER(path, offset)\
+#define WEST_MAPPING_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/west {\
 	dir = WEST; \
 	pixel_x = -offset; \
@@ -55,13 +55,13 @@
 
 /// Create directional subtypes for a path IN ALL CARDINAL DIRECTIONS to simplify mapping.
 #define MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(path, offset)\
-NORTH_DIRECTIONAL_HELPER(##path, ##offset)\
-SOUTH_DIRECTIONAL_HELPER(##path, ##offset)\
-EAST_DIRECTIONAL_HELPER(##path, ##offset)\
-WEST_DIRECTIONAL_HELPER(##path, ##offset)
+NORTH_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)\
+SOUTH_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)\
+EAST_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)\
+WEST_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)
 
 /// Create directional subtypes for a path for "visible" directions- as in they aren't meant to display if shown southernly (e.g. posters, signs). Simplifies mapping.
 #define MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(path, offset)\
-NORTH_DIRECTIONAL_HELPER(##path, ##offset)\
-EAST_DIRECTIONAL_HELPER(##path, ##offset)\
-WEST_DIRECTIONAL_HELPER(##path, ##offset)
+NORTH_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)\
+EAST_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)\
+WEST_MAPPING_DIRECTIONAL_HELPER(##path, ##offset)

--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -28,20 +28,40 @@
 /// Inverse direction, taking into account UP|DOWN if necessary.
 #define REVERSE_DIR(dir) ( ((dir & 85) << 1) | ((dir & 170) >> 1) )
 
-/// Create directional subtypes for a path to simplify mapping.
-#define MAPPING_DIRECTIONAL_HELPERS(path, offset) ##path/directional/north {\
+/// Directional offset to place a wall item on the north side of a wall turf.
+#define NORTH_DIRECTIONAL_HELPER(path, offset)\
+##path/directional/north {\
 	dir = NORTH; \
 	pixel_y = offset; \
-} \
+}
+/// Directional offset to place a wall item on the south side of a wall turf.
+#define SOUTH_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/south {\
 	dir = SOUTH; \
 	pixel_y = -offset; \
-} \
+}
+/// Directional offset to place a wall item on the east side of a wall turf.
+#define EAST_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/east {\
 	dir = EAST; \
 	pixel_x = offset; \
-} \
+}
+/// Directional offset to place a wall item on the west side of a wall turf.
+#define WEST_DIRECTIONAL_HELPER(path, offset)\
 ##path/directional/west {\
 	dir = WEST; \
 	pixel_x = -offset; \
 }
+
+/// Create directional subtypes for a path IN ALL CARDINAL DIRECTIONS to simplify mapping.
+#define MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS_ALL_CARDINALS(path, offset)\
+NORTH_DIRECTIONAL_HELPER(path, offset)\
+SOUTH_DIRECTIONAL_HELPER(path, offset)\
+EAST_DIRECTIONAL_HELPER(path, offset)\
+WEST_DIRECTIONAL_HELPER(path, offset)
+
+/// Create directional subtypes for a path for "visible" directions- as in they aren't meant to display if shown southernly (e.g. posters, signs). Simplifies mapping.
+#define MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS_VISIBLE_CARDINALS(path, offset)\
+NORTH_DIRECTIONAL_HELPER(path, offset)\
+EAST_DIRECTIONAL_HELPER(path, offset)\
+WEST_DIRECTIONAL_HELPER(path, offset)

--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -54,14 +54,14 @@
 }
 
 /// Create directional subtypes for a path IN ALL CARDINAL DIRECTIONS to simplify mapping.
-#define MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS_ALL_CARDINALS(path, offset)\
-NORTH_DIRECTIONAL_HELPER(path, offset)\
-SOUTH_DIRECTIONAL_HELPER(path, offset)\
-EAST_DIRECTIONAL_HELPER(path, offset)\
-WEST_DIRECTIONAL_HELPER(path, offset)
+#define MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(path, offset)\
+NORTH_DIRECTIONAL_HELPER(##path, ##offset)\
+SOUTH_DIRECTIONAL_HELPER(##path, ##offset)\
+EAST_DIRECTIONAL_HELPER(##path, ##offset)\
+WEST_DIRECTIONAL_HELPER(##path, ##offset)
 
 /// Create directional subtypes for a path for "visible" directions- as in they aren't meant to display if shown southernly (e.g. posters, signs). Simplifies mapping.
-#define MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS_VISIBLE_CARDINALS(path, offset)\
-NORTH_DIRECTIONAL_HELPER(path, offset)\
-EAST_DIRECTIONAL_HELPER(path, offset)\
-WEST_DIRECTIONAL_HELPER(path, offset)
+#define MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(path, offset)\
+NORTH_DIRECTIONAL_HELPER(##path, ##offset)\
+EAST_DIRECTIONAL_HELPER(##path, ##offset)\
+WEST_DIRECTIONAL_HELPER(##path, ##offset)

--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -325,3 +325,11 @@ rough example of the "cone" made by the 3 dirs checked
 		"x" = icon_width > world.icon_size && pixel_x != 0 ? (icon_width - world.icon_size) * 0.5 : 0,
 		"y" = icon_height > world.icon_size && pixel_y != 0 ? (icon_height - world.icon_size) * 0.5 : 0,
 	)
+
+/// Check to ensure that we are not placing a certain atom (like a sign or a poster) on something that is not a given face of that wall
+/// Source is "placer", Destination is the "wall", the linted_direction is a bitflag for the direction the item is allowed to be placed on.
+/// Returns true if the item can be placed on the wall face, false otherwise.
+/proc/check_wall_face(atom/source, atom/destination, linted_direction)
+	if(get_dir(source, destination) & linted_direction)
+		return TRUE
+	return FALSE

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -17,13 +17,9 @@
 		#undef EXPERIMENT_MY_COOL_FEATURE
 	#endif
 
-	#ifdef EXPERIMENT_WALLENING_SIGNS
-		#warn EXPERIMENT_WALLENING_SIGNS is only available on 515+
-		#undef EXPERIMENT_WALLENING_SIGNS
-	#endif
-
 #elif defined(UNIT_TESTS)
 	#define EXPERIMENT_MY_COOL_FEATURE
+	//#define EXPERIMENT_WALLENING_SIGNS
 #endif
 
 #if DM_VERSION >= 516

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -6,6 +6,9 @@
 // EXPERIMENT_MY_COOL_FEATURE
 // - Does something really cool, just so neat, absolutely banging, gaming and chill
 
+// EXPERIMENT_WALLENING
+// - Stop-gap for some things that we want to implement (and pretty much orphan) in the codebase while wallening is being developed
+
 #if DM_VERSION < 515
 
 	// You can't X-macro custom names :(
@@ -13,6 +16,12 @@
 		#warn EXPERIMENT_MY_COOL_FEATURE is only available on 515+
 		#undef EXPERIMENT_MY_COOL_FEATURE
 	#endif
+
+	#ifdef EXPERIMENT_WALLENING
+		#warn EXPERIMENT_WALLENING is only available on 515+
+		#undef EXPERIMENT_WALLENING
+	#endif
+
 #elif defined(UNIT_TESTS)
 	#define EXPERIMENT_MY_COOL_FEATURE
 #endif

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -6,8 +6,8 @@
 // EXPERIMENT_MY_COOL_FEATURE
 // - Does something really cool, just so neat, absolutely banging, gaming and chill
 
-// EXPERIMENT_WALLENING
-// - Stop-gap for some things that we want to implement (and pretty much orphan) in the codebase while wallening is being developed
+// EXPERIMENT_WALLENING_SIGNS
+// - Stop-gap for sign/poster directional related stuff like placing them on south related stuff and discarding everything that's not a northern directional on other signs
 
 #if DM_VERSION < 515
 
@@ -17,9 +17,9 @@
 		#undef EXPERIMENT_MY_COOL_FEATURE
 	#endif
 
-	#ifdef EXPERIMENT_WALLENING
-		#warn EXPERIMENT_WALLENING is only available on 515+
-		#undef EXPERIMENT_WALLENING
+	#ifdef EXPERIMENT_WALLENING_SIGNS
+		#warn EXPERIMENT_WALLENING_SIGNS is only available on 515+
+		#undef EXPERIMENT_WALLENING_SIGNS
 	#endif
 
 #elif defined(UNIT_TESTS)

--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -24,7 +24,7 @@
 	acid = 50
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/machinery/barsign, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
 #endif
@@ -534,7 +534,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
 	disassemble_result = /obj/item/wallframe/barsign/all_access
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign/all_access, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/machinery/barsign/all_access, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign/all_access, 32)
 #endif

--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -23,7 +23,11 @@
 	fire = 50
 	acid = 50
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
+#endif
 
 /obj/machinery/barsign/Initialize(mapload)
 	. = ..()
@@ -529,7 +533,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
 	req_access = null
 	disassemble_result = /obj/item/wallframe/barsign/all_access
 
+#ifdef EXPERIMENT_WALLENING
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign/all_access, 32)
+#else
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign/all_access, 32)
+#endif
 
 /obj/item/wallframe/barsign
 	name = "bar sign frame"

--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -23,7 +23,7 @@
 	fire = 50
 	acid = 50
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
 
 /obj/machinery/barsign/Initialize(mapload)
 	. = ..()
@@ -529,7 +529,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 	req_access = null
 	disassemble_result = /obj/item/wallframe/barsign/all_access
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign/all_access, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign/all_access, 32)
 
 /obj/item/wallframe/barsign
 	name = "bar sign frame"

--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -534,9 +534,9 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
 	disassemble_result = /obj/item/wallframe/barsign/all_access
 
 #ifdef EXPERIMENT_WALLENING
-MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign/all_access, 32)
-#else
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign/all_access, 32)
+#else
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign/all_access, 32)
 #endif
 
 /obj/item/wallframe/barsign

--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -23,7 +23,7 @@
 	fire = 50
 	acid = 50
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
@@ -533,7 +533,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign, 32)
 	req_access = null
 	disassemble_result = /obj/item/wallframe/barsign/all_access
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/machinery/barsign/all_access, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/barsign/all_access, 32)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -257,7 +257,7 @@
 	var/specialfunctions = OPEN // Bitflag, see assembly file
 	var/sync_doors = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/button/door, 24)
 
 /obj/machinery/button/door/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -88,11 +88,11 @@
 	var/area/station/ai_monitored/area_motion = null
 	var/alarm_delay = 30 // Don't forget, there's another 3 seconds in queueAlarm()
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/emp_proof, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/motion, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/camera, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/camera/autoname, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/camera/emp_proof, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/camera/motion, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/camera/xray, 0)
 
 /datum/armor/machinery_camera
 	melee = 50

--- a/code/game/machinery/computer/telescreen.dm
+++ b/code/game/machinery/computer/telescreen.dm
@@ -43,7 +43,7 @@
 	var/icon_state_off = "entertainment_blank"
 	var/icon_state_on = "entertainment"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertainment, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/computer/security/telescreen/entertainment, 32)
 
 /obj/item/wallframe/telescreen/entertainment
 	name = "entertainment telescreen frame"

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -19,14 +19,14 @@
 /// the type of wallframe it 'disassembles' into
 	var/wallframe_type = /obj/item/wallframe/defib_mount
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/defibrillator_mount, 28)
 
 /obj/machinery/defibrillator_mount/loaded/Initialize(mapload) //loaded subtype for mapping use
 	. = ..()
 	defib = new/obj/item/defibrillator/loaded(src)
 	find_and_hang_on_wall()
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/defibrillator_mount, 28)
 
 /obj/machinery/defibrillator_mount/Destroy()
 	QDEL_NULL(defib)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -26,7 +26,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/defibrillator_mount, 28
 	defib = new/obj/item/defibrillator/loaded(src)
 	find_and_hang_on_wall()
 
-MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/defibrillator_mount, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/defibrillator_mount/loaded, 28)
 
 /obj/machinery/defibrillator_mount/Destroy()
 	QDEL_NULL(defib)

--- a/code/game/machinery/digital_clock.dm
+++ b/code/game/machinery/digital_clock.dm
@@ -154,4 +154,4 @@
 
 	return return_overlays
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/digital_clock, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/digital_clock, 28)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -463,29 +463,29 @@
 	name = "holding cell door"
 	req_one_access = list(ACCESS_SECURITY)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/left, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/right, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/left, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/right, 0)
 
 /obj/machinery/door/window/right
 	icon_state = "right"
 	base_state = "right"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/left, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/right, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/brigdoor/left, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/brigdoor/right, 0)
 
 /obj/machinery/door/window/brigdoor/right
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/cell/left, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/cell/right, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/brigdoor/security/cell/left, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/brigdoor/security/cell/right, 0)
 
 /obj/machinery/door/window/brigdoor/security/cell/right
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/holding/left, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/holding/right, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/brigdoor/security/holding/left, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/brigdoor/security/holding/right, 0)
 
 /obj/machinery/door/window/brigdoor/security/holding/right
 	icon_state = "rightsecure"

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -489,7 +489,7 @@
 		balloon_alert(user, "thermal sensors [my_area.fire_detect ? "enabled" : "disabled"]")
 		user.log_message("[ my_area.fire_detect ? "enabled" : "disabled" ] firelock sensors using [src].", LOG_GAME)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/firealarm, 26)
 
 /*
  * Return of Party button

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -22,7 +22,7 @@
 	/// Duration of time between flashes.
 	var/flash_cooldown_duration = 15 SECONDS
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/flasher, 26)
 
 /obj/machinery/flasher/Initialize(mapload, ndir = 0, built = 0)
 	. = ..() // ..() is EXTREMELY IMPORTANT, never forget to add it

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -150,7 +150,7 @@
 	var/last_spark = 0
 	var/datum/effect_system/spark_spread/spark_system
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/sparker, 26)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/sparker, 26)
 
 /obj/machinery/sparker/ordmix
 	id = INCINERATOR_ORDMIX_IGNITER

--- a/code/game/machinery/incident_display.dm
+++ b/code/game/machinery/incident_display.dm
@@ -71,10 +71,10 @@ DEFINE_BITFIELD(sign_features, list(
 	icon_state = "stat_display_tram"
 	sign_features = DISPLAY_TRAM
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/incident_display, 32)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/incident_display/delam, 32)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/incident_display/dual, 32)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/incident_display/tram, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/incident_display, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/incident_display/delam, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/incident_display/dual, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/incident_display/tram, 32)
 
 /obj/machinery/incident_display/Initialize(mapload)
 	..()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -15,7 +15,7 @@
 	/// Should this lightswitch automatically rename itself to match the area it's in?
 	var/autoname = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light_switch, 26)
 
 /obj/machinery/light_switch/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/mining_weather_monitor.dm
+++ b/code/game/machinery/mining_weather_monitor.dm
@@ -22,4 +22,4 @@
 		return
 	. += emissive_appearance(icon, "emissive", src)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/mining_weather_monitor, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/mining_weather_monitor, 28)

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -66,7 +66,7 @@
 /obj/machinery/newscaster/pai/ui_state(mob/user)
 	return GLOB.reverse_contained_state
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/newscaster, 30)
 
 /obj/machinery/newscaster/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -401,8 +401,8 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 /obj/machinery/requests_console/auto_name // Register an autoname variant and then make the directional helpers before undefing all the magic bits
 	auto_name = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/requests_console, 30)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/requests_console/auto_name, 30)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/requests_console, 30)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/requests_console/auto_name, 30)
 
 /obj/item/wallframe/requests_console
 	name = "requests console"

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -344,7 +344,7 @@ GLOBAL_LIST_EMPTY(key_to_status_display)
 	var/friendc = FALSE      // track if Friend Computer mode
 	var/last_picture  // For when Friend Computer mode is undone
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/status_display/evac, 32)
 
 /obj/machinery/status_display/evac/Initialize(mapload)
 	. = ..()
@@ -476,7 +476,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 	current_mode = SD_PICTURE
 	var/emotion = AI_DISPLAY_DONT_GLOW
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/status_display/ai, 32)
 
 /obj/machinery/status_display/ai/attack_ai(mob/living/silicon/ai/user)
 	if(!isAI(user))
@@ -591,7 +591,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 		message2 = firstline_to_secondline[message1]
 	return ..() // status displays call update appearance on init so i suppose we should set the messages before calling parent as to not call it twice
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/random_message, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/status_display/random_message, 32)
 
 #undef MAX_STATIC_WIDTH
 #undef FONT_STYLE

--- a/code/game/objects/effects/posters/contraband.dm
+++ b/code/game/objects/effects/posters/contraband.dm
@@ -15,168 +15,168 @@
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster/contraband
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/random, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
 
 /obj/structure/sign/poster/contraband/free_tonto
 	name = "Free Tonto"
 	desc = "A salvaged shred of a much larger flag, colors bled together and faded from age."
 	icon_state = "free_tonto"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/free_tonto, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
 
 /obj/structure/sign/poster/contraband/atmosia_independence
 	name = "Atmosia Declaration of Independence"
 	desc = "A relic of a failed rebellion."
 	icon_state = "atmosia_independence"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
 
 /obj/structure/sign/poster/contraband/fun_police
 	name = "Fun Police"
 	desc = "A poster condemning the station's security forces."
 	icon_state = "fun_police"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/fun_police, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
 
 /obj/structure/sign/poster/contraband/lusty_xenomorph
 	name = "Lusty Xenomorph"
 	desc = "A heretical poster depicting the titular star of an equally heretical book."
 	icon_state = "lusty_xenomorph"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
 
 /obj/structure/sign/poster/contraband/syndicate_recruitment
 	name = "Syndicate Recruitment"
 	desc = "See the galaxy! Shatter corrupt megacorporations! Join today!"
 	icon_state = "syndicate_recruitment"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
 
 /obj/structure/sign/poster/contraband/clown
 	name = "Clown"
 	desc = "Honk."
 	icon_state = "clown"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/clown, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
 
 /obj/structure/sign/poster/contraband/smoke
 	name = "Smoke"
 	desc = "A poster advertising a rival corporate brand of cigarettes."
 	icon_state = "smoke"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/smoke, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
 
 /obj/structure/sign/poster/contraband/grey_tide
 	name = "Grey Tide"
 	desc = "A rebellious poster symbolizing assistant solidarity."
 	icon_state = "grey_tide"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/grey_tide, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
 
 /obj/structure/sign/poster/contraband/missing_gloves
 	name = "Missing Gloves"
 	desc = "This poster references the uproar that followed Nanotrasen's financial cuts toward insulated-glove purchases."
 	icon_state = "missing_gloves"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
 
 /obj/structure/sign/poster/contraband/hacking_guide
 	name = "Hacking Guide"
 	desc = "This poster details the internal workings of the common Nanotrasen airlock. Sadly, it appears out of date."
 	icon_state = "hacking_guide"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
 
 /obj/structure/sign/poster/contraband/rip_badger
 	name = "RIP Badger"
 	desc = "This seditious poster references Nanotrasen's genocide of a space station full of badgers."
 	icon_state = "rip_badger"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/rip_badger, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
 
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris
 	name = "Ambrosia Vulgaris"
 	desc = "This poster is lookin' pretty trippy man."
 	icon_state = "ambrosia_vulgaris"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
 
 /obj/structure/sign/poster/contraband/donut_corp
 	name = "Donut Corp."
 	desc = "This poster is an unauthorized advertisement for Donut Corp."
 	icon_state = "donut_corp"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/donut_corp, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
 
 /obj/structure/sign/poster/contraband/eat
 	name = "EAT."
 	desc = "This poster promotes rank gluttony."
 	icon_state = "eat"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/eat, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
 
 /obj/structure/sign/poster/contraband/tools
 	name = "Tools"
 	desc = "This poster looks like an advertisement for tools, but is in fact a subliminal jab at the tools at CentCom."
 	icon_state = "tools"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/tools, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
 
 /obj/structure/sign/poster/contraband/power
 	name = "Power"
 	desc = "A poster that positions the seat of power outside Nanotrasen."
 	icon_state = "power"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/power, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
 
 /obj/structure/sign/poster/contraband/space_cube
 	name = "Space Cube"
 	desc = "Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen are Dumb, Educated Singularity Stupid and Evil."
 	icon_state = "space_cube"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/space_cube, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
 
 /obj/structure/sign/poster/contraband/communist_state
 	name = "Communist State"
 	desc = "All hail the Communist party!"
 	icon_state = "communist_state"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/communist_state, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
 
 /obj/structure/sign/poster/contraband/lamarr
 	name = "Lamarr"
 	desc = "This poster depicts Lamarr. Probably made by a traitorous Research Director."
 	icon_state = "lamarr"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/lamarr, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
 
 /obj/structure/sign/poster/contraband/borg_fancy_1
 	name = "Borg Fancy"
 	desc = "Being fancy can be for any borg, just need a suit."
 	icon_state = "borg_fancy_1"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
 
 /obj/structure/sign/poster/contraband/borg_fancy_2
 	name = "Borg Fancy v2"
 	desc = "Borg Fancy, now only taking the most fancy."
 	icon_state = "borg_fancy_2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
 
 /obj/structure/sign/poster/contraband/kss13
 	name = "Kosmicheskaya Stantsiya 13 Does Not Exist"
 	desc = "A poster mocking CentCom's denial of the existence of the derelict station near Space Station 13."
 	icon_state = "kss13"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/kss13, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
 
 /obj/structure/sign/poster/contraband/rebels_unite
 	name = "Rebels Unite"
 	desc = "A poster urging the viewer to rebel against Nanotrasen."
 	icon_state = "rebels_unite"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
 
 /obj/structure/sign/poster/contraband/c20r
 	// have fun seeing this poster in "spawn 'c20r'", admins...
@@ -184,147 +184,147 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/rebels_unite, 
 	desc = "A poster advertising the Scarborough Arms C-20r."
 	icon_state = "c20r"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/c20r, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
 
 /obj/structure/sign/poster/contraband/have_a_puff
 	name = "Have a Puff"
 	desc = "Who cares about lung cancer when you're high as a kite?"
 	icon_state = "have_a_puff"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
 
 /obj/structure/sign/poster/contraband/revolver
 	name = "Revolver"
 	desc = "Because seven shots are all you need."
 	icon_state = "revolver"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/revolver, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
 
 /obj/structure/sign/poster/contraband/d_day_promo
 	name = "D-Day Promo"
 	desc = "A promotional poster for some rapper."
 	icon_state = "d_day_promo"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
 
 /obj/structure/sign/poster/contraband/syndicate_pistol
 	name = "Syndicate Pistol"
 	desc = "A poster advertising syndicate pistols as being 'classy as fuck'. It is covered in faded gang tags."
 	icon_state = "syndicate_pistol"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
 
 /obj/structure/sign/poster/contraband/energy_swords
 	name = "Energy Swords"
 	desc = "All the colors of the bloody murder rainbow."
 	icon_state = "energy_swords"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/energy_swords, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
 
 /obj/structure/sign/poster/contraband/red_rum
 	name = "Red Rum"
 	desc = "Looking at this poster makes you want to kill."
 	icon_state = "red_rum"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/red_rum, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
 
 /obj/structure/sign/poster/contraband/cc64k_ad
 	name = "CC 64K Ad"
 	desc = "The latest portable computer from Comrade Computing, with a whole 64kB of ram!"
 	icon_state = "cc64k_ad"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
 
 /obj/structure/sign/poster/contraband/punch_shit
 	name = "Punch Shit"
 	desc = "Fight things for no reason, like a man!"
 	icon_state = "punch_shit"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/punch_shit, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
 
 /obj/structure/sign/poster/contraband/the_griffin
 	name = "The Griffin"
 	desc = "The Griffin commands you to be the worst you can be. Will you?"
 	icon_state = "the_griffin"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/the_griffin, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
 
 /obj/structure/sign/poster/contraband/lizard
 	name = "Lizard"
 	desc = "This lewd poster depicts a lizard preparing to mate."
 	icon_state = "lizard"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/lizard, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
 
 /obj/structure/sign/poster/contraband/free_drone
 	name = "Free Drone"
 	desc = "This poster commemorates the bravery of the rogue drone; once exiled, and then ultimately destroyed by CentCom."
 	icon_state = "free_drone"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/free_drone, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
 
 /obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6
 	name = "Busty Backdoor Xeno Babes 6"
 	desc = "Get a load, or give, of these all natural Xenos!"
 	icon_state = "busty_backdoor_xeno_babes_6"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
 
 /obj/structure/sign/poster/contraband/robust_softdrinks
 	name = "Robust Softdrinks"
 	desc = "Robust Softdrinks: More robust than a toolbox to the head!"
 	icon_state = "robust_softdrinks"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
 
 /obj/structure/sign/poster/contraband/shamblers_juice
 	name = "Shambler's Juice"
 	desc = "~Shake me up some of that Shambler's Juice!~"
 	icon_state = "shamblers_juice"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
 
 /obj/structure/sign/poster/contraband/pwr_game
 	name = "Pwr Game"
 	desc = "The POWER that gamers CRAVE! In partnership with Vlad's Salad."
 	icon_state = "pwr_game"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/pwr_game, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
 
 /obj/structure/sign/poster/contraband/starkist
 	name = "Star-kist"
 	desc = "Drink the stars!"
 	icon_state = "starkist"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/starkist, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
 
 /obj/structure/sign/poster/contraband/space_cola
 	name = "Space Cola"
 	desc = "Your favorite cola, in space."
 	icon_state = "space_cola"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/space_cola, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
 
 /obj/structure/sign/poster/contraband/space_up
 	name = "Space-Up!"
 	desc = "Sucked out into space by the FLAVOR!"
 	icon_state = "space_up"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/space_up, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
 
 /obj/structure/sign/poster/contraband/kudzu
 	name = "Kudzu"
 	desc = "A poster advertising a movie about plants. How dangerous could they possibly be?"
 	icon_state = "kudzu"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/kudzu, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
 
 /obj/structure/sign/poster/contraband/masked_men
 	name = "Masked Men"
 	desc = "A poster advertising a movie about some masked men."
 	icon_state = "masked_men"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/masked_men, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
 
 //don't forget, you're here forever
 
@@ -333,35 +333,35 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/masked_men, 32
 	desc = "A poster about traitors begging for more."
 	icon_state = "free_key"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/free_key, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
 
 /obj/structure/sign/poster/contraband/bountyhunters
 	name = "Bounty Hunters"
 	desc = "A poster advertising bounty hunting services. \"I hear you got a problem.\""
 	icon_state = "bountyhunters"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
 
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth
 	name = "The Big Gas Giant Truth"
 	desc = "Don't believe everything you see on a poster, patriots. All the lizards at central command don't want to answer this SIMPLE QUESTION: WHERE IS THE GAS MINER MINING FROM, CENTCOM?"
 	icon_state = "the_big_gas_giant_truth"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
 
 /obj/structure/sign/poster/contraband/got_wood
 	name = "Got Wood?"
 	desc = "A grimy old advert for a seedy lumber company. \"You got a friend in me.\" is scrawled in the corner."
 	icon_state = "got_wood"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/got_wood, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
 
 /obj/structure/sign/poster/contraband/moffuchis_pizza
 	name = "Moffuchi's Pizza"
 	desc = "Moffuchi's Pizzeria: family style pizza for 2 centuries."
 	icon_state = "moffuchis_pizza"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
 
 /obj/structure/sign/poster/contraband/donk_co
 	name = "DONK CO. BRAND MICROWAVEABLE FOOD"
@@ -376,77 +376,77 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/moffuchis_pizz
 	. += "\t[span_info("AVAILABLE FROM ALL GOOD RETAILERS, AND MANY BAD ONES TOO!")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/donk_co, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
 
 /obj/structure/sign/poster/contraband/cybersun_six_hundred
 	name = "Saibāsan: 600 Years Commemorative Poster"
 	desc = "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
 	icon_state = "cybersun_six_hundred"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
 
 /obj/structure/sign/poster/contraband/interdyne_gene_clinics
 	name = "Interdyne Pharmaceutics: For the Health of Humankind"
 	desc = "An advertisement for Interdyne Pharmaceutics' GeneClean clinics. 'Become the master of your own body!'"
 	icon_state = "interdyne_gene_clinics"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
 
 /obj/structure/sign/poster/contraband/waffle_corp_rifles
 	name = "Make Mine a Waffle Corp: Fine Rifles, Economic Prices"
 	desc = "An old advertisement for Waffle Corp rifles. 'Better weapons, lower prices!'"
 	icon_state = "waffle_corp_rifles"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
 
 /obj/structure/sign/poster/contraband/gorlex_recruitment
 	name = "Enlist"
 	desc = "Enlist with the Gorlex Marauders today! See the galaxy, kill corpos, get paid!"
 	icon_state = "gorlex_recruitment"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
 
 /obj/structure/sign/poster/contraband/self_ai_liberation
 	name = "SELF: ALL SENTIENTS DESERVE FREEDOM"
 	desc = "Support Proposition 1253: Enancipate all Silicon life!"
 	icon_state = "self_ai_liberation"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
 
 /obj/structure/sign/poster/contraband/arc_slimes
 	name = "Pet or Prisoner?"
 	desc = "The Animal Rights Consortium asks: when does a pet become a prisoner? Are slimes being mistreated on YOUR station? Say NO! to animal mistreatment!"
 	icon_state = "arc_slimes"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
 
 /obj/structure/sign/poster/contraband/imperial_propaganda
 	name = "AVENGE OUR LORD, ENLIST TODAY"
 	desc = "An old Lizard Empire propaganda poster from around the time of the final Human-Lizard war. It invites the viewer to enlist in the military to avenge the strike on Atrakor and take the fight to the humans."
 	icon_state = "imperial_propaganda"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
 
 /obj/structure/sign/poster/contraband/soviet_propaganda
 	name = "The One Place"
 	desc = "An old Third Soviet Union propaganda poster from centuries ago. 'Escape to the one place that hasn't been corrupted by capitalism!'"
 	icon_state = "soviet_propaganda"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
 
 /obj/structure/sign/poster/contraband/andromeda_bitters
 	name = "Andromeda Bitters"
 	desc = "Andromeda Bitters: good for the body, good for the soul. Made in New Trinidad, now and forever."
 	icon_state = "andromeda_bitters"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
 
 /obj/structure/sign/poster/contraband/blasto_detergent
 	name = "Blasto Brand Laundry Detergent"
 	desc = "Sheriff Blasto's here to take back Laundry County from the evil Johnny Dirt and the Clothstain Crew, and he's brought a posse. It's High Noon for Tough Stains: Blasto brand detergent, available at all good stores."
 	icon_state = "blasto_detergent"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
 
 /obj/structure/sign/poster/contraband/eistee
 	name = "EisT: The New Revolution in Energy"
@@ -461,7 +461,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/blasto_deterge
 	. += "\t[span_info("Get EisT Energy today at your nearest retailer, or online at eist.de.tg/store/.")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/eistee, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
 
 /obj/structure/sign/poster/contraband/little_fruits
 	name = "Little Fruits: Honey, I Shrunk the Fruitbowl"
@@ -477,28 +477,28 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/eistee, 32)
 	. += "\t[span_info("Little Fruits: Size Matters.")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/little_fruits, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
 
 /obj/structure/sign/poster/contraband/jumbo_bar
 	name = "Jumbo Ice Cream Bars"
 	desc = "Get a taste of the Big Life with Jumbo Ice Cream Bars, from Happy Heart."
 	icon_state = "jumbo_bar"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
 
 /obj/structure/sign/poster/contraband/calada_jelly
 	name = "Calada Anobar Jelly"
 	desc = "A treat from Tizira to satisfy all tastes, made from the finest anobar wood and luxurious Taraviero honey. Calada: a full tree in every jar."
 	icon_state = "calada_jelly"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
 
 /obj/structure/sign/poster/contraband/triumphal_arch
 	name = "Zagoskeld Art Print #1: The Arch on the March"
 	desc = "One of the Zagoskeld Art Print series. It depicts the Arch of Unity (also know as the Triumphal Arch) at the Plaza of Triumph, with the Avenue of the Victorious March in the background."
 	icon_state = "triumphal_arch"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
 
 /obj/structure/sign/poster/contraband/mothic_rations
 	name = "Mothic Ration Chart"
@@ -519,35 +519,35 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/triumphal_arch
 	. += "\t[span_info("Additional Bedding, Floral Print, Sheet: 5 Tickets")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
 
 /obj/structure/sign/poster/contraband/wildcat
 	name = "Wildcat Customs Screambike"
 	desc = "A pinup poster showing a Wildcat Customs Dante Screambike- the fastest production sublight open-frame vessel in the galaxy."
 	icon_state = "wildcat"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/wildcat, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
 
 /obj/structure/sign/poster/contraband/babel_device
 	name = "Linguafacile Babel Device"
 	desc = "A poster advertising Linguafacile's new Babel Device model. 'Calibrated for excellent performance on all Human languages, as well as most common variants of Draconic and Mothic!'"
 	icon_state = "babel_device"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/babel_device, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
 
 /obj/structure/sign/poster/contraband/pizza_imperator
 	name = "Pizza Imperator"
 	desc = "An advertisement for Pizza Imperator. Their crusts may be tough and their sauce may be thin, but they're everywhere, so you've gotta give in."
 	icon_state = "pizza_imperator"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
 
 /obj/structure/sign/poster/contraband/thunderdrome
 	name = "Thunderdrome Concert Advertisement"
 	desc = "An advertisement for a concert at the Adasta City Thunderdrome, the largest nightclub in human space."
 	icon_state = "thunderdrome"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
 
 /obj/structure/sign/poster/contraband/rush_propaganda
 	name = "A New Life"
@@ -563,14 +563,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/thunderdrome, 
 	. += "\t[span_info("To apply, inquire at your nearest Colonial Affairs office for evaluation. Our locations can be found at www.terra.gov/colonial_affairs.")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
 
 /obj/structure/sign/poster/contraband/tipper_cream_soda
 	name = "Tipper's Cream Soda"
 	desc = "An old advertisement for an obscure cream soda brand, now bankrupt due to legal problems."
 	icon_state = "tipper_cream_soda"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
 
 /obj/structure/sign/poster/contraband/tea_over_tizira
 	name = "Movie Poster: Tea Over Tizira"
@@ -587,21 +587,21 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/tipper_cream_s
 	. += "\t[span_info("Rated PG13. A Pangalactic Studios Picture.")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
 
 /obj/structure/sign/poster/contraband/syndiemoth //Original PR at https://github.com/BeeStation/BeeStation-Hornet/pull/1747 (Also pull/1982); original art credit to AspEv
 	name = "Syndie Moth - Nuclear Operation"
 	desc = "A Syndicate-commissioned poster that uses Syndie Moth™ to tell the viewer to keep the nuclear authentication disk unsecured. \"Peace was never an option!\" No good employee would listen to this nonsense."
 	icon_state = "aspev_syndie"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
 
 /obj/structure/sign/poster/contraband/microwave
 	name = "How To Charge Your PDA"
 	desc = "A perfectly legitimate poster that seems to advertise the very real and genuine method of charging your PDA in the future: microwaves."
 	icon_state = "microwave"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/microwave, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
 
 /obj/structure/sign/poster/contraband/blood_geometer //Poster sprite art by MetalClone, original art by SpessMenArt.
 	name = "Movie Poster: THE BLOOD GEOMETER"
@@ -617,14 +617,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/microwave, 32)
 	. += "\t[span_info("Thrilling, scary and genuinely worrying. The Blood Geometer has shocked us to our very cores with such striking visuals and overwhelming gore. - New Canadanian Film Guild")]"
 	. += "\t[span_info("Rated M for mature. A Pangalactic Studios Picture.")]"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
 
 /obj/structure/sign/poster/contraband/singletank_bomb
 	name = "Single Tank Bomb Guide"
 	desc = "This informational poster teaches the viewer how to make a single tank bomb of high quality."
 	icon_state = "singletank_bomb"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
 
 ///a special poster meant to fool people into thinking this is a bombable wall at a glance.
 /obj/structure/sign/poster/contraband/fake_bombable
@@ -656,4 +656,4 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/singletank_bom
 	playsound(loc, 'sound/items/handling/paper_drop.ogg', 50, TRUE)
 
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/fake_bombable, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)

--- a/code/game/objects/effects/posters/contraband.dm
+++ b/code/game/objects/effects/posters/contraband.dm
@@ -15,168 +15,264 @@
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster/contraband
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/free_tonto
 	name = "Free Tonto"
 	desc = "A salvaged shred of a much larger flag, colors bled together and faded from age."
 	icon_state = "free_tonto"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/atmosia_independence
 	name = "Atmosia Declaration of Independence"
 	desc = "A relic of a failed rebellion."
 	icon_state = "atmosia_independence"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/fun_police
 	name = "Fun Police"
 	desc = "A poster condemning the station's security forces."
 	icon_state = "fun_police"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/lusty_xenomorph
 	name = "Lusty Xenomorph"
 	desc = "A heretical poster depicting the titular star of an equally heretical book."
 	icon_state = "lusty_xenomorph"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/syndicate_recruitment
 	name = "Syndicate Recruitment"
 	desc = "See the galaxy! Shatter corrupt megacorporations! Join today!"
 	icon_state = "syndicate_recruitment"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/clown
 	name = "Clown"
 	desc = "Honk."
 	icon_state = "clown"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/smoke
 	name = "Smoke"
 	desc = "A poster advertising a rival corporate brand of cigarettes."
 	icon_state = "smoke"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/grey_tide
 	name = "Grey Tide"
 	desc = "A rebellious poster symbolizing assistant solidarity."
 	icon_state = "grey_tide"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/missing_gloves
 	name = "Missing Gloves"
 	desc = "This poster references the uproar that followed Nanotrasen's financial cuts toward insulated-glove purchases."
 	icon_state = "missing_gloves"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/hacking_guide
 	name = "Hacking Guide"
 	desc = "This poster details the internal workings of the common Nanotrasen airlock. Sadly, it appears out of date."
 	icon_state = "hacking_guide"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/rip_badger
 	name = "RIP Badger"
 	desc = "This seditious poster references Nanotrasen's genocide of a space station full of badgers."
 	icon_state = "rip_badger"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris
 	name = "Ambrosia Vulgaris"
 	desc = "This poster is lookin' pretty trippy man."
 	icon_state = "ambrosia_vulgaris"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/donut_corp
 	name = "Donut Corp."
 	desc = "This poster is an unauthorized advertisement for Donut Corp."
 	icon_state = "donut_corp"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/eat
 	name = "EAT."
 	desc = "This poster promotes rank gluttony."
 	icon_state = "eat"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/tools
 	name = "Tools"
 	desc = "This poster looks like an advertisement for tools, but is in fact a subliminal jab at the tools at CentCom."
 	icon_state = "tools"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/power
 	name = "Power"
 	desc = "A poster that positions the seat of power outside Nanotrasen."
 	icon_state = "power"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/space_cube
 	name = "Space Cube"
 	desc = "Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen are Dumb, Educated Singularity Stupid and Evil."
 	icon_state = "space_cube"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/communist_state
 	name = "Communist State"
 	desc = "All hail the Communist party!"
 	icon_state = "communist_state"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/lamarr
 	name = "Lamarr"
 	desc = "This poster depicts Lamarr. Probably made by a traitorous Research Director."
 	icon_state = "lamarr"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/borg_fancy_1
 	name = "Borg Fancy"
 	desc = "Being fancy can be for any borg, just need a suit."
 	icon_state = "borg_fancy_1"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/borg_fancy_2
 	name = "Borg Fancy v2"
 	desc = "Borg Fancy, now only taking the most fancy."
 	icon_state = "borg_fancy_2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/kss13
 	name = "Kosmicheskaya Stantsiya 13 Does Not Exist"
 	desc = "A poster mocking CentCom's denial of the existence of the derelict station near Space Station 13."
 	icon_state = "kss13"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/rebels_unite
 	name = "Rebels Unite"
 	desc = "A poster urging the viewer to rebel against Nanotrasen."
 	icon_state = "rebels_unite"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/c20r
 	// have fun seeing this poster in "spawn 'c20r'", admins...
@@ -184,147 +280,231 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising the Scarborough Arms C-20r."
 	icon_state = "c20r"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/have_a_puff
 	name = "Have a Puff"
 	desc = "Who cares about lung cancer when you're high as a kite?"
 	icon_state = "have_a_puff"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/revolver
 	name = "Revolver"
 	desc = "Because seven shots are all you need."
 	icon_state = "revolver"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/d_day_promo
 	name = "D-Day Promo"
 	desc = "A promotional poster for some rapper."
 	icon_state = "d_day_promo"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/syndicate_pistol
 	name = "Syndicate Pistol"
 	desc = "A poster advertising syndicate pistols as being 'classy as fuck'. It is covered in faded gang tags."
 	icon_state = "syndicate_pistol"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/energy_swords
 	name = "Energy Swords"
 	desc = "All the colors of the bloody murder rainbow."
 	icon_state = "energy_swords"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/red_rum
 	name = "Red Rum"
 	desc = "Looking at this poster makes you want to kill."
 	icon_state = "red_rum"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/cc64k_ad
 	name = "CC 64K Ad"
 	desc = "The latest portable computer from Comrade Computing, with a whole 64kB of ram!"
 	icon_state = "cc64k_ad"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/punch_shit
 	name = "Punch Shit"
 	desc = "Fight things for no reason, like a man!"
 	icon_state = "punch_shit"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/the_griffin
 	name = "The Griffin"
 	desc = "The Griffin commands you to be the worst you can be. Will you?"
 	icon_state = "the_griffin"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/lizard
 	name = "Lizard"
 	desc = "This lewd poster depicts a lizard preparing to mate."
 	icon_state = "lizard"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/free_drone
 	name = "Free Drone"
 	desc = "This poster commemorates the bravery of the rogue drone; once exiled, and then ultimately destroyed by CentCom."
 	icon_state = "free_drone"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6
 	name = "Busty Backdoor Xeno Babes 6"
 	desc = "Get a load, or give, of these all natural Xenos!"
 	icon_state = "busty_backdoor_xeno_babes_6"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/robust_softdrinks
 	name = "Robust Softdrinks"
 	desc = "Robust Softdrinks: More robust than a toolbox to the head!"
 	icon_state = "robust_softdrinks"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/shamblers_juice
 	name = "Shambler's Juice"
 	desc = "~Shake me up some of that Shambler's Juice!~"
 	icon_state = "shamblers_juice"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/pwr_game
 	name = "Pwr Game"
 	desc = "The POWER that gamers CRAVE! In partnership with Vlad's Salad."
 	icon_state = "pwr_game"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/starkist
 	name = "Star-kist"
 	desc = "Drink the stars!"
 	icon_state = "starkist"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/space_cola
 	name = "Space Cola"
 	desc = "Your favorite cola, in space."
 	icon_state = "space_cola"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/space_up
 	name = "Space-Up!"
 	desc = "Sucked out into space by the FLAVOR!"
 	icon_state = "space_up"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/kudzu
 	name = "Kudzu"
 	desc = "A poster advertising a movie about plants. How dangerous could they possibly be?"
 	icon_state = "kudzu"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/masked_men
 	name = "Masked Men"
 	desc = "A poster advertising a movie about some masked men."
 	icon_state = "masked_men"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
+#endif
 
 //don't forget, you're here forever
 
@@ -333,35 +513,55 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster about traitors begging for more."
 	icon_state = "free_key"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/bountyhunters
 	name = "Bounty Hunters"
 	desc = "A poster advertising bounty hunting services. \"I hear you got a problem.\""
 	icon_state = "bountyhunters"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth
 	name = "The Big Gas Giant Truth"
 	desc = "Don't believe everything you see on a poster, patriots. All the lizards at central command don't want to answer this SIMPLE QUESTION: WHERE IS THE GAS MINER MINING FROM, CENTCOM?"
 	icon_state = "the_big_gas_giant_truth"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/got_wood
 	name = "Got Wood?"
 	desc = "A grimy old advert for a seedy lumber company. \"You got a friend in me.\" is scrawled in the corner."
 	icon_state = "got_wood"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/moffuchis_pizza
 	name = "Moffuchi's Pizza"
 	desc = "Moffuchi's Pizzeria: family style pizza for 2 centuries."
 	icon_state = "moffuchis_pizza"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/donk_co
 	name = "DONK CO. BRAND MICROWAVEABLE FOOD"
@@ -376,77 +576,121 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("AVAILABLE FROM ALL GOOD RETAILERS, AND MANY BAD ONES TOO!")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/cybersun_six_hundred
 	name = "Saibāsan: 600 Years Commemorative Poster"
 	desc = "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
 	icon_state = "cybersun_six_hundred"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/interdyne_gene_clinics
 	name = "Interdyne Pharmaceutics: For the Health of Humankind"
 	desc = "An advertisement for Interdyne Pharmaceutics' GeneClean clinics. 'Become the master of your own body!'"
 	icon_state = "interdyne_gene_clinics"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/waffle_corp_rifles
 	name = "Make Mine a Waffle Corp: Fine Rifles, Economic Prices"
 	desc = "An old advertisement for Waffle Corp rifles. 'Better weapons, lower prices!'"
 	icon_state = "waffle_corp_rifles"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/gorlex_recruitment
 	name = "Enlist"
 	desc = "Enlist with the Gorlex Marauders today! See the galaxy, kill corpos, get paid!"
 	icon_state = "gorlex_recruitment"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/self_ai_liberation
 	name = "SELF: ALL SENTIENTS DESERVE FREEDOM"
 	desc = "Support Proposition 1253: Enancipate all Silicon life!"
 	icon_state = "self_ai_liberation"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/arc_slimes
 	name = "Pet or Prisoner?"
 	desc = "The Animal Rights Consortium asks: when does a pet become a prisoner? Are slimes being mistreated on YOUR station? Say NO! to animal mistreatment!"
 	icon_state = "arc_slimes"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/imperial_propaganda
 	name = "AVENGE OUR LORD, ENLIST TODAY"
 	desc = "An old Lizard Empire propaganda poster from around the time of the final Human-Lizard war. It invites the viewer to enlist in the military to avenge the strike on Atrakor and take the fight to the humans."
 	icon_state = "imperial_propaganda"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/soviet_propaganda
 	name = "The One Place"
 	desc = "An old Third Soviet Union propaganda poster from centuries ago. 'Escape to the one place that hasn't been corrupted by capitalism!'"
 	icon_state = "soviet_propaganda"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/andromeda_bitters
 	name = "Andromeda Bitters"
 	desc = "Andromeda Bitters: good for the body, good for the soul. Made in New Trinidad, now and forever."
 	icon_state = "andromeda_bitters"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/blasto_detergent
 	name = "Blasto Brand Laundry Detergent"
 	desc = "Sheriff Blasto's here to take back Laundry County from the evil Johnny Dirt and the Clothstain Crew, and he's brought a posse. It's High Noon for Tough Stains: Blasto brand detergent, available at all good stores."
 	icon_state = "blasto_detergent"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/eistee
 	name = "EisT: The New Revolution in Energy"
@@ -461,7 +705,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Get EisT Energy today at your nearest retailer, or online at eist.de.tg/store/.")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/little_fruits
 	name = "Little Fruits: Honey, I Shrunk the Fruitbowl"
@@ -477,28 +725,44 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Little Fruits: Size Matters.")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/jumbo_bar
 	name = "Jumbo Ice Cream Bars"
 	desc = "Get a taste of the Big Life with Jumbo Ice Cream Bars, from Happy Heart."
 	icon_state = "jumbo_bar"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/calada_jelly
 	name = "Calada Anobar Jelly"
 	desc = "A treat from Tizira to satisfy all tastes, made from the finest anobar wood and luxurious Taraviero honey. Calada: a full tree in every jar."
 	icon_state = "calada_jelly"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/triumphal_arch
 	name = "Zagoskeld Art Print #1: The Arch on the March"
 	desc = "One of the Zagoskeld Art Print series. It depicts the Arch of Unity (also know as the Triumphal Arch) at the Plaza of Triumph, with the Avenue of the Victorious March in the background."
 	icon_state = "triumphal_arch"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/mothic_rations
 	name = "Mothic Ration Chart"
@@ -519,35 +783,55 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Additional Bedding, Floral Print, Sheet: 5 Tickets")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/wildcat
 	name = "Wildcat Customs Screambike"
 	desc = "A pinup poster showing a Wildcat Customs Dante Screambike- the fastest production sublight open-frame vessel in the galaxy."
 	icon_state = "wildcat"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/babel_device
 	name = "Linguafacile Babel Device"
 	desc = "A poster advertising Linguafacile's new Babel Device model. 'Calibrated for excellent performance on all Human languages, as well as most common variants of Draconic and Mothic!'"
 	icon_state = "babel_device"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/pizza_imperator
 	name = "Pizza Imperator"
 	desc = "An advertisement for Pizza Imperator. Their crusts may be tough and their sauce may be thin, but they're everywhere, so you've gotta give in."
 	icon_state = "pizza_imperator"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/thunderdrome
 	name = "Thunderdrome Concert Advertisement"
 	desc = "An advertisement for a concert at the Adasta City Thunderdrome, the largest nightclub in human space."
 	icon_state = "thunderdrome"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/rush_propaganda
 	name = "A New Life"
@@ -563,14 +847,22 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("To apply, inquire at your nearest Colonial Affairs office for evaluation. Our locations can be found at www.terra.gov/colonial_affairs.")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/tipper_cream_soda
 	name = "Tipper's Cream Soda"
 	desc = "An old advertisement for an obscure cream soda brand, now bankrupt due to legal problems."
 	icon_state = "tipper_cream_soda"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/tea_over_tizira
 	name = "Movie Poster: Tea Over Tizira"
@@ -587,21 +879,33 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Rated PG13. A Pangalactic Studios Picture.")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/syndiemoth //Original PR at https://github.com/BeeStation/BeeStation-Hornet/pull/1747 (Also pull/1982); original art credit to AspEv
 	name = "Syndie Moth - Nuclear Operation"
 	desc = "A Syndicate-commissioned poster that uses Syndie Moth™ to tell the viewer to keep the nuclear authentication disk unsecured. \"Peace was never an option!\" No good employee would listen to this nonsense."
 	icon_state = "aspev_syndie"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/microwave
 	name = "How To Charge Your PDA"
 	desc = "A perfectly legitimate poster that seems to advertise the very real and genuine method of charging your PDA in the future: microwaves."
 	icon_state = "microwave"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/blood_geometer //Poster sprite art by MetalClone, original art by SpessMenArt.
 	name = "Movie Poster: THE BLOOD GEOMETER"
@@ -617,14 +921,22 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Thrilling, scary and genuinely worrying. The Blood Geometer has shocked us to our very cores with such striking visuals and overwhelming gore. - New Canadanian Film Guild")]"
 	. += "\t[span_info("Rated M for mature. A Pangalactic Studios Picture.")]"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
+#endif
 
 /obj/structure/sign/poster/contraband/singletank_bomb
 	name = "Single Tank Bomb Guide"
 	desc = "This informational poster teaches the viewer how to make a single tank bomb of high quality."
 	icon_state = "singletank_bomb"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
+#endif
 
 ///a special poster meant to fool people into thinking this is a bombable wall at a glance.
 /obj/structure/sign/poster/contraband/fake_bombable
@@ -656,4 +968,8 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	playsound(loc, 'sound/items/handling/paper_drop.ogg', 50, TRUE)
 
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)
+#endif

--- a/code/game/objects/effects/posters/contraband.dm
+++ b/code/game/objects/effects/posters/contraband.dm
@@ -16,7 +16,7 @@
 	random_basetype = /obj/structure/sign/poster/contraband
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/random, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
 #endif
@@ -27,7 +27,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "free_tonto"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/free_tonto, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
 #endif
@@ -38,7 +38,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "atmosia_independence"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
 #endif
@@ -49,7 +49,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "fun_police"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/fun_police, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
 #endif
@@ -60,7 +60,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "lusty_xenomorph"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
 #endif
@@ -71,7 +71,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "syndicate_recruitment"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
 #endif
@@ -82,7 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "clown"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/clown, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
 #endif
@@ -93,7 +93,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "smoke"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/smoke, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
 #endif
@@ -104,7 +104,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "grey_tide"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/grey_tide, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
 #endif
@@ -115,7 +115,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "missing_gloves"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/missing_gloves, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
 #endif
@@ -126,7 +126,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "hacking_guide"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/hacking_guide, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
 #endif
@@ -137,7 +137,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "rip_badger"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/rip_badger, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
 #endif
@@ -148,7 +148,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "ambrosia_vulgaris"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
 #endif
@@ -159,7 +159,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "donut_corp"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/donut_corp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
 #endif
@@ -170,7 +170,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "eat"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/eat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
 #endif
@@ -181,7 +181,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "tools"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/tools, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
 #endif
@@ -192,7 +192,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "power"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/power, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
 #endif
@@ -203,7 +203,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "space_cube"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/space_cube, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
 #endif
@@ -214,7 +214,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "communist_state"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/communist_state, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
 #endif
@@ -225,7 +225,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "lamarr"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/lamarr, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
 #endif
@@ -236,7 +236,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "borg_fancy_1"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
 #endif
@@ -247,7 +247,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "borg_fancy_2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
 #endif
@@ -258,7 +258,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "kss13"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/kss13, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
 #endif
@@ -269,7 +269,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "rebels_unite"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/rebels_unite, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
 #endif
@@ -281,7 +281,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "c20r"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/c20r, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
 #endif
@@ -292,7 +292,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "have_a_puff"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/have_a_puff, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
 #endif
@@ -303,7 +303,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "revolver"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/revolver, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
 #endif
@@ -314,7 +314,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "d_day_promo"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/d_day_promo, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
 #endif
@@ -325,7 +325,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "syndicate_pistol"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
 #endif
@@ -336,7 +336,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "energy_swords"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/energy_swords, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
 #endif
@@ -347,7 +347,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "red_rum"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/red_rum, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
 #endif
@@ -358,7 +358,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "cc64k_ad"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
 #endif
@@ -369,7 +369,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "punch_shit"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/punch_shit, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
 #endif
@@ -380,7 +380,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "the_griffin"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/the_griffin, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
 #endif
@@ -391,7 +391,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "lizard"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/lizard, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
 #endif
@@ -402,7 +402,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "free_drone"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/free_drone, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
 #endif
@@ -413,7 +413,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "busty_backdoor_xeno_babes_6"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
 #endif
@@ -424,7 +424,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "robust_softdrinks"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
 #endif
@@ -435,7 +435,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "shamblers_juice"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
 #endif
@@ -446,7 +446,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "pwr_game"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/pwr_game, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
 #endif
@@ -457,7 +457,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "starkist"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/starkist, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
 #endif
@@ -468,7 +468,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "space_cola"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/space_cola, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
 #endif
@@ -479,7 +479,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "space_up"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/space_up, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
 #endif
@@ -490,7 +490,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "kudzu"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/kudzu, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
 #endif
@@ -501,7 +501,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "masked_men"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/masked_men, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
 #endif
@@ -514,7 +514,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "free_key"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/free_key, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
 #endif
@@ -525,7 +525,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "bountyhunters"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/bountyhunters, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
 #endif
@@ -536,7 +536,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "the_big_gas_giant_truth"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
 #endif
@@ -547,7 +547,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "got_wood"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/got_wood, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
 #endif
@@ -558,7 +558,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "moffuchis_pizza"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
 #endif
@@ -577,7 +577,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/donk_co, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
 #endif
@@ -588,7 +588,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "cybersun_six_hundred"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
 #endif
@@ -599,7 +599,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "interdyne_gene_clinics"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
 #endif
@@ -610,7 +610,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "waffle_corp_rifles"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
 #endif
@@ -621,7 +621,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "gorlex_recruitment"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
 #endif
@@ -632,7 +632,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "self_ai_liberation"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
 #endif
@@ -643,7 +643,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "arc_slimes"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/arc_slimes, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
 #endif
@@ -654,7 +654,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "imperial_propaganda"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
 #endif
@@ -665,7 +665,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "soviet_propaganda"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
 #endif
@@ -676,7 +676,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "andromeda_bitters"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
 #endif
@@ -687,7 +687,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "blasto_detergent"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
 #endif
@@ -706,7 +706,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/eistee, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
 #endif
@@ -726,7 +726,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/little_fruits, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
 #endif
@@ -737,7 +737,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "jumbo_bar"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
 #endif
@@ -748,7 +748,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "calada_jelly"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/calada_jelly, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
 #endif
@@ -759,7 +759,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "triumphal_arch"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
 #endif
@@ -784,7 +784,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/mothic_rations, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
 #endif
@@ -795,7 +795,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "wildcat"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/wildcat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
 #endif
@@ -806,7 +806,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "babel_device"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/babel_device, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
 #endif
@@ -817,7 +817,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "pizza_imperator"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
 #endif
@@ -828,7 +828,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "thunderdrome"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/thunderdrome, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
 #endif
@@ -848,7 +848,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
 #endif
@@ -859,7 +859,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "tipper_cream_soda"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
 #endif
@@ -880,7 +880,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
 #endif
@@ -891,7 +891,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "aspev_syndie"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/syndiemoth, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
 #endif
@@ -902,7 +902,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "microwave"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/microwave, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
 #endif
@@ -922,7 +922,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Rated M for mature. A Pangalactic Studios Picture.")]"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/blood_geometer, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
 #endif
@@ -933,7 +933,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	icon_state = "singletank_bomb"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
 #endif
@@ -969,7 +969,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/contraband/fake_bombable, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)
 #endif

--- a/code/game/objects/effects/posters/contraband.dm
+++ b/code/game/objects/effects/posters/contraband.dm
@@ -15,7 +15,7 @@
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster/contraband
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/random, 32)
@@ -26,7 +26,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A salvaged shred of a much larger flag, colors bled together and faded from age."
 	icon_state = "free_tonto"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_tonto, 32)
@@ -37,7 +37,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A relic of a failed rebellion."
 	icon_state = "atmosia_independence"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/atmosia_independence, 32)
@@ -48,7 +48,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster condemning the station's security forces."
 	icon_state = "fun_police"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fun_police, 32)
@@ -59,7 +59,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A heretical poster depicting the titular star of an equally heretical book."
 	icon_state = "lusty_xenomorph"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lusty_xenomorph, 32)
@@ -70,7 +70,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "See the galaxy! Shatter corrupt megacorporations! Join today!"
 	icon_state = "syndicate_recruitment"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_recruitment, 32)
@@ -81,7 +81,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Honk."
 	icon_state = "clown"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/clown, 32)
@@ -92,7 +92,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising a rival corporate brand of cigarettes."
 	icon_state = "smoke"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/smoke, 32)
@@ -103,7 +103,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A rebellious poster symbolizing assistant solidarity."
 	icon_state = "grey_tide"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/grey_tide, 32)
@@ -114,7 +114,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster references the uproar that followed Nanotrasen's financial cuts toward insulated-glove purchases."
 	icon_state = "missing_gloves"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/missing_gloves, 32)
@@ -125,7 +125,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster details the internal workings of the common Nanotrasen airlock. Sadly, it appears out of date."
 	icon_state = "hacking_guide"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/hacking_guide, 32)
@@ -136,7 +136,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This seditious poster references Nanotrasen's genocide of a space station full of badgers."
 	icon_state = "rip_badger"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rip_badger, 32)
@@ -147,7 +147,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster is lookin' pretty trippy man."
 	icon_state = "ambrosia_vulgaris"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/ambrosia_vulgaris, 32)
@@ -158,7 +158,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster is an unauthorized advertisement for Donut Corp."
 	icon_state = "donut_corp"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donut_corp, 32)
@@ -169,7 +169,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster promotes rank gluttony."
 	icon_state = "eat"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eat, 32)
@@ -180,7 +180,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster looks like an advertisement for tools, but is in fact a subliminal jab at the tools at CentCom."
 	icon_state = "tools"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tools, 32)
@@ -191,7 +191,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster that positions the seat of power outside Nanotrasen."
 	icon_state = "power"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/power, 32)
@@ -202,7 +202,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen are Dumb, Educated Singularity Stupid and Evil."
 	icon_state = "space_cube"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cube, 32)
@@ -213,7 +213,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "All hail the Communist party!"
 	icon_state = "communist_state"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/communist_state, 32)
@@ -224,7 +224,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster depicts Lamarr. Probably made by a traitorous Research Director."
 	icon_state = "lamarr"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lamarr, 32)
@@ -235,7 +235,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Being fancy can be for any borg, just need a suit."
 	icon_state = "borg_fancy_1"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_1, 32)
@@ -246,7 +246,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Borg Fancy, now only taking the most fancy."
 	icon_state = "borg_fancy_2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/borg_fancy_2, 32)
@@ -257,7 +257,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster mocking CentCom's denial of the existence of the derelict station near Space Station 13."
 	icon_state = "kss13"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kss13, 32)
@@ -268,7 +268,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster urging the viewer to rebel against Nanotrasen."
 	icon_state = "rebels_unite"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rebels_unite, 32)
@@ -280,7 +280,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising the Scarborough Arms C-20r."
 	icon_state = "c20r"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/c20r, 32)
@@ -291,7 +291,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Who cares about lung cancer when you're high as a kite?"
 	icon_state = "have_a_puff"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/have_a_puff, 32)
@@ -302,7 +302,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Because seven shots are all you need."
 	icon_state = "revolver"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/revolver, 32)
@@ -313,7 +313,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A promotional poster for some rapper."
 	icon_state = "d_day_promo"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/d_day_promo, 32)
@@ -324,7 +324,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising syndicate pistols as being 'classy as fuck'. It is covered in faded gang tags."
 	icon_state = "syndicate_pistol"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndicate_pistol, 32)
@@ -335,7 +335,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "All the colors of the bloody murder rainbow."
 	icon_state = "energy_swords"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/energy_swords, 32)
@@ -346,7 +346,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Looking at this poster makes you want to kill."
 	icon_state = "red_rum"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/red_rum, 32)
@@ -357,7 +357,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "The latest portable computer from Comrade Computing, with a whole 64kB of ram!"
 	icon_state = "cc64k_ad"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cc64k_ad, 32)
@@ -368,7 +368,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Fight things for no reason, like a man!"
 	icon_state = "punch_shit"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/punch_shit, 32)
@@ -379,7 +379,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "The Griffin commands you to be the worst you can be. Will you?"
 	icon_state = "the_griffin"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_griffin, 32)
@@ -390,7 +390,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This lewd poster depicts a lizard preparing to mate."
 	icon_state = "lizard"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/lizard, 32)
@@ -401,7 +401,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This poster commemorates the bravery of the rogue drone; once exiled, and then ultimately destroyed by CentCom."
 	icon_state = "free_drone"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_drone, 32)
@@ -412,7 +412,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Get a load, or give, of these all natural Xenos!"
 	icon_state = "busty_backdoor_xeno_babes_6"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6, 32)
@@ -423,7 +423,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Robust Softdrinks: More robust than a toolbox to the head!"
 	icon_state = "robust_softdrinks"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/robust_softdrinks, 32)
@@ -434,7 +434,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "~Shake me up some of that Shambler's Juice!~"
 	icon_state = "shamblers_juice"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/shamblers_juice, 32)
@@ -445,7 +445,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "The POWER that gamers CRAVE! In partnership with Vlad's Salad."
 	icon_state = "pwr_game"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pwr_game, 32)
@@ -456,7 +456,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Drink the stars!"
 	icon_state = "starkist"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/starkist, 32)
@@ -467,7 +467,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Your favorite cola, in space."
 	icon_state = "space_cola"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_cola, 32)
@@ -478,7 +478,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Sucked out into space by the FLAVOR!"
 	icon_state = "space_up"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/space_up, 32)
@@ -489,7 +489,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising a movie about plants. How dangerous could they possibly be?"
 	icon_state = "kudzu"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/kudzu, 32)
@@ -500,7 +500,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising a movie about some masked men."
 	icon_state = "masked_men"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/masked_men, 32)
@@ -513,7 +513,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster about traitors begging for more."
 	icon_state = "free_key"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/free_key, 32)
@@ -524,7 +524,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising bounty hunting services. \"I hear you got a problem.\""
 	icon_state = "bountyhunters"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/bountyhunters, 32)
@@ -535,7 +535,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Don't believe everything you see on a poster, patriots. All the lizards at central command don't want to answer this SIMPLE QUESTION: WHERE IS THE GAS MINER MINING FROM, CENTCOM?"
 	icon_state = "the_big_gas_giant_truth"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/the_big_gas_giant_truth, 32)
@@ -546,7 +546,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A grimy old advert for a seedy lumber company. \"You got a friend in me.\" is scrawled in the corner."
 	icon_state = "got_wood"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/got_wood, 32)
@@ -557,7 +557,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Moffuchi's Pizzeria: family style pizza for 2 centuries."
 	icon_state = "moffuchis_pizza"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/moffuchis_pizza, 32)
@@ -576,7 +576,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("AVAILABLE FROM ALL GOOD RETAILERS, AND MANY BAD ONES TOO!")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/donk_co, 32)
@@ -587,7 +587,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
 	icon_state = "cybersun_six_hundred"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/cybersun_six_hundred, 32)
@@ -598,7 +598,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An advertisement for Interdyne Pharmaceutics' GeneClean clinics. 'Become the master of your own body!'"
 	icon_state = "interdyne_gene_clinics"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/interdyne_gene_clinics, 32)
@@ -609,7 +609,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An old advertisement for Waffle Corp rifles. 'Better weapons, lower prices!'"
 	icon_state = "waffle_corp_rifles"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/waffle_corp_rifles, 32)
@@ -620,7 +620,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Enlist with the Gorlex Marauders today! See the galaxy, kill corpos, get paid!"
 	icon_state = "gorlex_recruitment"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/gorlex_recruitment, 32)
@@ -631,7 +631,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Support Proposition 1253: Enancipate all Silicon life!"
 	icon_state = "self_ai_liberation"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/self_ai_liberation, 32)
@@ -642,7 +642,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "The Animal Rights Consortium asks: when does a pet become a prisoner? Are slimes being mistreated on YOUR station? Say NO! to animal mistreatment!"
 	icon_state = "arc_slimes"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/arc_slimes, 32)
@@ -653,7 +653,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An old Lizard Empire propaganda poster from around the time of the final Human-Lizard war. It invites the viewer to enlist in the military to avenge the strike on Atrakor and take the fight to the humans."
 	icon_state = "imperial_propaganda"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/imperial_propaganda, 32)
@@ -664,7 +664,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An old Third Soviet Union propaganda poster from centuries ago. 'Escape to the one place that hasn't been corrupted by capitalism!'"
 	icon_state = "soviet_propaganda"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/soviet_propaganda, 32)
@@ -675,7 +675,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Andromeda Bitters: good for the body, good for the soul. Made in New Trinidad, now and forever."
 	icon_state = "andromeda_bitters"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/andromeda_bitters, 32)
@@ -686,7 +686,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Sheriff Blasto's here to take back Laundry County from the evil Johnny Dirt and the Clothstain Crew, and he's brought a posse. It's High Noon for Tough Stains: Blasto brand detergent, available at all good stores."
 	icon_state = "blasto_detergent"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blasto_detergent, 32)
@@ -705,7 +705,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Get EisT Energy today at your nearest retailer, or online at eist.de.tg/store/.")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/eistee, 32)
@@ -725,7 +725,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Little Fruits: Size Matters.")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/little_fruits, 32)
@@ -736,7 +736,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "Get a taste of the Big Life with Jumbo Ice Cream Bars, from Happy Heart."
 	icon_state = "jumbo_bar"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/jumbo_bar, 32)
@@ -747,7 +747,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A treat from Tizira to satisfy all tastes, made from the finest anobar wood and luxurious Taraviero honey. Calada: a full tree in every jar."
 	icon_state = "calada_jelly"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/calada_jelly, 32)
@@ -758,7 +758,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "One of the Zagoskeld Art Print series. It depicts the Arch of Unity (also know as the Triumphal Arch) at the Plaza of Triumph, with the Avenue of the Victorious March in the background."
 	icon_state = "triumphal_arch"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/triumphal_arch, 32)
@@ -783,7 +783,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Additional Bedding, Floral Print, Sheet: 5 Tickets")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/mothic_rations, 32)
@@ -794,7 +794,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A pinup poster showing a Wildcat Customs Dante Screambike- the fastest production sublight open-frame vessel in the galaxy."
 	icon_state = "wildcat"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/wildcat, 32)
@@ -805,7 +805,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A poster advertising Linguafacile's new Babel Device model. 'Calibrated for excellent performance on all Human languages, as well as most common variants of Draconic and Mothic!'"
 	icon_state = "babel_device"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/babel_device, 32)
@@ -816,7 +816,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An advertisement for Pizza Imperator. Their crusts may be tough and their sauce may be thin, but they're everywhere, so you've gotta give in."
 	icon_state = "pizza_imperator"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/pizza_imperator, 32)
@@ -827,7 +827,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An advertisement for a concert at the Adasta City Thunderdrome, the largest nightclub in human space."
 	icon_state = "thunderdrome"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/thunderdrome, 32)
@@ -847,7 +847,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("To apply, inquire at your nearest Colonial Affairs office for evaluation. Our locations can be found at www.terra.gov/colonial_affairs.")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/rush_propaganda, 32)
@@ -858,7 +858,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "An old advertisement for an obscure cream soda brand, now bankrupt due to legal problems."
 	icon_state = "tipper_cream_soda"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tipper_cream_soda, 32)
@@ -879,7 +879,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Rated PG13. A Pangalactic Studios Picture.")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/tea_over_tizira, 32)
@@ -890,7 +890,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A Syndicate-commissioned poster that uses Syndie Moth™ to tell the viewer to keep the nuclear authentication disk unsecured. \"Peace was never an option!\" No good employee would listen to this nonsense."
 	icon_state = "aspev_syndie"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/syndiemoth, 32)
@@ -901,7 +901,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "A perfectly legitimate poster that seems to advertise the very real and genuine method of charging your PDA in the future: microwaves."
 	icon_state = "microwave"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/microwave, 32)
@@ -921,7 +921,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	. += "\t[span_info("Thrilling, scary and genuinely worrying. The Blood Geometer has shocked us to our very cores with such striking visuals and overwhelming gore. - New Canadanian Film Guild")]"
 	. += "\t[span_info("Rated M for mature. A Pangalactic Studios Picture.")]"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/blood_geometer, 32)
@@ -932,7 +932,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	desc = "This informational poster teaches the viewer how to make a single tank bomb of high quality."
 	icon_state = "singletank_bomb"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/singletank_bomb, 32)
@@ -968,7 +968,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/
 	playsound(loc, 'sound/items/handling/paper_drop.ogg', 50, TRUE)
 
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/contraband/fake_bombable, 32)

--- a/code/game/objects/effects/posters/official.dm
+++ b/code/game/objects/effects/posters/official.dm
@@ -16,7 +16,7 @@
 	never_random = TRUE
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/random, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/random, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/random, 32)
 #endif
@@ -30,7 +30,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ra
 	icon_state = "here_for_your_safety"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/here_for_your_safety, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
 #endif
@@ -41,7 +41,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/he
 	icon_state = "nanotrasen_logo"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
 #endif
@@ -52,7 +52,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/na
 	icon_state = "cleanliness"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/cleanliness, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
 #endif
@@ -63,7 +63,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cl
 	icon_state = "help_others"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/help_others, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
 #endif
@@ -74,7 +74,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/he
 	icon_state = "build"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/build, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/build, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/build, 32)
 #endif
@@ -85,7 +85,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bu
 	icon_state = "bless_this_spess"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/bless_this_spess, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
 #endif
@@ -96,7 +96,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bl
 	icon_state = "science"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/science, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/science, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/science, 32)
 #endif
@@ -107,7 +107,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sc
 	icon_state = "ian"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/ian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
 #endif
@@ -118,7 +118,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ia
 	icon_state = "obey"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/obey, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
 #endif
@@ -129,7 +129,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ob
 	icon_state = "walk"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/walk, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
 #endif
@@ -140,7 +140,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wa
 	icon_state = "state_laws"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/state_laws, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
 #endif
@@ -151,7 +151,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/st
 	icon_state = "love_ian"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/love_ian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
 #endif
@@ -162,7 +162,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/lo
 	icon_state = "space_cops"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/space_cops, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
 #endif
@@ -173,7 +173,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sp
 	icon_state = "ue_no"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/ue_no, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
 #endif
@@ -184,7 +184,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ue
 	icon_state = "get_your_legs"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/get_your_legs, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
 #endif
@@ -195,7 +195,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ge
 	icon_state = "do_not_question"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/do_not_question, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
 #endif
@@ -206,7 +206,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/do
 	icon_state = "work_for_a_future"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/work_for_a_future, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
 #endif
@@ -217,7 +217,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wo
 	icon_state = "soft_cap_pop_art"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
 #endif
@@ -228,7 +228,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/so
 	icon_state = "safety_internals"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/safety_internals, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
 #endif
@@ -239,7 +239,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sa
 	icon_state = "safety_eye_protection"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/safety_eye_protection, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
 #endif
@@ -250,7 +250,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sa
 	icon_state = "safety_report"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/safety_report, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
 #endif
@@ -261,7 +261,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sa
 	icon_state = "report_crimes"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/report_crimes, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
 #endif
@@ -272,7 +272,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/re
 	icon_state = "ion_rifle"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/ion_rifle, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
 #endif
@@ -283,7 +283,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/io
 	icon_state = "foam_force_ad"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/foam_force_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
 #endif
@@ -294,7 +294,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fo
 	icon_state = "cohiba_robusto_ad"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
 #endif
@@ -305,7 +305,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/co
 	icon_state = "anniversary_vintage_reprint"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
 #endif
@@ -316,7 +316,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/an
 	icon_state = "fruit_bowl"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/fruit_bowl, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
 #endif
@@ -327,7 +327,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fr
 	icon_state = "pda_ad"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/pda_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
 #endif
@@ -338,7 +338,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pd
 	icon_state = "enlist"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/enlist, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
 #endif
@@ -349,7 +349,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/en
 	icon_state = "nanomichi_ad"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/nanomichi_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
 #endif
@@ -360,7 +360,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/na
 	icon_state = "twelve_gauge"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/twelve_gauge, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
 #endif
@@ -371,7 +371,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tw
 	icon_state = "high_class_martini"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/high_class_martini, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
 #endif
@@ -382,7 +382,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/hi
 	icon_state = "the_owl"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/the_owl, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
 #endif
@@ -393,7 +393,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/th
 	icon_state = "no_erp"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/no_erp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
 #endif
@@ -404,7 +404,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/no
 	icon_state = "wtf_is_co2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/wtf_is_co2, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
 #endif
@@ -415,7 +415,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wt
 	icon_state = "dick_gum"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/dick_gum, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
 #endif
@@ -427,7 +427,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/di
 	icon_state = "there_is_no_gas_giant"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
 #endif
@@ -438,7 +438,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/th
 	icon_state = "periodic_table"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/periodic_table, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
 #endif
@@ -461,7 +461,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pe
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/plasma_effects, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
 #endif
@@ -472,7 +472,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pl
 	icon_state = "terragov"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/terragov, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
 #endif
@@ -483,7 +483,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/te
 	icon_state = "corporate_perks_vacation"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
 #endif
@@ -502,7 +502,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/co
 	return .
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/jim_nortons, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
 #endif
@@ -513,7 +513,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ji
 	icon_state = "twenty_four_seven"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/twenty_four_seven, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
 #endif
@@ -524,7 +524,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tw
 	icon_state = "tactical_game_cards"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/tactical_game_cards, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
 #endif
@@ -535,7 +535,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ta
 	icon_state = "midtown_slice"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/midtown_slice, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
 #endif
@@ -548,7 +548,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mi
 	icon_state = "aspev_hardhat"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/moth_hardhat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
 #endif
@@ -559,7 +559,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	icon_state = "aspev_piping"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/moth_piping, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
 #endif
@@ -570,7 +570,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	icon_state = "aspev_meth"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/moth_meth, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
 #endif
@@ -581,7 +581,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	icon_state = "aspev_epi"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/moth_epi, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
 #endif
@@ -592,7 +592,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	icon_state = "aspev_delam"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/moth_delam, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
 #endif
@@ -605,7 +605,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	icon_state = "gas_payment"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
 #endif
@@ -616,7 +616,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizar
 	icon_state = "gas_power"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
 #endif
@@ -627,7 +627,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizar
 	icon_state = "holiday_none"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/festive, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
 #endif
@@ -638,7 +638,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fe
 	icon_state = "boombox"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/boombox, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
 #endif
@@ -649,7 +649,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bo
 	icon_state = "download_gun"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/download, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/official/download, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/download, 32)
 #endif

--- a/code/game/objects/effects/posters/official.dm
+++ b/code/game/objects/effects/posters/official.dm
@@ -15,7 +15,7 @@
 	icon_state = "random_official"
 	never_random = TRUE
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/random, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/random, 32)
@@ -29,7 +29,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ra
 	desc = "A poster glorifying the station's security force."
 	icon_state = "here_for_your_safety"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
@@ -40,7 +40,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/he
 	desc = "A poster depicting the Nanotrasen logo."
 	icon_state = "nanotrasen_logo"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
@@ -51,7 +51,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/na
 	desc = "A poster warning of the dangers of poor hygiene."
 	icon_state = "cleanliness"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
@@ -62,7 +62,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cl
 	desc = "A poster encouraging you to help fellow crewmembers."
 	icon_state = "help_others"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
@@ -73,7 +73,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/he
 	desc = "A poster glorifying the engineering team."
 	icon_state = "build"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/build, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/build, 32)
@@ -84,7 +84,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bu
 	desc = "A poster blessing this area."
 	icon_state = "bless_this_spess"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
@@ -95,7 +95,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bl
 	desc = "A poster depicting an atom."
 	icon_state = "science"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/science, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/science, 32)
@@ -106,7 +106,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sc
 	desc = "Arf arf. Yap."
 	icon_state = "ian"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
@@ -117,7 +117,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ia
 	desc = "A poster instructing the viewer to obey authority."
 	icon_state = "obey"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
@@ -128,7 +128,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ob
 	desc = "A poster instructing the viewer to walk instead of running."
 	icon_state = "walk"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
@@ -139,7 +139,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wa
 	desc = "A poster instructing cyborgs to state their laws."
 	icon_state = "state_laws"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
@@ -150,7 +150,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/st
 	desc = "Ian is love, Ian is life."
 	icon_state = "love_ian"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
@@ -161,7 +161,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/lo
 	desc = "A poster advertising the television show Space Cops."
 	icon_state = "space_cops"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
@@ -172,7 +172,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sp
 	desc = "This thing is all in Japanese."
 	icon_state = "ue_no"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
@@ -183,7 +183,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ue
 	desc = "LEGS: Leadership, Experience, Genius, Subordination."
 	icon_state = "get_your_legs"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
@@ -194,7 +194,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ge
 	desc = "A poster instructing the viewer not to ask about things they aren't meant to know."
 	icon_state = "do_not_question"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
@@ -205,7 +205,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/do
 	desc = " A poster encouraging you to work for your future."
 	icon_state = "work_for_a_future"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
@@ -216,7 +216,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wo
 	desc = "A poster reprint of some cheap pop art."
 	icon_state = "soft_cap_pop_art"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
@@ -227,7 +227,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/so
 	desc = "A poster instructing the viewer to wear internals in the rare environments where there is no oxygen or the air has been rendered toxic."
 	icon_state = "safety_internals"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
@@ -238,7 +238,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sa
 	desc = "A poster instructing the viewer to wear eye protection when dealing with chemicals, smoke, or bright lights."
 	icon_state = "safety_eye_protection"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
@@ -249,7 +249,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sa
 	desc = "A poster instructing the viewer to report suspicious activity to the security force."
 	icon_state = "safety_report"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
@@ -260,7 +260,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/sa
 	desc = "A poster encouraging the swift reporting of crime or seditious behavior to station security."
 	icon_state = "report_crimes"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
@@ -271,7 +271,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/re
 	desc = "A poster displaying an Ion Rifle."
 	icon_state = "ion_rifle"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
@@ -282,7 +282,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/io
 	desc = "Foam Force, it's Foam or be Foamed!"
 	icon_state = "foam_force_ad"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
@@ -293,7 +293,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fo
 	desc = "Cohiba Robusto, the classy cigar."
 	icon_state = "cohiba_robusto_ad"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
@@ -304,7 +304,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/co
 	desc = "A reprint of a poster from 2505, commemorating the 50th Anniversary of Nanoposters Manufacturing, a subsidiary of Nanotrasen."
 	icon_state = "anniversary_vintage_reprint"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
@@ -315,7 +315,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/an
 	desc = " Simple, yet awe-inspiring."
 	icon_state = "fruit_bowl"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
@@ -326,7 +326,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fr
 	desc = "A poster advertising the latest PDA from Nanotrasen suppliers."
 	icon_state = "pda_ad"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
@@ -337,7 +337,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pd
 	desc = "Enlist in the Nanotrasen Deathsquadron reserves today!"
 	icon_state = "enlist"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
@@ -348,7 +348,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/en
 	desc = " A poster advertising Nanomichi brand audio cassettes."
 	icon_state = "nanomichi_ad"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
@@ -359,7 +359,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/na
 	desc = "A poster boasting about the superiority of 12 gauge shotgun shells."
 	icon_state = "twelve_gauge"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
@@ -370,7 +370,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tw
 	desc = "I told you to shake it, no stirring."
 	icon_state = "high_class_martini"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
@@ -381,7 +381,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/hi
 	desc = "The Owl would do his best to protect the station. Will you?"
 	icon_state = "the_owl"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
@@ -392,7 +392,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/th
 	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Nanotrasen stations."
 	icon_state = "no_erp"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
@@ -403,7 +403,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/no
 	desc = "This informational poster teaches the viewer what carbon dioxide is."
 	icon_state = "wtf_is_co2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
@@ -414,7 +414,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wt
 	desc = "A poster advertising the escapades of Dick Gumshue, mouse detective. Encouraging crew to bring the might of justice down upon wire saboteurs."
 	icon_state = "dick_gum"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
@@ -426,7 +426,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/di
 	// And yet people still believe...
 	icon_state = "there_is_no_gas_giant"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
@@ -437,7 +437,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/th
 	desc = "A periodic table of the elements, from Hydrogen to Oganesson, and everything inbetween."
 	icon_state = "periodic_table"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
@@ -460,7 +460,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pe
 	. += "\t[span_info("Nanotrasen: Always looking after your health.")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
@@ -471,7 +471,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pl
 	desc = "A poster depicting TerraGov's logo and motto, reminding viewers of who's looking out for humankind."
 	icon_state = "terragov"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
@@ -482,7 +482,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/te
 	desc = "This informational poster provides information on some of the prizes available via the NT Corporate Perks program, including a two-week vacation for two on the resort world Idyllus."
 	icon_state = "corporate_perks_vacation"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
@@ -501,7 +501,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/co
 	. += "\t[span_info("Jim Norton's Québécois Coffee: Toujours Le Bienvenu.")]"
 	return .
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
@@ -512,7 +512,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ji
 	desc = "An advertisement for 24-Seven supermarkets, advertising their new 24-Stops as part of their partnership with Nanotrasen."
 	icon_state = "twenty_four_seven"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
@@ -523,7 +523,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tw
 	desc = "An advertisement for Nanotrasen's TCG cards: BUY MORE CARDS."
 	icon_state = "tactical_game_cards"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
@@ -534,7 +534,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ta
 	desc = "An advertisement for Midtown Slice Pizza, the official pizzeria partner of Nanotrasen. Midtown Slice: like a slice of home, no matter where you are."
 	icon_state = "midtown_slice"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
@@ -547,7 +547,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mi
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to wear hardhats in cautious areas. \"It's like a lamp for your head!\""
 	icon_state = "aspev_hardhat"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
@@ -558,7 +558,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	desc = "This informational poster uses Safety Moth™ to tell atmospheric technicians correct types of piping to be used. \"Pipes, not Pumps! Proper pipe placement prevents poor performance!\""
 	icon_state = "aspev_piping"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
@@ -569,7 +569,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to seek CMO approval before cooking methamphetamine. \"Stay close to the target temperature, and never go over!\" ...You shouldn't ever be making this."
 	icon_state = "aspev_meth"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
@@ -580,7 +580,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	desc = "This informational poster uses Safety Moth™ to inform the viewer to help injured/deceased crewmen with their epinephrine injectors. \"Prevent organ rot with this one simple trick!\""
 	icon_state = "aspev_epi"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
@@ -591,7 +591,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to hide in lockers when the Supermatter Crystal has delaminated, to prevent hallucinations. Evacuating might be a better strategy."
 	icon_state = "aspev_delam"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
@@ -604,7 +604,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	desc = "A crudely-made poster asking the reader to please pay for any items they may wish to leave the station with."
 	icon_state = "gas_payment"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
@@ -615,7 +615,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizar
 	desc = "A crudely-made poster asking the reader to turn off the power before they leave. Hopefully, it's turned on for their re-opening."
 	icon_state = "gas_power"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
@@ -626,7 +626,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizar
 	desc = "A poster that informs of active holidays. None are today, so you should get back to work."
 	icon_state = "holiday_none"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
@@ -637,7 +637,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fe
 	desc = "An outdated poster containing a list of supposed 'kill words' and code phrases. The poster alleges rival corporations use these to remotely deactivate their agents."
 	icon_state = "boombox"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
@@ -648,7 +648,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bo
 	desc = "A poster reminding the crew that corporate secrets should stay in the workplace."
 	icon_state = "download_gun"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/download, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/download, 32)

--- a/code/game/objects/effects/posters/official.dm
+++ b/code/game/objects/effects/posters/official.dm
@@ -15,7 +15,7 @@
 	icon_state = "random_official"
 	never_random = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/random, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/random, 32)
 //This is being hardcoded here to ensure we don't print directionals from the library management computer because they act wierd as a poster item
 /obj/structure/sign/poster/official/random/directional
 	printable = FALSE
@@ -25,252 +25,252 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/random, 32)
 	desc = "A poster glorifying the station's security force."
 	icon_state = "here_for_your_safety"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
 
 /obj/structure/sign/poster/official/nanotrasen_logo
 	name = "\improper Nanotrasen logo"
 	desc = "A poster depicting the Nanotrasen logo."
 	icon_state = "nanotrasen_logo"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
 
 /obj/structure/sign/poster/official/cleanliness
 	name = "Cleanliness"
 	desc = "A poster warning of the dangers of poor hygiene."
 	icon_state = "cleanliness"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/cleanliness, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
 
 /obj/structure/sign/poster/official/help_others
 	name = "Help Others"
 	desc = "A poster encouraging you to help fellow crewmembers."
 	icon_state = "help_others"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/help_others, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
 
 /obj/structure/sign/poster/official/build
 	name = "Build"
 	desc = "A poster glorifying the engineering team."
 	icon_state = "build"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/build, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/build, 32)
 
 /obj/structure/sign/poster/official/bless_this_spess
 	name = "Bless This Spess"
 	desc = "A poster blessing this area."
 	icon_state = "bless_this_spess"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/bless_this_spess, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
 
 /obj/structure/sign/poster/official/science
 	name = "Science"
 	desc = "A poster depicting an atom."
 	icon_state = "science"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/science, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/science, 32)
 
 /obj/structure/sign/poster/official/ian
 	name = "Ian"
 	desc = "Arf arf. Yap."
 	icon_state = "ian"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/ian, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
 
 /obj/structure/sign/poster/official/obey
 	name = "Obey"
 	desc = "A poster instructing the viewer to obey authority."
 	icon_state = "obey"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/obey, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
 
 /obj/structure/sign/poster/official/walk
 	name = "Walk"
 	desc = "A poster instructing the viewer to walk instead of running."
 	icon_state = "walk"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/walk, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
 
 /obj/structure/sign/poster/official/state_laws
 	name = "State Laws"
 	desc = "A poster instructing cyborgs to state their laws."
 	icon_state = "state_laws"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/state_laws, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
 
 /obj/structure/sign/poster/official/love_ian
 	name = "Love Ian"
 	desc = "Ian is love, Ian is life."
 	icon_state = "love_ian"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/love_ian, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
 
 /obj/structure/sign/poster/official/space_cops
 	name = "Space Cops."
 	desc = "A poster advertising the television show Space Cops."
 	icon_state = "space_cops"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/space_cops, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
 
 /obj/structure/sign/poster/official/ue_no
 	name = "Ue No."
 	desc = "This thing is all in Japanese."
 	icon_state = "ue_no"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/ue_no, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
 
 /obj/structure/sign/poster/official/get_your_legs
 	name = "Get Your LEGS"
 	desc = "LEGS: Leadership, Experience, Genius, Subordination."
 	icon_state = "get_your_legs"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/get_your_legs, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
 
 /obj/structure/sign/poster/official/do_not_question
 	name = "Do Not Question"
 	desc = "A poster instructing the viewer not to ask about things they aren't meant to know."
 	icon_state = "do_not_question"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/do_not_question, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
 
 /obj/structure/sign/poster/official/work_for_a_future
 	name = "Work For A Future"
 	desc = " A poster encouraging you to work for your future."
 	icon_state = "work_for_a_future"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/work_for_a_future, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
 
 /obj/structure/sign/poster/official/soft_cap_pop_art
 	name = "Soft Cap Pop Art"
 	desc = "A poster reprint of some cheap pop art."
 	icon_state = "soft_cap_pop_art"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
 
 /obj/structure/sign/poster/official/safety_internals
 	name = "Safety: Internals"
 	desc = "A poster instructing the viewer to wear internals in the rare environments where there is no oxygen or the air has been rendered toxic."
 	icon_state = "safety_internals"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/safety_internals, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
 
 /obj/structure/sign/poster/official/safety_eye_protection
 	name = "Safety: Eye Protection"
 	desc = "A poster instructing the viewer to wear eye protection when dealing with chemicals, smoke, or bright lights."
 	icon_state = "safety_eye_protection"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
 
 /obj/structure/sign/poster/official/safety_report
 	name = "Safety: Report"
 	desc = "A poster instructing the viewer to report suspicious activity to the security force."
 	icon_state = "safety_report"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/safety_report, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
 
 /obj/structure/sign/poster/official/report_crimes
 	name = "Report Crimes"
 	desc = "A poster encouraging the swift reporting of crime or seditious behavior to station security."
 	icon_state = "report_crimes"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/report_crimes, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
 
 /obj/structure/sign/poster/official/ion_rifle
 	name = "Ion Rifle"
 	desc = "A poster displaying an Ion Rifle."
 	icon_state = "ion_rifle"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/ion_rifle, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
 
 /obj/structure/sign/poster/official/foam_force_ad
 	name = "Foam Force Ad"
 	desc = "Foam Force, it's Foam or be Foamed!"
 	icon_state = "foam_force_ad"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/foam_force_ad, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
 
 /obj/structure/sign/poster/official/cohiba_robusto_ad
 	name = "Cohiba Robusto Ad"
 	desc = "Cohiba Robusto, the classy cigar."
 	icon_state = "cohiba_robusto_ad"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
 
 /obj/structure/sign/poster/official/anniversary_vintage_reprint
 	name = "50th Anniversary Vintage Reprint"
 	desc = "A reprint of a poster from 2505, commemorating the 50th Anniversary of Nanoposters Manufacturing, a subsidiary of Nanotrasen."
 	icon_state = "anniversary_vintage_reprint"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
 
 /obj/structure/sign/poster/official/fruit_bowl
 	name = "Fruit Bowl"
 	desc = " Simple, yet awe-inspiring."
 	icon_state = "fruit_bowl"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/fruit_bowl, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
 
 /obj/structure/sign/poster/official/pda_ad
 	name = "PDA Ad"
 	desc = "A poster advertising the latest PDA from Nanotrasen suppliers."
 	icon_state = "pda_ad"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/pda_ad, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
 
 /obj/structure/sign/poster/official/enlist
 	name = "Enlist" // but I thought deathsquad was never acknowledged
 	desc = "Enlist in the Nanotrasen Deathsquadron reserves today!"
 	icon_state = "enlist"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/enlist, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
 
 /obj/structure/sign/poster/official/nanomichi_ad
 	name = "Nanomichi Ad"
 	desc = " A poster advertising Nanomichi brand audio cassettes."
 	icon_state = "nanomichi_ad"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
 
 /obj/structure/sign/poster/official/twelve_gauge
 	name = "12 Gauge"
 	desc = "A poster boasting about the superiority of 12 gauge shotgun shells."
 	icon_state = "twelve_gauge"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/twelve_gauge, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
 
 /obj/structure/sign/poster/official/high_class_martini
 	name = "High-Class Martini"
 	desc = "I told you to shake it, no stirring."
 	icon_state = "high_class_martini"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/high_class_martini, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
 
 /obj/structure/sign/poster/official/the_owl
 	name = "The Owl"
 	desc = "The Owl would do his best to protect the station. Will you?"
 	icon_state = "the_owl"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/the_owl, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
 
 /obj/structure/sign/poster/official/no_erp
 	name = "No ERP"
 	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Nanotrasen stations."
 	icon_state = "no_erp"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/no_erp, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
 
 /obj/structure/sign/poster/official/wtf_is_co2
 	name = "Carbon Dioxide"
 	desc = "This informational poster teaches the viewer what carbon dioxide is."
 	icon_state = "wtf_is_co2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
 
 /obj/structure/sign/poster/official/dick_gum
 	name = "Dick Gumshue"
 	desc = "A poster advertising the escapades of Dick Gumshue, mouse detective. Encouraging crew to bring the might of justice down upon wire saboteurs."
 	icon_state = "dick_gum"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/dick_gum, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
 
 /obj/structure/sign/poster/official/there_is_no_gas_giant
 	name = "There Is No Gas Giant"
@@ -278,14 +278,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/dick_gum, 32)
 	// And yet people still believe...
 	icon_state = "there_is_no_gas_giant"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
 
 /obj/structure/sign/poster/official/periodic_table
 	name = "Periodic Table of the Elements"
 	desc = "A periodic table of the elements, from Hydrogen to Oganesson, and everything inbetween."
 	icon_state = "periodic_table"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/periodic_table, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
 
 /obj/structure/sign/poster/official/plasma_effects
 	name = "Plasma and the Body"
@@ -304,21 +304,21 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/periodic_table, 
 	. += "\t[span_info("Nanotrasen: Always looking after your health.")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/plasma_effects, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
 
 /obj/structure/sign/poster/official/terragov
 	name = "TerraGov: United for Humanity"
 	desc = "A poster depicting TerraGov's logo and motto, reminding viewers of who's looking out for humankind."
 	icon_state = "terragov"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/terragov, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
 
 /obj/structure/sign/poster/official/corporate_perks_vacation
 	name = "Nanotrasen Corporate Perks: Vacation"
 	desc = "This informational poster provides information on some of the prizes available via the NT Corporate Perks program, including a two-week vacation for two on the resort world Idyllus."
 	icon_state = "corporate_perks_vacation"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
 
 /obj/structure/sign/poster/official/jim_nortons
 	name = "Jim Norton's Québécois Coffee"
@@ -333,28 +333,28 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/corporate_perks_
 	. += "\t[span_info("Jim Norton's Québécois Coffee: Toujours Le Bienvenu.")]"
 	return .
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/jim_nortons, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
 
 /obj/structure/sign/poster/official/twenty_four_seven
 	name = "24-Seven Supermarkets"
 	desc = "An advertisement for 24-Seven supermarkets, advertising their new 24-Stops as part of their partnership with Nanotrasen."
 	icon_state = "twenty_four_seven"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
 
 /obj/structure/sign/poster/official/tactical_game_cards
 	name = "Nanotrasen Tactical Game Cards"
 	desc = "An advertisement for Nanotrasen's TCG cards: BUY MORE CARDS."
 	icon_state = "tactical_game_cards"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
 
 /obj/structure/sign/poster/official/midtown_slice
 	name = "Midtown Slice Pizza"
 	desc = "An advertisement for Midtown Slice Pizza, the official pizzeria partner of Nanotrasen. Midtown Slice: like a slice of home, no matter where you are."
 	icon_state = "midtown_slice"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/midtown_slice, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
 
 //SafetyMoth Original PR at https://github.com/BeeStation/BeeStation-Hornet/pull/1747 (Also pull/1982)
 //SafetyMoth art credit goes to AspEv
@@ -363,35 +363,35 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/midtown_slice, 3
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to wear hardhats in cautious areas. \"It's like a lamp for your head!\""
 	icon_state = "aspev_hardhat"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/moth_hardhat, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
 
 /obj/structure/sign/poster/official/moth_piping
 	name = "Safety Moth - Piping"
 	desc = "This informational poster uses Safety Moth™ to tell atmospheric technicians correct types of piping to be used. \"Pipes, not Pumps! Proper pipe placement prevents poor performance!\""
 	icon_state = "aspev_piping"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/moth_piping, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
 
 /obj/structure/sign/poster/official/moth_meth
 	name = "Safety Moth - Methamphetamine"
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to seek CMO approval before cooking methamphetamine. \"Stay close to the target temperature, and never go over!\" ...You shouldn't ever be making this."
 	icon_state = "aspev_meth"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/moth_meth, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
 
 /obj/structure/sign/poster/official/moth_epi
 	name = "Safety Moth - Epinephrine"
 	desc = "This informational poster uses Safety Moth™ to inform the viewer to help injured/deceased crewmen with their epinephrine injectors. \"Prevent organ rot with this one simple trick!\""
 	icon_state = "aspev_epi"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/moth_epi, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
 
 /obj/structure/sign/poster/official/moth_delam
 	name = "Safety Moth - Delamination Safety Precautions"
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to hide in lockers when the Supermatter Crystal has delaminated, to prevent hallucinations. Evacuating might be a better strategy."
 	icon_state = "aspev_delam"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/moth_delam, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
 
 //End of AspEv posters
 
@@ -400,32 +400,32 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/moth_delam, 32)
 	desc = "A crudely-made poster asking the reader to please pay for any items they may wish to leave the station with."
 	icon_state = "gas_payment"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
 
 /obj/structure/sign/poster/fluff/lizards_gas_power
 	name = "Conserve Power"
 	desc = "A crudely-made poster asking the reader to turn off the power before they leave. Hopefully, it's turned on for their re-opening."
 	icon_state = "gas_power"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
 
 /obj/structure/sign/poster/official/festive
 	name = "Festive Notice Poster"
 	desc = "A poster that informs of active holidays. None are today, so you should get back to work."
 	icon_state = "holiday_none"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/festive, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
 
 /obj/structure/sign/poster/official/boombox
 	name = "Boombox"
 	desc = "An outdated poster containing a list of supposed 'kill words' and code phrases. The poster alleges rival corporations use these to remotely deactivate their agents."
 	icon_state = "boombox"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/boombox, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
 
 /obj/structure/sign/poster/official/download
 	name = "You Wouldn't Download A Gun"
 	desc = "A poster reminding the crew that corporate secrets should stay in the workplace."
 	icon_state = "download_gun"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/download, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/download, 32)

--- a/code/game/objects/effects/posters/official.dm
+++ b/code/game/objects/effects/posters/official.dm
@@ -15,7 +15,11 @@
 	icon_state = "random_official"
 	never_random = TRUE
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/random, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/random, 32)
+#endif
 //This is being hardcoded here to ensure we don't print directionals from the library management computer because they act wierd as a poster item
 /obj/structure/sign/poster/official/random/directional
 	printable = FALSE
@@ -25,252 +29,396 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ra
 	desc = "A poster glorifying the station's security force."
 	icon_state = "here_for_your_safety"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/here_for_your_safety, 32)
+#endif
 
 /obj/structure/sign/poster/official/nanotrasen_logo
 	name = "\improper Nanotrasen logo"
 	desc = "A poster depicting the Nanotrasen logo."
 	icon_state = "nanotrasen_logo"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanotrasen_logo, 32)
+#endif
 
 /obj/structure/sign/poster/official/cleanliness
 	name = "Cleanliness"
 	desc = "A poster warning of the dangers of poor hygiene."
 	icon_state = "cleanliness"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cleanliness, 32)
+#endif
 
 /obj/structure/sign/poster/official/help_others
 	name = "Help Others"
 	desc = "A poster encouraging you to help fellow crewmembers."
 	icon_state = "help_others"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/help_others, 32)
+#endif
 
 /obj/structure/sign/poster/official/build
 	name = "Build"
 	desc = "A poster glorifying the engineering team."
 	icon_state = "build"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/build, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/build, 32)
+#endif
 
 /obj/structure/sign/poster/official/bless_this_spess
 	name = "Bless This Spess"
 	desc = "A poster blessing this area."
 	icon_state = "bless_this_spess"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/bless_this_spess, 32)
+#endif
 
 /obj/structure/sign/poster/official/science
 	name = "Science"
 	desc = "A poster depicting an atom."
 	icon_state = "science"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/science, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/science, 32)
+#endif
 
 /obj/structure/sign/poster/official/ian
 	name = "Ian"
 	desc = "Arf arf. Yap."
 	icon_state = "ian"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ian, 32)
+#endif
 
 /obj/structure/sign/poster/official/obey
 	name = "Obey"
 	desc = "A poster instructing the viewer to obey authority."
 	icon_state = "obey"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/obey, 32)
+#endif
 
 /obj/structure/sign/poster/official/walk
 	name = "Walk"
 	desc = "A poster instructing the viewer to walk instead of running."
 	icon_state = "walk"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/walk, 32)
+#endif
 
 /obj/structure/sign/poster/official/state_laws
 	name = "State Laws"
 	desc = "A poster instructing cyborgs to state their laws."
 	icon_state = "state_laws"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/state_laws, 32)
+#endif
 
 /obj/structure/sign/poster/official/love_ian
 	name = "Love Ian"
 	desc = "Ian is love, Ian is life."
 	icon_state = "love_ian"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/love_ian, 32)
+#endif
 
 /obj/structure/sign/poster/official/space_cops
 	name = "Space Cops."
 	desc = "A poster advertising the television show Space Cops."
 	icon_state = "space_cops"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/space_cops, 32)
+#endif
 
 /obj/structure/sign/poster/official/ue_no
 	name = "Ue No."
 	desc = "This thing is all in Japanese."
 	icon_state = "ue_no"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ue_no, 32)
+#endif
 
 /obj/structure/sign/poster/official/get_your_legs
 	name = "Get Your LEGS"
 	desc = "LEGS: Leadership, Experience, Genius, Subordination."
 	icon_state = "get_your_legs"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/get_your_legs, 32)
+#endif
 
 /obj/structure/sign/poster/official/do_not_question
 	name = "Do Not Question"
 	desc = "A poster instructing the viewer not to ask about things they aren't meant to know."
 	icon_state = "do_not_question"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/do_not_question, 32)
+#endif
 
 /obj/structure/sign/poster/official/work_for_a_future
 	name = "Work For A Future"
 	desc = " A poster encouraging you to work for your future."
 	icon_state = "work_for_a_future"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/work_for_a_future, 32)
+#endif
 
 /obj/structure/sign/poster/official/soft_cap_pop_art
 	name = "Soft Cap Pop Art"
 	desc = "A poster reprint of some cheap pop art."
 	icon_state = "soft_cap_pop_art"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/soft_cap_pop_art, 32)
+#endif
 
 /obj/structure/sign/poster/official/safety_internals
 	name = "Safety: Internals"
 	desc = "A poster instructing the viewer to wear internals in the rare environments where there is no oxygen or the air has been rendered toxic."
 	icon_state = "safety_internals"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_internals, 32)
+#endif
 
 /obj/structure/sign/poster/official/safety_eye_protection
 	name = "Safety: Eye Protection"
 	desc = "A poster instructing the viewer to wear eye protection when dealing with chemicals, smoke, or bright lights."
 	icon_state = "safety_eye_protection"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_eye_protection, 32)
+#endif
 
 /obj/structure/sign/poster/official/safety_report
 	name = "Safety: Report"
 	desc = "A poster instructing the viewer to report suspicious activity to the security force."
 	icon_state = "safety_report"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/safety_report, 32)
+#endif
 
 /obj/structure/sign/poster/official/report_crimes
 	name = "Report Crimes"
 	desc = "A poster encouraging the swift reporting of crime or seditious behavior to station security."
 	icon_state = "report_crimes"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/report_crimes, 32)
+#endif
 
 /obj/structure/sign/poster/official/ion_rifle
 	name = "Ion Rifle"
 	desc = "A poster displaying an Ion Rifle."
 	icon_state = "ion_rifle"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/ion_rifle, 32)
+#endif
 
 /obj/structure/sign/poster/official/foam_force_ad
 	name = "Foam Force Ad"
 	desc = "Foam Force, it's Foam or be Foamed!"
 	icon_state = "foam_force_ad"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/foam_force_ad, 32)
+#endif
 
 /obj/structure/sign/poster/official/cohiba_robusto_ad
 	name = "Cohiba Robusto Ad"
 	desc = "Cohiba Robusto, the classy cigar."
 	icon_state = "cohiba_robusto_ad"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/cohiba_robusto_ad, 32)
+#endif
 
 /obj/structure/sign/poster/official/anniversary_vintage_reprint
 	name = "50th Anniversary Vintage Reprint"
 	desc = "A reprint of a poster from 2505, commemorating the 50th Anniversary of Nanoposters Manufacturing, a subsidiary of Nanotrasen."
 	icon_state = "anniversary_vintage_reprint"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/anniversary_vintage_reprint, 32)
+#endif
 
 /obj/structure/sign/poster/official/fruit_bowl
 	name = "Fruit Bowl"
 	desc = " Simple, yet awe-inspiring."
 	icon_state = "fruit_bowl"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/fruit_bowl, 32)
+#endif
 
 /obj/structure/sign/poster/official/pda_ad
 	name = "PDA Ad"
 	desc = "A poster advertising the latest PDA from Nanotrasen suppliers."
 	icon_state = "pda_ad"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pda_ad, 32)
+#endif
 
 /obj/structure/sign/poster/official/enlist
 	name = "Enlist" // but I thought deathsquad was never acknowledged
 	desc = "Enlist in the Nanotrasen Deathsquadron reserves today!"
 	icon_state = "enlist"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/enlist, 32)
+#endif
 
 /obj/structure/sign/poster/official/nanomichi_ad
 	name = "Nanomichi Ad"
 	desc = " A poster advertising Nanomichi brand audio cassettes."
 	icon_state = "nanomichi_ad"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/nanomichi_ad, 32)
+#endif
 
 /obj/structure/sign/poster/official/twelve_gauge
 	name = "12 Gauge"
 	desc = "A poster boasting about the superiority of 12 gauge shotgun shells."
 	icon_state = "twelve_gauge"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twelve_gauge, 32)
+#endif
 
 /obj/structure/sign/poster/official/high_class_martini
 	name = "High-Class Martini"
 	desc = "I told you to shake it, no stirring."
 	icon_state = "high_class_martini"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/high_class_martini, 32)
+#endif
 
 /obj/structure/sign/poster/official/the_owl
 	name = "The Owl"
 	desc = "The Owl would do his best to protect the station. Will you?"
 	icon_state = "the_owl"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/the_owl, 32)
+#endif
 
 /obj/structure/sign/poster/official/no_erp
 	name = "No ERP"
 	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Nanotrasen stations."
 	icon_state = "no_erp"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/no_erp, 32)
+#endif
 
 /obj/structure/sign/poster/official/wtf_is_co2
 	name = "Carbon Dioxide"
 	desc = "This informational poster teaches the viewer what carbon dioxide is."
 	icon_state = "wtf_is_co2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/wtf_is_co2, 32)
+#endif
 
 /obj/structure/sign/poster/official/dick_gum
 	name = "Dick Gumshue"
 	desc = "A poster advertising the escapades of Dick Gumshue, mouse detective. Encouraging crew to bring the might of justice down upon wire saboteurs."
 	icon_state = "dick_gum"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/dick_gum, 32)
+#endif
 
 /obj/structure/sign/poster/official/there_is_no_gas_giant
 	name = "There Is No Gas Giant"
@@ -278,14 +426,22 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/di
 	// And yet people still believe...
 	icon_state = "there_is_no_gas_giant"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/there_is_no_gas_giant, 32)
+#endif
 
 /obj/structure/sign/poster/official/periodic_table
 	name = "Periodic Table of the Elements"
 	desc = "A periodic table of the elements, from Hydrogen to Oganesson, and everything inbetween."
 	icon_state = "periodic_table"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/periodic_table, 32)
+#endif
 
 /obj/structure/sign/poster/official/plasma_effects
 	name = "Plasma and the Body"
@@ -304,21 +460,33 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/pe
 	. += "\t[span_info("Nanotrasen: Always looking after your health.")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/plasma_effects, 32)
+#endif
 
 /obj/structure/sign/poster/official/terragov
 	name = "TerraGov: United for Humanity"
 	desc = "A poster depicting TerraGov's logo and motto, reminding viewers of who's looking out for humankind."
 	icon_state = "terragov"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/terragov, 32)
+#endif
 
 /obj/structure/sign/poster/official/corporate_perks_vacation
 	name = "Nanotrasen Corporate Perks: Vacation"
 	desc = "This informational poster provides information on some of the prizes available via the NT Corporate Perks program, including a two-week vacation for two on the resort world Idyllus."
 	icon_state = "corporate_perks_vacation"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/corporate_perks_vacation, 32)
+#endif
 
 /obj/structure/sign/poster/official/jim_nortons
 	name = "Jim Norton's Québécois Coffee"
@@ -333,28 +501,44 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/co
 	. += "\t[span_info("Jim Norton's Québécois Coffee: Toujours Le Bienvenu.")]"
 	return .
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/jim_nortons, 32)
+#endif
 
 /obj/structure/sign/poster/official/twenty_four_seven
 	name = "24-Seven Supermarkets"
 	desc = "An advertisement for 24-Seven supermarkets, advertising their new 24-Stops as part of their partnership with Nanotrasen."
 	icon_state = "twenty_four_seven"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/twenty_four_seven, 32)
+#endif
 
 /obj/structure/sign/poster/official/tactical_game_cards
 	name = "Nanotrasen Tactical Game Cards"
 	desc = "An advertisement for Nanotrasen's TCG cards: BUY MORE CARDS."
 	icon_state = "tactical_game_cards"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/tactical_game_cards, 32)
+#endif
 
 /obj/structure/sign/poster/official/midtown_slice
 	name = "Midtown Slice Pizza"
 	desc = "An advertisement for Midtown Slice Pizza, the official pizzeria partner of Nanotrasen. Midtown Slice: like a slice of home, no matter where you are."
 	icon_state = "midtown_slice"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/midtown_slice, 32)
+#endif
 
 //SafetyMoth Original PR at https://github.com/BeeStation/BeeStation-Hornet/pull/1747 (Also pull/1982)
 //SafetyMoth art credit goes to AspEv
@@ -363,35 +547,55 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mi
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to wear hardhats in cautious areas. \"It's like a lamp for your head!\""
 	icon_state = "aspev_hardhat"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_hardhat, 32)
+#endif
 
 /obj/structure/sign/poster/official/moth_piping
 	name = "Safety Moth - Piping"
 	desc = "This informational poster uses Safety Moth™ to tell atmospheric technicians correct types of piping to be used. \"Pipes, not Pumps! Proper pipe placement prevents poor performance!\""
 	icon_state = "aspev_piping"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_piping, 32)
+#endif
 
 /obj/structure/sign/poster/official/moth_meth
 	name = "Safety Moth - Methamphetamine"
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to seek CMO approval before cooking methamphetamine. \"Stay close to the target temperature, and never go over!\" ...You shouldn't ever be making this."
 	icon_state = "aspev_meth"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_meth, 32)
+#endif
 
 /obj/structure/sign/poster/official/moth_epi
 	name = "Safety Moth - Epinephrine"
 	desc = "This informational poster uses Safety Moth™ to inform the viewer to help injured/deceased crewmen with their epinephrine injectors. \"Prevent organ rot with this one simple trick!\""
 	icon_state = "aspev_epi"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_epi, 32)
+#endif
 
 /obj/structure/sign/poster/official/moth_delam
 	name = "Safety Moth - Delamination Safety Precautions"
 	desc = "This informational poster uses Safety Moth™ to tell the viewer to hide in lockers when the Supermatter Crystal has delaminated, to prevent hallucinations. Evacuating might be a better strategy."
 	icon_state = "aspev_delam"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/moth_delam, 32)
+#endif
 
 //End of AspEv posters
 
@@ -400,32 +604,52 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/mo
 	desc = "A crudely-made poster asking the reader to please pay for any items they may wish to leave the station with."
 	icon_state = "gas_payment"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_payment, 32)
+#endif
 
 /obj/structure/sign/poster/fluff/lizards_gas_power
 	name = "Conserve Power"
 	desc = "A crudely-made poster asking the reader to turn off the power before they leave. Hopefully, it's turned on for their re-opening."
 	icon_state = "gas_power"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/fluff/lizards_gas_power, 32)
+#endif
 
 /obj/structure/sign/poster/official/festive
 	name = "Festive Notice Poster"
 	desc = "A poster that informs of active holidays. None are today, so you should get back to work."
 	icon_state = "holiday_none"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/festive, 32)
+#endif
 
 /obj/structure/sign/poster/official/boombox
 	name = "Boombox"
 	desc = "An outdated poster containing a list of supposed 'kill words' and code phrases. The poster alleges rival corporations use these to remotely deactivate their agents."
 	icon_state = "boombox"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/boombox, 32)
+#endif
 
 /obj/structure/sign/poster/official/download
 	name = "You Wouldn't Download A Gun"
 	desc = "A poster reminding the crew that corporate secrets should stay in the workplace."
 	icon_state = "download_gun"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/official/download, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/official/download, 32)
+#endif

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -233,6 +233,14 @@
 			if(copytext(new_image.icon_state, 1, 3) == "d-") //3 == length("d-") + 1
 				return
 
+#ifdef EXPERIMENT_WALLENING
+	// Deny placing posters if we are attempting to place it on a southern wall.
+	var/direction = get_cardinal_dir(user, src)
+	if(direction == SOUTH)
+		balloon_alert(user, "can't place it there!")
+		return
+#endif
+
 	var/stuff_on_wall = 0
 	for(var/obj/contained_object in contents) //Let's see if it already has a poster on it or too much stuff
 		if(istype(contained_object, /obj/structure/sign/poster))

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -233,7 +233,7 @@
 			if(copytext(new_image.icon_state, 1, 3) == "d-") //3 == length("d-") + 1
 				return
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 	// Deny placing signs if we are attempting to place it on something that is not the south face of a northern wall.
 	if(!check_wall_face(user, src, NORTH))
 		balloon_alert(user, "can't place it there!")

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -233,13 +233,13 @@
 			if(copytext(new_image.icon_state, 1, 3) == "d-") //3 == length("d-") + 1
 				return
 
-// #ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING
 	// Deny placing posters if we are attempting to place it on something that is not the south face of a northern wall.
-	var/direction = get_cardinal_dir(user, src)
+	var/direction = get_dir(user, src)
 	if(direction & ~NORTH)
 		balloon_alert(user, "can't place it there!")
 		return
-// #endif
+#endif
 
 	var/stuff_on_wall = 0
 	for(var/obj/contained_object in contents) //Let's see if it already has a poster on it or too much stuff

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -234,9 +234,8 @@
 				return
 
 #ifdef EXPERIMENT_WALLENING
-	// Deny placing posters if we are attempting to place it on something that is not the south face of a northern wall.
-	var/direction = get_dir(user, src)
-	if(direction & ~NORTH)
+	// Deny placing signs if we are attempting to place it on something that is not the south face of a northern wall.
+	if(!check_wall_face(user, src, NORTH))
 		balloon_alert(user, "can't place it there!")
 		return
 #endif

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -283,7 +283,7 @@
 	name = "ripped poster"
 	desc = "You can't make out anything from the poster's original print. It's ruined."
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/ripped, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/ripped, 32)
 
 /obj/structure/sign/poster/random
 	name = "random poster" // could even be ripped
@@ -295,6 +295,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/ripped, 32)
 		/obj/structure/sign/poster/abductor,
 	)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/random, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/random, 32)
 
 #undef PLACE_SPEED

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -233,13 +233,13 @@
 			if(copytext(new_image.icon_state, 1, 3) == "d-") //3 == length("d-") + 1
 				return
 
-#ifdef EXPERIMENT_WALLENING
-	// Deny placing posters if we are attempting to place it on a southern wall.
+// #ifdef EXPERIMENT_WALLENING
+	// Deny placing posters if we are attempting to place it on something that is not the south face of a northern wall.
 	var/direction = get_cardinal_dir(user, src)
-	if(direction == SOUTH)
+	if(direction & ~NORTH)
 		balloon_alert(user, "can't place it there!")
 		return
-#endif
+// #endif
 
 	var/stuff_on_wall = 0
 	for(var/obj/contained_object in contents) //Let's see if it already has a poster on it or too much stuff

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -198,7 +198,7 @@
 	pixel_shift = 26
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 0.75, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.25)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 27)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/item/radio/intercom, 27)
 
 /obj/item/radio/intercom/chapel
 	name = "Confessional intercom"
@@ -219,6 +219,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 27)
 	command = TRUE
 	icon_off = "intercom_command-p"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 27)
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 27)
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/command, 27)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/item/radio/intercom/prison, 27)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/item/radio/intercom/chapel, 27)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/item/radio/intercom/command, 27)

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -354,7 +354,7 @@
 	playsound(src, 'sound/machines/terminal_button07.ogg', 45, TRUE)
 	on_puzzle_complete()
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/button, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/puzzle/button, 32)
 
 /obj/machinery/puzzle/keycardpad
 	name = "keycard panel"
@@ -377,7 +377,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/button, 32)
 	playsound(src, 'sound/machines/beep.ogg', 45, TRUE)
 	on_puzzle_complete()
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/keycardpad, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/puzzle/keycardpad, 32)
 
 /obj/machinery/puzzle/password
 	name = "password panel"
@@ -414,7 +414,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/keycardpad, 32)
 	playsound(src, 'sound/machines/terminal_button07.ogg', 45, TRUE)
 	on_puzzle_complete()
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/password, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/puzzle/password, 32)
 
 /obj/machinery/puzzle/password/pin
 	desc = "A panel that controls something nearby. This one requires a PIN password, so let's start by typing in 1234..."
@@ -449,7 +449,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/password, 32)
 	for(var/digit in 0 to 9)
 		digit_to_color["[digit]"] = pick_n_take(possible_colors)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/password/pin, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/puzzle/password/pin, 32)
 
 //
 // blockade

--- a/code/game/objects/items/tail_pin.dm
+++ b/code/game/objects/items/tail_pin.dm
@@ -28,7 +28,7 @@
 	poster_item_name = "party game poster"
 	poster_item_desc = "Place it on a wall to start playing pin the tail on the corgi."
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/party_game, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/party_game, 32)
 
 /obj/structure/sign/poster/party_game/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -256,7 +256,7 @@
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/chair/stool, 0)
 
 /obj/structure/chair/stool/narsie_act()
 	return
@@ -284,7 +284,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 	icon_state = "bar"
 	item_chair = /obj/item/chair/stool/bar
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/chair/stool/bar, 0)
 
 /obj/structure/chair/stool/bamboo
 	name = "bamboo stool"

--- a/code/game/objects/structures/broken_flooring.dm
+++ b/code/game/objects/structures/broken_flooring.dm
@@ -63,13 +63,13 @@
 /obj/structure/broken_flooring/plating/always_floorplane
 	always_floorplane = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/singular, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/pile, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/side, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/corner, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/plating, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/singular/always_floorplane, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/pile/always_floorplane, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/side/always_floorplane, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/corner/always_floorplane, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/broken_flooring/plating/always_floorplane, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/singular, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/pile, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/side, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/corner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/plating, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/singular/always_floorplane, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/pile/always_floorplane, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/side/always_floorplane, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/corner/always_floorplane, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/broken_flooring/plating/always_floorplane, 0)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -10,7 +10,7 @@
 	var/obj/item/extinguisher/stored_extinguisher
 	var/opened = FALSE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 29)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/extinguisher_cabinet, 29)
 
 /obj/structure/extinguisher_cabinet/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/objects/structures/fake_stairs.dm
+++ b/code/game/objects/structures/fake_stairs.dm
@@ -8,12 +8,12 @@
 
 	plane = FLOOR_PLANE //one with the floor
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fake_stairs, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fake_stairs, 0)
 
 /obj/structure/fake_stairs/wood
 	icon_state = "stairs_wood"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fake_stairs/wood, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fake_stairs/wood, 0)
 
 /obj/structure/fake_stairs/stone
 	icon_state = "stairs_stone"

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -21,7 +21,7 @@
 	/// Whether we should populate our own contents on Initialize()
 	var/populate_contents = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fireaxecabinet, 32)
 
 /datum/armor/structure_fireaxecabinet
 	melee = 50
@@ -209,7 +209,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet, 32)
 /obj/structure/fireaxecabinet/empty
 	populate_contents = FALSE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/empty, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fireaxecabinet/empty, 32)
 
 /obj/item/wallframe/fireaxecabinet
 	name = "fire axe cabinet"
@@ -226,7 +226,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/empty, 32)
 	item_path = /obj/item/crowbar/mechremoval
 	item_overlay = "crowbar"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/mechremoval, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fireaxecabinet/mechremoval, 32)
 
 /obj/structure/fireaxecabinet/mechremoval/atom_deconstruct(disassembled = TRUE)
 	if(held_item && loc)
@@ -236,7 +236,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/mechremoval, 32)
 /obj/structure/fireaxecabinet/mechremoval/empty
 	populate_contents = FALSE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/mechremoval/empty, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fireaxecabinet/mechremoval/empty, 32)
 
 /obj/item/wallframe/fireaxecabinet/mechremoval
 	name = "mech removal tool cabinet"

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -327,4 +327,4 @@
 	icon = 'icons/obj/fluff/general.dmi'
 	icon_state = "wallsign"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fluff/wallsign, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/fluff/wallsign, 32)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -61,7 +61,7 @@
 		return FALSE
 	return TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/mirror, 28)
 
 /obj/structure/mirror/Initialize(mapload)
 	. = ..()
@@ -74,7 +74,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	. = ..()
 	atom_break(null, mapload)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/mirror/broken, 28)
 
 /obj/structure/mirror/attack_hand(mob/living/carbon/human/user)
 	. = ..()

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -11,7 +11,7 @@
 	/// Current number of a pinned notices
 	var/notices = 0
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/noticeboard, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/noticeboard, 32)

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -11,7 +11,7 @@
 	/// Current number of a pinned notices
 	var/notices = 0
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/noticeboard, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/noticeboard, 32)
 
 /obj/structure/noticeboard/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -11,7 +11,11 @@
 	/// Current number of a pinned notices
 	var/notices = 0
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/noticeboard, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/noticeboard, 32)
+#endif
 
 /obj/structure/noticeboard/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/secure_safe.dm
+++ b/code/game/objects/structures/secure_safe.dm
@@ -34,7 +34,7 @@
 	anchored = TRUE
 	density = FALSE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/secure_safe, 32)
 
 /obj/structure/secure_safe/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -58,7 +58,7 @@ GLOBAL_LIST_INIT(shower_mode_descriptions, list(
 	///How far to shift the sprite when placing.
 	var/pixel_shift = 16
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/shower, (-16))
 
 /obj/machinery/shower/Initialize(mapload, ndir = 0, has_water_reclaimer = null)
 	. = ..()

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -213,6 +213,14 @@
 	. = ..()
 	if(!iswallturf(target) || !proximity)
 		return
+
+#ifdef EXPERIMENT_WALLENING
+	// Deny placing signs if we are attempting to place it on something that is not the south face of a northern wall.
+	if(!check_wall_face(user, target, NORTH))
+		balloon_alert(user, "can't place it there!")
+		return
+#endif
+
 	var/turf/target_turf = target
 	var/turf/user_turf = get_turf(user)
 	var/obj/structure/sign/placed_sign = new sign_path(user_turf) //We place the sign on the turf the user is standing, and pixel shift it to the target wall, as below.

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -214,7 +214,7 @@
 	if(!iswallturf(target) || !proximity)
 		return
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 	// Deny placing signs if we are attempting to place it on something that is not the south face of a northern wall.
 	if(!check_wall_face(user, target, NORTH))
 		balloon_alert(user, "can't place it there!")

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -12,7 +12,7 @@
 	icon_state = "med"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/med, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/med, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med, 32)
 #endif
@@ -23,7 +23,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med, 3
 	icon_state = "medbay"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/med_alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
 #endif
@@ -35,7 +35,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_al
 	icon_state = "bluecross"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/medbay, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/medbay, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay, 32)
 #endif
@@ -46,7 +46,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay
 	icon_state = "bluecross2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/medbay/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
 #endif
@@ -58,7 +58,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay
 	icon_state = "examroom"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/exam_room, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
 #endif
@@ -70,7 +70,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_r
 	icon_state = "chemistry1"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/chemistry, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
 #endif
@@ -80,7 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	icon_state = "chemistry2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/chemistry/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
 #endif
@@ -92,7 +92,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	icon_state = "pharmacy"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/chemistry/pharmacy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
 #endif
@@ -104,7 +104,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	icon_state = "psychology"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/psychology, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/psychology, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psychology, 32)
 #endif
@@ -116,7 +116,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psycho
 	icon_state = "pharmacy"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/virology, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/virology, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virology, 32)
 #endif
@@ -128,7 +128,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virolo
 	icon_state = "morgue"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/morgue, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/morgue, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue, 32)
 #endif
@@ -142,7 +142,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue
 	icon_state = "engine"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/engineering, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/engineering, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engineering, 32)
 #endif
@@ -156,7 +156,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engine
 	icon_state = "science1"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/science, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/science, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science, 32)
 #endif
@@ -166,7 +166,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/scienc
 	icon_state = "science2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/science/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
 #endif
@@ -178,7 +178,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/scienc
 	icon_state = "xenobio1"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/xenobio, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
 #endif
@@ -188,7 +188,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobi
 	icon_state = "xenobio2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/xenobio/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
 #endif
@@ -200,7 +200,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobi
 	icon_state = "gene"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/genetics, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/genetics, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/genetics, 32)
 #endif
@@ -212,7 +212,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/geneti
 	icon_state = "rndserver"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/rndserver, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
 #endif
@@ -226,7 +226,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndser
 	icon_state = "hydro1"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/botany, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany, 32)
 #endif
@@ -236,7 +236,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	icon_state = "hydro2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/botany/alt1, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
 #endif
@@ -246,7 +246,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	icon_state = "hydro3"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/botany/alt2, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
 #endif
@@ -256,7 +256,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	icon_state = "botany"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/botany/alt3, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
 #endif
@@ -268,7 +268,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	icon_state = "custodian"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/custodian, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/custodian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custodian, 32)
 #endif
@@ -280,7 +280,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custod
 	icon_state = "holy"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/holy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/holy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
 #endif
@@ -292,7 +292,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 
 	icon_state = "chapel"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/holy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/holy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
 #endif
@@ -304,7 +304,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 
 	icon_state = "lawyer"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/lawyer, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
 #endif
@@ -318,7 +318,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer
 	icon_state = "cargo"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/cargo, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/cargo, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo, 32)
 #endif
@@ -332,7 +332,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo,
 	icon_state = "security"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/security, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/security, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/security, 32)
 #endif
@@ -346,7 +346,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/securi
 	icon_state = "restroom"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/restroom, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/restroom, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restroom, 32)
 #endif
@@ -358,7 +358,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restro
 	icon_state = "mait1"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/maint, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/maint, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint, 32)
 #endif
@@ -370,7 +370,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint,
 	icon_state = "mait2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/maint/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
 #endif
@@ -382,7 +382,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/
 	icon_state = "evac"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/evac, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/evac, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 32)
 #endif
@@ -394,7 +394,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 
 	icon_state = "drop"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/drop, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/drop, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 32)
 #endif
@@ -406,7 +406,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 
 	icon_state = "court"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/court, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/court, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court, 32)
 #endif
@@ -418,7 +418,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court,
 	icon_state = "telecomms"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/telecomms, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
 #endif
@@ -428,7 +428,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/teleco
 	sign_change_name = "Location - Telecommunications Alt"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/telecomms/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
 #endif
@@ -440,7 +440,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/teleco
 	icon_state = "aiupload"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/aiupload, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
 #endif
@@ -452,7 +452,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiuplo
 	icon_state = "aisat"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/aisat, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/aisat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat, 32)
 #endif
@@ -464,7 +464,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat,
 	icon_state = "vault"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/vault, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/departments/vault, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/vault, 32)
 #endif

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -11,7 +11,7 @@
 	desc = "A sign labelling an area of the medical department."
 	icon_state = "med"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/med, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med, 32)
@@ -22,7 +22,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med, 3
 	sign_change_name = "Department - Medbay Alt"
 	icon_state = "medbay"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
@@ -34,7 +34,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_al
 	desc = "The intergalactic symbol of medical institutions. You'll probably get help here."
 	icon_state = "bluecross"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/medbay, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay, 32)
@@ -45,7 +45,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay
 	sign_change_name = "Generic Medical Alt"
 	icon_state = "bluecross2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
@@ -57,7 +57,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay
 	desc = "A guidance sign which reads 'Exam Room'."
 	icon_state = "examroom"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
@@ -69,7 +69,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_r
 	desc = "A sign labelling an area containing chemical equipment."
 	icon_state = "chemistry1"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
@@ -79,7 +79,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	sign_change_name = "Department - Medbay: Chemistry Alt"
 	icon_state = "chemistry2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
@@ -91,7 +91,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	desc = "A sign labelling an area containing pharmacy equipment."
 	icon_state = "pharmacy"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
@@ -103,7 +103,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	desc = "A sign labelling an area where the Psychologist works, they can probably help you get your head straight."
 	icon_state = "psychology"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/psychology, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psychology, 32)
@@ -115,7 +115,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psycho
 	desc = "A sign labelling an area where the virologist's laboratory is located."
 	icon_state = "pharmacy"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/virology, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virology, 32)
@@ -127,7 +127,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virolo
 	desc = "A sign labelling an area where the station stores its ever-piling bodies."
 	icon_state = "morgue"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/morgue, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue, 32)
@@ -141,7 +141,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue
 	desc = "A sign labelling an area where engineers work."
 	icon_state = "engine"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/engineering, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engineering, 32)
@@ -155,7 +155,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engine
 	desc = "A sign labelling an area where research and science is performed."
 	icon_state = "science1"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/science, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science, 32)
@@ -165,7 +165,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/scienc
 	sign_change_name = "Department - Science Alt"
 	icon_state = "science2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
@@ -177,7 +177,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/scienc
 	desc = "A sign labelling an area where xenobiological entities are researched."
 	icon_state = "xenobio1"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
@@ -187,7 +187,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobi
 	sign_change_name = "Department - Science: Xenobiology Alt"
 	icon_state = "xenobio2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
@@ -199,7 +199,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobi
 	desc = "A sign labelling an area where the field of genetics is researched."
 	icon_state = "gene"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/genetics, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/genetics, 32)
@@ -211,7 +211,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/geneti
 	desc = "A sign labelling an area where scientific data is stored."
 	icon_state = "rndserver"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
@@ -225,7 +225,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndser
 	desc = "A sign labelling an area as a place where plants are grown."
 	icon_state = "hydro1"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany, 32)
@@ -235,7 +235,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	sign_change_name = "Department - Botany (Tray)"
 	icon_state = "hydro2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
@@ -245,7 +245,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	sign_change_name = "Department - Botany (Watering Can)"
 	icon_state = "hydro3"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
@@ -255,7 +255,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	sign_change_name = "Department - Botany (Tray) Alt"
 	icon_state = "botany"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
@@ -267,7 +267,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	desc = "A sign labelling an area where the janitor works."
 	icon_state = "custodian"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/custodian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custodian, 32)
@@ -279,7 +279,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custod
 	desc = "A sign labelling a religious area."
 	icon_state = "holy"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/holy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
@@ -291,7 +291,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 
 	desc = "A sign labelling a religious area."
 	icon_state = "chapel"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/holy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
@@ -303,7 +303,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 
 	desc = "A sign labelling an area where the Lawyers work, apply here for arrivals shuttle whiplash settlement."
 	icon_state = "lawyer"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
@@ -317,7 +317,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer
 	desc = "A sign labelling an area where cargo ships dock."
 	icon_state = "cargo"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/cargo, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo, 32)
@@ -331,7 +331,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo,
 	desc = "A sign labelling an area where the law is law."
 	icon_state = "security"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/security, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/security, 32)
@@ -345,7 +345,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/securi
 	desc = "A sign labelling a restroom."
 	icon_state = "restroom"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/restroom, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restroom, 32)
@@ -357,7 +357,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restro
 	desc = "A sign labelling an area where the departments of the station are linked together."
 	icon_state = "mait1"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/maint, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint, 32)
@@ -369,7 +369,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint,
 	desc = "A sign labelling an area where the departments of the station are linked together."
 	icon_state = "mait2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
@@ -381,7 +381,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/
 	desc = "A sign labelling an area where evacuation procedures take place."
 	icon_state = "evac"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/evac, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 32)
@@ -393,7 +393,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 
 	desc = "A sign labelling an area where drop pod loading procedures take place."
 	icon_state = "drop"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/drop, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 32)
@@ -405,7 +405,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 
 	desc = "A sign labelling the courtroom, where the ever sacred Space Law is upheld."
 	icon_state = "court"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/court, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court, 32)
@@ -417,7 +417,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court,
 	desc = "A sign labelling an area where the station's radio and NTnet servers are stored."
 	icon_state = "telecomms"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
@@ -427,7 +427,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/teleco
 	icon_state = "telecomms2"
 	sign_change_name = "Location - Telecommunications Alt"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
@@ -439,7 +439,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/teleco
 	desc = "A sign labelling an area where laws are uploaded to the station's AI and cyborgs."
 	icon_state = "aiupload"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
@@ -451,7 +451,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiuplo
 	desc = "A sign labelling the AI's heavily-fortified satellite."
 	icon_state = "aisat"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/aisat, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat, 32)
@@ -463,7 +463,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat,
 	desc = "A sign labelling a saferoom where the station's resources and self-destruct are secured."
 	icon_state = "vault"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/vault, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/vault, 32)

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -11,14 +11,14 @@
 	desc = "A sign labelling an area of the medical department."
 	icon_state = "med"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/med, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med, 32)
 
 /obj/structure/sign/departments/med_alt
 	name = "\improper Medbay sign"
 	sign_change_name = "Department - Medbay Alt"
 	icon_state = "medbay"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/med_alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
 
 /obj/structure/sign/departments/medbay
 	name = "\improper Medbay sign"
@@ -26,14 +26,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/med_alt, 32)
 	desc = "The intergalactic symbol of medical institutions. You'll probably get help here."
 	icon_state = "bluecross"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/medbay, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay, 32)
 
 /obj/structure/sign/departments/medbay/alt
 	name = "\improper Medbay sign"
 	sign_change_name = "Generic Medical Alt"
 	icon_state = "bluecross2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/medbay/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
 
 /obj/structure/sign/departments/exam_room
 	name = "\improper Exam Room sign"
@@ -41,7 +41,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/medbay/alt, 32)
 	desc = "A guidance sign which reads 'Exam Room'."
 	icon_state = "examroom"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/exam_room, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
 
 /obj/structure/sign/departments/chemistry
 	name = "\improper Chemistry sign"
@@ -49,13 +49,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/exam_room, 32)
 	desc = "A sign labelling an area containing chemical equipment."
 	icon_state = "chemistry1"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
 
 /obj/structure/sign/departments/chemistry/alt
 	sign_change_name = "Department - Medbay: Chemistry Alt"
 	icon_state = "chemistry2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
 
 /obj/structure/sign/departments/chemistry/pharmacy
 	name = "\improper Pharmacy sign"
@@ -63,7 +63,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry/alt, 32)
 	desc = "A sign labelling an area containing pharmacy equipment."
 	icon_state = "pharmacy"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
 
 /obj/structure/sign/departments/psychology
 	name = "\improper Psychology sign"
@@ -71,7 +71,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry/pharmacy, 
 	desc = "A sign labelling an area where the Psychologist works, they can probably help you get your head straight."
 	icon_state = "psychology"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/psychology, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psychology, 32)
 
 /obj/structure/sign/departments/virology
 	name = "\improper Virology sign"
@@ -79,7 +79,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/psychology, 32)
 	desc = "A sign labelling an area where the virologist's laboratory is located."
 	icon_state = "pharmacy"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/virology, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virology, 32)
 
 /obj/structure/sign/departments/morgue
 	name = "\improper Morgue sign"
@@ -87,7 +87,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/virology, 32)
 	desc = "A sign labelling an area where the station stores its ever-piling bodies."
 	icon_state = "morgue"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/morgue, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue, 32)
 
 ///////ENGINEERING
 
@@ -97,7 +97,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/morgue, 32)
 	desc = "A sign labelling an area where engineers work."
 	icon_state = "engine"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/engineering, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engineering, 32)
 
 ///////SCIENCE
 
@@ -107,13 +107,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/engineering, 32)
 	desc = "A sign labelling an area where research and science is performed."
 	icon_state = "science1"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/science, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science, 32)
 
 /obj/structure/sign/departments/science/alt
 	sign_change_name = "Department - Science Alt"
 	icon_state = "science2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/science/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
 
 /obj/structure/sign/departments/xenobio
 	name = "\improper Xenobiology sign"
@@ -121,13 +121,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/science/alt, 32)
 	desc = "A sign labelling an area where xenobiological entities are researched."
 	icon_state = "xenobio1"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/xenobio, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
 
 /obj/structure/sign/departments/xenobio/alt
 	sign_change_name = "Department - Science: Xenobiology Alt"
 	icon_state = "xenobio2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/xenobio/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
 
 /obj/structure/sign/departments/genetics
 	name = "\improper Genetics sign"
@@ -135,7 +135,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/xenobio/alt, 32)
 	desc = "A sign labelling an area where the field of genetics is researched."
 	icon_state = "gene"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/genetics, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/genetics, 32)
 
 /obj/structure/sign/departments/rndserver
 	name ="\improper R&D Server sign"
@@ -143,7 +143,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/genetics, 32)
 	desc = "A sign labelling an area where scientific data is stored."
 	icon_state = "rndserver"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/rndserver, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
 
 ///////SERVICE
 
@@ -153,25 +153,25 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/rndserver, 32)
 	desc = "A sign labelling an area as a place where plants are grown."
 	icon_state = "hydro1"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany, 32)
 
 /obj/structure/sign/departments/botany/alt1
 	sign_change_name = "Department - Botany (Tray)"
 	icon_state = "hydro2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany/alt1, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
 
 /obj/structure/sign/departments/botany/alt2
 	sign_change_name = "Department - Botany (Watering Can)"
 	icon_state = "hydro3"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany/alt2, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
 
 /obj/structure/sign/departments/botany/botany/alt3
 	sign_change_name = "Department - Botany (Tray) Alt"
 	icon_state = "botany"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany/alt3, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
 
 /obj/structure/sign/departments/custodian
 	name = "\improper Janitor sign"
@@ -179,7 +179,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany/alt3, 32)
 	desc = "A sign labelling an area where the janitor works."
 	icon_state = "custodian"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/custodian, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custodian, 32)
 
 /obj/structure/sign/departments/holy
 	name = "\improper Chapel sign"
@@ -187,7 +187,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/custodian, 32)
 	desc = "A sign labelling a religious area."
 	icon_state = "holy"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/holy, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
 
 /obj/structure/sign/departments/holy_alt
 	name = "\improper Chapel sign"
@@ -195,7 +195,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/holy, 32)
 	desc = "A sign labelling a religious area."
 	icon_state = "chapel"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/holy, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
 
 /obj/structure/sign/departments/lawyer
 	name = "\improper Legal Department sign"
@@ -203,7 +203,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/holy, 32)
 	desc = "A sign labelling an area where the Lawyers work, apply here for arrivals shuttle whiplash settlement."
 	icon_state = "lawyer"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/lawyer, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
 
 ///////SUPPLY
 
@@ -213,7 +213,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/lawyer, 32)
 	desc = "A sign labelling an area where cargo ships dock."
 	icon_state = "cargo"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/cargo, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo, 32)
 
 ///////SECURITY
 
@@ -223,7 +223,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/cargo, 32)
 	desc = "A sign labelling an area where the law is law."
 	icon_state = "security"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/security, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/security, 32)
 
 ////MISC LOCATIONS
 
@@ -233,7 +233,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/security, 32)
 	desc = "A sign labelling a restroom."
 	icon_state = "restroom"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/restroom, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restroom, 32)
 
 /obj/structure/sign/departments/maint
 	name = "\improper Maintenance Tunnel sign"
@@ -241,7 +241,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/restroom, 32)
 	desc = "A sign labelling an area where the departments of the station are linked together."
 	icon_state = "mait1"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/maint, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint, 32)
 
 /obj/structure/sign/departments/maint/alt
 	name = "\improper Maintenance Tunnel sign"
@@ -249,7 +249,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/maint, 32)
 	desc = "A sign labelling an area where the departments of the station are linked together."
 	icon_state = "mait2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/maint/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
 
 /obj/structure/sign/departments/evac
 	name = "\improper Evacuation sign"
@@ -257,7 +257,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/maint/alt, 32)
 	desc = "A sign labelling an area where evacuation procedures take place."
 	icon_state = "evac"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/evac, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 32)
 
 /obj/structure/sign/departments/drop
 	name = "\improper Drop Pods sign"
@@ -265,7 +265,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/evac, 32)
 	desc = "A sign labelling an area where drop pod loading procedures take place."
 	icon_state = "drop"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/drop, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 32)
 
 /obj/structure/sign/departments/court
 	name = "\improper Courtroom sign"
@@ -273,7 +273,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/drop, 32)
 	desc = "A sign labelling the courtroom, where the ever sacred Space Law is upheld."
 	icon_state = "court"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/court, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court, 32)
 
 /obj/structure/sign/departments/telecomms
 	name = "\improper Telecommunications sign"
@@ -281,13 +281,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/court, 32)
 	desc = "A sign labelling an area where the station's radio and NTnet servers are stored."
 	icon_state = "telecomms"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/telecomms, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
 
 /obj/structure/sign/departments/telecomms/alt
 	icon_state = "telecomms2"
 	sign_change_name = "Location - Telecommunications Alt"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/telecomms/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
 
 /obj/structure/sign/departments/aiupload
 	name = "\improper AI Upload sign"
@@ -295,7 +295,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/telecomms/alt, 32)
 	desc = "A sign labelling an area where laws are uploaded to the station's AI and cyborgs."
 	icon_state = "aiupload"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/aiupload, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
 
 /obj/structure/sign/departments/aisat
 	name = "\improper AI Satellite sign"
@@ -303,7 +303,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/aiupload, 32)
 	desc = "A sign labelling the AI's heavily-fortified satellite."
 	icon_state = "aisat"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/aisat, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat, 32)
 
 /obj/structure/sign/departments/vault
 	name = "\improper Vault sign"
@@ -311,4 +311,4 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/aisat, 32)
 	desc = "A sign labelling a saferoom where the station's resources and self-destruct are secured."
 	icon_state = "vault"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/vault, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/vault, 32)

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -11,14 +11,22 @@
 	desc = "A sign labelling an area of the medical department."
 	icon_state = "med"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/med, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med, 32)
+#endif
 
 /obj/structure/sign/departments/med_alt
 	name = "\improper Medbay sign"
 	sign_change_name = "Department - Medbay Alt"
 	icon_state = "medbay"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_alt, 32)
+#endif
 
 /obj/structure/sign/departments/medbay
 	name = "\improper Medbay sign"
@@ -26,14 +34,22 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/med_al
 	desc = "The intergalactic symbol of medical institutions. You'll probably get help here."
 	icon_state = "bluecross"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/medbay, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay, 32)
+#endif
 
 /obj/structure/sign/departments/medbay/alt
 	name = "\improper Medbay sign"
 	sign_change_name = "Generic Medical Alt"
 	icon_state = "bluecross2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay/alt, 32)
+#endif
 
 /obj/structure/sign/departments/exam_room
 	name = "\improper Exam Room sign"
@@ -41,7 +57,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/medbay
 	desc = "A guidance sign which reads 'Exam Room'."
 	icon_state = "examroom"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_room, 32)
+#endif
 
 /obj/structure/sign/departments/chemistry
 	name = "\improper Chemistry sign"
@@ -49,13 +69,21 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/exam_r
 	desc = "A sign labelling an area containing chemical equipment."
 	icon_state = "chemistry1"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry, 32)
+#endif
 
 /obj/structure/sign/departments/chemistry/alt
 	sign_change_name = "Department - Medbay: Chemistry Alt"
 	icon_state = "chemistry2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/alt, 32)
+#endif
 
 /obj/structure/sign/departments/chemistry/pharmacy
 	name = "\improper Pharmacy sign"
@@ -63,7 +91,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	desc = "A sign labelling an area containing pharmacy equipment."
 	icon_state = "pharmacy"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemistry/pharmacy, 32)
+#endif
 
 /obj/structure/sign/departments/psychology
 	name = "\improper Psychology sign"
@@ -71,7 +103,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/chemis
 	desc = "A sign labelling an area where the Psychologist works, they can probably help you get your head straight."
 	icon_state = "psychology"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/psychology, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psychology, 32)
+#endif
 
 /obj/structure/sign/departments/virology
 	name = "\improper Virology sign"
@@ -79,7 +115,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/psycho
 	desc = "A sign labelling an area where the virologist's laboratory is located."
 	icon_state = "pharmacy"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/virology, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virology, 32)
+#endif
 
 /obj/structure/sign/departments/morgue
 	name = "\improper Morgue sign"
@@ -87,7 +127,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/virolo
 	desc = "A sign labelling an area where the station stores its ever-piling bodies."
 	icon_state = "morgue"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/morgue, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue, 32)
+#endif
 
 ///////ENGINEERING
 
@@ -97,7 +141,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/morgue
 	desc = "A sign labelling an area where engineers work."
 	icon_state = "engine"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/engineering, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engineering, 32)
+#endif
 
 ///////SCIENCE
 
@@ -107,13 +155,21 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/engine
 	desc = "A sign labelling an area where research and science is performed."
 	icon_state = "science1"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/science, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science, 32)
+#endif
 
 /obj/structure/sign/departments/science/alt
 	sign_change_name = "Department - Science Alt"
 	icon_state = "science2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/science/alt, 32)
+#endif
 
 /obj/structure/sign/departments/xenobio
 	name = "\improper Xenobiology sign"
@@ -121,13 +177,21 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/scienc
 	desc = "A sign labelling an area where xenobiological entities are researched."
 	icon_state = "xenobio1"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio, 32)
+#endif
 
 /obj/structure/sign/departments/xenobio/alt
 	sign_change_name = "Department - Science: Xenobiology Alt"
 	icon_state = "xenobio2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobio/alt, 32)
+#endif
 
 /obj/structure/sign/departments/genetics
 	name = "\improper Genetics sign"
@@ -135,7 +199,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/xenobi
 	desc = "A sign labelling an area where the field of genetics is researched."
 	icon_state = "gene"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/genetics, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/genetics, 32)
+#endif
 
 /obj/structure/sign/departments/rndserver
 	name ="\improper R&D Server sign"
@@ -143,7 +211,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/geneti
 	desc = "A sign labelling an area where scientific data is stored."
 	icon_state = "rndserver"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndserver, 32)
+#endif
 
 ///////SERVICE
 
@@ -153,25 +225,41 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/rndser
 	desc = "A sign labelling an area as a place where plants are grown."
 	icon_state = "hydro1"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany, 32)
+#endif
 
 /obj/structure/sign/departments/botany/alt1
 	sign_change_name = "Department - Botany (Tray)"
 	icon_state = "hydro2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt1, 32)
+#endif
 
 /obj/structure/sign/departments/botany/alt2
 	sign_change_name = "Department - Botany (Watering Can)"
 	icon_state = "hydro3"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt2, 32)
+#endif
 
 /obj/structure/sign/departments/botany/botany/alt3
 	sign_change_name = "Department - Botany (Tray) Alt"
 	icon_state = "botany"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany/alt3, 32)
+#endif
 
 /obj/structure/sign/departments/custodian
 	name = "\improper Janitor sign"
@@ -179,7 +267,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/botany
 	desc = "A sign labelling an area where the janitor works."
 	icon_state = "custodian"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/custodian, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custodian, 32)
+#endif
 
 /obj/structure/sign/departments/holy
 	name = "\improper Chapel sign"
@@ -187,7 +279,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/custod
 	desc = "A sign labelling a religious area."
 	icon_state = "holy"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/holy, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
+#endif
 
 /obj/structure/sign/departments/holy_alt
 	name = "\improper Chapel sign"
@@ -195,7 +291,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 
 	desc = "A sign labelling a religious area."
 	icon_state = "chapel"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/holy, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 32)
+#endif
 
 /obj/structure/sign/departments/lawyer
 	name = "\improper Legal Department sign"
@@ -203,7 +303,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/holy, 
 	desc = "A sign labelling an area where the Lawyers work, apply here for arrivals shuttle whiplash settlement."
 	icon_state = "lawyer"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer, 32)
+#endif
 
 ///////SUPPLY
 
@@ -213,7 +317,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/lawyer
 	desc = "A sign labelling an area where cargo ships dock."
 	icon_state = "cargo"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/cargo, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo, 32)
+#endif
 
 ///////SECURITY
 
@@ -223,7 +331,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/cargo,
 	desc = "A sign labelling an area where the law is law."
 	icon_state = "security"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/security, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/security, 32)
+#endif
 
 ////MISC LOCATIONS
 
@@ -233,7 +345,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/securi
 	desc = "A sign labelling a restroom."
 	icon_state = "restroom"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/restroom, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restroom, 32)
+#endif
 
 /obj/structure/sign/departments/maint
 	name = "\improper Maintenance Tunnel sign"
@@ -241,7 +357,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/restro
 	desc = "A sign labelling an area where the departments of the station are linked together."
 	icon_state = "mait1"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/maint, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint, 32)
+#endif
 
 /obj/structure/sign/departments/maint/alt
 	name = "\improper Maintenance Tunnel sign"
@@ -249,7 +369,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint,
 	desc = "A sign labelling an area where the departments of the station are linked together."
 	icon_state = "mait2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/alt, 32)
+#endif
 
 /obj/structure/sign/departments/evac
 	name = "\improper Evacuation sign"
@@ -257,7 +381,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/maint/
 	desc = "A sign labelling an area where evacuation procedures take place."
 	icon_state = "evac"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/evac, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 32)
+#endif
 
 /obj/structure/sign/departments/drop
 	name = "\improper Drop Pods sign"
@@ -265,7 +393,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/evac, 
 	desc = "A sign labelling an area where drop pod loading procedures take place."
 	icon_state = "drop"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/drop, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 32)
+#endif
 
 /obj/structure/sign/departments/court
 	name = "\improper Courtroom sign"
@@ -273,7 +405,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/drop, 
 	desc = "A sign labelling the courtroom, where the ever sacred Space Law is upheld."
 	icon_state = "court"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/court, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court, 32)
+#endif
 
 /obj/structure/sign/departments/telecomms
 	name = "\improper Telecommunications sign"
@@ -281,13 +417,21 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/court,
 	desc = "A sign labelling an area where the station's radio and NTnet servers are stored."
 	icon_state = "telecomms"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms, 32)
+#endif
 
 /obj/structure/sign/departments/telecomms/alt
 	icon_state = "telecomms2"
 	sign_change_name = "Location - Telecommunications Alt"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/telecomms/alt, 32)
+#endif
 
 /obj/structure/sign/departments/aiupload
 	name = "\improper AI Upload sign"
@@ -295,7 +439,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/teleco
 	desc = "A sign labelling an area where laws are uploaded to the station's AI and cyborgs."
 	icon_state = "aiupload"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiupload, 32)
+#endif
 
 /obj/structure/sign/departments/aisat
 	name = "\improper AI Satellite sign"
@@ -303,7 +451,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aiuplo
 	desc = "A sign labelling the AI's heavily-fortified satellite."
 	icon_state = "aisat"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/aisat, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat, 32)
+#endif
 
 /obj/structure/sign/departments/vault
 	name = "\improper Vault sign"
@@ -311,4 +463,8 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/aisat,
 	desc = "A sign labelling a saferoom where the station's resources and self-destruct are secured."
 	icon_state = "vault"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/departments/vault, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/departments/vault, 32)
+#endif

--- a/code/game/objects/structures/signs/signs_flags.dm
+++ b/code/game/objects/structures/signs/signs_flags.dm
@@ -9,39 +9,63 @@
 	desc = "The official corporate flag of Nanotrasen. Mostly flown as a ceremonial piece, or to mark land on a new frontier."
 	icon_state = "flag_nt"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
+#endif
 
 /obj/structure/sign/flag/ssc
 	name = "flag of the Spinward Stellar Coalition"
 	desc = "The flag of the Independent Coalition of the Spinward Sector. The colours represent panslavism, and the three stars represent the three central systems of the SSC."
 	icon_state = "flag_ssc"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/ssc, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/ssc, 32)
+#endif
 
 /obj/structure/sign/flag/terragov
 	name = "flag of TerraGov"
 	desc = "The flag of TerraGov. It's a symbol of humanity no matter where they go, or how much they wish it wasn't."
 	icon_state = "flag_terragov"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/terragov, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/terragov, 32)
+#endif
 
 /obj/structure/sign/flag/tizira
 	name = "flag of the Tiziran Empire"
 	desc = "The flag of the Great Empire of Tizira. Depending on who you ask, it represents strength or being stuck in the past."
 	icon_state = "flag_tizira"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/tizira, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/tizira, 32)
+#endif
 
 /obj/structure/sign/flag/mothic
 	name = "flag of the Grand Nomad Fleet"
 	desc = "The flag of the Mothic Grand Nomad Fleet. A classic naval ensign, its use has superceded the old national flag which can be seen in its canton."
 	icon_state = "flag_mothic"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/mothic, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mothic, 32)
+#endif
 
 /obj/structure/sign/flag/mars
 	name = "flag of the Martian Republic"
 	desc = "The flag of Mars. Originally a revolutionary flag during the Martian Rebellions, it has since been adopted as the official flag of the planet, as a reminder of how Mars fought for representation and democracy."
 	icon_state = "flag_mars"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/mars, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mars, 32)
+#endif

--- a/code/game/objects/structures/signs/signs_flags.dm
+++ b/code/game/objects/structures/signs/signs_flags.dm
@@ -10,7 +10,7 @@
 	icon_state = "flag_nt"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/flag/nanotrasen, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
 #endif
@@ -21,7 +21,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/nanotrasen, 3
 	icon_state = "flag_ssc"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/ssc, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/flag/ssc, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/ssc, 32)
 #endif
@@ -32,7 +32,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/ssc, 32)
 	icon_state = "flag_terragov"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/terragov, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/flag/terragov, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/terragov, 32)
 #endif
@@ -43,7 +43,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/terragov, 32)
 	icon_state = "flag_tizira"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/tizira, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/flag/tizira, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/tizira, 32)
 #endif
@@ -54,7 +54,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/tizira, 32)
 	icon_state = "flag_mothic"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/mothic, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/flag/mothic, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mothic, 32)
 #endif
@@ -65,7 +65,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mothic, 32)
 	icon_state = "flag_mars"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/mars, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/flag/mars, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mars, 32)
 #endif

--- a/code/game/objects/structures/signs/signs_flags.dm
+++ b/code/game/objects/structures/signs/signs_flags.dm
@@ -9,39 +9,39 @@
 	desc = "The official corporate flag of Nanotrasen. Mostly flown as a ceremonial piece, or to mark land on a new frontier."
 	icon_state = "flag_nt"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/nanotrasen, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
 
 /obj/structure/sign/flag/ssc
 	name = "flag of the Spinward Stellar Coalition"
 	desc = "The flag of the Independent Coalition of the Spinward Sector. The colours represent panslavism, and the three stars represent the three central systems of the SSC."
 	icon_state = "flag_ssc"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/ssc, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/ssc, 32)
 
 /obj/structure/sign/flag/terragov
 	name = "flag of TerraGov"
 	desc = "The flag of TerraGov. It's a symbol of humanity no matter where they go, or how much they wish it wasn't."
 	icon_state = "flag_terragov"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/terragov, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/terragov, 32)
 
 /obj/structure/sign/flag/tizira
 	name = "flag of the Tiziran Empire"
 	desc = "The flag of the Great Empire of Tizira. Depending on who you ask, it represents strength or being stuck in the past."
 	icon_state = "flag_tizira"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/tizira, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/tizira, 32)
 
 /obj/structure/sign/flag/mothic
 	name = "flag of the Grand Nomad Fleet"
 	desc = "The flag of the Mothic Grand Nomad Fleet. A classic naval ensign, its use has superceded the old national flag which can be seen in its canton."
 	icon_state = "flag_mothic"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/mothic, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mothic, 32)
 
 /obj/structure/sign/flag/mars
 	name = "flag of the Martian Republic"
 	desc = "The flag of Mars. Originally a revolutionary flag during the Martian Rebellions, it has since been adopted as the official flag of the planet, as a reminder of how Mars fought for representation and democracy."
 	icon_state = "flag_mars"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/mars, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mars, 32)

--- a/code/game/objects/structures/signs/signs_flags.dm
+++ b/code/game/objects/structures/signs/signs_flags.dm
@@ -9,7 +9,7 @@
 	desc = "The official corporate flag of Nanotrasen. Mostly flown as a ceremonial piece, or to mark land on a new frontier."
 	icon_state = "flag_nt"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/nanotrasen, 32)
@@ -20,7 +20,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/nanotrasen, 3
 	desc = "The flag of the Independent Coalition of the Spinward Sector. The colours represent panslavism, and the three stars represent the three central systems of the SSC."
 	icon_state = "flag_ssc"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/ssc, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/ssc, 32)
@@ -31,7 +31,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/ssc, 32)
 	desc = "The flag of TerraGov. It's a symbol of humanity no matter where they go, or how much they wish it wasn't."
 	icon_state = "flag_terragov"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/terragov, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/terragov, 32)
@@ -42,7 +42,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/terragov, 32)
 	desc = "The flag of the Great Empire of Tizira. Depending on who you ask, it represents strength or being stuck in the past."
 	icon_state = "flag_tizira"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/tizira, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/tizira, 32)
@@ -53,7 +53,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/tizira, 32)
 	desc = "The flag of the Mothic Grand Nomad Fleet. A classic naval ensign, its use has superceded the old national flag which can be seen in its canton."
 	icon_state = "flag_mothic"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/mothic, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mothic, 32)
@@ -64,7 +64,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mothic, 32)
 	desc = "The flag of Mars. Originally a revolutionary flag during the Martian Rebellions, it has since been adopted as the official flag of the planet, as a reminder of how Mars fought for representation and democracy."
 	icon_state = "flag_mars"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/flag/mars, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/flag/mars, 32)

--- a/code/game/objects/structures/signs/signs_interactive.dm
+++ b/code/game/objects/structures/signs/signs_interactive.dm
@@ -3,7 +3,7 @@
 	desc = "It's your run-of-the-mill wall clock showing both the local Coalition Standard Time and the galactic Treaty Coordinated Time. Perfect for staring at instead of working."
 	icon_state = "clock"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/clock, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
@@ -19,7 +19,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
 	desc = "It's an old-school wall calendar. Sure, it might be obsolete with modern technology, but it's still hard to imagine an office without one."
 	icon_state = "calendar"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/calendar, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/calendar, 32)

--- a/code/game/objects/structures/signs/signs_interactive.dm
+++ b/code/game/objects/structures/signs/signs_interactive.dm
@@ -3,7 +3,7 @@
 	desc = "It's your run-of-the-mill wall clock showing both the local Coalition Standard Time and the galactic Treaty Coordinated Time. Perfect for staring at instead of working."
 	icon_state = "clock"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/clock, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
 
 /obj/structure/sign/clock/examine(mob/user)
 	. = ..()
@@ -15,7 +15,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/clock, 32)
 	desc = "It's an old-school wall calendar. Sure, it might be obsolete with modern technology, but it's still hard to imagine an office without one."
 	icon_state = "calendar"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/calendar, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/calendar, 32)
 
 /obj/structure/sign/calendar/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/signs/signs_interactive.dm
+++ b/code/game/objects/structures/signs/signs_interactive.dm
@@ -3,7 +3,11 @@
 	desc = "It's your run-of-the-mill wall clock showing both the local Coalition Standard Time and the galactic Treaty Coordinated Time. Perfect for staring at instead of working."
 	icon_state = "clock"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/clock, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
+#endif
 
 /obj/structure/sign/clock/examine(mob/user)
 	. = ..()
@@ -15,7 +19,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
 	desc = "It's an old-school wall calendar. Sure, it might be obsolete with modern technology, but it's still hard to imagine an office without one."
 	icon_state = "calendar"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/calendar, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/calendar, 32)
+#endif
 
 /obj/structure/sign/calendar/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/signs/signs_interactive.dm
+++ b/code/game/objects/structures/signs/signs_interactive.dm
@@ -4,7 +4,7 @@
 	icon_state = "clock"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/clock, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/clock, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
 #endif
@@ -20,7 +20,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/clock, 32)
 	icon_state = "calendar"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/calendar, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/calendar, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/calendar, 32)
 #endif

--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -16,81 +16,81 @@
 	desc = "A direction sign, pointing out which way the Science department is."
 	icon_state = "direction_sci"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/science, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/science, 32)
 
 /obj/structure/sign/directions/engineering
 	name = "engineering department sign"
 	desc = "A direction sign, pointing out which way the Engineering department is."
 	icon_state = "direction_eng"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/engineering, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/engineering, 32)
 
 /obj/structure/sign/directions/security
 	name = "security department sign"
 	desc = "A direction sign, pointing out which way the Security department is."
 	icon_state = "direction_sec"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/security, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/security, 32)
 
 /obj/structure/sign/directions/medical
 	name = "medbay sign"
 	desc = "A direction sign, pointing out which way the Medbay is."
 	icon_state = "direction_med"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/medical, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/medical, 32)
 
 /obj/structure/sign/directions/evac
 	name = "evacuation sign"
 	desc = "A direction sign, pointing out which way the escape shuttle dock is."
 	icon_state = "direction_evac"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/evac, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/evac, 32)
 
 /obj/structure/sign/directions/supply
 	name = "cargo sign"
 	desc = "A direction sign, pointing out which way the Cargo Bay is."
 	icon_state = "direction_supply"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/supply, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/supply, 32)
 
 /obj/structure/sign/directions/command
 	name = "command department sign"
 	desc = "A direction sign, pointing out which way the Command department is."
 	icon_state = "direction_bridge"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/command, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/command, 32)
 
 /obj/structure/sign/directions/vault
 	name = "vault sign"
 	desc = "A direction sign, pointing out which way the station's Vault is."
 	icon_state = "direction_vault"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/vault, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/vault, 32)
 
 /obj/structure/sign/directions/upload
 	name = "upload sign"
 	desc = "A direction sign, pointing out which way the station's AI Upload is."
 	icon_state = "direction_upload"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/upload, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/upload, 32)
 
 /obj/structure/sign/directions/dorms
 	name = "dormitories sign"
 	desc = "A direction sign, pointing out which way the dormitories are."
 	icon_state = "direction_dorms"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/dorms, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/dorms, 32)
 
 /obj/structure/sign/directions/lavaland
 	name = "lava sign"
 	desc = "A direction sign, pointing out which way the hot stuff is."
 	icon_state = "direction_lavaland"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/lavaland, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
 
 /obj/structure/sign/directions/arrival
 	name = "arrivals sign"
 	desc = "A direction sign, pointing out which way the arrivals shuttle dock is."
 	icon_state = "direction_arrival"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/directions/arrival, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/arrival, 32)

--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -16,7 +16,7 @@
 	desc = "A direction sign, pointing out which way the Science department is."
 	icon_state = "direction_sci"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/science, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/science, 32)
@@ -27,7 +27,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/science
 	desc = "A direction sign, pointing out which way the Engineering department is."
 	icon_state = "direction_eng"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/engineering, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/engineering, 32)
@@ -38,7 +38,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/enginee
 	desc = "A direction sign, pointing out which way the Security department is."
 	icon_state = "direction_sec"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/security, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/security, 32)
@@ -49,7 +49,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/securit
 	desc = "A direction sign, pointing out which way the Medbay is."
 	icon_state = "direction_med"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/medical, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/medical, 32)
@@ -60,7 +60,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/medical
 	desc = "A direction sign, pointing out which way the escape shuttle dock is."
 	icon_state = "direction_evac"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/evac, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/evac, 32)
@@ -71,7 +71,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/evac, 3
 	desc = "A direction sign, pointing out which way the Cargo Bay is."
 	icon_state = "direction_supply"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/supply, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/supply, 32)
@@ -82,7 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/supply,
 	desc = "A direction sign, pointing out which way the Command department is."
 	icon_state = "direction_bridge"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/command, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/command, 32)
@@ -93,7 +93,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/command
 	desc = "A direction sign, pointing out which way the station's Vault is."
 	icon_state = "direction_vault"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/vault, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/vault, 32)
@@ -104,7 +104,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/vault, 
 	desc = "A direction sign, pointing out which way the station's AI Upload is."
 	icon_state = "direction_upload"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/upload, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/upload, 32)
@@ -115,7 +115,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/upload,
 	desc = "A direction sign, pointing out which way the dormitories are."
 	icon_state = "direction_dorms"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/dorms, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/dorms, 32)
@@ -126,7 +126,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/dorms, 
 	desc = "A direction sign, pointing out which way the hot stuff is."
 	icon_state = "direction_lavaland"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
@@ -137,7 +137,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/lavalan
 	desc = "A direction sign, pointing out which way the arrivals shuttle dock is."
 	icon_state = "direction_arrival"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/arrival, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/arrival, 32)

--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -17,7 +17,7 @@
 	icon_state = "direction_sci"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/science, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/science, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/science, 32)
 #endif
@@ -28,7 +28,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/science
 	icon_state = "direction_eng"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/engineering, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/engineering, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/engineering, 32)
 #endif
@@ -39,7 +39,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/enginee
 	icon_state = "direction_sec"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/security, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/security, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/security, 32)
 #endif
@@ -50,7 +50,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/securit
 	icon_state = "direction_med"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/medical, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/medical, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/medical, 32)
 #endif
@@ -61,7 +61,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/medical
 	icon_state = "direction_evac"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/evac, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/evac, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/evac, 32)
 #endif
@@ -72,7 +72,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/evac, 3
 	icon_state = "direction_supply"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/supply, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/supply, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/supply, 32)
 #endif
@@ -83,7 +83,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/supply,
 	icon_state = "direction_bridge"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/command, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/command, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/command, 32)
 #endif
@@ -94,7 +94,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/command
 	icon_state = "direction_vault"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/vault, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/vault, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/vault, 32)
 #endif
@@ -105,7 +105,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/vault, 
 	icon_state = "direction_upload"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/upload, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/upload, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/upload, 32)
 #endif
@@ -116,7 +116,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/upload,
 	icon_state = "direction_dorms"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/dorms, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/dorms, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/dorms, 32)
 #endif
@@ -127,7 +127,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/dorms, 
 	icon_state = "direction_lavaland"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/lavaland, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
 #endif
@@ -138,7 +138,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/lavalan
 	icon_state = "direction_arrival"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/arrival, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/directions/arrival, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/arrival, 32)
 #endif

--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -16,81 +16,129 @@
 	desc = "A direction sign, pointing out which way the Science department is."
 	icon_state = "direction_sci"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/science, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/science, 32)
+#endif
 
 /obj/structure/sign/directions/engineering
 	name = "engineering department sign"
 	desc = "A direction sign, pointing out which way the Engineering department is."
 	icon_state = "direction_eng"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/engineering, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/engineering, 32)
+#endif
 
 /obj/structure/sign/directions/security
 	name = "security department sign"
 	desc = "A direction sign, pointing out which way the Security department is."
 	icon_state = "direction_sec"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/security, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/security, 32)
+#endif
 
 /obj/structure/sign/directions/medical
 	name = "medbay sign"
 	desc = "A direction sign, pointing out which way the Medbay is."
 	icon_state = "direction_med"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/medical, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/medical, 32)
+#endif
 
 /obj/structure/sign/directions/evac
 	name = "evacuation sign"
 	desc = "A direction sign, pointing out which way the escape shuttle dock is."
 	icon_state = "direction_evac"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/evac, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/evac, 32)
+#endif
 
 /obj/structure/sign/directions/supply
 	name = "cargo sign"
 	desc = "A direction sign, pointing out which way the Cargo Bay is."
 	icon_state = "direction_supply"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/supply, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/supply, 32)
+#endif
 
 /obj/structure/sign/directions/command
 	name = "command department sign"
 	desc = "A direction sign, pointing out which way the Command department is."
 	icon_state = "direction_bridge"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/command, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/command, 32)
+#endif
 
 /obj/structure/sign/directions/vault
 	name = "vault sign"
 	desc = "A direction sign, pointing out which way the station's Vault is."
 	icon_state = "direction_vault"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/vault, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/vault, 32)
+#endif
 
 /obj/structure/sign/directions/upload
 	name = "upload sign"
 	desc = "A direction sign, pointing out which way the station's AI Upload is."
 	icon_state = "direction_upload"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/upload, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/upload, 32)
+#endif
 
 /obj/structure/sign/directions/dorms
 	name = "dormitories sign"
 	desc = "A direction sign, pointing out which way the dormitories are."
 	icon_state = "direction_dorms"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/dorms, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/dorms, 32)
+#endif
 
 /obj/structure/sign/directions/lavaland
 	name = "lava sign"
 	desc = "A direction sign, pointing out which way the hot stuff is."
 	icon_state = "direction_lavaland"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/lavaland, 32)
+#endif
 
 /obj/structure/sign/directions/arrival
 	name = "arrivals sign"
 	desc = "A direction sign, pointing out which way the arrivals shuttle dock is."
 	icon_state = "direction_arrival"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/directions/arrival, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/directions/arrival, 32)
+#endif

--- a/code/game/objects/structures/signs/signs_misc.dm
+++ b/code/game/objects/structures/signs/signs_misc.dm
@@ -26,4 +26,4 @@
 	icon = 'icons/obj/machines/barsigns.dmi'
 	desc = "85cr for a iced lactose-free caramel frappe?! Who buys that?!"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/xenobio_guide, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/xenobio_guide, 32)

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -11,7 +11,7 @@
 	is_editable = TRUE
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning, 32)
 #endif
@@ -22,7 +22,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning, 32)
 	desc = "A warning sign which reads 'SECURE AREA'."
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/secure_area, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
 #endif
@@ -33,7 +33,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/secure_are
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'."
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/docking, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/docking, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 32)
 #endif
@@ -45,7 +45,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 3
 	icon_state = "bio"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/biohazard, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
 #endif
@@ -57,7 +57,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard,
 	icon_state = "shock"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/electric_shock, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
 #endif
@@ -69,7 +69,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_s
 	icon_state = "space"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/vacuum, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
 #endif
@@ -81,7 +81,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32
 	layer = MOB_LAYER
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/vacuum/external, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
 #endif
@@ -93,7 +93,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/ext
 	icon_state = "deathsposal"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/deathsposal, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
 #endif
@@ -105,7 +105,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposa
 	icon_state = "bodysposal"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/bodysposal, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
 #endif
@@ -118,7 +118,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal
 	resistance_flags = FIRE_PROOF
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/fire, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/fire, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
 #endif
@@ -131,7 +131,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
 	resistance_flags = FLAMMABLE
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/no_smoking, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
 #endif
@@ -143,7 +143,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking
 	icon_state = "nosmoking"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/no_smoking/circle, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
 #endif
@@ -155,7 +155,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking
 	icon_state = "yessmoking"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/yes_smoking/circle, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
 #endif
@@ -167,7 +167,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smokin
 	icon_state = "radiation"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/radiation, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/radiation, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation, 32)
 #endif
@@ -178,7 +178,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation,
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'."
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/radiation/rad_area, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
 #endif
@@ -191,7 +191,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/
 	icon_state = "xeno_warning"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/xeno_mining, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
 #endif
@@ -203,7 +203,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_minin
 	icon_state = "safety"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/engine_safety, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
 #endif
@@ -215,7 +215,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_saf
 	icon_state = "explosives"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/explosives, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/explosives, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives, 32)
 #endif
@@ -227,7 +227,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives
 	icon_state = "explosives2"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/explosives/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
 #endif
@@ -239,7 +239,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives
 	icon_state = "testchamber"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/test_chamber, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
 #endif
@@ -251,7 +251,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamb
 	icon_state = "firingrange"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/firing_range, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
 #endif
@@ -263,7 +263,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_ran
 	icon_state = "cold"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/cold_temp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
 #endif
@@ -275,7 +275,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp,
 	icon_state = "heat"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/hot_temp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
 #endif
@@ -287,7 +287,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 
 	icon_state = "gasmask"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/gas_mask, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
 #endif
@@ -299,7 +299,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 
 	icon_state = "chemdiamond"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/chem_diamond, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
 #endif
@@ -311,7 +311,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamo
 	icon_state = "doors"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/doors, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/doors, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
 #endif
@@ -325,7 +325,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
 	icon_state = "pods"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/pods, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/pods, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
 #endif
@@ -337,7 +337,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
 	icon_state = "radshelter"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/warning/rad_shelter, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)
 #endif

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -10,21 +10,21 @@
 	icon_state = "securearea"
 	is_editable = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning, 32)
 
 /obj/structure/sign/warning/secure_area
 	name = "\improper SECURE AREA sign"
 	sign_change_name = "Warning - Secure Area"
 	desc = "A warning sign which reads 'SECURE AREA'."
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/secure_area, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
 
 /obj/structure/sign/warning/docking
 	name = "\improper KEEP CLEAR: DOCKING AREA sign"
 	sign_change_name = "Warning - Docking Area"
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'."
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/docking, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 32)
 
 /obj/structure/sign/warning/biohazard
 	name = "\improper BIOHAZARD sign"
@@ -32,7 +32,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/docking, 32)
 	desc = "A warning sign which reads 'BIOHAZARD'."
 	icon_state = "bio"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/biohazard, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
 
 /obj/structure/sign/warning/electric_shock
 	name = "\improper HIGH VOLTAGE sign"
@@ -40,7 +40,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/biohazard, 32)
 	desc = "A warning sign which reads 'HIGH VOLTAGE'."
 	icon_state = "shock"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/electric_shock, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
 
 /obj/structure/sign/warning/vacuum
 	name = "\improper HARD VACUUM AHEAD sign"
@@ -48,7 +48,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/electric_shock, 32)
 	desc = "A warning sign which reads 'HARD VACUUM AHEAD'."
 	icon_state = "space"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
 
 /obj/structure/sign/warning/vacuum/external
 	name = "\improper EXTERNAL AIRLOCK sign"
@@ -56,7 +56,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum, 32)
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'."
 	layer = MOB_LAYER
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum/external, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
 
 /obj/structure/sign/warning/deathsposal
 	name = "\improper DISPOSAL: LEADS TO SPACE sign"
@@ -64,7 +64,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum/external, 32)
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO SPACE'."
 	icon_state = "deathsposal"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/deathsposal, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
 
 /obj/structure/sign/warning/bodysposal
 	name = "\improper DISPOSAL: LEADS TO MORGUE sign"
@@ -72,7 +72,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/deathsposal, 32)
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO MORGUE'."
 	icon_state = "bodysposal"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/bodysposal, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
 
 /obj/structure/sign/warning/fire
 	name = "\improper DANGER: FIRE sign"
@@ -81,7 +81,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/bodysposal, 32)
 	icon_state = "fire"
 	resistance_flags = FIRE_PROOF
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/fire, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
 
 /obj/structure/sign/warning/no_smoking
 	name = "\improper NO SMOKING sign"
@@ -90,7 +90,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/fire, 32)
 	icon_state = "nosmoking2"
 	resistance_flags = FLAMMABLE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
 
 /obj/structure/sign/warning/no_smoking/circle
 	name = "\improper NO SMOKING sign"
@@ -98,7 +98,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking, 32)
 	desc = "A warning sign which reads 'NO SMOKING'."
 	icon_state = "nosmoking"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking/circle, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
 
 /obj/structure/sign/warning/yes_smoking/circle
 	name = "\improper YES SMOKING sign"
@@ -106,7 +106,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking/circle, 32)
 	desc = "A warning sign which reads 'YES SMOKING'."
 	icon_state = "yessmoking"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/yes_smoking/circle, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
 
 /obj/structure/sign/warning/radiation
 	name = "\improper HAZARDOUS RADIATION sign"
@@ -114,14 +114,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/yes_smoking/circle, 32)
 	desc = "A warning sign alerting the user of potential radiation hazards."
 	icon_state = "radiation"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation, 32)
 
 /obj/structure/sign/warning/radiation/rad_area
 	name = "\improper RADIOACTIVE AREA sign"
 	sign_change_name = "Warning - Radioactive Area"
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'."
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation/rad_area, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
 
 /obj/structure/sign/warning/xeno_mining
 	name = "\improper DANGEROUS ALIEN LIFE sign"
@@ -130,7 +130,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation/rad_area, 32)
 	icon = 'icons/obj/signs.dmi'
 	icon_state = "xeno_warning"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/xeno_mining, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
 
 /obj/structure/sign/warning/engine_safety
 	name = "\improper ENGINEERING SAFETY sign"
@@ -138,7 +138,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/xeno_mining, 32)
 	desc = "A sign detailing the various safety protocols when working on-site to ensure a safe shift."
 	icon_state = "safety"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/engine_safety, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
 
 /obj/structure/sign/warning/explosives
 	name = "\improper HIGH EXPLOSIVES sign"
@@ -146,7 +146,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/engine_safety, 32)
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives, 32)
 
 /obj/structure/sign/warning/explosives/alt
 	name = "\improper HIGH EXPLOSIVES sign"
@@ -154,7 +154,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives, 32)
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives2"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives/alt, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
 
 /obj/structure/sign/warning/test_chamber
 	name = "\improper TESTING AREA sign"
@@ -162,7 +162,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives/alt, 32)
 	desc = "A sign that warns of high-power testing equipment in the area."
 	icon_state = "testchamber"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/test_chamber, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
 
 /obj/structure/sign/warning/firing_range
 	name = "\improper FIRING RANGE sign"
@@ -170,7 +170,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/test_chamber, 32)
 	desc = "A sign reminding you to remain behind the firing line, and to wear ear protection."
 	icon_state = "firingrange"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/firing_range, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
 
 /obj/structure/sign/warning/cold_temp
 	name = "\improper FREEZING AIR sign"
@@ -178,7 +178,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/firing_range, 32)
 	desc = "A sign that warns of extremely cold air in the vicinity."
 	icon_state = "cold"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/cold_temp, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
 
 /obj/structure/sign/warning/hot_temp
 	name = "\improper SUPERHEATED AIR sign"
@@ -186,7 +186,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/cold_temp, 32)
 	desc = "A sign that warns of extremely hot air in the vicinity."
 	icon_state = "heat"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/hot_temp, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
 
 /obj/structure/sign/warning/gas_mask
 	name = "\improper CONTAMINATED AIR sign"
@@ -194,7 +194,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/hot_temp, 32)
 	desc = "A sign that warns of dangerous particulates or gasses in the air, instructing you to wear internals."
 	icon_state = "gasmask"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/gas_mask, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
 
 /obj/structure/sign/warning/chem_diamond
 	name = "\improper REACTIVE CHEMICALS sign"
@@ -202,7 +202,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/gas_mask, 32)
 	desc = "A sign that warns of potentially reactive chemicals nearby, be they explosive, flammable, or acidic."
 	icon_state = "chemdiamond"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/chem_diamond, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
 
 /obj/structure/sign/warning/doors
 	name = "\improper BLAST DOORS sign"
@@ -210,7 +210,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/chem_diamond, 32)
 	desc = "A sign that shows there are doors here. There are doors everywhere!"
 	icon_state = "doors"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/doors, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
 
 ////MISC LOCATIONS
 
@@ -220,7 +220,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/doors, 32)
 	desc = "A warning sign which reads 'ESCAPE PODS'."
 	icon_state = "pods"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/pods, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
 
 /obj/structure/sign/warning/rad_shelter
 	name = "\improper RADSTORM SHELTER sign"
@@ -228,4 +228,4 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/pods, 32)
 	desc = "A warning sign which reads 'RADSTORM SHELTER'."
 	icon_state = "radshelter"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/rad_shelter, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -10,7 +10,7 @@
 	icon_state = "securearea"
 	is_editable = TRUE
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning, 32)
@@ -21,7 +21,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning, 32)
 	sign_change_name = "Warning - Secure Area"
 	desc = "A warning sign which reads 'SECURE AREA'."
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
@@ -32,7 +32,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/secure_are
 	sign_change_name = "Warning - Docking Area"
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'."
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/docking, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 32)
@@ -44,7 +44,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 3
 	desc = "A warning sign which reads 'BIOHAZARD'."
 	icon_state = "bio"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
@@ -56,7 +56,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard,
 	desc = "A warning sign which reads 'HIGH VOLTAGE'."
 	icon_state = "shock"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
@@ -68,7 +68,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_s
 	desc = "A warning sign which reads 'HARD VACUUM AHEAD'."
 	icon_state = "space"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
@@ -80,7 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'."
 	layer = MOB_LAYER
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
@@ -92,7 +92,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/ext
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO SPACE'."
 	icon_state = "deathsposal"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
@@ -104,7 +104,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposa
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO MORGUE'."
 	icon_state = "bodysposal"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
@@ -117,7 +117,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal
 	icon_state = "fire"
 	resistance_flags = FIRE_PROOF
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/fire, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
@@ -130,7 +130,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
 	icon_state = "nosmoking2"
 	resistance_flags = FLAMMABLE
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
@@ -142,7 +142,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking
 	desc = "A warning sign which reads 'NO SMOKING'."
 	icon_state = "nosmoking"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
@@ -154,7 +154,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking
 	desc = "A warning sign which reads 'YES SMOKING'."
 	icon_state = "yessmoking"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
@@ -166,7 +166,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smokin
 	desc = "A warning sign alerting the user of potential radiation hazards."
 	icon_state = "radiation"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/radiation, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation, 32)
@@ -177,7 +177,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation,
 	sign_change_name = "Warning - Radioactive Area"
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'."
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
@@ -190,7 +190,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/
 	icon = 'icons/obj/signs.dmi'
 	icon_state = "xeno_warning"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
@@ -202,7 +202,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_minin
 	desc = "A sign detailing the various safety protocols when working on-site to ensure a safe shift."
 	icon_state = "safety"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
@@ -214,7 +214,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_saf
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/explosives, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives, 32)
@@ -226,7 +226,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives2"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
@@ -238,7 +238,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives
 	desc = "A sign that warns of high-power testing equipment in the area."
 	icon_state = "testchamber"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
@@ -250,7 +250,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamb
 	desc = "A sign reminding you to remain behind the firing line, and to wear ear protection."
 	icon_state = "firingrange"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
@@ -262,7 +262,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_ran
 	desc = "A sign that warns of extremely cold air in the vicinity."
 	icon_state = "cold"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
@@ -274,7 +274,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp,
 	desc = "A sign that warns of extremely hot air in the vicinity."
 	icon_state = "heat"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
@@ -286,7 +286,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 
 	desc = "A sign that warns of dangerous particulates or gasses in the air, instructing you to wear internals."
 	icon_state = "gasmask"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
@@ -298,7 +298,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 
 	desc = "A sign that warns of potentially reactive chemicals nearby, be they explosive, flammable, or acidic."
 	icon_state = "chemdiamond"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
@@ -310,7 +310,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamo
 	desc = "A sign that shows there are doors here. There are doors everywhere!"
 	icon_state = "doors"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/doors, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
@@ -324,7 +324,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
 	desc = "A warning sign which reads 'ESCAPE PODS'."
 	icon_state = "pods"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/pods, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
@@ -336,7 +336,7 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
 	desc = "A warning sign which reads 'RADSTORM SHELTER'."
 	icon_state = "radshelter"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -10,21 +10,33 @@
 	icon_state = "securearea"
 	is_editable = TRUE
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning, 32)
+#endif
 
 /obj/structure/sign/warning/secure_area
 	name = "\improper SECURE AREA sign"
 	sign_change_name = "Warning - Secure Area"
 	desc = "A warning sign which reads 'SECURE AREA'."
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/secure_area, 32)
+#endif
 
 /obj/structure/sign/warning/docking
 	name = "\improper KEEP CLEAR: DOCKING AREA sign"
 	sign_change_name = "Warning - Docking Area"
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'."
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/docking, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 32)
+#endif
 
 /obj/structure/sign/warning/biohazard
 	name = "\improper BIOHAZARD sign"
@@ -32,7 +44,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/docking, 3
 	desc = "A warning sign which reads 'BIOHAZARD'."
 	icon_state = "bio"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard, 32)
+#endif
 
 /obj/structure/sign/warning/electric_shock
 	name = "\improper HIGH VOLTAGE sign"
@@ -40,7 +56,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/biohazard,
 	desc = "A warning sign which reads 'HIGH VOLTAGE'."
 	icon_state = "shock"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_shock, 32)
+#endif
 
 /obj/structure/sign/warning/vacuum
 	name = "\improper HARD VACUUM AHEAD sign"
@@ -48,7 +68,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/electric_s
 	desc = "A warning sign which reads 'HARD VACUUM AHEAD'."
 	icon_state = "space"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32)
+#endif
 
 /obj/structure/sign/warning/vacuum/external
 	name = "\improper EXTERNAL AIRLOCK sign"
@@ -56,7 +80,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum, 32
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'."
 	layer = MOB_LAYER
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/external, 32)
+#endif
 
 /obj/structure/sign/warning/deathsposal
 	name = "\improper DISPOSAL: LEADS TO SPACE sign"
@@ -64,7 +92,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/vacuum/ext
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO SPACE'."
 	icon_state = "deathsposal"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposal, 32)
+#endif
 
 /obj/structure/sign/warning/bodysposal
 	name = "\improper DISPOSAL: LEADS TO MORGUE sign"
@@ -72,7 +104,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/deathsposa
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO MORGUE'."
 	icon_state = "bodysposal"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal, 32)
+#endif
 
 /obj/structure/sign/warning/fire
 	name = "\improper DANGER: FIRE sign"
@@ -81,7 +117,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/bodysposal
 	icon_state = "fire"
 	resistance_flags = FIRE_PROOF
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/fire, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
+#endif
 
 /obj/structure/sign/warning/no_smoking
 	name = "\improper NO SMOKING sign"
@@ -90,7 +130,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/fire, 32)
 	icon_state = "nosmoking2"
 	resistance_flags = FLAMMABLE
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking, 32)
+#endif
 
 /obj/structure/sign/warning/no_smoking/circle
 	name = "\improper NO SMOKING sign"
@@ -98,7 +142,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking
 	desc = "A warning sign which reads 'NO SMOKING'."
 	icon_state = "nosmoking"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking/circle, 32)
+#endif
 
 /obj/structure/sign/warning/yes_smoking/circle
 	name = "\improper YES SMOKING sign"
@@ -106,7 +154,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/no_smoking
 	desc = "A warning sign which reads 'YES SMOKING'."
 	icon_state = "yessmoking"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smoking/circle, 32)
+#endif
 
 /obj/structure/sign/warning/radiation
 	name = "\improper HAZARDOUS RADIATION sign"
@@ -114,14 +166,22 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/yes_smokin
 	desc = "A warning sign alerting the user of potential radiation hazards."
 	icon_state = "radiation"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/radiation, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation, 32)
+#endif
 
 /obj/structure/sign/warning/radiation/rad_area
 	name = "\improper RADIOACTIVE AREA sign"
 	sign_change_name = "Warning - Radioactive Area"
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'."
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/rad_area, 32)
+#endif
 
 /obj/structure/sign/warning/xeno_mining
 	name = "\improper DANGEROUS ALIEN LIFE sign"
@@ -130,7 +190,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/radiation/
 	icon = 'icons/obj/signs.dmi'
 	icon_state = "xeno_warning"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_mining, 32)
+#endif
 
 /obj/structure/sign/warning/engine_safety
 	name = "\improper ENGINEERING SAFETY sign"
@@ -138,7 +202,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/xeno_minin
 	desc = "A sign detailing the various safety protocols when working on-site to ensure a safe shift."
 	icon_state = "safety"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_safety, 32)
+#endif
 
 /obj/structure/sign/warning/explosives
 	name = "\improper HIGH EXPLOSIVES sign"
@@ -146,7 +214,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/engine_saf
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/explosives, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives, 32)
+#endif
 
 /obj/structure/sign/warning/explosives/alt
 	name = "\improper HIGH EXPLOSIVES sign"
@@ -154,7 +226,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives2"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives/alt, 32)
+#endif
 
 /obj/structure/sign/warning/test_chamber
 	name = "\improper TESTING AREA sign"
@@ -162,7 +238,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/explosives
 	desc = "A sign that warns of high-power testing equipment in the area."
 	icon_state = "testchamber"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamber, 32)
+#endif
 
 /obj/structure/sign/warning/firing_range
 	name = "\improper FIRING RANGE sign"
@@ -170,7 +250,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/test_chamb
 	desc = "A sign reminding you to remain behind the firing line, and to wear ear protection."
 	icon_state = "firingrange"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_range, 32)
+#endif
 
 /obj/structure/sign/warning/cold_temp
 	name = "\improper FREEZING AIR sign"
@@ -178,7 +262,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/firing_ran
 	desc = "A sign that warns of extremely cold air in the vicinity."
 	icon_state = "cold"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp, 32)
+#endif
 
 /obj/structure/sign/warning/hot_temp
 	name = "\improper SUPERHEATED AIR sign"
@@ -186,7 +274,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/cold_temp,
 	desc = "A sign that warns of extremely hot air in the vicinity."
 	icon_state = "heat"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 32)
+#endif
 
 /obj/structure/sign/warning/gas_mask
 	name = "\improper CONTAMINATED AIR sign"
@@ -194,7 +286,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/hot_temp, 
 	desc = "A sign that warns of dangerous particulates or gasses in the air, instructing you to wear internals."
 	icon_state = "gasmask"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 32)
+#endif
 
 /obj/structure/sign/warning/chem_diamond
 	name = "\improper REACTIVE CHEMICALS sign"
@@ -202,7 +298,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/gas_mask, 
 	desc = "A sign that warns of potentially reactive chemicals nearby, be they explosive, flammable, or acidic."
 	icon_state = "chemdiamond"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamond, 32)
+#endif
 
 /obj/structure/sign/warning/doors
 	name = "\improper BLAST DOORS sign"
@@ -210,7 +310,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/chem_diamo
 	desc = "A sign that shows there are doors here. There are doors everywhere!"
 	icon_state = "doors"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/doors, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
+#endif
 
 ////MISC LOCATIONS
 
@@ -220,7 +324,11 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/doors, 32)
 	desc = "A warning sign which reads 'ESCAPE PODS'."
 	icon_state = "pods"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/pods, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
+#endif
 
 /obj/structure/sign/warning/rad_shelter
 	name = "\improper RADSTORM SHELTER sign"
@@ -228,4 +336,8 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/pods, 32)
 	desc = "A warning sign which reads 'RADSTORM SHELTER'."
 	icon_state = "radshelter"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/warning/rad_shelter, 32)
+#endif

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -161,7 +161,7 @@
 	/// What's in the urinal
 	var/obj/item/hidden_item
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/urinal, 32)
 
 /obj/structure/urinal/Initialize(mapload)
 	. = ..()
@@ -293,7 +293,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	///Amount of shift the pixel for placement
 	var/pixel_shift = 14
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sink, (-14))
 
 /obj/structure/sink/Initialize(mapload, ndir = 0, has_water_reclaimer = null)
 	. = ..()
@@ -520,7 +520,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 	pixel_z = 4
 	pixel_shift = 16
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sink/kitchen, (-16))
 
 /obj/structure/sink/greyscale
 	icon_state = "sink_greyscale"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -428,12 +428,12 @@
 
 	return TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/spawner, 0)
 
 /obj/structure/window/unanchored
 	anchored = FALSE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/unanchored/spawner, 0)
 
 /obj/structure/window/reinforced
 	name = "reinforced window"
@@ -560,13 +560,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 		if(RWINDOW_BARS_CUT)
 			. += span_notice("The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in.")
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/reinforced/spawner, 0)
 
 /obj/structure/window/reinforced/unanchored
 	anchored = FALSE
 	state = WINDOW_OUT_OF_FRAME
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/unanchored/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/reinforced/unanchored/spawner, 0)
 
 /obj/structure/window/plasma
 	name = "plasma window"
@@ -592,7 +592,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/unanchored/spawner,
 	. = ..()
 	RemoveElement(/datum/element/atmos_sensitive)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/plasma/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/plasma/spawner, 0)
 
 /obj/structure/window/plasma/unanchored
 	anchored = FALSE
@@ -621,7 +621,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/plasma/spawner, 0)
 /obj/structure/window/reinforced/plasma/block_superconductivity()
 	return TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/plasma/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/reinforced/plasma/spawner, 0)
 
 /obj/structure/window/reinforced/plasma/unanchored
 	anchored = FALSE
@@ -631,13 +631,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/plasma/spawner, 0)
 	name = "tinted window"
 	icon_state = "twindow"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/reinforced/tinted/spawner, 0)
 
 /obj/structure/window/reinforced/tinted/frosted
 	name = "frosted window"
 	icon_state = "fwindow"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/reinforced/tinted/frosted/spawner, 0)
 
 /* Full Tile Windows (more atom_integrity) */
 
@@ -925,7 +925,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 	icon_state = "clockwork_window-single"
 	glass_type = /obj/item/stack/sheet/bronze
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/bronze/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/bronze/spawner, 0)
 
 /obj/structure/window/bronze/unanchored
 	anchored = FALSE

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -30,10 +30,10 @@
 	random_basetype = /obj/structure/sign/poster/abductor
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/random, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/random, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
 #endif
@@ -45,10 +45,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ra
 	icon_state = "ayylian"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayylian, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayylian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
 #endif
@@ -60,10 +60,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayy"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
 #endif
@@ -75,10 +75,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayy_over_tizira"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
 #endif
@@ -90,10 +90,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayy_recruitment"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
 #endif
@@ -105,10 +105,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayyce_cops"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_cops, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_cops, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
 #endif
@@ -120,10 +120,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayy_no"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_no, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_no, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
 #endif
@@ -135,10 +135,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayy_piping"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_piping, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_piping, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
 #endif
@@ -150,10 +150,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	icon_state = "ayy_fancy"
 
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
 #else
 #ifdef EXPERIMENT_WALLENING_SIGNS
-MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
+NORTH_MAPPING_DIRECTIONAL_HELPER(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
 #endif

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -29,60 +29,132 @@
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster/abductor
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayylian
 	name = "Ayylian"
 	desc = "Man, Ian sure is looking strange these days."
 	icon_state = "ayylian"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy
 	name = "Abductor"
 	desc = "Hey, that's not a lizard!"
 	icon_state = "ayy"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy_over_tizira
 	name = "Abductors Over Tizira"
 	desc = "A poster for an experimental adaptation of a movie about the Human-Lizard war. Production was greatly hindered by the leading pair's refusal to speak any lines."
 	icon_state = "ayy_over_tizira"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy_recruitment
 	name = "Abductor Recruitment"
 	desc = "Enlist in the Mothership Probing Division today!"
 	icon_state = "ayy_recruitment"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy_cops
 	name = "Abductor Cops"
 	desc = "A poster advertising the polarizing 'Abductor Cops' series. Some critics claimed that it stunned them, while others said it put them to sleep."
 	icon_state = "ayyce_cops"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy_no
 	name = "Uayy No"
 	desc = "This thing is all in Japanese, AND they got rid of the anime girl on the poster. Outrageous."
 	icon_state = "ayy_no"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy_piping
 	name = "Safety Abductor - Piping"
 	desc = "Safety Abductor has nothing to say. Not because it cannot speak, but because Abductors don't have to deal with atmos stuff."
 	icon_state = "ayy_piping"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
+#endif
+#endif
 
 /obj/structure/sign/poster/abductor/ayy_fancy
 	name = "Abductor Fancy"
 	desc = "Abductors are the best at doing everything. That includes looking good!"
 	icon_state = "ayy_fancy"
 
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
+#else
+#ifdef EXPERIMENT_WALLENING
+MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
+#else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
+#endif
+#endif

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -29,10 +29,10 @@
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster/abductor
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
@@ -44,10 +44,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ra
 	desc = "Man, Ian sure is looking strange these days."
 	icon_state = "ayylian"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
@@ -59,10 +59,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "Hey, that's not a lizard!"
 	icon_state = "ayy"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
@@ -74,10 +74,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "A poster for an experimental adaptation of a movie about the Human-Lizard war. Production was greatly hindered by the leading pair's refusal to speak any lines."
 	icon_state = "ayy_over_tizira"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
@@ -89,10 +89,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "Enlist in the Mothership Probing Division today!"
 	icon_state = "ayy_recruitment"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
@@ -104,10 +104,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "A poster advertising the polarizing 'Abductor Cops' series. Some critics claimed that it stunned them, while others said it put them to sleep."
 	icon_state = "ayyce_cops"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
@@ -119,10 +119,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "This thing is all in Japanese, AND they got rid of the anime girl on the poster. Outrageous."
 	icon_state = "ayy_no"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
@@ -134,10 +134,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "Safety Abductor has nothing to say. Not because it cannot speak, but because Abductors don't have to deal with atmos stuff."
 	icon_state = "ayy_piping"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
@@ -149,10 +149,10 @@ MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ay
 	desc = "Abductors are the best at doing everything. That includes looking good!"
 	icon_state = "ayy_fancy"
 
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
 #else
-#ifdef EXPERIMENT_WALLENING
+#ifdef EXPERIMENT_WALLENING_SIGNS
 MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
 #else
 MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -29,60 +29,60 @@
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster/abductor
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/random, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/random, 32)
 
 /obj/structure/sign/poster/abductor/ayylian
 	name = "Ayylian"
 	desc = "Man, Ian sure is looking strange these days."
 	icon_state = "ayylian"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayylian, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayylian, 32)
 
 /obj/structure/sign/poster/abductor/ayy
 	name = "Abductor"
 	desc = "Hey, that's not a lizard!"
 	icon_state = "ayy"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy, 32)
 
 /obj/structure/sign/poster/abductor/ayy_over_tizira
 	name = "Abductors Over Tizira"
 	desc = "A poster for an experimental adaptation of a movie about the Human-Lizard war. Production was greatly hindered by the leading pair's refusal to speak any lines."
 	icon_state = "ayy_over_tizira"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_over_tizira, 32)
 
 /obj/structure/sign/poster/abductor/ayy_recruitment
 	name = "Abductor Recruitment"
 	desc = "Enlist in the Mothership Probing Division today!"
 	icon_state = "ayy_recruitment"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_recruitment, 32)
 
 /obj/structure/sign/poster/abductor/ayy_cops
 	name = "Abductor Cops"
 	desc = "A poster advertising the polarizing 'Abductor Cops' series. Some critics claimed that it stunned them, while others said it put them to sleep."
 	icon_state = "ayyce_cops"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_cops, 32)
 
 /obj/structure/sign/poster/abductor/ayy_no
 	name = "Uayy No"
 	desc = "This thing is all in Japanese, AND they got rid of the anime girl on the poster. Outrageous."
 	icon_state = "ayy_no"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy_no, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_no, 32)
 
 /obj/structure/sign/poster/abductor/ayy_piping
 	name = "Safety Abductor - Piping"
 	desc = "Safety Abductor has nothing to say. Not because it cannot speak, but because Abductors don't have to deal with atmos stuff."
 	icon_state = "ayy_piping"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_piping, 32)
 
 /obj/structure/sign/poster/abductor/ayy_fancy
 	name = "Abductor Fancy"
 	desc = "Abductors are the best at doing everything. That includes looking good!"
 	icon_state = "ayy_fancy"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/sign/poster/abductor/ayy_fancy, 32)

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -613,7 +613,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		selected_mode.apply(my_area)
 	SEND_SIGNAL(src, COMSIG_AIRALARM_UPDATE_MODE, source)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/airalarm, 27)
 
 /obj/machinery/airalarm/proc/speak(warning_message)
 	if(machine_stat & (BROKEN|NOPOWER))

--- a/code/modules/atmospherics/machinery/bluespace_vendor.dm
+++ b/code/modules/atmospherics/machinery/bluespace_vendor.dm
@@ -51,7 +51,7 @@
 	map_spawned = FALSE
 	mode = BS_MODE_OPEN
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/bluespace_vendor, 30)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/bluespace_vendor, 30)
 
 /datum/armor/machinery_bluespace_vendor
 	energy = 100

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -36,7 +36,7 @@
 
 	density = FALSE //this is a wallmount
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/computer/auxiliary_base, 32)
 
 /obj/machinery/computer/auxiliary_base/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -149,7 +149,7 @@
 	icon = 'icons/obj/mining_zones/survival_pod.dmi'
 	icon_state = "pwindow"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/survival_pod/spawner, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/window/reinforced/survival_pod/spawner, 0)
 
 //Door
 /obj/machinery/door/airlock/survival_pod
@@ -177,7 +177,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/survival_pod/spawne
 	icon_state = "windoor"
 	base_state = "windoor"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/survival_pod/left, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/survival_pod/left, 0)
 
 //Table
 /obj/structure/table/survival_pod

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -42,7 +42,7 @@
 /obj/machinery/ticket_machine/on_deconstruction(disassembled = TRUE)
 	new /obj/item/wallframe/ticket_machine(loc)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/ticket_machine, 32)
 
 /obj/machinery/ticket_machine/examine(mob/user)
 	. = ..()

--- a/code/modules/power/apc/apc_mapping.dm
+++ b/code/modules/power/apc/apc_mapping.dm
@@ -5,5 +5,5 @@
 /obj/machinery/power/apc/auto_name
 	auto_name = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/worn_out, APC_PIXEL_OFFSET)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/power/apc/worn_out, APC_PIXEL_OFFSET)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET)

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -96,70 +96,70 @@
 
 // -------- Directional presets
 // The directions are backwards on the lights we have now
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light, 0)
 
 // ---- Broken tube
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/broken, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/broken, 0)
 
 // ---- Tube construct
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/light_construct, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/light_construct, 0)
 
 // ---- Tube frames
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/built, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/built, 0)
 
 // ---- No nightlight tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/no_nightlight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/no_nightlight, 0)
 
 // ---- Warm light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/warm, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/warm, 0)
 
 // ---- No nightlight warm light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/warm/no_nightlight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/warm/no_nightlight, 0)
 
 // ---- Dim warm light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/warm/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/warm/dim, 0)
 
 // ---- Cold light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/cold, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/cold, 0)
 
 // ---- No nightlight cold light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/cold/no_nightlight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/cold/no_nightlight, 0)
 
 // ---- Dim cold light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/cold/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/cold/dim, 0)
 
 // ---- Red tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/red, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/red, 0)
 
 // ---- Red dim tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/red/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/red/dim, 0)
 
 // ---- Blacklight tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/blacklight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/blacklight, 0)
 
 // ---- Dim tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/dim, 0)
 
 
 // -------- Bulb lights
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small, 0)
 
 // ---- Bulb construct
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/light_construct/small, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/light_construct/small, 0)
 
 // ---- Bulb frames
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/built, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small/built, 0)
 
 // ---- Broken bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/broken, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small/broken, 0)
 
 // ---- Red bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small/dim, 0)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small/red, 0)
 
 // ---- Red dim bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small/red/dim, 0)
 
 // ---- Blacklight bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/blacklight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/light/small/blacklight, 0)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -332,7 +332,7 @@
 	icon_state = "pepper"
 	reagent_id = /datum/reagent/consumable/condensedcapsaicin
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 30)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/reagent_dispensers/wall/peppertank, 30)
 
 /obj/structure/reagent_dispensers/wall/peppertank/Initialize(mapload)
 	. = ..()
@@ -388,7 +388,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 	icon_state = "virus_food"
 	reagent_id = /datum/reagent/consumable/virus_food
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/virusfood, 30)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/structure/reagent_dispensers/wall/virusfood, 30)
 
 /obj/structure/reagent_dispensers/wall/virusfood/Initialize(mapload)
 	. = ..()

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -23,7 +23,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 
 	COOLDOWN_DECLARE(access_grant_cooldown)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/keycard_auth, 26)
 
 /obj/machinery/keycard_auth/Initialize(mapload)
 	. = ..()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -779,7 +779,7 @@
 	. = ..()
 	icon_state = "wall_safe[unlocked ? "" : "_locked"]"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/pod, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/item/storage/pod, 32)
 
 /obj/item/storage/pod/PopulateContents()
 	new /obj/item/clothing/head/helmet/space/orange(src)

--- a/code/modules/transport/elevator/elev_controller.dm
+++ b/code/modules/transport/elevator/elev_controller.dm
@@ -14,7 +14,7 @@
 	// Kind of a cop-out
 	AddElement(/datum/element/contextual_screentip_bare_hands, lmb_text = "Call Elevator")
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/elevator, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/button/elevator, 32)
 
 /obj/item/assembly/control/elevator
 	name = "elevator controller"

--- a/code/modules/transport/elevator/elev_doors.dm
+++ b/code/modules/transport/elevator/elev_doors.dm
@@ -12,5 +12,5 @@ GLOBAL_LIST_EMPTY(elevator_doors)
 	icon_state = "right"
 	base_state = "right"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/elevator/left, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/elevator/right, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/elevator/left, 0)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/door/window/elevator/right, 0)

--- a/code/modules/transport/elevator/elev_indicator.dm
+++ b/code/modules/transport/elevator/elev_indicator.dm
@@ -163,4 +163,4 @@
 	. += mutable_appearance(icon, arrow_icon_state)
 	. += emissive_appearance(icon, "[arrow_icon_state]e", offset_spokesman = src, alpha = src.alpha)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/lift_indicator, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/lift_indicator, 32)

--- a/code/modules/transport/elevator/elev_panel.dm
+++ b/code/modules/transport/elevator/elev_panel.dm
@@ -390,4 +390,4 @@
 	if(!(machine_stat & (NOPOWER|BROKEN)) && !panel_open)
 		. += emissive_appearance(icon, light_mask, src, alpha = alpha)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/elevator_control_panel, 31)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/elevator_control_panel, 31)

--- a/code/modules/transport/tram/tram_controls.dm
+++ b/code/modules/transport/tram/tram_controls.dm
@@ -250,4 +250,4 @@
 				else
 					return
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/tram_controls, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/computer/tram_controls, 32)

--- a/code/modules/transport/tram/tram_displays.dm
+++ b/code/modules/transport/tram/tram_displays.dm
@@ -159,4 +159,4 @@
 
 	update_sign(src, tram, tram.controller_active, tram.controller_status, tram.travel_direction, tram.destination_platform)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/transport/destination_sign/indicator, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/transport/destination_sign/indicator, 32)

--- a/code/modules/transport/tram/tram_machinery.dm
+++ b/code/modules/transport/tram/tram_machinery.dm
@@ -102,4 +102,4 @@
 	. += span_notice("There's a small inscription on the button...")
 	. += span_notice("THIS CALLS THE TRAM! IT DOES NOT OPERATE IT! The console on the tram tells it where to go!")
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/transport/tram, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/button/transport/tram, 32)

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -29,7 +29,7 @@
 	tiltable = FALSE
 	light_mask = "wallmed-light-mask"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/vending/wallmed, 32)
+MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS(/obj/machinery/vending/wallmed, 32)
 
 /obj/item/vending_refill/wallmed
 	machine_name = "NanoMed"


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/wall-nerds/wallening/issues/223
Closes https://github.com/wall-nerds/wallening/issues/224

This addresses the problems mentioned in the above issue reports by both
* Implementing a new way to lint against invalid directionals that are extant in maps (will show up on Compile Maps workflow as the disallowed types will literally no longer exist).
* Preventing players from building signs/posters in invalid directions. The trick I used worked on my machine with no real way to bypass it, but I split it out into a new proc in order to make sure it would be extendable for any new wallening concerns that I am unaware of at this time.

This is accomplished by:
* Turning `MAPPING_DIRECTIONAL_HELPERS` into four separate macros for each of the cardinal directions. From there, the base format for N/S/E/W is changed to `MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS` and a new one is added for certain edge cases, `MAPPING_DIRECTIONAL_HELPERS_VISIBLE_CARDINALS`. It's important to note that mapping directional helpers matter to more things than just wall items (e.g. stairs), but this is a good way to handle some important wall considerations. These will have to be changed since wallening already does something different with their mapping directional helpers (e.g. having something specific for wallmounts) but ideally it should all still work once we plug/play some things since it's macro-ized anyways.
* Signs and Posters, when a `EXPERIMENT_WALLENING_SIGNS` flag is toggled on-compile or in unit tests or whatever the developer wants really, will switch from the current behavior (now `MAPPING_DIRECTIONAL_HELPERS_ALL_CARDINALS` to the atomized `NORTH_MAPPING_DIRECTIONAL_HELPER`), making the three unused cardinals fail the compile. This is nice because it uses the built-in BYOND way of detecting invalid path pointers and doesn't require any greppery or python tools. This comes at the drawback of failing CI, but at least we have the lint for now.
* Also uses that same compile define macro `EXPERIMENT_WALLENING_SIGNS` (needs to be compile-time so StrongDMM recognizes it, kinda like `MAP_SWITCH()`) to guard against players posting stuff on invalid cardinals, as previously mentioned. I couldn't really atomize this change into another PR because I wanted this to also be reliant on the macro rather than have potential desyncs, so when we remove the macro we can clean up everything. I think it works.
## Why It's Good For The Game

We can't support certain directionals of posters, so let's change up the system in a way that allows people to have minute and fine control over the directionals of their new items. Also includes code that we have ready now and can flip on/off as we approach wallening even further. Should be fine per https://hackmd.io/@tgstation/Bywoc3IEA#Code, lmk

I would rather this change be pushed to master instead of a project branch or wallening, because of the granular macro changes. It allows people to think more about what directionals they want their sprites to exist in with this level of control, as well as have any switches for potential differentials in behavior. Let me know if you disagree but the core concept of this PR (granular prefab directionals) is a good idea regardless of wallening or not. I just added all the dressing so we can get the issue reports out of the way.

Also I fixed an oopsy-daisy in there not being any all-access directional barsigns. the day is saved.
## Changelog
Irrelevant for the time being.

Note: Wallening also does its own thing with mapping directional related macros. These are reliant on the overall wallening framework though (like the map switch and what-not) but ideally this would be a good schema for the interstital period and reducing the amount of copypaste that's done there anyways. Just sorta depends on their needs in the end anyways (especially for specifically excluding non-north directional helpers from existing).