### PR TITLE
print 5 cable coils instead of 1 in lathes

### DIFF
--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -153,7 +153,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/cable_coil
-	name = "Cable"
+	name = "Cable (5x)"
 	id = "cable_coil"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.5)

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -33,6 +33,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
+
 /datum/design/tscanner
 	name = "T-Ray Scanner"
 	id = "tscanner"

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -153,7 +153,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/cable_coil
-	name = "Cable Coil"
+	name = "Cable"
 	id = "cable_coil"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.5)

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -156,7 +156,7 @@
 	name = "Cable Coil"
 	id = "cable_coil"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.1, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.1)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.5)
 	build_path = /obj/item/stack/cable_coil/five
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -157,7 +157,7 @@
 	id = "cable_coil"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.1, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.1)
-	build_path = /obj/item/stack/cable_coil
+	build_path = /obj/item/stack/cable_coil/five
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -32,7 +32,7 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
-	
+
 /datum/design/tscanner
 	name = "T-Ray Scanner"
 	id = "tscanner"

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -153,7 +153,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/cable_coil
-	name = "Cable (5x)"
+	name = "Cable (x5)"
 	id = "cable_coil"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.5)


### PR DESCRIPTION

## About The Pull Request
What the title says.
## Why It's Good For The Game
It is incredibly tedious to get a large amount of cables from lathes, considering you need a lot most of the time (especially in engineering), it should be printing way more than one piece of cable.
## Changelog
:cl: grungussuss
qol: lathes will now print cables coils in packs of 5
/:cl:
