### PR TITLE
Allows pacifists to use the psychotic brawling martial art, but at a cost.

### DIFF
--- a/code/datums/martial/psychotic_brawl.dm
+++ b/code/datums/martial/psychotic_brawl.dm
@@ -1,6 +1,7 @@
 /datum/martial_art/psychotic_brawling
 	name = "Psychotic Brawling"
 	id = MARTIALART_PSYCHOBRAWL
+	pacifist_style = TRUE
 
 /datum/martial_art/psychotic_brawling/disarm_act(mob/living/attacker, mob/living/defender)
 	return psycho_attack(attacker, defender)
@@ -75,6 +76,8 @@
 					carbon_defender.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 			attacker.Stun(rand(1 SECONDS, 4.5 SECONDS))
 			defender.Stun(rand(0.5 SECONDS, 3 SECONDS))
+			if(HAS_TRAIT(attacker, TRAIT_PACIFISM))
+				attacker.add_mood_event("bypassed_pacifism", /datum/mood_event/pacifism_bypassed)
 		if(5,6)
 			atk_verb = pick("kick", "hit", "slam")
 			if(defender.check_block(attacker, 0, "[attacker]'s [atk_verb]", UNARMED_ATTACK))
@@ -94,6 +97,8 @@
 			var/throwtarget = get_edge_target_turf(attacker, get_dir(attacker, get_step_away(defender, attacker)))
 			defender.throw_at(throwtarget, 4, 2, attacker)//So stuff gets tossed around at the same time.
 			defender.Paralyze(6 SECONDS)
+			if(HAS_TRAIT(attacker, TRAIT_PACIFISM))
+				attacker.add_mood_event("bypassed_pacifism", /datum/mood_event/pacifism_bypassed)
 		if(7,8)
 			return MARTIAL_ATTACK_INVALID //Resume default behaviour
 

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -494,3 +494,9 @@
 	description = "Nothing will ever rival with what I seen in the past..."
 	mood_change = -3
 	special_screen_obj = "mood_desentized"
+
+//Used for the psychotic brawling martial art, if the person is a pacifist.
+/datum/mood_event/pacifism_bypassed
+	description = "I DIDN'T MEAN TO HURT THEM!"
+	mood_change = -20
+	timeout = 10 MINUTES


### PR DESCRIPTION

## About The Pull Request
There's a bug wherein you can use psychotic brawling as a pacifist if you disarm, but rather than fix it I think leaning into it would be really interesting. You get a big -20 mood debuff for 10 minutes, but you can still harm people.
## Why It's Good For The Game
It's funny, it's interesting, and it makes it more consistent.
## Changelog
:cl:
balance: Pacifists can now use psychotic brawling, at major mood costs.
/:cl:
