### PR TITLE
Fixes being permanently attached to tram

### DIFF
--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -250,6 +250,7 @@
 	for(var/obj/structure/transport/linear/tram/transport_module as anything in transport_modules) //only thing everyone needs to know is the new location.
 		if(transport_module.travelling) //wee woo wee woo there was a double action queued. damn multi tile structs
 			return //we don't care to undo cover_locked controls, though, as that will resolve itself
+		transport_module.verify_transport_contents()
 		transport_module.glide_size_override = DELAY_TO_GLIDE_SIZE(speed_limiter)
 		transport_module.set_travelling(TRUE)
 

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -165,7 +165,7 @@
 
 				initial_contents += new_initial_contents
 
-///scan the locs we're on for anything that should be added to our transport_contents and builds the list
+///verify the movables in our list of contents are actually on our loc
 /obj/structure/transport/linear/proc/verify_transport_contents()
 	for(var/atom/movable/movable_contents as anything in transport_contents)
 		if(!(movable_contents.loc in locs))

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -167,13 +167,9 @@
 
 ///scan the locs we're on for anything that should be added to our transport_contents and builds the list
 /obj/structure/transport/linear/proc/verify_transport_contents()
-	transport_contents = list()
-	for(var/turf/turf_loc in locs)
-		for(var/atom/movable/movable_contents as anything in turf_loc)
-			if(movable_contents == src)
-				continue
-
-			add_item_on_transport(src, movable_contents)
+	for(var/atom/movable/movable_contents as anything in transport_contents)
+		if(!(movable_contents.loc in locs))
+			remove_item_from_transport(movable_contents)
 
 ///signal handler for COMSIG_MOVABLE_UPDATE_GLIDE_SIZE: when a movable in transport_contents changes its glide_size independently.
 ///adds that movable to a lazy list, movables in that list have their glide_size updated when the tram next moves

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -165,6 +165,16 @@
 
 				initial_contents += new_initial_contents
 
+///scan the locs we're on for anything that should be added to our transport_contents and builds the list
+/obj/structure/transport/linear/proc/verify_transport_contents()
+	transport_contents = list()
+	for(var/turf/turf_loc in locs)
+		for(var/atom/movable/movable_contents as anything in turf_loc)
+			if(movable_contents == src)
+				continue
+
+			add_item_on_transport(src, movable_contents)
+
 ///signal handler for COMSIG_MOVABLE_UPDATE_GLIDE_SIZE: when a movable in transport_contents changes its glide_size independently.
 ///adds that movable to a lazy list, movables in that list have their glide_size updated when the tram next moves
 /obj/structure/transport/linear/proc/on_changed_glide_size(atom/movable/moving_contents, new_glide_size)


### PR DESCRIPTION
## About The Pull Request

Verifies transport contents at time of tram departure, removing any invalid movables

Fixes https://github.com/tgstation/tgstation/issues/77722

## Why It's Good For The Game

Movables no longer get invisibly, permanently attached to the tram in rare event transport moves before contents are updated.

## Changelog

:cl: LT3
fix: Fixed bug where players could be invisibly attached to the tram forever
/:cl: