### PR TITLE
Fixes incorrect arguments in Status Displays

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_EMPTY(key_to_status_display)
  */
 /obj/machinery/status_display/proc/update_message(current_key, line_y, message, x_offset, line_pair)
 	var/obj/effect/overlay/status_display_text/current_overlay = get_status_text(current_key)
-	var/obj/effect/overlay/status_display_text/new_overlay = generate_status_text(line_y, message, text_color, header_text_color, x_offset, line_pair)
+	var/obj/effect/overlay/status_display_text/new_overlay = generate_status_text(line_y, message, x_offset, text_color, header_text_color, line_pair)
 
 	if(current_overlay == new_overlay)
 		return current_key


### PR DESCRIPTION
## About The Pull Request

Introduced in #83296 (9c58d7d1b9bd9cd447289cb02d0c49772b75a24a)

Args for `generate_status_text()`: `line_y, message, x_offset, text_color, header_text_color, line_pair`

The positional args we were feeding it via `/obj/machinery/status_display/proc/update_message()`: `line_y, message, text_color, header_text_color, x_offset, line_pair`

This PR just moves `x_offset` to the proper position so we aren't plugging the wrong numbers into the positional arguments.
## Why It's Good For The Game

Was likely broken, now it is fixed. In my test case, I found that it would break really weirdly and badly without this fix and worked fine with this fix. Probably due to the keys actually working. Anyways this was almost definitely the correct behavior seeing as x_offset is always the third argument everywhere so
## Changelog

:cl:
fix: Status displays should now no longer sporadically randomly break when in the custom message mode
/:cl: