### PR TITLE
Patches exploit with (and pre-emptively bumps the usage costs) to the new Adrenal Glands

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -3,10 +3,21 @@
 	desc = "We shift almost all available muscle mass from the arms to the legs, disabling the former but making us unable to be downed for 15 seconds. Costs 10 chemicals."
 	helptext = "Disables your arms and retracts bioweaponry, but regenerates your legs, grants you speed, and wakes you up from any stun."
 	button_icon_state = "adrenaline"
-	chemical_cost = 10
-	dna_cost = 1
+	chemical_cost = 25 // similar cost to biodegrade, as they serve similar purposes
+	dna_cost = 2
 	req_human = FALSE
 	req_stat = CONSCIOUS
+
+/datum/action/changeling/adrenaline/can_sting(mob/living/user, mob/living/target)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	if(HAS_TRAIT_FROM(user, TRAIT_IGNOREDAMAGESLOWDOWN, CHANGELING_TRAIT))
+		user.balloon_alert(user, "already boosted!")
+		return FALSE
+
+	return .
 
 //Recover from stuns.
 /datum/action/changeling/adrenaline/sting_action(mob/living/carbon/user)
@@ -17,13 +28,12 @@
 		weapon_ability.unequip_held(user)
 
 	// Destroy legcuffs with our IMMENSE LEG STRENGTH.
-	if(user.legcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
-		if(!istype(O))
-			return FALSE
-		qdel(O)
-		user.visible_message(span_warning("[user]'s legs suddenly rip [O] apart!"), \
-			span_warning("We rip apart our leg restraints!"))
+	if(istype(user.legcuffed))
+		user.visible_message(
+			span_warning("[user]'s legs suddenly rip [user.legcuffed] apart!"),
+			span_warning("We rip apart our leg restraints!"),
+		)
+		qdel(user.legcuffed)
 
 	// Regenerate our legs only.
 	var/our_leg_zones = (GLOB.all_body_zones - GLOB.leg_zones)
@@ -32,7 +42,7 @@
 	user.add_traits(list(TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_PARALYSIS_L_ARM, TRAIT_PARALYSIS_R_ARM), CHANGELING_TRAIT)
 
 	// Revert above mob changes.
-	addtimer(CALLBACK(src, PROC_REF(unsting_action), user), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(unsting_action), user), 20 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 	// Get us standing up.
 	user.SetAllImmobility(0)
@@ -47,4 +57,3 @@
 /datum/action/changeling/adrenaline/proc/unsting_action(mob/living/user)
 	to_chat(user, span_changeling("The muscles in our limbs shift back to their usual places."))
 	user.remove_traits(list(TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_PARALYSIS_L_ARM, TRAIT_PARALYSIS_R_ARM), CHANGELING_TRAIT)
-	return


### PR DESCRIPTION
## About The Pull Request

1.

Because the reset timer was not done with `TIMER_UNIQUE|TIMER_OVERRIDE`, this meant that you could pop the ability, wait 19 seconds, and then pop it again. And now you had all the benefits of the ability without any of the downsides, because the timers would not reset and instead run simultaneously. 

I fixed this by both adding the timer flags and by preventing usage of the skill while you are under the effects of it. (Just in case.) 

2.

With permission from Jacquerel, I bumped the chemical cost and dna cost back up to similar numbers as before. I think the PR swung the hammer way too far in that direction (You don't make it more spammable while also making it better, you either do one or the other!)

## Changelog

:cl: Melbert
balance: Re-ups the cost of the new ling adrenal ability
fix: Patches an exploit with new ling adrenal ability
/:cl:

