### PR TITLE
Floor diseases are easier to cure

### DIFF
--- a/code/datums/diseases/advance/floor_diseases/carpellosis.dm
+++ b/code/datums/diseases/advance/floor_diseases/carpellosis.dm
@@ -6,7 +6,7 @@
 	desc = "You have an angry space carp inside."
 	form = "Parasite"
 	agent = "Carp Ella"
-	cures = list(/datum/reagent/carpet)
+	cures = list(/datum/reagent/chlorine)
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	severity = DISEASE_SEVERITY_MEDIUM

--- a/code/datums/diseases/advance/floor_diseases/gastritium.dm
+++ b/code/datums/diseases/advance/floor_diseases/gastritium.dm
@@ -4,7 +4,7 @@
 	desc = "If left untreated, may manifest in severe Tritium heartburn."
 	form = "Infection"
 	agent = "Atmobacter Polyri"
-	cures = list(/datum/reagent/firefighting_foam)
+	cures = list(/datum/reagent/consumable/milk)
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	severity = DISEASE_SEVERITY_HARMFUL

--- a/code/datums/diseases/advance/floor_diseases/nebula_nausea.dm
+++ b/code/datums/diseases/advance/floor_diseases/nebula_nausea.dm
@@ -4,7 +4,7 @@
 	desc = "You can't contain the colorful beauty of the cosmos inside."
 	form = "Condition"
 	agent = "Stars"
-	cures = list(/datum/reagent/bluespace)
+	cures = list(/datum/reagent/space_cleaner)
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	severity = DISEASE_SEVERITY_MEDIUM


### PR DESCRIPTION
## About The Pull Request

The floor diseases were supposed to be more of a joke, but it seems to be a bother for many due to the scarcity of cures.

This PR changes the floor diseases cures to some common chemicals.

## Why It's Good For The Game

They weren't supposed to suffer this much.

## Changelog

:cl:
balance: Floor diseases cures are now common chemicals: Milk, Chlorine, Space Cleaner
/:cl:

