### PR TITLE
Changeling Rebalance: Kill It With Fire, feat. Armblade Rework

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -260,6 +260,10 @@
  */
 /datum/antagonist/changeling/proc/on_life(datum/source, seconds_per_tick, times_fired)
 	SIGNAL_HANDLER
+	if(isliving(owner))
+		var/mob/living/living_owner = owner
+		if(living_owner.fire_stacks && living_owner.on_fire)
+			return // No chemical regen while on fire.
 
 	var/delta_time = DELTA_WORLD_TIME(SSmobs)
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -260,8 +260,8 @@
  */
 /datum/antagonist/changeling/proc/on_life(datum/source, seconds_per_tick, times_fired)
 	SIGNAL_HANDLER
-	if(isliving(owner))
-		var/mob/living/living_owner = owner
+	if(isliving(owner.current))
+		var/mob/living/living_owner = owner.current
 		if(living_owner.fire_stacks && living_owner.on_fire)
 			return // No chemical regen while on fire.
 

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -81,6 +81,10 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 /datum/action/changeling/proc/can_sting(mob/living/user, mob/living/target)
 	if(!can_be_used_by(user))
 		return FALSE
+	if(user.fire_stacks && user.on_fire)
+		user.balloon_alert(user, "on fire!")
+		to_chat(user, span_boldwarning("WE CANNOT DO THIS WHILE ENGULFED IN FLAMES!!! PUT OUT THE FIRE FIRST!!!"))
+		return FALSE
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
 	if(changeling.chem_charges < chemical_cost)
 		user.balloon_alert(user, "needs [chemical_cost] chemicals!")

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -173,14 +173,22 @@
 \***************************************/
 /datum/action/changeling/weapon/arm_blade
 	name = "Arm Blade"
-	desc = "We reform one of our arms into a deadly blade. Costs 20 chemicals."
-	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
+	desc = "We reform one of our arms into a deadly blade that breaks after a number of hits, improvable by absorbing genomes. Costs 40 chemicals."
+	helptext = "We may retract our armblade in the same manner as we form it. Organic tissue is not perfect; the armblade will break after it is used too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
-	chemical_cost = 20
-	dna_cost = 2
+	chemical_cost = 40
+	dna_cost = 4
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
+
+/datum/action/changeling/weapon/arm_blade/sting_action(mob/living/carbon/user)
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user) //So we can read the absorbed_count.
+	if(!changeling)
+		return
+
+	var/obj/item/melee/arm_blade/blade = ..(user)
+	blade.remaining_uses = round(changeling.absorbed_count * 3)
 
 /obj/item/melee/arm_blade
 	name = "arm blade"
@@ -203,8 +211,10 @@
 	wound_bonus = 10
 	bare_wound_bonus = 10
 	armour_penetration = 35
+	resistance_flags = FLAMMABLE
 	var/can_drop = FALSE
 	var/fake = FALSE
+	var/remaining_uses
 
 /obj/item/melee/arm_blade/Initialize(mapload,silent,synthetic)
 	. = ..()
@@ -249,6 +259,15 @@
 		user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("We force the [opening] to open."), \
 		span_hear("You hear a metal screeching sound."))
 		opening.open(BYPASS_DOOR_CHECKS)
+
+	if(remaining_uses < 1)
+		if(ishuman(loc))
+			var/mob/living/carbon/human/changeling = loc
+			changeling.visible_message(span_warning("With a sickening crunch, [changeling] reforms [changeling.p_their()] [src] into an arm!"), span_notice("We assimilate our armblade into our body."), "<span class='italics'>You hear organic matter ripping and tearing!</span>")
+		qdel(src)
+	else
+		remaining_uses--
+
 
 /obj/item/melee/arm_blade/dropped(mob/user)
 	..()
@@ -297,6 +316,7 @@
 	throw_range = 0
 	throw_speed = 0
 	can_hold_up = FALSE
+	resistance_flags = FLAMMABLE
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent)
 	. = ..()
@@ -502,6 +522,7 @@
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	block_chance = 50
+	resistance_flags = FLAMMABLE
 
 	var/remaining_uses //Set by the changeling ability.
 
@@ -551,6 +572,7 @@
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = 0
 	heat_protection = 0
+	resistance_flags = FLAMMABLE
 
 /datum/armor/armor_changeling
 	melee = 40
@@ -559,7 +581,7 @@
 	energy = 50
 	bomb = 10
 	bio = 10
-	fire = 90
+	fire = -100
 	acid = 90
 
 /obj/item/clothing/suit/armor/changeling/Initialize(mapload)
@@ -576,6 +598,7 @@
 	item_flags = DROPDEL
 	armor_type = /datum/armor/helmet_changeling
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEEYES|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
+	resistance_flags = FLAMMABLE
 
 /datum/armor/helmet_changeling
 	melee = 40
@@ -584,7 +607,7 @@
 	energy = 50
 	bomb = 10
 	bio = 10
-	fire = 90
+	fire = -90
 	acid = 90
 
 /obj/item/clothing/head/helmet/changeling/Initialize(mapload)
@@ -614,6 +637,7 @@
 	armor_type = /datum/armor/changeling_hivehead
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEEYES|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
 	actions_types = list(/datum/action/cooldown/hivehead_spawn_minions)
+	resistance_flags = FLAMMABLE
 	///Does this hive head hold reagents?
 	var/holds_reagents = TRUE
 
@@ -628,6 +652,7 @@
 	laser = 10
 	energy = 10
 	bio = 50
+	fire = -100
 
 /obj/item/clothing/head/helmet/changeling_hivehead/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -187,7 +187,7 @@
 	if(!changeling)
 		return
 
-	var/obj/item/melee/arm_blade/blade = ..(user)
+	var/obj/item/melee/arm_blade/blade = ..()
 	blade.remaining_uses = round(changeling.absorbed_count * 3)
 	return TRUE
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -189,6 +189,7 @@
 
 	var/obj/item/melee/arm_blade/blade = ..(user)
 	blade.remaining_uses = round(changeling.absorbed_count * 3)
+	return TRUE
 
 /obj/item/melee/arm_blade
 	name = "arm blade"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -176,8 +176,8 @@
 	desc = "We reform one of our arms into a deadly blade that breaks after a number of hits, improvable by absorbing genomes. Costs 40 chemicals."
 	helptext = "We may retract our armblade in the same manner as we form it. Organic tissue is not perfect; the armblade will break after it is used too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
-	chemical_cost = 40
-	dna_cost = 4
+	chemical_cost = 30
+	dna_cost = 3
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -260,7 +260,7 @@
 		span_hear("You hear a metal screeching sound."))
 		opening.open(BYPASS_DOOR_CHECKS)
 
-	if(remaining_uses < 1)
+	if(remaining_uses <= 1)
 		if(ishuman(loc))
 			var/mob/living/carbon/human/changeling = loc
 			changeling.visible_message(span_warning("With a sickening crunch, [changeling] reforms [changeling.p_their()] [src] into an arm!"), span_notice("We assimilate our armblade into our body."), "<span class='italics'>You hear organic matter ripping and tearing!</span>")
@@ -513,6 +513,9 @@
 	S.remaining_uses = round(changeling.absorbed_count * 3)
 	return TRUE
 
+/datum/armor/item_shield/changeling
+	fire = -100
+
 /obj/item/shield/changeling
 	name = "shield-like mass"
 	desc = "A mass of tough, boney tissue. You can still see the fingers as a twisted pattern in the shield."
@@ -522,6 +525,7 @@
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	block_chance = 50
+	armor_type = /datum/armor/item_shield/changeling
 	resistance_flags = FLAMMABLE
 
 	var/remaining_uses //Set by the changeling ability.
@@ -533,7 +537,7 @@
 		loc.visible_message(span_warning("The end of [loc.name]\'s hand inflates rapidly, forming a huge shield-like mass!"), span_warning("We inflate our hand into a strong shield."), span_hear("You hear organic matter ripping and tearing!"))
 
 /obj/item/shield/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
-	if(remaining_uses < 1)
+	if(remaining_uses <= 1)
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc
 			H.visible_message(span_warning("With a sickening crunch, [H] reforms [H.p_their()] shield into an arm!"), span_notice("We assimilate our shield into our body"), "<span class='italics>You hear organic matter ripping and tearing!</span>")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -796,6 +796,9 @@
 	if(leg_clothes)
 		burning_items |= leg_clothes
 
+	for(var/obj/item/burnable_item in held_items)
+		burning_items |= burnable_item
+
 	for(var/obj/item/burning in burning_items)
 		burning.fire_act((stacks * 25 * seconds_per_tick)) //damage taken is reduced to 2% of this value by fire_act()
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/assets/4081722/684da396-fb28-4022-9f46-0fc4feb34b7a

Changelings now do not like fire, as is tradition.
If they are on fire, they no longer generate chemicals until they put the fire out.
If they are on fire, they no longer can use any changeling powers until they put the fire out.
All changeling equippable items like armblades, shields, armor, spacesuits, etc. are now flammable and super-duper vulnerable to flames.
The Armblade now costs 30 chemicals to equip, and has a DNA cost of 3, compared to the previous 20 chemicals and 2 DNA cost.
The Armblade now shatters after enough uses in exactly the same way as the Shield; extract genomes with Absorb to maximize your Armblade's efficiency. for its' chemical cost.
Fixes items you're holding not catching on fire alongside the rest of you when you light on fire.
Fixes the Changeling Shield having one more hit than it was supposed to.

## Why It's Good For The Game

Changeling has been in a relatively incredibly rough state ever since someone walked up to this predominatly stealth and intrigue based antagonist and went "lets turn it into a carbon copy of an early 2000s action game I just played".

![image - 2024-05-31T180546 466](https://github.com/tgstation/tgstation/assets/4081722/31f6b1bf-4c1d-4e38-be4a-d931c806a689)

Since then, just about every changeling has been a loud changeling. The stats speak for themselves; Changelings are no longer a stealth antag and they're defined by having an undroppable e-sword, armor, and HP regen they can use mid-fight. They're just loud beatsticks now instead of the scary stealth antagonist they were years ago.

I'm expecting a lot of pushback from the adrenaline addicts who dislike the concept of stealth, to which I say: too bad.

Giving Changelings a weak point in the form of fire is not only thematically appropriate for the original inspiration for Changeling, but also provides the crew a way to actually scare off changelings back into hiding, and encourages more usage of fire-causing weapons. This is going to shake up changelings, and 

Nerfing the hell out of the Armblade is going to encourage changelings to take stealthier approaches to combat, and utilize the rest of their power assortment that isn't just focused around being a gigantic unstoppable beatstick.

## Changelog
:cl:
balance: Changelings now do not like fire, as is tradition.
balance: If they are on fire, they no longer generate chemicals until they put the fire out.
balance: If they are on fire, they no longer can use any changeling powers until they put the fire out.
balance: All changeling equippable items like armblades, shields, armor, spacesuits, etc. are now flammable and super-duper vulnerable to flames.
balance: The Armblade now costs 30 chemicals to equip, and has a DNA cost of 3, compared to the previous 20 chemicals and 2 DNA cost.
add: The Armblade now shatters after enough uses in exactly the same way as the Shield; extract genomes with Absorb to maximize your Armblade's efficiency. for its' chemical cost.
fix: Fixes items you're holding not catching on fire alongside the rest of you when you light on fire.
fix: Fixes the Changeling Shield having one more hit than it was supposed to.
/:cl:

