### PR TITLE
Changeling specializations + rebalancing

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -112,7 +112,17 @@
 //Being on fire will suppress this healing
 /datum/status_effect/fleshmend
 	id = "fleshmend"
-	duration = 10 SECONDS
+	duration = 20 SECONDS
+	/// Healing multiplier
+	var/healfactor = 1
+	alert_type = /atom/movable/screen/alert/status_effect/fleshmend
+	show_duration = TRUE
+
+//Stealth lings need to make a quick getaway, so fleshmend faster for 40 HP
+/datum/status_effect/fleshmend/stealth
+	id = "fleshmend"
+	duration = 5 SECONDS
+	healfactor = 3
 	alert_type = /atom/movable/screen/alert/status_effect/fleshmend
 	show_duration = TRUE
 
@@ -140,9 +150,9 @@
 		return
 
 	var/need_mob_update = FALSE
-	need_mob_update += owner.adjustBruteLoss(-4 * seconds_between_ticks, updating_health = FALSE)
-	need_mob_update += owner.adjustFireLoss(-2 * seconds_between_ticks, updating_health = FALSE)
-	need_mob_update += owner.adjustOxyLoss(-4 * seconds_between_ticks, updating_health = FALSE)
+	need_mob_update += owner.adjustBruteLoss(-4 * healfactor * seconds_between_ticks, updating_health = FALSE)
+	need_mob_update += owner.adjustFireLoss(-2 * healfactor * seconds_between_ticks, updating_health = FALSE)
+	need_mob_update += owner.adjustOxyLoss(-4 * healfactor * seconds_between_ticks, updating_health = FALSE)
 	if(need_mob_update)
 		owner.updatehealth()
 

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -71,7 +71,7 @@
 
 /datum/cellular_emporium/ui_act(action, params)
 	. = ..()
-	if(.)
+	if(. || !changeling.specialization)
 		return
 
 	switch(action)
@@ -102,5 +102,9 @@
 /datum/action/cellular_emporium/Trigger(trigger_flags)
 	. = ..()
 	if(!.)
+		return
+	var/datum/antagonist/changeling/ling = IS_CHANGELING(owner)
+	if(!ling.specialization)
+		ling.specialize()
 		return
 	target.ui_interact(owner)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -55,6 +55,10 @@
 	/// Associated list of all powers we have evolved / bought from the emporium. [path] = [instance of path]
 	var/list/purchased_powers = list()
 
+	/// What specialization are we?
+	var/specialization = ""
+	var/specializations = list("stealth", "combat")
+
 	/// The voice we're mimicing via the changeling voice ability.
 	var/mimicing = ""
 	/// Whether we can currently respec in the cellular emporium.
@@ -382,6 +386,10 @@
 		to_chat(owner.current, span_warning("We lack the absorbed DNA to evolve this ability!"))
 		return FALSE
 
+	if(initial(sting_path.req_spec) && specialization != initial(sting_path.req_spec))
+		to_chat(owner.current, span_warning("Our specialization restricts us from evolving this ability!"))
+		return FALSE
+
 	if(initial(sting_path.dna_cost) < 0)
 		to_chat(owner.current, span_warning("We cannot evolve this ability!"))
 		return FALSE
@@ -441,7 +449,20 @@
 	can_respec = FALSE
 	SSblackbox.record_feedback("tally", "changeling_power_purchase", 1, "Readapt")
 	log_changeling_power("[key_name(owner)] readapted their changeling powers")
+	specialization = ""
+	specialize()
 	return TRUE
+
+/*
+* Lets the user choose a changeling specialization
+*/
+/datum/antagonist/changeling/proc/specialize()
+	to_chat(owner, "Select a specialization. Certain powers are only available to certain types of changelings, and some powers can be stronger or weaker if they align with your type.")
+	specialization = tgui_input_list(owner.current, "Select your specialization", "Changeling Specialization", specializations)
+	if(specialization)
+		to_chat(owner, "You specialize in [specialization].")
+		return TRUE
+	return FALSE
 
 /*
  * Get the corresponding changeling profile for the passed name.

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -24,6 +24,8 @@
 	var/req_human = FALSE
 	/// Similar to req_dna, but only gained from absorbing, not DNA sting
 	var/req_absorbs = 0
+	/// requires a specialization?/what type?
+	var/req_spec = ""
 	/// Maximum stat before the ability is blocked.
 	/// For example, `UNCONSCIOUS` prevents it from being used when in hard crit or dead,
 	/// while `DEAD` allows the ability to be used on any stat values.
@@ -77,7 +79,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 /datum/action/changeling/proc/sting_feedback(mob/living/user, mob/living/target)
 	return FALSE
 
-// Fairly important to remember to return 1 on success >.< // Return TRUE not 1 >.<
+// Fairly important to remember to return TRUE on success
 /datum/action/changeling/proc/can_sting(mob/living/user, mob/living/target)
 	if(!can_be_used_by(user))
 		return FALSE

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -3,9 +3,10 @@
 	desc = "Our skin pigmentation rapidly changes to suit our current environment. Costs 10 chemicals."
 	helptext = "Allows us to become invisible after a few seconds of standing still. Can be toggled on and off."
 	button_icon_state = "chameleon_skin"
-	dna_cost = 1
+	dna_cost = 0
 	chemical_cost = 10
 	req_human = TRUE
+	req_spec = "stealth"
 
 /datum/action/changeling/chameleon_skin/sting_action(mob/user)
 	var/mob/living/carbon/human/cling = user //SHOULD always be human, because req_human = TRUE

--- a/code/modules/antagonists/changeling/powers/digitalcamo.dm
+++ b/code/modules/antagonists/changeling/powers/digitalcamo.dm
@@ -3,7 +3,8 @@
 	desc = "By evolving the ability to distort our form and proportions, we defeat common algorithms used to detect lifeforms on cameras."
 	helptext = "We cannot be tracked by camera or seen by AI units while using this skill. However, humans looking at us will find us... uncanny."
 	button_icon_state = "digital_camo"
-	dna_cost = 1
+	dna_cost = 0
+	req_spec = "stealth"
 	active = FALSE
 
 //Prevents AIs tracking you but makes you easily detectable to the human-eye.

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -17,6 +17,10 @@
 //Fake our own death and fully heal. You will appear to be dead but regenerate fully after a short delay.
 /datum/action/changeling/fakedeath/sting_action(mob/living/user)
 	..()
+	//Stealth lings go faster so they have a slightly more generous window for escape
+	var/datum/antagonist/changeling/ling = IS_CHANGELING(user)
+	if(ling && ling.specialization == "stealth")
+		fakedeath_duration = 30
 	if(revive_ready)
 		INVOKE_ASYNC(src, PROC_REF(revive), user)
 		return TRUE

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -15,7 +15,13 @@
 		return
 	..()
 	to_chat(user, span_notice("We begin to heal rapidly."))
-	user.apply_status_effect(/datum/status_effect/fleshmend)
+	var/datum/antagonist/changeling/ling = IS_CHANGELING(user)
+	if(ling && ling.specialization == "stealth")
+		// stealth lings heal a bit less but 5x faster.
+		// they can make a quick getaway, but the heal isn't as good in ongoing combat
+		user.apply_status_effect(/datum/status_effect/fleshmend/stealth)
+	else
+		user.apply_status_effect(/datum/status_effect/fleshmend)
 	return TRUE
 
 //Check buffs.dm for the fleshmend status effect code

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -1,9 +1,9 @@
 /datum/action/changeling/headcrab
 	name = "Last Resort"
-	desc = "We sacrifice our current body in a moment of need, placing us in control of a vessel that can plant our likeness in a new host. Costs 20 chemicals."
+	desc = "We sacrifice our current body in a moment of need, placing us in control of a vessel that can plant our likeness in a new host. Costs 5 chemicals."
 	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us."
 	button_icon_state = "last_resort"
-	chemical_cost = 20
+	chemical_cost = 5 // same as lesser form
 	dna_cost = 1
 	req_human = TRUE
 	req_stat = DEAD

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -4,7 +4,8 @@
 	button_icon_state = "mimic_voice"
 	helptext = "Will turn your voice into the name that you enter. We must constantly expend chemicals to maintain our form like this."
 	chemical_cost = 0//constant chemical drain hardcoded
-	dna_cost = 1
+	dna_cost = 0
+	req_spec = "stealth"
 	req_human = TRUE
 
 // Fake Voice

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -6,6 +6,7 @@
 		Shield
 		Armor
 		Tentacles
+		Release Bees
 */
 
 
@@ -179,6 +180,7 @@
 	chemical_cost = 20
 	dna_cost = 2
 	req_human = TRUE
+	req_spec = "combat"
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
 
@@ -270,6 +272,7 @@
 	chemical_cost = 10
 	dna_cost = 2
 	req_human = TRUE
+	req_spec = "combat"
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
 	silent = TRUE
@@ -480,6 +483,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = TRUE
+	req_spec = "combat"
 
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"
@@ -533,6 +537,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = TRUE
+	req_spec = "combat"
 	recharge_slowdown = 0.125
 
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = TRUE
+	req_spec = "stealth"
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
@@ -41,6 +41,7 @@
 	button_icon_state = "dissonant_shriek"
 	chemical_cost = 20
 	dna_cost = 1
+	req_spec = "combat"
 
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	..()

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -1,11 +1,12 @@
 /datum/action/changeling/spiders
 	name = "Spread Infestation"
-	desc = "Our form divides, creating a cluster of eggs which will grow into a deadly arachnid. Costs 45 chemicals."
+	desc = "Our form divides, creating a cluster of eggs which will grow into a deadly arachnid. Costs 35 chemicals."
 	helptext = "The spiders are ruthless creatures, and may attack their creators when fully grown. Requires at least 3 DNA absorptions."
 	button_icon_state = "spread_infestation"
-	chemical_cost = 45
+	chemical_cost = 35
 	dna_cost = 1
-	req_absorbs = 3
+	req_absorbs = 2
+	req_spec = "combat"
 
 //Makes a spider egg cluster. Allows you enable further general havok by introducing spiders to the station.
 /datum/action/changeling/spiders/sting_action(mob/user)

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -10,17 +10,22 @@
 	dna_cost = 1
 	req_human = TRUE
 	var/stacks = 0 //Increments every 5 seconds; damage increases over time
+	var/maxstacks = 10 //The threshhold of stacks that paralyzes you when you disable the power
 	active = FALSE //Whether or not you are a hedgehog
 
 /datum/action/changeling/strained_muscles/sting_action(mob/living/carbon/user)
 	..()
+	var/datum/antagonist/changeling/ling = IS_CHANGELING(user)
+	if(ling && ling.specialization == "combat")
+		// combat lings can endure more strain
+		maxstacks = 15
 	active = !active
 	if(active)
 		to_chat(user, span_notice("Our muscles tense and strengthen."))
 	else
 		user.remove_movespeed_modifier(/datum/movespeed_modifier/strained_muscles)
 		to_chat(user, span_notice("Our muscles relax."))
-		if(stacks >= 10)
+		if(stacks >= maxstacks)
 			to_chat(user, span_danger("We collapse in exhaustion."))
 			user.Paralyze(60)
 			user.emote("gasp")
@@ -50,7 +55,7 @@
 
 		user.adjustStaminaLoss(stacks * 1.3) //At first the changeling may regenerate stamina fast enough to nullify fatigue, but it will stack
 
-		if(stacks == 11) //Warning message that the stacks are getting too high
+		if(stacks == maxstacks - 2) //10 second warning message that the stacks are getting too high
 			to_chat(user, span_warning("Our legs are really starting to hurt..."))
 
 		sleep(4 SECONDS)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -220,6 +220,7 @@
 	button_icon_state = "sting_mute"
 	chemical_cost = 20
 	dna_cost = 2
+	req_spec = "stealth"
 
 /datum/action/changeling/sting/mute/sting_action(mob/user, mob/living/carbon/target)
 	..()


### PR DESCRIPTION
## About The Pull Request

- Lings now have to pick between Combat and Stealth specializations
- Some powers work slightly differently depending on what type of ling you are
- Some powers are locked if you're the wrong type of ling
- Performing a respec lets you pick a different specialization

Changed powers:
- Fleshmend: Lasts for twice as long for combat lings, heals less but in a quick burst for stealth lings
- Chameleon skin, Digital camo, Mimic voice: Stealth ling only, but costs no DNA
- Revival coma: 10 seconds faster for stealth lings
- Headcrab: Costs 5 chemicals down from 20, same as lesser form since it's basically just a worse lesser form
- Confusion screech, mute sting: Stealth ling only
- Armblade, Tentacle arm, Chitin armor, Shield, EMP screech, spiders: Combat ling only
- Strained muscles: Now warns you 10 seconds BEFORE you're overstrained, combat lings can endure 5 more stacks of strain

## Why It's Good For The Game

Armblade murderbone ling gives changeling a bad name, especially because being really hard to kill and transforming a lot while doing crimes under different names is WAY WAY WAY more fun and cool. Also the combat skills are the most picked ones, someone linked the stats in the discord and its like woah wtf. Anyway this makes the cooler, better playstyle more appealing by giving it lots of goodies that you're locked out of if you go the murderbone route.

Some powers were made stealth-only but 0-cost, those being powers that are mechanically interesting but never picked because of their DNA cost never being worth it. This brings those back into the limelight a bit too.

This was made in like three hours and was tested, albeit not super thoroughly. I am not dead set on any of the balance changes within so feedback very welcome and if anybody has a cool idea that conflicts with this PR conceptually I'd be happy to close it outright in favor of your idea instead. This PR is more "for your consideration, can we build something really cool out of this" than "I NEED THIS IN THE GAME RIGHT NOW," although it could technically be merged as is I think (pending review of course, I would bet I missed some stuff).

## Changelog
:cl:
balance: Changelings now have to pick between the Combat and Stealth paths when picking their powers. Many powers have been tweaked.
balance: Fleshmend: Lasts for twice as long for combat lings, heals less but in a quick burst for stealth lings
balance: Chameleon skin, Digital camo, Mimic voice: Stealth ling only, but costs no DNA
balance: Revival coma: 10 seconds faster for stealth lings
balance: Last resort: Costs 5 chemicals down from 20, same as lesser form since it's basically just a worse lesser form
balance: Confusion screech, mute sting: Stealth ling only
balance: Armblade, Tentacle arm, Chitin armor, Shield, EMP screech, spiders: Combat ling only
balance: Strained muscles: Now warns you 10 seconds BEFORE you're overstrained, combat lings can endure 5 more stacks of strain
/:cl:
