### PR TITLE
Stops janiborgs from killing the machinery subsystem by charging light replacers 200000 times a charge tick

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -283,11 +283,13 @@
 		return TRUE
 	return FALSE
 
-/obj/item/lightreplacer/proc/Charge(mob/user)
-	charge += 1
-	if(charge > 3)
-		add_uses(1)
-		charge = 1
+/obj/item/lightreplacer/proc/Charge(mob/user, coeff)
+	#define LIGHT_CHARGE_COEFF 30000
+	charge += coeff
+	if(charge > LIGHT_CHARGE_COEFF)
+		add_uses(floor(charge / LIGHT_CHARGE_COEFF))
+		charge = charge % LIGHT_CHARGE_COEFF
+	#undef LIGHT_CHARGE_COEFF
 
 /obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/user)
 	//Confirm that it's a light we're testing, because afterattack runs this for everything on a given turf and will runtime

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -283,13 +283,14 @@
 		return TRUE
 	return FALSE
 
+#define LIGHT_CHARGE_COEFF 30000
 /obj/item/lightreplacer/proc/Charge(mob/user, coeff)
-	#define LIGHT_CHARGE_COEFF 30000
 	charge += coeff
 	if(charge > LIGHT_CHARGE_COEFF)
 		add_uses(floor(charge / LIGHT_CHARGE_COEFF))
 		charge = charge % LIGHT_CHARGE_COEFF
-	#undef LIGHT_CHARGE_COEFF
+
+#undef LIGHT_CHARGE_COEFF
 
 /obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/user)
 	//Confirm that it's a light we're testing, because afterattack runs this for everything on a given turf and will runtime

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -626,8 +626,7 @@
 	..()
 	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
 	if(light_replacer)
-		for(var/charge in 1 to coeff)
-			light_replacer.Charge(cyborg)
+		light_replacer.Charge(cyborg, coeff)
 
 	var/obj/item/reagent_containers/spray/cyborg_drying/drying_agent = locate(/obj/item/reagent_containers/spray/cyborg_drying) in basic_modules
 	if(drying_agent)


### PR DESCRIPTION
## About The Pull Request

So, with the somewhat-recent power changes, cells now have a shitton of charge compared to the old one.

Now, recently, the `model.respawn_consumable` call in `/mob/living/silicon/robot/proc/charge` was changed to use this variable, so every time you had a borg inside a charger, it would constantly drain 0.5% of its cell charge, and use it for the light replacer charge calculation. 

### The light replacer

So, we now have about 200000 as the charge coefficient on bluespace cells. On code that was made back for 1000 charge in like 2012 according to the gitblame. Slight issue: **There's a fucking for loop looping 200000 times every time we charge**, calling `/obj/item/lightreplacer/proc/Charge` every time it loops. It has no break condition, so it does this every machinery tick. This, with a single janiborg with a blue cell kills the machinery subsystem and causes a hell of a lot of overtime, and a hilarious profiler log:
![image](https://github.com/tgstation/tgstation/assets/49160555/92726216-3bc3-4504-ab69-a2f2adf954f8)

### The fix

Simply not make the light replacer calculation loop like this and just use division and a modulo, like a normal sensible coder, plus adjust it to the new cell values.

See the profiler log now:
![image](https://github.com/tgstation/tgstation/assets/49160555/d909de18-f0a2-4172-ae8d-98f2641bcc89)

## Why It's Good For The Game

It fixes a potentially game killing bug. A FUCK moment to be sure

## Warning for upstreams

_Looks at Nova and Skyrat_ check your Charge() proc usages, I know you have at least one extra hit for it.

## Changelog

:cl:
fix: Fixes janitor borgs killing the machinery subsystem by charging light replacers 200k times a tick.
/:cl:
