### PR TITLE
Makes engineer construction bag normal size instead of bulky

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -536,6 +536,7 @@
 	worn_icon_state = "construction_bag"
 	desc = "A bag for storing small construction components."
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/construction/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Title self explanatory
## Why It's Good For The Game
construction bags are super useful for carrying all types of electronics and cables for engineers, but they are never used - which leads to engineers never having an APC board or air alarm board on hand, which makes repairing broken APCs/air alarms/firelocks a gigantic chore for which you have to go back to engineering and get a board. This should make repairs easier and contribute to round health by allowing engineers to repair easier.
## Changelog
:cl: grungussuss
balance: engineer construction bag is now normal size and can fit into bags
/:cl:
