### PR TITLE
White dwarf meta knowledge check fix

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -388,14 +388,10 @@ SUBSYSTEM_DEF(dynamic)
 
 	switch(round(shown_threat))
 		//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
-		if(0)
-			if(round(threat_level) == 0)
-				advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
-				advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
-			else
-				advisory_string += "Advisory Level: <b>Green Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department of Intelligence advises maintaining vigilance against potential threats, regardless of a lack of known threats."
-		if(1 to 19)
+		if(0 && round(threat_level) == 0)
+			advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
+			advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
+		if(0 to 19)
 			var/show_core_territory = (GLOB.current_living_antags.len > 0)
 			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))
 				show_core_territory = !show_core_territory

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -385,12 +385,13 @@ SUBSYSTEM_DEF(dynamic)
 		advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
 		advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
 		return advisory_string
+	//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
+	if(0 && round(threat_level) == 0)
+		advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
+		advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
+		return advisory_string
 
 	switch(round(shown_threat))
-		//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
-		if(0 && round(threat_level) == 0)
-			advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
-			advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
 		if(0 to 19)
 			var/show_core_territory = (GLOB.current_living_antags.len > 0)
 			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -387,9 +387,14 @@ SUBSYSTEM_DEF(dynamic)
 		return advisory_string
 
 	switch(round(shown_threat))
+		//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
 		if(0)
-			advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
-			advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
+			if(round(threat_level) == 0)
+				advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
+				advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
+			else
+				advisory_string += "Advisory Level: <b>Green Star</b></center><BR>"
+				advisory_string += "Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department of Intelligence advises maintaining vigilance against potential threats, regardless of a lack of known threats."
 		if(1 to 19)
 			var/show_core_territory = (GLOB.current_living_antags.len > 0)
 			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -386,7 +386,7 @@ SUBSYSTEM_DEF(dynamic)
 		advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
 		return advisory_string
 	//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
-	if(0 && round(threat_level) == 0)
+	if(round(shown_threat) == 0 && round(threat_level) == 0)
 		advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
 		advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
 		return advisory_string


### PR DESCRIPTION

## About The Pull Request
There is two values for round threat, the shown value and the real value, sometimes the shown threat can be 0, while the real threat is higher, which in turn does not trigger the green alert on getting the classified report and does not make a special announcement, "Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", nor does it enable all station construction projects, so we should disable being able to fake white dwarf on classified report.
## Why It's Good For The Game
Knowing when your classified report is fake is meta knowledge and shouldn't be a thing.
## Changelog
:cl: grungussuss
fix: fixed getting a fake white dwarf report when the shift isn't extended mode, which lead to meta knowledge being used.
/:cl:
