### PR TITLE
Makes The Automute Thingo Yell At You A Bit Louder

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -213,7 +213,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return TRUE
 		if(src.last_message_count >= SPAM_TRIGGER_WARNING)
 			//"auto-ban" sends the message that the cold and uncaring gamecode has been designed to quiash you like a bug in short measure should you continue, and it's quite intentional that the user isn't told exactly what that entails.
-			to_chat(src, span_danger("You are nearing the auto-ban limit for identical messages."))
+			to_chat(src, span_userdanger("You are nearing the auto-ban limit for identical messages."))
+			mob.balloon_alert(mob, "stop spamming!")
 			return FALSE
 	else
 		last_message = message


### PR DESCRIPTION

## About The Pull Request
It makes the automute use bigger, redder text and also balloon alert
I know ppl dont like punctuation in balloon alerts so I can remove the exclamation mark if u want, i like it tho
I guess if u support darwinism u could leave it as is but in the era of runetext and TTS ppl cant pay attention to the chat window they're too busy watching subway surfers on their second monitor and scrolling tiktok on their phone
Doesnt change the text so it stays deliberately vague like the comment says it should

Before:
<img src="https://i.ibb.co/3hDnpQm/Automute-Before.png">
After:
<img src="https://i.ibb.co/0qSwJFB/Automute-After.png">
<img src="https://i.ibb.co/n3ch9fg/Automute-Balloon-Alert.png">
## Why It's Good For The Game
Being automuted when there's no admins on cuz u got a bit carried away isnt cool and then u have to urgent ahelp it, which is understandable cuz it's making the round unplayable for you but you did kinda bring it on yourself and the admin might not be too happy with you about it.
## Changelog
:cl:
admin: The auto-mute system yells at you harder when you send a bunch of identical messages.
/:cl:
