### PR TITLE
nerfs bdm eye crusher trophy

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -87,10 +87,10 @@
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, BLOODDRUNK_TRAIT)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
-		human_owner.physiology.brute_mod *= 0.1
-		human_owner.physiology.burn_mod *= 0.1
-		human_owner.physiology.tox_mod *= 0.1
-		human_owner.physiology.oxy_mod *= 0.1
+		human_owner.physiology.brute_mod *= 0.5
+		human_owner.physiology.burn_mod *= 0.5
+		human_owner.physiology.tox_mod *= 0.5
+		human_owner.physiology.oxy_mod *= 0.5
 		human_owner.physiology.stamina_mod *= 0.1
 	owner.add_stun_absorption(source = id, priority = 4)
 	owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1, use_reverb = FALSE)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -99,10 +99,10 @@
 /datum/status_effect/blooddrunk/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
-		human_owner.physiology.brute_mod *= 10
-		human_owner.physiology.burn_mod *= 10
-		human_owner.physiology.tox_mod *= 10
-		human_owner.physiology.oxy_mod *= 10
+		human_owner.physiology.brute_mod *= 2
+		human_owner.physiology.burn_mod *= 2
+		human_owner.physiology.tox_mod *= 2
+		human_owner.physiology.oxy_mod *= 2
 		human_owner.physiology.stamina_mod *= 10
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, BLOODDRUNK_TRAIT)
 	owner.remove_stun_absorption(id)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -351,7 +351,7 @@
 	denied_type = /obj/item/crusher_trophy/miner_eye
 
 /obj/item/crusher_trophy/miner_eye/effect_desc()
-	return "mark detonation to grant stun immunity and <b>90%</b> damage reduction for <b>1</b> second"
+	return "mark detonation to grant stun immunity and <b>50%</b> damage reduction for <b>1</b> second"
 
 /obj/item/crusher_trophy/miner_eye/on_mark_detonation(mob/living/target, mob/living/user)
 	user.apply_status_effect(/datum/status_effect/blooddrunk)


### PR DESCRIPTION
## About The Pull Request
nerfs the bdm's eye to make it so instead of getting 90% resistance to damage you get 50%, doesn't change duration or stun resistance
## Why It's Good For The Game
when you're putting out 1 hit every 2 seconds and you get 1 second of what's basically immunity every hit, you end up facetanking shit that would otherwise kill you instantly.
i'm not against a "block mechanic", but it shouldn't be triggered by the main action of the weapon, perhaps whoever made it this way was trying to prevent the initial melee strike that you usually receive when getting close to the megafauna, but there's already a trophy that prevents megafauna from striking with a melee too fast (the lobster claw, when it decides to work).
what this trophy ends up doing ingame, for most miners, is accidentally saving them from things that they should have not survived, teaching them nothing about any error they made, and instead just rewarding them with their powergame loot just by mindlessly hitting the big demon with an axe.

## Changelog
:cl: John Mining
balance: Nerfed the Blood-Drunk Miner's crusher trophy to only apply a 50% damage resistance for 1 second.
/:cl:
