### PR TITLE
Fix null authors breaking test merge bot

### DIFF
--- a/tools/test_merge_bot/main.js
+++ b/tools/test_merge_bot/main.js
@@ -76,7 +76,7 @@ export async function processTestMerges({ github, context }) {
 		const existingComment =
 			comments.repository.pullRequest.comments.nodes.find(
 				(comment) =>
-					comment.author.login === "github-actions" &&
+					comment.author?.login === "github-actions" &&
 					comment.body.startsWith(TEST_MERGE_COMMENT_HEADER)
 			);
 


### PR DESCRIPTION
These can be null if they're ghost