### PR TITLE
removes the force drop when trying to attack with an unwielded crusher

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -85,7 +85,7 @@
 
 /obj/item/kinetic_crusher/attack(mob/living/target, mob/living/carbon/user)
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
-		to_chat(user, span_warning("[src] is too heavy to use with one hand!."))
+		user.balloon_alert(user, "must be wielded!")
 		return
 	var/datum/status_effect/crusher_damage/crusher_damage_effect = target.has_status_effect(/datum/status_effect/crusher_damage)
 	if(!crusher_damage_effect)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -85,8 +85,7 @@
 
 /obj/item/kinetic_crusher/attack(mob/living/target, mob/living/carbon/user)
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
-		to_chat(user, span_warning("[src] is too heavy to use with one hand! You fumble and drop everything."))
-		user.drop_all_held_items()
+		to_chat(user, span_warning("[src] is too heavy to use with one hand!."))
 		return
 	var/datum/status_effect/crusher_damage/crusher_damage_effect = target.has_status_effect(/datum/status_effect/crusher_damage)
 	if(!crusher_damage_effect)


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. If you're not wielding the crusher, rather than forcefully dropping everything in your hands, you simply just don't attack.

## Why It's Good For The Game

This was added when the crusher was able to be held in one-hand, before we got the two-handed component. However, for some inexplicable reason there was a noob trap added into that feature that has existed for almost five years. Maybe skoglol had their reasons for putting it in there at the time, but I don't believe this is anything other than unnecessarily punishing in the modern state of the code. A return works just fine.

The PR that added it for anyone curious https://github.com/tgstation/tgstation/pull/45110

## Changelog
:cl:
qol: Failing to hit someone with a proto-kinetic crusher one-handedly no longer force drops everything in your hands.
/:cl:
