### PR TITLE
Added the zipzap to the ocean sources

### DIFF
--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -7,6 +7,7 @@
 		/obj/item/fish/cardinal = 15,
 		/obj/item/fish/greenchromis = 15,
 		/obj/item/fish/lanternfish = 5,
+		/obj/item/fish/zipzap = 5,
 		/obj/item/fish/clownfish/lube = 3,
 	)
 	fish_counts = list(
@@ -67,6 +68,7 @@
 		/obj/item/fish/gunner_jellyfish = 5,
 		/obj/item/fish/needlefish = 5,
 		/obj/item/fish/armorfish = 5,
+		/obj/item/fish/zipzap = 5,
 	)
 	catalog_description = "Ocean dimension (Fishing portal generator)"
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10


### PR DESCRIPTION

## About The Pull Request

In this PR I am just adding the Anxious Zipzap from #83508 to an actual fishing source, as that was left out of the original PR by mistake. It compiled properly and loaded as a server.
## Why It's Good For The Game

Adding a way to actually obtain a recently added fish (with the only other way to interact with the power generation mechanics being an emag) seems like it would be good overall.
## Changelog
:cl:
fix: Made the anxious zipzap accessible.
/:cl:
