### PR TITLE
Renames Mindbreaker Toxin to Mindbreaker Serum

### DIFF
--- a/code/datums/quirks/negative_quirks/insanity.dm
+++ b/code/datums/quirks/negative_quirks/insanity.dm
@@ -1,7 +1,7 @@
 /datum/quirk/insanity
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. \
-		Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. \
+		Mindbreaker serum can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. \
 		THIS IS NOT A LICENSE TO GRIEF."
 	icon = FA_ICON_GRIN_TONGUE_WINK
 	value = -8

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -635,7 +635,7 @@
 		new /obj/item/reagent_containers/pill/happinesspsych(src)
 
 /obj/item/storage/pill_bottle/lsdpsych
-	name = "mindbreaker toxin pills"
+	name = "mindbreaker serum pills"
 	desc = "!FOR THERAPEUTIC USE ONLY! Contains pills used to alleviate the symptoms of Reality Dissociation Syndrome."
 
 /obj/item/storage/pill_bottle/lsdpsych/PopulateContents()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_toxin_reagents.dm
@@ -47,10 +47,10 @@
 	if(owner.adjustToxLoss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
-//Mindbreaker Toxin - Impure Version
+//Mindbreaker Serum - Impure Version
 /datum/reagent/impurity/rosenol
 	name = "Rosenol"
-	description = "A strange, blue liquid that is produced during impure mindbreaker toxin reactions. Historically it has been abused to write poetry."
+	description = "A strange, blue liquid that is produced during impure mindbreaker serum reactions. Historically it has been abused to write poetry."
 	reagent_state = LIQUID
 	color = "#0963ad"
 	ph = 7

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -303,7 +303,7 @@
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/mindbreaker
-	name = "Mindbreaker Toxin"
+	name = "Mindbreaker Serum"
 	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patients. it counteracts their symptoms and anchors them to reality."
 	color = "#B31008" // rgb: 139, 166, 233
 	toxpwr = 0
@@ -318,7 +318,7 @@
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	// mindbreaker toxin assuages hallucinations in those plagued with it, mentally
+	// mindbreaker serum assuages hallucinations in those plagued with it, mentally
 	if(affected_mob.has_trauma_type(/datum/brain_trauma/mild/hallucinations))
 		affected_mob.remove_status_effect(/datum/status_effect/hallucination)
 


### PR DESCRIPTION

## About The Pull Request
See title.
## Why It's Good For The Game
The name implies it either does toxin damage or damages the brain. It doesn't do either, it makes you hallucinate.
## Changelog
:cl:
spellcheck: 'Mindbreaker Toxin' now named 'Mindbreaker Serum'
/:cl:
