### PR TITLE
[NO GBP] Only add the armor plate prefix once.

### DIFF
--- a/code/datums/components/armor_plate.dm
+++ b/code/datums/components/armor_plate.dm
@@ -11,6 +11,8 @@
 	var/upgrade_name
 	/// Adds a prefix to the item, demonstrating that it is upgraded in some way.
 	var/upgrade_prefix = "reinforced"
+	/// Tracks whether or not we've received an upgrade or not.
+	var/have_upgraded = FALSE
 
 /datum/armor/armor_plate
 	melee = 10
@@ -81,10 +83,10 @@
 		to_chat(user, span_info("You strengthen [mecha_for_upgrading], improving its resistance against attacks."))
 	else
 		SEND_SIGNAL(target_for_upgrading, COMSIG_ARMOR_PLATED, amount, maxamount)
-		if(upgrade_prefix && amount == 0)
+		if(upgrade_prefix && !have_upgraded)
 			target_for_upgrading.name = "[upgrade_prefix] [target_for_upgrading.name]"
+			have_upgraded = TRUE
 		to_chat(user, span_info("You strengthen [target_for_upgrading], improving its resistance against attacks."))
-
 
 /datum/component/armor_plate/proc/dropplates(datum/source, force)
 	SIGNAL_HANDLER

--- a/code/datums/components/armor_plate.dm
+++ b/code/datums/components/armor_plate.dm
@@ -81,7 +81,7 @@
 		to_chat(user, span_info("You strengthen [mecha_for_upgrading], improving its resistance against attacks."))
 	else
 		SEND_SIGNAL(target_for_upgrading, COMSIG_ARMOR_PLATED, amount, maxamount)
-		if(upgrade_prefix)
+		if(upgrade_prefix && amount == 0)
 			target_for_upgrading.name = "[upgrade_prefix] [target_for_upgrading.name]"
 		to_chat(user, span_info("You strengthen [target_for_upgrading], improving its resistance against attacks."))
 


### PR DESCRIPTION

## About The Pull Request

Currently, this will add the prefix for every upgrade. We only want to add it once.

## Why It's Good For The Game

Oops. This isn't working as intended.

## Changelog
:cl:
fix: The armor plate component only adds the prefix once.
/:cl:
