### PR TITLE
Mindshield implants protect from cult stun

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -426,6 +426,10 @@
 			var/old_color = target.color
 			target.color = rgb(0, 128, 0)
 			animate(target, color = old_color, time = 1 SECONDS, easing = EASE_IN)
+		if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+			to_chat(user, span_warning("[target] is briefly staggered but quickly regains their senses! [target] is protected by a Mindshield!"))
+			to_chat(target, span_warning("You are protected by your mindshield."))
+			target.adjust_confusion(2 SECONDS)
 		else if(target.can_block_magic())
 			to_chat(user, span_warning("The spell had no effect!"))
 		else

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -426,7 +426,7 @@
 			var/old_color = target.color
 			target.color = rgb(0, 128, 0)
 			animate(target, color = old_color, time = 1 SECONDS, easing = EASE_IN)
-		if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		else if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 			to_chat(user, span_warning("[target] is briefly staggered but quickly regains their senses! [target] is protected by a Mindshield!"))
 			to_chat(target, span_warning("You are protected by your mindshield."))
 			target.adjust_confusion(2 SECONDS)


### PR DESCRIPTION

## About The Pull Request

Mindshield implants protect from cult stun instead applying confusion

## Why It's Good For The Game

Every single cultist has a 16 second paralyze hand that they can get 1 minute from spawning which is just not fun gameplay while trying to fight the cult
As such only making it affect the non-mindshielded should make it actually possible to melee a cultist because they cant use their cooler variant esword blocking your hits before touching you with the win hand
Non-mindshielded are still affected and may be dragged off for conversion

## Changelog
:cl:
balance: mindshield implant prevents cult stun
/:cl:
