### PR TITLE
cult stun gets weaker at when cult gets red eyes, and then also halo stage

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -434,9 +434,6 @@
 		user.visible_message(span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"), \
 		span_cult_italic("You attempt to stun [target] with the spell!"))
 		user.mob_light(range = 1.1, power = 2, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.2 SECONDS)
-		if(target.check_block(src,0,name,MELEE_ATTACK))
-			uses--
-			return ..()
 		else if(IS_HERETIC(target))
 			to_chat(user, span_warning("Some force greater than you intervenes! [target] is protected by the Forgotten Gods!"))
 			to_chat(target, span_warning("You are protected by your faith to the Forgotten Gods."))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -158,6 +158,17 @@
 	magic_path = "/obj/item/melee/blood_magic/stun"
 	health_cost = 10
 
+/datum/action/innate/cult/blood_spell/IsAvailable(feedback = FALSE)
+	. = ..()
+	if(!.)
+		return .
+	var/datum/antagonist/cult/cultist = IS_CULTIST(owner)
+	var/datum/team/cult/team = cultist.get_team()
+	if(team.cult_ascendent)
+		qdel(src)
+		return FALSE
+	return ..()
+
 /datum/action/innate/cult/blood_spell/teleport
 	name = "Teleport"
 	desc = "Empowers your hand to teleport yourself or another cultist to a teleport rune on contact."
@@ -416,11 +427,17 @@
 		return
 	if(IS_CULTIST(target))
 		return
-	if(IS_CULTIST(user))
+	var/datum/antagonist/cult/cultist = IS_CULTIST(user)
+	if(!isnull(cultist))
+		var/datum/team/cult/cult_team = cultist.get_team()
+		var/effect_coef = cult_team.cult_risen ? 0.6 : 1
 		user.visible_message(span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"), \
 		span_cult_italic("You attempt to stun [target] with the spell!"))
 		user.mob_light(range = 1.1, power = 2, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.2 SECONDS)
-		if(IS_HERETIC(target))
+		if(target.check_block(src,0,name,MELEE_ATTACK))
+			uses--
+			return ..()
+		else if(IS_HERETIC(target))
 			to_chat(user, span_warning("Some force greater than you intervenes! [target] is protected by the Forgotten Gods!"))
 			to_chat(target, span_warning("You are protected by your faith to the Forgotten Gods."))
 			var/old_color = target.color
@@ -430,17 +447,17 @@
 			to_chat(user, span_warning("The spell had no effect!"))
 		else
 			to_chat(user, span_cult_italic("In a brilliant flash of red, [target] falls to the ground!"))
-			target.Paralyze(16 SECONDS)
+			target.Paralyze(16 SECONDS * effect_coef)
 			target.flash_act(1, TRUE)
 			if(issilicon(target))
 				var/mob/living/silicon/silicon_target = target
 				silicon_target.emp_act(EMP_HEAVY)
 			else if(iscarbon(target))
 				var/mob/living/carbon/carbon_target = target
-				carbon_target.adjust_silence(12 SECONDS)
-				carbon_target.adjust_stutter(30 SECONDS)
-				carbon_target.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/slurring/cult)
-				carbon_target.set_jitter_if_lower(30 SECONDS)
+				carbon_target.adjust_silence(12 SECONDS * effect_coef)
+				carbon_target.adjust_stutter(30 SECONDS * effect_coef)
+				carbon_target.adjust_timed_status_effect(30 SECONDS * effect_coef, /datum/status_effect/speech/slurring/cult)
+				carbon_target.set_jitter_if_lower(30 SECONDS * effect_coef)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -419,11 +419,11 @@
 	var/datum/antagonist/cult/cultist = IS_CULTIST(user)
 	if(!isnull(cultist))
 		var/datum/team/cult/cult_team = cultist.get_team()
-		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4) - (cult.team.cult_ascendent ? 0.45)
+		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4) - (cult.team.cult_ascendent ? 0.5)
 		user.visible_message(span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"), \
 		span_cult_italic("You attempt to stun [target] with the spell!"))
 		user.mob_light(range = 1.1, power = 2, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.2 SECONDS)
-		else if(IS_HERETIC(target))
+		if(IS_HERETIC(target))
 			to_chat(user, span_warning("Some force greater than you intervenes! [target] is protected by the Forgotten Gods!"))
 			to_chat(target, span_warning("You are protected by your faith to the Forgotten Gods."))
 			var/old_color = target.color

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -153,21 +153,10 @@
 //Cult Blood Spells
 /datum/action/innate/cult/blood_spell/stun
 	name = "Stun"
-	desc = "Empowers your hand to stun and mute a victim on contact."
+	desc = "Empowers your hand to stun and mute a victim on contact. Gets weaker depending on how many have joined the Cult."
 	button_icon_state = "hand"
 	magic_path = "/obj/item/melee/blood_magic/stun"
 	health_cost = 10
-
-/datum/action/innate/cult/blood_spell/IsAvailable(feedback = FALSE)
-	. = ..()
-	if(!.)
-		return .
-	var/datum/antagonist/cult/cultist = IS_CULTIST(owner)
-	var/datum/team/cult/team = cultist.get_team()
-	if(team.cult_ascendent)
-		qdel(src)
-		return FALSE
-	return ..()
 
 /datum/action/innate/cult/blood_spell/teleport
 	name = "Teleport"

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -419,7 +419,7 @@
 	var/datum/antagonist/cult/cultist = IS_CULTIST(user)
 	if(!isnull(cultist))
 		var/datum/team/cult/cult_team = cultist.get_team()
-		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4 : 0) - (cult.team.cult_ascendent ? 0.5 : 0)
+		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4 : 0) - (cult_team.cult_ascendent ? 0.5 : 0)
 		user.visible_message(span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"), \
 		span_cult_italic("You attempt to stun [target] with the spell!"))
 		user.mob_light(range = 1.1, power = 2, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.2 SECONDS)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -419,7 +419,7 @@
 	var/datum/antagonist/cult/cultist = IS_CULTIST(user)
 	if(!isnull(cultist))
 		var/datum/team/cult/cult_team = cultist.get_team()
-		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4) - (cult.team.cult_ascendent ? 0.5)
+		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4 : 0) - (cult.team.cult_ascendent ? 0.5 : 0)
 		user.visible_message(span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"), \
 		span_cult_italic("You attempt to stun [target] with the spell!"))
 		user.mob_light(range = 1.1, power = 2, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.2 SECONDS)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -430,7 +430,7 @@
 	var/datum/antagonist/cult/cultist = IS_CULTIST(user)
 	if(!isnull(cultist))
 		var/datum/team/cult/cult_team = cultist.get_team()
-		var/effect_coef = cult_team.cult_risen ? 0.6 : 1
+		var/effect_coef = 1 - (cult_team.cult_risen ? 0.4) - (cult.team.cult_ascendent ? 0.45)
 		user.visible_message(span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"), \
 		span_cult_italic("You attempt to stun [target] with the spell!"))
 		user.mob_light(range = 1.1, power = 2, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.2 SECONDS)


### PR DESCRIPTION

## About The Pull Request

cult stun gets weaker with cult stage
at red eyes, stun lasts 9.6 seconds from 16 seconds by default
at halo, stun lasts 1.9 seconds

## Why It's Good For The Game

getting stinky handed in the middle of a fight with a halo cultist just isnt really fun because then the cultist has like 16 seconds to beat you to death
with this you may have a chance of getting back on your feet and showing the narsie scum whos boss

## Changelog
:cl:
balance: cult stun gets weaker when they get red eyes and later more when they have halos
/:cl:
