### PR TITLE
Fixes crutches crippling you and giving infinite speedboosts

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -521,12 +521,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/cane/proc/movement_support_add(mob/living/user)
 	RegisterSignal(user, COMSIG_CARBON_LIMPING, PROC_REF(handle_limping))
-	user.set_usable_legs()
 	return TRUE
 
 /obj/item/cane/proc/movement_support_del(mob/living/user)
 	UnregisterSignal(user, list(COMSIG_CARBON_LIMPING))
-	user.set_usable_legs()
 	return TRUE
 
 /obj/item/cane/proc/handle_limping(mob/living/user)
@@ -565,8 +563,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(!.)
 		return
-	user.update_usable_leg_status()
 	UnregisterSignal(user, list(COMSIG_LIVING_LIMBLESS_SLOWDOWN, COMSIG_CARBON_LIMPING))
+	user.update_usable_leg_status()
 	REMOVE_TRAIT(user, TRAIT_WADDLING, REF(src))
 
 /obj/item/cane/crutch/proc/handle_slowdown(mob/living/user, limbless_slowdown, list/slowdown_mods)


### PR DESCRIPTION
Fixes #83646 

Fixes crutches setting your legs to null whenever you pick them up or drop them
Fixes slowdown reduction on crutches being permanent (this was hard to notice because they instantly cripple you)

:cl:
fix: fixes touching a crutch permanently crippling you
fix: fixes crutches giving permanent speedboosts even when dropped
/:cl:

