### PR TITLE
Ash Ascension spells have high transparency

### DIFF
--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -53,8 +53,8 @@
 		return
 
 	for(var/turf/nearby_turf as anything in RANGE_TURFS(1, owner))
-		var/obj/effect/hotspot/flame_tile = new(nearby_turf)
-		flame_tile.alpha = 50
+		var/obj/effect/hotspot/flame_tile = locate(nearby_turf) || new(nearby_turf)
+		flame_tile.alpha = 125
 		nearby_turf.hotspot_expose(750, 25 * seconds_between_ticks, 1)
 		for(var/mob/living/fried_living in nearby_turf.contents - owner)
 			fried_living.apply_damage(2.5 * seconds_between_ticks, BURN)
@@ -87,8 +87,8 @@
 /datum/action/cooldown/spell/fire_cascade/proc/fire_cascade(atom/centre, flame_radius = 1)
 	for(var/i in 0 to flame_radius)
 		for(var/turf/nearby_turf as anything in spiral_range_turfs(i + 1, centre))
-			var/obj/effect/hotspot/flame_tile = new(nearby_turf)
-			flame_tile.alpha = 50
+			var/obj/effect/hotspot/flame_tile = locate(nearby_turf) || new(nearby_turf)
+			flame_tile.alpha = 125
 			nearby_turf.hotspot_expose(750, 50, 1)
 			for(var/mob/living/fried_living in nearby_turf.contents - owner)
 				fried_living.apply_damage(5, BURN)

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -53,7 +53,8 @@
 		return
 
 	for(var/turf/nearby_turf as anything in RANGE_TURFS(1, owner))
-		new /obj/effect/hotspot(nearby_turf)
+		var/obj/effect/hotspot/flame_tile = new(nearby_turf)
+		flame_tile.alpha = 50
 		nearby_turf.hotspot_expose(750, 25 * seconds_between_ticks, 1)
 		for(var/mob/living/fried_living in nearby_turf.contents - owner)
 			fried_living.apply_damage(2.5 * seconds_between_ticks, BURN)
@@ -86,7 +87,8 @@
 /datum/action/cooldown/spell/fire_cascade/proc/fire_cascade(atom/centre, flame_radius = 1)
 	for(var/i in 0 to flame_radius)
 		for(var/turf/nearby_turf as anything in spiral_range_turfs(i + 1, centre))
-			new /obj/effect/hotspot(nearby_turf)
+			var/obj/effect/hotspot/flame_tile = new(nearby_turf)
+			flame_tile.alpha = 50
 			nearby_turf.hotspot_expose(750, 50, 1)
 			for(var/mob/living/fried_living in nearby_turf.contents - owner)
 				fried_living.apply_damage(5, BURN)


### PR DESCRIPTION
## About The Pull Request
Ash ascension flame hotspot effects are now 150 alpha
Oath of flame (ring)=
![image](https://github.com/tgstation/tgstation/assets/53100513/994b186d-4e25-49ec-b882-ac8705b84a7b)
cascade
pre-post-burst
![image](https://github.com/tgstation/tgstation/assets/53100513/dd2841bb-54a2-46a9-be96-957f8dd0acce)
during burst
![image](https://github.com/tgstation/tgstation/assets/53100513/0dcb1789-6700-4e8b-806e-6ed081016eaa)


The effect ingame is that every time the flame bursts again it makes it hard to see for a second but then it's a transparent cool 'background' effect. I think its perfect !

## Why It's Good For The Game

I want to see the fucking game

## Changelog

:cl:
qol:Ash Ascension spells have high transparency
/:cl:

