### PR TITLE
Fix Meta cargo lobby being unconnected to power

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13266,6 +13266,7 @@
 /area/station/science/research)
 "eMY" = (
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "eNb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15201,6 +15201,7 @@
 	},
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "fvE" = (
@@ -28671,6 +28672,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "keK" = (
@@ -63883,7 +63885,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "wrt" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request
Moves a misplaced wire to be connecting the cargo lobby APC instead of right next to it. Also adds a missing wire in maintenance from cargo's maintenance to the vault hallway and another one connecting the APC in the maintenance above mining.

## Why It's Good For The Game
Allows meta's cargo lobby & mining maintence to actually charge without someone having to add a wire.

## Changelog
:cl: Goat
fix: meta's cargo lobby and mining maintenance APCs is now connected to the power line
/:cl:
