### PR TITLE
Adds a tiny fan to Tramstation's disposals room

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2346,6 +2346,7 @@
 /obj/machinery/door/poddoor/massdriver_trash{
 	id = "fortnitedoor"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "ajc" = (


### PR DESCRIPTION

## About The Pull Request
Adds a tiny fan under the blast doors by the mass driver in Tramstation's disposals room.
## Why It's Good For The Game
Fixes a consistency issue with other station's disposal rooms.
The tiny fan prevents the disposals room from becoming depressurized after repeated use of the mass driver, or if the blast doors get left open.
## Changelog
:cl:
fix: A tiny fan was added to Tramstation's disposal room under the blast doors. No more accidental depressurizations.
/:cl:
