### PR TITLE
Make AI's jump to AI Core button work while on backup power

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -10,7 +10,7 @@
 	icon_state = "ai_core"
 
 /atom/movable/screen/ai/aicore/Click()
-	if(..())
+	if(isobserver(usr))
 		return
 	var/mob/living/silicon/ai/AI = usr
 	AI.view_core()


### PR DESCRIPTION
## About The Pull Request

Allows the AI Core button which snaps their camera to their mob to work even on backup power.

I don't consider this a balance change because there are already a myriad of ways to get `AI.view_core()` to be called besides the button (one of them being to simply reconnect), or other ways to bypass like what I have taken to doing is prepare a camera hotkey at roundstart since those do continue to work fine on backup power for some reason.

## Why It's Good For The Game

QoL good. Makes AI a little more intuitive to play especially when s*it hits the fan.

## Changelog
:cl:
qol: AI's jump to AI Core button works while on backup power (likely when needed most).
/:cl:
