### PR TITLE
The memories for Smoker and Alcoholic now actually mention the preferred brand

### DIFF
--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -115,7 +115,7 @@
 	return ..()
 
 /datum/memory/key/quirk_smoker/get_names()
-	return list("[protagonist_name]'s smoking problem.")
+	return list("[protagonist_name]'s addiction to [preferred_brand] cigarettes.")
 
 /datum/memory/key/quirk_smoker/get_starts()
 	return list(
@@ -143,7 +143,7 @@
 	return ..()
 
 /datum/memory/key/quirk_alcoholic/get_names()
-	return list("[protagonist_name]'s drinking problem.")
+	return list("[protagonist_name]'s addiction to [preferred_brandy] alcohol.")
 
 /datum/memory/key/quirk_alcoholic/get_starts()
 	return list(


### PR DESCRIPTION
## About The Pull Request

This revises the descriptions for the smoker/alcoholic quirk memories to actually mention the preferred brand:



## Why It's Good For The Game

Because memories should help you, well, remember stuff, and "Joe's smoking problem" is kinda useless when you've forgotten _which_ brand your character prefers.

`[name]'s smoking problem.` -> `[name]'s addiction to [preferred_brand] cigarettes.`
`[name]'s drinking problem.` -> `[name]'s addiction to [preferred_brandy] alcohol.`

## Changelog
:cl:
qol: The memories for Smoker and Alcoholic now actually mention the preferred brand.
/:cl:
