### PR TITLE
Plexagon Access Management now tells you that you need a Trim to use Templates for ID cards

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -99,7 +99,6 @@ export const NtosCardContent = (props) => {
         }
         {!hasTrim &&
           "Templates require a trim already applied to the card. Please use an ID Painter to apply a trim."
-		  
         }
         </Section>
       )}

--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -94,12 +94,9 @@ export const NtosCardContent = (props) => {
             />
           }
         >
-        {!!hasTrim &&
-          <TemplateDropdown templates={templates} />
-        }
-        {!hasTrim &&
-          "Templates require a trim already applied to the card. Please use an ID Painter to apply a trim."
-        }
+          {!!hasTrim && <TemplateDropdown templates={templates} />}
+          {!hasTrim &&
+            'Templates require a trim already applied to the card. Please use an ID Painter to apply a trim.'}
         </Section>
       )}
       <Stack mt={1}>

--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -69,6 +69,7 @@ export const NtosCardContent = (props) => {
     trimAccess,
     wildcardFlags,
     wildcardSlots,
+    hasTrim,
   } = data;
 
   return (
@@ -93,7 +94,13 @@ export const NtosCardContent = (props) => {
             />
           }
         >
+        {!!hasTrim &&
           <TemplateDropdown templates={templates} />
+        }
+        {!hasTrim &&
+          "Templates require a trim already applied to the card. Please use an ID Painter to apply a trim."
+		  
+        }
         </Section>
       )}
       <Stack mt={1}>

--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -94,9 +94,11 @@ export const NtosCardContent = (props) => {
             />
           }
         >
-          {!!hasTrim && <TemplateDropdown templates={templates} />}
-          {!hasTrim &&
-            'Templates require a trim already applied to the card. Please use an ID Painter to apply a trim.'}
+          {hasTrim ? (
+            <TemplateDropdown templates={templates} />
+          ) : (
+            'Templates require a trim already applied to the card. Please use an ID Painter to apply a trim.'
+          )}
         </Section>
       )}
       <Stack mt={1}>


### PR DESCRIPTION

## About The Pull Request
Plexagon Access Management now removes the Templates dropdown, and puts in a note about trim in its place, if the inserted card does not have a trim attached.
## Why It's Good For The Game
You can't apply a template without a trim on the card. The proc that handles it does a bitwise AND between what the template and the trim have for access, and applies it to the ID card. This is not mentioned anywhere in the program.

I spent hours tracing ID procs trying to find the supposed bug preventing templates from applying before I stumbled upon this. So now it tells the user.

I do not know why you're allowed to choose templates that aren't related to the currently applied trim, but that's out of scope for my frustration.
## Changelog
:cl:
qol: Plexagon Access Management now tells you that you need an ID Trim before applying a Template, rather than silently failing.
/:cl:
