### PR TITLE
monkeys cant turn into legion anymore

### DIFF
--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -47,7 +47,7 @@
 	return ..()
 
 /mob/living/basic/legion_brood/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)
-	if (ishuman(target) && target.stat > SOFT_CRIT)
+	if (ishuman(target) && target.stat > SOFT_CRIT && !ismonkey(target))
 		infest(target)
 		return
 


### PR DESCRIPTION

## About The Pull Request

monkeys cant turn into legion anymore

will close this if it costs gbp or gets 15 downreddits

## Why It's Good For The Game

i think the gimmick of 300 legions making a part of the station uninhabitable for very little effort has run its course, they were never meant to do that

## Changelog

:cl:
fix: monkeys cant turn into legion anymore
/:cl:

