### PR TITLE
Slightly improves "icebox safe" mob temperature variance tolerance

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -47,7 +47,7 @@
 /// The maximum temperature of Lavaland
 #define LAVALAND_MAX_TEMPERATURE 350
 /// The minimum temperature of Icebox
-#define ICEBOX_MIN_TEMPERATURE 180
+#define ICEBOX_MIN_TEMPERATURE 178
 
 /// The natural temperature for a body
 #define BODYTEMP_NORMAL 310.15


### PR DESCRIPTION
## About The Pull Request

Fixes a random CI error we have had a couple of times by slightly reducing the minimum temperature define which is understood to be safe for Icebox mobs.

## Why It's Good For The Game

There is a small amount of variance in temperature which meant that this was sometimes not actually an icebox-safe temperature, which would kill the mob shortly after spawn and also lead to thrown errors during CI as the mob detects it has spawned in an unviable location.

## Changelog

:cl:
fix: Mobs considered to be able to live safely in Icebox's temperature should now be able to live safely in Icebox's temperature
/:cl:
