### PR TITLE
Fixes Bubblegums Melee Cooldown

### DIFF
--- a/code/datums/actions/mobs/charge.dm
+++ b/code/datums/actions/mobs/charge.dm
@@ -24,7 +24,7 @@
 /datum/action/cooldown/mob_cooldown/charge/Activate(atom/target_atom)
 	disable_cooldown_actions()
 	// No charging and meleeing (overridded by StartCooldown after charge ends)
-	next_melee_use_time = world.time + 10 SECONDS
+	next_melee_use_time = world.time + 100 SECONDS
 	charge_sequence(owner, target_atom, charge_delay, charge_past)
 	StartCooldown()
 	enable_cooldown_actions()

--- a/code/datums/actions/mobs/charge.dm
+++ b/code/datums/actions/mobs/charge.dm
@@ -23,6 +23,8 @@
 
 /datum/action/cooldown/mob_cooldown/charge/Activate(atom/target_atom)
 	disable_cooldown_actions()
+	// No charging and meleeing (overridded by StartCooldown after charge ends)
+	next_melee_use_time = world.time + 10 SECONDS
 	charge_sequence(owner, target_atom, charge_delay, charge_past)
 	StartCooldown()
 	enable_cooldown_actions()


### PR DESCRIPTION
## About The Pull Request

Fixes #63886 

(The previous pr to fix added melee cooldown time but that only applies after the ability ends)

Adds a cooldown to melee before the bubblegum starts charging so it won't melee while charging.

## Why It's Good For The Game

This is how Bubblegum's charge worked before mob abilities but at the time of this abilities creation melee cooldowns were not apart of mob abilities and did not work properly together.

## Changelog

:cl:
fix: Bubblegum can no longer melee you while using his charge abilities.
/:cl:
