### PR TITLE
Increase wildcard slots on grey and silver IDs [NO GBP]

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -10,12 +10,12 @@
  * explicitly equal 0 for all compatible wildcard slots.
  */
 
-/// Wildcard slot define for basic grey cards. Only hold 2 common wildcards.
-#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 2, usage = list()))
-/// Wildcard slot define for Head of Staff silver cards. Can hold 3 common, 1 command and 1 private command.
+/// Wildcard slot define for basic grey cards. Only hold 4 common wildcards.
+#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 4, usage = list()))
+/// Wildcard slot define for Head of Staff silver cards. Can hold 6 common, 2 command and 1 private command.
 #define WILDCARD_LIMIT_SILVER list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
+	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
 	WILDCARD_NAME_PRV_COMMAND = list(limit = 1, usage = list()) \
 )
 /// Wildcard slot define for Captain gold cards. Can hold infinite of any Captain level wildcard.
@@ -28,10 +28,10 @@
 #define WILDCARD_LIMIT_CENTCOM list(WILDCARD_NAME_CENTCOM = list(limit = -1, usage = list()))
 /// Wildcard slot define for Prisoner orange cards. No wildcard slots.
 #define WILDCARD_LIMIT_PRISONER list()
-/// Wildcard slot define for Chameleon/Agent ID grey cards. Can hold 3 common, 1 command and 1 captain access.
+/// Wildcard slot define for Chameleon/Agent ID grey cards. Can hold 6 common, 2 command and 1 captain access.
 #define WILDCARD_LIMIT_CHAMELEON list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
+	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
 	WILDCARD_NAME_CAPTAIN = list(limit = 1, usage = list()) \
 )
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.


### PR DESCRIPTION
## About The Pull Request

Increases the amount of wildcard access slots on the grey and silver IDs.

Grey: 2 > 4 common wildcard slots
Silver: 3 > 6 common wildcard slots, 1 > 2 command wildcard slots

## Why It's Good For The Game

This allows a wider range of ID changes to be performed by the HoP without access to the trim printer or issue a second ID card. With the amount of variation between slots that a particular trim has, this allows for better ID customization while leaving the crewmember with their originally assigned trim.

## Changelog

:cl: LT3
balance: Doubled number of assignable wildcard slots on grey ID cards
balance: Doubled number of assignable wildcard slots on silver ID cards
balance: Doubled number of assignable wildcard slots on agent/chameleon ID cards
/:cl: