### PR TITLE
Spacecoin market now shows where it will land with animated circle

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -227,8 +227,8 @@
 /obj/effect/dumpeet_target
 	name = "Landing Zone Indicator"
 	desc = "A holographic projection designating the landing zone of something. It's probably best to stand back."
-	icon = 'icons/mob/actions/actions_items.dmi'
-	icon_state = "sniper_zoom"
+	icon = 'icons/mob/telegraphing/telegraph_holographic.dmi'
+	icon_state = "target_circle"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 	light_range = 2
 	var/obj/effect/dumpeet_fall/DF


### PR DESCRIPTION
## About The Pull Request

Spacecoin market telegraph was changed so it will not be just sniper scope button icon
![image](https://github.com/tgstation/tgstation/assets/99420088/806ba78e-8f7b-4caa-8398-a3e22561d6ea)

## Why It's Good For The Game

Sniper scope icon as telegraph for spacecoin looks shitty, this pr fixes that
## Changelog
:cl:
code: crab17 telegraph now uses animated spinning telegraph circle instead of sniper scope button
/:cl:
