### PR TITLE
[NO GBP] Fixes drake empowerment for berserker armor by adding drake remains, which are used to make drake armor and empower the suit

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -255,10 +255,19 @@
 /datum/crafting_recipe/drakecloak
 	name = "Ash Drake Armour"
 	result = /obj/item/clothing/suit/hooded/cloak/drake
-	time = 6 SECONDS
+	time = 4 SECONDS
+	reqs = list(
+		/obj/item/stack/sheet/sinew = 2,
+		/obj/item/drake_remains = 1,
+	)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/drakeremains
+	name = "Drake Remains"
+	result = /obj/item/drake_remains
+	time = 1 SECONDS
 	reqs = list(
 		/obj/item/stack/sheet/bone = 10,
-		/obj/item/stack/sheet/sinew = 2,
 		/obj/item/stack/sheet/animalhide/ashdrake = 5,
 	)
 	category = CAT_CLOTHING

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -33,6 +33,7 @@
 	export_types = list(
 		/obj/item/dragons_blood,
 		/obj/item/guardian_creator/miner,
+		/obj/item/drake_remains,
 		/obj/item/lava_staff,
 		/obj/item/melee/ghost_sword,
 		/obj/item/prisoncube,

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -661,8 +661,8 @@
 	name = "berserker armor"
 	desc = "This hulking armor seems to possess some kind of dark force within; howling in rage, hungry for carnage. \
 		The self-sealing stem bolts that allowed this suit to be spaceworthy have long since corroded. However, the entity \
-		sealed within the suit seems to hunger for the fleeting lifeforce found in the remains left within drake armor. \
-		Feeding it seems to empower a suit piece, though turns the drake armor back to lifeless ash."
+		sealed within the suit seems to hunger for the fleeting lifeforce found in the remains left in the remains of drakes. \
+		Feeding it drake remains seems to empower a suit piece, though turns the remains back to lifeless ash."
 	icon_state = "berserker"
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
@@ -697,7 +697,7 @@
 /obj/item/clothing/suit/hooded/berserker/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/anti_magic, ALL, inventory_flags = ITEM_SLOT_OCLOTHING)
-	AddComponent(/datum/component/armor_plate, maxamount = 1, upgrade_item = /obj/item/clothing/suit/hooded/cloak/drake, armor_mod = /datum/armor/drake_empowerment, upgrade_prefix = "empowered")
+	AddComponent(/datum/component/armor_plate, maxamount = 1, upgrade_item = /obj/item/drake_remains, armor_mod = /datum/armor/drake_empowerment, upgrade_prefix = "empowered")
 	allowed = GLOB.mining_suit_allowed
 
 #define MAX_BERSERK_CHARGE 100
@@ -710,8 +710,8 @@
 	name = "berserker helmet"
 	desc = "This burdensome helmet seems to possess some kind of dark force within; howling in rage, hungry for carnage. \
 		The self-sealing stem bolts that allowed this helmet to be spaceworthy have long since corroded. However, the entity \
-		sealed within the suit seems to hunger for the fleeting lifeforce found in the remains left within drake armor. \
-		Feeding it seems to empower a suit piece, though turns the drake armor back to lifeless ash."
+		sealed within the suit seems to hunger for the fleeting lifeforce found in the remains left in the remains of drakes. \
+		Feeding it drake remains seems to empower a suit piece, though turns the remains back to lifeless ash."
 	icon_state = "berserker"
 	icon = 'icons/obj/clothing/head/helmet.dmi'
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
@@ -732,7 +732,7 @@
 /obj/item/clothing/head/hooded/berserker/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, LOCKED_HELMET_TRAIT)
-	AddComponent(/datum/component/armor_plate, maxamount = 1, upgrade_item = /obj/item/clothing/suit/hooded/cloak/drake, armor_mod = /datum/armor/drake_empowerment, upgrade_prefix = "empowered")
+	AddComponent(/datum/component/armor_plate, maxamount = 1, upgrade_item = /obj/item/drake_remains, armor_mod = /datum/armor/drake_empowerment, upgrade_prefix = "empowered")
 
 /obj/item/clothing/head/hooded/berserker/examine()
 	. = ..()
@@ -799,6 +799,16 @@
 #undef DAMAGE_TO_CHARGE_SCALE
 #undef CHARGE_DRAINED_PER_SECOND
 #undef BERSERK_ATTACK_SPEED_MODIFIER
+
+/obj/item/drake_remains
+	name = "drake remains"
+	desc = "The gathered remains of a drake. It still crackles with heat, and smells distinctly of brimstone."
+	icon = 'icons/obj/clothing/head/helmet.dmi'
+	icon_state = "dragon"
+
+/obj/item/drake_remains/Initialize(mapload)
+	. = ..()
+	particles = new /particles/bonfire()
 
 /obj/item/clothing/glasses/godeye
 	name = "eye of god"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/83684

Adds an intermediary item called drake remains, which are used to construct drake armor and empower berserker armor.

There is no functional balance change here, as the components to make a drake armor are relatively the same.

## Why It's Good For The Game

I borked it. This is the most reasonable and flexible method to fix the bug and what I should have done in the first place.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Drake empowerment for berserker armor now uses valuable drake remains, made from ashdrake hides and bones.
add: Drake armor is made use drake remains to construct. (This is a net neutral to the previous recipe)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
