### PR TITLE
Fixes disconnected apc in MetaCargo

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15201,6 +15201,7 @@
 	},
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "fvE" = (
@@ -48105,7 +48106,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/nuke_storage)
 "qYW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -67812,6 +67812,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "xLR" = (


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/tgstation/assets/109891564/f3f07293-95cd-482e-a948-4087f4a26aa3)
(This apc was disconnected from the powerline entirely
## Why It's Good For The Game
Fix bug get point
## Changelog
:cl:
fix: Fixed disconnected APC in Metastation Cargo Lobby
/:cl:
