### PR TITLE
Right-Click To Unset Keybinding Slot

### DIFF
--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -6,6 +6,7 @@
 		"reset_all_keybinds" = PROC_REF(reset_all_keybinds),
 		"reset_keybinds_to_defaults" = PROC_REF(reset_keybinds_to_defaults),
 		"set_keybindings" = PROC_REF(set_keybindings),
+		"unset_keybinding" = PROC_REF(unset_keybinding),
 	)
 
 /datum/preference_middleware/keybindings/get_ui_static_data(mob/user)
@@ -75,6 +76,23 @@
 	preferences.key_bindings[keybind_name] = hotkeys
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 
+	user.client.update_special_keybinds()
+
+	return TRUE
+
+/datum/preference_middleware/keybindings/proc/unset_keybinding(list/params, mob/user)
+	var/keybind_name = params["keybind_name"]
+
+	if (isnull(GLOB.keybindings_by_name[keybind_name]))
+		return FALSE
+
+	var/keybind_slot = params["slot"]
+	var/keybindings_list = preferences.key_bindings[keybind_name]
+
+	keybindings_list[keybind_slot] = "Unbound"
+	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
+
+	preferences.update_static_data(user)
 	user.client.update_special_keybinds()
 
 	return TRUE

--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -80,6 +80,7 @@
 
 	return TRUE
 
+/// Sets the specific position of a keybinding's list to "Unbound" in order to help the user unset things they don't want.
 /datum/preference_middleware/keybindings/proc/unset_keybinding(list/params, mob/user)
 	var/keybind_name = params["keybind_name"]
 

--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -83,14 +83,15 @@
 /// Sets the specific position of a keybinding's list to "Unbound" in order to help the user unset things they don't want.
 /datum/preference_middleware/keybindings/proc/unset_keybinding(list/params, mob/user)
 	var/keybind_name = params["keybind_name"]
+	var/current_binding = params["current_binding"]
 
-	if (isnull(GLOB.keybindings_by_name[keybind_name]))
+	if (isnull(GLOB.keybindings_by_name[keybind_name]) || isnull(current_binding)) // no need to do any work if we're already unbound
 		return FALSE
 
 	var/keybind_slot = params["slot"] + 1 // fuck you byond
 	var/keybindings_list = preferences.key_bindings[keybind_name]
 
-	keybindings_list[keybind_slot] = "Unbound"
+	keybindings_list[keybind_slot] = null
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 
 	preferences.update_static_data(user)

--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -86,7 +86,7 @@
 	if (isnull(GLOB.keybindings_by_name[keybind_name]))
 		return FALSE
 
-	var/keybind_slot = params["slot"]
+	var/keybind_slot = params["slot"] + 1 // fuck you byond
 	var/keybindings_list = preferences.key_bindings[keybind_name]
 
 	keybindings_list[keybind_slot] = "Unbound"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -443,6 +443,7 @@ export class KeybindingsPage extends Component<{}, KeybindingsPageState> {
                                       onContextMenu={(e) => {
                                         act('unset_keybinding', {
                                           keybind_name: keybindingId,
+                                          current_binding: keys[key],
                                           slot: key,
                                         });
                                       }}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -117,6 +117,7 @@ const moveToBottom = (entries: [string, unknown][], findCategory: string) => {
 class KeybindingButton extends Component<{
   currentHotkey?: string;
   onClick?: () => void;
+  onContextMenu?: () => void;
   typingHotkey?: string;
 }> {
   shouldComponentUpdate(nextProps) {
@@ -127,7 +128,7 @@ class KeybindingButton extends Component<{
   }
 
   render() {
-    const { currentHotkey, onClick, typingHotkey } = this.props;
+    const { currentHotkey, onClick, onContextMenu, typingHotkey } = this.props;
 
     const child = (
       <Button
@@ -137,6 +138,10 @@ class KeybindingButton extends Component<{
         onClick={(event) => {
           event.stopPropagation();
           onClick?.();
+        }}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          onContextMenu?.();
         }}
         selected={typingHotkey !== undefined}
       >
@@ -435,6 +440,11 @@ export class KeybindingsPage extends Component<{}, KeybindingsPageState> {
                                         keybindingId,
                                         key,
                                       )}
+                                      onContextMenu={(e) => {
+                                        act('reset_keybinds_to_defaults', {
+                                          keybind_name: keybindingId,
+                                        });
+                                      }}
                                     />
                                   </Stack.Item>
                                 ))}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -441,8 +441,9 @@ export class KeybindingsPage extends Component<{}, KeybindingsPageState> {
                                         key,
                                       )}
                                       onContextMenu={(e) => {
-                                        act('reset_keybinds_to_defaults', {
+                                        act('unset_keybinding', {
                                           keybind_name: keybindingId,
+                                          slot: key,
                                         });
                                       }}
                                     />


### PR DESCRIPTION

## About The Pull Request

On the tin, you can right click any keybinding slot **OUTSIDE OF THE EDITING CONTEXT** in order to set it to "Unbound". The code might be a bit wonky but:

✅ This code has been tested.
## Why It's Good For The Game

Important that users can unbind any key that they don't want bound while playing the game. Now you can either left-click on the preferences button to edit it or right click it to unset it. Neato burrito.
## Changelog
:cl:
fix: Unbinding keybinds should work now, just right-click (outside of the editing context (when the button turns green)) in order to set any key's binding to Unbound.
/:cl:
