### PR TITLE
Significantly increase screen shaking from bomb

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -60,7 +60,7 @@
 /// The minimum temperature hydrogen combusts at.
 #define HYDROGEN_MINIMUM_BURN_TEMPERATURE FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 /// The amount of energy released by burning one mole of hydrogen.
-#define FIRE_HYDROGEN_ENERGY_RELEASED 2.8e10
+#define FIRE_HYDROGEN_ENERGY_RELEASED 2.8e6
 /// Multiplier for hydrogen fire with O2 moles * HYDROGEN_OXYGEN_FULLBURN for the maximum fuel consumption
 #define HYDROGEN_OXYGEN_FULLBURN 10
 /// The divisor for the maximum hydrogen burn rate. (1/2 of the hydrogen can burn in one reaction tick.)

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -60,7 +60,7 @@
 /// The minimum temperature hydrogen combusts at.
 #define HYDROGEN_MINIMUM_BURN_TEMPERATURE FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 /// The amount of energy released by burning one mole of hydrogen.
-#define FIRE_HYDROGEN_ENERGY_RELEASED 2.8e6
+#define FIRE_HYDROGEN_ENERGY_RELEASED 2.8e10
 /// Multiplier for hydrogen fire with O2 moles * HYDROGEN_OXYGEN_FULLBURN for the maximum fuel consumption
 #define HYDROGEN_OXYGEN_FULLBURN 10
 /// The divisor for the maximum hydrogen burn rate. (1/2 of the hydrogen can burn in one reaction tick.)

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -556,14 +556,14 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 				listener.playsound_local(epicenter, null, far_volume, TRUE, frequency, sound_to_use = echo_sound, distance_multiplier = 0)
 
 			if(base_shake_amount || quake_factor)
-				base_shake_amount = max(base_shake_amount, quake_factor * 5, 0) // Devastating explosions rock the station and ground
+				base_shake_amount = max(base_shake_amount, quake_factor * 6, 0) // Devastating explosions rock the station and ground
 				shake_camera(listener, FAR_SHAKE_DURATION, min(base_shake_amount, FAR_SHAKE_CAP))
 
 		else if(!isspaceturf(listener_turf) && echo_factor) // Big enough explosions echo through the hull.
 			var/echo_volume
 			if(quake_factor)
 				echo_volume = 60
-				shake_camera(listener, FAR_SHAKE_DURATION, clamp(quake_factor / 4, 0, FAR_SHAKE_CAP))
+				shake_camera(listener, FAR_SHAKE_DURATION, clamp(quake_factor / 2, 0, FAR_SHAKE_CAP))
 			else
 				echo_volume = 40
 			listener.playsound_local(epicenter, null, echo_volume, TRUE, frequency, sound_to_use = echo_sound, distance_multiplier = 0)

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -556,7 +556,7 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 				listener.playsound_local(epicenter, null, far_volume, TRUE, frequency, sound_to_use = echo_sound, distance_multiplier = 0)
 
 			if(base_shake_amount || quake_factor)
-				base_shake_amount = max(base_shake_amount, quake_factor * 3, 0) // Devastating explosions rock the station and ground
+				base_shake_amount = max(base_shake_amount, quake_factor * 5, 0) // Devastating explosions rock the station and ground
 				shake_camera(listener, FAR_SHAKE_DURATION, min(base_shake_amount, FAR_SHAKE_CAP))
 
 		else if(!isspaceturf(listener_turf) && echo_factor) // Big enough explosions echo through the hull.


### PR DESCRIPTION
## About The Pull Request
Increases the amount of screen shake for the average ordinance bomb
## Why It's Good For The Game
Lately Ive been getting back into toxin/ordinance and completing maximum sized bomb for research according to the wiki. The sad thing is the screen shake and size report is so small now that people do not say nice anymore when completing these bombs. By increasing the screen shake I am making a bigger impression on the crew and hopefully reestablish the tradition of saying "nice" everytime someone does these bombs. The reason behind this is entirely aesthetic as i want people to be more impressed by the sub department that announces itself rarely.
Demonstration bombs are all done using wiki mix with the exception of plasma being heated to 3000K
Current bomb:


https://github.com/tgstation/tgstation/assets/92416224/faa0024c-a9fc-4347-af05-b9c363ea0d37

New bomb:


https://github.com/tgstation/tgstation/assets/92416224/f0605bd8-15e0-42de-a18f-db63fa9c0151
## Changelog
:cl:
qol: Increase the screen shake of bombs to make ordinance bomb more noticeable to crew
/:cl:
