### PR TITLE
lowers mutadone pill volume from 50 to 5

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -162,7 +162,7 @@
 	name = "mutadone pill"
 	desc = "Used to treat genetic damage."
 	icon_state = "pill20"
-	list_reagents = list(/datum/reagent/medicine/mutadone = 50)
+	list_reagents = list(/datum/reagent/medicine/mutadone = 5)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/salicylic


### PR DESCRIPTION
## About The Pull Request
This pr lowers the volume for roundstart mutadone pills from 50 to 5

## Why It's Good For The Game
Realisticly you only need a single unit of mutadone and it will wipe all your mutations 50 units in roundstart bottles were overkill it would mean genetics would start with 250 units of mutadone which would have upto 250 uses lowering the amount will also be more player friendly that uses a pill to change a mutation or something quick and not have 50 units run trough their system and unable to add powers to themselves for the next 10 minutes

## Changelog

:cl:
balance: Roundstart mutadone pills now have less chems in them from 50 to 5
/:cl:
