### PR TITLE
Fixes Icebox active turfs in an attempt to save Peter Junior from cold

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -48074,9 +48074,6 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
-"otC" = (
-/turf/open/genturf,
-/area/icemoon/surface/outdoors/nospawn)
 "otG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -272422,7 +272419,7 @@ wNO
 aaX
 wNO
 wNO
-otC
+bln
 hHG
 hHG
 hHG


### PR DESCRIPTION

## About The Pull Request
Fixes ATs caused by ungen turf being inside explored area. May or may not fix icebox CI failure caused by atmos inside some ruins being a fraction of degree lower (and causing to peter jr and icebox foxes to die horrible death). Completely unrelated problems but for some reason as soon as I replaced ungen turf with normal snow, every ruin stopped having slightly different atmos composition. Why and how is beyond me.
## Why It's Good For The Game
HEY! LISTEN! Right now were wasted processing 4 turf(s) 

lets not waste right nows
## Changelog
