### PR TITLE
Adds the Cytology Lab to Wawa

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2096,16 +2096,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aIX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "aJa" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -4994,6 +4989,14 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/upper)
+"bMK" = (
+/obj/item/flashlight/glowstick/orange{
+	start_on = 1;
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "bMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5111,6 +5114,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"bPg" = (
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "bPu" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/turf_decal/stripes/line{
@@ -10573,12 +10583,17 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "dOg" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/item/petri_dish{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/food/pizzaslice/moldy/bacteria{
+	pixel_y = 15;
+	pixel_x = 3
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "dOv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -10751,11 +10766,9 @@
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "dRh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/door_assembly/door_assembly_science,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/obj/structure/closet/secure_closet/cytology,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "dRi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -11026,17 +11039,16 @@
 /area/station/medical/storage)
 "dVp" = (
 /turf/closed/wall,
-/area/station/science/auxlab)
+/area/station/science/cytology)
 "dVs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "dVt" = (
-/obj/structure/barricade/wooden/crude,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/science/cytology)
 "dVu" = (
 /obj/structure/railing{
 	dir = 8
@@ -14086,10 +14098,9 @@
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "fdN" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "fdQ" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette,
@@ -15622,12 +15633,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fFg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/item/flashlight/glowstick/cyan{
+	start_on = 1;
+	pixel_y = 7
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "fFj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -16286,6 +16297,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"fQd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "fQf" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/spawner/random/trash/soap{
@@ -16505,6 +16522,10 @@
 "fTX" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"fUh" = (
+/mob/living/carbon/human/species/monkey,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "fUj" = (
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/effect/turf_decal/stripes/end,
@@ -19131,11 +19152,16 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gTf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/wirecutters,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/swab{
+	pixel_x = 15
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "gTh" = (
 /obj/structure/table/wood,
 /obj/item/gift,
@@ -21028,6 +21054,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"hxW" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "hye" = (
 /obj/effect/spawner/random/structure/closet_empty/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -22611,6 +22643,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
+"idD" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/machinery/door/airlock/maintenance/external/glass,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "idH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -22754,6 +22793,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/xenobiology)
+"ieZ" = (
+/obj/machinery/plumbing/input{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "ifc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/firealarm/directional/south,
@@ -23265,12 +23311,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "ipx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "ipJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -24381,8 +24426,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iJT" = (
-/turf/closed/wall/r_wall,
-/area/station/science/auxlab)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "iKb" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "ordstorage"
@@ -30542,6 +30589,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central)
+"kQn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/openspace,
+/area/station/science/research)
 "kQt" = (
 /obj/structure/sign/warning/yes_smoking/circle/directional/west,
 /obj/item/cigbutt,
@@ -33285,6 +33336,15 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"lPo" = (
+/obj/structure/closet,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "lPp" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/power/emitter,
@@ -35219,6 +35279,7 @@
 "mzB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/closet/firecloset/full,
+/obj/structure/sign/departments/science/alt/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mzI" = (
@@ -36383,14 +36444,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "mWS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/glass,
-/obj/item/stack/rods/two,
-/obj/item/shard,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/obj/machinery/duct,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "mWX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -36426,14 +36482,11 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "mXJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/broken/directional/south,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "mXK" = (
 /obj/item/clothing/mask/gas/clown_hat,
 /obj/effect/decal/remains/human,
@@ -40847,12 +40900,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oGQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/obj/structure/chair,
-/obj/item/restraints/handcuffs/cable/zipties/used,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/obj/structure/table,
+/obj/structure/microscope,
+/obj/item/storage/box/beakers{
+	pixel_y = 18;
+	pixel_x = -14
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "oGX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -41502,14 +41557,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "oSG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/south,
-/obj/structure/fluff/broken_canister_frame,
-/obj/machinery/camera/autoname/directional/west{
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "oSJ" = (
 /obj/structure/stairs/east,
 /turf/open/floor/iron/white/smooth_large,
@@ -41726,7 +41778,6 @@
 "oWg" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/science/lobby)
 "oWr" = (
@@ -42395,6 +42446,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"pir" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "piu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -43002,6 +43058,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"psO" = (
+/turf/closed/wall/r_wall,
+/area/station/science/cytology)
 "psT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51019,6 +51078,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"scI" = (
+/obj/effect/mob_spawn/corpse/human/clown,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "scS" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/sand/plating,
@@ -51937,9 +52001,8 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/welded,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "stj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
@@ -52056,10 +52119,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "suw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/machinery/chem_master,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "suB" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/liqueur{
@@ -56128,11 +56190,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "tQI" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "tQM" = (
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/airlock/mining{
@@ -57041,6 +57101,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"uha" = (
+/obj/machinery/plumbing/growing_vat,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "uhc" = (
 /turf/open/floor/grass,
 /area/station/science/genetics)
@@ -58583,6 +58647,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/solars/port)
+"uJj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/knife/kitchen{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/soap{
+	pixel_y = -2
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "uJt" = (
 /obj/effect/mapping_helpers/engraving,
 /turf/closed/wall,
@@ -60361,13 +60440,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vqN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "vqY" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -60624,6 +60698,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"vxK" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "vxX" = (
 /turf/closed/mineral/random/stationside/asteroid/porus{
 	mineralChance = 20
@@ -67102,10 +67186,27 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "xNo" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
+/obj/structure/table,
+/obj/machinery/light/small/directional/east,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 14;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_y = 7;
+	pixel_x = 10
+	},
+/obj/item/book/manual/wiki/cytology{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/biopsy_tool{
+	pixel_x = -14;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "xNp" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -167229,7 +167330,7 @@ vxX
 vxX
 vxX
 vxX
-gMk
+xUx
 uet
 vxX
 vxX
@@ -167483,13 +167584,13 @@ tqD
 gQu
 gvF
 vxX
+fFg
 gMk
 gMk
+fUh
 gMk
 gMk
-gMk
-gMk
-gMk
+vxX
 vxX
 vxX
 vxX
@@ -167743,10 +167844,10 @@ gMk
 fXf
 gMk
 gMk
-vxX
-vxX
 gMk
 gMk
+gMk
+scI
 vxX
 vxX
 vxX
@@ -167997,11 +168098,11 @@ gOc
 gOc
 gvF
 vxX
-vxX
-vxX
-vxX
-vxX
-vxX
+xUx
+gMk
+gMk
+gMk
+gMk
 gMk
 gMk
 vxX
@@ -168255,9 +168356,9 @@ gOc
 gvF
 vxX
 vxX
-vxX
-vxX
+uet
 gMk
+uha
 gMk
 gMk
 gMk
@@ -168512,9 +168613,9 @@ gOc
 gvF
 vxX
 vxX
-vxX
-vxX
-vxX
+lPo
+gMk
+mWS
 gMk
 gMk
 gMk
@@ -168770,9 +168871,9 @@ gvF
 vxX
 vxX
 vxX
-vxX
-vxX
-vxX
+gMk
+mWS
+bMK
 vxX
 vxX
 gMk
@@ -169027,8 +169128,8 @@ cMZ
 cMZ
 cMZ
 vxX
-vxX
-vxX
+uet
+mWS
 vxX
 vxX
 uet
@@ -169283,10 +169384,10 @@ nas
 bbe
 ycq
 cMZ
+psO
+dVt
 iJT
-iJT
-iJT
-vxX
+psO
 vxX
 vxX
 gMk
@@ -169542,9 +169643,9 @@ jnw
 gKt
 gTf
 dOg
-iJT
-iJT
-vxX
+ieZ
+psO
+psO
 vxX
 gMk
 vxX
@@ -169800,9 +169901,9 @@ gKt
 oGQ
 aIX
 oSG
-iJT
-vxX
-gMk
+bPg
+dVt
+fQd
 gMk
 xUx
 uet
@@ -170058,8 +170159,8 @@ xNo
 suw
 fdN
 tQI
-gMk
-gMk
+idD
+fQd
 gMk
 gMk
 gMk
@@ -170313,9 +170414,9 @@ dpp
 gKt
 dVp
 dRh
-mWS
-iJT
-vxX
+fdN
+vxK
+psO
 vxX
 gMk
 gMk
@@ -170571,10 +170672,10 @@ mzB
 dVp
 vqN
 mXJ
-iJT
-vxX
+hxW
+psO
 uKm
-aXH
+pir
 gMk
 ent
 vxX
@@ -170827,11 +170928,11 @@ iHH
 iHH
 sti
 ipx
-fFg
-iJT
+ipx
+uJj
+psO
 vxX
-vxX
-gMk
+uet
 gMk
 vxX
 vxX
@@ -171085,8 +171186,8 @@ frG
 dVp
 dVt
 dVt
-iJT
-vxX
+psO
+psO
 vxX
 vxX
 vxX
@@ -172110,7 +172211,7 @@ vRA
 vRA
 vRA
 vRA
-vRA
+kQn
 vRA
 vRA
 jxF

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -3727,13 +3727,6 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"bpI" = (
-/obj/machinery/camera/autoname/directional/west{
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "bpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance,
@@ -4917,6 +4910,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"bKL" = (
+/obj/item/flashlight/glowstick/cyan{
+	start_on = 1;
+	pixel_y = 7
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "bKQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
@@ -5819,6 +5819,11 @@
 "cdk" = (
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"cdl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "cdo" = (
 /obj/machinery/elevator_control_panel/directional/south{
 	linked_elevator_id = "aisat";
@@ -5994,6 +5999,10 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness/recreation)
+"cgu" = (
+/obj/machinery/duct,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "cgw" = (
 /obj/machinery/disposal/bin{
 	desc = "A pneumatic waste disposal unit. This one leads into space!";
@@ -8723,6 +8732,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dhR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/knife/kitchen{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/soap{
+	pixel_y = -2
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "dic" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -10095,10 +10119,6 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"dDV" = (
-/obj/machinery/plumbing/growing_vat,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "dDZ" = (
 /obj/structure/fluff/minepost,
 /turf/open/misc/asteroid,
@@ -15276,11 +15296,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
-"fzi" = (
-/obj/effect/mob_spawn/corpse/human/clown,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "fzx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -15635,9 +15650,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fFg" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "fFj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -15925,6 +15942,14 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
+"fJs" = (
+/obj/item/stock_parts/cell/bluespace{
+	rigged = 1;
+	pixel_x = -5;
+	pixel_y = -8
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "fJz" = (
 /obj/item/reagent_containers/condiment/vegetable_oil,
 /obj/machinery/grill,
@@ -16389,9 +16414,16 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "fSi" = (
-/obj/structure/microscope,
-/obj/structure/table/glass,
 /obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/hand_labeler{
+	pixel_y = 10;
+	pixel_x = -13
+	},
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
 "fSk" = (
@@ -16581,9 +16613,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fVf" = (
-/obj/item/stock_parts/cell/bluespace{
-	rigged = 1
-	},
+/obj/effect/mob_spawn/corpse/human/clown,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "fVs" = (
@@ -17089,13 +17120,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"get" = (
-/obj/item/flashlight/glowstick/cyan{
-	start_on = 1;
-	pixel_y = 7
-	},
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "gey" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/east,
@@ -18113,13 +18137,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"gxX" = (
-/obj/machinery/plumbing/input{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "gya" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/decal/cleanable/dirt,
@@ -21083,6 +21100,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"hyM" = (
+/obj/structure/closet,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "hyS" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
@@ -23003,6 +23029,22 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"ikp" = (
+/obj/structure/table,
+/obj/item/toy/plush/slimeplushie{
+	pixel_y = 12;
+	pixel_x = 3
+	},
+/obj/item/stamp{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/science/xenobiology)
 "ikD" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -23294,10 +23336,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "ipx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/small,
+/turf/closed/wall/r_wall,
 /area/station/science/cytology)
 "ipJ" = (
 /obj/effect/turf_decal/tile/red{
@@ -24186,13 +24225,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"iGA" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/full,
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/obj/machinery/door/airlock/maintenance/external/glass,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "iGC" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -24416,18 +24448,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iJT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/knife/kitchen{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/soap{
-	pixel_y = -2
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/science/cytology)
 "iKb" = (
@@ -24960,15 +24983,11 @@
 /turf/open/floor/glass/reinforced,
 /area/station/command/meeting_room)
 "iXn" = (
-/obj/structure/closet/secure_closet/cytology,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/white/textured_corner{
 	dir = 8
 	},
@@ -29161,6 +29180,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
+"kqf" = (
+/obj/machinery/plumbing/input{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "kqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -36431,8 +36457,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "mWS" = (
-/turf/closed/wall/r_wall,
-/area/station/science/cytology)
+/obj/machinery/light/small/directional/north,
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "mWX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -40898,15 +40926,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
-"oGY" = (
-/obj/structure/closet,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "oHd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable/layer3,
@@ -41983,11 +42002,6 @@
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/catwalk_floor/iron_dark/telecomms,
 /area/station/ai_monitored/turret_protected/ai)
-"oZo" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/flora/rock/pile/style_random,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "oZp" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark/telecomms,
@@ -42535,15 +42549,11 @@
 	},
 /area/station/service/theater)
 "pjL" = (
-/obj/item/book/manual/wiki/cytology{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/obj/item/biopsy_tool{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/structure/table/glass,
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
 "pjN" = (
@@ -43072,6 +43082,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pti" = (
+/obj/machinery/plumbing/growing_vat,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "ptq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44898,12 +44912,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/uppernorth)
-"pYA" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "pYE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45480,12 +45488,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"qjf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "qjk" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/space/openspace,
@@ -50830,6 +50832,10 @@
 "rZc" = (
 /turf/open/floor/cult,
 /area/station/service/chapel/office)
+"rZg" = (
+/mob/living/carbon/human/species/monkey,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "rZz" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance Bathroom"
@@ -51585,11 +51591,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
-"smg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/science/cytology)
 "smh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -54019,10 +54020,6 @@
 /obj/structure/cable,
 /turf/open/openspace,
 /area/station/engineering/supermatter/room)
-"teC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/openspace,
-/area/station/science/research)
 "teG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -55117,6 +55114,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
+"tzy" = (
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "tzT" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
@@ -58104,10 +58108,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"uyz" = (
-/obj/machinery/duct,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "uyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken/directional/east,
@@ -58286,10 +58286,10 @@
 	},
 /area/station/command/emergency_closet)
 "uCr" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 8
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Xenobiology Desk";
+	name = "Xenobiology's Fax Machine"
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
@@ -62631,14 +62631,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"wgG" = (
-/obj/item/flashlight/glowstick/orange{
-	start_on = 1;
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "wgI" = (
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
@@ -65608,6 +65600,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"xje" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "xjh" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -66283,6 +66285,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/pharmacy)
+"xwe" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/machinery/door/airlock/maintenance/external/glass,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "xwf" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -66686,6 +66695,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/station/service/library)
+"xCX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "xDf" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Security Shutters";
@@ -67905,16 +67920,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"ybN" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "ybO" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -68337,6 +68342,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"yjm" = (
+/obj/item/flashlight/glowstick/orange{
+	start_on = 1;
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "yjw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/chair/sofa/bench{
@@ -167585,10 +167598,10 @@ tqD
 gQu
 gvF
 vxX
-get
+bKL
 gMk
 gMk
-fFg
+rZg
 gMk
 gMk
 vxX
@@ -167848,7 +167861,7 @@ gMk
 gMk
 gMk
 gMk
-fzi
+fVf
 vxX
 vxX
 vxX
@@ -168359,7 +168372,7 @@ vxX
 vxX
 uet
 gMk
-dDV
+pti
 gMk
 gMk
 gMk
@@ -168614,9 +168627,9 @@ gOc
 gvF
 vxX
 vxX
-oGY
+hyM
 gMk
-uyz
+cgu
 gMk
 gMk
 gMk
@@ -168873,8 +168886,8 @@ vxX
 vxX
 vxX
 gMk
-uyz
-wgG
+cgu
+yjm
 vxX
 vxX
 gMk
@@ -169130,7 +169143,7 @@ cMZ
 cMZ
 vxX
 uet
-uyz
+cgu
 vxX
 vxX
 uet
@@ -169385,16 +169398,16 @@ nas
 bbe
 ycq
 cMZ
-mWS
+ipx
 dVt
-smg
-mWS
+cdl
+ipx
 vxX
 vxX
 gMk
 gMk
 gMk
-fVf
+gMk
 vxX
 vxX
 kTV
@@ -169644,9 +169657,9 @@ jnw
 gKt
 gTf
 dOg
-gxX
-mWS
-mWS
+kqf
+ipx
+ipx
 vxX
 gMk
 vxX
@@ -169902,9 +169915,9 @@ gKt
 oGQ
 aIX
 oSG
-bpI
+tzy
 dVt
-qjf
+xCX
 gMk
 xUx
 uet
@@ -170160,8 +170173,8 @@ xNo
 suw
 fdN
 tQI
-iGA
-qjf
+xwe
+xCX
 gMk
 gMk
 gMk
@@ -170416,8 +170429,8 @@ gKt
 dVp
 dRh
 fdN
-ybN
-mWS
+xje
+ipx
 vxX
 gMk
 gMk
@@ -170434,7 +170447,7 @@ vxX
 vxX
 vxX
 gMk
-gMk
+fJs
 vxX
 dtQ
 vxX
@@ -170673,10 +170686,10 @@ mzB
 dVp
 vqN
 mXJ
-pYA
-mWS
+iJT
+ipx
 uKm
-oZo
+mWS
 gMk
 ent
 vxX
@@ -170928,10 +170941,10 @@ bNp
 iHH
 iHH
 sti
+fFg
+fFg
+dhR
 ipx
-ipx
-iJT
-mWS
 vxX
 uet
 gMk
@@ -171187,8 +171200,8 @@ frG
 dVp
 dVt
 dVt
-mWS
-mWS
+ipx
+ipx
 vxX
 vxX
 vxX
@@ -172212,7 +172225,7 @@ vRA
 vRA
 vRA
 vRA
-teC
+vRA
 vRA
 vRA
 jxF
@@ -187387,7 +187400,7 @@ hhX
 fZF
 jQS
 uCr
-jEt
+ikp
 hLP
 cWc
 wnA

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2099,6 +2099,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark/small,
 /area/station/science/cytology)
 "aJa" = (
@@ -3726,6 +3727,13 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"bpI" = (
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "bpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance,
@@ -4989,14 +4997,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/upper)
-"bMK" = (
-/obj/item/flashlight/glowstick/orange{
-	start_on = 1;
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "bMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5114,13 +5114,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"bPg" = (
-/obj/machinery/camera/autoname/directional/west{
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "bPu" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/turf_decal/stripes/line{
@@ -10102,6 +10095,10 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"dDV" = (
+/obj/machinery/plumbing/growing_vat,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "dDZ" = (
 /obj/structure/fluff/minepost,
 /turf/open/misc/asteroid,
@@ -15279,6 +15276,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
+"fzi" = (
+/obj/effect/mob_spawn/corpse/human/clown,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "fzx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -15633,10 +15635,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fFg" = (
-/obj/item/flashlight/glowstick/cyan{
-	start_on = 1;
-	pixel_y = 7
-	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "fFj" = (
@@ -16297,12 +16296,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"fQd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "fQf" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/spawner/random/trash/soap{
@@ -16522,10 +16515,6 @@
 "fTX" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"fUh" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "fUj" = (
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/effect/turf_decal/stripes/end,
@@ -17100,6 +17089,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"get" = (
+/obj/item/flashlight/glowstick/cyan{
+	start_on = 1;
+	pixel_y = 7
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "gey" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/east,
@@ -18117,6 +18113,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"gxX" = (
+/obj/machinery/plumbing/input{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "gya" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/decal/cleanable/dirt,
@@ -21054,12 +21057,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"hxW" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "hye" = (
 /obj/effect/spawner/random/structure/closet_empty/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -22643,13 +22640,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
-"idD" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/full,
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/obj/machinery/door/airlock/maintenance/external/glass,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "idH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -22793,13 +22783,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/xenobiology)
-"ieZ" = (
-/obj/machinery/plumbing/input{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "ifc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/firealarm/directional/south,
@@ -24203,6 +24186,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"iGA" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/machinery/door/airlock/maintenance/external/glass,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "iGC" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -24426,9 +24416,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iJT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/duct,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/knife/kitchen{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/soap{
+	pixel_y = -2
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/small,
 /area/station/science/cytology)
 "iKb" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -30589,10 +30589,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central)
-"kQn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/openspace,
-/area/station/science/research)
 "kQt" = (
 /obj/structure/sign/warning/yes_smoking/circle/directional/west,
 /obj/item/cigbutt,
@@ -33336,15 +33332,6 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"lPo" = (
-/obj/structure/closet,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/obj/item/food/grown/banana,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "lPp" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/power/emitter,
@@ -36444,9 +36431,8 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "mWS" = (
-/obj/machinery/duct,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
+/turf/closed/wall/r_wall,
+/area/station/science/cytology)
 "mWX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -40912,6 +40898,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
+"oGY" = (
+/obj/structure/closet,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/banana,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "oHd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable/layer3,
@@ -41988,6 +41983,11 @@
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/catwalk_floor/iron_dark/telecomms,
 /area/station/ai_monitored/turret_protected/ai)
+"oZo" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "oZp" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark/telecomms,
@@ -42446,11 +42446,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"pir" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/flora/rock/pile/style_random,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "piu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -43058,9 +43053,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"psO" = (
-/turf/closed/wall/r_wall,
-/area/station/science/cytology)
 "psT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44906,6 +44898,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/uppernorth)
+"pYA" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "pYE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45482,6 +45480,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"qjf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "qjk" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/space/openspace,
@@ -51078,11 +51082,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"scI" = (
-/obj/effect/mob_spawn/corpse/human/clown,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "scS" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/sand/plating,
@@ -51586,6 +51585,11 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
+"smg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "smh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -54015,6 +54019,10 @@
 /obj/structure/cable,
 /turf/open/openspace,
 /area/station/engineering/supermatter/room)
+"teC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/openspace,
+/area/station/science/research)
 "teG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -57101,10 +57109,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"uha" = (
-/obj/machinery/plumbing/growing_vat,
-/turf/open/misc/asteroid,
-/area/station/asteroid)
 "uhc" = (
 /turf/open/floor/grass,
 /area/station/science/genetics)
@@ -58100,6 +58104,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"uyz" = (
+/obj/machinery/duct,
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "uyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken/directional/east,
@@ -58647,21 +58655,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/solars/port)
-"uJj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/knife/kitchen{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/soap{
-	pixel_y = -2
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "uJt" = (
 /obj/effect/mapping_helpers/engraving,
 /turf/closed/wall,
@@ -60698,16 +60691,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"vxK" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/science/cytology)
 "vxX" = (
 /turf/closed/mineral/random/stationside/asteroid/porus{
 	mineralChance = 20
@@ -62648,6 +62631,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"wgG" = (
+/obj/item/flashlight/glowstick/orange{
+	start_on = 1;
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/turf/open/misc/asteroid,
+/area/station/asteroid)
 "wgI" = (
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
@@ -67914,6 +67905,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"ybN" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "ybO" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -167584,10 +167585,10 @@ tqD
 gQu
 gvF
 vxX
+get
+gMk
+gMk
 fFg
-gMk
-gMk
-fUh
 gMk
 gMk
 vxX
@@ -167847,7 +167848,7 @@ gMk
 gMk
 gMk
 gMk
-scI
+fzi
 vxX
 vxX
 vxX
@@ -168358,7 +168359,7 @@ vxX
 vxX
 uet
 gMk
-uha
+dDV
 gMk
 gMk
 gMk
@@ -168613,9 +168614,9 @@ gOc
 gvF
 vxX
 vxX
-lPo
+oGY
 gMk
-mWS
+uyz
 gMk
 gMk
 gMk
@@ -168872,8 +168873,8 @@ vxX
 vxX
 vxX
 gMk
-mWS
-bMK
+uyz
+wgG
 vxX
 vxX
 gMk
@@ -169129,7 +169130,7 @@ cMZ
 cMZ
 vxX
 uet
-mWS
+uyz
 vxX
 vxX
 uet
@@ -169384,10 +169385,10 @@ nas
 bbe
 ycq
 cMZ
-psO
+mWS
 dVt
-iJT
-psO
+smg
+mWS
 vxX
 vxX
 gMk
@@ -169643,9 +169644,9 @@ jnw
 gKt
 gTf
 dOg
-ieZ
-psO
-psO
+gxX
+mWS
+mWS
 vxX
 gMk
 vxX
@@ -169901,9 +169902,9 @@ gKt
 oGQ
 aIX
 oSG
-bPg
+bpI
 dVt
-fQd
+qjf
 gMk
 xUx
 uet
@@ -170159,8 +170160,8 @@ xNo
 suw
 fdN
 tQI
-idD
-fQd
+iGA
+qjf
 gMk
 gMk
 gMk
@@ -170415,8 +170416,8 @@ gKt
 dVp
 dRh
 fdN
-vxK
-psO
+ybN
+mWS
 vxX
 gMk
 gMk
@@ -170672,10 +170673,10 @@ mzB
 dVp
 vqN
 mXJ
-hxW
-psO
+pYA
+mWS
 uKm
-pir
+oZo
 gMk
 ent
 vxX
@@ -170929,8 +170930,8 @@ iHH
 sti
 ipx
 ipx
-uJj
-psO
+iJT
+mWS
 vxX
 uet
 gMk
@@ -171186,8 +171187,8 @@ frG
 dVp
 dVt
 dVt
-psO
-psO
+mWS
+mWS
 vxX
 vxX
 vxX
@@ -172211,7 +172212,7 @@ vRA
 vRA
 vRA
 vRA
-kQn
+teC
 vRA
 vRA
 jxF


### PR DESCRIPTION

## About The Pull Request

Adds the Cytology Lab to Wawa! Previously they just had a desk inside Xenobio, not even their own pen or a lot of goodies. This gives them their own lab, stationed much closer to the entrance of sci (important for Cytologists who need to enter and leave lots of times during a shift), alongside a preinstalled growing vat and goodies to kickstart the projects.

![image](https://github.com/tgstation/tgstation/assets/84548101/b05c13c0-a02b-4511-8b67-9f884a65c6b4)


## Why It's Good For The Game

Cytology takes a lot of time and effort and this change gives them tons of QoL in Wawa, from faster travel times to better starting equipment. It brings Wawa's cyto to the same standard as the other stations alongside making it a lot smaller of a pain to do.

## Changelog
:cl:
add: New room in Wawastation, the Cytology Lab! Positioned behind the test fire range.
/:cl:
