### PR TITLE
reactive armor spelling

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -121,7 +121,7 @@
 	dir = 6
 	},
 /obj/structure/table/reinforced,
-/obj/item/reactive_armour_shell,
+/obj/item/reactive_armor_shell,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/misc/anomaly_research)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -1,6 +1,6 @@
 /obj/item/reactive_armour_shell
-	name = "reactive armour shell"
-	desc = "An experimental suit of armour, awaiting installation of an anomaly core."
+	name = "reactive armor shell"
+	desc = "An experimental suit of armor, awaiting installation of an anomaly core."
 	icon_state = "reactiveoff"
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -1,11 +1,11 @@
-/obj/item/reactive_armour_shell
+/obj/item/reactive_armor_shell
 	name = "reactive armor shell"
 	desc = "An experimental suit of armor, awaiting installation of an anomaly core."
 	icon_state = "reactiveoff"
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/reactive_armour_shell/attackby(obj/item/weapon, mob/user, params)
+/obj/item/reactive_armor_shell/attackby(obj/item/weapon, mob/user, params)
 	..()
 	var/static/list/anomaly_armour_types = list(
 		/obj/effect/anomaly/grav = /obj/item/clothing/suit/armor/reactive/repulse,

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -731,7 +731,7 @@
 		/datum/material/silver = SHEET_MATERIAL_AMOUNT*2.5,
 		/datum/material/gold = SHEET_MATERIAL_AMOUNT * 2.5,
 	)
-	build_path = /obj/item/reactive_armour_shell
+	build_path = /obj/item/reactive_armor_shell
 	category = list(
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
 	)

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -720,7 +720,7 @@
 // Armour
 
 /datum/design/reactive_armour
-	name = "Reactive Armour Shell"
+	name = "Reactive Armor Shell"
 	desc = "An experimental suit of armour capable of utilizing an implanted anomaly core to protect the user."
 	id = "reactive_armour"
 	build_type = PROTOLATHE | AWAY_LATHE


### PR DESCRIPTION

## About The Pull Request
All instances of reactive armor are now reactive armor, instead of some being "armour"
## Why It's Good For The Game
Consistency
## Changelog
:cl: grungussuss
spellcheck: all instances of reactive armor are now spelt the same
/:cl:
