### PR TITLE
Fixes RLD glowsticks not actually glowing

### DIFF
--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -188,12 +188,12 @@
 			if(!useResource(GLOW_STICK_COST, user))
 				return FALSE
 			activate()
-			var/obj/item/flashlight/glowstick/G = new /obj/item/flashlight/glowstick(start)
-			G.color = color_choice
-			G.set_light_color(G.color)
-			G.throw_at(A, 9, 3, user)
-			G.light_on = TRUE
-			G.update_brightness()
+			var/obj/item/flashlight/glowstick/new_stick = new /obj/item/flashlight/glowstick(start)
+			new_stick.color = color_choice
+			new_stick.set_light_color(new_stick.color)
+			new_stick.throw_at(A, 9, 3, user)
+			new_stick.turn_on()
+			new_stick.update_brightness()
 
 			return TRUE
 


### PR DESCRIPTION

## About The Pull Request

So apparently RLD glowsticks just straight up didn't glow, but also thought they were on.
Looking into it, this seemed to be an issue of it using `G.light_on = TRUE` rather than `G.turn_on()`.
Replacing it with the latter fixes our issue.

We then also just, replace the single letter variable `G`.
## Why It's Good For The Game

Y'know I think glowsticks should probably like, actually glow, right?
## Changelog
:cl:
fix: RLD glowsticks actually glow again.
/:cl:
