### PR TITLE
Fixes COMSIG_ATOM_POST_DIR_CHANGE sending the wrong oldDir argument

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -565,8 +565,9 @@
 		newdir = dir
 		return
 	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, dir, newdir)
+	var/oldDir = dir
 	dir = newdir
-	SEND_SIGNAL(src, COMSIG_ATOM_POST_DIR_CHANGE, dir, newdir)
+	SEND_SIGNAL(src, COMSIG_ATOM_POST_DIR_CHANGE, oldDir, newdir)
 	if(smoothing_flags & SMOOTH_BORDER_OBJECT)
 		QUEUE_SMOOTH_NEIGHBORS(src)
 


### PR DESCRIPTION

## About The Pull Request

It didn't cache dir, so it just sent newDir. 
## Why It's Good For The Game

im starting to hate this signal
## Changelog
:cl:
fix: COMSIG_ATOM_POST_DIR_CHANGE should ACTUALLY work now
/:cl:
