### PR TITLE
Paradox clones copy the voice.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -315,6 +315,8 @@
 	clone.fully_replace_character_name(null, dna.real_name)
 	copy_clothing_prefs(clone)
 	clone.age = age
+	clone.voice = voice
+	clone.pitch = pitch
 	dna.transfer_identity(clone, transfer_SE = TRUE, transfer_species = TRUE)
 
 	clone.dress_up_as_job(SSjob.GetJob(job))


### PR DESCRIPTION
## About The Pull Request
I have no idea if this works because I didn't setup TTS to test, but it's simple. Makes paradox clones use the victim's voice.
## Why It's Good For The Game
Closes #81450

Because it doesn't make sense for a clone to have a different voice.
## Changelog
:cl:
fix: Fixes paradox clones using a different voice from the owner.
/:cl:
