### PR TITLE
Makes photo albums as resistant as the black box

### DIFF
--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -10,7 +10,7 @@
 	lefthand_file = 'icons/mob/inhands/items/books_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/books_righthand.dmi'
 	storage_type = /datum/storage/photo_album
-	resistance_flags = FLAMMABLE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	var/persistence_id


### PR DESCRIPTION
## About The Pull Request

So since photo albums are flammable -- or otherwise vulnerable to destruction -- then you can lose every photo you have by your backpack on the ground getting burned with your album in it, thus burning your album and causing all the photos to fall out (wiping your album in the process). This PR makes photo albums as indestructible as the black box to prevent all but the most deliberate destruction of photo albums.

If you want to steal someone's album to take their photos out (why?) you can still do that.
## Why It's Good For The Game

It lets people with photo albums enter immensely dangerous situations without worrying about losing photos that they've collected over weeks, months, or years.
## Changelog
:cl: Bisar
qol: Thanks to investments in sappy memory technology, photo albums are now as resistant to destruction as the station's black box.
/:cl:
