### PR TITLE
Fix admin borg panel unable to install/remove upgrades

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -32,7 +32,7 @@
 		to_chat(borg, span_alert("Upgrade mounting error! No suitable hardpoint detected."))
 		to_chat(user, span_warning("There's no mounting point for the module!"))
 		return FALSE
-	if(!allow_duplicates && (locate(type) in borg.contents))
+	if(!allow_duplicates && (locate(type) in borg.upgrades))
 		to_chat(borg, span_alert("Upgrade mounting error! Hardpoint already occupied!"))
 		to_chat(user, span_warning("The mounting point for the module is already occupied!"))
 		return FALSE

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -134,17 +134,19 @@ ADMIN_VERB(borg_panel, R_ADMIN, "Show Borg Panel", ADMIN_VERB_NO_DESCRIPTION, AD
 			borg.fully_replace_character_name(borg.real_name,new_name)
 		if ("toggle_upgrade")
 			var/upgradepath = text2path(params["upgrade"])
-			var/obj/item/borg/upgrade/installedupgrade = locate(upgradepath) in borg
+			var/obj/item/borg/upgrade/installedupgrade = locate(upgradepath) in borg.upgrades
 			if (installedupgrade)
 				message_admins("[key_name_admin(user)] removed the [installedupgrade] upgrade from [ADMIN_LOOKUPFLW(borg)].")
 				log_silicon("[key_name(user)] removed the [installedupgrade] upgrade from [key_name(borg)].")
 				qdel(installedupgrade) // see [mob/living/silicon/robot/on_upgrade_deleted()].
 			else
 				var/obj/item/borg/upgrade/upgrade = new upgradepath(borg)
-				upgrade.action(borg, user)
-				borg.upgrades += upgrade
 				message_admins("[key_name_admin(user)] added the [upgrade] borg upgrade to [ADMIN_LOOKUPFLW(borg)].")
 				log_silicon("[key_name(user)] added the [upgrade] borg upgrade to [key_name(borg)].")
+				if(upgrade.action(borg, user))
+					borg.add_to_upgrades(upgrade)
+				else
+					qdel(upgrade)
 		if ("toggle_radio")
 			var/channel = params["channel"]
 			if (channel in borg.radio.channels) // We're removing a channel


### PR DESCRIPTION
## About The Pull Request
Fixes the admin borg panel's upgrade functionality. Caused by not registering the signals for deletion and also by the upgrade code checking the robot's contents instead of upgrades list (since the borg panel spawns the item in the borg, it appears in the borg's contents, making the check think the borg already has it installed.)
## Why It's Good For The Game
Easier testing new borg modules
## Changelog
:cl:
fix: Fixes admin borg panel upgrade functions
/:cl:
