### PR TITLE
stacking machine consoles check in area instead of a tiny view range on init

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -13,7 +13,7 @@
 /obj/machinery/mineral/stacking_unit_console/Initialize(mapload)
 	. = ..()
 	var/area/our_area = get_area(src)
-	for (var/list/zlevel_turfs as anything in our_area.get_zlevel_turf_lists())
+	for (var/list/zlevel_turfs as anything in our_area.get_zlevel_turf_lists()[z])
 		for(var/turf/area_turf as anything in zlevel_turfs)
 			var/obj/machinery/mineral/stacking_machine/found_machine = locate(/obj/machinery/mineral/stacking_machine) in area_turf
 			if(!isnull(found_machine) && isnull(found_machine.console))

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -12,12 +12,17 @@
 
 /obj/machinery/mineral/stacking_unit_console/Initialize(mapload)
 	. = ..()
-	machine = locate(/obj/machinery/mineral/stacking_machine) in view(2, src)
-	if (machine)
-		machine.console = src
+	var/area/our_area = get_area(src)
+	for (var/list/zlevel_turfs as anything in our_area.get_zlevel_turf_lists())
+		for(var/turf/area_turf as anything in zlevel_turfs)
+			var/obj/machinery/mineral/stacking_machine/found_machine = locate(/obj/machinery/mineral/stacking_machine) in area_turf
+			if(!isnull(found_machine) && isnull(found_machine.console))
+				found_machine.console = src
+				machine = found_machine
+				break
 
 /obj/machinery/mineral/stacking_unit_console/Destroy()
-	if(machine)
+	if(!isnull(machine))
 		machine.console = null
 		machine = null
 	return ..()
@@ -109,7 +114,7 @@
 	)
 
 /obj/machinery/mineral/stacking_machine/Destroy()
-	if(console)
+	if(!isnull(console))
 		console.machine = null
 		console = null
 	materials = null

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -13,7 +13,13 @@
 /obj/machinery/mineral/stacking_unit_console/Initialize(mapload)
 	. = ..()
 	var/area/our_area = get_area(src)
-	for (var/turf/area_turf as anything in our_area.get_zlevel_turf_lists()[z])
+	if(!isnull(our_area))
+		return
+	var/list/turf_lists = our_area.get_zlevel_turf_lists()
+	if(!islist(turf_lists[z]))
+		return
+	var/list/turf_list = turf_lists[z]
+	for (var/turf/area_turf as anything in turf_list)
 		var/obj/machinery/mineral/stacking_machine/found_machine = locate(/obj/machinery/mineral/stacking_machine) in area_turf
 		if(!isnull(found_machine) && isnull(found_machine.console))
 			found_machine.console = src

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -13,13 +13,12 @@
 /obj/machinery/mineral/stacking_unit_console/Initialize(mapload)
 	. = ..()
 	var/area/our_area = get_area(src)
-	for (var/list/zlevel_turfs as anything in our_area.get_zlevel_turf_lists()[z])
-		for(var/turf/area_turf as anything in zlevel_turfs)
-			var/obj/machinery/mineral/stacking_machine/found_machine = locate(/obj/machinery/mineral/stacking_machine) in area_turf
-			if(!isnull(found_machine) && isnull(found_machine.console))
-				found_machine.console = src
-				machine = found_machine
-				break
+	for (var/turf/area_turf as anything in our_area.get_zlevel_turf_lists()[z])
+		var/obj/machinery/mineral/stacking_machine/found_machine = locate(/obj/machinery/mineral/stacking_machine) in area_turf
+		if(!isnull(found_machine) && isnull(found_machine.console))
+			found_machine.console = src
+			machine = found_machine
+			break
 
 /obj/machinery/mineral/stacking_unit_console/Destroy()
 	if(!isnull(machine))

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -15,10 +15,9 @@
 	var/area/our_area = get_area(src)
 	if(!isnull(our_area))
 		return
-	var/list/turf_lists = our_area.get_zlevel_turf_lists()
-	if(!islist(turf_lists[z]))
+	var/list/turf_list = our_area.get_turfs_by_zlevel(z)
+	if(!islist(turf_list))
 		return
-	var/list/turf_list = turf_lists[z]
 	for (var/turf/area_turf as anything in turf_list)
 		var/obj/machinery/mineral/stacking_machine/found_machine = locate(/obj/machinery/mineral/stacking_machine) in area_turf
 		if(!isnull(found_machine) && isnull(found_machine.console))


### PR DESCRIPTION

## About The Pull Request

stacking machine consoles check in area instead of a tiny view range on init

## Why It's Good For The Game

turns out there are areas where you cant cram the console directly next to a stacker

## Changelog
:cl:
code: stacking machine consoles check in area instead of a tiny view range on init
/:cl:
