### PR TITLE
Fix crew records not accounting for quirks for latejoiners

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -216,7 +216,6 @@
 		humanc = character //Let's retypecast the var to be human,
 
 	if(humanc) //These procs all expect humans
-		GLOB.manifest.inject(humanc)
 		if(SSshuttle.arrivals)
 			SSshuttle.arrivals.QueueAnnounce(humanc, rank)
 		else
@@ -242,6 +241,9 @@
 
 	if((job.job_flags & JOB_ASSIGN_QUIRKS) && humanc && CONFIG_GET(flag/roundstart_traits))
 		SSquirks.AssignQuirks(humanc, humanc.client)
+
+	if(humanc) // Quirks may change manifest datapoints, so inject only after assigning quirks
+		GLOB.manifest.inject(humanc)
 
 	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
 	if(humanc && arrivals && !arrivals.power_environ) //arrivals depowered


### PR DESCRIPTION
## About The Pull Request

So crew records weren't actually showing the right quirks for latejoiners, and in at least one instance (heterochromatic eyes) even the fingerprint was wrong. The latter seemed to be caused by a recent fix pr making the quirk actually update your dna, for the sake of paradox clones/changelings.
Looking into it, this seemed to be because we assign quirks to latejoiners _after_ injecting them into the manifest:
https://github.com/tgstation/tgstation/blob/b7225d8486476fc4971ef32ed3c83fd778e7e46d/code/modules/mob/dead/new_player/new_player.dm#L218-L244
See line 219 and 244.

So we move manifest injection to be _after_ quirk assignment:
```dm
(line 242-246)
	if((job.job_flags & JOB_ASSIGN_QUIRKS) && humanc && CONFIG_GET(flag/roundstart_traits))
		SSquirks.AssignQuirks(humanc, humanc.client)

	if(humanc) // Quirks may change manifest datapoints, so inject only after assigning quirks
		GLOB.manifest.inject(humanc)
```
This fixes it.
## Why It's Good For The Game

Makes quirks actually show in the medical records for latejoiners.
Makes latejoiners with heterochromatic eyes not have the wrong fingerprint in the security records.
_Probably_ fixes #83681.
Fixes #56469.
## Changelog
:cl:
fix: Latejoiners with heterochromatic eyes no longer have the wrong fingerprint in the security records.
fix: Latejoiners actually have their quirks visible in the medical records.
/:cl:
