### PR TITLE
[NO GBP] Only filled graves will provide a mood modifier

### DIFF
--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -160,6 +160,8 @@
 	var/first_open = FALSE
 	/// was a shovel used to close this grave
 	var/dug_closed = FALSE
+	/// do we have a mood effect tied to accessing this type of grave?
+	var/affect_mood = TRUE
 
 /obj/structure/closet/crate/grave/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	if(isnull(held_item))
@@ -252,7 +254,7 @@
 		if(opened)
 			dug_closed = TRUE
 			close(user)
-		else if(open(user, force = TRUE))
+		else if(open(user, force = TRUE) && affect_mood)
 			if(HAS_MIND_TRAIT(user, TRAIT_MORBID))
 				user.add_mood_event("morbid_graverobbing", /datum/mood_event/morbid_graverobbing)
 			else
@@ -314,6 +316,7 @@
 	icon_state = "grave_fresh"
 	base_icon_state = "grave_fresh"
 	material_drop_amount = 0
+	affect_mood = FALSE
 
 /obj/structure/closet/crate/grave/filled/lead_researcher
 	name = "ominous burial mound"

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -161,7 +161,7 @@
 	/// was a shovel used to close this grave
 	var/dug_closed = FALSE
 	/// do we have a mood effect tied to accessing this type of grave?
-	var/affect_mood = TRUE
+	var/affect_mood = FALSE
 
 /obj/structure/closet/crate/grave/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	if(isnull(held_item))
@@ -181,6 +181,9 @@
 /obj/structure/closet/crate/grave/examine(mob/user)
 	. = ..()
 	. += span_notice("It can be [EXAMINE_HINT((opened ? "closed" : "dug open"))] with a shovel.")
+
+/obj/structure/closet/crate/grave/filled
+	affect_mood = TRUE
 
 /obj/structure/closet/crate/grave/filled/PopulateContents()  //GRAVEROBBING IS NOW A FEATURE
 	..()
@@ -316,7 +319,6 @@
 	icon_state = "grave_fresh"
 	base_icon_state = "grave_fresh"
 	material_drop_amount = 0
-	affect_mood = FALSE
 
 /obj/structure/closet/crate/grave/filled/lead_researcher
 	name = "ominous burial mound"


### PR DESCRIPTION

## About The Pull Request
Only the "filled" subtype of graves will provide a mood debuff (buff if you're a coroner).

This means that graves that spawn with loot/remains, such as the two featured on the icebox coroner graveyard or the ones in the Elephant Graveyard Lavaland ruin, will impact your mood. The unfilled graves at the icebox chapel/morgue will not affect mood, nor will recently created ones.

![image](https://github.com/tgstation/tgstation/assets/28870487/2722e454-0b73-48f8-bcb5-e12f682eec23)
## Why It's Good For The Game

It makes a bit more sense. You shouldn't be beating yourself up over graverobbing when you aren't actually disturbing anyone's grave, especially when it lines up with what the actual mood event text says.

Closes #83704.
## Changelog
:cl: Rhials
fix: Only filled graves will impact your mood.
/:cl:
