### PR TITLE
[NO GBP] Post-Rust Heretic's Rework adjustments.

### DIFF
--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -109,6 +109,8 @@
 	var/mob/living/victim = entered
 	if(IS_HERETIC(victim))
 		return
+	if(victim.can_block_magic(MAGIC_RESISTANCE))
+		return
 	victim.apply_status_effect(/datum/status_effect/rust_corruption)
 
 /datum/element/rust/heretic/proc/on_exited(turf/source, atom/movable/gone)

--- a/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
@@ -76,7 +76,7 @@
 
 /datum/heretic_knowledge/summon/rusty
 	name = "Rusted Ritual"
-	desc = "Allows you to transmute a pool of vomit, some cable coil, and 5 sheets of iron into a Rust Walker. \
+	desc = "Allows you to transmute a pool of vomit, some cable coil, and 10 sheets of titanium into a Rust Walker. \
 		Rust Walkers excel at spreading rust and are moderately strong in combat."
 	gain_text = "I combined my knowledge of creation with my desire for corruption. The Marshal knew my name, and the Rusted Hills echoed out."
 	next_knowledge = list(
@@ -85,7 +85,7 @@
 	)
 	required_atoms = list(
 		/obj/effect/decal/cleanable/vomit = 1,
-		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stack/sheet/mineral/titanium = 10,
 		/obj/item/stack/cable_coil = 15,
 	)
 	mob_to_summon = /mob/living/basic/heretic_summon/rust_walker

--- a/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
@@ -76,7 +76,7 @@
 
 /datum/heretic_knowledge/summon/rusty
 	name = "Rusted Ritual"
-	desc = "Allows you to transmute a pool of vomit, some cable coil, and 10 sheets of titanium into a Rust Walker. \
+	desc = "Allows you to transmute a pool of vomit, some cable coil, and 5 sheets of titanium into a Rust Walker. \
 		Rust Walkers excel at spreading rust and are moderately strong in combat."
 	gain_text = "I combined my knowledge of creation with my desire for corruption. The Marshal knew my name, and the Rusted Hills echoed out."
 	next_knowledge = list(
@@ -85,7 +85,7 @@
 	)
 	required_atoms = list(
 		/obj/effect/decal/cleanable/vomit = 1,
-		/obj/item/stack/sheet/mineral/titanium = 10,
+		/obj/item/stack/sheet/mineral/titanium = 5,
 		/obj/item/stack/cable_coil = 15,
 	)
 	mob_to_summon = /mob/living/basic/heretic_summon/rust_walker


### PR DESCRIPTION
## About The Pull Request
Fixes antimagic, not preventing the disgust builtup from standing on rusted tiles, makes rust walkers more expensive to summon.
## Why It's Good For The Game

I'm very happy with the end result of my Rust heretic rework; but they came up a tad stronger than i wanted them to be.

Carlac already changed the Vomit stun to knockdown,  but i wanted to add a couple of things myself.

Having anti magic now makes you fully immune to the effects of rusted tiles, not just the spells.

Rust walkers summoning ritual now requires titanium instead of iron sheets.

As of right now, they are way too easy to spam, Titanium is a bit harder to come by than iron so that'll do for now.

I was planning to set a limit to how many you can summon at the time, but i'd rather wait a few months to see how rust behaves before i add more nerfs.
## Changelog
:cl:
balance: Rust walkers' summoning ritual now requires 5 sheets of Titanium instead of Iron.
fix: Magic resistance grants complete immunity from the passive disgust buildup from standing on Rusted turfs.
/:cl:
