### PR TITLE
Change the pAI display face selection to a radial

### DIFF
--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -131,12 +131,17 @@
 /**
  * Changes the image displayed on the pAI.
  *
- * @param {mob} user - The user who is changing the image.
- *
  * @returns {boolean} - TRUE if the image was changed, FALSE otherwise.
  */
 /mob/living/silicon/pai/proc/change_image()
-	var/new_image = tgui_input_list(src, "Select your new display image", "Display Image", possible_overlays)
+	var/list/possible_choices = list()
+	for(var/face_option in possible_overlays)
+		var/datum/radial_menu_choice/choice = new
+		choice.name = face_option
+		choice.image = image(icon = card.icon, icon_state = "pai-[face_option]")
+		possible_choices[face_option] += choice
+	var/atom/anchor = get_atom_on_turf(src)
+	var/new_image = show_radial_menu(src, anchor, possible_choices, custom_check = CALLBACK(src, PROC_REF(check_menu), anchor), radius = 40, require_near = TRUE)
 	if(isnull(new_image))
 		return FALSE
 	card.emotion_icon = new_image


### PR DESCRIPTION
## About The Pull Request
This PR changes the pAI's face display selection from a tgui input list, to a radial menu, with the actual faces displayed on the radial.

![image](https://github.com/tgstation/tgstation/assets/1008889/c89c9cf4-c3f3-4be9-9b79-08c1176687b4)

This PR also removes part of the comment for `/mob/living/silicon/pai/proc/change_image()` that is no longer applicable.

## Why It's Good For The Game
The radial menu makes pAI face display selection clearer, because players now see what the face looks like, rather than having to guess what a face might look like from the... frankly, very vague names given. Seriously, what is `Null` supposed to be? What is `Face` supposed to be?!

## Changelog

:cl: MichiRecRoom
qol: Personal AI's face display selection is now a radial menu. As a bonus, now you can see what the faces look like before selecting them.
/:cl: