### PR TITLE
Add Engineering Access to Birdshot Engineering Doors

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -40716,6 +40716,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "oJn" = (
@@ -54321,13 +54322,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "sKD" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Airlock"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Main Engineering"
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "sKE" = (


### PR DESCRIPTION

## About The Pull Request

Gives the main engineering doors on Birdshot general engineering OR construction access, when previously they were just construction access. This matches how the main engi entrance doors are on other stations (eg: Meta). 
Also changes the names of both to Main Engineering so that they match.
## Why It's Good For The Game

Fixes: #83763 
## Changelog
:cl: Thlumyn
fix: add general engineering access to birdshot engineering entrance
/:cl:
