### PR TITLE
Wall button refactor and qol

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -146,7 +146,7 @@
 
 /obj/machinery/button/proc/airlock_electronics_act(mob/living/user, obj/item/electronics/airlock/new_board)
 	if(board)
-		to_chat(user, span_warning("\The button already contains a board!"))
+		to_chat(user, span_warning("The button already contains a board!"))
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(new_board, src, silent = FALSE))
 		to_chat(user, span_warning("\The [new_board] is stuck to you!"))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -182,8 +182,7 @@
 		return ITEM_INTERACT_BLOCKING
 
 	to_chat(user, span_notice("You start unsecuring the button frame..."))
-	tool.play_tool_sound(src)
-	if(tool.use_tool(src, user, 40))
+	if(tool.use_tool(src, user, 40, volume=50))
 		to_chat(user, span_notice("You unsecure the button frame."))
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 		deconstruct(TRUE)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -132,7 +132,7 @@
 
 /obj/machinery/button/proc/assembly_act(mob/living/user, obj/item/assembly/new_device)
 	if(device)
-		to_chat(user, span_warning("\The button already contains a device!"))
+		to_chat(user, span_warning("The button already contains a device!"))
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(new_device, src, silent = FALSE))
 		to_chat(user, span_warning("\The [new_device] is stuck to you!"))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -21,7 +21,7 @@
 	var/obj/item/electronics/airlock/board
 	var/device_type = null
 	var/id = null
-	var/initialized_button = 0
+	var/initialized_button = FALSE
 	var/silicon_access_disabled = FALSE
 
 /obj/machinery/button/indestructible
@@ -58,6 +58,7 @@
 
 	setup_device()
 	find_and_hang_on_wall()
+	register_context()
 
 /obj/machinery/button/Destroy()
 	QDEL_NULL(device)
@@ -94,53 +95,85 @@
 	if(!(machine_stat & (NOPOWER|BROKEN)) && !panel_open)
 		. += emissive_appearance(icon, "[base_icon_state]-light-mask", src, alpha = src.alpha)
 
+/obj/machinery/button/on_set_panel_open(old_value)
+	if(panel_open) // Only allow renaming while the panel is open
+		obj_flags |= UNIQUE_RENAME
+	else
+		obj_flags &= ~UNIQUE_RENAME
+
 /obj/machinery/button/screwdriver_act(mob/living/user, obj/item/tool)
 	if(panel_open || allowed(user))
 		default_deconstruction_screwdriver(user, "[base_icon_state][skin]-open", "[base_icon_state][skin]", tool)
 		update_appearance()
+		return ITEM_INTERACT_SUCCESS
+
+	balloon_alert(user, "access denied")
+	flick_overlay_view("[base_icon_state]-overlay-error", 1 SECONDS)
+	return ITEM_INTERACT_BLOCKING
+
+/obj/machinery/button/wrench_act(mob/living/user, obj/item/tool)
+	if(device || board)
+		balloon_alert(user, "empty button first")
+		return ITEM_INTERACT_BLOCKING
+
+	to_chat(user, span_notice("You start unsecuring the button frame..."))
+	tool.play_tool_sound(src)
+	if(tool.use_tool(src, user, 40))
+		to_chat(user, span_notice("You unsecure the button frame."))
+		transfer_fingerprints_to(new /obj/item/wallframe/button(get_turf(src)))
+		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+		qdel(src)
+
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/button/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(.)
+		return .
+	// This is in here so it's called only after every other item interaction.
+	if(!user.combat_mode && !(tool.item_flags & NOBLUDGEON) && !panel_open)
+		return attempt_press(user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
+
+/obj/machinery/button/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!panel_open)
+		return NONE
+
+	if(isassembly(tool))
+		return assembly_act(user, tool)
+	else if(istype(tool, /obj/item/electronics/airlock))
+		return airlock_electronics_act(user, tool)
+
+/obj/machinery/button/proc/assembly_act(mob/living/user, obj/item/assembly/new_device)
+	if(device)
+		to_chat(user, span_warning("\The button already contains a device!"))
+		return ITEM_INTERACT_BLOCKING
+	if(!user.transferItemToLoc(new_device, src, silent = FALSE))
+		to_chat(user, span_warning("\The [new_device] is stuck to you!"))
+		return ITEM_INTERACT_BLOCKING
+
+	device = new_device
+	to_chat(user, span_notice("You add \the [new_device] to the button."))
+
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/button/proc/airlock_electronics_act(mob/living/user, obj/item/electronics/airlock/new_board)
+	if(board)
+		to_chat(user, span_warning("\The button already contains a board!"))
+		return ITEM_INTERACT_BLOCKING
+	if(!user.transferItemToLoc(new_board, src, silent = FALSE))
+		to_chat(user, span_warning("\The [new_board] is stuck to you!"))
+		return ITEM_INTERACT_BLOCKING
+
+	board = new_board
+	if(board.one_access)
+		req_one_access = board.accesses
 	else
-		balloon_alert(user, "access denied")
-		flick_overlay_view("[base_icon_state]-overlay-error", 1 SECONDS)
+		req_access = board.accesses
+	to_chat(user, span_notice("You add \the [new_board] to the button."))
 
-	return TRUE
-
-/obj/machinery/button/attackby(obj/item/W, mob/living/user, params)
-	if(panel_open)
-		if(!device && isassembly(W))
-			if(!user.transferItemToLoc(W, src))
-				to_chat(user, span_warning("\The [W] is stuck to you!"))
-				return
-			device = W
-			to_chat(user, span_notice("You add [W] to the button."))
-
-		if(!board && istype(W, /obj/item/electronics/airlock))
-			if(!user.transferItemToLoc(W, src))
-				to_chat(user, span_warning("\The [W] is stuck to you!"))
-				return
-			board = W
-			if(board.one_access)
-				req_one_access = board.accesses
-			else
-				req_access = board.accesses
-			balloon_alert(user, "electronics added")
-			to_chat(user, span_notice("You add [W] to the button."))
-
-		if(!device && !board && W.tool_behaviour == TOOL_WRENCH)
-			to_chat(user, span_notice("You start unsecuring the button frame..."))
-			W.play_tool_sound(src)
-			if(W.use_tool(src, user, 40))
-				to_chat(user, span_notice("You unsecure the button frame."))
-				transfer_fingerprints_to(new /obj/item/wallframe/button(get_turf(src)))
-				playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-				qdel(src)
-
-		update_appearance()
-		return
-
-	if(!user.combat_mode && !(W.item_flags & NOBLUDGEON))
-		return attack_hand(user)
-	else
-		return ..()
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/button/emag_act(mob/user, obj/item/card/emag/emag_card)
 	. = ..()
@@ -159,7 +192,7 @@
 
 /obj/machinery/button/attack_ai(mob/user)
 	if(!silicon_access_disabled && !panel_open)
-		return attack_hand(user)
+		return attempt_press(user)
 
 /obj/machinery/button/attack_robot(mob/user)
 	return attack_ai(user)
@@ -172,14 +205,52 @@
 		. += span_notice("There is \a [device] inside, which could be removed with an <b>empty hand</b>.")
 	if(board)
 		. += span_notice("There is \a [board] inside, which could be removed with an <b>empty hand</b>.")
-	if(!board && !device)
+	if(isnull(board) && isnull(device))
 		. += span_notice("There is nothing currently installed in \the [src].")
+
+/obj/machinery/button/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(panel_open)
+		if(isnull(held_item))
+			if(board && device)
+				context[SCREENTIP_CONTEXT_LMB] = "Remove Board"
+				context[SCREENTIP_CONTEXT_RMB] = "Remove Device"
+				return CONTEXTUAL_SCREENTIP_SET
+			else if(board)
+				context[SCREENTIP_CONTEXT_LMB] = "Remove Board"
+				return CONTEXTUAL_SCREENTIP_SET
+			else if(device)
+				context[SCREENTIP_CONTEXT_LMB] = "Remove Device"
+				return CONTEXTUAL_SCREENTIP_SET
+			else if(can_alter_skin)
+				context[SCREENTIP_CONTEXT_LMB] = "Swap Style"
+				return CONTEXTUAL_SCREENTIP_SET
+		else if(isassembly(held_item))
+			context[SCREENTIP_CONTEXT_LMB] = "Install Device"
+			return CONTEXTUAL_SCREENTIP_SET
+		else if(istype(held_item, /obj/item/electronics/airlock))
+			context[SCREENTIP_CONTEXT_LMB] = "Install Board"
+			return CONTEXTUAL_SCREENTIP_SET
+		else if(held_item.tool_behaviour == TOOL_WRENCH)
+			context[SCREENTIP_CONTEXT_LMB] = "Deconstruct Button"
+			return CONTEXTUAL_SCREENTIP_SET
+		else if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = "Close Button"
+			return CONTEXTUAL_SCREENTIP_SET
+	else
+		if(isnull(held_item))
+			context[SCREENTIP_CONTEXT_LMB] = "Press Button"
+			return CONTEXTUAL_SCREENTIP_SET
+		else if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = "Open Button"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
 
 /obj/machinery/button/proc/setup_device()
 	if(id && istype(device, /obj/item/assembly/control))
-		var/obj/item/assembly/control/A = device
-		A.id = id
-	initialized_button = 1
+		var/obj/item/assembly/control/control_device = device
+		control_device.id = id
+	initialized_button = TRUE
 
 /obj/machinery/button/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	if(id)
@@ -193,48 +264,78 @@
 	if(!initialized_button)
 		setup_device()
 	add_fingerprint(user)
-	if(panel_open)
-		if(device || board)
-			if(device)
-				user.put_in_hands(device)
-				device = null
-			if(board)
-				user.put_in_hands(board)
-				req_access = list()
-				req_one_access = list()
-				board = null
-			update_appearance(UPDATE_ICON)
-			balloon_alert(user, "electronics removed")
-			to_chat(user, span_notice("You remove electronics from the button frame."))
 
-		else if(can_alter_skin)
-			if(skin == "")
-				skin = "-warning"
-				to_chat(user, span_notice("You change the button frame's front panel to warning lines."))
-			else
-				skin = ""
-				to_chat(user, span_notice("You change the button frame's front panel to default."))
-			update_appearance(UPDATE_ICON)
-			balloon_alert(user, "swapped style")
+	if(!panel_open)
+		attempt_press(user)
 		return
 
+	if(board)
+		remove_airlock_electronics(user)
+		return
+	if(device)
+		remove_assembly(user)
+		return
+
+	if(can_alter_skin)
+		if(skin == "")
+			skin = "-warning"
+			to_chat(user, span_notice("You change the button frame's front panel to warning lines."))
+		else
+			skin = ""
+			to_chat(user, span_notice("You change the button frame's front panel to default."))
+		update_appearance(UPDATE_ICON)
+		balloon_alert(user, "style swapped")
+
+/obj/machinery/button/attack_hand_secondary(mob/user, list/modifiers)
+	if(!initialized_button)
+		setup_device()
+	add_fingerprint(user)
+
+	if(!panel_open)
+		return SECONDARY_ATTACK_CALL_NORMAL
+
+	if(device)
+		remove_assembly(user)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(board)
+		remove_airlock_electronics(user)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return ..()
+
+/obj/machinery/button/proc/remove_assembly(mob/user)
+	user.put_in_hands(device)
+	to_chat(user, span_notice("You remove \the [device] from the button frame."))
+	device = null
+	update_appearance(UPDATE_ICON)
+
+/obj/machinery/button/proc/remove_airlock_electronics(mob/user)
+	user.put_in_hands(board)
+	to_chat(user, span_notice("You remove the board from the button frame."))
+	req_access = list()
+	req_one_access = list()
+	board = null
+	update_appearance(UPDATE_ICON)
+
+/obj/machinery/button/proc/attempt_press(mob/user)
 	if((machine_stat & (NOPOWER|BROKEN)))
-		return
+		return FALSE
 
 	if(device && device.next_activate > world.time)
-		return
+		return FALSE
 
 	if(!allowed(user))
 		balloon_alert(user, "access denied")
 		flick_overlay_view("[base_icon_state]-overlay-error", 1 SECONDS)
-		return
+		return FALSE
 
 	use_energy(5 JOULES)
 	flick_overlay_view("[base_icon_state]-overlay-success", 1 SECONDS)
 
 	if(device)
 		device.pulsed(user)
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_BUTTON_PRESSED,src)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_BUTTON_PRESSED, src)
+	return TRUE
 
 /**
  * Called when the mounted button's wall is knocked down.
@@ -265,13 +366,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
 /obj/machinery/button/door/setup_device()
 	if(!device)
 		if(normaldoorcontrol)
-			var/obj/item/assembly/control/airlock/A = new(src)
-			A.specialfunctions = specialfunctions
-			device = A
+			var/obj/item/assembly/control/airlock/airlock_device = new(src)
+			airlock_device.specialfunctions = specialfunctions
+			device = airlock_device
 		else
-			var/obj/item/assembly/control/C = new(src)
-			C.sync_doors = sync_doors
-			device = C
+			var/obj/item/assembly/control/control_device = new(src)
+			control_device.sync_doors = sync_doors
+			device = control_device
 	..()
 
 /obj/machinery/button/door/incinerator_vent_ordmix


### PR DESCRIPTION

## About The Pull Request

Originally this started as me getting annoyed at buttons dropping both of their items when you try to remove one, but looking at the code I decided to just go ahead and update it to the newer procs.
This should hopefully also make it easier to split it off into wall and table buttons to replace those wall-buttons-on-tables in preparation for the wallening, though I'll have to wait on doing that for a bit more.

I normally like doing detailed pr bodies for refactors, but I'm honestly kinda tired, so I'm leaving out the parts where I display the new code and only explain what's changed.

Right so, the biggest part of this pr is moving the item interaction and deconstruction code to the newer systems, so let's start with that.

### Begone `attackby(...)`
Previously, buttons still used a big old `attackby(...)` proc:
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L107-L143
Some of which even handles wrench interaction, which we have `wrench_act(...)` for nowadays.

So, first order of business! Remove that, move it to `wrench_act(...)`, and add feedback for the button needing to be opened and emptied.

Then create two new procs for the leftover assembly and airlock electronics interactions, `assembly_act(...)` and `airlock_electronics_act(...)`, add feedback for those items already being in the button, and put those procs in `item_interaction(...)`.

Finally, we're left with the following:
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L140-L143
Which we move to `base_item_interaction(...)`, as it must be ran after any and all other item interactions.

### Update `screwdriver_act(...)`
Buttons _did_ use `screwdriver_act(...)` already, but this didn't actually return the proper item interaction flags, so we update it to return those.

### Deconstruction fuckery
So rather than deconstructing properly when being wrenched, we'd just make a wallframe item, call `qdel(...)`, and call it a day:
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L128-L138
On top of that, we would just flat out `QDEL_NULL(...)` our internal items when destroyed.
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L62-L65
This leads to the situations where:
1. We don't actually care about `NO_DEBRIS_AFTER_DECONSTRUCTION`, and drop our frame anyways.
2. Destroying our button in any way would flat out delete its contents, which uh. Isn't great.

So to resolve this, we move the wallframe creation and fingerprint transferring to `on_deconstruction(...)`, make `dump_inventory_contents(...)` reset our variables for good measure, then make deconstructing it with a wrench actually call `deconstruct(TRUE)`.
This resolves the fuckery.

### Other unused deconstruction fuckery
Oh hey look, unused code:
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L239-L251
I believe this would, theoretically, be registered to be called by `find_and_hang_on_wall(...)` during `Initialize(...)`, and then called when the wall it's on is destroyed.
But, it _isn't_, and importantly? We no longer need to!

Because the code for this defaults to `deconstruct(...)` and, hey, look, we already set up our deconstruction behaviour, and what we want here is essentially the same!
So we just remove it.

### Cleaning up `interact(...)`
We want to make our item removal and button pressing interactions a bit nicer, which requires dealing with `interact(...)` but ooooh boyyy what a mess:
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L189-L237
This is what actually handles pressing our button! And reskinning it. And removing our items.
That's not great. Time to change it.

First off, we have a bunch of other stuff that wants to just press the button, but really calls `attack_hand(...)` so it can in turn call `interact(...)` so it can in turn press the button.
That's especially not great.
So we move this part to a new proc `attempt_press(...)`, and instead make all the other things that want to press stuff call that instead, skipping by all the stuff we _don't_ want. This is somewhat nicer.

Then, we want to be able to individually remove our internal items, so we split removing those off into their own new procs too, `remove_assembly(...)` and `remove_airlock_electronics(...)`.
We leave the reskinning in there mostly as-is, as we don't need it in other places and it's too small to bother, but just add a balloon alert onto it.

### Left-click right-click item removal priority
We don't have an `interact_secondary(...)`, but it doesn't really matter given `attack_hand_secondary(...)` works perfectly fine for our purposes. So we construct a new `attack_hand_secondary(...)` that's almost identical to `interact(...)` but with the airlock electronics and assembly removal priorities swapped and reskinning removed, and have it forward to the normal chain when item removal isn't necessary.
This lets us take out the airlock electronics or assembly device individually using left-click and right-click, but due to it just being priorities lets us take out both in turn with left-click if we do want to.

### Sound nitpicks
When working with buttons, I'd notice it'd play the pickup sound when removing an assembly device, but not play any sound when putting one in.
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L109-L118
So we just make these `transferItemToLoc(...)` procs not silent by setting `silent = FALSE`, and that feels much nicer.
Sadly airlock electronics do not have such sounds, but that is outside of the scope of this pr.

### Allowing renaming for sanity's sake
To let us replicate roundstart buttons, or for that matter avoid having six identically named buttons, we set the `UNIQUE_RENAME` flag.
However, this would let people rename buttons they don't have access to, so instead we set or remove `UNIQUE_RENAME` on `on_set_panel_open(...)`, so it's only possible to rename while the button is opened. This stops people without access from abusing this.

### Added screentips
Most of this is relatively normal, we just register context during init and have a bigass `add_context(...)` proc.

### Remove single letter variables
We had single letter variables in our `attackby(...)` and two of our `setup_device(...)` procs.
Each of those have been removed and replace with a slightly saner variable name.

### Replace boolean `0` with `FALSE`
One of our vars, `initialized_button`, is set to `0`, while its purpose is entirely boolean.
https://github.com/tgstation/tgstation/blob/db5907a41ecd76e028f76e643f5fb37e083de888/code/game/machinery/buttons.dm#L24
So we just replace it with `FALSE` for clarity's sake.

### Code reorganization
Because the file was getting long, I decided it'd be best to split it up into grouped segments, in order:
- Initialization
- Appearance
- Interaction
- Deconstruction
- Information
- Mapping Presets

Where Interaction is grouped (without labels) into item and hand interaction.
This is for posterity, when I or someone else comes back later to kick this fucker in the shins for table buttons.

I believe that's all. If not I probably forgot.
## Why It's Good For The Game

Overall, it tends to be better when we actually use the tool act type procs and destruction procs.
Having it only play the item sound when you take it out feels a bit off.
Screentips are nice.
It's nice when destroyed objects don't just miraculously disintegrate their contained items.

As for renaming:
Allowing renaming is necessary to allow players to replicate the starting gamestate after destruction, as a lot of roundstart buttons are named. In addition, it's nice to not just have six identically named buttons when constructing them.
We avoid people renaming buttons they don't have access to by only setting the flag when the panel is opened, which can only be done by people with access.

And adjusting item removal:
Attempting to remove an item dropping both items at once is awkward, given one will probably end up dropping on the floor, and not uncommonly you'll want to change out only one of them in the first place. But just making it pick one first and then the other is awkward on its own, if you want to just swap the second item out.
Making it so left click prioritizes the airlock electronics and right click prioritizes the assembly device, moving on to the other one when unavailable, should avoid that issue while resolving the former.
## Changelog
:cl:
refactor: Refactored wall button code, please report any issues.
fix: Wall buttons actually drop their contents when destroyed.
sound: Putting items into wall buttons actually plays a sound. This matters for assembly devices, but airlock electronics do not have a sound.
qol: Added screentips to wall buttons.
qol: You can now take out the airlock electronics or assembly device out of wall buttons individually. Left click prioritises the board, right click prioritises the device.
qol: Wall buttons are renamable with a pen when opened.
qol: Attempting to wrench deconstruct a wall button or put in airlock electronics or an assembly device when you can't actually gives feedback.
/:cl:
