### PR TITLE
Adds a chat message for fishing in a chasm with a normal and rescue hook

### DIFF
--- a/code/datums/components/fishing_spot.dm
+++ b/code/datums/components/fishing_spot.dm
@@ -84,6 +84,8 @@
 	if(denial_reason)
 		to_chat(user, span_warning(denial_reason))
 		return COMPONENT_NO_AFTERATTACK
+	// In case the fishing source has anything else to do before beginning to fish.
+	fish_source.on_start_fishing(rod, user, parent)
 	start_fishing_challenge(rod, user)
 	return COMPONENT_NO_AFTERATTACK
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -69,6 +69,13 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 /datum/fish_source/proc/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	return rod.reason_we_cant_fish(src)
 
+/// Called below above proc, in case the fishing source has anything to do that isn't denial
+/datum/fish_source/proc/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	if(istype(rod.hook, /obj/item/fishing_hook/rescue))
+		to_chat(fisherman, span_notice("The rescue hook falls straight down the chasm! Hopefully it catches a corpse."))
+		return
+	to_chat(fisherman, span_danger("Your fishing hook makes a soft 'thud' noise as it gets stuck on the wall of the chasm. It doesn't look like it's going to catch much of anything, except maybe some detritus."))
+
 /**
  * Calculates the difficulty of the minigame:
  *

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -71,10 +71,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 
 /// Called below above proc, in case the fishing source has anything to do that isn't denial
 /datum/fish_source/proc/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
-	if(istype(rod.hook, /obj/item/fishing_hook/rescue))
-		to_chat(fisherman, span_notice("The rescue hook falls straight down the chasm! Hopefully it catches a corpse."))
-		return
-	to_chat(fisherman, span_danger("Your fishing hook makes a soft 'thud' noise as it gets stuck on the wall of the chasm. It doesn't look like it's going to catch much of anything, except maybe some detritus."))
+	return
 
 /**
  * Calculates the difficulty of the minigame:

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -196,6 +196,13 @@
 
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
 
+/datum/fish_source/chasm/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	. = ..()
+	if(istype(rod.hook, /obj/item/fishing_hook/rescue))
+		to_chat(fisherman, span_notice("The rescue hook falls straight down the chasm! Hopefully it catches a corpse."))
+		return
+	to_chat(fisherman, span_danger("Your fishing hook makes a soft 'thud' noise as it gets stuck on the wall of the chasm. It doesn't look like it's going to catch much of anything, except maybe some detritus."))
+
 /datum/fish_source/chasm/roll_reward(obj/item/fishing_rod/rod, mob/fisherman)
 	var/rolled_reward = ..()
 

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -204,6 +204,8 @@
 
 	return rod.hook.chasm_detritus_type
 
+/datum/fish_source/chasm
+
 /datum/fish_source/lavaland
 	catalog_description = "Lava vents"
 	background = "background_lavaland"


### PR DESCRIPTION

## About The Pull Request

Title, warns you if you have anormal hook and gives you a heads up it might work otherwise.

## Why It's Good For The Game

Everyone knows 'fish in chasm to get body', but not many people know 'you can ONLY use the rescue hook to get body'. This clarifies that! It reduces misinformation and confusion.

## Changelog

:cl:
qol: Adds a chat message for fishing in a chasm with a normal and rescue hook, to clarify that only rescue hooks can drag up corpses.
/:cl:

