### PR TITLE
Whitelists the fishing trait "Anxiety" to only detect fish.

### DIFF
--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -397,7 +397,7 @@ GLOBAL_LIST_INIT(fish_traits, init_subtypes_w_path_keys(/datum/fish_trait, list(
 	var/fish_tolerance = 3
 	if(!fish.loc || fish.status == FISH_DEAD)
 		return
-	for(var/obj/item/other_fish in fish.loc.contents)
+	for(var/obj/item/fish/other_fish in fish.loc.contents)
 		if(fish_tolerance <= 0)
 			fish.loc.visible_message(span_warning("[fish] seems to freak out for a moment, then it stops moving..."))
 			fish.set_status(FISH_DEAD)


### PR DESCRIPTION

## About The Pull Request

Anxiety, As implied by the code, causes any fish with it to die if it is within the same loc as 3 other fish.

Anxiety, As it currently works, causes any fish with it to die if its within the same loc as _**ANY**_ 3 /obj/items, meaning if you are a well mannered fisherman wearing your fishermans hat, your good ol' overall, some good ol' wading boots, and you caught an anxious zipzap, A rare fish that can only be caught in the ocean or any ocean portal thingymajig, It would *instantly* die, even if every other fish was dead and on the barbeque already 

For video evidence: Here's how it's currently coded. (For the sake of explanation, i've used game panel instead of fished.)

https://github.com/tgstation/tgstation/assets/28457065/951c82e4-2d4b-44df-8323-2e3bbc54b368

As you can see, The first fish spawned on the ground (Because i was dumb and didn't spawn it in my hand.). But the moment i spawned one in my hand, it _**INSTANTLY**_ died. (Or, well, not instantly but before many could react to put it into a fish tank/generator system)

 Now, With the fish being patched:
 
https://github.com/tgstation/tgstation/assets/28457065/cd36e315-bc17-4b09-829e-504f33e3fbae

As advertised. You can hold one fish. Two fish. _even three_. but the moment a fourth was in the same loc, they all triggered their anxiety


## Why It's Good For The Game

I shouldn't have to be ass naked to go fishing for some anxious thing that'd tazer me.

## Changelog
:cl:
fix: fish with the Anxiety gene wont die when in the same loc as any 3 items
/:cl:
