### PR TITLE
Fix coders leaving coderbus

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -19,7 +19,8 @@
 "an" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/item/toy/plush/pkplush{
-	pixel_z = 17
+	pixel_z = 17;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -39,7 +40,8 @@
 	pixel_y = 15
 	},
 /obj/item/toy/plush/lizard_plushie/green{
-	pixel_z = 17
+	pixel_z = 17;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -49,7 +51,8 @@
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/helmet/knight{
-	pixel_z = 16
+	pixel_z = 16;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -60,11 +63,13 @@
 /obj/item/grown/novaflower{
 	offset_at_init = 0;
 	pixel_z = 24;
-	pixel_y = 1
+	pixel_y = 1;
+	anchored = 1
 	},
 /obj/item/food/grown/watermelon{
 	offset_at_init = 0;
-	pixel_z = 17
+	pixel_z = 17;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -75,15 +80,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/plush/moth{
 	pixel_z = 26;
-	pixel_y = 2
+	pixel_y = 2;
+	anchored = 1
 	},
 /obj/item/food/grown/citrus/orange{
 	offset_at_init = 0;
 	pixel_z = 18;
-	pixel_y = 1
+	pixel_y = 1;
+	anchored = 1
 	},
 /obj/item/toy/talking/ai{
-	pixel_z = 16
+	pixel_z = 16;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -149,10 +157,12 @@
 /obj/item/bodypart/arm/right{
 	pixel_z = 25;
 	pixel_y = 1;
-	pixel_x = -4
+	pixel_x = -4;
+	anchored = 1
 	},
 /obj/item/food/meat/slab/penguin{
-	pixel_z = 13
+	pixel_z = 13;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -188,12 +198,14 @@
 /obj/item/food/grown/tomato{
 	offset_at_init = 0;
 	pixel_z = 23;
-	pixel_y = 2
+	pixel_y = 2;
+	anchored = 1
 	},
 /obj/item/food/donut/plain{
 	pixel_z = 15;
 	pixel_y = 1;
-	pixel_x = 1
+	pixel_x = 1;
+	anchored = 1
 	},
 /obj/effect/decal/cleanable/ants{
 	pixel_z = 8;
@@ -291,7 +303,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/plush/awakenedplushie{
 	pixel_z = 26;
-	pixel_y = 1
+	pixel_y = 1;
+	anchored = 1
 	},
 /obj/machinery/telecomms/server{
 	pixel_z = 12;
@@ -384,11 +397,13 @@
 /obj/item/toy/singlecard{
 	pixel_z = 24;
 	pixel_y = 1;
-	pixel_x = 0
+	pixel_x = 0;
+	anchored = 1
 	},
 /obj/item/food/grown/potato{
 	offset_at_init = 0;
-	pixel_z = 15
+	pixel_z = 15;
+	anchored = 1
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"


### PR DESCRIPTION
## About The Pull Request

The coders on the coderbus are now anchored to the seats and can't be taken to the station

## Why It's Good For The Game

Coders don't play

## Changelog

:cl: Melbert
balance: Coders are now locked to the coderbus
/:cl:

