### PR TITLE
Fixes fake announcements for the shuttle loan event

### DIFF
--- a/code/modules/events/shuttle_loan/shuttle_loan_event.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_event.dm
@@ -40,12 +40,15 @@
 	situation = new situation()
 
 /datum/round_event/shuttle_loan/announce(fake)
-	var/announcement_text = situation?.announcement_text
-	if(isnull(announcement_text) || fake)
+	if(fake)
 		var/datum/shuttle_loan_situation/fake_situation = pick(subtypesof(/datum/shuttle_loan_situation))
-		announcement_text = initial(fake_situation.announcement_text)
-	priority_announce("Cargo: [announcement_text]", situation.sender)
-	SSshuttle.shuttle_loan = src
+		situation = new fake_situation
+	else
+		SSshuttle.shuttle_loan = src
+	priority_announce("Cargo: [situation.announcement_text]", situation.sender)
+	if(fake)
+		qdel(situation)
+
 
 /datum/round_event/shuttle_loan/proc/loan_shuttle()
 	priority_announce(situation.thanks_msg, "Cargo shuttle commandeered by [command_name()].")


### PR DESCRIPTION
```
[18:29:06] Runtime in code/modules/events/shuttle_loan/shuttle_loan_event.dm, line 47: Cannot read null.sender
proc name: announce (/datum/round_event/shuttle_loan/announce)
src: /datum/round_event/shuttle_loa... (/datum/round_event/shuttle_loan)
call stack:
/datum/round_event/shuttle_loa... (/datum/round_event/shuttle_loan): announce(1)
/datum/round_event/falsealarm (/datum/round_event/falsealarm): announce(0)
/datum/round_event/falsealarm (/datum/round_event/falsealarm): process(2)
Events (/datum/controller/subsystem/events): fire(0)
Events (/datum/controller/subsystem/events): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```