### PR TITLE
Fixes rare runtime from cyborg apparatus tools

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -25,7 +25,7 @@
 	if(istype(loc, /obj/item/robot_model))
 		RegisterSignal(loc.loc, COMSIG_BORG_SAFE_DECONSTRUCT, PROC_REF(safedecon))
 		return
-	CRASH("Unable to set up safedecon signal for [src] - location check matched neither cyborg nor cyborg model. Location is actually [loc.type].")
+	CRASH("Unable to set up safedecon signal for [src] - location check matched neither cyborg nor cyborg model. Location is actually [loc].")
 
 ///If we're safely deconstructed, we put the item neatly onto the ground, rather than deleting it.
 /obj/item/borg/apparatus/proc/safedecon()


### PR DESCRIPTION

## About The Pull Request
Very rarely, the following runtime can occur;

```
RUNTIME: runtime error: Cannot read null.loc
 - proc name: Initialize (/obj/item/borg/apparatus/Initialize)
 -   source file: code/game/objects/items/robot/items/storage.dm,12
```

This is on the first line of the apparatus Init() code, where a signal is attempted to be registered to the apparatus' loc's loc (apparatus > borg model > borg). For some reason, the location is not guaranteed to be set when the Init() is called, causing this issue. Since Init() runtimes, it breaks the rest of the code, leaving the borg with a nonfunctional tool that can't even be selected.

To solve this, setting the signal is moved to its own proc, called by a timer after 1 second. The signal's purpose is to detect when the borg is safely deconstructed, which most likely won't happen within the second delay. Additionally, while the runtime shouldn't pop up again, even if it does it won't be as catastrophic for the tool. This signal isn't important enough to brick the item if it fails to register.
## Why It's Good For The Game
Bugfix.
## Changelog
:cl:
fix: Fixed a very rare case where a cyborg's apparatus tools or upgrades could be bricked and unusable.
/:cl:
