### PR TITLE
Contractor baton excluded from TBaton spy bounty

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -244,7 +244,7 @@
 	steal_hint = "A self-defense weapon standard-issue for all heads of staffs barring the Head of Security. Rarely found off of their person."
 
 /datum/objective_item/steal/traitor/telebaton/check_special_completion(obj/item/thing)
-    return thing.type == /obj/item/melee/baton/telescopic
+	return thing.type == /obj/item/melee/baton/telescopic
 
 /obj/item/melee/baton/telescopic/add_stealing_item_objective()
 	if(type == /obj/item/melee/baton/telescopic)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -243,8 +243,12 @@
 	difficulty = 3
 	steal_hint = "A self-defense weapon standard-issue for all heads of staffs barring the Head of Security. Rarely found off of their person."
 
+/datum/objective_item/steal/traitor/telebaton/check_special_completion(obj/item/thing)
+    return thing.type == /obj/item/melee/baton/telescopic
+
 /obj/item/melee/baton/telescopic/add_stealing_item_objective()
-	return add_item_to_steal(src, /obj/item/melee/baton/telescopic)
+	if(type == /obj/item/melee/baton/telescopic)
+		return add_item_to_steal(src, /obj/item/melee/baton/telescopic)
 
 /datum/objective_item/steal/traitor/cargo_budget
 	name = "cargo's departmental budget"


### PR DESCRIPTION
## About The Pull Request
The game adds the Contractor Baton to the "global tracker" whatever the hell that is, from what I understand it's what determines the potential bounty item pool, since the contractor baton is a subtype of the telescopic baton; Which of course is not very appropriate considering the baton came from the Syndicate in the first place. The code excludes all subtypes of the telescopic baton so that we don't get something goofy like this:
![aJboHU3](https://github.com/tgstation/tgstation/assets/125638858/a581ccbb-480c-4090-825e-a661a87e1a50)
Credit: _shod for the image
## Why It's Good For The Game
When problem is fixed, problem no longer bad.

Originally I wanted to just add a custom text saying what a contractor baton is instead of the telescopic baton, but was told it's not a good idea. Boowomp. Anyways, stealing back a contractor baton from the Syndicate who just GAVE someone that baton is a little weird I suppooosseee.....
## Changelog
:cl:
fix: You may no longer submit, or obtain, a spy bounty for the contractor baton.
/:cl:
