### PR TITLE
Adds a means to clean up multiple monkey bodies using the xenobio console.

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -441,13 +441,20 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 /obj/machinery/computer/camera_advanced/xenobio/proc/XenoTurfClickCtrl(mob/living/user, turf/open/target_turf)
 	SIGNAL_HANDLER
 
+	var/cleanup = FALSE
 	var/mob/camera/ai_eye/remote/xenobio/remote_eye = user.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin
 
 	if(!xeno_console.validate_area(user, remote_eye, target_turf))
 		return
 
-	xeno_console.feed_slime(user, target_turf)
+	for(var/mob/M in target_turf)
+		if(ismonkey(M) && M.stat == DEAD)
+			cleanup = TRUE
+			xeno_console.monkey_recycle(user, M)
+
+	if(!cleanup)
+		xeno_console.feed_slime(user, target_turf)
 
 ///Picks up a dead monkey for recycling
 /obj/machinery/computer/camera_advanced/xenobio/proc/XenoMonkeyClickCtrl(mob/living/user, mob/living/carbon/human/target_mob)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -449,9 +449,9 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		return
 
 	for(var/mob/monkey in target_turf)
-		if(ismonkey(M) && M.stat == DEAD)
+		if(ismonkey(monkey) && monkey.stat == DEAD)
 			cleanup = TRUE
-			xeno_console.monkey_recycle(user, M)
+			xeno_console.monkey_recycle(user, monkey)
 
 	if(!cleanup)
 		xeno_console.feed_slime(user, target_turf)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -448,7 +448,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 	if(!xeno_console.validate_area(user, remote_eye, target_turf))
 		return
 
-	for(var/mob/M in target_turf)
+	for(var/mob/monkey in target_turf)
 		if(ismonkey(M) && M.stat == DEAD)
 			cleanup = TRUE
 			xeno_console.monkey_recycle(user, M)


### PR DESCRIPTION
## About The Pull Request
This adds a functionality to the 'feed slimes' ctrl-click action for the xenobio console. Before placing a monkey, it checks for dead and therefore recycleable monkies, and then calls the proc to recycle said monkeys. It will also not place a monkey if it clears dead monkeys, meaning you can avoid adding more monkeys if you want to empty the pen.
## Why It's Good For The Game
Pixel hunting for dead monkeys is just dogshit and this is way better. It's so easy to accidentally place monkeys while trying to clear ONE dead monkey.
## Changelog
:cl:
qol:  The xenobio console's monkey placing command also clears dead monkeys on the tile.
/:cl:
