### PR TITLE
PDA messenger & message monitor show actual emoji, other fixes

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -268,6 +268,9 @@
 		ui = new(user, src, "MessageMonitor", name)
 		ui.open()
 
+/obj/machinery/computer/message_monitor/ui_assets(mob/user)
+	. = ..()
+	. += get_asset_datum(/datum/asset/spritesheet/chat)
 
 #undef MSG_MON_SCREEN_MAIN
 #undef MSG_MON_SCREEN_LOGS

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -729,7 +729,7 @@
 
 	if(QDELETED(src))
 		return
-	if(!usr.can_perform_action(computer, FORBID_TELEKINESIS_REACH))
+	if(!usr.can_perform_action(computer, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
 		return
 
 	// send an activation message and open the messenger

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -681,7 +681,7 @@
 			viewing_messages_of = REF(chat)
 
 	var/list/mob/living/receievers = list()
-	if(computer.inserted_pai)
+	if(computer.inserted_pai && computer.inserted_pai.pai)
 		receievers += computer.inserted_pai.pai
 	if(computer.loc && isliving(computer.loc))
 		receievers += computer.loc

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -166,7 +166,8 @@
 		if("PDA_ringSet")
 			var/mob/living/user = usr
 			var/new_ringtone = tgui_input_text(user, "Enter a new ringtone", "Ringtone", ringtone, encode = FALSE)
-			if(!in_range(computer, user) || computer.loc != user)
+			if(!computer.can_interact(user))
+				computer.balloon_alert(user, "can't reach!")
 				return FALSE
 			return set_ringtone(new_ringtone, user)
 

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -382,6 +382,10 @@
 		data["sending_virus"] = sending_virus
 	return data
 
+/datum/computer_file/program/messenger/ui_assets(mob/user)
+	. = ..()
+	. += get_asset_datum(/datum/asset/spritesheet/chat)
+
 //////////////////////
 // MESSAGE HANDLING //
 //////////////////////
@@ -464,7 +468,7 @@
 	if(sender && !check_pda_message_against_filter(message, sender))
 		return null
 
-	return message
+	return emoji_parse(message)
 
 /// Sends a message to targets via PDA. When sending to everyone, set `everyone` to true so the message is formatted accordingly
 /datum/computer_file/program/messenger/proc/send_message(atom/source, message, list/targets, everyone = FALSE)
@@ -629,8 +633,6 @@
 	if(rigged)
 		log_bomber(sender, "sent a rigged PDA message (Name: [fake_name]. Job: [fake_job]) to [english_list(stringified_targets)] [!is_special_character(sender) ? "(SENT BY NON-ANTAG)" : ""]")
 
-	message = emoji_parse(message) //already sent- this just shows the sent emoji as one to the sender in the to_chat
-
 	// Show it to ghosts
 	var/ghost_message = span_game_say("[span_name(signal.format_sender())] [rigged ? "(as [span_name(fake_name)]) Rigged " : ""]PDA Message --> [span_name("[signal.format_target()]")]: \"[signal.format_message()]\"")
 	var/list/message_listeners = GLOB.dead_player_list + GLOB.current_observers_list
@@ -709,7 +711,6 @@
 			sender_title = "<a href='?src=[REF(messaged_mob)];track=[html_encode(sender_name)]'>[sender_title]</a>"
 
 		var/inbound_message = "[signal.format_message()]"
-		inbound_message = emoji_parse(inbound_message)
 
 		var/photo_message = signal.data["photo"] ? " (<a href='byond://?src=[REF(src)];choice=[photo_href];skiprefresh=1;target=[REF(chat)]'>Photo Attached</a>)" : ""
 		to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>\"[inbound_message]\"[photo_message] [reply]"))

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -631,7 +631,7 @@
 	message = emoji_parse(message) //already sent- this just shows the sent emoji as one to the sender in the to_chat
 
 	// Show it to ghosts
-	var/ghost_message = span_game_say("[span_name("[source]")] [rigged ? "(as [span_name(fake_name)]) Rigged " : ""]PDA Message --> [span_name("[signal.format_target()]")]: \"[signal.format_message()]\"")
+	var/ghost_message = span_game_say("[span_name(signal.format_sender())] [rigged ? "(as [span_name(fake_name)]) Rigged " : ""]PDA Message --> [span_name("[signal.format_target()]")]: \"[signal.format_message()]\"")
 	var/list/message_listeners = GLOB.dead_player_list + GLOB.current_observers_list
 	for(var/mob/listener as anything in message_listeners)
 		if(!(get_chat_toggles(listener) & CHAT_GHOSTPDA))

--- a/tgui/packages/tgui/interfaces/MessageMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/MessageMonitor.tsx
@@ -133,7 +133,12 @@ const MessageLogsScreen = (props) => {
                 </Table.Cell>
                 <Table.Cell>{message.sender}</Table.Cell>
                 <Table.Cell>{message.recipient}</Table.Cell>
-                <Table.Cell>{message.message}</Table.Cell>
+                <Table.Cell>
+                  <Box
+                    as="span"
+                    dangerouslySetInnerHTML={{ __html: message.message }}
+                  />
+                </Table.Cell>
               </Table.Row>
             ))}
           </Table>

--- a/tgui/packages/tgui/interfaces/NtosMessenger/ChatScreen.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/ChatScreen.tsx
@@ -1,5 +1,4 @@
 import { BooleanLike } from 'common/react';
-import { decodeHtmlEntities } from 'common/string';
 import { Component, createRef, RefObject } from 'react';
 
 import { useBackend } from '../../backend';
@@ -402,12 +401,14 @@ const ChatMessage = (props: ChatMessageProps) => {
   const { message, everyone, outgoing, photoPath, timestamp, onPreviewImage } =
     props;
 
-  const displayMessage = decodeHtmlEntities(message);
+  const messageHTML = {
+    __html: `${message}`,
+  };
 
   return (
     <Box className={`NtosChatMessage${outgoing ? '_outgoing' : ''}`}>
       <Box className="NtosChatMessage__content">
-        <Box as="span">{displayMessage}</Box>
+        <Box as="span" dangerouslySetInnerHTML={messageHTML} />
         <Tooltip content={timestamp} position={outgoing ? 'left' : 'right'}>
           <Icon
             className="NtosChatMessage__timestamp"


### PR DESCRIPTION
## About The Pull Request
Makes pda messages actually appear in the messenger UI, as was supposed to be the case way back in #75820
Does the same for tcomm's message server monitor, making sure anyone trying to view pda messages is actually able to get a cohesive idea of what the message actually contained.
Also a couple of other small fixes, listed in the changelogs
![image](https://github.com/tgstation/tgstation/assets/25628932/6ee5fd4a-d1bb-4c0a-9563-18d6b5541540)
![image](https://github.com/tgstation/tgstation/assets/25628932/65f74316-ac2e-4e28-9c5c-8ba4a9c22fcd)

Fixes #77856
## Why It's Good For The Game
Consistency, fix bugs
## Changelog
:cl: Fluffles
fix: emoji show up in the messenger UI
fix: emoji show up in the message server monitor UI
fix: you can adjust your pda ringtone in-game
fix: having an empty pAI in your pda doesn't break ringtones
fix: pdas specifically set to not consume power don't constantly switch to messenger
fix: you can use the quick-reply button for messages while resting
fix: deadchat pda messages show the imprinted sender's name instead of whoever is holding the pda
fix: emoji show up in deadchat pda messages
/:cl:
