### PR TITLE
Replace BDM spawn lava tiles with ash tiles

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_blooddrunk1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_blooddrunk1.dmm
@@ -93,7 +93,7 @@
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "r" = (
 /obj/structure/stone_tile/block{
@@ -106,7 +106,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "t" = (
 /obj/structure/stone_tile/surrounding/cracked{
@@ -115,14 +115,14 @@
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner{
 	dir = 1
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "u" = (
 /obj/structure/stone_tile{
 	dir = 1
 	},
 /obj/structure/stone_tile/block/cracked,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "v" = (
 /obj/structure/stone_tile{
@@ -136,7 +136,7 @@
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "x" = (
 /obj/structure/stone_tile{


### PR DESCRIPTION

## About The Pull Request
Replaces the lava tiles on `lavaland_surface-blooddrunk1` with ash tiles. 

## Why It's Good For The Game
Allows BDM to move off of his spawn tile. BDM would not path over the lava tiles and therefor would be stuck unless the person attacking decided to move far enough for a dash attack to trigger. Megafauna being able to properly fight back is good.
fix #83615 

## Changelog
:cl: Goat
fix: blood drunk miner no longer gets stuck on his spawn tile
/:cl:
