### PR TITLE
Adds proto-kinetic accelerator modkit and proto-kinetic crusher trophy disks to the bitrunning vendor

### DIFF
--- a/code/modules/bitrunning/objects/disks.dm
+++ b/code/modules/bitrunning/objects/disks.dm
@@ -142,3 +142,46 @@
 		/obj/item/dualsaber/green,
 		/obj/item/grenade/syndieminibomb,
 	)
+
+///proto-kinetic accelerator mods, to be applied to pka's given inside domains
+/obj/item/bitrunning_disk/item/pka_mods
+	name = "bitrunning gear: proto-kinetic accelerator mods"
+	selectable_items = list(
+		/obj/item/borg/upgrade/modkit/range,
+		/obj/item/borg/upgrade/modkit/damage,
+		/obj/item/borg/upgrade/modkit/cooldown,
+		/obj/item/borg/upgrade/modkit/aoe/mobs,
+		/obj/item/borg/upgrade/modkit/human_passthrough,
+	)
+
+/obj/item/bitrunning_disk/item/pka_mods/premium
+	name = "bitrunning gear: premium proto-kinetic accelerator mods"
+	selectable_items = list(
+		/obj/item/borg/upgrade/modkit/cooldown/repeater,
+		/obj/item/borg/upgrade/modkit/lifesteal,
+		/obj/item/borg/upgrade/modkit/resonator_blasts,
+		/obj/item/borg/upgrade/modkit/bounty,
+		/obj/item/borg/upgrade/modkit/indoors,
+	)
+
+///proto-kinetic crusher trophies, to be applied to pkc's given inside domains
+/obj/item/bitrunning_disk/item/pkc_mods
+	name = "bitrunning gear: proto-kinetic crusher mods"
+	selectable_items = list(
+		/obj/item/crusher_trophy/watcher_wing,
+		/obj/item/crusher_trophy/blaster_tubes/magma_wing,
+		/obj/item/crusher_trophy/legion_skull,
+		/obj/item/crusher_trophy/wolf_ear,
+	)
+
+/obj/item/bitrunning_disk/item/pkc_mods/premium
+	name = "bitrunning gear: premium proto-kinetic crusher mods"
+	selectable_items = list(
+		/obj/item/crusher_trophy/watcher_wing/ice_wing,
+		/obj/item/crusher_trophy/blaster_tubes,
+		/obj/item/crusher_trophy/miner_eye,
+		/obj/item/crusher_trophy/tail_spike,
+		/obj/item/crusher_trophy/demon_claws,
+		/obj/item/crusher_trophy/vortex_talisman,
+		/obj/item/crusher_trophy/ice_demon_cube,
+	)

--- a/code/modules/bitrunning/orders/tech.dm
+++ b/code/modules/bitrunning/orders/tech.dm
@@ -53,4 +53,4 @@
 /datum/orderable_item/bitrunning_tech/pkc_mod/premium
 	item_path = /obj/item/bitrunning_disk/item/pkc_mods/premium
 	cost_per_order = 1800
-	desc = "This disk contains a program that lets you equip stronger trophies for the proto-kinetic crusher. Proto-kinetic crusher no included."
+	desc = "This disk contains a program that lets you equip stronger trophies for the proto-kinetic crusher. Proto-kinetic crusher not included."

--- a/code/modules/bitrunning/orders/tech.dm
+++ b/code/modules/bitrunning/orders/tech.dm
@@ -34,3 +34,23 @@
 /datum/orderable_item/bitrunning_tech/flip_skillchip
 	item_path = /obj/item/skillchip/matrix_flip
 	cost_per_order = 2000
+
+/datum/orderable_item/bitrunning_tech/pka_mod
+	item_path = /obj/item/bitrunning_disk/item/pka_mods
+	cost_per_order = 2000
+	desc = "This disk contains a program that lets you equip modkits for the proto-kinetic accelerator. Proto-kinetic accelerator not included."
+
+/datum/orderable_item/bitrunning_tech/pka_mod/premium
+	item_path = /obj/item/bitrunning_disk/item/pka_mods/premium
+	cost_per_order = 3000
+	desc = "This disk contains a program that lets you equip stronger modkits for the proto-kinetic accelerator. Proto-kinetic accelerator not included."
+
+/datum/orderable_item/bitrunning_tech/pkc_mod
+	item_path = /obj/item/bitrunning_disk/item/pkc_mods
+	cost_per_order = 2000
+	desc = "This disk contains a program that lets you equip trophies for the proto-kinetic crusher. Proto-kinetic crusher no included."
+
+/datum/orderable_item/bitrunning_tech/pkc_mod/premium
+	item_path = /obj/item/bitrunning_disk/item/pkc_mods/premium
+	cost_per_order = 3000
+	desc = "This disk contains a program that lets you equip stronger trophies for the proto-kinetic crusher. Proto-kinetic crusher no included."

--- a/code/modules/bitrunning/orders/tech.dm
+++ b/code/modules/bitrunning/orders/tech.dm
@@ -37,20 +37,20 @@
 
 /datum/orderable_item/bitrunning_tech/pka_mod
 	item_path = /obj/item/bitrunning_disk/item/pka_mods
-	cost_per_order = 2000
+	cost_per_order = 750
 	desc = "This disk contains a program that lets you equip modkits for the proto-kinetic accelerator. Proto-kinetic accelerator not included."
 
 /datum/orderable_item/bitrunning_tech/pka_mod/premium
 	item_path = /obj/item/bitrunning_disk/item/pka_mods/premium
-	cost_per_order = 3000
+	cost_per_order = 1800
 	desc = "This disk contains a program that lets you equip stronger modkits for the proto-kinetic accelerator. Proto-kinetic accelerator not included."
 
 /datum/orderable_item/bitrunning_tech/pkc_mod
 	item_path = /obj/item/bitrunning_disk/item/pkc_mods
-	cost_per_order = 2000
+	cost_per_order = 750
 	desc = "This disk contains a program that lets you equip trophies for the proto-kinetic crusher. Proto-kinetic crusher no included."
 
 /datum/orderable_item/bitrunning_tech/pkc_mod/premium
 	item_path = /obj/item/bitrunning_disk/item/pkc_mods/premium
-	cost_per_order = 3000
+	cost_per_order = 1800
 	desc = "This disk contains a program that lets you equip stronger trophies for the proto-kinetic crusher. Proto-kinetic crusher no included."


### PR DESCRIPTION
## About The Pull Request
Adds disks to the bitrunning vendor that give the pka and pkc additional parts.
I have no idea if any of these numbers are balanced, I am not good at balance, and these are just random numbers I came up with. If anyone has any recommendations on how to better order or price it, I would love to know.

## Why It's Good For The Game
It gives people a way to test fights against megafauna using unique combinations of accelerator modkits and crusher trophies with less risks.

## Changelog
:cl:
add: Added disks for accelerator modkits and crusher trophies to the bitrunning vendor
/:cl:
