### PR TITLE
Gets rid of BDM's islava check

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -122,7 +122,7 @@ Difficulty: Medium
 		new /obj/effect/temp_visual/dir_setting/miner_death(loc, dir)
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Move(atom/newloc)
-	if(newloc && newloc.z == z && (islava(newloc) || ischasm(newloc))) //we're not stupid!
+	if(newloc && newloc.z == z && ischasm(newloc)) //we're not stupid!
 		return FALSE
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
Removes `islava(newloc)` from BDM's move atom.

## Why It's Good For The Game
Megafauna have lava immunity and so won't take any damage from pathing over lava. BDM would get stuck on his lava tile spawn due to this as well. 
fix #83615 

## Changelog
:cl: Goat
fix: blood drunk miner can now path over lava
/:cl:
