### PR TITLE
make janitorialcart hold more water

### DIFF
--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -73,6 +73,7 @@
 
 /obj/structure/mop_bucket/janitorialcart/Initialize(mapload)
 	. = ..()
+	reagents.maximum_volume *= 2.5
 	GLOB.janitor_devices += src
 
 /obj/structure/mop_bucket/janitorialcart/Destroy()


### PR DESCRIPTION
not 3 buckets in a trench coat
## About The Pull Request
 
the cart is big so it should hold more water

## Why It's Good For The Game

hives human janitors a point vs borgs or an assistant pulling a clean bot

## Changelog
:cl:
qol: make the cart hold 2.5x more water
/:cl:
