### PR TITLE
Webbing production mutation lets you pass through webs.

### DIFF
--- a/code/datums/mutations/webbing.dm
+++ b/code/datums/mutations/webbing.dm
@@ -24,8 +24,10 @@
 	if(..())
 		return
 	ADD_TRAIT(owner, TRAIT_WEB_WEAVER, GENETIC_MUTATION)
+	ADD_TRAIT(owner, TRAIT_WEB_SURFER, GENETIC_MUTATION)
 
 /datum/mutation/human/webbing/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_WEB_WEAVER, GENETIC_MUTATION)
+	REMOVE_TRAIT(owner, TRAIT_WEB_SURFER, GENETIC_MUTATION)


### PR DESCRIPTION
## About The Pull Request
Webbing production mutation gives you TRAIT_WEB_SURFER, so that you can pass through webs like the gene says you can.

## Why It's Good For The Game
If a gene says it lets you do something, it should actually be true.

## Changelog
:cl:
balance: Webbing production mutation makes you able to pass through all webs.
/:cl:
