### PR TITLE
Corpses won't remain cultists when ghouled by a flesheretic

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/ghoul.dm
+++ b/code/modules/antagonists/heretic/status_effects/ghoul.dm
@@ -67,6 +67,7 @@
 	if(human_target.mind)
 		var/datum/antagonist/heretic_monster/heretic_monster = human_target.mind.add_antag_datum(/datum/antagonist/heretic_monster)
 		heretic_monster.set_owner(master_mind)
+		human_target.mind.remove_antag_datum(/datum/antagonist/cult)
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Fixed cultists retaining their datum when ghouled, which resulted in double antag.

## Why It's Good For The Game

Silly and weird and confusing and buggy.

## Changelog

:cl:
balance: Corpses won't remain cultists when ghouled by a flesheretic
/:cl:

