### PR TITLE
Armblade will now tell you the correct chemical cost

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -173,7 +173,7 @@
 \***************************************/
 /datum/action/changeling/weapon/arm_blade
 	name = "Arm Blade"
-	desc = "We reform one of our arms into a deadly blade that breaks after a number of hits, improvable by absorbing genomes. Costs 40 chemicals."
+	desc = "We reform one of our arms into a deadly blade that breaks after a number of hits, improvable by absorbing genomes. Costs 30 chemicals."
 	helptext = "We may retract our armblade in the same manner as we form it. Organic tissue is not perfect; the armblade will break after it is used too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 30


### PR DESCRIPTION
## About The Pull Request

The action description for the armblade will no longer say it costs 40 chemicals instead of the 30 it actually costs

## Why It's Good For The Game

New players playing ling shouldn't be baited by the action description saying its 40 chemicals instead of 30

## Changelog

:cl:
spellcheck: The armblade now shows its actual chemical cost
/:cl: