### PR TITLE
You can kill people with the Armblade

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -32,6 +32,8 @@
 	var/ignores_fakedeath = FALSE
 	/// used by a few powers that toggle
 	var/active = FALSE
+	/// Does this ability stop working if you are burning?
+	var/disabled_by_fire = TRUE
 
 /*
 changeling code now relies on on_purchase to grant powers.
@@ -81,9 +83,8 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 /datum/action/changeling/proc/can_sting(mob/living/user, mob/living/target)
 	if(!can_be_used_by(user))
 		return FALSE
-	if(user.fire_stacks && user.on_fire)
+	if(disabled_by_fire && user.fire_stacks && user.on_fire)
 		user.balloon_alert(user, "on fire!")
-		to_chat(user, span_boldwarning("WE CANNOT DO THIS WHILE ENGULFED IN FLAMES!!! PUT OUT THE FIRE FIRST!!!"))
 		return FALSE
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
 	if(changeling.chem_charges < chemical_cost)

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -7,6 +7,7 @@
 	req_dna = 1
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
+	disabled_by_fire = FALSE
 
 	/// How long it takes for revival to ready upon entering stasis.
 	/// The changeling can opt to stay in fakedeath for longer, though.

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -8,6 +8,7 @@
 	req_human = TRUE
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -177,7 +177,7 @@
 	helptext = "We may retract our armblade in the same manner as we form it. Organic tissue is not perfect; the armblade will break after it is used too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 30
-	dna_cost = 3
+	dna_cost = 2
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -188,7 +188,7 @@
 		return
 
 	var/obj/item/melee/arm_blade/blade = ..()
-	blade.remaining_uses = round(changeling.absorbed_count * 3)
+	blade.remaining_uses += changeling.true_absorbs * 2
 	return TRUE
 
 /obj/item/melee/arm_blade
@@ -201,7 +201,7 @@
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
-	force = 25
+	force = 40
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
@@ -213,20 +213,19 @@
 	bare_wound_bonus = 10
 	armour_penetration = 35
 	resistance_flags = FLAMMABLE
-	var/can_drop = FALSE
+	/// Is this a real arm blade?
 	var/fake = FALSE
-	var/remaining_uses
+	/// How many times can you use this before it retracts?
+	var/remaining_uses = 4
 
-/obj/item/melee/arm_blade/Initialize(mapload,silent,synthetic)
+/obj/item/melee/arm_blade/Initialize(mapload, silent)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
 	if(ismob(loc) && !silent)
 		loc.visible_message(span_warning("A grotesque blade forms around [loc.name]\'s arm!"), span_warning("Our arm twists and mutates, transforming it into a deadly blade."), span_hear("You hear organic matter ripping and tearing!"))
-	if(synthetic)
-		can_drop = TRUE
 	AddComponent(/datum/component/butchering, \
-	speed = 6 SECONDS, \
-	effectiveness = 80, \
+		speed = 6 SECONDS, \
+		effectiveness = 80, \
 	)
 
 /obj/item/melee/arm_blade/afterattack(atom/target, mob/user, proximity)
@@ -266,14 +265,17 @@
 			var/mob/living/carbon/human/changeling = loc
 			changeling.visible_message(span_warning("With a sickening crunch, [changeling] reforms [changeling.p_their()] [src] into an arm!"), span_notice("We assimilate our armblade into our body."), "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 		qdel(src)
-	else
+	else if isliving(target)
 		remaining_uses--
 
 
-/obj/item/melee/arm_blade/dropped(mob/user)
-	..()
-	if(can_drop)
-		new /obj/item/melee/synthetic_arm_blade(get_turf(user))
+/obj/item/melee/arm_blade/prosthetic
+	force = 25
+	remaining_uses = INFINITE
+
+/obj/item/melee/arm_blade/prosthetic/dropped(mob/user)
+	. = ..()
+	new /obj/item/melee/synthetic_arm_blade(get_turf(user))
 
 /***************************************\
 |***********COMBAT TENTACLES*************|

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -131,7 +131,7 @@
 			return
 		else if(istype(tool, /obj/item/melee/synthetic_arm_blade))
 			qdel(tool)
-			var/obj/item/melee/arm_blade/new_arm = new(target,TRUE,TRUE)
+			var/obj/item/melee/arm_blade/prosthetic/new_arm = new(target,TRUE)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return
 	return ..() //if for some reason we fail everything we'll print out some text okay?


### PR DESCRIPTION
## About The Pull Request

If we end up fully reverting goof's PR instead then we won't need this but I started it before Oranges opened his revert PR so I might as well post it,

- Armblade once more costs 2 genetics points.
- It does 40 damage.
- You can use it four times before it retracts (plus 2 per person you have fully absorbed), which should actually critically injure people you attack with it and will very frequently inflict wounds (or two people, after you've absorbed one person).
- You can use regenerative stasis and last resort while on fire.

## Why It's Good For The Game

I think that we went a little bit too far to be honest.
With this change the Armblade becomes a tool you can quickly use to deal with one or two people before returning to stealth rather than being functionally pointless as a weapon.

## Changelog

:cl:
balance: The Armblade now does more damage and can be used more times.
balance: You can use regenerative stasis and last resort while on fire.
/:cl:
