### PR TITLE
tgui: Excludes corejs from transpilation

### DIFF
--- a/tgui/.eslintignore
+++ b/tgui/.eslintignore
@@ -14,3 +14,4 @@
 **.woff2
 **.eot
 **.ttf
+/public

--- a/tgui/webpack.config.js
+++ b/tgui/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = (env = {}, argv) => {
       rules: [
         {
           test: /\.([tj]s(x)?|cjs)$/,
+          exclude: /node_modules[\\/]core-js/,
           use: [
             {
               loader: require.resolve('swc-loader'),


### PR DESCRIPTION

## About The Pull Request
1. We're not actually supposed to bundle core-js https://github.com/zloirock/core-js/issues/916#issuecomment-790602732
2. Prevents eslint from searching the public folder, there's no reason it should work there
## Why It's Good For The Game
Minor fixes for tgui
## Changelog

n/a