### PR TITLE
Changes up carbon EMP handling

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -233,8 +233,6 @@
 	. = ..()
 	if(. & EMP_PROTECT_CONTENTS)
 		return
-	for(var/obj/item/organ/organ as anything in organs)
-		organ.emp_act(severity)
 	for(var/obj/item/bodypart/bodypart as anything in src.bodyparts)
 		bodypart.emp_act(severity)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -229,13 +229,6 @@
 		show_message(span_userdanger("The blob attacks!"))
 		adjustBruteLoss(10)
 
-/mob/living/carbon/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_CONTENTS)
-		return
-	for(var/obj/item/bodypart/bodypart as anything in src.bodyparts)
-		bodypart.emp_act(severity)
-
 ///Adds to the parent by also adding functionality to propagate shocks through pulling and doing some fluff effects.
 /mob/living/carbon/electrocute_act(shock_damage, source, siemens_coeff = 1, flags = NONE, jitter_time = 20 SECONDS, stutter_time = 4 SECONDS, stun_duration = 4 SECONDS)
 	. = ..()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1310,7 +1310,7 @@
 	else
 		update_icon_dropped()
 
-// Note: Does NOT return EMP protection value from parent call or pass it on to subtypes
+// Note: For effects on subtypes, use the emp_effect() proc instead
 /obj/item/bodypart/emp_act(severity)
 	var/protection = ..()
 	// If the limb doesn't protect contents, strike them first

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1324,7 +1324,7 @@
 	emp_effect(severity, protection)
 	return protection
 
-// The actual effect of EMPs on the limb. Allows children to override it however they want
+/// The actual effect of EMPs on the limb. Allows children to override it however they want
 /obj/item/bodypart/proc/emp_effect(severity, protection)
 	if(!IS_ROBOTIC_LIMB(src))
 		return FALSE

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1318,9 +1318,15 @@
 		for(var/atom/content as anything in contents)
 			content.emp_act(severity)
 
-	if((protection & (EMP_PROTECT_WIRES | EMP_PROTECT_SELF)) || !IS_ROBOTIC_LIMB(src))
+	if((protection & (EMP_PROTECT_WIRES | EMP_PROTECT_SELF)))
 		return FALSE
 
+	return emp_effect(severity, protection)
+
+// The actual effect of EMPs on the limb. Allows children to override it however they want
+/obj/item/bodypart/proc/emp_effect(severity, protection)
+	if(!IS_ROBOTIC_LIMB(src))
+		return FALSE
 	// with defines at the time of writing, this is 2 brute and 1.5 burn
 	// 2 + 1.5 = 3,5, with 6 limbs thats 21, on a heavy 42
 	// 42 * 0.8 = 33.6

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1319,9 +1319,10 @@
 			content.emp_act(severity)
 
 	if((protection & (EMP_PROTECT_WIRES | EMP_PROTECT_SELF)))
-		return FALSE
+		return protection
 
-	return emp_effect(severity, protection)
+	emp_effect(severity, protection)
+	return protection
 
 // The actual effect of EMPs on the limb. Allows children to override it however they want
 /obj/item/bodypart/proc/emp_effect(severity, protection)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1313,7 +1313,12 @@
 // Note: Does NOT return EMP protection value from parent call or pass it on to subtypes
 /obj/item/bodypart/emp_act(severity)
 	var/protection = ..()
-	if((protection & EMP_PROTECT_WIRES) || !IS_ROBOTIC_LIMB(src))
+	// If the limb doesn't protect contents, strike them first
+	if(!(protection & EMP_PROTECT_CONTENTS))
+		for(var/atom/content as anything in contents)
+			content.emp_act(severity)
+
+	if((protection & (EMP_PROTECT_WIRES | EMP_PROTECT_SELF)) || !IS_ROBOTIC_LIMB(src))
 		return FALSE
 
 	// with defines at the time of writing, this is 2 brute and 1.5 burn

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -115,18 +115,19 @@
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
 	bodypart_flags = BODYPART_UNHUSKABLE
 
-/obj/item/bodypart/leg/left/robot/emp_act(severity)
+/obj/item/bodypart/leg/left/robot/emp_effect(severity, protection)
 	. = ..()
-	if(!. || isnull(owner))
-		return
+	if(isnull(owner))
+		return FALSE
 
 	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
 	if (severity == EMP_HEAVY)
 		knockdown_time *= 2
 	owner.Knockdown(knockdown_time)
 	if(owner.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
-		return
+		return FALSE
 	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
+	return TRUE
 
 /obj/item/bodypart/leg/right/robot
 	name = "cyborg right leg"
@@ -163,18 +164,19 @@
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
 	bodypart_flags = BODYPART_UNHUSKABLE
 
-/obj/item/bodypart/leg/right/robot/emp_act(severity)
+/obj/item/bodypart/leg/right/robot/emp_effect(severity, protection)
 	. = ..()
-	if(!. || isnull(owner))
-		return
+	if(isnull(owner))
+		return FALSE
 
 	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
 	if (severity == EMP_HEAVY)
 		knockdown_time *= 2
 	owner.Knockdown(knockdown_time)
 	if(owner.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
-		return
+		return FALSE
 	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
+	return TRUE
 
 /obj/item/bodypart/chest/robot
 	name = "cyborg torso"
@@ -215,10 +217,10 @@
 	var/wired = FALSE
 	var/obj/item/stock_parts/cell/cell = null
 
-/obj/item/bodypart/chest/robot/emp_act(severity)
+/obj/item/bodypart/chest/robot/emp_effect(severity, protection)
 	. = ..()
-	if(!. || isnull(owner))
-		return
+	if(isnull(owner))
+		return FALSE
 
 	var/stun_time = 0
 	var/shift_x = 3
@@ -236,6 +238,7 @@
 		to_chat(owner, span_danger("Your [plaintext_zone]'s logic boards temporarily become unresponsive!"))
 		owner.Stun(stun_time)
 	owner.Shake(pixelshiftx = shift_x, pixelshifty = shift_y, duration = shake_duration)
+	return TRUE
 
 /obj/item/bodypart/chest/robot/get_cell()
 	return cell
@@ -390,10 +393,10 @@
 
 #define EMP_GLITCH "EMP_GLITCH"
 
-/obj/item/bodypart/head/robot/emp_act(severity)
+/obj/item/bodypart/head/robot/emp_effect(severity, protection)
 	. = ..()
-	if(!. || isnull(owner))
-		return
+	if(isnull(owner))
+		return FALSE
 
 	to_chat(owner, span_danger("Your [plaintext_zone]'s optical transponders glitch out and malfunction!"))
 
@@ -404,6 +407,7 @@
 	owner.add_client_colour(/datum/client_colour/malfunction)
 
 	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, remove_client_colour), /datum/client_colour/malfunction), glitch_duration)
+	return TRUE
 
 #undef EMP_GLITCH
 

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -117,8 +117,8 @@
 
 /obj/item/bodypart/leg/left/robot/emp_effect(severity, protection)
 	. = ..()
-	if(isnull(owner))
-		return FALSE
+	if(!. || isnull(owner))
+		return
 
 	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
 	if (severity == EMP_HEAVY)
@@ -127,7 +127,7 @@
 	if(owner.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
 		return FALSE
 	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
-	return TRUE
+	return
 
 /obj/item/bodypart/leg/right/robot
 	name = "cyborg right leg"
@@ -166,8 +166,8 @@
 
 /obj/item/bodypart/leg/right/robot/emp_effect(severity, protection)
 	. = ..()
-	if(isnull(owner))
-		return FALSE
+	if(!. || isnull(owner))
+		return
 
 	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
 	if (severity == EMP_HEAVY)
@@ -176,7 +176,7 @@
 	if(owner.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
 		return FALSE
 	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
-	return TRUE
+	return
 
 /obj/item/bodypart/chest/robot
 	name = "cyborg torso"
@@ -219,8 +219,8 @@
 
 /obj/item/bodypart/chest/robot/emp_effect(severity, protection)
 	. = ..()
-	if(isnull(owner))
-		return FALSE
+	if(!. || isnull(owner))
+		return
 
 	var/stun_time = 0
 	var/shift_x = 3
@@ -238,7 +238,7 @@
 		to_chat(owner, span_danger("Your [plaintext_zone]'s logic boards temporarily become unresponsive!"))
 		owner.Stun(stun_time)
 	owner.Shake(pixelshiftx = shift_x, pixelshifty = shift_y, duration = shake_duration)
-	return TRUE
+	return
 
 /obj/item/bodypart/chest/robot/get_cell()
 	return cell
@@ -395,8 +395,8 @@
 
 /obj/item/bodypart/head/robot/emp_effect(severity, protection)
 	. = ..()
-	if(isnull(owner))
-		return FALSE
+	if(!. || isnull(owner))
+		return
 
 	to_chat(owner, span_danger("Your [plaintext_zone]'s optical transponders glitch out and malfunction!"))
 
@@ -407,7 +407,7 @@
 	owner.add_client_colour(/datum/client_colour/malfunction)
 
 	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, remove_client_colour), /datum/client_colour/malfunction), glitch_duration)
-	return TRUE
+	return
 
 #undef EMP_GLITCH
 


### PR DESCRIPTION
## About The Pull Request

The organ refactor 6 months ago changed up organs, making them be actually inside bodyparts and the mob. This introduced the bug of all emp effects being called twice on everything thanks to how /mob/living handles it (Fixed in this PR), but also some new stuff:

Made bodyparts handle organ EMPs. This also means we can now have support for bodyparts with EMP_PROTECT_CONTENTS protecting the organs inside.
Made a new proc for bodyparts once they are successfully hit by an emp. Makes it much easier to add overrides for the behaviour.
Fixed emps hitting bodyparts twice

## Why It's Good For The Game

It lays a groundwork for some interesting limb concepts, and makes organ emps make a bit more sense.

Fixes a bug that laid unnoticed for 6 months.

## Changelog

:cl:
fix: EMPs on carbons no longer happen twice
code: Moves organ emps under bodyparts, changes how bodyparts handle emp effects
/:cl:
