### PR TITLE
Fix Enviro suit lights staying on when welder visor is put down

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -104,6 +104,7 @@
 		return
 	if(helmet_on)
 		to_chat(user, span_notice("Your helmet's torch can't pass through your welding visor!"))
+		set_light_on(FALSE)
 		helmet_on = FALSE
 	playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Visors don't just come from nothing
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request
Adds a missing `set_light_on(FALSE)` to `adjust_visor`

## Why It's Good For The Game
The head light is not supposed to be able to be on when the visor is down. The helmet model would show an off light but still continue to produce light if the welding visor was put on when the light was on. 
fix #45882 

## Changelog
:cl: Goat
fix: Enviro suit lights no longer stay on when the welding visor is activated.
/:cl:
