### PR TITLE
Pretties up the Chemical Analyzer's output

### DIFF
--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -120,7 +120,7 @@
 		return NONE
 	var/list/out_message = list()
 	to_chat(user, "<i>The chemistry meter beeps and displays:</i>")
-	out_message += "<span class='notice'><b>Total volume: [round(cont.volume, 0.01)] Current temperature: [round(cont.reagents.chem_temp, 0.1)]K Total pH: [round(cont.reagents.ph, 0.01)]\n"
+	out_message += "<b>Total volume: [round(cont.volume, 0.01)] Current temperature: [round(cont.reagents.chem_temp, 0.1)]K Total pH: [round(cont.reagents.ph, 0.01)]\n"
 	out_message += "Chemicals found in [interacting_with.name]:</b>\n"
 	if(cont.reagents.is_reacting)
 		out_message += "[span_warning("A reaction appears to be occuring currently.")]<span class='notice'>\n"
@@ -132,7 +132,7 @@
 			out_message += "<b>[round(reagent.volume, 0.01)]u of [reagent.name]</b>, <b>Purity:</b> [round(reagent.purity, 0.000001)*100]%, [(scanmode?"[(reagent.overdose_threshold?"<b>Overdose:</b> [reagent.overdose_threshold]u, ":"")]<b>Base pH:</b> [initial(reagent.ph)], <b>Current pH:</b> [reagent.ph].":"<b>Current pH:</b> [reagent.ph].")]\n"
 		if(scanmode)
 			out_message += "<b>Analysis:</b> [reagent.description]\n"
-	to_chat(user, "[out_message.Join()]</span>")
+	to_chat(user, examine_block(span_notice("[out_message.Join()]")))
 	desc = "An electrode attached to a small circuit box that will display details of a solution. Can be toggled to provide a description of each of the reagents. The screen currently displays detected vol: [round(cont.volume, 0.01)] detected pH:[round(cont.reagents.ph, 0.1)]."
 	return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

This just wraps the chem analyzer's output in an examine block, like so:

![2024-06-10 (1718057959) ~ dreamseeker](https://github.com/tgstation/tgstation/assets/65794972/6e8fe3ee-8cf5-4b2d-a24f-64e3a002d2bc)


## Why It's Good For The Game

It looks better, and is less of a pain to read if you're scanning multiple things.

## Changelog
:cl:
qol: Prettied up the Chemical Analyzer's output in chat, making it easier to read, especially when scanning multiple things.
/:cl:
