### PR TITLE
Cult pylons slowly close bleeding wounds

### DIFF
--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -29,6 +29,9 @@
 	/// Amount of blood to heal over a second
 	var/blood_heal = 0
 
+	/// Amount of bleed/pierce wound lowering per second.
+	var/wound_clotting = 0
+
 	/// Map of organ (such as ORGAN_SLOT_BRAIN) to damage heal over a second
 	var/list/organ_healing = null
 
@@ -56,6 +59,7 @@
 	suffocation_heal = 0,
 	stamina_heal = 0,
 	blood_heal = 0,
+	wound_clotting = 0,
 	organ_healing = null,
 	simple_heal = 0,
 	limit_to_trait = null,
@@ -74,6 +78,7 @@
 	src.suffocation_heal = suffocation_heal
 	src.stamina_heal = stamina_heal
 	src.blood_heal = blood_heal
+	src.wound_clotting = wound_clotting
 	src.organ_healing = organ_healing
 	src.simple_heal = simple_heal
 	src.limit_to_trait = limit_to_trait
@@ -130,6 +135,10 @@
 
 			for (var/organ in organ_healing)
 				candidate.adjustOrganLoss(organ, -organ_healing[organ] * seconds_per_tick)
+			var/mob/living/carbon/carbidate = candidate
+			for(var/datum/wound/iter_wound as anything in carbidate.all_wounds)
+				iter_wound.adjust_blood_flow(-wound_clotting * seconds_per_tick)
+
 		else if (isanimal(candidate))
 			var/mob/living/simple_animal/animal_candidate = candidate
 			animal_candidate.adjustHealth(-simple_heal * seconds_per_tick, updating_health = FALSE)

--- a/code/modules/antagonists/cult/cult_structure_pylon.dm
+++ b/code/modules/antagonists/cult/cult_structure_pylon.dm
@@ -22,6 +22,7 @@
 		burn_heal = 0.4, \
 		blood_heal = 0.4, \
 		simple_heal = 1.2, \
+		wound_clotting = 0.1, \
 		requires_visibility = FALSE, \
 		limit_to_trait = TRAIT_HEALS_FROM_CULT_PYLONS, \
 		healing_color = COLOR_CULT_RED, \


### PR DESCRIPTION

## About The Pull Request

Cult pylons will now slowly close bleeding wounds.

## Why It's Good For The Game

Pylons were never updated alongside wounds, so it's an EXTREMELY common sight to see people dead or dying next to pylons purely from blood loss. Even  havign 4 pylons near isn't enough to help you up - it doesn't oxy heal, so if you're in crit, you're fucked.

The blood cult should be able to deal with blood loss.

## Changelog

:cl:
qol: Cult pylons slowly close bleeding wounds
refactor: allowed aura healing to clot wounds shut
/:cl:

