### PR TITLE
Corrects all 3 improperly rotated recyclers (Snow Cabin, Deep Storage, Cyborg Mothership)

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -42,7 +42,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "am" = (
-/obj/machinery/recycler/deathtrap,
+/obj/machinery/recycler/deathtrap{
+	dir = 8
+	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "bunkerrecycle"

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -3392,7 +3392,8 @@
 /area/awaymission/cabin/caves)
 "wq" = (
 /obj/machinery/recycler/lumbermill{
-	desc = "Is better at killing people than cutting logs, for some reason."
+	desc = "Is better at killing people than cutting logs, for some reason.";
+	dir = 8
 	},
 /obj/machinery/conveyor{
 	dir = 4;

--- a/_maps/shuttles/ruin_cyborg_mothership.dmm
+++ b/_maps/shuttles/ruin_cyborg_mothership.dmm
@@ -12,7 +12,7 @@
 	id = "mothership_main"
 	},
 /obj/machinery/recycler{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ruin/cyborg_mothership)


### PR DESCRIPTION

## About The Pull Request
The recyclers (those things that destroy trash in disposals) in three instances were rotated incorrectly.
Snow Cabin's lumbermill and the Deep Storage waste room had their recyclers perpendicular to the conveyor they are on (bad)
The Cyborg Mothership's recycler was facing the wrong way on its conveyor, causing things to go through it in reverse (bad)
## Why It's Good For The Game
why have a recycler on a conveyor belt when the conveyor just runs into the side of it (or, in the cyborg ship's case, through the back of it)
## Changelog
:cl:
fix: The recyclers in the snow cabin gateway, the cyborg mothership, and the deep storage space ruin are now rotated properly.
/:cl:
