### PR TITLE
RHD's cancel build when blueprint is changed

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -254,7 +254,7 @@
 	if(ranged)
 		var/atom/beam_source = owner ? owner : user
 		beam = beam_source.Beam(target, icon_state = "rped_upgrade", time = delay)
-	if(delay && !do_after(user, delay, target = target)) // no need for do_after with no delay
+	if(!build_delay(user, delay, target = target)) // no need for do_after with no delay
 		qdel(rcd_effect)
 		if(!isnull(beam))
 			qdel(beam)
@@ -379,6 +379,7 @@
 			construction_mode = mode
 			rcd_design_path = design["[RCD_DESIGN_PATH]"]
 			design_title = initial(rcd_design_path.name)
+			blueprint_changed = TRUE
 
 		else
 			airlock_electronics.do_action(action, params)

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -37,6 +37,8 @@
 	var/datum/component/remote_materials/silo_mats
 	/// switch to use internal or remote storage
 	var/silo_link = FALSE
+	/// has the blueprint design changed
+	var/blueprint_changed = FALSE
 
 /datum/armor/item_construction
 	fire = 100
@@ -50,6 +52,18 @@
 	if(upgrade & RCD_UPGRADE_SILO_LINK)
 		silo_mats = AddComponent(/datum/component/remote_materials, mapload, FALSE)
 	update_appearance()
+
+///An do_after() specially designed for rhd devices
+/obj/item/construction/proc/build_delay(mob/user, delay, atom/target)
+	if(delay <= 0)
+		return TRUE
+
+	blueprint_changed = FALSE
+
+	return do_after(user, delay, target, extra_checks = CALLBACK(src, PROC_REF(blueprint_change)))
+
+/obj/item/construction/proc/blueprint_change()
+	return !blueprint_changed
 
 ///used for examining the RCD and for its UI
 /obj/item/construction/proc/get_silo_iron()

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -177,6 +177,7 @@
 			if(!design)
 				return FALSE
 			blueprint = design
+			blueprint_changed = TRUE
 
 			playsound(src, 'sound/effects/pop.ogg', 50, vary = FALSE)
 
@@ -202,7 +203,7 @@
 		if(!is_allowed)
 			balloon_alert(user, "turf is blocked!")
 		return FALSE
-	if(!do_after(user, cost, target = destination)) //"cost" is relative to delay at a rate of 10 matter/second  (1matter/decisecond) rather than playing with 2 different variables since everyone set it to this rate anyways.
+	if(!build_delay(user, cost, target = destination))
 		return FALSE
 	if(!checkResource(cost, user) || !(is_allowed = canPlace(destination)))
 		if(!is_allowed)

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -224,6 +224,7 @@
 			QDEL_LIST(design_overlays)
 			design_category = params["category_name"]
 			selected_design.set_info(target_design)
+			blueprint_changed = TRUE
 
 	return TRUE
 
@@ -274,7 +275,7 @@
 		return TRUE
 	var/beam = user.Beam(floor, icon_state = "light_beam", time = delay)
 	playsound(loc, 'sound/effects/light_flicker.ogg', 50, FALSE)
-	if(!do_after(user, delay, target = floor))
+	if(!build_delay(user, delay, target = floor))
 		qdel(beam)
 		qdel(rcd_effect)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request
- Fixes #83679

RHD(Rapid handheld device) refers to the RCD, RPLD & RTD. During the `do_after()` when building the design if the blueprint is changed then the build process is cancelled. This way we don't use the wrong amount of resource when the design changes mid build

## Changelog
:cl:
fix:  RCD, RPLD & RTD cancels their build process if their design is changed during build.
/:cl:
