### PR TITLE
Fix of a inaccuracy in the fax interface

### DIFF
--- a/tgui/packages/tgui/interfaces/Fax.tsx
+++ b/tgui/packages/tgui/interfaces/Fax.tsx
@@ -49,6 +49,9 @@ export const Fax = (props) => {
         (sortFax: FaxInfo) => sortFax.fax_name,
       )
     : [];
+  const special_networks = data.syndicate_network
+    ? data.special_faxes
+    : data.special_faxes.filter((fax: FaxSpecial) => !fax.emag_needed);
   return (
     <Window width={340} height={540}>
       <Window.Content scrollable>
@@ -81,33 +84,26 @@ export const Fax = (props) => {
           </LabeledList.Item>
         </Section>
         <Section title="Send">
-          {faxes.length === 0 && data.special_faxes.length === 0 ? (
+          {faxes.length === 0 && special_networks.length === 0 ? (
             "The fax couldn't detect any other faxes on the network."
           ) : (
             <Box mt={0.4}>
-              {data.special_faxes.length !== 0
-                ? (data.syndicate_network
-                    ? data.special_faxes
-                    : data.special_faxes.filter(
-                        (fax: FaxSpecial) => !fax.emag_needed,
-                      )
-                  ).map((special: FaxSpecial) => (
-                    <Button
-                      key={special.fax_id}
-                      tooltip={special.fax_name}
-                      disabled={!data.has_paper}
-                      color={special.color}
-                      onClick={() =>
-                        act('send_special', {
-                          id: special.fax_id,
-                          name: special.fax_name,
-                        })
-                      }
-                    >
-                      {special.fax_name}
-                    </Button>
-                  ))
-                : null}
+              {special_networks.map((special: FaxSpecial) => (
+                <Button
+                  key={special.fax_id}
+                  tooltip={special.fax_name}
+                  disabled={!data.has_paper}
+                  color={special.color}
+                  onClick={() =>
+                    act('send_special', {
+                      id: special.fax_id,
+                      name: special.fax_name,
+                    })
+                  }
+                >
+                  {special.fax_name}
+                </Button>
+              ))}
               {faxes.length !== 0
                 ? faxes.map((fax: FaxInfo) => (
                     <Button

--- a/tgui/packages/tgui/interfaces/Fax.tsx
+++ b/tgui/packages/tgui/interfaces/Fax.tsx
@@ -81,72 +81,52 @@ export const Fax = (props) => {
           </LabeledList.Item>
         </Section>
         <Section title="Send">
-          {faxes.length !== 0 ? (
-            <Box mt={0.4}>
-              {(data.syndicate_network
-                ? data.special_faxes
-                : data.special_faxes.filter(
-                    (fax: FaxSpecial) => !fax.emag_needed,
-                  )
-              ).map((special: FaxSpecial) => (
-                <Button
-                  key={special.fax_id}
-                  tooltip={special.fax_name}
-                  disabled={!data.has_paper}
-                  color={special.color}
-                  onClick={() =>
-                    act('send_special', {
-                      id: special.fax_id,
-                      name: special.fax_name,
-                    })
-                  }
-                >
-                  {special.fax_name}
-                </Button>
-              ))}
-              {faxes.map((fax: FaxInfo) => (
-                <Button
-                  key={fax.fax_id}
-                  tooltip={fax.fax_name}
-                  disabled={!data.has_paper}
-                  color={fax.syndicate_network ? 'red' : 'blue'}
-                  onClick={() =>
-                    act('send', {
-                      id: fax.fax_id,
-                      name: fax.fax_name,
-                    })
-                  }
-                >
-                  {fax.fax_name}
-                </Button>
-              ))}
-            </Box>
-          ) : data.special_faxes.length !== 0 ? (
-            <Box mt={0.4}>
-              {(data.syndicate_network
-                ? data.special_faxes
-                : data.special_faxes.filter(
-                    (fax: FaxSpecial) => !fax.emag_needed,
-                  )
-              ).map((special: FaxSpecial) => (
-                <Button
-                  key={special.fax_id}
-                  tooltip={special.fax_name}
-                  disabled={!data.has_paper}
-                  color={special.color}
-                  onClick={() =>
-                    act('send_special', {
-                      id: special.fax_id,
-                      name: special.fax_name,
-                    })
-                  }
-                >
-                  {special.fax_name}
-                </Button>
-              ))}
-            </Box>
-          ) : (
+          {faxes.length === 0 && data.special_faxes.length === 0 ? (
             "The fax couldn't detect any other faxes on the network."
+          ) : (
+            <Box mt={0.4}>
+              {data.special_faxes.length !== 0
+                ? (data.syndicate_network
+                    ? data.special_faxes
+                    : data.special_faxes.filter(
+                        (fax: FaxSpecial) => !fax.emag_needed,
+                      )
+                  ).map((special: FaxSpecial) => (
+                    <Button
+                      key={special.fax_id}
+                      tooltip={special.fax_name}
+                      disabled={!data.has_paper}
+                      color={special.color}
+                      onClick={() =>
+                        act('send_special', {
+                          id: special.fax_id,
+                          name: special.fax_name,
+                        })
+                      }
+                    >
+                      {special.fax_name}
+                    </Button>
+                  ))
+                : null}
+              {faxes.length !== 0
+                ? faxes.map((fax: FaxInfo) => (
+                    <Button
+                      key={fax.fax_id}
+                      tooltip={fax.fax_name}
+                      disabled={!data.has_paper}
+                      color={fax.syndicate_network ? 'red' : 'blue'}
+                      onClick={() =>
+                        act('send', {
+                          id: fax.fax_id,
+                          name: fax.fax_name,
+                        })
+                      }
+                    >
+                      {fax.fax_name}
+                    </Button>
+                  ))
+                : null}
+            </Box>
           )}
         </Section>
         <Section

--- a/tgui/packages/tgui/interfaces/Fax.tsx
+++ b/tgui/packages/tgui/interfaces/Fax.tsx
@@ -121,6 +121,30 @@ export const Fax = (props) => {
                 </Button>
               ))}
             </Box>
+          ) : data.special_faxes.length !== 0 ? (
+            <Box mt={0.4}>
+              {(data.syndicate_network
+                ? data.special_faxes
+                : data.special_faxes.filter(
+                    (fax: FaxSpecial) => !fax.emag_needed,
+                  )
+              ).map((special: FaxSpecial) => (
+                <Button
+                  key={special.fax_id}
+                  tooltip={special.fax_name}
+                  disabled={!data.has_paper}
+                  color={special.color}
+                  onClick={() =>
+                    act('send_special', {
+                      id: special.fax_id,
+                      name: special.fax_name,
+                    })
+                  }
+                >
+                  {special.fax_name}
+                </Button>
+              ))}
+            </Box>
           ) : (
             "The fax couldn't detect any other faxes on the network."
           )}


### PR DESCRIPTION

## About The Pull Request

If there is only 1 fax in the entire game world, then even special networks were not shown in its interface. It's fixed now
![изображение_2024-06-11_234232078](https://github.com/tgstation/tgstation/assets/112967882/94f6e744-0829-4e30-aeff-e9f39b1ad8e9)
## Why It's Good For The Game

This is a mistake, and they need to be corrected... Perhaps useful for those who create maps?
## Changelog
:cl:
fix: special networks are now displayed in the fax if it is the only one in the world
/:cl:
