### PR TITLE
No-gravity now properly ignores missing leg slowdown

### DIFF
--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -89,6 +89,7 @@
 /datum/movespeed_modifier/limbless
 	variable = TRUE
 	movetypes = GROUND
+	blacklisted_movetypes = FLOATING
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/simplemob_varspeed


### PR DESCRIPTION

## About The Pull Request

Fixes #74911.

## Why It's Good For The Game

Issue #74911 confirms that the slowdown from missing legs is a bug, and I'd like to fix it.

## Changelog
:cl:
fix: Missing legs no longer slow you down in non-gravity environments.
/:cl:
