### PR TITLE
The "mopper" gimmick assistant outfit no longer spawns janicarts on every surrounding tiles

### DIFF
--- a/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
+++ b/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
@@ -111,6 +111,7 @@
 			continue
 		var/obj/structure/mop_bucket/bucket = new /obj/structure/mop_bucket(turf)
 		equipped.start_pulling(bucket)
+		break
 
 /datum/outfit/job/assistant/gimmick/broomer
 	name = "Gimmick Assistant - Broomer"


### PR DESCRIPTION

## About The Pull Request

Gimmick assistants who get the fake janitor outfit no longer spawn surrounded by janitor carts.

![image](https://github.com/tgstation/tgstation/assets/28870487/d77186d7-e68d-4d23-aca9-6cedee1ff3ea)

Now:

![image](https://github.com/tgstation/tgstation/assets/28870487/4717a89b-d76c-4685-87cb-8bd45a5b8b09)
## Why It's Good For The Game

The janitor cart economy is in shambles and this is the first step towards fixing it.
## Changelog
:cl: Rhials
fix: The "mopper" gimmick assistant outfit spawns with one cart instead of nine.
/:cl:
