### PR TITLE
You can now microwave pets

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -675,7 +675,7 @@
 	if(cycles == 1) //Only needs to try to shock mobs once, towards the end of the loop
 		var/successful_shock
 		var/list/microwave_contents = list()
-		microwave_contents += src.get_all_contents() //Mobs are often hid inside of mob holders, which could be fried and made into a burger...
+		microwave_contents += get_all_contents() //Mobs are often hid inside of mob holders, which could be fried and made into a burger...
 		for(var/mob/living/victim in microwave_contents)
 			if(victim.electrocute_act(shock_damage = 100, source = src, siemens_coeff = 1, flags = SHOCK_NOGLOVES))
 				successful_shock = TRUE

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -114,6 +114,7 @@
 	QDEL_LIST(ingredients)
 	QDEL_NULL(wires)
 	QDEL_NULL(soundloop)
+	remove_smoke()
 	if(!isnull(cell))
 		QDEL_NULL(cell)
 	return ..()
@@ -676,7 +677,7 @@
 		var/list/microwave_contents = list()
 		microwave_contents += src.get_all_contents() //Mobs are often hid inside of mob holders, which could be fried and made into a burger...
 		for(var/mob/living/victim in microwave_contents)
-			if(victim.electrocute_act(100, src, 1, SHOCK_NOGLOVES))
+			if(victim.electrocute_act(shock_damage = 100, source = src, siemens_coeff = 1, flags = SHOCK_NOGLOVES))
 				successful_shock = TRUE
 				if(victim.stat == DEAD) //This is mostly so humans that can_be_held don't get gibbed from one microwave run alone, but mice become burnt messes
 					victim.gib()
@@ -689,7 +690,7 @@
 			visible_message(span_danger("You smell a burnt smell coming from [src]!"), ignored_mobs = cant_smell)
 			particles = new /particles/smoke()
 			addtimer(CALLBACK(src, PROC_REF(remove_smoke)), 10 SECONDS)
-			src.Shake(duration = 1 SECONDS)
+			Shake(duration = 1 SECONDS)
 
 	cycles--
 	use_energy(active_power_usage)

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -671,15 +671,32 @@
 				pre_success(cooker)
 		return
 
-	if(cycles % 3)
+	if(cycles == 1) //Only needs to try to shock mobs once, towards the end of the loop
+		var/successful_shock
 		var/list/microwave_contents = list()
 		microwave_contents += src.get_all_contents() //Mobs are often hid inside of mob holders, which could be fried and made into a burger...
 		for(var/mob/living/victim in microwave_contents)
-			victim.electrocute_act(30, src, 1, SHOCK_NOGLOVES)
+			if(victim.electrocute_act(100, src, 1, SHOCK_NOGLOVES))
+				successful_shock = TRUE
+				if(victim.stat == DEAD) //This is mostly so humans that can_be_held don't get gibbed from one microwave run alone, but mice become burnt messes
+					victim.gib()
+					muck()
+		if(successful_shock) //We only want to give feedback once, regardless of how many mobs got shocked
+			var/list/cant_smell = list()
+			for(var/mob/smeller in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src))
+				if(HAS_TRAIT(smeller, TRAIT_ANOSMIA))
+					cant_smell += smeller
+			visible_message(span_danger("You smell a burnt smell coming from [src]!"), ignored_mobs = cant_smell)
+			particles = new /particles/smoke()
+			addtimer(CALLBACK(src, PROC_REF(remove_smoke)), 10 SECONDS)
+			src.Shake(duration = 1 SECONDS)
 
 	cycles--
 	use_energy(active_power_usage)
 	addtimer(CALLBACK(src, PROC_REF(cook_loop), type, cycles, wait, cooker), wait)
+
+/obj/machinery/microwave/proc/remove_smoke()
+	QDEL_NULL(particles)
 
 /obj/machinery/microwave/power_change()
 	. = ..()

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -114,7 +114,7 @@
 	QDEL_LIST(ingredients)
 	QDEL_NULL(wires)
 	QDEL_NULL(soundloop)
-	remove_smoke()
+	QDEL_NULL(particles)
 	if(!isnull(cell))
 		QDEL_NULL(cell)
 	return ..()

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -536,8 +536,9 @@
 
 /obj/machinery/microwave/proc/eject()
 	var/atom/drop_loc = drop_location()
-	for(var/atom/movable/movable_ingredient as anything in ingredients)
-		movable_ingredient.forceMove(drop_loc)
+	for(var/obj/item/item_ingredient as anything in ingredients)
+		item_ingredient.forceMove(drop_loc)
+		item_ingredient.dropped() //Mob holders can be on the ground if we don't do this
 	open(autoclose = 1.4 SECONDS)
 
 /obj/machinery/microwave/proc/start_cycle(mob/user)
@@ -669,6 +670,13 @@
 			if(MICROWAVE_PRE)
 				pre_success(cooker)
 		return
+
+	if(cycles % 3)
+		var/list/microwave_contents = list()
+		microwave_contents += src.get_all_contents() //Mobs are often hid inside of mob holders, which could be fried and made into a burger...
+		for(var/mob/living/victim in microwave_contents)
+			victim.electrocute_act(30, src, 1, SHOCK_NOGLOVES)
+
 	cycles--
 	use_energy(active_power_usage)
 	addtimer(CALLBACK(src, PROC_REF(cook_loop), type, cycles, wait, cooker), wait)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -118,6 +118,10 @@
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
 		var/obj/item/food/deadmouse/mouse = new(loc)
+		if(istype(mouse.loc.loc, /obj/machinery/microwave))//If our mouse is dying in place holder in a microwave, put the dead mouse in the microwave
+			var/obj/machinery/microwave/found_microwave = mouse.loc.loc
+			mouse.forceMove(found_microwave)
+			found_microwave.ingredients += mouse
 		mouse.copy_corpse(src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -117,17 +117,19 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc)
-		if(istype(mouse.loc, /obj/item/clothing/head/mob_holder))//If our mouse is dying in place holder we want to put the dead mouse where the place holder was
-			var/obj/item/clothing/head/mob_holder/found_holder = mouse.loc
-			mouse.forceMove(found_holder.loc)
-			if(istype(found_holder.loc, /obj/machinery/microwave))//If the mouse is dying in a microwave add it to ingredients too
-				var/obj/machinery/microwave/found_microwave = found_holder.loc
-				found_microwave.ingredients += mouse
-		mouse.copy_corpse(src)
-		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
-			mouse.desc = "They're toast."
-			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
+		var/make_a_corpse = TRUE
+		var/place_to_make_corpse = loc
+		if(istype(loc, /obj/item/clothing/head/mob_holder))//If our mouse is dying in place holder we want to put the dead mouse where the place holder was
+			var/obj/item/clothing/head/mob_holder/found_holder = loc
+			place_to_make_corpse = found_holder.loc
+			if(istype(found_holder.loc, /obj/machinery/microwave))//Microwaves gib things that die when cooked, so we don't need to make a dead body too
+				make_a_corpse = FALSE
+		if(make_a_corpse)
+			var/obj/item/food/deadmouse/mouse = new(place_to_make_corpse)
+			mouse.copy_corpse(src)
+			if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
+				mouse.desc = "They're toast."
+				mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
 	qdel(src)
 
 /mob/living/basic/mouse/UnarmedAttack(atom/attack_target, proximity_flag, list/modifiers)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -118,10 +118,12 @@
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
 		var/obj/item/food/deadmouse/mouse = new(loc)
-		if(istype(mouse.loc.loc, /obj/machinery/microwave))//If our mouse is dying in place holder in a microwave, put the dead mouse in the microwave
-			var/obj/machinery/microwave/found_microwave = mouse.loc.loc
-			mouse.forceMove(found_microwave)
-			found_microwave.ingredients += mouse
+		if(istype(mouse.loc, /obj/item/clothing/head/mob_holder))//If our mouse is dying in place holder we want to put the dead mouse where the place holder was
+			var/obj/item/clothing/head/mob_holder/found_holder = mouse.loc
+			mouse.forceMove(found_holder.loc)
+			if(istype(found_holder.loc, /obj/machinery/microwave))//If the mouse is dying in a microwave add it to ingredients too
+				var/obj/machinery/microwave/found_microwave = found_holder.loc
+				found_microwave.ingredients += mouse
 		mouse.copy_corpse(src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."


### PR DESCRIPTION
## About The Pull Request
Mob placeholders could be microwaved prior, but it wouldn't do anything besides spit out the placeholder on the ground
Now they get electrocuted, and if this kills them it gibs them, making a mess.
This works for spacemen if they're varedited to be able to be held too, so go wild microwaving the clown or something I guess.


https://github.com/tgstation/tgstation/assets/51932756/f4fdcb6b-54aa-4872-992d-78706dc9568f



## Why It's Good For The Game
Uhhh.... 
It adds a lot of potential comedy into the sandbox by allowing shocking events like stuffing ian into the deepfryer, putting him into a burger and then microwaving his body out of said burger to the horror of all who witness such an act of profane cookery

## Changelog
:cl:
add: You can now microwave station pets that you can pick up, with predictable outcomes
/:cl: