### PR TITLE
Re-adds bagulo (remastered), 3 max bluespace cores, singulos may collapse if a third BoH is added

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -1,5 +1,5 @@
 // Max amounts of cores you can make
-#define MAX_CORES_BLUESPACE 8
+#define MAX_CORES_BLUESPACE 6
 #define MAX_CORES_GRAVITATIONAL 8
 #define MAX_CORES_FLUX 8
 #define MAX_CORES_VORTEX 8

--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -1,5 +1,5 @@
 // Max amounts of cores you can make
-#define MAX_CORES_BLUESPACE 6
+#define MAX_CORES_BLUESPACE 3
 #define MAX_CORES_GRAVITATIONAL 8
 #define MAX_CORES_FLUX 8
 #define MAX_CORES_VORTEX 8

--- a/code/datums/storage/subtypes/bag_of_holding.dm
+++ b/code/datums/storage/subtypes/bag_of_holding.dm
@@ -32,13 +32,13 @@
 		span_userdanger("The Bluespace interfaces of the two devices catastrophically malfunction!"),
 		span_danger("The Bluespace interfaces of the two devices catastrophically malfunction!"),
 	)
-	playsound(rift_loc, 'sound/effects/supermatter.ogg', 200, TRUE)
 
 	message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(rift_loc)].")
 	user.log_message("detonated a bag of holding at [loc_name(rift_loc)].", LOG_ATTACK, color = "red")
 
 	user.investigate_log("has been gibbed by a bag of holding recursive insertion.", INVESTIGATE_DEATHS)
 	user.gib()
-	new /obj/boh_tear(rift_loc)
+	var/obj/boh_tear/tear = new(rift_loc)
+	tear.start_disaster()
 	qdel(to_insert)
 	qdel(parent)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -65,9 +65,6 @@
 	armor_type = /datum/armor/backpack_holding
 	storage_type = /datum/storage/bag_of_holding
 
-/obj/item/storage/backpack/holding/singularity_act()
-	return
-
 /datum/armor/backpack_holding
 	fire = 60
 	acid = 50

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -65,6 +65,9 @@
 	armor_type = /datum/armor/backpack_holding
 	storage_type = /datum/storage/bag_of_holding
 
+/obj/item/storage/backpack/holding/singularity_act()
+	return
+
 /datum/armor/backpack_holding
 	fire = 60
 	acid = 50

--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -27,10 +27,8 @@
 		singularity_size = STAGE_SIX, \
 	)
 	addtimer(CALLBACK(src, PROC_REF(bagulo_time)), 9 SECONDS, TIMER_DELETE_ME)
-	var/matrix/smaller = matrix(transform).Scale(0.25)
-	var/matrix/bigger = matrix(transform).Scale(2)
-	animate(src, time = 7.5 SECONDS, transform = bigger, flags = ANIMATION_PARALLEL)
-	animate(time = 2 SECONDS, transform = smaller, easing = ELASTIC_EASING)
+	animate(src, time = 7.5 SECONDS, transform = transform.Scale(2), flags = ANIMATION_PARALLEL)
+	animate(time = 2 SECONDS, transform = transform.Scale(0.25), easing = ELASTIC_EASING)
 	animate(time = 0.5 SECONDS, alpha = 0)
 
 /obj/boh_tear/proc/bagulo_time()

--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -1,12 +1,6 @@
-/// BoH tear
-/// The BoH tear is a stationary singularity with a really high gravitational pull, which collapses briefly after being created
-/// The BoH isn't deleted for 10 minutes (only moved to nullspace) so that admins may retrieve the things back in case of a grief
-#define BOH_TEAR_CONSUME_RANGE 1
-#define BOH_TEAR_GRAV_PULL 25
-
 /obj/boh_tear
 	name = "tear in the fabric of reality"
-	desc = "Your own comprehension of reality starts bending as you stare this."
+	desc = "As you gaze into the abyss, the only thing you can think is... \"Should I really be this close to it?\""
 	anchored = TRUE
 	appearance_flags = LONG_GLIDE
 	density = TRUE
@@ -22,17 +16,29 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	flags_1 = SUPERMATTER_IGNORES_1
 
-/obj/boh_tear/Initialize(mapload)
-	. = ..()
-	QDEL_IN(src, 5 SECONDS) // vanishes after 5 seconds
-
+/obj/boh_tear/proc/start_disaster()
+	apply_wibbly_filters(src)
+	playsound(loc, 'sound/effects/clockcult_gateway_disrupted.ogg', 200, extrarange = 3, falloff_exponent = 1, frequency = 0.33)
 	AddComponent(
 		/datum/component/singularity, \
-		consume_range = BOH_TEAR_CONSUME_RANGE, \
-		grav_pull = BOH_TEAR_GRAV_PULL, \
+		consume_range = 1, \
+		grav_pull = 21, \
 		roaming = FALSE, \
 		singularity_size = STAGE_SIX, \
 	)
+	addtimer(CALLBACK(src, PROC_REF(bagulo_time)), 9 SECONDS, TIMER_DELETE_ME)
+	var/matrix/smaller = matrix(transform).Scale(0.25)
+	var/matrix/bigger = matrix(transform).Scale(2)
+	animate(src, time = 7.5 SECONDS, transform = bigger, flags = ANIMATION_PARALLEL)
+	animate(time = 2 SECONDS, transform = smaller, easing = ELASTIC_EASING)
+	animate(time = 0.5 SECONDS, alpha = 0)
+
+/obj/boh_tear/proc/bagulo_time()
+	playsound(loc, 'sound/effects/supermatter.ogg', 200, TRUE, extrarange = 3, falloff_exponent = 1, frequency = 0.5)
+	var/obj/singularity/bagulo = new(loc)
+	bagulo.expand(STAGE_TWO)
+	bagulo.energy = 400
+	qdel(src)
 
 /obj/boh_tear/attack_tk(mob/user)
 	if(!isliving(user))
@@ -43,6 +49,3 @@
 	jedi.spawn_dust()
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, attack_hand), jedi), 0.5 SECONDS)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
-
-#undef BOH_TEAR_CONSUME_RANGE
-#undef BOH_TEAR_GRAV_PULL

--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -18,7 +18,7 @@
 
 /obj/boh_tear/proc/start_disaster()
 	apply_wibbly_filters(src)
-	playsound(loc, 'sound/effects/clockcult_gateway_disrupted.ogg', 200, extrarange = 3, falloff_exponent = 1, frequency = 0.33)
+	playsound(loc, 'sound/effects/clockcult_gateway_disrupted.ogg', vary = 200, extrarange = 3, falloff_exponent = 1, frequency = 0.33, pressure_affected = FALSE, ignore_walls = TRUE, falloff_distance = 7)
 	AddComponent(
 		/datum/component/singularity, \
 		consume_range = 1, \
@@ -34,7 +34,7 @@
 	animate(time = 0.5 SECONDS, alpha = 0)
 
 /obj/boh_tear/proc/bagulo_time()
-	playsound(loc, 'sound/effects/supermatter.ogg', 200, TRUE, extrarange = 3, falloff_exponent = 1, frequency = 0.5)
+	playsound(loc, 'sound/effects/supermatter.ogg', 200, vary = TRUE, extrarange = 3, falloff_exponent = 1, frequency = 0.5, pressure_affected = FALSE, ignore_walls = TRUE, falloff_distance = 7)
 	var/obj/singularity/bagulo = new(loc)
 	bagulo.expand(STAGE_TWO)
 	bagulo.energy = 400

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -335,12 +335,9 @@
 		blind_message = span_hear("You hear aggressive crackling!"),
 		vision_distance = 15,
 	)
-	var/sound/collapse = sound('sound/effects/clockcult_gateway_disrupted.ogg')
-	collapse.pitch = -1
-	collapse.frequency = 0.5
-	playsound(loc, collapse, 200, vary = TRUE, extrarange = 3, falloff_exponent = 1, pressure_affected = FALSE, ignore_walls = TRUE, falloff_distance = 7)
+	playsound(loc, 'sound/effects/clockcult_gateway_disrupted.ogg', 200, vary = TRUE, extrarange = 3, falloff_exponent = 1, frequency = -1, pressure_affected = FALSE, ignore_walls = TRUE, falloff_distance = 7)
 	addtimer(CALLBACK(src, PROC_REF(consume_boh_sfx)), 4 SECONDS)
-	animate(src, time = 4.5 SECONDS, transform = matrix(transform).Scale(0.25), flags = ANIMATION_PARALLEL, easing = ELASTIC_EASING)
+	animate(src, time = 4 SECONDS, transform = transform.Scale(0.25), flags = ANIMATION_PARALLEL, easing = ELASTIC_EASING)
 	animate(time = 0.5 SECONDS, alpha = 0)
 	QDEL_IN(src, 4.1 SECONDS)
 	qdel(boh)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -309,6 +309,10 @@
 	return TRUE
 
 /obj/singularity/proc/consume(atom/thing)
+	if(istype(thing, /obj/item/storage/backpack/holding))
+		consume_boh(thing)
+		return
+
 	var/gain = thing.singularity_act(current_size, src)
 	energy += gain
 	if(istype(thing, /obj/machinery/power/supermatter_crystal) && !consumed_supermatter)
@@ -319,6 +323,19 @@
 	desc = "[initial(desc)] It glows fiercely with inner fire."
 	consumed_supermatter = TRUE
 	set_light(10)
+
+/obj/singularity/proc/consume_boh(obj/boh)
+	visible_message(
+		message = span_danger("As [src] consumes [boh], it begins to collapse in on itself!"),
+		blind_message = span_hear("You hear aggressive crackling!"),
+		vision_distance = 15,
+	)
+	playsound(loc, 'sound/effects/clockcult_gateway_disrupted.ogg', 200, TRUE, extrarange = 3, falloff_exponent = 1, frequency = 0.5)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), loc, 'sound/effects/supermatter.ogg', 200, TRUE, 3, 1, 0.5), 4 SECONDS)
+	animate(src, time = 4.5 SECONDS, transform = matrix(transform).Scale(0.25), flags = ANIMATION_PARALLEL, easing = ELASTIC_EASING)
+	animate(src, time = 0.5 SECONDS, alpha = 0)
+	QDEL_IN(src, 4.1 SECONDS)
+	qdel(boh)
 
 /obj/singularity/proc/check_cardinals_range(steps, retry_with_move = FALSE)
 	. = length(GLOB.cardinals) //Should be 4.

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -309,7 +309,7 @@
 	return TRUE
 
 /obj/singularity/proc/consume(atom/thing)
-	if(istype(thing, /obj/item/storage/backpack/holding))
+	if(istype(thing, /obj/item/storage/backpack/holding) && !consumed_supermatter)
 		consume_boh(thing)
 		return
 


### PR DESCRIPTION
## About The Pull Request

- BoH + BoH = Singulo 
   - This time it has a unique animation associated with it spawning, it starts off as a tear and then becomes a singulo after a short time. 

- Max number of bluespace cores available to the crew reduced from 8 to 3

- Chucking a BoH into a singulo causes it to collapse in on itself. (Supermatter charged singulos are immune.)

## Why It's Good For The Game

BoH is generally harder to acquire now which means we can bring back soul

The max core number was reduced just to make sure it doesn't get spammed too much. Four's a crowd. 
It also might be the first time we actually hit a core limit

I thought it would be fun to make it so you can do something to stop it, so if you're a bad enough dude and can make a third BoH, you can chuck it into the bagulo to cause it to collapse. Singuloose generally ends the round regardless so I thought letting people have hero moments would be fun. 

## Changelog

:cl: Melbert
balance: Re-adds Bagulo
balance: The max number of bluespace cores available to the crew has been reduced to 3 (was: 8)
balance: Chucking a BoH into an uncharged singulo may save the station. 
/:cl:

