### PR TITLE
Fixes station trait based event weight modifiers being added for events that aren't valid on the current map

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -95,8 +95,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		return
 
-	for(var/i in subtypesof(/datum/station_trait))
-		var/datum/station_trait/trait_typepath = i
+	for(var/datum/station_trait/trait_typepath as anything in subtypesof(/datum/station_trait))
 
 		// If forced, (probably debugging), just set it up now, keep it out of the pool.
 		if(initial(trait_typepath.force))
@@ -114,6 +113,14 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		if(!(initial(trait_typepath.trait_flags) & STATION_TRAIT_REQUIRES_AI) && !CONFIG_GET(flag/allow_ai)) //can't have AI traits without AI
 			continue
+
+		if(ispath(trait_typepath, /datum/station_trait/random_event_weight_modifier)) //Don't add event modifiers for events that can't occur on our map.
+			var/datum/station_trait/random_event_weight_modifier/random_trait_typepath = trait_typepath
+			var/datum/round_event_control/event_to_check = initial(random_trait_typepath.event_control_path)
+			if(event_to_check)
+				event_to_check = new event_to_check()
+				if(!event_to_check.valid_for_map())
+					continue
 
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -285,7 +285,7 @@
 	weight = 0
 
 	/// The path to the round_event_control that we modify.
-	var/event_control_path
+	var/datum/round_event_control/event_control_path
 	/// Multiplier applied to the weight of the event.
 	var/weight_multiplier = 1
 	/// Flat modifier added to the amount of max occurances the random event can have.


### PR DESCRIPTION
```
[2024-06-12 02:12:22.135] RUNTIME: runtime error: Cannot execute /datum/round_event_control/met... (/datum/round_event_control/meteor_wave/dust_storm).valid for map().
 - proc name: New (/datum/station_trait/random_event_weight_modifier/New)
 -   source file: code/datums/station_traits/negative_traits.dm,296
 -   usr: null
 -   src: Dust Stormfront (/datum/station_trait/random_event_weight_modifier/dust_storms)
 -   call stack:
 - Dust Stormfront (/datum/station_trait/random_event_weight_modifier/dust_storms): New()
 - Station (/datum/controller/subsystem/processing/station): setup trait(/datum/station_trait/random_ev... (/datum/station_trait/random_event_weight_modifier/dust_storms))
 - Station (/datum/controller/subsystem/processing/station): SetupTraits()
 - Station (/datum/controller/subsystem/processing/station): Initialize()
 - Master (/datum/controller/master): init subsystem(Station (/datum/controller/subsystem/processing/station))
 - Master (/datum/controller/master): Initialize(10, 0, 1)
 - 
```

:cl: ShizCalev
fix: Fixed a bug with station traits being added to modify weights for events that couldn't actually occur on the current map! 
/:cl:
