### PR TITLE
Fixes two alt-click behaviors [no gbp]

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -18,7 +18,7 @@
 	attack_verb_simple = list("slam", "whack", "bash", "thunk", "batter", "bludgeon", "thrash")
 	dog_fashion = /datum/dog_fashion/back
 	resistance_flags = FIRE_PROOF
-	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS
+	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
 	/// The max amount of water this extinguisher can hold.
 	var/max_water = 50
 	/// Does the welder extinguisher start with water.
@@ -52,6 +52,15 @@
 		/datum/component/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+
+	register_context()
+
+/obj/item/extinguisher/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	if(held_item != src)
+		return
+	context[SCREENTIP_CONTEXT_LMB] = "Engage nozzle"
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Empty"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/extinguisher/empty
 	starting_water = FALSE

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -30,6 +30,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	siemens_coefficient = 0.5
 	alternate_worn_layer = HANDS_LAYER+0.1 //we want it to go above generally everything, but not hands
+	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
 	/// The MOD's theme, decides on some stuff like armor and statistics.
 	var/datum/mod_theme/theme = /datum/mod_theme
 	/// Looks of the MOD.


### PR DESCRIPTION

## About The Pull Request
You can now alt click mod suit bags and extinguishers while resting
Adds screentips to extinguishers
## Why It's Good For The Game
Fixes #83896
## Changelog
:cl:
add: Added screentips to extinguishers.
fix: Fixed alt-click interaction with extinguishers and mod control units.
/:cl:
