### PR TITLE
Fix unable to interact with depowered shocked door

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -74,7 +74,7 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/door/airlock/airlock = holder
-	if(!HAS_SILICON_ACCESS(user) && !isdrone(user) && airlock.isElectrified())
+	if(!HAS_SILICON_ACCESS(user) && !isdrone(user) && airlock.isElectrified() && airlock.hasPower())
 		var/mob/living/carbon/carbon_user = user
 		if (!istype(carbon_user) || carbon_user.should_electrocute(get_area(airlock)))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request
Fixes bug where you can't interact with a shocked door without shock protection even if it is depowered.
## Why It's Good For The Game
Prevents cheese where if you get lucky and depower a door, you can easily find its shock wire and also easily test if budget insuls you have work.
## Changelog
:cl:
fix: Fix bug where you can't interact with a shocked door without shock protection even if it is depowered.
/:cl:
