### PR TITLE
Remove contact for support clause from README of midi2piano

### DIFF
--- a/tools/midi2piano/README.txt
+++ b/tools/midi2piano/README.txt
@@ -29,5 +29,4 @@ Additional notes:
 
 This tool is considered final.
 
-Made by EditorRUS/Delta Epsilon from Animus Station, ss13.ru
-Contact me in Discord if you find any major issues: DeltaEpsilon#7787
+Made by Delta Epsilon from Animus Station, ss13.ru


### PR DESCRIPTION
It's been 10 years, but I still keep getting DMs to provide support for midi2piano use.
This would not have been such a problem if it wasn't for #71575 rewriting and breaking it completely, yet still making my name remain there.
@PeriodicChaos don't fix what ain't broke, especially fix it in a way that breaks it.

I would suggest reverting #71575 to restore functionality as the pre-PR version is just what I keep sending people anyway. I have no mind to otherwise try to fix the broken code or do the revert myself at this moment.
The code _is_ ultra-shit though, a rewrite to a more pleasant format would be nice, buuuut it works.