### PR TITLE
Moves Round Logs Website Message before the sleep in Reboot

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -697,6 +697,13 @@ SUBSYSTEM_DEF(ticker)
 
 	to_chat(world, span_boldannounce("Rebooting World in [DisplayTimeText(delay)]. [reason]"))
 
+	var/statspage = CONFIG_GET(string/roundstatsurl)
+	var/gamelogloc = CONFIG_GET(string/gamelogurl)
+	if(statspage)
+		to_chat(world, span_info("Round statistics and logs can be viewed <a href=\"[statspage][GLOB.round_id]\">at this website!</a>"))
+	else if(gamelogloc)
+		to_chat(world, span_info("Round logs can be located <a href=\"[gamelogloc]\">at this website!</a>"))
+
 	var/start_wait = world.time
 	UNTIL(round_end_sound_sent || (world.time - start_wait) > (delay * 2)) //don't wait forever
 	sleep(delay - (world.time - start_wait))
@@ -706,13 +713,6 @@ SUBSYSTEM_DEF(ticker)
 		return
 	if(end_string)
 		end_state = end_string
-
-	var/statspage = CONFIG_GET(string/roundstatsurl)
-	var/gamelogloc = CONFIG_GET(string/gamelogurl)
-	if(statspage)
-		to_chat(world, span_info("Round statistics and logs can be viewed <a href=\"[statspage][GLOB.round_id]\">at this website!</a>"))
-	else if(gamelogloc)
-		to_chat(world, span_info("Round logs can be located <a href=\"[gamelogloc]\">at this website!</a>"))
 
 	log_game(span_boldannounce("Rebooting World. [reason]"))
 


### PR DESCRIPTION

## About The Pull Request

Closes #83823

Move the message about "You can access round logs and statistics at this website" up before we actually start the reboot countdown sleep. The logs probably won't have posted by that point (depending on how the server is set up) but at least it's slightly more useful before the links (apparently) invalidate. Also the reboot timer is ~60 seconds on /tg/ servers and people are either chatting in OOC or something around this time, may as well get the link to save for later in that "cooldown" period.
## Why It's Good For The Game

I've actually never seen this message before and I think moving it slightly more upwards would be of value.
## Changelog
:cl:
qol: A message with a link to publicly accessible logs (if enabled by your server operators) should now be visible far earlier when a world is about to reboot.
/:cl:
