### PR TITLE
Fixes construction devices being unable to reload by clicking on mats

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -391,6 +391,10 @@
 	ui_interact(user)
 
 /obj/item/construction/rcd/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ..()
+	if (. == ITEM_INTERACT_SUCCESS)
+		return .
+
 	mode = construction_mode
 	rcd_create(interacting_with, user)
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -37,7 +37,7 @@
 	var/datum/component/remote_materials/silo_mats
 	/// switch to use internal or remote storage
 	var/silo_link = FALSE
-	/// has the blueprint design changed
+		/// has the blueprint design changed
 	var/blueprint_changed = FALSE
 
 /datum/armor/item_construction
@@ -89,12 +89,12 @@
 	silo_mats = null
 	return ..()
 
-/obj/item/construction/pre_attack(atom/target, mob/user, params)
-	if(istype(target, /obj/item/rcd_upgrade))
-		install_upgrade(target, user)
-		return TRUE
-	if(insert_matter(target, user))
-		return TRUE
+/obj/item/construction/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(istype(interacting_with, /obj/item/rcd_upgrade))
+		install_upgrade(interacting_with, user)
+		return ITEM_INTERACT_SUCCESS
+	if(insert_matter(interacting_with, user))
+		return ITEM_INTERACT_SUCCESS
 	return ..()
 
 /obj/item/construction/attackby(obj/item/item, mob/user, params)

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -37,7 +37,7 @@
 	var/datum/component/remote_materials/silo_mats
 	/// switch to use internal or remote storage
 	var/silo_link = FALSE
-		/// has the blueprint design changed
+	/// has the blueprint design changed
 	var/blueprint_changed = FALSE
 
 /datum/armor/item_construction

--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -91,12 +91,6 @@
 /obj/item/construction/rld/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!range_check(interacting_with, user))
 		return NONE
-	return interact_with_atom(interacting_with, user, modifiers)
-
-/obj/item/construction/rld/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
-	. = ..()
-	if (. == ITEM_INTERACT_SUCCESS)
-		return .
 
 	var/turf/start = get_turf(src)
 	switch(mode)
@@ -193,6 +187,12 @@
 			return ITEM_INTERACT_SUCCESS
 
 	return NONE
+
+/obj/item/construction/rld/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ..()
+	if (. == ITEM_INTERACT_SUCCESS)
+		return .
+	return ranged_interact_with_atom(interacting_with, user, modifiers)
 
 /obj/item/construction/rld/mini
 	name = "mini-rapid-light-device"

--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -94,6 +94,10 @@
 	return interact_with_atom(interacting_with, user, modifiers)
 
 /obj/item/construction/rld/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ..()
+	if (. == ITEM_INTERACT_SUCCESS)
+		return .
+
 	var/turf/start = get_turf(src)
 	switch(mode)
 		if(REMOVE_MODE)

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -242,6 +242,10 @@
 				return FALSE
 
 /obj/item/construction/plumbing/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ..()
+	if (. == ITEM_INTERACT_SUCCESS)
+		return .
+
 	for(var/category_name in plumbing_design_types)
 		var/list/designs = plumbing_design_types[category_name]
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -238,6 +238,11 @@
 	. = ..()
 	if (. == ITEM_INTERACT_SUCCESS)
 		return .
+	return ranged_interact_with_atom(interacting_with, user, modifiers)
+
+/obj/item/construction/rtd/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!range_check(interacting_with, user))
+		return NONE
 
 	var/turf/open/floor/floor = interacting_with
 	if(!istype(floor))

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -235,6 +235,10 @@
 
 
 /obj/item/construction/rtd/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ..()
+	if (. == ITEM_INTERACT_SUCCESS)
+		return .
+
 	var/turf/open/floor/floor = interacting_with
 	if(!istype(floor))
 		return NONE


### PR DESCRIPTION

## About The Pull Request
Prior to #83818 construction devices (RCD, RLD, RTD and Plumbing Constructor) could refill their ammo by clicking on stacks of materials. This restores that old behaviour by moving the code for it from pre_attack to interact_with_atom. Also moves some code from interact_with_atom to ranged_interact_with_atom to make sure they can't refill from range.
## Changelog
:cl:
fix: Fixed construction devices being unable to refill ammo by clicking on materials.
/:cl:
