### PR TITLE
Adds logging for ore vent mobs spawned and killed

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -283,6 +283,8 @@
 
 		tapped = TRUE //The Node Drone has survived the wave defense, and the ore vent is tapped.
 		SSore_generation.processed_vents += src
+		log_game("Ore vent [key_name_and_tag(src)] was tapped")
+		SSblackbox.record_feedback("tally", "ore_vent_completed", 1, type)
 		balloon_alert_to_viewers("vent tapped!")
 		icon_state = icon_state_tapped
 		update_appearance(UPDATE_ICON_STATE)
@@ -431,16 +433,18 @@
 /**
  * Handle logging for mobs spawned
  */
-/obj/structure/ore_vent/proc/log_mob_spawned(mob/living/created)
+/obj/structure/ore_vent/proc/log_mob_spawned(datum/source, mob/living/created)
 	SIGNAL_HANDLER
+	log_game("Ore vent [key_name_and_tag(src)] spawned the following mob: [key_name_and_tag(created)]")
 	SSblackbox.record_feedback("tally", "ore_vent_mobs_spawned", 1, created.type)
 	RegisterSignal(created, COMSIG_LIVING_DEATH, PROC_REF(log_mob_killed))
 
 /**
  * Handle logging for mobs killed
  */
-/obj/structure/ore_vent/proc/log_mob_killed(mob/living/killed)
+/obj/structure/ore_vent/proc/log_mob_killed(datum/source, mob/living/killed)
 	SIGNAL_HANDLER
+	log_game("Vent-spawned mob [key_name_and_tag(killed)] was killed")
 	SSblackbox.record_feedback("tally", "ore_vent_mobs_killed", 1, killed.type)
 
 //comes with the station, and is already tapped.

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -84,6 +84,7 @@
 		add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER))
 
 	RegisterSignal(src, COMSIG_SPAWNER_SPAWNED_DEFAULT, PROC_REF(anti_cheese))
+	RegisterSignal(src, COMSIG_SPAWNER_SPAWNED, PROC_REF(log_mob_spawned))
 	return ..()
 
 /obj/structure/ore_vent/Destroy()
@@ -427,6 +428,21 @@
 /obj/structure/ore_vent/proc/anti_cheese()
 	explosion(src, heavy_impact_range = 1, light_impact_range = 3, flame_range = 0, flash_range = 0, adminlog = FALSE)
 
+/**
+ * Handle logging for mobs spawned
+ */
+/obj/structure/ore_vent/proc/log_mob_spawned(mob/living/created)
+	SIGNAL_HANDLER
+	SSblackbox.record_feedback("tally", "ore_vent_mobs_spawned", 1, created.type)
+	RegisterSignal(created, COMSIG_LIVING_DEATH, PROC_REF(log_mob_killed))
+
+/**
+ * Handle logging for mobs killed
+ */
+/obj/structure/ore_vent/proc/log_mob_killed(mob/living/killed)
+	SIGNAL_HANDLER
+	SSblackbox.record_feedback("tally", "ore_vent_mobs_killed", 1, killed.type)
+
 //comes with the station, and is already tapped.
 /obj/structure/ore_vent/starter_resources
 	name = "active ore vent"
@@ -550,11 +566,13 @@
 	// Completely override the normal wave defense, and just spawn the boss.
 	var/mob/living/simple_animal/hostile/megafauna/boss = new summoned_boss(loc)
 	RegisterSignal(boss, COMSIG_LIVING_DEATH, PROC_REF(handle_wave_conclusion))
+	SSblackbox.record_feedback("tally", "ore_vent_mobs_spawned", 1, summoned_boss)
 	COOLDOWN_START(src, wave_cooldown, INFINITY) //Basically forever
 	boss.say(boss.summon_line) //Pull their specific summon line to say. Default is meme text so make sure that they have theirs set already.
 
 /obj/structure/ore_vent/boss/handle_wave_conclusion()
 	node = new /mob/living/basic/node_drone(loc) //We're spawning the vent after the boss dies, so the player can just focus on the boss.
+	SSblackbox.record_feedback("tally", "ore_vent_mobs_killed", 1, summoned_boss)
 	COOLDOWN_RESET(src, wave_cooldown)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Basically what the title says. Adds logging for every mob spawned by an ore vent by type (bosses included). Adds similar logging for spawned mobs being killed, that way people can tell if vents are being cheesed.
## Why It's Good For The Game

Logging is good. Also this:
![free gbp](https://github.com/tgstation/tgstation/assets/21979502/329c75b7-f56b-4385-9a86-3d28965bc4f9)
## Changelog
No player facing changes.
