### PR TITLE
Changelings are (once again) weak to fire

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -32,6 +32,8 @@
 	var/ignores_fakedeath = FALSE
 	/// used by a few powers that toggle
 	var/active = FALSE
+	/// Does this ability stop working if you are burning?
+	var/disabled_by_fire = TRUE
 
 /*
 changeling code now relies on on_purchase to grant powers.
@@ -60,6 +62,9 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
  */
 /datum/action/changeling/proc/try_to_sting(mob/living/user, mob/living/target)
 	if(!can_sting(user, target))
+		return FALSE
+	if(disabled_by_fire && user.fire_stacks && user.on_fire)
+		user.balloon_alert(user, "on fire!")
 		return FALSE
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
 	if(sting_action(user, target))

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -7,6 +7,7 @@
 	dna_cost = 2
 	req_human = FALSE
 	req_stat = CONSCIOUS
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/adrenaline/can_sting(mob/living/user, mob/living/target)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -6,6 +6,7 @@
 	chemical_cost = 30 //High cost to prevent spam
 	dna_cost = 2
 	req_human = TRUE
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	if(user.handcuffed)

--- a/code/modules/antagonists/changeling/powers/defib_grasp.dm
+++ b/code/modules/antagonists/changeling/powers/defib_grasp.dm
@@ -6,6 +6,7 @@
 		while we are dead or in stasis. Will also stun cyborgs momentarily."
 	owner_has_control = FALSE
 	dna_cost = 0
+	disabled_by_fire = FALSE
 
 	/// Flags to pass to fully heal when we get zapped
 	var/heal_flags = HEAL_DAMAGE|HEAL_BODY|HEAL_STATUS|HEAL_CC_STATUS

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -7,6 +7,7 @@
 	req_dna = 1
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
+	disabled_by_fire = FALSE
 
 	/// How long it takes for revival to ready upon entering stasis.
 	/// The changeling can opt to stay in fakedeath for longer, though.

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -8,6 +8,7 @@
 	req_human = TRUE
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -6,6 +6,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = TRUE
+	disabled_by_fire = FALSE
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
@@ -41,6 +42,7 @@
 	button_icon_state = "dissonant_shriek"
 	chemical_cost = 20
 	dna_cost = 1
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	..()

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -11,6 +11,7 @@
 	req_human = TRUE
 	var/stacks = 0 //Increments every 5 seconds; damage increases over time
 	active = FALSE //Whether or not you are a hedgehog
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/strained_muscles/sting_action(mob/living/carbon/user)
 	..()


### PR DESCRIPTION
## About The Pull Request

Being on fire will make the ling unable to use any ability that isn't for getting out of danger or reviving themselves (Adrenals, Fakedeath, Strained Muscles, Last Resort, Shriek, Defib Grasp and Biodegrade). And no, there is no armblade nerf, it is fine as it is.

## Why It's Good For The Game

Changelings are really busted, as they are effectively immortal until completely removed (which means finding a cremator/gibber/shuttle, and by the time you get there most of the time they are already ready to revive) which really limits counterplay. Goof and Jac's approach to nerfing lings was a bit too much since it nerfed the armblade massively as well, but I found that their approach about lings being weak to fire was really good counterplay for lings (besides BZ (who even uses it?)). We shouldnt just leave the guys that are almost immortal and spawn multiple in a round with one single counterplay that relies on a knowledge check.

## Changelog

:cl:
balance: Certain changeling abilities won't work while on fire.
/:cl: