### PR TITLE
Fixes bluespace launchpad reset button

### DIFF
--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -137,10 +137,16 @@
 		if("move_pos")
 			var/plus_x = text2num(params["x"])
 			var/plus_y = text2num(params["y"])
-			current_pad.set_offset(
-				x = current_pad.x_offset + plus_x,
-				y = current_pad.y_offset + plus_y
-			)
+			if(plus_x || plus_y)
+				current_pad.set_offset(
+					x = current_pad.x_offset + plus_x,
+					y = current_pad.y_offset + plus_y
+				)
+			else
+				current_pad.set_offset(
+					x = 0,
+					y = 0
+				)
 			. = TRUE
 		if("rename")
 			. = TRUE

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -140,12 +140,12 @@
 			if(plus_x || plus_y)
 				current_pad.set_offset(
 					x = current_pad.x_offset + plus_x,
-					y = current_pad.y_offset + plus_y
+					y = current_pad.y_offset + plus_y,
 				)
 			else
 				current_pad.set_offset(
 					x = 0,
-					y = 0
+					y = 0,
 				)
 			. = TRUE
 		if("rename")


### PR DESCRIPTION

## About The Pull Request

The reset button for the bluespace launchpad was broken. Based on the code, it looks like someone rewrote the code at some point and forgot to properly account for it, so the button just didn't do anything for a while. Now it works again. Fixes #83780 
## Changelog
:cl:
fix: The reset button in the bluespace launchpad UI should work again.
/:cl:
