### PR TITLE
Logs bitrunning domain loading and completion

### DIFF
--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -22,6 +22,7 @@
 
 /// Handles spawning the (new) crate and deleting the former
 /obj/machinery/quantum_server/proc/generate_loot(obj/cache, obj/machinery/byteforge/chosen_forge)
+	SSblackbox.record_feedback("tally", "bitrunning_domain_primary_completed", 1, generated_domain.key)
 	for(var/mob/person in cache.contents)
 		SEND_SIGNAL(person, COMSIG_BITRUNNER_CACHE_SEVER)
 
@@ -47,6 +48,7 @@
 	reward_cache.update_appearance()
 
 	if(can_generate_tech_disk(grade))
+		SSblackbox.record_feedback("tally", "bitrunning_bepis_rewarded", 1, generated_domain.key)
 		new /obj/item/disk/design_disk/bepis/remove_tech(reward_cache)
 		generated_domain.disk_reward_spawned = TRUE
 
@@ -54,6 +56,7 @@
 	return TRUE
 
 /obj/machinery/quantum_server/proc/generate_secondary_loot(obj/curiosity, obj/machinery/byteforge/chosen_forge)
+	SSblackbox.record_feedback("tally", "bitrunning_domain_secondary_completed", 1, generated_domain.key)
 	spark_at_location(curiosity) // abracadabra!
 	qdel(curiosity) // and it's gone!
 

--- a/code/modules/bitrunning/server/map_handling.dm
+++ b/code/modules/bitrunning/server/map_handling.dm
@@ -51,6 +51,8 @@
 		is_ready = TRUE
 		return FALSE
 
+	SSblackbox.record_feedback("tally", "bitrunning_domain_loaded", 1, map_key)
+
 	is_ready = TRUE
 
 	if(prob(clamp((threat * glitch_chance), 1, 10)))


### PR DESCRIPTION

## About The Pull Request

This PR tallies the following:

- Each time a domain is loaded, by key
- Each time a domain's primary reward is loaded (completed the domain)
- Each time a domain's secondary reward is found
- Each time a BEPIS disk is rewarded

## Why It's Good For The Game

Its nice to know which are the meta domains, which ones are easy to compete, and how often do people earn a BEPIS disk per round.

## Changelog

Nothing player facing