### PR TITLE
Fixes mech sleeper not displaying patient information without a mech syringe gun attached

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -72,7 +72,8 @@
 	data["contained_reagents"] = get_reagent_data(patient.reagents.reagent_list)
 
 	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/shooter = locate(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun) in chassis
-	data["injectible_reagents"] = get_reagent_data(shooter.reagents.reagent_list)
+	if(shooter)
+		data["injectible_reagents"] = get_reagent_data(shooter.reagents.reagent_list)
 	return data
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/handle_ui_act(action, list/params)
@@ -85,7 +86,7 @@
 		if(action == ("inject_reagent_" + medication.name))
 			inject_reagent(medication, shooter)
 			break // or maybe return TRUE? i'm not certain
-				
+
 	return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/action(mob/source, atom/atomtarget, list/modifiers)

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -82,10 +82,11 @@
 			go_out()
 			return TRUE
 	var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/shooter = locate() in chassis
-	for(var/datum/reagent/medication in shooter.reagents.reagent_list)
-		if(action == ("inject_reagent_" + medication.name))
-			inject_reagent(medication, shooter)
-			break // or maybe return TRUE? i'm not certain
+	if(shooter)
+		for(var/datum/reagent/medication in shooter.reagents.reagent_list)
+			if(action == ("inject_reagent_" + medication.name))
+				inject_reagent(medication, shooter)
+				break // or maybe return TRUE? i'm not certain
 
 	return FALSE
 

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -474,26 +474,28 @@ const SnowflakeSleeper = (props) => {
         ))}
       </LabeledList.Item>
       <LabeledList.Item label="Reagent Injection">
-        {injectible_reagents.map((reagent) => (
-          <LabeledList.Item
-            className="candystripe"
-            key={reagent.name}
-            label={reagent.name}
-          >
-            <LabeledList.Item label={`${reagent.volume}u`}>
-              <Button
-                onClick={() =>
-                  act('equip_act', {
-                    ref: ref,
-                    gear_action: `inject_reagent_${reagent.name}`,
-                  })
-                }
-              >
-                Inject
-              </Button>
+        {!!injectible_reagents &&
+          injectible_reagents.map((reagent) => (
+            <LabeledList.Item
+              className="candystripe"
+              key={reagent.name}
+              label={reagent.name}
+            >
+              <LabeledList.Item label={`${reagent.volume}u`}>
+                <Button
+                  onClick={() =>
+                    act('equip_act', {
+                      ref: ref,
+                      gear_action: `inject_reagent_${reagent.name}`,
+                    })
+                  }
+                >
+                  Inject
+                </Button>
+              </LabeledList.Item>
             </LabeledList.Item>
-          </LabeledList.Item>
-        ))}
+          ))}
+        {!injectible_reagents && 'Unavailable'}
       </LabeledList.Item>
     </>
   );

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -474,28 +474,28 @@ const SnowflakeSleeper = (props) => {
         ))}
       </LabeledList.Item>
       <LabeledList.Item label="Reagent Injection">
-        {!!injectible_reagents &&
-          injectible_reagents.map((reagent) => (
-            <LabeledList.Item
-              className="candystripe"
-              key={reagent.name}
-              label={reagent.name}
-            >
-              <LabeledList.Item label={`${reagent.volume}u`}>
-                <Button
-                  onClick={() =>
-                    act('equip_act', {
-                      ref: ref,
-                      gear_action: `inject_reagent_${reagent.name}`,
-                    })
-                  }
-                >
-                  Inject
-                </Button>
+        {injectible_reagents
+          ? injectible_reagents.map((reagent) => (
+              <LabeledList.Item
+                className="candystripe"
+                key={reagent.name}
+                label={reagent.name}
+              >
+                <LabeledList.Item label={`${reagent.volume}u`}>
+                  <Button
+                    onClick={() =>
+                      act('equip_act', {
+                        ref: ref,
+                        gear_action: `inject_reagent_${reagent.name}`,
+                      })
+                    }
+                  >
+                    Inject
+                  </Button>
+                </LabeledList.Item>
               </LabeledList.Item>
-            </LabeledList.Item>
-          ))}
-        {!injectible_reagents && 'Unavailable'}
+            ))
+          : 'Unavailable'}
       </LabeledList.Item>
     </>
   );


### PR DESCRIPTION

## About The Pull Request
Fixes a runtime that was occurring with the mech sleeper module that would prevent the patient information from being displayed in the sleeper interface if the mech didn't also have a syringe gun attached.
## Why It's Good For The Game
Fixes #83938
## Changelog
:cl:
fix: Fixed the patient information for the mech sleeper module not displaying when the mech didn't also have a syringe gun.
/:cl:
