### PR TITLE
Moves cult spells off attack_atom

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -379,24 +379,25 @@
 	cast_spell(user, user)
 
 /obj/item/melee/blood_magic/attack(mob/living/M, mob/living/carbon/user)
-	if(!iscarbon(user) || !IS_CULTIST(user))
-		uses = 0
-		qdel(src)
-		return
 	log_combat(user, M, "used a cult spell on", source.name, "")
 	SSblackbox.record_feedback("tally", "cult_spell_invoke", 1, "[name]")
 	M.lastattacker = user.real_name
 	M.lastattackerckey = user.ckey
 	cast_spell(M, user)
 
-/obj/item/melee/blood_magic/attack_atom(atom/attacked_atom, mob/living/user, params)
+/obj/item/melee/blood_magic/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!iscarbon(user) || !IS_CULTIST(user))
 		uses = 0
 		qdel(src)
-		return
-	log_combat(user, attacked_atom, "used a cult spell on", source.name, "")
+		return ITEM_INTERACT_BLOCKING
+
+	if(isliving(interacting_with))
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
+	log_combat(user, interacting_with, "used a cult spell on", source.name, "")
 	SSblackbox.record_feedback("tally", "cult_spell_invoke", 1, "[name]")
-	cast_spell(attacked_atom, user)
+	cast_spell(interacting_with, user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/melee/blood_magic/proc/cast_spell(atom/target, mob/living/carbon/user)
 	if(invocation)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -383,6 +383,7 @@
 	SSblackbox.record_feedback("tally", "cult_spell_invoke", 1, "[name]")
 	M.lastattacker = user.real_name
 	M.lastattackerckey = user.ckey
+	user.do_attack_animation(M)
 	cast_spell(M, user)
 
 /obj/item/melee/blood_magic/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
@@ -394,6 +395,7 @@
 	if(isliving(interacting_with))
 		return ITEM_INTERACT_SKIP_TO_ATTACK
 
+	user.do_attack_animation(interacting_with)
 	log_combat(user, interacting_with, "used a cult spell on", source.name, "")
 	SSblackbox.record_feedback("tally", "cult_spell_invoke", 1, "[name]")
 	cast_spell(interacting_with, user)


### PR DESCRIPTION
## About The Pull Request

`attack_atom`, while sensibly sounding, isn't called for most items, because they can't be attacked. 

## Changelog

:cl: Melbert
qol: Attack animations for cult spells on attackable objects (people, airlocks)
fix: Fix cult spells on non-attackable objects (metal sheets, blood decals)
/:cl:


