### PR TITLE
Fixes thermal holster trait issues

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -11,11 +11,11 @@
 /obj/item/storage/belt/holster/equipped(mob/user, slot)
 	. = ..()
 	if(slot & (ITEM_SLOT_BELT|ITEM_SLOT_SUITSTORE))
-		ADD_TRAIT(user, TRAIT_GUNFLIP, CLOTHING_TRAIT)
+		ADD_CLOTHING_TRAIT(user, TRAIT_GUNFLIP)
 
 /obj/item/storage/belt/holster/dropped(mob/user)
 	. = ..()
-	REMOVE_TRAIT(user, TRAIT_GUNFLIP, CLOTHING_TRAIT)
+	REMOVE_CLOTHING_TRAIT(user, TRAIT_GUNFLIP)
 
 /obj/item/storage/belt/holster/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Uses ADD_CLOTHING_TRAIT to store a ref to the individual holster item that's providing the gunflip trait. This fixes an issue that was happening where having one holster equipped and dropping or unequipping another would remove the trait from you, even though you were still wearing one.
## Why It's Good For The Game
Fixes #83762 
## Changelog
:cl:
fix: Fixed thermal pistols sometimes not recognising an equipped holster when trying to spin them to recharge.
/:cl:
