### PR TITLE
Fixes crossbow healium bolt sleeping silicons! Oops!

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -124,7 +124,7 @@
 
 /obj/projectile/bullet/rebar/healium/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	if(!isliving(target))
+	if(!isliving(target)||!iscarbon(target))
 		return BULLET_ACT_HIT
 	var/mob/living/breather = target
 	breather.SetSleeping(3 SECONDS)

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -124,7 +124,7 @@
 
 /obj/projectile/bullet/rebar/healium/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	if(!isliving(target)||!iscarbon(target))
+	if(!iscarbon(target))
 		return BULLET_ACT_HIT
 	var/mob/living/breather = target
 	breather.SetSleeping(3 SECONDS)


### PR DESCRIPTION

See title.
## Why It's Good For The Game

I thought I had this in the pr itself, with the check_bodytype code in the healium bolt, but I was wrong.
Turns out the check statement only effected the healing but the sleep portion was left out of it by mistake. During testing I never thought to spawn in a borg. 

## Changelog
:cl: WebcomicArtist
fix: Healium bolt now no longer affects silicons.
/:cl:
