### PR TITLE
Fix button frame hard delete

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -64,6 +64,11 @@
 	find_and_hang_on_wall()
 	register_context()
 
+/obj/machinery/button/Destroy()
+	QDEL_NULL(device)
+	QDEL_NULL(board)
+	return ..()
+
 /obj/machinery/button/proc/setup_device()
 	if(id && istype(device, /obj/item/assembly/control))
 		var/obj/item/assembly/control/control_device = device


### PR DESCRIPTION

## About The Pull Request
Re-adds the destroy proc removed in #83774. Deconstructing/destroying buttons would appropriately clean up their components, but deleting them otherwise would not.
## Why It's Good For The Game
I like my deletes like I like my drinks
## Changelog
Not player facing
