### PR TITLE
Revert "Mouse drag & drop refactored attack chain"

### DIFF
--- a/code/__DEFINES/click.dm
+++ b/code/__DEFINES/click.dm
@@ -4,4 +4,5 @@
 #define CLICK_ACTION_BLOCKING (1<<1)
 /// Either return state
 #define CLICK_ACTION_ANY (CLICK_ACTION_SUCCESS | CLICK_ACTION_BLOCKING)
+
 /// Use NONE for continue interaction

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -22,10 +22,9 @@
 #define COMSIG_CLICK_CTRL_SHIFT "ctrl_shift_click"
 ///from base of atom/MouseDrop(): (/atom/over, /mob/user)
 #define COMSIG_MOUSEDROP_ONTO "mousedrop_onto"
-	#define COMPONENT_CANCEL_MOUSEDROP_ONTO (1<<0)
-///from base of atom/handle_mouse_drop_receive: (/atom/from, /mob/user)
+	#define COMPONENT_NO_MOUSEDROP (1<<0)
+///from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"
-	#define COMPONENT_CANCEL_MOUSEDROPPED_ONTO (1<<0)
 ///from base of mob/MouseWheelOn(): (/atom, delta_x, delta_y, params)
 #define COMSIG_MOUSE_SCROLL_ON "mousescroll_on"
 /// From /atom/movable/screen/click(): (atom/target, atom/location, control, params, mob/user)

--- a/code/__DEFINES/interaction_flags.dm
+++ b/code/__DEFINES/interaction_flags.dm
@@ -20,12 +20,6 @@
 #define INTERACT_ATOM_ALLOW_USER_LOCATION (1<<9)
 /// ignores mobility check
 #define INTERACT_ATOM_IGNORE_MOBILITY (1<<10)
-// Bypass all adjacency checks for mouse drop
-#define INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT (1<<11)
-/// Bypass all can_perform_action checks for mouse drop
-#define INTERACT_ATOM_MOUSEDROP_IGNORE_USABILITY (1<<12)
-/// Bypass all adjacency and other checks for mouse drop
-#define INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS (INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT | INTERACT_ATOM_MOUSEDROP_IGNORE_USABILITY)
 
 /// attempt pickup on attack_hand for items
 #define INTERACT_ITEM_ATTACK_HAND_PICKUP (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -827,10 +827,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define ALLOW_RESTING (1<<7)
 /// If this is accessible to creatures with ventcrawl capabilities
 #define NEED_VENTCRAWL (1<<8)
-/// Skips adjacency checks
-#define BYPASS_ADJACENCY (1<<9)
 /// Checks for base adjacency, but silences the error
-#define SILENT_ADJACENCY (1<<10)
+#define SILENT_ADJACENCY (1<<9)
 
 /// The default mob sprite size (used for shrinking or enlarging the mob sprite to regular size)
 #define RESIZE_DEFAULT_SIZE 1

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,64 +6,18 @@
 	almost anything into a trash can.
 */
 /atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
-	SHOULD_NOT_OVERRIDE(TRUE)
-
 	if(!usr || !over)
 		return
-
+	if(SEND_SIGNAL(src, COMSIG_MOUSEDROP_ONTO, over, usr) & COMPONENT_NO_MOUSEDROP) //Whatever is receiving will verify themselves for adjacency.
+		return
 	var/proximity_check = usr.client.check_drag_proximity(src, over, src_location, over_location, src_control, over_control, params)
 	if(proximity_check)
 		return proximity_check
 
-	base_mouse_drop_handler(over, src_location, over_location, params)
+	if(!Adjacent(usr) || !over.Adjacent(usr))
+		return // should stop you from dragging through windows
 
-/**
- * Called when all sanity checks for mouse dropping have passed. Handles adjacency & other sanity checks before delegating the event
- * down to lower level handlers. Do not override unless you are trying to create hud & screen elements which do not require proximity
- * or other checks
- */
-/atom/proc/base_mouse_drop_handler(atom/over, src_location, over_location, params)
-	PROTECTED_PROC(TRUE)
-	SHOULD_NOT_OVERRIDE(TRUE)
-
-	var/mob/user = usr
-
-	if(SEND_SIGNAL(src, COMSIG_MOUSEDROP_ONTO, over, user) & COMPONENT_CANCEL_MOUSEDROP_ONTO)
-		return
-
-	if(SEND_SIGNAL(over, COMSIG_MOUSEDROPPED_ONTO, src, user, params) & COMPONENT_CANCEL_MOUSEDROPPED_ONTO)
-		return
-
-	// only if both dragged object & receiver agree to do checks do we proceed
-	var/combined_atom_flags = interaction_flags_atom | over.interaction_flags_atom
-	if(!(combined_atom_flags & INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS))
-		if(!(combined_atom_flags & INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT))
-			if(!Adjacent(user) || !over.Adjacent(user))
-				return // should stop you from dragging through windows
-
-		if(!(combined_atom_flags & INTERACT_ATOM_MOUSEDROP_IGNORE_USABILITY))
-			var/combined_flags = interaction_flags_mouse_drop | over.interaction_flags_mouse_drop
-			if(combined_atom_flags & INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT)
-				combined_flags |= BYPASS_ADJACENCY
-			else
-				combined_flags |= SILENT_ADJACENCY
-			if(!user.can_perform_action(src, combined_flags))
-				return // is the mob not able to drag the object with both sides conditions applied
-
-	mouse_drop_dragged(over, user, src_location, over_location, params)
-
-	over.mouse_drop_receive(src, user, params)
-
-/// The proc that should be overridden by subtypes to handle mouse drop. Called on the atom being dragged
-/atom/proc/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	PROTECTED_PROC(TRUE)
-
-	return
-
-/// The proc that should be overridden by subtypes to handle mouse drop. Called on the atom receiving a dragged object
-/atom/proc/mouse_drop_receive(atom/dropped, mob/user, params)
-	PROTECTED_PROC(TRUE)
-
+	over.MouseDrop_T(src,usr, params)
 	return
 
 /// Handles treating drags as clicks if they're within some conditions
@@ -123,6 +77,11 @@
 		return FALSE
 
 	return TRUE
+
+// receive a mousedrop
+/atom/proc/MouseDrop_T(atom/dropping, mob/user, params)
+	SEND_SIGNAL(src, COMSIG_MOUSEDROPPED_ONTO, dropping, user, params)
+
 
 /client/MouseDown(datum/object, location, control, params)
 	if(QDELETED(object)) //Yep, you can click on qdeleted things before they have time to nullspace. Fun.
@@ -187,8 +146,6 @@
 	return ..()
 
 /client/MouseDrop(atom/src_object, atom/over_object, atom/src_location, atom/over_location, src_control, over_control, params)
-	SHOULD_NOT_OVERRIDE(TRUE)
-
 	if (IS_WEAKREF_OF(src_object, middle_drag_atom_ref))
 		middragtime = 0
 		middle_drag_atom_ref = null

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -105,7 +105,7 @@
 	closeToolTip(usr)
 	return ..()
 
-/atom/movable/screen/movable/action_button/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
+/atom/movable/screen/movable/action_button/MouseDrop(over_object)
 	last_hovored_ref = null
 	if(!can_use(usr))
 		return
@@ -130,6 +130,7 @@
 		our_hud.position_action_relative(src, button)
 		save_position()
 		return
+	. = ..()
 	our_hud.position_action(src, screen_loc)
 	save_position()
 

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -20,7 +20,7 @@
 /atom/movable/screen/movable/snap
 	snap2grid = TRUE
 
-/atom/movable/screen/movable/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
+/atom/movable/screen/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
 	var/position = mouse_params_to_position(params)
 	if(!position)
 		return

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -15,7 +15,6 @@
 	animate_movement = SLIDE_STEPS
 	speech_span = SPAN_ROBOT
 	appearance_flags = APPEARANCE_UI
-	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS
 	/// A reference to the object in the slot. Grabs or items, generally, but any datum will do.
 	var/datum/weakref/master_ref = null
 	/// A reference to the owner HUD, if any.
@@ -58,10 +57,6 @@
 		SEND_SIGNAL(src, COMSIG_SCREEN_ELEMENT_CLICK, location, control, params, usr)
 	if(default_click)
 		return ..()
-
-///Screen elements are always on top of the players screen and don't move so yes they are adjacent
-/atom/movable/screen/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
-	return TRUE
 
 /atom/movable/screen/examine(mob/user)
 	return list()
@@ -246,7 +241,6 @@
 	var/mutable_appearance/handcuff_overlay
 	var/static/mutable_appearance/blocked_overlay = mutable_appearance('icons/hud/screen_gen.dmi', "blocked")
 	var/held_index = 0
-	interaction_flags_atom = NONE //so dragging objects into hands icon don't skip adjacency & other checks
 
 /atom/movable/screen/inventory/hand/update_overlays()
 	. = ..()

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -111,8 +111,6 @@
 ///Handles climbing onto the atom when you click-drag
 /datum/element/climbable/proc/mousedrop_receive(atom/climbed_thing, atom/movable/dropped_atom, mob/user, params)
 	SIGNAL_HANDLER
-
-	. = COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 	if(user != dropped_atom || !isliving(dropped_atom))
 		return
 	if(!HAS_TRAIT(dropped_atom, TRAIT_FENCE_CLIMBER) && !HAS_TRAIT(dropped_atom, TRAIT_CAN_HOLD_ITEMS)) // If you can hold items you can probably climb a fence

--- a/code/datums/elements/drag_pickup.dm
+++ b/code/datums/elements/drag_pickup.dm
@@ -17,10 +17,8 @@
 
 /datum/element/drag_pickup/proc/pick_up(atom/source, atom/over, mob/user)
 	SIGNAL_HANDLER
-
-	. = COMPONENT_CANCEL_MOUSEDROP_ONTO
 	var/mob/living/picker = user
-	if(!istype(picker) || !user.can_perform_action(source, FORBID_TELEKINESIS_REACH))
+	if(!istype(picker) || picker.incapacitated() || !source.Adjacent(picker))
 		return
 
 	if(over == picker)

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -36,12 +36,10 @@
 /datum/element/strippable/proc/mouse_drop_onto(datum/source, atom/over, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROP_ONTO
 	if (user == source)
 		return
+
 	if (over != user)
-		return
-	if(!user.can_perform_action(source, FORBID_TELEKINESIS_REACH))
 		return
 
 	// Cyborgs buckle people by dragging them onto them, unless in combat mode.

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -714,35 +714,25 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_mousedrop_onto(datum/source, atom/over_object, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROP_ONTO
-	if(ismecha(user.loc) || !user.canUseStorage())
+	if(ismecha(user.loc) || user.incapacitated() || !user.canUseStorage())
 		return
 
+	parent.add_fingerprint(user)
+
 	if(istype(over_object, /atom/movable/screen/inventory/hand))
-		if(real_location.loc != user || !user.can_perform_action(parent, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
+		if(real_location.loc != user)
 			return
 
 		var/atom/movable/screen/inventory/hand/hand = over_object
 		user.putItemFromInventoryInHandIfPossible(parent, hand.held_index)
-		parent.add_fingerprint(user)
 
 	else if(ismob(over_object))
-		if(over_object != user || !user.can_perform_action(parent, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
+		if(over_object != user)
 			return
 
-		parent.add_fingerprint(user)
 		INVOKE_ASYNC(src, PROC_REF(open_storage), user)
 
 	else if(!istype(over_object, /atom/movable/screen))
-		var/action_status
-		if(isturf(over_object))
-			action_status = user.can_perform_turf_action(over_object)
-		else
-			action_status = user.can_perform_action(over_object, FORBID_TELEKINESIS_REACH)
-		if(!action_status)
-			return
-
-		parent.add_fingerprint(user)
 		INVOKE_ASYNC(src, PROC_REF(dump_content_at), over_object, user)
 
 /**
@@ -789,16 +779,17 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_mousedropped_onto(datum/source, obj/item/dropping, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 	if(!istype(dropping))
 		return
 	if(dropping != user.get_active_held_item())
 		return
-	if(!user.can_perform_action(source, FORBID_TELEKINESIS_REACH))
-		return
 	if(dropping.atom_storage) // If it has storage it should be trying to dump, not insert.
 		return
+
 	if(!iscarbon(user) && !isdrone(user))
+		return
+	var/mob/living/user_living = user
+	if(user_living.incapacitated())
 		return
 
 	attempt_insert(dropping, user)

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -138,8 +138,6 @@
 
 	/// Flags to check for in can_perform_action. Used in alt-click & ctrl-click checks
 	var/interaction_flags_click = NONE
-	/// Flags to check for in can_perform_action for mouse drag & drop checks. To bypass checks see interaction_flags_atom mouse drop flags
-	var/interaction_flags_mouse_drop = NONE
 
 /**
  * Top level of the destroy chain for most atoms

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -9,7 +9,6 @@
 	circuit = /obj/item/circuitboard/machine/autolathe
 	layer = BELOW_OBJ_LAYER
 	processing_flags = NONE
-	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS
 
 	///Is the autolathe hacked via wiring
 	var/hacked = FALSE
@@ -392,17 +391,18 @@
 	busy = FALSE
 	SStgui.update_uis(src)
 
-/obj/machinery/autolathe/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	if(!can_interact(user) || (!HAS_SILICON_ACCESS(user) && !isAdminGhostAI(user)) && !Adjacent(user))
+/obj/machinery/autolathe/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	if(!can_interact(usr) || (!HAS_SILICON_ACCESS(usr) && !isAdminGhostAI(usr)) && !Adjacent(usr))
 		return
 	if(busy)
-		balloon_alert(user, "printing started!")
+		balloon_alert(usr, "printing started!")
 		return
 	var/direction = get_dir(src, over_location)
 	if(!direction)
 		return
 	drop_direction = direction
-	balloon_alert(user, "dropping [dir2text(drop_direction)]")
+	balloon_alert(usr, "dropping [dir2text(drop_direction)]")
 
 /obj/machinery/autolathe/click_alt(mob/user)
 	if(!drop_direction)

--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -11,9 +11,7 @@
 	base_icon_state = "infuser"
 	density = TRUE
 	obj_flags = BLOCKS_CONSTRUCTION // Becomes undense when the door is open
-	interaction_flags_mouse_drop = NEED_HANDS | NEED_DEXTERITY
 	circuit = /obj/item/circuitboard/machine/dna_infuser
-
 	/// maximum tier this will infuse
 	var/max_tier_allowed = DNA_MUTANT_TIER_ONE
 	///currently infusing a vict- subject
@@ -201,7 +199,7 @@
 	infusing_from = target
 
 // mostly good for dead mobs like corpses (drag to add).
-/obj/machinery/dna_infuser/mouse_drop_receive(atom/target, mob/user, params)
+/obj/machinery/dna_infuser/MouseDrop_T(atom/movable/target, mob/user)
 	// if the machine is closed, already has a infusion target, or the target is not valid then no mouse drop.
 	if(!is_valid_infusion(target, user))
 		return
@@ -210,6 +208,8 @@
 
 /// Verify that the given infusion source/mob is a dead creature.
 /obj/machinery/dna_infuser/proc/is_valid_infusion(atom/movable/target, mob/user)
+	if(user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !user.Adjacent(target) || !ISADVANCEDTOOLUSER(user))
+		return FALSE
 	var/datum/component/edible/food_comp = IS_EDIBLE(target)
 	if(infusing_from)
 		balloon_alert(user, "empty the machine first!")

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -6,10 +6,8 @@
 	base_icon_state = "scanner"
 	density = TRUE
 	obj_flags = BLOCKS_CONSTRUCTION // Becomes undense when the door is open
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 	occupant_typecache = list(/mob/living, /obj/item/bodypart/head, /obj/item/organ/internal/brain)
 	circuit = /obj/item/circuitboard/machine/dnascanner
-
 	var/locked = FALSE
 	var/damage_coeff
 	var/scan_level
@@ -142,8 +140,8 @@
 /obj/machinery/dna_scannernew/interact(mob/user)
 	toggle_open(user)
 
-/obj/machinery/dna_scannernew/mouse_drop_receive(atom/target, mob/user, params)
-	if(!iscarbon(target))
+/obj/machinery/dna_scannernew/MouseDrop_T(mob/target, mob/user)
+	if(user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !user.Adjacent(target) || !iscarbon(target) || !ISADVANCEDTOOLUSER(user))
 		return
 	close_machine(target)
 

--- a/code/game/machinery/hypnochair.dm
+++ b/code/game/machinery/hypnochair.dm
@@ -7,20 +7,13 @@
 	circuit = /obj/item/circuitboard/machine/hypnochair
 	density = TRUE
 	opacity = FALSE
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 
-	///Keeps track of the victim to apply effects if it teleports away
-	var/mob/living/carbon/victim = null
-	///Is the device currently interrogating someone?
-	var/interrogating = FALSE
-	///Time when the interrogation was started, to calculate effect in case of interruption
-	var/start_time = 0
-	///Trigger phrase to implant
-	var/trigger_phrase = ""
-	///Timer ID for interrogations
-	var/timerid = 0
-	///Cooldown for breakout message
-	var/message_cooldown = 0
+	var/mob/living/carbon/victim = null ///Keeps track of the victim to apply effects if it teleports away
+	var/interrogating = FALSE ///Is the device currently interrogating someone?
+	var/start_time = 0 ///Time when the interrogation was started, to calculate effect in case of interruption
+	var/trigger_phrase = "" ///Trigger phrase to implant
+	var/timerid = 0 ///Timer ID for interrogations
+	var/message_cooldown = 0 ///Cooldown for breakout message
 
 /obj/machinery/hypnochair/Initialize(mapload)
 	. = ..()
@@ -201,7 +194,8 @@
 		to_chat(user, span_warning("[src]'s door won't budge!"))
 
 
-/obj/machinery/hypnochair/mouse_drop_receive(atom/target, mob/user, params)
-	if(!isliving(target))
+/obj/machinery/hypnochair/MouseDrop_T(mob/target, mob/user)
+	if(HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !user.Adjacent(target) || !isliving(target) || !ISADVANCEDTOOLUSER(user))
 		return
+
 	close_machine(target)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -23,7 +23,6 @@
 	anchored = FALSE
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	use_power = NO_POWER_USE
-	interaction_flags_mouse_drop = NEED_HANDS
 
 	///What are we sticking our needle in?
 	var/atom/attached
@@ -162,22 +161,25 @@
 		filling.color = mix_color_from_reagents(container_reagents.reagent_list)
 		. += filling
 
-/obj/machinery/iv_drip/mouse_drop_dragged(atom/target, mob/user)
-	if(!isliving(user))
-		to_chat(user, span_warning("You can't do that!"))
+/obj/machinery/iv_drip/MouseDrop(atom/target)
+	. = ..()
+	if(!Adjacent(target) || !usr.can_perform_action(src))
+		return
+	if(!isliving(usr))
+		to_chat(usr, span_warning("You can't do that!"))
 		return
 	if(!get_reagents())
-		to_chat(user, span_warning("There's nothing attached to the IV drip!"))
+		to_chat(usr, span_warning("There's nothing attached to the IV drip!"))
 		return
-	if(!target.is_injectable(user))
-		to_chat(user, span_warning("Can't inject into this!"))
+	if(!target.is_injectable(usr))
+		to_chat(usr, span_warning("Can't inject into this!"))
 		return
 	if(attached)
 		visible_message(span_warning("[attached] is detached from [src]."))
 		attached = null
 		update_appearance(UPDATE_ICON)
-	user.visible_message(span_warning("[user] attaches [src] to [target]."), span_notice("You attach [src] to [target]."))
-	attach_iv(target, user)
+	usr.visible_message(span_warning("[usr] attaches [src] to [target]."), span_notice("You attach [src] to [target]."))
+	attach_iv(target, usr)
 
 /obj/machinery/iv_drip/attackby(obj/item/W, mob/user, params)
 	if(use_internal_storage)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -7,9 +7,7 @@
 	icon_state = "lpad-idle"
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2.5
 	hud_possible = list(DIAG_LAUNCHPAD_HUD)
-	interaction_flags_mouse_drop = NEED_DEXTERITY | NEED_HANDS
 	circuit = /obj/item/circuitboard/machine/launchpad
-
 	/// The beam icon
 	var/icon_teleport = "lpad-beam"
 	/// To prevent briefcase pad deconstruction and such
@@ -300,13 +298,14 @@
 		return FALSE
 	return TRUE
 
-/obj/machinery/launchpad/briefcase/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
-	if(over_object == user)
-		if(!briefcase)
+/obj/machinery/launchpad/briefcase/MouseDrop(over_object, src_location, over_location)
+	. = ..()
+	if(over_object == usr)
+		if(!briefcase || !usr.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
 			return
-		user.visible_message(span_notice("[usr] starts closing [src]..."), span_notice("You start closing [src]..."))
-		if(do_after(user, 3 SECONDS, target = user))
-			user.put_in_hands(briefcase)
+		usr.visible_message(span_notice("[usr] starts closing [src]..."), span_notice("You start closing [src]..."))
+		if(do_after(usr, 3 SECONDS, target = usr))
+			usr.put_in_hands(briefcase)
 			moveToNullspace() //hides it from suitcase contents
 			closed = TRUE
 			update_indicator()

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -9,8 +9,6 @@
 	desc = "Dispenses countless types of pipes. Very useful if you need pipes."
 	density = TRUE
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_OFFLINE
-	interaction_flags_mouse_drop = NEED_DEXTERITY
-
 	var/wait = 0
 	var/piping_layer = PIPING_LAYER_DEFAULT
 	///color of pipe
@@ -185,18 +183,23 @@
 	density = TRUE
 	category = DISPOSAL_PIPEDISPENSER
 
+
 //Allow you to drag-drop disposal pipes and transit tubes into it
-/obj/machinery/pipedispenser/disposal/mouse_drop_receive(obj/structure/pipe, mob/user, params)
+/obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/pipe, mob/usr)
+	if(!usr.incapacitated())
+		return
+
 	if (!istype(pipe, /obj/structure/disposalconstruct) && !istype(pipe, /obj/structure/c_transit_tube) && !istype(pipe, /obj/structure/c_transit_tube_pod))
 		return
 
-	if (get_dist(user, src) > 1 || get_dist(src, pipe) > 1 )
+	if (get_dist(usr, src) > 1 || get_dist(src,pipe) > 1 )
 		return
 
 	if (pipe.anchored)
 		return
 
 	qdel(pipe)
+
 
 //transit tube dispenser
 //inherit disposal for the dragging proc

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -7,7 +7,6 @@
 	density = FALSE
 	obj_flags = BLOCKS_CONSTRUCTION
 	state_open = TRUE
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 	circuit = /obj/item/circuitboard/machine/sleeper
 
 	payment_department = ACCOUNT_MED
@@ -115,8 +114,9 @@
 	if(is_operational && occupant)
 		open_machine()
 
-/obj/machinery/sleeper/mouse_drop_receive(atom/target, mob/user, params)
-	if(!iscarbon(target))
+
+/obj/machinery/sleeper/MouseDrop_T(mob/target, mob/user)
+	if(HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !user.Adjacent(target) || !iscarbon(target) || !ISADVANCEDTOOLUSER(user))
 		return
 	close_machine(target)
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -9,7 +9,6 @@
 	power_channel = AREA_USAGE_EQUIP
 	density = TRUE
 	obj_flags = BLOCKS_CONSTRUCTION // Becomes undense when the unit is open
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 	max_integrity = 250
 	req_access = list()
 	state_open = FALSE
@@ -447,9 +446,13 @@
 	image.color = COLOR_RED
 	return image
 
-/obj/machinery/suit_storage_unit/mouse_drop_receive(atom/A, mob/living/user, params)
-	if(!isliving(A))
+/obj/machinery/suit_storage_unit/MouseDrop_T(atom/A, mob/living/user)
+	if(!istype(user) || user.stat || !Adjacent(user) || !Adjacent(A) || !isliving(A))
 		return
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.body_position == LYING_DOWN)
+			return
 	var/mob/living/target = A
 	if(!state_open)
 		to_chat(user, span_warning("The unit's doors are shut!"))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -42,7 +42,8 @@
 		else
 			return user_unbuckle_mob(buckled_mobs[1], user)
 
-/atom/movable/mouse_drop_receive(mob/living/M, mob/user, params)
+/atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
+	. = ..()
 	return mouse_buckle_handling(M, user)
 
 /**

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1076,11 +1076,8 @@
 			else
 				apply_outline() //if the player's alive and well we send the command with no color set, so it uses the theme's color
 
-/obj/item/base_mouse_drop_handler(atom/over, src_location, over_location, params)
-	SHOULD_NOT_OVERRIDE(TRUE)
-
+/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	. = ..()
-
 	remove_filter(HOVER_OUTLINE_FILTER) //get rid of the hover effect in case the mouse exit isn't called if someone drags and drops an item and somthing goes wrong
 
 /obj/item/MouseExited()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -136,10 +136,11 @@
 		ui_action_click() //checks for this are handled in defibrillator.mount.dm
 	return ..()
 
-/obj/item/defibrillator/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
+/obj/item/defibrillator/MouseDrop(obj/over_object)
+	. = ..()
 	if(ismob(loc))
 		var/mob/M = loc
-		if(istype(over_object, /atom/movable/screen/inventory/hand))
+		if(!M.incapacitated() && istype(over_object, /atom/movable/screen/inventory/hand))
 			var/atom/movable/screen/inventory/hand/H = over_object
 			M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT * 0.75)
 	subspace_transmission = TRUE
 	canhear_range = 0 // can't hear headsets from very far away
-	interaction_flags_mouse_drop = FORBID_TELEKINESIS_REACH
+
 	slot_flags = ITEM_SLOT_EARS
 	dog_fashion = null
 	var/obj/item/encryptionkey/keyslot2 = null
@@ -91,9 +91,11 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	. = ..()
 	.["headset"] = TRUE
 
-/obj/item/radio/headset/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	if(user == over)
-		return attack_self(user)
+/obj/item/radio/headset/MouseDrop(mob/over, src_location, over_location)
+	var/mob/headset_user = usr
+	if((headset_user == over) && headset_user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+		return attack_self(headset_user)
+	return ..()
 
 /// Grants all the languages this headset allows the mob to understand via installed chips.
 /obj/item/radio/headset/proc/grant_headset_languages(mob/grant_to)

--- a/code/game/objects/items/implants/implantchair.dm
+++ b/code/game/objects/items/implants/implantchair.dm
@@ -5,7 +5,6 @@
 	icon_state = "implantchair"
 	density = TRUE
 	opacity = FALSE
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 
 	var/ready = TRUE
 	var/replenishing = FALSE
@@ -143,10 +142,16 @@
 		message_cooldown = world.time + 50
 		to_chat(user, span_warning("[src]'s door won't budge!"))
 
-/obj/machinery/implantchair/mouse_drop_receive(mob/target, mob/user, params)
-	if(!isliving(target))
+
+/obj/machinery/implantchair/MouseDrop_T(mob/target, mob/user)
+	if(user.stat || !Adjacent(user) || !user.Adjacent(target) || !isliving(target) || !ISADVANCEDTOOLUSER(user))
 		return
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.body_position == LYING_DOWN)
+			return
 	close_machine(target)
+
 
 /obj/machinery/implantchair/close_machine(mob/living/user, density_to_set = TRUE)
 	if((isnull(user) || istype(user)) && state_open)

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -18,8 +18,6 @@
 	throw_speed = 2
 	throw_range = 3
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT * 7.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT)
-	interaction_flags_mouse_drop = NEED_DEXTERITY
-
 	var/open = TRUE
 	var/locked = FALSE
 	var/list/occupants = list()
@@ -155,9 +153,10 @@
 	if(!open)
 		. += "[base_icon_state]_[locked ? "" : "un"]locked"
 
-/obj/item/pet_carrier/mouse_drop_dragged(atom/over_atom, mob/user, src_location, over_location, params)
-	if(isopenturf(over_atom) && open && occupants.len)
-		user.visible_message(span_notice("[user] unloads [src]."), \
+/obj/item/pet_carrier/MouseDrop(atom/over_atom)
+	. = ..()
+	if(isopenturf(over_atom) && usr.can_perform_action(src, NEED_DEXTERITY) && usr.Adjacent(over_atom) && open && occupants.len)
+		usr.visible_message(span_notice("[usr] unloads [src]."), \
 		span_notice("You unload [src] onto [over_atom]."))
 		for(var/V in occupants)
 			remove_occupant(V, over_atom)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -14,7 +14,6 @@
 	max_integrity = 200
 	armor_type = /datum/armor/item_watertank
 	resistance_flags = FIRE_PROOF
-	interaction_flags_mouse_drop = ALLOW_RESTING
 
 	var/obj/item/noz
 	var/volume = 500
@@ -94,11 +93,12 @@
 	else
 		return ..()
 
-/obj/item/watertank/mouse_drop_dragged(atom/over_object)
+/obj/item/watertank/MouseDrop(obj/over_object)
 	var/mob/M = loc
 	if(istype(M) && istype(over_object, /atom/movable/screen/inventory/hand))
 		var/atom/movable/screen/inventory/hand/H = over_object
 		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
+	return ..()
 
 /obj/item/watertank/attackby(obj/item/attacking_item, mob/user, params)
 	if(attacking_item == noz)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -11,8 +11,6 @@
 	integrity_failure = 0.1
 	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
 	layer = OBJ_LAYER
-	interaction_flags_mouse_drop = NEED_HANDS | NEED_DEXTERITY
-
 	var/buildstacktype = /obj/item/stack/sheet/iron
 	var/buildstackamount = 1
 	var/item_chair = /obj/item/chair // if null it can't be picked up
@@ -263,15 +261,18 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 /obj/structure/chair/stool/narsie_act()
 	return
 
-/obj/structure/chair/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
-	if(over_object == user)
+/obj/structure/chair/MouseDrop(over_object, src_location, over_location)
+	. = ..()
+	if(over_object == usr && Adjacent(usr))
 		if(!item_chair || has_buckled_mobs())
 			return
-		user.visible_message(span_notice("[user] grabs \the [src.name]."), span_notice("You grab \the [src.name]."))
+		if(!usr.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS))
+			return
+		usr.visible_message(span_notice("[usr] grabs \the [src.name]."), span_notice("You grab \the [src.name]."))
 		var/obj/item/C = new item_chair(loc)
 		C.set_custom_materials(custom_materials)
 		TransferComponents(C)
-		user.put_in_hands(C)
+		usr.put_in_hands(C)
 		qdel(src)
 
 /obj/structure/chair/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -911,8 +911,12 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 /obj/structure/closet/proc/after_weld(weld_state)
 	return
 
-/obj/structure/closet/mouse_drop_receive(atom/movable/O, mob/living/user, params)
+/obj/structure/closet/MouseDrop_T(atom/movable/O, mob/living/user)
 	if(!istype(O) || O.anchored || istype(O, /atom/movable/screen))
+		return
+	if(!istype(user) || user.incapacitated() || user.body_position == LYING_DOWN)
+		return
+	if(!Adjacent(user) || !user.Adjacent(O))
 		return
 	if(user == O) //try to climb onto it
 		return ..()
@@ -947,6 +951,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			log_combat(user, O, "stuffed", addition = "inside of [src]")
 	else
 		O.forceMove(T)
+	return 1
 
 /obj/structure/closet/relaymove(mob/living/user, direction)
 	if(user.stat || !isturf(loc))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -518,7 +518,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	density = TRUE
 	anchored = TRUE
 	pass_flags_self = PASSTABLE | LETPASSTHROW
-
 	max_integrity = 350
 
 	///The bodycontainer we are a tray to.
@@ -559,10 +558,10 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	if(carried_mob == user) //Piggyback user.
 		return
 	user.unbuckle_mob(carried_mob)
-	mouse_drop_receive(carried_mob, user)
+	MouseDrop_T(carried_mob, user)
 
-/obj/structure/tray/mouse_drop_receive(atom/movable/O as mob|obj, mob/user, params)
-	if(!ismovable(O) || O.anchored || O.loc == user)
+/obj/structure/tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user)
+	if(!ismovable(O) || O.anchored || !Adjacent(user) || !user.Adjacent(O) || O.loc == user)
 		return
 	if(!ismob(O))
 		if(!istype(O, /obj/structure/closet/body_bag))
@@ -571,9 +570,16 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		var/mob/M = O
 		if(M.buckled)
 			return
+	if(!ismob(user) || user.incapacitated())
+		return
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.body_position == LYING_DOWN)
+			return
 	O.forceMove(src.loc)
 	if (user != O)
 		visible_message(span_warning("[user] stuffs [O] into [src]."))
+	return
 
 /*
  * Crematorium tray

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -14,7 +14,6 @@
 	exit_delay = 1
 	enter_delay = 2
 	tube_construction = /obj/structure/c_transit_tube/station
-
 	var/open_status = STATION_TUBE_CLOSED
 	var/pod_moving = FALSE
 	var/cooldown_delay = 50
@@ -41,9 +40,14 @@
 				pod.update_appearance()
 				return
 
+
 //pod insertion
-/obj/structure/transit_tube/station/mouse_drop_receive(obj/structure/c_transit_tube_pod/R, mob/user, params)
-	if (!istype(R) || get_dist(user, src) > 1 || get_dist(src, R) > 1)
+/obj/structure/transit_tube/station/MouseDrop_T(obj/structure/c_transit_tube_pod/R, mob/user)
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.incapacitated())
+			return
+	if (!istype(R) || get_dist(user, src) > 1 || get_dist(src,R) > 1)
 		return
 	for(var/obj/structure/transit_tube_pod/pod in loc)
 		return //no fun allowed

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -34,7 +34,8 @@
 
 	var/list/dent_decals
 
-/turf/closed/wall/mouse_drop_receive(atom/dropping, mob/user, params)
+/turf/closed/wall/MouseDrop_T(atom/dropping, mob/user, params)
+	..()
 	if(dropping != user)
 		return
 	if(!iscarbon(dropping) && !iscyborg(dropping))

--- a/code/modules/admin/verbs/light_debug.dm
+++ b/code/modules/admin/verbs/light_debug.dm
@@ -129,7 +129,8 @@ GLOBAL_LIST_EMPTY(light_debugged_atoms)
 	last_hovored_ref = WEAKREF(over_object)
 	over_object.MouseEntered(over_location, over_control, params)
 
-/atom/movable/screen/light_button/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
+/atom/movable/screen/light_button/MouseDrop(over_object)
+	. = ..()
 	last_hovored_ref = null
 
 /atom/movable/screen/light_button/MouseEntered(location, control, params)
@@ -329,7 +330,8 @@ GLOBAL_LIST_EMPTY(light_debugged_atoms)
 	icon_state = "light_move"
 	mouse_drag_pointer = 'icons/effects/mouse_pointers/light_drag.dmi'
 
-/atom/movable/screen/light_button/move/mouse_drop_dragged(atom/over_object)
+/atom/movable/screen/light_button/move/MouseDrop(over_object)
+	. = ..()
 	if(!ismovable(loc))
 		return
 	var/atom/movable/movable_owner = loc

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -5,8 +5,6 @@
 	icon_state = "experiment-open"
 	density = FALSE
 	state_open = TRUE
-	interaction_flags_mouse_drop = NEED_DEXTERITY
-
 	var/points = 0
 	var/credits = 0
 	var/list/history
@@ -23,8 +21,10 @@
 		console = null
 	return ..()
 
-/obj/machinery/abductor/experiment/mouse_drop_receive(mob/target, mob/user, params)
-	if(!ishuman(target) || isabductor(target))
+/obj/machinery/abductor/experiment/MouseDrop_T(mob/target, mob/user)
+	if(user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !target.Adjacent(user) || !ishuman(target))
+		return
+	if(isabductor(target))
 		return
 	close_machine(target)
 

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -7,15 +7,16 @@
 	icon_state = "bluespace-prison"
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //ha ha no getting out!!
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 
 /obj/machinery/fugitive_capture/examine(mob/user)
 	. = ..()
 	. += span_notice("Add a prisoner by dragging them into the machine.")
 
-/obj/machinery/fugitive_capture/mouse_drop_receive(mob/target, mob/user, params)
+/obj/machinery/fugitive_capture/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/fugitive_hunter = user
-	if(!isliving(fugitive_hunter) || !ishuman(target))
+	if(!isliving(fugitive_hunter))
+		return
+	if(HAS_TRAIT(fugitive_hunter, TRAIT_UI_BLOCKED) || !Adjacent(fugitive_hunter) || !target.Adjacent(fugitive_hunter) || !ishuman(target))
 		return
 	var/mob/living/carbon/human/fugitive = target
 	var/datum/antagonist/fugitive/fug_antag = fugitive.mind.has_antag_datum(/datum/antagonist/fugitive)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -80,7 +80,6 @@
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.75
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 1.5
 	flags_1 = PREVENT_CLICK_UNDER_1
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 
 	///If TRUE will eject the mob once healing is complete
 	var/autoeject = TRUE
@@ -643,19 +642,15 @@
 	return CLICK_ACTION_BLOCKING
 
 /obj/machinery/cryo_cell/click_alt(mob/user)
-	//Required so players don't close the cryo on themselves without a doctor's help
-	if(get_turf(user) == get_turf(src))
-		return CLICK_ACTION_BLOCKING
-
-	if(state_open )
+	if(state_open)
 		close_machine()
 	else
 		open_machine()
 	balloon_alert(user, "door [state_open ? "opened" : "closed"]")
 	return CLICK_ACTION_SUCCESS
 
-/obj/machinery/cryo_cell/mouse_drop_receive(mob/target, mob/user, params)
-	if(!iscarbon(target))
+/obj/machinery/cryo_cell/MouseDrop_T(mob/target, mob/user)
+	if(user.incapacitated() || !Adjacent(user) || !user.Adjacent(target) || !iscarbon(target) || !ISADVANCEDTOOLUSER(user))
 		return
 
 	if(isliving(target))

--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -11,8 +11,6 @@
 	max_integrity = 300
 	obj_flags = BLOCKS_CONSTRUCTION
 	state_open = TRUE
-	interaction_flags_mouse_drop = NEED_HANDS | NEED_DEXTERITY
-
 	/// Whether we have an ongoing connection
 	var/connected = FALSE
 	/// A player selected outfit by clicking the netpod
@@ -95,10 +93,12 @@
 
 	return ..()
 
-/obj/machinery/netpod/mouse_drop_receive(mob/target, mob/user, params)
+/obj/machinery/netpod/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/carbon/player = user
+	if(!iscarbon(player) || !Adjacent(player) || !ISADVANCEDTOOLUSER(player) || !is_operational || !state_open)
+		return
 
-	if(!iscarbon(player) || !is_operational || !state_open || player.buckled)
+	if(player.buckled || HAS_TRAIT(player, TRAIT_HANDS_BLOCKED))
 		return
 
 	close_machine(target)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -63,16 +63,17 @@
 	if(!icon_state)
 		item_flags |= ABSTRACT
 
-/obj/item/clothing/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
-	var/mob/M = user
+/obj/item/clothing/MouseDrop(atom/over_object)
+	. = ..()
+	var/mob/M = usr
 
 	if(ismecha(M.loc)) // stops inventory actions in a mech
 		return
 
-	if(loc == M && istype(over_object, /atom/movable/screen/inventory/hand))
+	if(!M.incapacitated() && loc == M && istype(over_object, /atom/movable/screen/inventory/hand))
 		var/atom/movable/screen/inventory/hand/H = over_object
 		if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
-			add_fingerprint(user)
+			add_fingerprint(usr)
 
 /obj/item/food/clothing
 	name = "temporary moth clothing snack item"

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -8,7 +8,6 @@
 	clothing_flags = ANTI_TINFOIL_MANEUVER
 	var/datum/brain_trauma/mild/phobia/conspiracies/paranoia
 	var/warped = FALSE
-	interaction_flags_mouse_drop = NEED_HANDS
 
 /datum/armor/costume_foilhat
 	laser = -5
@@ -43,10 +42,10 @@
 	user.gain_trauma(paranoia, TRAUMA_RESILIENCE_MAGIC)
 	to_chat(user, span_warning("As you don the foiled hat, an entire world of conspiracy theories and seemingly insane ideas suddenly rush into your mind. What you once thought unbelievable suddenly seems.. undeniable. Everything is connected and nothing happens just by accident. You know too much and now they're out to get you. "))
 
-/obj/item/clothing/head/costume/foilhat/mouse_drop_dragged(atom/over_object, mob/user)
+/obj/item/clothing/head/costume/foilhat/MouseDrop(atom/over_object)
 	//God Im sorry
-	if(!warped && iscarbon(user))
-		var/mob/living/carbon/C = user
+	if(!warped && iscarbon(usr))
+		var/mob/living/carbon/C = usr
 		if(src == C.head)
 			to_chat(C, span_userdanger("Why would you want to take this off? Do you want them to get into your mind?!"))
 			return

--- a/code/modules/clothing/shoes/cowboy.dm
+++ b/code/modules/clothing/shoes/cowboy.dm
@@ -5,8 +5,6 @@
 	armor_type = /datum/armor/shoes_cowboy
 	custom_price = PAYCHECK_CREW
 	can_be_tied = FALSE
-	interaction_flags_mouse_drop = NEED_HANDS | NEED_DEXTERITY
-
 	var/max_occupants = 4
 	/// Do these boots have spur sounds?
 	var/has_spurs = FALSE
@@ -54,9 +52,9 @@
 	user.say(pick("Hot damn!", "Hoo-wee!", "Got-dang!"), spans = list(SPAN_YELL), forced=TRUE)
 	user.client?.give_award(/datum/award/achievement/misc/hot_damn, user)
 
-/obj/item/clothing/shoes/cowboy/mouse_drop_receive(mob/living/target, mob/living/user, params)
+/obj/item/clothing/shoes/cowboy/MouseDrop_T(mob/living/target, mob/living/user)
 	. = ..()
-	if(!(user.mobility_flags & MOBILITY_USE) || !isliving(target))
+	if(!(user.mobility_flags & MOBILITY_USE) || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !isliving(target) || !user.Adjacent(target) || target.stat == DEAD)
 		return
 	if(contents.len >= max_occupants)
 		to_chat(user, span_warning("[src] are full!"))

--- a/code/modules/clothing/shoes/sneakers.dm
+++ b/code/modules/clothing/shoes/sneakers.dm
@@ -10,7 +10,6 @@
 	greyscale_config_inhand_left = /datum/greyscale_config/sneakers/inhand_left
 	greyscale_config_inhand_right = /datum/greyscale_config/sneakers/inhand_right
 	flags_1 = IS_PLAYER_COLORABLE_1
-	interaction_flags_mouse_drop = NEED_HANDS
 
 /obj/item/clothing/shoes/sneakers/black
 	name = "black shoes"
@@ -147,9 +146,10 @@
 			return FALSE
 	return ..()
 
-/obj/item/clothing/shoes/sneakers/orange/mouse_drop_dragged(atom/over_object, mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/c = user
+/obj/item/clothing/shoes/sneakers/orange/MouseDrop(atom/over)
+	var/mob/m = usr
+	if(ishuman(m))
+		var/mob/living/carbon/human/c = m
 		if(c.shoes == src && attached_cuffs)
 			to_chat(c, span_warning("You need help taking these off!"))
 			return

--- a/code/modules/food_and_drinks/machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/machinery/monkeyrecycler.dm
@@ -6,10 +6,8 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	icon = 'icons/obj/machines/kitchen.dmi'
 	icon_state = "grinder"
 	layer = BELOW_OBJ_LAYER
-	interaction_flags_mouse_drop = NEED_DEXTERITY
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/monkey_recycler
-
 	var/stored_matter = 0
 	var/cube_production = 0.2
 	var/list/connected = list() //Keeps track of connected xenobio consoles, for deletion in /Destroy()
@@ -61,7 +59,7 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	else
 		return ..()
 
-/obj/machinery/monkey_recycler/mouse_drop_receive(mob/living/target, mob/living/user, params)
+/obj/machinery/monkey_recycler/MouseDrop_T(mob/living/target, mob/living/user)
 	if(!istype(target))
 		return
 	if(ismonkey(target))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -160,7 +160,6 @@
 	close_sound = 'sound/machines/trapdoor/trapdoor_shut.ogg'
 	set_dir_on_move = TRUE
 	can_buckle = TRUE
-
 	/// Whether we're on a set of rails or just on the ground
 	var/on_rails = FALSE
 	/// How many turfs we are travelling, also functions as speed (more momentum = faster)
@@ -296,16 +295,17 @@
 	update_rail_state(FALSE)
 	return ..()
 
-/obj/structure/closet/crate/miningcar/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	if(!isliving(user))
+/obj/structure/closet/crate/miningcar/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	if(!isliving(usr) || !usr.Adjacent(over) || !usr.Adjacent(src))
 		return
 	if(on_rails)
 		if(isopenturf(over))
-			try_take_off_rails(user, over)
+			try_take_off_rails(usr, over)
 		return
 
 	if(istype(over, /obj/structure/minecart_rail) || (isopenturf(over) && (locate(/obj/structure/minecart_rail) in over)))
-		try_put_on_rails(user, get_turf(over))
+		try_put_on_rails(usr, get_turf(over))
 		return
 
 /**

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -5,7 +5,6 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 /mob/dead
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 	move_resist = INFINITY
-	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS
 	throwforce = 0
 
 /mob/dead/Initialize(mapload)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -691,10 +691,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	GLOB.manifest.ui_interact(src)
 
 //this is called when a ghost is drag clicked to something.
-/mob/dead/observer/mouse_drop_dragged(atom/over, mob/user)
-	if (isobserver(user) && user.client.holder && (isliving(over) || iscameramob(over)))
-		if (user.client.holder.cmd_ghost_drag(src,over))
+/mob/dead/observer/MouseDrop(atom/over)
+	if(!usr || !over)
+		return
+	if (isobserver(usr) && usr.client.holder && (isliving(over) || iscameramob(over)) )
+		if (usr.client.holder.cmd_ghost_drag(src,over))
 			return
+
+	return ..()
 
 /mob/dead/observer/Topic(href, href_list)
 	..()

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -204,11 +204,12 @@
 		. += "Growth: [amount_grown]/[SLIME_EVOLUTION_THRESHOLD]"
 		. += "Power Level: [powerlevel]/[SLIME_MAX_POWER]"
 
-/mob/living/basic/slime/mouse_drop_dragged(atom/target_atom, mob/user)
-	if(isliving(target_atom) && target_atom != src && user == src)
+/mob/living/basic/slime/MouseDrop(atom/movable/target_atom as mob|obj)
+	if(isliving(target_atom) && target_atom != src && usr == src)
 		var/mob/living/food = target_atom
 		if(can_feed_on(food))
 			start_feeding(food)
+	return ..()
 
 ///Slimes can hop off mobs they have latched onto
 /mob/living/basic/slime/resist_buckle()

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -8,7 +8,6 @@
 	melee_damage_lower = 20 //Refers to unarmed damage, aliens do unarmed attacks.
 	melee_damage_upper = 20
 	max_grab = GRAB_AGGRESSIVE
-
 	var/caste = ""
 	var/alt_icon = 'icons/mob/nonhuman-player/alienleap.dmi' //used to switch between the two alien icon files.
 	var/leap_on_click = 0
@@ -92,7 +91,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 			if(. <= GRAB_AGGRESSIVE)
 				ADD_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
 
-/mob/living/carbon/alien/adult/mouse_drop_receive(atom/dropping, mob/user, params)
+/mob/living/carbon/alien/adult/MouseDrop_T(atom/dropping, atom/user)
 	if(devour_lad(dropping))
 		return
 	return ..()

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -121,4 +121,3 @@
 	var/bodyshape = BODYSHAPE_HUMANOID
 
 	COOLDOWN_DECLARE(bleeding_message_cd)
-

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1314,21 +1314,6 @@
 	if(!istype(target))
 		CRASH("Missing target arg for can_perform_action")
 
-	if(!(interaction_flags_atom & INTERACT_ATOM_IGNORE_INCAPACITATED))
-		var/ignore_flags = NONE
-		if(interaction_flags_atom & INTERACT_ATOM_IGNORE_RESTRAINED)
-			ignore_flags |= IGNORE_RESTRAINTS
-		if(!(interaction_flags_atom & INTERACT_ATOM_CHECK_GRAB))
-			ignore_flags |= IGNORE_GRAB
-
-		if(incapacitated(ignore_flags))
-			to_chat(src, span_warning("You are incapacitated at the moment!"))
-			return FALSE
-
-	if(stat == DEAD || stat != CONSCIOUS)
-		to_chat(src, span_warning("You are in no physical condition to do this!"))
-		return FALSE
-
 	// If the MOBILITY_UI bitflag is not set it indicates the mob's hands are cutoff, blocked, or handcuffed
 	// Note - AI's and borgs have the MOBILITY_UI bitflag set even though they don't have hands
 	// Also if it is not set, the mob could be incapcitated, knocked out, unconscious, asleep, EMP'd, etc.
@@ -1338,14 +1323,11 @@
 
 	// NEED_HANDS is already checked by MOBILITY_UI for humans so this is for silicons
 	if((action_bitflags & NEED_HANDS))
-		if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
-			to_chat(src, span_warning("You can't do that right now!"))
-			return FALSE
 		if(!can_hold_items(isitem(target) ? target : null)) // almost redundant if it weren't for mobs
 			to_chat(src, span_warning("You don't have the physical ability to do this!"))
 			return FALSE
 
-	if(!(action_bitflags & BYPASS_ADJACENCY) && !Adjacent(target) && (target.loc != src) && !recursive_loc_check(src, target))
+	if(!Adjacent(target) && (target.loc != src) && !recursive_loc_check(src, target))
 		if(HAS_SILICON_ACCESS(src) && !ispAI(src))
 			if(!(action_bitflags & ALLOW_SILICON_REACH)) // silicons can ignore range checks (except pAIs)
 				if(!(action_bitflags & SILENT_ADJACENCY))
@@ -1353,8 +1335,7 @@
 				return FALSE
 		else // just a normal carbon mob
 			if((action_bitflags & FORBID_TELEKINESIS_REACH))
-				if(!(action_bitflags & SILENT_ADJACENCY))
-					to_chat(src, span_warning("You are too far away!"))
+				to_chat(src, span_warning("You are too far away!"))
 				return FALSE
 
 			var/datum/dna/mob_DNA = has_dna()
@@ -1831,7 +1812,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	..()
 	update_z(new_turf?.z)
 
-/mob/living/mouse_drop_receive(atom/dropping, atom/user, params)
+/mob/living/MouseDrop_T(atom/dropping, atom/user)
 	var/mob/living/U = user
 	if(isliving(dropping))
 		var/mob/living/M = dropping

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -2,6 +2,7 @@
 	see_invisible = SEE_INVISIBLE_LIVING
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD)
 	pressure_resistance = 10
+
 	hud_type = /datum/hud/living
 
 	///Tracks the current size of the mob in relation to its original size. Use update_transform(resize) to change it.

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -27,6 +27,7 @@
 	mob_size = MOB_SIZE_LARGE
 	buckle_prevents_pull = TRUE // No pulling loaded shit
 	bot_mode_flags = ~BOT_MODE_ROUNDSTART_POSSESSION
+
 	req_one_access = list(ACCESS_ROBOTICS, ACCESS_CARGO)
 	radio_key = /obj/item/encryptionkey/headset_cargo
 	radio_channel = RADIO_CHANNEL_SUPPLY
@@ -377,14 +378,20 @@
 
 // mousedrop a crate to load the bot
 // can load anything if hacked
-/mob/living/simple_animal/bot/mulebot/mouse_drop_receive(atom/movable/AM, mob/user, params)
-	if(!isliving(user))
+/mob/living/simple_animal/bot/mulebot/MouseDrop_T(atom/movable/AM, mob/user)
+	var/mob/living/L = user
+
+	if (!istype(L))
+		return
+
+	if(user.incapacitated() || (istype(L) && L.body_position == LYING_DOWN))
 		return
 
 	if(!istype(AM) || isdead(AM) || iscameramob(AM) || istype(AM, /obj/effect/dummy/phased_mob))
 		return
 
 	load(AM)
+
 
 // called to load a crate
 /mob/living/simple_animal/bot/mulebot/proc/load(atom/movable/AM)
@@ -805,7 +812,8 @@
 	icon_state = "paranormalmulebot0"
 	base_icon = "paranormalmulebot"
 
-/mob/living/simple_animal/bot/mulebot/paranormal/mouse_drop_receive(atom/movable/AM, mob/user, params)
+
+/mob/living/simple_animal/bot/mulebot/paranormal/MouseDrop_T(atom/movable/AM, mob/user)
 	var/mob/living/L = user
 
 	if(user.incapacitated() || (istype(L) && L.body_position == LYING_DOWN))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -889,6 +889,20 @@
 	set category = null
 	return
 
+/**
+ * Controls if a mouse drop succeeds (return null if it doesnt)
+ */
+/mob/MouseDrop(mob/M)
+	. = ..()
+	if(M != usr)
+		return
+	if(usr == src)
+		return
+	if(!Adjacent(usr))
+		return
+	if(isAI(M))
+		return
+
 ///Is the mob muzzled (default false)
 /mob/proc/is_muzzled()
 	return FALSE
@@ -1158,8 +1172,6 @@
  * * ALLOW_SILICON_REACH - If silicons are allowed to perform action from a distance (silicons can operate airlocks from far away)
  * * ALLOW_RESTING - If resting on the floor is allowed to perform action ()
  * * ALLOW_VENTCRAWL - Mobs with ventcrawl traits can alt-click this to vent
- * * BYPASS_ADJACENCY - The target does not have to be adjacent
- * * SILENT_ADJACENCY - Adjacency is required but errors are not printed
  *
  * silence_adjacency: Sometimes we want to use this proc to check interaction without allowing it to throw errors for base case adjacency
  * Alt click uses this, as otherwise you can detect what is interactable from a distance via the error message

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -13,7 +13,6 @@
 	base_icon_state = "control"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	interaction_flags_mouse_drop = NEED_HANDS
 	strip_delay = 10 SECONDS
 	armor_type = /datum/armor/none
 	actions_types = list(
@@ -229,9 +228,9 @@
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, FALSE, SILENCED_SOUND_EXTRARANGE)
 			return FALSE
 
-/obj/item/mod/control/mouse_drop_dragged(atom/over_object, mob/user)
-	if(user != wearer || !istype(over_object, /atom/movable/screen/inventory/hand))
-		return
+/obj/item/mod/control/MouseDrop(atom/over_object)
+	if(usr != wearer || !istype(over_object, /atom/movable/screen/inventory/hand))
+		return ..()
 	for(var/obj/item/part as anything in get_parts())
 		if(part.loc != src)
 			balloon_alert(wearer, "retract parts first!")
@@ -240,7 +239,8 @@
 	if(!wearer.incapacitated())
 		var/atom/movable/screen/inventory/hand/ui_hand = over_object
 		if(wearer.putItemFromInventoryInHandIfPossible(src, ui_hand.held_index))
-			add_fingerprint(user)
+			add_fingerprint(usr)
+			return ..()
 
 /obj/item/mod/control/wrench_act(mob/living/user, obj/item/wrench)
 	if(seconds_electrified && get_charge() && shock(user))

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -12,7 +12,6 @@
 	max_integrity = 100
 	armor_type = /datum/armor/item_modular_computer
 	light_system = OVERLAY_LIGHT_DIRECTIONAL
-	interaction_flags_mouse_drop = NEED_HANDS | ALLOW_RESTING
 
 	///The ID currently stored in the computer.
 	var/obj/item/card/id/computer_id_slot
@@ -335,9 +334,11 @@
 	update_appearance()
 	return TRUE
 
-/obj/item/modular_computer/mouse_drop_dragged(atom/over_object, mob/user)
-	if(!istype(over_object, /atom/movable/screen))
-		return attack_self(user)
+/obj/item/modular_computer/MouseDrop(obj/over_object, src_location, over_location)
+	var/mob/M = usr
+	if((!istype(over_object, /atom/movable/screen)) && usr.can_perform_action(src))
+		return attack_self(M)
+	return ..()
 
 /obj/item/modular_computer/attack_ai(mob/user)
 	return attack_self(user)

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -11,8 +11,6 @@
 	hardware_flag = PROGRAM_LAPTOP
 	max_idle_programs = 3
 	w_class = WEIGHT_CLASS_NORMAL
-	interaction_flags_mouse_drop = NEED_HANDS
-
 
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND
@@ -60,15 +58,20 @@
 
 	try_toggle_open(usr)
 
-/obj/item/modular_computer/laptop/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
-	if(over_object == user || over_object == src)
-		try_toggle_open(user)
+/obj/item/modular_computer/laptop/MouseDrop(obj/over_object, src_location, over_location)
+	. = ..()
+	if(over_object == usr || over_object == src)
+		try_toggle_open(usr)
 		return
 	if(istype(over_object, /atom/movable/screen/inventory/hand))
 		var/atom/movable/screen/inventory/hand/H = over_object
-		if(!isturf(loc))
+		var/mob/M = usr
+
+		if(M.stat != CONSCIOUS || HAS_TRAIT(M, TRAIT_HANDS_BLOCKED))
 			return
-		user.put_in_hand(src, H.held_index)
+		if(!isturf(loc) || !Adjacent(M))
+			return
+		M.put_in_hand(src, H.held_index)
 
 /obj/item/modular_computer/laptop/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -9,7 +9,6 @@
 	anchored = FALSE
 	pass_flags = PASSTABLE // Able to place on tables
 	max_integrity = 5000 // To make attacking it not instantly break it
-
 	/// The amount of times this bell has been rang, used to check the chance it breaks
 	var/times_rang = 0
 	/// Is this bell broken?
@@ -111,14 +110,17 @@
 	desc = "The cornerstone of any customer service job. This one's been modified for hyper-performance."
 	ring_cooldown_length = 0
 
-/obj/structure/desk_bell/mouse_drop_dragged(atom/over_object, mob/user)
+/obj/structure/desk_bell/MouseDrop(obj/over_object, src_location, over_location)
 	if(!istype(over_object, /obj/vehicle/ridden/wheelchair))
+		return
+	if(!Adjacent(over_object) || !Adjacent(usr))
 		return
 	var/obj/vehicle/ridden/wheelchair/target = over_object
 	if(target.bell_attached)
-		user.balloon_alert(user, "already has a bell!")
+		usr.balloon_alert(usr, "already has a bell!")
 		return
-	user.balloon_alert(user, "attaching bell...")
-	if(!do_after(user, 0.5 SECONDS))
+	usr.balloon_alert(usr, "attaching bell...")
+	if(!do_after(usr, 0.5 SECONDS))
 		return
 	target.attach_bell(src)
+	return ..()

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -177,7 +177,12 @@
 	new /obj/item/paper/paperslip(get_turf(src))
 	update_appearance()
 
-/obj/item/papercutter/mouse_drop_dragged(atom/over_object, mob/user)
+/obj/item/papercutter/MouseDrop(atom/over_object)
+	. = ..()
+	var/mob/user = usr
+	if(user.incapacitated() || !Adjacent(user))
+		return
+
 	if(over_object == user)
 		user.put_in_hands(src)
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -66,8 +66,6 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 	power_channel = AREA_USAGE_EQUIP
 	max_integrity = 300
 	integrity_failure = 0.33
-	interaction_flags_mouse_drop = NEED_DEXTERITY | ALLOW_RESTING
-
 	/// A reference to a mob on top of the photocopier trying to copy their ass. Null if there is no mob.
 	var/mob/living/ass
 	/// A reference to the toner cartridge that's inserted into the copier. Null if there is no cartridge.
@@ -88,7 +86,6 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 	var/starting_paper = 30
 	/// A stack for all the empty paper we have newly inserted (LIFO)
 	var/list/paper_stack = list()
-
 
 /obj/machinery/photocopier/Initialize(mapload)
 	. = ..()
@@ -589,8 +586,8 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 		new /obj/effect/decal/cleanable/oil(get_turf(src))
 		toner_cartridge.charges = 0
 
-/obj/machinery/photocopier/mouse_drop_receive(mob/target, mob/user, params)
-	if(!istype(target) || target.anchored || target.buckled || target == ass || copier_blocked())
+/obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
+	if(!istype(target) || target.anchored || target.buckled || !Adjacent(target) || !user.can_perform_action(src, action_bitflags = ALLOW_RESTING) || target == ass || copier_blocked())
 		return
 	add_fingerprint(user)
 	if(target == user)
@@ -629,7 +626,7 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 	return TRUE
 
 /**
- * Checks if the copier is deleted, or has something dense at its location. Called in `mouse_drop_receive()`
+ * Checks if the copier is deleted, or has something dense at its location. Called in `MouseDrop_T()`
  */
 /obj/machinery/photocopier/proc/copier_blocked()
 	if(QDELETED(src))

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -295,7 +295,7 @@ All the important duct code:
 	disconnect_duct()
 	return ..()
 
-/obj/machinery/duct/mouse_drop_receive(atom/drag_source, mob/living/user, params)
+/obj/machinery/duct/MouseDrop_T(atom/drag_source, mob/living/user)
 	if(!istype(drag_source, /obj/machinery/duct))
 		return
 	var/obj/machinery/duct/other = drag_source

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -11,7 +11,6 @@
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_HUGE
-
 	var/obj/item/gun/energy/minigun/gun
 	var/obj/item/stock_parts/cell/minigun/battery
 	var/armed = FALSE //whether the gun is attached, FALSE is attached, TRUE is the gun is wielded.
@@ -64,14 +63,22 @@
 	if(armed)
 		user.dropItemToGround(gun, TRUE)
 
-/obj/item/minigunpack/mouse_drop_dragged(atom/over_object, mob/user)
+/obj/item/minigunpack/MouseDrop(atom/over_object)
+	. = ..()
 	if(armed)
 		return
+	if(iscarbon(usr))
+		var/mob/M = usr
 
-	if(iscarbon(user))
-		if(istype(over_object, /atom/movable/screen/inventory/hand))
-			var/atom/movable/screen/inventory/hand/H = over_object
-			user.putItemFromInventoryInHandIfPossible(src, H.held_index)
+		if(!over_object)
+			return
+
+		if(!M.incapacitated())
+
+			if(istype(over_object, /atom/movable/screen/inventory/hand))
+				var/atom/movable/screen/inventory/hand/H = over_object
+				M.putItemFromInventoryInHandIfPossible(src, H.held_index)
+
 
 /obj/item/minigunpack/update_icon_state()
 	icon_state = armed ? "notholstered" : "holstered"

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -14,8 +14,6 @@
 	item_flags = NOBLUDGEON
 	resistance_flags = FLAMMABLE
 	w_class = WEIGHT_CLASS_TINY
-	interaction_flags_mouse_drop = NEED_HANDS
-
 	///How many pages the booklet holds
 	var/number_of_pages = 50
 
@@ -43,8 +41,11 @@
 		user.put_in_active_hand(src)
 	return ..()
 
-/obj/item/ph_booklet/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	if(!isliving(user))
+/obj/item/ph_booklet/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	var/mob/living/user = usr
+	if(!isliving(user) || !Adjacent(user))
+		return
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	if(!number_of_pages)
 		to_chat(user, span_warning("[src] is empty!"))

--- a/code/modules/reagents/chemistry/machinery/portable_chem_mixer.dm
+++ b/code/modules/reagents/chemistry/machinery/portable_chem_mixer.dm
@@ -10,7 +10,6 @@
 	custom_price = PAYCHECK_CREW * 10
 	custom_premium_price = PAYCHECK_CREW * 14
 	interaction_flags_click = FORBID_TELEKINESIS_REACH
-	interaction_flags_mouse_drop = FORBID_TELEKINESIS_REACH
 
 	///Creating an empty slot for a beaker that can be added to dispense into
 	var/obj/item/reagent_containers/beaker
@@ -244,10 +243,11 @@
 			update_appearance()
 			return TRUE
 
-/obj/item/storage/portable_chem_mixer/mouse_drop_dragged(atom/over_object)
+/obj/item/storage/portable_chem_mixer/MouseDrop(obj/over_object)
+	. = ..()
 	if(ismob(loc))
 		var/mob/M = loc
-		if(istype(over_object, /atom/movable/screen/inventory/hand))
+		if(!M.incapacitated() && istype(over_object, /atom/movable/screen/inventory/hand))
 			var/atom/movable/screen/inventory/hand/H = over_object
 			M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -164,7 +164,7 @@
 	user.visible_message(span_notice("[user.name] places \the [I] into \the [src]."), span_notice("You place \the [I] into \the [src]."))
 
 /// Mouse drop another mob or self
-/obj/machinery/disposal/mouse_drop_receive(mob/living/target, mob/living/user, params)
+/obj/machinery/disposal/MouseDrop_T(mob/living/target, mob/living/user)
 	if(istype(target))
 		stuff_mob_in(target, user)
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -3,7 +3,6 @@
 	desc = "Makes researched and prototype items with materials and energy."
 	/// Energy cost per full stack of materials spent. Material insertion is 40% of this.
 	active_power_usage = 0.05 * STANDARD_CELL_RATE
-	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS
 
 	/// The efficiency coefficient. Material costs and print times are multiplied by this number;
 	var/efficiency_coeff = 1
@@ -439,17 +438,18 @@
 	SStgui.update_uis(src)
 	icon_state = initial(icon_state)
 
-/obj/machinery/rnd/production/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	if(!can_interact(user) || (!HAS_SILICON_ACCESS(user) && !isAdminGhostAI(user)) && !Adjacent(user))
+/obj/machinery/rnd/production/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	if(!can_interact(usr) || (!issilicon(usr) && !isAdminGhostAI(usr)) && !Adjacent(usr))
 		return
 	if(busy)
-		balloon_alert(user, "busy printing!")
+		balloon_alert(usr, "busy printing!")
 		return
 	var/direction = get_dir(src, over_location)
 	if(!direction)
 		return
 	drop_direction = direction
-	balloon_alert(user, "dropping [dir2text(drop_direction)]")
+	balloon_alert(usr, "dropping [dir2text(drop_direction)]")
 
 /obj/machinery/rnd/production/click_alt(mob/user)
 	if(drop_direction == 0)

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -16,7 +16,6 @@ Slimecrossing Armor
 	armor_type = /datum/armor/mask_nobreath
 	flags_cover = MASKCOVERSMOUTH
 	resistance_flags = NONE
-	interaction_flags_mouse_drop = NEED_HANDS
 
 /datum/armor/mask_nobreath
 	bio = 50
@@ -126,8 +125,8 @@ Slimecrossing Armor
 		return
 	return ..()
 
-/obj/item/clothing/head/peaceflower/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	if(at_peace_check(user))
+/obj/item/clothing/head/peaceflower/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(at_peace_check(usr))
 		return
 	return ..()
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -805,6 +805,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/pod, 32)
 		atom_storage?.show_contents(user)
 	return TRUE
 
+/obj/item/storage/pod/MouseDrop(over_object, src_location, over_location)
+	if(can_interact(usr))
+		return ..()
+
 /obj/item/storage/pod/attack_hand_secondary(mob/user, list/modifiers)
 	if(!can_interact(user))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -1,7 +1,6 @@
 /obj/vehicle/sealed/car
 	layer = ABOVE_MOB_LAYER
 	move_resist = MOVE_FORCE_VERY_STRONG
-
 	///Bitflags for special behavior such as kidnapping
 	var/car_traits = NONE
 	///Sound file(s) to play when we drive around
@@ -22,9 +21,9 @@
 	if(car_traits & CAN_KIDNAP)
 		initialize_controller_action_type(/datum/action/vehicle/sealed/dump_kidnapped_mobs, VEHICLE_CONTROL_DRIVE)
 
-/obj/vehicle/sealed/car/mouse_drop_receive(atom/dropping, mob/M, params)
-	if(HAS_TRAIT(M, TRAIT_HANDS_BLOCKED) && !is_driver(M))
-		return
+/obj/vehicle/sealed/car/MouseDrop_T(atom/dropping, mob/M)
+	if(M.incapacitated() || (HAS_TRAIT(M, TRAIT_HANDS_BLOCKED) && !is_driver(M)))
+		return FALSE
 	if((car_traits & CAN_KIDNAP) && isliving(dropping) && M != dropping)
 		var/mob/living/kidnapped = dropping
 		kidnapped.visible_message(span_warning("[M] starts forcing [kidnapped] into [src]!"))

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -161,8 +161,9 @@
 			victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
 	addtimer(CALLBACK(src, PROC_REF(grind)), 0.1 SECONDS)
 
-/obj/vehicle/ridden/scooter/skateboard/mouse_drop_dragged(atom/over_object, mob/user)
-	var/mob/living/carbon/skater = user
+/obj/vehicle/ridden/scooter/skateboard/MouseDrop(atom/over_object)
+	. = ..()
+	var/mob/living/carbon/skater = usr
 	if(!istype(skater))
 		return
 	if (over_object == skater)

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -1,7 +1,5 @@
 /obj/vehicle/sealed
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
-	interaction_flags_mouse_drop = NEED_HANDS
-
 	var/enter_delay = 2 SECONDS
 	var/mouse_pointer
 	var/headlights_toggle = FALSE
@@ -22,7 +20,7 @@
 	if(istype(E))
 		E.vehicle_entered_target = src
 
-/obj/vehicle/sealed/mouse_drop_receive(atom/dropping, mob/M, params)
+/obj/vehicle/sealed/MouseDrop_T(atom/dropping, mob/M)
 	if(!istype(dropping) || !istype(M))
 		return ..()
 	if(M == dropping)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -6,9 +6,7 @@
 	layer = OBJ_LAYER
 	max_integrity = 100
 	armor_type = /datum/armor/ridden_wheelchair
-	density = FALSE
-	interaction_flags_mouse_drop = ALLOW_RESTING
-
+	density = FALSE //Thought I couldn't fix this one easily, phew
 	/// Run speed delay is multiplied with this for vehicle move delay.
 	var/delay_multiplier = 6.7
 	/// This variable is used to specify which overlay icon is used for the wheelchair, ensures wheelchair can cover your legs
@@ -124,14 +122,17 @@
 	fire = 30
 	acid = 40
 
-/obj/vehicle/ridden/wheelchair/mouse_drop_dragged(atom/over_object, mob/user)  //Lets you collapse wheelchair
-	if(over_object != user || !foldabletype || !ishuman(user))
+/obj/vehicle/ridden/wheelchair/MouseDrop(over_object, src_location, over_location)  //Lets you collapse wheelchair
+	. = ..()
+	if(over_object != usr || !Adjacent(usr) || !foldabletype)
+		return FALSE
+	if(!ishuman(usr) || !usr.can_perform_action(src, ALLOW_RESTING))
 		return FALSE
 	if(has_buckled_mobs())
 		return FALSE
-	user.visible_message(span_notice("[user] collapses [src]."), span_notice("You collapse [src]."))
+	usr.visible_message(span_notice("[usr] collapses [src]."), span_notice("You collapse [src]."))
 	var/obj/vehicle/ridden/wheelchair/wheelchair_folded = new foldabletype(get_turf(src))
-	user.put_in_hands(wheelchair_folded)
+	usr.put_in_hands(wheelchair_folded)
 	qdel(src)
 
 /obj/item/wheelchair/attack_self(mob/user)  //Deploys wheelchair on in-hand use


### PR DESCRIPTION
Reverts tgstation/tgstation#83690

click-dragging is completely broken now

as seen in this round: [ROUND](https://scrubby.melonmesa.com/round/230496)

and this issue report: [ISSUE](https://github.com/tgstation/tgstation/issues/83967#issue-2352209905)