### PR TITLE
Fix mousedrop handling on some atoms

### DIFF
--- a/code/datums/elements/drag_pickup.dm
+++ b/code/datums/elements/drag_pickup.dm
@@ -18,7 +18,6 @@
 /datum/element/drag_pickup/proc/pick_up(atom/source, atom/over, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROP_ONTO
 	var/mob/living/picker = user
 	if(!istype(picker) || !user.can_perform_action(source, FORBID_TELEKINESIS_REACH))
 		return
@@ -28,3 +27,4 @@
 	else if(istype(over, /atom/movable/screen/inventory/hand))
 		var/atom/movable/screen/inventory/hand/Selected_hand = over
 		picker.putItemFromInventoryInHandIfPossible(source, Selected_hand.held_index)
+	return COMPONENT_CANCEL_MOUSEDROP_ONTO

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -36,7 +36,6 @@
 /datum/element/strippable/proc/mouse_drop_onto(datum/source, atom/over, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROP_ONTO
 	if (user == source)
 		return
 	if (over != user)
@@ -60,6 +59,7 @@
 		LAZYSET(strip_menus, source, strip_menu)
 
 	INVOKE_ASYNC(strip_menu, TYPE_PROC_REF(/datum/, ui_interact), user)
+	return COMPONENT_CANCEL_MOUSEDROP_ONTO
 
 /// A representation of an item that can be stripped down
 /datum/strippable_item

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -714,7 +714,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_mousedrop_onto(datum/source, atom/over_object, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROP_ONTO
 	if(ismecha(user.loc) || !user.canUseStorage())
 		return
 
@@ -725,6 +724,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		var/atom/movable/screen/inventory/hand/hand = over_object
 		user.putItemFromInventoryInHandIfPossible(parent, hand.held_index)
 		parent.add_fingerprint(user)
+		return COMPONENT_CANCEL_MOUSEDROP_ONTO
 
 	else if(ismob(over_object))
 		if(over_object != user || !user.can_perform_action(parent, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
@@ -732,6 +732,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 		parent.add_fingerprint(user)
 		INVOKE_ASYNC(src, PROC_REF(open_storage), user)
+		return COMPONENT_CANCEL_MOUSEDROP_ONTO
 
 	else if(!istype(over_object, /atom/movable/screen))
 		var/action_status
@@ -744,6 +745,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 		parent.add_fingerprint(user)
 		INVOKE_ASYNC(src, PROC_REF(dump_content_at), over_object, user)
+		return COMPONENT_CANCEL_MOUSEDROP_ONTO
 
 /**
  * Dumps all of our contents at a specific location.


### PR DESCRIPTION
## About The Pull Request

One should really err on the side of caution when preventing all humans from being mousedroppable entirely

## Changelog

:cl: Melbert
fix: Human mousedropping
/:cl:

