### PR TITLE
Openspace Item Handler doesn't think stuff in bags are valid

### DIFF
--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -24,6 +24,6 @@
 		checked_turf = GET_TURF_ABOVE(checked_turf)
 		if(checked_turf?.z == user.z && user.CanReach(checked_turf, source))
 			INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), checked_turf, user, click_parameters)
-			break
+			return ITEM_INTERACT_BLOCKING
 
-	return ITEM_INTERACT_BLOCKING
+	return NONE

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -17,7 +17,7 @@
 //Invokes the proctype with a turf above as target.
 /datum/element/openspace_item_click_handler/proc/divert_interaction(obj/item/source, mob/user, atom/target, click_parameters)
 	SIGNAL_HANDLER
-	if(!target.z || !user.z || target.z == user.z)
+	if((target.z == 0) || (user.z == 0) || target.z == user.z)
 		return NONE
 	var/turf/checked_turf = get_turf(target)
 	while(!isnull(checked_turf))

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -17,7 +17,7 @@
 //Invokes the proctype with a turf above as target.
 /datum/element/openspace_item_click_handler/proc/divert_interaction(obj/item/source, mob/user, atom/target, click_parameters)
 	SIGNAL_HANDLER
-	if(target.z == user.z)
+	if(!target.z || !user.z || target.z == user.z)
 		return NONE
 	var/turf/checked_turf = get_turf(target)
 	while(!isnull(checked_turf))


### PR DESCRIPTION
## About The Pull Request

Fixes #83972 

Clicking on stuff in your bag with stuff that has `openspace_item_click_handler` makes it think you're on a different z level (which is technically true) so it overrides the click and does its own thing. 

So we check that z is not 0. Also move the return to be safe. 


## Changelog

:cl: Melbert
fix: Fix inability to make r-glass by hand inside your backpack
/:cl:
