### PR TITLE
Fixes LateSpawn runtime when someone latejoins as the only command member

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -200,7 +200,7 @@
 		is_captain = IS_FULL_CAPTAIN
 		captain_sound = 'sound/misc/announce.ogg'
 	// If we don't have an assigned cap yet, check if this person qualifies for some from of captaincy.
-	else if(!SSjob.assigned_captain && ishuman(character) && SSjob.chain_of_command[rank] && !is_banned_from(ckey, list(JOB_CAPTAIN)))
+	else if(!SSjob.assigned_captain && ishuman(character) && SSjob.chain_of_command[rank] && !is_banned_from(character.ckey, list(JOB_CAPTAIN)))
 		is_captain = IS_ACTING_CAPTAIN
 	if(is_captain != IS_NOT_CAPTAIN)
 		minor_announce(job.get_captaincy_announcement(character), sound_override = captain_sound)


### PR DESCRIPTION
the mob's key was already transferred from this mob to the new one before this. guess we've been lucky to never see this runtime on live. 

```
[2024-06-14 05:40:50.631] RUNTIME: runtime error: Called is_banned_from without specifying a ckey.
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: code/__HELPERS/stack_trace.dm,4
 -   usr: ShizCalev (/mob/dead/new_player)
 -   src: null
 -   usr.loc: null
 -   call stack:
 -  stack trace("Called is_banned_from without ...", "code/modules/admin/sql_ban_sys...", 19)
 - is banned from(null, /list (/list))
 - ShizCalev (/mob/dead/new_player): AttemptLateSpawn("Chief Medical Officer")
 - /datum/latejoin_menu (/datum/latejoin_menu): ui act("select_job", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/new_player_sta... (/datum/ui_state/new_player_state))
 - /datum/tgui (/datum/tgui): on act message("select_job", /list (/list), /datum/ui_state/new_player_sta... (/datum/ui_state/new_player_state))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - /datum/tgui (/datum/tgui): on message("act/select_job", /list (/list), /list (/list))
 - /datum/tgui_window (/datum/tgui_window): on message("act/select_job", /list (/list), /list (/list))
 - tgui Topic(/list (/list))
 - ShizCalev (/client): Topic("type=act%2Fselect_job&payload=...", /list (/list), null, null)
 - 
```