### PR TITLE
Fix revenant spawning next to brains and other unharvestable mobs

### DIFF
--- a/code/modules/events/ghost_role/revenant_event.dm
+++ b/code/modules/events/ghost_role/revenant_event.dm
@@ -34,7 +34,7 @@
 	if(isnull(chosen_one))
 		return NOT_ENOUGH_PLAYERS
 	var/list/spawn_locs = list()
-	for(var/mob/living/L in GLOB.dead_mob_list) //look for any dead bodies
+	for(var/mob/living/carbon/human/L in GLOB.dead_mob_list) //look for any harvestable bodies
 		var/turf/T = get_turf(L)
 		if(T && is_station_level(T.z))
 			spawn_locs += T


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Currently we are adding all dead `mob/living/` to the list of potential revenant spawns whether or not they are valid harvest targets.

Decreases the odds of getting a spawn that is not immediately useful as revenant.

## Why It's Good For The Game

Fix good.

Harvesting only works with `mob/living/carbon/human/` so naturally we should avoid adding other mobs to the list of potential spawn points.

## Changelog
:cl:
fix: Fixed revenant spawning next to brains and other unharvestable dead mobs.
/:cl:
