### PR TITLE
Fixes some more climbing/buckling issues

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -82,6 +82,10 @@
 			log_combat(user, climbed_thing, "climbed onto")
 			if(adjusted_climb_stun)
 				user.Stun(adjusted_climb_stun)
+			var/atom/movable/buckle_target = climbed_thing
+			if(istype(buckle_target))
+				if(buckle_target.is_buckle_possible(user))
+					buckle_target.buckle_mob(user)
 		else
 			to_chat(user, span_warning("You fail to climb onto [climbed_thing]."))
 	LAZYREMOVEASSOC(current_climbers, climbed_thing, user)
@@ -112,7 +116,6 @@
 /datum/element/climbable/proc/mousedrop_receive(atom/climbed_thing, atom/movable/dropped_atom, mob/user, params)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 	if(user != dropped_atom || !isliving(dropped_atom))
 		return
 	if(!HAS_TRAIT(dropped_atom, TRAIT_FENCE_CLIMBER) && !HAS_TRAIT(dropped_atom, TRAIT_CAN_HOLD_ITEMS)) // If you can hold items you can probably climb a fence
@@ -120,3 +123,4 @@
 	var/mob/living/living_target = dropped_atom
 	if(living_target.mobility_flags & MOBILITY_MOVE)
 		INVOKE_ASYNC(src, PROC_REF(climb_structure), climbed_thing, living_target, params)
+	return COMPONENT_CANCEL_MOUSEDROPPED_ONTO

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -791,7 +791,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_mousedropped_onto(datum/source, obj/item/dropping, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 	if(!istype(dropping))
 		return
 	if(dropping != user.get_active_held_item())
@@ -804,6 +803,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return
 
 	attempt_insert(dropping, user)
+	return COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 
 /// Signal handler for whenever we're attacked by an object.
 /datum/storage/proc/on_item_interact(datum/source, mob/user, obj/item/thing, params)


### PR DESCRIPTION
## About The Pull Request

First of all, updates `COMPONENT_CANCEL_MOUSEDROPPED_ONTO` in the same way Melbert did for `COMPONENT_CANCEL_MOUSEDROP_ONTO`, so it will only block other interactions if it succeeds. Second of all, makes the climbable element compatible with buckling again, since the two behaviors have a lot of overlap. 
## Why It's Good For The Game

Fixes a bug (Fixes #83998) where the chaplain altar can't be buckled to. There might be other, similar cases that I'm not aware of.
## Changelog
:cl:
fix: The chaplain altar can once again be buckled to. 
/:cl:
