### PR TITLE
Gorillas have big fingers

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -54,7 +54,7 @@
 
 /mob/living/basic/gorilla/Initialize(mapload)
 	. = ..()
-	add_traits(list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP), ROUNDSTART_TRAIT)
+	add_traits(list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP, TRAIT_CHUNKYFINGERS), ROUNDSTART_TRAIT)
 	AddElement(/datum/element/wall_tearer, allow_reinforced = FALSE)
 	AddElement(/datum/element/dextrous)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_BAREFOOT)


### PR DESCRIPTION
## About The Pull Request

Gives gorillas the big fingers trait

## Why It's Good For The Game

because gorillas have big fingers
this doesnt actually have a lot of effects because Gorillas already can't use guns for unrelated reasons, but as gorillas have hands it might come up some day as we expand the number of items which interact with this trait

currently this stops gorillas from using stun batons, and laser pointers
gorillas dont need to use stun batons because they can just beat you to death with their fists

## Changelog

:cl:
balance: Gorillas have big fingers, which mostly just prevents them from using laser pointers and stun batons
/:cl:
