### PR TITLE
[NO GBP]Supermatter zap power generation takes perspective of the machines subsystem.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -153,7 +153,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	///Stores the time of when the last zap occurred
 	var/last_power_zap = 0
-	var/last_high_energy_zap = 0
+	///Stores the tick of the machines subsystem of when the last zap occurred. Gives a passage of time in the perspective of SSmachines.
+	var/last_power_zap_perspective_machines = 0
+	///Same as [last_power_zap_perspective_machines], but based around the high energy zaps found in handle_high_power().
+	var/last_high_energy_zap_perspective_machines = 0
 	///Do we show this crystal in the CIMS modular program
 	var/include_in_cims = TRUE
 
@@ -294,13 +297,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	// PART 3: POWER PROCESSING
 	internal_energy_factors = calculate_internal_energy()
 	zap_factors = calculate_zap_transmission_rate()
-	if(internal_energy && (last_power_zap + (4 - internal_energy * 0.001) SECONDS) < world.time)
+	if(delta_time && internal_energy && (last_power_zap + (4 - internal_energy * 0.001) SECONDS) < world.time)
 		playsound(src, 'sound/weapons/emitter2.ogg', 70, TRUE)
 		hue_angle_shift = clamp(903 * log(10, (internal_energy + 8000)) - 3590, -50, 240)
 		var/zap_color = color_matrix_rotate_hue(hue_angle_shift)
-		//Scale the strength of the zap with the world's time elapsed between zaps in seconds.
-		//Capped at 16 seconds to prevent a crazy burst of energy if atmos was halted for a long time.
-		var/delta_time = min((world.time - last_power_zap) * 0.1, 16)
 		supermatter_zap(
 			zapstart = src,
 			range = 3,
@@ -311,6 +311,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			color = zap_color,
 		)
 		last_power_zap = world.time
+		last_power_zap_perspective_machines = SSmachines.times_fired
 
 	// PART 4: DAMAGE PROCESSING
 	temp_limit_factors = calculate_temp_limit()
@@ -714,6 +715,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		activation_logged = TRUE // so we dont spam the log.
 	else if(!internal_energy)
 		last_power_zap = world.time
+		last_power_zap_perspective_machines = SSmachines.times_fired
 	return additive_power
 
 /** Log when the supermatter is activated for the first time.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -297,6 +297,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	// PART 3: POWER PROCESSING
 	internal_energy_factors = calculate_internal_energy()
 	zap_factors = calculate_zap_transmission_rate()
+	var/delta_time = (SSmachines.times_fired - last_power_zap_perspective_machines) * SSmachines.wait / (1 SECONDS)
 	if(delta_time && internal_energy && (last_power_zap + (4 - internal_energy * 0.001) SECONDS) < world.time)
 		playsound(src, 'sound/weapons/emitter2.ogg', 70, TRUE)
 		hue_angle_shift = clamp(903 * log(10, (internal_energy + 8000)) - 3590, -50, 240)

--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -91,7 +91,7 @@
 
 /obj/machinery/power/supermatter_crystal/proc/handle_high_power()
 	if(internal_energy <= POWER_PENALTY_THRESHOLD && damage <= danger_point) //If the power is above 5000 or if the damage is above 550
-		last_high_energy_zap = world.time //Prevent oddly high initial zap due to high energy zaps not getting triggered via too low energy.
+		last_high_energy_zap_perspective_machines = SSmachines.times_fired //Prevent oddly high initial zap due to high energy zaps not getting triggered via too low energy.
 		return
 	var/range = 4
 	zap_cutoff = 1500
@@ -129,10 +129,10 @@
 
 	if(zap_count >= 1)
 		playsound(loc, 'sound/weapons/emitter2.ogg', 100, TRUE, extrarange = 10)
-		var/delta_time = min((world.time - last_high_energy_zap) * 0.1, 16)
+		var/delta_time = (SSmachines.times_fired - last_high_energy_zap_perspective_machines) * SSmachines.wait / (1 SECONDS)
 		for(var/i in 1 to zap_count)
 			supermatter_zap(src, range, clamp(internal_energy * 3200, 6.4e6, 3.2e7) * delta_time, flags, zap_cutoff = src.zap_cutoff * delta_time, power_level = internal_energy, zap_icon = src.zap_icon)
-		last_high_energy_zap = world.time
+		last_high_energy_zap_perspective_machines = SSmachines.times_fired
 	if(prob(5))
 		supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
 	if(prob(5))


### PR DESCRIPTION

## About The Pull Request
The power generation of supermatter zaps will scale by the perceived time passage of the machines subsystem, rather than the world. This will prevent the supermatter from outputting a higher power in the machines subsystem perspective when the machines subsystem lag than what the supermatter is reporting. Also removes the delta time limit.

Testmerge this first, because I suck at testing lag.
## Why It's Good For The Game
This will make the power transmission from what NT CIMS report more accurate regardless of SSmachines lag, which should reduce confusion. The vast, vast majority of power consumption scales by the machines tick rate, so it doesn't make sense to let the supermatter be more effective for power due to machines lag. Actually makes it possible to balance supermatter power generation and makes it far more meaningful without having to worry about lag.

Also subsystems taking minutes to fire because a meteor is moving through space is getting normalized, so lets just remove the delta time cap for the supermatter zaps. I think people will care more about the power generation than the 1 in a million chance someone decides to remove the grounding rods and let themselves get zapped after atmos slept for an hour.
## Changelog
:cl:
code: Supermatter zap power generation takes perspective of the machines subsystem.
/:cl:
