### PR TITLE
Fixes mulebots being able to run over players leaning on walls

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -486,7 +486,8 @@
 	. = ..()
 	if(has_gravity())
 		for(var/mob/living/carbon/human/future_pancake in loc)
-			run_over(future_pancake)
+			if(future_pancake.body_position == LYING_DOWN)
+				run_over(future_pancake)
 
 	diag_hud_set_mulebotcell()
 


### PR DESCRIPTION

## About The Pull Request
Mulebot was running over anyone who was on the same tile as it when it moved without checking if they were actually lying down, which meant they could run over people who were leaning against a wall.
## Why It's Good For The Game
Fixes #84015 
## Changelog
:cl:
fix: Fixed mulebots being able to run over people who are leaning against a wall.
/:cl:
