### PR TITLE
Fixes Icebox NanoDrug airlock access

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -23048,7 +23048,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
@@ -47295,7 +47295,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical/central)
 "oiD" = (


### PR DESCRIPTION
## About The Pull Request

Fixes the access for the westmost airlock in the medical hallway (the NanoDrug.) The room should have general med with the inner door being restricted to chemistry, same as the East door.

## Why It's Good For The Game

Consistent airlock access into a room.

## Changelog

:cl: LT3
fix: Fixed paramedics not having access to the Icebox NanoDrug using the west airlock
/:cl: