### PR TITLE
Fixes the other half of the crusher bug

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -31,7 +31,7 @@
 	SIGNAL_HANDLER
 
 	if(istype(attacking_item, /obj/item/kinetic_crusher))
-		total_damage += damage_dealt
+		total_damage += (-1 * damage_dealt)
 
 /datum/status_effect/syphon_mark
 	id = "syphon_mark"


### PR DESCRIPTION
## About The Pull Request

Fixes #83906

So when I test the first issue I just whacked the guy and the checked VV to see if it was tracking damage at all then I called it a day, turns out while it was applying damage it was actually negative damage from the crusher itself so while the final number of damage dealt may look like "2500" the tracker tracked like "1400". 

(I mean that's still a pretty interesting statistic is shows that the crusher itself, with none of its special effects, does just under 60% of the total damage dealt, so cool)

## Changelog

:cl: Melbert
fix: Crusher Fix For Real 
/:cl:

