### PR TITLE
Slime transparency fix [NO GBP]

### DIFF
--- a/code/__DEFINES/research/slimes.dm
+++ b/code/__DEFINES/research/slimes.dm
@@ -61,3 +61,6 @@
 #define SLIME_TYPE_SEPIA "sepia"
 #define SLIME_TYPE_SILVER "silver"
 #define SLIME_TYPE_YELLOW "yellow"
+
+// The alpha value of transperent slime types
+#define SLIME_TRANSPARENCY_ALPHA 180

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -187,6 +187,8 @@
 
 /mob/living/basic/slime/regenerate_icons()
 	cut_overlays()
+	if(slime_type.transparent)
+		alpha = SLIME_TRANSPARENCY_ALPHA
 	var/icon_text = "[slime_type.colour]-[life_stage]"
 	icon_dead = "[icon_text]-dead"
 	if(stat != DEAD)

--- a/code/modules/mob/living/basic/slime/slime_type.dm
+++ b/code/modules/mob/living/basic/slime/slime_type.dm
@@ -2,7 +2,7 @@
 	///Our slime's colour as text. Used by both description, and icon
 	var/colour
 	///Whether the slime icons should be semi-transparent
-	var/transparent
+	var/transparent = FALSE
 	///The type our slime spawns
 	var/core_type
 	///The possible mutations of our slime

--- a/code/modules/mob/living/basic/slime/slime_type.dm
+++ b/code/modules/mob/living/basic/slime/slime_type.dm
@@ -1,6 +1,8 @@
 /datum/slime_type
 	///Our slime's colour as text. Used by both description, and icon
 	var/colour
+	///Whether the slime icons should be semi-transparent
+	var/transparent
 	///The type our slime spawns
 	var/core_type
 	///The possible mutations of our slime
@@ -12,6 +14,7 @@
 
 /datum/slime_type/grey
 	colour = SLIME_TYPE_GREY
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/grey
 	mutations = list(
 		/datum/slime_type/blue = 1,
@@ -21,11 +24,11 @@
 	)
 	rgb_code = COLOR_SLIME_GREY
 
-
 //TIER 1
 
 /datum/slime_type/blue
 	colour = SLIME_TYPE_BLUE
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/blue
 	mutations = list(
 		/datum/slime_type/darkblue = 1,
@@ -46,6 +49,7 @@
 
 /datum/slime_type/purple
 	colour = SLIME_TYPE_PURPLE
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/purple
 	mutations = list(
 		/datum/slime_type/darkblue = 1,
@@ -56,6 +60,7 @@
 
 /datum/slime_type/orange
 	colour = SLIME_TYPE_ORANGE
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/orange
 	mutations = list(
 		/datum/slime_type/darkpurple = 1,
@@ -68,6 +73,7 @@
 
 /datum/slime_type/darkblue
 	colour = SLIME_TYPE_DARK_BLUE
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/darkblue
 	mutations = list(
 		/datum/slime_type/blue = 1,
@@ -98,6 +104,7 @@
 
 /datum/slime_type/yellow
 	colour = SLIME_TYPE_YELLOW
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/yellow
 	mutations = list(
 		/datum/slime_type/bluespace = 2,
@@ -119,6 +126,7 @@
 
 /datum/slime_type/cerulean
 	colour = SLIME_TYPE_CERULEAN
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/cerulean
 	mutations = list(
 		/datum/slime_type/cerulean = 1,
@@ -135,6 +143,7 @@
 
 /datum/slime_type/sepia
 	colour = SLIME_TYPE_SEPIA
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/sepia
 	mutations = list(
 		/datum/slime_type/sepia = 1,
@@ -154,6 +163,7 @@
 
 /datum/slime_type/green
 	colour = SLIME_TYPE_GREEN
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/green
 	mutations = list(
 		/datum/slime_type/black = 1,
@@ -163,6 +173,7 @@
 
 /datum/slime_type/pink
 	colour = SLIME_TYPE_PINK
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/pink
 	mutations = list(
 		/datum/slime_type/lightpink = 1,
@@ -172,6 +183,7 @@
 
 /datum/slime_type/red
 	colour = SLIME_TYPE_RED
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/red
 	mutations = list(
 		/datum/slime_type/oil = 1,
@@ -191,6 +203,7 @@
 
 /datum/slime_type/black
 	colour = SLIME_TYPE_BLACK
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/black
 	mutations = list(
 		/datum/slime_type/black = 1,
@@ -199,6 +212,7 @@
 
 /datum/slime_type/lightpink
 	colour = SLIME_TYPE_LIGHT_PINK
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/lightpink
 	mutations = list(
 		/datum/slime_type/lightpink = 1,
@@ -217,6 +231,7 @@
 
 /datum/slime_type/rainbow
 	colour = SLIME_TYPE_RAINBOW
+	transparent = TRUE
 	core_type = /obj/item/slime_extract/rainbow
 	mutations = list(
 		/datum/slime_type/rainbow = 1,


### PR DESCRIPTION
## About The Pull Request

I forgot to add transparency for the non-metallic slime subtypes. This PR fixes that.

![image](https://github.com/tgstation/tgstation/assets/3625094/82a3c04a-ad41-4446-9665-dab9d38b40fb)

## Why It's Good For The Game

A mistake was made.

## Changelog

:cl:
fix: Non-metallic slime types are semi-transparent
/:cl:


