### PR TITLE
Ashwalkers start with Settler benefits (taming/riding/fishing)

### DIFF
--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -28,7 +28,6 @@
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, PROC_REF(on_examinate))
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
-	ADD_TRAIT(owner, TRAIT_SETTLER, ROLE_ASHWALKER)
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -28,6 +28,7 @@
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, PROC_REF(on_examinate))
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
+	owner.add_traits(list(TRAIT_SETTLER), ROLE_ASHWALKER)
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, PROC_REF(on_examinate))
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
-	owner.add_traits(list(TRAIT_SETTLER), ROLE_ASHWALKER)
+	ADD_TRAIT(owner, TRAIT_SETTLER, ROLE_ASHWALKER)
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -394,7 +394,12 @@
 /obj/item/organ/internal/brain/primitive //No like books and stompy metal men
 	name = "primitive brain"
 	desc = "This juicy piece of meat has a clearly underdeveloped frontal lobe."
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP, TRAIT_PRIMITIVE) // No literacy
+	organ_traits = list(
+	TRAIT_ADVANCEDTOOLUSER,
+	TRAIT_CAN_STRIP,
+	TRAIT_PRIMITIVE,
+	TRAIT_SETTLER,
+	TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION) // No literacy, live off land, ride raptor, eat fish...
 
 /obj/item/organ/internal/brain/golem
 	name = "crystalline matrix"

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -158,7 +158,6 @@ Lizard subspecies: ASHWALKERS
 	inherent_traits = list(
 		TRAIT_MUTANT_COLORS,
 		TRAIT_VIRUSIMMUNE,
-		TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION,
 	)
 	species_language_holder = /datum/language_holder/lizard/ash
 	digitigrade_customization = DIGITIGRADE_FORCED


### PR DESCRIPTION
## About The Pull Request

This pull request gives the settler trait to ashwalkers, since they're native denizens of lavaland. The effect is that they are better at taming, riding, and fishing. It has no effect on their movespeed, hunger, or height, as they get the trait instead of the full quirk.
## Why It's Good For The Game

Ashwalkers should be good at these things inherently.
## Changelog

Ashwalkers now have the benefits of the settler trait.
:cl:
balance: Ashwalkers are now as good at taming, fishing, and riding as other planet-borne settlers!
code: Ashwalkers not being able to use the shuttle consoles has been made a trait of their brain, instead of inherent to their species (for cases such as someone being forcibly made into an ashwalker, or brain transplants, etc)
/:cl:
