### PR TITLE
[no gbp] you may open the panel of a flatpacker

### DIFF
--- a/code/game/machinery/flatpacker.dm
+++ b/code/game/machinery/flatpacker.dm
@@ -231,6 +231,10 @@
 			materials.retrieve_sheets(amount, ejecting, drop_location())
 			return TRUE
 
+/obj/machinery/flatpacker/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ITEM_INTERACT_BLOCKING
+	if(default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
+		return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/flatpacker/Destroy()
 	QDEL_NULL(inserted_board)


### PR DESCRIPTION

## About The Pull Request

you may open the panel of a flatpacker with a screwdriver
so you can upgrade it

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: you may now open the panel of a flatpacker with a screwdriver
/:cl:
