### PR TITLE
Fixes logging path on civilian bounties

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -168,7 +168,7 @@
 		return
 	inserted_scan_id.registered_account.civilian_bounty = inserted_scan_id.registered_account.bounties[choice]
 	inserted_scan_id.registered_account.bounties = null
-	SSblackbox.record_feedback("tally", "bounties_assigned", 1, choice.type)
+	SSblackbox.record_feedback("tally", "bounties_assigned", 1, inserted_scan_id.registered_account.civilian_bounty.type)
 	return inserted_scan_id.registered_account.civilian_bounty
 
 /obj/machinery/computer/piratepad_control/civilian/click_alt(mob/user)


### PR DESCRIPTION
## About The Pull Request

Oops! The Civilian Bounty logging PR I did last week was runtiming and NOT working properly!
Switches the object that an attempted bounty logs for it's type.

## Why It's Good For The Game

Makes the logging work properly, and pulls the type straight from the ID's reserved bounty type.

## Changelog

Once again, no player facing changes.