### PR TITLE
durand shield is a tad bit stronger and also doesnt immediately depower the mech when taking stamina damage

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -271,7 +271,9 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_energy((max_integrity - atom_integrity) * 0.1 * STANDARD_CELL_CHARGE))
+	if(!.)
+		return
+	if(!chassis.use_energy(. * (STANDARD_CELL_CHARGE / 15)))
 		chassis.cell?.charge = 0
 		for(var/O in chassis.occupants)
 			var/mob/living/occupant = O


### PR DESCRIPTION

## About The Pull Request

durand shield is a tad bit stronger and also doesnt immediately depower the mech when taking stamina damage

## Why It's Good For The Game
i mean this shit almost immediately depowers the mecha if you hit it a few times with a toolbox and thats bad for something that costs shittons of mats
making it not as bad should make it not a noob trap
also bug bad

## Changelog
:cl:
fix: durand shield doesnt immediately depower the mech when taking stamina damage
balance: durand shield is a bit stronger
/:cl:
