### PR TITLE
Mining borgs can now get multiple copies of a single modkit again

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -254,6 +254,8 @@
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/miner)
 	model_flags = BORG_MODEL_MINER
+	//Most modkits are supposed to allow duplicates. The ones that don't should be blocked by PKA code anyways.
+	allow_duplicates = TRUE
 	var/denied_type = null
 	var/maximum_of_type = 1
 	var/cost = 30


### PR DESCRIPTION

## About The Pull Request

A previous pull request cleaned borg upgrade code up a lot, and included a check to prevent duplicate upgrades from being installed. Usually this is a good thing, but there are some upgrades that are intended to allow duplicates. Namely, PKA modkits in mining borgs. This PR just fixes that, so mining borgs can have multiple modkits again. This does NOT allow borgs to go above the 90% complexity limit on their PKAs, as a separate piece of code handles that.
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: Mining borgs can get multiple modkits of the same type installed again.
/:cl:
