### PR TITLE
[no gbp] tgui-say: fixes emotes getting their contents glorfed

### DIFF
--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -274,6 +274,7 @@ export class TguiSay extends Component<{}, State> {
   };
 
   reset() {
+    this.currentPrefix = null;
     this.setValue('');
     this.setSize();
     this.setState({

--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -162,7 +162,7 @@ export class TguiSay extends Component<{}, State> {
       ? prefix + currentValue
       : currentValue;
 
-    this.messages.forceSayMsg(grunt);
+    this.messages.forceSayMsg(grunt, this.channelIterator.current());
     this.reset();
   }
 

--- a/tgui/packages/tgui-say/timers.ts
+++ b/tgui/packages/tgui-say/timers.ts
@@ -1,5 +1,7 @@
 import { debounce, throttle } from 'common/timer';
 
+import { Channel } from './ChannelIterator';
+
 const SECONDS = 1000;
 
 /** Timers: Prevents overloading the server, throttles messages */
@@ -10,7 +12,8 @@ export const byondMessages = {
     0.4 * SECONDS,
   ),
   forceSayMsg: debounce(
-    (entry: string) => Byond.sendMessage('force', { entry, channel: 'Say' }),
+    (entry: string, channel: Channel) =>
+      Byond.sendMessage('force', { entry, channel }),
     1 * SECONDS,
     true,
   ),


### PR DESCRIPTION

## About The Pull Request
When read by an innocent bystander, what possibly could this PR title mean

TGUI Say was, for some reason that I totally don't remember, just sending all forced messages to say. This now will properly cut out /me contents if you get attacked during.

It also fixes an issue where the channel color would get stuck if you were attacked as well
## Why It's Good For The Game
Fixes #84018
## Changelog
:cl:
fix: TGUI say will no longer spill your /me contents when you get attacked
/:cl:
