### PR TITLE
Removes the locker staff from Ragin' Mages deathmatch

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -85,7 +85,6 @@ GLOBAL_LIST_INIT(mystery_magic, list(
 	/obj/item/gun/magic/staff/door,
 	/obj/item/gun/magic/staff/honk,
 	/obj/item/gun/magic/staff/spellblade,
-	/obj/item/gun/magic/staff/locker,
 	/obj/item/gun/magic/staff/flying,
 	/obj/item/gun/magic/staff/babel,
 	/obj/item/singularityhammer,


### PR DESCRIPTION

## About The Pull Request

See title, removes this particular staff from the loot list.

## Why It's Good For The Game

Locker staffs only serve to drag out the match unreasonably, while denying everyone involved their time and fun. It's boring to be the person trapped in one having to wait a whole minute to resist out, and it's boring to be the last other person left alive unable to finish the match because you can't find the other guy who is actually stuck in one of the 20 lockers scattered across the arena.

## Changelog
:cl:
del: Locker staffs have been removed from the Ragin' Mages deathmatch lootcrate pool.
/:cl:
