### PR TITLE
Fullscreen QoL

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -26,6 +26,7 @@
 //Client
 #define COMSIG_KB_CLIENT_GETHELP_DOWN "keybinding_client_gethelp_down"
 #define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
+#define COMSIG_KB_CLIENT_FULLSCREEN_DOWN "keybinding_client_fullscreen_down"
 #define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"
 
 //Communication

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -32,6 +32,20 @@
 	winset(user, null, "command=.auto")
 	return TRUE
 
+/datum/keybinding/client/toggle_fullscreen
+	hotkey_keys = list("F11")
+	name = "toggle_fullscreen"
+	full_name = "Toggle Fullscreen"
+	description = "Makes the game window fullscreen."
+	keybind_signal = COMSIG_KB_CLIENT_FULLSCREEN_DOWN
+
+/datum/keybinding/client/toggle_fullscreen/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.toggle_fullscreen()
+	return TRUE
+
 /datum/keybinding/client/minimal_hud
 	hotkey_keys = list("F12")
 	name = "minimal_hud"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -70,8 +70,8 @@ window "mainwindow"
 		menu = "menu"
 	elem "split"
 		type = CHILD
-		pos = 3,0
-		size = 634x440
+		pos = 0,0
+		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"
@@ -159,58 +159,67 @@ window "infowindow"
 		is-vert = false
 	elem "changelog"
 		type = BUTTON
-		pos = 16,5
-		size = 104x20
-		anchor1 = 3,0
-		anchor2 = 19,0
+		pos = 5,5
+		size = 90x20
+		anchor1 = 1,0
+		anchor2 = 15,0
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "changelog"
 	elem "rules"
 		type = BUTTON
-		pos = 120,5
-		size = 100x20
-		anchor1 = 19,0
-		anchor2 = 34,0
+		pos = 95,5
+		size = 90x20
+		anchor1 = 15,0
+		anchor2 = 29,0
 		saved-params = "is-checked"
 		text = "Rules"
 		command = "rules"
 	elem "wiki"
 		type = BUTTON
-		pos = 220,5
-		size = 100x20
-		anchor1 = 34,0
-		anchor2 = 50,0
+		pos = 185,5
+		size = 90x20
+		anchor1 = 29,0
+		anchor2 = 43,0
 		saved-params = "is-checked"
 		text = "Wiki"
 		command = "wiki"
 	elem "forum"
 		type = BUTTON
-		pos = 320,5
-		size = 100x20
-		anchor1 = 50,0
-		anchor2 = 66,0
+		pos = 275,5
+		size = 90x20
+		anchor1 = 43,0
+		anchor2 = 57,0
 		saved-params = "is-checked"
 		text = "Forum"
 		command = "forum"
 	elem "github"
 		type = BUTTON
-		pos = 420,5
-		size = 100x20
-		anchor1 = 66,0
-		anchor2 = 81,0
+		pos = 365,5
+		size = 90x20
+		anchor1 = 57,0
+		anchor2 = 71,0
 		saved-params = "is-checked"
 		text = "Github"
 		command = "github"
 	elem "report-issue"
 		type = BUTTON
-		pos = 520,5
-		size = 100x20
-		anchor1 = 81,0
-		anchor2 = 97,0
+		pos = 455,5
+		size = 90x20
+		anchor1 = 71,0
+		anchor2 = 85,0
 		saved-params = "is-checked"
 		text = "Report Issue"
 		command = "report-issue"
+	elem "fullscreen-toggle"
+		type = BUTTON
+		pos = 545,5
+		size = 90x20
+		anchor1 = 85,0
+		anchor2 = 99,0
+		saved-params = "is-checked"
+		text = "Fullscreen"
+		command = "fullscreen"
 
 window "outputwindow"
 	elem "outputwindow"

--- a/tgui/packages/tgui-panel/themes.ts
+++ b/tgui/packages/tgui-panel/themes.ts
@@ -57,6 +57,8 @@ export const setClientTheme = (name) => {
       'github.text-color': '#000000',
       'report-issue.background-color': 'none',
       'report-issue.text-color': '#000000',
+      'fullscreen-toggle.background-color': 'none',
+      'fullscreen-toggle.text-color': '#000000',
       // Status and verb tabs
       'output.background-color': 'none',
       'output.text-color': '#000000',
@@ -109,6 +111,8 @@ export const setClientTheme = (name) => {
       'github.text-color': COLOR_DARK_TEXT,
       'report-issue.background-color': '#492020',
       'report-issue.text-color': COLOR_DARK_TEXT,
+      'fullscreen-toggle.background-color': '#494949',
+      'fullscreen-toggle.text-color': COLOR_DARK_TEXT,
       // Status and verb tabs
       'output.background-color': COLOR_DARK_BG_DARKER,
       'output.text-color': COLOR_DARK_TEXT,


### PR DESCRIPTION
## About The Pull Request
Add hotkey for toggling fullscreen (F11)
Add toggle fullscreen button to the skin buttons
Also, fix little padding on the left and right, maybe that was the intention, so please tell me if this needs to be returned, screenshots bellow
| Before | After(With padding) | After(Without padding/final result) |
| - | - | - |
| ![image](https://github.com/tgstation/tgstation/assets/69762909/3c8863dc-94cf-40e9-9eec-24fe548f1474) | ![image](https://github.com/tgstation/tgstation/assets/69762909/ae167f4d-02e3-4b6d-874f-3b5c38d77bc8) | ![image](https://github.com/tgstation/tgstation/assets/69762909/30a4ed6c-fc0f-468c-ab01-7c4b66551d0f) |

## Why It's Good For The Game
It is a little bit not convenient to search for the Toggle Fullscreen button in any of the tabs, I think no one will argue that the hotkey is more convenient

## Changelog

:cl:
qol: Fullscreen mode can now be toggled by pressing F11 or the button at the top right
/:cl:
