### PR TITLE
Heretic spell invocations now use one dead language per path

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of Ash.
+ * Spell names are in this language: OLD NORDIC
+ * Both are related: Nordic Mythology-Yggdrassil-Ash Tree Genus-Ash
  *
  * Goes as follows:
  *
@@ -215,7 +217,7 @@
 		text = "[generate_heretic_text()] Fear the blaze, for the Ashlord, [user.real_name] has ascended! The flames shall consume all! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_ash.ogg',
-		color_override = "pink",
+		color_override = "white",
 	)
 
 	var/datum/action/cooldown/spell/fire_sworn/circle_spell = new(user.mind)

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of Blades. Stab stab.
+ * Spell names are in this language: ARAMAIC
+ * Both are related: Aramaic-Damascus-Blade
  *
  * Goes as follows:
  *

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of Cosmos.
+ * Spell names are in this language: SUMERIAN
+ * Both are related: Sumerian-Original-Primordial-Cosmic
  *
  * Goes as follows:
  *
@@ -271,7 +273,7 @@
 		text = "[generate_heretic_text()] A Star Gazer has arrived into the station, [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_cosmic.ogg',
-		color_override = "pink",
+		color_override = "purple",
 	)
 	var/mob/living/basic/heretic_summon/star_gazer/star_gazer_mob = new /mob/living/basic/heretic_summon/star_gazer(loc)
 	star_gazer_mob.maxHealth = INFINITY

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -5,6 +5,8 @@
 
 /**
  * # The path of Flesh.
+ * Spell names are in this language: LATIN
+ * Both are related: Latin-Rome-Hedonism-Flesh
  *
  * Goes as follows:
  *
@@ -315,7 +317,7 @@
 		text = "[generate_heretic_text()] Ever coiling vortex. Reality unfolded. ARMS OUTREACHED, THE LORD OF THE NIGHT, [user.real_name] has ascended! Fear the ever twisting hand! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_flesh.ogg',
-		color_override = "pink",
+		color_override = "red",
 	)
 
 	var/datum/action/cooldown/spell/shapeshift/shed_human_form/worm_spell = new(user.mind)

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of Lock.
+ * Spell names are in this language: EGYPTIAN
+ * Both are related: Egyptian-Mysteries-Secrets-Lock
  *
  * Goes as follows:
  *
@@ -225,7 +227,7 @@
 		text = "Delta-class dimensional anomaly detec[generate_heretic_text()] Reality rended, torn. Gates open, doors open, [user.real_name] has ascended! Fear the tide! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_knock.ogg',
-		color_override = "pink",
+		color_override = "yellow",
 	)
 	user.client?.give_award(/datum/award/achievement/misc/lock_ascension, user)
 

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of Moon.
+ * Spell names are in this language: ANCIENT HEBREW
+ * Both are related: Ancient Hebrew-Moon Mysticism-Moon
  *
  * Goes as follows:
  *
@@ -194,7 +196,7 @@
 				The truth shall finally devour the lie! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_moon.ogg',
-		color_override = "pink",
+		color_override = "blue",
 	)
 
 	user.client?.give_award(/datum/award/achievement/misc/moon_ascension, user)

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of Rust.
+ * Spell names are in this language: OLD SLAVIC
+ * Both are related:
  *
  * Goes as follows:
  *
@@ -288,7 +290,7 @@
 		text = "[generate_heretic_text()] Fear the decay, for the Rustbringer, [user.real_name] has ascended! None shall escape the corrosion! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_rust.ogg',
-		color_override = "pink",
+		color_override = "brown",
 	)
 	trigger(loc)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -1,7 +1,6 @@
 /**
  * # The path of Rust.
  * Spell names are in this language: OLD SLAVIC
- * Both are related:
  *
  * Goes as follows:
  *

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -1,4 +1,5 @@
 // Heretic starting knowledge.
+// Default heretic language is Ancient Greek, because, uh, they're like ancient and shit.
 
 /// Global list of all heretic knowledge that have route = PATH_START. List of PATHS.
 GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -1,5 +1,7 @@
 /**
  * # The path of VOID.
+ * Spell names are in this language: PALI
+ * Both are related: Pali-Buddhism-Nothingness-Void
  *
  * Goes as follows:
  *
@@ -203,7 +205,7 @@
 		text = "[generate_heretic_text()] The nobleman of void [user.real_name] has arrived, stepping along the Waltz that ends worlds! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_void.ogg',
-		color_override = "pink",
+		color_override = "blue",
 	)
 	user.client?.give_award(/datum/award/achievement/misc/void_ascension, user)
 	ADD_TRAIT(user, TRAIT_RESISTLOWPRESSURE, MAGIC_TRAIT)

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -10,8 +10,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Agresivnyy rasprostraneniye!"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "Agresiv'nyy rasprostra-neniye!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	aoe_radius = 2

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "A'GRSV SPR'D"
+	invocation = "Agresivnyy rasprostraneniye!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Agresiv'nyy rasprostra-neniye!"
+	invocation = "Agresiv'noe rasprostra-neniye!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/apetravulnera.dm
+++ b/code/modules/antagonists/heretic/magic/apetravulnera.dm
@@ -11,7 +11,7 @@
 	cooldown_time = 45 SECONDS
 
 	invocation = "Shea' shen-eh!"
-	invocation_type = INVOCATION_WHISPER
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	cast_range = 4

--- a/code/modules/antagonists/heretic/magic/apetravulnera.dm
+++ b/code/modules/antagonists/heretic/magic/apetravulnera.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "AP'TRA VULN'RA!"
+	invocation = "Shea' shen-eh!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 70 SECONDS
 
-	invocation = "FL'MS"
+	invocation = "EIDR ELDR!!!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -72,8 +72,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "C'SC'DE"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "ILLA'LASARA-FOSS!!!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	/// The radius the flames will go around the caster.
@@ -112,7 +112,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 300
 
-	invocation = "F'RE"
+	invocation = "Eld'sky!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 70 SECONDS
 
-	invocation = "EIDR ELDR!!!"
+	invocation = "EID'R-ELDR!!!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -72,7 +72,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "ILLA'LASARA-FOSS!!!"
+	invocation = "ILLA-LASARA'FOSS!!!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/ash_jaunt.dm
+++ b/code/modules/antagonists/heretic/magic/ash_jaunt.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "ASH'N P'SSG'"
+	invocation = "Askgraar' goetur!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "CL'VE!"
+	invocation = "Fer're!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "FL'MS O'ET'RN'ITY."
+	invocation = "Sanguis suctio!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/burglar_finesse.dm
+++ b/code/modules/antagonists/heretic/magic/burglar_finesse.dm
@@ -9,7 +9,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 40 SECONDS
 
-	invocation = "Y'O'K!"
+	invocation = "Khenem"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -26,7 +26,7 @@
 		return FALSE
 
 	var/obj/storage_item = locate(/obj/item/storage/backpack) in cast_on.contents
-	
+
 	if(isnull(storage_item))
 		return FALSE
 

--- a/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "C'SM'S 'XP'ND"
+	invocation = "An'gar baltil!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/cosmic_runes.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_runes.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "ST'R R'N'"
+	invocation = "Is'zara-runen"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/eldritch_blind.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_blind.dm
@@ -5,7 +5,7 @@
 	overlay_icon_state = "bg_heretic_border"
 
 	school = SCHOOL_FORBIDDEN
-	invocation = "E'E'S"
+	invocation = "Caecus"
 	spell_requirements = NONE
 
 	cast_range = 10

--- a/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
@@ -8,7 +8,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "E'P"
+	invocation = "Pulsus Energiae"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
@@ -7,7 +7,7 @@
 	overlay_icon_state = "bg_heretic_border"
 
 	school = SCHOOL_FORBIDDEN
-	invocation = "SH'PE"
+	invocation = "Forma"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/fire_blast.dm
+++ b/code/modules/antagonists/heretic/magic/fire_blast.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "V'LC'N!"
+	invocation = "Eld'fjall!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	channel_time = 5 SECONDS

--- a/code/modules/antagonists/heretic/magic/flesh_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_ascension.dm
@@ -9,7 +9,7 @@
 
 	school = SCHOOL_FORBIDDEN
 
-	invocation = "REALITY UNCOIL!"
+	invocation = "REALITAS EXSERPAT!!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -11,8 +11,8 @@
 
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
-	invocation = "CL'M M'N!" // "CLAIM MINE", but also almost "KALI MA"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "Carnis chirurgia"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	hand_path = /obj/item/melee/touch_attack/flesh_surgery

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -11,7 +11,7 @@
 
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 60 SECONDS
-	invocation = "F'LSH'NG S'LV'R!"
+	invocation = "Ham'sana-qasep!"
 	invocation_type = INVOCATION_SHOUT
 
 	spell_requirements = NONE

--- a/code/modules/antagonists/heretic/magic/manse_link.dm
+++ b/code/modules/antagonists/heretic/magic/manse_link.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "PI'RC' TH' M'ND."
+	invocation = "Diaperaste' to-myalo!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_EVOCATION
 	cooldown_time = 10 SECONDS
 
-	invocation = "R'CH T'H TR'TH!"
+	invocation = "Ftaste-tin' alithea!"
 	invocation_type = INVOCATION_SHOUT
 	// Mimes can cast it. Chaplains can cast it. Anyone can cast it, so long as they have a hand.
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_EVOCATION
 	cooldown_time = 10 SECONDS
 
-	invocation = "Ftaste-tin' alithea!"
+	invocation = "Ad verum per aspera!"
 	invocation_type = INVOCATION_SHOUT
 	// Mimes can cast it. Chaplains can cast it. Anyone can cast it, so long as they have a hand.
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION

--- a/code/modules/antagonists/heretic/magic/mind_gate.dm
+++ b/code/modules/antagonists/heretic/magic/mind_gate.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Op' 'oY 'Mi'd"
+	invocation = "Sha'ar ha-da'at"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 	cast_range = 6

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "L'N'R P'RAD"
+	invocation = "Tsiyun' levani!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 
-	invocation = "R''S 'E"
+	invocation = "Manahel-qomem!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/moon_smile.dm
+++ b/code/modules/antagonists/heretic/magic/moon_smile.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Mo'N S'M'LE"
+	invocation = "Hiyuk-levana!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	cast_range = 6

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 
-	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER"
+	invocation = "Dyrth a Vaktryggjandi"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_HUMAN
 

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 
-	invocation = "Dyrth a Vaktryggjandi"
+	invocation = "Dyrth-a Vaktry'ggjandi"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_HUMAN
 

--- a/code/modules/antagonists/heretic/magic/realignment.dm
+++ b/code/modules/antagonists/heretic/magic/realignment.dm
@@ -14,8 +14,8 @@
 	cooldown_reduction_per_rank = -6 SECONDS // we're not a wizard spell but we use the levelling mechanic
 	spell_max_level = 10 // we can get up to / over a minute duration cd time
 
-	invocation = "R'S'T."
-	invocation_type = INVOCATION_SHOUT
+	invocation = "Rasut"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 /datum/action/cooldown/spell/realignment/is_valid_target(atom/cast_on)

--- a/code/modules/antagonists/heretic/magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_wave.dm
@@ -13,8 +13,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "'NTR'P'C PL'M'"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "Entro'pichniy-plim!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	cone_levels = 5
@@ -75,8 +75,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 35 SECONDS
 
-	invocation = "SPR'D TH' WO'D"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "Diffunde' verbum!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	projectile_type = /obj/projectile/magic/aoe/rust_wave

--- a/code/modules/antagonists/heretic/magic/star_blast.dm
+++ b/code/modules/antagonists/heretic/magic/star_blast.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "R'T'T' ST'R!"
+	invocation = "Pi-rig is'zara!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -13,7 +13,7 @@
 	sound = 'sound/items/welder.ogg'
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
-	invocation = "ST'R 'N'RG'!"
+	invocation = "An'gar sig!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	antimagic_flags = MAGIC_RESISTANCE

--- a/code/modules/antagonists/heretic/magic/void_cold_cone.dm
+++ b/code/modules/antagonists/heretic/magic/void_cold_cone.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "FR'ZE!"
+	invocation = "Sunya'kop!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -12,8 +12,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "RE'L'TY PH'S'E."
-	invocation_type = INVOCATION_WHISPER
+	invocation = "Sunya'sthiti!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	cast_range = 9

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -11,8 +11,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 40 SECONDS
 
-	invocation = "BR'NG F'RTH TH'M T' M'."
-	invocation_type = INVOCATION_WHISPER
+	invocation = "Sunya'apamkti!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	aoe_radius = 7

--- a/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
+++ b/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 5 MINUTES
 
-	invocation = "F'K 'FF."
+	invocation = "Kher' Sekh-em waaef'k"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
+++ b/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
@@ -11,8 +11,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 5 MINUTES
 
-	invocation = "Kher' Sekh-em waaef'k"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "Kher' Sekh-em waaef'k!"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	aoe_radius = 3


### PR DESCRIPTION

## About The Pull Request

Heretic invocations are now translations of their spell name/older invocation into a dead language, one per path.

Base spells use Ancient Greek, because it's ancient and sounds cool.
Ash spells use Old Norse, because both myths are linked to ash.
Flesh spells use Latin, as a nod to Roman hedonism.
Void spells use Pali, as a nod to Buddhism and its philosophy of nothingness.
Blade spells use Aramaic, due to its relation with the city of Damascus.
Rust spells use Old Slavic, which was recommended to me by a slavic linguist friend of mine but the jerk didn't say why.
Cosmos spells use Sumerian, as both are 'primordial'
Lock spells use Egyptian, as both relate to secrets and mysteries.
Moon spells use Ancient Hebrew, due to the culture's strong relation with the moon.

These language picks are mostly just to be cute. The main intention of the PR is to replace the awful convention of 'spell name but the vowels are replaced with an apostrophe for some reason'. 

The secondary intention is to have each path's spell invocations be visibly different from eachother, and from wizardly spells, befitting their status as being from different entities.

## Why It's Good For The Game

Our current spell invocations are an affront, not just to the eyes, but the ears as well with TTS garbling all the invocations because they hide every vowel. They're also conceptually lame.

Giving each path a unique invocation language or pattern will go some ways to distinguishing each of them in active gameplay and in flavor. 

If someone wants to add new spells they can just make some shit up that sounds similar to the spell invocations I translated - historical accuracy isn't really the focus here more than getting the 'feel' of each language across.

## Changelog

:cl:
spellcheck: Heretic spell invocations now use one dead language per path. Altered a few invocation types.
/:cl:

