### PR TITLE
Fixes item interaction between crayons & washing machine

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -339,6 +339,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		update_appearance()
 		return ITEM_INTERACT_SUCCESS
 	return ITEM_INTERACT_BLOCKING
+
 /obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)
 	if(user.combat_mode)
 		return NONE

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -334,10 +334,11 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/washing_machine/screwdriver_act(mob/living/user, obj/item/tool)
-	default_deconstruction_screwdriver(user, null, null, tool)
-	update_appearance()
-	return ITEM_INTERACT_SUCCESS
-
+	if (!state_open)
+		default_deconstruction_screwdriver(user, null, null, tool)
+		update_appearance()
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING
 /obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)
 	if(!user.combat_mode)
 		if (!state_open)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -345,15 +345,12 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	if (!state_open)
 		to_chat(user, span_warning("Open the door first!"))
 		return ITEM_INTERACT_BLOCKING
-
 	if(bloody_mess)
 		to_chat(user, span_warning("[src] must be cleaned up first!"))
 		return ITEM_INTERACT_BLOCKING
-
 	if(contents.len >= max_wash_capacity)
 		to_chat(user, span_warning("The washing machine is full!"))
 		return ITEM_INTERACT_BLOCKING
-
 	if(!user.transferItemToLoc(item, src))
 		to_chat(user, span_warning("\The [item] is stuck to your hand, you cannot put it in the washing machine!"))
 		return ITEM_INTERACT_SUCCESS
@@ -361,8 +358,6 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		color_source = item
 	update_appearance()
 
-	else
-		return NONE
 
 /obj/machinery/washing_machine/attack_hand(mob/living/user, list/modifiers)
 	. = ..()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -354,10 +354,11 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(item, src))
 		to_chat(user, span_warning("\The [item] is stuck to your hand, you cannot put it in the washing machine!"))
-		return ITEM_INTERACT_SUCCESS
+		return ITEM_INTERACT_BLOCKING
 	if(item.dye_color)
 		color_source = item
 	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 
 /obj/machinery/washing_machine/attack_hand(mob/living/user, list/modifiers)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -334,9 +334,8 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/washing_machine/screwdriver_act(mob/living/user, obj/item/tool)
-	if(busy)
-		return FALSE
 	default_deconstruction_screwdriver(user, null, null, tool)
+	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -332,13 +332,13 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		return FALSE
 	default_unfasten_wrench(user, tool)
 	return ITEM_INTERACT_SUCCESS
-
+/obj/machinery/washing_machine/screwdriver_act(mob/living/user, obj/item/tool)
+	if(busy)
+		return FALSE
+	default_deconstruction_screwdriver(user, null, null, tool)
+	return ITEM_INTERACT_SUCCESS
 /obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)
-	if(default_deconstruction_screwdriver(user, null, null, item))
-		update_appearance()
-		return
-
-	else if(!user.combat_mode)
+	if(!user.combat_mode)
 		if (!state_open)
 			to_chat(user, span_warning("Open the door first!"))
 			return ITEM_INTERACT_SUCCESS

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -340,25 +340,26 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		return ITEM_INTERACT_SUCCESS
 	return ITEM_INTERACT_BLOCKING
 /obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)
-	if(!user.combat_mode)
-		if (!state_open)
-			to_chat(user, span_warning("Open the door first!"))
-			return ITEM_INTERACT_BLOCKING
+	if(user.combat_mode)
+		return NONE
+	if (!state_open)
+		to_chat(user, span_warning("Open the door first!"))
+		return ITEM_INTERACT_BLOCKING
 
-		if(bloody_mess)
-			to_chat(user, span_warning("[src] must be cleaned up first!"))
-			return ITEM_INTERACT_BLOCKING
+	if(bloody_mess)
+		to_chat(user, span_warning("[src] must be cleaned up first!"))
+		return ITEM_INTERACT_BLOCKING
 
-		if(contents.len >= max_wash_capacity)
-			to_chat(user, span_warning("The washing machine is full!"))
-			return ITEM_INTERACT_BLOCKING
+	if(contents.len >= max_wash_capacity)
+		to_chat(user, span_warning("The washing machine is full!"))
+		return ITEM_INTERACT_BLOCKING
 
-		if(!user.transferItemToLoc(item, src))
-			to_chat(user, span_warning("\The [item] is stuck to your hand, you cannot put it in the washing machine!"))
-			return ITEM_INTERACT_SUCCESS
-		if(item.dye_color)
-			color_source = item
-		update_appearance()
+	if(!user.transferItemToLoc(item, src))
+		to_chat(user, span_warning("\The [item] is stuck to your hand, you cannot put it in the washing machine!"))
+		return ITEM_INTERACT_SUCCESS
+	if(item.dye_color)
+		color_source = item
+	update_appearance()
 
 	else
 		return NONE

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -332,24 +332,26 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		return FALSE
 	default_unfasten_wrench(user, tool)
 	return ITEM_INTERACT_SUCCESS
+
 /obj/machinery/washing_machine/screwdriver_act(mob/living/user, obj/item/tool)
 	if(busy)
 		return FALSE
 	default_deconstruction_screwdriver(user, null, null, tool)
 	return ITEM_INTERACT_SUCCESS
+
 /obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)
 	if(!user.combat_mode)
 		if (!state_open)
 			to_chat(user, span_warning("Open the door first!"))
-			return ITEM_INTERACT_SUCCESS
+			return ITEM_INTERACT_BLOCKING
 
 		if(bloody_mess)
 			to_chat(user, span_warning("[src] must be cleaned up first!"))
-			return ITEM_INTERACT_SUCCESS
+			return ITEM_INTERACT_BLOCKING
 
 		if(contents.len >= max_wash_capacity)
 			to_chat(user, span_warning("The washing machine is full!"))
-			return ITEM_INTERACT_SUCCESS
+			return ITEM_INTERACT_BLOCKING
 
 		if(!user.transferItemToLoc(item, src))
 			to_chat(user, span_warning("\The [item] is stuck to your hand, you cannot put it in the washing machine!"))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -333,33 +333,33 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	default_unfasten_wrench(user, tool)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/washing_machine/attackby(obj/item/W, mob/living/user, params)
-	if(default_deconstruction_screwdriver(user, null, null, W))
+/obj/machinery/washing_machine/item_interaction(mob/living/user, obj/item/item, list/modifiers)
+	if(default_deconstruction_screwdriver(user, null, null, item))
 		update_appearance()
 		return
 
 	else if(!user.combat_mode)
 		if (!state_open)
 			to_chat(user, span_warning("Open the door first!"))
-			return TRUE
+			return ITEM_INTERACT_SUCCESS
 
 		if(bloody_mess)
 			to_chat(user, span_warning("[src] must be cleaned up first!"))
-			return TRUE
+			return ITEM_INTERACT_SUCCESS
 
 		if(contents.len >= max_wash_capacity)
 			to_chat(user, span_warning("The washing machine is full!"))
-			return TRUE
+			return ITEM_INTERACT_SUCCESS
 
-		if(!user.transferItemToLoc(W, src))
-			to_chat(user, span_warning("\The [W] is stuck to your hand, you cannot put it in the washing machine!"))
-			return TRUE
-		if(W.dye_color)
-			color_source = W
+		if(!user.transferItemToLoc(item, src))
+			to_chat(user, span_warning("\The [item] is stuck to your hand, you cannot put it in the washing machine!"))
+			return ITEM_INTERACT_SUCCESS
+		if(item.dye_color)
+			color_source = item
 		update_appearance()
 
 	else
-		return ..()
+		return
 
 /obj/machinery/washing_machine/attack_hand(mob/living/user, list/modifiers)
 	. = ..()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -359,7 +359,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		update_appearance()
 
 	else
-		return
+		return NONE
 
 /obj/machinery/washing_machine/attack_hand(mob/living/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes #84063
Allows crayons to go into washing machines once more
## Why It's Good For The Game
Dying insuls for le ultimate powergaming under sec's nose is cool, and i miss it
(and bugs suck)
## Changelog
:cl:
fix: crayons interact with washing machine once again
/:cl:
