### PR TITLE
Fix runtime during screen element mouse drag

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -78,7 +78,7 @@
 // Very much byond logic, but I want nice behavior, so we fake it with drag
 /atom/movable/screen/movable/action_button/MouseDrag(atom/over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()
-	if(!can_use(usr))
+	if(!over_object || !can_use(usr))
 		return
 	if(IS_WEAKREF_OF(over_object, last_hovored_ref))
 		return

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -78,7 +78,7 @@
 // Very much byond logic, but I want nice behavior, so we fake it with drag
 /atom/movable/screen/movable/action_button/MouseDrag(atom/over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()
-	if(!over_object || !can_use(usr))
+	if(!can_use(usr))
 		return
 	if(IS_WEAKREF_OF(over_object, last_hovored_ref))
 		return
@@ -94,7 +94,7 @@
 		old_object.MouseExited(over_location, over_control, params)
 
 	last_hovored_ref = WEAKREF(over_object)
-	over_object.MouseEntered(over_location, over_control, params)
+	over_object?.MouseEntered(over_location, over_control, params)
 
 /atom/movable/screen/movable/action_button/MouseEntered(location, control, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes this
![Screenshot (424)](https://github.com/tgstation/tgstation/assets/110812394/52825b5e-1af0-490b-9139-7f7747ee998a)

When you drag a screen element across empty space that isn't over another screen element

- Fixes #84045

## Changelog
:cl:
fix: You can move around ui buttons in your action bar
/:cl:
