### PR TITLE
Anomaly fix/code improvement

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -119,6 +119,7 @@
 		return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
+		return ITEM_INTERACT_BLOCKING
 
 	return ..()
 

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -113,8 +113,8 @@
 
 	qdel(src)
 
-/obj/effect/anomaly/attackby(obj/item/weapon, mob/user, params)
-	if(weapon.tool_behaviour == TOOL_ANALYZER && anomaly_core)
+/obj/effect/anomaly/analyzer_act(mob/living/user, obj/item/analyzer/tool)
+	if(anomaly_core)
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
 		return TRUE
 

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -117,6 +117,8 @@
 	if(anomaly_core)
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
 		return TRUE
+	else
+		to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
 
 	return ..()
 

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -121,7 +121,6 @@
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
 		return ITEM_INTERACT_BLOCKING
 
-	return ..()
 
 ///Stabilize an anomaly, letting it stay around forever or untill destabilizes by a player. An anomaly without a core can't be signalled, but can be destabilized
 /obj/effect/anomaly/proc/stabilize(anchor = FALSE, has_core = TRUE)

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -114,7 +114,7 @@
 	qdel(src)
 
 /obj/effect/anomaly/analyzer_act(mob/living/user, obj/item/analyzer/tool)
-	if(anomaly_core)
+	if(!isnull(anomaly_core))
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
 		return ITEM_INTERACT_SUCCESS
 	to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -117,9 +117,8 @@
 	if(anomaly_core)
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
 		return ITEM_INTERACT_SUCCESS
-	else
-		to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
-		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
+	return ITEM_INTERACT_BLOCKING
 
 
 ///Stabilize an anomaly, letting it stay around forever or untill destabilizes by a player. An anomaly without a core can't be signalled, but can be destabilized

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -116,7 +116,7 @@
 /obj/effect/anomaly/analyzer_act(mob/living/user, obj/item/analyzer/tool)
 	if(anomaly_core)
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
-		return TRUE
+		return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
 


### PR DESCRIPTION

## About The Pull Request

Makes anomaly cores use `analyzer_act` instead of `attackby`. Fixes #83994.
## Why It's Good For The Game

`attackby` is old and kinda poor practice to use in this case. `analyzer_act` does everything necessary, so it just makes sense to do that instead.
## Changelog
:cl:
fix: Analyzers should work on bioscrambler anomalies again.
/:cl:
