### PR TITLE
Makes interacting with an assembly bomb interact with the assembly instead of opening the tank UI

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -413,6 +413,12 @@
 	if(tank_assembly)
 		tank_assembly.attack_hand()
 
+/obj/item/tank/attack_self(mob/user, modifiers)
+	if (tank_assembly)
+		tank_assembly.attack_self(user)
+		return TRUE
+	return ..()
+
 /obj/item/tank/Move()
 	. = ..()
 	if(tank_assembly)

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -419,6 +419,10 @@
 		return TRUE
 	return ..()
 
+/obj/item/tank/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	ui_interact(user)
+
 /obj/item/tank/Move()
 	. = ..()
 	if(tank_assembly)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -153,7 +153,7 @@
  * * user: The mob handling the trap
  */
 /obj/item/assembly/mousetrap/proc/clumsy_check(mob/living/carbon/human/user)
-	if(!armed)
+	if(!armed || !user)
 		return FALSE
 	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
 		var/which_hand = BODY_ZONE_PRECISE_L_HAND


### PR DESCRIPTION
## About The Pull Request
Changes it so that interacting in hand with an assembly bomb will interact with the assemble instead of opening the tank UI.
## Why It's Good For The Game
Currently when you interact with an assembly bomb in hand it opens the tank UI instead of interacting with the assembly, which makes them awkward to use as you have to configure the assembly before attaching it to the tank and welding the tank.

Fixes #84073 
## Changelog
:cl:
fix: Interacting with an assembly bomb in hand will now allow you to interact with the attached assembly instead of opening the gas tank UI. Right-clicking will display the gas tank UI instead.
/:cl:
