### PR TITLE
Activating a lighter or match while covered in flammable liquids now ignites you, even if you're really, really, really ridiculously good looking

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -55,6 +55,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A [initial(name)]. This one is lit."
 	attack_verb_continuous = string_list(list("burns", "singes"))
 	attack_verb_simple = string_list(list("burn", "singe"))
+	if(isliving(loc))
+		var/mob/living/male_model = loc
+		if(male_model.fire_stacks && !(male_model.on_fire))
+			male_model.ignite_mob()
 	START_PROCESSING(SSobj, src)
 	update_appearance()
 
@@ -876,6 +880,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		attack_verb_continuous = string_list(list("burns", "singes"))
 		attack_verb_simple = string_list(list("burn", "singe"))
 		START_PROCESSING(SSobj, src)
+		if(isliving(loc))
+			var/mob/living/male_model = loc
+			if(male_model.fire_stacks && !(male_model.on_fire))
+				male_model.ignite_mob()
 	else
 		hitsound = SFX_SWING_HIT
 		force = 0


### PR DESCRIPTION

## About The Pull Request

This pull request adds a couple of lines to the code for matches and lighters that has it check to see if its location (which would also be its user) is a living mob with flammable liquid on them. If so, they get lit on fire.
## Why It's Good For The Game

It adds a goofy interaction for people unfortunate enough to get splashed with flammable liquid. Beyond a possible way of making a half-assed attempt to assassinate a smoker, it's also a good safety lesson. Just look at these poor young men below...


https://github.com/tgstation/tgstation/assets/49173900/f073f71f-6b37-46ce-8ea3-eb30ec2378a1
## Changelog
:cl: Bisar
add: The Nanotrasen safety commission reminds employees to properly clean themselves of all flammable material before going on smoke breaks.
/:cl:
