### PR TITLE
Fix ambience pref not being toggleable in game

### DIFF
--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -48,3 +48,6 @@
 
 /datum/client_interface/proc/set_macros()
 	return
+
+/datum/client_interface/proc/update_ambience_pref()
+	return

--- a/code/modules/client/preferences/sounds.dm
+++ b/code/modules/client/preferences/sounds.dm
@@ -4,6 +4,9 @@
 	savefile_key = "sound_ambience"
 	savefile_identifier = PREFERENCE_PLAYER
 
+/datum/preference/toggle/sound_ambience/apply_to_client(client/client, value)
+	client.update_ambience_pref()
+
 /// Controls hearing announcement sounds
 /datum/preference/toggle/sound_announcements
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
@@ -10,6 +10,7 @@ import { FeatureDropdownInput } from '../dropdowns';
 export const sound_ambience: FeatureToggle = {
   name: 'Enable ambience',
   category: 'SOUND',
+  description: `Ambience refers to the more noticeable ambient sounds that play on occasion.`,
   component: CheckboxInput,
 };
 
@@ -81,6 +82,7 @@ export const sound_midi: FeatureToggle = {
 export const sound_ship_ambience: FeatureToggle = {
   name: 'Enable ship ambience',
   category: 'SOUND',
+  description: `Ship ambience refers to the low ambient buzz that plays on loop.`,
   component: CheckboxInput,
 };
 


### PR DESCRIPTION
## About The Pull Request

The only time people were added to the ambience SS's list is when you log in, meaning if you toggle the preference on/off mid game, it does nothing. 

Fixes #61495

## Changelog

:cl: Melbert
fix: Enabling or disabling ambience mid round will properly enable or disable ambience
qol: Added descriptions differentiating "Ship ambience" from "ambience" 
/:cl:


