### PR TITLE
Repurposed Glands (Adrenals) now show the correct chemical cost and duration

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/adrenaline
 	name = "Repurposed Glands"
-	desc = "We shift almost all available muscle mass from the arms to the legs, disabling the former but making us unable to be downed for 15 seconds. Costs 10 chemicals."
+	desc = "We shift almost all available muscle mass from the arms to the legs, disabling the former but making us unable to be downed for 20 seconds. Costs 25 chemicals."
 	helptext = "Disables your arms and retracts bioweaponry, but regenerates your legs, grants you speed, and wakes you up from any stun."
 	button_icon_state = "adrenaline"
 	chemical_cost = 25 // similar cost to biodegrade, as they serve similar purposes


### PR DESCRIPTION
## About The Pull Request

Adrenals now show the actual chemical cost it inquires and its correct duration in its description in the action button and cellular emporium.
Also yeah I did kinda forgot to atomize this while working on the ling balance changes, oopsies!

## Why It's Good For The Game

Misiformation in the description = new player bait = bad

## Changelog

:cl:
fix: Repurposed Glands (Adrenals) now show their correct duration and chemical cost in its description.
/:cl:
