### PR TITLE
Swaps Genetics and Cyto tech

### DIFF
--- a/code/modules/research/techweb/nodes/biology_nodes.dm
+++ b/code/modules/research/techweb/nodes/biology_nodes.dm
@@ -18,7 +18,7 @@
 	id = "cytology"
 	display_name = "Cytology"
 	description = "Cellular biology research focused on cultivation of limbs and diverse organisms from cells."
-	prereq_ids = list("bio_scan")
+	prereq_ids = list("xenobiology","selection")
 	design_ids = list(
 		"limbgrower",
 		"pandemic",
@@ -48,7 +48,7 @@
 	id = "gene_engineering"
 	display_name = "Gene Engineering"
 	description = "Research into sophisticated DNA manipulation techniques, enabling the modification of human genetic traits to unlock specific abilities and enhancements."
-	prereq_ids = list("selection", "xenobiology")
+	prereq_ids = list("bio_scan")
 	design_ids = list(
 		"dnascanner",
 		"scan_console",

--- a/code/modules/research/techweb/nodes/biology_nodes.dm
+++ b/code/modules/research/techweb/nodes/biology_nodes.dm
@@ -42,7 +42,6 @@
 		"limbdesign_plasmaman",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
-	required_experiments = list(/datum/experiment/scanning/random/cytology)
 
 /datum/techweb_node/gene_engineering
 	id = "gene_engineering"
@@ -58,6 +57,7 @@
 		"mod_dna_lock",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
+	required_experiments = list(/datum/experiment/scanning/random/cytology)
 	discount_experiments = list(
 		/datum/experiment/scanning/random/plants/traits = TECHWEB_TIER_2_POINTS,
 		/datum/experiment/scanning/points/slime/hard = TECHWEB_TIER_2_POINTS,

--- a/code/modules/research/techweb/nodes/biology_nodes.dm
+++ b/code/modules/research/techweb/nodes/biology_nodes.dm
@@ -26,7 +26,7 @@
 		"swab",
 		"biopsy_tool",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 
 /datum/techweb_node/xenobiology
 	id = "xenobiology"
@@ -57,7 +57,7 @@
 		"genescanner",
 		"mod_dna_lock",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 	discount_experiments = list(
 		/datum/experiment/scanning/random/plants/traits = TECHWEB_TIER_2_POINTS,
 		/datum/experiment/scanning/points/slime/hard = TECHWEB_TIER_2_POINTS,


### PR DESCRIPTION

## About The Pull Request

This swaps the cyto and genetics tech- this means that you get tech as bio -> genetic -> xenobio -> cyto

## Why It's Good For The Game

It means that you can actually get genetics tech before botany and xenobio- and is also not locked behind 30k points. Genetics is normally seen as a "more simple" thing than cyto, which means that the tech should come early.

## Changelog
:cl:
balance: Cyto and Genetics tech are swapped
/:cl:
