### PR TITLE
moves flatpacker to the closest Industrial Engineering equivalent

### DIFF
--- a/code/modules/research/techweb/nodes/atmos_nodes.dm
+++ b/code/modules/research/techweb/nodes/atmos_nodes.dm
@@ -82,7 +82,6 @@
 	description = "Enhances the functionality and versatility of station tools."
 	prereq_ids = list("fusion")
 	design_ids = list(
-		"flatpacker",
 		"handdrill",
 		"exwelder",
 		"jawsoflife",

--- a/code/modules/research/techweb/nodes/engi_nodes.dm
+++ b/code/modules/research/techweb/nodes/engi_nodes.dm
@@ -37,6 +37,7 @@
 		"adv_matter_bin",
 		"adv_scanning",
 		"super_cell",
+		"flatpacker",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 


### PR DESCRIPTION
## About The Pull Request

moves flatpacker to the closest Industrial Engineering equivalent; Upgraded Parts

## Why It's Good For The Game

im labelling this shit a fix PR because flatpackers were meant to be roundstart to near roundstart and god am i not reading some huge flowchart to see if my item got moved

exp tools is absolutely not roundstart and this should correct it to be in is intended place

## Changelog
:cl:
balance: flatpackers have been moved to the closest Industrial Engineering equivalent, Upgraded Parts
/:cl:
