### PR TITLE
Refactors card attackby chains into item_interaction

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -552,26 +552,26 @@
 				if(ispath(trim))
 					SSid_access.apply_trim_to_card(src, trim)
 
-/obj/item/card/id/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/rupee))
+/obj/item/card/id/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/rupee))
 		to_chat(user, span_warning("Your ID smartly rejects the strange shard of glass. Who knew, apparently it's not ACTUALLY valuable!"))
-		return
-	else if(iscash(W))
-		insert_money(W, user)
-		return
-	else if(istype(W, /obj/item/storage/bag/money))
-		var/obj/item/storage/bag/money/money_bag = W
+		return ITEM_INTERACT_BLOCKING
+	else if(iscash(tool))
+		return insert_money(tool, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
+	else if(istype(tool, /obj/item/storage/bag/money))
+		var/obj/item/storage/bag/money/money_bag = tool
 		var/list/money_contained = money_bag.contents
 		var/money_added = mass_insert_money(money_contained, user)
-		if (money_added)
-			to_chat(user, span_notice("You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [money_added] worth of credits to the linked account."))
-		return
-	else
-		return ..()
+		if(!money_added)
+			return ITEM_INTERACT_BLOCKING
+		to_chat(user, span_notice("You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [money_added] worth of credits to the linked account."))
+		return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /**
  * Insert credits or coins into the ID card and add their value to the associated bank account.
  *
+ * Returns TRUE if the money was successfully inserted, FALSE otherwise.
  * Arguments:
  * money - The item to attempt to convert to credits and insert into the card.
  * user - The user inserting the item.
@@ -584,11 +584,11 @@
 
 	if(!registered_account)
 		to_chat(user, span_warning("[src] doesn't have a linked account to deposit [money] into!"))
-		return
+		return FALSE
 	var/cash_money = money.get_item_credit_value()
 	if(!cash_money)
 		to_chat(user, span_warning("[money] doesn't seem to be worth anything!"))
-		return
+		return FALSE
 	registered_account.adjust_money(cash_money, "System: Deposit")
 	SSblackbox.record_feedback("amount", "credits_inserted", cash_money)
 	log_econ("[cash_money] credits were inserted into [src] owned by [src.registered_name]")
@@ -599,6 +599,7 @@
 
 	to_chat(user, span_notice("The linked account now reports a balance of [registered_account.account_balance] cr."))
 	qdel(money)
+	return TRUE
 
 /**
  * Insert multiple money or money-equivalent items at once.
@@ -953,20 +954,41 @@
 
 	return ..()
 
-
-/obj/item/card/id/advanced/attackby(obj/item/W, mob/user, params)
+/obj/item/card/id/advanced/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
-	if(istype(W, /obj/item/toy/crayon))
-		var/obj/item/toy/crayon/our_crayon = W
-		if(tgui_alert(usr, "Recolor Department or Subdepartment?", "Recoloring ID...", list("Department", "Subdepartment")) == "Department")
-			if(!do_after(user, 2 SECONDS)) // Doesn't technically require a spraycan's cap to be off but shhh
-				return
+	if(.)
+		return .
+
+	if(istype(tool, /obj/item/toy/crayon))
+		return recolor_id(user, tool)
+
+/obj/item/card/id/advanced/proc/recolor_id(mob/living/user, obj/item/toy/crayon/our_crayon)
+	if(our_crayon.is_capped)
+		balloon_alert(user, "take the cap off first!")
+		return ITEM_INTERACT_BLOCKING
+	var/choice = tgui_alert(usr, "Recolor Department or Subdepartment?", "Recoloring ID...", list("Department", "Subdepartment"))
+	if(isnull(choice) \
+		|| QDELETED(user) \
+		|| QDELETED(src) \
+		|| QDELETED(our_crayon) \
+		|| !usr.can_perform_action(src, ALLOW_RESTING) \
+		|| !usr.can_perform_action(our_crayon, ALLOW_RESTING) \
+	)
+		return ITEM_INTERACT_BLOCKING
+
+	switch(choice)
+		if("Department")
+			if(!do_after(user, 2 SECONDS))
+				return ITEM_INTERACT_BLOCKING
 			department_color_override = our_crayon.paint_color
 			balloon_alert(user, "recolored")
-		else if(do_after(user, 1 SECONDS))
+		if("Subdepartment")
+			if(!do_after(user, 1 SECONDS))
+				return ITEM_INTERACT_BLOCKING
 			subdepartment_color_override = our_crayon.paint_color
 			balloon_alert(user, "recolored")
-		update_icon()
+	update_icon()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/proc/update_intern_status(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
@@ -1275,27 +1297,38 @@
 	/// Time left on a card till they can leave.
 	var/time_left = 0
 
-/obj/item/card/id/advanced/prisoner/attackby(obj/item/card/id/C, mob/user)
-	..()
-	var/list/id_access = C.GetAccess()
+/obj/item/card/id/advanced/prisoner/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(.)
+		return .
+
+	if(isidcard(tool))
+		return set_sentence_time(user, tool)
+
+/obj/item/card/id/advanced/prisoner/proc/set_sentence_time(mob/living/user, obj/item/card/id/our_card)
+	var/list/id_access = our_card.GetAccess()
 	if(!(ACCESS_BRIG in id_access))
-		return FALSE
-	if(loc != user)
+		balloon_alert(user, "access denied!")
+		return ITEM_INTERACT_BLOCKING
+	if(!user.is_holding(src))
 		to_chat(user, span_warning("You must be holding the ID to continue!"))
-		return FALSE
-	if(timed)
+		return ITEM_INTERACT_BLOCKING
+
+	if(timed) // If we already have a time set, reset the card
 		timed = FALSE
 		time_to_assign = initial(time_to_assign)
 		registered_name = initial(registered_name)
 		STOP_PROCESSING(SSobj, src)
-		to_chat(user, "Restating prisoner ID to default parameters.")
-		return
+		to_chat(user, "Resetting prisoner ID to default parameters.")
+		return ITEM_INTERACT_SUCCESS
+
 	var/choice = tgui_input_number(user, "Sentence time in seconds", "Sentencing")
-	if(!choice || QDELETED(user) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH) || loc != user)
-		return FALSE
+	if(isnull(choice) || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH) || !user.is_holding(src))
+		return ITEM_INTERACT_BLOCKING
 	time_to_assign = choice
-	to_chat(user, "You set the sentence time to [time_to_assign] seconds.")
+	to_chat(user, "You set the sentence time to [DisplayTimeText(time_to_assign * 10)].")
 	timed = TRUE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/prisoner/proc/start_timer()
 	say("Sentence started, welcome to the corporate rehabilitation center!")
@@ -1307,10 +1340,15 @@
 		return
 
 	if(timed)
-		if(time_left <= 0)
+		if(time_to_assign > 0)
+			. += span_notice("The digital timer on the card is set to [DisplayTimeText(time_to_assign * 10)]. The timer will start once the prisoner passes through the prison gate scanners.")
+		else if(time_left <= 0)
 			. += span_notice("The digital timer on the card has zero seconds remaining. You leave a changed man, but a free man nonetheless.")
 		else
-			. += span_notice("The digital timer on the card has [time_left] seconds remaining. Don't do the crime if you can't do the time.")
+			. += span_notice("The digital timer on the card has [DisplayTimeText(time_left * 10)] remaining. Don't do the crime if you can't do the time.")
+
+	. += span_notice("[EXAMINE_HINT("Swipe")] a security ID on the card to [timed ? "re" : ""]set the genpop sentence time.")
+	. += span_notice("Remember to [EXAMINE_HINT("swipe")] the card on a genpop locker to link it.")
 
 /obj/item/card/id/advanced/prisoner/process(seconds_per_tick)
 	if(!timed)
@@ -1761,11 +1799,10 @@
 		voice_name += " (as [scribbled_name])"
 	stored_name[NAME_PART_INDEX] = voice_name
 
-/obj/item/card/cardboard/attackby(obj/item/item, mob/living/user, params)
-	if(user.can_write(item, TRUE))
-		INVOKE_ASYNC(src, PROC_REF(modify_card), user, item)
-		return TRUE
-	return ..()
+/obj/item/card/cardboard/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.can_write(tool, TRUE))
+		INVOKE_ASYNC(src, PROC_REF(modify_card), user, tool)
+		return ITEM_INTERACT_SUCCESS
 
 ///Lets the user write a name, assignment or trim on the card, or reset it. Only the name is important for the component.
 /obj/item/card/cardboard/proc/modify_card(mob/living/user, obj/item/item)


### PR DESCRIPTION

## About The Pull Request

Funnily enough I was already working on this before shit broke, but here we go.
This is mostly just the same behaviour but ported to `item_interaction(...)`.
Primary changes include splitting off ID recoloring into its own method for clarity, adding more sanity checks when using tgui windows, and slightly improving the comprehensibility of genpop prisoner id interactions (proper time text instead of seconds, actual usage descs).
## Why It's Good For The Game

Better to use `item_interaction(...)` than `attackby(...)`.
Fixes an interaction bug introduced by the recent afterattack refactor.
Nice to have a better idea of how to use genpop.
## Changelog
:cl:
refactor: Updated cards/ids to use the proper item interaction system instead of attackby, please report any issues.
fix: You can no longer recolour an ID at any point if you open the menu but then don't select anything until later.
fix: ID cards can be recoloured using crayons/spraycans again.
qol: Prisoner IDs show genpop sentence time in hours/minutes/seconds instead of seconds.
qol: Prisoner IDs have genpop usage tips in their examine.
/:cl:
