### PR TITLE
every engineering lobby starts with a flatpacked flatpacker and multitool

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -12780,6 +12780,9 @@
 /area/station/security/checkpoint/science)
 "fnm" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/item/book/manual/wiki/engineering_guide{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
 "fnw" = (
@@ -17534,10 +17537,6 @@
 /obj/structure/table/greyscale,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/wrench,
-/obj/item/multitool{
-	pixel_x = 4;
-	pixel_y = 5
-	},
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
 "gUC" = (
@@ -29651,8 +29650,14 @@
 	pixel_y = 4
 	},
 /obj/machinery/light/small/directional/south,
-/obj/item/book/manual/wiki/engineering_guide{
-	pixel_y = 4
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = -2
 	},
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -78577,6 +78577,15 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/multitool{
+	pixel_x = 8
+	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "tFG" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -74888,8 +74888,13 @@
 /obj/effect/turf_decal/siding/yellow/corner,
 /obj/machinery/status_display/evac/directional/south,
 /obj/structure/table,
-/obj/effect/spawner/random/trash/food_packaging,
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -5
+	},
+/obj/item/multitool{
+	pixel_x = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wve" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9215,6 +9215,9 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
+/obj/item/lightreplacer{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -58915,12 +58918,16 @@
 "uJz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
-/obj/item/lightreplacer{
-	pixel_y = 7
-	},
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -5
+	},
+/obj/item/multitool{
+	pixel_x = 8
 	},
 /turf/open/floor/iron/checker,
 /area/station/engineering/storage_shared)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -53022,7 +53022,19 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/corner{
 	dir = 4
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -49386,6 +49386,13 @@
 	},
 /obj/structure/cable,
 /obj/structure/table,
+/obj/item/multitool{
+	pixel_x = 8
+	},
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "qwq" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -6900,7 +6900,13 @@
 /area/station/cargo/storage)
 "cAy" = (
 /obj/structure/table/glass,
-/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -5
+	},
+/obj/item/multitool{
+	pixel_x = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cAC" = (
@@ -39883,6 +39889,7 @@
 "omE" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/random/food_or_drink/snack,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "omL" = (

--- a/code/game/machinery/flatpacker.dm
+++ b/code/game/machinery/flatpacker.dm
@@ -242,7 +242,7 @@
 
 /obj/item/flatpack
 	name = "flatpack"
-	desc = "A box containing a compacted packed machine. Use multitool to deploy."
+	desc = "A box containing a compactly packed machine. Use multitool to deploy."
 	icon = 'icons/obj/devices/circuitry_n_data.dmi'
 	icon_state = "flatpack"
 	w_class = WEIGHT_CLASS_HUGE //cart time
@@ -253,13 +253,25 @@
 	/// The board we deploy
 	var/obj/item/circuitboard/machine/board
 
-/obj/item/flatpack/Initialize(mapload, obj/item/circuitboard/machine/board)
+/obj/item/flatpack/Initialize(mapload, obj/item/circuitboard/machine/new_board)
 	. = ..()
-	if(!isnull(board))
-		src.board = board // i got board
+	var/static/list/tool_behaviors
+	if(!tool_behaviors)
+		tool_behaviors = string_assoc_nested_list(list(
+			TOOL_MULTITOOL = list(
+				SCREENTIP_CONTEXT_LMB = "Deploy",
+			),
+		))
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+	if(isnull(board) && isnull(new_board))
+		return INITIALIZE_HINT_QDEL //how
+
+	board = !isnull(new_board) ? new_board : new board(src) // i got board
+	if(board.loc != src)
 		board.forceMove(src)
-		var/obj/machinery/build = initial(board.build_path)
-		name += " ([initial(build.name)])"
+	var/obj/machinery/build = initial(board.build_path)
+	name += " ([initial(build.name)])"
+
 
 /obj/item/flatpack/Destroy()
 	QDEL_NULL(board)


### PR DESCRIPTION

## About The Pull Request

every engineering lobby starts with a flatpacked flatpacker and multitool

## Why It's Good For The Game

flatpackers should be roundstart and they were already but with the new techtree theyre locked behind exp tools
this makes them roundstart as intended but limited in quantity per new tech tree, and something traitors could destroy if they wanted

## Changelog
:cl:
add: every engineering lobby starts with a flatpacked flatpacker and multitool
/:cl:
