### PR TITLE
Allow mimes to break their vow as an MMI

### DIFF
--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -8,7 +8,8 @@
 	panel = "Mime"
 
 	school = SCHOOL_MIME
-	spell_requirements = NONE
+	//MMI mimes should be able to break their vow
+	spell_requirements = SPELL_CASTABLE_AS_BRAIN
 
 	spell_max_level = 1
 


### PR DESCRIPTION
## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/80967
closes https://github.com/tgstation/tgstation/issues/84094
## Changelog
:cl: grungussuss
fix: mimes can now break their vow while borged or an MMI
/:cl:
