### PR TITLE
[no gbp] Sparks don't ignite furniture (unless you made it out of plasma you fucking lunatic), sparks have a decreasing chance to ignite bigger items, small fix to obj/fire_act() signal

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -79,7 +79,7 @@
 				return
 			else
 				var/ignite_chance = 120 // base chance applies to anything under WEIGHT_CLASS_NORMAL, so burn everything flammable that's small/tiny
-				ignite_chance = ignite_chance - (singed_obj.w_class > WEIGHT_CLASS_SMALL ? (singed_obj.w_class * 2 + round(singed_obj.w_class * 0.5)) | 0) // 50% normal size, 20% bulky, no chance to ignite bigger items
+				ignite_chance = ignite_chance - (singed_obj.w_class > WEIGHT_CLASS_SMALL ? (singed_obj.w_class * 2 + round(singed_obj.w_class * 0.5)) : 0) // 50% normal size, 20% bulky, no chance to ignite bigger items
 				if(prob(ignite_chance))
 					singed_obj.fire_act(1,100)
 		if(singed_obj.reagents)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -75,7 +75,13 @@
 	if(isobj(singed))
 		var/obj/singed_obj = singed
 		if(singed_obj.resistance_flags & FLAMMABLE && !(singed_obj.resistance_flags & ON_FIRE)) //only fire_act flammable objects instead of burning EVERYTHING
-			singed_obj.fire_act(1,100)
+			if(isstructure(singed_obj)) // don't ignite furniture even if it's flammable; we can leave that to actual fires
+				return
+			else
+				var/ignite_chance = 120 // base chance applies to anything under WEIGHT_CLASS_NORMAL, so burn everything flammable that's small/tiny
+				ignite_chance = ignite_chance - (singed_obj.w_class > WEIGHT_CLASS_SMALL ? (singed_obj.w_class * 2 + round(singed_obj.w_class * 0.5)) | 0) // 50% normal size, 20% bulky, no chance to ignite bigger items
+				if(prob(ignite_chance))
+					singed_obj.fire_act(1,100)
 		if(singed_obj.reagents)
 			var/datum/reagents/reagents = singed_obj.reagents
 			reagents?.expose_temperature(1000)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -77,11 +77,14 @@
 		if(singed_obj.resistance_flags & FLAMMABLE && !(singed_obj.resistance_flags & ON_FIRE)) //only fire_act flammable objects instead of burning EVERYTHING
 			if(isstructure(singed_obj)) // don't ignite furniture even if it's flammable; we can leave that to actual fires
 				return
-			else
+			else if(isitem(singed_obj))
+				var/obj/item/singed_item = singed_obj
 				var/ignite_chance = 120 // base chance applies to anything under WEIGHT_CLASS_NORMAL, so burn everything flammable that's small/tiny
-				ignite_chance = ignite_chance - (singed_obj.w_class > WEIGHT_CLASS_SMALL ? (singed_obj.w_class * 2 + round(singed_obj.w_class * 0.5)) : 0) // 50% normal size, 20% bulky, no chance to ignite bigger items
+				ignite_chance = ignite_chance - (singed_item.w_class > WEIGHT_CLASS_SMALL ? (singed_item.w_class * 2 + round(singed_item.w_class * 0.5)) : 0) // 50% normal size, 20% bulky, no chance to ignite bigger items
 				if(prob(ignite_chance))
-					singed_obj.fire_act(1,100)
+					singed_item.fire_act(1,100)
+			else
+				singed_obj.fire_act(1,100)
 		if(singed_obj.reagents)
 			var/datum/reagents/reagents = singed_obj.reagents
 			reagents?.expose_temperature(1000)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -74,21 +74,27 @@
 
 	if(isobj(singed))
 		var/obj/singed_obj = singed
-		if(isstructure(singed_obj)) // don't ignite furniture even if it's flammable; we can leave that to actual fires
+		if(singed_obj.reagents)
+			var/datum/reagents/reagents = singed_obj.reagents // heat up things that contain reagents before we check to see if they burn
+			reagents?.expose_temperature(1000) // we set this at 1000 because that's the max reagent temp for a chem heater, higher temps require more than sparks
+		if(singed_obj.custom_materials && (GET_MATERIAL_REF(/datum/material/plasma) in singed_obj.custom_materials))
+			singed_obj.fire_act(FIRE_MINIMUM_TEMPERATURE_TO_SPREAD,100)
+			return // if it's made of plasma we just start burning no matter what, even furniture (see right below)
+		if(isstructure(singed_obj) || ismachinery(singed_obj)) // don't ignite furniture even if it's flammable, leave that to actual fires
 			return
 		if(singed_obj.resistance_flags & FLAMMABLE && !(singed_obj.resistance_flags & ON_FIRE)) //only fire_act flammable objects instead of burning EVERYTHING
 			if(isitem(singed_obj))
 				var/obj/item/singed_item = singed_obj
 				var/ignite_chance = 120 // base chance applies to anything under WEIGHT_CLASS_NORMAL, so burn everything flammable that's small/tiny
-				ignite_chance = ignite_chance - (singed_item.w_class > WEIGHT_CLASS_SMALL ? (singed_item.w_class * 2 + round(singed_item.w_class * 0.5)) : 0) // 50% normal size, 20% bulky, no chance to ignite bigger items
+				if(singed_item.w_class > WEIGHT_CLASS_SMALL)
+					var/ignite_chance_penalty = (singed_item.w_class * 2 + round(singed_item.w_class * 0.5)) * 10 // size penalties to ignite chance: normal = 70, bulky = 100,
+					ignite_chance -= ignite_chance_penalty // the bigger the item, the less likely it is to ignite
 				if(prob(ignite_chance))
-					singed_item.fire_act(1,100)
+					singed_item.fire_act(FIRE_MINIMUM_TEMPERATURE_TO_SPREAD,100)
+				return
 			else
-				singed_obj.fire_act(1,100)
-		if(singed_obj.reagents)
-			var/datum/reagents/reagents = singed_obj.reagents
-			reagents?.expose_temperature(1000)
-		return
+				singed_obj.fire_act(FIRE_MINIMUM_TEMPERATURE_TO_SPREAD,100)
+				return
 	if(isliving(singed))
 		var/mob/living/singed_living = singed
 		if(singed_living.fire_stacks)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -74,10 +74,10 @@
 
 	if(isobj(singed))
 		var/obj/singed_obj = singed
+		if(isstructure(singed_obj)) // don't ignite furniture even if it's flammable; we can leave that to actual fires
+			return
 		if(singed_obj.resistance_flags & FLAMMABLE && !(singed_obj.resistance_flags & ON_FIRE)) //only fire_act flammable objects instead of burning EVERYTHING
-			if(isstructure(singed_obj)) // don't ignite furniture even if it's flammable; we can leave that to actual fires
-				return
-			else if(isitem(singed_obj))
+			if(isitem(singed_obj))
 				var/obj/item/singed_item = singed_obj
 				var/ignite_chance = 120 // base chance applies to anything under WEIGHT_CLASS_NORMAL, so burn everything flammable that's small/tiny
 				ignite_chance = ignite_chance - (singed_item.w_class > WEIGHT_CLASS_SMALL ? (singed_item.w_class * 2 + round(singed_item.w_class * 0.5)) : 0) // 50% normal size, 20% bulky, no chance to ignite bigger items

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -132,6 +132,7 @@
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, FIRE, 0)
 	if(!(resistance_flags & ON_FIRE) && (resistance_flags & FLAMMABLE) && !(resistance_flags & FIRE_PROOF))
 		AddComponent(/datum/component/burning, custom_fire_overlay || GLOB.fire_overlay, burning_particles)
+		SEND_SIGNAL(src, COMSIG_ATOM_FIRE_ACT, exposed_temperature, exposed_volume)
 		return TRUE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Even though it's hilarious, sparks currently ignite any flammable thing they touch whatsoever; including gigantic wooden/cloth items, or tables and chairs. Turning areas with wooden furnitures into fields of ash wasn't the intent, so I adjusted sparks to not ignite furniture (you can put welding fuel under them if that's your intent) and items bigger than small items have a steadily decreasing chance to get ignited by sparks (normal is 50%, bulky is 20%, bigger than bulky won't ignite only from sparks)
## Why It's Good For The Game

Even in a death trap space station of the future, sparks aren't THAT much of a fire hazard.
## Changelog
:cl:
fix: Sparks will no longer turn areas with wooden furniture or similar into naught but a field of ashes; they no longer ignite furniture, (unless it's made of plasma(?!)) and have a decreasing chance to ignite items bigger than small size.
/:cl:
