### PR TITLE
Compact Compressor UI

### DIFF
--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -321,10 +321,6 @@
 	data["transferRate"] = transfer_rate
 	data["lastPressure"] = last_recorded_pressure
 
-	data["inputData"] = gas_mixture_parser(airs[2], "Input Port")
-	data["outputData"] = gas_mixture_parser(airs[1], "Ouput Port")
-	data["bufferData"] = gas_mixture_parser(leaked_gas_buffer, "Gas Buffer")
-
 	data["disk"] = inserted_disk?.name
 	data["storage"] = "[inserted_disk?.used_capacity] / [inserted_disk?.max_capacity] GQ"
 	data["records"] = list()

--- a/tgui/packages/tgui/interfaces/TankCompressor.jsx
+++ b/tgui/packages/tgui/interfaces/TankCompressor.jsx
@@ -108,8 +108,6 @@ const TankCompressorControls = (props) => {
         {!usingLastData && pressure >= fragmentPressure && (
           <NoticeBox danger>Explosive Hazard</NoticeBox>
         )}
-      </Section>
-      <Section>
         <LabeledControls px={2}>
           <LabeledControls.Item label="Pressure">
             <RoundGauge

--- a/tgui/packages/tgui/interfaces/TankCompressor.jsx
+++ b/tgui/packages/tgui/interfaces/TankCompressor.jsx
@@ -250,7 +250,7 @@ const TankCompressorRecords = (props) => {
               <LabeledList.Item label="Actions">
                 <Button
                   icon="floppy-disk"
-                  content="Save to disk"
+                  content="Save to Disk"
                   disabled={!disk}
                   tooltip="Save the record selected to an inserted data disk."
                   tooltipPosition="bottom"

--- a/tgui/packages/tgui/interfaces/TankCompressor.tsx
+++ b/tgui/packages/tgui/interfaces/TankCompressor.tsx
@@ -67,12 +67,9 @@ export const TankCompressor = (props) => {
 const TankCompressorContent = (props) => {
   const { act, data } = useBackend<Data>();
   const { disk, storage } = data;
-  const [currentTab, changeTab] = useSharedState('compressorTab', 1);
 
   return (
     <Stack vertical fill>
-      {currentTab === 1 && <TankCompressorControls />}
-      {currentTab === 2 && <TankCompressorRecords />}
       <Stack.Item grow>
         <Section
           scrollable
@@ -135,6 +132,7 @@ const TankCompressorControls = (props) => {
             : pressure < fragmentPressure
               ? 'Leak Hazard'
               : 'Explosive Hazard';
+
   return (
     <Stack.Item>
       <Section


### PR DESCRIPTION
## About The Pull Request

Made the tank compressor UI more compact, removing the data on gas mixes.

## Before:

![image](https://github.com/tgstation/tgstation/assets/3625094/cd857de3-6c92-46f7-9eee-9a4a801421fb)

## After:

![image](https://github.com/tgstation/tgstation/assets/3625094/51f09447-c6e8-4ac2-ac60-c2d4821adaff)

## Why It's Good For The Game

The old UI was overcomplicated, the gas mixes can be analyzed with gas analyzer.

## Changelog

:cl:
refactor: Compressor UI to TypeScript
qol: Simplified Compressor UI layout
/:cl:
