### PR TITLE
Halves(ish) the energy bola slowdown

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -523,6 +523,7 @@
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
 	breakouttime = 2 SECONDS // Cyborgs shouldn't have a strong restraint
+	slowdown = 3
 
 /obj/item/restraints/legcuffs/bola
 	name = "bola"


### PR DESCRIPTION
## About The Pull Request

This halves the slowdown incurred by the energy bola, and by extension, the "cyborg energy bear trap" that this item is inexplicably tied to.

Before:

![slow ass](https://github.com/tgstation/tgstation/assets/28870487/b715a711-1257-432e-b808-af78036e8589)

After:

![halved](https://github.com/tgstation/tgstation/assets/28870487/e8af6dcd-04f0-4531-ac73-0ad1b8fad725)

Unrestrained (Control):

![no problem](https://github.com/tgstation/tgstation/assets/28870487/d2fbe055-6e7a-4959-ac7e-dc9b37a8da92)
## Why It's Good For The Game

The energy bola is a very important part of the security kit. It's available at roundstart and complements very well with a baton to the face. The slowdown, however, is too extreme. Extreme to the point that anyone hit by one of these is at too far of a disadvantage to even properly fight back.

Summarily, if you get hit by one of these, and if you don't have a teleport on-hand, you're cooked. Not even a firearm will save you. They're uncatchable, unblockable, and work on prone targets.

Reducing the slowdown, in my opinion, enables it to be a tool used for preventing a criminal from evading you, rather than completely crippling them. It's not the final say in a combat encounter, but rather you forcing that person to stand and fight (at a fair disadvantage) instead of continuing to run away.
## Changelog
:cl: Rhials
balance: The energy bola slowdown has been (roughly) halved, to allow for more retaliation when used on a criminal.
/:cl:
