### PR TITLE
Fix bodytype bitflag check for prosthetic repair

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -368,7 +368,7 @@
 
 /mob/living/carbon/human/proc/item_heal(mob/user, brute_heal, burn_heal, heal_message_brute, heal_message_burn, required_bodytype)
 	var/obj/item/bodypart/affecting = src.get_bodypart(check_zone(user.zone_selected))
-	if (!affecting || !(affecting.bodytype == required_bodytype))
+	if (!affecting || !(affecting.bodytype & required_bodytype))
 		to_chat(user, span_warning("[affecting] is already in good condition!"))
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request
bodytype is a bitflag, and can have multiple biotypes selected. Shouldn't use equality comparisons for bitflags.
## Changelog
:cl:
fix: limbs that are both robotic and something else can be repaired properly
/:cl:
