### PR TITLE
Ashwalkers now start out in their proper faction; Lavaland mobs also have this if ashwalkers don't attack them

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	icon_state = "tendril"
 
-	faction = list(FACTION_MINING)
+	faction = list(FACTION_MINING, FACTION_ASHWALKER)
 	max_mobs = 3
 	max_integrity = 250
 	mob_types = list(/mob/living/basic/mining/watcher)

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -28,10 +28,14 @@
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, PROC_REF(on_examinate))
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
+	if(FACTION_NEUTRAL in owner.current.faction)
+		owner.current.faction.Remove(FACTION_NEUTRAL) // ashwalkers aren't neutral; they're ashwalker-aligned
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()
 	UnregisterSignal(owner.current, COMSIG_MOB_EXAMINATE)
+	if(!(FACTION_NEUTRAL in owner.current.faction))
+		owner.current.faction.Add(FACTION_NEUTRAL)
 
 /datum/antagonist/ashwalker/proc/on_examinate(datum/source, atom/A)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -5,7 +5,7 @@
 	status_flags = NONE //don't inherit standard basicmob flags
 	mob_size = MOB_SIZE_LARGE
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	faction = list(FACTION_MINING)
+	faction = list(FACTION_MINING, FACTION_ASHWALKER)
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
 	maximum_survivable_temperature = INFINITY
@@ -42,3 +42,11 @@
 			drop_mod = crusher_drop_chance,\
 			drop_immediately = basic_mob_flags & DEL_ON_DEATH,\
 		)
+	RegisterSignal(src, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(check_ashwalker_peace_violation))
+
+/mob/living/basic/mining/proc/check_ashwalker_peace_violation(datum/source, mob/living/carbon/human/possible_ashwalker)
+	SIGNAL_HANDLER
+
+	if(!isashwalker(possible_ashwalker) || !(FACTION_ASHWALKER in faction))
+		return
+	faction.Remove(FACTION_ASHWALKER)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -159,6 +159,7 @@ Lizard subspecies: ASHWALKERS
 		TRAIT_VIRUSIMMUNE,
 		TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION,
 	)
+	inherent_factions = list(FACTION_ASHWALKER)
 	species_language_holder = /datum/language_holder/lizard/ash
 	digitigrade_customization = DIGITIGRADE_FORCED
 	examine_limb_id = SPECIES_LIZARD


### PR DESCRIPTION

## About The Pull Request

Ashwalkers and the various denizens of lavaland are meant to be offshoots of whatever horrible gestalt consciousness encourages the growth of necropolis tendrils. As such, I made some changes to their factions and faction logic; ashwalkers are now in their own faction instead of FACTION_NEUTRAL (this seems like a fix); as well, lavaland mobs besides raptors now also have FACTION_ASHWALKER alongside FACTION_MINING; they will be on the same side as ashwalkers as long as ashwalkers don't attack them.

As a result, ashwalkers are a more serious threat to miners if they manage to flee into a crowd of legion, goliath, watchers, or what-have you. But by the same token, if ashwalkers take to attacking the mobs in order to feed their nest, it'll be the current behavior, where the mobs attack the ashwalkers on sight.

This has no effect on the megafauna of the area. They still have their own set of factions, and they are NOT allied with ashwalkers.

As a result of this, ashwalkers who tame pets can order these pets to attack people/things in the neutral faction, which will probably primarily be miners, unless a method for them to attack the station is introduced down the line.
## Why It's Good For The Game

Ashwalkers and lavaland fauna are meant to be part of the same loose entity that's creating the tendrils and all the other messed up shit going on down there. Ashwalkers are still sentient, however, and can choose to break away from this connection to feed their own nest.

This change brings their mechanics in line with the lore, and also makes them a slightly more serious threat to miners; miners are still likely to dogwalk them after that tipping point of points where they have 12 lux pens and a PKA with a full set of mods.
## Changelog
:cl: Bisar
add: Ashwalkers now start out allied to lavaland fauna (except for raptors). Attacking the fauna will break this alliance with the attacked beast and any who witness it.
fix: Ashwalkers are now actually in the ashwalker faction, instead of the neutral one.
/:cl:
