### PR TITLE
Two atmos related if statement fixes

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -102,9 +102,9 @@
 /obj/machinery/portable_atmospherics/canister/examine(user)
 	. = ..()
 	if(atom_integrity < max_integrity)
-		. += span_notice("The cracks could be repaired with a [EXAMINE_HINT("welding tool")].")
+		. . += span_notice("Integrity compromised, repair hull with a welding tool.")
 	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(temp_limit, "K", 0)]</b>.")
-	. += span_notice("The hull could be cut apart with a [EXAMINE_HINT("welding tool")].")
+	. += span_notice("The hull is <b>welded</b> together and can be cut apart.")
 	if(internal_cell)
 		. += span_notice("The internal cell has [internal_cell.percent()]% of its total charge.")
 	else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -109,7 +109,7 @@
 		. += span_notice("Warning, no cell installed, use a screwdriver to open the hatch and insert one.")
 	if(panel_open)
 		. += span_notice("Hatch open, close it with a screwdriver.")
-	if(integrity_failure)
+	if(atom_integrity < max_integrity)
 		. += span_notice("Integrity compromised, repair hull with a welding tool.")
 
 // Please keep the canister types sorted

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -102,7 +102,7 @@
 /obj/machinery/portable_atmospherics/canister/examine(user)
 	. = ..()
 	if(atom_integrity < max_integrity)
-		. . += span_notice("Integrity compromised, repair hull with a welding tool.")
+		. += span_notice("Integrity compromised, repair hull with a welding tool.")
 	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(temp_limit, "K", 0)]</b>.")
 	. += span_notice("The hull is <b>welded</b> together and can be cut apart.")
 	if(internal_cell)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -104,7 +104,7 @@
 	if(atom_integrity < max_integrity)
 		. += span_notice("The cracks could be repaired with a [EXAMINE_HINT("welding tool")].")
 	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(temp_limit, "K", 0)]</b>.")
-	. += span_notice("The cracks could be cut apart with a [EXAMINE_HINT("welding tool")].")
+	. += span_notice("The hull could be cut apart with a [EXAMINE_HINT("welding tool")].")
 	if(internal_cell)
 		. += span_notice("The internal cell has [internal_cell.percent()]% of its total charge.")
 	else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -104,7 +104,7 @@
 	if(atom_integrity < max_integrity)
 		. += span_notice("The cracks could be repaired with a [EXAMINE_HINT("welding tool")].")
 	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(temp_limit, "K", 0)]</b>.")
-	. += span_notice("The hull is <b>welded</b> together and can be cut apart.")
+	. += span_notice("The cracks could be cut apart with a [EXAMINE_HINT("welding tool")].")
 	if(internal_cell)
 		. += span_notice("The internal cell has [internal_cell.percent()]% of its total charge.")
 	else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -101,6 +101,8 @@
 
 /obj/machinery/portable_atmospherics/canister/examine(user)
 	. = ..()
+	if(atom_integrity < max_integrity)
+		. += span_notice("The cracks could be repaired with a [EXAMINE_HINT("welding tool")].")
 	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(temp_limit, "K", 0)]</b>.")
 	. += span_notice("The hull is <b>welded</b> together and can be cut apart.")
 	if(internal_cell)
@@ -109,8 +111,6 @@
 		. += span_notice("Warning, no cell installed, use a screwdriver to open the hatch and insert one.")
 	if(panel_open)
 		. += span_notice("Hatch open, close it with a screwdriver.")
-	if(atom_integrity < max_integrity)
-		. += span_notice("The cracks could be [EXAMINE_HINT("welded")] together.")
 
 // Please keep the canister types sorted
 // Basic canister per gas below here

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -110,7 +110,7 @@
 	if(panel_open)
 		. += span_notice("Hatch open, close it with a screwdriver.")
 	if(atom_integrity < max_integrity)
-		. += span_notice("Integrity compromised, repair hull with a welding tool.")
+		. += span_notice("The cracks could be [EXAMINE_HINT("welded")] together.")
 
 // Please keep the canister types sorted
 // Basic canister per gas below here

--- a/code/modules/power/supermatter/supermatter_gas.dm
+++ b/code/modules/power/supermatter/supermatter_gas.dm
@@ -216,7 +216,7 @@ GLOBAL_LIST_INIT(sm_gas_behavior, init_sm_gas())
 	desc = "Will generate electrical zaps."
 
 /datum/sm_gas/zauker/extra_effects(obj/machinery/power/supermatter_crystal/sm)
-	if(!prob(sm.gas_percentage[/datum/gas/zauker]))
+	if(!prob(sm.gas_percentage[/datum/gas/zauker] * 100))
 		return
 	playsound(sm.loc, 'sound/weapons/emitter2.ogg', 100, TRUE, extrarange = 10)
 	sm.supermatter_zap(


### PR DESCRIPTION
## About The Pull Request
Fixes two if statements.
## Why It's Good For The Game
Canisters are no longer falsely said to be compromised when they have zero damage.
![canisterfix](https://github.com/tgstation/tgstation/assets/98193039/d78c328e-32fa-4a72-b17d-9a08799e4c68)


The reaction of zauker in the Supermatter has been broken for ages. Things working correctly is good. (gas_percentage scales from 0 to 1 and prob() expects a number from 0-100)
## Changelog
:cl: Chestlet
fix: Nanotrasen sent us a batch of faulty canisters. They've been recalled and replaced with less faulty canisters.
fix: Zauker SM interaction works correctly now.
/:cl:
