### PR TITLE
reduces the price for most livestock crates

### DIFF
--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -43,7 +43,7 @@
 /datum/supply_pack/imports/duct_spider
 	name = "Duct Spider Crate"
 	desc = "Awww! Straight from the Australicus sector to your station's ventilation system!"
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/basic/spider/maintenance)
 	crate_name = "duct spider crate"
 	crate_type = /obj/structure/closet/crate/critter
@@ -52,7 +52,7 @@
 /datum/supply_pack/imports/duct_spider/dangerous
 	name = "Duct Spider Crate?"
 	desc = "Wait, is this the right crate? It has a frowny face, what does that mean?"
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/basic/spider/giant/hunter)
 	contraband = TRUE
 

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -97,7 +97,7 @@
 /datum/supply_pack/critter/pony
 	name = "Pony Crate"
 	desc = "Ponies, yay! (Just the one.)"
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/mob/living/basic/pony)
 	crate_name = "pony crate"
 

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -124,7 +124,7 @@
 	name = "Exotic Corgi Crate"
 	desc = "Corgi fit for a king, this corgi comes in a unique color to signify their superiority. \
 		Comes with a cute collar!"
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/mob/living/basic/pet/dog/corgi/exoticcorgi,
 					/obj/item/clothing/neck/petcollar,
 				)

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -5,7 +5,7 @@
 /datum/supply_pack/critter/parrot
 	name = "Bird Crate"
 	desc = "Contains five expert telecommunication birds."
-	cost = CARGO_CRATE_VALUE * 8
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/basic/parrot)
 	crate_name = "parrot crate"
 
@@ -30,7 +30,7 @@
 /datum/supply_pack/critter/cat
 	name = "Cat Crate"
 	desc = "The cat goes meow! Comes with a collar and a nice cat toy! Cheeseburger not included."//i can't believe im making this reference
-	cost = CARGO_CRATE_VALUE * 10 //Cats are worth as much as corgis.
+	cost = CARGO_CRATE_VALUE * 4 //Cats are worth as much as corgis.
 	contains = list(
 		/mob/living/basic/pet/cat,
 		/obj/item/clothing/neck/petcollar,
@@ -51,7 +51,7 @@
 /datum/supply_pack/critter/chick
 	name = "Chicken Crate"
 	desc = "The chicken goes bwaak!"
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/mob/living/basic/chick)
 	crate_name = "chicken crate"
 
@@ -59,7 +59,7 @@
 	name = "Corgi Crate"
 	desc = "Considered the optimal dog breed by thousands of research scientists, this Corgi is but \
 		one dog from the millions of Ian's noble bloodline. Comes with a cute collar!"
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/basic/pet/dog/corgi,
 					/obj/item/clothing/neck/petcollar,
 				)
@@ -76,28 +76,28 @@
 /datum/supply_pack/critter/cow
 	name = "Cow Crate"
 	desc = "The cow goes moo! Contains one cow."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/mob/living/basic/cow)
 	crate_name = "cow crate"
 
 /datum/supply_pack/critter/sheep
 	name = "Sheep Crate"
 	desc = "The sheep goes BAAAA! Contains one sheep."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/mob/living/basic/sheep)
 	crate_name = "sheep crate"
 
 /datum/supply_pack/critter/pig
 	name = "Pig Crate"
 	desc = "The pig goes oink! Contains one pig."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/mob/living/basic/pig)
 	crate_name = "pig crate"
 
 /datum/supply_pack/critter/pony
 	name = "Pony Crate"
 	desc = "Ponies, yay! (Just the one.)"
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/mob/living/basic/pony)
 	crate_name = "pony crate"
 
@@ -124,7 +124,7 @@
 	name = "Exotic Corgi Crate"
 	desc = "Corgi fit for a king, this corgi comes in a unique color to signify their superiority. \
 		Comes with a cute collar!"
-	cost = CARGO_CRATE_VALUE * 11
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/mob/living/basic/pet/dog/corgi/exoticcorgi,
 					/obj/item/clothing/neck/petcollar,
 				)
@@ -133,7 +133,7 @@
 /datum/supply_pack/critter/fox
 	name = "Fox Crate"
 	desc = "The fox goes...? Contains one fox. Comes with a collar!"//what does the fox say
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(
 		/mob/living/basic/pet/fox,
 		/obj/item/clothing/neck/petcollar,
@@ -143,14 +143,14 @@
 /datum/supply_pack/critter/goat
 	name = "Goat Crate"
 	desc = "The goat goes baa! Contains one goat. Warranty void if used as a replacement for Pete."
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/mob/living/basic/goat)
 	crate_name = "goat crate"
 
 /datum/supply_pack/critter/rabbit
 	name = "Rabbit Crate"
 	desc = "What noise do rabbits even make? Contains one rabbit."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/mob/living/basic/rabbit)
 	crate_name = "rabbit crate"
 
@@ -158,7 +158,7 @@
 	name = "Mothroach Crate"
 	desc = "Put the mothroach on your head and find out what true cuteness looks like. \
 		Contains one mothroach."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/mob/living/basic/mothroach)
 	crate_name = "mothroach crate"
 
@@ -173,7 +173,7 @@
 /datum/supply_pack/critter/pug
 	name = "Pug Crate"
 	desc = "Like a normal dog, but... squished. Contains one pug. Comes with a nice collar!"
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/basic/pet/dog/pug,
 					/obj/item/clothing/neck/petcollar,
 				)
@@ -183,7 +183,7 @@
 	name = "Bull Terrier Crate"
 	desc = "Like a normal dog, but with a head the shape of an egg. Contains one bull terrier. \
 		Comes with a nice collar!"
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/basic/pet/dog/bullterrier,
 					/obj/item/clothing/neck/petcollar,
 				)
@@ -193,7 +193,7 @@
 	name = "Snake Crate"
 	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? \
 		Then this isn't the crate for you. Contains three venomous snakes."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/mob/living/basic/snake = 3)
 	crate_name = "snake crate"
 
@@ -201,7 +201,7 @@
 	name = "Amphibian Friends Crate"
 	desc = "Two disgustingly cute slimey friends. Cytologists love them! \
 		Contains one frog and one axolotl. Warning: Frog may have hallucinogenic properties."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(
 		/mob/living/basic/axolotl,
 		/mob/living/basic/frog,
@@ -211,7 +211,7 @@
 /datum/supply_pack/critter/lizard
 	name = "Lizard Crate"
 	desc = "Hisss! Containssss a friendly lizard. Not to be confusssed with a lizardperssson."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/mob/living/basic/lizard)
 	crate_name = "lizard crate"
 
@@ -219,7 +219,7 @@
 	name = "Garden Gnome Crate"
 	desc = "Collect them all for your garden. Comes with three!"
 	hidden = TRUE
-	cost = CARGO_CRATE_VALUE * 20
+	cost = CARGO_CRATE_VALUE * 15
 	contains = list(/mob/living/basic/garden_gnome)
 	crate_name = "garden gnome crate"
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE


### PR DESCRIPTION
## About The Pull Request

this ones always been itching at the back of my head, mainly because i'm greedy, and you should be too, animals in cargo are hardcore expensive, 2000 credits for a cat? 800 credits per single chicken? 1200 per pig? obscene! this PR lowers the costs across the board with some exceptions, which i'll note here: 

crab rockets remain the same price as they were, you get 50 crabs PER rocket, thats ALOT of crabs per cubic inch, what would you do with so many? i don't know, but its why they're remaining expensive, at 1600 per rocket.


butterfly crates also retain their original price, as you also get 50 butterflies per crate purchased, at a cost of 1000 credits for a crate of 50, i think this is fair.


monkey cubes, truth be told this one i'm kinda scratching my head on, they're remaining the same price right now due to how accessible they are from other avenues (xenobiology, botany both public and private), but i'm willing to change their price to accommodate if they seem to be needing a price reduction, but overall i think that theres alot of ways to accrue them so them remaining particularly expensive isn't necessarily a bad thing. 


one part of this PR that bothered me was that i couldn't figure out how to display gnomes on either the cargo console or the express console, but they also have been price slashed, down from 4000 credits per 3 gnomes to 3000 credits per 3 gnomes, overall a 25% decrease in cost, think of all the mystical forest friends you can have for that price!

EDIT: i forgot about duct spiders, whoopsy me, they aren't in the livestock crates tab and are considered imports instead, so it slipped my mind completely, they are down from 1200 credits to 800, still moderately expensive, but still a discount nonetheless.


heres two pictures displaying the before-the-price decrease values, and the after-the-price- decrease values: 

BEFORE 
![Screenshot 2024-06-19 002027](https://github.com/tgstation/tgstation/assets/120208006/d0d5925d-d489-41e0-8345-e22fbd5cdd09)

  AFTER
![Screenshot 2024-06-19 005017](https://github.com/tgstation/tgstation/assets/120208006/824c28e1-2103-4cf1-ab77-077a845318e1)

i'll gladly edit or change any prices that seem way too low, and provide what i believe are reasonable answers for all of them, and i'd gladly love feedback from anyone on whether or not they think somethings too low, or still too high.


## Why It's Good For The Game

buying animals from cargo is generally a very difficult think to pull off for mass gimmicks due to the difficulty of accruing wealth crew-side in the jobs that would more than likely attempt to participate in such gimmicks (assistants, for one) so i think cutting their prices will not only help people actually be able to realize their gimmicks in round, but also drum up more cash for cargo, as you can now reasonably buy multiple animals without immediately going bankrupt and having to farm exorbitant amounts of money that you probably won't be able to make within the scope of an average round without some truly exotic methods, i think this will improve the cashflow for the livestocks tab, while also healthily promoting peoples funny little critter gimmicks.

## Changelog

:cl:
balance: most livestock crates, with some exception, have been made cheaper to facilitate healthier mental states in the crew, go build a farm!
/:cl:


