### PR TITLE
Send signal on help intent checks before handling fire

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -284,11 +284,11 @@
 		Knockdown(stun_duration)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/helper)
-	if(on_fire)
-		to_chat(helper, span_warning("You can't put [p_them()] out with just your bare hands!"))
+	if(SEND_SIGNAL(src, COMSIG_CARBON_PRE_MISC_HELP, helper) & COMPONENT_BLOCK_MISC_HELP)
 		return
 
-	if(SEND_SIGNAL(src, COMSIG_CARBON_PRE_MISC_HELP, helper) & COMPONENT_BLOCK_MISC_HELP)
+	if(on_fire)
+		to_chat(helper, span_warning("You can't put [p_them()] out with just your bare hands!"))
 		return
 
 	if(helper == src)


### PR DESCRIPTION
## About The Pull Request

Noticed this when doing work downstream - `help_shake_act` dies on the `on_fire` check before it fires the signal, meaning that any signal-related help intent behavior related to fire can basically never be written. Very simple rearrangement to fix this.

Hopefully should be little player facing result.

## Why It's Good For The Game

Allows for better, less spaghetti-code handling of fire-related behaviors using signals instead of horrific overrides or drop-in edits.
