### PR TITLE
Fix chem reaction spawning issue

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -345,6 +345,7 @@
 
 /datum/chemical_reaction/medicine/medsuture
 	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 20, /datum/reagent/medicine/polypyr = 15) //This might be a bit much, reagent cost should be reviewed after implementation.
+	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE
 
 /datum/chemical_reaction/medicine/medsuture/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
@@ -354,6 +355,7 @@
 
 /datum/chemical_reaction/medicine/medmesh
 	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BURN
 
 /datum/chemical_reaction/medicine/medmesh/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
@@ -363,6 +365,7 @@
 
 /datum/chemical_reaction/medicine/poultice
 	required_reagents = list(/datum/reagent/toxin/bungotoxin = 20, /datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20)
+	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN
 
 /datum/chemical_reaction/medicine/poultice/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)


### PR DESCRIPTION
## About The Pull Request

Adds the instant reaction flag to the recipes for medicated sutures, advanced regenerative mesh, and mourning poultice. 

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/84128.

Full disclosure, I don't really know why this works, I kinda just copied SyncIt21's solution from https://github.com/tgstation/tgstation/pull/83354, and it worked locally without any runtimes.

Edit :  I've updated the linked issue with a better explanation of the bug.

## Changelog

:cl:
fix: Medicated suture, advanced regenerative mesh, and mourning poultice reactions should more consistently spawn the items they are meant to produce.
/:cl:
