### PR TITLE
Bounty Hunters have personalized arrival announcements

### DIFF
--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -152,35 +152,35 @@
 					header = "Spawn Here!",
 				)
 
-	var/announcement_text = ""
+	var/list/announcement_text_list = list()
 	var/announcement_title = ""
 	switch(backstory)
 		if(HUNTER_PACK_COPS)
-			announcement_text += "Attention Crew of [GLOB.station_name], this is the Police. A wanted criminal has been reported taking refuge on your station."
-			announcement_text += " We have a warrant from the SSC authorities to take them into custody. Officers have been dispatched to your location."
-			announcement_text += " We demand your cooperation in bringing this criminal to justice."
+			announcement_text_list += "Attention Crew of [GLOB.station_name], this is the Police. A wanted criminal has been reported taking refuge on your station."
+			announcement_text_list += "We have a warrant from the SSC authorities to take them into custody. Officers have been dispatched to your location."
+			announcement_text_list += "We demand your cooperation in bringing this criminal to justice."
 			announcement_title += "Spacepol Command"
 		if(HUNTER_PACK_RUSSIAN)
-			announcement_text += "Zdraviya zhelaju, [GLOB.station_name] crew. We are coming to your station."
-			announcement_text += " There is a criminal aboard. We will arrest them and return them to the gulag. That's good, yes?"
+			announcement_text_list += "Zdraviya zhelaju, [GLOB.station_name] crew. We are coming to your station."
+			announcement_text_list += "There is a criminal aboard. We will arrest them and return them to the gulag. That's good, yes?"
 			announcement_title += "Russian Freighter"
 		if(HUNTER_PACK_BOUNTY)
-			announcement_text += "[GLOB.station_name]. One of our bounty marks has ended up on your station. We will be arriving to collect shortly."
-			announcement_text += " Let's make this quick. If you don't want trouble, stay the hell out of our way."
+			announcement_text_list += "[GLOB.station_name]. One of our bounty marks has ended up on your station. We will be arriving to collect shortly."
+			announcement_text_list += "Let's make this quick. If you don't want trouble, stay the hell out of our way."
 			announcement_title += "Unregistered Signal"
 		if(HUNTER_PACK_PSYKER)
-			announcement_text += "HEY, CAN YOU HEAR US? We're coming to your station. There's a bad guy down there, really bad guy. We need to arrest them."
-			announcement_text += " We're also offering fortune telling services out from the front door, if you have paying customers."
+			announcement_text_list += "HEY, CAN YOU HEAR US? We're coming to your station. There's a bad guy down there, really bad guy. We need to arrest them."
+			announcement_text_list += "We're also offering fortune telling services out from the front door, if you have paying customers."
 			announcement_title += "Fortune-Telling Entertainment Shuttle"
 
-	if(!length(announcement_text))
-		announcement_text += "Unidentified ship detected near the station."
+	if(!length(announcement_text_list))
+		announcement_text_list += "Unidentified ship detected near the station."
 		stack_trace("Fugitive hunter announcement was unable to generate an announcement text based on backstory: [backstory]")
 
 	if(!length(announcement_title))
 		announcement_title += "Unknown Signal"
 		stack_trace("Fugitive hunter announcement was unable to generate an announcement title based on backstory: [backstory]")
 
-	priority_announce(announcement_text, announcement_title)
+	priority_announce(jointext(announcement_text_list, " "), announcement_title)
 
 #undef TEAM_BACKSTORY_SIZE

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -152,6 +152,35 @@
 					header = "Spawn Here!",
 				)
 
-	priority_announce("Unidentified ship detected near the station.")
+	var/announcement_text = ""
+	var/announcement_title = ""
+	switch(backstory)
+		if(HUNTER_PACK_COPS)
+			announcement_text += "Attention Crew of [GLOB.station_name], this is the Police. A wanted criminal has been reported taking refuge on your station."
+			announcement_text += " We have a warrant from the SSC authorities to take them into custody. Officers have been dispatched to your location."
+			announcement_text += " We demand your cooperation in bringing this criminal to justice."
+			announcement_title += "Spacepol Command"
+		if(HUNTER_PACK_RUSSIAN)
+			announcement_text += "Zdraviya zhelaju, [GLOB.station_name] crew. We are coming to your station."
+			announcement_text += " There is a criminal aboard. We will arrest them and return them to the gulag. That's good, yes?"
+			announcement_title += "Russian Freighter"
+		if(HUNTER_PACK_BOUNTY)
+			announcement_text += "[GLOB.station_name]. One of our bounty marks has ended up on your station. We will be arriving to collect shortly."
+			announcement_text += " Let's make this quick. If you don't want trouble, stay the hell out of our way."
+			announcement_title += "Unregistered Signal"
+		if(HUNTER_PACK_PSYKER)
+			announcement_text += "HEY, CAN YOU HEAR US? We're coming to your station. There's a bad guy down there, really bad guy. We need to arrest them."
+			announcement_text += " We're also offering fortune telling services out from the front door, if you have paying customers."
+			announcement_title += "Fortune-Telling Entertainment Shuttle"
+
+	if(!length(announcement_text))
+		announcement_text += "Unidentified ship detected near the station."
+		stack_trace("Fugitive hunter announcement was unable to generate an announcement text based on backstory: [backstory]")
+
+	if(!length(announcement_title))
+		announcement_title += "Unknown Signal"
+		stack_trace("Fugitive hunter announcement was unable to generate an announcement title based on backstory: [backstory]")
+
+	priority_announce(announcement_text, announcement_title)
 
 #undef TEAM_BACKSTORY_SIZE

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -170,7 +170,7 @@
 			announcement_title += "Unregistered Signal"
 		if(HUNTER_PACK_PSYKER)
 			announcement_text_list += "HEY, CAN YOU HEAR US? We're coming to your station. There's a bad guy down there, really bad guy. We need to arrest them."
-			announcement_text_list += "We're also offering fortune telling services out from the front door, if you have paying customers."
+			announcement_text_list += "We're also offering fortune telling services out of the front door if you have paying customers."
 			announcement_title += "Fortune-Telling Entertainment Shuttle"
 
 	if(!length(announcement_text_list))


### PR DESCRIPTION

## About The Pull Request

Fugitive Hunters now have a personalized message for when they arrive, replacing the generic "Unidentified ship detected near the station" message.

Spacepol:

![image](https://github.com/tgstation/tgstation/assets/28870487/d00fef5b-f2eb-4dea-baa6-f102546b11b9)

Russians:

![image](https://github.com/tgstation/tgstation/assets/28870487/74aa6f82-5741-4bc8-81be-18da75d35697)

Bounty Hunters:

![image](https://github.com/tgstation/tgstation/assets/28870487/015d4741-5367-4d98-8e10-de513c4654ce)

Psykers:

![image](https://github.com/tgstation/tgstation/assets/28870487/23754b72-7932-42d6-a3d8-2335e7238c0d)

I swear, someday I'll datumize these backstories like we did for pirates. Maybe after this PR is resolved.
## Why It's Good For The Game

Added flavor is nice. It also gives the crew a cue on how to react to the hunters, seeing as some hunters are received far more cooperatively than others (looking at you, SpacePol).

The generic message used to be a fakeout for pirates, but now that THEY have personalized messages, it doesn't really need to be like that anymore.
## Changelog
:cl:
add: Bounty Hunter teams now have personalized announcements for when they are spawned in.
/:cl:
