### PR TITLE
Light eater can eat all lights again

### DIFF
--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -34,7 +34,7 @@
 /datum/element/light_eater/Detach(datum/source)
 	UnregisterSignal(source, list(
 		COMSIG_MOVABLE_IMPACT,
-		COMSIG_ITEM_AFTERATTACK,
+		COMSIG_ITEM_INTERACTING_WITH_ATOM,
 		COMSIG_ITEM_HIT_REACT,
 		COMSIG_PROJECTILE_ON_HIT,
 		COMSIG_REAGENT_EXPOSE_ATOM,
@@ -118,13 +118,12 @@
 	return NONE
 
 /**
- * Called when a target is attacked with a source item
+ * Called when a target is interacted with by a source item
  *
  * Arguments:
  * - [source][/obj/item]: The item what was used to strike the target
- * - [target][/atom]: The atom being struck by the user with the source
  * - [user][/mob/living]: The mob using the source to strike the target
- * - proximity: Whether the strike was in melee range so you can't eat lights from cameras
+ * - [target][/atom]: The atom being struck by the user with the source
  */
 /datum/element/light_eater/proc/on_interacting_with(obj/item/source, mob/living/user, atom/target)
 	SIGNAL_HANDLER

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -18,7 +18,7 @@
 			if(isitem(target))
 				if(isgun(target))
 					RegisterSignal(target, COMSIG_PROJECTILE_ON_HIT, PROC_REF(on_projectile_hit))
-				RegisterSignal(target, COMSIG_ITEM_AFTERATTACK, PROC_REF(on_afterattack))
+				RegisterSignal(target, COMSIG_ITEM_INTERACTING_WITH_ATOM, PROC_REF(on_interacting_with))
 				RegisterSignal(target, COMSIG_ITEM_HIT_REACT, PROC_REF(on_hit_reaction))
 			else if(isprojectile(target))
 				RegisterSignal(target, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(on_projectile_self_hit))
@@ -126,7 +126,7 @@
  * - [user][/mob/living]: The mob using the source to strike the target
  * - proximity: Whether the strike was in melee range so you can't eat lights from cameras
  */
-/datum/element/light_eater/proc/on_afterattack(obj/item/source, atom/target, mob/living/user)
+/datum/element/light_eater/proc/on_interacting_with(obj/item/source, mob/living/user, atom/target)
 	SIGNAL_HANDLER
 	eat_lights(target, source)
 


### PR DESCRIPTION

## About The Pull Request

The light eater was working off of afterattack instead of interaction for a lot of its light eating; now it works off interaction. Incidentally, there was a 3 year old proc not being called when it broke fixtures that gets called now; it turns out it's supposed to turn the bulbs in light fixtures to ash.
## Why It's Good For The Game

Light eater was hungry, it gets to eat lights again
Fixes #84065 
## Changelog
:cl: Bisar
fix: The light eater can now again eat lights from things with lights.
/:cl:
