### PR TITLE
Felinids no longer get negative moodlets roundstart about their tail

### DIFF
--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -23,10 +23,11 @@
 /obj/item/organ/external/tail/Insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()
 	if(.)
-		original_owner ||= WEAKREF(receiver)
-
 		receiver.clear_mood_event("tail_lost")
 		receiver.clear_mood_event("tail_balance_lost")
+
+	if(!special) // if some admin wants to give someone tail moodles for tail shenanigans, they can spawn it and do it by hand
+		original_owner ||= WEAKREF(receiver)
 
 		// If it's your tail, an infinite debuff is replaced with a timed one
 		// If it's not your tail but of same species, I guess it works, but we are more sad


### PR DESCRIPTION

## About The Pull Request

Felinids receive their tail during creation of their character; the code wasn't accounting for special cases like this and always giving them negative mood events when they received a tail, even if they hadn't lost it yet. This no longer happens.
## Why It's Good For The Game

Nanotrasen re-education programs guarantee memory loss for felinid employees from the Tail Wars of 2277, and this bring the code in line with that.
Fixes #84048 
## Changelog
:cl: Bisar
fix: Felinids no longer remember losing their tail and regaining it roundstart; you need to do it during the round to get that mood event.
/:cl:
