### PR TITLE
[no gbp] Food as a generic isn't flammable

### DIFF
--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -2,7 +2,6 @@
 /obj/item/food
 	name = "food"
 	desc = "you eat this"
-	resistance_flags = FLAMMABLE
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = null


### PR DESCRIPTION

## About The Pull Request

Every single food item is marked as flammable, when it really shouldn't be. If someone wants to go through and mark really dry foods as flammable that would make sense but anything edible being a fire hazard doesn't.
## Why It's Good For The Game

Food isn't universally flammable.
Addresses an unintended side effect mentioned in #84169 
## Changelog
:cl:
balance: Every single edible item is no longer flammable under any circumstance.
/:cl:
