### PR TITLE
Brings back breathing nitrium randomly making you burp

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -540,6 +540,10 @@
 // Breath in nitrium. It's helpful, but has nasty side effects
 /obj/item/organ/internal/lungs/proc/too_much_nitrium(mob/living/carbon/breather, datum/gas_mixture/breath, nitrium_pp, old_nitrium_pp)
 	breathe_gas_volume(breath, /datum/gas/nitrium)
+
+	if(prob(20))
+		breather.emote("burp")
+
 	// Random chance to inflict side effects increases with pressure.
 	if((prob(nitrium_pp) && (nitrium_pp > 15)))
 		// Nitrium side-effect.


### PR DESCRIPTION

## About The Pull Request
Before it got combined into nitrium, breathing nitryl had a chance to make you burp every time you breathed it in. This PR adds this back to nitrium.
## Why It's Good For The Game
Drugged up atmos techs constantly burping is the peak of soul how was this ever removed
## Changelog
:cl:
add: Breathing nitrium now has a chance to make you burp.
/:cl:
