### PR TITLE
Adds a fake emag emag act

### DIFF
--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -68,10 +68,11 @@
 /obj/item/card/emagfake/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
 		return
-	obj_flags |= EMAGGED
-	balloon_alert(user, "rigged")
 	playsound(src, SFX_SPARKS, 50, TRUE, SILENCED_SOUND_EXTRARANGE)
 	desc = /obj/item/card/emag::desc
+	obj_flags |= EMAGGED
+	if(user)
+		balloon_alert(user, "rigged")
 
 /obj/item/card/emag/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -52,6 +52,7 @@
 	if(exploding)
 		playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE, frequency = 2)
 	else if(obj_flags & EMAGGED)
+		log_bomber(user, "triggered", src, "(rigged/emagged)")
 		visible_message(span_boldwarning("[src] begins to heat up!"))
 		playsound(src, 'sound/items/bikehorn.ogg', 100, TRUE, frequency = 0.25)
 		addtimer(CALLBACK(src, PROC_REF(blow_up)), 1 SECONDS, TIMER_DELETE_ME)
@@ -67,12 +68,14 @@
 
 /obj/item/card/emagfake/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
-		return
+		return FALSE
 	playsound(src, SFX_SPARKS, 50, TRUE, SILENCED_SOUND_EXTRARANGE)
 	desc = /obj/item/card/emag::desc
 	obj_flags |= EMAGGED
 	if(user)
-		balloon_alert(user, "rigged")
+		balloon_alert(user, "rigged to blow")
+		log_bomber(user, "rigged to blow", src, "(emagging)")
+	return TRUE
 
 /obj/item/card/emag/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -34,11 +34,14 @@
 	icon_state = "hack_o_lantern"
 
 /obj/item/card/emagfake
-	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a \"Donk Co.\" logo stamped on the back."
-	name = "cryptographic sequencer"
-	icon_state = "emag"
+	name = /obj/item/card/emag::name
+	desc = /obj/item/card/emag::desc + " Closer inspection shows that this card is a poorly made replica, with a \"Donk Co.\" logo stamped on the back."
+	icon = /obj/item/card/emag::icon
+	icon_state = /obj/item/card/emag::icon_state
+	worn_icon_state = /obj/item/card/emag::worn_icon_state
 	slot_flags = ITEM_SLOT_ID
-	worn_icon_state = "emag"
+	/// Whether we are exploding
+	var/exploding = FALSE
 
 /obj/item/card/emagfake/attack_self(mob/user) //for assistants with balls of plasteel
 	if(Adjacent(user))
@@ -46,8 +49,29 @@
 	add_fingerprint(user)
 
 /obj/item/card/emagfake/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
-	playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE)
+	if(exploding)
+		playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE, frequency = 2)
+	else if(obj_flags & EMAGGED)
+		visible_message(span_boldwarning("[src] begins to heat up!"))
+		playsound(src, 'sound/items/bikehorn.ogg', 100, TRUE, frequency = 0.25)
+		addtimer(CALLBACK(src, PROC_REF(blow_up)), 1 SECONDS, TIMER_DELETE_ME)
+		exploding = TRUE
+	else
+		playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE)
 	return ITEM_INTERACT_SKIP_TO_ATTACK // So it does the attack animation.
+
+/obj/item/card/emagfake/proc/blow_up()
+	visible_message(span_boldwarning("[src] explodes!"))
+	explosion(src, light_impact_range = 1, explosion_cause = src)
+	qdel(src)
+
+/obj/item/card/emagfake/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	balloon_alert(user, "rigged")
+	playsound(src, SFX_SPARKS, 50, TRUE, SILENCED_SOUND_EXTRARANGE)
+	desc = /obj/item/card/emag::desc
 
 /obj/item/card/emag/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Inspired by #84154 and a discord post someone made

You can emag a fake emag, this removes the "`This card is a poorly made replica`" part of the description (IE, makes it look real) 

Additionally when you use an emagged fake emag (which looks like a real emag) it explodes after 1 second

## Why It's Good For The Game

I thought it was conceptually a very funny way to trick people

## Changelog

:cl: Melbert
add: Adds an effect for emagging a fake emag
/:cl:

