### PR TITLE
Fixes smartfridge unpowered check

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -302,6 +302,10 @@
 				to_chat(user, span_warning("There is nothing in [weapon] to put in [src]!"))
 				return FALSE
 
+	if(!powered())
+		to_chat(user, span_warning("\The [src]'s magnetic door won't open without power!"))
+		return FALSE
+
 	if(!user.combat_mode)
 		to_chat(user, span_warning("\The [src] smartly refuses [weapon]."))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Fixes the smartfridge to give a relevant failure message when items can't be added due to power loss.

## Changelog

:cl: LT3
fix: Smartfridge will now correctly respond 'no power' instead of 'forbidden item' when it doesn't have power
/:cl: