### PR TITLE
Fix touch spells not having click CD (and misc small things)

### DIFF
--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -191,7 +191,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /// Checks if the passed victim can be cast on by the caster.
-/datum/action/cooldown/spell/touch/proc/can_hit_with_hand(atom/victim, mob/caster)
+/datum/action/cooldown/spell/touch/proc/can_hit_with_hand(atom/victim, mob/living/caster)
 	if(!can_cast_on_self && victim == caster)
 		return FALSE
 	if(!is_valid_target(victim))

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -198,6 +198,9 @@
 		return FALSE
 	if(!can_cast_spell(feedback = TRUE))
 		return FALSE
+	if(!(caster.mobility_flags & MOBILITY_USE))
+		caster.balloon_alert(caster, "can't reach out!")
+		return TRUE
 
 	return TRUE
 
@@ -222,6 +225,8 @@
 	log_combat(caster, victim, "cast the touch spell [name] on", hand)
 	spell_feedback(caster)
 	caster.do_attack_animation(victim)
+	caster.changeNext_move(CLICK_CD_MELEE)
+	victim.add_fingerprint(caster)
 	remove_hand(caster)
 
 /**
@@ -240,6 +245,8 @@
 			log_combat(caster, victim, "cast the touch spell [name] on", hand, "(secondary / alt cast)")
 			spell_feedback(caster)
 			caster.do_attack_animation(victim)
+			caster.changeNext_move(CLICK_CD_MELEE)
+			victim.add_fingerprint(caster)
 			remove_hand(caster)
 
 		// Call normal will call the normal cast proc
@@ -345,14 +352,6 @@
 
 	if(spell)
 		spell_which_made_us = WEAKREF(spell)
-
-/obj/item/melee/touch_attack/attack(mob/target, mob/living/carbon/user)
-	if(!iscarbon(user)) //Look ma, no hands
-		return TRUE
-	if(!(user.mobility_flags & MOBILITY_USE))
-		user.balloon_alert(user, "can't reach out!")
-		return TRUE
-	return ..()
 
 /**
  * When the hand component of a touch spell is qdel'd, (the hand is dropped or otherwise lost),

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -200,7 +200,7 @@
 		return FALSE
 	if(!(caster.mobility_flags & MOBILITY_USE))
 		caster.balloon_alert(caster, "can't reach out!")
-		return TRUE
+		return FALSE
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

My fault for forgetting about these in the PR I merged

Given `attack` is what gives you the attack click CD, not going into attack = no click cd. Kinda bad

We're also missing a few other things from attack so let's throw them back in

## Changelog

:cl: Melbert
fix: Touch Spells now apply click CD again
fix: Touch Spells now apply fingerprints again
fix: Touch Spells now check if your hands are blocked again
/:cl:


