### PR TITLE
Fixes some objects not being pulled with ctrl-click

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
@@ -61,7 +61,8 @@ GLOBAL_LIST_EMPTY_TYPED(bluespace_senders, /obj/machinery/atmospherics/component
 
 /obj/machinery/atmospherics/components/unary/bluespace_sender/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Turn [on ? "off" : "on"]"
+	if(anchored && !panel_open && is_operational)
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Turn [on ? "off" : "on"]"
 	if(!held_item)
 		return CONTEXTUAL_SCREENTIP_SET
 	switch(held_item.tool_behaviour)
@@ -156,7 +157,7 @@ GLOBAL_LIST_EMPTY_TYPED(bluespace_senders, /obj/machinery/atmospherics/component
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 		update_appearance()
 		return CLICK_ACTION_SUCCESS
-	return CLICK_ACTION_BLOCKING
+	return NONE
 
 /obj/machinery/atmospherics/components/unary/bluespace_sender/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1088,11 +1088,11 @@
 			user.examinate(src)
 
 /obj/machinery/hydroponics/click_ctrl(mob/user)
+	if(!anchored)
+		return NONE
 	if(!powered())
 		to_chat(user, span_warning("[name] has no power."))
 		update_use_power(NO_POWER_USE)
-		return CLICK_ACTION_BLOCKING
-	if(!anchored)
 		return CLICK_ACTION_BLOCKING
 	set_self_sustaining(!self_sustaining)
 	to_chat(user, span_notice("You [self_sustaining ? "activate" : "deactivated"] [src]'s autogrow function[self_sustaining ? ", maintaining the tray's health while using high amounts of power" : ""]."))


### PR DESCRIPTION
## About The Pull Request
Fix for a bug where using ctrl-click to try to pull the bluespace gas sender and hydroponics tray isn't working. Seems to be broken since the ctrl-click refactor.

Fixes #84222
## Changelog
:cl:
fix: Fixed ctrl-click not dragging the bluespace gas sender or hydroponics trays.
/:cl:
