### PR TITLE
Fixes runtime with out of bounds hitscan projectiles

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -930,6 +930,8 @@
 		trajectory.increment(trajectory_multiplier)
 		var/turf/T = trajectory.return_turf()
 		if(!istype(T))
+			// step back to the last valid turf before we Destroy
+			trajectory.increment(-trajectory_multiplier)
 			qdel(src)
 			return
 		if(T.z != loc.z)


### PR DESCRIPTION

## About The Pull Request
When projectiles cross into an invalid turf (like crossing out of the bounds of the map), they are automatically qdel'd. If the projectile is hitscanning, the `Destroy()` will call `finalize_hitscan_and_generate_tracers()`. The projectile's `trajectory`, which points to the invalid turf that caused the deletion in the first place, is passed as the `ending_atom` of `get_line()`, which returns a list of turfs between the shooter and the point (turf) of termination. 

Since the ending turf is by necessity null at this point, a runtime occurs. Instead, we decrement the trajectory back a step (`-trajectory_multiplier`) so that it's pointing at a valid turf on `Destroy()`.


## Why It's Good For The Game
We experienced this runtime on Paradise a lot and the log spam got kind of annoying. Since it's the same system, I figured I would PR it upstream as well.
