### PR TITLE
[no gbp] Reworked sparks to not be so immensely destructive in benign circumstances

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -133,3 +133,7 @@
 #define COMSIG_ATOM_PRE_CLEAN "atom_pre_clean"
 	///cancel clean
 	#define COMSIG_ATOM_CANCEL_CLEAN (1<<0)
+
+/// From /obj/effect/particle_effect/sparks/proc/sparks_touched(datum/source, atom/movable/singed)
+#define COMSIG_ATOM_TOUCHED_SPARKS "atom_touched_sparks"
+#define COMSIG_ATOM_TOUCHED_HAZARDOUS_SPARKS "atom_touched_hazardous_sparks"

--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -13,6 +13,7 @@
 
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(attackby_react))
 	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, PROC_REF(flame_react))
+	RegisterSignal(parent, COMSIG_ATOM_TOUCHED_SPARKS, PROC_REF(sparks_react))
 	RegisterSignal(parent, COMSIG_ATOM_BULLET_ACT, PROC_REF(projectile_react))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), PROC_REF(welder_react))
 	if(isturf(parent))
@@ -61,6 +62,13 @@
 
 	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		flood(null, exposed_temperature)
+
+/// sparks_touched reaction.
+/datum/component/combustible_flooder/proc/sparks_react(datum/source, obj/effect/particle_effect/sparks/sparks)
+	SIGNAL_HANDLER
+
+	if(sparks) // this shouldn't ever be false but existence is mysterious
+		flood(null, FIRE_MINIMUM_TEMPERATURE_TO_SPREAD)
 
 /// Hotspot reaction.
 /datum/component/combustible_flooder/proc/hotspots_react(datum/source, air, exposed_temperature)

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -136,6 +136,18 @@
 	/// Type of mob light emitter we use when on fire
 	var/moblight_type = /obj/effect/dummy/lighting_obj/moblight/fire
 
+/datum/status_effect/fire_handler/fire_stacks/proc/owner_touched_sparks()
+	SIGNAL_HANDLER
+
+	ignite()
+
+/datum/status_effect/fire_handler/fire_stacks/on_creation(mob/living/new_owner, new_stacks, forced = FALSE)
+	. = ..()
+	RegisterSignal(owner, COMSIG_ATOM_TOUCHED_SPARKS, PROC_REF(owner_touched_sparks))
+
+/datum/status_effect/fire_handler/fire_stacks/on_remove()
+	UnregisterSignal(owner, COMSIG_ATOM_TOUCHED_SPARKS)
+
 /datum/status_effect/fire_handler/fire_stacks/tick(seconds_between_ticks)
 	if(stacks <= 0)
 		qdel(src)

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -458,6 +458,7 @@
 		COMSIG_TURF_MOVABLE_THROW_LANDED = PROC_REF(ignition_trigger),
 	)
 	AddElement(/datum/element/connect_loc, ignition_trigger_connections)
+	RegisterSignal(src, COMSIG_ATOM_TOUCHED_SPARKS, PROC_REF(ignition_trigger))
 	for(var/obj/effect/decal/cleanable/fuel_pool/pool in get_turf(src)) //Can't use locate because we also belong to that turf
 		if(pool == src)
 			continue
@@ -532,6 +533,8 @@
 		var/mob/living/enflamed_liver = enflammable_atom
 		if(enflamed_liver.on_fire)
 			ignite()
+	else if(istype(enflammable_atom, /obj/effect/particle_effect/sparks))
+		ignite()
 
 
 /obj/effect/decal/cleanable/fuel_pool/hivis

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -57,6 +57,7 @@
 */
 /obj/effect/particle_effect/sparks/proc/affect_location(turf/location, just_initialized = FALSE)
 	location.hotspot_expose(1000,100)
+	SEND_SIGNAL(location, COMSIG_ATOM_TOUCHED_SPARKS, src) // for plasma floors; other floor types only have to worry about the mysterious HAZARDOUS sparks
 	if(just_initialized)
 		for(var/atom/movable/singed in location)
 			sparks_touched(src, singed)
@@ -67,42 +68,26 @@
 * This is invoked by the signals sent by every atom when they're crossed or crossing something. It
 * signifies that something has been touched by sparks, and should be affected by possible pyrotechnic affects..
 * datum/source - Can either be the spark itself or an object that just walked into it
-* mob/living/singed_mob - The mob that was touched by the spark
+* mob/living/singed - What was touched by the spark
 */
-/obj/effect/particle_effect/sparks/proc/sparks_touched(datum/source, atom/movable/singed)
+/obj/effect/particle_effect/sparks/proc/sparks_touched(datum/source, atom/singed)
 	SIGNAL_HANDLER
 
+	SEND_SIGNAL(singed, COMSIG_ATOM_TOUCHED_SPARKS, src)
 	if(isobj(singed))
-		var/obj/singed_obj = singed
-		if(singed_obj.reagents)
-			var/datum/reagents/reagents = singed_obj.reagents // heat up things that contain reagents before we check to see if they burn
+		if(singed.reagents)
+			var/datum/reagents/reagents = singed.reagents // heat up things that contain reagents before we check to see if they burn
 			reagents?.expose_temperature(1000) // we set this at 1000 because that's the max reagent temp for a chem heater, higher temps require more than sparks
-		if(singed_obj.custom_materials && (GET_MATERIAL_REF(/datum/material/plasma) in singed_obj.custom_materials))
-			singed_obj.fire_act(FIRE_MINIMUM_TEMPERATURE_TO_SPREAD,100)
-			return // if it's made of plasma we just start burning no matter what, even furniture (see right below)
-		if(isstructure(singed_obj) || ismachinery(singed_obj)) // don't ignite furniture even if it's flammable, leave that to actual fires
-			return
-		if(singed_obj.resistance_flags & FLAMMABLE && !(singed_obj.resistance_flags & ON_FIRE)) //only fire_act flammable objects instead of burning EVERYTHING
-			if(isitem(singed_obj))
-				var/obj/item/singed_item = singed_obj
-				var/ignite_chance = 120 // base chance applies to anything under WEIGHT_CLASS_NORMAL, so burn everything flammable that's small/tiny
-				if(singed_item.w_class > WEIGHT_CLASS_SMALL)
-					var/ignite_chance_penalty = (singed_item.w_class * 2 + round(singed_item.w_class * 0.5)) * 10 // size penalties to ignite chance: normal = 70, bulky = 100,
-					ignite_chance -= ignite_chance_penalty // the bigger the item, the less likely it is to ignite
-				if(prob(ignite_chance))
-					singed_item.fire_act(FIRE_MINIMUM_TEMPERATURE_TO_SPREAD,100)
-				return
-			else
-				singed_obj.fire_act(FIRE_MINIMUM_TEMPERATURE_TO_SPREAD,100)
-				return
-	if(isliving(singed))
-		var/mob/living/singed_living = singed
-		if(singed_living.fire_stacks)
-			singed_living.ignite_mob(FALSE) //ignite the mob, silent = FALSE (You're set on fire!)
 		return
+	if(ishuman(singed))
+		var/mob/living/carbon/human/singed_human = singed
+		for(var/obj/item/anything in singed_human.get_visible_items())
+			sparks_touched(src, anything)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks
+
+
 
 /datum/effect_system/spark_spread/quantum
 	effect_type = /obj/effect/particle_effect/sparks/quantum

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -189,6 +189,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		light()
 	AddComponent(/datum/component/knockoff, 90, list(BODY_ZONE_PRECISE_MOUTH), slot_flags) //90% to knock off when wearing a mask
 	AddElement(/datum/element/update_icon_updates_onmob)
+	RegisterSignal(src, COMSIG_ATOM_TOUCHED_SPARKS, PROC_REF(sparks_touched))
 	icon_state = icon_off
 	inhand_icon_state = inhand_icon_off
 
@@ -305,6 +306,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else
 		icon_state = icon_off
 		inhand_icon_state = inhand_icon_off
+
+
+/obj/item/clothing/mask/cigarette/proc/sparks_touched(datum/source, obj/effect/particle_effect)
+	SIGNAL_HANDLER
+
+	if(lit)
+		return
+	light()
 
 /// Lights the cigarette with given flavor text.
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)


### PR DESCRIPTION
## About The Pull Request

So sparks were laying waste to every department that had sparks as a little pizzazz particle effect, which turned out to be seemingly every single department, and also just a bunch of random shit we had laying around. That wasn't really the goal so I've reworked them, for now, until I'm able to more comprehensively address how we handle things that are combustible vs things that are actually dangerously flammable, which we don't differentiate for now.

Sparks now send a signal to whatever thing is touching those sparks. Right now I've specifically made pools of welding fuel, things made of plasma, people covered in flammables, and cigarettes respond to this signal. Sparks that touch objects with reagents in them will heat those reagents marginally (approximately 40kelvin increase from 300 kelvin underneath a popped lightbulb). There is also another signal 'HAZARDOUS_SPARKS' but as of this PR it is not used.

If you walk into sparks or get showered by them, the sparks will also interact with any of your visible equipment (outerwear and held items), but to reiterate, nothing besides the above stated items have interactions with sparks... for now...
## Why It's Good For The Game

I won't apologize for being hilarious but turning departments into fields of burnt boxes, tables, vegetables, and crates wasn't really the intent.
Addresses #84169 and similar
## Changelog
:cl: Bisar
balance: Sparks have been heavily adjusted; they only affect items made of plasma, pools of welding fuel, flammable people, cigarettes, and items that contain reagents... for now. Their long-standing behavior of igniting flammable gas has been untouched.
/:cl:
