### PR TITLE
Fixes non-sensical attack messages for certain mobs

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -460,7 +460,8 @@
 	var/message_verb_simple = length(I.attack_verb_simple) ? "[pick(I.attack_verb_simple)]" : "attack"
 	var/message_hit_area = ""
 	if(hit_area)
-		message_hit_area = " in the [hit_area]"
+		message_hit_area = get_hit_area_message(hit_area)
+
 	var/attack_message_spectator = "[src] [message_verb_continuous][message_hit_area] with [I]!"
 	var/attack_message_victim = "Something [message_verb_continuous] you[message_hit_area] with [I]!"
 	var/attack_message_attacker = "You [message_verb_simple] [src][message_hit_area] with [I]!"
@@ -475,3 +476,7 @@
 		to_chat(src, span_danger("Someone hits you[message_hit_area]!"))
 	to_chat(user, span_danger("[attack_message_attacker]"))
 	return 1
+
+/// Overridable proc so subtypes can have unique targetted strike zone messages
+/mob/living/proc/get_hit_area_message(input_area)
+	return " in the [input_area]"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -477,4 +477,8 @@
 
 /// Overridable proc so subtypes can have unique targetted strike zone messages, return a string.
 /mob/living/proc/get_hit_area_message(input_area)
-	return " in the [input_area]"
+	if(input_area)
+		return " in the [input_area]"
+
+	return ""
+

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -458,9 +458,7 @@
 		return
 	var/message_verb_continuous = length(I.attack_verb_continuous) ? "[pick(I.attack_verb_continuous)]" : "attacks"
 	var/message_verb_simple = length(I.attack_verb_simple) ? "[pick(I.attack_verb_simple)]" : "attack"
-	var/message_hit_area = ""
-	if(hit_area)
-		message_hit_area = get_hit_area_message(hit_area)
+	var/message_hit_area = get_hit_area_message(hit_area)
 
 	var/attack_message_spectator = "[src] [message_verb_continuous][message_hit_area] with [I]!"
 	var/attack_message_victim = "Something [message_verb_continuous] you[message_hit_area] with [I]!"
@@ -477,6 +475,6 @@
 	to_chat(user, span_danger("[attack_message_attacker]"))
 	return 1
 
-/// Overridable proc so subtypes can have unique targetted strike zone messages
+/// Overridable proc so subtypes can have unique targetted strike zone messages, return a string.
 /mob/living/proc/get_hit_area_message(input_area)
 	return " in the [input_area]"

--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -814,6 +814,11 @@ GLOBAL_LIST_INIT(command_strings, list(
 /mob/living/basic/bot/spawn_gibs(drop_bitflags = NONE)
 	new /obj/effect/gibspawner/robot(drop_location(), src)
 
+/mob/living/basic/bot/get_hit_area_message(input_area)
+	// we just get hit, there's no complexity for hitting an arm (if it exists) or anything.
+	// we also need to return an empty string as otherwise it would falsely say that we get hit in the chest or something strange like that (bots don't have "chests")
+	return ""
+
 /mob/living/basic/bot/proc/on_bot_movement(atom/movable/source, atom/oldloc, dir, forced)
 	return
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1215,3 +1215,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/spawn_gibs(drop_bitflags = NONE)
 	new /obj/effect/gibspawner/robot(drop_location(), src)
+
+/mob/living/simple_animal/bot/get_hit_area_message(input_area)
+	// we just get hit, there's no complexity for hitting an arm (if it exists) or anything.
+	// we also need to return an empty string as otherwise it would falsely say that we get hit in the chest or something strange like that (bots don't have "chests")
+	return ""


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/34697715/4d56fc5f-b50c-45ac-9be4-da86929fbb96)

There's a really long standing tradition in the code (at least 13 years old) that every mob should, at a base, be attacked in the chest. However, this can cause some strangeness for mobs that don't have chests (bots). Basically, what we do is we override this message so that bots don't get hit in the chest, because this proc will always require a zone input (and default input is the chest (and disentangling that will take more time that what I can afford)) so let's just hide the message to the user.

this is also a nice thing to just have in general because a hook into the strike zone portion of the item attack message can have some pretty nice effects (e.g. what if you want to add on a descriptor of the head, or say eye for a creature that only has a eye for a head, or whatever).
## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/34697715/f0c62ed8-2ca8-4f31-ba1c-77ba0aac8c9e)

Better hook for code improvement, less confusing code messages.
## Changelog
:cl:
fix: You should no longer attack mobs that don't have a chest in the chest (bots).
/:cl:
