### PR TITLE
Autopsy experiments available roundstart [NO GBP]

### DIFF
--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -27,6 +27,11 @@
 		"dropper",
 		"pillbottle",
 	)
+	experiments_to_unlock = list(
+		/datum/experiment/autopsy/human,
+		/datum/experiment/autopsy/nonhuman,
+		/datum/experiment/autopsy/xenomorph,
+	)
 
 /datum/techweb_node/chem_synthesis
 	id = "chem_synthesis"


### PR DESCRIPTION
## About The Pull Request

Made tecweb mark autopsy experiments as completed while the node with the experiments is not yet unlocked.

## Why It's Good For The Game

Oversight in my tech tree update.

## Changelog

:cl:
fix: Autopsy experiments for techweb can be performed roundstart
/:cl:
