### PR TITLE
Fixes deaf mobs hearing ship/area ambience

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(ambience)
 			client_old_areas -= client_iterator
 			continue
 
-		if(HAS_TRAIT(client_mob, TRAIT_DEAF)) //WHAT? I CAN'T HEAR YOU
+		if(!client_mob.can_hear()) //WHAT? I CAN'T HEAR YOU
 			continue
 
 		//Check to see if the client-mob is in a valid area

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -27,6 +27,9 @@ SUBSYSTEM_DEF(ambience)
 			client_old_areas -= client_iterator
 			continue
 
+		if(HAS_TRAIT(client_mob, TRAIT_DEAF)) //WHAT? I CAN'T HEAR YOU
+			continue
+
 		//Check to see if the client-mob is in a valid area
 		var/area/current_area = get_area(client_mob)
 		if(!current_area) //Something's gone horribly wrong

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -554,7 +554,11 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /mob/proc/refresh_looping_ambience()
 	var/area/my_area = get_area(src)
 
-	if(!(client?.prefs.read_preference(/datum/preference/toggle/sound_ship_ambience)) || !my_area.ambient_buzz)
+	if(!my_area.ambient_buzz || !(client?.prefs.read_preference(/datum/preference/toggle/sound_ship_ambience)))
+		SEND_SOUND(src, sound(null, repeat = 0, wait = 0, channel = CHANNEL_BUZZ))
+		return
+
+	if(HAS_TRAIT(src, TRAIT_DEAF))
 		SEND_SOUND(src, sound(null, repeat = 0, wait = 0, channel = CHANNEL_BUZZ))
 		return
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -552,17 +552,26 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 ///Tries to play looping ambience to the mobs.
 /mob/proc/refresh_looping_ambience()
+	if(!client) //if a tree falls in the woods...
+		return
 	var/area/my_area = get_area(src)
+	var/sound_to_use = my_area.ambient_buzz
 
-	if(!my_area.ambient_buzz || !(client?.prefs.read_preference(/datum/preference/toggle/sound_ship_ambience)))
+	if(!sound_to_use || !(client.prefs.read_preference(/datum/preference/toggle/sound_ship_ambience)))
 		SEND_SOUND(src, sound(null, repeat = 0, wait = 0, channel = CHANNEL_BUZZ))
+		client.current_ambient_sound = null
 		return
 
-	if(HAS_TRAIT(src, TRAIT_DEAF))
+	if(!can_hear())
 		SEND_SOUND(src, sound(null, repeat = 0, wait = 0, channel = CHANNEL_BUZZ))
+		client.current_ambient_sound = null
 		return
 
-	SEND_SOUND(src, sound(my_area.ambient_buzz, repeat = 1, wait = 0, volume = my_area.ambient_buzz_vol, channel = CHANNEL_BUZZ))
+	if(sound_to_use == client.current_ambient_sound)
+		return //don't reset current loops.
+
+	client.current_ambient_sound = sound_to_use
+	SEND_SOUND(src, sound(sound_to_use, repeat = 1, wait = 0, volume = my_area.ambient_buzz_vol, channel = CHANNEL_BUZZ))
 
 
 /**

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -268,3 +268,6 @@
 
 	/// Loot panel for the client
 	var/datum/lootpanel/loot_panel
+
+	///Which ambient sound this client is currently being provided.
+	var/current_ambient_sound

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -38,6 +38,9 @@
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_RESTRAINED), PROC_REF(on_restrained_trait_gain))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_RESTRAINED), PROC_REF(on_restrained_trait_loss))
 
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_DEAF), PROC_REF(on_hearing_loss))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_DEAF), PROC_REF(on_hearing_regain))
+
 	RegisterSignals(src, list(
 		SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION),
 		SIGNAL_REMOVETRAIT(TRAIT_CRITICAL_CONDITION),
@@ -272,3 +275,14 @@
 /mob/living/proc/undense_changed(datum/source)
 	SIGNAL_HANDLER
 	update_density()
+
+///Called when [TRAIT_DEAF] is added to the mob.
+/mob/living/proc/on_hearing_loss()
+	SIGNAL_HANDLER
+	refresh_looping_ambience()
+	stop_sound_channel(CHANNEL_AMBIENCE)
+
+///Called when [TRAIT_DEAF] is added to the mob.
+/mob/living/proc/on_hearing_regain()
+	SIGNAL_HANDLER
+	refresh_looping_ambience()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2277,6 +2277,10 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			REMOVE_TRAIT(src, TRAIT_CRITICAL_CONDITION, STAT_TRAIT)
 			remove_from_alive_mob_list()
 			add_to_dead_mob_list()
+	if(!can_hear())
+		stop_sound_channel(CHANNEL_AMBIENCE)
+	refresh_looping_ambience()
+
 
 
 ///Reports the event of the change in value of the buckled variable.

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -100,6 +100,8 @@
 	update_client_colour()
 	update_mouse_pointer()
 	refresh_looping_ambience()
+	if(!can_hear())
+		stop_sound_channel(CHANNEL_AMBIENCE)
 
 	if(client)
 		if(client.view_size)


### PR DESCRIPTION
Fixes #65618

:cl: ShizCalev
fix: Deafened mobs will no longer hear the station's ambient sounds.
fix: Fixed ambient sounds resetting their loop when entering different bodies (ie admin ghosting, being moved to other mobs, ect.)
/:cl:
