### PR TITLE
Icebox Head of Personnel's Request Console fix

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8257,7 +8257,10 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/west,
-/obj/machinery/requests_console/directional/west,
+/obj/machinery/requests_console/directional/west{
+	department = "Head of Personnel's Desk";
+	name = "Head of Personnel's Requests Console"
+	},
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,


### PR DESCRIPTION

## About The Pull Request

Previously, the HoP's request console on Icebox was unregistered to the HoP, that is, announcements made from it would show up as unknown announcements rather than announcements from the Head of Personnel. This fixes that.
## Why It's Good For The Game

Having things work as intended is good, actually
## Changelog
:cl:
fix: [IceBox] The Head of Personnel's Requests Console announcements now correctly display the HoP as the announcer, rather than "Unknown"
/:cl:
