### PR TITLE
Admin-only deadchat broadcasts don't repeat the "this is for admins only" message

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -331,6 +331,9 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 /proc/deadchat_broadcast(message, source=null, mob/follow_target=null, turf/turf_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR, admin_only=FALSE)
 	message = span_deadsay("[source][span_linkify(message)]")
 
+	if(admin_only)
+		message += span_deadsay(" (This is viewable to admins only).")
+
 	for(var/mob/M in GLOB.player_list)
 		var/chat_toggles = TOGGLES_DEFAULT_CHAT
 		var/toggles = TOGGLES_DEFAULT
@@ -340,11 +343,6 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 			chat_toggles = prefs.chat_toggles
 			toggles = prefs.toggles
 			ignoring = prefs.ignoring
-		if(admin_only)
-			if (!M.client?.holder)
-				return
-			else
-				message += span_deadsay(" (This is viewable to admins only).")
 		var/override = FALSE
 		if(M.client?.holder && (chat_toggles & CHAT_DEAD))
 			override = TRUE

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -343,6 +343,9 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 			chat_toggles = prefs.chat_toggles
 			toggles = prefs.toggles
 			ignoring = prefs.ignoring
+		if(admin_only)
+			if(!M.client?.holder)
+				continue
 		var/override = FALSE
 		if(M.client?.holder && (chat_toggles & CHAT_DEAD))
 			override = TRUE


### PR DESCRIPTION

## About The Pull Request

This makes it so that, when an admin-only deadchat broadcast is sent, it doesn't add the "this is for admins only" message for every admin in the server.
## Why It's Good For The Game

I saw this and it annoyed me and we can do this in a better way.
## Changelog
:cl: Rhials
fix: Admin-only deadchat broadcasts don't append a second "this message is for admins only" string for every admin online.
/:cl:
