### PR TITLE
fix bloody feetprints only going 1 tile

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -76,7 +76,7 @@
 ///lowers bloody_shoes[index] by adjust_by
 /datum/component/bloodysoles/proc/adjust_bloody_shoes(index, adjust_by)
 	bloody_shoes[index] = max(bloody_shoes[index] - adjust_by, 0)
-	on_changed_bloody_shoes()
+	on_changed_bloody_shoes(index)
 
 /datum/component/bloodysoles/proc/set_bloody_shoes(index, new_value)
 	bloody_shoes[index] = new_value


### PR DESCRIPTION
## About The Pull Request

if you pass nothing to `on_changed_bloody_shoes` it unregistered the signal that leaves the footprints

## Changelog

:cl: Melbert
fix: Bloody footprints now go until you run out of blood on your feet instead if only a single tile
/:cl:

