### PR TITLE
Modular computer startup program

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -33,7 +33,7 @@
 	var/list/datum/computer_file/stored_files = list()
 
 	///Non-static list of programs the computer should receive on Initialize.
-	var/list/datum/computer_file/starting_programs = list()
+	var/list/datum/computer_file/preinstalled_programs = list()
 	///Static list of default programs that come with ALL computers, here so computers don't have to repeat this.
 	var/static/list/datum/computer_file/default_programs = list(
 		/datum/computer_file/program/themeify,
@@ -171,7 +171,7 @@
 
 /obj/item/modular_computer/proc/install_default_programs()
 	SHOULD_CALL_PARENT(FALSE)
-	for(var/programs in default_programs + starting_programs)
+	for(var/programs in default_programs + preinstalled_programs)
 		var/datum/computer_file/program_type = new programs
 		store_file(program_type)
 
@@ -970,5 +970,5 @@
 	max_capacity = INFINITY
 
 /obj/item/modular_computer/debug/Initialize(mapload)
-	starting_programs += subtypesof(/datum/computer_file/program)
+	preinstalled_programs += subtypesof(/datum/computer_file/program)
 	return ..()

--- a/code/modules/modular_computers/computers/item/disks/computer_disk.dm
+++ b/code/modules/modular_computers/computers/item/disks/computer_disk.dm
@@ -12,11 +12,11 @@
 	var/list/datum/computer_file/stored_files = list()
 
 	///List of all programs that the disk should start with.
-	var/list/datum/computer_file/starting_programs = list()
+	var/list/datum/computer_file/preinstalled_programs = list()
 
 /obj/item/computer_disk/Initialize(mapload)
 	. = ..()
-	for(var/programs in starting_programs)
+	for(var/programs in preinstalled_programs)
 		var/datum/computer_file/program_type = new programs
 		add_file(program_type)
 

--- a/code/modules/modular_computers/computers/item/disks/maintenance_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/maintenance_disks.dm
@@ -4,24 +4,24 @@
 
 /// Medical health analyzer app
 /obj/item/computer_disk/maintenance/scanner
-	starting_programs = list(/datum/computer_file/program/maintenance/phys_scanner)
+	preinstalled_programs = list(/datum/computer_file/program/maintenance/phys_scanner)
 
 ///Camera app, forced to always have largest image size
 /obj/item/computer_disk/maintenance/camera
-	starting_programs = list(/datum/computer_file/program/maintenance/camera)
+	preinstalled_programs = list(/datum/computer_file/program/maintenance/camera)
 
 ///MODsuit UI, in your PDA!
 /obj/item/computer_disk/maintenance/modsuit_control
-	starting_programs = list(/datum/computer_file/program/maintenance/modsuit_control)
+	preinstalled_programs = list(/datum/computer_file/program/maintenance/modsuit_control)
 
 ///Returns A 'spookiness' value based on the number of ghastly creature and hauntium and their distance from the PC.
 /obj/item/computer_disk/maintenance/spectre_meter
-	starting_programs = list(/datum/computer_file/program/maintenance/spectre_meter)
+	preinstalled_programs = list(/datum/computer_file/program/maintenance/spectre_meter)
 
 ///A version of the arcade program with less HP/MP for the enemy and more for the player
 /obj/item/computer_disk/maintenance/arcade
-	starting_programs = list(/datum/computer_file/program/arcade/eazy)
+	preinstalled_programs = list(/datum/computer_file/program/arcade/eazy)
 
 /obj/item/computer_disk/maintenance/theme/Initialize(mapload)
-	starting_programs = list(pick(subtypesof(/datum/computer_file/program/maintenance/theme)))
+	preinstalled_programs = list(pick(subtypesof(/datum/computer_file/program/maintenance/theme)))
 	return ..()

--- a/code/modules/modular_computers/computers/item/disks/role_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/role_disks.dm
@@ -21,7 +21,7 @@
 	name = "captain data disk"
 	desc = "Removable disk used to download essential Captain tablet apps."
 	icon_state = "datadisk10"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/records/medical,
 	)
@@ -29,14 +29,14 @@
 /obj/item/computer_disk/command/cmo
 	name = "chief medical officer data disk"
 	desc = "Removable disk used to download essential CMO tablet apps."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 	)
 
 /obj/item/computer_disk/command/rd
 	name = "research director data disk"
 	desc = "Removable disk used to download essential RD tablet apps."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/signal_commander,
 	)
 
@@ -44,14 +44,14 @@
 	name = "head of security data disk"
 	desc = "Removable disk used to download essential HoS tablet apps."
 	icon_state = "datadisk9"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 	)
 
 /obj/item/computer_disk/command/hop
 	name = "head of personnel data disk"
 	desc = "Removable disk used to download essential HoP tablet apps."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/job_management,
 	)
@@ -59,7 +59,7 @@
 /obj/item/computer_disk/command/ce
 	name = "chief engineer data disk"
 	desc = "Removable disk used to download essential CE tablet apps."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/supermatter_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
@@ -72,7 +72,7 @@
 	name = "security officer data disk"
 	desc = "Removable disk used to download security-related tablet apps."
 	icon_state = "datadisk9"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/crew_manifest,
 	)
@@ -84,7 +84,7 @@
 	name = "medical doctor data disk"
 	desc = "Removable disk used to download medical-related tablet apps."
 	icon_state = "datadisk7"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 	)
 
@@ -95,7 +95,7 @@
 	name = "cargo data disk"
 	desc = "Removable disk used to download cargo-related tablet apps."
 	icon_state = "cargodisk"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/shipping,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/restock_tracker,
@@ -108,7 +108,7 @@
 	name = "ordnance data disk"
 	desc = "Removable disk used to download ordnance-related tablet apps."
 	icon_state = "datadisk5"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/signal_commander,
 		/datum/computer_file/program/scipaper_program,
 	)
@@ -120,7 +120,7 @@
 	name = "engineering data disk"
 	desc = "Removable disk used to download engineering-related tablet apps."
 	icon_state = "datadisk6"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/alarm_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/supermatter_monitor,

--- a/code/modules/modular_computers/computers/item/disks/unique_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/unique_disks.dm
@@ -5,10 +5,10 @@
 	custom_materials = list(/datum/material/gold = SMALL_MATERIAL_AMOUNT)
 
 /obj/item/computer_disk/syndicate/camera_app
-	starting_programs = list(/datum/computer_file/program/secureye/syndicate)
+	preinstalled_programs = list(/datum/computer_file/program/secureye/syndicate)
 
 /obj/item/computer_disk/syndicate/contractor
-	starting_programs = list(/datum/computer_file/program/contract_uplink)
+	preinstalled_programs = list(/datum/computer_file/program/contract_uplink)
 
 /obj/item/computer_disk/black_market
 	desc = "Removable disk used to store data. This one has a smudged piece of paper glued to it, reading \"PC softwarez\"."
@@ -32,7 +32,7 @@
 	for(var/i in 1 to rand(2, 4))
 		var/datum/computer_file/program/to_add = pick_n_take(potential_programs)
 		total_programs_size += initial(to_add.size)
-		starting_programs += to_add
+		preinstalled_programs += to_add
 	///Make sure the disk has enough space for all the programs
 	max_capacity = max(total_programs_size, max_capacity)
 	return ..()

--- a/code/modules/modular_computers/computers/item/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop_presets.dm
@@ -1,11 +1,11 @@
 /obj/item/modular_computer/laptop/preset/civilian
 	desc = "A low-end laptop often used for personal recreation."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 	)
 
 //Used for Mafia testing purposes.
 /obj/item/modular_computer/laptop/preset/mafia
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/mafia,
 	)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -63,7 +63,7 @@
 	var/list/apps_to_download = list()
 	if(has_pda_programs)
 		apps_to_download += default_programs + pda_programs
-	apps_to_download += starting_programs
+	apps_to_download += preinstalled_programs
 
 	for(var/programs as anything in apps_to_download)
 		var/datum/computer_file/program/program_type = new programs
@@ -254,7 +254,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#a80001#5C070F#000000"
 	long_ranged = TRUE
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/radar/fission360,
 	)
 
@@ -274,7 +274,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_double
 	greyscale_colors = "#696969#000000#FFA500"
 
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/contract_uplink,
 		/datum/computer_file/program/secureye/syndicate,
 	)
@@ -295,7 +295,7 @@
 	comp_light_luminosity = 0
 	inserted_item = null
 	has_pda_programs = FALSE
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/messenger,
 	)
 
@@ -307,7 +307,7 @@
 	var/mob/living/silicon/silicon_owner
 
 /obj/item/modular_computer/pda/silicon/cyborg
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/filemanager,
 		/datum/computer_file/program/robotact,
 	)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -5,7 +5,7 @@
 /obj/item/modular_computer/pda/heads
 	greyscale_config = /datum/greyscale_config/tablet/head
 	greyscale_colors = "#67A364#a92323"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
@@ -33,7 +33,7 @@
 	name = "head of personnel PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#374f7e#a52f29#a52f29"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
@@ -48,7 +48,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/head
 	greyscale_colors = "#EA3232#0000CC"
 	inserted_item = /obj/item/pen/red/security
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
@@ -61,7 +61,7 @@
 	name = "chief engineer PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#D99A2E#69DBF3#FAFAFA"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
@@ -76,7 +76,7 @@
 	name = "chief medical officer PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#FAFAFA#000099#3F96CC"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
@@ -91,7 +91,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#FAFAFA#000099#B347BC"
 	inserted_item = /obj/item/pen/fountain
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/borg_monitor,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/crew_manifest,
@@ -108,7 +108,7 @@
 	greyscale_colors = "#c4b787#18191e#8b4c31"
 	inserted_item = /obj/item/pen/survival
 	stored_paper = 20
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
@@ -126,7 +126,7 @@
 	name = "security PDA"
 	greyscale_colors = "#EA3232#0000cc"
 	inserted_item = /obj/item/pen/red/security
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
@@ -136,7 +136,7 @@
 	name = "detective PDA"
 	greyscale_colors = "#805A2F#990202"
 	inserted_item = /obj/item/pen/red/security
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
@@ -147,7 +147,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_double
 	greyscale_colors = "#EA3232#0000CC#363636"
 	inserted_item = /obj/item/pen/red/security
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
@@ -161,7 +161,7 @@
 	name = "engineering PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/alarm_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/supermatter_monitor,
@@ -171,7 +171,7 @@
 	name = "atmospherics PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#EEDC43#00E5DA#727272"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/alarm_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/supermatter_monitor,
@@ -185,7 +185,7 @@
 	name = "scientist PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#FAFAFA#000099#B347BC"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/scipaper_program,
@@ -196,7 +196,7 @@
 	name = "roboticist PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_double
 	greyscale_colors = "#484848#0099CC#D94927"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
 		/datum/computer_file/program/borg_monitor,
@@ -206,7 +206,7 @@
 	name = "geneticist PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_double
 	greyscale_colors = "#FAFAFA#000099#0097CA"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 	)
 
@@ -218,7 +218,7 @@
 	name = "medical PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#FAFAFA#000099#3F96CC"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/robocontrol,
 	)
@@ -227,7 +227,7 @@
 	name = "paramedic PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_double
 	greyscale_colors = "#28334D#000099#3F96CC"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/radar/lifeline,
 	)
@@ -241,7 +241,7 @@
 	name = "coroner PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#FAFAFA#000099#1f2026"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/crew_manifest,
 	)
@@ -254,7 +254,7 @@
 	name = "cargo technician PDA"
 	greyscale_colors = "#8b4c31#2c2e32"
 	stored_paper = 20
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/shipping,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/robocontrol,
@@ -265,14 +265,14 @@
 	name = "shaft miner PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#927444#8b4c31#4c202d"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/skill_tracker,
 	)
 
 /obj/item/modular_computer/pda/bitrunner
 	name = "bit runner PDA"
 	greyscale_colors = "#D6B328#6BC906"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/arcade,
 		/datum/computer_file/program/skill_tracker,
 	)
@@ -284,7 +284,7 @@
 /obj/item/modular_computer/pda/janitor
 	name = "janitor PDA"
 	greyscale_colors = "#933ea8#235AB2"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/skill_tracker,
 		/datum/computer_file/program/radar/custodial_locator,
 	)
@@ -298,7 +298,7 @@
 	name = "lawyer PDA"
 	greyscale_colors = "#4C76C8#FFE243"
 	inserted_item = /obj/item/pen/fountain
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 	)
 
@@ -370,7 +370,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/mime
 	greyscale_colors = "#FAFAFA#EA3232"
 	inserted_item = /obj/item/toy/crayon/mime
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/emojipedia,
 	)
 
@@ -388,7 +388,7 @@
 	icon_state = "pda-library"
 	inserted_item = /obj/item/pen/fountain
 	long_ranged = TRUE
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/emojipedia,
 		/datum/computer_file/program/newscaster,
 	)
@@ -402,7 +402,7 @@
 	name = "psychologist PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#333333#000099#3F96CC"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
@@ -413,14 +413,14 @@
  */
 /obj/item/modular_computer/pda/assistant
 	name = "assistant PDA"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/bounty_board,
 	)
 
 /obj/item/modular_computer/pda/bridge_assistant
 	name = "bridge assistant PDA"
 	greyscale_colors = "#374f7e#a92323"
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 	)
@@ -429,7 +429,7 @@
 	name = "security advisor PDA"
 	greyscale_colors = "#EA3232#FFD700"
 	inserted_item = /obj/item/pen/fountain
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/records/security,
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/coupon, //veteran discount
@@ -447,7 +447,7 @@
 	comp_light_luminosity = 0
 	inserted_item = null
 	has_pda_programs = FALSE
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/messenger,
 		/datum/computer_file/program/secureye/human_ai,
 		/datum/computer_file/program/alarm_monitor,

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -1,21 +1,38 @@
 /obj/machinery/modular_computer/preset
 	///List of programs the computer starts with, given on Initialize.
-	var/list/datum/computer_file/starting_programs = list()
+	var/list/datum/computer_file/preinstalled_programs = list()
+	///If set, computer will automatically boot and load this program
+	var/startup_program
 
 /obj/machinery/modular_computer/preset/Initialize(mapload)
 	. = ..()
 	if(!cpu)
 		return
 
-	for(var/programs in starting_programs)
+	for(var/programs in preinstalled_programs)
 		var/datum/computer_file/program_type = new programs
 		cpu.store_file(program_type)
+
+	if(!isnull(startup_program))
+		INVOKE_ASYNC(src, PROC_REF(run_startup_program))
+
+/// If a startup program is specified and exists on the modular computer, run it after init.
+/obj/machinery/modular_computer/preset/proc/run_startup_program()
+	if(isnull(startup_program))
+		CRASH("[src] was requested to run a program on startup, but none is set!")
+
+	var/datum/computer_file/program/startup_file = cpu.find_file_by_name(startup_program)
+	if(isnull(startup_file))
+		return
+
+	cpu.active_program = startup_file
+	cpu.turn_on()
 
 // ===== ENGINEERING CONSOLE =====
 /obj/machinery/modular_computer/preset/engineering
 	name = "engineering console"
 	desc = "A stationary computer. This one comes preloaded with engineering programs."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/power_monitor,
 		/datum/computer_file/program/alarm_monitor,
 		/datum/computer_file/program/supermatter_monitor,
@@ -25,7 +42,7 @@
 /obj/machinery/modular_computer/preset/research
 	name = "research director's console"
 	desc = "A stationary computer. This one comes preloaded with research programs."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/ntnetmonitor,
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/ai_restorer,
@@ -37,7 +54,7 @@
 /obj/machinery/modular_computer/preset/command
 	name = "command console"
 	desc = "A stationary computer. This one comes preloaded with command programs."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/card_mod,
 	)
@@ -46,12 +63,13 @@
 /obj/machinery/modular_computer/preset/id
 	name = "identification console"
 	desc = "A stationary computer. This one comes preloaded with identification modification programs."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/job_management,
 		/datum/computer_file/program/crew_manifest,
 	)
+	startup_program = "plexagonidwriter"
 
 /obj/machinery/modular_computer/preset/id/centcom
 	desc = "A stationary computer. This one comes preloaded with CentCom identification modification programs."
@@ -65,7 +83,7 @@
 /obj/machinery/modular_computer/preset/civilian
 	name = "civilian console"
 	desc = "A stationary computer. This one comes preloaded with generic programs."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/arcade,
 	)
@@ -74,7 +92,7 @@
 /obj/machinery/modular_computer/preset/curator
 	name = "curator console"
 	desc = "A stationary computer. This one comes preloaded with art programs."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/portrait_printer,
 	)
 
@@ -82,7 +100,7 @@
 /obj/machinery/modular_computer/preset/cargochat
 	name = "cargo interfacing console"
 	desc = "A stationary computer that comes pre-loaded with software to interface with the cargo department."
-	starting_programs = list(
+	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 	)
 	/// What department type is assigned to this console?
@@ -98,7 +116,7 @@
 		cpu.name = name
 
 /obj/machinery/modular_computer/preset/cargochat/proc/add_starting_software()
-	starting_programs += /datum/computer_file/program/department_order
+	preinstalled_programs += /datum/computer_file/program/department_order
 
 /obj/machinery/modular_computer/preset/cargochat/proc/setup_starting_software()
 	if(!department_type)
@@ -134,10 +152,10 @@
 	desc = "A stationary computer that comes pre-loaded with software to interface with incoming departmental cargo requests."
 
 /obj/machinery/modular_computer/preset/cargochat/cargo/add_starting_software()
-	starting_programs += /datum/computer_file/program/bounty_board
-	starting_programs += /datum/computer_file/program/budgetorders
-	starting_programs += /datum/computer_file/program/shipping
-	starting_programs += /datum/computer_file/program/restock_tracker
+	preinstalled_programs += /datum/computer_file/program/bounty_board
+	preinstalled_programs += /datum/computer_file/program/budgetorders
+	preinstalled_programs += /datum/computer_file/program/shipping
+	preinstalled_programs += /datum/computer_file/program/restock_tracker
 
 /obj/machinery/modular_computer/preset/cargochat/cargo/setup_starting_software()
 	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -119,7 +119,7 @@
 	if(!department_type)
 		return
 
-	var/datum/computer_file/program/department_order/orderprogram = cpu.active_program
+	var/datum/computer_file/program/department_order/orderprogram = cpu.find_file_by_name("dept_order")
 	orderprogram.set_linked_department(department_type) // Set department in program dept_order
 
 	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -102,7 +102,7 @@
 	startup_program = "dept_order"
 	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
-		/datum/computer_file/program/department_order
+		/datum/computer_file/program/department_order,
 	)
 	/// What department type is assigned to this console?
 	var/datum/job_department/department_type

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -154,7 +154,7 @@
 		/datum/computer_file/program/bounty_board,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/shipping,
-		/datum/computer_file/program/restock_tracker
+		/datum/computer_file/program/restock_tracker,
 	)
 
 /obj/machinery/modular_computer/preset/cargochat/cargo/post_machine_initialize()

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -75,7 +75,7 @@
 
 /obj/machinery/modular_computer/preset/id/centcom/Initialize(mapload)
 	. = ..()
-	var/datum/computer_file/program/card_mod/card_mod_centcom = cpu.find_file_by_name("plexagonidwriter")
+	var/datum/computer_file/program/card_mod/card_mod_centcom = cpu.find_file_by_name(/datum/computer_file/program/card_mod::filename)
 	card_mod_centcom.is_centcom = TRUE
 
 // ===== CIVILIAN CONSOLE =====
@@ -99,7 +99,7 @@
 /obj/machinery/modular_computer/preset/cargochat
 	name = "cargo interfacing console"
 	desc = "A stationary computer that comes pre-loaded with software to interface with the cargo department."
-	startup_program = "dept_order"
+	startup_program = /datum/computer_file/program/department_order::filename
 	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/department_order,
@@ -119,10 +119,10 @@
 	if(!department_type)
 		return
 
-	var/datum/computer_file/program/department_order/orderprogram = cpu.find_file_by_name("dept_order")
+	var/datum/computer_file/program/department_order/orderprogram = cpu.find_file_by_name(/datum/computer_file/program/department_order::filename)
 	orderprogram.set_linked_department(department_type) // Set department in program dept_order
 
-	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
+	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name(/datum/computer_file/program/chatclient::filename)
 	chatprogram.username = "[LOWER_TEXT(initial(department_type.department_name))]_department"
 	cpu.idle_threads += chatprogram
 
@@ -147,7 +147,7 @@
 	department_type = /datum/job_department/cargo
 	name = "departmental interfacing console"
 	desc = "A stationary computer that comes pre-loaded with software to interface with incoming departmental cargo requests."
-	startup_program = "ntnrc_client"
+	startup_program = /datum/computer_file/program/chatclient::filename
 	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/department_order,
@@ -159,13 +159,13 @@
 
 /obj/machinery/modular_computer/preset/cargochat/cargo/post_machine_initialize()
 	. = ..()
-	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
+	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name(startup_program)
 	chatprogram.username = "cargo_requests_operator"
 
 	var/datum/ntnet_conversation/cargochat = chatprogram.create_new_channel("#cargobus", strong = TRUE)
 	for(var/obj/machinery/modular_computer/preset/cargochat/cargochat_console as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/modular_computer/preset/cargochat))
 		if(cargochat_console == src)
 			continue
-		var/datum/computer_file/program/chatclient/other_chatprograms = cargochat_console.cpu.find_file_by_name("ntnrc_client")
+		var/datum/computer_file/program/chatclient/other_chatprograms = cargochat_console.cpu.find_file_by_name(startup_program)
 		other_chatprograms.active_channel = chatprogram.active_channel
 		cargochat.add_client(other_chatprograms, silent = TRUE)

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -1,8 +1,8 @@
 /obj/machinery/modular_computer/preset
-	///List of programs the computer starts with, given on Initialize.
-	var/list/datum/computer_file/preinstalled_programs = list()
 	///If set, computer will automatically boot and load this program
 	var/startup_program
+	///List of programs the computer starts with, given on Initialize.
+	var/list/datum/computer_file/preinstalled_programs = list()
 
 /obj/machinery/modular_computer/preset/Initialize(mapload)
 	. = ..()
@@ -99,11 +99,11 @@
 /obj/machinery/modular_computer/preset/cargochat
 	name = "cargo interfacing console"
 	desc = "A stationary computer that comes pre-loaded with software to interface with the cargo department."
+	startup_program = "dept_order"
 	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/department_order
 	)
-	startup_program = "dept_order"
 	/// What department type is assigned to this console?
 	var/datum/job_department/department_type
 
@@ -148,8 +148,6 @@
 	name = "departmental interfacing console"
 	desc = "A stationary computer that comes pre-loaded with software to interface with incoming departmental cargo requests."
 	startup_program = "ntnrc_client"
-
-/obj/machinery/modular_computer/preset/cargochat/cargo
 	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
 		/datum/computer_file/program/department_order,

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -69,7 +69,6 @@
 		/datum/computer_file/program/job_management,
 		/datum/computer_file/program/crew_manifest,
 	)
-	startup_program = "plexagonidwriter"
 
 /obj/machinery/modular_computer/preset/id/centcom
 	desc = "A stationary computer. This one comes preloaded with CentCom identification modification programs."

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -25,7 +25,6 @@
 	if(isnull(startup_file))
 		return
 
-	cpu.turn_on()
 	cpu.active_program = startup_file
 
 // ===== ENGINEERING CONSOLE =====

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -25,8 +25,8 @@
 	if(isnull(startup_file))
 		return
 
-	cpu.active_program = startup_file
 	cpu.turn_on()
+	cpu.active_program = startup_file
 
 // ===== ENGINEERING CONSOLE =====
 /obj/machinery/modular_computer/preset/engineering
@@ -101,33 +101,31 @@
 	desc = "A stationary computer that comes pre-loaded with software to interface with the cargo department."
 	preinstalled_programs = list(
 		/datum/computer_file/program/chatclient,
+		/datum/computer_file/program/department_order
 	)
+	startup_program = "dept_order"
 	/// What department type is assigned to this console?
 	var/datum/job_department/department_type
 
 /obj/machinery/modular_computer/preset/cargochat/Initialize(mapload)
-	add_starting_software()
 	. = ..()
-	setup_starting_software()
 	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 	if(department_type)
 		name = "[LOWER_TEXT(initial(department_type.department_name))] [name]"
 		cpu.name = name
 
-/obj/machinery/modular_computer/preset/cargochat/proc/add_starting_software()
-	preinstalled_programs += /datum/computer_file/program/department_order
-
-/obj/machinery/modular_computer/preset/cargochat/proc/setup_starting_software()
+/obj/machinery/modular_computer/preset/cargochat/run_startup_program()
+	. = ..()
 	if(!department_type)
 		return
+
+	var/datum/computer_file/program/department_order/orderprogram = cpu.active_program
+	orderprogram.set_linked_department(department_type) // Set department in program dept_order
 
 	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
 	chatprogram.username = "[LOWER_TEXT(initial(department_type.department_name))]_department"
 	cpu.idle_threads += chatprogram
 
-	var/datum/computer_file/program/department_order/orderprogram = cpu.find_file_by_name("dept_order")
-	orderprogram.set_linked_department(department_type)
-	cpu.active_program = orderprogram
 	update_appearance(UPDATE_ICON)
 
 /obj/machinery/modular_computer/preset/cargochat/service
@@ -149,18 +147,17 @@
 	department_type = /datum/job_department/cargo
 	name = "departmental interfacing console"
 	desc = "A stationary computer that comes pre-loaded with software to interface with incoming departmental cargo requests."
+	startup_program = "ntnrc_client"
 
-/obj/machinery/modular_computer/preset/cargochat/cargo/add_starting_software()
-	preinstalled_programs += /datum/computer_file/program/bounty_board
-	preinstalled_programs += /datum/computer_file/program/budgetorders
-	preinstalled_programs += /datum/computer_file/program/shipping
-	preinstalled_programs += /datum/computer_file/program/restock_tracker
-
-/obj/machinery/modular_computer/preset/cargochat/cargo/setup_starting_software()
-	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
-	cpu.active_program = chatprogram
-	update_appearance(UPDATE_ICON)
-	// Rest of the chat program setup is done in LateInit
+/obj/machinery/modular_computer/preset/cargochat/cargo
+	preinstalled_programs = list(
+		/datum/computer_file/program/chatclient,
+		/datum/computer_file/program/department_order,
+		/datum/computer_file/program/bounty_board,
+		/datum/computer_file/program/budgetorders,
+		/datum/computer_file/program/shipping,
+		/datum/computer_file/program/restock_tracker
+	)
 
 /obj/machinery/modular_computer/preset/cargochat/cargo/post_machine_initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds a var to the modular computer to specify a default startup program.

## Why It's Good For The Game

Moving it from a cargo computer specific proc to a general modular computer one allows any preset modular computer to have a startup program.

## Changelog

:cl: LT3
code: All preset modular computers can now have a program launch automatically on startup
/:cl: