### PR TITLE
Fix plate shard variants never appearing (and slight tweaks)

### DIFF
--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -121,6 +121,7 @@
 	icon = 'icons/obj/service/kitchen.dmi'
 	icon_state = "plate_shard1"
 	base_icon_state = "plate_shard"
+	hitsound = 'sound/weapons/bladeslice.ogg'
 	w_class = WEIGHT_CLASS_TINY
 	force = 5
 	throwforce = 5
@@ -131,6 +132,6 @@
 /obj/item/plate_shard/Initialize(mapload)
 	. = ..()
 
-	AddComponent(/datum/component/caltrop, min_damage = force)
+	AddComponent(/datum/component/caltrop, min_damage = force, paralyze_duration = 2 SECONDS, soundfile = hitsound)
 
-	icon_state = "[base_icon_state][pick(1,variants)]"
+	icon_state = "[base_icon_state][rand(1, variants)]"


### PR DESCRIPTION
## About The Pull Request

Using `pick` instead of `rand` = only two variants showed up, the first or the last. Easy fix. 

While I'm here I made them a bit more "immersive" I guess, better hitsound (they're sharp!), caltrop sound, and reduced the stun from default (6 seconds) to 2 seconds

## Changelog

:cl: Melbert
fix: Fixed plate shards not randomizing icon correctly
qol: Gives plate sharts a more fitting hitsound / caltrop sound, gives them a set caltrop stun duration (instead of default)
/:cl:


