### PR TITLE
Fixes the Stimmed mutation instability being defined twice

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -359,7 +359,6 @@
 	quality = POSITIVE
 	instability = POSITIVE_INSTABILITY_MINI
 	text_gain_indication = "<span class='notice'>You feel stimmed.</span>"
-	instability = 15
 	difficulty = 16
 
 /datum/mutation/human/stimmed/on_acquiring(mob/living/carbon/human/owner)


### PR DESCRIPTION

## About The Pull Request

What is says on the tin. This was likely missed during the genetics rework when instability was defined.

## Why It's Good For The Game

Little accidents happen in a big shake up.

## Changelog
:cl:
fix: The Stimmed mutation now has the appropriate instability value for a largely meaningless mutation.
/:cl:
