### PR TITLE
Fixes the Infiltrator Module not having the correct welder protection and not adding the correct traits, improves welding protection defines.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -443,13 +443,14 @@
 #define REM REAGENTS_EFFECT_MULTIPLIER //! Shorthand for the above define for ease of use in equations and the like
 
 // Eye protection
+// THese values are additive to determine your overall flash protection.
 #define FLASH_PROTECTION_HYPER_SENSITIVE -2
 #define FLASH_PROTECTION_SENSITIVE -1
 #define FLASH_PROTECTION_NONE 0
 #define FLASH_PROTECTION_FLASH 1
 #define FLASH_PROTECTION_WELDER 2
-#define FLASH_PROTECTION_WELDER_PLUS 3
-#define FLASH_PROTECTION_MAXIMUM 4
+#define FLASH_PROTECTION_WELDER_SENSITIVE 3
+#define FLASH_PROTECTION_WELDER_HYPER_SENSITIVE 4
 
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY 5

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -516,10 +516,10 @@
 	mod.item_flags &= ~EXAMINE_SKIP
 
 /obj/item/mod/module/infiltrator/on_suit_activation()
-	mod.wearer.add_traits(list(TRAIT_SILENT_FOOTSTEPS, TRAIT_UNKNOWN), MOD_TRAIT)
+	mod.wearer.add_traits(traits_to_add, MOD_TRAIT)
 	var/obj/item/clothing/head_cover = mod.get_part_from_slot(ITEM_SLOT_HEAD)
 	if(istype(head_cover))
-		head_cover.flash_protect = FLASH_PROTECTION_WELDER
+		head_cover.flash_protect = FLASH_PROTECTION_WELDER_HYPER_SENSITIVE
 
 /obj/item/mod/module/infiltrator/on_suit_deactivation(deleting = FALSE)
 	mod.wearer.remove_traits(traits_to_add, MOD_TRAIT)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -16,7 +16,7 @@
 	var/obj/item/clothing/head_cover = mod.get_part_from_slot(ITEM_SLOT_HEAD) || mod.get_part_from_slot(ITEM_SLOT_MASK) || mod.get_part_from_slot(ITEM_SLOT_EYES)
 	if(istype(head_cover))
 		//this is a screen that displays an image, so flash sensitives can use this to protect against flashes.
-		head_cover.flash_protect = FLASH_PROTECTION_MAXIMUM
+		head_cover.flash_protect = FLASH_PROTECTION_WELDER_HYPER_SENSITIVE
 
 /obj/item/mod/module/welding/on_suit_deactivation(deleting = FALSE)
 	if(deleting)


### PR DESCRIPTION

## About The Pull Request

The Infiltrator module provides the same welding protection as the welding protection module, which it is not compatible with but is meant to be analogous with.

The module properly adds the traits it is meant to add on activation.

Updates the definitions for the welding flash protections so that they are more clear as to what they mean.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/pull/84112 added higher protections to the engineering module, but did not update the Infiltrator module which also provides this protection. Easy mistake.

The module was not correctly adding the head protection trait is meant to be providing. This resolves that.

The definitions were still not clear as to what level of protection they were supposed to provide. There is an arbitrary value of protection level in the game, there is no way to get a 'maximum' value.

## Changelog
:cl:
fix: The Infiltrator module now has the same welding protections as the engineering module.
fix: The infiltrator module now properly protects you from head impacts. Helpful if you wipe out on your hoverboard while fleeing the cops.
code: Improves the definitions for welding protection values.
/:cl:
