### PR TITLE
Slime core removal surgery changes

### DIFF
--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -239,7 +239,7 @@
 		processed_slime.balloon_alert_to_viewers("crawls free")
 		return
 	var/core_count = processed_slime.cores
-	for(var/i in 1 to (core_count+rating_amount-1))
+	for(var/i in 1 to core_count)
 		var/atom/movable/item = new processed_slime.slime_type.core_type(drop_location())
 		adjust_item_drop_location(item)
 		SSblackbox.record_feedback("tally", "slime_core_harvested", 1, processed_slime.slime_type.colour)

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -239,7 +239,7 @@
 		processed_slime.balloon_alert_to_viewers("crawls free")
 		return
 	var/core_count = processed_slime.cores
-	for(var/i in 1 to core_count)
+	for(var/i in 1 to rating_amount)
 		var/atom/movable/item = new processed_slime.slime_type.core_type(drop_location())
 		adjust_item_drop_location(item)
 		SSblackbox.record_feedback("tally", "slime_core_harvested", 1, processed_slime.slime_type.colour)

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -238,7 +238,7 @@
 		processed_slime.forceMove(drop_location())
 		processed_slime.balloon_alert_to_viewers("crawls free")
 		return
-	var/core_count = processed_slime.cores
+
 	for(var/i in 1 to rating_amount)
 		var/atom/movable/item = new processed_slime.slime_type.core_type(drop_location())
 		adjust_item_drop_location(item)

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -239,7 +239,9 @@
 		processed_slime.balloon_alert_to_viewers("crawls free")
 		return
 
-	for(var/i in 1 to rating_amount)
+	var/core_count = processed_slime.cores
+	var/extra_cores = rating_amount - 1 // 0-3 bonus cores above what slime already has with upgraded parts
+	for(var/i in 1 to (core_count + extra_cores))
 		var/atom/movable/item = new processed_slime.slime_type.core_type(drop_location())
 		adjust_item_drop_location(item)
 		SSblackbox.record_feedback("tally", "slime_core_harvested", 1, processed_slime.slime_type.colour)

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -67,7 +67,7 @@
 	var/current_mood = SLIME_MOOD_NONE
 
 	///The number of /obj/item/slime_extract's the slime has left inside
-	var/cores = 1
+	var/cores = 2
 	///Chance of mutating, should be between 25 and 35
 	var/mutation_chance = 30
 	///1-10 controls how much electricity they are generating
@@ -189,15 +189,17 @@
 	cut_overlays()
 	if(slime_type.transparent)
 		alpha = SLIME_TRANSPARENCY_ALPHA
-	var/icon_text = "[slime_type.colour]-[life_stage]"
-	icon_dead = "[icon_text]-dead"
+
+	icon_dead = !cores ? "[slime_type.colour]-cut" : "[slime_type.colour]-[life_stage]-dead"
+
 	if(stat != DEAD)
-		icon_state = icon_text
+		icon_state = "[slime_type.colour]-[life_stage]"
 		if(current_mood && current_mood != SLIME_MOOD_NONE && !stat)
 			add_overlay("aslime-[current_mood]")
 	else
 		icon_state = icon_dead
-	..()
+
+	return ..()
 
 /mob/living/basic/slime/get_status_tab_items()
 	. = ..()
@@ -266,6 +268,8 @@
 			melee_damage_lower += 10
 			melee_damage_upper += 10
 			wound_bonus = -90
+
+			cores *= 2
 
 	ai_controller.set_blackboard_key(BB_SLIME_LIFE_STAGE, life_stage)
 	update_mob_action_buttons()
@@ -364,6 +368,21 @@
 		visible_message(span_warning("The mutated core shudders, and collapses into a puddle, unable to maintain its form."))
 	qdel(src)
 
+///Proc for slime core removal surgery, tries to remove cores from a dead slime.
+/mob/living/basic/slime/proc/try_extract_cores(count = 1)
+	if(stat != DEAD)
+		return FALSE
+	if(count <= 0 || cores < count)
+		return FALSE
+
+	var/core_count = min(count, cores)
+	for(var/i in 1 to core_count)
+		new slime_type.core_type(loc)
+		cores--
+
+	regenerate_icons()
+
+	return TRUE
 
 ///Makes the slime peaceful and content
 /mob/living/basic/slime/proc/set_pacified_behaviour()

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -67,7 +67,7 @@
 	var/current_mood = SLIME_MOOD_NONE
 
 	///The number of /obj/item/slime_extract's the slime has left inside
-	var/cores = 2
+	var/cores = 1
 	///Chance of mutating, should be between 25 and 35
 	var/mutation_chance = 30
 	///1-10 controls how much electricity they are generating

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -269,8 +269,6 @@
 			melee_damage_upper += 10
 			wound_bonus = -90
 
-			cores *= 2
-
 	ai_controller.set_blackboard_key(BB_SLIME_LIFE_STAGE, life_stage)
 	update_mob_action_buttons()
 

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -37,8 +37,7 @@
 
 /datum/surgery_step/extract_core/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/basic/slime/target_slime = target
-	if(target_slime.cores > 0)
-		target_slime.cores--
+	if(target_slime.try_extract_cores(count = 1))
 		display_results(
 			user,
 			target,
@@ -46,14 +45,10 @@
 			span_notice("[user] successfully extracts a core from [target]!"),
 			span_notice("[user] successfully extracts a core from [target]!"),
 		)
-
-		new target_slime.slime_type.core_type(target_slime.loc)
-
-		if(target_slime.cores <= 0)
-			target_slime.icon_state = "[target_slime.slime_type.colour] baby slime dead-nocore"
-			return ..()
+		if(target_slime.cores > 0)
+			return FALSE // Continue extracting
 		else
-			return FALSE
+			return TRUE
 	else
 		to_chat(user, span_warning("There aren't any cores left in [target]!"))
-		return ..()
+	return ..()

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -37,18 +37,15 @@
 
 /datum/surgery_step/extract_core/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/basic/slime/target_slime = target
-	if(target_slime.try_extract_cores(count = 1))
+	var/core_count = target_slime.cores
+	if(core_count && target_slime.try_extract_cores(count = core_count))
 		display_results(
 			user,
 			target,
-			span_notice("You successfully extract a core from [target]. [target_slime.cores] core\s remaining."),
-			span_notice("[user] successfully extracts a core from [target]!"),
-			span_notice("[user] successfully extracts a core from [target]!"),
+			span_notice("You successfully extract [core_count] core\s from [target]."),
+			span_notice("[user] successfully extracts [core_count] core\s from [target]!"),
+			span_notice("[user] successfully extracts [core_count] core\s from [target]!"),
 		)
-		if(target_slime.cores > 0)
-			return FALSE // Continue extracting
-		else
-			return TRUE
-	else
-		to_chat(user, span_warning("There aren't any cores left in [target]!"))
+		return TRUE
+	to_chat(user, span_warning("There aren't any cores left in [target]!"))
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixed an issue with incorrect slime dead icon after core removal surgery. Made the surgery yield all cores in case if the slime had a steroid potion applied.

## Why It's Good For The Game

The icon was broken. Less clicks for surgery.

## Changelog

:cl:
fix: Fixed dead slime icon not showing when cores are extracted
qol: Slime core removal surgery extracts all cores on completion
/:cl:

