### PR TITLE
Gun Refactor Part 1: Bayonet Componentization

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -340,6 +340,10 @@
 #define COMSIG_GUN_CHAMBER_PROCESSED "gun_chamber_processed"
 ///called in /obj/item/gun/ballistic/process_chamber (casing)
 #define COMSIG_CASING_EJECTED "casing_ejected"
+///called in /obj/item/gun/ballistic/sawoff(mob/user, obj/item/saw, handle_modifications) : (mob/user)
+#define COMSIG_GUN_BEING_SAWNOFF "gun_being_sawnoff"
+	#define COMPONENT_CANCEL_SAWING_OFF (1<<0)
+#define COMSIG_GUN_SAWN_OFF "gun_sawn_off"
 
 // Jetpack things
 // Please kill me

--- a/code/datums/components/bayonet_attachable.dm
+++ b/code/datums/components/bayonet_attachable.dm
@@ -1,0 +1,191 @@
+/**
+ * Component which allows you to attach a bayonet to an item,
+ * be it a piece of clothing or a tool.
+ */
+/datum/component/bayonet_attachable
+	/// Whenever we can remove the bayonet with a screwdriver
+	var/removable = TRUE
+	/// If passed, we wil simply update our item's icon_state when a bayonet is attached.
+	/// Formatted as parent_base_state-[bayonet_icon_state-state]
+	var/bayonet_icon_state
+	/// If passed, we will use a specific overlay instead of using the knife itself
+	/// The state to take from the bayonet overlay icon if supplied.
+	var/bayonet_overlay
+	/// This is the icon file it grabs the overlay from.
+	var/bayonet_overlay_icon
+	/// Offsets for the bayonet overlay
+	var/offset_x = 0
+	var/offset_y = 0
+
+	// Internal vars
+	/// Currently attached bayonet
+	var/obj/item/knife/bayonet
+	/// Static typecache of all knives that can become bayonets
+	var/static/list/valid_bayonets = typecacheof(list(/obj/item/knife/combat))
+
+/datum/component/bayonet_attachable/Initialize(
+	obj/item/knife/starting_bayonet,
+	offset_x = 0,
+	offset_y = 0,
+	removable = TRUE,
+	bayonet_icon_state = null,
+	bayonet_overlay = "bayonet",
+	bayonet_overlay_icon = 'icons/obj/weapons/guns/bayonets.dmi'
+)
+
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.removable = removable
+	src.bayonet_icon_state = bayonet_icon_state
+	src.bayonet_overlay = bayonet_overlay
+	src.bayonet_overlay_icon = bayonet_overlay_icon
+	src.offset_x = offset_x
+	src.offset_y = offset_y
+
+	if (istype(starting_bayonet))
+		add_bayonet(starting_bayonet)
+
+/datum/component/bayonet_attachable/Destroy(force)
+	if(bayonet)
+		remove_bayonet()
+	return ..()
+
+/datum/component/bayonet_attachable/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_OBJ_DECONSTRUCT, PROC_REF(on_parent_deconstructed))
+	RegisterSignal(parent, COMSIG_ATOM_EXITED, PROC_REF(on_item_exit))
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), PROC_REF(on_screwdriver))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON_STATE, PROC_REF(on_update_icon_state))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
+	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_parent_deleted))
+	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(on_pre_attack))
+
+/datum/component/bayonet_attachable/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_OBJ_DECONSTRUCT,
+		COMSIG_ATOM_EXITED,
+		COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER),
+		COMSIG_ATOM_UPDATE_ICON_STATE,
+		COMSIG_ATOM_UPDATE_OVERLAYS,
+		COMSIG_ATOM_ATTACKBY,
+		COMSIG_ATOM_EXAMINE,
+		COMSIG_QDELETING,
+		COMSIG_ITEM_PRE_ATTACK
+	))
+
+/datum/component/bayonet_attachable/proc/on_examine(obj/item/source, mob/examiner, list/examine_list)
+	SIGNAL_HANDLER
+
+	if(!bayonet)
+		examine_list += "It has a <b>bayonet</b> lug on it."
+		return
+
+	examine_list += "It has \a [bayonet] [removable ? "" : "permanently "]affixed to it."
+	if(removable)
+		examine_list += span_info("[bayonet] looks like it can be <b>unscrewed</b> from [src].")
+
+/datum/component/bayonet_attachable/proc/on_pre_attack(obj/item/source, atom/target, mob/living/user, params)
+	SIGNAL_HANDLER
+
+	if (!bayonet || !user.combat_mode)
+		return NONE
+
+	INVOKE_ASYNC(bayonet, TYPE_PROC_REF(/obj/item, melee_attack_chain), user, target, params)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/datum/component/bayonet_attachable/proc/on_attackby(obj/item/source, obj/item/attacking_item, mob/attacker, params)
+	SIGNAL_HANDLER
+
+	if(!is_type_in_typecache(attacking_item, valid_bayonets))
+		return
+
+	if(bayonet)
+		source.balloon_alert(attacker, "already has \a [bayonet]!")
+		return
+
+	if(!attacker.transferItemToLoc(attacking_item, source))
+		return
+
+	add_bayonet(attacking_item, attacker)
+	source.balloon_alert(attacker, "attached [attacking_item]")
+	return COMPONENT_NO_AFTERATTACK
+
+/datum/component/bayonet_attachable/proc/add_bayonet(obj/item/knife/new_bayonet, mob/attacher)
+	if(bayonet)
+		CRASH("[type] tried to add a new bayonet when it already had one.")
+
+	bayonet = new_bayonet
+	if(bayonet.loc != parent)
+		bayonet.forceMove(parent)
+	var/obj/item/item_parent = parent
+	item_parent.update_appearance()
+
+/datum/component/bayonet_attachable/proc/remove_bayonet()
+	bayonet = null
+	var/obj/item/item_parent = parent
+	item_parent.update_appearance()
+
+/datum/component/bayonet_attachable/proc/on_item_exit(obj/item/source, atom/movable/gone, direction)
+	SIGNAL_HANDLER
+
+	if(gone == bayonet)
+		remove_bayonet()
+
+/datum/component/bayonet_attachable/proc/on_parent_deconstructed(obj/item/source, disassembled)
+	SIGNAL_HANDLER
+
+	if(QDELETED(bayonet) || !removable)
+		remove_bayonet()
+		return
+
+	bayonet.forceMove(source.drop_location())
+
+/datum/component/bayonet_attachable/proc/on_screwdriver(obj/item/source, mob/user, obj/item/tool)
+	SIGNAL_HANDLER
+
+	if(!bayonet || !removable)
+		return
+
+	INVOKE_ASYNC(src, PROC_REF(unscrew_bayonet), source, user, tool)
+	return ITEM_INTERACT_BLOCKING
+
+/datum/component/bayonet_attachable/proc/unscrew_bayonet(obj/item/source, mob/user, obj/item/tool)
+	tool?.play_tool_sound(source)
+	source.balloon_alert(user, "unscrewed [bayonet]")
+
+	var/obj/item/knife/to_remove = bayonet
+	to_remove.forceMove(source.drop_location())
+	if(source.Adjacent(user) && !issilicon(user))
+		user.put_in_hands(to_remove)
+
+/datum/component/bayonet_attachable/proc/on_update_overlays(obj/item/source, list/overlays)
+	SIGNAL_HANDLER
+
+	if(!bayonet_overlay || !bayonet_overlay_icon)
+		return
+
+	if(!bayonet)
+		return
+
+	var/mutable_appearance/bayonet_appearance = mutable_appearance(bayonet_overlay_icon, bayonet_overlay)
+	bayonet_appearance.pixel_x = offset_x
+	bayonet_appearance.pixel_y = offset_y
+	overlays += bayonet_appearance
+
+/datum/component/bayonet_attachable/proc/on_update_icon_state(obj/item/source)
+	SIGNAL_HANDLER
+
+	if(!bayonet_icon_state)
+		return
+
+	var/base_state = source.base_icon_state || initial(source.icon_state)
+	if(bayonet)
+		source.icon_state = "[base_state]-[bayonet_icon_state]"
+	else if(source.icon_state != base_state)
+		source.icon_state = base_state
+
+/datum/component/bayonet_attachable/proc/on_parent_deleted(obj/item/source)
+	SIGNAL_HANDLER
+	QDEL_NULL(bayonet)

--- a/code/datums/components/bayonet_attachable.dm
+++ b/code/datums/components/bayonet_attachable.dm
@@ -203,7 +203,7 @@
 
 	if (!bayonet || allow_sawnoff)
 		return
-	source.balloon_alert(user, "[bayonet.bayonet.name] must be removed!")
+	source.balloon_alert(user, "[bayonet.name] must be removed!")
 	return COMPONENT_CANCEL_SAWING_OFF
 
 /datum/component/bayonet_attachable/proc/on_sawn_off(obj/item/source, mob/user)

--- a/code/datums/components/bayonet_attachable.dm
+++ b/code/datums/components/bayonet_attachable.dm
@@ -21,12 +21,12 @@
 
 	// Internal vars
 	/// Currently attached bayonet
-	var/obj/item/knife/bayonet
+	var/obj/item/bayonet
 	/// Static typecache of all knives that can become bayonets
 	var/static/list/valid_bayonets = typecacheof(list(/obj/item/knife/combat))
 
 /datum/component/bayonet_attachable/Initialize(
-	obj/item/knife/starting_bayonet,
+	obj/item/starting_bayonet,
 	offset_x = 0,
 	offset_y = 0,
 	removable = TRUE,
@@ -86,7 +86,7 @@
 /datum/component/bayonet_attachable/proc/on_examine(obj/item/source, mob/examiner, list/examine_list)
 	SIGNAL_HANDLER
 
-	if(!bayonet)
+	if(isnull(bayonet))
 		examine_list += "It has a <b>bayonet</b> lug on it."
 		return
 
@@ -97,7 +97,7 @@
 /datum/component/bayonet_attachable/proc/on_pre_attack(obj/item/source, atom/target, mob/living/user, params)
 	SIGNAL_HANDLER
 
-	if (!bayonet || !user.combat_mode)
+	if (isnull(bayonet) || !user.combat_mode)
 		return NONE
 
 	INVOKE_ASYNC(bayonet, TYPE_PROC_REF(/obj/item, melee_attack_chain), user, target, params)
@@ -117,10 +117,10 @@
 		return
 
 	add_bayonet(attacking_item, attacker)
-	source.balloon_alert(attacker, "attached [attacking_item]")
+	source.balloon_alert(attacker, "attached")
 	return COMPONENT_NO_AFTERATTACK
 
-/datum/component/bayonet_attachable/proc/add_bayonet(obj/item/knife/new_bayonet, mob/attacher)
+/datum/component/bayonet_attachable/proc/add_bayonet(obj/item/new_bayonet, mob/attacher)
 	if(bayonet)
 		CRASH("[type] tried to add a new bayonet when it already had one.")
 
@@ -163,7 +163,7 @@
 	tool?.play_tool_sound(source)
 	source.balloon_alert(user, "unscrewed [bayonet]")
 
-	var/obj/item/knife/to_remove = bayonet
+	var/obj/item/to_remove = bayonet
 	to_remove.forceMove(source.drop_location())
 	if(source.Adjacent(user) && !issilicon(user))
 		user.put_in_hands(to_remove)
@@ -203,7 +203,7 @@
 
 	if (!bayonet || allow_sawnoff)
 		return
-	source.balloon_alert(user, "[bayonet.name] must be removed!")
+	source.balloon_alert(user, "bayonet must be removed!")
 	return COMPONENT_CANCEL_SAWING_OFF
 
 /datum/component/bayonet_attachable/proc/on_sawn_off(obj/item/source, mob/user)

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -21,7 +21,6 @@
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	armor_type = /datum/armor/item_knife
-	var/bayonet = FALSE //Can this be attached to a gun?
 	wound_bonus = 5
 	bare_wound_bonus = 15
 	tool_behaviour = TOOL_KNIFE
@@ -130,7 +129,6 @@
 	throwforce = 20
 	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "cuts")
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "cut")
-	bayonet = TRUE
 	slot_flags = ITEM_SLOT_MASK
 
 /obj/item/knife/combat/Initialize(mapload)
@@ -161,7 +159,6 @@
 	desc = "A hunting grade survival knife."
 	force = 15
 	throwforce = 15
-	bayonet = TRUE
 
 /obj/item/knife/combat/bone
 	name = "bone dagger"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -112,8 +112,8 @@
 			var/obj/item/stack/sheet/animalhide/goliath_hide/plating = new()
 			explorer_suit.hood.attackby(plating)
 	for(var/obj/item/gun/energy/recharge/kinetic_accelerator/accelerator in miner_contents)
-		var/obj/item/knife/combat/survival/knife = new(accelerator)
-		accelerator.bayonet = knife
+		var/datum/component/bayonet_attachable/bayonet = accelerator.GetComponent(/datum/component/bayonet_attachable)
+		bayonet.add_bayonet(new /obj/item/knife/combat/survival(accelerator))
 		var/obj/item/flashlight/seclite/flashlight = new()
 		var/datum/component/seclite_attachable/light_component = accelerator.GetComponent(/datum/component/seclite_attachable)
 		light_component.add_light(flashlight)

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -12,13 +12,11 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "\improper Russian revolver cylinder"
-	ammo_type = /obj/item/ammo_casing/a357/spent
+	ammo_type = /obj/item/ammo_casing/a357
 	caliber = CALIBER_357
 	max_ammo = 6
 	multiload = FALSE
 
-/obj/item/ammo_box/magazine/internal/cylinder/rus357/Initialize(mapload)
-	var/first_round = stored_ammo[1]
-	stored_ammo[1] = new ammo_type(src)
-	qdel(first_round)
+/obj/item/ammo_box/magazine/internal/rus357/Initialize(mapload)
+	stored_ammo += new ammo_type(src)
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -12,11 +12,13 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "\improper Russian revolver cylinder"
-	ammo_type = /obj/item/ammo_casing/a357
+	ammo_type = /obj/item/ammo_casing/a357/spent
 	caliber = CALIBER_357
 	max_ammo = 6
 	multiload = FALSE
 
-/obj/item/ammo_box/magazine/internal/rus357/Initialize(mapload)
-	stored_ammo += new ammo_type(src)
+/obj/item/ammo_box/magazine/internal/cylinder/rus357/Initialize(mapload)
+	var/first_round = stored_ammo[1]
+	stored_ammo[1] = new ammo_type(src)
+	qdel(first_round)
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,11 +64,6 @@
 	/// True if a gun dosen't need a pin, mostly used for abstract guns like tentacles and meathooks
 	var/pinless = FALSE
 
-	var/can_bayonet = FALSE //if a bayonet can be added or removed if it already has one.
-	var/obj/item/knife/bayonet
-	var/knife_x_offset = 0
-	var/knife_y_offset = 0
-
 	var/ammo_x_offset = 0 //used for positioning ammo count overlay on sprite
 	var/ammo_y_offset = 0
 
@@ -83,12 +78,11 @@
 		pin = new pin(src)
 
 	add_seclight_point()
+	add_bayonet_point()
 
 /obj/item/gun/Destroy()
 	if(isobj(pin)) //Can still be the initial path, then we skip
 		QDEL_NULL(pin)
-	if(bayonet)
-		QDEL_NULL(bayonet)
 	if(chambered) //Not all guns are chambered (EMP'ed energy guns etc)
 		QDEL_NULL(chambered)
 	if(isatom(suppressed)) //SUPPRESSED IS USED AS BOTH A TRUE/FALSE AND AS A REF, WHAT THE FUCKKKKKKKKKKKKKKKKK
@@ -111,6 +105,10 @@
 /obj/item/gun/proc/add_seclight_point()
 	return
 
+/// Similarly to add_seclight_point(), handles [the bayonet attachment component][/datum/component/bayonet_attachable]
+/obj/item/gun/proc/add_bayonet_point()
+	return
+
 /obj/item/gun/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == pin)
@@ -120,10 +118,6 @@
 		update_appearance()
 	if(gone == suppressed)
 		clear_suppressor()
-	if(gone == bayonet)
-		bayonet = null
-		if(!QDELING(src))
-			update_appearance()
 
 ///Clears var and updates icon. In the case of ballistic weapons, also updates the gun's weight.
 /obj/item/gun/proc/clear_suppressor()
@@ -143,13 +137,6 @@
 				. += span_info("[pin] looks like [pin.p_theyre()] firmly locked in, [pin.p_they()] looks impossible to remove.")
 		else
 			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
-
-	if(bayonet)
-		. += "It has \a [bayonet] [can_bayonet ? "" : "permanently "]affixed to it."
-		if(can_bayonet) //if it has a bayonet and this is false, the bayonet is permanent.
-			. += span_info("[bayonet] looks like it can be <b>unscrewed</b> from [src].")
-	if(can_bayonet)
-		. += "It has a <b>bayonet</b> lug on it."
 
 //called after the gun has successfully fired its chambered ammo.
 /obj/item/gun/proc/process_chamber(empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE)
@@ -247,31 +234,6 @@
 		playsound(src, 'sound/items/handling/ammobox_pickup.ogg', 20, FALSE)
 
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-/obj/item/gun/pre_attack(atom/A, mob/living/user, params)
-	. = ..()
-	if(.)
-		return .
-	if(isnull(bayonet) || !user.combat_mode)
-		return .
-	return bayonet.melee_attack_chain(user, A, params)
-
-/obj/item/gun/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(user.combat_mode)
-		return NONE
-
-	if(istype(tool, /obj/item/knife))
-		var/obj/item/knife/new_stabber = tool
-		if(!can_bayonet || !new_stabber.bayonet || !isnull(bayonet)) //ensure the gun has an attachment point available, and that the knife is compatible with it.
-			return ITEM_INTERACT_BLOCKING
-		if(!user.transferItemToLoc(new_stabber, src))
-			return ITEM_INTERACT_BLOCKING
-		to_chat(user, span_notice("You attach [new_stabber] to [src]'s bayonet lug."))
-		bayonet = new_stabber
-		update_appearance()
-		return ITEM_INTERACT_SUCCESS
-
-	return NONE
 
 /obj/item/gun/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(user.combat_mode && isliving(interacting_with))
@@ -508,17 +470,7 @@
 		return
 	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
-
-	if(bayonet && can_bayonet) //if it has a bayonet, and the bayonet can be removed
-		I.play_tool_sound(src)
-		to_chat(user, span_notice("You unfix [bayonet] from [src]."))
-		bayonet.forceMove(drop_location())
-
-		if(Adjacent(user) && !issilicon(user))
-			user.put_in_hands(bayonet)
-		return ITEM_INTERACT_SUCCESS
-
-	else if(pin?.pin_removable && user.is_holding(src))
+	if(pin?.pin_removable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))
@@ -562,19 +514,6 @@
 								span_warning("You rip [pin] out of [src] with [I], mangling the pin in the process."), null, 3)
 			QDEL_NULL(pin)
 			return TRUE
-
-/obj/item/gun/update_overlays()
-	. = ..()
-	if(bayonet)
-		var/mutable_appearance/knife_overlay
-		var/state = "bayonet" //Generic state.
-		if(bayonet.icon_state in icon_states('icons/obj/weapons/guns/bayonets.dmi')) //Snowflake state?
-			state = bayonet.icon_state
-		var/icon/bayonet_icons = 'icons/obj/weapons/guns/bayonets.dmi'
-		knife_overlay = mutable_appearance(bayonet_icons, state)
-		knife_overlay.pixel_x = knife_x_offset
-		knife_overlay.pixel_y = knife_y_offset
-		. += knife_overlay
 
 /obj/item/gun/animate_atom_living(mob/living/owner)
 	new /mob/living/simple_animal/hostile/mimic/copy/ranged(drop_location(), src, owner)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -638,8 +638,9 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	if(sawn_off)
 		balloon_alert(user, "it's already shortened!")
 		return
-	if(bayonet)
-		balloon_alert(user, "[bayonet.name] must be removed!")
+	var/datum/component/bayonet_attachable/bayonet = GetComponent(/datum/component/bayonet_attachable)
+	if(bayonet && bayonet.bayonet)
+		balloon_alert(user, "[bayonet.bayonet.name] must be removed!")
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.visible_message(span_notice("[user] begins to shorten [src]."), span_notice("You begin to shorten [src]..."))

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -638,9 +638,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	if(sawn_off)
 		balloon_alert(user, "it's already shortened!")
 		return
-	var/datum/component/bayonet_attachable/bayonet = GetComponent(/datum/component/bayonet_attachable)
-	if(bayonet && bayonet.bayonet)
-		balloon_alert(user, "[bayonet.bayonet.name] must be removed!")
+	if (SEND_SIGNAL(src, COMSIG_GUN_BEING_SAWNOFF, user) & COMPONENT_CANCEL_SAWING_OFF)
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.visible_message(span_notice("[user] begins to shorten [src]."), span_notice("You begin to shorten [src]..."))
@@ -650,27 +648,30 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		user.visible_message(span_danger("[src] goes off!"), span_danger("[src] goes off in your face!"))
 		return
 
-	if(do_after(user, 3 SECONDS, target = src))
-		if(sawn_off)
-			return
-		user.visible_message(span_notice("[user] shortens [src]!"), span_notice("You shorten [src]."))
-		sawn_off = TRUE
-		if(handle_modifications)
-			name = "sawn-off [src.name]"
-			desc = sawn_desc
-			update_weight_class(WEIGHT_CLASS_NORMAL)
-			//The file might not have a "gun" icon, let's prepare for this
-			lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
-			righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
-			inhand_x_dimension = 32
-			inhand_y_dimension = 32
-			inhand_icon_state = "gun"
-			worn_icon_state = "gun"
-			slot_flags &= ~ITEM_SLOT_BACK //you can't sling it on your back
-			slot_flags |= ITEM_SLOT_BELT //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
-			recoil = SAWN_OFF_RECOIL
-			update_appearance()
+	if(!do_after(user, 3 SECONDS, target = src))
+		return
+	if(sawn_off)
+		return
+	user.visible_message(span_notice("[user] shortens [src]!"), span_notice("You shorten [src]."))
+	sawn_off = TRUE
+	SEND_SIGNAL(src, COMSIG_GUN_SAWN_OFF)
+	if(!handle_modifications)
 		return TRUE
+	name = "sawn-off [src.name]"
+	desc = sawn_desc
+	update_weight_class(WEIGHT_CLASS_NORMAL)
+	//The file might not have a "gun" icon, let's prepare for this
+	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
+	inhand_x_dimension = 32
+	inhand_y_dimension = 32
+	inhand_icon_state = "gun"
+	worn_icon_state = "gun"
+	slot_flags &= ~ITEM_SLOT_BACK //you can't sling it on your back
+	slot_flags |= ITEM_SLOT_BELT //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
+	recoil = SAWN_OFF_RECOIL
+	update_appearance()
+	return TRUE
 
 /obj/item/gun/ballistic/proc/guncleaning(mob/user, obj/item/A)
 	if(misfire_probability == initial(misfire_probability))

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -41,12 +41,12 @@
 	fire_delay = 2
 	burst_size = 3
 	pin = /obj/item/firing_pin/implant/pindicate
-	can_bayonet = TRUE
-	knife_x_offset = 26
-	knife_y_offset = 12
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
+
+/obj/item/gun/ballistic/automatic/c20r/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 26, offset_y = 12)
 
 /obj/item/gun/ballistic/automatic/c20r/update_overlays()
 	. = ..()
@@ -75,9 +75,6 @@
 	can_suppress = FALSE
 	burst_size = 1
 	actions_types = list()
-	can_bayonet = TRUE
-	knife_x_offset = 25
-	knife_y_offset = 12
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
@@ -85,6 +82,9 @@
 /obj/item/gun/ballistic/automatic/wt550/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
+
+/obj/item/gun/ballistic/automatic/wt550/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 25, offset_y = 12)
 
 /obj/item/gun/ballistic/automatic/plastikov
 	name = "\improper PP-95 SMG"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -54,9 +54,6 @@
 
 	slot_flags = ITEM_SLOT_BACK
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction
-	can_bayonet = TRUE
-	knife_x_offset = 42
-	knife_y_offset = 12
 	can_be_sawn_off = TRUE
 	weapon_weight = WEAPON_HEAVY
 	var/jamming_chance = 20
@@ -67,11 +64,14 @@
 
 	SET_BASE_PIXEL(-8, 0)
 
+/obj/item/gun/ballistic/rifle/boltaction/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 32, offset_y = 12)
+
 /obj/item/gun/ballistic/rifle/boltaction/sawoff(mob/user)
 	. = ..()
 	if(.)
 		spread = 36
-		can_bayonet = FALSE
+		qdel(GetComponent(/datum/component/bayonet_attachable))
 		SET_BASE_PIXEL(0, 0)
 		update_appearance()
 
@@ -271,13 +271,13 @@
 
 	projectile_damage_multiplier = 1.35
 	obj_flags = UNIQUE_RENAME
-	can_bayonet = TRUE
-	knife_x_offset = 35
-	knife_y_offset = 10
 	can_be_sawn_off = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 	SET_BASE_PIXEL(-8, 0)
+
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 35, offset_y = 10)
 
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/handle_chamber()
 	. = ..()
@@ -305,10 +305,12 @@
 	spread = 15 //kinda inaccurate
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
-	can_bayonet = FALSE
 	weapon_weight = WEAPON_MEDIUM
 
 	SET_BASE_PIXEL(0, 0)
+
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/pipepistol/add_bayonet_point()
+	return
 
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/prime
 	name = "regal pipegun"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -71,7 +71,6 @@
 	. = ..()
 	if(.)
 		spread = 36
-		qdel(GetComponent(/datum/component/bayonet_attachable))
 		SET_BASE_PIXEL(0, 0)
 		update_appearance()
 

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -7,9 +7,9 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket)
 	slot_flags = ITEM_SLOT_BACK
 	obj_flags = UNIQUE_RENAME
-	can_bayonet = TRUE
-	knife_x_offset = 22
-	knife_y_offset = 11
+
+/obj/item/gun/energy/laser/musket/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 22, offset_y = 11)
 
 /obj/item/gun/energy/laser/musket/Initialize(mapload)
 	. = ..()
@@ -84,11 +84,11 @@
 	shaded_charge = TRUE
 	ammo_x_offset = 1
 	obj_flags = UNIQUE_RENAME
-	can_bayonet = TRUE
-	knife_x_offset = 19
-	knife_y_offset = 13
 	w_class = WEIGHT_CLASS_NORMAL
 	dual_wield_spread = 5 //as intended by the coders
+
+/obj/item/gun/energy/laser/thermal/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 19, offset_y = 13)
 
 /obj/item/gun/energy/laser/thermal/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -9,9 +9,6 @@
 	obj_flags = UNIQUE_RENAME
 	resistance_flags = FIRE_PROOF
 	weapon_weight = WEAPON_LIGHT
-	can_bayonet = TRUE
-	knife_x_offset = 20
-	knife_y_offset = 12
 	gun_flags = NOT_A_REAL_GUN
 	///List of all mobs that projectiles fired from this gun will ignore.
 	var/list/ignored_mob_types
@@ -19,6 +16,9 @@
 	var/list/obj/item/borg/upgrade/modkit/modkits = list()
 	///The max capacity of modkits the PKA can have installed at once.
 	var/max_mod_capacity = 100
+
+/obj/item/gun/energy/recharge/kinetic_accelerator/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 20, offset_y = 12)
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -111,9 +111,9 @@
 	recharge_time = 2 SECONDS
 	holds_charge = TRUE
 	unique_frequency = TRUE
-	can_bayonet = TRUE
-	knife_x_offset = 20
-	knife_y_offset = 12
+
+/obj/item/gun/energy/recharge/ebow/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 20, offset_y = 12)
 
 /obj/item/gun/energy/recharge/ebow/halloween
 	name = "candy corn crossbow"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1028,6 +1028,7 @@
 #include "code\datums\components\basic_inhands.dm"
 #include "code\datums\components\basic_mob_attack_telegraph.dm"
 #include "code\datums\components\basic_ranged_ready_overlay.dm"
+#include "code\datums\components\bayonet_attachable.dm"
 #include "code\datums\components\beetlejuice.dm"
 #include "code\datums\components\blob_minion.dm"
 #include "code\datums\components\blood_walk.dm"


### PR DESCRIPTION

## About The Pull Request
The gun code is an absolute mess that seems to have been untouched for the better part of the decade and finally gave way due to the attack chain refactor. This PR is the first in my attempts to refactor this mess by making bayonet attachment a component instead of /obj/item/gun variables. Followup PRs may or may not be atomic changes or a monolith due to how horribly the original code is structured.

## Why It's Good For The Game
Gun code is ancient, unmaintained, barely readable and started actively breaking in the past weeks.

## Changelog
:cl:
refactor: Bayonet attachment is now a component.
/:cl:
