### PR TITLE
Fixes magazine overflow and russian roulette starting with 6(7) bullets

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -94,7 +94,7 @@
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
-	for(var/i in max(1, stored_ammo.len) to max_ammo)
+	for(var/i in max(1, stored_ammo.len + 1) to max_ammo)
 		stored_ammo += new round_check(src)
 	update_appearance()
 

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -12,11 +12,11 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "\improper Russian revolver cylinder"
-	ammo_type = /obj/item/ammo_casing/a357
+	ammo_type = /obj/item/ammo_casing/a357/spent
 	caliber = CALIBER_357
 	max_ammo = 6
 	multiload = FALSE
 
-/obj/item/ammo_box/magazine/internal/rus357/Initialize(mapload)
-	stored_ammo += new ammo_type(src)
+/obj/item/ammo_box/magazine/internal/cylinder/rus357/Initialize(mapload)
+	stored_ammo += new /obj/item/ammo_casing/a357(src)
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -12,11 +12,14 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "\improper Russian revolver cylinder"
-	ammo_type = /obj/item/ammo_casing/a357/spent
+	ammo_type = /obj/item/ammo_casing/a357
 	caliber = CALIBER_357
 	max_ammo = 6
 	multiload = FALSE
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357/Initialize(mapload)
-	stored_ammo += new /obj/item/ammo_casing/a357(src)
 	. = ..()
+	for (var/i in 1 to 5)
+		stored_ammo += new /obj/item/ammo_casing/a357/spent(src)
+	stored_ammo += new /obj/item/ammo_casing/a357(src)

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -20,6 +20,6 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357/Initialize(mapload)
 	. = ..()
-	for (var/i in 1 to 5)
+	for (var/i in 1 to max_ammo - 1)
 		stored_ammo += new /obj/item/ammo_casing/a357/spent(src)
 	stored_ammo += new /obj/item/ammo_casing/a357(src)


### PR DESCRIPTION

## About The Pull Request
Box magazine code started from ``.len`` instead of ``.len + 1`` when refilling mags which would be fine if BYOND's ``to`` didn't include the last number. Unfortunately, it does, and if the mag has bullets when its refilled it will have one over the limit.

Russian revolver code had a type typo where ammo was added in nonexistent ``/obj/item/ammo_box/magazine/internal/rus357``'s ``Initialize`` instead of ``/obj/item/ammo_box/magazine/internal/cylinder/rus357``. It was pretty clearly was meant to start with a single bullet instead of 6, but neither removing existing ammo nor adding new was implemented properly. I stuff it with 5 blanks instead of making it empty because this will at least allow it to click with current guncode instead of bashing yourself over the head without any feedback, until I rework it.

Related to #84057 but doesn't close it.

## Why It's Good For The Game

Overflow could happen on chaplain's revolver when pray-reloading, giving them one more shot than intended.
Russian revolver is still broken, just slightly less as it now can at least tell you that you failed at killing yourself.

## Changelog
:cl:
fix: Guns no longer can be overfilled by 1 bullet
fix: Russian revolvers now spawn with only 1 live round as originally intended, and click when firing a blank.
/:cl:
