### PR TITLE
You can now stick a fork in an APC to electrocute yourself.

### DIFF
--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -21,6 +21,9 @@
 		. = pseudocircuit_act(user, tool)
 	else if(istype(tool, /obj/item/wallframe/apc))
 		. = wallframe_act(user, tool)
+	else if(istype(tool, /obj/item/kitchen/fork)
+		user.visible_message("[user] sticks [tool] into the plug on [src]!")
+		electrocute_mob(user, src, tool)
 	if(.)
 		return .
 


### PR DESCRIPTION
## About The Pull Request

You can now stick a fork in an APC to electrocute yourself.

## Why It's Good For The Game

![Discord_WVQ53A8pOF](https://github.com/tgstation/tgstation/assets/4081722/f0bb8ab0-9f71-4ca3-b90f-3561f3e42caa)

## Changelog
:cl:
qol: You can now stick a fork in an APC to electrocute yourself.
/:cl: