### PR TITLE
Fixed limb slowdown and hunger affecting your speed in nograv

### DIFF
--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -7,11 +7,12 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/snail
-	movetypes = ~FLYING
+	blacklisted_movetypes = FLYING
 	variable = TRUE
 
+// no reason for leg loss (or gain) to affect speed if drifting
 /datum/movespeed_modifier/bodypart
-	movetypes = ~FLYING
+	blacklisted_movetypes = (FLYING|FLOATING)
 	variable = TRUE
 
 /datum/movespeed_modifier/dna_vault_speedup

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,4 +1,5 @@
 /datum/movespeed_modifier/obesity
+	// large weight slows even if flying and floating
 	multiplicative_slowdown = 1.5
 
 /datum/movespeed_modifier/monkey_reagent_speedmod
@@ -11,6 +12,7 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/hunger
+	movetypes = GROUND
 	variable = TRUE
 
 /datum/movespeed_modifier/golem_hunger
@@ -89,7 +91,7 @@
 /datum/movespeed_modifier/limbless
 	variable = TRUE
 	movetypes = GROUND
-	blacklisted_movetypes = FLOATING
+	blacklisted_movetypes = FLOATING|FLYING
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/simplemob_varspeed

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -12,7 +12,7 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/hunger
-	movetypes = GROUND
+	movetypes = GROUND|FLYING
 	variable = TRUE
 
 /datum/movespeed_modifier/golem_hunger


### PR DESCRIPTION

## About The Pull Request

Limbs with unique slowdown, such as that of mushies and zombies, won't affect it when they aren't actually using them.

Hunger will now only slow you down in ground movement.

## Why It's Good For The Game

Being hungry isn't meant to make you move slower while using a jetpack - that makes no sense.

Similarly, mush or zombie or any limbs slow the zombie down despite not being used in nograv, which I think is silly.

## Changelog

Limbslow not mentioned as its not very relevant to the average round

:cl:
fix: Fixed hunger affecting your speed in nograv
/:cl:

