### PR TITLE
fix tile/rod/rcd multi-z hole repairs

### DIFF
--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -349,8 +349,8 @@
 	. = ..()
 	AddElement(/datum/element/openspace_item_click_handler)
 
-/obj/item/trapdoor_kit/handle_openspace_click(turf/target, mob/user, click_parameters)
-	interact_with_atom(target, user, click_parameters)
+/obj/item/trapdoor_kit/handle_openspace_click(turf/target, mob/user, list/modifiers)
+	interact_with_atom(target, user, modifiers)
 
 /obj/item/trapdoor_kit/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	var/turf/target_turf = get_turf(interacting_with)

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -19,7 +19,7 @@
 	SIGNAL_HANDLER
 	if((target.z == 0) || (user.z == 0) || target.z == user.z)
 		return NONE
-	var/turf/target_turf = parse_caught_click_modifiers(modifiers, get_turf(user.client ? user.client.eye : user), user.client)
+	var/turf/target_turf = parse_caught_click_modifiers(modifiers, get_turf(user.client?.eye || user), user.client)
 	if(target_turf?.z == user.z && user.CanReach(target_turf, source))
 		INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), target_turf, user, modifiers)
 		return ITEM_INTERACT_BLOCKING

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -8,22 +8,19 @@
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
-	RegisterSignal(target, COMSIG_ITEM_INTERACTING_WITH_ATOM, PROC_REF(divert_interaction))
+	RegisterSignal(target, COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM, PROC_REF(divert_interaction))
 
 /datum/element/openspace_item_click_handler/Detach(datum/source)
-	UnregisterSignal(source, COMSIG_ITEM_INTERACTING_WITH_ATOM)
+	UnregisterSignal(source, COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM)
 	return ..()
 
 //Invokes the proctype with a turf above as target.
-/datum/element/openspace_item_click_handler/proc/divert_interaction(obj/item/source, mob/user, atom/target, click_parameters)
+/datum/element/openspace_item_click_handler/proc/divert_interaction(obj/item/source, mob/user, atom/target, list/modifiers)
 	SIGNAL_HANDLER
 	if((target.z == 0) || (user.z == 0) || target.z == user.z)
 		return NONE
-	var/turf/checked_turf = get_turf(target)
-	while(!isnull(checked_turf))
-		checked_turf = GET_TURF_ABOVE(checked_turf)
-		if(checked_turf?.z == user.z && user.CanReach(checked_turf, source))
-			INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), checked_turf, user, click_parameters)
-			return ITEM_INTERACT_BLOCKING
-
+	var/turf/target_turf = parse_caught_click_modifiers(modifiers, get_turf(user.client ? user.client.eye : user), user.client)
+	if(target_turf?.z == user.z && user.CanReach(target_turf, source))
+		INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), target_turf, user, modifiers)
+		return ITEM_INTERACT_BLOCKING
 	return NONE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1426,7 +1426,7 @@
 		mob_loc.update_clothing(slot_flags)
 
 /// Called on [/datum/element/openspace_item_click_handler/proc/on_afterattack]. Check the relative file for information.
-/obj/item/proc/handle_openspace_click(turf/target, mob/user, click_parameters)
+/obj/item/proc/handle_openspace_click(turf/target, mob/user, list/modifiers)
 	stack_trace("Undefined handle_openspace_click() behaviour. Ascertain the openspace_item_click_handler element has been attached to the right item and that its proc override doesn't call parent.")
 
 /**

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -26,8 +26,8 @@
 	AddElement(/datum/element/openspace_item_click_handler)
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, TYPE_PROC_REF(/obj/item/holosign_creator, on_color_change))
 
-/obj/item/holosign_creator/handle_openspace_click(turf/target, mob/user, click_parameters)
-	interact_with_atom(target, user, click_parameters)
+/obj/item/holosign_creator/handle_openspace_click(turf/target, mob/user, list/modifiers)
+	interact_with_atom(target, user, modifiers)
 
 /obj/item/holosign_creator/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -70,6 +70,7 @@
 	construction_mode = mode
 
 	GLOB.rcd_list += src
+	AddElement(/datum/element/openspace_item_click_handler)
 
 /obj/item/construction/rcd/Destroy()
 	QDEL_NULL(airlock_electronics)
@@ -419,6 +420,9 @@
 	mode = RCD_DECONSTRUCT
 	rcd_create(interacting_with, user)
 	return ITEM_INTERACT_SUCCESS
+
+/obj/item/construction/rcd/handle_openspace_click(turf/target, mob/user, click_parameters)
+		interact_with_atom(target, user, params2list(click_parameters))
 
 /obj/item/construction/rcd/proc/detonate_pulse()
 	audible_message("<span class='danger'><b>[src] begins to vibrate and \

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -421,8 +421,8 @@
 	rcd_create(interacting_with, user)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/item/construction/rcd/handle_openspace_click(turf/target, mob/user, click_parameters)
-		interact_with_atom(target, user, params2list(click_parameters))
+/obj/item/construction/rcd/handle_openspace_click(turf/target, mob/user, list/modifiers)
+	interact_with_atom(target, user, modifiers)
 
 /obj/item/construction/rcd/proc/detonate_pulse()
 	audible_message("<span class='danger'><b>[src] begins to vibrate and \

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -63,8 +63,8 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
-/obj/item/stack/rods/handle_openspace_click(turf/target, mob/user, click_parameters)
-	target.attackby(src, user, click_parameters)
+/obj/item/stack/rods/handle_openspace_click(turf/target, mob/user, list/modifiers)
+	target.attackby(src, user, list2params(modifiers))
 
 /obj/item/stack/rods/get_main_recipes()
 	. = ..()

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -101,8 +101,8 @@
 	playsound(target_plating, 'sound/weapons/genhit.ogg', 50, TRUE)
 	return target_plating
 
-/obj/item/stack/tile/handle_openspace_click(turf/target, mob/user, click_parameters)
-	target.attackby(src, user, click_parameters)
+/obj/item/stack/tile/handle_openspace_click(turf/target, mob/user, list/modifiers)
+	target.attackby(src, user, list2params(modifiers))
 
 //Grass
 /obj/item/stack/tile/grass


### PR DESCRIPTION

## About The Pull Request
Fixes some interactions with attempting to patch multi-z holes.

1. openspace clicks happen on different z levels, so it's inherently a *ranged* interaction- it was being ignored due to using the non ranged signal
2. RCD was lacking the open space click handler,
3. #77540 still exists to a degree, I've refactored the click handler to use parse_caught_click_modifiers to always grab the tile you're aiming at rather than going off of whatever item you happened to click on
4. handle_openspace_click was treating the modifiers list as the old parameters list
## Why It's Good For The Game
fix bugs, being able to repair holes is a very important and time sensitive task that needs to flow well, and not require pixel hunting
## Changelog
:cl:
fix: multi-z hole repair works better, especially when the turf below is blocked by items
/:cl:
