### PR TITLE
Adjustments to athletics experience gain

### DIFF
--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -93,7 +93,7 @@
 
 	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
 
-	//Determines damage dealt on a punch. Against a boxing defender, we apply our skill bonus.
+	// Determines damage dealt on a punch. Against a boxing defender, we apply our skill bonus.
 	var/damage = rand(lower_force, upper_force)
 
 	if(honor_check(defender))
@@ -134,6 +134,9 @@
 	)
 
 	to_chat(attacker, span_danger("You [current_atk_verbed] [defender]!"))
+
+	// Determines the total amount of experience earned per punch
+	var/experience_earned = round(damage * 0.25, 0.1)
 
 	defender.apply_damage(damage, damage_type, affecting, armor_block)
 
@@ -181,9 +184,11 @@
 		to_chat(attacker, span_danger("You stagger [defender] with a haymaker!"))
 		log_combat(attacker, defender, "staggered (boxing) ")
 
+	experience_earned *= 2 //Double our experience gain on a crit hit
+
 	playsound(defender, 'sound/effects/coin2.ogg', 40, TRUE)
 	new /obj/effect/temp_visual/crit(get_turf(defender))
-	skill_experience_adjustment(attacker, (damage/lower_force)) //double experience for a successful crit
+	skill_experience_adjustment(attacker, experience_earned) //double experience for a successful crit
 
 	return TRUE
 
@@ -203,7 +208,7 @@
 	var/gravity_modifier = boxer.has_gravity() > STANDARD_GRAVITY ? 1 : 0.5
 
 	//You gotta sleep before you get any experience!
-	boxer.mind?.adjust_experience(/datum/skill/athletics, experience_value * gravity_modifier)
+	boxer.mind?.adjust_experience(/datum/skill/athletics, round(experience_value * gravity_modifier, 0.1))
 	boxer.apply_status_effect(/datum/status_effect/exercised)
 
 /// Handles our blocking signals, similar to hit_reaction() on items. Only blocks while the boxer is in throw mode.
@@ -227,6 +232,14 @@
 
 	var/block_text = pick("block", "evade")
 
+	var/experience_earned = round(damage * 0.25, 0.1)
+
+	if(!damage)
+		experience_earned = 2
+
+	// WE reward experience for getting punched while boxing
+	skill_experience_adjustment(boxer, experience_earned) //just getting hit a bunch doesn't net you much experience however
+
 	if(!prob(block_chance))
 		return NONE
 
@@ -245,8 +258,6 @@
 	)
 	if(block_text == "evade")
 		playsound(boxer.loc, active_arm.unarmed_miss_sound, 25, TRUE, -1)
-
-	skill_experience_adjustment(boxer, 1) //just getting hit a bunch doesn't net you much experience
 
 	return SUCCESSFUL_BLOCK
 

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -232,6 +232,11 @@
 
 	var/block_text = pick("block", "evade")
 
+	var/mob/living/attacker = GET_ASSAILANT(hitby)
+
+	if(!honor_check(attacker))
+		return NONE
+
 	var/experience_earned = round(damage * 0.25, 0.1)
 
 	if(!damage)
@@ -241,11 +246,6 @@
 	skill_experience_adjustment(boxer, experience_earned) //just getting hit a bunch doesn't net you much experience however
 
 	if(!prob(block_chance))
-		return NONE
-
-	var/mob/living/attacker = GET_ASSAILANT(hitby)
-
-	if(!honor_check(attacker))
 		return NONE
 
 	if(istype(attacker) && boxer.Adjacent(attacker))

--- a/code/game/objects/structures/gym/punching_bag.dm
+++ b/code/game/objects/structures/gym/punching_bag.dm
@@ -57,12 +57,12 @@
 			stamina_exhaustion = 2
 	if (is_heavy_gravity)
 		stamina_exhaustion *= 1.5
-	
+
 	if(HAS_TRAIT(user, TRAIT_STRENGTH)) //The strong get reductions to stamina damage taken while exercising
 		stamina_exhaustion *= 0.5
 
 	user.adjustStaminaLoss(stamina_exhaustion)
-	user.mind?.adjust_experience(/datum/skill/athletics, is_heavy_gravity ? 0.2 : 0.1)
+	user.mind?.adjust_experience(/datum/skill/athletics, is_heavy_gravity ? 0.6 : 0.3)
 	user.apply_status_effect(/datum/status_effect/exercised)
 
 /obj/structure/punching_bag/wrench_act_secondary(mob/living/user, obj/item/tool)


### PR DESCRIPTION

## About The Pull Request

Punching bags are now an actually reasonably alternative to the workout machines for gaining athletics experience. They should be roughly equivalent for stamina drain to experience gained.

Boxing in of itself is now a much better method of gaining athletics experience. This encourages you to actually spar with people to train.

## Why It's Good For The Game

The punching bag is the single worst method in the game for getting fit. The reason is likely that the math was never actually checked for experience per stamina spent. While technically, it is possible to earn this experience faster in a small window of time than the machine, you are always still limited by your stamina drain. The rewards are effectively dreadful for using the punching bag.

Boxing in of itself didn't give very good rewards despite being the focus of Athletics. Now, getting punched by a boxer and punching a boxer give pretty reasonable amounts of experience. Since it only matters for boxing, it isn't exactly a Monk 2.0 scenario :U

## Changelog
:cl:
qol: Punching bags are now a equal method of training to the fitness machinery.
qol: Boxing grants more experience overall for participation.
/:cl:
