### PR TITLE
Removes hugbox variants of the supermatter crystals. Replaces instances of them with real supermatter crystals.

### DIFF
--- a/_maps/deathmatch/OSHA_Violator.dmm
+++ b/_maps/deathmatch/OSHA_Violator.dmm
@@ -662,7 +662,7 @@
 /turf/open/indestructible,
 /area/deathmatch)
 "Fv" = (
-/obj/machinery/power/supermatter_crystal/hugbox,
+/obj/machinery/power/supermatter_crystal,
 /turf/open/indestructible,
 /area/deathmatch)
 "FM" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -100,7 +100,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aB" = (
-/obj/machinery/power/supermatter_crystal/hugbox,
+/obj/machinery/power/supermatter_crystal,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aD" = (
@@ -189,7 +189,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "aV" = (
-/obj/machinery/power/supermatter_crystal/shard/hugbox,
+/obj/machinery/power/supermatter_crystal/shard,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "aW" = (

--- a/code/modules/power/supermatter/supermatter_variants.dm
+++ b/code/modules/power/supermatter/supermatter_variants.dm
@@ -1,10 +1,3 @@
-/// Normal SM with it's processing disabled.
-/obj/machinery/power/supermatter_crystal/hugbox
-	disable_damage = TRUE
-	disable_gas =  TRUE
-	disable_power_change = TRUE
-	disable_process = SM_PROCESS_DISABLED
-
 /// Normal SM designated as main engine.
 /obj/machinery/power/supermatter_crystal/engine
 	is_main_engine = TRUE
@@ -34,17 +27,6 @@
 	if(held_item?.tool_behaviour == TOOL_WRENCH)
 		context[SCREENTIP_CONTEXT_LMB] = anchored ? "Unanchor" : "Anchor"
 		return CONTEXTUAL_SCREENTIP_SET
-
-
-/// Shard SM with it's processing disabled.
-/obj/machinery/power/supermatter_crystal/shard/hugbox
-	name = "anchored supermatter shard"
-	disable_damage = TRUE
-	disable_gas =  TRUE
-	disable_power_change = TRUE
-	disable_process = SM_PROCESS_DISABLED
-	moveable = FALSE
-	anchored = TRUE
 
 /// Shard SM designated as the main engine.
 /obj/machinery/power/supermatter_crystal/shard/engine


### PR DESCRIPTION

## About The Pull Request
All hugbox variants of supermatter crystals are replaced with real ones. This includes the hyperfractal shuttle and the OSHA violator deathmatch map.
## Why It's Good For The Game
So people don't get disappointed.
## Changelog
:cl:
balance: The hugbox supermatter crystals in the hyperfractal shuttle and OSHA violator deathmach map are replaced with real ones.
/:cl:
