### PR TITLE
Fixes the duration of wizard spell mutate

### DIFF
--- a/code/modules/spells/spell_types/self/mutate.dm
+++ b/code/modules/spells/spell_types/self/mutate.dm
@@ -57,7 +57,7 @@
 	cast_on.add_atom_colour(COLOR_VIBRANT_LIME, TEMPORARY_COLOUR_PRIORITY)
 
 /datum/action/cooldown/spell/apply_mutations/mutate/remove_mutations(mob/living/carbon/human/cast_on)
-	if(QDELETED(cast_on) || !is_valid_target(cast_on))
+	if(QDELETED(cast_on) || !is_valid_target(cast_on)) // Not 100% sure if this check is still needed, leaving it just in case
 		return
-
+	..()
 	cast_on.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)


### PR DESCRIPTION

## About The Pull Request
Fixes the remove_mutations proc of the wizard's spell mutate, so it calls the parent and actually removes the said mutations. Honestly the fact that it previously didn't call the parent function is byond me.

Fixes #79491

## Why It's Good For The Game
No more infinite hulk for wizards!
## Changelog
:cl: MrDas
fix: Fixed the duration of wizard's mutate spell.
/:cl:
