### PR TITLE
Fixes quirk config tooltips rendering behind the popper

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -211,6 +211,7 @@ function QuirkPopper(props: QuirkPopperProps) {
       placement="bottom-end"
       onClickOutside={() => setCustomizationExpanded(false)}
       isOpen={customizationExpanded}
+      baseZIndex={1}
       content={
         <div>
           {!!customization_options && hasExpandableCustomization && (


### PR DESCRIPTION
## About The Pull Request

Essentially the same issue as https://github.com/tgstation/tgstation/pull/81571 , and the work has already been done for me there so I am just plugging in their solution. Shout out to MrMelbert for remembering this PR and pointing me in the right direction!!

<details><summary>Before/after (note this is a nova quirk. but it's easiest to see the issue with long tooltips)</summary>

![I0ByU8Z8c7](https://github.com/tgstation/tgstation/assets/13398309/a3749961-0929-4aa1-afae-f602cd628b1c)

![QNPj5bg9og](https://github.com/tgstation/tgstation/assets/13398309/020a9086-d920-483b-b1a0-cdc33a5b2c2e)

</details>

## Why It's Good For The Game

Fixes a prefs menu bug.

## Changelog

:cl:
fix: fixes an issue that was causing the quirk config tooltips to render behind the window, making them nearly impossible to read.
/:cl:

