### PR TITLE
Fixes sentience helmet monkeys being notified about being able to ventcrawl

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -14,9 +14,7 @@
 		update_z(T.z)
 
 	//Vents
-	var/ventcrawler = HAS_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS) || HAS_TRAIT(src, TRAIT_VENTCRAWLER_NUDE)
-	if(ventcrawler)
-		to_chat(src, span_notice("You can ventcrawl! Use alt+click on vents to quickly travel about the station."))
+	notify_ventcrawler_on_login()
 
 	med_hud_set_status()
 

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -1,4 +1,19 @@
 // VENTCRAWLING
+
+/mob/living/proc/notify_ventcrawler_on_login()
+	var/ventcrawler = HAS_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS) || HAS_TRAIT(src, TRAIT_VENTCRAWLER_NUDE)
+	if(!ventcrawler)
+		return
+	to_chat(src, span_notice("You can ventcrawl! Use alt+click on vents to quickly travel about the station."))
+
+/mob/living/carbon/human/notify_ventcrawler_on_login()
+	if(!ismonkey(src))
+		return ..()
+	if(!istype(head, /obj/item/clothing/head/helmet/monkey_sentience)) //don't notify them about ventcrawling if they're wearing the sentience helmet, because they can't ventcrawl with it on, and if they take it off they'll no longer be in control of the mob.
+		return ..()
+
+
+
 /// Checks if the mob is able to enter the vent, and provides feedback if they are unable to.
 /mob/living/proc/can_enter_vent(obj/machinery/atmospherics/components/ventcrawl_target, provide_feedback = TRUE)
 	// Being able to always ventcrawl trumps being only able to ventcrawl when wearing nothing


### PR DESCRIPTION
:cl: ShizCalev
fix: Monkeys that become sentient through the sentience helmet will no longer be notified that they can ventcrawl.
/:cl:

Fixes #84259