### PR TITLE
Slime Nutrition Minimization

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -309,7 +309,7 @@
 #define SLIME_EVOLUTION_THRESHOLD 10
 
 //Slime evolution cost in nutrition
-#define SLIME_EVOLUTION_COST 200
+#define SLIME_EVOLUTION_COST 100
 
 //Slime extract crossing. Controls how many extracts is required to feed to a slime to core-cross.
 #define SLIME_EXTRACT_CROSSING_REQUIRED 10

--- a/code/__DEFINES/research/slimes.dm
+++ b/code/__DEFINES/research/slimes.dm
@@ -11,15 +11,15 @@
 #define SLIME_MAX_POWER 10
 
 ///The maximum amount of nutrition a slime can contain
-#define SLIME_MAX_NUTRITION 1000
+#define SLIME_MAX_NUTRITION 200
 ///The starting nutrition of a slime
-#define SLIME_STARTING_NUTRITION 700
+#define SLIME_STARTING_NUTRITION 100
 /// Above it we grow our amount_grown and our power_level, below it we can eat
-#define SLIME_GROW_NUTRITION 800
+#define SLIME_GROW_NUTRITION 150
 /// Below this, we feel hungry
-#define SLIME_HUNGER_NUTRITION 500
+#define SLIME_HUNGER_NUTRITION 50
 /// Below this, we feel starving
-#define SLIME_STARVE_NUTRITION 200
+#define SLIME_STARVE_NUTRITION 10
 
 ///The slime is not hungry. It might try to feed anyways.
 #define SLIME_HUNGER_NONE 0

--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -36,10 +36,10 @@
 ///Handles the consumption of nutrition, and growth
 /mob/living/basic/slime/proc/handle_nutrition(seconds_per_tick = SSMOBS_DT)
 	if(hunger_disabled) //God as my witness, I will never go hungry again
-		set_nutrition(700)
+		set_nutrition(100)
 		return
 
-	if(SPT_PROB(7.5, seconds_per_tick))
+	if(SPT_PROB(1.25, seconds_per_tick))
 		adjust_nutrition((life_stage == SLIME_LIFE_STAGE_ADULT ? -1 : -0.5) * seconds_per_tick)
 
 	if(nutrition < SLIME_STARVE_NUTRITION)
@@ -63,7 +63,7 @@
 	if (SLIME_GROW_NUTRITION <= nutrition)
 
 		if(amount_grown < SLIME_EVOLUTION_THRESHOLD)
-			adjust_nutrition(-10 * seconds_per_tick)
+			adjust_nutrition(-2.5 * seconds_per_tick)
 			amount_grown++
 
 		if(powerlevel < SLIME_MAX_POWER && SPT_PROB(30-powerlevel*2, seconds_per_tick))


### PR DESCRIPTION
Substantially decreases the nutrition needed or otherwise held by slimes without altering their hunger too drastically. This results in: Roughly 3x Monkey Efficiency (A single monkey can cause one slime to become an adult, split, then become an adult again), Faster slime growth and splitting (especially when the server is lagging and the slimes take MINUTES to eat a single monkey), and a more accessible xenobiology for midgame/lategame interaction.

Tested this in-game, and by god does it feel so much better.

## About The Pull Request

Recently got back into xenobiology and quickly learned why i stopped. As fun and (often) powerful as xenobiology can be, it's almost never seen because xenobiology TAKES WAY TO FUCKING LONG TO ACHIEVE WHAT YOU WANT. For example, in my most recent round i wanted the following: Green Slimes (For lumi species), Bluespace Slimes (For stabilized bluespace extract, and bluespace extract for the lumi specie), and a stabilized purple extract. Wanna know how long that took? A little over an hour! How's anyone supposed to use xenobiology until late into the round when the shuttle is likely about to be called?

This is unfortunately due to two noteable factors: RNG and Lag.

Sometimes the RNG just won't give you what you want and it'll take 30 minutes to get one slime color, sometimes 5 minutes. (Looking at YOU, virology.)
Sometimes it's thirty minutes in on a 70 pop, and the server is chugging so badly that the slime AI slows to a crawl and it takes 10 minutes for a single slime to become an adult.

## Why It's Good For The Game

Altering the nutrition actually makes Xenobiology MUCH faster now that slimes hardly have to eat a monkey to death, unlatch, latch onto another monkey, eat it till it dies, THEN split. The RNG if it's unfavorable to the player can actually be reasonably bruteforced by mass slime+monkey action, and the less actions required on the slime AI's part to make progress will be surely appreciated when the server begins chugging.

Additionally, this makes xenobiology relatively viable atleast for midround interaction, as farming up some slime cores doesn't practically require roundstart investment to get anywhere at all.

Finally, most maps have one-or-two monkey cube boxes to start, which isn't a whole lot and the first thing i do as an experienced xenobiologist is grind up grays and inject my own blood to effectively triple my monkey cubes. Saving me time and likely any new xenobiologists a LOT of wiki reading on 'how to xenobio effectively'.

## Changelog

:cl:
balance: Thanks to incredible strides in selective slime breeding, slimes require substantially less nutrients to grow into adults, and split into children.
/:cl: