### PR TITLE
Adds rounding to research points to prevent floating point errors from occuring

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -108,7 +108,7 @@
 /datum/techweb/proc/add_point_list(list/pointlist)
 	for(var/i in pointlist)
 		if((i in SSresearch.point_types) && pointlist[i] > 0)
-			research_points[i] += pointlist[i]
+			research_points[i] = FLOOR(research_points[i] + pointlist[i], 0.1)
 
 /datum/techweb/proc/add_points_all(amount)
 	var/list/l = SSresearch.point_types.Copy()
@@ -119,7 +119,7 @@
 /datum/techweb/proc/remove_point_list(list/pointlist)
 	for(var/i in pointlist)
 		if((i in SSresearch.point_types) && pointlist[i] > 0)
-			research_points[i] = max(0, research_points[i] - pointlist[i])
+			research_points[i] = FLOOR(max(0, research_points[i] - pointlist[i]), 0.1)
 
 /datum/techweb/proc/remove_points_all(amount)
 	var/list/l = SSresearch.point_types.Copy()
@@ -130,7 +130,7 @@
 /datum/techweb/proc/modify_point_list(list/pointlist)
 	for(var/i in pointlist)
 		if((i in SSresearch.point_types) && pointlist[i] != 0)
-			research_points[i] = max(0, research_points[i] + pointlist[i])
+			research_points[i] = FLOOR(max(0, research_points[i] + pointlist[i]), 0.1)
 
 /datum/techweb/proc/modify_points_all(amount)
 	var/list/l = SSresearch.point_types.Copy()


### PR DESCRIPTION

## About The Pull Request

Right now research points sometimes bug out and get additional .000...1 added to them due to a floating point error. I just added rounding to only keep one digit after the point.

## Why It's Good For The Game

No more annoying numbers in the RND console

## Changelog
:cl:
fix: RND console now properly rounds research points
/:cl:
