### PR TITLE
Projectile Dampener field now reduces stuns and stamina damage from incoming projectiles (ebow projectiles in particular)

### DIFF
--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -314,6 +314,8 @@
 	var/field_radius = 2
 	/// Damage multiplier on projectiles.
 	var/damage_multiplier = 0.75
+	/// Debuff multiplier on projectiles.
+	var/debuff_multiplier = 0.66
 	/// Speed multiplier on projectiles, higher means slower.
 	var/speed_multiplier = 2.5
 	/// List of all tracked projectiles.
@@ -347,6 +349,9 @@
 	SIGNAL_HANDLER
 
 	projectile.damage *= damage_multiplier
+	projectile.stamina *= damage_multiplier
+	projectile.stun *= debuff_multiplier
+	projectile.knockdown *= debuff_multiplier
 	projectile.speed *= speed_multiplier
 	projectile.add_overlay(projectile_effect)
 
@@ -355,6 +360,9 @@
 
 	projectile.damage /= damage_multiplier
 	projectile.speed /= speed_multiplier
+	projectile.stamina /= damage_multiplier
+	projectile.stun /= debuff_multiplier
+	projectile.knockdown /= debuff_multiplier
 	projectile.cut_overlay(projectile_effect)
 
 ///Active Sonar - Displays a hud circle on the turf of any living creatures in the given radius


### PR DESCRIPTION

## About The Pull Request

Projectile Dampener field now reduces stuns and stamina damage from incoming projectiles. Stamina damage is reduced by the same value as damage, stuns and knockdowns by 33%

## Why It's Good For The Game

This is a pretty cool but underused module, and it doesn't really make sense in my opinion that it only affects damage. It should affect any other meaningful value the projectile has, which fits in with the flavor and makes the item more valuable and usable. It doing absolutely nothing to disabler shots is unintuitive and lame. You can always just baton them.

## Changelog

:cl:
add: Projectile Dampener field now reduces stuns and stamina damage from incoming projectiles
/:cl:

