### PR TITLE
Adds crystallizer boards to delta and tram HFR project rooms

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60933,6 +60933,8 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
+/obj/item/circuitboard/machine/crystallizer,
+/obj/item/stack/cable_coil/thirty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "pnV" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -23151,6 +23151,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/circuitboard/machine/crystallizer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "hiZ" = (


### PR DESCRIPTION
## About The Pull Request

Adds crystallizer boards to delta and tram HFR project rooms

## Why It's Good For The Game

Now that the crystallizer is locked behind required ordnance experiments, the crystallizer really doesn't get researched in many of the rounds. I've found that crystallizer is researched maybe one in every three rounds, even during 60+ pop rounds. This results in atmos techs breaking into ordnance and doing science's job for them on delta or tram for a tool that's available round start on every other station.
Also brings delta and tram atmos a little more in line with the other stations while keeping some uniqueness and requiring the machines to be built.

## Changelog

:cl:
add: Crystallizer boards added to Delta and Tram HFR rooms
/:cl:

