### PR TITLE
Fixes broken soup autowiki icons for soups that don't have unique sprites

### DIFF
--- a/code/modules/autowiki/pages/soup.dm
+++ b/code/modules/autowiki/pages/soup.dm
@@ -27,6 +27,7 @@
 		var/result_name
 		var/result_desc
 		var/result_tastes
+		var/result_soup_type
 		// Solid food item results take priority over reagents for showcasing results
 		if(soup_recipe.resulting_food_path)
 			var/obj/item/resulting_food = new soup_recipe.resulting_food_path()
@@ -45,7 +46,7 @@
 
 		// Otherwise, it should be a reagent.
 		else
-			var/result_soup_type = soup_recipe.results[1]
+			result_soup_type = soup_recipe.results[1]
 			var/datum/reagent/result_soup = new result_soup_type()
 			result_name = format_text(result_soup.name)
 			result_desc = result_soup.description
@@ -122,8 +123,14 @@
 		template_list["results"] = escape_value(compiled_results)
 
 		// -- While we're here, generate an icon of the bowl --
-		var/image/compiled_image = image(icon = soup_icon, icon_state = soup_icon_state)
-		upload_icon(getFlatIcon(compiled_image, no_anim = TRUE), filename)
+		if(!soup_icon_state)
+			var/obj/item/reagent_containers/cup/bowl/soup_bowl = new()
+			soup_bowl.reagents.add_reagent(result_soup_type, soup_bowl.reagents.maximum_volume)
+			upload_icon(getFlatIcon(soup_bowl, no_anim = TRUE), filename)
+			qdel(soup_bowl)
+		else
+			var/image/compiled_image = image(icon = soup_icon, icon_state = soup_icon_state)
+			upload_icon(getFlatIcon(compiled_image, no_anim = TRUE), filename)
 
 		// -- Cleanup --
 		qdel(soup_recipe)


### PR DESCRIPTION
Fixes #80024

:cl: ShizCalev
fix: The soups wiki page no longer has error icons for soups that don't have unique sprites.
/:cl: