### PR TITLE
Fixed lights stopping emitting light in some situations

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -40,3 +40,6 @@
 #define COMSIG_TURF_RESET_ELEVATION "turf_reset_elevation"
 	#define ELEVATION_CURRENT_PIXEL_SHIFT 1
 	#define ELEVATION_MAX_PIXEL_SHIFT 2
+
+///Called when turf no longer blocks light from passing through
+#define COMSIG_TURF_NO_LONGER_BLOCK_LIGHT "turf_no_longer_block_light"

--- a/code/datums/elements/light_blocking.dm
+++ b/code/datums/elements/light_blocking.dm
@@ -25,12 +25,6 @@
 		return
 	for(var/turf/turf_loc as anything in movable_target.locs)
 		turf_loc.remove_opacity_source(target)
-		for(var/atom/elem in turf_loc.contents)
-			for(var/datum/light_source/source in elem.light_sources)
-				if(!source)
-					continue
-				if(!source.effect_str)
-					source.update_corners()
 
 
 ///Updates old and new turf loc opacities.

--- a/code/datums/elements/light_blocking.dm
+++ b/code/datums/elements/light_blocking.dm
@@ -25,6 +25,12 @@
 		return
 	for(var/turf/turf_loc as anything in movable_target.locs)
 		turf_loc.remove_opacity_source(target)
+		for(var/atom/elem in turf_loc.contents)
+			for(var/datum/light_source/source in elem.light_sources)
+				if(!source)
+					continue
+				if(!source.effect_str)
+					source.update_corners()
 
 
 ///Updates old and new turf loc opacities.

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -96,6 +96,7 @@
 	//yes, we register the signal to the top atom too, this is intentional and ensures contained lighting updates properly
 	if(ismovable(new_atom_host))
 		RegisterSignal(new_atom_host, COMSIG_MOVABLE_MOVED, PROC_REF(update_host_lights))
+	RegisterSignal(new_atom_host, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT, PROC_REF(force_update))
 	return TRUE
 
 ///remove this light source from old_atom_host's light_sources list, unsetting movement registrations
@@ -106,6 +107,7 @@
 	LAZYREMOVE(old_atom_host.light_sources, src)
 	if(ismovable(old_atom_host))
 		UnregisterSignal(old_atom_host, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(old_atom_host, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT)
 	return TRUE
 
 // Yes this doesn't align correctly on anything other than 4 width tabs.

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -92,7 +92,7 @@
 		for(var/atom/elem in src.contents)
 			for(var/datum/light_source/source in elem.light_sources)
 				if(!source?.effect_str)
-					source.vis_update()
+					source.force_update()
 	if(. != directional_opacity && (. == ALL_CARDINALS || directional_opacity == ALL_CARDINALS))
 		reconsider_lights() //The lighting system only cares whether the tile is fully concealed from all directions or not.
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -89,7 +89,7 @@
 				directional_opacity = ALL_CARDINALS
 				break
 	else
-		for(var/atom/content in contents)
+		for(var/atom/movable/content as anything in contents)
 			SEND_SIGNAL(content, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT)
 	if(. != directional_opacity && (. == ALL_CARDINALS || directional_opacity == ALL_CARDINALS))
 		reconsider_lights() //The lighting system only cares whether the tile is fully concealed from all directions or not.

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -88,6 +88,11 @@
 			else //If fulltile and opaque, then the whole tile blocks view, no need to continue checking.
 				directional_opacity = ALL_CARDINALS
 				break
+	else
+		for(var/atom/elem in src.contents)
+			for(var/datum/light_source/source in elem.light_sources)
+				if(!source?.effect_str)
+					source.vis_update()
 	if(. != directional_opacity && (. == ALL_CARDINALS || directional_opacity == ALL_CARDINALS))
 		reconsider_lights() //The lighting system only cares whether the tile is fully concealed from all directions or not.
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -89,10 +89,8 @@
 				directional_opacity = ALL_CARDINALS
 				break
 	else
-		for(var/atom/elem in src.contents)
-			for(var/datum/light_source/source in elem.light_sources)
-				if(!source?.effect_str)
-					source.force_update()
+		for(var/atom/content in contents)
+			SEND_SIGNAL(content, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT)
 	if(. != directional_opacity && (. == ALL_CARDINALS || directional_opacity == ALL_CARDINALS))
 		reconsider_lights() //The lighting system only cares whether the tile is fully concealed from all directions or not.
 


### PR DESCRIPTION
## About The Pull Request

closes #77789
edt: also closes #82600

Light sources stop emitting light if the tile in which the light source itself is located and all 4 adjacent tile block the light. This usually happens when a smoke grenade is thrown, or something went wrong in the chemistry again

<details>
<summary>Videos</summary>

As it was before

https://github.com/tgstation/tgstation/assets/112967882/44ff556b-d09f-4024-945e-c2c105f511a9

Now

https://github.com/tgstation/tgstation/assets/112967882/9f9f8f43-47a9-47be-8499-99bab39fc166


</details>

## Why It's Good For The Game

You wont need to switch the lights twice to make them work after someone threw smoke grenades into the hallways anymore

## Changelog
:cl:
fix: Fixed lights stopping emitting light in some situations
/:cl:
