### PR TITLE
Moves sugar from polypore mycelium to fireblossoms

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -311,7 +311,7 @@
 	product = /obj/item/food/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/service/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02)
 
 /obj/item/seeds/lavaland/porcini
 	name = "pack of porcini mycelium"
@@ -322,7 +322,7 @@
 	product = /obj/item/food/grown/ash_flora/mushroom_leaf
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/service/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.06, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.06,  /datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04)
 
 /obj/item/seeds/lavaland/inocybe
 	name = "pack of inocybe mycelium"


### PR DESCRIPTION
## About The Pull Request

So the 'large mushrooms' from lavalands contain sugar and ethanol in a ratio such that most of the ethanol instantly reacts with the sugar to form Fringe Weaver (an alcoholic beverage).

![image](https://github.com/tgstation/tgstation/assets/13398309/2a133bfe-5128-4f15-bd78-60e54a417817)

![yOMR4g9IHo](https://github.com/tgstation/tgstation/assets/13398309/d2f05386-e3a8-42b9-921d-ee63faa36b8b)

This is not ideal and makes it impossible to extract any useable quantity of ethanol, so to solve this issue the sugar has been removed from large mushrooms and put into the fireblossoms instead (they had a similar quantity of nutriment).

## Why It's Good For The Game

Makes ghetto chemistry more enjoyable in the lavalands. Sugar can still be acquired, just from a different kind of mushroom now.

## Changelog

:cl:
qol: polypore mycelium no longer contains sugar, preventing it from instantly creating fringe weaver beverage when ground up. qol: sugar may be acquired from grinding fireblossoms instead of polypore mycelium.
/:cl:
