### PR TITLE
station side raptor tweaks

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -137,25 +137,18 @@
 	return ..()
 
 /// Yeets the rider off, used for animals and cyborgs, redefined for humans who shove their piggyback rider off
-/datum/component/riding/creature/proc/force_dismount(mob/living/rider, gentle = FALSE)
+/datum/component/riding/creature/proc/force_dismount(mob/living/rider, throw_range = 8, throw_speed = 3, gentle = FALSE)
 	var/atom/movable/movable_parent = parent
 	movable_parent.unbuckle_mob(rider)
-
+	rider.Knockdown(3 SECONDS)
+	if(throw_range == 0)
+		return
 	if(!iscyborg(movable_parent) && !isanimal_or_basicmob(movable_parent))
 		return
-
 	var/turf/target = get_edge_target_turf(movable_parent, movable_parent.dir)
-	var/turf/targetm = get_step(get_turf(movable_parent), movable_parent.dir)
-	rider.Move(targetm)
-	rider.Knockdown(3 SECONDS)
-	if(gentle)
-		rider.visible_message(span_warning("[rider] is thrown clear of [movable_parent]!"), \
-		span_warning("You're thrown clear of [movable_parent]!"))
-		rider.throw_at(target, 8, 3, movable_parent, gentle = TRUE)
-	else
-		rider.visible_message(span_warning("[rider] is thrown violently from [movable_parent]!"), \
-		span_warning("You're thrown violently from [movable_parent]!"))
-		rider.throw_at(target, 14, 5, movable_parent, gentle = FALSE)
+	rider.visible_message(span_warning("[rider] is thrown clear of [movable_parent]!"), \
+	span_warning("You're thrown clear of [movable_parent]!"))
+	rider.throw_at(target, throw_range, throw_speed, movable_parent, gentle = gentle)
 
 /// If we're a cyborg or animal and we spin, we yeet whoever's on us off us
 /datum/component/riding/creature/proc/check_emote(mob/living/user, datum/emote/emote)
@@ -540,7 +533,33 @@
 
 /datum/component/riding/creature/raptor
 	require_minigame = TRUE
-	ride_check_flags = RIDER_NEEDS_ARM
+	ride_check_flags = RIDER_NEEDS_ARM | UNBUCKLE_DISABLED_RIDER
+
+/datum/component/riding/creature/raptor/Initialize(mob/living/riding_mob, force, ride_check_flags, potion_boost)
+	. = ..()
+	RegisterSignal(parent, COMSIG_PROJECTILE_PREHIT, PROC_REF(on_bullet_hit))
+	RegisterSignal(parent, COMSIG_MOB_AFTER_APPLY_DAMAGE, PROC_REF(on_attacked))
+
+/datum/component/riding/creature/raptor/proc/on_bullet_hit(atom/target, list/bullet_args, obj/projectile/hit_projectile)
+	SIGNAL_HANDLER
+
+	if(hit_projectile.armor_flag != ENERGY)
+		freak_out()
+
+/datum/component/riding/creature/raptor/proc/on_attacked(mob/living/source, damage_dealt, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, obj/item/attacking_item)
+	SIGNAL_HANDLER
+
+	if(damagetype == STAMINA)
+		freak_out()
+
+/datum/component/riding/creature/raptor/proc/freak_out()
+	var/mob/living/living_parent = parent
+	if(!length(living_parent.buckled_mobs))
+		return
+	living_parent.balloon_alert_to_viewers("freaks out!")
+	living_parent.spin(spintime = 2 SECONDS, speed = 1)
+	for(var/mob/living/buckled_mob in living_parent.buckled_mobs)
+		force_dismount(buckled_mob, throw_range = 2, gentle = TRUE)
 
 /datum/component/riding/creature/raptor/handle_specials()
 	. = ..()

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -543,7 +543,7 @@
 /datum/component/riding/creature/raptor/proc/on_bullet_hit(atom/target, list/bullet_args, obj/projectile/hit_projectile)
 	SIGNAL_HANDLER
 
-	if(hit_projectile.armor_flag != ENERGY)
+	if(hit_projectile.armor_flag == ENERGY)
 		freak_out()
 
 /datum/component/riding/creature/raptor/proc/on_attacked(mob/living/source, damage_dealt, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, obj/item/attacking_item)

--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -309,4 +309,8 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	animated = FALSE
 	insert_on_attack = FALSE
 
+/datum/storage/raptor_storage/on_mousedropped_onto(datum/source, obj/item/dropping, mob/user)
+	. = ..()
+	return NONE
+
 #undef HAPPINESS_BOOST_DAMPENER

--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -310,7 +310,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	insert_on_attack = FALSE
 
 /datum/storage/raptor_storage/on_mousedropped_onto(datum/source, obj/item/dropping, mob/user)
-	. = ..()
+	..()
 	return NONE
 
 #undef HAPPINESS_BOOST_DAMPENER


### PR DESCRIPTION

## About The Pull Request
nerfs on station raptors. now raptors will freak out if hit by an energy gun of any kind, or if they recieve any form of stamina damage (for example from a baton) and will knock their rider off rendering them disabled for a few seconds. im open to other suggestions and feedback

## Why It's Good For The Game
i was a bit saddened to learn these are still being brought up station and some being abused for on-station combat as meatshields. they were primarily balanced around the lavaland tower defense minigames which might make them too tanky of a vehicle on station and unfair for whoever has to deal with them. this pr hopefully restores them to only serve their original purpose, which was to be super nieche mining tools

## Changelog
:cl:
balance: raptors will now knock off their rider and disable them if hit by any energy projectiles or if they recieve any stamina damage
/:cl:
