### PR TITLE
Fix advanced proximity monitors being 1 tile too small (again...)

### DIFF
--- a/code/datums/proximity_monitor/field.dm
+++ b/code/datums/proximity_monitor/field.dm
@@ -129,7 +129,7 @@
 	if(current_range > 0)
 		local_field_turfs += RANGE_TURFS(current_range - 1, center)
 	if(current_range > 1)
-		local_edge_turfs = local_field_turfs - RANGE_TURFS(current_range, center)
+		local_edge_turfs = RANGE_TURFS(current_range, center) - local_field_turfs
 	return list(FIELD_TURFS_KEY = local_field_turfs, EDGE_TURFS_KEY = local_edge_turfs)
 
 //Gets edge direction/corner, only works with square radius/WDH fields!
@@ -169,6 +169,7 @@
 	name = "strange multitool"
 	desc = "Seems to project a colored field!"
 	var/operating = FALSE
+	var/range_to_use = 5
 	var/datum/proximity_monitor/advanced/debug/current = null
 
 /obj/item/multitool/field_debug/Destroy()
@@ -176,7 +177,7 @@
 	return ..()
 
 /obj/item/multitool/field_debug/proc/setup_debug_field()
-	current = new(src, 5, FALSE)
+	current = new(src, range_to_use, FALSE)
 	current.set_fieldturf_color = "#aaffff"
 	current.set_edgeturf_color = "#ffaaff"
 	current.recalculate_field(full_recalc = TRUE)

--- a/code/datums/proximity_monitor/fields/projectile_dampener.dm
+++ b/code/datums/proximity_monitor/fields/projectile_dampener.dm
@@ -28,6 +28,10 @@
 		release_projectile(projectile)
 	return ..()
 
+/datum/proximity_monitor/advanced/projectile_dampener/recalculate_field(full_recalc)
+	full_recalc = TRUE // We always perform a full recalc because we need to update ALL the sprites
+	return ..()
+
 /datum/proximity_monitor/advanced/projectile_dampener/process()
 	var/list/ranged = list()
 	for(var/obj/projectile/projectile in range(current_range, get_turf(host)))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -255,6 +255,7 @@
 #include "spell_mindswap.dm"
 #include "spell_names.dm"
 #include "spell_shapeshift.dm"
+#include "spell_timestop.dm"
 #include "spies.dm"
 #include "spritesheets.dm"
 #include "stack_singular_name.dm"

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -28,4 +28,3 @@
 
 	// cleanup
 	qdel(time_effect)
-	TEST_ASSERT(!kakyoin.IsStun(), "Timestopper should have unfrozen the any frozen targets after the effect expires")

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -15,8 +15,11 @@
 	jotaro.forceMove(out_of_range)
 
 	var/datum/action/cooldown/spell/timestop/timestop = new(dio)
+	timestop.spell_requirements = NONE
 	timestop.Grant(dio)
 	timestop.Trigger()
+	var/obj/effect/timestop/time_effect = locate() in center
+	TEST_ASSERT(time_effect, "Failed to create timestop effect")
 	sleep(0.1 SECONDS) // timestop is invoked async so let's just wait
 
 	TEST_ASSERT(!dio.IsStun(), "Timestopper should not have frozen themselves when using timestop")
@@ -24,6 +27,5 @@
 	TEST_ASSERT(!jotaro.IsStun(), "Timestopper should not have frozen the target outside of 2 tiles of range when using timestop")
 
 	// cleanup
-	var/obj/effect/timestop/time_effect = locate() in center
 	qdel(time_effect)
 	TEST_ASSERT(!kakyoin.IsStun(), "Timestopper should have unfrozen the any frozen targets after the effect expires")

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -1,0 +1,29 @@
+/// Regression test for timestop being a 3x3 instead of a 5x5
+/datum/unit_test/timestop
+
+/datum/unit_test/timestop/Run()
+	var/mob/living/carbon/human/dio = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/kakyoin = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/jotaro = allocate(/mob/living/carbon/human/consistent)
+
+	var/turf/center = run_loc_floor_bottom_left
+	var/turf/in_range = locate(center.x + 2, center.y + 2, center.z)
+	var/turf/out_of_range = locate(in_range.x + 1, in_range.y + 1, in_range.z)
+
+	dio.forceMove(center)
+	kakyoin.forceMove(in_range)
+	jotaro.forceMove(out_of_range)
+
+	var/datum/action/cooldown/spell/timestop/timestop = new(dio)
+	timestop.Grant(dio)
+	timestop.Trigger()
+	sleep(0.1 SECONDS) // timestop is invoked async so let's just wait
+
+	TEST_ASSERT(!dio.IsStun(), "Timestopper should not have frozen themselves when using timestop")
+	TEST_ASSERT(kakyoin.IsStun(), "Timestopper should have frozen the target within 2 tiles of range when using timestop")
+	TEST_ASSERT(!jotaro.IsStun(), "Timestopper should not have frozen the target outside of 2 tiles of range when using timestop")
+
+	// cleanup
+	var/obj/effect/timestop/time_effect = locate() in center
+	qdel(time_effect)
+	TEST_ASSERT(!kakyoin.IsStun(), "Timestopper should have unfrozen the any frozen targets after the effect expires")


### PR DESCRIPTION
## About The Pull Request

Fixes #84301 

Right here, 

https://github.com/tgstation/tgstation/blob/d1051ec8a80b34ca3f3cab2a14e75421e3bae3d6/code/datums/proximity_monitor/field.dm#L129-L132

We get the inner turfs and then use them to find the outer turfs

But

We subtract the inner turfs from the outer turfs instead of subtracting the outer turfs from the inner turfs...

(also adds a unit test and updates the field debugger for better field debugging) 

## Changelog

:cl: Melbert
fix: Fix timestop being 1 tile too small again, and fixes a lot of other field effects from being 1-small as well
/:cl:

