### PR TITLE
Linear effectiveness armour stacking. Removes the maximum armour cap.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -349,10 +349,10 @@ GLOBAL_LIST_INIT(arm_zones, list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 
 /// IF an object is weak against armor, this is the value that any present armor is multiplied by
 #define ARMOR_WEAKENED_MULTIPLIER 2
-/// Armor can't block more than this as a percentage
-#define ARMOR_MAX_BLOCK 90
 /// Calculates the new armour value after armour penetration. Can return negative values, and those must be caught.
 #define PENETRATE_ARMOUR(armour, penetration) (penetration == 100 ? 0 : 100 * (armour - penetration) / (100 - penetration))
+/// Calculates the armour value of stacking two pieces of armour together.
+#define STACK_ARMOUR(armour1, armour2) (armour1 == 100 ? 100 : (10000 * (armour1 + armour2) - 200 * armour1 * armour2) / (10000 - armour1 * armour2))
 
 /// Return values used in item/melee/baton/baton_attack.
 /// Does a normal item attack.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -293,14 +293,14 @@
 
 	send_item_attack_message(attacking_item, user, targeting_human_readable, targeting)
 
-	var/armor_block = min(run_armor_check(
+	var/armor_block = run_armor_check(
 			def_zone = targeting,
 			attack_flag = MELEE,
 			absorb_text = span_notice("Your armor has protected your [targeting_human_readable]!"),
 			soften_text = span_warning("Your armor has softened a hit to your [targeting_human_readable]!"),
 			armour_penetration = attacking_item.armour_penetration,
 			weak_against_armour = attacking_item.weak_against_armour,
-		), ARMOR_MAX_BLOCK)
+		)
 
 	var/damage = attacking_item.force
 	if(mob_biotypes & MOB_ROBOTIC)

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -314,7 +314,6 @@
 					// but this isn't important enough to warrant all the extra loops of mostly redundant armor checks
 					var/mob/living/carbon/hit_carbon = target
 					var/armor_factor = hit_carbon.getarmor(hit_part, initial(P.armor_flag))
-					armor_factor = min(ARMOR_MAX_BLOCK, armor_factor) //cap damage reduction at 90%
 					if(armor_factor > 0)
 						if(initial(P.weak_against_armour) && armor_factor >= 0)
 							armor_factor *= ARMOR_WEAKENED_MULTIPLIER

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -20,16 +20,22 @@
 	return (armorval/max(organnum, 1))
 
 
+/**
+ * Gets the stacked armour rating of a body part, including the clothes covering that body part.
+ * Arguments:
+ * * obj/item/bodypart/def_zone: The body part to check for.
+ * * damage_type: The damage flag to check the rating for. code\__DEFINES\combat.dm
+ * Returns: The armour rating value of the body part and armour surrounding it.
+ */
 /mob/living/carbon/human/proc/check_armor(obj/item/bodypart/def_zone, damage_type)
 	if(!damage_type)
 		return 0
-	var/protection = 100
+	var/protection = min(physiology.armor.get_rating(damage_type), 100)
 	var/list/covering_clothing = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id, wear_neck) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
 	for(var/obj/item/clothing/clothing_item in covering_clothing)
 		if(clothing_item.body_parts_covered & def_zone.body_part)
-			protection *= (100 - min(clothing_item.get_armor_rating(damage_type), 100)) * 0.01
-	protection *= (100 - min(physiology.armor.get_rating(damage_type), 100)) * 0.01
-	return 100 - protection
+			protection = STACK_ARMOUR(protection, min(clothing_item.get_armor_rating(damage_type), 100))
+	return protection
 
 ///Get all the clothing on a specific body part
 /mob/living/carbon/human/proc/get_clothing_on_part(obj/item/bodypart/def_zone)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -106,7 +106,7 @@
 		damage = hitting_projectile.damage,
 		damagetype = hitting_projectile.damage_type,
 		def_zone = def_zone,
-		blocked = min(ARMOR_MAX_BLOCK, armor_check),  //cap damage reduction at 90%
+		blocked = armor_check,
 		wound_bonus = hitting_projectile.wound_bonus,
 		bare_wound_bonus = hitting_projectile.bare_wound_bonus,
 		sharpness = hitting_projectile.sharpness,


### PR DESCRIPTION
Converts armour stacking to be a function of increasing the effectiveness linearly, and adds a macro for it. The measure for effectiveness of armour is assumed to be the extra required force to deal a unit amount of damage. Also removes the maximum armour cap.
## About The Pull Request
Stacking armour increases the effectiveness linearly. We assume the effectiveness of armour is measured by the extra required force to deal a unit amount of damage.

Example: It takes 1 force to deal 1 damage to an unarmoured target. If the target has an armour rating of 50%, then it takes 2 force to deal 1 damage, so we can measure the effectiveness of that armour as the extra force per damage it adds to the target, which would be 1 force per damage. If we were to stack two pieces of armour with a rating of 50%, then we add the extra forces per damage together, which would be 2 force per damage added, which yields an armour rating of 200%/3 (~66.7%).

Removes the armour cap of 90%.
## Why It's Good For The Game
The existence of the armour cap implies that the armour stacking system was too unstable to be left trusted alone. By converting it from en exponentially effective system to a linearly effective one, achieving ridiculous armour values would either require a ridiculous amount of armour stacking or finding armour with ridiculous values in the first place. This prevents things from getting out of hands while also letting admin armour actually stop pretty much anything except an unstoppable force.
## Changelog
:cl:
balance: Stacking armour will give a body part an armour rating that gives an added force per damage equal to the sum of the added forces per damage of the armours involved.
balance: Armour ratings can go above 90%.
/:cl:
