### PR TITLE
Requires Unregulated Bluespace Research for the Event Horizon Anti-Existential Beam Rifle

### DIFF
--- a/code/modules/research/techweb/nodes/security_nodes.dm
+++ b/code/modules/research/techweb/nodes/security_nodes.dm
@@ -101,7 +101,6 @@
 	description = "So advanced, even engineers are baffled by its operational principles."
 	prereq_ids = list("electric_weapons")
 	design_ids = list(
-		"beamrifle",
 		"xray_laser",
 		"nuclear_gun",
 	)

--- a/code/modules/research/techweb/nodes/syndicate_nodes.dm
+++ b/code/modules/research/techweb/nodes/syndicate_nodes.dm
@@ -44,5 +44,6 @@
 	prereq_ids = list("parts_bluespace", "syndicate_basic")
 	design_ids = list(
 		"desynchronizer",
+		"beamrifle",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)


### PR DESCRIPTION
## About The Pull Request

The Event Horizon Anti-Existential Beam Rifle now requires Unregulated Bluespace Research, which itself requires both Bluespace Parts and Illegal Tech. This puts it in the same tier as the Desynchronizer.

![image](https://github.com/tgstation/tgstation/assets/7019927/90ce5fd8-bc0e-4d97-828e-a9daf368d06a)

## Why It's Good For The Game

The original intent for the weapon was for it to be an extremely late-game option as the end-all, be-all gun where only one really could exist at a time. This thing is an absolute _monster_ in that it has very little cooldown, can hit things multiple screens away, and gibs whoever it hits. I'm down for it - it's fun and stupid and goofy and something I would love to see _sometimes_.

I saw it in like 4 rounds in a row earlier today. Fuck.

I feel like it's either "make it harder to get" or "nerf it into obscurity" and I really don't want what we replaced the meme rifle with to end up being as shitty as the meme rifle was.

Worth noting that a lot of people were recommending a change that would make the rifle require only a single vortex core, but would require and consume a vortex core when it fires, meaning it can only be fired a total of like 4-5 times in a round. That sounds great but I don't know how to go about coding it and I feel like a change needs to be made sooner rather than later, so we're doing this for now. If someone comes back and implements that instead before this gets merged, I'll close this PR.

Also @optimumtact told me to ping him when I post this.
## Changelog
:cl: Vekter
balance: The Event Horizon Anti-Existential Beam Rifle now requires Unregulated Bluespace Research to be constructed.
/:cl:
