### PR TITLE
Xenobio Slime Extract Nerfs

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -367,7 +367,7 @@ GLOBAL_LIST_INIT(snow_recipes, list ( \
 
 
 GLOBAL_LIST_INIT(adamantine_recipes, list(
-	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=1, res_amount=1, category = CAT_ROBOT),
+	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=3, res_amount=1, category = CAT_ROBOT),
 	))
 
 /obj/item/stack/sheet/mineral/adamantine

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -88,7 +88,7 @@
 
 //Gold
 /datum/chemical_reaction/slime/slimemobspawn
-	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 15)
 	required_container = /obj/item/slime_extract/gold
 	deletes_extract = FALSE //we do delete, but we don't do so instantly
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_SLIME | REACTION_TAG_DANGEROUS
@@ -103,7 +103,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message(span_danger("The slime extract begins to vibrate violently!"))
-	addtimer(CALLBACK(src, PROC_REF(chemical_mob_spawn), holder, 5, "Gold Slime", HOSTILE_SPAWN), 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(chemical_mob_spawn), holder, 4, "Gold Slime", HOSTILE_SPAWN), 5 SECONDS)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser
 	required_reagents = list(/datum/reagent/blood = 1)
@@ -222,7 +222,7 @@
 	required_container = /obj/item/slime_extract/orange
 
 /datum/chemical_reaction/slime/slimefire
-	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 15)
 	required_container = /obj/item/slime_extract/orange
 	deletes_extract = FALSE
 
@@ -249,12 +249,12 @@
 
 //Yellow
 /datum/chemical_reaction/slime/slimeoverload
-	required_reagents = list(/datum/reagent/blood = 1)
+	required_reagents = list(/datum/reagent/blood = 15)
 	required_container = /obj/item/slime_extract/yellow
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_SLIME | REACTION_TAG_DANGEROUS
 
 /datum/chemical_reaction/slime/slimeoverload/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	empulse(get_turf(holder.my_atom), 3, 7)
+	empulse(get_turf(holder.my_atom), 3, 5)
 	..()
 
 /datum/chemical_reaction/slime/slimecell
@@ -356,7 +356,7 @@
 
 //Oil
 /datum/chemical_reaction/slime/slimeexplosion
-	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 15)
 	required_container = /obj/item/slime_extract/oil
 	deletes_extract = FALSE
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_SLIME | REACTION_TAG_DANGEROUS
@@ -380,7 +380,7 @@
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder?.my_atom)
-		explosion(holder.my_atom, devastation_range = 1, heavy_impact_range = 3, light_impact_range = 6, explosion_cause = src)
+		explosion(holder.my_atom, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, explosion_cause = src)
 
 
 /datum/chemical_reaction/slime/slimeoil
@@ -408,7 +408,7 @@
 
 //Adamantine
 /datum/chemical_reaction/slime/adamantine
-	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 15)
 	required_container = /obj/item/slime_extract/adamantine
 
 /datum/chemical_reaction/slime/adamantine/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)


### PR DESCRIPTION
Oil, Adamantine, Orange, and Gold slime extracts require 15 units of liquid plasma (up from 1 unit) to activate their plasma reaction. Yellow requires 15 units of blood to activate a blood reaction (up from 1 unit). Gold slime extracts spawn 4 hostile mobs (down from 5) during a plasma reaction. Yellow slime extracts have an EMP range of 5 (down from 7) during a blood reaction. Oil slime extracts have a 1,2,4 explosion range (down from 1,3,6). All of this is to compensate for xenobio effectively being sped up by 3x from a previous PR i made. Adamantine golem shells require 3 (up from 1) adamantine sheets to make.

(https://github.com/tgstation/tgstation/pull/84278)

## About The Pull Request

In the comments of the previous PR, a rather good point was made about how spamable a certain few of the extracts were, and i've taken the liberty of making a few nerfs to compensate.

## Why It's Good For The Game

Increasing the plasma cost of certain slime extracts to fifteen likely won't slow anyone down from using them, but it does ensure the user will drain their plasma supply quickly and limit how many slime cores they can use. Of course, restocking plasma isn't super difficult in xenobiology alone but it WILL ensure both downtime between assaults as the user will seek out a grinder for liquid plasma and force the user to spend time stocking up on plasma in the first place.

If that wasn't enough, i took the liberty of nerfing Gold, and Oil plasma reactions, also after some thinking, Yellow blood reactions. We also don't want golem armies (as fun as that was to fight).

Having an abundance of monster parties, explosive grenades, or emp grenades is likely frustrating to deal with, so more nerfs were necessary.

## Changelog

:cl:
balance: Due to selective breeding of slimes, some species require roughly 3x more plasma than normal to activate a plasma reaction. Slime extracts affected are: Oil, Adamantine, Orange, and Gold. Yellow slimes require 3x more blood to activate a blood reaction.
balance: Oil slime extracts have become less potent during a plasma reaction due to selective breeding conditions.
balance: Gold slime extracts give rise to one less monster during a plasma reaction due to selective breeding conditions.
balance: Yellow slime extracts have become less potent during a blood reaction due to selective breeding conditions.
balance: Adamantine golem shells require 3 sheets rather than 1, due to unknown circumstances.
/:cl:
