### PR TITLE
Fixed quirk conflict between transhumanist and prosthetic limb

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(nearsighted_glasses, list(
 ))
 
 ///Options for the prosthetic limb quirk to choose from
-GLOBAL_LIST_INIT(limb_choice, list(
+GLOBAL_LIST_INIT(prosthetic_limb_choice, list(
 	"Left Arm" = /obj/item/bodypart/arm/left/robot/surplus,
 	"Right Arm" = /obj/item/bodypart/arm/right/robot/surplus,
 	"Left Leg" = /obj/item/bodypart/leg/left/robot/surplus,

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/item_quirk/clown_enjoyer, /datum/quirk/item_quirk/mime_fan),
 	list(/datum/quirk/bad_touch, /datum/quirk/friendly),
 	list(/datum/quirk/extrovert, /datum/quirk/introvert),
-	list(/datum/quirk/prosthetic_limb, /datum/quirk/quadruple_amputee, /datum/quirk/transhumanist, /datum/quirk/body_purist),
+	list(/datum/quirk/prosthetic_limb, /datum/quirk/quadruple_amputee, /datum/quirk/body_purist),
 	list(/datum/quirk/prosthetic_organ, /datum/quirk/tin_man, /datum/quirk/body_purist),
 	list(/datum/quirk/quadruple_amputee, /datum/quirk/paraplegic, /datum/quirk/hemiplegic),
 	list(/datum/quirk/quadruple_amputee, /datum/quirk/frail),

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/bad_touch, /datum/quirk/friendly),
 	list(/datum/quirk/extrovert, /datum/quirk/introvert),
 	list(/datum/quirk/prosthetic_limb, /datum/quirk/quadruple_amputee, /datum/quirk/body_purist),
+	list(/datum/quirk/transhumanist, /datum/quirk/body_purist),
 	list(/datum/quirk/prosthetic_organ, /datum/quirk/tin_man, /datum/quirk/body_purist),
 	list(/datum/quirk/quadruple_amputee, /datum/quirk/paraplegic, /datum/quirk/hemiplegic),
 	list(/datum/quirk/quadruple_amputee, /datum/quirk/frail),

--- a/code/datums/quirks/negative_quirks/prosthetic_limb.dm
+++ b/code/datums/quirks/negative_quirks/prosthetic_limb.dm
@@ -16,9 +16,9 @@
 	customization_options = list(/datum/preference/choiced/prosthetic)
 
 /datum/quirk/prosthetic_limb/add_unique(client/client_source)
-	var/limb_type = GLOB.limb_choice[client_source?.prefs?.read_preference(/datum/preference/choiced/prosthetic)]
+	var/limb_type = GLOB.prosthetic_limb_choice[client_source?.prefs?.read_preference(/datum/preference/choiced/prosthetic)]
 	if(isnull(limb_type))  //Client gone or they chose a random prosthetic
-		limb_type = GLOB.limb_choice[pick(GLOB.limb_choice)]
+		limb_type = GLOB.prosthetic_limb_choice[pick(GLOB.prosthetic_limb_choice)]
 
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/bodypart/surplus = new limb_type()

--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -110,6 +110,14 @@
 	if(isnull(part_type))  //Client gone or they chose a random part
 		part_type = GLOB.part_choice_transhuman[pick(GLOB.part_choice_transhuman)]
 
+	if(quirk_holder.has_quirk(/datum/quirk/prosthetic_limb))
+		var/obj/item/bodypart/shit_limb = GLOB.prosthetic_limb_choice[client_source?.prefs?.read_preference(/datum/preference/choiced/prosthetic)]
+		var/obj/item/bodypart/part_part = part_type
+		if(ispath(shit_limb, /obj/item/bodypart) && ispath(part_part, /obj/item/bodypart))
+			// dumbass already has a part in the same spot so let's just let the shoddy trait do its thing instead
+			if(initial(shit_limb.body_zone) == initial(part_part.body_zone))
+				return
+
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/new_part = new part_type()
 	if(isbodypart(new_part))

--- a/code/modules/client/preferences/prosthetic_limb.dm
+++ b/code/modules/client/preferences/prosthetic_limb.dm
@@ -4,7 +4,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 
 /datum/preference/choiced/prosthetic/init_possible_values()
-	return list("Random") + GLOB.limb_choice
+	return list("Random") + GLOB.prosthetic_limb_choice
 
 /datum/preference/choiced/prosthetic/is_accessible(datum/preferences/preferences)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Transhumanist and prosthetic limb no longer conflict. If you pick the same limb for both it uses the weaker prosthetic (dumbass)

Made the name for prosthetic limb global list more intelligible

## Why It's Good For The Game

> Transhumanist and prosthetic limb no longer conflict. If you pick the same limb for both it uses the weaker prosthetic (dumbass)

I wanted to RP a guy with a robotic voicebox and prosthetic limb but the game didn't let me, which I thought was pretty lame! Since the root issue is likely that both can have the same limb which ends up as Free Points as transhuman takes priority, I just added a check to ensure that can't happen and is overridden by the negative instead. Any transhumanist mood point benefits are made up for by the bad limb.

> Made the name for prosthetic limb global list more intelligible

It was bad

## Changelog

:cl:
qol: Transhumanist and prosthetic limb no longer conflict. If you pick the same limb for both it uses the weaker prosthetic (dumbass)
code: Made the name for prosthetic limb global list more intelligible

/:cl:

