### PR TITLE
Holodeck closet & crate items are marked as holograms

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_closet.dm
+++ b/code/__DEFINES/dcs/signals/signals_closet.dm
@@ -1,2 +1,2 @@
 /// Called in /obj/structure/closet/PopulateContents()
-#define COMSIG_CLOSET_POPULATE_CONTENTS "closet_populate_contents"
+#define COMSIG_CLOSET_CONTENTS_INITIALIZED "closet_populate_contents"

--- a/code/__DEFINES/dcs/signals/signals_closet.dm
+++ b/code/__DEFINES/dcs/signals/signals_closet.dm
@@ -1,2 +1,2 @@
 /// Called in /obj/structure/closet/PopulateContents()
-#define COMSIG_CLOSET_CONTENTS_INITIALIZED "closet_populate_contents"
+#define COMSIG_CLOSET_CONTENTS_INITIALIZED "closet_initialize_contents"

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -123,7 +123,7 @@
 
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot/make_item(spawn_loc, type_path_to_make)
 	var/obj/structure/closet/closet_to_fill = ..()
-	closet_to_fill.RegisterSignal(closet_to_fill, COMSIG_CLOSET_POPULATE_CONTENTS, TYPE_PROC_REF(/obj/structure/closet/, populate_with_random_maint_loot))
+	closet_to_fill.RegisterSignal(closet_to_fill, COMSIG_CLOSET_CONTENTS_INITIALIZED, TYPE_PROC_REF(/obj/structure/closet/, populate_with_random_maint_loot))
 
 	return closet_to_fill
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -452,7 +452,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	if (!contents_initialized)
 		contents_initialized = TRUE
 		PopulateContents()
-		SEND_SIGNAL(src, COMSIG_CLOSET_POPULATE_CONTENTS)
+		SEND_SIGNAL(src, COMSIG_CLOSET_CONTENTS_INITIALIZED)
 
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -182,7 +182,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()
-	SEND_SIGNAL(src, COMSIG_CLOSET_POPULATE_CONTENTS)
+	return
 
 /// Populate the closet with stuff that needs to be added before it is opened.
 /// This is useful for things like traitor objectives.
@@ -452,6 +452,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	if (!contents_initialized)
 		contents_initialized = TRUE
 		PopulateContents()
+		SEND_SIGNAL(src, COMSIG_CLOSET_POPULATE_CONTENTS)
 
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -140,7 +140,7 @@
 	for (var/i in 1 to rand(2,6))
 		new /obj/effect/spawner/random/maintenance(src)
 
-	UnregisterSignal(src, COMSIG_CLOSET_POPULATE_CONTENTS)
+	UnregisterSignal(src, COMSIG_CLOSET_CONTENTS_INITIALIZED)
 
 ///Removes the supply manifest from the closet
 /obj/structure/closet/crate/proc/tear_manifest(mob/user)

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -293,6 +293,8 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 		if(isstructure(holo_object))
 			holo_object.obj_flags |= NO_DEBRIS_AFTER_DECONSTRUCTION
+			if(istype(holo_object, /obj/structure/closet))
+				RegisterSignal(holo_object, COMSIG_CLOSET_POPULATE_CONTENTS, PROC_REF(register_contents))
 			return
 
 		if(ismachinery(holo_object))
@@ -303,6 +305,12 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 			if(istype(holo_machine, /obj/machinery/button))
 				var/obj/machinery/button/holo_button = holo_machine
 				holo_button.setup_device()
+
+/obj/machinery/computer/holodeck/proc/register_contents(obj/structure/closet/storage)
+	SIGNAL_HANDLER
+
+	for(var/atom/movable/item as anything in storage.get_all_contents_type(/atom/movable))
+		add_to_spawned(item)
 
 /**
  * A separate proc for objects that weren't loaded by the template nor spawned by holo effects

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -310,6 +310,8 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	SIGNAL_HANDLER
 
 	for(var/atom/movable/item as anything in storage.get_all_contents_type(/atom/movable))
+		if(item == storage)
+			continue
 		add_to_spawned(item)
 
 /**

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -294,7 +294,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 		if(isstructure(holo_object))
 			holo_object.obj_flags |= NO_DEBRIS_AFTER_DECONSTRUCTION
 			if(istype(holo_object, /obj/structure/closet))
-				RegisterSignal(holo_object, COMSIG_CLOSET_POPULATE_CONTENTS, PROC_REF(register_contents))
+				RegisterSignal(holo_object, COMSIG_CLOSET_CONTENTS_INITIALIZED, PROC_REF(register_contents))
 			return
 
 		if(ismachinery(holo_object))


### PR DESCRIPTION
## About The Pull Request
- Fixes #83834
- Fixes #74765

When a holographic closet/crate is opened for the 1st time all their items are marked as holograms & get deleted when the simulation is changed

## Changelog
:cl:
fix: Holodeck closet & crate items are marked as holograms as well
fix: Holodeck closet & crate items delete themselves when the program is changed
/:cl:
