### PR TITLE
Surgical omnitool upgrade upgrades the health analyzer

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -421,6 +421,9 @@
 	model_type = list(/obj/item/robot_model/medical,  /obj/item/robot_model/syndicate_medical)
 	model_flags = BORG_MODEL_MEDICAL
 
+	items_to_add = list(/obj/item/healthanalyzer/advanced)
+	items_to_remove = list(/obj/item/healthanalyzer)
+
 /obj/item/borg/upgrade/surgery_omnitool/action(mob/living/silicon/robot/cyborg, mob/living/user = usr)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
#84305
That pr's branch was broken in some way so I had to make a new one to change it
## About The Pull Request

The mediborg omnitool upgrade makes your health analyzer advanced now

## Why It's Good For The Game

It's weird that mediborgs can't get advanced health analyzers. The omnitool upgrade makes your tools better (including the syringe which isn't part of the omnitool) so it makes sense to put it in here.

## Changelog

:cl:
balance: Mediborg surgical omnitool upgrade makes the health analyzer advanced
/:cl:
