### PR TITLE
Fix cyborg omnitool regression

### DIFF
--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -300,10 +300,9 @@
 	deselect()
 	return ..()
 
-/obj/item/borg/cyborg_omnitool/pre_attack(atom/atom, mob/living/user, params)
+/obj/item/borg/cyborg_omnitool/melee_attack_chain(mob/user, atom/target, params)
 	if(selected)
-		selected.melee_attack_chain(user, atom, params)
-		return TRUE
+		return selected.melee_attack_chain(user, target, params)
 	return ..()
 
 /obj/item/borg/cyborg_omnitool/engineering

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -127,6 +127,7 @@
 #include "container_sanity.dm"
 #include "crayons.dm"
 #include "create_and_destroy.dm"
+#include "cyborg_tool.dm"
 #include "dcs_check_list_arguments.dm"
 #include "dcs_get_id_from_elements.dm"
 #include "designs.dm"

--- a/code/modules/unit_tests/cyborg_tool.dm
+++ b/code/modules/unit_tests/cyborg_tool.dm
@@ -4,7 +4,7 @@
 
 /datum/unit_test/cyborg_tool/Run()
 	var/mob/living/carbon/human/consistent/not_a_borg = allocate(__IMPLIED_TYPE__)
-	var/obj/item/borg/cyborg_omnitool/tool = allocate(__IMPLIED_TYPE__)
+	var/obj/item/borg/cyborg_omnitool/engineering/tool = allocate(__IMPLIED_TYPE__)
 	tool.selected = locate(/obj/item/wrench/cyborg) in tool.toolbox.omnitools
 
 	not_a_borg.put_in_active_hand(tool)

--- a/code/modules/unit_tests/cyborg_tool.dm
+++ b/code/modules/unit_tests/cyborg_tool.dm
@@ -1,0 +1,20 @@
+/// Regression test for the cyborg omnitool to ensure it goes through proper channels
+/datum/unit_test/cyborg_tool
+	var/times_wrenched = 0
+
+/datum/unit_test/cyborg_tool/Run()
+	var/mob/living/carbon/human/consistent/not_a_borg = allocate(__IMPLIED_TYPE__)
+	var/obj/item/borg/cyborg_omnitool/tool = allocate(__IMPLIED_TYPE__)
+	tool.selected = locate(/obj/item/wrench/cyborg) in tool.toolbox.omnitools
+
+	not_a_borg.put_in_active_hand(tool)
+
+	var/obj/structure/frame/machine/frame = allocate(__IMPLIED_TYPE__)
+	RegisterSignal(frame, COMSIG_ATOM_TOOL_ACT(TOOL_WRENCH), PROC_REF(wrenched))
+
+	not_a_borg.ClickOn(frame)
+	TEST_ASSERT_EQUAL(times_wrenched, 1, "Wrenching the frame with a cyborg omnitool should have triggered the wrenched signal")
+
+/datum/unit_test/cyborg_tool/proc/wrenched(...)
+	SIGNAL_HANDLER
+	times_wrenched += 1

--- a/code/modules/unit_tests/cyborg_tool.dm
+++ b/code/modules/unit_tests/cyborg_tool.dm
@@ -5,7 +5,7 @@
 /datum/unit_test/cyborg_tool/Run()
 	var/mob/living/carbon/human/consistent/not_a_borg = allocate(__IMPLIED_TYPE__)
 	var/obj/item/borg/cyborg_omnitool/engineering/tool = allocate(__IMPLIED_TYPE__)
-	tool.selected = locate(/obj/item/wrench/cyborg) in tool.toolbox.omnitools
+	tool.selected = allocate(/obj/item/wrench/cyborg)
 
 	not_a_borg.put_in_active_hand(tool)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #84340 

It hooked pre-attack for tool usage, which is deprecated. 

## Changelog

:cl: Melbert
fix: Fixed cyborg omnitools being unusable on some things
/:cl:

