### PR TITLE
Fixes head protector modules doing...nothing

### DIFF
--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -218,10 +218,10 @@
 	incompatible_modules = list(/obj/item/mod/module/armor_booster, /obj/item/mod/module/infiltrator)
 	required_slots = list(ITEM_SLOT_HEAD)
 
-/obj/item/mod/module/constructor/on_suit_activation()
+/obj/item/mod/module/headprotector/on_suit_activation()
 	ADD_TRAIT(mod.wearer, TRAIT_HEAD_INJURY_BLOCKED, MOD_TRAIT)
 
-/obj/item/mod/module/constructor/on_suit_deactivation(deleting = FALSE)
+/obj/item/mod/module/headprotector/on_suit_deactivation(deleting = FALSE)
 	REMOVE_TRAIT(mod.wearer, TRAIT_HEAD_INJURY_BLOCKED, MOD_TRAIT)
 
 ///Mister - Sprays water over an area.


### PR DESCRIPTION

## About The Pull Request

The head protector module actually applies the trait appropriately.

## Why It's Good For The Game

Apparently head protection started at the hands.

## Changelog
:cl:
fix: Headprotector modules and constructor modules work properly once more.
/:cl:
