### PR TITLE
Toggle the ability for the dead to vote in-game + understandability for the dead whether voting is disabled.

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -293,6 +293,7 @@ SUBSYSTEM_DEF(vote)
 
 	data["user"] = list(
 		"ckey" = user.client?.ckey,
+		"isGhost" = CONFIG_GET(flag/no_dead_vote) && user.stat == DEAD && !user.client?.holder,
 		"isLowerAdmin" = is_lower_admin,
 		"isUpperAdmin" = is_upper_admin,
 		// What the current user has selected in any ongoing votes.

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -274,6 +274,15 @@ SUBSYSTEM_DEF(vote)
 		return FALSE
 
 	return TRUE
+
+/datum/controller/subsystem/vote/proc/toggle_dead_voting(mob/toggle_initiator)
+	var/switch_deadvote_config = !CONFIG_GET(flag/no_dead_vote)
+	CONFIG_SET(flag/no_dead_vote, switch_deadvote_config)
+	var/text_verb = !switch_deadvote_config ? "enabled" : "disabled"
+	log_admin("[key_name(toggle_initiator)] [text_verb] Dead Vote.")
+	message_admins("[key_name_admin(toggle_initiator)] [text_verb] Dead Vote.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead Vote", text_verb))
+
 /datum/controller/subsystem/vote/ui_state()
 	return GLOB.always_state
 
@@ -376,6 +385,15 @@ SUBSYSTEM_DEF(vote)
 			voter.log_message("ended the current vote early", LOG_ADMIN)
 			message_admins("[key_name_admin(voter)] has ended the current vote.")
 			end_vote()
+			return TRUE
+
+		if("toggleDeadVote")
+			if(!check_rights_for(voter.client, R_ADMIN))
+				message_admins("[key_name(voter)] tried to toggle vote abillity for ghosts while having improper rights, \
+					this is potentially a malicious exploit and worth noting.")
+				return
+
+			toggle_dead_voting(voter)
 			return TRUE
 
 		if("toggleVote")

--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -74,6 +74,14 @@ ADMIN_VERB(toggle_ooc_dead, R_ADMIN, "Toggle Dead OOC", "Toggle the OOC channel 
 	message_admins("[key_name_admin(user)] toggled Dead OOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]"))
 
+ADMIN_VERB(toggle_vote_dead, R_ADMIN, "Toggle Dead Vote", "Toggle the vote for dead players on or off.", ADMIN_CATEGORY_SERVER)
+	var/switch_deadvote_config = !CONFIG_GET(flag/no_dead_vote)
+	CONFIG_SET(flag/no_dead_vote, switch_deadvote_config)
+	var/text_verb = !switch_deadvote_config ? "enabled" : "disabled"
+	log_admin("[key_name(user)] [text_verb] Dead Vote.")
+	message_admins("[key_name_admin(user)] [text_verb] Dead Vote.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead Vote", text_verb))
+
 ADMIN_VERB(start_now, R_SERVER, "Start Now", "Start the round RIGHT NOW.", ADMIN_CATEGORY_SERVER)
 	var/static/list/waiting_states = list(GAME_STATE_PREGAME, GAME_STATE_STARTUP)
 	if(!(SSticker.current_state in waiting_states))

--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -75,12 +75,7 @@ ADMIN_VERB(toggle_ooc_dead, R_ADMIN, "Toggle Dead OOC", "Toggle the OOC channel 
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]"))
 
 ADMIN_VERB(toggle_vote_dead, R_ADMIN, "Toggle Dead Vote", "Toggle the vote for dead players on or off.", ADMIN_CATEGORY_SERVER)
-	var/switch_deadvote_config = !CONFIG_GET(flag/no_dead_vote)
-	CONFIG_SET(flag/no_dead_vote, switch_deadvote_config)
-	var/text_verb = !switch_deadvote_config ? "enabled" : "disabled"
-	log_admin("[key_name(user)] [text_verb] Dead Vote.")
-	message_admins("[key_name_admin(user)] [text_verb] Dead Vote.")
-	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead Vote", text_verb))
+	SSvote.toggle_dead_voting(user)
 
 ADMIN_VERB(start_now, R_SERVER, "Start Now", "Start the round RIGHT NOW.", ADMIN_CATEGORY_SERVER)
 	var/static/list/waiting_states = list(GAME_STATE_PREGAME, GAME_STATE_STARTUP)

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -43,6 +43,7 @@ type ActiveVote = {
 
 type UserData = {
   ckey: string;
+  isGhost: BooleanLike;
   isLowerAdmin: BooleanLike;
   isUpperAdmin: BooleanLike;
   singleSelection: string | null;
@@ -242,7 +243,10 @@ const ChoicesPanel = (props) => {
                   textAlign="right"
                   buttons={
                     <Button
-                      disabled={user.singleSelection === choice.name}
+                      tooltip={user.isGhost && 'Voting is off for the dead.'}
+                      disabled={
+                        user.singleSelection === choice.name || user.isGhost
+                      }
                       onClick={() => {
                         act('voteSingle', { voteOption: choice.name });
                       }}
@@ -283,6 +287,8 @@ const ChoicesPanel = (props) => {
                   textAlign="right"
                   buttons={
                     <Button
+                      tooltip={user.isGhost && 'Voting is off for the dead.'}
+                      disabled={user.isGhost}
                       onClick={() => {
                         act('voteMulti', { voteOption: choice.name });
                       }}

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -243,7 +243,9 @@ const ChoicesPanel = (props) => {
                   textAlign="right"
                   buttons={
                     <Button
-                      tooltip={user.isGhost && 'Voting is off for the dead.'}
+                      tooltip={
+                        user.isGhost && 'Ghost voting was disabled by an admin.'
+                      }
                       disabled={
                         user.singleSelection === choice.name || user.isGhost
                       }
@@ -287,7 +289,9 @@ const ChoicesPanel = (props) => {
                   textAlign="right"
                   buttons={
                     <Button
-                      tooltip={user.isGhost && 'Voting is off for the dead.'}
+                      tooltip={
+                        user.isGhost && 'Ghost voting was disabled by an admin.'
+                      }
                       disabled={user.isGhost}
                       onClick={() => {
                         act('voteMulti', { voteOption: choice.name });

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -89,12 +89,24 @@ export const VotePanel = (props) => {
             title="Create Vote"
             buttons={
               !!user.isLowerAdmin && (
-                <Button
-                  icon="refresh"
-                  content="Reset Cooldown"
-                  disabled={LastVoteTime + VoteCD <= 0}
-                  onClick={() => act('resetCooldown')}
-                />
+                <Stack>
+                  <Stack.Item>
+                    <Button
+                      icon="refresh"
+                      content="Reset Cooldown"
+                      disabled={LastVoteTime + VoteCD <= 0}
+                      onClick={() => act('resetCooldown')}
+                    />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="skull"
+                      content="Toggle dead vote"
+                      disabled={!user.isUpperAdmin}
+                      onClick={() => act('toggleDeadVote')}
+                    />
+                  </Stack.Item>
+                </Stack>
               )
             }
           >


### PR DESCRIPTION

## About The Pull Request

Adds a convenient switch to change the ability to vote dead (previously only in the config), and also turns off the button and adds a tooltip to let players know why they can't vote (previously, you could just click, since the button wasn't turned off, but the vote didn't count).


https://github.com/tgstation/tgstation/assets/78199449/404aac9c-0b41-4c16-8ffd-2a435cf25e2c

## Why It's Good For The Game

At the right moments, you can just stop considering the opinions of dead players.
The dead players will be able to understand why they can't vote.

## Changelog

:cl: Vishenka0704
qol: With voting turned off for the dead, you can now understand why you can't vote (being dead).
admin: Voting switch for the dead players
/:cl:
