### PR TITLE
Space Heaters no longer deplete their starting cell instantly, and scale appropriately

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -2,7 +2,7 @@
 #define HEATER_MODE_HEAT "heat"
 #define HEATER_MODE_COOL "cool"
 #define HEATER_MODE_AUTO "auto"
-#define BASE_HEATING_ENERGY (STANDARD_CELL_CHARGE * 0.1)
+#define BASE_HEATING_ENERGY (STANDARD_CELL_RATE * 0.1)
 
 /obj/machinery/space_heater
 	anchored = FALSE

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -2,7 +2,7 @@
 #define HEATER_MODE_HEAT "heat"
 #define HEATER_MODE_COOL "cool"
 #define HEATER_MODE_AUTO "auto"
-#define BASE_HEATING_ENERGY (40 KILO JOULES)
+#define BASE_HEATING_ENERGY (STANDARD_CELL_CHARGE * 0.1)
 
 /obj/machinery/space_heater
 	anchored = FALSE
@@ -20,7 +20,7 @@
 	//We don't use area power, we always use the cell
 	use_power = NO_POWER_USE
 	///The cell we spawn with
-	var/obj/item/stock_parts/power_store/cell = /obj/item/stock_parts/power_store/cell
+	var/obj/item/stock_parts/power_store/cell = /obj/item/stock_parts/power_store/cell/high
 	///Is the machine on?
 	var/on = FALSE
 	///What is the mode we are in now?
@@ -30,7 +30,7 @@
 	///The temperature we trying to get to
 	var/target_temperature = T20C
 	///How much heat/cold we can deliver
-	var/heating_energy = 40 KILO JOULES
+	var/heating_energy = BASE_HEATING_ENERGY
 	///How efficiently we can deliver that heat/cold (higher indicates less cell consumption)
 	var/efficiency = 20
 	///The amount of degrees above and below the target temperature for us to change mode to heater or cooler
@@ -468,7 +468,7 @@
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
 		capacitors_rating += capacitor.tier
 
-	heating_energy = lasers_rating * 20000
+	heating_energy = lasers_rating * BASE_HEATING_ENERGY
 
 	settable_temperature_range = capacitors_rating * 50 //-20 - 80 at base
 	efficiency = (capacitors_rating + 1) * 10


### PR DESCRIPTION

## About The Pull Request

The value for base heating energy now utilizes a multiplier of the define for cell charge.

Space heaters start with a larger cell due to the fact that their old cell was woefully underperforming with the new values.

Also makes the improvised chem heater also use the define and not a hardcoded value.

## Why It's Good For The Game

I tested the values, and while the cell definitely doesn't immediately deplete from the temperature adjustments anymore, it certainly still feels, at best, a lethargic adjustment. I suspect this may need a rework, but all I am interested in doing is getting it working right now.

## Changelog
:cl:
fix: Space heaters do not completely drain their starting cell while trying to change their room temperature by a few degrees.
/:cl:
