### PR TITLE
Fixes instruments enhanced by the portable tuning rite not being able to cast any rites

### DIFF
--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -140,7 +140,10 @@
 			select_sect(usr, params["path"])
 			return TRUE //they picked a sect lets update so some weird spammy shit doesn't happen
 		if("perform_rite")
-			perform_rite(usr, params["path"])
+			if(!ispath(text2path(params["path"]), /datum/religion_rites))
+				message_admins("[ADMIN_LOOKUPFLW(usr)] has tried to spawn an item when performing a rite.")
+				return
+			perform_rite(usr, text2path(params["path"]))
 
 /// Select the sect, called from [/datum/component/religious_tool/proc/AttemptActions]
 /datum/component/religious_tool/proc/select_sect(mob/living/user, path)
@@ -154,9 +157,6 @@
 
 /// Perform the rite, called from [/datum/component/religious_tool/proc/AttemptActions]
 /datum/component/religious_tool/proc/perform_rite(mob/living/user, path)
-	if(!ispath(text2path(path), /datum/religion_rites))
-		message_admins("[ADMIN_LOOKUPFLW(usr)] has tried to spawn an item when performing a rite.")
-		return
 	if(user.mind.holy_role < HOLY_ROLE_PRIEST)
 		if(user.mind.holy_role == HOLY_ROLE_DEACON)
 			to_chat(user, "<span class='warning'>You are merely a deacon of [GLOB.deity], and therefore cannot perform rites.")


### PR DESCRIPTION

## About The Pull Request

The string path that has been passed to `perform_rite` has not been converted to an actual type path. This meant that religious tools that had a whitelist of rites they could perform, could not actually perform these rights, as a string path does not equals with a typepath. This PR fixes that.

## Why It's Good For The Game

Makes a mechanic work, allowing the chaplain to store up rite slots as intended.
Fixes #83997

## Changelog

:cl:
fix: Instruments enhanced with portable tuning can perform the rites that have been granted
/:cl:

