### PR TITLE
Fixes pipe visibility in Northstar ordnance lab

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -18802,10 +18802,10 @@
 /area/station/service/kitchen)
 "eSq" = (
 /obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/purple,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "eSw" = (
@@ -28830,7 +28830,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "hAI" = (
@@ -37314,7 +37314,7 @@
 /area/station/maintenance/floor4/starboard)
 "jJM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/purple,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "jJP" = (


### PR DESCRIPTION

## About The Pull Request
There was clearly some confusion about what this specific scrubber was hooked up to in the ordnance lab, so I moved the pipes up a layer to make it easier to understand.

![image](https://github.com/tgstation/tgstation/assets/7019927/f2b32c37-b816-4487-abd7-a673fac5d010)

Fixes #84336.
## Why It's Good For The Game
Consistency/visibility good.
## Changelog
:cl: Vekter
fix: Fixed the visibility of a pipe in Northstar's ordnance lab
/:cl:
