### PR TITLE
Lavaland mobs are friendly now to Lavaland elite

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -7,7 +7,7 @@
 	name = "elite"
 	desc = "An elite monster, found in one of the strange tumors on lavaland."
 	icon = 'icons/mob/simple/lavaland/lavaland_elites.dmi'
-	faction = list(FACTION_BOSS)
+	faction = list(FACTION_MINING, FACTION_BOSS)
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE


### PR DESCRIPTION

## About The Pull Request

Lavaland mobs are friendly now to Lavaland elite

## Why It's Good For The Game

Someone forgot that recreating the list in subtypes OVERRIDES previous list, so lavaland elite are only at Faction_Boss faction

## Changelog
:cl:
fix: Lavaland elite are at lavaland fauna faction now
/:cl:
