### PR TITLE
Removes a bush from the wall on tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -174490,7 +174490,7 @@ afy
 age
 afy
 afy
-agm
+abW
 aaa
 abM
 abM


### PR DESCRIPTION

## About The Pull Request
Removes a bush that is clipping inside a wall on Tramstation in the maintenance above the morgue.

## Why It's Good For The Game
it's probably an oversight that was missed because maintenance doesn't exist until the map is loaded so it's only noticeable in game and not in the map editor.

## Changelog
:cl:
fix: Removed a bush trapped inside a wall above morgue on Tramstation
/:cl:
