### PR TITLE
[MDB IGNORE] Map lints the `layer` var and scrubs it off our maps

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -686,7 +686,6 @@
 "Ro" = (
 /obj/structure/table/wood,
 /obj/item/bedsheet/rd/royal_cape{
-	layer = 3;
 	pixel_x = 5;
 	pixel_y = 9
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -549,9 +549,7 @@
 /turf/open/misc/beach/sand,
 /area/ruin/powered/beach)
 "rU" = (
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 5
 	},
@@ -920,9 +918,7 @@
 /area/ruin/powered/beach)
 "GA" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/chair/stool/directional/south,
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/under/shorts/red,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
@@ -496,7 +496,6 @@
 /obj/structure/flora/rock/style_random,
 /obj/structure/cable,
 /obj/item/pickaxe{
-	layer = 2.5;
 	pixel_x = -8;
 	pixel_y = 5
 	},

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -306,7 +306,6 @@
 	},
 /obj/machinery/telecomms/server{
 	pixel_z = 12;
-	layer = 2.91;
 	name = "tgsv3";
 	desc = "It's, uh... pending an upgrade."
 	},

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -29,7 +29,6 @@
 "ao" = (
 /obj/machinery/telecomms/server{
 	pixel_z = 12;
-	layer = 2.91;
 	name = "tgsv3";
 	desc = "It's, uh... pending an upgrade."
 	},
@@ -240,8 +239,7 @@
 /area/ruin/space)
 "ud" = (
 /obj/structure/fluff/bus/passable{
-	icon_state = "bottomdoor";
-	layer = 3
+	icon_state = "bottomdoor"
 	},
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)

--- a/_maps/RandomRuins/SpaceRuins/clericden.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clericden.dmm
@@ -108,9 +108,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space)
 "A" = (
-/obj/structure/table/wood{
-	layer = 3.3
-	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack/airless,
 /area/ruin/space)
 "B" = (

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -362,8 +362,7 @@
 /obj/structure/door_assembly/door_assembly_hatch{
 	anchored = 1;
 	name = "crew quarters";
-	desc = "People lived in this place.";
-	layer = 2.8
+	desc = "People lived in this place."
 	},
 /turf/template_noop,
 /area/ruin/space/has_grav/infested_frigate)
@@ -381,10 +380,7 @@
 	pixel_y = 6
 	},
 /obj/item/phone{
-	layer = 3.1
-	},
-/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes{
-	default_raw_text = "<b>STERILIZATION ORDERS</b> <BR><BR><i>Detailed findings:</i><BR><BR>A biological research lab within the HD-10180 system has suffered from a complete containment failure. The SYN-C Brutus is to deliver a nuclear payload via strike team. Everything inside and outside the facility is to be killed on sight, including any research staff. Nuclear authentication codes have been sent via red phone, as have other detailed orders.<BR><BR><b>The rest of the documents are maps and mundane information regarding the crew's destination.</b>";
+	,/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes{default_raw_text = "<b>STERILIZATION ORDERS</b> <BR><BR><i>Detailed findings:</i><BR><BR>A biological research lab within the HD-10180 system has suffered from a complete containment failure. The SYN-C Brutus is to deliver a nuclear payload via strike team. Everything inside and outside the facility is to be killed on sight, including any research staff. Nuclear authentication codes have been sent via red phone, as have other detailed orders.<BR><BR><b>The rest of the documents are maps and mundane information regarding the crew's destination.</b>";
 	name = "STERILIZATION ORDERS";
 	desc = "These are particularly boring for what they entail."
 	},
@@ -638,9 +634,7 @@
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/infested_frigate)
 "jx" = (
-/obj/effect/decal/cleanable/glass{
-	layer = 3.1
-	},
+/obj/effect/decal/cleanable/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
@@ -653,9 +647,7 @@
 	desc = "It would have been locked anyway.";
 	name = "syndicate navigation console"
 	},
-/obj/effect/decal/cleanable/glass{
-	layer = 3.1
-	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "kc" = (
@@ -862,9 +854,7 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
 	},
-/obj/item/ammo_casing/spent{
-	layer = 3.1
-	},
+/obj/item/ammo_casing/spent,
 /obj/item/gun/ballistic/automatic/plastikov,
 /obj/effect/mob_spawn/corpse/human/syndicatepilot,
 /turf/open/floor/mineral/plastitanium/red,
@@ -981,8 +971,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/button/door/directional/north{
 	name = "prisoner isolation shutter";
-	id = "captivity";
-	layer = 3.4
+	id = "captivity"
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
@@ -1238,12 +1227,9 @@
 /area/ruin/space/has_grav/infested_frigate)
 "vj" = (
 /obj/machinery/door/poddoor{
-	id = "Brutusexterior";
-	closingLayer = 2.65
+	id = "Brutusexterior"
 	},
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
-	layer = 2.9
-	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "vm" = (
@@ -1626,9 +1612,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
 "yZ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
-	layer = 2.9
-	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "zg" = (
@@ -1926,9 +1910,7 @@
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gib1-old"
 	},
-/obj/machinery/door/window/left/directional/east{
-	layer = 3.2
-	},
+/obj/machinery/door/window/left/directional/east,
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "captivity"
 	},

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -379,8 +379,9 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/item/phone{
-	,/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes{default_raw_text = "<b>STERILIZATION ORDERS</b> <BR><BR><i>Detailed findings:</i><BR><BR>A biological research lab within the HD-10180 system has suffered from a complete containment failure. The SYN-C Brutus is to deliver a nuclear payload via strike team. Everything inside and outside the facility is to be killed on sight, including any research staff. Nuclear authentication codes have been sent via red phone, as have other detailed orders.<BR><BR><b>The rest of the documents are maps and mundane information regarding the crew's destination.</b>";
+/obj/item/phone,
+/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes{
+	default_raw_text = "<b>STERILIZATION ORDERS</b> <BR><BR><i>Detailed findings:</i><BR><BR>A biological research lab within the HD-10180 system has suffered from a complete containment failure. The SYN-C Brutus is to deliver a nuclear payload via strike team. Everything inside and outside the facility is to be killed on sight, including any research staff. Nuclear authentication codes have been sent via red phone, as have other detailed orders.<BR><BR><b>The rest of the documents are maps and mundane information regarding the crew's destination.</b>";
 	name = "STERILIZATION ORDERS";
 	desc = "These are particularly boring for what they entail."
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -3535,9 +3535,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/atmos)
 "pv" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine/n2,
 /area/ruin/space/ancientstation/beta/atmos)
 "pD" = (
@@ -3866,9 +3864,7 @@
 /area/ruin/space/ancientstation/charlie/hall)
 "se" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/engie)
@@ -4208,9 +4204,7 @@
 /area/ruin/space/ancientstation/beta/hall)
 "uC" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	dir = 8;
 	chamber_id = "beta-n2"
@@ -5104,9 +5098,7 @@
 "Bq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/ancientstation/charlie/kitchen)
 "Bs" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -847,9 +847,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,

--- a/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
@@ -87,12 +87,9 @@
 /area/ruin/space/has_grav/the_outlet/researchrooms)
 "cL" = (
 /obj/effect/rune/apocalypse{
-	req_cultists = 999;
-	layer = 2
+	req_cultists = 999
 	},
-/obj/structure/destructible/cult/pants_altar{
-	layer = 3
-	},
+/obj/structure/destructible/cult/pants_altar,
 /turf/open/floor/cult,
 /area/ruin/space/has_grav/the_outlet/cultinfluence)
 "cZ" = (

--- a/_maps/RandomRuins/SpaceRuins/transit_booth.dmm
+++ b/_maps/RandomRuins/SpaceRuins/transit_booth.dmm
@@ -16,16 +16,6 @@
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/transit_booth)
-"ad" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/transit_booth)
 "ae" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
@@ -92,23 +82,6 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/transit_booth)
-"an" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/cohiba_robusto_ad/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/transit_booth)
-"ao" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/transit_booth)
 "ap" = (
 /obj/machinery/door/airlock/external{
@@ -262,9 +235,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/transit_booth)
 "aF" = (
-/obj/structure/window/reinforced/spawner/directional/south{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/glass/bottle/absinthe/premium{
 	pixel_x = 6
@@ -280,9 +251,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/transit_booth)
 "aG" = (
-/obj/structure/window/reinforced/spawner/directional/south{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/mass_driver{
 	dir = 1;
 	id = "north"
@@ -325,14 +294,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/transit_booth)
-"aJ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/transit_booth)
 "aK" = (
 /obj/machinery/door/poddoor{
 	id = "south"
@@ -341,17 +302,6 @@
 /obj/structure/sign/warning/directional/east,
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/transit_booth)
-"aL" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_y = 11;
-	pixel_x = 3
-	},
-/obj/item/lighter{
-	pixel_x = -8
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/transit_booth)
 "aM" = (
 /obj/machinery/door/poddoor{
@@ -442,9 +392,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/transit_booth)
 "aV" = (
-/obj/structure/window/reinforced/spawner/directional/south{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/rack,
 /obj/item/book/random{
 	pixel_x = -5;
@@ -461,9 +409,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/transit_booth)
 "aW" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "east"
@@ -484,13 +430,6 @@
 /obj/machinery/door/window/right/directional/east{
 	name = "Westbound"
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/transit_booth)
-"aY" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/high_class_martini/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/transit_booth)
 "aZ" = (

--- a/_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
+++ b/_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
@@ -69,9 +69,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/travelers_rest)

--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -1105,13 +1105,11 @@
 "rF" = (
 /obj/machinery/button/door/directional/east{
 	id = "Blastdoor_load";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -6
 	},
 /obj/machinery/button/door/directional/east{
 	id = "Blastdoor_unload";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 6
 	},
@@ -2241,9 +2239,7 @@
 /area/ruin/space/has_grav/waystation/securestorage)
 "NK" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/tank/air{
-	piping_layer = 4
-	},
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/waystation)
 "NT" = (

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -2771,14 +2771,12 @@
 /obj/item/claymore/weak/ceremonial{
 	desc = "Brought to you by the guys in charge of making replica katana toys!";
 	force = 1;
-	layer = 3.01;
 	name = "replica claymore";
 	pixel_x = 5;
 	pixel_y = 8;
 	throwforce = 2
 	},
 /obj/item/shield/roman/fake{
-	layer = 3.01;
 	pixel_x = -7
 	},
 /obj/effect/light_emitter{
@@ -3379,7 +3377,6 @@
 /obj/item/gun/magic/wand{
 	desc = "It's just a fancy staff so that holy clerics and priests look cool. What? You didn't think someone would leave a REAL magic artifact with a snowman out in the cold, did you?";
 	icon_state = "revivewand";
-	layer = 3.01;
 	name = "holy staff";
 	pixel_y = -2
 	},
@@ -4417,9 +4414,7 @@
 	pixel_x = -1;
 	pixel_y = 13
 	},
-/obj/item/staff{
-	layer = 3.01
-	},
+/obj/item/staff,
 /obj/effect/light_emitter{
 	set_cap = 3;
 	set_luminosity = 6;

--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -2023,7 +2023,6 @@
 "Aa" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/condiment/enzyme{
-	layer = 5;
 	pixel_x = 9;
 	pixel_y = 5
 	},
@@ -2510,9 +2509,7 @@
 /area/awaymission/beach)
 "Ft" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/chair/stool/directional/south,
 /obj/item/clothing/glasses/sunglasses{
 	pixel_y = -2;

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -112,7 +112,6 @@
 "aJ" = (
 /obj/machinery/door/poddoor{
 	id = "AwayRD";
-	layer = 2.9;
 	name = "Privacy Shutter"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -929,7 +928,6 @@
 /obj/machinery/door/poddoor{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
 	id = "Awaybiohazard";
-	layer = 2.9;
 	name = "Acid-Proof Biohazard Containment Door"
 	},
 /obj/effect/turf_decal/delivery,
@@ -2233,7 +2231,6 @@
 /obj/machinery/door/poddoor{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
 	id = "Awaybiohazard";
-	layer = 2.9;
 	name = "Acid-Proof Biohazard Containment Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -2377,9 +2374,7 @@
 /area/awaymission/moonoutpost19/syndicate)
 "pF" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/item/clothing/neck/tie/black,
@@ -3455,8 +3450,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains. The skeleton is laid out on its side and there seems to have been no sign of struggle.";
-	layer = 4.1
+	desc = "They look like human remains. The skeleton is laid out on its side and there seems to have been no sign of struggle."
 	},
 /obj/machinery/button/door/directional/west{
 	id = "awaydorm3";
@@ -3773,7 +3767,6 @@
 "yx" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "awaysyndie";
-	layer = 3.1;
 	name = "mining conveyor"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4122,7 +4115,6 @@
 	dir = 1
 	},
 /obj/item/crowbar{
-	layer = 2.9;
 	pixel_x = 7;
 	pixel_y = -13
 	},
@@ -4751,7 +4743,6 @@
 /area/awaymission/moonoutpost19/research)
 "Fw" = (
 /obj/item/pickaxe{
-	layer = 2.9;
 	pixel_x = -12;
 	pixel_y = 6
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -2461,9 +2461,7 @@
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lN" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -2707,25 +2705,19 @@
 "mK" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/awaymission/research/interior/escapepods)
 "mL" = (
 /obj/structure/flora/bush/ferny/style_random,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/awaymission/research/interior/escapepods)
 "mM" = (
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/awaymission/research/interior/escapepods)
 "mO" = (

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -11586,7 +11586,6 @@
 /obj/machinery/door_buttons/access_button{
 	idDoor = "snowdin_turbine_interior";
 	idSelf = "snowdin_turbine_access";
-	layer = 3.1;
 	name = "Turbine Airlock Control";
 	pixel_x = 8;
 	pixel_y = -24

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -629,9 +629,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/central)
 "do" = (
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
@@ -1360,9 +1358,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/undergroundoutpost45/central)
 "fT" = (
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -1723,9 +1719,7 @@
 "hq" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -2459,9 +2453,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "kh" = (
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/awaymission/undergroundoutpost45/research)
@@ -3270,9 +3262,7 @@
 /area/awaymission/undergroundoutpost45/research)
 "mQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -4019,9 +4009,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/research)
 "pl" = (
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
@@ -4232,7 +4220,6 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "qd" = (
 /obj/machinery/meter{
-	layer = 3.3;
 	name = "Mixed Air Tank Out"
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/supply,
@@ -4241,7 +4228,6 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "qe" = (
 /obj/machinery/meter{
-	layer = 3.3;
 	name = "Mixed Air Tank In"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general,
@@ -4354,9 +4340,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "qI" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/closet/secure_closet/engineering_personal{
 	req_access = list("away_maintenance")
 	},
@@ -4535,9 +4519,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "rk" = (
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
@@ -4937,9 +4919,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "sq" = (
-/obj/machinery/meter{
-	layer = 3.3
-	},
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5108,9 +5088,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "td" = (
-/obj/machinery/meter{
-	layer = 3.3
-	},
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/layer_manifold/orange{
 	dir = 4
 	},
@@ -5197,9 +5175,7 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "tw" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -5548,17 +5524,13 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/engineering)
 "uI" = (
-/obj/machinery/meter{
-	layer = 3.3
-	},
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/layer_manifold/orange,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/undergroundoutpost45/engineering)
 "uJ" = (
-/obj/machinery/meter{
-	layer = 3.3
-	},
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5967,9 +5939,7 @@
 /area/awaymission/undergroundoutpost45/mining)
 "wg" = (
 /obj/machinery/light/small/directional/north,
-/obj/item/kirbyplants{
-	layer = 5
-	},
+/obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -6104,9 +6074,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "xd" = (
-/obj/machinery/meter{
-	layer = 3.3
-	},
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,

--- a/_maps/deathmatch/ragin_mages.dmm
+++ b/_maps/deathmatch/ragin_mages.dmm
@@ -761,11 +761,8 @@
 /turf/open/floor/engine/cult,
 /area/deathmatch/teleport)
 "Xv" = (
+/obj/structure/railing,
 /obj/structure/railing{
-	layer = 3.1
-	},
-/obj/structure/railing{
-	layer = 3.1;
 	dir = 1
 	},
 /turf/open/floor/engine/cult,

--- a/_maps/map_files/Basketball/ass_blast_usa.dmm
+++ b/_maps/map_files/Basketball/ass_blast_usa.dmm
@@ -102,9 +102,7 @@
 "jj" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/bun,
 /obj/item/food/bun,
 /obj/item/food/bun,

--- a/_maps/map_files/Basketball/beach_bums.dmm
+++ b/_maps/map_files/Basketball/beach_bums.dmm
@@ -459,7 +459,6 @@
 	pixel_y = 13
 	},
 /obj/item/fishing_line{
-	layer = 4;
 	pixel_x = 6;
 	pixel_y = 3
 	},

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -31750,14 +31750,12 @@
 "kQe" = (
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -8;
 	req_access = list("cargo")
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor2";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 8;
 	req_access = list("cargo")
@@ -41404,9 +41402,7 @@
 /area/station/security/tram)
 "nTz" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
@@ -54839,9 +54835,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
@@ -68802,9 +68796,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
@@ -72007,7 +71999,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/right/directional/south{
-	layer = 3.1;
 	name = "Upload Console Window";
 	req_access = list("ai_upload")
 	},

--- a/_maps/map_files/CTF/downtown.dmm
+++ b/_maps/map_files/CTF/downtown.dmm
@@ -1831,7 +1831,6 @@
 "Ok" = (
 /obj/structure/fluff/bus/passable{
 	icon_state = "bottomdoor";
-	layer = 3;
 	resistance_flags = 64
 	},
 /obj/effect/turf_decal/siding/yellow,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7269,13 +7269,11 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door/directional/east{
 	id = "cargounload";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 6
 	},
 /obj/machinery/button/door/directional/east{
 	id = "cargoload";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -6
 	},
@@ -36139,9 +36137,7 @@
 /area/station/commons/toilet/locker)
 "iYp" = (
 /obj/structure/cable,
-/obj/machinery/nuclearbomb/selfdestruct{
-	layer = 2
-	},
+/obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -58291,9 +58287,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/right/directional/east{
-	layer = 3
-	},
+/obj/machinery/door/window/right/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "oGr" = (
@@ -64088,9 +64082,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/disposal/bin{
-	layer = 3.21
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -77251,9 +77243,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "trC" = (
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/kitchen/rollingpin,
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bowl,
@@ -94386,7 +94376,6 @@
 /obj/item/reagent_containers/blood/random,
 /obj/effect/turf_decal/bot,
 /obj/item/reagent_containers/condiment/enzyme{
-	layer = 5;
 	pixel_x = -6;
 	pixel_y = 8
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1102,7 +1102,6 @@
 /obj/structure/cable,
 /obj/machinery/button/door/directional/east{
 	id = "xenobio10";
-	layer = 4;
 	name = "Xenobio Pen 10 Blast DOors";
 	req_access = list("xenobiology")
 	},
@@ -6245,9 +6244,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "bOy" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering Lobby"
@@ -7153,7 +7150,6 @@
 "cbP" = (
 /obj/machinery/button/door/directional/east{
 	id = "xenobio9";
-	layer = 4;
 	name = "Xenobio Pen 9 Blast DOors";
 	req_access = list("xenobiology")
 	},
@@ -11261,9 +11257,7 @@
 /area/station/science/robotics/lab)
 "dkB" = (
 /obj/structure/rack,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
@@ -11345,7 +11339,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/button/door/directional/east{
 	id = "xenobio11";
-	layer = 4;
 	name = "Xenobio Pen 11 Blast DOors";
 	req_access = list("xenobiology")
 	},
@@ -11488,7 +11481,6 @@
 "doK" = (
 /obj/machinery/button/door/directional/east{
 	id = "xenobio8";
-	layer = 4;
 	name = "Xenobio Pen 8 Blast DOors";
 	req_access = list("xenobiology")
 	},
@@ -13059,9 +13051,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
@@ -27156,7 +27146,6 @@
 "ihN" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio4";
-	layer = 4;
 	name = "Xenobio Pen 4 Blast Door";
 	req_access = list("xenobiology")
 	},
@@ -30959,7 +30948,6 @@
 "jrc" = (
 /obj/machinery/button/door/directional/east{
 	id = "xenobio6";
-	layer = 4;
 	name = "Xenobio Pen 6 Blast DOors";
 	req_access = list("xenobiology")
 	},
@@ -32594,9 +32582,7 @@
 	location = "Medbay"
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/central)
@@ -39721,9 +39707,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Monitoring"
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -40126,7 +40110,6 @@
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	id = "xenobio1";
-	layer = 4;
 	name = "Xenobio Pen 1 Blast Door";
 	req_access = list("xenobiology")
 	},
@@ -44404,9 +44387,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "nsq" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -50345,14 +50326,12 @@
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -8;
 	req_access = list("cargo")
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor2";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 8;
 	req_access = list("cargo")
@@ -50464,7 +50443,6 @@
 /obj/structure/sink/directional/east,
 /obj/machinery/button/door/directional/west{
 	id = "xenobio2";
-	layer = 4;
 	name = "Xenobio Pen 2 Blast Door";
 	req_access = list("xenobiology")
 	},
@@ -57780,7 +57758,6 @@
 "rjT" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio3";
-	layer = 4;
 	name = "Xenobio Pen 3 Blast Door";
 	req_access = list("xenobiology")
 	},
@@ -60369,7 +60346,6 @@
 "rXD" = (
 /obj/machinery/button/door/directional/east{
 	id = "xenobio7";
-	layer = 4;
 	name = "Xenobio Pen 7 Blast DOors";
 	req_access = list("xenobiology")
 	},
@@ -61344,9 +61320,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "snv" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "riot";
 	name = "Security Shutters"
@@ -63810,9 +63784,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "sXf" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table/reinforced,
 /obj/item/stack/wrapping_paper{
 	pixel_x = 3;
@@ -69856,9 +69828,7 @@
 /area/station/medical/medbay/aft)
 "uTc" = (
 /obj/machinery/chem_heater/withbuffer,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
@@ -72408,9 +72378,7 @@
 /area/station/cargo/sorting)
 "vHM" = (
 /obj/structure/rack,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
@@ -78748,7 +78716,6 @@
 "xCh" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio5";
-	layer = 4;
 	name = "Xenobio Pen 5 Blast Door";
 	req_access = list("xenobiology")
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4663,9 +4663,7 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "bFN" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/machinery/button/door/directional/north{
 	id = "pharmacy_shutters";
 	name = "pharmacy shutters control";
@@ -5738,7 +5736,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio6";
-	layer = 3.3;
 	name = "Xenobio Pen 6 Blast Doors";
 	pixel_y = 1;
 	req_access = list("xenobiology")
@@ -9613,9 +9610,7 @@
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/west,
-/obj/machinery/door/window/right/directional/east{
-	layer = 3
-	},
+/obj/machinery/door/window/right/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "dwJ" = (
@@ -17311,7 +17306,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio7";
-	layer = 3.3;
 	name = "Xenobio Pen 7 Blast Doors";
 	pixel_y = 4;
 	req_access = list("xenobiology")
@@ -24709,7 +24703,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio2";
-	layer = 3.3;
 	name = "Xenobio Pen 2 Blast Doors";
 	pixel_y = 1;
 	req_access = list("xenobiology")
@@ -25105,7 +25098,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio1";
-	layer = 3.3;
 	name = "Xenobio Pen 1 Blast Doors";
 	pixel_y = 1;
 	req_access = list("xenobiology")
@@ -29078,14 +29070,12 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -8;
 	req_access = list("cargo")
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor2";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 8;
 	req_access = list("cargo")
@@ -33378,7 +33368,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio8";
-	layer = 3.3;
 	name = "Xenobio Pen 8 Blast Doors";
 	pixel_y = 4;
 	req_access = list("xenobiology")
@@ -34031,7 +34020,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio4";
-	layer = 3.3;
 	name = "Xenobio Pen 4 Blast Doors";
 	pixel_y = 4;
 	req_access = list("xenobiology");
@@ -35236,7 +35224,6 @@
 "mzm" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
-	layer = 3.1;
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -35496,7 +35483,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio5";
-	layer = 3.3;
 	name = "Xenobio Pen 5 Blast Doors";
 	pixel_y = 4;
 	req_access = list("xenobiology")
@@ -38129,8 +38115,7 @@
 /obj/machinery/computer/upload/ai,
 /obj/machinery/door/window/right/directional/south{
 	name = "Upload Console Window";
-	req_access = list("ai_upload");
-	layer = 3.1
+	req_access = list("ai_upload")
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -38793,9 +38778,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "nJn" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -50317,7 +50300,6 @@
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "xenobio3";
-	layer = 3.3;
 	name = "Xenobio Pen 3 Blast Doors";
 	pixel_y = 4;
 	req_access = list("xenobiology")
@@ -60173,9 +60155,7 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "vhb" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
@@ -60255,7 +60235,6 @@
 "viF" = (
 /obj/machinery/computer/upload/borg,
 /obj/machinery/door/window/left/directional/south{
-	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access = list("ai_upload")
 	},
@@ -67603,7 +67582,6 @@
 "xIK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/enzyme{
-	layer = 5;
 	pixel_x = -7;
 	pixel_y = 13
 	},

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -15635,9 +15635,7 @@
 /obj/item/storage/box/syringes{
 	pixel_y = 6
 	},
-/obj/item/stack/medical/mesh{
-	layer = 3.01
-	},
+/obj/item/stack/medical/mesh,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dXz" = (
@@ -23286,9 +23284,7 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/table/reinforced/rglass,
 /obj/item/pai_card,
-/obj/item/reagent_containers/spray/cleaner{
-	layer = 3.01
-	},
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "gcs" = (
@@ -23653,16 +23649,14 @@
 	pixel_y = 10
 	},
 /obj/machinery/cell_charger{
-	pixel_y = 1;
-	layer = 2.91
+	pixel_y = 1
 	},
 /obj/item/stock_parts/power_store/cell/high{
 	pixel_y = 9;
 	pixel_x = -1
 	},
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = -1;
-	layer = 3.01
+	pixel_x = -1
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
@@ -27036,9 +27030,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "hbW" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
@@ -33798,8 +33790,7 @@
 	},
 /obj/machinery/door/window/right/directional/south{
 	name = "Upload Console Window";
-	req_access = list("ai_upload");
-	layer = 3
+	req_access = list("ai_upload")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -44096,9 +44087,7 @@
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/iron/dark/textured_large,
@@ -45974,7 +45963,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/left/directional/south{
-	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access = list("ai_upload")
 	},
@@ -82529,9 +82517,7 @@
 /area/station/maintenance/floor4/port/fore)
 "voX" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
@@ -83410,9 +83396,7 @@
 /area/station/cargo/lobby)
 "vzo" = (
 /obj/machinery/netpod,
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
 "vzu" = (
@@ -86312,7 +86296,6 @@
 "wkP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
-	layer = 3.1;
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -91108,9 +91091,7 @@
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 5
 	},
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "xvO" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1273,13 +1273,11 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door/directional/east{
 	id = "cargounload";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 8
 	},
 /obj/machinery/button/door/directional/east{
 	id = "cargoload";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -8
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -914,8 +914,7 @@
 /area/centcom/central_command_areas/control)
 "ec" = (
 /obj/structure/railing{
-	dir = 4;
-	layer = 4.1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -2091,14 +2090,12 @@
 "jy" = (
 /obj/machinery/button/door/indestructible{
 	id = "XCCQMLoaddoor";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -27;
 	pixel_y = -5
 	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCQMLoaddoor2";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -27;
 	pixel_y = 5
@@ -2798,7 +2795,6 @@
 /obj/machinery/recharger,
 /obj/machinery/button/door/indestructible{
 	id = "XCCsecdepartment";
-	layer = 3;
 	name = "CC Security Checkpoint Control";
 	pixel_x = 24;
 	pixel_y = 24
@@ -4044,8 +4040,7 @@
 /area/centcom/central_command_areas/ferry)
 "sw" = (
 /obj/structure/railing{
-	dir = 8;
-	layer = 4.1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -4910,14 +4905,12 @@
 	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCcustoms1";
-	layer = 3.5;
 	name = "CC Customs 1 Control";
 	pixel_x = 8;
 	pixel_y = -24
 	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCcustoms2";
-	layer = 3.5;
 	name = "CC Customs 2 Control";
 	pixel_x = -8;
 	pixel_y = -24
@@ -6450,8 +6443,7 @@
 "CT" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
-	dir = 8;
-	layer = 4.1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -7319,8 +7311,7 @@
 /area/centcom/central_command_areas/control)
 "HZ" = (
 /obj/structure/railing{
-	dir = 6;
-	layer = 3.1
+	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -7798,8 +7789,7 @@
 /area/centcom/central_command_areas/evacuation)
 "Lz" = (
 /obj/structure/railing{
-	dir = 10;
-	layer = 3.1
+	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -8931,8 +8921,7 @@
 "QB" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
-	dir = 4;
-	layer = 4.1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -10090,7 +10079,6 @@
 	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCcustoms1";
-	layer = 3;
 	name = "CC Emergency Docks Control";
 	pixel_x = 24;
 	pixel_y = 24

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2957,7 +2957,6 @@
 /area/station/security/checkpoint/engineering)
 "aoN" = (
 /obj/machinery/elevator_control_panel{
-	layer = 3.1;
 	pixel_y = 2;
 	linked_elevator_id = "tram_xeno_lift";
 	preset_destination_names = list("2"="Lower                                                                Deck", "3"="Upper                                                                Deck")
@@ -66516,8 +66515,7 @@
 /area/station/science/explab)
 "wrJ" = (
 /obj/structure/railing{
-	dir = 4;
-	layer = 3.1
+	dir = 4
 	},
 /obj/machinery/netpod,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -69614,7 +69612,6 @@
 /area/station/cargo/storage)
 "xAM" = (
 /obj/machinery/elevator_control_panel{
-	layer = 3.1;
 	pixel_y = 2;
 	linked_elevator_id = "tram_xeno_lift";
 	preset_destination_names = list("2"="Lower                                                                Deck", "3"="Upper                                                                Deck")

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2256,7 +2256,6 @@
 "aKU" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/machinery/door/window/brigdoor/left/directional/north{
-	layer = 4.1;
 	name = "Tertiary AI Core Access";
 	req_access = list("ai_upload");
 	pixel_y = 3
@@ -10111,9 +10110,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "dCv" = (
-/obj/structure/railing{
-	layer = 3.01
-	},
+/obj/structure/railing,
 /obj/structure/dresser,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/red,
@@ -13296,8 +13293,7 @@
 /area/station/engineering/supermatter/room)
 "eIo" = (
 /obj/structure/statue/sandstone/venus{
-	dir = 1;
-	layer = 3.3
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/station/science/research)
@@ -14485,9 +14481,7 @@
 /area/station/construction/mining/aux_base)
 "fjb" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fjg" = (
@@ -17947,14 +17941,12 @@
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -8;
 	req_access = list("cargo")
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor2";
-	layer = 4;
 	name = "Loading Doors";
 	pixel_y = 8;
 	req_access = list("cargo")
@@ -22402,9 +22394,7 @@
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 5
 	},
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hUm" = (
@@ -23455,7 +23445,6 @@
 "ipq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
-	layer = 3.1;
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -23574,7 +23563,6 @@
 "irf" = (
 /obj/structure/ladder,
 /obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9;
 	pixel_x = 3
 	},
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -29493,12 +29481,9 @@
 "krz" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4;
-	name = "euthanization chamber freezer";
-	layer = 2.89
+	name = "euthanization chamber freezer"
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -32078,9 +32063,7 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "lny" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -34813,9 +34796,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine)
 "mnm" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -38061,8 +38042,7 @@
 /area/station/service/chapel)
 "nur" = (
 /obj/structure/chair/wood{
-	dir = 1;
-	layer = 2.89
+	dir = 1
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet,
@@ -44295,9 +44275,7 @@
 "pKI" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/science/research)
 "pLd" = (
@@ -44484,9 +44462,7 @@
 /area/station/maintenance/department/cargo)
 "pNW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -44931,8 +44907,7 @@
 /area/station/commons/storage/art)
 "pVd" = (
 /obj/structure/chair/wood{
-	dir = 1;
-	layer = 2.89
+	dir = 1
 	},
 /obj/structure/railing,
 /turf/open/floor/carpet,
@@ -48132,9 +48107,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rdP" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_dispenser,
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -52835,9 +52808,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "sDq" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -56094,9 +56065,7 @@
 /turf/open/floor/plating/reinforced,
 /area/station/command/emergency_closet)
 "tMu" = (
-/obj/structure/railing{
-	layer = 3.01
-	},
+/obj/structure/railing,
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
@@ -57663,9 +57632,7 @@
 /area/station/hallway/primary/starboard)
 "umA" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "umK" = (
@@ -61393,9 +61360,7 @@
 "vFG" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/stairs/north,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage/tech)
 "vFH" = (
@@ -61655,9 +61620,7 @@
 /area/station/maintenance/department/cargo)
 "vLa" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/science/research)
 "vLs" = (
@@ -66665,9 +66628,7 @@
 "xxO" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/science/research)
 "xxT" = (
@@ -67887,7 +67848,6 @@
 "xWR" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/machinery/door/window/brigdoor/right/directional/south{
-	layer = 4.1;
 	name = "Secondary AI Core Access";
 	req_access = list("ai_upload");
 	pixel_y = -4

--- a/_maps/modular_generic/ice_l_storage.dmm
+++ b/_maps/modular_generic/ice_l_storage.dmm
@@ -38,9 +38,7 @@
 /turf/closed/wall/ice,
 /area/template_noop)
 "i" = (
-/obj/structure/railing{
-	layer = 4
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
 /turf/open/floor/plastic,
@@ -122,17 +120,13 @@
 	},
 /obj/item/trash/can,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	layer = 4
-	},
+/obj/structure/railing,
 /turf/open/floor/plastic,
 /area/template_noop)
 "y" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	layer = 4
-	},
+/obj/structure/railing,
 /turf/open/floor/plastic,
 /area/template_noop)
 "z" = (
@@ -164,9 +158,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "D" = (
-/obj/structure/railing{
-	layer = 4
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plastic,
 /area/template_noop)

--- a/_maps/modular_generic/ice_l_storage.dmm
+++ b/_maps/modular_generic/ice_l_storage.dmm
@@ -195,9 +195,7 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/obj/structure/railing{
-	layer = 4
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plastic,
 /area/template_noop)

--- a/_maps/shuttles/emergency_casino.dmm
+++ b/_maps/shuttles/emergency_casino.dmm
@@ -753,7 +753,6 @@
 /area/shuttle/escape)
 "wv" = (
 /obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -857,7 +857,6 @@
 "sz" = (
 /obj/machinery/shuttle_manipulator{
 	desc = "A holographic display of the cruise shuttle we're on right now.";
-	layer = 2.7;
 	max_integrity = 99999;
 	name = "shuttle holographic display"
 	},
@@ -1345,7 +1344,6 @@
 	density = 1;
 	icon = 'icons/obj/machines/shuttle_manipulator.dmi';
 	icon_state = "hologram_on";
-	layer = 2.8;
 	light_color = "#2cb2e8";
 	light_range = 2;
 	max_integrity = 7500;
@@ -1358,7 +1356,6 @@
 	desc = "This is the shuttle we're on. It's amazing what Nanotrasen can do once they actually put more than ten seconds of effort into their projects.";
 	icon = 'icons/obj/machines/shuttle_manipulator.dmi';
 	icon_state = "hologram_whiteship";
-	layer = 4;
 	light_color = "#2cb2e8";
 	light_range = 7;
 	max_integrity = 75000;

--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -605,7 +605,6 @@
 /area/shuttle/escape/brig)
 "zc" = (
 /obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -311,20 +311,17 @@
 "qO" = (
 /obj/structure/table/wood,
 /obj/item/fishing_line{
-	layer = 4;
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/item/fishing_hook{
-	layer = 5;
-	pixel_y = 3
-	},
 /obj/item/bait_can/worm{
-	pixel_x = -5;
 	pixel_y = 13
 	},
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 4
+	},
+/obj/item/fishing_hook{
+	pixel_y = 3
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
@@ -586,12 +583,7 @@
 /area/shuttle/escape)
 "IM" = (
 /obj/structure/table/wood,
-/obj/item/fishing_hook{
-	layer = 5;
-	pixel_y = 3
-	},
 /obj/item/fishing_line{
-	layer = 4;
 	pixel_x = 6;
 	pixel_y = 3
 	},
@@ -601,6 +593,9 @@
 	},
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 4
+	},
+/obj/item/fishing_hook{
+	pixel_y = 3
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -138,9 +138,7 @@
 	name = "Escape Shuttle Cell"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/scanner_gate/luxury_shuttle{
-	layer = 2.6
-	},
+/obj/machinery/scanner_gate/luxury_shuttle,
 /turf/open/indestructible/white,
 /area/shuttle/escape/brig)
 "gY" = (
@@ -340,9 +338,7 @@
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/item/toy/plush/rouny{
 	name = "rouny plushie"
 	},
@@ -444,9 +440,7 @@
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "sH" = (
@@ -630,9 +624,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape/luxury)
 "Bj" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/iron/white/herringbone,
 /area/shuttle/escape/luxury)
@@ -653,9 +645,7 @@
 /area/shuttle/escape)
 "BK" = (
 /obj/structure/girder,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -667,9 +657,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "Ck" = (
-/obj/machinery/scanner_gate/luxury_shuttle{
-	layer = 2.6
-	},
+/obj/machinery/scanner_gate/luxury_shuttle,
 /obj/machinery/door/airlock/silver{
 	name = "First Class"
 	},
@@ -695,18 +683,14 @@
 	dir = 2;
 	name = "Luxurious Emergency Shuttle"
 	},
-/obj/machinery/scanner_gate/luxury_shuttle{
-	layer = 2.6
-	},
+/obj/machinery/scanner_gate/luxury_shuttle,
 /obj/machinery/door/airlock/silver{
 	name = "First Class"
 	},
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/luxury)
 "Dj" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/rack,
 /obj/effect/spawner/random/trash/soap,
 /turf/open/floor/iron/white/herringbone,
@@ -792,9 +776,7 @@
 /obj/structure/girder,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "EZ" = (
@@ -1080,9 +1062,7 @@
 /turf/open/floor/carpet/green,
 /area/shuttle/escape/luxury)
 "Rk" = (
-/obj/machinery/scanner_gate/luxury_shuttle{
-	layer = 2.6
-	},
+/obj/machinery/scanner_gate/luxury_shuttle,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell"

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -160,7 +160,6 @@
 /area/shuttle/escape)
 "aA" = (
 /obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/emergency_meteor.dmm
+++ b/_maps/shuttles/emergency_meteor.dmm
@@ -6,9 +6,7 @@
 /turf/closed/mineral/asteroid/porous,
 /area/shuttle/escape/meteor)
 "c" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/misc/asteroid,
 /area/shuttle/escape/meteor)
 "d" = (

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -40,13 +40,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/shuttle/escape)
-"aN" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/shuttle/escape)
 "aO" = (
 /obj/structure/sign/plaques/kiddie{
 	desc = "It reads: PRIVATE EXHIBIT -  Please inquire with library staff for guided tours.";
@@ -65,16 +58,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/shuttle/escape)
-"aT" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/shuttle/escape)
 "aW" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/shuttle/escape)
@@ -103,9 +88,7 @@
 /area/shuttle/escape)
 "bl" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/basic,
 /area/shuttle/escape)
 "bn" = (
@@ -145,13 +128,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"bx" = (
-/obj/machinery/power/shuttle_engine/propulsion,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "by" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library_private{
@@ -162,13 +138,9 @@
 /area/shuttle/escape)
 "bC" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bI" = (
@@ -428,13 +400,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/basic,
 /area/shuttle/escape)
-"hC" = (
-/obj/machinery/power/shuttle_engine/propulsion,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "hI" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -467,9 +432,7 @@
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/space/basic,
 /area/shuttle/escape)
 "hW" = (
@@ -495,7 +458,6 @@
 "hZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	layer = 2.9;
 	pixel_x = -2;
 	pixel_y = 4
 	},
@@ -633,9 +595,7 @@
 "jt" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "jx" = (
@@ -910,12 +870,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"nQ" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/shuttle/escape)
 "oa" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet,
@@ -931,12 +885,6 @@
 "od" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
-"om" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
-/turf/open/space,
 /area/shuttle/escape)
 "ov" = (
 /obj/machinery/light/small/directional/east,
@@ -1078,7 +1026,6 @@
 "qi" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	layer = 2.9;
 	pixel_x = -2;
 	pixel_y = 4
 	},
@@ -1632,7 +1579,6 @@
 "yP" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/condiment/saltshaker{
-	layer = 3.1;
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -1662,12 +1608,9 @@
 /area/shuttle/escape)
 "zh" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
+/obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron{
-	amount = 20;
-	layer = 3.1
+	amount = 20
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -2162,9 +2105,7 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/condiment/peppermill,
-/obj/item/storage/box/ingredients/wildcard{
-	layer = 3.1
-	},
+/obj/item/storage/box/ingredients/wildcard,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "FA" = (
@@ -2664,12 +2605,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"Ms" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/turf/open/space,
-/area/shuttle/escape)
 "Mt" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -2712,12 +2647,8 @@
 /area/shuttle/escape)
 "Nb" = (
 /obj/machinery/power/shuttle_engine/propulsion,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Nf" = (
@@ -2886,9 +2817,7 @@
 "Pb" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Pe" = (
@@ -2974,7 +2903,6 @@
 "Qj" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	layer = 2.9;
 	pixel_x = -2;
 	pixel_y = 4
 	},
@@ -3254,9 +3182,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "SU" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "SV" = (
@@ -3498,9 +3424,7 @@
 /area/shuttle/escape)
 "VF" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	name = "Outlet Injector"
 	},
@@ -3508,9 +3432,7 @@
 /area/shuttle/escape)
 "VM" = (
 /obj/machinery/mass_driver/chapelgun,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -3632,9 +3554,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Xx" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -3750,9 +3670,7 @@
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/basic,
 /area/shuttle/escape)
 "YZ" = (
@@ -3797,9 +3715,7 @@
 /area/shuttle/escape)
 "Zn" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "Zr" = (
@@ -4380,8 +4296,8 @@ nr
 nr
 nr
 nr
-om
-nQ
+af
+hq
 JG
 JG
 JG
@@ -5118,8 +5034,8 @@ nr
 nr
 nr
 nr
-aT
-aT
+IM
+IM
 JG
 JG
 JG
@@ -5483,9 +5399,9 @@ JG
 (21,1,1) = {"
 af
 af
-nQ
+hq
 aW
-nQ
+hq
 bl
 zE
 jc
@@ -6056,7 +5972,7 @@ JG
 "}
 (28,1,1) = {"
 JG
-aN
+jS
 zE
 wt
 Mf
@@ -6216,7 +6132,7 @@ Ho
 Ho
 Ho
 jt
-bx
+bv
 "}
 (30,1,1) = {"
 JG
@@ -6380,17 +6296,17 @@ Ho
 Ho
 Ho
 Pb
-hC
+Ye
 "}
 (32,1,1) = {"
 JG
 JG
-aT
-aT
-Ms
-Ms
-Ms
-aT
+IM
+IM
+Jl
+Jl
+Jl
+IM
 JG
 JG
 JG

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -177,7 +177,6 @@
 	dir = 10
 	},
 /obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -276,9 +276,7 @@
 /area/shuttle/escape)
 "bd" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table,
 /obj/item/food/canned/beans{
 	pixel_x = 3;
@@ -395,15 +393,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "bB" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "bC" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "bD" = (
@@ -485,9 +479,7 @@
 /area/shuttle/escape)
 "jO" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/food/butterdog,
 /obj/item/food/cakeslice/apple,
 /obj/item/food/cakeslice/brioche,
@@ -548,9 +540,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "xt" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Br" = (
@@ -599,9 +589,7 @@
 "ZM" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/regular,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/vending/wallmed/directional/north{
 	use_power = 0
 	},

--- a/_maps/shuttles/emergency_tranquility.dmm
+++ b/_maps/shuttles/emergency_tranquility.dmm
@@ -37,8 +37,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 4;
-	layer = 4.1
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
@@ -354,8 +353,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
-	layer = 3.1
+	dir = 2
 	},
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
@@ -461,8 +459,7 @@
 "jl" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 10;
-	layer = 3.1
+	dir = 10
 	},
 /obj/structure/flora/bush/fullgrass/style_2,
 /obj/effect/turf_decal/siding/wood{
@@ -511,8 +508,7 @@
 "jM" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 6;
-	layer = 3.1
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -537,8 +533,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 10;
-	layer = 3.1
+	dir = 10
 	},
 /obj/structure/flora/bush/fullgrass,
 /obj/effect/turf_decal/siding/wood{
@@ -695,8 +690,7 @@
 "nA" = (
 /obj/structure/railing/corner{
 	dir = 8;
-	color = "#A47449";
-	layer = 3.1
+	color = "#A47449"
 	},
 /obj/structure/flora/rock/pile/jungle/style_3{
 	pixel_x = -4
@@ -739,8 +733,7 @@
 "oj" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 10;
-	layer = 3.1
+	dir = 10
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -767,8 +760,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 10;
-	layer = 3.1
+	dir = 10
 	},
 /turf/open/floor/grass,
 /area/shuttle/escape)
@@ -819,8 +811,7 @@
 "pf" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 6;
-	layer = 3.1
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -1013,8 +1004,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 6;
-	layer = 3.1
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -1058,9 +1048,7 @@
 /area/shuttle/escape)
 "uR" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /turf/open/floor/wood/large,
 /area/shuttle/escape)
 "uT" = (
@@ -1211,16 +1199,14 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 4;
-	layer = 4.1
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "ya" = (
 /obj/structure/railing/corner{
 	dir = 8;
-	color = "#A47449";
-	layer = 3.1
+	color = "#A47449"
 	},
 /obj/structure/flora/bush/large/style_2{
 	pixel_x = -6;
@@ -1283,8 +1269,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 6;
-	layer = 3.1
+	dir = 6
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -1315,8 +1300,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 4;
-	layer = 4.1
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -1515,8 +1499,7 @@
 "Ci" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 6;
-	layer = 3.1
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -1563,8 +1546,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
-	layer = 3.1
+	dir = 2
 	},
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -1796,9 +1778,7 @@
 /turf/open/floor/iron/dark/small,
 /area/shuttle/escape)
 "Hq" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/small,
@@ -1944,9 +1924,7 @@
 /turf/open/water,
 /area/shuttle/escape)
 "Kk" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/machinery/light/floor,
@@ -2011,8 +1989,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	layer = 3.2
+	dir = 4
 	},
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/flora/bush/flowers_pp/style_2,
@@ -2122,8 +2099,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	layer = 3.2
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/shuttle/escape)
@@ -2176,8 +2152,7 @@
 "Oj" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 10;
-	layer = 3.1
+	dir = 10
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -2357,8 +2332,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	pixel_x = 7;
-	pixel_y = 14;
-	layer = 3.1
+	pixel_y = 14
 	},
 /obj/item/paper_bin{
 	pixel_x = -5;
@@ -2377,15 +2351,11 @@
 /area/shuttle/escape)
 "Sl" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "St" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/machinery/computer/communications{
 	dir = 8
 	},
@@ -2454,7 +2424,6 @@
 /area/shuttle/escape)
 "Tw" = (
 /obj/structure/statue/sandstone/venus{
-	layer = 4;
 	anchored = 1
 	},
 /turf/open/floor/wood,
@@ -2540,8 +2509,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
-	layer = 3.1
+	dir = 2
 	},
 /obj/machinery/microwave,
 /obj/structure/table/wood,

--- a/_maps/shuttles/emergency_venture.dmm
+++ b/_maps/shuttles/emergency_venture.dmm
@@ -647,7 +647,6 @@
 /area/shuttle/escape)
 "Jz" = (
 /obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/emergency_wawa.dmm
+++ b/_maps/shuttles/emergency_wawa.dmm
@@ -210,8 +210,7 @@
 	},
 /obj/structure/fans/tiny/shield{
 	max_integrity = 400;
-	name = "recycling shield";
-	layer = 2.61
+	name = "recycling shield"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -573,8 +572,7 @@
 	},
 /obj/structure/fans/tiny/shield{
 	max_integrity = 400;
-	name = "recycling shield";
-	layer = 2.61
+	name = "recycling shield"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -192,8 +192,7 @@
 "bb" = (
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "garbage";
-	layer = 2.5
+	id = "garbage"
 	},
 /turf/open/floor/wood,
 /area/shuttle/transport)

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -104,9 +104,7 @@
 /area/shuttle/labor)
 "r" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
 "s" = (

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -242,9 +242,7 @@
 /area/shuttle/labor)
 "x" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)

--- a/_maps/shuttles/labour_generic.dmm
+++ b/_maps/shuttles/labour_generic.dmm
@@ -99,9 +99,7 @@
 /area/shuttle/labor)
 "r" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
 "s" = (

--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -45,9 +45,7 @@
 /area/shuttle/mining)
 "j" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,

--- a/_maps/shuttles/mining_common_meta.dmm
+++ b/_maps/shuttles/mining_common_meta.dmm
@@ -45,9 +45,7 @@
 /area/shuttle/mining)
 "j" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -224,9 +224,7 @@
 /area/shuttle/mining)
 "t" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -322,9 +322,7 @@
 /area/shuttle/mining/large)
 "G" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/mining/large)
 "H" = (

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -837,8 +837,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/storage/box/lethalshot,
 /obj/item/gun/ballistic/shotgun/automatic/combat{

--- a/_maps/shuttles/pirate_irs.dmm
+++ b/_maps/shuttles/pirate_irs.dmm
@@ -1027,9 +1027,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/obj/machinery/shower/directional/south{
-	layer = 4
-	},
+/obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/box,
 /obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/dark,

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -355,8 +355,7 @@
 /area/shuttle/pirate)
 "xR" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/melee/energy/sword/saber/purple{
 	pixel_y = 12
@@ -695,12 +694,10 @@
 	pixel_y = 10
 	},
 /obj/item/reagent_containers/cup/glass/bottle/hcider{
-	layer = 3.1;
 	pixel_x = -6;
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/cup/glass/bottle/rum{
-	layer = 3.2;
 	pixel_x = -15;
 	pixel_y = 4
 	},
@@ -713,7 +710,6 @@
 	pixel_y = 15
 	},
 /obj/item/reagent_containers/cup/glass/bottle/wine{
-	layer = 3.1;
 	pixel_x = 3;
 	pixel_y = 5
 	},
@@ -784,8 +780,7 @@
 /area/shuttle/pirate)
 "RO" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/ammo_box/strilka310,
 /obj/item/ammo_box/strilka310{
@@ -942,8 +937,7 @@
 /area/shuttle/pirate)
 "Yj" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,

--- a/_maps/shuttles/ruin_cyborg_mothership.dmm
+++ b/_maps/shuttles/ruin_cyborg_mothership.dmm
@@ -43,9 +43,7 @@
 /area/shuttle/ruin/cyborg_mothership)
 "dI" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/template_noop,
 /area/shuttle/ruin/cyborg_mothership)
 "dO" = (
@@ -232,9 +230,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/ruin/cyborg_mothership)
 "nM" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/closet/crate/preopen,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -733,9 +729,7 @@
 /area/shuttle/ruin/cyborg_mothership)
 "OY" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
 /area/shuttle/ruin/cyborg_mothership)
@@ -796,9 +790,7 @@
 /area/shuttle/ruin/cyborg_mothership)
 "SV" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/template_noop,
 /area/shuttle/ruin/cyborg_mothership)
@@ -809,9 +801,7 @@
 /area/shuttle/ruin/cyborg_mothership)
 "TH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},

--- a/_maps/shuttles/starfury_corvette.dmm
+++ b/_maps/shuttles/starfury_corvette.dmm
@@ -290,8 +290,7 @@
 /area/shuttle/sbc_corvette)
 "aO" = (
 /obj/machinery/door/poddoor/preopen{
-	id = "SBC_corvette_blast";
-	layer = 3
+	id = "SBC_corvette_blast"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_birdshot.dmm
+++ b/_maps/shuttles/whiteship_birdshot.dmm
@@ -366,9 +366,7 @@
 /area/shuttle/abandoned/crew)
 "nz" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/meat/slab/synthmeat{
 	pixel_x = -3;
 	pixel_y = 3

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -36,9 +36,7 @@
 /area/shuttle/abandoned)
 "aX" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "be" = (

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1361,7 +1361,6 @@
 	pixel_y = 14
 	},
 /obj/item/reagent_containers/condiment/enzyme{
-	layer = 5;
 	pixel_x = -5;
 	pixel_y = 6
 	},

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -595,9 +595,7 @@
 /area/shuttle/abandoned)
 "zw" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "zY" = (

--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -21,8 +21,7 @@
 /area/shuttle/sbc_starfury)
 "ad" = (
 /obj/machinery/door/poddoor/preopen{
-	id = "syndie_battlecruier_bridge_blast";
-	layer = 3
+	id = "syndie_battlecruier_bridge_blast"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -409,8 +408,7 @@
 /area/shuttle/sbc_starfury)
 "bx" = (
 /obj/machinery/door/poddoor/preopen{
-	id = "syndie_battlecruier_bridge_blast";
-	layer = 3
+	id = "syndie_battlecruier_bridge_blast"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/structure/cable,
@@ -989,7 +987,6 @@
 /obj/structure/sign/warning/secure_area/directional/east{
 	desc = "A warning sign which reads 'KEEP CLEAR: SHUTTLE BAY'";
 	icon_state = "space";
-	layer = 4;
 	name = "KEEP CLEAR: SHUTTLE BAY"
 	},
 /obj/effect/turf_decal/stripes/red/line,
@@ -999,7 +996,6 @@
 /obj/structure/sign/warning/secure_area/directional/west{
 	desc = "A warning sign which reads 'KEEP CLEAR: SHUTTLE BAY'";
 	icon_state = "space";
-	layer = 4;
 	name = "KEEP CLEAR: SHUTTLE BAY"
 	},
 /obj/effect/turf_decal/stripes/red/line,
@@ -1650,7 +1646,6 @@
 /obj/structure/sign/warning/secure_area/directional/east{
 	desc = "A warning sign which reads 'KEEP CLEAR: SHUTTLE BAY'";
 	icon_state = "space";
-	layer = 4;
 	name = "KEEP CLEAR: SHUTTLE BAY"
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -1691,7 +1686,6 @@
 /obj/structure/sign/warning/secure_area/directional/west{
 	desc = "A warning sign which reads 'KEEP CLEAR: SHUTTLE BAY'";
 	icon_state = "space";
-	layer = 4;
 	name = "KEEP CLEAR: SHUTTLE BAY"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -2192,8 +2186,7 @@
 /area/shuttle/sbc_starfury)
 "hZ" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/gun/ballistic/automatic/m90{
 	pixel_x = -3;
@@ -2208,8 +2201,7 @@
 /area/shuttle/sbc_starfury)
 "ia" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/gun/ballistic/shotgun/bulldog{
 	pixel_x = -3;
@@ -2370,8 +2362,7 @@
 /area/shuttle/sbc_starfury)
 "io" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/gun/ballistic/revolver/syndicate{
 	pixel_x = 2;
@@ -2451,8 +2442,7 @@
 /area/shuttle/sbc_starfury)
 "ix" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/storage/belt/military,
 /obj/item/ammo_box/magazine/m7mm,
@@ -2559,8 +2549,7 @@
 /area/shuttle/sbc_starfury)
 "iN" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/mod/control/pre_equipped/elite{
 	pixel_x = 1;
@@ -3176,7 +3165,6 @@
 /obj/structure/sign/warning/secure_area/directional/north{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
-	layer = 4;
 	name = "EXTERNAL AIRLOCK"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3248,7 +3236,6 @@
 /obj/structure/sign/warning/secure_area/directional/north{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
-	layer = 4;
 	name = "EXTERNAL AIRLOCK"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4887,8 +4874,7 @@
 /area/shuttle/sbc_starfury)
 "Jl" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/item/storage/belt/military,
@@ -4928,8 +4914,7 @@
 /area/shuttle/sbc_starfury)
 "JL" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/card/emag{
 	pixel_x = -2;

--- a/_maps/templates/holodeck_basketball.dmm
+++ b/_maps/templates/holodeck_basketball.dmm
@@ -9,8 +9,7 @@
 /area/template_noop)
 "b" = (
 /obj/structure/hoop{
-	dir = 1;
-	layer = 4.1
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/holofloor,
@@ -44,9 +43,7 @@
 /turf/open/floor/holofloor,
 /area/template_noop)
 "k" = (
-/obj/structure/hoop{
-	layer = 3.9
-	},
+/obj/structure/hoop,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},

--- a/_maps/templates/holodeck_kobayashi.dmm
+++ b/_maps/templates/holodeck_kobayashi.dmm
@@ -5,14 +5,12 @@
 "c" = (
 /obj/machinery/button/massdriver/indestructible{
 	id = "trektorpedo1";
-	layer = 3.9;
 	name = "photon torpedo button";
 	pixel_x = -16;
 	pixel_y = -5
 	},
 /obj/machinery/button/massdriver/indestructible{
 	id = "trektorpedo2";
-	layer = 3.9;
 	name = "photon torpedo button";
 	pixel_x = 16;
 	pixel_y = -5
@@ -131,9 +129,7 @@
 /obj/structure/rack,
 /obj/item/clothing/under/trek/engsec,
 /obj/item/clothing/under/trek/engsec,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
@@ -144,9 +140,7 @@
 /turf/open/floor/holofloor/plating,
 /area/template_noop)
 "J" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},

--- a/_maps/templates/holodeck_lounge.dmm
+++ b/_maps/templates/holodeck_lounge.dmm
@@ -33,9 +33,7 @@
 /area/template_noop)
 "f" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	layer = 3.3
-	},
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "wood"
@@ -56,9 +54,7 @@
 	},
 /area/template_noop)
 "j" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "wood"
@@ -74,9 +70,7 @@
 /area/template_noop)
 "l" = (
 /obj/structure/chair/stool/bar/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "wood"
@@ -279,9 +273,7 @@
 /area/template_noop)
 "Y" = (
 /obj/structure/table/wood/shuttle_bar,
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "wood"

--- a/_maps/templates/lazy_templates/ninja_den.dmm
+++ b/_maps/templates/lazy_templates/ninja_den.dmm
@@ -1691,7 +1691,6 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/condiment/enzyme{
-	layer = 5;
 	pixel_x = 10;
 	pixel_y = 2
 	},
@@ -2040,9 +2039,7 @@
 /obj/item/food/grown/cabbage,
 /obj/item/food/grown/cherries,
 /obj/item/food/grown/cherries,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/grown/redbeet,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/holding)

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -1487,9 +1487,7 @@
 /obj/item/food/grown/tomato,
 /obj/item/food/grown/tomato,
 /obj/item/food/grown/tomato,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
 /obj/item/reagent_containers/condiment/milk,

--- a/_maps/templates/lazy_templates/wizard_den.dmm
+++ b/_maps/templates/lazy_templates/wizard_den.dmm
@@ -328,11 +328,8 @@
 /turf/open/floor/iron,
 /area/centcom/wizard_station)
 "qg" = (
+/obj/structure/railing,
 /obj/structure/railing{
-	layer = 3.1
-	},
-/obj/structure/railing{
-	layer = 3.1;
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
@@ -511,9 +508,7 @@
 /turf/open/floor/plastic,
 /area/centcom/wizard_station)
 "yX" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
+/obj/structure/railing,
 /obj/structure/railing/corner{
 	dir = 4
 	},

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -62,9 +62,7 @@
 /turf/open/floor/pod,
 /area/misc/survivalpod)
 "n" = (
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west{
-	layer = 3
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/machinery/door/window/survival_pod/left/directional/north,
 /turf/open/floor/carpet/black,
 /area/misc/survivalpod)

--- a/_maps/virtual_domains/beach_bar.dmm
+++ b/_maps/virtual_domains/beach_bar.dmm
@@ -491,9 +491,7 @@
 /area/virtual_domain/fullbright)
 "xR" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/chair/stool/directional/south,
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/under/shorts/red,
@@ -685,9 +683,7 @@
 /turf/closed/wall/mineral/sandstone,
 /area/virtual_domain/fullbright)
 "Em" = (
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
+/obj/item/reagent_containers/condiment/enzyme,
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 5
 	},

--- a/tools/maplint/lints/banned_obj_vars.yml
+++ b/tools/maplint/lints/banned_obj_vars.yml
@@ -1,0 +1,4 @@
+help: "This var is obsolete/no longer in use. Please remove it."
+/obj:
+  banned_variables:
+    layer:


### PR DESCRIPTION
## About The Pull Request
Titles.

## Why It's Good For The Game

THIS IS PART 1 OF A 2 PART PR. I'LL BE ADDRESSING THE `PIPING_LAYER` VAR IN ANOTHER PR.

I was asked to do this, and I have no issue with scrubbing and linting vars that are unnecessary. 
Vire/Maurukas explains the details better than I could.

![image](https://github.com/tgstation/tgstation/assets/70232195/b3c75eb8-1923-43e9-a15d-0a54b0c91c20)

Also, enzyme bottle with layer =5, I wish you an eternal burn in Hell.
![image](https://github.com/tgstation/tgstation/assets/70232195/8727d45f-1aa2-40a1-a64c-456085e542bd)


## Changelog

:cl: Jolly
code: Behind the scenes, maps had a little bit of tweaking. If you see things rendering in weird ways, or they don't look like how they used to/supposed to, please report them on GitHub!
/:cl:

