### PR TITLE
firefighter firesuits no longer hide the gloves you are wearing.

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -57,6 +57,7 @@
 /obj/item/clothing/suit/utility/fire/firefighter
 	icon_state = "firesuit"
 	inhand_icon_state = "firefighter"
+	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS


### PR DESCRIPTION

## About The Pull Request

As it says in the title. Fixes https://github.com/tgstation/tgstation/issues/84389

## Why It's Good For The Game

The sprite does not actually cover the gloves, nor does the suit cover your hands. This is an inheritance problem. Simple fix.

## Changelog
:cl:
fix: Emergency firesuits no longer hide your gloves.
/:cl:
