### PR TITLE
You can't force open doors with Jaws of Life unless you have Wire Knowledge from the skillchip.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1173,7 +1173,10 @@
 
 			if(!density)//already open
 				return
-
+			if(!HAS_TRAIT(user, TRAIT_KNOW_ENGI_WIRES))
+				user.balloon_alert(user, "don't know wires!")
+				to_chat(user, span_warning("You don't know which wires to avoid when forcing open the airlock safely!"))
+				return
 			if(!prying_so_hard)
 				var/time_to_open = 50
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?


### PR DESCRIPTION
## About The Pull Request

You can't force open doors with Jaws of Life unless you have Wire Knowledge from the skillchip.

## Why It's Good For The Game

Paramedics greytiding has been a historical issue, and we've limited their access accordingly to reduce this. However, the jaws of life has become a constant presence on every single Paramedic regardless, and overall the proliferation of Jaws results in, after a certain point, access no longer existing because everyone and their mom is carrying jaws as soon as they become researched. It's the priority research every single round, and I think this massively undercuts the effectiveness of @Timberpoes's access rework which we intentionally did to reduce the volume of crew with all access in the round. This brings down the volume of people who can have the all-access afforded by jaws to just Engineering and the number of engineering skill chips present in the CE's locker.

This will improve the gameplay around access, reduce the volume of all access in the round, and improve the gameplay of Engineering by reducing the volume of airlocks they have to fix, along with bringing back Hacking as a prevalent skill(and the gear requirement for insulated gloves accordingly).

## Changelog

:cl:
balance: You can't force open doors with Jaws of Life unless you have Wire Knowledge from the skillchip.
/:cl:
