### PR TITLE
Canister shielding fixes

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -467,12 +467,14 @@
 	if(shielding_powered)
 		var/energy_factor = round(log(10, max(our_pressure - pressure_limit, 1)) + log(10, max(our_temperature - temp_limit, 1)))
 		var/energy_consumed = energy_factor * 250 * seconds_per_tick
-		if(powered(AREA_USAGE_EQUIP, ignore_use_power = TRUE))
-			use_energy(energy_consumed, channel = AREA_USAGE_EQUIP)
-		else if(!internal_cell?.use(energy_consumed * 0.025))
-			shielding_powered = FALSE
-			SSair.start_processing_machine(src)
-			investigate_log("shielding turned off due to power loss")
+		if(energy_consumed)
+			if(powered(AREA_USAGE_EQUIP, ignore_use_power = TRUE))
+				use_energy(energy_consumed, channel = AREA_USAGE_EQUIP)
+			else if(!internal_cell?.use(energy_consumed * 0.025))
+				shielding_powered = FALSE
+				SSair.start_processing_machine(src)
+				investigate_log("shielding turned off due to power loss")
+				update_appearance()
 
 ///return the icon_state component for the canister's indicator light based on its current pressure reading
 /obj/machinery/portable_atmospherics/canister/proc/get_pressure_state()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -461,20 +461,24 @@
 		user.investigate_log("started a transfer into [holding].", INVESTIGATE_ATMOS)
 
 /obj/machinery/portable_atmospherics/canister/process(seconds_per_tick)
+	if(!shielding_powered)
+		return
+
 	var/our_pressure = air_contents.return_pressure()
 	var/our_temperature = air_contents.return_temperature()
+	var/energy_factor = round(log(10, max(our_pressure - pressure_limit, 1)) + log(10, max(our_temperature - temp_limit, 1)))
+	var/energy_consumed = energy_factor * 250 * seconds_per_tick
 
-	if(shielding_powered)
-		var/energy_factor = round(log(10, max(our_pressure - pressure_limit, 1)) + log(10, max(our_temperature - temp_limit, 1)))
-		var/energy_consumed = energy_factor * 250 * seconds_per_tick
-		if(energy_consumed)
-			if(powered(AREA_USAGE_EQUIP, ignore_use_power = TRUE))
-				use_energy(energy_consumed, channel = AREA_USAGE_EQUIP)
-			else if(!internal_cell?.use(energy_consumed * 0.025))
-				shielding_powered = FALSE
-				SSair.start_processing_machine(src)
-				investigate_log("shielding turned off due to power loss")
-				update_appearance()
+	if(!energy_consumed)
+		return
+
+	if(powered(AREA_USAGE_EQUIP, ignore_use_power = TRUE))
+		use_energy(energy_consumed, channel = AREA_USAGE_EQUIP)
+	else if(!internal_cell?.use(energy_consumed * 0.025))
+		shielding_powered = FALSE
+		SSair.start_processing_machine(src)
+		investigate_log("shielding turned off due to power loss")
+		update_appearance()
 
 ///return the icon_state component for the canister's indicator light based on its current pressure reading
 /obj/machinery/portable_atmospherics/canister/proc/get_pressure_state()


### PR DESCRIPTION

## About The Pull Request
Fixes canister shielding turning off in unpowered areas if there is 0 energy consumed from the cell.
Fixes canister appearance not updating when shields turn off from lack of energy.
## Why It's Good For The Game
Canister shields shouldn't be turning themselves off if they aren't using power.
## Changelog
:cl:
fix: Fixed gas canister shields turning themselves off in unpowered areas when they weren't drawing any cell power.
/:cl:
