### PR TITLE
Reworks Maintenance God into Greytide God (also add a couple of signals + components + optional custom religion descriptions)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -87,6 +87,12 @@
 #define COMSIG_CARBON_GAIN_ADDICTION "carbon_gain_addiction"
 ///Called when a carbon is no longer addicted (source = what addiction datum was lost, addicted_mind = mind of the freed carbon)
 #define COMSIG_CARBON_LOSE_ADDICTION "carbon_lose_addiction"
+///Called when a carbon starts going into withdrawals
+#define COMSIG_CARBON_BEGIN_WITHDRAWAL "carbon_begin_withdrawal"
+	#define COMPONENT_WITHDRAWAL_BEGIN_PREVENT (1<<0)
+///Callend when a carbon is no longer in withdrawals
+#define COMSIG_CARBON_END_WITHDRAWAL "carbon_end_withdrawal"
+	#define COMPONENT_WITHDRAWAL_END_PREVENT (1<<0)
 ///Called when a carbon gets a brain trauma (source = carbon, trauma = what trauma was added) - this is before on_gain()
 #define COMSIG_CARBON_GAIN_TRAUMA "carbon_gain_trauma"
 ///Called when a carbon loses a brain trauma (source = carbon, trauma = what trauma was removed)

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -226,6 +226,8 @@
  * Generates an english list (so string) of wanted sac items. Returns null if no targets!
  */
 /datum/component/religious_tool/proc/generate_sacrifice_list()
+	if(easy_access_sect?.custom_sacrifice_description)
+		return easy_access_sect.custom_sacrifice_description
 	if(!length(easy_access_sect?.desired_items))
 		return //specifically null so the data sends as such
 	var/list/item_names = list()

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -78,6 +78,9 @@
 		else
 			withdrawal_stage = 0
 
+	if(withdrawal_stage && (SEND_SIGNAL(affected_carbon, COMSIG_CARBON_BEGIN_WITHDRAWAL, src) & COMPONENT_WITHDRAWAL_BEGIN_PREVENT))
+		withdrawal_stage = 0
+
 	if(!on_drug_of_this_addiction && !HAS_TRAIT(affected_carbon, TRAIT_HOPELESSLY_ADDICTED))
 		if(affected_carbon.mind.remove_addiction_points(type, addiction_loss_per_stage[withdrawal_stage + 1] * seconds_per_tick)) //If true was returned, we lost the addiction!
 			return
@@ -117,6 +120,8 @@
 	affected_carbon.add_mood_event("[type]_addiction", severe_withdrawal_moodlet, name)
 
 /datum/addiction/proc/end_withdrawal(mob/living/carbon/affected_carbon)
+	if(SEND_SIGNAL(affected_carbon, COMSIG_CARBON_END_WITHDRAWAL, src) & COMPONENT_WITHDRAWAL_END_PREVENT)
+		return
 	LAZYSET(affected_carbon.mind.active_addictions, type, 1) //Keeps withdrawal at first cycle.
 	affected_carbon.clear_mood_event("[type]_addiction")
 

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -446,11 +446,12 @@
 		/obj/item/crowbar = 15, // long is the way, and hard, that out of maint leads up to the light
 		/obj/item/wirecutters = 15, // doorhacking is patient and kind; it does not rcd or shock.
 		)
-	custom_sacrifice_description = "organic slurry, and the tools of the tide: yellow gloves... \
+	custom_sacrifice_description = "\
+	organic slurry, and the tools of the tide: yellow gloves... \
 	 Maintenance pump up, but also the baton of those who make it necessary, or your own improvised stunprods. \
-	  Spears: pointed with glass from windows that blocked the way of your gospel.\
-	    Crowbars -- or even the hallowed jaws of life -- and the wirecutters that make them the locus of your power...\
-	    GREYTIDE STATIONWIDE"
+	 Spears: pointed with glass from windows that blocked the way of your gospel. \
+	 Crowbars -- or even the hallowed jaws of life -- and the wirecutters that make them the locus of your power... \
+	 GREYTIDE STATIONWIDE"
 
 	var/list/tide_whispers = list(
 		"comdom",

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -240,15 +240,30 @@
 	to_chat(user, span_warning("You feel your genes rattled and reshaped. <b>You're becoming something new.</b>"))
 	user.emote("laugh")
 	ADD_TRAIT(user, TRAIT_HOPELESSLY_ADDICTED, "maint_adaptation")
+	ADD_TRAIT(user, TRAIT_TOXINLOVER, "maint_adaptation")
 	//addiction sends some nasty mood effects but we want the maint adaption to be enjoyed like a fine wine
 	user.add_mood_event("maint_adaptation", /datum/mood_event/maintenance_adaptation)
+	user.mind.add_addiction_points(/datum/addiction/maintenance_drugs, 1000)
+	var/datum/addiction/maintenance_drugs/maint_addiction = SSaddiction.all_addictions[/datum/addiction/maintenance_drugs]
+	maint_addiction.withdrawal_enters_stage_1(user)
+	maint_addiction.withdrawal_enters_stage_2(user)
+	maint_addiction.withdrawal_enters_stage_3(user) // stay in the tunnels, you horrible little creature
+	//then we forcibly jump their maintenance addiction withdrawal and register to our proc to cancel ending withdrawal
+	//we use LAZYSET type because that's how addictions are built
+	LAZYSET(user.mind.active_addictions, maint_addiction.type, 1000)
+	RegisterSignal(user, COMSIG_CARBON_END_WITHDRAWAL, PROC_REF(remain_maint_adapted))
 	if(iscarbon(user))
 		var/mob/living/carbon/vomitorium = user
 		vomitorium.vomit(VOMIT_CATEGORY_DEFAULT)
 		var/datum/dna/dna = vomitorium.has_dna()
 		dna?.add_mutation(/datum/mutation/human/stimmed) //some fluff mutations
 		dna?.add_mutation(/datum/mutation/human/strong)
-	user.mind.add_addiction_points(/datum/addiction/maintenance_drugs, 1000)//ensure addiction
+
+/datum/religion_rites/maint_adaptation/proc/remain_maint_adapted(datum/source, datum/addiction)
+	SIGNAL_HANDLER
+
+	if(istype(addiction, /datum/addiction/maintenance_drugs))
+		return COMPONENT_WITHDRAWAL_END_PREVENT
 
 /datum/religion_rites/adapted_eyes
 	name = "Adapted Eyes"


### PR DESCRIPTION

## About The Pull Request

Maintenance God is like the burdened god, except that you only just kill yourself, because there aren't enough mice on station to make enough slurry to get anything besides maintenance adaption and a couple of moldied foods. You also don't get any resistance to the toxin/organ damage from eating anything except an extremely specific subset of gross food.

There are a few other reasons it sucks, so I've reworked it into Greytide God instead. Maintenance adaption stays -- and in fact, I made it severe and permanent to boot -- but in exchange you get toxin lover to facilitate the fact that you're meant to be a constantly drug addled, trash eating maintenance creature. You can also gain favor from turning in a set of Greytide themed sacrifice items.

Toxin lover makes you invert toxin damage -- heal from damage, hurt from healing -- so this also encourages you to use a few of the drugs that cause toxin damage to ludicrous excess, though it won't do anything about profound organ failure besides saving you specifically from liver failure killing you with tox (it will not affect liver failure knocking you out until you get it replaced).

I also added goofy whispers and sounds to Greytide God.

Somewhat related: I added signals to addiction code to facilitate preventing the end -- or the beginning -- of withdrawal with accompanying signals and components, and also a bit of logic to religions to let people give their sacrifice description custom text instead of the autogenerated muck it defaults to.
## Why It's Good For The Game

Maintenance God seems like it's a joke religion except the joke is on you for picking it. I changed it to Greytide God and played the joke up, and gave it TOXIN_LOVER so you can play out the maints dwelling trash man to your heart's content.

### ASK ME HOW GREYTIDE GOD CHANGED MY LIFE
![BorisTrailer](https://github.com/tgstation/tgstation/assets/49173900/4706103f-d024-437c-ab4b-fce15bd9bcb8)
## Changelog
:cl: Bisar
add: Maintenance God has been reworked into Greytide God.
add: Alongside organic slurry, Greytide God also desires several items known to be carried by their faithful at all times.
add: Maintenance adaption immediately sets you at the maximum withdrawal for maintenance drugs and locks you there.
add: Maintenance adaption gives you TOXIN_LOVER trait, which reverses the effects of toxin damage. Organ failure will still ruin your day.
code: Added signals for stopping the beginning or end of withdrawal, and signals for the beginning and end of withdrawal.
code: Added optional customized descriptions for religion sacrifice lists, if you don't want the auto-generated one.
/:cl:
