### PR TITLE
Makes extinguisher  has_reagent check subtypes

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -190,7 +190,7 @@
 			balloon_alert(user, "already full!")
 			return TRUE
 		// Make sure we're refilling with the proper chem.
-		if(!(target.reagents.has_reagent(chem)))
+		if(!(target.reagents.has_reagent(chem, check_subtypes = TRUE)))
 			balloon_alert(user, "can't refill with this liquid!")
 			return TRUE
 		var/obj/structure/reagent_dispensers/W = target //will it work?


### PR DESCRIPTION

## About The Pull Request
Fixes #84140
## Why It's Good For The Game
I like spraying cultists with the power of jesus christ
## Changelog
:cl: lorwp
fix: extinguishers now can be filled with subtypes of water again (Namely, holy water)
/:cl:
