### PR TITLE
Fixes a bunch of small issues on various Whiteships

### DIFF
--- a/_maps/shuttles/whiteship_birdshot.dmm
+++ b/_maps/shuttles/whiteship_birdshot.dmm
@@ -26,9 +26,6 @@
 /obj/machinery/meter,
 /turf/open/floor/catwalk_floor,
 /area/shuttle/abandoned/engine)
-"bp" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/abandoned/engine)
 "bq" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -181,11 +178,12 @@
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/overspace,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/crew)
 "gj" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	dir = 1
+	dir = 1;
+	x_offset = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
@@ -338,9 +336,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/smooth_large,
-/area/shuttle/abandoned/cargo)
-"ma" = (
-/turf/closed/wall/mineral/titanium/overspace,
 /area/shuttle/abandoned/cargo)
 "mU" = (
 /obj/structure/toilet{
@@ -538,7 +533,7 @@
 /turf/open/floor/iron/small,
 /area/shuttle/abandoned/medbay)
 "ry" = (
-/turf/closed/wall/mineral/titanium/overspace,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bar)
 "rO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -598,9 +593,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/shuttle/abandoned/engine)
-"uk" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/abandoned/pod)
 "ur" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -1170,7 +1162,7 @@
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/overspace,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/pod)
 "Ll" = (
 /obj/structure/cable,
@@ -1277,7 +1269,7 @@
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/overspace,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bridge)
 "Ql" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1448,9 +1440,6 @@
 /obj/machinery/light/built/directional/west,
 /turf/open/floor/carpet/green,
 /area/shuttle/abandoned/bar)
-"WG" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/abandoned/bridge)
 "WW" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -1538,9 +1527,9 @@
 (1,1,1) = {"
 lt
 lt
-bp
+Gi
 BH
-bp
+Gi
 lt
 lt
 lt
@@ -1552,15 +1541,15 @@ lt
 lt
 lt
 lt
-bp
+Gi
 BH
-bp
+Gi
 lt
 lt
 "}
 (2,1,1) = {"
 lt
-bp
+Gi
 Om
 oe
 Gi
@@ -1578,7 +1567,7 @@ BH
 Gi
 oe
 Om
-bp
+Gi
 lt
 "}
 (3,1,1) = {"
@@ -1588,7 +1577,7 @@ Wu
 RH
 Gi
 oe
-bp
+Gi
 lt
 lt
 lt
@@ -1596,7 +1585,7 @@ lt
 lt
 lt
 lt
-bp
+Gi
 oe
 Gi
 qn
@@ -1674,7 +1663,7 @@ Gi
 lt
 "}
 (7,1,1) = {"
-ma
+Tg
 kQ
 DK
 er
@@ -1694,7 +1683,7 @@ uF
 uF
 BR
 kQ
-ma
+Tg
 "}
 (8,1,1) = {"
 kQ
@@ -1928,7 +1917,7 @@ lt
 "}
 (18,1,1) = {"
 lt
-uk
+PN
 pv
 pv
 pv
@@ -1946,7 +1935,7 @@ KR
 JP
 JP
 JP
-WG
+XB
 lt
 "}
 (19,1,1) = {"
@@ -2021,7 +2010,7 @@ lt
 (22,1,1) = {"
 lt
 lt
-uk
+PN
 pv
 xr
 qO
@@ -2032,12 +2021,12 @@ lt
 lt
 lt
 lt
-WG
+XB
 JP
 Hk
 Bs
 JP
-WG
+XB
 lt
 lt
 "}
@@ -2045,7 +2034,7 @@ lt
 lt
 lt
 lt
-uk
+PN
 BZ
 BZ
 Lj
@@ -2059,7 +2048,7 @@ lt
 Qf
 YJ
 YJ
-WG
+XB
 lt
 lt
 lt

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -685,7 +685,9 @@
 "Hw" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	dir = 1
+	dir = 1;
+	x_offset = 0;
+	y_offset = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -468,7 +468,9 @@
 /area/shuttle/abandoned)
 "XY" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	dir = 1
+	dir = 1;
+	x_offset = 0;
+	y_offset = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/disk/holodisk/donutstation/whiteship,

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -207,7 +207,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/left{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "jM" = (
 /obj/structure/table,
@@ -249,8 +249,8 @@
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Mining Shuttle";
-	port_direction = 4;
-	preferred_direction = 8
+	port_direction = 8;
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
@@ -327,7 +327,7 @@
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "nt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -355,7 +355,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/right{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/bar)
 "pI" = (
 /obj/effect/turf_decal/delivery,
@@ -416,7 +416,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/right{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "rX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -868,7 +868,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "Nh" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -909,7 +909,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/bar)
 "Pe" = (
 /obj/machinery/button/door/directional/north{
@@ -931,7 +931,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/left{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/bar)
 "PR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1031,7 +1031,9 @@
 	},
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
 	dir = 4;
-	view_range = 14
+	view_range = 14;
+	y_offset = 5;
+	x_offset = 0
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8

--- a/_maps/shuttles/whiteship_obelisk.dmm
+++ b/_maps/shuttles/whiteship_obelisk.dmm
@@ -206,7 +206,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/left{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "mQ" = (
 /obj/structure/cable,
@@ -271,14 +271,14 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "ot" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
 	dir = 4;
 	view_range = 14;
-	x_offset = -3;
-	y_offset = -3
+	x_offset = -2;
+	y_offset = -7
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_blue/anticorner{
@@ -438,7 +438,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "zj" = (
 /obj/structure/cable,
@@ -699,7 +699,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/right{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "PR" = (
 /obj/structure/table/wood,

--- a/_maps/shuttles/whiteship_personalshuttle.dmm
+++ b/_maps/shuttles/whiteship_personalshuttle.dmm
@@ -90,7 +90,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/right{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "cM" = (
 /turf/template_noop,
@@ -100,7 +100,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "cY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -372,9 +372,8 @@
 "DT" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
 	dir = 1;
-	view_range = 14;
-	x_offset = -3;
-	y_offset = -3
+	x_offset = 0;
+	y_offset = -5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
@@ -523,7 +522,7 @@
 /obj/machinery/power/shuttle_engine/propulsion/left{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "WL" = (
 /obj/machinery/light/cold/no_nightlight/directional/west,

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -271,7 +271,7 @@
 "lV" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
 	y_offset = 2;
-	x_offset = -7
+	x_offset = -8
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -550,7 +550,7 @@
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	name = "White Ship";
-	port_direction = 2
+	port_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -1164,7 +1164,9 @@
 /area/shuttle/abandoned/cargo)
 "Ft" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	dir = 8
+	dir = 8;
+	x_offset = 0;
+	y_offset = 13
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1

--- a/code/datums/shuttles/whiteship.dm
+++ b/code/datums/shuttles/whiteship.dm
@@ -24,7 +24,7 @@
 /datum/map_template/shuttle/whiteship/birdshot
 	suffix = "birdshot"
 	name = "NT Patrol Bee"
-	description = "A small patrol vessel with a central corridor connecting all rooms. Features 2 small cargo bays and a brig. Spawns with an agressive and deadly Gelatinous Cube"
+	description = "A small patrol vessel with a central corridor connecting all rooms. Features 2 small cargo bays and a brig. Spawns with an aggressive and deadly Gelatinous Cube"
 
 /datum/map_template/shuttle/whiteship/kilo
 	suffix = "kilo"

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -20,7 +20,9 @@
 	// Traits forbided for custom docking
 	var/list/locked_traits = list(ZTRAIT_RESERVED, ZTRAIT_CENTCOM, ZTRAIT_AWAY)
 	var/view_range = 0
+	///x offset for where the camera eye will spawn. Starts from shuttle's docking port
 	var/x_offset = 0
+	///y offset for where the camera eye will spawn. Starts from the shuttle's docking port
 	var/y_offset = 0
 	var/list/whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava, /turf/open/openspace)
 	var/see_hidden = FALSE

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -379,6 +379,7 @@
 		"whiteship_tram",
 		"whiteship_personalshuttle",
 		"whiteship_obelisk",
+		"whiteship_birdshot",
 	)
 
 /// Helper proc that tests to ensure all whiteship templates can spawn at their docking port, and logs their sizes


### PR DESCRIPTION
## About The Pull Request
A lot of White ships in the game had minor issues like the camera eye being way offset in the shuttle navigation console or the ship just flying backwards through space. I also caught a few active turfs on shuttle engine plating.


<details>
  <summary>Full changes</summary>

- Fixed camera offset issues on: whiteship_birdshot.dmm, whiteship_donut.dmm, whiteship_personalshuttle.dmm, whiteship_pubby.dmm, whiteship_obelisk.dmm, whiteship_tram.dmm, whiteship_kilo.dmm, whiteship_cere.dmm

- Fixed whiteship_pubby.dmm, whiteship_kilo.dmm  flying in the wrong direction

- Removed use of /turf/closed/wall/mineral/titanium/overspace on whiteship_birdshot.dmm: These aren't used on any other whiteship so I assume it was used incorrectly here.

- Fixed spelling of "aggressive" in shuttle manipulator for Birdshot's Whiteship.

- Replaced platings that were active turfs with their airless variants on: whiteship_obelisk.dmm, whiteship_personalshuttle.dmm, whiteship_kilo.dmm

- Added an autodoc comment to x_offset and y_offset for shuttles. 

- Fixed whiteship_birdshot.dmm not being able to spawn.

</details>


## Why It's Good For The Game
makes the shuttle navigation console easier to use if you can actually see the ship, also ships drifting sideways through hyperspace is funny but (probably) unintended.



## Changelog
:cl:
fix: Fixed the camera offset for the navigation console on a handful of Whiteships.
fix: Fixed the Pubby Whiteship drifting sideways through hyperspace when in flight.
fix: Fixed the Kilo Whiteship flying backwards through hyperspace when in flight.
fix: The Birdshot Whiteship should actually be able to spawn now.
spellcheck: fixed spelling of "aggressive" in the shuttle manipulator description for the Birdshot Whiteship.
/:cl:
