### PR TITLE
Better Shieldgen Lighting

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -286,6 +286,10 @@
 	icon = 'icons/obj/machines/shield_generator.dmi'
 	icon_state = "shield_wall_gen"
 	base_icon_state = "shield_wall_gen"
+	light_on = FALSE
+	light_range = 2.5
+	light_power = 2
+	light_color = LIGHT_COLOR_BLUE
 	anchored = FALSE
 	density = TRUE
 	req_access = list(ACCESS_TELEPORTER)
@@ -324,6 +328,10 @@
 		connect_to_network()
 	RegisterSignal(src, COMSIG_ATOM_SINGULARITY_TRY_MOVE, PROC_REF(block_singularity_if_active))
 	set_wires(new /datum/wires/shieldwallgen(src))
+
+/obj/machinery/power/shieldwallgen/update_appearance(updates)
+	. = ..()
+	set_light(l_on = !!active)
 
 /obj/machinery/power/shieldwallgen/update_icon_state()
 	icon_state = "[base_icon_state][active ? "_on" : ""]"
@@ -530,7 +538,10 @@
 	icon_state = "shieldwall"
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	light_range = 3
+	light_range = 2.5
+	light_power = 0.7
+	light_color = LIGHT_COLOR_BLUE
+	var/primary_direction = NONE
 	var/needs_power = FALSE
 	var/obj/machinery/power/shieldwallgen/gen_primary
 	var/obj/machinery/power/shieldwallgen/gen_secondary
@@ -553,6 +564,10 @@
 	gen_primary = null
 	gen_secondary = null
 	return ..()
+
+/obj/machinery/shieldwall/update_overlays()
+	. = ..()
+	. += emissive_appearance(icon, icon_state, src, alpha = 200)
 
 /obj/machinery/shieldwall/process()
 	if(needs_power)


### PR DESCRIPTION

## About The Pull Request

Shield walls should not be flat white 3 tile lights. it looks bad. Instead, we'll make em blue, slightly dim on their own but stronger with friends.
Also we'll make em lightly emissive, as a joke.

Shield generators should also light up when active, to match their animation.

## Why It's Good For The Game

Wallening upstreaming of something I thought looked nice.

![image](https://github.com/tgstation/tgstation/assets/58055496/e1b048ee-a827-4603-89e5-ecdcc555f03d)

## Changelog
:cl:
add: Shield generators and shield gen walls now glow a light blue. Pretty!
/:cl:
