### PR TITLE
buffs portable air scrubbers

### DIFF
--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -3,14 +3,14 @@
 	icon_state = "scrubber"
 	density = TRUE
 	max_integrity = 250
-	volume = 1000
+	volume = 2000
 
 	///Is the machine on?
 	var/on = FALSE
 	///the rate the machine will scrub air
-	var/volume_rate = 1000
+	var/volume_rate = 650
 	///Multiplier with ONE_ATMOSPHERE, if the enviroment pressure is higher than that, the scrubber won't work
-	var/overpressure_m = 80
+	var/overpressure_m = 100
 	///Should the machine use overlay in update_overlays() when open/close?
 	var/use_overlays = TRUE
 	///List of gases that can be scrubbed
@@ -59,8 +59,13 @@
 
 	excited = TRUE
 
-	var/atom/target = holding || get_turf(src)
-	scrub(target.return_air())
+	if(!isnull(holding))
+		scrub(holding.return_air())
+		return ..()
+
+	var/turf/epicentre = get_turf(src)
+	for(var/turf/open/openturf in epicentre.get_atmos_adjacent_turfs(alldir = TRUE))
+		scrub(openturf.return_air())
 	return ..()
 
 /**
@@ -68,28 +73,39 @@
  * Arguments:
  * * mixture: the gas mixture to be scrubbed
  */
-/obj/machinery/portable_atmospherics/scrubber/proc/scrub(datum/gas_mixture/mixture)
+/obj/machinery/portable_atmospherics/scrubber/proc/scrub(datum/gas_mixture/environment)
 	if(air_contents.return_pressure() >= overpressure_m * ONE_ATMOSPHERE)
 		return
 
-	var/transfer_moles = min(1, volume_rate / mixture.volume) * mixture.total_moles()
+	var/list/env_gases = environment.gases
 
-	var/datum/gas_mixture/filtering = mixture.remove(transfer_moles) // Remove part of the mixture to filter.
-	var/datum/gas_mixture/filtered = new
-	if(!filtering)
-		return
+	//contains all of the gas we're sucking out of the tile, gets put into our parent pipenet
+	var/datum/gas_mixture/filtered_out = new
+	var/list/filtered_gases = filtered_out.gases
+	filtered_out.temperature = environment.temperature
 
-	filtered.temperature = filtering.temperature
-	for(var/gas in filtering.gases & scrubbing)
-		filtered.add_gas(gas)
-		filtered.gases[gas][MOLES] = filtering.gases[gas][MOLES] // Shuffle the "bad" gasses to the filtered mixture.
-		filtering.gases[gas][MOLES] = 0
-	filtering.garbage_collect() // Now that the gasses are set to 0, clean up the mixture.
+	//maximum percentage of the turfs gas we can filter
+	var/removal_ratio =  min(1, volume_rate / environment.volume)
 
-	air_contents.merge(filtered) // Store filtered out gasses.
-	mixture.merge(filtering) // Returned the cleaned gas.
-	if(!holding)
-		air_update_turf(FALSE, FALSE)
+	var/total_moles_to_remove = 0
+	for(var/gas in scrubbing & env_gases)
+		total_moles_to_remove += env_gases[gas][MOLES]
+
+	if(total_moles_to_remove == 0)//sometimes this gets non gc'd values
+		environment.garbage_collect()
+		return FALSE
+
+	for(var/gas in scrubbing & env_gases)
+		filtered_out.add_gas(gas)
+		var/transferred_moles = max(QUANTIZE(env_gases[gas][MOLES] * removal_ratio * (env_gases[gas][MOLES] / total_moles_to_remove)), min(MOLAR_ACCURACY*1000, env_gases[gas][MOLES]))
+
+		filtered_gases[gas][MOLES] = transferred_moles
+		env_gases[gas][MOLES] -= transferred_moles
+
+	environment.garbage_collect()
+
+	//Remix the resulting gases
+	air_contents.merge(filtered_out)
 
 /obj/machinery/portable_atmospherics/scrubber/emp_act(severity)
 	. = ..()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -1,5 +1,6 @@
 /obj/machinery/portable_atmospherics/scrubber
 	name = "portable air scrubber"
+	desc = "A portable variant of the station scrubbers, capable of filtering gas from the air around it or inserted tank. May also be wrenched into a port."
 	icon_state = "scrubber"
 	density = TRUE
 	max_integrity = 250


### PR DESCRIPTION

## About The Pull Request

the normal portable air scrubber now scrubs all unblocked tiles in a 3x3 radius + has the same volume as an actual canister (instead of half)

https://github.com/tgstation/tgstation/assets/70376633/2d44760a-f826-495f-9f2b-5c9d37fc3d77


also gives it a description and essentially basically pastes the normal scrubber proc into this ones proc

## Why It's Good For The Game

portable air scrubbers cannot even scrub up one opened canister right now which kinda sucks and makes repairing the air horrible if scrubbers are off/nonfunctional/sabotaged/welded/etc.
with a 3x3 scrub radius and the same volume as a normal canister we can expect it to contain smaller to medium gas spills within a reasonable time unlike right now where it takes ages for it to do its thing
large gas spills still may need to warrant the huge air scrubber (unchanged)

## Changelog
:cl:
balance: portable air scrubbers scrub in a 3x3 square + hold as much gas as a canister
/:cl:
