### PR TITLE
Various bola fixes

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -537,8 +537,9 @@
 	gender = NEUTER
 	///Amount of time to knock the target down for once it's hit in deciseconds.
 	var/knockdown = 0
-	///Used for ensnaring when target is hit in after_throw override
+	///Used for ensnaring the target when hit in after_throw override
 	var/is_mob_hit = FALSE
+	///Weakref of the mob we will attempt to snare
 	var/datum/weakref/ensnare_mob_ref
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, gentle = FALSE, quickstart = TRUE)
@@ -549,7 +550,7 @@
 /obj/item/restraints/legcuffs/bola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
 		return//abort
-	// Set up flags so we will ensnare the mob after the after_throw proc
+	// Update the flag so we will ensnare the mob after the after_throw proc
 	is_mob_hit = TRUE
 	ensnare_mob_ref = WEAKREF(hit_atom)
 
@@ -568,15 +569,15 @@
  * Attempts to legcuff someone with the bola
  *
  * Arguments:
- * * C - the carbon that we will try to ensnare
+ * * snared_mob - the carbon that we will try to ensnare
  */
-/obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/C)
-	if(C.legcuffed || C.num_legs < 2)
+/obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/snared_mob)
+	if(snared_mob.legcuffed || snared_mob.num_legs < 2)
 		return
-	visible_message(span_danger("\The [src] ensnares [C]!"), span_userdanger("\The [src] ensnares you!"))
-	C.equip_to_slot(src, ITEM_SLOT_LEGCUFFED)
+	visible_message(span_danger("\The [src] ensnares [snared_mob]!"), span_userdanger("\The [src] ensnares you!"))
+	snared_mob.equip_to_slot(src, ITEM_SLOT_LEGCUFFED)
 	SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-	C.Knockdown(knockdown)
+	snared_mob.Knockdown(knockdown)
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /**

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -558,8 +558,7 @@
 	. = ..()
 	if (!is_mob_hit && !ensnare_mob_ref)
 		return
-	/var/atom/ensnare_mob
-	ensnare_mob = ensnare_mob_ref.resolve()
+	var/atom/ensnare_mob = ensnare_mob_ref.resolve()
 	if (is_mob_hit && !isnull(ensnare_mob))
 		ensnare(ensnare_mob)
 	is_mob_hit = FALSE

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -537,9 +537,7 @@
 	gender = NEUTER
 	///Amount of time to knock the target down for once it's hit in deciseconds.
 	var/knockdown = 0
-	///Used for ensnaring the target when hit in after_throw override
-	var/is_mob_hit = FALSE
-	///Weakref of the mob we will attempt to snare
+	///Reference of the mob we will attempt to snare
 	var/datum/weakref/ensnare_mob_ref
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, gentle = FALSE, quickstart = TRUE)
@@ -550,18 +548,16 @@
 /obj/item/restraints/legcuffs/bola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
 		return//abort
-	// Update the flag so we will ensnare the mob after the after_throw proc
-	is_mob_hit = TRUE
+	//The mob has been hit, save the reference for ensnaring
 	ensnare_mob_ref = WEAKREF(hit_atom)
 
 /obj/item/restraints/legcuffs/bola/after_throw(datum/callback/callback)
 	. = ..()
-	if (!is_mob_hit && !ensnare_mob_ref)
+	if (isnull(ensnare_mob_ref))
 		return
 	var/atom/ensnare_mob = ensnare_mob_ref.resolve()
-	if (is_mob_hit && !isnull(ensnare_mob))
+	if (!isnull(ensnare_mob))
 		ensnare(ensnare_mob)
-	is_mob_hit = FALSE
 	ensnare_mob_ref = null
 
 /**

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -560,7 +560,7 @@
 		return
 	/var/atom/ensnare_mob
 	ensnare_mob = ensnare_mob_ref.resolve()
-	if (is_mob_hit)
+	if (is_mob_hit && !isnull(ensnare_mob))
 		ensnare(ensnare_mob)
 	is_mob_hit = FALSE
 	ensnare_mob_ref = null

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -162,6 +162,7 @@ Striking a noncultist, however, will tear their flesh."}
 	else
 		to_chat(user, span_warning("The bola seems to take on a life of its own!"))
 		ensnare(user)
+		user.update_held_items()
 #undef CULT_BOLA_PICKUP_STUN
 
 


### PR DESCRIPTION

## About The Pull Request
Fixes and rewrites bola ensnaring so it works properly. 
Fixed cult bolas leaving in-hand sprite when they ensnare non-cult user.
Fixes #83577 
## Why It's Good For The Game
Bolas were one of the main ways of stopping hulked criminals when security officer was not equipped with lethal weaponry. This PR makes bola slowdown apply as it should be. Also while looking at bolas I've noticed cult bolas leave in-hand sprite when ensnaring non-cult user, so I've fixed that as well. Big thanks to @GoblinBackwards for figuring out what was wrong with bolas.
## Changelog
:cl: MrDas
fix: Bolas now slowdown properly.
fix: Cult bolas no longer leave in-hand sprite when they ensnare to non-cult user.
/:cl:
