### PR TITLE
Removes traitor posters from Metastation's walls, moved them to secure areas.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12799,6 +12799,7 @@
 /obj/machinery/camera/directional/north,
 /obj/machinery/digital_clock/directional/east,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/item/poster/traitor,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "ezT" = (
@@ -16265,6 +16266,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "fNI" = (
@@ -28632,6 +28634,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/item/poster/traitor,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "kbo" = (
@@ -28994,6 +28997,7 @@
 	pixel_x = -9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "kir" = (
@@ -48546,10 +48550,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"rgM" = (
-/obj/structure/sign/poster/traitor/random,
-/turf/closed/wall,
-/area/station/cargo/warehouse)
 "rgS" = (
 /obj/machinery/modular_computer/preset/civilian{
 	dir = 1
@@ -54710,6 +54710,7 @@
 "tnF" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "tnG" = (
@@ -60250,6 +60251,7 @@
 /obj/item/folder/documents,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/poster/traitor,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "viF" = (
@@ -85738,7 +85740,7 @@ cbz
 dBE
 vQs
 vQs
-rgM
+vQs
 hor
 vQs
 vQs
@@ -85998,7 +86000,7 @@ ePj
 tnF
 dKY
 kif
-rgM
+vQs
 dHc
 dHc
 bZY
@@ -87027,7 +87029,7 @@ kZI
 nbd
 vKn
 fNz
-rgM
+vQs
 vQs
 hyW
 xOw


### PR DESCRIPTION

## About The Pull Request
Removes the three random traitor posters from the walls in the cargo bay. They were here.

![evidence - exhibit a](https://i.imgur.com/NO47X3o.png)

Puts in three random rolled-up traitor posters to replace them. You will need to break into the QM's office, the Vault, and the Brig's Evidence Storage to get them.

![where da posters are now](https://i.imgur.com/C6SwyPb.png)
## Why It's Good For The Game
These posters nuke your mood if you're not an antagonist and currently not only do these posters blast cargo techs with them if they go into the warehouse, they also lower the mood of every non-antag who passes by arrivals because it doesn't use directionals so it's visible through walls.
Also these posters are legitimate traitor gear, this makes them much more inconvenient to get and forces you to do an IC punishible crime if you really want free traitor items.
## Changelog
:cl:
fix: Removed three traitor posters from Cargo Warehouse's walls. (Metastation)
balance: Added one traitor poster each to the QM's Office, Vault and Evidence Storage to compensate. (Metastation)
/:cl:
