### PR TITLE
Blood filter surgery update

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -15,6 +15,13 @@
 	return ..()
 
 /datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
+	display_results(
+		user,
+		target,
+		span_notice("You begin filtering [target]'s blood..."),
+		span_notice("[user] uses [tool] to filter [target]'s blood."),
+		span_notice("[user] uses [tool] on [target]'s chest."),
+	)
 	if(!..())
 		return
 	while(has_filterable_chems(target, tool))
@@ -33,6 +40,8 @@
  */
 /datum/surgery_step/filter_blood/proc/has_filterable_chems(mob/living/carbon/target, obj/item/blood_filter/bloodfilter)
 	if(!length(target.reagents?.reagent_list))
+		bloodfilter.audible_message(span_notice("The [bloodfilter] pings as it reports no chemicals detected in [target]'s blood."))
+		playsound(get_turf(target), 'sound/machines/ping.ogg', 75, TRUE, falloff_exponent = 12, falloff_distance = 1)
 		return FALSE
 
 	if(!length(bloodfilter.whitelist))
@@ -49,16 +58,9 @@
 	implements = list(/obj/item/blood_filter = 95)
 	repeatable = TRUE
 	time = 2.5 SECONDS
-	success_sound = 'sound/machines/ping.ogg'
+	success_sound = 'sound/machines/fan_loop.ogg'
 
 /datum/surgery_step/filter_blood/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(
-		user,
-		target,
-		span_notice("You begin filtering [target]'s blood..."),
-		span_notice("[user] uses [tool] to filter [target]'s blood."),
-		span_notice("[user] uses [tool] on [target]'s chest."),
-	)
 	display_pain(target, "You feel a throbbing pain in your chest!")
 
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
@@ -70,9 +72,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("\The [tool] pings as it finishes filtering [target]'s blood."),
-		span_notice("\The [tool] pings as it stops pumping [target]'s blood."),
-		span_notice("\The [tool] pings as it stops pumping."),
+		span_notice("\The [tool] completes a cycle filtering [target]'s blood."),
+		span_notice("\The [tool] whirrs as it filters [target]'s blood."),
+		span_notice("\The [tool] whirrs as it pumps."),
 	)
 
 	if(locate(/obj/item/healthanalyzer) in user.held_items)


### PR DESCRIPTION
## About The Pull Request

Updates the blood filter surgery step to be less chat and sound spammy, only going 'ping' when it's completed filtering blood as the text message implies. During the filter running process instead the sound is a softer hum.

## Why It's Good For The Game

We have progress bars above our head and cogwheels to other viewers. We don't need two text log lines and a 'ping' every time it runs the filter loop. It should only say completed and ping when it's actually completed.

## Changelog

:cl: LT3
code: Blood filter only pings and says finished when it's actually finished
/:cl: