### PR TITLE
Improve light switch deconstruction

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -82,6 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	user.visible_message(span_notice("[user] unscrews [src]!"), span_notice("You detach [src] from the wall."))
 	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
 	deconstruct()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/light_switch/proc/set_lights(status)
 	if(area.lightswitch == status)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -42,8 +42,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	if(isnull(held_item))
 		context[SCREENTIP_CONTEXT_LMB] = area.lightswitch ? "Flick off" : "Flick on"
 		return CONTEXTUAL_SCREENTIP_SET
-	if(held_item.tool_behaviour != TOOL_SCREWDRIVER)
-		context[SCREENTIP_CONTEXT_RMB] = "Deconstruct"
+	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
 		return CONTEXTUAL_SCREENTIP_SET
 	return .
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -69,6 +69,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 /obj/machinery/light_switch/examine(mob/user)
 	. = ..()
 	. += "It is [(machine_stat & NOPOWER) ? "unpowered" : (area.lightswitch ? "on" : "off")]."
+	. += span_notice("It's <b>screwed</b> and secured to the wall.")
 
 /obj/machinery/light_switch/interact(mob/user)
 	. = ..()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -75,12 +75,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	. = ..()
 	set_lights(!area.lightswitch)
 
-/obj/machinery/light_switch/attackby_secondary(obj/item/weapon, mob/user, params)
-	if(weapon.tool_behaviour == TOOL_SCREWDRIVER)
-		to_chat(user, "You pop \the [src] off the wall.")
-		deconstruct()
-		return COMPONENT_CANCEL_ATTACK_CHAIN
-	return ..()
+/obj/machinery/light_switch/screwdriver_act(mob/living/user, obj/item/tool)
+	user.visible_message(span_notice("[user] starts unscrewing [src]..."), span_notice("You start unscrewing [src]..."))
+	if(!tool.use_tool(src, user, 40, volume = 50))
+		return ITEM_INTERACT_BLOCKING
+	user.visible_message(span_notice("[user] unscrews [src]!"), span_notice("You detach [src] from the wall."))
+	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
+	deconstruct()
 
 /obj/machinery/light_switch/proc/set_lights(status)
 	if(area.lightswitch == status)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -81,7 +81,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 		return ITEM_INTERACT_BLOCKING
 	user.visible_message(span_notice("[user] unscrews [src]!"), span_notice("You detach [src] from the wall."))
 	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-	deconstruct()
+	deconstruct(TRUE)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/light_switch/proc/set_lights(status)


### PR DESCRIPTION

## About The Pull Request

So a friend asked me how to deconstruct light switches, which prompted me to give the code a lookover as to why it wasn't intuitive.
Apparently the screentips are wrong, there is no examine hint otherwise, it uses right click instead of left click, and even in the case that you right click with a screwdriver it still hits it in addition to deconstructing it.

So in this pr we just, move it from `attackby_secondary(...)` to `screwdriver_act(...)` to fix the hitting, invert a statement to fix the screentips, add an examine to hint at unscrewing, make it use `use_tool(...)` which adds sounds and a short deconstruction delay, add visible messages like the intercom, and make it use `deconstruct(TRUE)` as it's disassembled.

This feels more coherent overall.
## Why It's Good For The Game

Makes deconstructing light switches less jank.
Functional screentips and helpful examines are nice.
## Changelog
:cl:
code: Deconstructing light switches now uses the proper tool action and tool usage code, please report any issues.
fix: Attempting to deconstruct a light switch by unscrewing it no longer makes you hit it even on a success.
sound: Deconstructing a light switch actually plays tool usage and deconstruction sounds.
qol: Deconstructing light switches is now a left click with a screwdriver parallel to other unscrewing actions.
fix: Screentips for deconstructing a light switch no longer show up on every item EXCEPT screwdrivers.
qol: Added an examine hint denoting light switches are screwed to the wall.
qol: Added visible messages for someone deconstructing a light switch parallel to deconstructing intercoms.
/:cl:
