### PR TITLE
adds swapping pens in PDAs

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -186,10 +186,6 @@
 		playsound(src, 'sound/machines/pda_button2.ogg', 50, TRUE)
 
 /obj/item/modular_computer/pda/proc/swap_pen(mob/user, obj/item/tool)
-
-	if(issilicon(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH)) //TK doesn't work even with this removed but here for readability
-		return
-
 	if(inserted_item)
 		balloon_alert(user, "swapped pens")
 		user.put_in_hands(inserted_item)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -149,14 +149,14 @@
 	if(tool.w_class >= WEIGHT_CLASS_SMALL) // Anything equal to or larger than small won't work
 		user.balloon_alert(user, "too big!")
 		return ITEM_INTERACT_BLOCKING
-	if(inserted_item)
-		balloon_alert(user, "no room!")
-		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(tool, src))
 		return ITEM_INTERACT_BLOCKING
-	balloon_alert(user, "inserted [tool]")
-	inserted_item = tool
-	playsound(src, 'sound/machines/pda_button1.ogg', 50, TRUE)
+	if(inserted_item)
+		swap_pen(user, tool)
+	else
+		balloon_alert(user, "inserted [tool]")
+		inserted_item = tool
+		playsound(src, 'sound/machines/pda_button1.ogg', 50, TRUE)
 	return ITEM_INTERACT_SUCCESS
 
 
@@ -184,6 +184,18 @@
 		inserted_item = null
 		update_appearance()
 		playsound(src, 'sound/machines/pda_button2.ogg', 50, TRUE)
+
+/obj/item/modular_computer/pda/proc/swap_pen(mob/user, obj/item/tool)
+
+	if(issilicon(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH)) //TK doesn't work even with this removed but here for readability
+		return
+
+	if(inserted_item)
+		balloon_alert(user, "swapped pens")
+		user.put_in_hands(inserted_item)
+		inserted_item = tool
+		update_appearance()
+		playsound(src, 'sound/machines/pda_button1.ogg', 50, TRUE)
 
 /obj/item/modular_computer/pda/proc/explode(mob/target, mob/bomber, from_message_menu = FALSE)
 	var/turf/current_turf = get_turf(src)


### PR DESCRIPTION
## About The Pull Request

Added the ability to swap items in PDAs


<details>
<summary>Videos</summary>

https://github.com/tgstation/tgstation/assets/112967882/b3c63d7b-7913-42a6-83e7-d2989cdac8b2

</details>

## Why It's Good For The Game

You can quickly change items stored in the PDA slots without doing unnecessary actions (pulling the pen out of the PDA, removing it, and inserting another pen)
## Changelog
:cl:
qol: you can now swap pens in pdas
/:cl:
