### PR TITLE
Humanizing monkeys removes undergarments 

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -67,6 +67,7 @@
 
 	transformation_timer = addtimer(CALLBACK(src, PROC_REF(finish_humanize), species), TRANSFORMATION_DURATION, TIMER_UNIQUE)
 
+
 /mob/living/carbon/proc/finish_humanize(species = /datum/species/human)
 	transformation_timer = null
 	to_chat(src, span_boldnotice("You are now a human."))
@@ -76,6 +77,12 @@
 	set_species(species)
 	SEND_SIGNAL(src, COMSIG_MONKEY_HUMANIZE)
 	return src
+
+/mob/living/carbon/human/finish_humanize(species = /datum/species/human, instant = FALSE)
+	underwear = "Nude"
+	undershirt = "Nude"
+	socks = "Nude"
+	return ..()
 
 /mob/proc/AIize(client/preference_source, move = TRUE)
 	var/list/turf/landmark_loc = list()


### PR DESCRIPTION

## About The Pull Request

Humanizing a monkey doesn't result in someone with trans thigh-highs and a bra

## Why It's Good For The Game

It is kinda weird and bad for immersion. Humans can just get it back from dressers anyways.

## Changelog

:cl: Melbert
add: Humanizing a monkey removes undergarments such as socks
/:cl:

