### PR TITLE
Adds more "curated" version of human randomization (for humonkeys, corpse spawners, and fresh characters)

### DIFF
--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -26,7 +26,7 @@
 	/// Determines if the accessory will be skipped or included in random hair generations.
 	var/gender = NEUTER
 	/// Something that can be worn by either gender, but looks different on each.
-	var/gender_specific
+	var/gender_specific = FALSE
 	/// Determines if the accessory will be skipped by color preferences.
 	var/use_static
 	/**
@@ -46,6 +46,9 @@
 	var/dimension_y = 32
 	/// Should this sprite block emissives?
 	var/em_block = FALSE
+	/// Determines if this is considered "sane" for the purpose of [/proc/randomize_human_sane]
+	/// Basically this is to blacklist the extremely wacky stuff from being picked in random human generation.
+	var/natural_spawn = TRUE
 
 /datum/sprite_accessory/blank
 	name = "None"
@@ -74,11 +77,13 @@
 /datum/sprite_accessory/hair/afro_large
 	name = "Afro (Large)"
 	icon_state = "hair_bigafro"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/afro_huge
 	name = "Afro (Huge)"
 	icon_state = "hair_hugeafro"
 	y_offset = 6
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/allthefuzz
 	name = "All The Fuzz"
@@ -119,6 +124,7 @@
 /datum/sprite_accessory/hair/bedheadfloorlength
 	name = "Floorlength Bedhead"
 	icon_state = "hair_floorlength_bedhead"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/badlycut
 	name = "Shorter Long Bedhead"
@@ -359,6 +365,7 @@
 /datum/sprite_accessory/hair/bigflattop
 	name = "Flat Top (Big)"
 	icon_state = "hair_bigflattop"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/flow_hair
 	name = "Flow Hair"
@@ -419,6 +426,7 @@
 /datum/sprite_accessory/hair/joestar
 	name = "Joestar"
 	icon_state = "hair_joestar"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/keanu
 	name = "Keanu Hair"
@@ -475,22 +483,27 @@
 /datum/sprite_accessory/hair/mohawk
 	name = "Mohawk"
 	icon_state = "hair_d"
+	natural_spawn = FALSE // sorry little one
 
 /datum/sprite_accessory/hair/nitori
 	name = "Nitori"
 	icon_state = "hair_nitori"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/reversemohawk
 	name = "Mohawk (Reverse)"
 	icon_state = "hair_reversemohawk"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/shavedmohawk
 	name = "Mohawk (Shaved)"
 	icon_state = "hair_shavedmohawk"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/unshavenmohawk
 	name = "Mohawk (Unshaven)"
 	icon_state = "hair_unshaven_mohawk"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/mulder
 	name = "Mulder"
@@ -499,6 +512,7 @@
 /datum/sprite_accessory/hair/odango
 	name = "Odango"
 	icon_state = "hair_odango"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/ombre
 	name = "Ombre"
@@ -531,14 +545,17 @@
 /datum/sprite_accessory/hair/kagami
 	name = "Pigtails"
 	icon_state = "hair_kagami"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/pigtail
 	name = "Pigtails 2"
 	icon_state = "hair_pigtails"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/pigtail2
 	name = "Pigtails 3"
 	icon_state = "hair_pigtails2"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/hair/pixie
 	name = "Pixie Cut"
@@ -917,6 +934,7 @@
 /datum/sprite_accessory/facial_hair/brokenman
 	name = "Beard (Broken Man)"
 	icon_state = "facial_brokenman"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/facial_hair/chinstrap
 	name = "Beard (Chinstrap)"
@@ -961,6 +979,7 @@
 /datum/sprite_accessory/facial_hair/martialartist
 	name = "Beard (Martial Artist)"
 	icon_state = "facial_martialartist"
+	natural_spawn = FALSE
 
 /datum/sprite_accessory/facial_hair/chinlessbeard
 	name = "Beard (Chinless Beard)"

--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -46,7 +46,7 @@
 	var/dimension_y = 32
 	/// Should this sprite block emissives?
 	var/em_block = FALSE
-	/// Determines if this is considered "sane" for the purpose of [/proc/randomize_human_sane]
+	/// Determines if this is considered "sane" for the purpose of [/proc/randomize_human_normie]
 	/// Basically this is to blacklist the extremely wacky stuff from being picked in random human generation.
 	var/natural_spawn = TRUE
 

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -31,3 +31,41 @@
 	// Snowflake for Ethereals
 	human.updatehealth()
 	human.updateappearance(mutcolor_update = TRUE)
+
+/**
+ * Randomize human but attempts to produce a ""sane"" result
+ */
+/proc/randomize_human_sane(mob/living/carbon/human/human, randomize_mutations = FALSE)
+	var/static/list/nautural_hair_colors = list(
+		"#111111", "#362925", "#412922", "#583322",
+		"#593029", "#703b30", "#714721", "#744729",
+		"#74482a", "#7b746e", "#855832", "#8c4734",
+		"#a15537", "#a17e61", "#b38b67", "#ba673c",
+		"#c89f73", "#d9b380", "#dbc9b8", "#e1621d",
+		"#e17d17", "#e1af93", "#f1cc8f", "#fbe7a1",
+	)
+
+	// OK I'm not calling enbys "insane" by not including it in this randomization
+	// I just don't think it fits well for the purpose of this proc don't cancel me
+	human.gender = human.dna.species.sexes ? pick(MALE, FEMALE) : PLURAL
+	human.physique = human.gender
+	human.real_name = human.generate_random_mob_name()
+	human.name = human.get_visible_name()
+	// No underwear generation we don't care
+	human.eye_color_left = random_eye_color()
+	human.eye_color_right = human.eye_color_left
+	human.skin_tone = pick(GLOB.skin_tones)
+	// Picking a natural hair color and natural hairstyles only
+	var/picked_color = pick(nautural_hair_colors)
+	human.set_haircolor(picked_color, update = FALSE)
+	human.set_facial_haircolor(picked_color, update = FALSE)
+	var/datum/sprite_accessory/hairstyle = SSaccessories.hairstyles_list[random_hairstyle(human.gender)]
+	if(hairstyle?.natural_spawn)
+		human.set_hairstyle(hairstyle.name, update = FALSE)
+	var/datum/sprite_accessory/facial_hair = SSaccessories.facial_hairstyles_list[random_facial_hairstyle(human.gender)]
+	if(facial_hair?.natural_spawn)
+		human.set_facial_hairstyle(facial_hair.name, update = FALSE)
+	// Normal DNA init stuff, these can generally be wacky but we care less, they're aliens after all
+	human.dna.initialize_dna(newblood_type = random_blood_type(), create_mutation_blocks = randomize_mutations, randomize_features = TRUE)
+	human.updatehealth()
+	human.updateappearance(mutcolor_update = TRUE)

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -11,7 +11,7 @@
 	user << browse(create_panel_helper(create_mob_html), "window=create_mob;size=425x475")
 
 /**
- * Randomizes everything about a human, including DNA and name
+ * Fully randomizes everything about a human, including DNA and name.
  */
 /proc/randomize_human(mob/living/carbon/human/human, randomize_mutations = FALSE)
 	human.gender = human.dna.species.sexes ? pick(MALE, FEMALE, PLURAL, NEUTER) : PLURAL
@@ -33,29 +33,30 @@
 	human.updateappearance(mutcolor_update = TRUE)
 
 /**
- * Randomize human but attempts to produce a ""sane"" result
+ * Randomizes a human, but produces someone who looks exceedingly average (by most standards).
+ *
+ * (IE, no wacky hair styles / colors)
  */
-/proc/randomize_human_sane(mob/living/carbon/human/human, randomize_mutations = FALSE)
-	var/static/list/nautural_hair_colors = list(
-		"#111111", "#362925", "#412922", "#583322",
-		"#593029", "#703b30", "#714721", "#744729",
-		"#74482a", "#7b746e", "#855832", "#8c4734",
-		"#a15537", "#a17e61", "#b38b67", "#ba673c",
-		"#c89f73", "#d9b380", "#dbc9b8", "#e1621d",
-		"#e17d17", "#e1af93", "#f1cc8f", "#fbe7a1",
+/proc/randomize_human_normie(mob/living/carbon/human/human, randomize_mutations = FALSE)
+	var/static/list/natural_hair_colors = list(
+		"#111111", "#362925", "#3B3831", "#41250C", "#412922",
+		"#544C49", "#583322", "#593029", "#703b30", "#714721",
+		"#744729", "#74482a", "#7b746e", "#855832", "#863019",
+		"#8c4734", "#9F550E", "#A29A96", "#A4381C", "#B17B41",
+		"#C0BAB7", "#EFE5E4", "#F7F3F1", "#FFF2D6", "#a15537",
+		"#a17e61", "#b38b67", "#ba673c", "#c89f73", "#d9b380",
+		"#dbc9b8", "#e1621d", "#e17d17", "#e1af93", "#f1cc8f",
+		"#fbe7a1",
 	)
-
-	// OK I'm not calling enbys "insane" by not including it in this randomization
-	// I just don't think it fits well for the purpose of this proc don't cancel me
+	// Sorry enbys but statistically you are not average enough
 	human.gender = human.dna.species.sexes ? pick(MALE, FEMALE) : PLURAL
 	human.physique = human.gender
 	human.real_name = human.generate_random_mob_name()
 	human.name = human.get_visible_name()
-	// No underwear generation we don't care
 	human.eye_color_left = random_eye_color()
 	human.eye_color_right = human.eye_color_left
 	human.skin_tone = pick(GLOB.skin_tones)
-	// Picking a natural hair color and natural hairstyles only
+	// No underwear generation handled here
 	var/picked_color = pick(nautural_hair_colors)
 	human.set_haircolor(picked_color, update = FALSE)
 	human.set_facial_haircolor(picked_color, update = FALSE)

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -57,7 +57,7 @@
 	human.eye_color_right = human.eye_color_left
 	human.skin_tone = pick(GLOB.skin_tones)
 	// No underwear generation handled here
-	var/picked_color = pick(nautural_hair_colors)
+	var/picked_color = pick(natural_hair_colors)
 	human.set_haircolor(picked_color, update = FALSE)
 	human.set_facial_haircolor(picked_color, update = FALSE)
 	var/datum/sprite_accessory/hairstyle = SSaccessories.hairstyles_list[random_hairstyle(human.gender)]

--- a/code/modules/admin/verbs/anonymousnames.dm
+++ b/code/modules/admin/verbs/anonymousnames.dm
@@ -94,7 +94,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
 			return
 		var/mob/living/carbon/human/human_mob = player
 		var/original_name = player.real_name //id will not be changed if you do not do this
-		randomize_human_sane(player) //do this first so the special name can be given
+		randomize_human_normie(player) //do this first so the special name can be given
 		player.fully_replace_character_name(original_name, anonymous_name(player))
 		if(extras_enabled)
 			player_extras(player)

--- a/code/modules/admin/verbs/anonymousnames.dm
+++ b/code/modules/admin/verbs/anonymousnames.dm
@@ -94,7 +94,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
 			return
 		var/mob/living/carbon/human/human_mob = player
 		var/original_name = player.real_name //id will not be changed if you do not do this
-		randomize_human(player) //do this first so the special name can be given
+		randomize_human_sane(player) //do this first so the special name can be given
 		player.fully_replace_character_name(original_name, anonymous_name(player))
 		if(extras_enabled)
 			player_extras(player)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -208,7 +208,7 @@ ADMIN_VERB(create_mapping_job_icons, R_DEBUG, "Generate job landmarks icons", "G
 			else
 				for(var/obj/item/I in D)
 					qdel(I)
-				randomize_human(D)
+				randomize_human_normie(D)
 				D.dress_up_as_job(
 					equipping = JB,
 					visual_only = TRUE,

--- a/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
@@ -22,7 +22,7 @@
 	if(!.)
 		return
 	var/mob/living/carbon/human/human_knight = .
-	randomize_human_sane(human_knight)
+	randomize_human_normie(human_knight)
 	human_knight.dna.add_mutation(/datum/mutation/human/medieval, MUT_OTHER)
 	var/oldname = human_knight.name
 	var/title = "error"

--- a/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
@@ -22,7 +22,7 @@
 	if(!.)
 		return
 	var/mob/living/carbon/human/human_knight = .
-	randomize_human(human_knight)
+	randomize_human_sane(human_knight)
 	human_knight.dna.add_mutation(/datum/mutation/human/medieval, MUT_OTHER)
 	var/oldname = human_knight.name
 	var/title = "error"

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -76,7 +76,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	cut_overlays(TRUE)
 
 /mob/living/carbon/human/dummy/setup_human_dna()
-	randomize_human(src, randomize_mutations = FALSE)
+	randomize_human_normie(src, randomize_mutations = FALSE)
 
 /mob/living/carbon/human/dummy/log_mob_tag(text)
 	return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -56,10 +56,7 @@
 	ADD_TRAIT(src, TRAIT_AGEUSIA, NO_TONGUE_TRAIT)
 
 /mob/living/carbon/human/proc/setup_human_dna()
-	randomize_human(src, randomize_mutations = TRUE)
-
-/mob/living/carbon/human/species/setup_human_dna()
-	randomize_human_sane(src, randomize_mutations = TRUE)
+	randomize_human_normie(src, randomize_mutations = TRUE)
 
 /mob/living/carbon/human/Destroy()
 	QDEL_NULL(physiology)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -58,6 +58,9 @@
 /mob/living/carbon/human/proc/setup_human_dna()
 	randomize_human(src, randomize_mutations = TRUE)
 
+/mob/living/carbon/human/species/setup_human_dna()
+	randomize_human_sane(src, randomize_mutations = TRUE)
+
 /mob/living/carbon/human/Destroy()
 	QDEL_NULL(physiology)
 	GLOB.human_list -= src

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -59,7 +59,7 @@
 		spawned_human.underwear = "Nude"
 		spawned_human.undershirt = "Nude"
 		spawned_human.socks = "Nude"
-		randomize_human_sane(spawned_human)
+		randomize_human_normie(spawned_human)
 		if(hairstyle)
 			spawned_human.set_hairstyle(hairstyle, update = FALSE)
 		if(facial_hairstyle)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -59,26 +59,15 @@
 		spawned_human.underwear = "Nude"
 		spawned_human.undershirt = "Nude"
 		spawned_human.socks = "Nude"
+		randomize_human_sane(spawned_human)
 		if(hairstyle)
-			spawned_human.hairstyle = hairstyle
-		else
-			spawned_human.hairstyle = random_hairstyle(spawned_human.gender)
+			spawned_human.set_hairstyle(hairstyle, update = FALSE)
 		if(facial_hairstyle)
-			spawned_human.facial_hairstyle = facial_hairstyle
-		else
-			spawned_human.facial_hairstyle = random_facial_hairstyle(spawned_human.gender)
+			spawned_human.set_facial_hairstyle(facial_hairstyle, update = FALSE)
 		if(haircolor)
-			spawned_human.hair_color = haircolor
-		else
-			spawned_human.hair_color = "#[random_color()]"
+			spawned_human.set_haircolor(haircolor, update = FALSE)
 		if(facial_haircolor)
-			spawned_human.facial_hair_color = facial_haircolor
-		else
-			spawned_human.facial_hair_color = "#[random_color()]"
-		if(skin_tone)
-			spawned_human.skin_tone = skin_tone
-		else
-			spawned_human.skin_tone = pick(GLOB.skin_tones)
+			spawned_human.set_facial_haircolor(facial_haircolor, update = FALSE)
 		spawned_human.update_body(is_creating = TRUE)
 
 /obj/effect/mob_spawn/proc/name_mob(mob/living/spawned_mob, forced_name)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -871,7 +871,7 @@
 		return
 	to_chat(affected_mob, span_warning("<b>You grit your teeth in pain as your body rapidly mutates!</b>"))
 	affected_mob.visible_message("<b>[affected_mob]</b> suddenly transforms!")
-	randomize_human_sane(affected_mob)
+	randomize_human_normie(affected_mob)
 
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -871,7 +871,7 @@
 		return
 	to_chat(affected_mob, span_warning("<b>You grit your teeth in pain as your body rapidly mutates!</b>"))
 	affected_mob.visible_message("<b>[affected_mob]</b> suddenly transforms!")
-	randomize_human(affected_mob)
+	randomize_human_sane(affected_mob)
 
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"


### PR DESCRIPTION
## About The Pull Request

Basically, adds a version of `randomize_human` that's a tad more curated, IE, primarily picks results to create a more "coherent" result than full randomization. 

Shown here: Humans, Lizards, Felinids. Looks a bit boring, but that's the point.

![image](https://github.com/tgstation/tgstation/assets/51863163/44338c7a-615e-4075-bb3d-03cc8fc9fd4e)


Non-humans I left almost entirely untouched, as they generally form a more "coherent" mob from pure randomization already. 

## Why It's Good For The Game

Basically just aiming to perform a more "consistent" style for humonkeys and corpses. 
For monkeys, it doesn't make the most sense when they pop up with a giant red afro. 
For corpses, it's a bit hard to feel immersed in the ruins when they've all got pink and green mustaches.

## Changelog

:cl: Melbert
add: Humonkeys and random corpse spawns now look more... human.
/:cl:
