### PR TITLE
Fixes a few minor issues on various Pirate Shuttles and one Syndicate Battlecruiser shuttle.

### DIFF
--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -487,8 +487,9 @@
 "xA" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
 	dir = 1;
-	x_offset = -4;
-	y_offset = -8
+	x_offset = 7;
+	y_offset = -3;
+	view_range = 10
 	},
 /turf/open/floor/carpet/royalblack/airless,
 /area/shuttle/pirate/flying_dutchman)

--- a/_maps/shuttles/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate_ex_interdyne.dmm
@@ -169,7 +169,7 @@
 "aF" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
 	dir = 4;
-	x_offset = -3;
+	x_offset = 0;
 	y_offset = 7
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/shuttles/pirate_geode.dmm
+++ b/_maps/shuttles/pirate_geode.dmm
@@ -430,8 +430,7 @@
 "vY" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
 	dir = 8;
-	x_offset = 10;
-	y_offset = 5
+	x_offset = -8
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 3
@@ -487,7 +486,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "yz" = (
 /obj/structure/flora/lunar_plant/style_3,
@@ -838,7 +837,7 @@
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "Pr" = (
 /obj/structure/table/wood,

--- a/_maps/shuttles/pirate_grey.dmm
+++ b/_maps/shuttles/pirate_grey.dmm
@@ -353,8 +353,9 @@
 /obj/machinery/light/small/directional/west,
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
 	dir = 4;
-	x_offset = -3;
-	y_offset = 7
+	x_offset = -5;
+	y_offset = 12;
+	view_range = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
@@ -854,7 +855,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/docking_port/mobile/pirate{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/light,

--- a/_maps/shuttles/pirate_irs.dmm
+++ b/_maps/shuttles/pirate_irs.dmm
@@ -1420,7 +1420,11 @@
 	},
 /area/shuttle/pirate)
 "LV" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate,
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
+	y_offset = 11;
+	x_offset = -4;
+	view_range = 10
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 5
 	},

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -79,10 +79,6 @@
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
-"eK" = (
-/obj/machinery/power/shuttle_engine/propulsion,
-/turf/open/floor/plating/airless,
-/area/shuttle/pirate)
 "eU" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/carpet/royalblack,
@@ -462,7 +458,7 @@
 	width = 26
 	},
 /obj/docking_port/mobile/pirate{
-	dir = 4;
+	dir = 8;
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Silverscale Cruiser";
@@ -652,8 +648,9 @@
 "Mo" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
 	dir = 8;
-	x_offset = 10;
-	y_offset = 5
+	x_offset = 12;
+	y_offset = 5;
+	view_range = 10
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -1022,7 +1019,7 @@ rB
 Ww
 Ww
 Ww
-eK
+Ww
 Ww
 Ww
 Ww

--- a/_maps/shuttles/starfury_corvette.dmm
+++ b/_maps/shuttles/starfury_corvette.dmm
@@ -58,7 +58,9 @@
 /area/shuttle/sbc_corvette)
 "ai" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/corvette{
-	dir = 8
+	dir = 8;
+	y_offset = 0;
+	x_offset = -3
 	},
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -70,7 +72,10 @@
 	id_tag = "SBC_corvette_bolt";
 	name = "Syndicate Corvette Airlock"
 	},
-/obj/docking_port/mobile/syndicate_corvette,
+/obj/docking_port/mobile/syndicate_corvette{
+	preferred_direction = 1;
+	port_direction = 4
+	},
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/effect/turf_decal/siding/thinplating_new/dark{


### PR DESCRIPTION

## About The Pull Request
More minor issues such as shuttles flying the wrong direction, camera eyes being off centre, and the occasional active turf.

<details>
  <summary>Full changes</summary>

- Fixed the Battlecruiser corvette, Silverscale shuttle, and Greytide pirate shuttle flying in the wrong direction
- Fixed camera eye being offset incorrectly on: Battlecruiser corvette, Flying Dutchman, Ex-Interdyne pirate shuttle, Greytide pirate shuttle, IRS pirate shuttle, and Geode pirate shuttle.
- Removed a random sideways thruster on the Silverscale pirate shuttle
- Increased the viewrange in the navigation console on: Silverscale shuttle, Flying Dutchman, Greytide shuttle, IRS shuttle.
- Fixed a few active turfs on: IRS pirate shuttle, Geode pirate shuttle.
</details>

## Why It's Good For The Game
Shuttles should fly in their expected direction, and should be relatively centred on the navigation camera. The viewrange was increased on a few of the pirate shuttles because you couldn't really see much area around them or the shuttle just didn't fit in the default viewrange.

## Changelog
:cl:
qol: Increased the viewrange in the navigation camera console on the following shuttles: Silverscale pirate shuttle, the Flying Dutchman pirate shuttle, the IRS pirate shuttle, and the Greytide pirate shuttle.
fix: Fixed the Battlecruiser corvette, Silverscale pirate shuttle, and the Greytide pirate shuttle flying in incorrect directions in hyperspace.
fix: Fixed the Navigation console camera eye on various pirate ships being off centre.
/:cl:
