### PR TITLE
Adds Xenobio (BZ) reinforced floor turfs to Xenobiology Secure Pens

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1138,7 +1138,7 @@
 /obj/machinery/sparker/directional/north{
 	id = "Xenobio"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "axX" = (
 /obj/effect/turf_decal/siding/yellow,
@@ -14149,6 +14149,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/button/door/directional/north{
 	id = "Xenolab";
 	name = "Test Chamber Blast Doors";
@@ -14156,7 +14157,6 @@
 	pixel_y = -2;
 	req_access = list("xenobiology")
 	},
-/obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -14543,10 +14543,8 @@
 /area/station/command/heads_quarters/hos)
 "fvH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/electropack,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "fvK" = (
 /obj/item/holosign_creator/robot_seat/restaurant,
@@ -16061,7 +16059,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "fSx" = (
 /obj/structure/cable,
@@ -17362,10 +17360,7 @@
 /area/station/maintenance/department/medical/central)
 "gpy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/plush/slimeplushie{
-	name = "Nanners"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "gpA" = (
 /obj/effect/turf_decal/siding/thinplating/terracotta,
@@ -19329,7 +19324,7 @@
 "gWf" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "gWk" = (
 /obj/effect/turf_decal/siding/wood,
@@ -28449,7 +28444,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "jML" = (
 /obj/structure/cable,
@@ -37258,12 +37253,9 @@
 /area/station/hallway/primary/aft)
 "mwJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "mwN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38923,24 +38915,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "mYT" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "Test Chamber Blast Door"
 	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/open/floor/engine,
+/obj/structure/sign/warning/gas_mask/directional/north,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
 "mYW" = (
 /obj/machinery/camera{
@@ -46252,14 +46232,6 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
-"pxW" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/power_store/cell/high,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "pxZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -52358,6 +52330,9 @@
 /turf/open/floor/iron/small,
 /area/station/ai_monitored/command/storage/eva)
 "rtI" = (
+/obj/item/toy/plush/slimeplushie{
+	name = "Nanners"
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -53692,7 +53667,7 @@
 /area/station/engineering/atmos/space_catwalk)
 "rQw" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "rQA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59422,7 +59397,7 @@
 /area/station/medical/chemistry)
 "tGp" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "tGq" = (
 /turf/closed/wall,
@@ -71619,7 +71594,7 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "xlP" = (
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "xlZ" = (
 /turf/open/floor/iron,
@@ -74848,11 +74823,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "ybF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "ybJ" = (
 /obj/structure/cable,
@@ -75193,7 +75167,7 @@
 	c_tag = "Xenobiology Lab - Test Chamber";
 	network = list("ss13","rd","xeno")
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "ygu" = (
 /turf/open/floor/iron/white,
@@ -118136,7 +118110,7 @@ gYH
 sYa
 yfs
 hPU
-xKX
+ybF
 fKN
 xMc
 xKX
@@ -118651,7 +118625,7 @@ sYa
 rtI
 dXU
 aSy
-deQ
+mYT
 tst
 deQ
 aSy
@@ -119423,7 +119397,7 @@ cVz
 sYa
 rQw
 xlP
-ybF
+fSg
 xlP
 tGp
 eWI
@@ -120192,11 +120166,11 @@ pXQ
 kwA
 xaR
 sYa
-pxW
+xlP
 xlP
 gpy
 xlP
-mYT
+xlP
 eWI
 eWI
 eWI

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -17550,9 +17550,8 @@
 	network = list("ss13","xeno","rd")
 	},
 /obj/machinery/status_display/ai/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/cold/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "eqU" = (
 /turf/open/space,
@@ -26773,7 +26772,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "gCt" = (
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "gCB" = (
 /obj/structure/cable,
@@ -35061,8 +35060,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJw" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "iJE" = (
 /obj/structure/table/wood/fancy,
@@ -57851,7 +57849,7 @@
 "ozA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "ozE" = (
 /obj/effect/turf_decal/stripes/line,
@@ -62568,7 +62566,7 @@
 /area/station/science/lab)
 "pJz" = (
 /obj/effect/decal/remains/xeno,
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "pJM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -72571,7 +72569,7 @@
 /area/station/maintenance/port/aft)
 "sfE" = (
 /obj/effect/decal/cleanable/xenoblood,
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "sfH" = (
 /obj/effect/landmark/start/hangover,
@@ -84082,15 +84080,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "uXU" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/disposal/delivery_chute{
+	dir = 8
+	},
 /obj/effect/turf_decal/box/red,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "uYg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92292,9 +92289,14 @@
 /turf/open/floor/iron/textured,
 /area/station/medical/medbay)
 "xcR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/circuit/green,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xcU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -92318,8 +92320,8 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/structure/sign/warning/gas_mask/directional/north,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "xdA" = (
 /obj/effect/spawner/random/decoration/carpet,
@@ -115368,11 +115370,11 @@ fqm
 djS
 nCi
 nCi
-sfN
-sfN
+gCt
+gCt
 eqP
-sfN
-sfN
+gCt
+gCt
 nCi
 nCi
 cJd
@@ -115624,13 +115626,13 @@ chp
 fqm
 vPU
 nCi
-sfN
-sfN
-sfN
+gCt
+gCt
+gCt
 iJw
-sfN
-sfN
-sfN
+gCt
+gCt
+gCt
 nCi
 vPU
 fqm
@@ -115881,13 +115883,13 @@ rXu
 nCi
 eVp
 nCi
-sfN
+gCt
 ozA
 pJz
-xcR
+gCt
 sfE
 gCt
-sfN
+gCt
 nCi
 mFq
 nCi
@@ -116138,13 +116140,13 @@ gbe
 nCi
 vPU
 nCi
-sfN
-sfN
-sfN
-sfN
-sfN
-sfN
-sfN
+gCt
+gCt
+gCt
+gCt
+gCt
+gCt
+gCt
 nCi
 vPU
 cfb
@@ -116398,7 +116400,7 @@ nCi
 rIb
 rIb
 xdn
-sfN
+gCt
 uXU
 uhb
 uhb
@@ -116653,7 +116655,7 @@ pyZ
 vBO
 uhb
 ebW
-kNG
+imx
 imx
 xsH
 umb
@@ -117169,7 +117171,7 @@ mKn
 fPl
 jqr
 vxQ
-vxQ
+xcR
 vxQ
 lzc
 plQ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3900,7 +3900,7 @@
 	network = list("ss13","test","rd","xeno")
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "biR" = (
 /obj/structure/table/glass,
@@ -6274,7 +6274,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "bOX" = (
 /obj/structure/cable,
@@ -54974,6 +54974,9 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"qvN" = (
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "qvQ" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
@@ -67710,7 +67713,7 @@
 /area/station/maintenance/port/aft)
 "ujp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "ujs" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -69133,7 +69136,7 @@
 	dir = 4
 	},
 /obj/structure/sign/warning/gas_mask/directional/north,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "uHV" = (
 /obj/structure/disposalpipe/trunk/multiz{
@@ -69907,7 +69910,7 @@
 /area/station/service/chapel)
 "uUn" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "uUq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
@@ -70712,7 +70715,7 @@
 /area/station/command/heads_quarters/captain)
 "viR" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "viV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -189001,12 +189004,12 @@ xMq
 alM
 oxO
 ffe
-abe
-abe
-abe
+qvN
+qvN
+qvN
 biI
-abe
-abe
+qvN
+qvN
 qLY
 eGN
 lZX
@@ -189258,12 +189261,12 @@ xMq
 alM
 oxO
 ffe
-abe
-abe
-abe
+qvN
+qvN
+qvN
 uUn
-abe
-abe
+qvN
+qvN
 qLY
 vfe
 tsa
@@ -189516,11 +189519,11 @@ alM
 oxO
 ffe
 viR
-abe
-abe
+qvN
+qvN
 bOT
-abe
-abe
+qvN
+qvN
 qLY
 tkP
 fPv
@@ -189776,7 +189779,7 @@ qLY
 qLY
 uHS
 ujp
-abe
+qvN
 ctF
 qLY
 qLY

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7770,11 +7770,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"cku" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ckN" = (
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/south,
@@ -16063,10 +16058,6 @@
 	dir = 8
 	},
 /area/station/maintenance/port/fore)
-"eLb" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "eLl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -16287,10 +16278,6 @@
 	dir = 4
 	},
 /area/station/ai_monitored/command/storage/eva)
-"eOS" = (
-/obj/structure/table,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ePd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/grille/broken,
@@ -39852,11 +39839,6 @@
 	dir = 4
 	},
 /area/station/engineering/storage_shared)
-"lVs" = (
-/obj/structure/table,
-/obj/item/clothing/mask/surgical,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "lVt" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/floor,
@@ -55692,14 +55674,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"qGe" = (
-/obj/structure/table,
-/obj/item/scalpel{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "qGg" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -69158,6 +69132,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/sign/warning/gas_mask/directional/north,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uHV" = (
@@ -69931,7 +69906,6 @@
 	},
 /area/station/service/chapel)
 "uUn" = (
-/obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -79471,8 +79445,8 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/ai_monitored/command/storage/eva)
 "xNa" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/engine,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "xNn" = (
 /obj/effect/turf_decal/stripes/line{
@@ -189027,12 +189001,12 @@ xMq
 alM
 oxO
 ffe
-lVs
+abe
 abe
 abe
 biI
 abe
-eOS
+abe
 qLY
 eGN
 lZX
@@ -189284,12 +189258,12 @@ xMq
 alM
 oxO
 ffe
-qGe
 abe
-cku
+abe
+abe
 uUn
-xNa
-eOS
+abe
+abe
 qLY
 vfe
 tsa
@@ -189546,7 +189520,7 @@ abe
 abe
 bOT
 abe
-eLb
+abe
 qLY
 tkP
 fPv
@@ -189799,7 +189773,7 @@ alM
 nsp
 ffe
 qLY
-ctF
+qLY
 uHS
 ujp
 abe
@@ -191086,7 +191060,7 @@ ffe
 oqd
 vHq
 aZk
-pMF
+xNa
 pMF
 rdl
 iQM

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2722,29 +2722,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "aYl" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Lab - Test Chamber";
 	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/light/cold/directional/east,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "aYw" = (
 /obj/machinery/door/airlock/external{
@@ -10282,7 +10265,7 @@
 /obj/machinery/sparker/directional/north{
 	id = "Xenobio"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "dLn" = (
 /obj/structure/rack,
@@ -11741,16 +11724,6 @@
 	dir = 8
 	},
 /area/station/service/chapel)
-"ehN" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/power_store/cell/high,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ehX" = (
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
@@ -18145,7 +18118,7 @@
 /area/station/engineering/atmos)
 "gyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "gyO" = (
 /obj/structure/cable,
@@ -28004,8 +27977,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "jQM" = (
 /obj/machinery/door/firedoor,
@@ -28726,12 +28698,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "kcu" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron{
-	amount = 10
-	},
-/obj/item/electropack,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "kcF" = (
 /obj/structure/disposalpipe/segment{
@@ -38816,7 +38783,7 @@
 /area/station/medical/treatment_center)
 "nJr" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "nJu" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -41444,6 +41411,7 @@
 /obj/effect/turf_decal/box,
 /obj/machinery/portable_atmospherics/canister,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/sign/warning/gas_mask/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "oGn" = (
@@ -68659,6 +68627,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ycv" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ycw" = (
@@ -117399,7 +117368,7 @@ rDf
 eUe
 eSb
 nnc
-hdy
+nnc
 nnc
 rvK
 nnc
@@ -117656,11 +117625,11 @@ hbK
 mgS
 hbK
 jlU
-mtu
-mtu
+kcu
+kcu
 gyK
-mtu
-mtu
+kcu
+kcu
 jlU
 hbK
 mTg
@@ -117914,10 +117883,10 @@ fGy
 wyo
 jlU
 dLm
-mtu
+kcu
 gyK
-mtu
-mtu
+kcu
+kcu
 jlU
 qgn
 mCV
@@ -118170,11 +118139,11 @@ pWT
 rDf
 uLa
 jlU
-mtu
-mtu
+kcu
+kcu
 jQz
 nJr
-mtu
+kcu
 jlU
 lUS
 pHt
@@ -118427,11 +118396,11 @@ hbK
 wrc
 wrc
 jlU
-mtu
-mtu
-mtu
-mtu
-mtu
+kcu
+kcu
+kcu
+kcu
+kcu
 jlU
 wrc
 wrc
@@ -118685,7 +118654,7 @@ aaa
 lMJ
 jlU
 jlU
-ehN
+kcu
 aYl
 kcu
 jlU

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -67017,7 +67017,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
 "rjB" = (
-/obj/structure/sign/warning/biohazard/directional/east,
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
@@ -69847,6 +69846,7 @@
 /area/station/maintenance/floor1/port)
 "sav" = (
 /obj/effect/turf_decal/box/corners,
+/obj/structure/sign/warning/biohazard/directional/east,
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "saA" = (
@@ -84899,6 +84899,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/structure/sign/warning/gas_mask/directional/east,
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "vTY" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6454,12 +6454,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"bhf" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "bhr" = (
 /turf/closed/wall/rock/porous,
 /area/station/security/prison/workout)
@@ -9190,16 +9184,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"cdM" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/power_store/cell/high,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "cdN" = (
 /obj/machinery/button/ignition/incinerator/atmos,
 /turf/closed/wall/r_wall,
@@ -32124,6 +32108,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/landmark/event_spawn,
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ksm" = (
@@ -50760,26 +50745,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
-"qVL" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "qVN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58219,14 +58184,6 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"tBo" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron{
-	amount = 10
-	},
-/obj/item/electropack,
-/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tBu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -182741,7 +182698,7 @@ pHX
 qVr
 cAK
 ttj
-bhf
+ttj
 ttj
 ttj
 nzg
@@ -183511,9 +183468,9 @@ vSa
 cJR
 qVr
 qVr
-cdM
-qVL
-tBo
+bfH
+bfH
+bfH
 qVr
 gYw
 vav

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6454,6 +6454,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
+"bhf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "bhr" = (
 /turf/closed/wall/rock/porous,
 /area/station/security/prison/workout)
@@ -10499,7 +10503,7 @@
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/light/directional/north,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "cBo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -32857,7 +32861,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "kGA" = (
 /obj/structure/railing,
@@ -38730,7 +38734,7 @@
 /obj/machinery/sparker/directional/west{
 	id = "Xenobio"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "mFo" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -57722,10 +57726,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
-"ttj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "tto" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
@@ -58185,6 +58185,9 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"tBo" = (
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "tBu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -58351,7 +58354,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "tED" = (
 /obj/effect/turf_decal/tile/neutral/tram,
@@ -181927,8 +181930,8 @@ umu
 qVr
 qVr
 mFh
-bfH
-bfH
+tBo
+tBo
 qVr
 gYw
 cHY
@@ -182183,9 +182186,9 @@ mAL
 nKU
 qVr
 tEx
-bfH
-bfH
-bfH
+tBo
+tBo
+tBo
 qVr
 pNa
 eiy
@@ -182439,11 +182442,11 @@ pbH
 bmz
 pIx
 qVr
-ttj
-bfH
-bfH
-bfH
-bfH
+bhf
+tBo
+tBo
+tBo
+tBo
 pNa
 qNk
 xmY
@@ -182697,10 +182700,10 @@ chE
 pHX
 qVr
 cAK
-ttj
-ttj
-ttj
-ttj
+bhf
+bhf
+bhf
+bhf
 nzg
 cwj
 ksk
@@ -182953,10 +182956,10 @@ pbH
 kBo
 kJA
 qVr
-bfH
-bfH
-bfH
-bfH
+tBo
+tBo
+tBo
+tBo
 kGv
 qSS
 cFQ
@@ -183210,10 +183213,10 @@ pbH
 mAL
 nKU
 qVr
-bfH
-bfH
-bfH
-bfH
+tBo
+tBo
+tBo
+tBo
 qVr
 jqK
 ijR
@@ -183468,9 +183471,9 @@ vSa
 cJR
 qVr
 qVr
-bfH
-bfH
-bfH
+tBo
+tBo
+tBo
 qVr
 gYw
 vav

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6454,10 +6454,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"bhf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "bhr" = (
 /turf/closed/wall/rock/porous,
 /area/station/security/prison/workout)
@@ -9188,6 +9184,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"cdM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	name = "Test Chamber Blast Door";
+	id = "Xenolab"
+	},
+/obj/structure/sign/warning/gas_mask/directional/north,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "cdN" = (
 /obj/machinery/button/ignition/incinerator/atmos,
 /turf/closed/wall/r_wall,
@@ -57726,6 +57732,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"ttj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "tto" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
@@ -182190,7 +182200,7 @@ tBo
 tBo
 tBo
 qVr
-pNa
+cdM
 eiy
 itq
 qyQ
@@ -182442,7 +182452,7 @@ pbH
 bmz
 pIx
 qVr
-bhf
+ttj
 tBo
 tBo
 tBo
@@ -182700,10 +182710,10 @@ chE
 pHX
 qVr
 cAK
-bhf
-bhf
-bhf
-bhf
+ttj
+ttj
+ttj
+ttj
 nzg
 cwj
 ksk

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -3330,7 +3330,7 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "bga" = (
 /obj/structure/chair/wood{
@@ -10518,10 +10518,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "dJM" = (
-/obj/structure/table/optable,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "dKp" = (
 /obj/structure/lattice/catwalk,
@@ -13168,12 +13167,10 @@
 /turf/open/floor/iron/textured,
 /area/station/security/processing)
 "eFJ" = (
-/obj/structure/table,
-/obj/item/biopsy_tool,
 /obj/machinery/sparker/directional/north{
 	id = "Xenobio"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "eFK" = (
 /obj/structure/cable,
@@ -15057,7 +15054,7 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib3-old"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "fsZ" = (
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -17667,8 +17664,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "gmm" = (
-/obj/structure/table,
-/obj/item/storage/box/monkeycubes,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "Test Chamber Blast Door"
+	},
+/obj/structure/sign/warning/gas_mask/directional/north,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "gms" = (
@@ -21631,7 +21633,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "hFO" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -26533,11 +26535,8 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jvV" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
 /obj/structure/sign/warning/biohazard/directional/east,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "jwa" = (
 /obj/structure/lattice,
@@ -28766,7 +28765,7 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "khL" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -33151,7 +33150,7 @@
 /area/station/engineering/storage/tech)
 "lHp" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "lHx" = (
 /obj/machinery/door/airlock/engineering{
@@ -41991,13 +41990,12 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "oVV" = (
-/obj/structure/table,
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Lab - Secure Pen";
 	network = list("ss13","rd","xeno")
 	},
 /obj/structure/sign/warning/biohazard/directional/east,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "oVX" = (
 /obj/structure/table,
@@ -46766,10 +46764,8 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "qEr" = (
-/obj/structure/table,
-/obj/item/electropack,
-/obj/item/electropack,
-/turf/open/floor/engine,
+/obj/machinery/light/floor,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "qEC" = (
 /obj/effect/turf_decal/stripes{
@@ -52329,16 +52325,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "sug" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter,
 /obj/machinery/sparker/directional/south{
 	id = "Xenobio"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "suq" = (
 /obj/effect/landmark/start/station_engineer,
@@ -55482,7 +55472,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "tBF" = (
 /obj/structure/closet/secure_closet/chief_medical,
@@ -56933,8 +56923,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/department/engine)
 "uak" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "Test Chamber Blast Door"
+	},
+/obj/structure/sign/warning/gas_mask/directional/south,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uat" = (
@@ -66085,9 +66080,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xna" = (
-/obj/structure/table,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/engine,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "xnc" = (
 /obj/machinery/door/airlock/command/glass{
@@ -122621,11 +122614,11 @@ jQS
 jQS
 jQS
 jQS
-pXV
+gmm
 pXV
 hNP
 pXV
-pXV
+uak
 jQS
 jQS
 jQS
@@ -122877,13 +122870,13 @@ fZF
 fZF
 jQS
 jQS
-kOL
-kOL
+xna
+xna
 fsV
 bfX
-kOL
-kOL
-kOL
+xna
+xna
+xna
 jQS
 jQS
 fZF
@@ -123135,12 +123128,12 @@ fZF
 jQS
 jQS
 eFJ
-kOL
-kOL
+xna
+xna
 tBC
-kOL
-kOL
-qEr
+xna
+xna
+xna
 jQS
 jQS
 fZF
@@ -123391,11 +123384,11 @@ bwC
 fZF
 jQS
 jQS
-gmm
-kOL
-mvh
+xna
+xna
+qEr
 hFN
-mvh
+qEr
 khJ
 sug
 jQS
@@ -123648,12 +123641,12 @@ cLf
 fZF
 jQS
 jQS
-kOL
-kOL
-kOL
-kOL
-kOL
-kOL
+xna
+xna
+xna
+xna
+xna
+xna
 lHp
 jQS
 jQS
@@ -123906,7 +123899,7 @@ fZF
 jQS
 jQS
 jQS
-uak
+xna
 oVV
 dJM
 jvV


### PR DESCRIPTION
## About The Pull Request
Replaces the `/turf/open/floor/engine` turfs inside all stations' Xenobiology Secure Pens with the `/turf/open/floor/engine/xenobio` turf. This means that they now start full of BZ. This PR also moves or removes various items, tables, and other assorted things in the Secure Pens. This does NOT remove the alien egg spawn, nor does it remove any items which aren't easily replaced (e.g. Nanners).
## Why It's Good For The Game
* Speeds up Xenobio, an infamously slow department
* Xenobio can now focus on breeding slimes without having to constantly worry about feeding every one that they're not immediately using.
* BZ Turfs, as opposed to cans, cannot be harvested without a scrubber setup. As such, it's harder for Cargo, Engineering, or Ordnance to immediately steal the BZ to use in their departments.
* Adds functionality to a part of Xenobio that was otherwise either an abnormally big slime pen or a place to gawk at an alien as it kills you.

This change is precedented, as this is already how Secure Pens on NorthStar are set up.

While the push for departmental cooperation that led to the BZ tank's removal is admirable, I've never once seen Ordnance actually make BZ for Xenobio. As a Xenobiologist, I've asked before, and they've never done it. When Ordnance isn't occupied and I've attempted to make BZ myself, it either takes long enough that the station's already gone to shit, or somebody else takes over Xenobiology. This includes rounds where I have played an RD and announced my intent to return to Xenobio when I am done with Ordnance.

As such, the BZ rarely, if ever, gets made, causing Xenobio, an already time-consuming, RNG-dependent, and frankly, dull department to be even more tedious and not worth the time. I used to semi-regularly make rainbows, while now I'm lucky to even occasionally get to tier 3 slimes on deadpop. Having to take care of every slime you need and kill every one you don't need often results in the Xenobiologist killing slimes that they could've evolved later, simply to not have to spend the space, food, and mental bandwidth on them.
## Changelog
:cl:Sosmaster9000
add:BZ floor turfs in all current station's Xenobio Containment Pens. 
del:Various items (e.g. tables, operating tables, tools, metal sheets, and surgery tools) have been removed from the chambers. 
balance: Xenobiologists now have a BZ-filled containment pen. Don't breathe that!
balance:Some items which either cannot be printed elsewhere or are part of game progression (e.g. teleporter endpoints and, of course, Nanners) have been moved. Alien Spawnpoints are in the same spot.
/:cl:
