### PR TITLE
Chat readability improvement

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -617,7 +617,7 @@
 		for(var/i in 1 to (length(result) - 1))
 			result[i] += "\n"
 
-	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"))
+	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"), to_info_tab = TRUE)
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)
 
 /mob/proc/blind_examine_check(atom/examined_thing)

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -55,11 +55,17 @@
 	type = null,
 	text = null,
 	avoid_highlighting = FALSE,
+	to_info_tab = FALSE,
 	// FIXME: These flags are now pointless and have no effect
 	handle_whitespace = TRUE,
 	trailing_newline = TRUE,
 	confidential = FALSE
 )
+	if(to_info_tab)
+		var/client/client = CLIENT_FROM_VAR(target)
+		client?.stat_panel.send_message("update_info", html);
+		return
+
 	if(isnull(Master) || !SSchat?.initialized || !MC_RUNNING(SSchat.init_stage))
 		to_chat_immediate(target, html, type, text, avoid_highlighting)
 		return

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -225,3 +225,10 @@ img {
 .interview_panel_stats {
 	margin-bottom: 10px;
 }
+
+.examine_block {
+	background: #1b1c1e;
+	border: 1px solid #a4bad6;
+	margin: 0.5em;
+	padding: 0.5em 0.75em;
+}

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -28,6 +28,7 @@ var interviewManager = { status: "", interviews: [] };
 var sdql2 = [];
 var permanent_tabs = []; // tabs that won't be cleared by wipes
 var turfcontents = [];
+var info_rows = "";
 var turfname = "";
 var imageRetryDelay = 500;
 var imageRetryLimit = 50;
@@ -263,6 +264,8 @@ function tab_change(tab) {
 		draw_interviews();
 	} else if (tab == "SDQL2") {
 		draw_sdql2();
+	} else if (tab == "Info") {
+		draw_info();
 	} else if (tab == turfname) {
 		draw_listedturf();
 	} else {
@@ -566,6 +569,10 @@ function draw_tickets() {
 	document.getElementById("statcontent").appendChild(table);
 }
 
+function draw_info() {
+	statcontentdiv.innerHTML = info_rows;
+}
+
 function draw_interviews() {
 	var body = document.createElement("div");
 	var header = document.createElement("h3");
@@ -800,6 +807,8 @@ document.addEventListener("keyup", restoreFocus);
 if (!current_tab) {
 	addPermanentTab("Status");
 	tab_change("Status");
+
+	addPermanentTab("Info");
 }
 
 window.onload = function () {
@@ -942,6 +951,15 @@ Byond.subscribeTo('update_listedturf', function (TC) {
 	turfcontents = TC;
 	if (current_tab == turfname) {
 		draw_listedturf();
+	}
+});
+
+Byond.subscribeTo('update_info', function (IR) {
+	info_rows = IR;
+	if (current_tab == "Info") {
+		draw_info();
+	} else {
+		tab_change("Info")
 	}
 });
 


### PR DESCRIPTION

## About The Pull Request

This PR adds a new tab in a right-top part of the window that can be used to display some repetitive info (like "examine" stuff).

This is just a draft by nature, because there are a few things that I want to discuss.
1. Do you need it? (Maybe Im the only one who thinks that its a cool thing)
2. What info should be there? (Its 100% good for "Examine" but there might be other things that might be good for this thing)
3. Should the new info rewrite the current one or should it be a list of HTML, just like in chat?

Also I was not an active SS13 coder for a while so Im open to any code suggestions, of cource

## Why It's Good For The Game

Chat will be cleaner, with less info that is not really related to the game process itself.

![image](https://github.com/tgstation/tgstation/assets/49074954/da4518d5-b993-4670-824b-c6aea3631a19)


## Changelog
:cl:
qol: "Examine" info was moved from the chat to a new "Info" tab
/:cl:
