### PR TITLE
Makes windoors stay open for longer

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -111,9 +111,9 @@
 		return
 	autoclose = TRUE
 	if(check_access(null))
-		sleep(5 SECONDS)
+		sleep(8 SECONDS)
 	else //secure doors close faster
-		sleep(2 SECONDS)
+		sleep(5 SECONDS)
 	if(!density && autoclose) //did someone change state while we slept?
 		close()
 


### PR DESCRIPTION

## About The Pull Request
Changed windoors to close in 8 seconds instead of 5.
Changed secure windoors to close in 5 seconds instead of 2.
## Why It's Good For The Game
These windoors close too fast and a lot of players get frustrated from not having enough time to do their stuff before they close.
## Changelog
:cl: grungussuss
qol: Windoors now stay open for 8 seconds instead of 5
qol: Secure windoors now stay open for 5 seconds instead of 2
/:cl:
