### PR TITLE
Gives designations to energy weapons

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -72,12 +72,12 @@
 	desc = "A suitcase containing the necessary gun parts to construct a tesla cannon around a stabilized flux anomaly. Handle with care."
 
 /obj/item/weaponcrafting/gunkit/xray
-	name = "x-ray laser gun parts kit (lethal)"
-	desc = "A suitcase containing the necessary gun parts to turn a laser gun into a x-ray laser gun. Do not point most parts directly towards face."
+	name = "X-06 x-ray laser gun parts kit (lethal)"
+	desc = "A suitcase containing the necessary gun parts to turn an X-03 laser gun into an X-06 x-ray laser gun. Do not point most parts directly towards face."
 
 /obj/item/weaponcrafting/gunkit/ion
 	name = "ion carbine parts kit (nonlethal/highly destructive/very lethal (silicons))"
-	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into a ion carbine. Perfect against lockers you don't have access to."
+	desc = "A suitcase containing the necessary gun parts to transform a standard X-03 laser gun into a ion carbine. Perfect against lockers you don't have access to."
 
 /obj/item/weaponcrafting/gunkit/temperature
 	name = "temperature gun parts kit (less lethal/very lethal (lizardpeople))"
@@ -92,5 +92,5 @@
 	desc = "Highly illegal weapons refurbishment kit that allows you to turn the standard proto-kinetic accelerator into a near-duplicate energy crossbow. Almost like the real thing!"
 
 /obj/item/weaponcrafting/gunkit/hellgun
-	name = "hellfire laser gun degradation kit (warcrime lethal)"
+	name = "X-02 "Hellfire" Laser Gun degradation kit (warcrime lethal)"
 	desc = "Take a perfectly functioning laser gun. Butcher the inside of the gun so it runs hot and mean. You now have a hellfire laser. You monster."

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -72,8 +72,8 @@
 	desc = "A suitcase containing the necessary gun parts to construct a tesla cannon around a stabilized flux anomaly. Handle with care."
 
 /obj/item/weaponcrafting/gunkit/xray
-	name = "X-06 x-ray laser gun parts kit (lethal)"
-	desc = "A suitcase containing the necessary gun parts to turn an X-03 laser gun into an X-06 x-ray laser gun. Do not point most parts directly towards face."
+	name = "X-07 x-ray laser gun parts kit (lethal)"
+	desc = "A suitcase containing the necessary gun parts to turn an X-03 laser gun into an X-07 x-ray laser gun. Do not point most parts directly towards face."
 
 /obj/item/weaponcrafting/gunkit/ion
 	name = "ion carbine parts kit (nonlethal/highly destructive/very lethal (silicons))"

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -96,7 +96,7 @@
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/xraylaser
-	name = "X-ray Laser Gun"
+	name = "X-07 x-ray Laser Gun"
 	result = /obj/item/gun/energy/xray
 	reqs = list(
 		/obj/item/gun/energy/laser = 1,

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -110,7 +110,7 @@
 	blacklist += subtypesof(/obj/item/gun/energy/laser)
 
 /datum/crafting_recipe/hellgun
-	name = "Hellfire Laser Gun"
+	name = "X-02 Hellfire Laser Gun"
 	result = /obj/item/gun/energy/laser/hellgun
 	reqs = list(
 		/obj/item/gun/energy/laser = 1,

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -704,7 +704,7 @@
 	steal_hint = "A hand-held disabler, often found in the possession of Security Officers."
 
 /datum/objective_item/steal/spy/energy_gun
-	name = "an energy gun"
+	name = "a E-05 energy gun"
 	targetitem = /obj/item/gun/energy/e_gun
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -730,7 +730,7 @@
 		return add_item_to_steal(src, /obj/item/gun/energy/e_gun)
 
 /datum/objective_item/steal/spy/laser_gun
-	name = "a laser gun"
+	name = "an X-03 laser gun"
 	targetitem = /obj/item/gun/energy/laser
 	excludefromjob = list(
 		JOB_CAPTAIN,

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -730,7 +730,7 @@
 		return add_item_to_steal(src, /obj/item/gun/energy/e_gun)
 
 /datum/objective_item/steal/spy/laser_gun
-	name = "an X-03 laser gun"
+	name = "an X-03 Laser Gun"
 	targetitem = /obj/item/gun/energy/laser
 	excludefromjob = list(
 		JOB_CAPTAIN,

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -79,4 +79,4 @@
 	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "WT-550 automatic rifle"
 	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
-	
+

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -74,7 +74,7 @@
 	contains = list(/obj/item/gun/energy/e_gun)
 
 /datum/supply_pack/goody/laser_single
-	name = "X-03 laser gun Single-Pack"
+	name = "X-03 Laser Gun Single-Pack"
 	desc = "Contains one X-03 laser gun, the lethal workhorse of Nanotrasen security everywhere."
 	cost = PAYCHECK_COMMAND * 6
 	access_view = ACCESS_WEAPONS

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -67,22 +67,22 @@
 	contains = list(/obj/item/storage/belt/holster/energy/disabler)
 
 /datum/supply_pack/goody/energy_single
-	name = "Energy Gun Single-Pack"
+	name = "E-05 Energy Gun Single-Pack"
 	desc = "Contains one energy gun, capable of firing both non-lethal and lethal blasts of light."
 	cost = PAYCHECK_COMMAND * 12
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/e_gun)
 
 /datum/supply_pack/goody/laser_single
-	name = "Laser Gun Single-Pack"
-	desc = "Contains one laser gun, the lethal workhorse of Nanotrasen security everywhere."
+	name = "X-03 laser gun Single-Pack"
+	desc = "Contains one X-03 laser gun, the lethal workhorse of Nanotrasen security everywhere."
 	cost = PAYCHECK_COMMAND * 6
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/laser)
 
 /datum/supply_pack/goody/hell_single
 	name = "Hellgun Kit Single-Pack"
-	desc = "Contains one hellgun degradation kit, an old pattern of laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Space Geneva Convention when used on humanoids."
+	desc = "Contains one hellgun degradation kit, an older model of the X-03 laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Space Geneva Convention when used on humanoids."
 	cost = PAYCHECK_CREW * 2
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/weaponcrafting/gunkit/hellgun)

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -58,7 +58,7 @@
 
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
-	desc = "Contains three lethal, high-energy laser guns."
+	desc = "Contains three lethal, high-energy X-03 laser guns."
 	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/energy/laser = 3)
@@ -223,7 +223,7 @@
 	crate_name = "\improper DRAGnet crate"
 
 /datum/supply_pack/security/armory/energy
-	name = "Energy Guns Crate"
+	name = "E-05 Energy Guns Crate"
 	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal \
 		blasts of light."
 	cost = CARGO_CRATE_VALUE * 18

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -68,7 +68,7 @@
 	maxcharge = STANDARD_CELL_CHARGE * 0.6
 
 /obj/item/stock_parts/power_store/cell/hos_gun
-	name = "X-01 multiphase energy gun power cell"
+	name = "multiphase energy gun power cell"
 	maxcharge = STANDARD_CELL_CHARGE * 1.2
 
 /obj/item/stock_parts/power_store/cell/pulse //200 pulse shots

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -57,7 +57,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/spec, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/gun/energy/e_gun/old
-	name = "prototype energy gun"
+	name = "E-01 prototype energy gun"
 	desc = "E-01 Prototype Energy Gun. Early stage development of a unique laser rifle that has multifaceted energy lens allowing the gun to alter the form of projectile it fires on command."
 	icon_state = "protolaser"
 	ammo_x_offset = 2

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/e_gun
-	name = "energy gun"
+	name = "E-05 energy gun"
 	desc = "A basic hybrid energy gun with two settings: disable and kill."
 	icon_state = "energy"
 	w_class = WEIGHT_CLASS_BULKY
@@ -29,7 +29,7 @@
 		overlay_y = 10)
 
 /obj/item/gun/energy/e_gun/mini
-	name = "miniature energy gun"
+	name = "E-09 miniature energy gun"
 	desc = "A small, pistol-sized energy gun with a built-in flashlight. It has two settings: disable and kill."
 	icon_state = "mini"
 	inhand_icon_state = "gun"
@@ -50,7 +50,7 @@
 		overlay_y = 13)
 
 /obj/item/gun/energy/e_gun/stun
-	name = "tactical energy gun"
+	name = "E-11 tactical energy gun"
 	desc = "Military issue energy gun, is able to fire stun rounds."
 	icon_state = "energytac"
 	ammo_x_offset = 2
@@ -58,7 +58,7 @@
 
 /obj/item/gun/energy/e_gun/old
 	name = "prototype energy gun"
-	desc = "NT-P:01 Prototype Energy Gun. Early stage development of a unique laser rifle that has multifaceted energy lens allowing the gun to alter the form of projectile it fires on command."
+	desc = "E-01 Prototype Energy Gun. Early stage development of a unique laser rifle that has multifaceted energy lens allowing the gun to alter the form of projectile it fires on command."
 	icon_state = "protolaser"
 	ammo_x_offset = 2
 	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/electrode/old)
@@ -73,7 +73,7 @@
 	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/e_gun/hos
-	name = "\improper X-01 MultiPhase Energy Gun"
+	name = "\improper E-23 MultiPhase Energy Gun"
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	cell_type = /obj/item/stock_parts/power_store/cell/hos_gun
 	icon_state = "hoslaser"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/laser
-	name = "laser gun"
+	name = "X-03 Laser Gun"
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
 	inhand_icon_state = "laser"
@@ -116,7 +116,7 @@
 ///Laser Cannon
 
 /obj/item/gun/energy/lasercannon
-	name = "accelerator laser cannon"
+	name = "X-06 accelerator laser cannon"
 	desc = "An advanced laser cannon that does more damage the farther away the target is."
 	icon_state = "lasercannon"
 	inhand_icon_state = "laser"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -23,21 +23,21 @@
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
-	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."
+	desc = "A modified version of the basic X-03 laser gun, this one fires less concentrated energy bolts designed for target practice."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
 	clumsy_check = FALSE
 	item_flags = NONE
 	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/laser/retro
-	name ="retro laser gun"
+	name ="X-01 laser gun"
 	icon_state = "retro"
-	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's private security or military forces. Nevertheless, it is still quite deadly and easy to maintain, making it a favorite amongst pirates and other outlaws."
+	desc = "An older model of the basic X-03 laser gun, no longer used by Nanotrasen's private security or military forces. Nevertheless, it is still quite deadly and easy to maintain, making it a favorite amongst pirates and other outlaws."
 	ammo_x_offset = 3
 
 /obj/item/gun/energy/laser/carbine
-	name = "laser carbine"
-	desc = "A modified laser gun which can shoot far faster, but each shot is far less damaging."
+	name = "X-04 laser carbine"
+	desc = "A modified X-03 laser gun which can shoot far faster, but each shot is far less damaging."
 	icon_state = "laser_carbine"
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/carbine)
 
@@ -47,21 +47,21 @@
 
 /obj/item/gun/energy/laser/carbine/practice
 	name = "practice laser carbine"
-	desc = "A modified version of the laser carbine, this one fires even less concentrated energy bolts designed for target practice."
+	desc = "A modified version of the X-04 laser carbine, this one fires even less concentrated energy bolts designed for target practice."
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/carbine/practice)
 	clumsy_check = FALSE
 	item_flags = NONE
 	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/laser/retro/old
-	name ="laser gun"
+	name ="X-01 laser gun"
 	icon_state = "retro"
 	desc = "First generation lasergun, developed by Nanotrasen. Suffers from ammo issues but its unique ability to recharge its ammo without the need of a magazine helps compensate. You really hope someone has developed a better lasergun while you were in cryo."
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/old)
 	ammo_x_offset = 3
 
 /obj/item/gun/energy/laser/hellgun
-	name ="hellfire laser gun"
+	name ="X-02 Hellfire Laser Gun"
 	desc = "A relic of a weapon, built before NT began installing regulators on its laser weaponry. This pattern of laser gun became infamous for the gruesome burn wounds it caused, and was quietly discontinued once it began to affect NT's reputation."
 	icon_state = "hellgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire)
@@ -71,7 +71,7 @@
 	icon_state = "caplaser"
 	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = null
-	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
+	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding. No one knows who made it or how it came to be."
 	force = 10
 	ammo_x_offset = 3
 	selfcharge = 1
@@ -98,8 +98,8 @@
 	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
 
 /obj/item/gun/energy/laser/scatter
-	name = "scatter laser gun"
-	desc = "A laser gun equipped with a refraction kit that spreads bolts."
+	name = "X-05 scatter laser gun"
+	desc = "An X-03 laser gun equipped with a refraction kit that spreads bolts."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/gun/energy/laser/scatter/shotty
@@ -196,6 +196,6 @@
 	payment_amount = 20
 
 /obj/item/gun/energy/laser/luxurypaywall
-	name = "luxurious laser gun"
-	desc = "A laser gun modified to cost 20 credits to fire. Point towards poor people."
+	name = "luxurious X-03 laser gun"
+	desc = "An X-03 laser gun modified to cost 20 credits to fire. Point towards poor people."
 	pin = /obj/item/firing_pin/paywall/luxury


### PR DESCRIPTION

## About The Pull Request
- The old retro laser is now the "X-01 laser gun"
- The hellfire laser is now the "X-02 Hellfire Laser Gun"
- The laser gun is now the "X-03 Laser Gun"
- The laser carbine is now the "X-04 laser carbine"
- The scatter laser gun is now the "X-05 scatter laser gun"
- The accelerator laser cannon is now the "X-06 accelerator laser cannon"
- The x-ray laser gun is now the "X-07 x-ray laser gun"
- The prototype energy gun is now the `E-01 Prototype Energy Gun"
- The energy gun is now the "E-05 energy gun"
- The miniature energy gun is now the "E-09 miniature energy gun"
- The tactical energy gun is now the "E-11 tactical energy gun"
- The X-01 MultiPhase Energy Gun is now the "E-23 MultiPhase Energy Gun"

Additionally changed the captain's laser gun description to be more mysterious
## Why It's Good For The Game
Gives some structure to the weapons: sets a setting for the lore and allows to chronologically specify which weapon design came first
## Changelog
:cl: grungussuss
spellcheck: NanoTrasen's weaponry department has classified their weapons into designations
/:cl:
