### PR TITLE
Fixes The Arcade Machine Telling You That You Don't Have Enough MP To Counterattack When You Try To Heavy Attack With Insufficient MP

### DIFF
--- a/code/game/machinery/computer/arcade/battle.dm
+++ b/code/game/machinery/computer/arcade/battle.dm
@@ -505,7 +505,7 @@
 					return TRUE
 				if(BATTLE_ARCADE_PLAYER_HEAVY_ATTACK)
 					if(player_current_mp < SPELL_MP_COST)
-						say("You don't have enough MP to counterattack!")
+						say("You don't have enough MP to heavy attack!")
 						player_turn = TRUE
 						return TRUE
 					player_current_mp -= SPELL_MP_COST


### PR DESCRIPTION

## About The Pull Request
This PR fixes the arcade machine tell you that you don't have enough MP to counterattack when using the heavy attack option. 
Before:
<img src="https://i.ibb.co/QMYTzv4/Gaming-Before.png">
After:
<img src="https://i.ibb.co/5WMDC9D/Gaming-After.png">
## Why It's Good For The Game
I like the arcade. I don't like bugs.
## Changelog
Not worth space in CL very small change.
