### PR TITLE
Fix /datum/weakref appearing when linking airlock heretic portals

### DIFF
--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -185,7 +185,7 @@
 
 	if(reference_resolved)
 		make_portal(user, reference_resolved, target)
-		to_chat(user, span_notice("You use [src], to link [link] and [target] together."))
+		to_chat(user, span_notice("You use [src], to link \the [reference_resolved] and \the [target] together."))
 		link = null
 		balloon_alert(user, "link 2/2")
 	else

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -185,7 +185,7 @@
 
 	if(reference_resolved)
 		make_portal(user, reference_resolved, target)
-		to_chat(user, span_notice("You use [src], to link \the [reference_resolved] and \the [target] together."))
+		to_chat(user, span_notice("You use [src], to link [reference_resolved] and [target] together."))
 		link = null
 		balloon_alert(user, "link 2/2")
 	else


### PR DESCRIPTION
## About The Pull Request

Fix /datum/weakref appearing when linking airlock heretic portals

## Why It's Good For The Game

buggo

impropero

## Changelog

:cl:
fix: Fix /datum/weakref appearing when linking airlock heretic portals
/:cl:

