### PR TITLE
some deathmatch fixes

### DIFF
--- a/_maps/deathmatch/OSHA_Violator.dmm
+++ b/_maps/deathmatch/OSHA_Violator.dmm
@@ -20,11 +20,18 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/indestructible,
 /area/deathmatch)
+"cl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/indestructible,
+/area/deathmatch)
 "cA" = (
 /turf/open/indestructible,
 /area/deathmatch)
 "cR" = (
-/obj/machinery/field/generator/starts_on,
+/obj/machinery/field/generator/starts_on/magic,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/indestructible,
@@ -36,7 +43,7 @@
 "dt" = (
 /obj/machinery/light/no_nightlight/directional/north,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/field/generator/starts_on,
+/obj/machinery/field/generator/starts_on/magic,
 /obj/structure/cable,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -581,7 +588,7 @@
 /area/deathmatch)
 "Bv" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/field/generator/starts_on,
+/obj/machinery/field/generator/starts_on/magic,
 /obj/structure/cable,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -683,6 +690,13 @@
 	dir = 8
 	},
 /obj/machinery/light/no_nightlight/directional/west,
+/turf/open/indestructible,
+/area/deathmatch)
+"Gw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/indestructible,
 /area/deathmatch)
 "Gx" = (
@@ -849,7 +863,7 @@
 /turf/open/indestructible,
 /area/deathmatch)
 "Pg" = (
-/obj/machinery/field/generator/starts_on,
+/obj/machinery/field/generator,
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -980,7 +994,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/field/generator/starts_on,
+/obj/machinery/field/generator/starts_on/magic,
 /obj/structure/cable,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -1042,8 +1056,11 @@
 /turf/open/indestructible,
 /area/deathmatch)
 "YA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/cable,
-/turf/closed/indestructible/fakeglass,
+/turf/open/indestructible,
 /area/deathmatch)
 "YJ" = (
 /obj/structure/cable,
@@ -1062,7 +1079,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/field/generator/starts_on,
+/obj/machinery/field/generator/starts_on/magic,
 /obj/structure/cable,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -1070,6 +1087,12 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"Zq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/indestructible,
 /area/deathmatch)
@@ -1387,7 +1410,7 @@ sa
 sa
 je
 ai
-YA
+cl
 ai
 gN
 cA
@@ -2008,7 +2031,7 @@ sa
 sa
 je
 ai
-bl
+Zq
 ai
 ai
 Bf
@@ -2026,7 +2049,7 @@ Bf
 Bf
 ai
 ai
-bl
+Gw
 ai
 je
 sa

--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -132,6 +132,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define QUIET_LOGS (1<<15)
 /// This area does not allow virtual entities to enter.
 #define VIRTUAL_SAFE_AREA (1<<16)
+/// This area does not allow the Binary channel
+#define BINARY_JAMMING (1<<17)
 
 /*
 	These defines are used specifically with the atom/pass_flags bitmask

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -673,7 +673,7 @@
 
 /datum/outfit/deathmatch_loadout/battler/clown/upgraded
 	name = "Deathmatch: Clown (Syndicate Gear)"
-	display_name = "Clown"
+	display_name = "Clown Commando"
 	desc = "They were bound to show up sooner or later."
 
 	shoes = /obj/item/clothing/shoes/clown_shoes/combat
@@ -727,7 +727,7 @@
 
 /datum/outfit/deathmatch_loadout/chef/upgraded
 	name = "Deathmatch: Master Chef"
-	display_name = "Chef"
+	display_name = "Master Chef"
 	desc = "Let him cook."
 
 	belt = /obj/item/gun/magic/hook

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -21,6 +21,8 @@
 	var/list/modifiers = list()
 	/// Is the modifiers modal menu open (for the host)
 	var/mod_menu_open = FALSE
+	/// artificial time padding when we start loading to give lighting a breather (admin starts will set this to 0)
+	var/start_time = 8 SECONDS
 
 /datum/deathmatch_lobby/New(mob/player)
 	. = ..()
@@ -79,7 +81,7 @@
 
 	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
 	map.template_in_use = FALSE
-	addtimer(CALLBACK(src, PROC_REF(start_game_after_delay)), 8 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(start_game_after_delay)), start_time)
 
 /datum/deathmatch_lobby/proc/start_game_after_delay()
 	if (!length(player_spawns) || length(player_spawns) < length(players))
@@ -152,7 +154,8 @@
 		GLOB.deathmatch_game.modifiers[modifier].apply(new_player, src)
 
 	// register death handling.
-	RegisterSignals(new_player, list(COMSIG_LIVING_DEATH, COMSIG_MOB_GHOSTIZED, COMSIG_QDELETING), PROC_REF(player_died))
+	RegisterSignals(new_player, list(COMSIG_LIVING_DEATH, COMSIG_QDELETING), PROC_REF(player_died))
+	RegisterSignal(new_player, COMSIG_MOB_GHOSTIZED, PROC_REF(player_ghosted))
 
 /datum/deathmatch_lobby/proc/game_took_too_long()
 	if (!location || QDELING(src))
@@ -184,6 +187,14 @@
 	clear_reservation()
 	GLOB.deathmatch_game.remove_lobby(host)
 	log_game("Deathmatch game [host] ended.")
+
+/datum/deathmatch_lobby/proc/player_ghosted(mob/living/player)
+	SIGNAL_HANDLER
+	var/mob/dead/observer/observer = GLOB.directory[player.ckey].mob
+	if(istype(observer))
+		player_died(player)
+		return
+	players[player.mind.key]["mob"] = player.mind.current
 
 /datum/deathmatch_lobby/proc/player_died(mob/living/player, gibbed)
 	SIGNAL_HANDLER
@@ -499,12 +510,13 @@
 
 		if ("admin") // Admin functions
 			if (!check_rights(R_ADMIN))
-				message_admins("[usr.key] has attempted to use admin functions in a deathmatch lobby!")
+				message_admins("[usr.key] has attempted to use admin functions in a deathmatch lobby without being an admin!")
 				log_admin("[key_name(usr)] tried to use the deathmatch lobby admin functions without authorization.")
 				return
 			switch (params["func"])
 				if ("Force start")
 					log_admin("[key_name(usr)] force started deathmatch lobby [host].")
+					start_time = 0
 					start_game()
 
 	return FALSE

--- a/code/modules/deathmatch/deathmatch_mapping.dm
+++ b/code/modules/deathmatch/deathmatch_mapping.dm
@@ -2,7 +2,7 @@
 	name = "Deathmatch Arena"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	area_flags = UNIQUE_AREA | NOTELEPORT | EVENT_PROTECTED | QUIET_LOGS
+	area_flags = UNIQUE_AREA | NOTELEPORT | EVENT_PROTECTED | QUIET_LOGS | NO_DEATH_MESSAGE | BINARY_JAMMING
 
 /area/deathmatch/fullbright
 	static_lighting = FALSE
@@ -12,7 +12,7 @@
 	name = "Deathmatch Player Spawner"
 
 /area/deathmatch/teleport //Prevent access to cross-z teleportation in the map itself (no wands of safety/teleportation scrolls). Cordons should prevent same-z teleportations outside of the arena.
-	area_flags = UNIQUE_AREA | EVENT_PROTECTED | QUIET_LOGS
+	area_flags = /area/deathmatch::area_flags & ~NOTELEPORT
 
 // for the illusion of a moving train
 /turf/open/chasm/true/no_smooth/fake_motion_sand

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -70,6 +70,9 @@
 	var/obj/item/radio/headset/dongle = ears
 	if(!istype(dongle))
 		return FALSE
+	var/area/our_area = get_area(src)
+	if(our_area.area_flags & BINARY_JAMMING)
+		return FALSE
 	return dongle.translate_binary
 
 /mob/living/carbon/human/radio(message, list/message_mods = list(), list/spans, language) //Poly has a copy of this, lazy bastard

--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -70,6 +70,9 @@
 			)
 
 /mob/living/silicon/binarycheck()
+	var/area/our_area = get_area(src)
+	if(our_area.area_flags & BINARY_JAMMING)
+		return FALSE
 	return TRUE
 
 /mob/living/silicon/radio(message, list/message_mods = list(), list/spans, language)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -51,6 +51,8 @@ no power level overlay is currently in the overlays list.
 	var/list/obj/machinery/field/generator/connected_gens = list()
 	///Check for asynk cleanups for this and the connected gens
 	var/clean_up = FALSE
+	/// we warm up and cool down instantly
+	var/instantenous = FALSE
 
 /datum/armor/field_generator
 	melee = 25
@@ -207,8 +209,11 @@ no power level overlay is currently in the overlays list.
 	can_atmos_pass = ATMOS_PASS_YES
 	air_update_turf(TRUE, FALSE)
 	INVOKE_ASYNC(src, PROC_REF(cleanup))
-	addtimer(CALLBACK(src, PROC_REF(cool_down)), 5 SECONDS)
 	RemoveElement(/datum/element/give_turf_traits, string_list(list(TRAIT_CONTAINMENT_FIELD)))
+	if(instantenous)
+		warming_up = 0
+		return
+	addtimer(CALLBACK(src, PROC_REF(cool_down)), 5 SECONDS)
 
 /obj/machinery/field/generator/proc/cool_down()
 	if(active || warming_up <= 0)
@@ -219,9 +224,14 @@ no power level overlay is currently in the overlays list.
 		addtimer(CALLBACK(src, PROC_REF(cool_down)), 5 SECONDS)
 
 /obj/machinery/field/generator/proc/turn_on()
+	AddElement(/datum/element/give_turf_traits, string_list(list(TRAIT_CONTAINMENT_FIELD)))
+	if(instantenous)
+		active = FG_ONLINE
+		warming_up = 3
+		start_fields()
+		return
 	active = FG_CHARGING
 	addtimer(CALLBACK(src, PROC_REF(warm_up)), 5 SECONDS)
-	AddElement(/datum/element/give_turf_traits, string_list(list(TRAIT_CONTAINMENT_FIELD)))
 
 /obj/machinery/field/generator/proc/warm_up()
 	if(!active)
@@ -421,7 +431,18 @@ no power level overlay is currently in the overlays list.
 
 /obj/machinery/field/generator/starts_on/Initialize(mapload)
 	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/field/generator/starts_on/post_machine_initialize()
+	. = ..()
 	turn_on()
+
+/obj/machinery/field/generator/starts_on/magic
+	power_level = 6 //forces the highest level overlay
+	instantenous = TRUE
+
+/obj/machinery/field/generator/starts_on/magic/process()
+	return PROCESS_KILL // this is the only place calc_power is called, and doing it here avoids one unnecessary proc call
 
 #undef FG_UNSECURED
 #undef FG_SECURED


### PR DESCRIPTION

## About The Pull Request

firstly and most importantly polymorphing works now
fixes field gens in OSHA Violator
map names are sorted alphabetically
binary chat may not be used in deathmatch arenas
Chef and Clown final destination loadout names were renamed to avoid confusion with loadouts of the same name


## Why It's Good For The Game

fixes #82791
fixes #82802
a feature of a deathmatch map working is good
loadout confusion = bad
also i guess sorting the list looks cool

## Changelog
:cl:
fix: deathmatch OSHA Violator map has actually functioning field gens now
fix: being polymorphed in deathmatch does not count you dead
fix: deathmatch cyborgs may not talk in binary
qol: deathmatch map names are sorted alphabetically
spellcheck: deathmatch final destination clown and chef loadouts have been renamed to avoid confusion
/:cl:
