### PR TITLE
Removes command remote from Cap's locker; Cap spawns with an omni remote instead

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -111,7 +111,7 @@
 	department = "omni"
 	region_access = REGION_ALL_STATION
 
-/obj/item/door_remote/captain
+/obj/item/door_remote/command
 	name = "command door remote"
 	department = "command"
 	region_access = REGION_COMMAND

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -16,7 +16,6 @@
 	new /obj/item/computer_disk/command/captain(src)
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/radio/headset/heads/captain(src)
-	new /obj/item/door_remote/captain(src)
 	new /obj/item/storage/photo_album/captain(src)
 
 /obj/structure/closet/secure_closet/captains/populate_contents_immediate()

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -67,6 +67,7 @@
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/station_charter = 1,
+		/obj/item/door_remote/omni = 1,
 		)
 	belt = /obj/item/modular_computer/pda/heads/captain
 	ears = /obj/item/radio/headset/heads/captain/alt
@@ -106,7 +107,16 @@
 
 /datum/outfit/job/captain/post_equip(mob/living/carbon/human/equipped, visualsOnly)
 	. = ..()
-	if(visualsOnly || !special_charter)
+	if(visualsOnly)
+		return
+
+	var/obj/item/door_remote/omni/cap_remote = locate() in equipped.get_item_by_slot(ITEM_SLOT_BACK)
+	if(isnull(cap_remote))
+		// failed to give out the remote, plop on the ground
+		cap_remote = new(get_turf(equipped))
+	cap_remote.name = "Captain's door remote"
+
+	if(!special_charter)
 		return
 
 	var/obj/item/station_charter/banner/celestial_charter = locate() in equipped.held_items


### PR DESCRIPTION

## About The Pull Request

This is meant to accompany a pull request I'm working on right now to make key rings obsolete and rework how people request access to an area temporarily (AI DOOR), but it's a significant enough shift that I thought it was appropriate to make it its own PR.

The command door remote no longer spawns in the Captain's locker; instead, an omni door remote spawns in the backpack of whoever joins as Captain. This lets them operate any door on the station they can see.
## Why It's Good For The Game

It's meant to be groundwork for another change I'm making, but it also seems more appropriate for Captains to be able to manipulate any door they see, rather than only doors with command access. Their ID is all access, so it stands to reason their door remote also would be. Having it spawn in their locker, however, seems a bridge too far, since the spare ID spawns inside a safe.

Summary: change to prepare for keyring obsolescence, a little perk for people who actually play Captain instead of hoping for antagonist Acting Captain, doesn't give remote AA to fireaxe wielding burglars
## Changelog
:cl: Bisar
add: The Captain (the actual job, not Acting Captain) now spawns with an omni door remote.
del: The captain's locker no longer spawns with a command door remote inside.
code: Changed the door remote provided to the Captain to prepare for subsequent PR that makes key rings obsolete.
/:cl:
