### PR TITLE
Fixes blood loss being able to knock you unconscious even at high blood amount

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -103,15 +103,15 @@
 				investigate_log("has died of bloodloss.", INVESTIGATE_DEATHS)
 				death()
 
-	// Blood ratio! if you have 230 blood, this equals 0.5 as that's half of the current value, 560.
-	var/effective_blood_ratio = blood_volume/BLOOD_VOLUME_NORMAL
+	// Blood ratio! if you have 280 blood, this equals 0.5 as that's half of the current value, 560.
+	var/effective_blood_ratio = blood_volume / BLOOD_VOLUME_NORMAL
 
-	// If your ratio is less than one (you're missing any blood) and your oxyloss is under that ratio %, start getting oxy damage.
+	// If your ratio is less than one (you're missing any blood) and your oxyloss is under missing blood %, start getting oxy damage.
 	// This damage accrues faster the less blood you have.
 	// If KO or in hardcrit, the damage accrues even then to prevent being perma-KO.
-	if(((effective_blood_ratio < 1) && (getOxyLoss() < (effective_blood_ratio * 100))) || (stat in list(UNCONSCIOUS, HARD_CRIT)))
+	if(((effective_blood_ratio < 1) && (getOxyLoss() < ((1 - effective_blood_ratio) * 100))) || (stat in list(UNCONSCIOUS, HARD_CRIT)))
 		// At roughly half blood this equals to 3 oxyloss per tick. At 90% blood it's close to 0.5
-		var/rounded_oxyloss = round(0.01 * (BLOOD_VOLUME_NORMAL - blood_volume) * seconds_per_tick, 0.25)
+		var/rounded_oxyloss = round(0.01 * (BLOOD_VOLUME_NORMAL - blood_volume), 0.25) * seconds_per_tick
 		adjustOxyLoss(rounded_oxyloss, updating_health = TRUE)
 
 /// Has each bodypart update its bleed/wound overlay icon states


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/83874 made small mistake, tying maximum oxyloss to current blood level and not missing percent, causing you to get 80 oxyloss when you have 80% of blood. Should be fixed now.
Also, moved `seconds_per_tick` outside of rounding.
Also also, fixed comment because 230 is not 50% of 560.
## Why It's Good For The Game
missing one drop of blood should not kill you.
## Changelog
:cl:
fix: fixed blood loss knocking you down at somewhat safe (~80%) blood levels
/:cl:
