### PR TITLE
Slime extracts can now be ground once again

### DIFF
--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -339,6 +339,7 @@
 				my_atom.visible_message(span_notice("[iconhtml] \The [my_atom]'s power is consumed in the reaction."))
 				extract.name = "used slime extract"
 				extract.desc = "This extract has been used up."
+				extract.grind_results.Cut()
 
 	//finish the reaction
 	selected_reaction.on_reaction(src, null, multiplier)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -10,7 +10,7 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 6
-	grind_results = list()
+	grind_results = list(/datum/reagent/toxin/slimejelly = 20)
 	///uses before it goes inert
 	var/extract_uses = 1
 	///deletion timer, for delayed reactions
@@ -43,11 +43,6 @@
 /obj/item/slime_extract/Initialize(mapload)
 	. = ..()
 	create_reagents(100, INJECTABLE | DRAWABLE)
-
-/obj/item/slime_extract/on_grind()
-	. = ..()
-	if(extract_uses)
-		grind_results[/datum/reagent/toxin/slimejelly] = 20
 
 /**
 * Effect when activated by a Luminescent.


### PR DESCRIPTION

## About The Pull Request

Slime extracts now have reagents by default and lose them when used instead of only acquiring them **upon** being blended.
Closes #84444

## Changelog
:cl:
fix: You can grind slime extracts in reagent grinders once more.
/:cl:
