### PR TITLE
Pyrokinesis bolts no longer have infinite range and hotspots

### DIFF
--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -61,3 +61,4 @@
 	var/turf/location = get_turf(src)
 	new /obj/effect/hotspot(location)
 	location.hotspot_expose(700, 50, 1)
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Closes #84483
Original author forgot to call the parent proc which was supposed to send a comsig and delete the projectile.

## Changelog
:cl:
fix: Pyrokinesis bolts no longer have infinite range and create trails of fiery doom.
/:cl:
