### PR TITLE
Seedlings are now properly apart of the "Plant" faction

### DIFF
--- a/code/modules/mob/living/basic/jungle/seedling/seedling.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling.dm
@@ -30,6 +30,7 @@
 	lighting_cutoff_green = 20
 	lighting_cutoff_blue = 25
 	mob_size = MOB_SIZE_LARGE
+	faction = list(FACTION_PLANTS)
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
 	ai_controller = /datum/ai_controller/basic_controller/seedling

--- a/code/modules/mob/living/basic/jungle/seedling/seedling.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling.dm
@@ -207,7 +207,7 @@
 /mob/living/basic/seedling/meanie
 	maxHealth = 400
 	health = 400
-	faction = list(FACTION_JUNGLE)
+	faction = list(FACTION_JUNGLE, FACTION_PLANTS)
 	ai_controller = /datum/ai_controller/basic_controller/seedling/meanie
 	seedling_commands = list(
 		/datum/pet_command/idle,


### PR DESCRIPTION
Adds seedlings to the "Plant" faction.

## About The Pull Request

Recently encountered what appeared to be a pretty big oversight on the coder's part. I can't recall what round i discovered this on. Tested the code on my own private server, as always.

Seedlings (and evil seedlings) both didn't get added to the "Plant" faction, which causes plant-based monsters such as Killer Tomatoes to attack and kill them. Kinda counter productive during a potential botanist antagonist round where you try to call forth an army of killer tomatoes to attack people entering botany, only for the killer tomatoes to go after your seedlings instead.

## Why It's Good For The Game

Doesn't make sense to have plant-based monsters attack other plant-based monsters.

Will likely take people by surprise (like it did me) when they try to use killer tomatoes as backup only to kill their seedlings instead.

## Changelog

:cl:
fix: Hostile plant monsters (EX: Killer Tomatoes) no longer act hostile toward Seedlings.
/:cl:
