### PR TITLE
Adds a check to prevent race condition runtimes by cigarettes.

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -493,7 +493,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/proc/make_cig_smoke()
 	cig_smoke = new(src, /particles/smoke/cig)
-	cig_smoke.particles.scale *= 1.5
+	cig_smoke.particles?.scale *= 1.5
 	return cig_smoke
 
 // Cigarette brands.


### PR DESCRIPTION
## About The Pull Request

Yesterday I was observing a few rounds and skimmed through the list for any easy runtime fixes. Here was one I found.

In the `make_cig_smoke()` by cigarettes, if particles weren't setup by the time it got to the next line, it would cause this runtime. This adds a ?. (called an elvis operator, fun fact) so that if `cig_smoke.particles` isn't there, it won't runtime.

## Why It's Good For The Game

Less runtimes, cleaner code results on live.

## Changelog

No player facing changes.
