### PR TITLE
Prevents air alarm runtime due to not getting an environment passed.

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -556,7 +556,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	if((machine_stat & (NOPOWER|BROKEN)) || shorted)
 		return
 
-
+	if(!environment)
+		return
 
 	var/old_danger = danger_level
 	danger_level = AIR_ALARM_ALERT_NONE

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -145,6 +145,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 /obj/machinery/airalarm/proc/check_enviroment()
 	var/turf/our_turf = connected_sensor ? get_turf(connected_sensor) : get_turf(src)
 	var/datum/gas_mixture/environment = our_turf.return_air()
+	if(isnull(environment))
+		return
 	check_danger(our_turf, environment, environment.temperature)
 
 /obj/machinery/airalarm/proc/get_enviroment()
@@ -553,6 +555,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	SIGNAL_HANDLER
 	if((machine_stat & (NOPOWER|BROKEN)) || shorted)
 		return
+
+
 
 	var/old_danger = danger_level
 	danger_level = AIR_ALARM_ALERT_NONE


### PR DESCRIPTION
## About The Pull Request

Part of a series of quickly checking in-round runtimes.

Air alarms call check_danger() and `check_environmet()` throughout their operation to collect data on the environment and air around the machinery, and then update overlays, alarms, etc. There were a few instances in round where it was being passed null to environment within check_danger, which was causing it to runtime. Running through the proc chain, the whole logic here seems to rely on being able to obtain it's environment variable, which is why I've added early returns if environment is not met on air alarms to prevent said runtimes.

## Why It's Good For The Game

Less runtimes means cleaner code on live.

## Changelog

No player facing changes.

