### PR TITLE
Adds examine steps and code comments to window doors.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -19,12 +19,16 @@
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
 	set_dir_on_move = FALSE
 	opens_with_door_remote = TRUE
+	/// Reference to the airlock electronics inside for determining window access.
 	var/obj/item/electronics/airlock/electronics = null
+	/// If the door is considered reinforced. If TRUE, the door will resist twice as much heat (1600 deg C vs 800 deg C).
 	var/reinf = 0
+	/// On deconstruction, how many shards to drop.
 	var/shards = 2
+	/// On deconstruction, how many rods to drop.
 	var/rods = 2
+	/// On deconstruction, how much cable to drop.
 	var/cable = 1
-	var/list/debris = list()
 
 /datum/armor/door_window
 	melee = 20
@@ -349,6 +353,10 @@
 	. = ..()
 	if(obj_flags & EMAGGED)
 		. += span_warning("Its access panel is smoking slightly.")
+	if(!density)
+		if(panel_open)
+			. += span_notice("The [span_boldnotice("airlock electronics")] could be [span_boldnotice("levered")] out.")
+
 
 /obj/machinery/door/window/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -5,7 +5,7 @@
  * Step 4: Wrench the assembly in place
  * Step 5: Add cables to the assembly
  * Step 6: Set access for the door.
- * Step 7: Screwdriver the door to complete
+ * Step 7: Crowbar the door to complete
  */
 
 
@@ -20,15 +20,21 @@
 	dir = NORTH
 	obj_flags = CAN_BE_HIT | BLOCKS_CONSTRUCTION_DIR
 	set_dir_on_move = FALSE
+	can_atmos_pass = ATMOS_PASS_PROC
 
+	/// Reference to the airlock electronics inside for determining window access.
 	var/obj/item/electronics/airlock/electronics = null
+	/// Player generated name string from renaming.
 	var/created_name = null
 
 	//Vars to help with the icon's name
-	var/facing = "l" //Does the windoor open to the left or right?
-	var/secure = FALSE //Whether or not this creates a secure windoor
-	var/state = "01" //How far the door assembly has progressed
-	can_atmos_pass = ATMOS_PASS_PROC
+	///Does the windoor open to the left or right?
+	var/facing = "l"
+	///Whether or not this creates a secure windoor
+	var/secure = FALSE
+	///How far the door assembly has progressed. See above comment for what each step is.
+	var/state = "01"
+
 
 /obj/structure/windoor_assembly/Initialize(mapload, set_dir)
 	. = ..()
@@ -278,6 +284,21 @@
 
 	//Update to reflect changes(if applicable)
 	update_appearance()
+
+/obj/structure/windoor_assembly/examine(mob/user)
+	. = ..()
+	if(!anchored)
+		. += span_notice("\The [src] can be [span_boldnotice("wrenched")] down.")
+		. += span_notice("\The [src] could also be [span_boldnotice("cut apart")] with a [span_boldnotice("welder")].")
+		returnx
+	switch(state)
+		if("01")
+			. += span_notice("\The [src] needs [span_boldnotice("wiring")].")
+		if("02")
+			if(!electronics)
+				. += span_notice("\The [src] needs [span_boldnotice("airlock electronics")] to continue installation.")
+			else
+				. += span_notice("\The [src] is ready to be [span_boldnotice("levered")] into place with a [span_boldnotice("crowbar")].")
 
 /obj/structure/windoor_assembly/proc/finish_door()
 	var/obj/machinery/door/window/windoor

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -1,13 +1,3 @@
-/* Windoor (window door) assembly -Nodrak
- * Step 1: Create a windoor out of rglass
- * Step 2: Add r-glass to the assembly to make a secure windoor (Optional)
- * Step 3: Rotate or Flip the assembly to face and open the way you want
- * Step 4: Wrench the assembly in place
- * Step 5: Add cables to the assembly
- * Step 6: Set access for the door.
- * Step 7: Crowbar the door to complete
- */
-
 
 /obj/structure/windoor_assembly
 	icon = 'icons/obj/doors/windoor.dmi'
@@ -32,7 +22,16 @@
 	var/facing = "l"
 	///Whether or not this creates a secure windoor
 	var/secure = FALSE
-	///How far the door assembly has progressed. See above comment for what each step is.
+	/**
+	  * Windoor (window door) assembly -Nodrak
+	  * Step 1: Create a windoor out of rglass
+	  * Step 2: Add r-glass to the assembly to make a secure windoor (Optional)
+	  * Step 3: Rotate or Flip the assembly to face and open the way you want
+	  * Step 4: Wrench the assembly in place
+	  * Step 5: Add cables to the assembly
+	  * Step 6: Set access for the door.
+	  * Step 7: Crowbar the door to complete
+	 */
 	var/state = "01"
 
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -290,7 +290,7 @@
 	if(!anchored)
 		. += span_notice("\The [src] can be [span_boldnotice("wrenched")] down.")
 		. += span_notice("\The [src] could also be [span_boldnotice("cut apart")] with a [span_boldnotice("welder")].")
-		returnx
+		return
 	switch(state)
 		if("01")
 			. += span_notice("\The [src] needs [span_boldnotice("wiring")], or could be [span_boldnotice("un-wrenched")] from the floor.")

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -293,10 +293,10 @@
 		returnx
 	switch(state)
 		if("01")
-			. += span_notice("\The [src] needs [span_boldnotice("wiring")].")
+			. += span_notice("\The [src] needs [span_boldnotice("wiring")], or could be [span_boldnotice("un-wrenched")] from the floor.")
 		if("02")
 			if(!electronics)
-				. += span_notice("\The [src] needs [span_boldnotice("airlock electronics")] to continue installation.")
+				. += span_notice("\The [src] needs [span_boldnotice("airlock electronics")] to continue installation, or [span_boldnotice("wirecutters")] to take apart.")
 			else
 				. += span_notice("\The [src] is ready to be [span_boldnotice("levered")] into place with a [span_boldnotice("crowbar")].")
 


### PR DESCRIPTION
## About The Pull Request

Window doors, unlike many machines and structures with multi-step construction, was lacking a set of examine instructions to let you know how to build it properly.

This PR adds those instructions, and basic instructions for deconstruction as well to windoors and windoor assemblies to make using them more seemless.

Also, updates some code comments in the file while I'm here because they're just straight up incorrect, as it turns out!

## Why It's Good For The Game

In playing a round, I had absolutely no clue on how to construct a windoor. I quickly checked the code, only to learn that the steps were completely wrong in the documentation too, so this should  help prevent this from being an issue going forward.

## Changelog

:cl:
qol: Examining a windoor will now provide the construction steps, like other standard buildable objects.
/:cl:

