### PR TITLE
Headslugs no longer can spawn in nullspace

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -40,7 +40,7 @@
 		user.investigate_log("has been gibbed by headslug burst.", INVESTIGATE_DEATHS)
 	user.gib(DROP_ALL_REMAINS)
 	. = TRUE
-	addtimer(CALLBACK(src, PROC_REF(spawn_headcrab), stored_mind, user_turf, organs), 1 SECONDS)
+	spawn_headcrab(stored_mind, user_turf, organs)
 
 /// Creates the headrab to occupy
 /datum/action/changeling/headcrab/proc/spawn_headcrab(datum/mind/stored_mind, turf/spawn_location, list/organs)

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -40,10 +40,11 @@
 		user.investigate_log("has been gibbed by headslug burst.", INVESTIGATE_DEATHS)
 	user.gib(DROP_ALL_REMAINS)
 	. = TRUE
-	spawn_headcrab(stored_mind, user_turf, organs)
+	addtimer(CALLBACK(src, PROC_REF(spawn_headcrab), stored_mind, organs, user_turf.x, user_turf.y, user_turf.z), 1 SECONDS)
 
 /// Creates the headrab to occupy
-/datum/action/changeling/headcrab/proc/spawn_headcrab(datum/mind/stored_mind, turf/spawn_location, list/organs)
+/datum/action/changeling/headcrab/proc/spawn_headcrab(datum/mind/stored_mind, list/organs, new_x, new_y, new_z)
+	var/turf/spawn_location = locate(new_x, new_y, new_z)
 	var/mob/living/basic/headslug/crab = new(spawn_location)
 	for(var/obj/item/organ/I in organs)
 		I.forceMove(crab)


### PR DESCRIPTION
## About The Pull Request

Closes #84493
Right now headslugs have a 1 second timer (assuming in order to only spawn after the gib animation is finished) before the spawn, so if they spawn after the turf the ling died on was blown up, they get nullspaced. I swapped turf arg for coordinates so even if the turf changed, the headslug can still spawn

## Changelog
:cl:
fix: Headslugs no longer can get nullspaced
/:cl:
