### PR TITLE
Improve bedsheet interactions

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -111,6 +111,7 @@ LINEN BINS
 	layer = ABOVE_MOB_LAYER
 	pixel_x = 0
 	pixel_y = 0
+	pixel_z = sleeper.pixel_z // Account for possible mob elevation
 	balloon_alert(sleeper, "covered")
 	var/angle = sleeper.lying_prev
 	dir = angle2dir(angle + 180) // 180 flips it to be the same direction as the mob
@@ -131,6 +132,7 @@ LINEN BINS
 	balloon_alert(sleeper, "smoothed sheets")
 	layer = initial(layer)
 	SET_PLANE_IMPLICIT(src, initial(plane))
+	pixel_z = 0
 	signal_sleeper = null
 
 // We need to do this in case someone picks up a bedsheet while a mob is covered up

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -104,7 +104,7 @@ LINEN BINS
 	add_fingerprint(user)
 
 /obj/item/bedsheet/click_alt(mob/living/user)
-	dir = REVERSE_DIR(dir)
+	setDir(REVERSE_DIR(dir))
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/bedsheet/proc/coverup(mob/living/sleeper)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -12,6 +12,8 @@ LINEN BINS
 	righthand_file = 'icons/mob/inhands/items/bedsheet_righthand.dmi'
 	icon_state = "sheetwhite"
 	inhand_icon_state = "sheetwhite"
+	drop_sound = 'sound/items/handling/cloth_drop.ogg'
+	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 	slot_flags = ITEM_SLOT_NECK
 	layer = BELOW_MOB_LAYER
 	throwforce = 0

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -146,6 +146,7 @@ LINEN BINS
 	UnregisterSignal(sleeper, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(sleeper, COMSIG_LIVING_SET_BODY_POSITION)
 	UnregisterSignal(sleeper, COMSIG_QDELETING)
+	pixel_z = 0
 	signal_sleeper = null
 
 /obj/item/bedsheet/blue


### PR DESCRIPTION

## About The Pull Request

This pr simply adds drop/pickup sounds to bedsheets, replaces its `attackby(...)` and `attack_secondary(...)` with `item_interaction(...)` and `interact_with_atom_secondary(...)`, and makes tucking in match the bedsheet `pixel_z` with that of the living we're tucking in. It also removes a check that's no longer needed to allow for telekinetically tucking someone in.

First bit of note, we use `item_interaction(...)` instead of `wirecutters_act(...)`/`tool_act(...)` as I think tearing up the bedsheets should be the interaction in combat mode too, and everything under `tool_act(...)` only gets called with combat mode being off.

Second bit of note, we remove the `!user.CanReach(target)` check from tucking people in, as I believe that's no longer necessary here. This allows us to tuck people in telekinetically, given the bedsheets are adjacent to the one we're tucking in.

Finally, we match the bedsheets' `pixel_z` with that of the living we're tucking in by setting it directly, and also reset it directly when we smooth the sheets.
I know the elevation element exists, but I believe that only cares about living instances, and besides that really we only want this to be set when tucking someone in rather than always. Most importantly, it works.
## Why It's Good For The Game

Using the new item interaction code is better than `attackby(...)` and such.
Cloth sounds are nicer than no sounds, and make sense given they're, well, cloth.
Tucking someone in with telekinesis is funny.

Previously, bedsheets would not offset their `pixel_z` to match that of the living they're tucking in, meaning if you were to say rest upon a table the bedsheets would always be awkwardly offset.
This fixes that.
## Changelog
:cl:
code: Moved bedsheet interactions to the item interaction code. Please report any issues.
fix: Bedsheets adjust their offset to match that of the living they're tucking in.
sound: Bedsheets use the cloth drop/pickup sounds instead of being silent.
qol: You can tuck someone in telekinetically.
/:cl:
