### PR TITLE
adds customization of signatures (%s) and date format (%d) in preferences

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -17,6 +17,16 @@
 /proc/station_time_timestamp(format = "hh:mm:ss", wtime)
 	return time2text(station_time(TRUE, wtime), format)
 
+/proc/station_date_timestamp(format = "YYYY-MM-DD", wtime)
+	if(findtext(format, "yyyy"))
+		var/list/layout = splittext(format, "yyyy")
+		format = layout.Join("[CURRENT_STATION_YEAR]")
+	if(findtext(format, "yy"))
+		var/list/layout = splittext(format, "yy")
+		format = layout.Join("[copytext(num2text(CURRENT_STATION_YEAR), 3, 5)]")
+
+	return time2text(station_time(TRUE, wtime), uppertext(format))
+
 /proc/station_time_debug(force_set)
 	if(isnum(force_set))
 		SSticker.gametime_offset = force_set

--- a/code/modules/client/preferences/paperwork.dm
+++ b/code/modules/client/preferences/paperwork.dm
@@ -1,0 +1,17 @@
+/datum/preference/text/custom_signature
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "signature"
+	maximum_value_length = 20
+
+/datum/preference/text/custom_signature/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+
+/datum/preference/text/custom_date
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "date_format"
+	maximum_value_length = 14
+
+/datum/preference/text/custom_date/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -210,13 +210,19 @@
 
 	var/field_text = text
 	if(is_signature)
-		field_text = signature_name
+		var/signature = usr?.client?.prefs.read_preference(/datum/preference/text/custom_signature)
+		if(!signature)
+			signature = signature_name
+		field_text = signature
 	else if(is_date)
-		field_text = "[time2text(world.timeofday, "DD/MM")]/[CURRENT_STATION_YEAR]"
+		var/date_format = usr?.client?.prefs.read_preference(/datum/preference/text/custom_date)
+		if(!date_format)
+			date_format = "DD/MM/YYYY"
+		field_text = station_date_timestamp(date_format)
 	else if(is_time)
 		field_text = time2text(world.timeofday, "hh:mm")
 
-	var/field_font = is_signature ? SIGNATURE_FONT : font
+	var/field_font = (is_signature || is_date || is_time) ? SIGNATURE_FONT : font
 
 	for(var/datum/paper_field/field_input in raw_field_input_data)
 		if(field_input.field_index == field_id)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3697,6 +3697,7 @@
 #include "code\modules\client\preferences\ooc.dm"
 #include "code\modules\client\preferences\operative_species.dm"
 #include "code\modules\client\preferences\paint_color.dm"
+#include "code\modules\client\preferences\paperwork.dm"
 #include "code\modules\client\preferences\parallax.dm"
 #include "code\modules\client\preferences\pda.dm"
 #include "code\modules\client\preferences\persistent_scars.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/paperwork.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/paperwork.tsx
@@ -1,0 +1,15 @@
+import { Feature, FeatureShortTextInput } from '../base';
+
+export const signature: Feature<string> = {
+  name: 'Paperwork - Signature',
+  description:
+    "Custom signature for your character. Applied when using %s in fields on paper. If left blank, the character's full name is used by default",
+  component: FeatureShortTextInput,
+};
+
+export const date_format: Feature<string> = {
+  name: 'Paperwork - Date Format',
+  description:
+    'Date format the character uses when using %d in fields on paper. You can use any of the following keywords: YYYY - year (2024), YY - year (24), DD - day of the month, DDD - day of the week (Mon, Tue), MM - number of the month, MMM - month (Jan, Feb). You can use any separators between the above. If left blank, DD/MM/YYYY format is used by default',
+  component: FeatureShortTextInput,
+};


### PR DESCRIPTION
## About The Pull Request

You can now set how your character will write dates when using %d or %date, and also which signature it will add when using %s or %sign

<details>
<summary> Screens </summary>

![image](https://github.com/tgstation/tgstation/assets/112967882/d5380d9d-b8ec-4be1-91ea-c52720b946da)

![image](https://github.com/tgstation/tgstation/assets/112967882/8e1f2be1-822b-467e-b25c-d9fc2126fc4f)

</details>

## Why It's Good For The Game

It's cool that you can choose your own signature for the character, and not just a full name. More uniqueness for characters doing paperwork. Same thing for dates
## Changelog
:cl:
add: adds customization of signatures and date format in preferences
code: %d, %s, %t now have a handwritten font
/:cl:
