### PR TITLE
Bedsheet bin interaction improvements

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -601,19 +601,21 @@ LINEN BINS
 			return CONTEXTUAL_SCREENTIP_SET
 		return
 
-	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
-		context[SCREENTIP_CONTEXT_LMB] = "Disassemble"
-		return CONTEXTUAL_SCREENTIP_SET
-	if(held_item.tool_behaviour == TOOL_WRENCH)
-		context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Una" : "A"]nchor"
-		return CONTEXTUAL_SCREENTIP_SET
 	if(istype(held_item, /obj/item/bedsheet))
 		context[SCREENTIP_CONTEXT_LMB] = "Put in"
 		return CONTEXTUAL_SCREENTIP_SET
+
+	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+		context[SCREENTIP_CONTEXT_RMB] = "Disassemble"
+		. = CONTEXTUAL_SCREENTIP_SET
+	else if(held_item.tool_behaviour == TOOL_WRENCH)
+		context[SCREENTIP_CONTEXT_RMB] = "[anchored ? "Una" : "A"]nchor"
+		. = CONTEXTUAL_SCREENTIP_SET
+
 	if(amount && held_item.w_class < WEIGHT_CLASS_BULKY)
 		context[SCREENTIP_CONTEXT_LMB] = "Hide item in"
-		return CONTEXTUAL_SCREENTIP_SET
-
+		. = CONTEXTUAL_SCREENTIP_SET
+	return .
 
 /obj/structure/bedsheetbin/update_icon_state()
 	switch(amount)
@@ -631,7 +633,7 @@ LINEN BINS
 		update_appearance()
 	..()
 
-/obj/structure/bedsheetbin/screwdriver_act(mob/living/user, obj/item/tool)
+/obj/structure/bedsheetbin/screwdriver_act_secondary(mob/living/user, obj/item/tool)
 	if(amount)
 		to_chat(user, span_warning("The [src] must be empty first!"))
 		return ITEM_INTERACT_SUCCESS
@@ -641,7 +643,7 @@ LINEN BINS
 		qdel(src)
 		return ITEM_INTERACT_SUCCESS
 
-/obj/structure/bedsheetbin/wrench_act(mob/living/user, obj/item/tool)
+/obj/structure/bedsheetbin/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
 	default_unfasten_wrench(user, tool, time = 0.5 SECONDS)
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -581,6 +581,10 @@ LINEN BINS
 	anchored = FALSE
 
 
+/obj/structure/bedsheetbin/Initialize(mapload)
+	. = ..()
+	register_context()
+
 /obj/structure/bedsheetbin/examine(mob/user)
 	. = ..()
 	if(amount < 1)
@@ -589,6 +593,26 @@ LINEN BINS
 		. += "There is one bed sheet in the bin."
 	else
 		. += "There are [amount] bed sheets in the bin."
+
+/obj/structure/bedsheetbin/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		if(amount)
+			context[SCREENTIP_CONTEXT_LMB] = "Take bedsheet"
+			return CONTEXTUAL_SCREENTIP_SET
+		return
+
+	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+		context[SCREENTIP_CONTEXT_LMB] = "Disassemble"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(held_item.tool_behaviour == TOOL_WRENCH)
+		context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Una" : "A"]nchor"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/bedsheet))
+		context[SCREENTIP_CONTEXT_LMB] = "Put in"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(amount && held_item.w_class < WEIGHT_CLASS_BULKY)
+		context[SCREENTIP_CONTEXT_LMB] = "Hide item in"
+		return CONTEXTUAL_SCREENTIP_SET
 
 
 /obj/structure/bedsheetbin/update_icon_state()


### PR DESCRIPTION

## About The Pull Request

This pr just replaces the bedsheet bin `attackby(...)` with `item_interaction(...)`, adds usage screentips to bedsheet bins, adds more balloon alert feedback to failing to hide items in bedsheet bins, and added `silent = FALSE` to the `user.transferItemToLoc(tool, src)` calls' parameters such that putting items in isn't silent.

Main thing to note is that we skip hiding items when in combat mode, such that you do not try to hide the item you are currently trying to beat up the bin with.

Tiny second thing to note is that we explicitly `return .` in `add_context(...)` due to adjusting the value of `.`.
## Why It's Good For The Game

Better to update `attackby(...)` to `item_interaction(...)`.
I think item interactions being internally consistent is more intuitive; left click always being hiding feels nicer than left click being hiding _except_ for tools where it's right click.
Then, I think hiding should be left click as "putting something in" is the primary item interaction we're expecting, parallel to tables or storage or racks or somesuch.

Nice to have screentips.
Nice to have more failure feedback.
Nice when things aren't silent.
## Changelog
:cl:
code: Moved bedsheet bin interactions to the item interaction code. Please report any issues.
qol: Made bedsheet bin tool interactions right click, such that left click is consistently for putting in items.
qol: Added usage screentips to bedsheet bins.
qol: Added more feedback to failing to hide items in bedsheet bins.
sound: Made putting items in bedsheet bins not silent (If the items have associated pickup/drop sounds).
/:cl:
