### PR TITLE
Fixed various issues with the genetics powers PR

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -50,5 +50,5 @@
 	result = /datum/mutation/human/martyrdom
 
 /datum/generecipe/heckacious
-	required = "/datum/mutation/human/wacky; /datum/mutation/human/trichromatic"
+	required = "/datum/mutation/human/wacky; /datum/mutation/human/stoner"
 	result = /datum/mutation/human/heckacious

--- a/code/datums/mutations/reach.dm
+++ b/code/datums/mutations/reach.dm
@@ -66,7 +66,7 @@
 /// signal sent when prompting if an item can be equipped
 /datum/mutation/human/elastic_arms/proc/on_owner_equipping_item(mob/living/carbon/human/owner, obj/item/pick_item)
 	SIGNAL_HANDLER
-	if(pick_item.w_class > WEIGHT_CLASS_BULKY) // cant decide if i should limit to huge or bulky.
+	if((pick_item.w_class > WEIGHT_CLASS_BULKY) && !(pick_item.item_flags & ABSTRACT|HAND_ITEM)) // cant decide if i should limit to huge or bulky.
 		pick_item.balloon_alert(owner, "arms too floppy to wield!")
 		return COMPONENT_LIVING_CANT_PUT_IN_HAND
 

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -100,7 +100,7 @@
 
 		// Random caps
 		if(prob(10))
-			editing_word = prob(85) ? uppertext(editing_word) : lowertext(editing_word)
+			editing_word = prob(85) ? uppertext(editing_word) : LOWER_TEXT(editing_word)
 		// some times....... we add DOTS...
 		if(prob(10))
 			for(var/dotnum in 1 to rand(2, 8))

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -40,24 +40,13 @@
 
 	speech_args[SPEECH_SPANS] |= SPAN_SANS
 
-// Lower rust floor probability
-// Make it only happen on open turf
-// Add early return to wall hitting
-// Fix throw at on cult sac
-// Reduce tochat prob on rust floor
-// add trait rusty to windows
-// aim assist on rc doesnt work
-// also in general
-// give master seek to rusted harvester
-
 /datum/mutation/human/heckacious
 	name = "heckacious larincks"
 	desc = "duge what is WISH your words man..........."
 	quality = MINOR_NEGATIVE
-	text_gain_indication = span_sans(span_red("aw SHIT man. your throat feels like FUCKASS."))
+	text_gain_indication = span_sans("aw SHIT man. your throat feels like FUCKASS.")
 	text_lose_indication = span_notice("The demonic entity possessing your larynx has finally released its grasp.")
 	locked = TRUE
-	conflicts = list(/datum/mutation/human/trichromatic) // they both modify with the same spans. also would be way too annoying
 
 /datum/mutation/human/heckacious/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -111,11 +100,15 @@
 
 		// Random caps
 		if(prob(10))
-			editing_word = uppertext(editing_word)
+			editing_word = prob(85) ? uppertext(editing_word) : lowertext(editing_word)
 		// some times....... we add DOTS...
 		if(prob(10))
 			for(var/dotnum in 1 to rand(2, 8))
 				editing_word += "."
+		// change for bold/italics/underline as well!
+		if(prob(10))
+			var/extra_emphasis = pick("+", "_", "|")
+			editing_word = extra_emphasis + editing_word + extra_emphasis
 
 		// If no replacement we do it manually
 		if(!word_edited)
@@ -133,9 +126,6 @@
 				patchword += replacetext(editing_word[letter], "", editing_word[letter] + editing_word[letter])
 			editing_word = patchword
 
-		// Some words are randomly recolored and resized so they get a few of these
-		editing_word = span_class_handler(editing_word)
-
 		LAZYADD(edited_message_words, editing_word)
 
 	var/edited_message = jointext(edited_message_words, " ")
@@ -143,74 +133,6 @@
 	message = trim(edited_message)
 
 	speech_args[SPEECH_MESSAGE] = message
-
-/datum/mutation/human/heckacious/proc/span_class_handler(message, looped = FALSE)
-	// Sadly combining span colors will not combine the colors of the message
-	if(prob(15))
-		switch(rand(1,3))
-			if(1)
-				message = span_red(message)
-			if(2)
-				message = span_blue(message)
-			if(3)
-				message = span_green(message)
-	if(prob(15))
-		switch(rand(1,2))
-			if(1)
-				message = span_big(message)
-			if(2)
-				message = span_small(message)
-	// do it AGAIN
-	if(prob(40))
-		span_class_handler(message, looped = TRUE)
-	return message
-
-/datum/mutation/human/trichromatic
-	name = "Trichromatic Larynx"
-	desc = "A strange mutation originating from Clown Planet which alters the color of the patient's vocal chords."
-	quality = MINOR_NEGATIVE
-	text_gain_indication = span_red("You") + span_blue(" feel ") + span_green("Weird.")
-	text_lose_indication = span_notice("Your colors feel normal again.")
-	conflicts = list(/datum/mutation/human/heckacious)
-
-/datum/mutation/human/trichromatic/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
-		return
-	RegisterSignal(owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-/datum/mutation/human/trichromatic/on_losing(mob/living/carbon/human/owner)
-	if(..())
-		return
-	UnregisterSignal(owner, COMSIG_MOB_SAY)
-
-/datum/mutation/human/trichromatic/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-
-	var/message = speech_args[SPEECH_MESSAGE]
-
-	var/list/message_words = splittext(message, " ")
-	var/list/static/span_combo_list = list("green", "red", "blue")
-	var/words_key = 1
-	for(var/i in message_words)
-		message_words[words_key] = span_class_handler(message_words[words_key])
-		words_key++
-
-	var/edited_message = jointext(message_words, " ")
-
-	message = trim(edited_message)
-
-	speech_args[SPEECH_MESSAGE] = message
-
-/datum/mutation/human/trichromatic/proc/span_class_handler(message)
-	// Sadly combining span colors will not combine the colors of the message
-	switch(rand(1,3))
-		if(1)
-			message = span_red(message)
-		if(2)
-			message = span_blue(message)
-		if(3)
-			message = span_green(message)
-	return message
 
 /datum/mutation/human/mute
 	name = "Mute"
@@ -369,7 +291,6 @@
 	name = "Stoner"
 	desc = "A common mutation that severely decreases intelligence."
 	quality = NEGATIVE
-	locked = TRUE
 	text_gain_indication = span_notice("You feel...totally chill, man!")
 	text_lose_indication = span_notice("You feel like you have a better sense of time.")
 

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -165,7 +165,7 @@
 		success = do_simple_heal(mendicant, hurtguy, heal_multiplier, pain_multiplier)
 
 	// Both types can be ignited (technically at least), so we can just do this here.
-	if(hurtguy.has_status_effect(/datum/status_effect/fire_handler/fire_stacks))
+	if(hurtguy.fire_stacks)
 		mendicant.set_fire_stacks(hurtguy.fire_stacks * pain_multiplier, remove_wet_stacks = TRUE)
 		if(hurtguy.on_fire)
 			mendicant.ignite_mob()

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -201,7 +201,7 @@
 		if(IS_ORGANIC_LIMB(possible_limb))
 			mendicant_organic_limbs += possible_limb
 	// None? Gtfo
-	if(isnull(mendicant_organic_limbs))
+	if(!length(mendicant_organic_limbs))
 		return .
 
 	// Try to use our active hand, otherwise pick at random

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -165,7 +165,7 @@
 		success = do_simple_heal(mendicant, hurtguy, heal_multiplier, pain_multiplier)
 
 	// Both types can be ignited (technically at least), so we can just do this here.
-	if(hurtguy.fire_stacks)
+	if(hurtguy.fire_stacks > 0)
 		mendicant.set_fire_stacks(hurtguy.fire_stacks * pain_multiplier, remove_wet_stacks = TRUE)
 		if(hurtguy.on_fire)
 			mendicant.ignite_mob()

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -142,8 +142,8 @@
 	// If you crunch the numbers it sounds crazy good,
 	// but I think that's a fair reward for combining the efforts of Genetics, Medbay, and Mining to reach a hidden mechanic.
 	if(HAS_TRAIT_FROM(mendicant, TRAIT_HIPPOCRATIC_OATH, HIPPOCRATIC_OATH_TRAIT))
-		heal_multiplier *= 2
-		pain_multiplier *= 0.5
+		heal_multiplier = 2
+		pain_multiplier = 0.5
 		to_chat(mendicant, span_green("You can feel the magic of the Rod of Aesculapius aiding your efforts!"))
 		beam_icon = "sendbeam"
 		var/obj/item/rod_of_asclepius/rod = locate() in mendicant.contents
@@ -154,8 +154,8 @@
 
 	// If a normal pacifist, heal and hurt more!
 	else if(HAS_TRAIT(mendicant, TRAIT_PACIFISM))
-		heal_multiplier *= 1.75
-		pain_multiplier *= 1.75
+		heal_multiplier = 1.75
+		pain_multiplier = 1.75
 		to_chat(mendicant, span_green("Your peaceful nature helps you guide all the pain to yourself."))
 
 	var/success

--- a/strings/heckacious.json
+++ b/strings/heckacious.json
@@ -75,7 +75,6 @@
     "seeing": "scoping",
     "great": "choice",
     "look": "lonk",
-    "shit": "balls warmed oveur",
     "battery": "babbery",
     "retard": "dicktard",
     "gay": "homo",
@@ -93,6 +92,7 @@
     "dude": [ "duge", "bro", "brah" ],
     "'": [ "'", "" ],
     "i'm": [ "im", "i am" ],
+    "shit": [ "balls warmed oveur", "shit" ],
     "he's": [ "hes", "he is", "he'ss" ]
   }
 }


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/tgstation/issues/84509
#84557
Removed Trichromatic Larynx per @mothblocks decision that it looks uggo.

Replaced heckacious laryncks' color and size changes with random bolding, italics, and underlining.

Stoner has been un-locked and replaces TL in the above's recipe.

Fixed elastic arms users being unable to use abstract items like mending touch or shock touch.

Fixed mending touch being bad

## Why It's Good For The Game

> Removed Trichromatic Larynx per @mothblocks decision that it looks uggo.

They say it looks ugly and bad. It also works like poop. So away it goes!

> Replaced heckacious laryncks' color and size changes with random bolding, italics, and underlining.

Removed color, but replaced with something just as neat.

> Stoner has been un-locked and replaces TL in the above's recipe.

No reason to lock it as far as I know.

> Fixed elastic arms users being unable to use abstract items like mending touch or shock touch.


Bugge

## Changelog

:cl:
del: Removed Trichromatic Larynx per @mothblocks decision that it looks uggo.
del: Replaced heckacious laryncks' color and size changes with random bolding, italics, and underlining.
add: Stoner has been un-locked and replaces TL in the above's recipe.
fix: Fixed elastic arms users being unable to use abstract items like mending touch or shock touch.
fix: Fixed mending touch being bad
/:cl:

