### PR TITLE
Moved data disks to lathes

### DIFF
--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -6,7 +6,7 @@
 	name = "Data Disk"
 	id = "portadrive_basic"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT*8)
+	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/computer_disk
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -18,7 +18,7 @@
 	name = "Advanced Data Disk"
 	id = "portadrive_advanced"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*1.5)
+	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT * 2)
 	build_path = /obj/item/computer_disk/advanced
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -30,7 +30,7 @@
 	name = "Super Data Disk"
 	id = "portadrive_super"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT*1.5)
+	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT * 4)
 	build_path = /obj/item/computer_disk/super
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -5,7 +5,7 @@
 /datum/design/portabledrive/basic
 	name = "Data Disk"
 	id = "portadrive_basic"
-	build_type = IMPRINTER | AWAY_IMPRINTER
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT*8)
 	build_path = /obj/item/computer_disk
 	category = list(
@@ -16,7 +16,7 @@
 /datum/design/portabledrive/advanced
 	name = "Advanced Data Disk"
 	id = "portadrive_advanced"
-	build_type = IMPRINTER | AWAY_IMPRINTER
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*1.5)
 	build_path = /obj/item/computer_disk/advanced
 	category = list(
@@ -27,7 +27,7 @@
 /datum/design/portabledrive/super
 	name = "Super Data Disk"
 	id = "portadrive_super"
-	build_type = IMPRINTER | AWAY_IMPRINTER
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT*1.5)
 	build_path = /obj/item/computer_disk/super
 	category = list(

--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -5,10 +5,11 @@
 /datum/design/portabledrive/basic
 	name = "Data Disk"
 	id = "portadrive_basic"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT*8)
 	build_path = /obj/item/computer_disk
 	category = list(
+		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_MODULAR_COMPUTERS + RND_SUBCATEGORY_MODULAR_COMPUTERS_PARTS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
@@ -16,10 +17,11 @@
 /datum/design/portabledrive/advanced
 	name = "Advanced Data Disk"
 	id = "portadrive_advanced"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*1.5)
 	build_path = /obj/item/computer_disk/advanced
 	category = list(
+		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_MODULAR_COMPUTERS + RND_SUBCATEGORY_MODULAR_COMPUTERS_PARTS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
@@ -27,10 +29,11 @@
 /datum/design/portabledrive/super
 	name = "Super Data Disk"
 	id = "portadrive_super"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT*1.5)
 	build_path = /obj/item/computer_disk/super
 	category = list(
+		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_MODULAR_COMPUTERS + RND_SUBCATEGORY_MODULAR_COMPUTERS_PARTS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING


### PR DESCRIPTION
## About The Pull Request

Moved all 3 versions of data disks to protolathe and autolathe.

## Why It's Good For The Game

It was confusing that you can't print it in lathe and they were considered circuitboards.

## Changelog

:cl:
qol: Data disks are now printed in lathes instead of circuit imprinter 
/:cl:
