### PR TITLE
Changes bitrunning hacker alias sanitization

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -241,12 +241,7 @@
 	if(last_char_group == SPACES_DETECTED)
 		t_out = copytext_char(t_out, 1, -1) //removes the last character (in this case a space)
 
-	for(var/bad_name in list("space","floor","wall","r-wall","monkey","unknown","inactive ai")) //prevents these common metagamey names
-		if(cmptext(t_out,bad_name))
-			return //(not case sensitive)
-
-	// Protects against names containing IC chat prohibited words.
-	if(is_ic_filtered(t_out) || is_soft_ic_filtered(t_out))
+	if(!filter_name_ic(t_out))
 		return
 
 	return t_out
@@ -256,6 +251,39 @@
 #undef NUMBERS_DETECTED
 #undef LETTERS_DETECTED
 
+
+/// Much more permissive version of reject_bad_name().
+/// Returns a trimmed string or null if the name is invalid.
+/// Allows most characters except for IC chat prohibited words.
+/proc/permissive_sanitize_name(value)
+	if(!istext(value)) // Not a string
+		return
+
+	var/name_length = length(value)
+	if(name_length < 3) // Too short
+		return
+
+	if(name_length > 3 * MAX_NAME_LEN) // Bad input
+		return
+
+	var/trimmed = trim(value, MAX_NAME_LEN)
+	if(!filter_name_ic(trimmed)) // Contains IC chat prohibited words
+		return
+
+	return trim_reduced(trimmed)
+
+
+/// Helper proc to check if a name is valid for the IC filter
+/proc/filter_name_ic(name)
+	for(var/bad_name in list("space", "floor", "wall", "r-wall", "monkey", "unknown", "inactive ai")) //prevents these common metagamey names
+		if(cmptext(name, bad_name))
+			return FALSE //(not case sensitive)
+
+	// Protects against names containing IC chat prohibited words.
+	if(is_ic_filtered(name) || is_soft_ic_filtered(name))
+		return FALSE
+
+	return TRUE
 
 
 //html_encode helper proc that returns the smallest non null of two numbers

--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -17,9 +17,6 @@
 	/// If the highest priority job matches this, will prioritize this name in the UI
 	var/relevant_job
 
-	/// Doesn't filter specific characters, allowing OOC-like names
-	var/permissive_names = FALSE
-
 
 /datum/preference/name/apply_to_human(mob/living/carbon/human/target, value)
 	// Only real_name applies directly, everything else is applied by something else
@@ -27,29 +24,17 @@
 
 
 /datum/preference/name/deserialize(input, datum/preferences/preferences)
-	if(permissive_names)
-		return permissive_sanitize_name(input)
-
 	return reject_bad_name("[input]", allow_numbers)
 
 
 /datum/preference/name/serialize(input)
-	if(permissive_names)
-		return permissive_sanitize_name(input)
-
 	// `is_valid` should always be run before `serialize`, so it should not
 	// be possible for this to return `null`.
 	return reject_bad_name(input, allow_numbers)
 
 
 /datum/preference/name/is_valid(value)
-	if(!istext(value))
-		return FALSE
-
-	if(permissive_names)
-		return !isnull(permissive_sanitize_name(value))
-
-	return !isnull(reject_bad_name(value, allow_numbers))
+	return istext(value) && !isnull(reject_bad_name(value, allow_numbers))
 
 
 /// A character's real name
@@ -202,8 +187,20 @@
 	group = "bitrunning"
 	savefile_key = "hacker_alias"
 	relevant_job = /datum/job/bitrunner
-	permissive_names = TRUE
 
 
 /datum/preference/name/hacker_alias/create_default_value()
 	return pick(GLOB.hacker_aliases)
+
+
+/datum/preference/name/hacker_alias/is_valid(value)
+	return !isnull(permissive_sanitize_name(value))
+
+
+/datum/preference/name/hacker_alias/deserialize(input, datum/preferences/preferences)
+	return permissive_sanitize_name(input)
+
+
+/datum/preference/name/hacker_alias/serialize(input)
+	return permissive_sanitize_name(input)
+

--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -17,20 +17,40 @@
 	/// If the highest priority job matches this, will prioritize this name in the UI
 	var/relevant_job
 
+	/// Doesn't filter specific characters, allowing OOC-like names
+	var/permissive_names = FALSE
+
+
 /datum/preference/name/apply_to_human(mob/living/carbon/human/target, value)
 	// Only real_name applies directly, everything else is applied by something else
 	return
 
+
 /datum/preference/name/deserialize(input, datum/preferences/preferences)
+	if(permissive_names)
+		return permissive_sanitize_name(input)
+
 	return reject_bad_name("[input]", allow_numbers)
 
+
 /datum/preference/name/serialize(input)
+	if(permissive_names)
+		return permissive_sanitize_name(input)
+
 	// `is_valid` should always be run before `serialize`, so it should not
 	// be possible for this to return `null`.
 	return reject_bad_name(input, allow_numbers)
 
+
 /datum/preference/name/is_valid(value)
-	return istext(value) && !isnull(reject_bad_name(value, allow_numbers))
+	if(!istext(value))
+		return FALSE
+
+	if(permissive_names)
+		return !isnull(permissive_sanitize_name(value))
+
+	return !isnull(reject_bad_name(value, allow_numbers))
+
 
 /// A character's real name
 /datum/preference/name/real_name
@@ -181,8 +201,9 @@
 	explanation = "Hacker alias"
 	group = "bitrunning"
 	savefile_key = "hacker_alias"
-	allow_numbers = TRUE
 	relevant_job = /datum/job/bitrunner
+	permissive_names = TRUE
+
 
 /datum/preference/name/hacker_alias/create_default_value()
 	return pick(GLOB.hacker_aliases)


### PR DESCRIPTION

## About The Pull Request
Bitrunning hacker names now permit most characters while staying within the IC filter and length requirements. Made some helper procs to keep it organized
## Why It's Good For The Game
You can now name yourself things like An1me_Sn1p3r
## Changelog
:cl:
fix: Bitrunning hacker aliases are now much more permissive
/:cl:
