### PR TITLE
fix step action signal logic

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -26,8 +26,9 @@
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
-	if(shoes && body_position == STANDING_UP && loc == NewLoc && has_gravity(loc))
-		SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
+	if(shoes && body_position == STANDING_UP && has_gravity(loc))
+		if((. && !moving_diagonally) || (!. && moving_diagonally == SECOND_DIAG_STEP))
+			SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	if(movement_type & FLYING || HAS_TRAIT(src, TRAIT_FREE_FLOAT_MOVEMENT))


### PR DESCRIPTION

## About The Pull Request

Only counts a step after a successful step.
## Why It's Good For The Game

Fixes #84386 
## Changelog
:cl: Bisar
fix: Dastardly clowns will no longer be able to get counted for three times the steps by moving diagonally.
/:cl:
