### PR TITLE
Voltaic Combat Cyberheart will no longer screw over slime people.

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -170,7 +170,7 @@
 	if(owner.health <= owner.crit_threshold)
 		owner.heal_overall_damage(5, 5)
 		owner.adjustOxyLoss(-5)
-		owner.adjustToxLoss(-5)
+		owner.adjustToxLoss(-5, forced = TRUE)
 
 /datum/status_effect/voltaic_overdrive/on_apply()
 	. = ..()


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/84519

## About The Pull Request

The Voltaic Combat Cyberheart adjusts toxin damage without forcing it, causing slime people (who take reversed toxin damage) to build up toxins, lose their form, and likely die shortly afterwards.

## Why It's Good For The Game

Fixes an oversight.

## Changelog

:cl:
fix: The Voltaic Combat Cyberheart no longer causes toxin damage in slimepeople.
/:cl:
