### PR TITLE
Starlight Condensation doesn't screw over slimepeople.

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -154,7 +154,7 @@
 	if(M.getToxLoss() && prob(5))
 		to_chat(M, span_notice("Your skin tingles as the starlight seems to heal you."))
 
-	M.adjustToxLoss(-(4 * heal_amt)) //most effective on toxins
+	M.adjustToxLoss(-(4 * heal_amt), forced = TRUE) //most effective on toxins
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, BODYTYPE_ORGANIC)
 


### PR DESCRIPTION
A similar idea to another PR fix i made.

## About The Pull Request

Starlight Condensation toxin healing isn't forced which actually took me by surprise once.

Slime people with a virus who heal from this symptom just kinda build up toxins and then get nuggeted. Most people won't know why, luckily i was once a virologist main and i figured out this problem shortly after it occurred to me during a round.

## Why It's Good For The Game

Fixes an oversight.

## Changelog

:cl:
fix: Starlight Condensation no longer causes toxin damage in slimepeople.
/:cl: