### PR TITLE
[NO GBP] Fixes hoverboard being able to be used in space.

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -49,6 +49,8 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 #define isspaceturf(A) (istype(A, /turf/open/space))
 
+#define is_space_or_openspace(A) (isopenspaceturf(A) || isspaceturf(A))
+
 #define isfloorturf(A) (istype(A, /turf/open/floor))
 
 #define ismiscturf(A) (istype(A, /turf/open/misc))

--- a/code/datums/ai/basic_mobs/basic_subtrees/go_for_swim.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/go_for_swim.dm
@@ -35,7 +35,7 @@
 	var/look_for_land = controller.blackboard[BB_CURRENTLY_SWIMMING]
 	var/list/possible_turfs = list()
 	for(var/turf/possible_turf in oview(search_range, living_pawn))
-		if(isclosedturf(possible_turf) || isspaceturf(possible_turf) || isopenspaceturf(possible_turf))
+		if(isclosedturf(possible_turf) || is_space_or_openspace(possible_turf))
 			continue
 		if(possible_turf.is_blocked_turf())
 			continue

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -242,12 +242,12 @@
 ///Makes sure that the hoverboard can move in zero-g in (open) space but only there's a ground turf on the z-level below.
 /datum/component/riding/vehicle/scooter/skateboard/hover/proc/hover_check(is_moving = FALSE)
 	var/atom/movable/movable = parent
-	if(!isopenspaceturf(movable.loc))
+	if(!is_space_or_openspace(movable.loc))
 		override_allow_spacemove = TRUE
 		return
 	var/turf/open/our_turf = movable.loc
 	var/turf/turf_below = GET_TURF_BELOW(our_turf)
-	if(isnull(turf_below) || (our_turf.zPassOut(DOWN) && isopenspaceturf(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN)))
+	if(our_turf.zPassOut(DOWN) && (isnull(turf_below) || (is_space_or_openspace(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN))))
 		override_allow_spacemove = FALSE
 		if(turf_below)
 			our_turf.zFall(movable, falling_from_move = is_moving)

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -247,7 +247,7 @@
 		return
 	var/turf/open/our_turf = movable.loc
 	var/turf/turf_below = GET_TURF_BELOW(our_turf)
-	if(our_turf.zPassOut(DOWN) && (isnull(turf_below) || (isopenspaceturf(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN))))
+	if(isnull(turf_below) || (our_turf.zPassOut(DOWN) && isopenspaceturf(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN)))
 		override_allow_spacemove = FALSE
 		if(turf_below)
 			our_turf.zFall(movable, falling_from_move = is_moving)

--- a/code/datums/elements/floorloving.dm
+++ b/code/datums/elements/floorloving.dm
@@ -14,7 +14,7 @@
 /// Block movement to any non-floor location
 /datum/element/floor_loving/proc/attempting_move(atom/movable/parent, newloc)
 	SIGNAL_HANDLER
-	if (!isopenturf(newloc) || isspaceturf(newloc) || isopenspaceturf(newloc))
+	if (!isopenturf(newloc) || is_space_or_openspace(newloc))
 		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
 	if (isliving(parent))
 		var/mob/living/living_parent = parent

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -161,7 +161,7 @@
 	if(!istype(stepturf))
 		return
 
-	if(isspaceturf(stepturf) || isopenspaceturf(stepturf) || !stepturf.Enter(src))
+	if(is_space_or_openspace(stepturf) || !stepturf.Enter(src))
 		return
 	if(ischasm(stepturf) && !HAS_TRAIT(stepturf, TRAIT_CHASM_STOPPED))
 		return

--- a/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
@@ -20,7 +20,7 @@
 	if (ismineralturf(loc))
 		var/turf/closed/mineral/floor = loc
 		floor.gets_drilled()
-	if (!isopenturf(loc) || isspaceturf(loc) || isopenspaceturf(loc))
+	if (!isopenturf(loc) || is_space_or_openspace(loc))
 		return INITIALIZE_HINT_QDEL
 	for (var/obj/effect/goliath_tentacle/tentacle in loc)
 		if (tentacle != src)

--- a/code/modules/mob/living/basic/pets/parrot/parrot_ai/parrot_hoarding.dm
+++ b/code/modules/mob/living/basic/pets/parrot/parrot_ai/parrot_hoarding.dm
@@ -29,7 +29,7 @@
 
 /datum/ai_behavior/find_and_set/hoard_location/search_tactic(datum/ai_controller/controller, locate_path, search_range)
 	for(var/turf/open/candidate in oview(search_range, controller.pawn))
-		if(isspaceturf(candidate) || isopenspaceturf(candidate))
+		if(is_space_or_openspace(candidate))
 			continue
 		if(candidate.is_blocked_turf(source_atom = controller.pawn))
 			continue


### PR DESCRIPTION
## About The Pull Request
Apparently I've left out that `isopenspaceturf(A)` returns false on normal (not multi-z) space turfs because they're of a different path. This should fix the fact you can use hoverboards as a substitute jetpacks, which wasn't intended. You can still use them in space if there's lattice/catwalk underneath, or another kind of turf on the z-level below however.

## Why It's Good For The Game
Unintended bit from the skateboard buff PR I had made months ago.

## Changelog

:cl:
fix: Hoverboards properly dysfunction in space without any kind of support underneath them.
/:cl:
