### PR TITLE
Fix telekinesis letting you grab people at a distance, and teleport them to you by strangling them

### DIFF
--- a/code/_onclick/click_ctrl.dm
+++ b/code/_onclick/click_ctrl.dm
@@ -34,7 +34,7 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	. = ..()
-	if(. || world.time < next_move || !can_perform_action(target, NOT_INSIDE_TARGET | SILENT_ADJACENCY))
+	if(. || world.time < next_move || !can_perform_action(target, NOT_INSIDE_TARGET | SILENT_ADJACENCY | FORBID_TELEKINESIS_REACH))
 		return
 
 	. = TRUE


### PR DESCRIPTION

## About The Pull Request

Was told that apparently recent changes have made it possible to grab and strangle people at a distance with telekinesis... which then teleports them to you.
Looking into it, it seems to be a missing flag in the following check preceding pulling living things:
https://github.com/tgstation/tgstation/blob/fe7da20ea3ed26d9f177aed894910451127fd851/code/_onclick/click_ctrl.dm#L37-L38
Adding `FORBID_TELEKINESIS_REACH` fixes this.
## Why It's Good For The Game

I recall telekinesis isn't supposed to let you grab people from a distance.
"Supposed to"s aside, being able to grab and obstruct people from a distance with no difficulties in doing so is annoying at best and awful at worst. The strangle teleporting is obviously just plain broken.
## Changelog
:cl:
fix: Fixed telekinesis letting you grab people at a distance, and teleport them to you by strangling them.
/:cl:
