### PR TITLE
Corrected the bio emergency crate

### DIFF
--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -6,8 +6,8 @@
 	name = "Biological Emergency Crate"
 	desc = "This crate includes 2 complete bio suits, along with a box containing sterile masks and latex gloves, providing effective protection against viruses."
 	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/clothing/head/bio_hood = 2,
-					/obj/item/clothing/suit/bio_suit = 2,
+	contains = list(/obj/item/clothing/head/bio_hood/general = 2,
+					/obj/item/clothing/suit/bio_suit/general = 2,
 					/obj/item/storage/bag/bio,
 					/obj/item/reagent_containers/syringe/antiviral = 2,
 					/obj/item/clothing/gloves/latex/nitrile = 2,


### PR DESCRIPTION

## About The Pull Request

Corrected the bioemergency crate to bring general instead of generic bio suits, thus allowing for a source of general biosuits to exist, and allowing for the Security Biosuits recipe to be crafted.

## Why It's Good For The Game

Allows for security to craft their own security bio suits, keeps the equipment consistent by making it so we get a general type of the object instead of the generic which shouldn't exist.

Fixes downstream: https://github.com/NovaSector/NovaSector/issues/530

## Changelog
:cl:
fix: Bio Emergency crates now bring Bio Suits and Hoods compatible with the Security Hoods and Suits Schematics.
/:cl:
