### PR TITLE
Obligatory NVs and meson googles screen/client color

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -300,7 +300,7 @@
 			new /obj/item/clothing/suit/armor/vest/marine/pmc(src) //The armor kit is comparable to the infiltrator, 6 TC
 			new /obj/item/clothing/head/helmet/marine/pmc(src)
 			new /obj/item/clothing/mask/gas/sechailer(src)
-			new /obj/item/clothing/glasses/night(src) // 3~ TC
+			new /obj/item/clothing/glasses/night/colorless(src) // 3~ TC
 			new /obj/item/clothing/gloves/krav_maga/combatglovesplus(src) //5TC
 			new /obj/item/clothing/shoes/jackboots(src)
 			new /obj/item/storage/belt/military/assault/fisher(src) //items in this belt easily costs 18 TC

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -20,7 +20,7 @@
 /obj/structure/closet/syndicate/personal/PopulateContents()
 	..()
 	new /obj/item/trench_tool(src)
-	new /obj/item/clothing/glasses/night(src)
+	new /obj/item/clothing/glasses/night/colorless(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/storage/belt/military(src)
 	new /obj/item/storage/belt/holster/nukie(src)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -463,6 +463,7 @@ Striking a noncultist, however, will tear their flesh."}
 	icon_state = "blindfold"
 	inhand_icon_state = "blindfold"
 	flash_protect = FLASH_PROTECTION_WELDER
+	forced_glass_color = FALSE
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)
 	..()

--- a/code/modules/antagonists/ninja/outfit.dm
+++ b/code/modules/antagonists/ninja/outfit.dm
@@ -1,7 +1,7 @@
 /datum/outfit/ninja
 	name = "Space Ninja"
 	uniform = /obj/item/clothing/under/syndicate/ninja
-	glasses = /obj/item/clothing/glasses/night
+	glasses = /obj/item/clothing/glasses/night/colorless
 	mask = /obj/item/clothing/mask/gas/ninja
 	ears = /obj/item/radio/headset
 	shoes = /obj/item/clothing/shoes/jackboots

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -67,7 +67,7 @@
 /datum/outfit/syndicate/full
 	name = "Syndicate Operative - Full Kit"
 
-	glasses = /obj/item/clothing/glasses/night
+	glasses = /obj/item/clothing/glasses/night/colorless
 	mask = /obj/item/clothing/mask/gas/syndicate
 	back = /obj/item/mod/control/pre_equipped/nuclear
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -164,12 +164,39 @@
 
 /datum/client_colour/glass_colour
 	priority = PRIORITY_LOW
+	///stuff like initial(color_matrix_list) won't work well, so we better cache the og colour
+	var/initial_colour
+	/**
+	 * Some glass colours (especially forced one like mesons and NVs) may be a bit tiresome to have around
+	 * mining, especially lavaland. So while we these glass colours, we aknowledge they need to be toned down a little
+	 * around miners stuff.
+	 */
+	var/mining_level_colour
+
+/datum/client_colour/glass_colour/New(mob/owner)
+	. = ..()
+	if(!owner || !mining_level_colour)
+		return
+	initial_colour = colour
+	var/turf/owner_turf = get_turf(owner)
+	if(is_mining_level(owner_turf.z))
+		colour = mining_level_colour
+	RegisterSignal(owner, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_changed_z_level))
+
+/datum/client_colour/glass_colour/proc/on_changed_z_level(datum/source, turf/old_turf, turf/new_turf, same_z_layer)
+	SIGNAL_HANDLER
+	if(colour == initial(colour) && is_mining_level(new_turf.z))
+		update_colour(mining_level_colour, 2 SECONDS)
+	else if(colour == mining_level_colour && !is_mining_level(new_turf.z))
+		update_colour(initial_colour, 2 SECONDS)
 
 /datum/client_colour/glass_colour/green
 	colour = "#aaffaa"
+	mining_level_colour = "#ccffcc"
 
 /datum/client_colour/glass_colour/lightgreen
 	colour = "#ccffcc"
+	mining_level_colour = "#eaffea"
 
 /datum/client_colour/glass_colour/blue
 	colour = "#aaaaff"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -119,6 +119,7 @@
 	// Night vision mesons get the same but more intense
 	color_cutoffs = list(10, 30, 10)
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/meson/gar
 	name = "gar mesons"
@@ -165,6 +166,7 @@
 	// Real vivid purple
 	color_cutoffs = list(50, 10, 30)
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/night
 	name = "night vision goggles"
@@ -176,6 +178,11 @@
 	// Dark green
 	color_cutoffs = list(10, 30, 10)
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	forced_glass_color = TRUE
+
+/obj/item/clothing/glasses/night/colorless
+	desc = "You can totally see in the dark now! Now with 50% less green!"
+	forced_glass_color = FALSE
 
 /obj/item/clothing/glasses/eyepatch
 	name = "eyepatch"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -105,6 +105,7 @@
 	// Mesons get to be lightly green
 	color_cutoffs = list(5, 15, 5)
 	glass_colour_type = /datum/client_colour/glass_colour/lightgreen
+	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/meson/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is putting \the [src] to [user.p_their()] eyes and overloading the brightness! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -18,7 +18,6 @@
 	inhand_icon_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
 	glass_colour_type = /datum/client_colour/glass_colour/gray
-	forced_glass_color = TRUE
 	gender = PLURAL
 
 	vision_flags = NONE

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -18,6 +18,7 @@
 	inhand_icon_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
 	glass_colour_type = /datum/client_colour/glass_colour/gray
+	forced_glass_color = TRUE
 	gender = PLURAL
 
 	vision_flags = NONE

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -4,7 +4,7 @@
 	flags_1 = null //doesn't protect eyes because it's a monocle, duh
 	var/hud_type = null
 
-	// NOTE: Just because you have a HUD display doesn't mean you should be able to interact with stuff on examine, that's where the associated trait (TRAIT_MEDICAL_HUD, TRAIT_SECURITY_HUD, etc) is necessary. 
+	// NOTE: Just because you have a HUD display doesn't mean you should be able to interact with stuff on examine, that's where the associated trait (TRAIT_MEDICAL_HUD, TRAIT_SECURITY_HUD, etc) is necessary.
 
 /obj/item/clothing/glasses/hud/equipped(mob/living/carbon/human/user, slot)
 	..()
@@ -69,6 +69,7 @@
 	// Blue green, dark
 	color_cutoffs = list(5, 15, 30)
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/hud/health/night/meson
 	name = "night vision meson health scanner HUD"
@@ -79,7 +80,8 @@
 	name = "night vision medical science scanner HUD"
 	desc = "An clandestine medical science heads-up display that allows operatives to find \
 		dying captains and the perfect poison to finish them off in complete darkness."
-	clothing_traits = list(TRAIT_REAGENT_SCANNER)
+	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_MEDICAL_HUD)
+	forced_glass_color = FALSE
 
 /obj/item/clothing/glasses/hud/health/sunglasses
 	name = "medical HUDSunglasses"
@@ -117,6 +119,7 @@
 	// Pale yellow
 	color_cutoffs = list(30, 20, 5)
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/hud/diagnostic/sunglasses
 	name = "diagnostic sunglasses"
@@ -189,6 +192,7 @@
 	// Red with a tint of green
 	color_cutoffs = list(35, 5, 5)
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/hud/security/sunglasses/gars
 	name = "\improper HUD gar glasses"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -242,7 +242,7 @@
 		/obj/item/storage/box/lights/mixed = 1,
 	)
 	belt = /obj/item/storage/belt/janitor/full
-	glasses = /obj/item/clothing/glasses/night
+	glasses = /obj/item/clothing/glasses/night/colorless
 	l_pocket = /obj/item/grenade/chem_grenade/cleaner
 	r_pocket = /obj/item/grenade/chem_grenade/cleaner
 	l_hand = /obj/item/storage/bag/trash/bluespace

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -308,7 +308,7 @@
 
 /datum/outfit/syndicatespace/syndicrew
 	name = "Syndicate Ship Crew Member"
-	glasses = /obj/item/clothing/glasses/night
+	glasses = /obj/item/clothing/glasses/night/colorless
 	mask = /obj/item/clothing/mask/gas/syndicate
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/knife/combat/survival


### PR DESCRIPTION
## About The Pull Request
This PR sets `forced_glasses_color` to TRUE for most night vision and meson googles in the game.

The zealot blindfold, as well as the MODsuit component (technical limitations) and NVs from syndicate-aligned outfits and mobs (and the space ninja) are **exempted** from this. The ratio is that it doesn't fit well with the zealot blindfold, while antags such as nuclear operatives and space ninjas tend to wear them throughout entirety of the round if they want to win, so that'd generate an en passe where nukies and the such are forced to get the green light (ba dum tshh) every round, which is mildly undesiderable.

For reference, this is the shade of green from **NVs**. 
![immagine](https://github.com/tgstation/tgstation/assets/42542238/77a4b211-b1d7-4fb1-8714-b4f2e78cf775)
You can compare it with both screenshots for mesons and control from #81328.

**EDIT: After some consideration, I've made it so the colors mesons and NVs gets fainter on lavaland, miners rejoice.**

## Why It's Good For The Game
Since #81328 happened, client screen coloring has generally become much more bearable, especially for the lighter tones like mesons, as shown in the PR itself. About NVs, I believe the green hue should be a cardinal feature of the clichè ~~though real-life NVs are a bit more stark normally, but we've got plenty of cases of people being motion and light sensitive here~~, I rest my case.

TL;DR Muh flavor.

## Changelog

:cl:
add: meson googles and night vision googles now color your screen. Always. Except for nukies and the space ninja.
/:cl:
