### PR TITLE
Meteors no longer qdel twice and dark matteors do not always claim to have missed

### DIFF
--- a/code/modules/meteors/meteor_changeling.dm
+++ b/code/modules/meteors/meteor_changeling.dm
@@ -30,7 +30,7 @@
 	return TRUE
 
 //If the meteor misses the station and deletes itself, we make absolutely sure the changeling reaches the station.
-/obj/effect/meteor/meaty/changeling/handle_stopping()
+/obj/effect/meteor/meaty/changeling/moved_off_z()
 	if(!landing_target)
 		//If our destination turf is gone for some reason, we chuck them at the observer_start landmark (usually at the center of the station) as a last resort.
 		landing_target = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list

--- a/code/modules/meteors/meteor_dark_matteor.dm
+++ b/code/modules/meteors/meteor_dark_matteor.dm
@@ -60,7 +60,7 @@
 	qdel(defender)
 	return FALSE
 
-/obj/effect/meteor/dark_matteor/handle_stopping()
+/obj/effect/meteor/dark_matteor/moved_off_z()
 	. = ..()
 	if(previous_security_level && SSsecurity_level.get_current_level_as_number() != SEC_LEVEL_DELTA)
 		SSsecurity_level.set_level(previous_security_level)

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -60,8 +60,7 @@
 			get_hit()
 
 	if(z != z_original || loc == get_turf(dest))
-		qdel(src)
-		return
+		moved_off_z()
 
 /obj/effect/meteor/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	return TRUE //Keeps us from drifting for no reason
@@ -80,13 +79,9 @@
 	if(!new_loop)
 		return
 
-	RegisterSignal(new_loop, COMSIG_QDELETING, PROC_REF(handle_stopping))
-
 ///Deals with what happens when we stop moving, IE we die
-/obj/effect/meteor/proc/handle_stopping()
-	SIGNAL_HANDLER
-	if(!QDELETED(src))
-		qdel(src)
+/obj/effect/meteor/proc/moved_off_z()
+	qdel(src)
 
 /obj/effect/meteor/proc/ram_turf(turf/T)
 	//first yell at mobs about them dying horribly
@@ -459,8 +454,8 @@
 /obj/effect/meteor/pumpkin
 	name = "PUMPKING"
 	desc = "THE PUMPKING'S COMING!"
-	icon = 'icons/obj/meteor.dmi'
-	icon_state = "spooky"
+	icon = 'icons/obj/meteor_spooky.dmi'
+	icon_state = "pumpkin"
 	hits = 10
 	heavy = TRUE
 	dropamt = 1

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -454,8 +454,8 @@
 /obj/effect/meteor/pumpkin
 	name = "PUMPKING"
 	desc = "THE PUMPKING'S COMING!"
-	icon = 'icons/obj/meteor_spooky.dmi'
-	icon_state = "pumpkin"
+	icon = 'icons/obj/meteor.dmi'
+	icon_state = "spooky"
 	hits = 10
 	heavy = TRUE
 	dropamt = 1


### PR DESCRIPTION

## About The Pull Request
Closes #83926
Meteor Z level exit was handled in COMSIG_QDELETING signal... deleting itself mid-qdel. I fixed that, and made it only call the new function when actually reaching the end of the map. Should also fix dark matteors always making a miss announcement and resetting the security level.

## Changelog
:cl:
fix: Dark matteors no longer claim that they  have missed when they actually impacted the station
/:cl:
