### PR TITLE
Fixes the Basic Sandwich

### DIFF
--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -9,7 +9,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 1,
 	)
 	tastes = list("meat" = 2, "cheese" = 1, "bread" = 2, "lettuce" = 1)
-	foodtypes = GRAIN | VEGETABLES
+	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
@@ -10,6 +10,7 @@
 	name = "Sandwich"
 	reqs = list(
 		/obj/item/food/breadslice/plain = 2,
+		/obj/item/food/grown/cabbage = 1,
 		/obj/item/food/meat/steak = 1,
 		/obj/item/food/cheese/wedge = 1
 	)


### PR DESCRIPTION

## About The Pull Request
Fixes the basic sandwich recipe from having the incorrect ingredients and incorrect food types. Now its consistent with its description, taste and ingredients.

## Why It's Good For The Game
Makes things consistent, gives a vegetable recipe the vegetable ingredient, and meat and dairy ingredients the meat and dairy tags.

Fixes downstream: https://github.com/NovaSector/NovaSector/issues/1318

## Changelog
:cl:
fix: Fixed the basic Sandwich recipe and tags, now it matches the description and original intent.
/:cl:
