### PR TITLE
Crew monitor defaults to vitals

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -26,7 +26,7 @@ const SORT_NAMES = {
 const STAT_LIVING = 0;
 const STAT_DEAD = 4;
 
-const SORT_OPTIONS = ['ijob', 'name', 'area', 'health'];
+const SORT_OPTIONS = ['health', 'ijob', 'name', 'area'];
 
 const jobIsHead = (jobId: number) => jobId % 10 === 0;
 
@@ -69,10 +69,10 @@ const statToIcon = (life_status: number) => {
 };
 
 const healthSort = (a: CrewSensor, b: CrewSensor) => {
-  if (a.life_status < b.life_status) return -1;
-  if (a.life_status > b.life_status) return 1;
-  if (a.health > b.health) return -1;
-  if (a.health < b.health) return 1;
+  if (a.life_status > b.life_status) return -1;
+  if (a.life_status < b.life_status) return 1;
+  if (a.health < b.health) return -1;
+  if (a.health > b.health) return 1;
   return 0;
 };
 


### PR DESCRIPTION
## About The Pull Request

Changes the crew monitor sort setting default to vitals, damaged crew on top.

![crewmonitor](https://github.com/tgstation/tgstation/assets/83487515/2ba7796c-bbf3-49eb-bcb0-6f1db414202d)

## Why It's Good For The Game

This way by default the injured/dead are at the top of the crew monitor, not needing to be adjusted each time

## Changelog

:cl: LT3
qol: Crew monitor defaults to sort by vitals
/:cl: