### PR TITLE
The Human AI station trait now turns the station circuit flooring into luminous carpet.

### DIFF
--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -116,3 +116,6 @@
 #define LARGE_TURF_SMOOTHING_X_OFFSET -9
 /// Defines the y offset to apply to larger smoothing turfs (such as grass).
 #define LARGE_TURF_SMOOTHING_Y_OFFSET -9
+
+// Usage for a bar light is 160, let's do a bit less then that since these tend to be used a lot in one place
+#define CIRCUIT_FLOOR_POWERUSE 120

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -351,6 +351,29 @@
 	merge_type = /obj/item/stack/tile/carpet/donk
 	tile_reskin_types = null
 
+/obj/item/stack/tile/carpet/luminous
+	name = "blue circuit carpet"
+	icon_state = "tile-carpet-blue"
+	inhand_icon_state = "tile-carpet-blue"
+	turf_type = /turf/open/floor/carpet/luminous
+	tableVariant = null
+	merge_type = /obj/item/stack/tile/carpet/luminous
+	tile_reskin_types = null
+
+/obj/item/stack/tile/carpet/luminous/green
+	name = "green circuit carpet"
+	icon_state = "tile-carpet-green"
+	inhand_icon_state = "tile-carpet-green"
+	turf_type = /turf/open/floor/carpet/luminous/green
+	merge_type = /obj/item/stack/tile/carpet/luminous/green
+
+/obj/item/stack/tile/carpet/luminous/red
+	name = "red circuit carpet"
+	icon_state = "tile-carpet-red"
+	inhand_icon_state = "tile-carpet-red"
+	turf_type = /turf/open/floor/carpet/luminous/red
+	merge_type = /obj/item/stack/tile/carpet/luminous/red
+
 /obj/item/stack/tile/carpet/fifty
 	amount = 50
 

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -838,6 +838,71 @@
 /turf/open/floor/carpet/blue/lavaland
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 
+///Snowflake carpet(s) used in place of circuit floors on the station when the Human AI station trait rolls.
+/turf/open/floor/carpet/luminous
+	name = "circuit carpet"
+	icon = 'icons/turf/floors/carpet_blue.dmi'
+	icon_state = "carpet_blue-255"
+	base_icon_state = "carpet_blue"
+	floor_tile = /obj/item/stack/tile/carpet/luminous
+	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_BLUE
+	canSmoothWith = SMOOTH_GROUP_CARPET_BLUE
+	light_color = LIGHT_COLOR_BABY_BLUE
+	/// If this floor is powered or not
+	/// We don't consume any power, but we do require it
+	var/on = 0
+
+/turf/open/floor/carpet/luminous/Initialize(mapload)
+	RegisterSignal(loc, COMSIG_AREA_POWER_CHANGE, PROC_REF(handle_powerchange))
+	handle_powerchange(loc)
+	return ..()
+
+/turf/open/floor/carpet/luminous/Destroy()
+	UnregisterSignal(loc, COMSIG_AREA_POWER_CHANGE)
+	return ..()
+
+/turf/open/floor/carpet/luminous/on_change_area(area/old_area, area/new_area)
+	. = ..()
+	UnregisterSignal(old_area, COMSIG_AREA_POWER_CHANGE)
+	RegisterSignal(new_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(handle_powerchange))
+	if(on)
+		old_area.removeStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
+	handle_powerchange(new_area)
+
+/// Enables/disables our lighting based off our source area
+/turf/open/floor/carpet/luminous/proc/handle_powerchange(area/source)
+	SIGNAL_HANDLER
+	var/old_on = on
+	on = source.powered(AREA_USAGE_LIGHT)
+	if(on == old_on)
+		return
+
+	if(on)
+		source.addStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
+		set_light_color(initial(light_color))
+		set_light(2, 1.5)
+	else
+		source.removeStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
+		set_light(0)
+
+/turf/open/floor/carpet/luminous/green
+	icon = 'icons/turf/floors/carpet_green.dmi'
+	icon_state = "carpet_green-255"
+	base_icon_state = "carpet_green"
+	floor_tile = /obj/item/stack/tile/carpet/luminous/green
+	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_GREEN
+	canSmoothWith = SMOOTH_GROUP_CARPET_GREEN
+	light_color = LIGHT_COLOR_VIVID_GREEN
+
+/turf/open/floor/carpet/luminous/red
+	icon = 'icons/turf/floors/carpet_red.dmi'
+	icon_state = "carpet_red-255"
+	base_icon_state = "carpet_red"
+	floor_tile = /obj/item/stack/tile/carpet/luminous/red
+	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_RED
+	canSmoothWith = SMOOTH_GROUP_CARPET_RED
+	light_color = LIGHT_COLOR_INTENSE_RED
+
 /turf/open/floor/fakepit
 	desc = "A clever illusion designed to look like a bottomless pit."
 	icon = 'icons/turf/floors/chasms.dmi'


### PR DESCRIPTION
## About The Pull Request
Maploaded circuits floors are now converted to equivalently illuminated carpet of respective colors when the Human AI station trait is rolled. Circuit flooring built during the round, or on non-station level is unaffected by it.
![immagine](https://github.com/tgstation/tgstation/assets/42542238/375ff76e-dcfa-4a71-81cb-af0b991cf583)

## Why It's Good For The Game
A subtle change to the station layout, announcing the departure of the silicon overlord and the arrival of a hopefully more humane one.

## Changelog

:cl:
add: The Human AI station trait now turns the station circuit flooring into (luminous) carpet.
/:cl:
