### PR TITLE
Possibly fixes a storage runtime

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -980,8 +980,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(to_show.active_storage != src && (to_show.stat == CONSCIOUS))
 		for(var/obj/item/thing in real_location)
-			if(thing.on_found(to_show))
-				to_show.active_storage.hide_contents(to_show)
+			thing.on_found(to_show)
 
 	if(to_show.active_storage)
 		to_show.active_storage.hide_contents(to_show)


### PR DESCRIPTION

## About The Pull Request

Old storage code had a chance to call ``to_show.active_storage.hide_contents(to_show)`` two or more times, which would have resulted in a runtime as ``hide_contents`` nulls viewer's active storage. As active storage would be closed anyways down the line if it exists, this code is unnecessary.

Could be the cause of #84507 but I have not been able to reproduce that issue myself locally, despite it being a frequent occurrence on live.

## Changelog
:cl:
fix: Fixes a potential storage runtime.
/:cl:
