### PR TITLE
Adds a signal to the stamina crit status effect for listeners to respond to

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -381,7 +381,7 @@ GLOBAL_LIST_INIT(leg_zones, list(BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 ///If the obstacle is an object at the border of the turf (so no signal from being sent to the other turf)
 #define SHOVE_DIRECTIONAL_BLOCKED (1<<6)
 
-///Bitfield returned by listeners for COMSIG_CARBON_ENTER_STAMCRIT or COMSIG_LIVING_ENTER_STAMCRIT when they perform some action that prevents a mob going into stamcrit.
+///Bitfield returned by listeners for COMSIG_LIVING_ENTER_STAMCRIT when they perform some action that prevents a mob going into stamcrit.
 #define STAMCRIT_CANCELLED (1<<0)
 
 ///Deathmatch lobby current status

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -381,7 +381,7 @@ GLOBAL_LIST_INIT(leg_zones, list(BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 ///If the obstacle is an object at the border of the turf (so no signal from being sent to the other turf)
 #define SHOVE_DIRECTIONAL_BLOCKED (1<<6)
 
-///Bitfield returned by listeners for COMSIG_CARBON_ENTER_STAMCRIT when they perform some action that prevents a mob going into stamcrit.
+///Bitfield returned by listeners for COMSIG_CARBON_ENTER_STAMCRIT or COMSIG_LIVING_ENTER_STAMCRIT when they perform some action that prevents a mob going into stamcrit.
 #define STAMCRIT_CANCELLED (1<<0)
 
 ///Deathmatch lobby current status

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -57,8 +57,6 @@
 /// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(mob/living/carbon/old_owner, special, dismembered)
 #define COMSIG_BODYPART_REMOVED "bodypart_removed"
 
-/// from /mob/living/carbon/enter_stamcrit()
-#define COMSIG_CARBON_ENTER_STAMCRIT "carbon_enter_stamcrit"
 ///from base of mob/living/carbon/soundbang_act(): (list(intensity))
 #define COMSIG_CARBON_SOUNDBANG "carbon_soundbang"
 ///from /item/organ/proc/Insert() (/obj/item/organ/)

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -21,6 +21,8 @@
 ///from base of mob/update_transform()
 #define COMSIG_LIVING_POST_UPDATE_TRANSFORM "living_post_update_transform"
 
+/// from /datum/status_effect/incapacitating/stamcrit/on_apply()
+#define COMSIG_LIVING_ENTER_STAMCRIT "living_enter_stamcrit"
 ///from /obj/structure/door/crush(): (mob/living/crushed, /obj/machinery/door/crushing_door)
 #define COMSIG_LIVING_DOORCRUSHED "living_doorcrush"
 ///from base of mob/living/resist() (/mob/living)

--- a/code/datums/status_effects/debuffs/stamcrit.dm
+++ b/code/datums/status_effects/debuffs/stamcrit.dm
@@ -28,6 +28,8 @@
 		return FALSE
 	if(owner.check_stun_immunity(CANKNOCKDOWN))
 		return FALSE
+	if(SEND_SIGNAL(owner, COMSIG_LIVING_ENTER_STAMCRIT) & STAMCRIT_CANCELLED)
+		return FALSE
 
 	. = ..()
 	if(!.)

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -5,19 +5,6 @@
 /mob/living/carbon/IsParalyzed(include_stamcrit = TRUE)
 	return ..() || (include_stamcrit && HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))
 
-/mob/living/carbon/proc/enter_stamcrit()
-	if(HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA)) //Already in stamcrit
-		return
-	if(check_stun_immunity(CANKNOCKDOWN))
-		return
-	if (SEND_SIGNAL(src, COMSIG_CARBON_ENTER_STAMCRIT) & STAMCRIT_CANCELLED)
-		return
-
-	to_chat(src, span_notice("You're too exhausted to keep going..."))
-	add_traits(list(TRAIT_INCAPACITATED, TRAIT_IMMOBILIZED, TRAIT_FLOORED), STAMINA)
-	if(getStaminaLoss() < 120) // Puts you a little further into the initial stamcrit, makes stamcrit harder to outright counter with chems.
-		adjustStaminaLoss(30, FALSE)
-
 /mob/living/carbon/adjust_disgust(amount, max = DISGUST_LEVEL_MAXEDOUT)
 	disgust = clamp(disgust + amount, 0, max)
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1379,7 +1379,7 @@
 	. = ..()
 	affected_mob.add_traits(list(TRAIT_SLEEPIMMUNE, TRAIT_BATON_RESISTANCE), type)
 	affected_mob.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-	RegisterSignal(affected_mob, COMSIG_CARBON_ENTER_STAMCRIT, PROC_REF(on_stamcrit))
+	RegisterSignals(affected_mob, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT), PROC_REF(on_stamcrit))
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -1387,7 +1387,7 @@
 	affected_mob.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	affected_mob.remove_status_effect(/datum/status_effect/dizziness)
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
-	UnregisterSignal(affected_mob, COMSIG_CARBON_ENTER_STAMCRIT)
+	UnregisterSignal(affected_mob, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT))
 
 /datum/reagent/medicine/changelingadrenaline/proc/on_stamcrit(mob/living/affected_mob)
 	SIGNAL_HANDLER

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1379,7 +1379,7 @@
 	. = ..()
 	affected_mob.add_traits(list(TRAIT_SLEEPIMMUNE, TRAIT_BATON_RESISTANCE), type)
 	affected_mob.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-	RegisterSignals(affected_mob, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT), PROC_REF(on_stamcrit))
+	RegisterSignal(affected_mob, COMSIG_LIVING_ENTER_STAMCRIT, PROC_REF(on_stamcrit))
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -1387,7 +1387,7 @@
 	affected_mob.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	affected_mob.remove_status_effect(/datum/status_effect/dizziness)
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
-	UnregisterSignal(affected_mob, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT))
+	UnregisterSignal(affected_mob, COMSIG_LIVING_ENTER_STAMCRIT)
 
 /datum/reagent/medicine/changelingadrenaline/proc/on_stamcrit(mob/living/affected_mob)
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -119,12 +119,12 @@
 /obj/item/organ/internal/cyberimp/brain/anti_stun/on_mob_remove(mob/living/carbon/implant_owner)
 	. = ..()
 	UnregisterSignal(implant_owner, signalCache)
-	UnregisterSignal(implant_owner, COMSIG_CARBON_ENTER_STAMCRIT)
+	UnregisterSignal(implant_owner, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT))
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/on_mob_insert(mob/living/carbon/receiver)
 	. = ..()
 	RegisterSignals(receiver, signalCache, PROC_REF(on_signal))
-	RegisterSignal(receiver, COMSIG_CARBON_ENTER_STAMCRIT, PROC_REF(on_stamcrit))
+	RegisterSignals(receiver, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT), PROC_REF(on_stamcrit))
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/on_signal(datum/source, amount)
 	SIGNAL_HANDLER
@@ -139,23 +139,23 @@
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/clear_stuns()
 	if(isnull(owner) || (organ_flags & ORGAN_FAILING) || !COOLDOWN_FINISHED(src, implant_cooldown))
 		return
-	
+
 	owner.SetStun(0)
 	owner.SetKnockdown(0)
 	owner.SetImmobilized(0)
 	owner.SetParalyzed(0)
 	owner.setStaminaLoss(0)
 	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living, setStaminaLoss), 0), stun_resistance_time)
-	
+
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
 	sparks.set_up(5, 1, src)
 	sparks.start()
 
 	owner.add_traits(list(TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_BATON_RESISTANCE, TRAIT_STUNIMMUNE), REF(src))
-	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_IGNOREDAMAGESLOWDOWN, REF(src)), stun_resistance_time)	
+	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_IGNOREDAMAGESLOWDOWN, REF(src)), stun_resistance_time)
 	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_BATON_RESISTANCE, REF(src)), stun_resistance_time)
 	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_STUNIMMUNE, REF(src)), stun_resistance_time)
-	
+
 	COOLDOWN_START(src, implant_cooldown, 60 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(implant_ready)),60 SECONDS)
 
@@ -171,7 +171,7 @@
 	addtimer(CALLBACK(src, PROC_REF(reboot)), 90 / severity)
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
-	organ_flags &= ~ORGAN_FAILING 
+	organ_flags &= ~ORGAN_FAILING
 	implant_ready()
 
 //[[[[MOUTH]]]]

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -119,12 +119,12 @@
 /obj/item/organ/internal/cyberimp/brain/anti_stun/on_mob_remove(mob/living/carbon/implant_owner)
 	. = ..()
 	UnregisterSignal(implant_owner, signalCache)
-	UnregisterSignal(implant_owner, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT))
+	UnregisterSignal(implant_owner, COMSIG_LIVING_ENTER_STAMCRIT)
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/on_mob_insert(mob/living/carbon/receiver)
 	. = ..()
 	RegisterSignals(receiver, signalCache, PROC_REF(on_signal))
-	RegisterSignals(receiver, list(COMSIG_CARBON_ENTER_STAMCRIT, COMSIG_LIVING_ENTER_STAMCRIT), PROC_REF(on_stamcrit))
+	RegisterSignal(receiver, COMSIG_LIVING_ENTER_STAMCRIT, PROC_REF(on_stamcrit))
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/on_signal(datum/source, amount)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Adds a signal to the stamina crit status effect for listeners to respond to
Closes: https://github.com/tgstation/tgstation/issues/84561
## Why It's Good For The Game
Code improvement
## Changelog
:cl:
fix: fixed CNS rebooter/Changeling adrenaline not preventing/fixing stamina crit
/:cl:
