### PR TITLE
Adds a station trait that fills maintenance with glowsticks

### DIFF
--- a/code/__DEFINES/station.dm
+++ b/code/__DEFINES/station.dm
@@ -8,8 +8,6 @@
 #define STATION_TRAIT_COST_LOW 0.5
 ///Cost for very little, and mainly neutral traits that hardly amount to anything really that interesting.
 #define STATION_TRAIT_COST_MINIMAL 0.3
-///Cost for station traits that can have a modest impact to the round frankly
-#define STATION_TRAIT_COST_HIGH 1.5
 
 /// Only run on planet stations
 #define STATION_TRAIT_PLANETARY (1<<0)

--- a/code/__DEFINES/station.dm
+++ b/code/__DEFINES/station.dm
@@ -8,6 +8,8 @@
 #define STATION_TRAIT_COST_LOW 0.5
 ///Cost for very little, and mainly neutral traits that hardly amount to anything really that interesting.
 #define STATION_TRAIT_COST_MINIMAL 0.3
+///Cost for station traits that can have a modest impact to the round frankly
+#define STATION_TRAIT_COST_HIGH 1.5
 
 /// Only run on planet stations
 #define STATION_TRAIT_PLANETARY (1<<0)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -69,7 +69,7 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 2
 	show_in_report = TRUE
-	report_message = "We've got glowsticks upon glowsticks to spare, so we scattered some around maintenance (plus a couple floor lights)."
+	report_message = "We've glowsticks upon glowsticks to spare, so we scattered some around maintenance (plus a couple floor lights)."
 
 /datum/station_trait/glowsticks/New()
 	..()
@@ -88,15 +88,19 @@
 	)
 	for(var/area/station/maintenance/maint in GLOB.areas)
 		var/list/turfs = get_area_turfs(maint)
-		for(var/i in 1 to length(turfs) * 0.12)
+		for(var/i in 1 to length(turfs) * 0.11)
 			CHECK_TICK
 			var/turf/open/chosen = pick_n_take(turfs)
 			if(!istype(chosen))
 				continue
+			var/skip_this = FALSE
 			for(var/atom/movable/mov as anything in chosen) //stop glowing sticks from spawning on windows
 				if(mov.density && !(mov.pass_flags_self & LETPASSTHROW))
-					continue
-			if(prob(3.4)) ///Rare, but this is something that can survive past the lifespawn of glowsticks.
+					skip_this = TRUE
+					break
+			if(skip_this)
+				continue
+			if(prob(3.3)) ///Rare, but this is something that can survive past the lifespawn of glowsticks.
 				new /obj/machinery/light/floor(chosen)
 				continue
 			var/stick_type = pick(glowsticks)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -73,10 +73,13 @@
 
 /datum/station_trait/glowsticks/New()
 	..()
-	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(light_the_night))
+	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(on_pregame))
 
-/datum/station_trait/glowsticks/proc/light_the_night(datum/source)
+/datum/station_trait/glowsticks/proc/on_pregame(datum/source)
 	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, PROC_REF(light_up_the_night))
+
+/datum/station_trait/glowsticks/proc/light_up_the_night()
 	var/list/glowsticks = list(
 		/obj/item/flashlight/glowstick,
 		/obj/item/flashlight/glowstick/red,
@@ -100,7 +103,7 @@
 					break
 			if(skip_this)
 				continue
-			if(prob(3.3)) ///Rare, but this is something that can survive past the lifespawn of glowsticks.
+			if(prob(3.4)) ///Rare, but this is something that can survive past the lifespawn of glowsticks.
 				new /obj/machinery/light/floor(chosen)
 				continue
 			var/stick_type = pick(glowsticks)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -88,7 +88,7 @@
 	)
 	for(var/area/station/maintenance/maint in GLOB.areas)
 		var/list/turfs = get_area_turfs(maint)
-		for(var/i in 1 to length(turfs) * 0.11)
+		for(var/i in 1 to round(length(turfs) * 0.11))
 			CHECK_TICK
 			var/turf/open/chosen = pick_n_take(turfs)
 			if(!istype(chosen))

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -88,7 +88,7 @@
 	)
 	for(var/area/station/maintenance/maint in GLOB.areas)
 		var/list/turfs = get_area_turfs(maint)
-		for(var/i in 1 to round(length(turfs) * 0.11))
+		for(var/i in 1 to round(length(turfs) * 0.115))
 			CHECK_TICK
 			var/turf/open/chosen = pick_n_take(turfs)
 			if(!istype(chosen))

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -63,6 +63,37 @@
 /datum/station_trait/bountiful_bounties/on_round_start()
 	SSeconomy.bounty_modifier *= 1.2
 
+/datum/station_trait/tiled_maintenance
+	name = "Maintenance tilework and illumination"
+	weight = 2
+	cost = STATION_TRAIT_COST_HIGH
+	show_in_report = TRUE
+	report_message = "We've allocated extra budget to improve the tiling and illumination of maintenance areas."
+
+/datum/station_trait/tiled_maintenance/New()
+	..()
+	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(begin_tilework))
+
+/datum/station_trait/tiled_maintenance/proc/begin_tilework(datum/source)
+	SIGNAL_HANDLER
+	var/list/floortype_choices = list(
+		/turf/open/floor/iron/dark = 50,
+		/turf/open/floor/iron/dark/small = 15,
+		/turf/open/floor/iron/dark/textured = 15,
+		/turf/open/floor/iron/dark/diagonal = 10,
+		/turf/open/floor/iron/dark/herringbone = 10,
+	)
+	var/floortype = pick_weight(floortype_choices)
+	for(var/area/station/maintenance/maint in GLOB.areas)
+		var/list/turfs = get_area_turfs(maint)
+		for(var/turf/open/floor/plating/plating in turfs)
+			if(!plating.allow_replacement)
+				continue
+			plating.place_on_top(floortype, flags = CHANGETURF_INHERIT_AIR)
+			if(prob(17) && !(locate(/obj/machinery/light/floor) in range(2, plating)))
+				new /obj/machinery/light/floor(plating)
+			CHECK_TICK
+
 /datum/station_trait/strong_supply_lines
 	name = "Strong supply lines"
 	trait_type = STATION_TRAIT_POSITIVE

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -63,6 +63,7 @@
 /datum/station_trait/bountiful_bounties/on_round_start()
 	SSeconomy.bounty_modifier *= 1.2
 
+///A station trait that places tiles on top of platings in maint and sprinkles them with floor lights.
 /datum/station_trait/tiled_maintenance
 	name = "Maintenance tilework and illumination"
 	weight = 2
@@ -72,7 +73,8 @@
 
 /datum/station_trait/tiled_maintenance/New()
 	..()
-	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(begin_tilework))
+	//we need to wait SSair before we change turfs, so that they can inherit atmos.
+	RegisterSignal(SSair, COMSIG_SUBSYSTEM_POST_INITIALIZE, PROC_REF(begin_tilework))
 
 /datum/station_trait/tiled_maintenance/proc/begin_tilework(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -63,7 +63,6 @@
 /datum/station_trait/bountiful_bounties/on_round_start()
 	SSeconomy.bounty_modifier *= 1.2
 
-///A station trait that places tiles on top of platings in maint and sprinkles them with floor lights.
 /datum/station_trait/tiled_maintenance
 	name = "Maintenance tilework and illumination"
 	weight = 2
@@ -92,7 +91,7 @@
 			if(!plating.allow_replacement)
 				continue
 			plating.place_on_top(floortype, flags = CHANGETURF_INHERIT_AIR)
-			if(prob(17) && !(locate(/obj/machinery/light/floor) in range(2, plating)))
+			if(prob(14) && !(locate(/obj/machinery/light/floor) in range(2, plating)))
 				new /obj/machinery/light/floor(plating)
 			CHECK_TICK
 


### PR DESCRIPTION
## About The Pull Request
This PR adds a station trait that fills maintenance with glowsticks (and rarely, floor lights). Thanks Smartkar for the idea. The PR was initially about something else, but people said that adding tiling to maint would ruin its style.

Here a couple examples (toned down distribution slightly) since then.
![glo1](https://github.com/tgstation/tgstation/assets/42542238/fc86c014-cc43-4353-8984-e455a1d43e44)
![glo2](https://github.com/tgstation/tgstation/assets/42542238/f88012a1-2b0c-41ac-ae11-0742ed4fd6cb)

## Why It's Good For The Game
An utilitarian station trait that also mildly aesthetic.

## Changelog

:cl:
add: A station trait that fills maintenance with glowsticks.
/:cl:
