### PR TITLE
Fixes fireproof reagent containers

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -266,9 +266,6 @@
 	reagents.expose_temperature(1000)
 	return ..() | COMPONENT_MICROWAVE_SUCCESS
 
-/obj/item/reagent_containers/fire_act(temperature, volume)
-	reagents.expose_temperature(temperature)
-
 /// Updates the icon of the container when the reagents change. Eats signal args
 /obj/item/reagent_containers/proc/on_reagent_change(datum/reagents/holder, ...)
 	SIGNAL_HANDLER


### PR DESCRIPTION
Fixes: https://github.com/tgstation/tgstation/issues/84592

## About The Pull Request

Reagent containers had a duplicated fire_act proc which somehow resulted in fireproof reagent containers of all kinds.
This is now deleted.

## Why It's Good For The Game

Fixes a bug.

## Changelog

:cl:
fix: Reagent containers are no longer mysteriously fireproof.
/:cl: