### PR TITLE
Reverts a change to scrubbers volume rate.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -9,7 +9,7 @@
 	///Is the machine on?
 	var/on = FALSE
 	///the rate the machine will scrub air
-	var/volume_rate = 650
+	var/volume_rate = 1000
 	///Multiplier with ONE_ATMOSPHERE, if the enviroment pressure is higher than that, the scrubber won't work
 	var/overpressure_m = 100
 	///Should the machine use overlay in update_overlays() when open/close?


### PR DESCRIPTION
## About The Pull Request

Scrubbers volume rate has been brought back to a 1000 units.

## Why It's Good For The Game

Minor revert of https://github.com/tgstation/tgstation/pull/84412/files .

This pr roughly nerfed scrubbers gas intake from 40% to 26% tick, now this was somewhat compensated by having them scrub in a 3x3, however it ended up being a direct nerf to single tile scrubbing, which is mostly used for several atmos pet projects, besides  atmos is already slow as hell, there is  no reason to make it even slower.

## Changelog

:cl:
balance: atmo scrubbers have their old volume_rate back.

/:cl:

