### PR TITLE
Various minor fixes to bounty hunter shuttles

### DIFF
--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -149,7 +149,9 @@
 /area/shuttle/hunter)
 "I" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
-	dir = 8
+	dir = 8;
+	y_offset = 6;
+	x_offset = 3
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/hunter)
@@ -232,7 +234,9 @@
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "hunter shuttle";
 	rechargeTime = 1800;
-	shuttle_id = "huntership"
+	shuttle_id = "huntership";
+	port_direction = 4;
+	preferred_direction = 4
 	},
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/all/hunter,

--- a/_maps/shuttles/hunter_mi13_foodtruck.dmm
+++ b/_maps/shuttles/hunter_mi13_foodtruck.dmm
@@ -509,8 +509,8 @@
 /area/shuttle/hunter/mi13_foodtruck)
 "Ak" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
-	x_offset = -6;
-	y_offset = -7
+	x_offset = 6;
+	y_offset = 1
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/circuit/red/off,

--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -180,7 +180,9 @@
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "hunter shuttle";
 	rechargeTime = 1800;
-	shuttle_id = "huntership"
+	shuttle_id = "huntership";
+	port_direction = 8;
+	preferred_direction = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/shuttle/hunter)
@@ -395,7 +397,9 @@
 /area/shuttle/hunter)
 "tT" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter/psyker{
-	dir = 4
+	dir = 4;
+	view_range = 12;
+	y_offset = 12
 	},
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/textured,

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -686,7 +686,9 @@
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "hunter shuttle";
 	rechargeTime = 1800;
-	shuttle_id = "huntership"
+	shuttle_id = "huntership";
+	port_direction = 4;
+	preferred_direction = 4
 	},
 /obj/docking_port/stationary{
 	dwidth = 11;
@@ -724,8 +726,8 @@
 "Zu" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
 	dir = 8;
-	x_offset = 0;
-	y_offset = 3
+	x_offset = -2;
+	y_offset = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -3,7 +3,7 @@
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
 	dir = 8;
 	view_range = 7;
-	x_offset = 6
+	x_offset = 5
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
@@ -125,7 +125,9 @@
 	dir = 4;
 	name = "hunter shuttle";
 	rechargeTime = 1800;
-	shuttle_id = "huntership"
+	shuttle_id = "huntership";
+	port_direction = 2;
+	preferred_direction = 4
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Interpolship"


### PR DESCRIPTION
## About The Pull Request
Another continuation of fixing shuttle issues such as bad offsets on the camera console, ships not fitting in the camera console's view and ships flying the wrong way

<details>
  <summary>Full changes</summary>

- Fixed incorrect camera offsets on the following: hunter_space_cop.dmm, hunter_russian.dmm, hunter_bounty.dmm, hunter_psyker.dmm, hunter_mi13_foodtruck.dmm
- Fixed the following shuttles flying in unexpected directions: hunter_space_cop.dmm, hunter_russian.dmm, hunter_bounty.dmm, hunter_psyker.dmm
- Increased view_range on Psyker hunters' navigation console so the entire ship is in the console's view

</details>

## Why It's Good For The Game
Shuttles should fly in their intended direction and the ship should be centred in the camera view and fit the whole ship.

## Changelog
:cl:
qol: Increased view_range on the Psyker Bounty Hunters' Shuttle navigation console.
fix: Fixed the shuttle navigation console camera eye being incorrectly offset on: the SpacePol van, the Russian bounty hunters, the default bounty hunters, the Psyker bounty hunters, and the MI13 Foodtruck.
fix: Fixed the SpacePol van, Russian bounty hunters, default bounty hunters, and Psyker bounty hunters' shuttles all flying in incorrect directions.
/:cl:
