### PR TITLE
Various minor fixes to Emergency Shuttles

### DIFF
--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -158,7 +158,8 @@
 /obj/docking_port/mobile/emergency{
 	dir = 8;
 	name = "Birdboat emergency escape shuttle";
-	port_direction = 4
+	port_direction = 2;
+	preferred_direction = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_birdshot.dmm
+++ b/_maps/shuttles/emergency_birdshot.dmm
@@ -9,9 +9,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"ax" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/escape)
 "aQ" = (
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/mineral/plastitanium/red,
@@ -235,7 +232,8 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 8;
-	name = "birdshot emergency shuttle"
+	name = "birdshot emergency shuttle";
+	port_direction = 4
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -1001,24 +999,24 @@ nQ
 nQ
 nQ
 nQ
-ax
-LX
-rZ
-LX
-ax
-nQ
-nQ
-nQ
-ax
-rZ
 LX
 LX
 rZ
 LX
 LX
+nQ
+nQ
+nQ
+LX
+rZ
 LX
 LX
-ax
+rZ
+LX
+LX
+LX
+LX
+LX
 nQ
 "}
 (2,1,1) = {"
@@ -1030,7 +1028,7 @@ nQ
 nQ
 nQ
 nQ
-ax
+LX
 LX
 LX
 ON
@@ -1058,7 +1056,7 @@ nQ
 nQ
 nQ
 nQ
-ax
+LX
 rZ
 rZ
 LX
@@ -1086,7 +1084,7 @@ vk
 (4,1,1) = {"
 nQ
 nQ
-ax
+LX
 LX
 LX
 LX
@@ -1185,13 +1183,13 @@ ye
 LX
 mU
 nQ
-ax
+LX
 LX
 LX
 hF
 LX
 LX
-ax
+LX
 nQ
 nQ
 mU
@@ -1200,9 +1198,9 @@ hF
 LX
 rZ
 LX
-ax
+LX
 nQ
-ax
+LX
 LX
 nQ
 nQ
@@ -1309,13 +1307,13 @@ eR
 LX
 mU
 nQ
-ax
+LX
 LX
 LX
 hF
 LX
 LX
-ax
+LX
 nQ
 nQ
 mU
@@ -1324,7 +1322,7 @@ hF
 LX
 rZ
 LX
-ax
+LX
 nQ
 bo
 mU
@@ -1396,7 +1394,7 @@ ST
 (14,1,1) = {"
 nQ
 nQ
-ax
+LX
 LX
 LX
 LX
@@ -1430,7 +1428,7 @@ nQ
 nQ
 nQ
 nQ
-ax
+LX
 rZ
 rZ
 LX
@@ -1464,7 +1462,7 @@ nQ
 nQ
 nQ
 nQ
-ax
+LX
 LX
 LX
 dv
@@ -1497,15 +1495,15 @@ nQ
 nQ
 nQ
 nQ
-ax
+LX
 Xy
 rZ
 Xy
-ax
+LX
 nQ
 nQ
 nQ
-ax
+LX
 ll
 LX
 lp
@@ -1514,6 +1512,6 @@ LX
 rZ
 rZ
 rZ
-ax
+LX
 nQ
 "}

--- a/_maps/shuttles/emergency_humpback.dmm
+++ b/_maps/shuttles/emergency_humpback.dmm
@@ -750,7 +750,10 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Emergency Shuttle Airlock"
 	},
-/obj/docking_port/mobile/emergency,
+/obj/docking_port/mobile/emergency{
+	port_direction = 4;
+	preferred_direction = 2
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "UR" = (

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -8,10 +8,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"af" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/space,
-/area/shuttle/escape)
 "ap" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -25,10 +21,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
-"as" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space,
-/area/shuttle/escape)
 "aF" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -38,7 +30,7 @@
 /area/shuttle/escape)
 "aH" = (
 /obj/structure/grille/broken,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "aO" = (
 /obj/structure/sign/plaques/kiddie{
@@ -58,11 +50,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/shuttle/escape)
-"aW" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/shuttle/escape)
 "bb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -77,7 +64,7 @@
 "bd" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "be" = (
 /obj/machinery/light/small/directional/west,
@@ -89,7 +76,7 @@
 "bl" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "bn" = (
 /obj/machinery/light/small/directional/east,
@@ -159,7 +146,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/lattice,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "cu" = (
 /obj/structure/table/wood,
@@ -215,7 +202,7 @@
 "dp" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/lattice,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "du" = (
 /obj/machinery/door/airlock/external/ruin,
@@ -243,7 +230,7 @@
 "dX" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "dY" = (
 /obj/structure/table/wood,
@@ -315,7 +302,7 @@
 "fm" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "fn" = (
 /obj/effect/spawner/xmastree,
@@ -350,16 +337,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"fA" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space,
-/area/shuttle/escape)
 "fL" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "fT" = (
 /obj/structure/table/wood,
@@ -379,7 +361,7 @@
 "gl" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "gp" = (
 /obj/machinery/door/airlock{
@@ -398,7 +380,7 @@
 /area/shuttle/escape)
 "hq" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "hI" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -433,7 +415,7 @@
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "hW" = (
 /obj/structure/flora/bush/leavy/style_random,
@@ -614,7 +596,7 @@
 "jS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "jU" = (
 /obj/item/shovel/spade,
@@ -693,7 +675,7 @@
 "kJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "kM" = (
 /obj/structure/table/wood/fancy,
@@ -714,10 +696,6 @@
 	},
 /obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"lj" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
 /area/shuttle/escape)
 "lm" = (
 /obj/machinery/meter,
@@ -752,7 +730,7 @@
 /area/shuttle/escape)
 "mm" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/template_noop,
 /area/shuttle/escape)
 "mn" = (
 /obj/structure/chair/wood,
@@ -1064,7 +1042,7 @@
 /area/shuttle/escape)
 "qA" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "qC" = (
 /obj/machinery/airalarm/directional/north,
@@ -1906,6 +1884,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"CW" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/template_noop,
+/area/shuttle/escape)
 "Dc" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -2324,7 +2307,7 @@
 /area/shuttle/escape)
 "IM" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "IR" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -2352,10 +2335,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
-"Jl" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space,
 /area/shuttle/escape)
 "Jp" = (
 /obj/structure/table,
@@ -2447,8 +2426,7 @@
 "JZ" = (
 /obj/docking_port/mobile/emergency{
 	movement_force = list("KNOCKDOWN"=3,"THROW"=6);
-	name = "\proper a monastery with engines strapped to it";
-	port_direction = 1
+	name = "\proper a monastery with engines strapped to it"
 	},
 /turf/closed/mineral,
 /area/shuttle/escape)
@@ -2604,10 +2582,6 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
-"Mt" = (
-/obj/structure/lattice,
-/turf/open/space,
 /area/shuttle/escape)
 "MC" = (
 /obj/structure/cable,
@@ -2858,7 +2832,7 @@
 /area/shuttle/escape)
 "PB" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "PC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -3645,7 +3619,7 @@
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "YC" = (
 /obj/machinery/light/small/directional/west,
@@ -3671,7 +3645,7 @@
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/shuttle/escape)
 "YZ" = (
 /obj/structure/table/wood,
@@ -4296,7 +4270,7 @@ nr
 nr
 nr
 nr
-af
+hq
 hq
 JG
 JG
@@ -4833,11 +4807,11 @@ JG
 JG
 JG
 PB
-lj
-iw
-iw
-iw
-iw
+mm
+CW
+CW
+CW
+CW
 gl
 zE
 SU
@@ -4915,7 +4889,7 @@ JG
 JG
 JG
 PB
-lj
+mm
 iw
 JG
 JG
@@ -4997,10 +4971,10 @@ JG
 JG
 JG
 PB
-lj
-Mt
-af
-fA
+mm
+PB
+hq
+gl
 zE
 zE
 AJ
@@ -5073,11 +5047,11 @@ JG
 JG
 JG
 JG
-iw
-Mt
-iw
-iw
-iw
+CW
+PB
+CW
+CW
+CW
 zE
 DS
 zE
@@ -5159,7 +5133,7 @@ iw
 JG
 JG
 dp
-af
+hq
 zE
 Zf
 zE
@@ -5238,7 +5212,7 @@ JG
 JG
 JG
 bd
-Mt
+PB
 bT
 zE
 zE
@@ -5317,10 +5291,10 @@ JG
 (20,1,1) = {"
 JG
 aH
-iw
-iw
-iw
-as
+CW
+CW
+CW
+qA
 zE
 zE
 jc
@@ -5397,10 +5371,10 @@ JG
 JG
 "}
 (21,1,1) = {"
-af
-af
 hq
-aW
+hq
+hq
+dp
 hq
 bl
 zE
@@ -5807,7 +5781,7 @@ JG
 JG
 "}
 (26,1,1) = {"
-as
+qA
 zE
 ox
 bb
@@ -6226,7 +6200,7 @@ LK
 zE
 LK
 dX
-Jl
+IM
 fm
 zE
 zE
@@ -6303,9 +6277,9 @@ JG
 JG
 IM
 IM
-Jl
-Jl
-Jl
+IM
+IM
+IM
 IM
 JG
 JG
@@ -6393,7 +6367,7 @@ JG
 JG
 JG
 JG
-Jl
+IM
 fm
 zE
 zE
@@ -6644,8 +6618,8 @@ JG
 JG
 JG
 JG
-Jl
-Jl
+IM
+IM
 jS
 zE
 ko
@@ -6893,7 +6867,7 @@ JG
 JG
 JG
 JG
-Mt
+PB
 mm
 kJ
 IM

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -30,7 +30,7 @@
 /area/shuttle/escape)
 "aH" = (
 /obj/structure/grille/broken,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "aO" = (
 /obj/structure/sign/plaques/kiddie{
@@ -64,7 +64,7 @@
 "bd" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "be" = (
 /obj/machinery/light/small/directional/west,
@@ -76,7 +76,7 @@
 "bl" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "bn" = (
 /obj/machinery/light/small/directional/east,
@@ -146,7 +146,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "cu" = (
 /obj/structure/table/wood,
@@ -162,6 +162,10 @@
 "cC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"cH" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/space,
 /area/shuttle/escape)
 "cT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -202,7 +206,7 @@
 "dp" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "du" = (
 /obj/machinery/door/airlock/external/ruin,
@@ -230,7 +234,7 @@
 "dX" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "dY" = (
 /obj/structure/table/wood,
@@ -302,7 +306,7 @@
 "fm" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "fn" = (
 /obj/effect/spawner/xmastree,
@@ -341,7 +345,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "fT" = (
 /obj/structure/table/wood,
@@ -361,7 +365,7 @@
 "gl" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "gp" = (
 /obj/machinery/door/airlock{
@@ -380,7 +384,7 @@
 /area/shuttle/escape)
 "hq" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "hI" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -415,7 +419,7 @@
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "hW" = (
 /obj/structure/flora/bush/leavy/style_random,
@@ -596,7 +600,7 @@
 "jS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "jU" = (
 /obj/item/shovel/spade,
@@ -675,7 +679,7 @@
 "kJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "kM" = (
 /obj/structure/table/wood/fancy,
@@ -700,6 +704,11 @@
 "lm" = (
 /obj/machinery/meter,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"ln" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/space,
 /area/shuttle/escape)
 "lB" = (
 /turf/open/floor/iron/chapel{
@@ -728,9 +737,13 @@
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
+"ml" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/space,
+/area/shuttle/escape)
 "mm" = (
 /obj/structure/lattice/catwalk,
-/turf/template_noop,
+/turf/open/space,
 /area/shuttle/escape)
 "mn" = (
 /obj/structure/chair/wood,
@@ -1042,7 +1055,7 @@
 /area/shuttle/escape)
 "qA" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "qC" = (
 /obj/machinery/airalarm/directional/north,
@@ -1137,6 +1150,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"rZ" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "sa" = (
 /obj/structure/chair/wood{
@@ -1236,6 +1254,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"ti" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/shuttle/escape)
 "tm" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/box/matches{
@@ -1301,6 +1323,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
+"uP" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/space,
+/area/shuttle/escape)
 "uX" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
@@ -1884,11 +1910,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"CW" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/template_noop,
-/area/shuttle/escape)
 "Dc" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -2307,7 +2328,7 @@
 /area/shuttle/escape)
 "IM" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "IR" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -2774,6 +2795,10 @@
 /obj/effect/station_crash/devastating,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"OL" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/escape)
 "OM" = (
 /obj/item/cultivator,
 /turf/open/floor/grass,
@@ -2832,7 +2857,7 @@
 /area/shuttle/escape)
 "PB" = (
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "PC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -3619,7 +3644,7 @@
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
 	},
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "YC" = (
 /obj/machinery/light/small/directional/west,
@@ -3645,7 +3670,7 @@
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/template_noop,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "YZ" = (
 /obj/structure/table/wood,
@@ -4270,7 +4295,7 @@ nr
 nr
 nr
 nr
-hq
+uP
 hq
 JG
 JG
@@ -4807,11 +4832,11 @@ JG
 JG
 JG
 PB
-mm
-CW
-CW
-CW
-CW
+ti
+iw
+iw
+iw
+iw
 gl
 zE
 SU
@@ -4889,7 +4914,7 @@ JG
 JG
 JG
 PB
-mm
+ti
 iw
 JG
 JG
@@ -4971,10 +4996,10 @@ JG
 JG
 JG
 PB
-mm
-PB
-hq
-gl
+ti
+OL
+uP
+ln
 zE
 zE
 AJ
@@ -5047,11 +5072,11 @@ JG
 JG
 JG
 JG
-CW
-PB
-CW
-CW
-CW
+iw
+OL
+iw
+iw
+iw
 zE
 DS
 zE
@@ -5133,7 +5158,7 @@ iw
 JG
 JG
 dp
-hq
+uP
 zE
 Zf
 zE
@@ -5212,7 +5237,7 @@ JG
 JG
 JG
 bd
-PB
+OL
 bT
 zE
 zE
@@ -5291,10 +5316,10 @@ JG
 (20,1,1) = {"
 JG
 aH
-CW
-CW
-CW
-qA
+iw
+iw
+iw
+cH
 zE
 zE
 jc
@@ -5371,10 +5396,10 @@ JG
 JG
 "}
 (21,1,1) = {"
+uP
+uP
 hq
-hq
-hq
-dp
+rZ
 hq
 bl
 zE
@@ -5781,7 +5806,7 @@ JG
 JG
 "}
 (26,1,1) = {"
-qA
+cH
 zE
 ox
 bb
@@ -6200,7 +6225,7 @@ LK
 zE
 LK
 dX
-IM
+ml
 fm
 zE
 zE
@@ -6277,9 +6302,9 @@ JG
 JG
 IM
 IM
-IM
-IM
-IM
+ml
+ml
+ml
 IM
 JG
 JG
@@ -6367,7 +6392,7 @@ JG
 JG
 JG
 JG
-IM
+ml
 fm
 zE
 zE
@@ -6618,8 +6643,8 @@ JG
 JG
 JG
 JG
-IM
-IM
+ml
+ml
 jS
 zE
 ko
@@ -6867,7 +6892,7 @@ JG
 JG
 JG
 JG
-PB
+OL
 mm
 kJ
 IM

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -58,7 +58,9 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Shuttle Airlock"
 	},
-/obj/docking_port/mobile/monastery,
+/obj/docking_port/mobile/monastery{
+	port_direction = 2
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "W" = (


### PR DESCRIPTION

## About The Pull Request
Another another continuation of fixing issues on shuttles. This one is mostly just fixing a few shuttles flying in the wrong direction. Next PR should be the last one for shuttle fixes as there's only a few more scattered around.
<details>
  <summary>Spoiler warning</summary>

- Fixed the following shuttles flying in unexpected directions: escape_pod_large.dmm, emergency_humpback.dmm, emergency_monastery.dmm, emergency_birdboat.dmm, emergency_birdshot.dmm
- Removed use of /turf/closed/wall/mineral/titanium/overspace on emergency_birdshot.dmm

</details>

## Why It's Good For The Game
it's just more bug fixes for shuttles 

## Changelog
:cl:
fix: Fixed the following shuttles flying in unexpected directions: Pubby escape pod,  Humpback emergency shuttle, Pubby monastery shuttle, Birdboat emergency shuttle, Birdshot emergency shuttle

/:cl:
