### PR TITLE
Reverts lootpanel change

### DIFF
--- a/code/modules/lootpanel/search_object.dm
+++ b/code/modules/lootpanel/search_object.dm
@@ -25,12 +25,15 @@
 
 	if(isturf(item))
 		RegisterSignal(item, COMSIG_TURF_CHANGE, PROC_REF(on_turf_change))
-		RegisterSignals(item, list(
-			COMSIG_ATOM_ENTERED,
-			COMSIG_ATOM_EXITED,
-			), PROC_REF(on_item_moved))
 	else
-		RegisterSignal(item, COMSIG_QDELETING, PROC_REF(on_item_moved))
+		// Lest we find ourselves here again, this is intentionally stupid.
+		// It tracks items going out and user actions, otherwise they can refresh the lootpanel.
+		// If this is to be made to track everything, we'll need to make a new signal to specifically create/delete a search object
+		RegisterSignals(item, list(
+			COMSIG_ITEM_PICKUP,
+			COMSIG_MOVABLE_MOVED,
+			COMSIG_QDELETING,
+			), PROC_REF(on_item_moved))
 
 	// Icon generation conditions //////////////
 	// Condition 1: Icon is complex


### PR DESCRIPTION

## About The Pull Request
#84513 made it so that every time an item is moved in/out it causes the lootpanel to delete its turf and does a full repopulation of contents. This goes against the design of the lootpanel and does so in a messy manner. If we wanted to change the design of the lootpanel to be fully interactive, that wouldn't be the way to do it.

The idea behind lootpanel was simple and performance-minded:
- You search a tile for contents
- The list is only subtracted from
- Each subtraction causes a manual update of the UI
- Users can search a tile again to see new items
## Why It's Good For The Game
## Changelog
:cl:
fix: Reverts the fully interactive lootpanel, please just refresh it if you want to see new contents
/:cl:
