### PR TITLE
Mind links won't highlight your own messages

### DIFF
--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -239,7 +239,6 @@
 	return ..() && (owner.stat != DEAD)
 
 /datum/action/innate/linked_speech/Activate()
-
 	var/datum/component/mind_linker/linker = target
 	var/mob/living/linker_parent = linker.parent
 
@@ -257,7 +256,8 @@
 	var/list/all_who_can_hear = assoc_to_keys(linker.linked_mobs) + linker_parent
 
 	for(var/mob/living/recipient as anything in all_who_can_hear)
-		to_chat(recipient, formatted_message)
+		var/avoid_highlighting = (recipient == owner) || (recipient == linker_parent)
+		to_chat(recipient, formatted_message, type = MESSAGE_TYPE_RADIO, avoid_highlighting = avoid_highlighting)
 
 	for(var/mob/recipient as anything in GLOB.dead_mob_list)
-		to_chat(recipient, "[FOLLOW_LINK(recipient, owner)] [formatted_message]")
+		to_chat(recipient, "[FOLLOW_LINK(recipient, owner)] [formatted_message]", type = MESSAGE_TYPE_RADIO)


### PR DESCRIPTION

## About The Pull Request

Linked speech now prevents messages from highlighting if its a message you sent, or if you are the owner of said link.

Also, linked speech messages are now marked as radio messages, for chat tab purposes.

## Why It's Good For The Game

Because when you have your own name highlighted, it's annoying having every message with `[Shion Rosenthal's Slime Link]` highlighted, even if it's _my own_ message.

## Changelog
:cl:
qol: Linked speech now prevents messages from highlighting if its a message you sent, or if you are the owner of said link..
qol: Linked speech messages are now marked as radio messages, for chat tab purposes.
/:cl:
