### PR TITLE
All crewmembers now start with a self-defense flash in their survival box.

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -45,6 +45,7 @@
 
 	if(SSmapping.is_planetary() && LAZYLEN(SSmapping.multiz_levels))
 		new /obj/item/climbing_hook/emergency(src)
+	new /obj/item/assembly/flash(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.


### PR DESCRIPTION
## About The Pull Request

All crewmembers now start with a self-defense flash in their survival box.
Closes #84614 as I think that this is the better change.

## Why It's Good For The Game

With the advent of blood brothers using flashes for conversion, it has now become part of the meta to shake nearby crewmembers down roundstart looking for flashes so that you can valid kill them for being a revhead/blood brother. This is bad for obvious reasons and if you need these reasons elaborated on, please consider taking a game design course or educating yourself on SS13 game design. As such, all crewmembers now start with a flash, so mere possession of a flash "too early" is no longer a valid reason to kill someone.

This also provides all crewmembers with a very basic self defense weapon that's easy to use defensively. I think this will be a net positive for the game but we'll see how it butterfly effects after testing.

## Changelog

:cl:
balance: All crewmembers now start with a self-defense flash in their survival box.
/:cl: