### PR TITLE
Pyro and cryo beams (the genetics powers) adjust temperature more severely, additional effects to make them more meaningfully interact with the world

### DIFF
--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -44,6 +44,7 @@
 			var/datum/reagents/reagents = objectification.reagents
 			reagents?.expose_temperature(temperature)
 
+	var/mob/living/living_target = target
 	if(isliving(target))
 		target.apply_status_effect(/datum/status_effect/freezing_blast)
 

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -24,6 +24,13 @@
 		// the new body temperature is adjusted by the bullet's effect temperature
 		L.adjust_bodytemperature((1 - blocked) * temperature)
 
+	if(isobj(target))
+		var/obj/objectification = target
+
+		if(objectification.reagents)
+			var/datum/reagents/reagents = objectification.reagents
+			reagents?.expose_temperature(temperature)
+
 /obj/projectile/temp/hot
 	name = "heat beam"
 	icon_state = "lava"
@@ -36,13 +43,6 @@
 
 /obj/projectile/temp/cryo/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-
-	if(isobj(target))
-		var/obj/objectification = target
-
-		if(objectification.reagents)
-			var/datum/reagents/reagents = objectification.reagents
-			reagents?.expose_temperature(temperature)
 
 	if(isliving(target))
 		var/mob/living/living_target = target
@@ -71,10 +71,6 @@
 
 		if(objectification.resistance_flags & ON_FIRE) //Don't burn something already on fire
 			return
-
-		if(objectification.reagents)
-			var/datum/reagents/reagents = objectification.reagents
-			reagents?.expose_temperature(temperature)
 
 		objectification.fire_act(temperature)
 

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -68,18 +68,14 @@
 	if(isobj(target))
 		var/obj/objectification = target
 
-		if(objectification.resistance_flags & FLAMMABLE && !(objectification.resistance_flags & ON_FIRE))
-			objectification.fire_act(temperature)
+		if(objectification.resistance_flags & ON_FIRE) //Don't burn something already on fire
+			return
 
 		if(objectification.reagents)
 			var/datum/reagents/reagents = objectification.reagents
 			reagents?.expose_temperature(temperature)
 
-		if(objectification.custom_materials && (GET_MATERIAL_REF(/datum/material/plasma) in objectification.custom_materials))
-			objectification.fire_act(temperature)
-
-		if(istype(objectification, /obj/structure/reagent_dispensers/fueltank))
-			objectification.fire_act(temperature)
+		objectification.fire_act(temperature)
 
 		return
 

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -32,7 +32,13 @@
 /obj/projectile/temp/cryo
 	name = "cryo beam"
 	range = 9
-	temperature = -240 // Single slow shot reduces temp greatly
+	temperature = -350 // Single slow shot reduces temp greatly
+
+/obj/projectile/temp/cryoon_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+	if(!isliving(target))
+		return
+	target.apply_status_effect(/datum/status_effect/freezing_blast)
 
 /obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)
@@ -44,8 +50,9 @@
 /obj/projectile/temp/pyro
 	name = "hot beam"
 	icon_state = "firebeam" // sets on fire, diff sprite!
+	damage = 1 //Mostly so that we set off objects like wleding tanks
 	range = 9
-	temperature = 240
+	temperature = 350
 
 /obj/projectile/temp/pyro/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -44,8 +44,8 @@
 			var/datum/reagents/reagents = objectification.reagents
 			reagents?.expose_temperature(temperature)
 
-	var/mob/living/living_target = target
-	if(isliving(living_target))
+	if(isliving(target))
+		var/mob/living/living_target = target
 		living_target.apply_status_effect(/datum/status_effect/freezing_blast)
 
 /obj/projectile/temp/cryo/on_range()
@@ -80,8 +80,8 @@
 
 		return
 
-	var/mob/living/living_target = target
-	if(istype(living_target))
+	if(isliving(target))
+		var/mob/living/living_target = target
 		living_target.adjust_fire_stacks(2)
 		living_target.ignite_mob()
 

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -45,8 +45,8 @@
 			reagents?.expose_temperature(temperature)
 
 	var/mob/living/living_target = target
-	if(isliving(target))
-		target.apply_status_effect(/datum/status_effect/freezing_blast)
+	if(isliving(living_target))
+		living_target.apply_status_effect(/datum/status_effect/freezing_blast)
 
 /obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -34,7 +34,7 @@
 	range = 9
 	temperature = -350 // Single slow shot reduces temp greatly
 
-/obj/projectile/temp/cryoon_hit(atom/target, blocked = 0, pierce_hit)
+/obj/projectile/temp/cryo/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
 
 	if(isobj(target))


### PR DESCRIPTION
## About The Pull Request

Pyro and cryo beams now adjust temperature by a much larger margin. This is to help them remain useful against....humans. Just straight up naked humans.

Pyro beams can ignite objects and heat reagents within an object. Cryo beams freeze reagents in an object.

Cryo beams directly inflict the freezing blast status effect so that you absolutely will slow someone down on hit. No more fucking around with temp to MAYBE get some kind of effect. 

## Why It's Good For The Game

There was a point where cryokinesis was actually fairly good at slowing people down. Unfortunately, the same person who last touched temperature code also made it nearly unusable against regular human targets due to the rapid pace at which humans normalize their temperature. It takes a good while before temperature slowdown starts to take effect. 

Pyro beams have additional on-hit effects, which cryobeam does not. Cryobeams only have the temperature adjustment and as noted, it is quite weak. Being on fire starts to damage equipment and present a more tangible danger in some environments, such as plasma floods or having just been hit with an accelerant such as alcohol.

By including a status effect onto the cryo beam that forces the target to slow down, we avoid the issue of people ignoring the effect of the cryobeam entirely as a meaningful attack compared to being shot by a pryro beam, which will usually cause people to start panicking or moving to remove the fire in some way.

I also think by adding some additional interactions to the beam to make them meaningfully affect some world objects, like flammable objects, helps to realizes the idea a bit better of them being blasters of temperature rather than just being bullets. It means it goes a little beyond just being a weapon and potentially now a tool. (It was thinking of Bioshock's plasmid advertising when I made this, like lighting cigarettes.)

## Changelog
:cl:
balance: Cryokinesis and pyrokinesis more severely adjust temperature.
balance: Cryokinesis forces a target to slow down on hit for a few seconds.
balance: Pyrokinesis can ignite objects.
balance: Temperature projectiles change the temperature of the target's contained reagents.
/:cl:
