### PR TITLE
Tones down the settler speeds by a considerable margin (both slowdown and speedup)

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -119,20 +119,20 @@
 			ride_benefit = rough_rider.mob_mood.sanity_level
 		switch(ride_benefit)
 			if(SANITY_LEVEL_GREAT)
-				modified_move_cooldown *= 0.5
-				modified_move_delay *= 0.5
-			if(SANITY_LEVEL_NEUTRAL)
 				modified_move_cooldown *= 0.8
 				modified_move_delay *= 0.8
+			if(SANITY_LEVEL_NEUTRAL)
+				modified_move_cooldown *= 0.9
+				modified_move_delay *= 0.9
 			if(SANITY_LEVEL_DISTURBED)
 				modified_move_cooldown *= 1
 				modified_move_delay *= 1
 			if(SANITY_LEVEL_CRAZY)
+				modified_move_cooldown *= 1.1
+				modified_move_delay *= 1.1
+			if(SANITY_LEVEL_INSANE)
 				modified_move_cooldown *= 1.2
 				modified_move_delay *= 1.2
-			if(SANITY_LEVEL_INSANE)
-				modified_move_cooldown *= 1.5
-				modified_move_delay *= 1.5
 	COOLDOWN_START(src, vehicle_move_cooldown = modified_move_cooldown, (last_move_diagonal ? 2 : 1) * modified_move_delay)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Reduces the upper and lower speed adjustments of the Settler's Roughrider trait.

## Why It's Good For The Game

I added this to settler as a suggestion from goof, but I promised myself that should this get overused to the point that it is abused on a regular basis, I was putting a bullet straight into the back of its head.

Unfortunately, because of this quirk, raptors had to get super nerfed just to account for the extra speed because people wouldn't stop bringing them up to the station to outspeed everyone on foot. People have since moved onto different mounts. This is going to keep continuing, so unfortunately for everyone this can no longer persist.

I brought it into this world, and now I'm...limiting it because I would like people to not worry about a quirk ruining the balance of their cool mount additions.

## Changelog
:cl:
balance: Settlers are a bit slower on their steeds.
/:cl:
