### PR TITLE
mood is more reactive to area beauty changes, also flips it for people with morbid trait.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_area.dm
+++ b/code/__DEFINES/dcs/signals/signals_area.dm
@@ -35,3 +35,6 @@
 #define COMSIG_WEATHER_BEGAN_IN_AREA(event_type) "weather_began_in_area_[event_type]"
 /// Called when some weather ends in this area
 #define COMSIG_WEATHER_ENDED_IN_AREA(event_type) "weather_ended_in_area_[event_type]"
+
+///From base of area/update_beauty()
+#define COMSIG_AREA_BEAUTY_UPDATED "area_beauty_updated"

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -411,6 +411,7 @@
 			switch(area_to_beautify.beauty)
 				if(BEAUTY_LEVEL_DECENT to BEAUTY_LEVEL_GOOD)
 					add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/ehroom)
+					return
 				if(BEAUTY_LEVEL_GOOD to BEAUTY_LEVEL_GREAT)
 					add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/badroom)
 					return

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -48,9 +48,14 @@
 
 	RegisterSignal(mob_to_make_moody, COMSIG_MOB_HUD_CREATED, PROC_REF(modify_hud))
 	RegisterSignal(mob_to_make_moody, COMSIG_ENTER_AREA, PROC_REF(check_area_mood))
+	RegisterSignal(mob_to_make_moody, COMSIG_EXIT_AREA, PROC_REF(exit_area))
 	RegisterSignal(mob_to_make_moody, COMSIG_LIVING_REVIVE, PROC_REF(on_revive))
 	RegisterSignal(mob_to_make_moody, COMSIG_MOB_STATCHANGE, PROC_REF(handle_mob_death))
 	RegisterSignal(mob_to_make_moody, COMSIG_QDELETING, PROC_REF(clear_parent_ref))
+
+	var/area/our_area = get_area(mob_to_make_moody)
+	if(our_area)
+		check_area_mood(null, our_area)
 
 	mob_to_make_moody.become_area_sensitive(MOOD_DATUM_TRAIT)
 	if(mob_to_make_moody.hud_used)
@@ -63,7 +68,10 @@
 
 	unmodify_hud()
 	mob_parent.lose_area_sensitivity(MOOD_DATUM_TRAIT)
-	UnregisterSignal(mob_parent, list(COMSIG_MOB_HUD_CREATED, COMSIG_ENTER_AREA, COMSIG_LIVING_REVIVE, COMSIG_MOB_STATCHANGE, COMSIG_QDELETING))
+	UnregisterSignal(mob_parent, list(COMSIG_MOB_HUD_CREATED, COMSIG_ENTER_AREA, COMSIG_EXIT_AREA, COMSIG_LIVING_REVIVE, COMSIG_MOB_STATCHANGE, COMSIG_QDELETING))
+	var/area/our_area = get_area(mob_parent)
+	if(our_area)
+		UnregisterSignal(our_area, COMSIG_AREA_BEAUTY_UPDATED)
 
 	mob_parent = null
 
@@ -383,6 +391,8 @@
 /datum/mood/proc/check_area_mood(datum/source, area/new_area)
 	SIGNAL_HANDLER
 
+	RegisterSignal(new_area, COMSIG_AREA_BEAUTY_UPDATED, PROC_REF(update_beauty))
+
 	update_beauty(new_area)
 	if (new_area.mood_bonus && (!new_area.mood_trait || HAS_TRAIT(source, new_area.mood_trait)))
 		add_mood_event("area", /datum/mood_event/area, new_area.mood_bonus, new_area.mood_message)
@@ -391,8 +401,29 @@
 
 /// Updates the mob's given beauty moodie, based on the area
 /datum/mood/proc/update_beauty(area/area_to_beautify)
+	SIGNAL_HANDLER
 	if (area_to_beautify.outdoors) // if we're outside, we don't care
 		clear_mood_event(MOOD_CATEGORY_AREA_BEAUTY)
+		return
+
+	if(HAS_TRAIT(mob_parent, TRAIT_MORBID))
+		if(HAS_TRAIT(mob_parent, TRAIT_SNOB))
+			switch(area_to_beautify.beauty)
+				if(BEAUTY_LEVEL_DECENT to BEAUTY_LEVEL_GOOD)
+					add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/ehroom)
+				if(BEAUTY_LEVEL_GOOD to BEAUTY_LEVEL_GREAT)
+					add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/badroom)
+					return
+				if(BEAUTY_LEVEL_GREAT to INFINITY)
+					add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/horridroom)
+					return
+		switch(area_to_beautify.beauty)
+			if(-INFINITY to BEAUTY_LEVEL_HORRID)
+				add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/greatroom)
+			if(BEAUTY_LEVEL_HORRID to BEAUTY_LEVEL_BAD)
+				add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/goodroom)
+			if(BEAUTY_LEVEL_BAD to BEAUTY_LEVEL_DECENT)
+				clear_mood_event(MOOD_CATEGORY_AREA_BEAUTY)
 		return
 
 	if(HAS_TRAIT(mob_parent, TRAIT_SNOB))
@@ -412,6 +443,10 @@
 			add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/goodroom)
 		if(BEAUTY_LEVEL_GREAT to INFINITY)
 			add_mood_event(MOOD_CATEGORY_AREA_BEAUTY, /datum/mood_event/greatroom)
+
+/datum/mood/proc/exit_area(datum/source, area/old_area)
+	SIGNAL_HANDLER
+	UnregisterSignal(old_area, COMSIG_AREA_BEAUTY_UPDATED)
 
 /// Called when parent is ahealed.
 /datum/mood/proc/on_revive(datum/source, full_heal)

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -55,7 +55,7 @@
 
 	var/area/our_area = get_area(mob_to_make_moody)
 	if(our_area)
-		check_area_mood(null, our_area)
+		check_area_mood(mob_to_make_moody, our_area)
 
 	mob_to_make_moody.become_area_sensitive(MOOD_DATUM_TRAIT)
 	if(mob_to_make_moody.hud_used)

--- a/code/datums/mood_events/beauty_events.dm
+++ b/code/datums/mood_events/beauty_events.dm
@@ -6,6 +6,10 @@
 	description = "This room looks really bad."
 	mood_change = -3
 
+/datum/mood_event/ehroom
+	description = "This room looks kinda bad."
+	mood_change = -1
+
 /datum/mood_event/decentroom
 	description = "This room looks alright."
 	mood_change = 1

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -567,6 +567,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		beauty = 0
 		return FALSE //Too big
 	beauty = totalbeauty / areasize
+	SEND_SIGNAL(src, COMSIG_AREA_BEAUTY_UPDATED)
 
 /**
  * Setup an area (with the given name)


### PR DESCRIPTION
## About The Pull Request
Previously, the mood datum would only react to beauty when entering an area, any later changes to the room wouldn't update it for the mood datum.

Also, mobs with the morbid trait (ie. the cononer) now like degradated-looking rooms and dislike (if they also have the snob trait), well-decorated ones.

## Why It's Good For The Game
Feature and improvement.

## Changelog

:cl:
qol: Mood more promptly reacts to the beauty of an area as it changes, and not just when changing areas.
add: Coroners (and potentially other mobs with the morbid trait), now like degradated-looking rooms.
/:cl:
