### PR TITLE
Makes the omnitool lathe proof

### DIFF
--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -274,7 +274,9 @@
 	//All messages to be displayed to chat
 	var/list/chat_msgs = list()
 	//differs from held_item when using TK
-	var/active_held = user.get_active_held_item()
+	var/obj/item/active_held = user.get_active_held_item()
+	//omni tools can act as any tool so get its real behaviour
+	active_held = active_held.get_proxy_attacker_for(held_item)
 
 	while(items.len)
 		//no point inserting more items


### PR DESCRIPTION
## About The Pull Request
- Fixes #84600

As mentioned in https://github.com/tgstation/tgstation/issues/84600#issuecomment-2204975628 there is no problem with omnitool & airlock interactions, but just with the lathe consuming the omnitool.


## Changelog
:cl:
fix: Autolathe won't eat the borg omni tool
/:cl:
