### PR TITLE
cult stun hand is unusable at halo stage

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -407,3 +407,12 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 
 /// Camera net used by battle royale objective
 #define BATTLE_ROYALE_CAMERA_NET "battle_royale_camera_net"
+
+/// If this flag is present, the cult has reached the halo stage
+#define CULTSTATE_HALO (1 << 1)
+/// If this flag is present, the cult has reached the glowing eyes stage
+#define CULTSTATE_EYES (1 << 2)
+/// If this flag is present, the cult has summoned NarNar
+#define CULTSTATE_NARSIE (1 << 3)
+
+#define CULTSTATE_ALL (CULTSTATE_HALO | CULTSTATE_EYES | CULTSTATE_NARSIE)

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -409,10 +409,10 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define BATTLE_ROYALE_CAMERA_NET "battle_royale_camera_net"
 
 /// If this flag is present, the cult has reached the halo stage
-#define CULTSTATE_HALO (1 << 1)
+#define CULT_STATE_HALO (1 << 1)
 /// If this flag is present, the cult has reached the glowing eyes stage
-#define CULTSTATE_EYES (1 << 2)
+#define CULT_STATE_EYES (1 << 2)
 /// If this flag is present, the cult has summoned NarNar
-#define CULTSTATE_NARSIE (1 << 3)
+#define CULT_STATE_NARSIE (1 << 3)
 
-#define CULTSTATE_ALL (CULTSTATE_HALO | CULTSTATE_EYES | CULTSTATE_NARSIE)
+#define CULT_STATE_ALL (CULT_STATE_HALO | CULT_STATE_EYES | CULT_STATE_NARSIE)

--- a/code/__DEFINES/dcs/signals/signals_datum.dm
+++ b/code/__DEFINES/dcs/signals/signals_datum.dm
@@ -45,3 +45,6 @@
 
 ///from /datum/bank_account/pay_debt(), after a portion or all the debt has been paid.
 #define COMSIG_BANK_ACCOUNT_DEBT_PAID "bank_account_debt_paid"
+
+///from /datum/team/cult/proc/rise_cult() or ascend_cult(), called when this proc causes the cult state flags to change
+#define COMSIG_CULTTEAM_STATE_CHANGED "bloodcult_team_state_change"

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -125,7 +125,7 @@
 	/// If false, the spell will not delete after running out of charges
 	var/deletes_on_empty = TRUE
 	/// This spell may only be used with these cultstate flags present
-	var/cult_state_flags = CULTSTATE_ALL
+	var/cult_state_flags = CULT_STATE_ALL
 
 /datum/action/innate/cult/blood_spell/Grant(mob/living/owner, datum/action/innate/cult/blood_magic/BM)
 	if(health_cost)
@@ -181,7 +181,7 @@
 	button_icon_state = "hand"
 	magic_path = "/obj/item/melee/blood_magic/stun"
 	health_cost = 10
-	cult_state_flags = parent_type::cult_state_flags & ~CULTSTATE_HALO
+	cult_state_flags = parent_type::cult_state_flags & ~CULT_STATE_HALO
 
 /datum/action/innate/cult/blood_spell/teleport
 	name = "Teleport"
@@ -454,7 +454,7 @@
 	var/datum/antagonist/cult/cultist = IS_CULTIST(user)
 	var/datum/team/cult/cult_team = cultist.get_team()
 	var/effect_coef = 1
-	if(cult_team.cult_state_flags & CULTSTATE_EYES)
+	if(cult_team.cult_state_flags & CULT_STATE_EYES)
 		effect_coef = 0.4
 	user.visible_message(
 		span_warning("[user] holds up [user.p_their()] hand, which explodes in a flash of red light!"),

--- a/code/modules/antagonists/cult/datums/cult_team.dm
+++ b/code/modules/antagonists/cult/datums/cult_team.dm
@@ -14,7 +14,7 @@
 	var/datum/antagonist/cult/cult_leader_datum
 	///Has the mass teleport been used yet?
 	var/reckoning_complete = FALSE
-	///Cult progression flags (check CULTSTATE_ALL)
+	///Cult progression flags (check CULT_STATE_ALL)
 	var/cult_state_flags = NONE
 
 	/// List that keeps track of which items have been unlocked after a heretic was sacked.
@@ -32,7 +32,7 @@
 	var/list/true_cultists = list()
 
 /datum/team/cult/proc/check_size()
-	if(cult_state_flags & CULTSTATE_HALO)
+	if(cult_state_flags & CULT_STATE_HALO)
 		return
 
 	// This proc is unnecessary clutter whilst running cult related unit tests
@@ -50,34 +50,34 @@
 
 	ASSERT(cultplayers) //we shouldn't be here.
 	var/ratio = alive ? cultplayers/alive : 1
-	if(ratio > CULT_RISEN && !(cult_state_flags & CULTSTATE_EYES))
+	if(ratio > CULT_RISEN && !(cult_state_flags & CULT_STATE_EYES))
 		rise_cult(cultplayers)
 
-	if(ratio > CULT_ASCENDENT && !(cult_state_flags & CULTSTATE_HALO))
+	if(ratio > CULT_ASCENDENT && !(cult_state_flags & CULT_STATE_HALO))
 		ascend_cult(cultplayers)
 #endif
 
 /datum/team/cult/proc/rise_cult(cultplayers=1)
-	if(cult_state_flags & CULTSTATE_EYES)
+	if(cult_state_flags & CULT_STATE_EYES)
 		return
 	for(var/datum/mind/mind as anything in members)
 		if(mind.current)
 			SEND_SOUND(mind.current, 'sound/ambience/antag/bloodcult/bloodcult_eyes.ogg')
 			to_chat(mind.current, span_cult_large(span_warning("The veil weakens as your cult grows, your eyes begin to glow...")))
 			mind.current.AddElement(/datum/element/cult_eyes)
-	cult_state_flags |= CULTSTATE_EYES
+	cult_state_flags |= CULT_STATE_EYES
 	log_game("The blood cult has risen with [cultplayers] players.")
 	SEND_SIGNAL(src, COMSIG_CULTTEAM_STATE_CHANGED, cult_state_flags)
 
 /datum/team/cult/proc/ascend_cult(cultplayers=1)
-	if(cult_state_flags & CULTSTATE_HALO)
+	if(cult_state_flags & CULT_STATE_HALO)
 		return
 	for(var/datum/mind/mind as anything in members)
 		if(mind.current)
 			SEND_SOUND(mind.current, 'sound/ambience/antag/bloodcult/bloodcult_halos.ogg')
 			to_chat(mind.current, span_cult_large(span_warning("Your cult is ascendent and the red harvest approaches - you cannot hide your true nature for much longer!!")))
 			mind.current.AddElement(/datum/element/cult_halo)
-	cult_state_flags |= CULTSTATE_HALO
+	cult_state_flags |= CULT_STATE_HALO
 	log_game("The blood cult has ascended with [cultplayers] players.")
 	SEND_SIGNAL(src, COMSIG_CULTTEAM_STATE_CHANGED, cult_state_flags)
 

--- a/code/modules/antagonists/cult/datums/cultist.dm
+++ b/code/modules/antagonists/cult/datums/cultist.dm
@@ -68,9 +68,9 @@
 	if(cult_team.blood_target && cult_team.blood_target_image && current.client)
 		current.client.images += cult_team.blood_target_image
 
-	if(cult_team.cult_state_flags & CULTSTATE_EYES)
+	if(cult_team.cult_state_flags & CULT_STATE_EYES)
 		current.AddElement(/datum/element/cult_eyes, initial_delay = 0 SECONDS)
-	if(cult_team.cult_state_flags & CULTSTATE_HALO)
+	if(cult_team.cult_state_flags & CULT_STATE_HALO)
 		current.AddElement(/datum/element/cult_halo, initial_delay = 0 SECONDS)
 
 	ADD_TRAIT(current, TRAIT_HEALS_FROM_CULT_PYLONS, CULT_TRAIT)

--- a/code/modules/antagonists/cult/datums/cultist.dm
+++ b/code/modules/antagonists/cult/datums/cultist.dm
@@ -68,9 +68,9 @@
 	if(cult_team.blood_target && cult_team.blood_target_image && current.client)
 		current.client.images += cult_team.blood_target_image
 
-	if(cult_team.cult_risen)
+	if(cult_team.cult_state_flags & CULTSTATE_EYES)
 		current.AddElement(/datum/element/cult_eyes, initial_delay = 0 SECONDS)
-	if(cult_team.cult_ascendent)
+	if(cult_team.cult_state_flags & CULTSTATE_HALO)
 		current.AddElement(/datum/element/cult_halo, initial_delay = 0 SECONDS)
 
 	ADD_TRAIT(current, TRAIT_HEALS_FROM_CULT_PYLONS, CULT_TRAIT)


### PR DESCRIPTION

## About The Pull Request

cult stun hand is unusable at halo stage
you may not carve this spell at halo stage and if you have it carved already and the cult gets Halos it is removed

## Why It's Good For The Game

right now any cultist at the halo stage tries to get a cheap stun in before meleeing you to death with their really big and fancy and good block chance sword
this is obviously not cool as this tends to shut down your opponent instantly and before they can even pick up their weapons and shields you can just cave their brain in with your sword which is just not good gameplay
with limiting the cult stun hand to the "stealth" (or the cult stages you should be stealthy and converting people) i believe this should resolve the issue, as if youre going loud with halos i dont believe you need to convert more people

## Changelog
:cl:
balance: cult stun hand is unusable at halo stage
/:cl:
