### PR TITLE
Positive moodlets when examining high-value paintings, plus tgui nitpicks

### DIFF
--- a/code/__DEFINES/art.dm
+++ b/code/__DEFINES/art.dm
@@ -14,3 +14,16 @@
 #define CRAYON_COST_SMALL 0.5
 #define CRAYON_COST_DEFAULT 1
 #define CRAYON_COST_LARGE 5
+
+/**
+ * Patronage thresholds for paintings.
+ * Different cosmetic frames become available as more credits are spent on the patronage.
+ * These also influence the artistic value (read: positive moodlets) of a painting.
+ */
+#define PATRONAGE_OK_FRAME (PAYCHECK_CREW * 3) // 150 credits, as of march 2022
+#define PATRONAGE_NICE_FRAME (PATRONAGE_OK_FRAME * 2.5)
+#define PATRONAGE_GREAT_FRAME (PATRONAGE_NICE_FRAME * 2)
+#define PATRONAGE_EXCELLENT_FRAME (PATRONAGE_GREAT_FRAME * 2)
+#define PATRONAGE_AMAZING_FRAME (PATRONAGE_EXCELLENT_FRAME * 2)
+#define PATRONAGE_SUPERB_FRAME (PATRONAGE_AMAZING_FRAME * 2)
+#define PATRONAGE_LEGENDARY_FRAME (PATRONAGE_SUPERB_FRAME * 2)

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -1,14 +1,5 @@
 #define PAINTINGS_DATA_FORMAT_VERSION 3
 
-// Patronage thresholds for paintings. Different cosmetic frames become available as more credits are spent on the patronage.
-#define PATRONAGE_OK_FRAME (PAYCHECK_CREW * 3) // 150 credits, as of march 2022
-#define PATRONAGE_NICE_FRAME (PATRONAGE_OK_FRAME * 2.5)
-#define PATRONAGE_GREAT_FRAME (PATRONAGE_NICE_FRAME * 2)
-#define PATRONAGE_EXCELLENT_FRAME (PATRONAGE_GREAT_FRAME * 2)
-#define PATRONAGE_AMAZING_FRAME (PATRONAGE_EXCELLENT_FRAME * 2)
-#define PATRONAGE_SUPERB_FRAME (PATRONAGE_AMAZING_FRAME * 2)
-#define PATRONAGE_LEGENDARY_FRAME (PATRONAGE_SUPERB_FRAME * 2)
-
 /*
 {
 	"version":2
@@ -332,13 +323,3 @@ SUBSYSTEM_DEF(persistent_paintings)
 	fdel(json_file)
 	WRITE_FILE(json_file, payload)
 	cache_paintings()
-
-#undef PAINTINGS_DATA_FORMAT_VERSION
-#undef PATRONAGE_OK_FRAME
-#undef PATRONAGE_NICE_FRAME
-#undef PATRONAGE_GREAT_FRAME
-#undef PATRONAGE_EXCELLENT_FRAME
-#undef PATRONAGE_AMAZING_FRAME
-#undef PATRONAGE_SUPERB_FRAME
-#undef PATRONAGE_LEGENDARY_FRAME
-

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -323,3 +323,5 @@ SUBSYSTEM_DEF(persistent_paintings)
 	fdel(json_file)
 	WRITE_FILE(json_file, payload)
 	cache_paintings()
+
+#undef PAINTINGS_DATA_FORMAT_VERSION

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -91,6 +91,14 @@
 	painting_metadata.height = height
 	ADD_KEEP_TOGETHER(src, INNATE_TRAIT)
 
+/obj/item/canvas/Destroy()
+	last_patron = null
+	if(istype(loc,/obj/structure/sign/painting))
+		var/obj/structure/sign/painting/frame = loc
+		frame.remove_art_element(painting_metadata.credit_value)
+	painting_metadata = null
+	return ..()
+
 /obj/item/canvas/proc/reset_grid()
 	grid = new/list(width,height)
 	for(var/x in 1 to width)
@@ -102,6 +110,8 @@
 	ui_interact(user)
 
 /obj/item/canvas/ui_state(mob/user)
+	if(isobserver(user))
+		return GLOB.observer_state
 	if(finalized)
 		return GLOB.physical_obscured_state
 	else
@@ -154,6 +164,9 @@
 	if(.)
 		return
 	var/mob/user = usr
+	///this is here to allow observers to zoom in and out but not do anything else.
+	if(action != "zoom_in" && action != "zoom_out" && isobserver(user))
+		return
 	switch(action)
 		if("paint")
 			if(finalized)
@@ -286,10 +299,16 @@
 					curator.adjust_money(curator_cut, "Painting: Patronage cut")
 					curator.bank_card_talk("Cut on patronage received, account now holds [curator.account_balance] cr.")
 
+	if(istype(loc, /obj/structure/sign/painting))
+		var/obj/structure/sign/painting/frame = loc
+		frame.remove_art_element(painting_metadata.credit_value)
+		frame.add_art_element(offer_amount)
+
 	painting_metadata.patron_ckey = user.ckey
 	painting_metadata.patron_name = user.real_name
 	painting_metadata.credit_value = offer_amount
 	last_patron = WEAKREF(user.mind)
+
 	to_chat(user, span_notice("Nanotrasen Trust Foundation thanks you for your contribution. You're now an official patron of this painting."))
 	var/list/possible_frames = SSpersistent_paintings.get_available_frames(offer_amount)
 	if(possible_frames.len <= 1) // Not much room for choices here.
@@ -566,6 +585,8 @@
 /obj/structure/sign/painting/Exited(atom/movable/movable, atom/newloc)
 	. = ..()
 	if(movable == current_canvas)
+		if(!QDELETED(current_canvas))
+			remove_art_element(current_canvas.painting_metadata.credit_value)
 		current_canvas = null
 		update_appearance()
 
@@ -585,6 +606,7 @@
 		if(!current_canvas.finalized)
 			current_canvas.finalize(user)
 		to_chat(user,span_notice("You frame [current_canvas]."))
+		add_art_element()
 		update_appearance()
 		return TRUE
 	return FALSE
@@ -654,9 +676,30 @@
 	new_canvas.finalized = TRUE
 	new_canvas.name = "painting - [painting.title]"
 	current_canvas = new_canvas
+	add_art_element()
 	current_canvas.update_appearance()
 	update_appearance()
 	return TRUE
+
+/obj/structure/sign/painting/proc/add_art_element()
+	var/artistic_value = get_art_value(current_canvas.painting_metadata.credit_value)
+	if(artistic_value)
+		AddElement(/datum/element/art, artistic_value)
+
+/obj/structure/sign/painting/proc/remove_art_element(patronage)
+	var/artistic_value = get_art_value(patronage)
+	if(artistic_value)
+		RemoveElement(/datum/element/art, artistic_value)
+
+/obj/structure/sign/painting/proc/get_art_value(patronage)
+	switch(patronage)
+		if(PATRONAGE_SUPERB_FRAME to INFINITY)
+			return GREAT_ART
+		if(PATRONAGE_EXCELLENT_FRAME to PATRONAGE_SUPERB_FRAME)
+			return GOOD_ART
+		if(PATRONAGE_NICE_FRAME to PATRONAGE_EXCELLENT_FRAME)
+			return OK_ART
+	return 0
 
 /obj/structure/sign/painting/proc/save_persistent()
 	if(!persistence_id || !current_canvas || current_canvas.no_save || current_canvas.painting_metadata.loaded_from_json)

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -264,10 +264,10 @@ export const Canvas = (props) => {
   const griddy = !!data.show_grid && !!data.editable && !!data.paint_tool_color;
   return (
     <Window
-      width={Math.max(scaled_width + 72, 262)}
+      width={Math.max(scaled_width + 72, 280)}
       height={
         scaled_height +
-        80 +
+        94 +
         (data.show_plaque ? average_plaque_height : 0) +
         (data.editable && data.paint_tool_palette ? palette_height : 0)
       }


### PR DESCRIPTION
## About The Pull Request
This PR makes it so that, when framed, paintings can give positive moodlets based on their art element, which is based upon their patronage, meaning, the higher tha patronage, the better the positive moodlets.

This PR also adjusts the tgui states to allow observers to interact with the painting, but only for zooming in and out. And expands the tgui window a little so hopefully you can see the plaquette when it's framed.

## Why It's Good For The Game
Higher-valued pieces tend to also look better, right? . . . right?
Ok, jokes apart, I think this is a nice touch to paintings.

## Changelog

:cl:
add: Examining high-value paintings now can give a positive moodlet.
qol: Observers can now zoom paintings in and out in the UI.
/:cl:
