### PR TITLE
Firefighting nozzle attack chain fixes

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -295,8 +295,8 @@
 
 	var/Adj = user.Adjacent(interacting_with)
 	if(nozzle_mode == RESIN_LAUNCHER)
-		if(Adj)
-			return ITEM_INTERACT_BLOCKING //Safety check so you don't blast yourself trying to refill your tank
+		if(Adj && user.combat_mode)
+			return ITEM_INTERACT_SKIP_TO_ATTACK
 		var/datum/reagents/R = reagents
 		if(R.total_volume < 100)
 			balloon_alert(user, "not enough water!")
@@ -316,7 +316,9 @@
 		return ITEM_INTERACT_SUCCESS
 
 	if(nozzle_mode == RESIN_FOAM)
-		if(!Adj || !isturf(interacting_with))
+		if(!isturf(interacting_with))
+			return NONE
+		if(!Adj)
 			balloon_alert(user, "too far!")
 			return ITEM_INTERACT_BLOCKING
 		for(var/thing in interacting_with)


### PR DESCRIPTION

## About The Pull Request
Fixes #84589
Makes it so the nozzle will hit adjacent objects when in resin foam mode, same for launcher mode as long as you're also in combat mode.

The launcher adj check in the old version isn't actually needed to protect you when refilling your tank, the attack chain already gets cancelled when trying to refill the tank at the start of this proc.
## Why It's Good For The Game
Being unable to destroy the foam using the nozzle makes it way more annoying to use.
## Changelog
:cl:
fix: Firefighting backpack tank nozzle can be used to hit objects and destroy atmos resin again.
/:cl:
