### PR TITLE
Fixes fucked rendering in StrongDMM

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -119,6 +119,11 @@
 /// Try and keep this to a nice whole number, so it's easy to look at a plane var and know what's going on
 #define PLANE_RANGE (HIGHEST_EVER_PLANE - LOWEST_EVER_PLANE)
 
+// Layer helper macros
+
+/// Gives us a way to hook into topdown layers so we can make stupid DUMBASS MAP EDITOR RENDERING happy
+#define MARK_TOPDOWN(layer, FLOOR, NORMALIZED, MAX) MAP_SWITCH(layer, ( ( (NORMALIZED) - (FLOOR) ) * ( ( (layer) - TOPDOWN_LAYER ) / (MAX) ) ) + (FLOOR))
+
 // PLANE_SPACE layer(s)
 #define SPACE_LAYER 1.8
 
@@ -132,23 +137,30 @@
 // this allows larger then bound floors to layer as we'd expect
 // ANYTHING on the floor plane needs TOPDOWN_LAYER, and nothing that isn't on the floor plane can have it
 
-//FLOOR_PLANE layers
+/// Max floor plane layer value (ignoring topdown)
+#define MAX_FLOOR_LAYER 13
+/// The minimum layer floor plane should have normalized to match up with its position in the plane stack
+#define MAPPING_FLOOR_LAYER_NORMALIZED_MIN 1.81
+/// The max layer floor plane should have normalized to match up with its position in the plane stack
+#define MAPPING_FLOOR_LAYER_NORMALIZED_MAX 2
+#define MARK_FLOOR_LAYER(layer) MARK_TOPDOWN(layer, MAPPING_FLOOR_LAYER_NORMALIZED_MIN, MAPPING_FLOOR_LAYER_NORMALIZED_MAX, MAX_FLOOR_LAYER)
+
 // NOTICE: we break from the pattern of increasing in steps of like 0.01 here
 // Because TOPDOWN_LAYER is 10000 and that's enough to floating point our modifications away
-#define LOW_FLOOR_LAYER (1 + TOPDOWN_LAYER)
-#define TURF_PLATING_DECAL_LAYER (2 + TOPDOWN_LAYER)
-#define TURF_DECAL_LAYER (3 + TOPDOWN_LAYER) //Makes turf decals appear in DM how they will look inworld.
-#define CULT_OVERLAY_LAYER (4 + TOPDOWN_LAYER)
-#define MID_TURF_LAYER (5 + TOPDOWN_LAYER)
-#define HIGH_TURF_LAYER (6 + TOPDOWN_LAYER)
-#define LATTICE_LAYER (7 + TOPDOWN_LAYER)
-#define DISPOSAL_PIPE_LAYER (8 + TOPDOWN_LAYER)
-#define WIRE_LAYER (9 + TOPDOWN_LAYER)
-#define GLASS_FLOOR_LAYER (10 + TOPDOWN_LAYER)
-#define TRAM_RAIL_LAYER (11 + TOPDOWN_LAYER)
+#define LOW_FLOOR_LAYER MARK_FLOOR_LAYER(1 + TOPDOWN_LAYER)
+#define TURF_PLATING_DECAL_LAYER MARK_FLOOR_LAYER(2 + TOPDOWN_LAYER)
+#define TURF_DECAL_LAYER MARK_FLOOR_LAYER(3 + TOPDOWN_LAYER) //Makes turf decals appear in DM how they will look inworld.
+#define CULT_OVERLAY_LAYER MARK_FLOOR_LAYER(4 + TOPDOWN_LAYER)
+#define MID_TURF_LAYER MARK_FLOOR_LAYER(5 + TOPDOWN_LAYER)
+#define HIGH_TURF_LAYER MARK_FLOOR_LAYER(6 + TOPDOWN_LAYER)
+#define LATTICE_LAYER MARK_FLOOR_LAYER(7 + TOPDOWN_LAYER)
+#define DISPOSAL_PIPE_LAYER MARK_FLOOR_LAYER(8 + TOPDOWN_LAYER)
+#define WIRE_LAYER MARK_FLOOR_LAYER(9 + TOPDOWN_LAYER)
+#define GLASS_FLOOR_LAYER MARK_FLOOR_LAYER(10 + TOPDOWN_LAYER)
+#define TRAM_RAIL_LAYER MARK_FLOOR_LAYER(11 + TOPDOWN_LAYER)
 ///catwalk overlay of /turf/open/floor/plating/catwalk_floor
-#define CATWALK_LAYER (12 + TOPDOWN_LAYER)
-#define ABOVE_OPEN_TURF_LAYER (13 + TOPDOWN_LAYER)
+#define CATWALK_LAYER MARK_FLOOR_LAYER(12 + TOPDOWN_LAYER)
+#define ABOVE_OPEN_TURF_LAYER MARK_FLOOR_LAYER(13 + TOPDOWN_LAYER)
 
 //WALL_PLANE layers
 #define BELOW_CLOSED_TURF_LAYER 2.053


### PR DESCRIPTION
## About The Pull Request

StrongDMM seemingly does not support plane as a layering aspect at ALL. 
This means we cannot rely on it to segment the floor plane from everything else.

Fun bonus, StrongDMM ALSO doesn't know about TOPDOWN_LAYER, so rather then treating it as a rendering instruction it treats it literally.

SOOO for the sake of mappers, we have to normalize our layering from `1 + TOPDOWN_LAYER -> 13 + TOPDOWN_LAYER` to `1.8 -> 2` See https://www.desmos.com/calculator/4wbxbctzsm

We accomplish this using MAP_SWITCH. Life is pain.

Before (Normal)
![image](https://github.com/tgstation/tgstation/assets/58055496/c4376b65-2ff4-472f-a6b5-d0d792940e96)
Before (Removing turfs)
![image](https://github.com/tgstation/tgstation/assets/58055496/fc2e37a3-4b01-4a6d-b808-76cffa227fdc)
After
![image](https://github.com/tgstation/tgstation/assets/58055496/65492051-1bf4-4541-a7d5-c3cc340d484c)

