### PR TITLE
Fixes knight helmets being flammable

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -395,6 +395,7 @@
 	armor_type = /datum/armor/helmet_knight
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	resistance_flags = null
 	strip_delay = 80
 	dog_fashion = null
 	clothing_traits = list(TRAIT_HEAD_INJURY_BLOCKED)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -395,7 +395,7 @@
 	armor_type = /datum/armor/helmet_knight
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	resistance_flags = null
+	resistance_flags = NONE
 	strip_delay = 80
 	dog_fashion = null
 	clothing_traits = list(TRAIT_HEAD_INJURY_BLOCKED)


### PR DESCRIPTION

## About The Pull Request

Knight helmets are flammable despite being made of metal. That's probably not intended.

## Why It's Good For The Game

I was set on fire and the only thing that did burn while wearing my fullplate armor was my helmet for some reason? So this resolves that. They're not fire immune, by the way, they just don't burn as though made of fabric.

## Changelog
:cl:
fix: Knight helmets no longer burn as though made of cloth.
/:cl:
