### PR TITLE
Various minor fixes for the remaining shuttles

### DIFF
--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -79,7 +79,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/mobile/supply{
-	dir = 4
+	dir = 4;
+	port_direction = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -91,7 +91,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/docking_port/mobile/supply{
-	dir = 4
+	dir = 4;
+	port_direction = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -140,7 +140,8 @@
 /area/shuttle/supply)
 "R" = (
 /obj/docking_port/mobile/supply{
-	dir = 4
+	dir = 4;
+	port_direction = 8
 	},
 /obj/machinery/door/airlock/shuttle{
 	name = "Supply Shuttle Airlock"

--- a/_maps/shuttles/ert_bounty.dmm
+++ b/_maps/shuttles/ert_bounty.dmm
@@ -18,7 +18,9 @@
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "hunter shuttle";
 	rechargeTime = 1800;
-	shuttle_id = "huntership"
+	shuttle_id = "huntership";
+	port_direction = 4;
+	preferred_direction = 4
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
@@ -205,7 +207,9 @@
 /area/shuttle/hunter)
 "H" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
-	dir = 8
+	dir = 8;
+	y_offset = 6;
+	x_offset = 3
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/hunter)

--- a/_maps/shuttles/ferry_base.dmm
+++ b/_maps/shuttles/ferry_base.dmm
@@ -48,7 +48,7 @@
 	dir = 8;
 	shuttle_id = "ferry";
 	name = "ferry shuttle";
-	port_direction = 2
+	preferred_direction = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -142,7 +142,7 @@
 	dir = 8;
 	shuttle_id = "ferry";
 	name = "The Lighthouse";
-	port_direction = 2
+	preferred_direction = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)

--- a/_maps/shuttles/ferry_meat.dmm
+++ b/_maps/shuttles/ferry_meat.dmm
@@ -105,7 +105,7 @@
 	dir = 8;
 	shuttle_id = "ferry";
 	name = "ferry shuttle";
-	port_direction = 2
+	preferred_direction = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/shuttle/transport)

--- a/code/datums/shuttles/arrival.dm
+++ b/code/datums/shuttles/arrival.dm
@@ -26,10 +26,6 @@
 	suffix = "pubby"
 	name = "arrival shuttle (Pubby)"
 
-/datum/map_template/shuttle/arrival/omega
-	suffix = "omega"
-	name = "arrival shuttle (Omega)"
-
 /datum/map_template/shuttle/arrival/northstar
 	suffix = "northstar"
 	name = "arrival shuttle (North Star)"

--- a/code/datums/shuttles/cargo.dm
+++ b/code/datums/shuttles/cargo.dm
@@ -11,10 +11,6 @@
 	suffix = "birdboat"
 	name = "supply shuttle (Birdboat)"
 
-/datum/map_template/shuttle/cargo/donut
-	suffix = "donut"
-	name = "supply shuttle (Donut)"
-
 /datum/map_template/shuttle/cargo/pubby
 	suffix = "pubby"
 	name = "supply shuttle (Pubby)"

--- a/code/datums/shuttles/ferry.dm
+++ b/code/datums/shuttles/ferry.dm
@@ -33,8 +33,3 @@
 	suffix = "kilo"
 	name = "kilo transport ferry"
 	description = "Standard issue CentCom Ferry for Kilo pattern stations. Includes additional equipment and rechargers."
-
-/datum/map_template/shuttle/ferry/northstar
-	suffix = "northstar"
-	name = "north star transport ferry"
-	description = "In the very depths of the frontier, you'll need a rugged shuttle capable of delivering crew, this is that."


### PR DESCRIPTION

## About The Pull Request
Final part of the 5 part series of fixing all the shuttles. This one is mostly more of the same except that there were a few shuttles that had templates so they would show up in the shuttle manipulator but seemingly there is no actual map file for them.
<details>
  <summary>Full changes</summary>

-  Fixed the following shuttles flying in unexpected directions: ferry_base.dmm*, ferry_meat.dmm, ferry_lighthouse.dmm, ert_bounty, cargo_kilo.dmm, cargo_pubby.dmm, cargo_delta.dmm
- Fixed ert_bounty.dmm having incorrect offsets in its navigation console
- Removed: the Northstar ferry template, Omegastation arrivals shuttle template, Donutstation cargo ferry template: I don't think any of these shuttles exist. I looked around in the map folder and couldn't find any of them. Trying to load one of them in the shuttle manipulator will just cause a runtime because it cant find a docking port. I don't know if I just missed these or if they don't exist, but it seems like the latter.

*The ferry is kind of debateable on which direction it's supposed to fly because it has engines on both sides but i'm going with the side that has more engines being the "back"

</details>

## Why It's Good For The Game
All the shuttles should now fly in their intended directions and all the navigation consoles should all be centred so they're usable. The templates were removed because it doesn't really make sense to have entries in the shuttle manipulator for shuttles that don't exist and cannot be spawned.

## Changelog
:cl:

del: Removed the shuttle manipulator entries for the following shuttles: Northstar ferry, Omegastation arrivals shuttle, and Donutstation cargo ferry. (These shuttles didn't actually exist but they still had entries in the manipulator.)

fix: Fixed the following shuttles flying in unexpected directions: Basic CC Ferry, Meat Ferry, Lighthouse Ferry, ERT bounty shuttle, Kilo cargo shuttle, Pubby cargo shuttle, and Delta cargo shuttle.

fix: Fixed the ERT bounty shuttle having incorrect offsets in the shuttle navigation console.

/:cl:
