### PR TITLE
Adds .38 ANCR Rounds (Bluespace grounding rounds)

### DIFF
--- a/code/game/objects/items/implants/security/implant_noteleport.dm
+++ b/code/game/objects/items/implants/security/implant_noteleport.dm
@@ -48,7 +48,7 @@
 	desc = "A smaller bluespace grounding implant that supplies power for only a few minutes."
 	implant_flags = NONE
 	///How long before this implant self-deletes?
-	var/lifespan = 5 MINUTES
+	var/lifespan = 1 MINUTES
 	///The id of the timer that's qdeleting us
 	var/timerid
 

--- a/code/game/objects/items/implants/security/implant_noteleport.dm
+++ b/code/game/objects/items/implants/security/implant_noteleport.dm
@@ -42,3 +42,24 @@
 	name = "implant case - 'Bluespace Grounding'"
 	desc = "A glass case containing a bluespace grounding implant."
 	imp_type = /obj/item/implant/teleport_blocker
+
+/obj/item/implant/teleport_blocker/c38
+	name = "ANCR implant"
+	desc = "A smaller bluespace grounding implant that supplies power for only a few minutes."
+	implant_flags = NONE
+	///How long before this implant self-deletes?
+	var/lifespan = 5 MINUTES
+	///The id of the timer that's qdeleting us
+	var/timerid
+
+/obj/item/implant/teleport_blocker/c38/implant(mob/living/target, mob/user, silent, force)
+	. = ..()
+	timerid = QDEL_IN_STOPPABLE(src, lifespan)
+
+/obj/item/implant/teleport_blocker/c38/removed(mob/living/source, silent, special)
+	. = ..()
+	deltimer(timerid)
+	timerid = null
+
+/obj/item/implant/teleport_blocker/c38/Destroy()
+	return ..()

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -67,3 +67,8 @@
 	name = ".38 Iceblox bullet casing"
 	desc = "A .38 Iceblox bullet casing."
 	projectile_type = /obj/projectile/bullet/c38/iceblox
+
+/obj/item/ammo_casing/c38/ancr
+	name = ".38 ANCR bullet casing"
+	desc = "A .38 \"ANCR\" bullet casing."
+	projectile_type = /obj/projectile/bullet/c38/ancr

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -78,6 +78,12 @@
 	ammo_type = /obj/item/ammo_casing/c38/iceblox
 	ammo_band_color = "#658e94"
 
+/obj/item/ammo_box/c38/ancr
+	name = "speed loader (.38 ANCR)"
+	desc = "Designed to quickly reload revolvers. ANCR bullets embed a bluespace grounding implant within the target's body."
+	ammo_type = /obj/item/ammo_casing/c38/ancr
+	ammo_band_color = "#00008b"
+
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"
 	icon_state = "9mmbox"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -78,6 +78,24 @@
 		imp = new /obj/item/implant/tracking/c38(M)
 		imp.implant(M)
 
+/obj/projectile/bullet/c38/ancr
+	name = ".38 ANCR bullet"
+	damage = 10
+	ricochets_max = 0
+
+/obj/projectile/bullet/c38/ancr/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+	var/mob/living/carbon/victim = target
+	if(!istype(victim))
+		return
+	var/obj/item/implant/teleport_blocker/c38/imp
+	for(var/obj/item/implant/teleport_blocker/c38/TI in victim.implants) //checks if the target already contains a tracking implant
+		imp = TI
+		return
+	if(!imp)
+		imp = new /obj/item/implant/teleport_blocker/c38(victim)
+		imp.implant(victim)
+
 /obj/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".38 Hot Shot bullet"
 	damage = 20

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -47,6 +47,18 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
+/datum/design/c38_ancr
+	name = "Speed Loader (.38 ANCR) (Less Lethal)"
+	desc = "Designed to quickly reload revolvers. ANCR bullets embed a bluespace grounding implant within the target's body."
+	id = "c38_ancr"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT * 2.5)
+	build_path = /obj/item/ammo_box/c38/ancr
+	category = list(
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
 /datum/design/c38_rubber
 	name = "Speed Loader (.38 Rubber) (Less Lethal)"
 	desc = "Designed to quickly reload revolvers. Rubber bullets are bouncy and less-than-lethal."

--- a/code/modules/research/techweb/nodes/security_nodes.dm
+++ b/code/modules/research/techweb/nodes/security_nodes.dm
@@ -78,6 +78,7 @@
 		"c38_hotshot",
 		"c38_iceblox",
 		"techshotshell",
+		"c38_ancr",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 	discount_experiments = list(/datum/experiment/ordnance/explosive/highyieldbomb = TECHWEB_TIER_4_POINTS)


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/10399117/91abdd18-6f2d-4e64-bb34-fef3b55cc9a9)
![image](https://github.com/tgstation/tgstation/assets/10399117/c510b02f-f6eb-48f4-bdd5-d2c5508dd535)
![image](https://github.com/tgstation/tgstation/assets/10399117/c414d600-7ba0-4d12-9843-a26960782a19)
Adds the ANCR rounds (it's short for "anchor"), a low-damage 38 caliber round that implants a temporary bluespace grounding implant, much like its sister ammo, the TRAC round.
ANCR rounds are available under the Exotic Ammo techweb node, like Hotshot/Iceblox rounds.
The lifespan is only a minute, which is forever in combat time, but completely shutting down escapes is more powerful than simply tracking where they went.

## Why It's Good For The Game

Adds a late-round solution for slippery teleport-spamming antags, Further aligns the detective as a support role for security like how TRAC rounds enable similar behavior, but in a more direct way.

## Changelog
:cl:
add: ANCR .38 rounds, exotic ammo technode. 38 bullets that implant a short-lived bluespace grounding implant.
/:cl:
