### PR TITLE
Fisherman's Discernment show list of fish properly

### DIFF
--- a/code/datums/components/fishing_spot.dm
+++ b/code/datums/components/fishing_spot.dm
@@ -42,7 +42,7 @@
 		return
 
 	var/has_known_fishes = FALSE
-	for(var/reward in fish_source.fish_counts)
+	for(var/reward in fish_source.fish_table)
 		if(!ispath(reward, /obj/item/fish))
 			continue
 		var/obj/item/fish/prototype = reward
@@ -60,7 +60,7 @@
 		return
 
 	var/list/known_fishes = list()
-	for(var/reward in fish_source.fish_counts)
+	for(var/reward in fish_source.fish_table)
 		if(!ispath(reward, /obj/item/fish))
 			continue
 		var/obj/item/fish/prototype = reward


### PR DESCRIPTION

## About The Pull Request

For some reason fish spot examine use fish_counts instead of fish_table and only show limited fishes. (if there were any at all). So I change it

## Why It's Good For The Game

Bug fix I guess

## Changelog

:cl:
fix:  Examining a fishing spot twice with sufficiently high fishing skill (or the skillchip) will get you a list of fishes that can ACTUALLY be caught
/:cl:
