### PR TITLE
Converts common speech modifiers into a component

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -163,3 +163,8 @@
 /// from /datum/status_effect/limp/proc/check_step(mob/whocares, OldLoc, Dir, forced) iodk where it shuld go
 #define COMSIG_CARBON_LIMPING "mob_limp_check"
 	#define COMPONENT_CANCEL_LIMP (1<<0)
+
+///Called from on_acquiring(mob/living/carbon/human/acquirer)
+#define COMSIG_MUTATION_GAINED "mutation_gained"
+///Called from on_losing(mob/living/carbon/human/owner)
+#define COMSIG_MUTATION_LOST "mutation_lost"

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -1,0 +1,116 @@
+/// Used to apply certain speech patterns
+/// Can be used on organs, wearables, mutations and mobs
+/datum/component/speechmod
+	/// Assoc list for strings/regexes and their replacements. Should be lowercase, as case will be automatically changed
+	var/list/replacements = list()
+	/// String added to the end of the message
+	var/end_string = ""
+	/// Chance for the end string to be applied
+	var/end_string_chance = 100
+	/// Current target for modification
+	var/mob/targeted
+	/// Slot tags in which this item works when equipped
+	var/slots
+	/// If set to true, turns all text to uppercase
+	var/uppercase = FALSE
+
+/datum/component/speechmod/Initialize(replacements = list(), end_string = "", end_string_chance = 100, slots, uppercase = FALSE)
+	if (!ismob(parent) && !isitem(parent) && !istype(parent, /datum/mutation/human))
+		return COMPONENT_INCOMPATIBLE
+
+	src.replacements = replacements
+	src.end_string = end_string
+	src.end_string_chance = end_string_chance
+	src.slots = slots
+	src.uppercase = uppercase
+
+	if (istype(parent, /datum/mutation/human))
+		RegisterSignal(parent, COMSIG_MUTATION_GAINED, PROC_REF(on_mutation_gained))
+		RegisterSignal(parent, COMSIG_MUTATION_LOST, PROC_REF(on_mutation_lost))
+		return
+
+	var/atom/owner = parent
+
+	if (ismob(parent))
+		targeted = parent
+		RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+		return
+
+	if (ismob(owner.loc))
+		targeted = owner.loc
+		RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equipped))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_unequipped))
+	RegisterSignal(parent, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_implanted))
+	RegisterSignal(parent, COMSIG_ORGAN_REMOVED, PROC_REF(on_removed))
+
+/datum/component/speechmod/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message[1] == "*")
+		return
+
+	for (var/to_replace in replacements)
+		var/replacement = replacements[to_replace]
+		// Values can be lists to be picked randomly from
+		if (islist(replacement))
+			replacement = pick(replacement)
+
+		message = replacetextEx(message, to_replace, replacement)
+	message = trim(message)
+	if (prob(end_string_chance))
+		message += islist(end_string) ? pick(end_string) : end_string
+	speech_args[SPEECH_MESSAGE] = trim(message)
+
+	if (uppercase)
+		return COMPONENT_UPPERCASE_SPEECH
+
+/datum/component/speechmod/proc/on_equipped(datum/source, mob/living/user, slot)
+	SIGNAL_HANDLER
+
+	if (!isnull(slots) && !(slot & slots))
+		if (!isnull(targeted))
+			UnregisterSignal(targeted, COMSIG_MOB_SAY)
+			targeted = null
+		return
+
+	targeted = user
+	RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/component/speechmod/proc/on_unequipped(datum/source, mob/living/user)
+	SIGNAL_HANDLER
+
+	if (isnull(targeted))
+		return
+	UnregisterSignal(targeted, COMSIG_MOB_SAY)
+	targeted = null
+
+/datum/component/speechmod/proc/on_implanted(datum/source, mob/living/carbon/receiver)
+	SIGNAL_HANDLER
+
+	targeted = receiver
+	RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/component/speechmod/proc/on_removed(datum/source, mob/living/carbon/former_owner)
+	SIGNAL_HANDLER
+
+	if (isnull(targeted))
+		return
+	UnregisterSignal(targeted, COMSIG_MOB_SAY)
+	targeted = null
+
+/datum/component/speechmod/proc/on_mutation_gained(datum/source, mob/living/carbon/human/owner)
+	SIGNAL_HANDLER
+
+	targeted = owner
+	RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/component/speechmod/proc/on_mutation_lost(datum/source, mob/living/carbon/human/owner)
+	SIGNAL_HANDLER
+
+	if (isnull(targeted))
+		return
+	UnregisterSignal(targeted, COMSIG_MOB_SAY)
+	targeted = null

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -76,6 +76,9 @@
 			targeted = null
 		return
 
+	if (targeted == user)
+		return
+
 	targeted = user
 	RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
@@ -90,6 +93,9 @@
 /datum/component/speechmod/proc/on_implanted(datum/source, mob/living/carbon/receiver)
 	SIGNAL_HANDLER
 
+	if (targeted == receiver)
+		return
+
 	targeted = receiver
 	RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
@@ -103,6 +109,9 @@
 
 /datum/component/speechmod/proc/on_mutation_gained(datum/source, mob/living/carbon/human/owner)
 	SIGNAL_HANDLER
+
+	if (targeted == owner)
+		return
 
 	targeted = owner
 	RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -132,6 +132,7 @@
 	owner = acquirer
 	dna = acquirer.dna
 	dna.mutations += src
+	SEND_SIGNAL(src, COMSIG_MUTATION_GAINED, acquirer)
 	if(text_gain_indication)
 		to_chat(owner, text_gain_indication)
 	if(visual_indicators.len)
@@ -158,6 +159,7 @@
 	if(!istype(owner) || !(owner.dna.mutations.Remove(src)))
 		return TRUE
 	. = FALSE
+	SEND_SIGNAL(src, COMSIG_MUTATION_LOST, owner)
 	if(text_lose_indication && owner.stat != DEAD)
 		to_chat(owner, text_lose_indication)
 	if(visual_indicators.len)

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -20,6 +20,9 @@
 		TRAIT_STUNIMMUNE,
 	)
 
+/datum/mutation/human/hulk/New(class, timer, datum/mutation/human/copymut)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = list("." = "!"), end_string = "!!", uppercase = TRUE)
 
 /datum/mutation/human/hulk/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -29,7 +32,6 @@
 	owner.update_body_parts()
 	owner.add_mood_event("hulk", /datum/mood_event/hulk)
 	RegisterSignal(owner, COMSIG_LIVING_EARLY_UNARMED_ATTACK, PROC_REF(on_attack_hand))
-	RegisterSignal(owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 	RegisterSignal(owner, COMSIG_MOB_CLICKON, PROC_REF(check_swing))
 
 /datum/mutation/human/hulk/proc/on_attack_hand(mob/living/carbon/human/source, atom/target, proximity, modifiers)
@@ -91,20 +93,7 @@
 	owner.update_body_parts()
 	owner.clear_mood_event("hulk")
 	UnregisterSignal(owner, COMSIG_LIVING_EARLY_UNARMED_ATTACK)
-	UnregisterSignal(owner, COMSIG_MOB_SAY)
 	UnregisterSignal(owner, COMSIG_MOB_CLICKON)
-
-/datum/mutation/human/hulk/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message)
-		message = "[replacetext(message, ".", "!")]!!"
-	speech_args[SPEECH_MESSAGE] = message
-
-	// the reason we don't just uppertext(message) in this proc is so that our hulk speech
-	// can uppercase all other speech moidifiers after they are done (by returning COMPONENT_UPPERCASE_SPEECH)
-	return COMPONENT_UPPERCASE_SPEECH
 
 /// How many steps it takes to throw the mob
 #define HULK_TAILTHROW_STEPS 28

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -177,30 +177,11 @@
 	quality = MINOR_NEGATIVE
 	text_gain_indication = span_notice("You feel Swedish, however that works.")
 	text_lose_indication = span_notice("The feeling of Swedishness passes.")
+	var/static/list/language_mutilation = list("w" = "v", "j" = "y", "bo" = "bjo", "a" = list("å","ä","æ","a"), "o" = list("ö","ø","o"))
 
-/datum/mutation/human/swedish/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
-		return
-	RegisterSignal(owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-/datum/mutation/human/swedish/on_losing(mob/living/carbon/human/owner)
-	if(..())
-		return
-	UnregisterSignal(owner, COMSIG_MOB_SAY)
-
-/datum/mutation/human/swedish/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message)
-		message = replacetext(message,"w","v")
-		message = replacetext(message,"j","y")
-		message = replacetext(message,"a",pick("å","ä","æ","a"))
-		message = replacetext(message,"bo","bjo")
-		message = replacetext(message,"o",pick("ö","ø","o"))
-		if(prob(30))
-			message += " Bork[pick("",", bork",", bork, bork")]!"
-		speech_args[SPEECH_MESSAGE] = trim(message)
+/datum/mutation/human/swedish/New(class, timer, datum/mutation/human/copymut)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = language_mutilation, end_string = list("",", bork",", bork, bork"), end_string_chance = 30)
 
 /datum/mutation/human/chav
 	name = "Chav"
@@ -210,35 +191,9 @@
 	text_gain_indication = span_notice("Ye feel like a reet prat like, innit?")
 	text_lose_indication = span_notice("You no longer feel like being rude and sassy.")
 
-/datum/mutation/human/chav/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
-		return
-	RegisterSignal(owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-/datum/mutation/human/chav/on_losing(mob/living/carbon/human/owner)
-	if(..())
-		return
-	UnregisterSignal(owner, COMSIG_MOB_SAY)
-
-/datum/mutation/human/chav/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = " [message]"
-		var/list/chav_words = strings("chav_replacement.json", "chav")
-
-		for(var/key in chav_words)
-			var/value = chav_words[key]
-			if(islist(value))
-				value = pick(value)
-
-			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
-			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
-			message = replacetextEx(message, " [key]", " [value]")
-		if(prob(30))
-			message += ", mate"
-		speech_args[SPEECH_MESSAGE] = trim(message)
+/datum/mutation/human/chav/New(class, timer, datum/mutation/human/copymut)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = strings("chav_replacement.json", "chav"), end_string = ", mate", end_string_chance = 30)
 
 /datum/mutation/human/elvis
 	name = "Elvis"
@@ -247,6 +202,10 @@
 	quality = MINOR_NEGATIVE
 	text_gain_indication = span_notice("You feel pretty good, honeydoll.")
 	text_lose_indication = span_notice("You feel a little less conversation would be great.")
+
+/datum/mutation/human/chav/New(class, timer, datum/mutation/human/copymut)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = strings("elvis_replacement.json", "elvis"))
 
 /datum/mutation/human/elvis/on_life(seconds_per_tick, times_fired)
 	switch(pick(1,2))
@@ -258,34 +217,6 @@
 		if(2)
 			if(SPT_PROB(7.5, seconds_per_tick))
 				owner.visible_message("<b>[owner]</b> [pick("jiggles their hips", "rotates their hips", "gyrates their hips", "taps their foot", "dances to an imaginary song", "jiggles their legs", "snaps their fingers")]!")
-
-/datum/mutation/human/elvis/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
-		return
-	RegisterSignal(owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-/datum/mutation/human/elvis/on_losing(mob/living/carbon/human/owner)
-	if(..())
-		return
-	UnregisterSignal(owner, COMSIG_MOB_SAY)
-
-/datum/mutation/human/elvis/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message)
-		message = " [message] "
-		message = replacetext(message," i'm not "," I ain't ")
-		message = replacetext(message," girl ",pick(" honey "," baby "," baby doll "))
-		message = replacetext(message," man ",pick(" son "," buddy "," brother"," pal "," friendo "))
-		message = replacetext(message," out of "," outta ")
-		message = replacetext(message," thank you "," thank you, thank you very much ")
-		message = replacetext(message," thanks "," thank you, thank you very much ")
-		message = replacetext(message," what are you "," whatcha ")
-		message = replacetext(message," yes ",pick(" sure", "yea "))
-		message = replacetext(message," muh valids "," my kicks ")
-		speech_args[SPEECH_MESSAGE] = trim(message)
-
 
 /datum/mutation/human/stoner
 	name = "Stoner"

--- a/code/game/machinery/dna_infuser/organ_sets/fly_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fly_organs.dm
@@ -42,17 +42,11 @@
 	toxic_foodtypes = NONE // these fucks eat vomit, i am sure they can handle drinking bleach or whatever too
 	modifies_speech = TRUE
 	languages_native = list(/datum/language/buzzwords)
+	var/static/list/speech_replacements = list(new /regex("z+", "g") = "zzz", new /regex("Z+", "g") = "ZZZ", "s" = "z", "S" = "Z")
 
-/obj/item/organ/internal/tongue/fly/modify_speech(datum/source, list/speech_args)
-	var/static/regex/fly_buzz = new("z+", "g")
-	var/static/regex/fly_buZZ = new("Z+", "g")
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = fly_buzz.Replace(message, "zzz")
-		message = fly_buZZ.Replace(message, "ZZZ")
-		message = replacetext(message, "s", "z")
-		message = replacetext(message, "S", "Z")
-	speech_args[SPEECH_MESSAGE] = message
+/obj/item/organ/internal/tongue/fly/New(class, timer, datum/mutation/human/copymut)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = speech_replacements)
 
 /obj/item/organ/internal/tongue/fly/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/head/frenchberet.dm
+++ b/code/modules/clothing/head/frenchberet.dm
@@ -6,37 +6,17 @@
 	greyscale_config_worn = /datum/greyscale_config/beret/worn
 	greyscale_colors = "#972A2A"
 
+/obj/item/clothing/head/frenchberet/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = strings("french_replacement.json", "french"), end_string = list(" Honh honh honh!"," Honh!"," Zut Alors!"), end_string_chance = 3, slots = ITEM_SLOT_HEAD)
 
 /obj/item/clothing/head/frenchberet/equipped(mob/M, slot)
 	. = ..()
 	if (slot & ITEM_SLOT_HEAD)
-		RegisterSignal(M, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 		ADD_TRAIT(M, TRAIT_GARLIC_BREATH, type)
 	else
-		UnregisterSignal(M, COMSIG_MOB_SAY)
 		REMOVE_TRAIT(M, TRAIT_GARLIC_BREATH, type)
 
 /obj/item/clothing/head/frenchberet/dropped(mob/M)
 	. = ..()
-	UnregisterSignal(M, COMSIG_MOB_SAY)
 	REMOVE_TRAIT(M, TRAIT_GARLIC_BREATH, type)
-
-/obj/item/clothing/head/frenchberet/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = " [message]"
-		var/list/french_words = strings("french_replacement.json", "french")
-
-		for(var/key in french_words)
-			var/value = french_words[key]
-			if(islist(value))
-				value = pick(value)
-
-			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
-			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
-			message = replacetextEx(message, " [key]", " [value]")
-
-		if(prob(3))
-			message += pick(" Honh honh honh!"," Honh!"," Zut Alors!")
-	speech_args[SPEECH_MESSAGE] = trim(message)

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -8,7 +8,6 @@
 	strip_delay = 40
 	equip_delay_other = 40
 	visor_vars_to_toggle = NONE
-	var/modifies_speech = FALSE
 	var/adjusted_flags = null
 	///Did we install a filtering cloth?
 	var/has_filter = FALSE
@@ -24,31 +23,6 @@
 		clothing_flags ^= (VOICEBOX_DISABLED)
 		var/status = !(clothing_flags & VOICEBOX_DISABLED)
 		to_chat(user, span_notice("You turn the voice box in [src] [status ? "on" : "off"]."))
-
-/obj/item/clothing/mask/equipped(mob/M, slot)
-	. = ..()
-	if ((slot & ITEM_SLOT_MASK) && modifies_speech)
-		RegisterSignal(M, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-	else
-		UnregisterSignal(M, COMSIG_MOB_SAY)
-
-/obj/item/clothing/mask/dropped(mob/M)
-	. = ..()
-	UnregisterSignal(M, COMSIG_MOB_SAY)
-
-/obj/item/clothing/mask/vv_edit_var(vname, vval)
-	if(vname == NAMEOF(src, modifies_speech) && ismob(loc))
-		var/mob/M = loc
-		if(M.get_item_by_slot(ITEM_SLOT_MASK) == src)
-			if(vval)
-				if(!modifies_speech)
-					RegisterSignal(M, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-			else if(modifies_speech)
-				UnregisterSignal(M, COMSIG_MOB_SAY)
-	return ..()
-
-/obj/item/clothing/mask/proc/handle_speech()
-	SIGNAL_HANDLER
 
 /obj/item/clothing/mask/worn_overlays(mutable_appearance/standing, isinhands = FALSE)
 	. = ..()

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -34,31 +34,10 @@
 	inhand_icon_state = null
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
-	modifies_speech = TRUE
 
-/obj/item/clothing/mask/luchador/handle_speech(datum/source, list/speech_args)
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = replacetext(message, "captain", "CAPITÁN")
-		message = replacetext(message, "station", "ESTACIÓN")
-		message = replacetext(message, "sir", "SEÑOR")
-		message = replacetext(message, "the ", "el ")
-		message = replacetext(message, "my ", "mi ")
-		message = replacetext(message, "is ", "es ")
-		message = replacetext(message, "it's", "es")
-		message = replacetext(message, "friend", "amigo")
-		message = replacetext(message, "buddy", "amigo")
-		message = replacetext(message, "hello", "hola")
-		message = replacetext(message, " hot", " caliente")
-		message = replacetext(message, " very ", " muy ")
-		message = replacetext(message, "sword", "espada")
-		message = replacetext(message, "library", "biblioteca")
-		message = replacetext(message, "traitor", "traidor")
-		message = replacetext(message, "wizard", "mago")
-		message = uppertext(message) //Things end up looking better this way (no mixed cases), and it fits the macho wrestler image.
-		if(prob(25))
-			message += " OLE!"
-	speech_args[SPEECH_MESSAGE] = message
+/obj/item/clothing/head/frenchberet/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = strings("luchador_replacement.json", "luchador"), end_string = " OLE!", end_string_chance = 25, uppercase = TRUE, slots = ITEM_SLOT_MASK)
 
 /obj/item/clothing/mask/luchador/tecnicos
 	name = "Tecnicos Mask"

--- a/code/modules/clothing/masks/gondola.dm
+++ b/code/modules/clothing/masks/gondola.dm
@@ -5,18 +5,7 @@
 	inhand_icon_state = null
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
-	modifies_speech = TRUE
 
-/obj/item/clothing/mask/gondola/handle_speech(datum/source, list/speech_args)
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = " [message]"
-		var/list/spurdo_words = strings("spurdo_replacement.json", "spurdo")
-		for(var/key in spurdo_words)
-			var/value = spurdo_words[key]
-			if(islist(value))
-				value = pick(value)
-			message = replacetextEx(message,regex(uppertext(key),"g"), "[uppertext(value)]")
-			message = replacetextEx(message,regex(capitalize(key),"g"), "[capitalize(value)]")
-			message = replacetextEx(message,regex(key,"g"), "[value]")
-	speech_args[SPEECH_MESSAGE] = trim(message)
+/obj/item/clothing/mask/gondola/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = strings("spurdo_replacement.json", "spurdo"), slots = ITEM_SLOT_MASK)

--- a/code/modules/clothing/masks/moustache.dm
+++ b/code/modules/clothing/masks/moustache.dm
@@ -10,23 +10,7 @@
 /obj/item/clothing/mask/fakemoustache/italian
 	name = "italian moustache"
 	desc = "Made from authentic Italian moustache hairs. Gives the wearer an irresistable urge to gesticulate wildly."
-	modifies_speech = TRUE
 
-/obj/item/clothing/mask/fakemoustache/italian/handle_speech(datum/source, list/speech_args)
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = " [message]"
-		var/list/italian_words = strings("italian_replacement.json", "italian")
-
-		for(var/key in italian_words)
-			var/value = italian_words[key]
-			if(islist(value))
-				value = pick(value)
-
-			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
-			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
-			message = replacetextEx(message, " [key]", " [value]")
-
-		if(prob(3))
-			message += pick(" Ravioli, ravioli, give me the formuoli!"," Mamma-mia!"," Mamma-mia! That's a spicy meat-ball!", " La la la la la funiculi funicula!")
-	speech_args[SPEECH_MESSAGE] = trim(message)
+/obj/item/clothing/mask/fakemoustache/italian/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = strings("italian_replacement.json", "italian"), end_string = list(" Ravioli, ravioli, give me the formuoli!"," Mamma-mia!"," Mamma-mia! That's a spicy meat-ball!", " La la la la la funiculi funicula!"), end_string_chance = 3, slots = ITEM_SLOT_MASK)

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -184,23 +184,11 @@
 	liked_foodtypes = GORE | MEAT | SEAFOOD | NUTS | BUGS
 	disliked_foodtypes = GRAIN | DAIRY | CLOTH | GROSS
 	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.9,aresample=%SAMPLE_RATE%,atempo=1/0.9,aformat=channel_layouts=mono,volume=0.2 [p0]; [out2] asetrate=%SAMPLE_RATE%*1.1,aresample=%SAMPLE_RATE%,atempo=1/1.1,aformat=channel_layouts=mono,volume=0.2[p2]; [p0][0][p2] amix=inputs=3"}
+	var/static/list/speech_replacements = list(new /regex("s+", "g") = "sss", new /regex("S+", "g") = "SSS", new /regex(@"(\w)x", "g") = "$1kss", new /regex(@"(\w)X", "g") = "$1KSSS", new /regex(@"\bx([\-|r|R]|\b)", "g") = "ecks$1", new /regex(@"\bX([\-|r|R]|\b)", "g") = "ECKS$1")
 
-/obj/item/organ/internal/tongue/lizard/modify_speech(datum/source, list/speech_args)
-	var/static/regex/lizard_hiss = new("s+", "g")
-	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_kss = new(@"(\w)x", "g")
-	var/static/regex/lizard_kSS = new(@"(\w)X", "g")
-	var/static/regex/lizard_ecks = new(@"\bx([\-|r|R]|\b)", "g")
-	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = lizard_hiss.Replace(message, "sss")
-		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_kss.Replace(message, "$1kss")
-		message = lizard_kSS.Replace(message, "$1KSS")
-		message = lizard_ecks.Replace(message, "ecks$1")
-		message = lizard_eckS.Replace(message, "ECKS$1")
-	speech_args[SPEECH_MESSAGE] = message
+/obj/item/organ/internal/tongue/lizard/New(class, timer, datum/mutation/human/copymut)
+	. = ..()
+	AddComponent(/datum/component/speechmod, replacements = speech_replacements)
 
 /obj/item/organ/internal/tongue/lizard/silver
 	name = "silver tongue"

--- a/strings/elvis_replacement.json
+++ b/strings/elvis_replacement.json
@@ -1,0 +1,13 @@
+{
+    "elvis": {
+		"i'm not ": "I ain't ",
+		" girl ": [" honey ", " baby ", " baby doll "],
+		" man ": [" son ", " buddy ", " brother ", " pal ", " friendo "],
+		" out of ": " outta ",
+		" thank you ": " thank you, thank you very much ",
+		" thanks ": " thank you, thank you very much ",
+		" what are you": " whatcha ",
+		" yes": [" sure ", " yea "],
+		" muh valids ": " my kicks "
+		}
+}

--- a/strings/luchador_replacement.json
+++ b/strings/luchador_replacement.json
@@ -1,0 +1,20 @@
+{
+	"luchador": {
+		"captain": "CAPITÁN",
+		"station": "ESTACIÓN",
+		"sir": "SEÑOR",
+		"the ": "el ",
+		"my ": "mi ",
+		"is ": "es ",
+		"it's": "es",
+		"friend": "amigo",
+		"buddy": "amigo",
+		"hello": "hola",
+		" hot": " caliente",
+		" very ": " muy ",
+		"sword": "espada",
+		"library": "biblioteca",
+		"traitor": "traidor",
+		"wizard": "mago"
+		}
+}

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1205,6 +1205,7 @@
 #include "code\datums\components\soulstoned.dm"
 #include "code\datums\components\sound_player.dm"
 #include "code\datums\components\spawner.dm"
+#include "code\datums\components\speechmod.dm"
 #include "code\datums\components\spill.dm"
 #include "code\datums\components\spin2win.dm"
 #include "code\datums\components\spinny.dm"


### PR DESCRIPTION

## About The Pull Request

Added a ``/datum/component/speechmod`` component which can be used to perform basic speech modifications. It use either simple replacements or regex, add a string at the end of any message (at a chance if required) and convert speech to uppercase. However, a good chunk of speechmods are far too niche and specific to be put into a speechmod component and thus have been left alone.

## Why It's Good For The Game

Cuts down on copypasted code, makes making new speechmods easier.

## Changelog
:cl:
refactor: Refactored a lot of speech modifiers to use a component instead of copied over code.
/:cl:
