### PR TITLE
Band-aid fix to Wawastation cryo cell

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -82497,7 +82497,7 @@ kFT
 mTZ
 hQK
 dPg
-fvo
+kFT
 jPO
 osT
 dci

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -32302,6 +32302,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ltk" = (


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/tgstation/assets/96586172/523aee83-20fe-482d-952c-56a705f6bb49)

Cryo cells don't function for some reason when below a window.
## Why It's Good For The Game
## Changelog
:cl: grungussuss
fix: Wawastation medbay's second cryo cell will work now
/:cl:
