### PR TITLE
Fixes ninja's adrenaline boost modsuit module not recharging

### DIFF
--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -418,11 +418,7 @@
 	if(IS_SPACE_NINJA(mod.wearer))
 		mod.wearer.say(pick_list_replacements(NINJA_FILE, "lines"), forced = type)
 	to_chat(mod.wearer, span_notice("You have used the adrenaline boost."))
-	mod.wearer.SetUnconscious(0)
-	mod.wearer.SetStun(0)
-	mod.wearer.SetKnockdown(0)
-	mod.wearer.SetImmobilized(0)
-	mod.wearer.SetParalyzed(0)
+	mod.wearer.SetAllImmobility(0)
 	mod.wearer.adjustStaminaLoss(-200)
 	mod.wearer.remove_status_effect(/datum/status_effect/speech/stutter)
 	mod.wearer.reagents.add_reagent(/datum/reagent/medicine/stimulants, 5)
@@ -430,24 +426,18 @@
 	addtimer(CALLBACK(src, PROC_REF(boost_aftereffects), mod.wearer), 7 SECONDS)
 
 /obj/item/mod/module/adrenaline_boost/on_install()
-	RegisterSignal(mod, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
+	RegisterSignal(mod, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(try_boost))
 
 /obj/item/mod/module/adrenaline_boost/on_uninstall(deleting = FALSE)
-	UnregisterSignal(mod, COMSIG_ATOM_ATTACKBY)
+	UnregisterSignal(mod, COMSIG_ATOM_ITEM_INTERACTION)
 
-/obj/item/mod/module/adrenaline_boost/attackby(obj/item/attacking_item, mob/user, params)
-	if(charge_boost(attacking_item, user))
-		return TRUE
-	return ..()
-
-/obj/item/mod/module/adrenaline_boost/proc/on_attackby(datum/source, obj/item/attacking_item, mob/user)
+/obj/item/mod/module/adrenaline_boost/proc/try_boost(source, mob/user, obj/item/attacking_item)
 	SIGNAL_HANDLER
-
-	if(charge_boost(attacking_item, user))
+	if(charge_boost(attacking_item))
 		return COMPONENT_NO_AFTERATTACK
 	return NONE
 
-/obj/item/mod/module/adrenaline_boost/proc/charge_boost(obj/item/attacking_item, mob/user)
+/obj/item/mod/module/adrenaline_boost/proc/charge_boost(obj/item/attacking_item)
 	if(!attacking_item.is_open_container())
 		return FALSE
 	if(reagents.has_reagent(reagent_required, reagent_required_amount))


### PR DESCRIPTION

## About The Pull Request
Makes `adrenaline_boost ` use higher attack chain signal, so you can actually recharge it instead of putting beaker in modsuit storage.
## Why It's Good For The Game
Functioning modsuit modules are good
## Changelog
:cl:

fix: fixed ninja's adrenaline boost module not being rechargable
/:cl:
