### PR TITLE
Crafting accepts machine subtypes

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -75,8 +75,14 @@
 		if(contents[requirement_path] < R.chem_catalysts[requirement_path])
 			return FALSE
 
+	var/mech_found = FALSE
 	for(var/machinery_path in R.machinery)
-		if(!machines[machinery_path])//We don't care for volume with machines, just if one is there or not
+		mech_found = FALSE
+		for(var/obj/machinery/machine as anything in machines)
+			if(ispath(machine, machinery_path))//We don't care for volume with machines, just if one is there or not
+				mech_found = TRUE
+				break
+		if(!mech_found)
 			return FALSE
 
 	for(var/required_structure_path in R.structures)


### PR DESCRIPTION
## About The Pull Request
- Fixes #84664

## Changelog
:cl:
fix: you can craft the singulo hammer with either a supermatter engine/shard again
/:cl:
