### PR TITLE
Adds kitchen knife to cytology closet prefab

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54911,7 +54911,6 @@
 	pixel_y = 4
 	},
 /obj/item/wrench,
-/obj/item/knife/kitchen,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "tsT" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -8783,10 +8783,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/rack,
 /obj/item/wrench,
-/obj/item/knife/kitchen{
-	pixel_x = 6;
-	pixel_y = 2
-	},
 /obj/item/soap{
 	pixel_y = -2
 	},

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -40,3 +40,4 @@
 		new /obj/item/biopsy_tool(src)
 		new /obj/item/storage/box/swab(src)
 	new /obj/item/reagent_containers/condiment/protein(src)
+	new /obj/item/knife/kitchen(src)


### PR DESCRIPTION

## About The Pull Request

A kitchen knife is very useful to people doing cytology, since a lot of samples come from dead monkeys. Meta and Wawa were the only maps which actually started with one, so I removed those and just added it to the prefab locker that spawns in every Cytology Lab.
## Why It's Good For The Game

Fixes #84466.

Important tools should be available to everyone doing the job that requires them.
## Changelog
:cl: Vekter
fix: Standardized the availability of a kitchen knife for cytology on all maps.
/:cl:
