### PR TITLE
Fix hacker alias name preference not working

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -60,7 +60,7 @@
 		var/datum/action/avatar_domain_info/action = new(help_datum)
 		action.Grant(avatar)
 
-	var/client/our_client = old_body.client
+	var/client/our_client = avatar.client
 	var/alias = our_client?.prefs?.read_preference(/datum/preference/name/hacker_alias) || pick(GLOB.hacker_aliases)
 
 	if(alias && avatar.real_name != alias)


### PR DESCRIPTION

## About The Pull Request

So recently bitrunner avatars were made to use stereotypical gamertag names, which introduced a new preference for 'hacker alias'.
This, however, didn't seem to actually work, and would always select a random gamertag.

Looking into it, this seemed to be because it uses `old_body.client`:
https://github.com/tgstation/tgstation/blob/bd14e92d04f3dc4fd7aa06a9c49b04ec05bcc172/code/modules/bitrunning/components/avatar_connection.dm#L63-L64
Which at this point in the code would return `null`.
Making it use `avatar.client` instead seems to fix our issue.
## Why It's Good For The Game

Fixes hacker alias name preference not working.
## Changelog
:cl:
fix: Fixes hacker alias name preference not working.
/:cl:
