### PR TITLE
Add skibidi to chaplain brain damage triggers

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain.dm
@@ -78,8 +78,8 @@
 				else
 					holy_bible.deity_name = pick("Gay Space Jesus", "Gandalf", "Dumbledore")
 			human_spawned.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // starts off brain damaged as fuck
-		if("lol", "wtf", "poo", "badmin", "shitmin", "deadmin", "meme", "memes")
-			new_bible = pick("Woody's Got Wood: The Aftermath", "Sweet Bro and Hella Jeff: Expanded Edition","F.A.T.A.L. Rulebook")
+		if("lol", "wtf", "poo", "badmin", "shitmin", "deadmin", "meme", "memes", "skibidi")
+			new_bible = pick("Woody's Got Wood: The Aftermath", "Sweet Bro and Hella Jeff: Expanded Edition","F.A.T.A.L. Rulebook", "Toilet Humor")
 			switch(new_bible)
 				if("Woody's Got Wood: The Aftermath")
 					holy_bible.deity_name = pick("Woody", "Andy", "Cherry Flavored Lube")
@@ -87,6 +87,8 @@
 					holy_bible.deity_name = pick("Sweet Bro", "Hella Jeff", "Stairs", "AH")
 				if("F.A.T.A.L. Rulebook")
 					holy_bible.deity_name = "Twenty Ten-Sided Dice"
+				if("Toilet Humor")
+					holy_bible.deity_name = pick("Skibidi Toilet", "Skibidi Wizard", "Skibidi Bathtub", "John Skibidi", "Skibidi Skibidi", "G-Toilet 1.0", "John Freeman")
 			human_spawned.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // also starts off brain damaged as fuck
 		if("servicianism", "partying")
 			holy_bible.desc = "Happy, Full, Clean. Live it and give it."


### PR DESCRIPTION

## About The Pull Request
Adds `skibidi` to the chaplain deity brain damage triggers, with related names for the bible and the deity added too
## Why It's Good For The Game
🧑 
🚽 
## Changelog
:cl: lorwp
add: using 'skibidi' as a chaplain deity now gives you brain damage
/:cl:
