### PR TITLE
Adjusts medical techweb nodes

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -481,10 +481,10 @@
 
 	/datum/experiment/scanning/reagent/haloperidol
 	name = "Pure Haloperidol Scan"
-	description = "We require testing related to the long-term treatment of chronic psychiatric disorders. Produce Haloperidol with at least 99% purity and scan the beaker."
+	description = "We require testing related to the long-term treatment of chronic psychiatric disorders. Produce Haloperidol with at least 98% purity and scan the beaker."
 	performance_hint = "Exothermic and consumes hydrogen during reaction."
 	required_reagent = /datum/reagent/medicine/haloperidol
-	min_purity = 0.99
+	min_purity = 0.98
 
 /datum/experiment/scanning/points/bluespace_crystal
 	name = "Bluespace Crystal Sampling"

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -479,7 +479,7 @@
 	required_reagent = /datum/reagent/cryostylane
 	min_purity = 0.99
 
-	/datum/experiment/scanning/reagent/haloperidol
+/datum/experiment/scanning/reagent/haloperidol
 	name = "Pure Haloperidol Scan"
 	description = "We require testing related to the long-term treatment of chronic psychiatric disorders. Produce Haloperidol with at least 98% purity and scan the beaker."
 	performance_hint = "Exothermic and consumes hydrogen during reaction."

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -479,6 +479,13 @@
 	required_reagent = /datum/reagent/cryostylane
 	min_purity = 0.99
 
+	/datum/experiment/scanning/reagent/haloperidol
+	name = "Pure Haloperidol Scan"
+	description = "We require testing related to the long-term treatment of chronic psychiatric disorders. Produce Haloperidol with at least 99% purity and scan the beaker."
+	performance_hint = "Exothermic and consumes hydrogen during reaction."
+	required_reagent = /datum/reagent/medicine/haloperidol
+	min_purity = 0.99
+
 /datum/experiment/scanning/points/bluespace_crystal
 	name = "Bluespace Crystal Sampling"
 	description = "Investigate the properties of bluespace crystals by scanning either an artificial or naturally occurring variant. This will help us deepen our understanding of bluespace phenomena."

--- a/code/modules/research/techweb/nodes/atmos_nodes.dm
+++ b/code/modules/research/techweb/nodes/atmos_nodes.dm
@@ -49,7 +49,6 @@
 	description = "Experiments with high-pressure gases and electricity resulting in crystallization and controlled plasma reactions."
 	prereq_ids = list(TECHWEB_NODE_GAS_COMPRESSION, TECHWEB_NODE_ENERGY_MANIPULATION)
 	design_ids = list(
-		"crystallizer",
 		"electrolyzer",
 		"pipe_scrubber",
 		"pacman",
@@ -75,6 +74,7 @@
 		"bolter_wrench",
 		"rpd_loaded",
 		"engine_goggles",
+		"crystallizer",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -69,26 +69,11 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 
-/datum/techweb_node/cryostasis
-	id = TECHWEB_NODE_CRYOSTASIS
-	display_name = "Cryostasis"
-	description = "The result of clown accidentally drinking a chemical, now repurposed for safely preserving crew members in suspended animation."
-	prereq_ids = list(TECHWEB_NODE_PLUMBING, TECHWEB_NODE_PLASMA_CONTROL)
-	design_ids = list(
-		"cryotube",
-		"mech_sleeper",
-		"stasis",
-		"cryo_grenade",
-		"splitbeaker",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
-	required_experiments = list(/datum/experiment/scanning/reagent/cryostylane)
-
 /datum/techweb_node/medbay_equip_adv
 	id = TECHWEB_NODE_MEDBAY_EQUIP_ADV
 	display_name = "Advanced Medbay Equipment"
 	description = "State-of-the-art medical gear for keeping the crew in one piece — mostly."
-	prereq_ids = list(TECHWEB_NODE_CRYOSTASIS)
+	prereq_ids = list(TECHWEB_NODE_PLUMBING)
 	design_ids = list(
 		"smoke_machine",
 		"chem_mass_spec",
@@ -99,4 +84,19 @@
 		"defibmount",
 		"medicalbed_emergency",
 	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
+
+/datum/techweb_node/cryostasis
+	id = TECHWEB_NODE_CRYOSTASIS
+	display_name = "Cryostasis"
+	description = "The result of clown accidentally drinking a chemical, now repurposed for safely preserving crew members in suspended animation."
+	prereq_ids = list(TECHWEB_NODE_MEDBAY_EQUIP_ADV, TECHWEB_NODE_PLASMA_CONTROL)
+	design_ids = list(
+		"cryotube",
+		"mech_sleeper",
+		"stasis",
+		"cryo_grenade",
+		"splitbeaker",
+	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
+	required_experiments = list(/datum/experiment/scanning/reagent/cryostylane)

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -85,12 +85,13 @@
 		"medicalbed_emergency",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
+	required_experiments = list(/datum/experiment/scanning/reagent/haloperidol)
 
 /datum/techweb_node/cryostasis
 	id = TECHWEB_NODE_CRYOSTASIS
 	display_name = "Cryostasis"
 	description = "The result of clown accidentally drinking a chemical, now repurposed for safely preserving crew members in suspended animation."
-	prereq_ids = list(TECHWEB_NODE_MEDBAY_EQUIP_ADV, TECHWEB_NODE_PLASMA_CONTROL)
+	prereq_ids = list(TECHWEB_NODE_FUSION)
 	design_ids = list(
 		"cryotube",
 		"mech_sleeper",
@@ -99,4 +100,4 @@
 		"splitbeaker",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
-	required_experiments = list(/datum/experiment/scanning/reagent/cryostylane)
+	discount_experiments = list(/datum/experiment/scanning/reagent/cryostylane = TECHWEB_TIER_4_POINTS)

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -33,6 +33,8 @@
 		/datum/experiment/autopsy/human,
 		/datum/experiment/autopsy/nonhuman,
 		/datum/experiment/autopsy/xenomorph,
+		/datum/experiment/scanning/reagent/haloperidol,
+		/datum/experiment/scanning/reagent/cryostylane,
 	)
 
 /datum/techweb_node/chem_synthesis


### PR DESCRIPTION
## About The Pull Request

Swaps 'advanced medbay equipment' and 'cryostasis' on the medbay tech tree, adjusting the required experiments and prerequisites as necessary.

## Why It's Good For The Game

Items like health analyzers, pinpointers, defibs and medical beds are lower tech, commonly used items and should come before  advanced cryo technology, not the other way around.

## Changelog

:cl: LT3
balance: Advanced Medbay Equipment research node lowered to tier 3
balance: Advanced Medbay Equipment now requires haloperidol scan experiment
balance: Haloperidol and cryostylane experiments can be performed roundstart
balance: Cryostasis research node raised to tier 4
balance: Cryostasis now has Fusion instead of Controlled Plasma as a prerequisite
balance: Cryostasis cryostylane scan is now a discount experiment
balance: Crystallizer moved from Controlled Plasma to Fusion
/:cl: