### PR TITLE
Fixes the randomization of external organs and species features

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -469,7 +469,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		generate_dna_blocks()
 	if(randomize_features)
 		for(var/species_type in GLOB.species_prototypes)
-			features |= GLOB.species_prototypes[species_type].randomize_features()
+			features += GLOB.species_prototypes[species_type].randomize_features()
 
 		features["mcolor"] = "#[random_color()]"
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -469,7 +469,9 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		generate_dna_blocks()
 	if(randomize_features)
 		for(var/species_type in GLOB.species_prototypes)
-			features += GLOB.species_prototypes[species_type].randomize_features()
+			var/list/new_features = GLOB.species_prototypes[species_type].randomize_features()
+			for(var/feature in new_features)
+				features[feature] = new_features[feature]
 
 		features["mcolor"] = "#[random_color()]"
 


### PR DESCRIPTION

## About The Pull Request

Humanoids would not have their external organs and features change when being randomized (with mulligans, for example).
The ´|=´ operator does nothing if the features list of the humanoid is already populated (i.e. we're not creating the humanoid). This new block instead overwrites each entry of the list.
## Why It's Good For The Game
Bugfix. This broke mulligan among some other things.
## Changelog
:cl:
fix: humanoid species featured are randomized correctly once again
/:cl:
