### PR TITLE
Allow copying blast door controller ids onto shutters/blast doors directly

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -56,6 +56,9 @@
 	if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS && istype(held_item, /obj/item/electronics/airlock))
 		context[SCREENTIP_CONTEXT_LMB] = "Add electronics"
 		return CONTEXTUAL_SCREENTIP_SET
+	if(deconstruction == BLASTDOOR_FINISHED && istype(held_item, /obj/item/assembly/control))
+		context[SCREENTIP_CONTEXT_LMB] = "Calibrate ID"
+		return CONTEXTUAL_SCREENTIP_SET
 	//we do not check for special effects like if they can actually perform the action because they will be told they can't do it when they try,
 	//with feedback on what they have to do in order to do so.
 	switch(held_item.tool_behaviour)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -40,7 +40,7 @@
 	if(panel_open)
 		if(deconstruction == BLASTDOOR_FINISHED)
 			. += span_notice("The maintenance panel is opened and the electronics could be <b>pried</b> out.")
-			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b>.")
+			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b> or a <b>blast door controller</b>.")
 		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
 			. += span_notice("The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.")
 		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -112,7 +112,6 @@
 			return ITEM_INTERACT_BLOCKING
 		var/obj/item/assembly/control/controller_item = tool
 		id = controller_item.id
-		to_chat(user, span_notice("You change the ID to [id]."))
 		balloon_alert(user, "id changed")
 		return ITEM_INTERACT_SUCCESS
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -99,6 +99,20 @@
 		balloon_alert(user, "electronics added")
 		deconstruction = BLASTDOOR_FINISHED
 		return ITEM_INTERACT_SUCCESS
+
+	if(deconstruction == BLASTDOOR_FINISHED && istype(tool, /obj/item/assembly/control))
+		if(density)
+			balloon_alert(user, "open the door first!")
+			return ITEM_INTERACT_BLOCKING
+		if(!panel_open)
+			balloon_alert(user, "open the panel first!")
+			return ITEM_INTERACT_BLOCKING
+		var/obj/item/assembly/control/controller_item = tool
+		id = controller_item.id
+		to_chat(user, span_notice("You change the ID to [id]."))
+		balloon_alert(user, "id changed")
+		return ITEM_INTERACT_SUCCESS
+
 	return NONE
 
 /obj/machinery/door/poddoor/screwdriver_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION

## About The Pull Request

So having built new shutters quite a bit, and having had to fix existing shutters a few times, needing to open a UI for every shutter you configure sucks- especially when fixing roundstart shutters requires you to reset the ID on all of the ones in the set to make them work again.

In this pr we simply add a new item interaction to blast doors/shutters where using a blast door controller on an open blast door/shutter with an open panel copies its ID onto it, to avoid needing to open a UI more than once (to configure the blast door controller). Then we just add examine and screentip info for this interaction.

You still need a multitool to configure the blast door controller itself, and it has the same state requirements as configuring it with a multitool would. You just no longer need to open the UI and set it manually if you already have a configured controller.
## Why It's Good For The Game

So currently, you must open an ID input UI for each shutter you build, which is _awful_ when building more than a few.
Generally, it's nicer to not need to open an additional UI each time when you're basically repeating the same action.
You still need a multitool to set the blast door controller ID, you still need to have them be open and screwdriver open the panels, you just no longer need to menu as much.

On top of that, all roundstart shutters use a non-numeric ID that you _cannot_ set manually!
So imagine for a moment the situation where someone breaks _exactly one_ of the kitchen's roundstart shutters.
Sure, you can rebuild the shutter, but you can't set the ID to what it was before- so the button doesn't work on it.
Instead, to have the button work again, you must now go through and manually reset _every other kitchen shutter_.
This _sucks_.
This pr addresses that by letting you just take the blast door controller out of the button and use it to reset the one new replacement shutter, and then put it back in the button and have it just work again.
## Changelog
:cl:
qol: You can now copy blast door controller IDs directly onto shutters/blast doors, avoiding the need to open a menu for each one. Additionally, this lets you fix sets of roundstart shutters without needing to change the IDs on all of the ones in that set.
/:cl:
