### PR TITLE
Hydroponic trays take in reagents proportionally from plumbing mech

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -33,6 +33,8 @@
 #define PATCH (1<<3)
 /// Used for direct injection of reagents.
 #define INJECT (1<<4)
+/// Exclusive to just plumbing. if set we use the round robin technique else we use proportional
+#define LINEAR (1<<5)
 
 /// When returned by on_mob_life(), on_mob_dead(), overdose_start() or overdose_processed(), will cause the mob to updatehealth() afterwards
 #define UPDATE_MOB_HEALTH 1

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -94,7 +94,7 @@
 	process_request(dir = dir)
 
 ///check who can give us what we want, and how many each of them will give us
-/datum/component/plumbing/proc/process_request(amount = MACHINE_REAGENT_TRANSFER, reagent, dir)
+/datum/component/plumbing/proc/process_request(amount = MACHINE_REAGENT_TRANSFER, reagent, dir, round_robin = TRUE)
 	//find the duct to take from
 	var/datum/ductnet/net
 	if(!ducts.Find(num2text(dir)))
@@ -115,7 +115,7 @@
 	var/target_volume = reagents.total_volume + amount
 	for(var/datum/component/plumbing/give as anything in valid_suppliers)
 		currentRequest = (target_volume - reagents.total_volume) / suppliersLeft
-		give.transfer_to(src, currentRequest, reagent, net)
+		give.transfer_to(src, currentRequest, reagent, net, round_robin)
 		suppliersLeft--
 	return TRUE
 
@@ -134,11 +134,11 @@
 	return FALSE
 
 ///this is where the reagent is actually transferred and is thus the finish point of our process()
-/datum/component/plumbing/proc/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
+/datum/component/plumbing/proc/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, round_robin = TRUE)
 	if(!reagents || !target || !target.reagents)
 		return FALSE
 
-	reagents.trans_to(target.recipient_reagents_holder, amount, target_id = reagent)
+	reagents.trans_to(target.recipient_reagents_holder, amount, target_id = reagent, methods = round_robin ? LINEAR : NONE)
 
 ///We create our luxurious piping overlays/underlays, to indicate where we do what. only called once if use_overlays = TRUE in Initialize()
 /datum/component/plumbing/proc/create_overlays(atom/movable/parent_movable, list/overlays)
@@ -376,46 +376,3 @@
 
 	// Defer to later frame because pixel_* is actually updated after all callbacks
 	addtimer(CALLBACK(parent_obj, TYPE_PROC_REF(/atom/, update_appearance)), 0.1 SECONDS)
-
-///has one pipe input that only takes, example is manual output pipe
-/datum/component/plumbing/simple_demand
-	demand_connects = SOUTH
-
-///has one pipe output that only supplies. example is liquid pump and manual input pipe
-/datum/component/plumbing/simple_supply
-	supply_connects = SOUTH
-
-///input and output, like a holding tank
-/datum/component/plumbing/tank
-	demand_connects = WEST
-	supply_connects = EAST
-
-/datum/component/plumbing/manifold
-	demand_connects = NORTH
-	supply_connects = SOUTH
-
-/datum/component/plumbing/manifold/change_ducting_layer(obj/caller, obj/changer, new_layer)
-	return
-
-#define READY 2
-///Baby component for the buffer plumbing machine
-/datum/component/plumbing/buffer
-	demand_connects = WEST
-	supply_connects = EAST
-
-/datum/component/plumbing/buffer/Initialize(start=TRUE, _turn_connects=TRUE, _ducting_layer, datum/reagents/custom_receiver)
-	if(!istype(parent, /obj/machinery/plumbing/buffer))
-		return COMPONENT_INCOMPATIBLE
-
-	return ..()
-
-/datum/component/plumbing/buffer/can_give(amount, reagent, datum/ductnet/net)
-	var/obj/machinery/plumbing/buffer/buffer = parent
-	return (buffer.mode == READY) ? ..() : FALSE
-
-#undef READY
-
-///Lazily demand from any direction. Overlays won't look good, and the aquarium sprite occupies about the entire 32x32 area anyway.
-/datum/component/plumbing/aquarium
-	demand_connects = SOUTH|NORTH|EAST|WEST
-	use_overlays = FALSE

--- a/code/datums/components/plumbing/buffer.dm
+++ b/code/datums/components/plumbing/buffer.dm
@@ -1,0 +1,17 @@
+#define READY 2
+
+/datum/component/plumbing/buffer
+	demand_connects = WEST
+	supply_connects = EAST
+
+/datum/component/plumbing/buffer/Initialize(start = TRUE, _turn_connects = TRUE, _ducting_layer, datum/reagents/custom_receiver)
+	if(!istype(parent, /obj/machinery/plumbing/buffer))
+		return COMPONENT_INCOMPATIBLE
+
+	return ..()
+
+/datum/component/plumbing/buffer/can_give(amount, reagent, datum/ductnet/net)
+	var/obj/machinery/plumbing/buffer/buffer = parent
+	return (buffer.mode == READY) ? ..() : FALSE
+
+#undef READY

--- a/code/datums/components/plumbing/filter.dm
+++ b/code/datums/components/plumbing/filter.dm
@@ -22,7 +22,7 @@
 			if(!can_give_in_direction(direction, reagent))
 				return FALSE
 
-/datum/component/plumbing/filter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
+/datum/component/plumbing/filter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, round_robin = TRUE)
 	if(!reagents || !target || !target.reagents)
 		return FALSE
 	var/direction
@@ -31,7 +31,7 @@
 			direction = get_original_direction(text2num(A))
 			break
 	if(reagent)
-		reagents.trans_to(target.parent, amount, target_id = reagent)
+		reagents.trans_to(target.parent, amount, target_id = reagent, methods = round_robin ? LINEAR : NONE)
 	else
 		for(var/A in reagents.reagent_list)
 			var/datum/reagent/R = A
@@ -40,10 +40,11 @@
 			var/new_amount
 			if(R.volume < amount)
 				new_amount = amount - R.volume
-			reagents.trans_to(target.parent, amount, target_id = R.type)
+			reagents.trans_to(target.parent, amount, target_id = R.type, methods = round_robin ? LINEAR : NONE)
 			amount = new_amount
 			if(amount <= 0)
 				break
+
 ///We check if the direction and reagent are valid to give. Needed for filters since different outputs have different behaviours
 /datum/component/plumbing/filter/proc/can_give_in_direction(dir, reagent)
 	var/obj/machinery/plumbing/filter/F = parent

--- a/code/datums/components/plumbing/simple_components.dm
+++ b/code/datums/components/plumbing/simple_components.dm
@@ -1,0 +1,44 @@
+
+///has one pipe input that only takes, example is manual output pipe
+/datum/component/plumbing/simple_demand
+	demand_connects = SOUTH
+
+///has one pipe output that only supplies. example is liquid pump and manual input pipe
+/datum/component/plumbing/simple_supply
+	supply_connects = SOUTH
+
+///input and output, like a holding tank
+/datum/component/plumbing/tank
+	demand_connects = WEST
+	supply_connects = EAST
+
+/datum/component/plumbing/manifold
+	demand_connects = NORTH
+	supply_connects = SOUTH
+
+/datum/component/plumbing/manifold/change_ducting_layer(obj/caller, obj/changer, new_layer)
+	return
+
+///Baby component for the buffer plumbing machine
+#define READY 2
+
+/datum/component/plumbing/buffer
+	demand_connects = WEST
+	supply_connects = EAST
+
+/datum/component/plumbing/buffer/Initialize(start=TRUE, _turn_connects=TRUE, _ducting_layer, datum/reagents/custom_receiver)
+	if(!istype(parent, /obj/machinery/plumbing/buffer))
+		return COMPONENT_INCOMPATIBLE
+
+	return ..()
+
+/datum/component/plumbing/buffer/can_give(amount, reagent, datum/ductnet/net)
+	var/obj/machinery/plumbing/buffer/buffer = parent
+	return (buffer.mode == READY) ? ..() : FALSE
+
+#undef READY
+
+///Lazily demand from any direction. Overlays won't look good, and the aquarium sprite occupies about the entire 32x32 area anyway.
+/datum/component/plumbing/aquarium
+	demand_connects = SOUTH|NORTH|EAST|WEST
+	use_overlays = FALSE

--- a/code/datums/components/plumbing/simple_components.dm
+++ b/code/datums/components/plumbing/simple_components.dm
@@ -12,33 +12,15 @@
 	demand_connects = WEST
 	supply_connects = EAST
 
+///Lazily demand from any direction. Overlays won't look good, and the aquarium sprite occupies about the entire 32x32 area anyway.
+/datum/component/plumbing/aquarium
+	demand_connects = SOUTH|NORTH|EAST|WEST
+	use_overlays = FALSE
+
+///Connects different layer of ducts
 /datum/component/plumbing/manifold
 	demand_connects = NORTH
 	supply_connects = SOUTH
 
 /datum/component/plumbing/manifold/change_ducting_layer(obj/caller, obj/changer, new_layer)
 	return
-
-///Baby component for the buffer plumbing machine
-#define READY 2
-
-/datum/component/plumbing/buffer
-	demand_connects = WEST
-	supply_connects = EAST
-
-/datum/component/plumbing/buffer/Initialize(start=TRUE, _turn_connects=TRUE, _ducting_layer, datum/reagents/custom_receiver)
-	if(!istype(parent, /obj/machinery/plumbing/buffer))
-		return COMPONENT_INCOMPATIBLE
-
-	return ..()
-
-/datum/component/plumbing/buffer/can_give(amount, reagent, datum/ductnet/net)
-	var/obj/machinery/plumbing/buffer/buffer = parent
-	return (buffer.mode == READY) ? ..() : FALSE
-
-#undef READY
-
-///Lazily demand from any direction. Overlays won't look good, and the aquarium sprite occupies about the entire 32x32 area anyway.
-/datum/component/plumbing/aquarium
-	demand_connects = SOUTH|NORTH|EAST|WEST
-	use_overlays = FALSE

--- a/code/datums/components/plumbing/splitter.dm
+++ b/code/datums/components/plumbing/splitter.dm
@@ -29,7 +29,7 @@
 	return FALSE
 
 
-/datum/component/plumbing/splitter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
+/datum/component/plumbing/splitter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, round_robin = TRUE)
 	var/direction
 	for(var/A in ducts)
 		if(ducts[A] == net)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -249,7 +249,7 @@
 		// So we'll let it leak in, and move the water over.
 		set_recipient_reagents_holder(nutri_reagents)
 		reagents = nutri_reagents
-		process_request(dir = dir)
+		process_request(dir = dir, round_robin = FALSE)
 
 		// Move the leaked water from nutrients to... water
 		var/leaking_water_amount = nutri_reagents.get_reagent_amount(/datum/reagent/water)
@@ -267,7 +267,7 @@
 		process_request(
 			amount = extra_water_to_gather,
 			reagent = /datum/reagent/water,
-			dir = dir,
+			dir = dir
 		)
 
 	// Now transfer all remaining water in that buffer and clear it out.

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -109,16 +109,27 @@
  */
 /datum/reagents/plumbing
 
+/**
+ * Same as the trans_to except only a few arguments have impact here & the rest of the arguments are discarded.
+ * Arguments
+ *
+ * * atom/target - the target we are transfering to
+ * * amount - amount tot ransfer
+ * * datum/reagent/target_id - the reagent id we want to transfer. if null everything gets transfered
+ * * methods - this is key for deciding between round-robin or proportional transfer. It does not mean the same as the
+ * parent proc. LINEAR for round robin(in this technique reagents are missing/lost/not preserved when there isn't enough space to hold them)
+ * NONE means everything is transfered regardless of how much space is available in the receiver in proportions
+ */
 /datum/reagents/plumbing/trans_to(
 	atom/target,
 	amount = 1,
 	multiplier = 1, //unused for plumbing
 	datum/reagent/target_id,
-	preserve_data = TRUE, //unused for plumbing
+	preserve_data = FALSE, //unused for plumbing
 	no_react = FALSE, //unused for plumbing we always want reactions
 	mob/transferred_by, //unused for plumbing logging is not important inside plumbing machines
 	remove_blacklisted = FALSE, //unused for plumbing, we don't care what reagents are inside us
-	methods = NONE, //unused for plumbing
+	methods = LINEAR, //default round robin technique for transferring reagents
 	show_message = TRUE, //unused for plumbing, used for logging only
 	ignore_stomach = FALSE //unused for plumbing, reagents flow only between machines & is not injected to mobs at any point in time
 )
@@ -139,8 +150,6 @@
 	else
 		target_holder = target.reagents
 
-	var/cached_amount = amount
-
 	// Prevents small amount problems, as well as zero and below zero amounts.
 	amount = round(min(amount, total_volume, target_holder.maximum_volume - target_holder.total_volume), CHEMICAL_QUANTISATION_LEVEL)
 	if(amount <= 0)
@@ -153,32 +162,43 @@
 	var/list/reagents_to_remove = list()
 	var/transfer_amount
 	var/transfered_amount
-	var/to_transfer = amount
 	var/total_transfered_amount = 0
+
+	var/round_robin = methods & LINEAR
+	var/part
+	var/to_transfer
+	if(round_robin)
+		to_transfer = amount
+	else
+		part = amount / total_volume
 
 	//first add reagents to target
 	for(var/datum/reagent/reagent as anything in cached_reagents)
-		if(!to_transfer)
+		if(round_robin && !to_transfer)
 			break
 
 		if(!isnull(target_id))
 			if(reagent.type == target_id)
 				force_stop_reagent_reacting(reagent)
-				transfer_amount = min(to_transfer, reagent.volume)
+				transfer_amount = min(amount, reagent.volume)
 			else
 				continue
 		else
-			transfer_amount = min(to_transfer, reagent.volume)
+			if(round_robin)
+				transfer_amount = min(to_transfer, reagent.volume)
+			else
+				transfer_amount = reagent.volume * part
 
-		if(reagent.intercept_reagents_transfer(target_holder, cached_amount))
+		if(reagent.intercept_reagents_transfer(target_holder, amount))
 			continue
 
-		transfered_amount = target_holder.add_reagent(reagent.type, transfer_amount * multiplier, copy_data(reagent), chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT) //we only handle reaction after every reagent has been transferred.
+		transfered_amount = target_holder.add_reagent(reagent.type, transfer_amount, copy_data(reagent), chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT) //we only handle reaction after every reagent has been transferred.
 		if(!transfered_amount)
 			continue
 		reagents_to_remove += list(list("R" = reagent, "T" = transfer_amount))
 		total_transfered_amount += transfered_amount
-		to_transfer -= transfered_amount
+		if(round_robin)
+			to_transfer -= transfered_amount
 
 		if(!isnull(target_id))
 			break

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -110,11 +110,11 @@
 /datum/reagents/plumbing
 
 /**
- * Same as the trans_to except only a few arguments have impact here & the rest of the arguments are discarded.
+ * Same as the parent trans_to except only a few arguments have impact here & the rest of the arguments are discarded.
  * Arguments
  *
  * * atom/target - the target we are transfering to
- * * amount - amount tot ransfer
+ * * amount - amount to transfer
  * * datum/reagent/target_id - the reagent id we want to transfer. if null everything gets transfered
  * * methods - this is key for deciding between round-robin or proportional transfer. It does not mean the same as the
  * parent proc. LINEAR for round robin(in this technique reagents are missing/lost/not preserved when there isn't enough space to hold them)
@@ -125,7 +125,7 @@
 	amount = 1,
 	multiplier = 1, //unused for plumbing
 	datum/reagent/target_id,
-	preserve_data = FALSE, //unused for plumbing
+	preserve_data = TRUE, //unused for plumbing
 	no_react = FALSE, //unused for plumbing we always want reactions
 	mob/transferred_by, //unused for plumbing logging is not important inside plumbing machines
 	remove_blacklisted = FALSE, //unused for plumbing, we don't care what reagents are inside us

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -2,6 +2,7 @@
 	name = "chemical bottler"
 	desc = "Puts reagents into containers, like bottles and beakers in the tile facing the green light spot, they will exit on the red light spot if successfully filled."
 	icon_state = "bottler"
+	reagents = /datum/reagents
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
 	reagent_flags = TRANSPARENT | DRAINABLE

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -440,8 +440,6 @@
 			target_holder = target.reagents
 			target_atom = target
 
-	var/cached_amount = amount
-
 	// Prevents small amount problems, as well as zero and below zero amounts.
 	amount = round(min(amount, total_volume, target_holder.maximum_volume - target_holder.total_volume), CHEMICAL_QUANTISATION_LEVEL)
 	if(amount <= 0)
@@ -477,7 +475,7 @@
 
 		if(preserve_data)
 			trans_data = copy_data(reagent)
-		if(reagent.intercept_reagents_transfer(target_holder, cached_amount))
+		if(reagent.intercept_reagents_transfer(target_holder, amount))
 			continue
 		transfered_amount = target_holder.add_reagent(reagent.type, transfer_amount * multiplier, trans_data, chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT) //we only handle reaction after every reagent has been transferred.
 		if(!transfered_amount)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1295,6 +1295,7 @@
 #include "code\datums\components\pet_commands\pet_command.dm"
 #include "code\datums\components\pet_commands\pet_commands_basic.dm"
 #include "code\datums\components\plumbing\_plumbing.dm"
+#include "code\datums\components\plumbing\buffer.dm"
 #include "code\datums\components\plumbing\chemical_acclimator.dm"
 #include "code\datums\components\plumbing\filter.dm"
 #include "code\datums\components\plumbing\reaction_chamber.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1298,6 +1298,7 @@
 #include "code\datums\components\plumbing\chemical_acclimator.dm"
 #include "code\datums\components\plumbing\filter.dm"
 #include "code\datums\components\plumbing\reaction_chamber.dm"
+#include "code\datums\components\plumbing\simple_components.dm"
 #include "code\datums\components\plumbing\splitter.dm"
 #include "code\datums\components\riding\riding.dm"
 #include "code\datums\components\riding\riding_mob.dm"


### PR DESCRIPTION
## About The Pull Request
- Fixes #84699

The issue isn't with reagents getting transferred one at a time. Yes this happens inside plumbing machinery and it isn't an issue there because they are not processed but simply stored(until all reagents can get there) until it is transferred to another machine that requests it.

This however is a problem with hydroponic trays which both store & process those reagents. So when 1 reagent comes into the tray & if the tray gets full before the other reagents can get there it leads to missing fertilizers/nutrients in the tray causing problems in plant growth & such.

For e.g. if your ducts have reagents like 3u sodium, 7u ash & 5u water & the tray has space for only 10u reagents. Using round robin it takes in 3u sodium + 7u ash = 10u reagents. The 5u water is left out cause the 10u request is complete causing the plants to dehydrate & die.

Now trays are reverted to use the old "proportional method" of transferring reagents leading to trays getting all their nutrients from plumbing ducts. So using the old technique we get sodium + ash + water = 10u i.e. all reagents in the tray so the plants are happy

Additionally bottler also uses the old "proportional method" of transferring reagents so it pumps out all reagents into the beaker

## Changelog
:cl:
fix: hydroponic trays take in all reagents "proportionally" from plumbing ducts without leaving any behind
fix: plumbing bottler pumps out all reagents "proportionally" into output beakers
/:cl:

