### PR TITLE
Fixes a missing firelock on wawa

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -59990,6 +59990,7 @@
 "veF" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "veW" = (


### PR DESCRIPTION

## About The Pull Request
Wawa was missing a firelock on the second floor of cargo riiiight here
![image](https://github.com/tgstation/tgstation/assets/44720187/334b507e-47a5-4089-88bb-4241fc8b3d2e)
Which made the rest of the firelocks useless
## Why It's Good For The Game

Cargo/mining shuttle no longer vents both floors if someone forgets to close the doors.

## Changelog
:cl:
fix: Added a forgotten firelock on second floor of wawa
/:cl:
