### PR TITLE
Adds informed default values for a bunch of preferences (to produce less outlandish random characters)

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -28,6 +28,20 @@
 		else
 			return COLOR_BLACK
 
+/proc/random_hair_color()
+	var/static/list/natural_hair_colors = list(
+		"#111111", "#362925", "#3B3831", "#41250C", "#412922",
+		"#544C49", "#583322", "#593029", "#703b30", "#714721",
+		"#744729", "#74482a", "#7b746e", "#855832", "#863019",
+		"#8c4734", "#9F550E", "#A29A96", "#A4381C", "#B17B41",
+		"#C0BAB7", "#EFE5E4", "#F7F3F1", "#FFF2D6", "#a15537",
+		"#a17e61", "#b38b67", "#ba673c", "#c89f73", "#d9b380",
+		"#dbc9b8", "#e1621d", "#e17d17", "#e1af93", "#f1cc8f",
+		"#fbe7a1",
+	)
+
+	return pick(natural_hair_colors)
+
 /proc/random_underwear(gender)
 	if(length(SSaccessories.underwear_list) == 0)
 		CRASH("No underwear to choose from!")

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -38,16 +38,6 @@
  * (IE, no wacky hair styles / colors)
  */
 /proc/randomize_human_normie(mob/living/carbon/human/human, randomize_mutations = FALSE)
-	var/static/list/natural_hair_colors = list(
-		"#111111", "#362925", "#3B3831", "#41250C", "#412922",
-		"#544C49", "#583322", "#593029", "#703b30", "#714721",
-		"#744729", "#74482a", "#7b746e", "#855832", "#863019",
-		"#8c4734", "#9F550E", "#A29A96", "#A4381C", "#B17B41",
-		"#C0BAB7", "#EFE5E4", "#F7F3F1", "#FFF2D6", "#a15537",
-		"#a17e61", "#b38b67", "#ba673c", "#c89f73", "#d9b380",
-		"#dbc9b8", "#e1621d", "#e17d17", "#e1af93", "#f1cc8f",
-		"#fbe7a1",
-	)
 	// Sorry enbys but statistically you are not average enough
 	human.gender = human.dna.species.sexes ? pick(MALE, FEMALE) : PLURAL
 	human.physique = human.gender
@@ -57,14 +47,14 @@
 	human.eye_color_right = human.eye_color_left
 	human.skin_tone = pick(GLOB.skin_tones)
 	// No underwear generation handled here
-	var/picked_color = pick(natural_hair_colors)
+	var/picked_color = random_hair_color()
 	human.set_haircolor(picked_color, update = FALSE)
 	human.set_facial_haircolor(picked_color, update = FALSE)
 	var/datum/sprite_accessory/hairstyle = SSaccessories.hairstyles_list[random_hairstyle(human.gender)]
-	if(hairstyle?.natural_spawn)
+	if(hairstyle && hairstyle.natural_spawn && !hairstyle.locked)
 		human.set_hairstyle(hairstyle.name, update = FALSE)
 	var/datum/sprite_accessory/facial_hair = SSaccessories.facial_hairstyles_list[random_facial_hairstyle(human.gender)]
-	if(facial_hair?.natural_spawn)
+	if(facial_hair && facial_hair.natural_spawn && !hairstyle.locked)
 		human.set_facial_hairstyle(facial_hair.name, update = FALSE)
 	// Normal DNA init stuff, these can generally be wacky but we care less, they're aliens after all
 	human.dna.initialize_dna(newblood_type = random_blood_type(), create_mutation_blocks = randomize_mutations, randomize_features = TRUE)

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -54,7 +54,7 @@
 	if(hairstyle && hairstyle.natural_spawn && !hairstyle.locked)
 		human.set_hairstyle(hairstyle.name, update = FALSE)
 	var/datum/sprite_accessory/facial_hair = SSaccessories.facial_hairstyles_list[random_facial_hairstyle(human.gender)]
-	if(facial_hair && facial_hair.natural_spawn && !hairstyle.locked)
+	if(facial_hair && facial_hair.natural_spawn && !facial_hair.locked)
 		human.set_facial_hairstyle(facial_hair.name, update = FALSE)
 	// Normal DNA init stuff, these can generally be wacky but we care less, they're aliens after all
 	human.dna.initialize_dna(newblood_type = random_blood_type(), create_mutation_blocks = randomize_mutations, randomize_features = TRUE)

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -18,16 +18,19 @@
 /// support the "use gender" option.
 #define PREFERENCE_PRIORITY_BODY_TYPE 5
 
+/// Used for preferences that rely on body setup being finalized.
+#define PREFERENCE_PRORITY_LATE_BODY_TYPE 6
+
 /// Equpping items based on preferences.
 /// Should happen after species and body type to make sure it looks right.
 /// Mostly redundant, but a safety net for saving/loading.
-#define PREFERENCE_PRIORITY_LOADOUT 6
+#define PREFERENCE_PRIORITY_LOADOUT 7
 
 /// The priority at which names are decided, needed for proper randomization.
-#define PREFERENCE_PRIORITY_NAMES 7
+#define PREFERENCE_PRIORITY_NAMES 8
 
 /// Preferences that aren't names, but change the name changes set by PREFERENCE_PRIORITY_NAMES.
-#define PREFERENCE_PRIORITY_NAME_MODIFICATIONS 8
+#define PREFERENCE_PRIORITY_NAME_MODIFICATIONS 9
 
 /// The maximum preference priority, keep this updated, but don't use it for `priority`.
 #define MAX_PREFERENCE_PRIORITY PREFERENCE_PRIORITY_NAME_MODIFICATIONS

--- a/code/modules/client/preferences/age.dm
+++ b/code/modules/client/preferences/age.dm
@@ -8,3 +8,6 @@
 
 /datum/preference/numeric/age/apply_to_human(mob/living/carbon/human/target, value)
 	target.age = value
+
+/datum/preference/numeric/age/create_informed_default_value(datum/preferences/preferences)
+	return rand(max(minimum, 21), min(maximum, 50))

--- a/code/modules/client/preferences/blindfold_color.dm
+++ b/code/modules/client/preferences/blindfold_color.dm
@@ -4,6 +4,9 @@
 	savefile_key = "blindfold_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 
+/datum/preference/color/blindfold_color/create_default_value()
+	return COLOR_WHITE
+
 /datum/preference/color/blindfold_color/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE

--- a/code/modules/client/preferences/body_type.dm
+++ b/code/modules/client/preferences/body_type.dm
@@ -5,6 +5,7 @@
 	priority = PREFERENCE_PRIORITY_BODY_TYPE
 	savefile_key = "body_type"
 	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
 
 /datum/preference/choiced/body_type/init_possible_values()
 	return list(USE_GENDER, MALE, FEMALE)

--- a/code/modules/client/preferences/clothing.dm
+++ b/code/modules/client/preferences/clothing.dm
@@ -33,6 +33,9 @@
 		DMESSENGER,
 	)
 
+/datum/preference/choiced/backpack/create_default_value()
+	return GBACKPACK
+
 /datum/preference/choiced/backpack/icon_for(value)
 	switch (value)
 		if (GBACKPACK)
@@ -66,6 +69,7 @@
 /datum/preference/choiced/jumpsuit
 	savefile_key = "jumpsuit_style"
 	savefile_identifier = PREFERENCE_CHARACTER
+	priority = PREFERENCE_PRIORITY_BODY_TYPE
 	main_feature_name = "Jumpsuit"
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
@@ -86,6 +90,15 @@
 /datum/preference/choiced/jumpsuit/apply_to_human(mob/living/carbon/human/target, value)
 	target.jumpsuit_style = value
 
+/datum/preference/choiced/jumpsuit/create_informed_default_value(datum/preferences/preferences)
+	switch(preferences.read_preference(/datum/preference/choiced/gender))
+		if(MALE)
+			return PREF_SUIT
+		if(FEMALE)
+			return PREF_SKIRT
+
+	return ..()
+
 /// Socks preference
 /datum/preference/choiced/socks
 	savefile_key = "socks"
@@ -93,9 +106,13 @@
 	main_feature_name = "Socks"
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
+	can_randomize = FALSE
 
 /datum/preference/choiced/socks/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.socks_list)
+
+/datum/preference/choiced/socks/create_default_value()
+	return "Nude"
 
 /datum/preference/choiced/socks/icon_for(value)
 	var/static/icon/lower_half
@@ -117,9 +134,13 @@
 	main_feature_name = "Undershirt"
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
+	can_randomize = FALSE
 
 /datum/preference/choiced/undershirt/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.undershirt_list)
+
+/datum/preference/choiced/undershirt/create_default_value()
+	return "Nude"
 
 /datum/preference/choiced/undershirt/icon_for(value)
 	var/static/icon/body
@@ -152,9 +173,13 @@
 	main_feature_name = "Underwear"
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
+	can_randomize = FALSE
 
 /datum/preference/choiced/underwear/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.underwear_list)
+
+/datum/preference/choiced/underwear/create_default_value()
+	return "Nude"
 
 /datum/preference/choiced/underwear/icon_for(value)
 	var/static/icon/lower_half

--- a/code/modules/client/preferences/clothing.dm
+++ b/code/modules/client/preferences/clothing.dm
@@ -112,7 +112,7 @@
 	return assoc_to_keys_features(SSaccessories.socks_list)
 
 /datum/preference/choiced/socks/create_default_value()
-	return "Nude"
+	return /datum/sprite_accessory/socks/nude::name
 
 /datum/preference/choiced/socks/icon_for(value)
 	var/static/icon/lower_half
@@ -131,6 +131,7 @@
 /datum/preference/choiced/undershirt
 	savefile_key = "undershirt"
 	savefile_identifier = PREFERENCE_CHARACTER
+	priority = PREFERENCE_PRIORITY_BODY_TYPE
 	main_feature_name = "Undershirt"
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
@@ -140,7 +141,16 @@
 	return assoc_to_keys_features(SSaccessories.undershirt_list)
 
 /datum/preference/choiced/undershirt/create_default_value()
-	return "Nude"
+	return /datum/sprite_accessory/undershirt/nude::name
+
+/datum/preference/choiced/undershirt/create_informed_default_value(datum/preferences/preferences)
+	switch(preferences.read_preference(/datum/preference/choiced/gender))
+		if(MALE)
+			return /datum/sprite_accessory/undershirt/nude::name
+		if(FEMALE)
+			return /datum/sprite_accessory/undershirt/sports_bra::name
+
+	return ..()
 
 /datum/preference/choiced/undershirt/icon_for(value)
 	var/static/icon/body
@@ -179,7 +189,7 @@
 	return assoc_to_keys_features(SSaccessories.underwear_list)
 
 /datum/preference/choiced/underwear/create_default_value()
-	return "Nude"
+	return /datum/sprite_accessory/underwear/male_hearts::name
 
 /datum/preference/choiced/underwear/icon_for(value)
 	var/static/icon/lower_half

--- a/code/modules/client/preferences/gender.dm
+++ b/code/modules/client/preferences/gender.dm
@@ -11,3 +11,8 @@
 	if(!target.dna.species.sexes)
 		value = PLURAL //disregard gender preferences on this species
 	target.gender = value
+
+/datum/preference/choiced/gender/create_informed_default_value(datum/preferences/preferences)
+	// The only reason I'm limiting this to male or female
+	// is that hairstyle randomization handles enbies poorly
+	return pick(MALE, FEMALE)

--- a/code/modules/client/preferences/glasses.dm
+++ b/code/modules/client/preferences/glasses.dm
@@ -4,6 +4,9 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	should_generate_icons = TRUE
 
+/datum/preference/choiced/glasses/create_default_value()
+	return "Random"
+
 /datum/preference/choiced/glasses/init_possible_values()
 	return assoc_to_keys(GLOB.nearsighted_glasses) + "Random"
 

--- a/code/modules/client/preferences/language.dm
+++ b/code/modules/client/preferences/language.dm
@@ -3,6 +3,9 @@
 	savefile_key = "language"
 	savefile_identifier = PREFERENCE_CHARACTER
 
+/datum/preference/choiced/language/create_default_value()
+	return "Random"
+
 /datum/preference/choiced/language/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE

--- a/code/modules/client/preferences/prosthetic_limb.dm
+++ b/code/modules/client/preferences/prosthetic_limb.dm
@@ -3,6 +3,9 @@
 	savefile_key = "prosthetic"
 	savefile_identifier = PREFERENCE_CHARACTER
 
+/datum/preference/choiced/prosthetic/create_default_value()
+	return "Random"
+
 /datum/preference/choiced/prosthetic/init_possible_values()
 	return list("Random") + GLOB.prosthetic_limb_choice
 

--- a/code/modules/client/preferences/prosthetic_organ.dm
+++ b/code/modules/client/preferences/prosthetic_organ.dm
@@ -3,6 +3,9 @@
 	savefile_key = "prosthetic_organ"
 	savefile_identifier = PREFERENCE_CHARACTER
 
+/datum/preference/choiced/prosthetic_organ/create_default_value()
+	return "Random"
+
 /datum/preference/choiced/prosthetic_organ/init_possible_values()
 	return list("Random") + GLOB.organ_choice
 

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -123,17 +123,17 @@
 /datum/preference/choiced/facial_hair_gradient/create_default_value()
 	return "None"
 
-/datum/preference/color/facial_hair_gradient_color
+/datum/preference/color/facial_hair_gradient
 	priority = PREFERENCE_PRORITY_LATE_BODY_TYPE
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "facial_hair_gradient_color"
 	relevant_head_flag = HEAD_FACIAL_HAIR
 
-/datum/preference/color/facial_hair_gradient_color/apply_to_human(mob/living/carbon/human/target, value)
+/datum/preference/color/facial_hair_gradient/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_facial_hair_gradient_color(new_color = value, update = FALSE)
 
-/datum/preference/color/facial_hair_gradient_color/is_accessible(datum/preferences/preferences)
+/datum/preference/color/facial_hair_gradient/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
 	return preferences.read_preference(/datum/preference/choiced/facial_hair_gradient) != "None"

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -52,7 +52,7 @@
 	return random_eye_color()
 
 /datum/preference/choiced/facial_hairstyle
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRORITY_LATE_BODY_TYPE
 	savefile_key = "facial_style_name"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_FEATURES
@@ -69,6 +69,23 @@
 /datum/preference/choiced/facial_hairstyle/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_facial_hairstyle(value, update = FALSE)
 
+/datum/preference/choiced/facial_hairstyle/create_default_value()
+	return "Shaved"
+
+/datum/preference/choiced/facial_hairstyle/create_informed_default_value(datum/preferences/preferences)
+	var/gender = preferences.read_preference(/datum/preference/choiced/gender)
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species_real = GLOB.species_prototypes[species_type]
+	if(!gender || !species_real || !species_real.sexes)
+		return ..()
+
+	var/picked_beard = random_facial_hairstyle(gender)
+	var/datum/sprite_accessory/beard_style = SSaccessories.facial_hairstyles_list[picked_beard]
+	if(!beard_style || !beard_style.natural_spawn || beard_style.locked) // Invalid, go with god(bald)
+		return ..()
+
+	return picked_beard
+
 /datum/preference/choiced/facial_hairstyle/compile_constant_data()
 	var/list/data = ..()
 
@@ -77,7 +94,7 @@
 	return data
 
 /datum/preference/color/facial_hair_color
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRORITY_LATE_BODY_TYPE // Need to happen after hair oclor is set so we can match by default
 	savefile_key = "facial_hair_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
@@ -86,12 +103,16 @@
 /datum/preference/color/facial_hair_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_facial_haircolor(value, update = FALSE)
 
+/datum/preference/color/facial_hair_color/create_informed_default_value(datum/preferences/preferences)
+	return preferences.read_preference(/datum/preference/color/hair_color) || random_hair_color()
+
 /datum/preference/choiced/facial_hair_gradient
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRORITY_LATE_BODY_TYPE
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "facial_hair_gradient"
 	relevant_head_flag = HEAD_FACIAL_HAIR
+	can_randomize = FALSE
 
 /datum/preference/choiced/facial_hair_gradient/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.facial_hair_gradients_list)
@@ -102,23 +123,23 @@
 /datum/preference/choiced/facial_hair_gradient/create_default_value()
 	return "None"
 
-/datum/preference/color/facial_hair_gradient
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+/datum/preference/color/facial_hair_gradient_color
+	priority = PREFERENCE_PRORITY_LATE_BODY_TYPE
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "facial_hair_gradient_color"
 	relevant_head_flag = HEAD_FACIAL_HAIR
 
-/datum/preference/color/facial_hair_gradient/apply_to_human(mob/living/carbon/human/target, value)
+/datum/preference/color/facial_hair_gradient_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_facial_hair_gradient_color(new_color = value, update = FALSE)
 
-/datum/preference/color/facial_hair_gradient/is_accessible(datum/preferences/preferences)
+/datum/preference/color/facial_hair_gradient_color/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
 	return preferences.read_preference(/datum/preference/choiced/facial_hair_gradient) != "None"
 
 /datum/preference/color/hair_color
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRIORITY_BODY_TYPE
 	savefile_key = "hair_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
@@ -127,8 +148,11 @@
 /datum/preference/color/hair_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_haircolor(value, update = FALSE)
 
+/datum/preference/color/hair_color/create_informed_default_value(datum/preferences/preferences)
+	return random_hair_color()
+
 /datum/preference/choiced/hairstyle
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRIORITY_BODY_TYPE // Happens after gender so we can picka hairstyle based on that
 	savefile_key = "hairstyle_name"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_FEATURES
@@ -146,6 +170,23 @@
 /datum/preference/choiced/hairstyle/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_hairstyle(value, update = FALSE)
 
+/datum/preference/choiced/hairstyle/create_default_value()
+	return "Bald"
+
+/datum/preference/choiced/hairstyle/create_informed_default_value(datum/preferences/preferences)
+	var/gender = preferences.read_preference(/datum/preference/choiced/gender)
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species_real = GLOB.species_prototypes[species_type]
+	if(!gender || !species_real || !species_real.sexes)
+		return ..()
+
+	var/picked_hair = random_hairstyle(gender)
+	var/datum/sprite_accessory/hair_style = SSaccessories.hairstyles_list[picked_hair]
+	if(!hair_style || !hair_style.natural_spawn || hair_style.locked) // Invalid, go with god(bald)
+		return ..()
+
+	return picked_hair
+
 /datum/preference/choiced/hairstyle/compile_constant_data()
 	var/list/data = ..()
 
@@ -154,11 +195,12 @@
 	return data
 
 /datum/preference/choiced/hair_gradient
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRIORITY_BODY_TYPE
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "hair_gradient"
 	relevant_head_flag = HEAD_HAIR
+	can_randomize = FALSE
 
 /datum/preference/choiced/hair_gradient/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.hair_gradients_list)
@@ -170,7 +212,7 @@
 	return "None"
 
 /datum/preference/color/hair_gradient
-	priority = PREFERENCE_PRIORITY_BODYPARTS
+	priority = PREFERENCE_PRIORITY_BODY_TYPE
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "hair_gradient_color"

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -70,7 +70,7 @@
 	target.set_facial_hairstyle(value, update = FALSE)
 
 /datum/preference/choiced/facial_hairstyle/create_default_value()
-	return "Shaved"
+	return /datum/sprite_accessory/facial_hair/shaved::name
 
 /datum/preference/choiced/facial_hairstyle/create_informed_default_value(datum/preferences/preferences)
 	var/gender = preferences.read_preference(/datum/preference/choiced/gender)
@@ -89,7 +89,7 @@
 /datum/preference/choiced/facial_hairstyle/compile_constant_data()
 	var/list/data = ..()
 
-	data[SUPPLEMENTAL_FEATURE_KEY] = "facial_hair_color"
+	data[SUPPLEMENTAL_FEATURE_KEY] = /datum/preference/color/facial_hair_color::savefile_key
 
 	return data
 
@@ -121,7 +121,7 @@
 	target.set_facial_hair_gradient_style(new_style = value, update = FALSE)
 
 /datum/preference/choiced/facial_hair_gradient/create_default_value()
-	return "None"
+	return /datum/sprite_accessory/gradient/none::name
 
 /datum/preference/color/facial_hair_gradient
 	priority = PREFERENCE_PRORITY_LATE_BODY_TYPE
@@ -136,7 +136,7 @@
 /datum/preference/color/facial_hair_gradient/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
-	return preferences.read_preference(/datum/preference/choiced/facial_hair_gradient) != "None"
+	return preferences.read_preference(/datum/preference/choiced/facial_hair_gradient) != /datum/sprite_accessory/gradient/none::name
 
 /datum/preference/color/hair_color
 	priority = PREFERENCE_PRIORITY_BODY_TYPE
@@ -171,7 +171,7 @@
 	target.set_hairstyle(value, update = FALSE)
 
 /datum/preference/choiced/hairstyle/create_default_value()
-	return "Bald"
+	return /datum/sprite_accessory/hair/bald::name
 
 /datum/preference/choiced/hairstyle/create_informed_default_value(datum/preferences/preferences)
 	var/gender = preferences.read_preference(/datum/preference/choiced/gender)
@@ -190,7 +190,7 @@
 /datum/preference/choiced/hairstyle/compile_constant_data()
 	var/list/data = ..()
 
-	data[SUPPLEMENTAL_FEATURE_KEY] = "hair_color"
+	data[SUPPLEMENTAL_FEATURE_KEY] = /datum/preference/color/hair_color::savefile_key
 
 	return data
 
@@ -209,7 +209,7 @@
 	target.set_hair_gradient_style(new_style = value, update = FALSE)
 
 /datum/preference/choiced/hair_gradient/create_default_value()
-	return "None"
+	return /datum/sprite_accessory/gradient/none::name
 
 /datum/preference/color/hair_gradient
 	priority = PREFERENCE_PRIORITY_BODY_TYPE
@@ -224,4 +224,4 @@
 /datum/preference/color/hair_gradient/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
-	return preferences.read_preference(/datum/preference/choiced/hair_gradient) != "None"
+	return preferences.read_preference(/datum/preference/choiced/hair_gradient) != /datum/sprite_accessory/gradient/none::name

--- a/code/modules/client/preferences/species_features/felinid.dm
+++ b/code/modules/client/preferences/species_features/felinid.dm
@@ -29,5 +29,4 @@
 	target.dna.features["ears"] = value
 
 /datum/preference/choiced/ears/create_default_value()
-	var/datum/sprite_accessory/ears/cat/ears = /datum/sprite_accessory/ears/cat
-	return initial(ears.name)
+	return /datum/sprite_accessory/ears/cat::name

--- a/code/modules/client/preferences/species_features/lizard.dm
+++ b/code/modules/client/preferences/species_features/lizard.dm
@@ -142,5 +142,4 @@
 	target.dna.features["tail_lizard"] = value
 
 /datum/preference/choiced/lizard_tail/create_default_value()
-	var/datum/sprite_accessory/tails/lizard/smooth/tail = /datum/sprite_accessory/tails/lizard/smooth
-	return initial(tail.name)
+	return /datum/sprite_accessory/tails/lizard/smooth::name

--- a/code/modules/client/preferences/species_features/monkey.dm
+++ b/code/modules/client/preferences/species_features/monkey.dm
@@ -12,5 +12,4 @@
 	target.dna.features["tail_monkey"] = value
 
 /datum/preference/choiced/monkey_tail/create_default_value()
-	var/datum/sprite_accessory/tails/monkey/default/tail = /datum/sprite_accessory/tails/monkey/default
-	return initial(tail.name)
+	return /datum/sprite_accessory/tails/monkey/default::name

--- a/code/modules/client/preferences/species_features/monkey.dm
+++ b/code/modules/client/preferences/species_features/monkey.dm
@@ -3,6 +3,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	relevant_external_organ = /obj/item/organ/external/tail/monkey
+	can_randomize = FALSE
 
 /datum/preference/choiced/monkey_tail/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.tails_list_monkey)

--- a/code/modules/client/preferences/trans_prosthetic.dm
+++ b/code/modules/client/preferences/trans_prosthetic.dm
@@ -3,6 +3,9 @@
 	savefile_key = "trans_prosthetic"
 	savefile_identifier = PREFERENCE_CHARACTER
 
+/datum/preference/choiced/trans_prosthetic/create_default_value()
+	return "Random"
+
 /datum/preference/choiced/trans_prosthetic/init_possible_values()
 	return list("Random") + GLOB.part_choice_transhuman
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -291,13 +291,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		return FALSE
 
 	// Read everything into cache
-	for (var/preference_type in GLOB.preference_entries)
-		var/datum/preference/preference = GLOB.preference_entries[preference_type]
+	// Uses priority order as some values may rely on others for creating default values
+	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
 		if (preference.savefile_identifier != PREFERENCE_CHARACTER)
 			continue
 
-		value_cache -= preference_type
-		read_preference(preference_type)
+		value_cache -= preference.type
+		read_preference(preference.type)
 
 	//Character
 	randomise = save_data?["randomise"]


### PR DESCRIPTION
## About The Pull Request

Goes through a bunch of character preferences and adds informed default values which produce less wacky results. 

Basically part 2 of #84443 . Preference randomization now results in a character similar to that pictured in the original pr.

Of course, you can still make your character look as wacky as ever. 

![image](https://github.com/tgstation/tgstation/assets/51863163/0adef385-8a3d-46ed-b657-8c6712ec5ccf)

## Why It's Good For The Game

Basically, fully random characters look horrendous, and unless you're playing a non-human, you stick out like a sore thumb if you hardcore random or just decide to random appearance. 

Ultimately, full-random people will stick out less, which I think is good.

## Changelog

:cl: Melbert
qol: Random player characters now look less like rainbow vomit and more like some of the most average people you know.
/:cl:

