### PR TITLE
Using a multitool inhand tells you where the area APC is

### DIFF
--- a/code/datums/proximity_monitor/field.dm
+++ b/code/datums/proximity_monitor/field.dm
@@ -168,6 +168,7 @@
 /obj/item/multitool/field_debug
 	name = "strange multitool"
 	desc = "Seems to project a colored field!"
+	apc_scanner = FALSE
 	var/operating = FALSE
 	var/range_to_use = 5
 	var/datum/proximity_monitor/advanced/debug/current = null

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -53,12 +53,9 @@
 	var/area/local_area = get_area(src)
 	var/power_controller = local_area.apc
 	if(power_controller)
-		var/msg = span_notice("The local APC is located ") + span_boldnotice("[get_dist(src, power_controller)] meters [dir2text(get_dir(src, power_controller))]!")
-		to_chat(user, msg)
-		user.balloon_alert(user, "[get_dist(src, power_controller)] units [dir2text(get_dir(src, power_controller))]")
+		user.balloon_alert(user, "[get_dist(src, power_controller)]m [dir2text(get_dir(src, power_controller))]")
 	else
-		to_chat(user, span_warning("ERROR: Could not locate local APC."))
-		user.balloon_alert(user, "couldn't find APC!")
+		user.balloon_alert(user, "couldn't find apc!")
 
 /obj/item/multitool/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] puts the [src] to [user.p_their()] chest. It looks like [user.p_theyre()] trying to pulse [user.p_their()] heart off!"))

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -12,7 +12,7 @@
 
 /obj/item/multitool
 	name = "multitool"
-	desc = "Used for pulsing wires to test which to cut. Not recommended by doctors."
+	desc = "Used for pulsing wires to test which to cut. Not recommended by doctors. You can activate it in-hand to locate the nearest APC."
 	icon = 'icons/obj/devices/tool.dmi'
 	icon_state = "multitool"
 	inhand_icon_state = "multitool"
@@ -32,10 +32,33 @@
 	usesound = 'sound/weapons/empty.ogg'
 	var/datum/buffer // simple machine buffer for device linkage
 	var/mode = 0
+	var/apc_scanner = TRUE
+	COOLDOWN_DECLARE(next_apc_scan)
 
 /obj/item/multitool/examine(mob/user)
 	. = ..()
 	. += span_notice("Its buffer [buffer ? "contains [buffer]." : "is empty."]")
+
+/obj/item/multitool/attack_self(mob/user, list/modifiers)
+	. = ..()
+
+	if(. || !apc_scanner)
+		return
+
+	if(!COOLDOWN_FINISHED(src, next_apc_scan))
+		return
+
+	COOLDOWN_START(src, next_apc_scan, 1 SECONDS)
+
+	var/area/local_area = get_area(src)
+	var/power_controller = local_area.apc
+	if(power_controller)
+		var/msg = span_notice("The local APC is located ") + span_boldnotice("[get_dist(src, power_controller)] meters [dir2text(get_dir(src, power_controller))]!")
+		to_chat(user, msg)
+		user.balloon_alert(user, "[get_dist(src, power_controller)] units [dir2text(get_dir(src, power_controller))]")
+	else
+		to_chat(user, span_warning("ERROR: Could not locate local APC."))
+		user.balloon_alert(user, "couldn't find APC!")
 
 /obj/item/multitool/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] puts the [src] to [user.p_their()] chest. It looks like [user.p_theyre()] trying to pulse [user.p_their()] heart off!"))

--- a/code/modules/wiremod/core/marker.dm
+++ b/code/modules/wiremod/core/marker.dm
@@ -3,6 +3,7 @@
 	desc = "A circuit multitool. Used to mark entities which can then be uploaded to components by pressing the upload button on a port. \
 	Acts as a normal multitool otherwise. Use in hand to clear marked entity so that you can mark another entity."
 	icon_state = "multitool_circuit"
+	apc_scanner = FALSE // would conflict with mark clearing
 
 	/// The marked atom of this multitool
 	var/atom/marked_atom


### PR DESCRIPTION

## About The Pull Request

Using a multitool inhand tells you where the area APC is

## Why It's Good For The Game

Sometimes it's a bit of a pain to find it. No need to keep it sikret when map knowledge is a thing.

## Changelog

:cl:
qol: Using a multitool inhand tells you where the area APC is
/:cl:

