### PR TITLE
Fixes welding helmet and hardhat pepperspray protection

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -9,6 +9,7 @@
 	var/flash_protect = FLASH_PROTECTION_NONE
 	var/tint = 0 //Sets the item's level of visual impairment tint, normally set to the same as flash_protect
 	var/up = FALSE //but separated to allow items to protect but not impair vision, like space helmets
+	var/pepper_protect = FALSE //Toggles pepper protection when an item is ajusted up/down
 	var/visor_flags = NONE //flags that are added/removed when an item is adjusted up/down
 	var/visor_flags_inv = NONE //same as visor_flags, but for flags_inv
 	var/visor_flags_cover = NONE //same as above, but for flags_cover
@@ -387,7 +388,7 @@
 			var/list/things_blocked = list()
 			if(flags_cover & HEADCOVERSMOUTH)
 				things_blocked += span_tooltip("Because this item is worn on the head and is covering the mouth, it will block facehugger proboscides, killing facehuggers.", "facehuggers")
-			if(flags_cover & PEPPERPROOF)
+			if(flags_cover & PEPPERPROOF || visor_vars_to_toggle & PEPPERPROOF)
 				things_blocked += "pepperspray"
 			if(length(things_blocked))
 				readout += "<b><u>COVERAGE</u></b>"
@@ -482,6 +483,8 @@ BLIND     // can't see anything
 
 	visor_toggling()
 
+	pepper_protect = !pepper_protect
+
 	to_chat(user, span_notice("You push [src] [up ? "out of the way" : "back into place"]."))
 
 	update_item_action_buttons()
@@ -511,6 +514,10 @@ BLIND     // can't see anything
 		flash_protect ^= initial(flash_protect)
 	if(visor_vars_to_toggle & VISOR_TINT)
 		tint ^= initial(tint)
+	if(pepper_protect & (visor_vars_to_toggle & PEPPERPROOF))
+		visor_flags_cover &= ~PEPPERPROOF
+	else
+		visor_flags_cover |= PEPPERPROOF
 	update_appearance() //most of the time the sprite changes
 
 /obj/item/clothing/proc/can_use(mob/user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -9,7 +9,6 @@
 	var/flash_protect = FLASH_PROTECTION_NONE
 	var/tint = 0 //Sets the item's level of visual impairment tint, normally set to the same as flash_protect
 	var/up = FALSE //but separated to allow items to protect but not impair vision, like space helmets
-	var/pepper_protect = FALSE //Toggles pepper protection when an item is ajusted up/down
 	var/visor_flags = NONE //flags that are added/removed when an item is adjusted up/down
 	var/visor_flags_inv = NONE //same as visor_flags, but for flags_inv
 	var/visor_flags_cover = NONE //same as above, but for flags_cover
@@ -388,7 +387,7 @@
 			var/list/things_blocked = list()
 			if(flags_cover & HEADCOVERSMOUTH)
 				things_blocked += span_tooltip("Because this item is worn on the head and is covering the mouth, it will block facehugger proboscides, killing facehuggers.", "facehuggers")
-			if(flags_cover & PEPPERPROOF || visor_vars_to_toggle & PEPPERPROOF)
+			if(flags_cover & PEPPERPROOF)
 				things_blocked += "pepperspray"
 			if(length(things_blocked))
 				readout += "<b><u>COVERAGE</u></b>"
@@ -483,8 +482,6 @@ BLIND     // can't see anything
 
 	visor_toggling()
 
-	pepper_protect = !pepper_protect
-
 	to_chat(user, span_notice("You push [src] [up ? "out of the way" : "back into place"]."))
 
 	update_item_action_buttons()
@@ -514,10 +511,6 @@ BLIND     // can't see anything
 		flash_protect ^= initial(flash_protect)
 	if(visor_vars_to_toggle & VISOR_TINT)
 		tint ^= initial(tint)
-	if(pepper_protect & (visor_vars_to_toggle & PEPPERPROOF))
-		visor_flags_cover &= ~PEPPERPROOF
-	else
-		visor_flags_cover |= PEPPERPROOF
 	update_appearance() //most of the time the sprite changes
 
 /obj/item/clothing/proc/can_use(mob/user)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -124,9 +124,9 @@
 	tint = 2
 	flags_inv = HIDEEYES | HIDEFACE | HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
+	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | PEPPERPROOF
 	visor_flags_inv = HIDEEYES | HIDEFACE | HIDESNOUT
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	///Icon state of the welding visor.
 	var/visor_state = "weldvisor"
 

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -123,10 +123,10 @@
 	flash_protect = FLASH_PROTECTION_WELDER
 	tint = 2
 	flags_inv = HIDEEYES | HIDEFACE | HIDESNOUT
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | PEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	visor_flags_inv = HIDEEYES | HIDEFACE | HIDESNOUT
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	///Icon state of the welding visor.
 	var/visor_state = "weldvisor"
 

--- a/code/modules/clothing/head/welding.dm
+++ b/code/modules/clothing/head/welding.dm
@@ -13,8 +13,8 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | PEPPERPROOF
 	resistance_flags = FIRE_PROOF
 	clothing_flags = SNUG_FIT | STACKABLE_HELMET_EXEMPT
 

--- a/code/modules/clothing/head/welding.dm
+++ b/code/modules/clothing/head/welding.dm
@@ -2,7 +2,7 @@
 	name = "welding helmet"
 	desc = "A head-mounted face cover designed to protect the wearer completely from space-arc eye."
 	icon_state = "welding"
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	inhand_icon_state = "welding"
 	lefthand_file = 'icons/mob/inhands/clothing/masks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing/masks_righthand.dmi'
@@ -13,8 +13,8 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | PEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	resistance_flags = FIRE_PROOF
 	clothing_flags = SNUG_FIT | STACKABLE_HELMET_EXEMPT
 


### PR DESCRIPTION
## About The Pull Request

Welding helmet/hardhat will now properly protect against pepperspray while its down

## Why It's Good For The Game

Fixes uhhh... apparently the guy that made the issue report got gitbanned or something?? Idk man, but it fixes that issue where welding helmets and hardhats protected against pepperspray while up and didnt while down.

## Changelog

:cl:
fix: Welding helmet and hardhat will now properly protect against pepperspray while its down
/:cl: