### PR TITLE
Fix power usage and heating power of space heaters

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -2,7 +2,7 @@
 #define HEATER_MODE_HEAT "heat"
 #define HEATER_MODE_COOL "cool"
 #define HEATER_MODE_AUTO "auto"
-#define BASE_HEATING_ENERGY (STANDARD_CELL_RATE * 0.1)
+#define BASE_HEATING_ENERGY (STANDARD_CELL_RATE * 4)
 
 /obj/machinery/space_heater
 	anchored = FALSE
@@ -32,7 +32,7 @@
 	///How much heat/cold we can deliver
 	var/heating_energy = BASE_HEATING_ENERGY
 	///How efficiently we can deliver that heat/cold (higher indicates less cell consumption)
-	var/efficiency = 20
+	var/efficiency = 200
 	///The amount of degrees above and below the target temperature for us to change mode to heater or cooler
 	var/temperature_tolerance = 1
 	///What's the middle point of our settable temperature (30 °C)
@@ -179,7 +179,7 @@
 	heating_energy = laser * BASE_HEATING_ENERGY
 
 	settable_temperature_range = cap * 30
-	efficiency = (cap + 1) * 10
+	efficiency = (cap + 1) * 100
 
 	target_temperature = clamp(target_temperature,
 		max(settable_temperature_median - settable_temperature_range, TCMB),

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -178,8 +178,8 @@
 
 	heating_energy = laser * BASE_HEATING_ENERGY
 
-	settable_temperature_range = cap * 30
-	efficiency = (cap + 1) * 100
+	settable_temperature_range = cap * initial(settable_temperature_range)
+	efficiency = (cap + 1) * initial(efficiency) * 0.5
 
 	target_temperature = clamp(target_temperature,
 		max(settable_temperature_median - settable_temperature_range, TCMB),


### PR DESCRIPTION
## About The Pull Request

Closes #84591 

I decided to just up heating power so it's the same as the value before the cell changes.
Then adjusted efficiency so the drain speed is the same as before changes.

I think technically this is a slight nerf to the heaters before all the changes since I based the value around the high-power cell that was added in the previous PR. So normal cells will be worse than before all this stuff, and so will bluespace cells.

Tested highly scientifically by setting the hallway outside of engi on fire with a flamethrower until the tank was empty, then dragging a space heater there. Then reverting to the commit before the megacell changes and testing to see if it matches, and it does!

## Why It's Good For The Game

Engineers can cool/heat rooms again. Currently it's even worse than before the last fix, since before that you could at least induce the heater even if it drained the cell very quickly. Now it just doesn't do much at all.

## Changelog
:cl:
fix: Fixed space heater heating power and power consumption

/:cl:
