### PR TITLE
Paintings can be sponsored again

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -265,7 +265,7 @@
 		return
 	var/sniped_amount = painting_metadata.credit_value
 	var/offer_amount = tgui_input_number(user, "How much do you want to offer?", "Patronage Amount", (painting_metadata.credit_value + 1), account.account_balance, painting_metadata.credit_value)
-	if(!offer_amount || QDELETED(user) || QDELETED(src) || !user.can_perform_action(loc, FORBID_TELEKINESIS_REACH))
+	if(!offer_amount || QDELETED(user) || QDELETED(src) || !istype(loc, /obj/structure/sign/painting) || !user.can_perform_action(loc, FORBID_TELEKINESIS_REACH))
 		return
 	if(sniped_amount != painting_metadata.credit_value)
 		return

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -265,7 +265,7 @@
 		return
 	var/sniped_amount = painting_metadata.credit_value
 	var/offer_amount = tgui_input_number(user, "How much do you want to offer?", "Patronage Amount", (painting_metadata.credit_value + 1), account.account_balance, painting_metadata.credit_value)
-	if(!offer_amount || QDELETED(user) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+	if(!offer_amount || QDELETED(user) || QDELETED(src) || !user.can_perform_action(loc, FORBID_TELEKINESIS_REACH))
 		return
 	if(sniped_amount != painting_metadata.credit_value)
 		return


### PR DESCRIPTION
## About The Pull Request
- Fixes #84735

Since the canvas(`/obj/item/canvas`) was inside the painting wallframe(`/obj/structure/sign/painting`) both `CanReach()` & `Adjacent()` would fail because of nested locs.

Now we check adjacency to the location of the canvas (if its in the wallframe) rather than the canvas itself

## Changelog
:cl:
fix: paintings can be sponsored again
/:cl:
