### PR TITLE
Bloody footprints no longer share their blood when you step on them

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -242,6 +242,7 @@
 			// If our feet are bloody enough, add an entered dir
 			pool_FP.entered_dirs |= wielder.dir
 			pool_FP.update_appearance()
+		return
 
 	share_blood(pool)
 


### PR DESCRIPTION

## About The Pull Request

Closes #84727
This stops you from picking up blood from existing bloody footprints which could result in a huge mess.

## Why It's Good For The Game

Bloody footprints are extremely messy after being fixed and then buffed, and while you could argue about it, picking up blood from the footsteps you made a second ago just by going in circles don't make a whole lot of sense.

## Changelog
:cl:
fix: Bloody footprints no longer bloody your shoes even more when walked over.
/:cl:
