### PR TITLE
Fixes an unrestricted airlock in metastation brig maints

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16308,9 +16308,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/range)
 "fOB" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/machinery/door/airlock/maintenance{
 	name = "Brig Maintenance"
@@ -16320,6 +16317,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fOS" = (


### PR DESCRIPTION

## About The Pull Request
Fixes this

![image](https://github.com/tgstation/tgstation/assets/96586172/84d544fd-80d4-4050-8daa-e2d0ed044fc3)
## Changelog
:cl: grungussuss
fix: fixed an unrestricted airlock in metastation brig maints
/:cl:
