### PR TITLE
[NO GBP] Embedding hotfix

### DIFF
--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -106,6 +106,7 @@
 		return // we don't care
 	var/payload_type = source.shrapnel_type
 	var/obj/item/payload = new payload_type(get_turf(hit))
+	payload.set_embed(source.get_embed())
 	if(istype(payload, /obj/item/shrapnel/bullet))
 		payload.name = source.name
 	SEND_SIGNAL(source, COMSIG_PROJECTILE_ON_SPAWN_EMBEDDED, payload)

--- a/code/datums/embed_data.dm
+++ b/code/datums/embed_data.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(embed_by_type, generate_embed_type_cache())
 	var/pain_stam_pct = 0
 
 /datum/embed_data/proc/generate_with_values(embed_chance, fall_chance, pain_chance, pain_mult, impact_pain_mult, remove_pain_mult, rip_time, ignore_throwspeed_threshold, jostle_chance, jostle_pain_mult, pain_stam_pct)
-	var/datum/embed_data/data = new()
+	var/datum/embed_data/data = isnull(GLOB.embed_by_type[type]) ? src : new()
 
 	data.embed_chance = !isnull(embed_chance) ? embed_chance : src.embed_chance
 	data.fall_chance = !isnull(fall_chance) ? fall_chance : src.fall_chance
@@ -52,3 +52,4 @@ GLOBAL_LIST_INIT(embed_by_type, generate_embed_type_cache())
 	data.jostle_chance = !isnull(jostle_chance) ? jostle_chance : src.jostle_chance
 	data.jostle_pain_mult = !isnull(jostle_pain_mult) ? jostle_pain_mult : src.jostle_pain_mult
 	data.pain_stam_pct = !isnull(pain_stam_pct) ? pain_stam_pct : src.pain_stam_pct
+	return data

--- a/code/datums/embed_data.dm
+++ b/code/datums/embed_data.dm
@@ -38,8 +38,8 @@ GLOBAL_LIST_INIT(embed_by_type, generate_embed_type_cache())
 	/// This percentage of all pain will be dealt as stam damage rather than brute (0-1)
 	var/pain_stam_pct = 0
 
-/datum/embed_data/proc/generate_with_values(embed_chance, fall_chance, pain_chance, pain_mult, impact_pain_mult, remove_pain_mult, rip_time, ignore_throwspeed_threshold, jostle_chance, jostle_pain_mult, pain_stam_pct)
-	var/datum/embed_data/data = isnull(GLOB.embed_by_type[type]) ? src : new()
+/datum/embed_data/proc/generate_with_values(embed_chance, fall_chance, pain_chance, pain_mult, impact_pain_mult, remove_pain_mult, rip_time, ignore_throwspeed_threshold, jostle_chance, jostle_pain_mult, pain_stam_pct, force_new = FALSE)
+	var/datum/embed_data/data = isnull(GLOB.embed_by_type[type]) && !force_new ? src : new()
 
 	data.embed_chance = !isnull(embed_chance) ? embed_chance : src.embed_chance
 	data.fall_chance = !isnull(fall_chance) ? fall_chance : src.fall_chance

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1719,7 +1719,7 @@
 /// Fetches embedding data
 /obj/item/proc/get_embed()
 	RETURN_TYPE(/datum/embed_data)
-	return embed_type ? (embed_data ||= get_embed_by_type(embed_type)) : null
+	return embed_type ? (embed_data ||= get_embed_by_type(embed_type)) : embed_data
 
 /obj/item/proc/set_embed(datum/embed_data/embed)
 	if(embed_data == embed)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1197,7 +1197,8 @@
 
 /// Fetches embedding data
 /obj/projectile/proc/get_embed()
-	return embed_type ? (embed_data ||= get_embed_by_type(embed_type)) : null
+	RETURN_TYPE(/datum/embed_data)
+	return embed_type ? (embed_data ||= get_embed_by_type(embed_type)) : embed_data
 
 /obj/projectile/proc/set_embed(datum/embed_data/embed)
 	if(embed_data == embed)


### PR DESCRIPTION

## About The Pull Request

I may have forgotten a return which was overlooked in reviews, and get_embed could fail if an object without an embed_type (shrapnel) got assigned embed. Also optimized generate_with_values to not recreate the datum if its not the "default" one.

## Changelog
:cl:
fix: Embedding now properly changes its values.
/:cl:
