### PR TITLE
Makes docked shuttle departure timer reset when a hostile environment threat is stopped

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -527,7 +527,7 @@ SUBSYSTEM_DEF(shuttle)
 			sender_override = "Emergency Shuttle Uplink Alert",
 			color_override = "grey",
 		)
-	if(!emergency_no_escape && (emergency.mode == SHUTTLE_STRANDED))
+	if(!emergency_no_escape && (emergency.mode == SHUTTLE_STRANDED || emergency.mode == SHUTTLE_DOCKED))
 		emergency.mode = SHUTTLE_DOCKED
 		emergency.setTimer(emergency_dock_time)
 		priority_announce(


### PR DESCRIPTION

## About The Pull Request
Changes hostile environments so that if the shuttle is docked then the ETD timer will be reset when the threat is stopped.
## Why It's Good For The Game
Right now, if you end a hostile environment threat before the shuttle timer goes to ERR the timer won't reset, which often leaves the people who went to deal with the threat unable to get back to the shuttle in time, which really sucks. People shouldn't be punished for stopping a threat.
## Changelog
:cl:
qol: Docked emergency shuttles will always reset their departure timer when a hostile environment is stopped, regardless of if the timer displays ETD or ERR.
/:cl:
