### PR TITLE
[NO GBP] Fixes the loot weight config + maintenance spawner nitpick

### DIFF
--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -2,14 +2,15 @@
 	name = "maintenance loot spawner"
 	desc = "Come on Lady Luck, spawn me a pair of sunglasses."
 	icon_state = "loot"
+	remove_if_cant_spawn = FALSE //don't remove stuff from the global maint list, which other can use.
 	// see code/_globalvars/lists/maintenance_loot.dm for loot table
 
 /// A subtype of maintenance loot spawner that does not spawn any decals, for when you want to place them on chasm turfs and such
 /// decals such as ashes will cause NeverShouldHaveComeHere() to fail on such turfs, which creates annoying rng based CI failures
 /obj/effect/spawner/random/maintenance/no_decals
 
-/obj/effect/spawner/random/maintenance/no_decals/can_spawn(atom/loot)
-	return !ispath(loot, /obj/effect/decal)
+/obj/effect/spawner/random/maintenance/no_decals/make_item(spawn_loc, type_path_to_make)
+	if(ispath(loot, /obj/effect/decal))
 
 /obj/effect/spawner/random/maintenance/examine(mob/user)
 	. = ..()
@@ -17,6 +18,14 @@
 
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	loot = GLOB.maintenance_loot
+	return ..()
+
+/obj/effect/spawner/random/maintenance/skew_loot_weights(list/loot_list, exponent)
+	///We only need to skew the weights once, since it's a global list used by all maint spawners.
+	var/static/already_done = FALSE
+	if(loot_list == GLOB.maintenance_loot && already_done)
+		return
+	already_done = TRUE
 	return ..()
 
 /obj/effect/spawner/random/maintenance/proc/hide()

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -9,9 +9,6 @@
 /// decals such as ashes will cause NeverShouldHaveComeHere() to fail on such turfs, which creates annoying rng based CI failures
 /obj/effect/spawner/random/maintenance/no_decals
 
-/obj/effect/spawner/random/maintenance/no_decals/make_item(spawn_loc, type_path_to_make)
-	if(ispath(loot, /obj/effect/decal))
-
 /obj/effect/spawner/random/maintenance/examine(mob/user)
 	. = ..()
 	. += span_info("This spawner has an effective loot count of [get_effective_lootcount()].")

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -29,6 +29,8 @@
 	var/spawn_scatter_radius = 0
 	/// Whether the items should have a random pixel_x/y offset (maxium offset distance is ±16 pixels for x/y)
 	var/spawn_random_offset = FALSE
+	/// Whether items that cannot be spawned will be removed from the loot list. Keep it TRUE unless you've a good reason.
+	var/remove_if_cant_spawn = TRUE
 
 /obj/effect/spawner/random/Initialize(mapload)
 	. = ..()
@@ -53,7 +55,7 @@
 		loot += subtypesof(loot_subtype_path)
 
 	if(CONFIG_GET(number/random_loot_weight_modifier) != 1)
-		skew_loot_weights(CONFIG_GET(number/random_loot_weight_modifier))
+		skew_loot_weights(loot, CONFIG_GET(number/random_loot_weight_modifier))
 
 	if(loot?.len)
 		var/loot_spawned = 0
@@ -61,7 +63,8 @@
 		while((spawn_loot_count-loot_spawned) && loot.len)
 			var/lootspawn = pick_weight_recursive(loot)
 			if(!can_spawn(lootspawn))
-				loot.Remove(lootspawn)
+				if(remove_if_cant_spawn)
+					loot.Remove(lootspawn)
 				continue
 			if(!spawn_loot_double)
 				loot.Remove(lootspawn)


### PR DESCRIPTION
## About The Pull Request
I've forgotten to fill the `loot_list` arg of the `skew_loot_weight` call, and I'm preventing the maintenance spawners from running the proc more times that necessary, also stopping the `no_decal` subtype from removing decals typepaths from the global `maintenance_loot` list.

## Why It's Good For The Game
Pseudo-bugfixing.

## Changelog
N/A