### PR TITLE
Tweaked the 'Linked Closets' trait.

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -383,30 +383,17 @@
 
 /datum/station_trait/linked_closets/on_round_start()
 	. = ..()
-	var/list/roundstart_non_secure_closets = GLOB.roundstart_station_closets.Copy()
-	for(var/obj/structure/closet/closet in roundstart_non_secure_closets)
-		if(closet.secure)
-			roundstart_non_secure_closets -= closet
+	var/list/roundstart_closets = GLOB.roundstart_station_closets.Copy()
 
 	/**
-	 * The number of links to perform.
-	 * Combined with 50/50 the probability of the link being triangular, the boundaries of any given
-	 * on-station, non-secure closet being linked are as high as 1 in 7/8 and as low as 1 in 16-17,
-	 * nearing an a mean of 1 in 9 to 11/12 the more repetitions are done.
-	 *
-	 * There are more than 220 roundstart closets on meta, around 150 of which aren't secure,
-	 * so, about 13 to 17 closets will be affected by this most of the times.
+	 * The number of links to perform. the chance of a closet being linked are about 1 in 10
+	 * There are more than 220 roundstart closets on meta, so, about 22 closets will be affected on average.
 	 */
-	var/number_of_links = round(length(roundstart_non_secure_closets) * (rand(350, 450)*0.0001), 1)
+	var/number_of_links = round(length(roundstart_non_secure_closets) * (rand(390, 430)*0.0001), 1)
 	for(var/repetition in 1 to number_of_links)
-		var/closets_left = length(roundstart_non_secure_closets)
-		if(closets_left < 2)
-			return
 		var/list/targets = list()
 		for(var/how_many in 1 to min(closets_left, rand(2,3)))
 			targets += pick_n_take(roundstart_non_secure_closets)
-		if(closets_left == 1) //there's only one closet left. Let's not leave it alone.
-			targets += roundstart_non_secure_closets[1]
 		GLOB.eigenstate_manager.create_new_link(targets)
 
 /datum/station_trait/triple_ai

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -389,11 +389,11 @@
 	 * The number of links to perform. the chance of a closet being linked are about 1 in 10
 	 * There are more than 220 roundstart closets on meta, so, about 22 closets will be affected on average.
 	 */
-	var/number_of_links = round(length(roundstart_non_secure_closets) * (rand(390, 430)*0.0001), 1)
+	var/number_of_links = round(length(roundstart_closets) * (rand(300, 430)*0.0001), 1)
 	for(var/repetition in 1 to number_of_links)
 		var/list/targets = list()
-		for(var/how_many in 1 to min(closets_left, rand(2,3)))
-			targets += pick_n_take(roundstart_non_secure_closets)
+		for(var/how_many in 1 to rand(2,3))
+			targets += pick_n_take(roundstart_closets)
 		GLOB.eigenstate_manager.create_new_link(targets)
 
 /datum/station_trait/triple_ai

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -389,7 +389,7 @@
 	 * The number of links to perform. the chance of a closet being linked are about 1 in 10
 	 * There are more than 220 roundstart closets on meta, so, about 22 closets will be affected on average.
 	 */
-	var/number_of_links = round(length(roundstart_closets) * (rand(300, 430)*0.0001), 1)
+	var/number_of_links = round(length(roundstart_closets) * (rand(400, 430)*0.0001), 1)
 	for(var/repetition in 1 to number_of_links)
 		var/list/targets = list()
 		for(var/how_many in 1 to rand(2,3))

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -389,7 +389,7 @@
 	 * The number of links to perform. the chance of a closet being linked are about 1 in 10
 	 * There are more than 220 roundstart closets on meta, so, about 22 closets will be affected on average.
 	 */
-	var/number_of_links = max(round(length(roundstart_closets) * (rand(400, 430)*0.0001), 1), min(length(roundstart_closets), 3))
+	var/number_of_links = round(length(roundstart_closets) * (rand(400, 430)*0.0001), 1)
 	for(var/repetition in 1 to number_of_links)
 		var/list/targets = list()
 		for(var/how_many in 1 to rand(2,3))

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -389,7 +389,7 @@
 	 * The number of links to perform. the chance of a closet being linked are about 1 in 10
 	 * There are more than 220 roundstart closets on meta, so, about 22 closets will be affected on average.
 	 */
-	var/number_of_links = round(length(roundstart_closets) * (rand(400, 430)*0.0001), 1)
+	var/number_of_links = max(round(length(roundstart_closets) * (rand(400, 430)*0.0001), 1), min(length(roundstart_closets), 3))
 	for(var/repetition in 1 to number_of_links)
 		var/list/targets = list()
 		for(var/how_many in 1 to rand(2,3))


### PR DESCRIPTION
## About The Pull Request
Cleaned/Changed out bits of code for the aforementioned station trait and made the comment more understandable.
I've also narrowed the range from 0.035 and 0.045 to 0.04 and 0.043. Yeah, it's a leaning a bit forward the higher end now.
However, the biggest change would be the inclusion of secure closets in the pool. I checked around, there are so many personal closets and all, that it isn't that big of a deal.

## Why It's Good For The Game
Tweaking the trait, bettering the code.

## Changelog

:cl:
balance: tweaked the Linked Closets station trait.
/:cl:
