### PR TITLE
Medical research nodes adjustment

### DIFF
--- a/code/__DEFINES/research/techweb_nodes.dm
+++ b/code/__DEFINES/research/techweb_nodes.dm
@@ -97,7 +97,6 @@
 #define TECHWEB_NODE_PASSIVE_IMPLANTS "passive_implants"
 #define TECHWEB_NODE_PLASMA_CONTROL "plasma_control"
 #define TECHWEB_NODE_PLASMA_MINING "plasma_mining"
-#define TECHWEB_NODE_PLUMBING "plumbing"
 #define TECHWEB_NODE_POSITRONIC_SPHERE "positronic_sphere"
 #define TECHWEB_NODE_PROGRAMMED_ROBOT "programmed_robot"
 #define TECHWEB_NODE_PROGRAMMED_SERVER "programmed_server"

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -54,28 +54,19 @@
 		"chem_heater",
 		"w-recycler",
 		"meta_beaker",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
-
-/datum/techweb_node/plumbing
-	id = TECHWEB_NODE_PLUMBING
-	display_name = "Plumbing"
-	description = "Essential infrastructure for building chemical factories. To scale up the production of happy pills to an industrial level."
-	prereq_ids = list(TECHWEB_NODE_CHEM_SYNTHESIS)
-	design_ids = list(
 		"plumbing_rcd",
 		"plumbing_rcd_service",
 		"plunger",
 		"fluid_ducts",
-		"piercesyringe",
+
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 
 /datum/techweb_node/medbay_equip_adv
 	id = TECHWEB_NODE_MEDBAY_EQUIP_ADV
 	display_name = "Advanced Medbay Equipment"
 	description = "State-of-the-art medical gear for keeping the crew in one piece — mostly."
-	prereq_ids = list(TECHWEB_NODE_PLUMBING)
+	prereq_ids = list(TECHWEB_NODE_CHEM_SYNTHESIS)
 	design_ids = list(
 		"smoke_machine",
 		"chem_mass_spec",
@@ -85,6 +76,7 @@
 		"defibrillator_compact",
 		"defibmount",
 		"medicalbed_emergency",
+		"piercesyringe",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	required_experiments = list(/datum/experiment/scanning/reagent/haloperidol)

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -58,7 +58,6 @@
 		"plumbing_rcd_service",
 		"plunger",
 		"fluid_ducts",
-
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -28,6 +28,7 @@
 		"syringe",
 		"dropper",
 		"pillbottle",
+		"xlarge_beaker",
 	)
 	experiments_to_unlock = list(
 		/datum/experiment/autopsy/human,
@@ -43,7 +44,6 @@
 	description = "Synthesizing complex chemicals from electricity and thin air... Don't ask how..."
 	prereq_ids = list(TECHWEB_NODE_MEDBAY_EQUIP)
 	design_ids = list(
-		"xlarge_beaker",
 		"med_spray_bottle",
 		"medigel",
 		"medipen_refiller",
@@ -53,6 +53,7 @@
 		"portable_chem_mixer",
 		"chem_heater",
 		"w-recycler",
+		"meta_beaker",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 
@@ -66,7 +67,6 @@
 		"plumbing_rcd_service",
 		"plunger",
 		"fluid_ducts",
-		"meta_beaker",
 		"piercesyringe",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)


### PR DESCRIPTION
## About The Pull Request
Moves XL beaker from Chemical Synthesis to Medbay Equipment
Removes Plumbing node and moves most items to Chemical synthesis node
Moves piercing syringe from Plumbing node to Advanced Medbay Equipment

![346569359-1dfa219c-85eb-4842-a47c-a1556c3dea61](https://github.com/tgstation/tgstation/assets/109347230/e4dc5ddc-8b1c-4782-ad91-12177d8cd6c1)

## Why It's Good For The Game
Love the science rework, there's just a few things that need to be moved around.

I've got two reasons for ya.
Bluespace beakers are often researched before metamaterial beakers due to the different node paths and the value of bluespace research being greater than plumbing research. It's a little weird that the higher volume beaker is so often available sooner
XL-beakers are pretty simple and are already locked behind plastic, they should probably be available to chemists at round start, just like they were before the research rework.

## Changelog
:cl:
balance: Moves XL beaker from Chemical Synthesis to Medbay Equipment
balance: Removes Plumbing node and moves most items to Chemical synthesis node
balance: Moves piercing syringe from Plumbing node to Advanced Medbay Equipment
/:cl:

