### PR TITLE
Nerf surgeries speed in stasis(S)

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -116,6 +116,9 @@
 	if(HAS_TRAIT(target, TRAIT_ANALGESIA))
 		speed_mod *= SURGERY_SPEED_TRAIT_ANALGESIA
 
+	if(HAS_TRAIT (target, TRAIT_STASIS))
+		to_chat(user, span_warning("[target] seems to be in stasis, it is impossible to work with [target] tissue!"))
+		speed_mod *= 5
 	var/implement_speed_mod = 1
 	if(implement_type) //this means it isn't a require hand or any item step.
 		implement_speed_mod = implements[implement_type] / 100.0


### PR DESCRIPTION

## About The Pull Request
Applies 5X surgery speed while the patient is in stasis.
## Why It's Good For The Game
Stasis beds are no more "perfect" bed for everything.
## Changelog
:cl:
balance: surgeries speed in stasis is nerfed
/:cl:
