### PR TITLE
Holy skateboard improvement + actually fixing space movement with hoverboards.

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -246,11 +246,25 @@
 		on_hover_enabled()
 		return
 	var/turf/open/our_turf = movable.loc
-	var/turf/turf_below = GET_TURF_BELOW(our_turf)
-	if(our_turf.zPassOut(DOWN) && (isnull(turf_below) || (is_space_or_openspace(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN))))
-		on_hover_fail(our_turf, turf_below, is_moving)
-	else
-		on_hover_enabled()
+	var/turf/below = GET_TURF_BELOW(our_turf)
+
+	if(!check_space_turf(our_turf))
+		on_hover_fail()
+		return
+	//it's open space without support and the turf below is null or space without lattice, or if it'd fall several z-levels.
+	if(isopenspaceturf(our_turf) && our_turf.zPassOut(DOWN) && (isnull(below) || !check_space_turf(below) || (below.zPassOut(DOWN) && below.zPassIn(DOWN))))
+		on_hover_fail(our_turf, below, is_moving)
+		return
+	on_hover_enabled()
+
+///Part of the hover_check proc that returns false if it's a space turf without lattice or such.
+/datum/component/riding/vehicle/scooter/skateboard/hover/proc/check_space_turf(turf/turf)
+	if(!isspaceturf(turf))
+		return TRUE
+	for(var/obj/object in turf.contents)
+		if(object.obj_flags & BLOCK_Z_OUT_DOWN)
+			return TRUE
+	return FALSE
 
 ///Called by hover_check() when the hoverboard is on a valid turf.
 /datum/component/riding/vehicle/scooter/skateboard/hover/proc/on_hover_enabled()

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -243,14 +243,39 @@
 /datum/component/riding/vehicle/scooter/skateboard/hover/proc/hover_check(is_moving = FALSE)
 	var/atom/movable/movable = parent
 	if(!is_space_or_openspace(movable.loc))
-		override_allow_spacemove = TRUE
+		on_hover_enabled()
 		return
 	var/turf/open/our_turf = movable.loc
 	var/turf/turf_below = GET_TURF_BELOW(our_turf)
 	if(our_turf.zPassOut(DOWN) && (isnull(turf_below) || (is_space_or_openspace(turf_below) && turf_below.zPassIn(DOWN) && turf_below.zPassOut(DOWN))))
-		override_allow_spacemove = FALSE
-		if(turf_below)
-			our_turf.zFall(movable, falling_from_move = is_moving)
+		on_hover_fail(our_turf, turf_below, is_moving)
+	else
+		on_hover_enabled()
+
+///Called by hover_check() when the hoverboard is on a valid turf.
+/datum/component/riding/vehicle/scooter/skateboard/hover/proc/on_hover_enabled()
+	override_allow_spacemove = TRUE
+
+///Called by hover_check() when the hoverboard is on space or open space turf without a support underneath it.
+/datum/component/riding/vehicle/scooter/skateboard/hover/proc/on_hover_fail(turf/open/our_turf, turf/turf_below, is_moving)
+	override_allow_spacemove = FALSE
+	if(turf_below)
+		our_turf.zFall(parent, falling_from_move = is_moving)
+
+/datum/component/riding/vehicle/scooter/skateboard/hover/holy
+	var/is_slown_down = FALSE
+
+/datum/component/riding/vehicle/scooter/skateboard/hover/holy/on_hover_enabled()
+	if(!is_slown_down)
+		return
+	is_slown_down = FALSE
+	vehicle_move_delay -= 1
+
+/datum/component/riding/vehicle/scooter/skateboard/hover/holy/on_hover_fail(turf/open/our_turf, turf/turf_below, is_moving)
+	if(is_slown_down)
+		return
+	is_slown_down = TRUE
+	vehicle_move_delay += 1
 
 /datum/component/riding/vehicle/scooter/skateboard/wheelys
 	vehicle_move_delay = 0

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -212,14 +212,13 @@
 	board_item_type = /obj/item/melee/skateboard/holyboard
 	instability = 3
 	icon_state = "hoverboard_holy"
-/obj/vehicle/ridden/scooter/skateboard/hoverboard/holyboarded/post_buckle_mob(mob/living/M)
-	M.AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
-	return ..()
 
-/obj/vehicle/ridden/scooter/skateboard/hoverboard/holyboarded/post_unbuckle_mob(mob/living/M)
-	if(!has_buckled_mobs())
-		qdel (M.GetComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY))
-		return ..()
+/obj/vehicle/ridden/scooter/skateboard/hoverboard/make_ridable()
+	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/hover/holy)
+
+/obj/vehicle/ridden/scooter/skateboard/hoverboard/holyboarded/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
 
 /obj/vehicle/ridden/scooter/skateboard/hoverboard/admin
 	name = "\improper Board Of Directors"


### PR DESCRIPTION
## About The Pull Request
Added anti-magic support for things that mob can buckle to, so that we don't have to add the anti-magic component to the mob riding the holy skateboard but the skateboard itself.

Also, made it possible for the holy skateboard to soar space and open space with no support without falling, at the cost of a moderate slowdown.

## Why It's Good For The Game
It's a first-time contributor that added this skateboard to the game, and it looked like he couldn't find a solution to some of the issues I brought on in my review. Plus the holy skateboard being usable in spess has some real Space Jesus vibes to it.

## Changelog

:cl:
fix: ACTUALLY fixed hoverboards being able to be used in space.
balance: However, you can soar space with the holy skateboard. at a slower speed.
/:cl:
