### PR TITLE
Adds the National Ice Cream Day.

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -40,6 +40,7 @@
 #define MOTH_WEEK "Moth Week"
 #define IAN_HOLIDAY "Ian's Birthday"
 #define HOTDOG_DAY "National Hot Dog Day"
+#define ICE_CREAM_DAY "National Ice Cream Day"
 /*
 
 Days of the week to make it easier to reference them.

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -387,7 +387,8 @@
 
 /obj/item/food/icecream/make_edible()
 	. = ..()
-	AddComponent(/datum/component/ice_cream_holder, filled_name = "ice cream", change_desc = TRUE, prefill_flavours = prefill_flavours)
+	var/max_scoops = check_holidays(ICE_CREAM_DAY) ? DEFAULT_MAX_ICE_CREAM_SCOOPS * 4 : DEFAULT_MAX_ICE_CREAM_SCOOPS
+	AddComponent(/datum/component/ice_cream_holder, max_scoops, filled_name = "ice cream", change_desc = TRUE, prefill_flavours = prefill_flavours)
 
 /obj/item/food/icecream/chocolate
 	name = "chocolate cone"

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -152,6 +152,10 @@
 	return NONE
 
 /obj/item/borg/lollipop/attack_self(mob/living/user)
+	switch_mode(user)
+	return ..()
+
+/obj/item/borg/lollipop/proc/switch_mode(mob/living/user)
 	switch(mode)
 		if(DISPENSE_LOLLIPOP_MODE)
 			mode = THROW_LOLLIPOP_MODE
@@ -165,7 +169,18 @@
 		if(DISPENSE_ICECREAM_MODE)
 			mode = DISPENSE_LOLLIPOP_MODE
 			to_chat(user, span_notice("Module is now dispensing lollipops."))
-	..()
+
+/obj/item/borg/lollipop/ice_cream
+	name = "ice cream fabricator"
+	desc = "Reward humans with vanilla ice cream. Can't go wrong with it."
+	icon_state = "lollipop"
+	candy = 4
+	candymax = 4
+	charge_delay = 15 SECONDS
+	mode = DISPENSE_ICECREAM_MODE
+
+/obj/item/borg/lollipop/ice_cream/switch_mode(mob/living/user)
+	return
 
 /obj/item/ammo_casing/gumball
 	name = "Gumball"

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -173,7 +173,6 @@
 /obj/item/borg/lollipop/ice_cream
 	name = "ice cream fabricator"
 	desc = "Reward humans with vanilla ice cream. Can't go wrong with it."
-	icon_state = "lollipop"
 	candy = 4
 	candymax = 4
 	charge_delay = 15 SECONDS

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -425,6 +425,10 @@ GLOBAL_LIST_EMPTY(crematoriums)
 
 /obj/structure/bodycontainer/crematorium/Initialize(mapload)
 	. = ..()
+	if(mapload && check_holidays(ICE_CREAM_DAY) && !istype(src, /obj/structure/bodycontainer/crematorium/creamatorium))
+		var/obj/structure/bodycontainer/crematorium/creamatorium/creamy = new(loc)
+		creamy.id = id
+		return INITIALIZE_HINT_QDEL
 	GLOB.crematoriums += src
 
 /obj/structure/bodycontainer/crematorium/Destroy()

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -75,13 +75,15 @@
 
 	RegisterSignal(src, COMSIG_ATOM_REAGENT_EXAMINE, PROC_REF(allow_reagent_scan))
 
-	create_reagents(300, NO_REACT|TRANSPARENT)
+	var/ice_cream_day = check_holidays(ICE_CREAM_DAY) //ice cream vats are more "robust" on this holiday
+
+	create_reagents(ice_cream_day ? 400 : 300, NO_REACT|TRANSPARENT)
 	reagents.chem_temp = T0C //So ice doesn't melt
 	register_context()
 
 	if(preinstall_reagents)
 		for(var/reagent in icecream_vat_reagents)
-			reagents.add_reagent(reagent, icecream_vat_reagents[reagent], reagtemp = T0C)
+			reagents.add_reagent(reagent, icecream_vat_reagents[reagent] * (ice_cream_day ? 2.5 : 1), reagtemp = T0C)
 
 /obj/machinery/icecream_vat/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -47,6 +47,10 @@
 /datum/customer_data/New()
 	. = ..()
 	name_prefixes = world.file2list(prefix_file)
+	if(check_holidays(ICE_CREAM_DAY)) ///customers are more likely to order ice cream on this holiday
+		var/list/orderable_restaurant = orderable_objects[VENUE_RESTAURANT]
+		if(orderable_restaurant[/datum/custom_order/icecream])
+			orderable_restaurant[/datum/custom_order/icecream] *= 3
 
 /// Can this customer be chosen for this venue?
 /datum/customer_data/proc/can_use(datum/venue/venue)

--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -49,7 +49,7 @@
 	name_prefixes = world.file2list(prefix_file)
 	if(check_holidays(ICE_CREAM_DAY)) ///customers are more likely to order ice cream on this holiday
 		var/list/orderable_restaurant = orderable_objects[VENUE_RESTAURANT]
-		if(orderable_restaurant[/datum/custom_order/icecream])
+		if(orderable_restaurant?[/datum/custom_order/icecream])
 			orderable_restaurant[/datum/custom_order/icecream] *= 3
 
 /// Can this customer be chosen for this venue?

--- a/code/modules/holiday/nth_week.dm
+++ b/code/modules/holiday/nth_week.dm
@@ -84,3 +84,11 @@
 
 /datum/holiday/nth_week/moth/getStationPrefix()
 	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")
+
+/datum/holiday/nth_week/ice_cream
+	name = ICE_CREAM_DAY
+	begin_week = 3
+	begin_weekday = SUNDAY
+
+/datum/holiday/nth_week/ice_cream/getStationPrefix()
+	return pick("Ice Cream", "Gelato", "Semifreddo", "Cornuto", "Soft Serve", "Cone", "Ice", "Cream", "I Scream", "Parfait", "Straccciatella", "Sherbet", "Snow", "Affogato", "Mochi", "Tartufo", "Sundae", "Neapolitan")

--- a/code/modules/holiday/nth_week.dm
+++ b/code/modules/holiday/nth_week.dm
@@ -88,6 +88,7 @@
 /datum/holiday/nth_week/ice_cream
 	name = ICE_CREAM_DAY
 	begin_week = 3
+	begin_month = JULY
 	begin_weekday = SUNDAY
 
 /datum/holiday/nth_week/ice_cream/getStationPrefix()

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -65,6 +65,9 @@
 		emag_modules += new_module
 		emag_modules -= path
 
+	if(check_holidays(ICE_CREAM_DAY) && !(locate(/obj/item/borg/lollipop) in basic_modules))
+		basic_modules += new /obj/item/borg/lollipop/ice_cream(src)
+
 /obj/item/robot_model/Destroy()
 	basic_modules.Cut()
 	emag_modules.Cut()


### PR DESCRIPTION
## About The Pull Request
This PR adds the National Ice Cream Day (yeah, it's one of those 'murrican holidays) to the game, bringing a few niche ice-cream-related effects to the game

During the Ice Cream Day:
- Crematoriums replaced with cre**a**matoriums.
- All cyborgs that don't already come with the treat dispenser are given (a slightly weaker) one stuck in ice cream mode.
- Robot customers order ice cream thrice as often.
- The ice cream vat starts with two times and a half more ingredients.
- Ice cream cones can hold up to four times as many scoops as normal.

## Why It's Good For The Game
I've got the idea after Burger closed his april fools creamatorium PR. Orange was right to say that it didn't fit well within aprils fools, but I digress...

We have just enough ice cream features to enstablish the holiday into the game without it passing as mere station prefixes fluff (also apparently it's a real, presidentally proclamated US holiday).

## Changelog

:cl:
add: Add the National Ice Cream Day holiday, which falls on the third Sunday of July.
/:cl:
