### PR TITLE
Security officers can now be made blood brothers if their mindshield is removed

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -94,7 +94,7 @@
 		flashed.balloon_alert(source, "[flashed.p_theyre()] loyal to someone else!")
 		return
 
-	if (HAS_TRAIT(flashed, TRAIT_MINDSHIELD) || flashed.mind.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
+	if (HAS_TRAIT(flashed, TRAIT_MINDSHIELD))
 		flashed.balloon_alert(source, "[flashed.p_they()] resist!")
 		return
 


### PR DESCRIPTION
## About The Pull Request

What the title says. If you go to the effort of kidnapping a secoff and removing their mindshield, then you can now flash them to make them your bloodbrother. This change was atomized out of #84766.
## Why It's Good For The Game

Making it work this way is consistent with revolutionaries, who can also convert un-shielded security officers. Given that both antags convert people in the same way, by flashing people, it stands to reason that they should work in a consistent manner. This is unlikely to be overpowered, as you can just flash any head of staff for almost the same benefit but without all the effort.
## Changelog
:cl:
balance: If you remove a security officer's mindshield, then you can flash them to make them your blood brother.
/:cl:
