### PR TITLE
Remote materials don't block multitool on failure

### DIFF
--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -147,7 +147,7 @@ handles linking back and forth.
 /datum/component/remote_materials/proc/OnMultitool(datum/source, mob/user, obj/item/multitool/M)
 	SIGNAL_HANDLER
 
-	. = ITEM_INTERACT_BLOCKING
+	. = NONE
 	if (!QDELETED(M.buffer) && istype(M.buffer, /obj/machinery/ore_silo))
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -127,13 +127,16 @@
 	if(istype(AM, /obj/item/stack/sheet) && AM.loc == get_step(src, input_dir))
 		process_sheet(AM)
 
-/obj/machinery/mineral/stacking_machine/multitool_act(mob/living/user, obj/item/multitool/M)
-	if(istype(M))
-		if(istype(M.buffer, /obj/machinery/mineral/stacking_unit_console))
-			console = M.buffer
-			console.machine = src
-			to_chat(user, span_notice("You link [src] to the console in [M]'s buffer."))
-			return TRUE
+/obj/machinery/mineral/stacking_machine/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
+	if(user.combat_mode || multi_tool.item_flags & ABSTRACT || multi_tool.flags_1 & HOLOGRAM_1)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
+	. = ITEM_INTERACT_BLOCKING
+	if(istype(multi_tool.buffer, /obj/machinery/mineral/stacking_unit_console))
+		console = multi_tool.buffer
+		console.machine = src
+		to_chat(user, span_notice("You link [src] to the console in [multi_tool]'s buffer."))
+		return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/mineral/stacking_machine/proc/rotate(input)
 	if (input)


### PR DESCRIPTION
## About The Pull Request
- Fixes #84794

`/datum/component/remote_materials` blocks the tool act from continuing when linking with ore silo fails. We don't want that for stacking machines

## Changelog
:cl:
fix: stacking machines can be linked with its console via multitool
/:cl:

