### PR TITLE
You have to open mech panel first to attach the mecha tracker.

### DIFF
--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -119,6 +119,9 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/M, attach_right = FALSE)
+	if(!(M.mecha_flags & PANEL_OPEN))
+		balloon_alert(user, "panel is closed!")
+		return
 	if(!..())
 		return
 	M.trackers += src

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -122,7 +122,8 @@
 	if(!(M.mecha_flags & PANEL_OPEN))
 		balloon_alert(user, "panel is closed!")
 		return
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	M.trackers += src
 	M.diag_hud_set_mechtracking()

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -122,8 +122,7 @@
 	if(!(M.mecha_flags & PANEL_OPEN))
 		balloon_alert(user, "panel is closed!")
 		return
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 	M.trackers += src
 	M.diag_hud_set_mechtracking()


### PR DESCRIPTION
## About The Pull Request
As stated in the title, now in order to attach the tracker to the mech, you must first open its panel with a screwdriver.
## Why It's Good For The Game
Is it a good thing that a mecha can be destroyed with an tiny item that attaches in 1 click no matter what?
## Changelog
:cl:
balance: You have to open mech panel first to attach the mecha tracker.
/:cl:
