### PR TITLE
The techweb no longer erroneously refers to MODsuits as exosuits

### DIFF
--- a/code/modules/research/techweb/nodes/mech_nodes.dm
+++ b/code/modules/research/techweb/nodes/mech_nodes.dm
@@ -1,8 +1,8 @@
 /datum/techweb_node/mech_assembly
 	id = TECHWEB_NODE_MECH_ASSEMBLY
 	starting_node = TRUE
-	display_name = "Mech Assembly"
-	description = "Development of mech designed to contend with artificial gravity while transporting cargo."
+	display_name = "Exosuit Assembly"
+	description = "Development of mechanical exosuits designed to contend with artificial gravity while transporting cargo."
 	prereq_ids = list(TECHWEB_NODE_ROBOTICS)
 	design_ids = list(
 		"mechapower",
@@ -21,7 +21,7 @@
 /datum/techweb_node/mech_equipment
 	id = TECHWEB_NODE_MECH_EQUIPMENT
 	display_name = "Expedition Equipment"
-	description = "Specialized mech gear tailored for navigating space and celestial bodies, ensuring durability and functionality in the harshest conditions."
+	description = "Specialized exosuit gear tailored for navigating space and celestial bodies, ensuring durability and functionality in the harshest conditions."
 	prereq_ids = list(TECHWEB_NODE_MECH_ASSEMBLY)
 	design_ids = list(
 		"mechacontrol",
@@ -63,7 +63,7 @@
 
 /datum/techweb_node/mech_medical
 	id = TECHWEB_NODE_MECH_MEDICAL
-	display_name = "Medical Mech"
+	display_name = "Medical Exosuit"
 	description = "Advanced robotic unit equipped with syringe guns and healing beams, revolutionizing medical assistance in hazardous environments."
 	prereq_ids = list(TECHWEB_NODE_MECH_ASSEMBLY, TECHWEB_NODE_CHEM_SYNTHESIS)
 	design_ids = list(
@@ -83,8 +83,8 @@
 
 /datum/techweb_node/mech_mining
 	id = TECHWEB_NODE_MECH_MINING
-	display_name = "Mining Mech"
-	description = "Robust mech engineered to withstand lava and storms for continuous off-station mining operations."
+	display_name = "Mining Exosuit"
+	description = "Robust exosuit engineered to withstand lava and storms for continuous off-station mining operations."
 	prereq_ids = list(TECHWEB_NODE_MECH_EQUIPMENT, TECHWEB_NODE_MINING)
 	design_ids = list(
 		"clarke_chassis",
@@ -99,8 +99,8 @@
 
 /datum/techweb_node/mech_combat
 	id = TECHWEB_NODE_MECH_COMBAT
-	display_name = "Combat Mechs"
-	description = "Modular armor upgrades and specialized equipment for security mechs."
+	display_name = "Combat Exosuits"
+	description = "Modular armor upgrades and specialized equipment for security exosuits."
 	prereq_ids = list(TECHWEB_NODE_MECH_EQUIPMENT)
 	design_ids = list(
 		"mech_ccw_armor",
@@ -115,8 +115,8 @@
 
 /datum/techweb_node/mech_assault
 	id = TECHWEB_NODE_MECH_ASSAULT
-	display_name = "Assault Mech"
-	description = "Heavy battle mech boasting robust armor but sacrificing speed for enhanced durability."
+	display_name = "Assault Exosuits"
+	description = "Heavy battle exosuits boasting robust armor but sacrificing speed for enhanced durability."
 	prereq_ids = list(TECHWEB_NODE_MECH_COMBAT)
 	design_ids = list(
 		"durand_armor",
@@ -135,8 +135,8 @@
 
 /datum/techweb_node/mech_light
 	id = TECHWEB_NODE_MECH_LIGHT
-	display_name = "Light Combat Mech"
-	description = "Agile combat mech equipped with overclocking capabilities for temporary speed boosts, prioritizing speed over durability on the battlefield."
+	display_name = "Light Combat Exosuits"
+	description = "Agile combat exosuits equipped with overclocking capabilities for temporary speed boosts, prioritizing speed over durability on the battlefield."
 	prereq_ids = list(TECHWEB_NODE_MECH_COMBAT)
 	design_ids = list(
 		"gygax_armor",
@@ -155,7 +155,7 @@
 
 /datum/techweb_node/mech_heavy
 	id = TECHWEB_NODE_MECH_HEAVY
-	display_name = "Heavy Mech"
+	display_name = "Heavy Exosuits"
 	description = "Advanced heavy mechanized unit with dual pilot capability, designed for robust battlefield performance and increased tactical versatility."
 	prereq_ids = list(TECHWEB_NODE_MECH_ASSAULT)
 	design_ids = list(
@@ -175,8 +175,8 @@
 
 /datum/techweb_node/mech_infiltrator
 	id = TECHWEB_NODE_MECH_INFILTRATOR
-	display_name = "Infiltration Mech"
-	description = "Advanced mech with phasing capabilities, allowing it to move through walls and obstacles, ideal for covert and special operations."
+	display_name = "Infiltration Exosuits"
+	description = "Advanced exosuit with phasing capabilities, allowing it to move through walls and obstacles, ideal for covert and special operations."
 	prereq_ids = list(TECHWEB_NODE_MECH_LIGHT, TECHWEB_NODE_ANOMALY_RESEARCH)
 	design_ids = list(
 		"phazon_armor",
@@ -211,8 +211,8 @@
 
 /datum/techweb_node/mech_energy_guns
 	id = TECHWEB_NODE_MECH_ENERGY_GUNS
-	display_name = "Mech Energy Guns"
-	description = "Scaled-up versions of electric weapons optimized for mech deployment."
+	display_name = "Exosuit Energy Guns"
+	description = "Scaled-up versions of electric weapons optimized for exosuit deployment."
 	prereq_ids = list(TECHWEB_NODE_MECH_COMBAT, TECHWEB_NODE_ELECTRIC_WEAPONS)
 	design_ids = list(
 		"mech_laser",
@@ -225,7 +225,7 @@
 
 /datum/techweb_node/mech_firearms
 	id = TECHWEB_NODE_MECH_FIREARMS
-	display_name = "Mech Firearms"
+	display_name = "Exosuit Firearms"
 	description = "Mounted ballistic weaponry, enhancing combat capabilities for mechanized units."
 	prereq_ids = list(TECHWEB_NODE_MECH_ENERGY_GUNS, TECHWEB_NODE_EXOTIC_AMMO)
 	design_ids = list(
@@ -240,7 +240,7 @@
 
 /datum/techweb_node/mech_heavy_arms
 	id = TECHWEB_NODE_MECH_HEAVY_ARMS
-	display_name = "Heavy Mech Firearms"
+	display_name = "Heavy Exosuit Firearms"
 	description = "High-impact weaponry integrated into mechs, optimized for maximum firepower."
 	prereq_ids = list(TECHWEB_NODE_MECH_HEAVY, TECHWEB_NODE_EXOTIC_AMMO)
 	design_ids = list(
@@ -255,7 +255,7 @@
 
 /datum/techweb_node/mech_equip_bluespace
 	id = TECHWEB_NODE_BLUESPACE
-	display_name = "Bluespace Mech Equipment"
+	display_name = "Bluespace Exosuit Equipment"
 	description = "An array of equipment empowered by bluespace, providing unmatched mobility and utility."
 	prereq_ids = list(TECHWEB_NODE_MECH_INFILTRATOR, TECHWEB_NODE_BLUESPACE_TRAVEL)
 	design_ids = list(

--- a/code/modules/research/techweb/nodes/modsuit_nodes.dm
+++ b/code/modules/research/techweb/nodes/modsuit_nodes.dm
@@ -1,7 +1,7 @@
 /datum/techweb_node/mod_suit
 	id = TECHWEB_NODE_MOD_SUIT
 	starting_node = TRUE
-	display_name = "Modular Exosuit"
+	display_name = "Modular Suit"
 	description = "Specialized back mounted power suits with various different modules."
 	prereq_ids = list(TECHWEB_NODE_ROBOTICS)
 	design_ids = list(
@@ -52,7 +52,7 @@
 /datum/techweb_node/mod_medical
 	id = TECHWEB_NODE_MOD_MEDICAL
 	display_name = "Medical Modular Suit"
-	description = "Medical exosuits for quick rescue purposes."
+	description = "Medical MODsuits for quick rescue purposes."
 	prereq_ids = list(TECHWEB_NODE_MOD_SUIT, TECHWEB_NODE_CHEM_SYNTHESIS)
 	design_ids = list(
 		"mod_plating_medical",
@@ -97,7 +97,7 @@
 /datum/techweb_node/mod_medical_adv
 	id = TECHWEB_NODE_MOD_MEDICAL_ADV
 	display_name = "Field Surgery Modules"
-	description = "Medical exosuit equipment designed for conducting surgical operations in field conditions."
+	description = "Medical MODsuit equipment designed for conducting surgical operations in field conditions."
 	prereq_ids = list(TECHWEB_NODE_MOD_MEDICAL, TECHWEB_NODE_SURGERY_ADV)
 	design_ids = list(
 		"mod_defib",
@@ -129,7 +129,7 @@
 /datum/techweb_node/mod_anomaly
 	id = TECHWEB_NODE_MOD_ANOMALY
 	display_name = "Anomalock Modular Suit"
-	description = "Modules for exosuits that require anomaly cores to function."
+	description = "Modules for MODsuits that require anomaly cores to function."
 	prereq_ids = list(TECHWEB_NODE_MOD_ENGI_ADV, TECHWEB_NODE_ANOMALY_RESEARCH)
 	design_ids = list(
 		"mod_antigrav",


### PR DESCRIPTION

## About The Pull Request

At some point, some of the techweb node descriptions were changed, so that it referred to certain modsuits as exosuits. This just changes it back.
## Why It's Good For The Game

The term "exosuit" is generally used for mechs, not modsuits. The techweb descriptions should refer to modsuits as modsuits.
## Changelog
:cl:
spellcheck: The techweb no longer erroneously refers to MODsuits as exosuits.
/:cl:
