### PR TITLE
Allows modsuits to remove the slowdown IN EXCHANGE for removing the spaceproofing

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -989,7 +989,7 @@
 
 /obj/item/mod/module/antislow
 	name = "MOD civilian conversion kit"
-	desc = "A conversion kit that removes much of the spaceproofing of the suit. This makes the suit much easier to \
+	desc = "A conversion kit that removes much of the spaceproofing parts of the suit. This makes the suit much easier to \
 		move around in, but also makes it incapable of protecting the wearer from the vacuum of space."
 	icon_state = "armor_booster"
 	complexity = 2
@@ -1004,12 +1004,12 @@
 	old_slowdown = mod.slowdown_active
 	mod.slowdown_active = 0
 	for(var/obj/item/clothing/clothing_part in mod.get_parts())
-		if(clothing_part.clothing_flags & STOPSPRESSUREDAMAGE)
-			clothing_part.clothing_flags &= ~STOPSPRESSUREDAMAGE
+		if(clothing_part.visor_flags & STOPSPRESSUREDAMAGE)
+			clothing_part.visor_flags &= ~STOPSPRESSUREDAMAGE
 			altered_parts += clothing_part
 
 /obj/item/mod/module/antislow/on_uninstall(deleting)
 	mod.slowdown_active = old_slowdown
 	for(var/obj/item/clothing/clothing_part in altered_parts)
-		clothing_part.clothing_flags |= STOPSPRESSUREDAMAGE
+		clothing_part.visor_flags |= STOPSPRESSUREDAMAGE
 	altered_parts.Cut()

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -986,3 +986,30 @@
 	var/datum/effect_system/lightning_spread/sparks = new /datum/effect_system/lightning_spread
 	sparks.set_up(number = 5, cardinals_only = TRUE, location = mod.wearer.loc)
 	sparks.start()
+
+/obj/item/mod/module/antislow
+	name = "MOD civilian conversion kit"
+	desc = "A conversion kit that removes much of the spaceproofing of the suit. This makes the suit much easier to \
+		move around in, but also makes it incapable of protecting the wearer from the vacuum of space."
+	icon_state = "armor_booster"
+	complexity = 2
+	module_type = MODULE_PASSIVE
+	incompatible_modules = list(/obj/item/mod/module/antislow, /obj/item/mod/module/armor_booster)
+	/// The original slowdown from the modsuit, so we can put it back when the module is removed.
+	var/old_slowdown
+	/// Keep a list of the parts that were made non-spaceproof, so we can undo it when the module is removed.
+	var/list/altered_parts = list()
+
+/obj/item/mod/module/antislow/on_install()
+	old_slowdown = mod.slowdown_active
+	mod.slowdown_active = 0
+	for(var/obj/item/clothing/clothing_part in mod.get_parts())
+		if(clothing_part.clothing_flags & STOPSPRESSUREDAMAGE)
+			clothing_part.clothing_flags &= ~STOPSPRESSUREDAMAGE
+			altered_parts += clothing_part
+
+/obj/item/mod/module/antislow/on_uninstall(deleting)
+	mod.slowdown_active = old_slowdown
+	for(var/obj/item/clothing/clothing_part in altered_parts)
+		clothing_part.clothing_flags |= STOPSPRESSUREDAMAGE
+	altered_parts.Cut()

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -2358,6 +2358,15 @@
 	)
 	build_path = /obj/item/mod/module/thermal_regulator
 
+/datum/design/module/antislow
+	name = "Civilian Conversion Kit"
+	id = "mod_antislow"
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/mod/module/antislow
+
 /datum/design/module/mod_injector
 	name = "Injector Module"
 	id = "mod_injector"

--- a/code/modules/research/techweb/nodes/modsuit_nodes.dm
+++ b/code/modules/research/techweb/nodes/modsuit_nodes.dm
@@ -32,6 +32,7 @@
 		"mod_mouthhole",
 		"mod_longfall",
 		"mod_thermal_regulator",
+		"mod_antislow",
 		"mod_sign_radio",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)


### PR DESCRIPTION
## About The Pull Request

There is now a new modsuit module, the civilian conversion kit. When installed, it removes the slowdown applied by a modsuit (only when the modsuit is active. The inactive slowdown is unchanged) in exchange for removing the pressure proofing from the modsuit as well. This module has been added to the techweb and has a mechfab design.
## Why It's Good For The Game

There are a lot of really cool modsuit modules that are hampered by the other drawbacks that modsuits have. These drawbacks exist for a good reason; space proof suits should have tradeoffs, especially ones available at the start of the round like modsuits are. But that doesn't really solve the problem with the modules.

One of the biggest examples of this problem is the pepper shoulders module that comes on security modsuits. It's a very cool module conceptually, but it tends to have limited usefulness in practice. Out in space, whoever you're fighting is likely wearing a  spacesuit of their own, which will make them completely immune to the pepper spray. On the station, the person wearing the suit has to deal with the slowdown from it, which will far outweigh any advantage granted by the pepper shoulders module.

I am not the first person to realize this issue. Nuclear operative modsuits come with an armor booster module, which does something similar to the conversion kit. It gives the modsuit wearer a toggle that gives full speed movement and combat-tier armor at the cost of temporarily removing the spaceproofing from the suit. Now, I'm sure this comparison has some of you worried about balance, which brings me to my next point...

## Balance

Can people install the module to move quickly, and then just remove it when they need to be spaceproof? Not really, no. The module only applies to slowdown while the modsuit is active; anyone who is actually benefitting from the conversion kit will have to wait for their suit to shutdown, remove the kit, and then wait for their suit to activate again. That's a lot of waiting, so I suspect that most people will just use the tried and true method of carrying an EVA suit around.
## Changelog
:cl:
add: Added the MODsuits Civilian Conversion Kit. This module will remove the active slowdown from a modsuit, but will also stop the suit from protecting the wearer from the vacuum of space.
/:cl:
