### PR TITLE
You can now see whether or not a piece of clothing is pressure-proof when examining

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -393,6 +393,17 @@
 				readout += "<b><u>COVERAGE</u></b>"
 				readout += "It will block [english_list(things_blocked)]."
 
+		if(clothing_flags & STOPSPRESSUREDAMAGE || visor_flags & STOPSPRESSUREDAMAGE)
+			var/list/parts_covered = list()
+			var/output_string = "It"
+			if(!(clothing_flags & STOPSPRESSUREDAMAGE))
+				output_string = "When sealed, it"
+			if(body_parts_covered & HEAD)
+				parts_covered += "head"
+			if(body_parts_covered & CHEST)
+				parts_covered += "torso"
+			if(length(parts_covered)) // Just in case someone makes spaceproof gloves or something
+				readout += "[output_string] will protect your [english_list(parts_covered)] from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."
 
 		if(!length(readout))
 			readout += "No armor or durability information available."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -353,7 +353,7 @@
 		how_cool_are_your_threads += "</span>"
 		. += how_cool_are_your_threads.Join()
 
-	if(get_armor().has_any_armor() || (flags_cover & (HEADCOVERSMOUTH|PEPPERPROOF)))
+	if(get_armor().has_any_armor() || (flags_cover & (HEADCOVERSMOUTH|PEPPERPROOF)) || (clothing_flags & STOPSPRESSUREDAMAGE) || (visor_flags & STOPSPRESSUREDAMAGE))
 		. += span_notice("It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.")
 
 /obj/item/clothing/Topic(href, href_list)
@@ -403,7 +403,10 @@
 			if(body_parts_covered & CHEST)
 				parts_covered += "torso"
 			if(length(parts_covered)) // Just in case someone makes spaceproof gloves or something
-				readout += "[output_string] will protect your [english_list(parts_covered)] from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."
+				readout += "[output_string] will protect the wearer's [english_list(parts_covered)] from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."
+
+		if(min_cold_protection_temperature == SPACE_SUIT_MIN_TEMP_PROTECT)
+			readout += "It will insulate the wearer from [span_tooltip("While not as dangerous as the lack of pressure, the extremely low temperature of space is also a hazard.", "the cold of space")]."
 
 		if(!length(readout))
 			readout += "No armor or durability information available."


### PR DESCRIPTION
## About The Pull Request

A picture is worth a thousand words: 
![unsealed](https://github.com/tgstation/tgstation/assets/21979502/10e3c778-2445-4232-be44-28170bc34826)
![sealed](https://github.com/tgstation/tgstation/assets/21979502/98825d56-9c05-4984-8b27-251c0405a1b0)
![helmet](https://github.com/tgstation/tgstation/assets/21979502/2b98ca1d-b4ce-42ec-86ce-0fc19650c400)
As you can see from the first picture, it takes unsealed modsuits (and similar items, if any exist) into account. It also has text for clothing that covers both the head and torso, but as far as I can tell no single item does this (hoods don't count since it's a separate item).
## Why It's Good For The Game

Knowing that a piece of gear protects you from space is vital information, especially to new players. For EVA suits, it might already be obvious, but how many new players will know that a firesuit does the same?
## Changelog
:cl:
qol: Clothing now tells you if it is pressure-proof and insulated enough for spacewalking when examining it.
/:cl:
