### PR TITLE
[Birdshot] Small mapping fixes

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -4478,6 +4478,7 @@
 	},
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "bJK" = (
@@ -4927,6 +4928,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "bUr" = (
@@ -9782,6 +9784,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/recreation/entertainment)
 "dEq" = (
@@ -17153,7 +17156,7 @@
 /area/station/engineering/main)
 "gla" = (
 /turf/open/floor/iron/grimy,
-/area/station/commons)
+/area/station/service/janitor)
 "gls" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18695,6 +18698,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "gLs" = (
@@ -20692,7 +20696,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/iron/small,
-/area/station/commons)
+/area/station/service/janitor)
 "hqm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -26455,6 +26459,7 @@
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "jfs" = (
@@ -29066,7 +29071,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/station/commons)
+/area/station/service/janitor)
 "jVe" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -29264,6 +29269,7 @@
 /area/station/security)
 "jXJ" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/central/aft)
 "jXQ" = (
@@ -30714,7 +30720,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/small,
-/area/station/commons)
+/area/station/service/janitor)
 "ktT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -30755,6 +30761,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "kuq" = (
@@ -36994,7 +37001,7 @@
 /obj/item/bedsheet/purple,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
-/area/station/commons)
+/area/station/service/janitor)
 "mqz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -38997,6 +39004,7 @@
 "mZj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "mZA" = (
@@ -39187,6 +39195,11 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"ndO" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation/entertainment)
 "ndY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -40759,6 +40772,14 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"nGc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/power/apc/auto_name/directional/west{
+	areastring = "/area/station/science/ordnance/freezerchamber"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "nGe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41082,6 +41103,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "nLH" = (
@@ -44972,7 +44994,7 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/small,
-/area/station/commons)
+/area/station/service/janitor)
 "pcv" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Bedroom"
@@ -46152,6 +46174,7 @@
 /area/station/commons/fitness/recreation/entertainment)
 "pvB" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "pvC" = (
@@ -48140,6 +48163,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "qbj" = (
@@ -48251,6 +48275,7 @@
 "qcC" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "qcF" = (
@@ -52827,6 +52852,7 @@
 	icon_state = "L9";
 	pixel_y = -15
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "rzJ" = (
@@ -52958,7 +52984,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
-/area/station/commons)
+/area/station/service/janitor)
 "rBy" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
@@ -55529,6 +55555,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "sso" = (
@@ -61908,7 +61935,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/iron/grimy,
-/area/station/commons)
+/area/station/service/janitor)
 "urd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62556,6 +62583,10 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"uCc" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "uCe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -66134,6 +66165,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"vCP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "vCQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -66858,6 +66896,7 @@
 "vNn" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "vNq" = (
@@ -66974,7 +67013,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/station/commons)
+/area/station/service/janitor)
 "vPw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69618,6 +69657,15 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
+"wGt" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation/entertainment)
 "wGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70977,9 +71025,6 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
-"wZl" = (
-/turf/closed/wall,
-/area/station/commons)
 "wZp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -71839,7 +71884,7 @@
 /obj/item/clothing/shoes/galoshes,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/small,
-/area/station/commons)
+/area/station/service/janitor)
 "xkK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -93175,7 +93220,7 @@ qBz
 qTR
 kym
 rHD
-qVR
+uCc
 wCR
 jRz
 qzP
@@ -109866,7 +109911,7 @@ nju
 iGt
 vtL
 sBP
-wZl
+sRL
 pcm
 gla
 vPt
@@ -110123,7 +110168,7 @@ wNd
 nFW
 tDB
 unK
-wZl
+sRL
 xkv
 ura
 jUU
@@ -110380,12 +110425,12 @@ rqw
 rqw
 qow
 rqw
-wZl
-wZl
-wZl
+sRL
+sRL
+sRL
 rBr
-wZl
-wZl
+sRL
+sRL
 eeJ
 lxp
 syA
@@ -111687,7 +111732,7 @@ pCv
 unc
 sWQ
 raZ
-qUa
+vCP
 qUa
 qUa
 qUa
@@ -111926,7 +111971,7 @@ ntZ
 jpp
 jpp
 dxw
-jpp
+ndO
 jpp
 jpp
 jpp
@@ -112183,7 +112228,7 @@ pzd
 tpG
 pvk
 pzd
-iCj
+wGt
 qMa
 uhy
 iCj
@@ -124812,7 +124857,7 @@ xFI
 gfu
 ckt
 ckt
-ckt
+nGc
 lwu
 lkV
 whF


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This PR fixes some areas lacking an APC and air alarms. Ever so minor.

## Changelog

:cl: Jolly
fix: [Birdshot] The Ordnance freezer chamber is now linked to an APC, much like the burn chamber.
fix: [Birdshot] The Janitors quarters no longer uses `/area/station/commons`, instead, it uses the janitors regular area.
fix: [Birdshot] The entertainment center now has an APC.
fix: [Birdshot] A handful of smaller areas have received air alarms.
/:cl:


