### PR TITLE
The random loot config is not an integer

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -471,5 +471,6 @@
  * If higher than 1, it'll lean toward common spawns even more.
  */
 /datum/config_entry/number/random_loot_weight_modifier
+	integer = FALSE
 	default = 1
 	min_val = 0.05


### PR DESCRIPTION
## About The Pull Request
Minor nitpick with the config.

## Why It's Good For The Game
It ain't an integer

## Changelog
N/A