### PR TITLE
[NO GBP] the random spawner loot weight config is not an integer

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -471,5 +471,6 @@
  * If higher than 1, it'll lean toward common spawns even more.
  */
 /datum/config_entry/number/random_loot_weight_modifier
+	integer = FALSE
 	default = 1
 	min_val = 0.05

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -103,7 +103,7 @@
 		var/loot_weight = loot_list[loot_type]
 		if(loot_weight <= 1)
 			if(exponent < 1)
-				loot_list[loot_type] *= precision
+				loot_list[loot_type] = precision
 			continue
 		loot_list[loot_type] = round(loot_weight ** exponent * precision, 1)
 


### PR DESCRIPTION
## About The Pull Request
Sets `integer` to false.
Also a tidbit about the `skew_loot_weight` proc, though loot lists with uneven weights all tend to add a value to all entries so it isn't an issue.

## Why It's Good For The Game
The config isn't an integer.

## Changelog
N/A