### PR TITLE
TV helmet no longer has fov or makes you flash sensitive

### DIFF
--- a/code/game/objects/effects/spawners/random/clothing.dm
+++ b/code/game/objects/effects/spawners/random/clothing.dm
@@ -211,7 +211,7 @@
 		/obj/item/clothing/head/costume/lobsterhat,
 		/obj/item/clothing/head/costume/cardborg,
 		/obj/item/clothing/head/costume/football_helmet,
-		/obj/item/clothing/head/costume/tv_head/fov_less,
+		/obj/item/clothing/head/costume/tv_head,
 		/obj/item/clothing/head/costume/tmc,
 		/obj/item/clothing/head/costume/deckers,
 		/obj/item/clothing/head/costume/yuri,

--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -156,10 +156,8 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi' //Grandfathered in from the wallframe for status displays.
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	clothing_flags = SNUG_FIT
-	flash_protect = FLASH_PROTECTION_SENSITIVE
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	flags_cover = HEADCOVERSEYES|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
-	var/has_fov = TRUE
 
 /datum/armor/costume_bronze
 	melee = 5
@@ -168,15 +166,6 @@
 	bomb = 10
 	fire = 20
 	acid = 20
-
-/obj/item/clothing/head/costume/tv_head/Initialize(mapload)
-	. = ..()
-	if(has_fov)
-		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
-
-/obj/item/clothing/head/costume/tv_head/fov_less
-	desc = "A mysterious headgear made from the hollowed out remains of a status display. How very retro-retro-futuristic of you. It's very easy to see out of this one."
-	has_fov = FALSE
 
 /obj/item/clothing/head/costume/irs
 	name = "internal revenue service cap"


### PR DESCRIPTION

## About The Pull Request

TV helmet no longer has gas mask FOV, nor does it give you flash sensitivity.

Since those are gone, removed pepper proof from it as well.

## Why It's Good For The Game

I don't really know why the tv helmet specifically was cucked like this. Out of all the costume helmets, none do this. I don't think it adds much? It just makes it a pain in the ass to use? I want to be a tv helmet guy and see 360 degrees and weld in peace, I don't think that's too much to ask.

For fairness sake it also doesn't have pepperproof anymore. You can replicate all its effects by just wearing a gas mask underneath.

## Changelog

:cl:
qol: TV helmet no longer has gas mask FOV, nor does it give you flash sensitivity.
qol: Since those are gone, removed pepper proof from it as well.
/:cl:

