### PR TITLE
Fixes meat producing copious amounts of blood

### DIFF
--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -16,12 +16,12 @@
 		/datum/component/blood_walk,\
 		blood_type = blood_decal_type,\
 		blood_spawn_chance = 45,\
-		max_blood = custom_materials[custom_materials[1]],\
+		max_blood = custom_materials[custom_materials[1]] / SHEET_MATERIAL_AMOUNT,\
 	)
 
 	AddComponent(
 		/datum/component/bloody_spreader,\
-		blood_left = custom_materials[custom_materials[1]],\
+		blood_left = custom_materials[custom_materials[1]] / SHEET_MATERIAL_AMOUNT,\
 		blood_dna = list("meaty DNA" = "MT-"),\
 		diseases = null,\
 	)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -277,11 +277,11 @@
 		/datum/component/blood_walk,\
 		blood_type = /obj/effect/decal/cleanable/blood,\
 		blood_spawn_chance = 15,\
-		max_blood = 300,\
+		max_blood = custom_materials[custom_materials[1]] / SHEET_MATERIAL_AMOUNT,\
 	)
 	AddComponent(
 		/datum/component/bloody_spreader,\
-		blood_left = INFINITY,\
+		blood_left = custom_materials[custom_materials[1]] / SHEET_MATERIAL_AMOUNT,\
 		blood_dna = list("MEAT DNA" = "MT+"),\
 		diseases = null,\
 	)


### PR DESCRIPTION

## About The Pull Request
Closes #83665
blood_walk component's amount of blood is actually the amount of tiles on which the component will leave blood. This makes steaks roughly consistent with the meat material, as previously they had copious 400 tiles of blood. Since by default blood decals hold 50 blood, this translates to... 20 thousand units of blood. 
Does same for the meatpack which copypasted code from the steak from the looks of it.

## Why It's Good For The Game

400 tiles is a nonsensical amount of blood for a single steak, and this is clearly an oversight. Maintainers are welcome to relabel this as balance if required.

## Changelog
:cl:
fix: Steaks and meatpacks no longer have an absurd amount of blood stored inside of them.
/:cl:
