### PR TITLE
Vapes use correct fill level overlays

### DIFF
--- a/code/datums/greyscale/config_types/greyscale_configs/greyscale_items.dm
+++ b/code/datums/greyscale/config_types/greyscale_configs/greyscale_items.dm
@@ -265,15 +265,15 @@
 
 /datum/greyscale_config/vape/open_low
 	name = "Open Vape Low"
-	json_config = 'code/datums/greyscale/json_configs/vape_open_low.json'
+	json_config = 'code/datums/greyscale/json_configs/vapeopen_low.json'
 
 /datum/greyscale_config/vape/open_med
 	name = "Open Vape Medium"
-	json_config = 'code/datums/greyscale/json_configs/vape_open_med.json'
+	json_config = 'code/datums/greyscale/json_configs/vapeopen_med.json'
 
 /datum/greyscale_config/vape/open_high
 	name = "Open Vape High"
-	json_config = 'code/datums/greyscale/json_configs/vape_open_high.json'
+	json_config = 'code/datums/greyscale/json_configs/vapeopen_high.json'
 
 //
 // TAPE

--- a/code/datums/greyscale/json_configs/vapeopen_high.json
+++ b/code/datums/greyscale/json_configs/vapeopen_high.json
@@ -1,5 +1,5 @@
 {
-    "vape_open_low": [
+    "vapeopen_high": [
         {
             "type": "icon_state",
             "icon_state": "vapeOutlet",
@@ -13,7 +13,7 @@
         },
 		{
             "type": "icon_state",
-            "icon_state": "vapeopen_low",
+            "icon_state": "vapeopen_high",
             "blend_mode": "overlay"
         }
     ]

--- a/code/datums/greyscale/json_configs/vapeopen_low.json
+++ b/code/datums/greyscale/json_configs/vapeopen_low.json
@@ -1,5 +1,5 @@
 {
-    "vape_open_med": [
+    "vapeopen_low": [
         {
             "type": "icon_state",
             "icon_state": "vapeOutlet",
@@ -13,7 +13,7 @@
         },
 		{
             "type": "icon_state",
-            "icon_state": "vapeopen_med",
+            "icon_state": "vapeopen_low",
             "blend_mode": "overlay"
         }
     ]

--- a/code/datums/greyscale/json_configs/vapeopen_med.json
+++ b/code/datums/greyscale/json_configs/vapeopen_med.json
@@ -1,5 +1,5 @@
 {
-    "vape_open_high": [
+    "vapeopen_med": [
         {
             "type": "icon_state",
             "icon_state": "vapeOutlet",
@@ -13,7 +13,7 @@
         },
 		{
             "type": "icon_state",
-            "icon_state": "vapeopen_high",
+            "icon_state": "vapeopen_med",
             "blend_mode": "overlay"
         }
     ]

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -1162,13 +1162,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		to_chat(user, span_notice("You open the cap on [src]."))
 		reagents.flags |= OPENCONTAINER
 		if(obj_flags & EMAGGED)
-			icon_state = "vape_open_high"
+			icon_state = "vapeopen_high"
 			set_greyscale(new_config = /datum/greyscale_config/vape/open_high)
 		else if(super)
-			icon_state = "vape_open_med"
+			icon_state = "vapeopen_med"
 			set_greyscale(new_config = /datum/greyscale_config/vape/open_med)
 		else
-			icon_state = "vape_open_low"
+			icon_state = "vapeopen_low"
 			set_greyscale(new_config = /datum/greyscale_config/vape/open_low)
 	else
 		screw = FALSE
@@ -1183,12 +1183,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(!super)
 			super = TRUE
 			to_chat(user, span_notice("You increase the voltage of [src]."))
-			icon_state = "vape_open_med"
+			icon_state = "vapeopen_med"
 			set_greyscale(new_config = /datum/greyscale_config/vape/open_med)
 		else
 			super = FALSE
 			to_chat(user, span_notice("You decrease the voltage of [src]."))
-			icon_state = "vape_open_low"
+			icon_state = "vapeopen_low"
 			set_greyscale(new_config = /datum/greyscale_config/vape/open_low)
 
 	if(screw && (obj_flags & EMAGGED))
@@ -1207,7 +1207,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	obj_flags |= EMAGGED
 	super = FALSE
 	balloon_alert(user, "voltage maximized")
-	icon_state = "vape_open_high"
+	icon_state = "vapeopen_high"
 	set_greyscale(new_config = /datum/greyscale_config/vape/open_high)
 	var/datum/effect_system/spark_spread/sp = new /datum/effect_system/spark_spread //for effect
 	sp.set_up(5, 1, src)


### PR DESCRIPTION

## About The Pull Request

Closes #83573 by removing an underscore

## Changelog
:cl:
fix: Vapes use correct fill level overlays
/:cl:
