### PR TITLE
You no longer try to pull out someones eyes in combat mode if they have cranial fissure

### DIFF
--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -81,7 +81,7 @@
 	)
 
 /datum/wound/cranial_fissure/try_handling(mob/living/user)
-	if (user.usable_hands <= 0)
+	if (user.usable_hands <= 0 || user.combat_mode)
 		return FALSE
 
 	if(!isnull(user.hud_used?.zone_select) && (user.zone_selected != BODY_ZONE_HEAD && user.zone_selected != BODY_ZONE_PRECISE_EYES))


### PR DESCRIPTION

## About The Pull Request

Closes #82526
Cranial fissure didn't check for combat mode so if someone had the trauma you weren't able to punch them in the head

## Changelog
:cl:
fix: You no longer try to pull out someones eyes in combat mode if they have cranial fissure
/:cl:
