### PR TITLE
Makes gigabeacon easier to research

### DIFF
--- a/code/modules/research/techweb/nodes/engi_nodes.dm
+++ b/code/modules/research/techweb/nodes/engi_nodes.dm
@@ -104,7 +104,6 @@
 		"s_filter",
 		"s_transmitter",
 		"s_treatment",
-		"gigabeacon",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS)
 

--- a/code/modules/research/techweb/nodes/research_nodes.dm
+++ b/code/modules/research/techweb/nodes/research_nodes.dm
@@ -45,6 +45,7 @@
 		"blutrash",
 		"light_replacer_blue",
 		"bluespacebodybag",
+		"gigabeacon",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 	required_experiments = list(/datum/experiment/scanning/points/bluespace_crystal)


### PR DESCRIPTION
## About The Pull Request
This changes the bluespace navigation gigabeacon to be unlocked with Applied Bluespace Research (T2) research node, instead of Telecommunications (T5).
## Why It's Good For The Game
Gigabeacon used to be its own node which nobody researched. #77223 changed that by tying it up with Telecommunications. After the techweb tree update, Telecommunications has become a tier 5 research, meaning that nobody researches gigabeacons again. This PR is meant to amend that, making gigabeacons more accessible again.
I have to admit that putting this item unlock on Applied Bluespace node is quite generous, since that node should be researched early on every round. However, I don't believe that to be an issue, but if needed I can move it to Bluespace Travel (prerequisite to t4 parts).
## Changelog
:cl:
balance: bluespace navigation gigabeacons are now unlocked with Applied Bluespace Research
/:cl:
