### PR TITLE
Restores jetpack speed (on space tiles)

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -111,11 +111,12 @@
 	SEND_SIGNAL(src, COMSIG_JETPACK_DEACTIVATED, user)
 	on = FALSE
 	update_icon(UPDATE_ICON_STATE)
+	if(user)
+		user.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/full_speed)
 
-/obj/item/tank/jetpack/proc/allow_thrust(num, use_fuel = TRUE)
+/obj/item/tank/jetpack/proc/allow_thrust(num, use_fuel = TRUE, mob/user)
 	if(!ismob(loc))
 		return FALSE
-	var/mob/user = loc
 
 	if((num < 0.005 || air_contents.total_moles() < num))
 		turn_off(user)
@@ -131,6 +132,10 @@
 		return FALSE
 
 	var/turf/T = get_turf(src)
+	if(isspaceturf(T) || ismiscturf(T))
+		user.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/full_speed)
+	else
+		user.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/full_speed)
 	T.assume_air(removed)
 	return TRUE
 

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -117,6 +117,7 @@
 /obj/item/tank/jetpack/proc/allow_thrust(num, use_fuel = TRUE, mob/user)
 	if(!ismob(loc))
 		return FALSE
+	user = loc
 
 	if((num < 0.005 || air_contents.total_moles() < num))
 		turn_off(user)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -155,7 +155,13 @@
 		return check_power(use_energy_cost)
 	if(!drain_power(use_energy_cost))
 		return FALSE
+	var/turf/T = get_turf(src)
+	if(isspaceturf(T) || ismiscturf(T))
+		usr.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/full_speed)
+	else
+		usr.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/full_speed)
 	return TRUE
+
 
 /// Cooldown to use if we didn't actually launch a jump jet
 #define FAILED_ACTIVATION_COOLDOWN 3 SECONDS

--- a/code/modules/movespeed/modifiers/items.dm
+++ b/code/modules/movespeed/modifiers/items.dm
@@ -5,6 +5,9 @@
 /datum/movespeed_modifier/jetpack/cybernetic
 	multiplicative_slowdown = -0.5
 
+/datum/movespeed_modifier/jetpack/full_speed
+	multiplicative_slowdown = -0.5
+
 /datum/movespeed_modifier/die_of_fate
 	multiplicative_slowdown = 1
 


### PR DESCRIPTION

## About The Pull Request
(all) jetpacks move faster on space tiles, same speed as previous jetpack speed
## Why It's Good For The Game
Nerf to space exploring was unwarranted. Also fast jetpack is badass. Keeps it in while being less viable in onstation combat.
## Changelog
:cl:
balance: jetpacks are now faster on space tiles
/:cl:
