### PR TITLE
Fixes mod paint kit

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -322,6 +322,29 @@
 			return ITEM_INTERACT_BLOCKING
 		insert_pai(user, tool)
 		return ITEM_INTERACT_SUCCESS
+	if(istype(tool, /obj/item/mod/paint))
+		var/obj/item/mod/paint/paint_kit = tool
+		if(LAZYACCESS(modifiers, RIGHT_CLICK)) // Right click
+			if(active || activating)
+				balloon_alert(user, "suit is active!")
+				return ITEM_INTERACT_BLOCKING
+			if(paint_kit.editing_mod == src)
+				return ITEM_INTERACT_BLOCKING
+			paint_kit.editing_mod = src
+			paint_kit.proxy_view = new()
+			paint_kit.proxy_view.generate_view("color_matrix_proxy_[REF(user.client)]")
+
+			paint_kit.proxy_view.appearance = paint_kit.editing_mod.appearance
+			paint_kit.proxy_view.color = null
+			paint_kit.proxy_view.display_to(user)
+			paint_kit.ui_interact(user)
+			return ITEM_INTERACT_SUCCESS
+		else // Left click
+			if(active || activating)
+				balloon_alert(user, "suit is active!")
+				return ITEM_INTERACT_BLOCKING
+			paint_kit.paint_skin(src, user)
+			return ITEM_INTERACT_SUCCESS
 	if(istype(tool, /obj/item/mod/module))
 		if(!open)
 			balloon_alert(user, "open the cover first!")

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -324,10 +324,10 @@
 		return ITEM_INTERACT_SUCCESS
 	if(istype(tool, /obj/item/mod/paint))
 		var/obj/item/mod/paint/paint_kit = tool
+		if(active || activating)
+			balloon_alert(user, "suit is active!")
+			return ITEM_INTERACT_BLOCKING
 		if(LAZYACCESS(modifiers, RIGHT_CLICK)) // Right click
-			if(active || activating)
-				balloon_alert(user, "suit is active!")
-				return ITEM_INTERACT_BLOCKING
 			if(paint_kit.editing_mod == src)
 				return ITEM_INTERACT_BLOCKING
 			paint_kit.editing_mod = src
@@ -340,9 +340,6 @@
 			paint_kit.ui_interact(user)
 			return ITEM_INTERACT_SUCCESS
 		else // Left click
-			if(active || activating)
-				balloon_alert(user, "suit is active!")
-				return ITEM_INTERACT_BLOCKING
 			paint_kit.paint_skin(src, user)
 			return ITEM_INTERACT_SUCCESS
 	if(istype(tool, /obj/item/mod/module))

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -23,34 +23,6 @@
 	. += span_notice("<b>Left-click</b> a MODsuit to change skin.")
 	. += span_notice("<b>Right-click</b> a MODsuit to recolor.")
 
-/obj/item/mod/paint/pre_attack(atom/attacked_atom, mob/living/user, params)
-	if(!istype(attacked_atom, /obj/item/mod/control))
-		return ..()
-	var/obj/item/mod/control/mod = attacked_atom
-	if(mod.active || mod.activating)
-		balloon_alert(user, "suit is active!")
-		return TRUE
-	paint_skin(mod, user)
-
-/obj/item/mod/paint/pre_attack_secondary(atom/attacked_atom, mob/living/user, params)
-	if(!istype(attacked_atom, /obj/item/mod/control))
-		return ..()
-	var/obj/item/mod/control/mod = attacked_atom
-	if(mod.active || mod.activating)
-		balloon_alert(user, "suit is active!")
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	if(editing_mod)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	editing_mod = mod
-	proxy_view = new()
-	proxy_view.generate_view("color_matrix_proxy_[REF(user.client)]")
-
-	proxy_view.appearance = editing_mod.appearance
-	proxy_view.color = null
-	proxy_view.display_to(user)
-	ui_interact(user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
 /obj/item/mod/paint/ui_interact(mob/user, datum/tgui/ui)
 	if(!editing_mod)
 		return


### PR DESCRIPTION

## About The Pull Request

After all the attack chain refactors, the modsuit paint kit was bugged. If you tried to use it on a modsuit that had storage installed, then the paint kit would simply be inserted into the modsuit instead of allowing you to change the skin/color.

Fixes #84620 
Fixes #84490 
## Changelog
:cl:
fix: The modsuit paint kit is no longer broken.
/:cl:
