### PR TITLE
Blackbox tally for successful emags

### DIFF
--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -144,7 +144,8 @@
 	if(!can_emag(interacting_with, user))
 		return ITEM_INTERACT_BLOCKING
 	log_combat(user, interacting_with, "attempted to emag")
-	interacting_with.emag_act(user, src)
+	if(interacting_with.emag_act(user, src))
+		SSblackbox.record_feedback("tally", "atom_emagged", 1, interacting_with.type)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/emag/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)


### PR DESCRIPTION
## About The Pull Request

We don't actually record emags outside of the log which makes it hard to parse, this should give us a better image of what people are using emags for.


