### PR TITLE
Fix newly created cardhands not inheriting singlecard offsets

### DIFF
--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -170,10 +170,10 @@
 			user.balloon_alert_to_viewers("deals a card")
 
 		var/obj/item/toy/cards/cardhand/new_cardhand = new (drop_location())
-		new_cardhand.insert(src)
-		new_cardhand.insert(card)
 		new_cardhand.pixel_x = pixel_x
 		new_cardhand.pixel_y = pixel_y
+		new_cardhand.insert(src)
+		new_cardhand.insert(card)
 
 		if(!isturf(loc)) // make a cardhand in our active hand
 			user.temporarilyRemoveItemFromInventory(src, TRUE)


### PR DESCRIPTION

## About The Pull Request

So while working on another pr, I noticed every time I used a deck to click on a single card, it'd create a cardhand... that's centered on the table.
Looking into it, I noticed we already have code for it... but it doesn't work?
This seems to be because we copy over the `pixel_x` and `pixel_y` values AFTER we insert the card into the cardhand:
https://github.com/tgstation/tgstation/blob/cb5a5c1c69adf00663791f86f9b56047dd52367e/code/modules/cards/singlecard.dm#L172-L176
Swapping these around fixes it.
## Why It's Good For The Game

It's kinda awkward to play card games around a single table if all your newly created cardhands decide to take up the same space on the table.
## Changelog
:cl:
fix: Using a dual wielded deck to add another card to a single card bases the position of the resulting hand of cards on the position of the card.
/:cl:
