### PR TITLE
Fixes grounding rods

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -127,6 +127,8 @@
 	density = TRUE
 	wants_powernet = FALSE
 
+	circuit = /obj/item/circuitboard/machine/grounding_rod
+
 	can_buckle = TRUE
 	buckle_lying = 0
 	buckle_requires_restraints = TRUE


### PR DESCRIPTION
## About The Pull Request

Grounding rods didn't have a circuit properly defined. This meant that mapped-in grounding rods (and presumably admin spawned ones) could not be upgraded and did not yield any parts or a circuit board when deconstructed. Now they do have a circuit defined.

Fixes #84588 
## Changelog
:cl:
fix: Mapped in grounding rods can be upgraded again (not that upgraded parts do anything for it) and don't disappear when deconstructed anymore.
/:cl:
