### PR TITLE
Love is stored in the heart (adds the love chem to hearts)

### DIFF
--- a/code/datums/quirks/positive_quirks/friendly.dm
+++ b/code/datums/quirks/positive_quirks/friendly.dm
@@ -9,3 +9,15 @@
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_MOODLET_BASED
 	medical_record_text = "Patient demonstrates low-inhibitions for physical contact and well-developed arms. Requesting another doctor take over this case."
 	mail_goodies = list(/obj/item/storage/box/hug)
+
+/datum/quirk/friendly/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_quirkholder = quirk_holder
+	var/obj/item/organ/internal/heart/holder_heart = human_quirkholder.get_organ_slot(ORGAN_SLOT_HEART)
+	if(isnull(holder_heart) || isnull(holder_heart.reagents))
+		return
+	holder_heart.reagents.maximum_volume = 20
+	// We have a bigger heart full of love!
+	holder_heart.reagents.add_reagent(/datum/reagent/love, 2.5)
+	// Like, physically bigger.
+	holder_heart.reagents.add_reagent(/datum/reagent/consumable/nutriment, 5)
+	holder_heart.transform = holder_heart.transform.Scale(1.5)

--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -70,6 +70,8 @@
 	visual = TRUE
 	color = COLOR_CRAYON_BLACK
 	decay_factor = 0
+	// No love is to be found in a heart so twisted.
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	/// How many life ticks in the dark the owner has been dead for. Used for nightmare respawns.
 	var/respawn_progress = 0
 	/// The armblade granted to the host of this heart.

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -18,6 +18,9 @@
 	attack_verb_continuous = list("beats", "thumps")
 	attack_verb_simple = list("beat", "thump")
 
+	// Love is stored in the heart.
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/love = 2.5)
+
 	// Heart attack code is in code/modules/mob/living/carbon/human/life.dm
 
 	/// Whether the heart is currently beating.


### PR DESCRIPTION

## About The Pull Request

Pretty much just sets the default food reagents for hearts to have 2.5u love in addition to the base 5u nutriment.
Then makes the friendly quirk double the volume and contents of your heart when it first gets applied, and also applying a 1.5 scale transform to it so it looks bigger too.
![image](https://github.com/tgstation/tgstation/assets/42909981/bc016269-3155-4c37-9eac-7e350da02d3f)
The transform does still feel a bit wonky though.
## Why It's Good For The Game

It came to me in a dream.
Or more so, I think it's incredibly funny, both just to say and the implied niche interactions from it.
Like hearts tasting like love, extracting love from people's hearts, friendly people having Physically bigger hearts.
Really a sopping-with-blood still-beating heart is just the _best_ gift for a friend.

It's still wildly more annoying to procure than just getting the k1ss skillchip and using that to extract love.
## Changelog
:cl:
add: Love is now stored in the heart.
balance: Characters with the Friendly quirk now have physically bigger hearts.
/:cl:
