### PR TITLE
H.A.R.S. no longer disables your skillchips (and also doesn't show you the brain-removal text)

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -583,9 +583,9 @@
 
 	var/obj/item/organ/internal/brain/brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(brain)
-		brain.Remove(owner, special = TRUE)
+		brain.Remove(owner, special = TRUE, movement_flags = NO_ID_TRANSFER)
 		brain.zone = BODY_ZONE_CHEST
-		brain.Insert(owner, special = TRUE)
+		brain.Insert(owner, special = TRUE, movement_flags = NO_ID_TRANSFER)
 
 	var/obj/item/bodypart/head/head = owner.get_bodypart(BODY_ZONE_HEAD)
 	if(head)
@@ -608,9 +608,9 @@
 		return TRUE
 	var/obj/item/organ/internal/brain/brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(brain)
-		brain.Remove(owner, special = TRUE)
+		brain.Remove(owner, special = TRUE, movement_flags = NO_ID_TRANSFER)
 		brain.zone = initial(brain.zone)
-		brain.Insert(owner, special = TRUE)
+		brain.Insert(owner, special = TRUE, movement_flags = NO_ID_TRANSFER)
 
 	owner.dna.species.regenerate_organs(owner, replace_current = FALSE, excluded_zones = list(BODY_ZONE_CHEST)) //replace_current needs to be FALSE to prevent weird adding and removing mutation healing
 	owner.apply_damage(damage = 50, damagetype = BRUTE, def_zone = BODY_ZONE_HEAD) //and this to DISCOURAGE organ farming, or at least not make it free.

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -113,10 +113,10 @@
 	if(!QDELETED(organ_owner) && length(skillchips))
 		if(!special)
 			to_chat(organ_owner, span_notice("You feel your skillchips enable emergency power saving mode, deactivating as your brain leaves your body..."))
-		for(var/chip in skillchips)
-			var/obj/item/skillchip/skillchip = chip
-			// Run the try_ proc with force = TRUE.
-			skillchip.try_deactivate_skillchip(silent = special, force = TRUE)
+			for(var/chip in skillchips)
+				var/obj/item/skillchip/skillchip = chip
+				// Run the try_ proc with force = TRUE.
+				skillchip.try_deactivate_skillchip(silent = special, force = TRUE)
 
 	. = ..()
 


### PR DESCRIPTION

## About The Pull Request

So, this one needs some explanation. First, how does H.A.R.S. work code wise? Well, it's pretty simple:

https://github.com/tgstation/tgstation/blob/7d7a6da73542f9958ab99a502b2d66459e5539f4/code/datums/mutations/body.dm#L611-L613

It removes the victim's brain from their head and then immediately puts it back into their chest. It also sets that special flag to true. This is what the docs have to say about that flag:

https://github.com/tgstation/tgstation/blob/7d7a6da73542f9958ab99a502b2d66459e5539f4/code/modules/surgery/organs/organ_movement.dm#L27

So basically, it suppresses the side effects of having the organ removed. This is why H.A.R.S. doesn't kill you instantly despite removing your brain. So why does still deactivate skillchips, since that's also a side effect? Well, that's because brain code doesn't actually take it into account properly:

https://github.com/tgstation/tgstation/blob/7d7a6da73542f9958ab99a502b2d66459e5539f4/code/modules/mob/living/brain/brain_item.dm#L112-L119

Instead of treating the special flag as "should we prevent side effects?" It treats it as "should we make this silent?" So I just took the obvious route and changed that part. 

There was also another bug, where you'd be shown this text upon gaining or losing H.A.R.S.:

> You feel slightly disoriented. That's normal when you're just a brain.

That obviously shouldn't be happening, so I made H.A.R.S. pass `movement_flags = NO_ID_TRANSFER` as well.

Fixes #84010 
## Why It's Good For The Game

Bugfix. To know why I fixed the bug in this way specifically, see above.
## Changelog
:cl:
fix: H.A.R.S. will no longer disable your skillchips or show you text reserved for total brain removal.
/:cl:
