### PR TITLE
Mannitol pills are 15u

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -140,7 +140,7 @@
 	name = "mannitol pill"
 	desc = "Used to treat brain damage."
 	icon_state = "pill17"
-	list_reagents = list(/datum/reagent/medicine/mannitol = 14)
+	list_reagents = list(/datum/reagent/medicine/mannitol = 15)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/sansufentanyl


### PR DESCRIPTION
## About The Pull Request

Roundstart mannitol pills are 15u (up from 14u)

## Why It's Good For The Game

This was changed like 4 years ago in #62334 to make roundstart pills not overdose you anymore (mannitol OD is 15u)

But the fact that they went with 14u instead of 15u irritates me. I'm being robbed of 1u of mannitol*. AND it's not a nice divisible-by-five number. So I up it by 1u. 

*(A 15u pill of a chem that overdoses at 15u won't overdose you, thanks to the fact that transfer from stomach to bloodstream happens over time. You never have 15u in you at once - at most, 9.8u.) 

## Changelog

:cl: Melbert
qol: Roundstart Mannitol pills are 15u (up from 14u) 
/:cl:
