### PR TITLE
Experimentor will no longer duplicate Bags of Holding

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -96,7 +96,6 @@
 		/obj/item/construction/rcd,
 		/obj/item/grenade,
 		/obj/item/aicard,
-		/obj/item/storage/backpack/holding,
 		/obj/item/slime_extract,
 		/obj/item/transfer_valve))
 


### PR DESCRIPTION
## About The Pull Request

This feature of the experimentor is ~6 years old, back when BoHs didn't need anomaly cores, but now that BoHs need anomaly cores this just bypasses the anomaly core limit. And now it will not.

Closes #84849 

## Why It's Good For The Game

Limits to the amount of anomaly core items that can exist aren't supposed to be able to be bypassed this easily.

## Changelog

:cl:
balance: Experimentor will no longer duplicate Bags of Holding
/:cl: