### PR TITLE
tgui: Loads icon refs at boot

### DIFF
--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -158,6 +158,11 @@ type ByondType = {
    * Loads a script into the document.
    */
   loadJs(url: string): void;
+
+  /**
+   * Maps icons to their ref
+   */
+  iconRefMap: Record<string, string>;
 };
 
 /**

--- a/tgui/packages/tgui/icons.ts
+++ b/tgui/packages/tgui/icons.ts
@@ -1,0 +1,14 @@
+import { resolveAsset } from './assets';
+import { fetchRetry } from './http';
+import { logger } from './logging';
+
+export function loadIconRefMap() {
+  if (Object.keys(Byond.iconRefMap).length > 0) {
+    return;
+  }
+
+  fetchRetry(resolveAsset('icon_ref_map.json'))
+    .then((res) => res.json())
+    .then((data) => (Byond.iconRefMap = data))
+    .catch((error) => logger.log(error));
+}

--- a/tgui/packages/tgui/index.tsx
+++ b/tgui/packages/tgui/index.tsx
@@ -32,6 +32,7 @@ import { setupHotReloading } from 'tgui-dev-server/link/client.cjs';
 import { setGlobalStore } from './backend';
 import { setupGlobalEvents } from './events';
 import { setupHotKeys } from './hotkeys';
+import { loadIconRefMap } from './icons';
 import { captureExternalLinks } from './links';
 import { createRenderer } from './renderer';
 import { configureStore } from './store';
@@ -43,13 +44,14 @@ const store = configureStore();
 
 const renderApp = createRenderer(() => {
   setGlobalStore(store);
+  loadIconRefMap();
 
   const { getRoutedComponent } = require('./routes');
   const Component = getRoutedComponent(store);
   return <Component />;
 });
 
-const setupApp = () => {
+function setupApp() {
   // Delay setup
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', setupApp);
@@ -79,6 +81,6 @@ const setupApp = () => {
       renderApp();
     });
   }
-};
+}
 
 setupApp();

--- a/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
@@ -1,4 +1,5 @@
-import { DmIcon, Icon, Image } from '../../components';
+import { DmIcon, Icon, Image } from 'tgui-core/components';
+
 import { SearchItem } from './types';
 
 type Props = {

--- a/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
+++ b/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
@@ -5,8 +5,8 @@ import { Component } from 'react';
 
 import { useBackend } from '../backend';
 import { Button, KeyListener, Stack } from '../components';
-import { BodyZone, BodyZoneSelector } from '../components/BodyZoneSelector';
 import { Window } from '../layouts';
+import { BodyZone, BodyZoneSelector } from './common/BodyZoneSelector';
 
 type Surgery = {
   name: string;

--- a/tgui/packages/tgui/interfaces/common/BodyZoneSelector.tsx
+++ b/tgui/packages/tgui/interfaces/common/BodyZoneSelector.tsx
@@ -1,7 +1,7 @@
 import { Component, createRef } from 'react';
 
-import { resolveAsset } from '../assets';
-import { Image } from './Image';
+import { resolveAsset } from '../../assets';
+import { Image } from '../../components/Image';
 
 export enum BodyZone {
   Head = 'head',
@@ -15,7 +15,7 @@ export enum BodyZone {
   Groin = 'groin',
 }
 
-const bodyZonePixelToZone = (x: number, y: number): BodyZone | null => {
+function bodyZonePixelToZone(x: number, y: number): BodyZone | null {
   // TypeScript translation of /atom/movable/screen/zone_sel/proc/get_zone_at
   if (y < 1) {
     return null;
@@ -52,7 +52,7 @@ const bodyZonePixelToZone = (x: number, y: number): BodyZone | null => {
   }
 
   return null;
-};
+}
 
 type BodyZoneSelectorProps = {
   onClick?: (zone: BodyZone) => void;

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-popper": "^2.3.0",
-    "tgui-core": "^1.1.3",
+    "tgui-core": "^1.1.18",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -292,7 +292,7 @@
     if (type === 'js') {
       var node = document.createElement('script');
       node.type = 'text/javascript';
-      node.crossOrigin = 'anonymous';      
+      node.crossOrigin = 'anonymous';
       node.src = url;
       if (sync) {
         node.defer = true;
@@ -313,7 +313,7 @@
     if (type === 'css') {
       var node = document.createElement('link');
       node.type = 'text/css';
-      node.rel = 'stylesheet';      
+      node.rel = 'stylesheet';
       node.href = url;
       // Temporarily set media to something inapplicable
       // to ensure it'll fetch without blocking render
@@ -344,6 +344,9 @@
   Byond.loadCss = function (url, sync) {
     loadAsset({ url: url, sync: sync, type: 'css' });
   };
+
+  // Icon cache
+  Byond.iconRefMap = {};
 })();
 
 // Error handling

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -8281,13 +8281,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"tgui-core@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "tgui-core@npm:1.1.3"
+"tgui-core@npm:^1.1.18":
+  version: 1.1.18
+  resolution: "tgui-core@npm:1.1.18"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/e4dccbf3f49d4fd46c9146bc21c586b739f562cc75cc86bf3d8c183e026bacbb04719f60a2dcaf937d05dfe084d9b69cc3208a0323462b28f62945fef94c5d01
+  checksum: 10c0/5c66bd68b409596dc0773debdd6cf57016827a82874f7e18ac2f05bf7285133e32d82ae4753583cd67d162c460c9d14e6c98ec11747950782da49c3a31bda49f
   languageName: node
   linkType: hard
 
@@ -8399,7 +8399,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-popper: "npm:^2.3.0"
-    tgui-core: "npm:^1.1.3"
+    tgui-core: "npm:^1.1.18"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown


### PR DESCRIPTION
## About The Pull Request
This stores the icon ref map for DmIcon globally so external libraries (tgui-core) can use it.

- Bumps tgui-core to latest for support of this feature
- Moves bodyzoneselector out to common interfaces (really a group of components)
## Why It's Good For The Game
Fixes #84756

Kind of silly to market a package which isn't able to provide our coolest component
## Changelog
:cl:
fix: Fixed a bluescreen in the heretic research ui
/:cl:
