### PR TITLE
Experimentor will now longer duplicate activated BoH's instead Inert ones

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -96,7 +96,7 @@
 		/obj/item/construction/rcd,
 		/obj/item/grenade,
 		/obj/item/aicard,
-		/obj/item/storage/backpack/holding,
+		/obj/item/bag_of_holding_inert,
 		/obj/item/slime_extract,
 		/obj/item/transfer_valve))
 


### PR DESCRIPTION
## About The Pull Request

Alternative to #84851

This feature of the experimentor is ~6 years old, back when BoHs didn't need anomaly cores, but now that BoHs need anomaly cores this just bypasses the anomaly core limit.

Closes https://github.com/tgstation/tgstation/issues/84849

## Why It's Good For The Game

Limits to the amount of anomaly core items that can exist aren't supposed to be able to be bypassed this easily.

## Changelog

:cl:
fix: Expirimentor will now only be able to copy inert Bag of Holdings
/:cl: