### PR TITLE
Adds an assistant preview outfit for previewing assistant loadouts

### DIFF
--- a/code/modules/jobs/job_types/assistant/assistant.dm
+++ b/code/modules/jobs/job_types/assistant/assistant.dm
@@ -39,7 +39,7 @@ Assistant
 
 /datum/job/assistant/get_outfit(consistent)
 	if(consistent)
-		return /datum/outfit/job/assistant/consistent
+		return /datum/outfit/job/assistant/preview
 	if(!HAS_TRAIT(SSstation, STATION_TRAIT_ASSISTANT_GIMMICKS))
 		return ..()
 
@@ -87,10 +87,7 @@ Assistant
 	name = "Assistant - Consistent"
 
 /datum/outfit/job/assistant/consistent/give_jumpsuit(mob/living/carbon/human/target)
-	if (target.jumpsuit_style == PREF_SUIT)
-		uniform = /obj/item/clothing/under/color/grey
-	else
-		uniform = /obj/item/clothing/under/color/jumpskirt/grey
+	uniform = /obj/item/clothing/under/color/grey
 
 /datum/outfit/job/assistant/consistent/post_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
@@ -99,3 +96,12 @@ Assistant
 	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
 		H.w_uniform?.update_greyscale()
 		H.update_worn_undersuit()
+
+/datum/outfit/job/assistant/preview
+	name = "Assistant - Preview"
+
+/datum/outfit/job/assistant/preview/give_jumpsuit(mob/living/carbon/human/target)
+	if (target.jumpsuit_style == PREF_SUIT)
+		uniform = /obj/item/clothing/under/color/grey
+	else
+		uniform = /obj/item/clothing/under/color/jumpskirt/grey

--- a/code/modules/jobs/job_types/assistant/assistant.dm
+++ b/code/modules/jobs/job_types/assistant/assistant.dm
@@ -87,7 +87,10 @@ Assistant
 	name = "Assistant - Consistent"
 
 /datum/outfit/job/assistant/consistent/give_jumpsuit(mob/living/carbon/human/target)
-	uniform = /obj/item/clothing/under/color/grey
+	if (target.jumpsuit_style == PREF_SUIT)
+		uniform = /obj/item/clothing/under/color/grey
+	else
+		uniform = /obj/item/clothing/under/color/jumpskirt/grey
 
 /datum/outfit/job/assistant/consistent/post_equip(mob/living/carbon/human/H, visualsOnly)
 	..()


### PR DESCRIPTION

## About The Pull Request
The loadout PR changed it so the assistant's loadout preview used an outfit called "Assistant - Consistent" to keep it a consistent grey, only issue is that the consistent outfit does not consider the user's suit preference so it'd stay as a grey jumpsuit even if skirts were preferred, this PR adds a new assistant outfit called "Assistant - Preview" to be used for loadout previews.

I opted against adding the suit check to the consistent outfit instead since as far as I can see it is meant to stay at a consistent grey suit for mob spawns, icons and unit tests and that could end up creating more issues otherwise.

https://github.com/tgstation/tgstation/assets/66234359/502cd0c5-ec51-43bf-bbc2-6f5435047d2a

Fixes https://github.com/tgstation/tgstation/issues/83908

## Why It's Good For The Game
It fixes an issue where only assistant jumpsuits were shown on the character preview if you have assistant selected to on, regardless of your suit preferences.

## Changelog
:cl: Hardly3D
fix: Added a preview assistant outfit, allowing assistant jumpskirts to be previewed again on character preferences.
/:cl:
