### PR TITLE
Minor Fishing rod QoL

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -214,7 +214,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/fishing_rod/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	return interact_with_atom_secondary(interacting_with, user, modifiers)
+	return ranged_interact_with_atom_secondary(interacting_with, user, modifiers)
 
 /obj/item/fishing_rod/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	//Stop reeling, delete the fishing line

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -71,6 +71,7 @@
 	. = ..()
 	if(currently_hooked)
 		context[SCREENTIP_CONTEXT_LMB] = "Reel in"
+		context[SCREENTIP_CONTEXT_RMB] = "Unhook"
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE
 
@@ -212,15 +213,22 @@
 	cast_line(interacting_with, user)
 	return ITEM_INTERACT_SUCCESS
 
+/obj/item/fishing_rod/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	return interact_with_atom_secondary(interacting_with, user, modifiers)
+
+/obj/item/fishing_rod/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	//Stop reeling, delete the fishing line
+	if(currently_hooked)
+		QDEL_NULL(fishing_line)
+		return ITEM_INTERACT_BLOCKING
+	return ..()
+
 /// If the line to whatever that is is clear and we're not already busy, try fishing in it
 /obj/item/fishing_rod/proc/cast_line(atom/target, mob/user)
 	if(casting || currently_hooked)
 		return
 	if(!hook)
 		balloon_alert(user, "install a hook first!")
-		return
-	if(!CheckToolReach(user, target, cast_range))
-		balloon_alert(user, "cannot reach there!")
 		return
 	if(!COOLDOWN_FINISHED(src, casting_cd))
 		return


### PR DESCRIPTION
## About The Pull Request
This PR removes the check that prevents rods from being casted if they click something they wouldn't reach. Projectile code already handles this stuff.

Also, I've added a secondary click interaction, letting you unhook the currently hooked movable without either dropping the rod or reel it all the way to your location (or fold it, for telescopic ones).

## Why It's Good For The Game
Making the experience of fucking around, casting fishing rods at people and items slightly more enjoyable.

## Changelog

:cl:
qol: removed a redundant, annoying reach check that prevents casting a fishing rod before the projectile is generated.
qol: You can now unhook the currently hooked item of a fishing rod with right-click.
/:cl:

