### PR TITLE
Adds K1SS to starting cook skillchips

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -78,7 +78,7 @@
 	head = /obj/item/clothing/head/utility/chefhat
 	mask = /obj/item/clothing/mask/fakemoustache/italian
 
-	skillchips = list(/obj/item/skillchip/job/chef)
+	skillchips = list(/obj/item/skillchip/job/chef, /obj/item/skillchip/chefs_kiss)
 
 /datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION

## About The Pull Request

Chefs and cooks now start with the K1SS skillchip which lets them do the chef's kiss.

## Why It's Good For The Game

Chefs being unable to do the chef's kiss without going to the skillchip machine is weird and having to do that is just unneeded tedium. The skillchip can still be found in the vendor for chefs to find out it exists.

## Changelog

:cl:
qol: Chefs and cooks start with the K1SS skillchip by default
/:cl:
