### PR TITLE
Fixes password doors and shutters not playing their sound effects

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -463,6 +463,7 @@
 /obj/machinery/door/proc/run_animation(animation)
 	set_animation(animation)
 	addtimer(CALLBACK(src, PROC_REF(set_animation), null), animation_length(animation), TIMER_UNIQUE|TIMER_OVERRIDE)
+	animation_effects(animation)
 
 // React to our animation changing
 /obj/machinery/door/proc/set_animation(animation)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/84631 implemented a proc for tying door effects to the animation stages but then forgot to call it.

Now it should actually get called!

## Why It's Good For The Game

Password doors will play the appropriate sound effects.

## Changelog

:cl:
fix: password doors and shutters will now play their sound effects again instead of just silently opening/closing
/:cl: