### PR TITLE
Fixes the french beret making you speak spanish

### DIFF
--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -35,7 +35,7 @@
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/clothing/head/frenchberet/Initialize(mapload)
+/obj/item/clothing/mask/luchador/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/speechmod, replacements = strings("luchador_replacement.json", "luchador"), end_string = " OLE!", end_string_chance = 25, uppercase = TRUE, slots = ITEM_SLOT_MASK)
 


### PR DESCRIPTION
## About The Pull Request

As a result of an epic copy paste failure, people who don the french beret will suddenly find themselves speaking spanish phrases instead of french ones.

<details><summary>Mais non...</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/323f9d6c-b01f-42b0-8694-f8b08d7d4615)

</details>

## Why It's Good For The Game

One luchador mask type was enough

## Changelog

:cl:
fix: french berets will no longer force the user to speak spanish
/:cl: