### PR TITLE
Heads of staff PDAs start with twice as much disk space

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -5,6 +5,7 @@
 /obj/item/modular_computer/pda/heads
 	greyscale_config = /datum/greyscale_config/tablet/head
 	greyscale_colors = "#67A364#a92323"
+	max_capacity = 128
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -5,7 +5,7 @@
 /obj/item/modular_computer/pda/heads
 	greyscale_config = /datum/greyscale_config/tablet/head
 	greyscale_colors = "#67A364#a92323"
-	max_capacity = 128
+	max_capacity = parent_type::max_capacity * 2
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,


### PR DESCRIPTION

## About The Pull Request

Title. Makes heads' and captain's PDAs have 128 GQ of memory instead of only 64.

## Why It's Good For The Game
RD and CE's PDAs are completely filled roundstart, and while its not critical for CE, RD needs to delete at least two apps in order to be able to submit gas shell experiments which is extremely annoying. Other heads of staff PDAs have been upgraded for parity.

## Changelog
:cl:
qol: Heads of staff PDAs start with twice as much disk space
/:cl:
