### PR TITLE
Other mobs no longer hear your breathing

### DIFF
--- a/code/datums/looping_sounds/breathing.dm
+++ b/code/datums/looping_sounds/breathing.dm
@@ -6,4 +6,3 @@
 	//spess station-
 	volume = 13
 	pressure_affected = FALSE
-	direct = TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -6,7 +6,7 @@
 
 	GLOB.carbon_list += src
 	ADD_TRAIT(src, TRAIT_CAN_HOLD_ITEMS, INNATE_TRAIT) // Carbons are assumed to be innately capable of having arms, we check their arms count instead
-	breathing_loop = new(src)
+	breathing_loop = new(src, _direct = TRUE)
 
 /mob/living/carbon/Destroy()
 	//This must be done first, so the mob ghosts correctly before DNA etc is nulled


### PR DESCRIPTION

## About The Pull Request

Closes #84809
Direct set in type was overriden by soundloop's constructor, which resulted in sound being played for everyone around the player at default volume/range settings. Now it properly respects your pref and doesnt play to others

## Changelog
:cl:
fix: Other mobs no longer hear your breathing
/:cl:
