### PR TITLE
"Job Playtime Exempt" now also applies to Account Age Restrictions

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -74,7 +74,7 @@
 #define EXP_TYPE_ADMIN "Admin"
 
 //Flags in the players table in the db
-#define DB_FLAG_EXEMPT 1
+#define DB_FLAG_EXEMPT (1<<0)
 
 #define DEFAULT_CYBORG_NAME "Default Cyborg Name"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/key_bindings_by_key = list()
 
 	var/toggles = TOGGLES_DEFAULT
-	var/db_flags
+	var/db_flags = NONE
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
 	var/ghost_form = "ghost"
 

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -203,6 +203,6 @@ GLOBAL_PROTECT(exp_to_update)
 	if(flags_read.NextRow())
 		prefs.db_flags = text2num(flags_read.item[1])
 	else if(isnull(prefs.db_flags))
-		prefs.db_flags = 0 //This PROBABLY won't happen, but better safe than sorry.
+		prefs.db_flags = NONE //This PROBABLY won't happen, but better safe than sorry.
 	qdel(flags_read)
 	return TRUE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -243,6 +243,11 @@
 	if(!SSdbcore.Connect())
 		return 0
 
+	// If they have been exempted from date availability checks, we assume they are old enough for all jobs.
+	// This is only added whenever an admin manually ticks the box for this player.
+	if(player.prefs?.db_flags & DB_FLAG_EXEMPT)
+		return 0
+
 	// As of the time of writing this comment, verifying database connection isn't "solved". Sometimes rust-g will report a
 	// connection mid-shift despite the database dying.
 	// If the client age is -1, it means that no code path has overwritten it. Even first time connections get it set to 0,


### PR DESCRIPTION

## About The Pull Request

Fixes #84478

Basically, this database flag only worked on playtime restrictions (i.e. how many hours you had to play on the server as a living person before you could unlock stuff like Captain). However, this database flag did not exempt BYOND Account Age restrictions, which is a bit of an annoying gap to have when it comes to fast-tracking new accounts for whatever an admin would need. This gap has been closed by having the `available_in_days` also listen to the same database flag.

If you want me to split it up into multiple flags (which might be annoying due to how the UI is setup, but possible), let me know.
## Why It's Good For The Game

Administration confusions are weird. I think if an admin is waiving an account through like this, they should expect to see everything unfurl as a result - which is why the aforementioned issue report was made.

I also typed the `dbflags` var as a bitflag instead of being null. Should work.
## Changelog
:cl:
admin: Ticking "Job Playtime Exempt" on a player's Job Playtime Tracker panel will also exempt them from BYOND Account Age restrictions now. It previously only exempted them from actual living playtime minutes - this is for the BYOND Account Age in days.
/:cl:
