### PR TITLE
Centcom fax

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6978,9 +6978,10 @@
 /area/centcom/tdome/observation)
 "Ga" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/taperecorder,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/fax{
+	centcom_fax = 1
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "Gb" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6979,9 +6979,7 @@
 "Ga" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/fax{
-	centcom_fax = 1
-	},
+/obj/machinery/fax,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "Gb" = (

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -73,6 +73,8 @@
 #define ADMIN_LUAVIEW_CHUNK(state, log_index) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];lua_state=[REF(state)];log_index=[log_index]'>VIEW CODE</a>)"
 /// Displays "(SHOW)" in the chat, when clicked it tries to show atom(paper). First you need to set the request_state variable to TRUE for the paper.
 #define ADMIN_SHOW_PAPER(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_paper=[REF(atom)]'>SHOW</a>)"
+// Displays "(PRINT)" in the chat, when clicked it will try to print the atom(paper) on the CentCom fax machine.
+#define ADMIN_PRINT_FAX(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];fax_paper=[REF(atom)];fax_name=[fax_name]'>PRINT</a>)"
 /// Displays "(PLAY)" in the chat, when clicked it tries to play internet sounds from the request.
 #define ADMIN_PLAY_INTERNET(text, credit) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];play_internet=[url_encode(text)];credit=[credit]'>PLAY</a>)"
 /// Displays "(SEE Z-LEVEL LAYOUT)" in the chat, when clicked it shows the z-level layouts for the current world state.

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -73,8 +73,8 @@
 #define ADMIN_LUAVIEW_CHUNK(state, log_index) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];lua_state=[REF(state)];log_index=[log_index]'>VIEW CODE</a>)"
 /// Displays "(SHOW)" in the chat, when clicked it tries to show atom(paper). First you need to set the request_state variable to TRUE for the paper.
 #define ADMIN_SHOW_PAPER(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_paper=[REF(atom)]'>SHOW</a>)"
-// Displays "(PRINT)" in the chat, when clicked it will try to print the atom(paper) on the CentCom fax machine.
-#define ADMIN_PRINT_FAX(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];fax_paper=[REF(atom)];fax_name=[fax_name]'>PRINT</a>)"
+/// Displays "(PRINT)" in the chat, when clicked it will try to print the atom(paper) on the CentCom fax machine.
+#define ADMIN_PRINT_FAX(atom, fax_name) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];print_fax=[REF(atom)];fax_name=[fax_name]'>PRINT</a>)"
 /// Displays "(PLAY)" in the chat, when clicked it tries to play internet sounds from the request.
 #define ADMIN_PLAY_INTERNET(text, credit) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];play_internet=[url_encode(text)];credit=[credit]'>PLAY</a>)"
 /// Displays "(SEE Z-LEVEL LAYOUT)" in the chat, when clicked it shows the z-level layouts for the current world state.

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1728,7 +1728,7 @@
 			return
 
 		for(var/obj/machinery/fax/FAX as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/fax))
-			if(!FAX.centcom_fax)
+			if(!is_centcom_level(FAX.z))
 				continue
 
 			FAX.receive(locate(href_list["print_fax"]), href_list["fax_name"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1731,7 +1731,7 @@
 			if(!FAX.centcom_fax)
 				continue
 
-			FAX.receive(locate(href_lift["fax_paper"]), href_list["fax_name"])
+			FAX.receive(locate(href_list["print_fax"]), href_list["fax_name"])
 	else if(href_list["play_internet"])
 		if(!check_rights(R_SOUND))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1722,6 +1722,16 @@
 		if(!paper_to_show)
 			return
 		paper_to_show.ui_interact(usr)
+
+	else if (href_list["print_fax"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		for(var/obj/machinery/fax/FAX as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/fax))
+			if(!FAX.centcom_fax)
+				continue
+
+			FAX.receive(locate(href_lift["fax_paper"]), href_list["fax_name"])
 	else if(href_list["play_internet"])
 		if(!check_rights(R_SOUND))
 			return

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -29,8 +29,6 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	var/hurl_contents = FALSE
 	/// If true you can fax things which strictly speaking are not paper.
 	var/allow_exotic_faxes = FALSE
-	/// True for the fax machine on CentCom
-	var/centcom_fax = FALSE
 	/// This is where the dispatch and reception history for each fax is stored.
 	var/list/fax_history = list()
 	/// List of types which should always be allowed to be faxed
@@ -235,7 +233,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	var/list/data = list()
 	//Record a list of all existing faxes.
 	for(var/obj/machinery/fax/FAX as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/fax))
-		if(FAX.fax_id == fax_id || FAX.centcom_fax) //skip yourself and the centcom fax machine.
+		if(FAX.fax_id == fax_id || is_centcom_level(FAX.z)) //skip yourself and the centcom fax machine.
 			continue
 		var/list/fax_data = list()
 		fax_data["fax_name"] = FAX.fax_name

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -29,6 +29,8 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	var/hurl_contents = FALSE
 	/// If true you can fax things which strictly speaking are not paper.
 	var/allow_exotic_faxes = FALSE
+	/// True for the fax machine on CentCom
+	var/centcom_fax = FALSE
 	/// This is where the dispatch and reception history for each fax is stored.
 	var/list/fax_history = list()
 	/// List of types which should always be allowed to be faxed
@@ -233,7 +235,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	var/list/data = list()
 	//Record a list of all existing faxes.
 	for(var/obj/machinery/fax/FAX as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/fax))
-		if(FAX.fax_id == fax_id) //skip yourself
+		if(FAX.fax_id == fax_id || FAX.centcom_fax) //skip yourself and the centcom fax machine.
 			continue
 		var/list/fax_data = list()
 		fax_data["fax_name"] = FAX.fax_name
@@ -301,7 +303,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 			history_add("Send", params["name"])
 
 			GLOB.requests.fax_request(usr.client, "sent a fax message from [fax_name]/[fax_id] to [params["name"]]", fax_paper)
-			to_chat(GLOB.admins, span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> [span_linkify("sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]")] [ADMIN_SHOW_PAPER(fax_paper)]"), confidential = TRUE)
+			to_chat(GLOB.admins, span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> [span_linkify("sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]")] [ADMIN_SHOW_PAPER(fax_paper)] [ADMIN_PRINT_FAX(fax_paper, fax_name)]"), confidential = TRUE)
 			for(var/client/staff as anything in GLOB.admins)
 				if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
 					SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))


### PR DESCRIPTION
## About The Pull Request
Adds a Fax machine to Central Command, which will only print upon admin request.

## Why It's Good For The Game
The fax panel is a bit clunky to use compared to actually being able to write a fax the old-fashioned way. Admins may still use it to write faxes, or they can now write faxes from Central Command. (Also, I really like CC have actually in-game utility)

## Changelog
:cl:

admin: Nanotrasen has brought Central Command kicking and screaming into the 20th Century by providing them with a real fax machine.
:cl:
