### PR TITLE
Fixes Icemoon syndie outpost APC's being affected by events

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -5,6 +5,8 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(
 	/area/station/engineering/supermatter,
 	/area/station/engineering/atmospherics_engine,
 	/area/station/ai_monitored/turret_protected/ai,
+	/area/ruin/comms_agent //fixes icemoon comms station being affected
+
 )))
 
 // Gets an atmos isolated contained space


### PR DESCRIPTION
…tation-side events
## About The Pull Request
What it says on the tin, adds syndie listening station area into the protected area list for power grid faliures
closes #83835
## Why It's Good For The Game
## Changelog
:cl:
fix: Fixes Icemoon syndie listening station APC's from being affected by station-side events
/:cl:
