### PR TITLE
Fixes overwatch glasses not adding HUDs 

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/overwatch_tools.dm
+++ b/code/modules/antagonists/nukeop/equipment/overwatch_tools.dm
@@ -44,3 +44,21 @@ Happy hunting!
 	flash_protect = FLASH_PROTECTION_WELDER
 	clothing_traits = list(TRAIT_REAGENT_SCANNER)
 	var/list/hudlist = list(DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED, DATA_HUD_SECURITY_ADVANCED)
+
+/obj/item/clothing/glasses/overwatch/equipped(mob/user, slot)
+	. = ..()
+	if(!(slot & ITEM_SLOT_EYES) || !ishuman(user))
+		return
+	for(var/hud in hudlist)
+		var/datum/atom_hud/our_hud = GLOB.huds[hud]
+		our_hud.show_to(user)
+	user.add_traits(list(TRAIT_MEDICAL_HUD, TRAIT_SECURITY_HUD, TRAIT_DIAGNOSTIC_HUD), GLASSES_TRAIT)
+
+/obj/item/clothing/glasses/overwatch/dropped(mob/user)
+	. = ..()
+	user.remove_traits(list(TRAIT_MEDICAL_HUD, TRAIT_SECURITY_HUD, TRAIT_DIAGNOSTIC_HUD), GLASSES_TRAIT)
+	if(!ishuman(user))
+		return
+	for(var/hud in hudlist)
+		var/datum/atom_hud/our_hud = GLOB.huds[hud]
+		our_hud.hide_from(user)


### PR DESCRIPTION

## About The Pull Request

Glasses given to the overwatch agent have list of HUDs but don't actually do anything with it, making them basically reagent scanner shadys.

## Why It's Good For The Game
They were pretty clearly intended to have those HUDs but didn't actually apply them. They are given to an *overwatch* agent for god's sake.

## Changelog
:cl:
fix: Fixes overwatch glasses not adding HUDs 
/:cl:
