### PR TITLE
[NO GBP] Fixes a regression with the no-decal maintenance loot spawner

### DIFF
--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -9,6 +9,11 @@
 /// decals such as ashes will cause NeverShouldHaveComeHere() to fail on such turfs, which creates annoying rng based CI failures
 /obj/effect/spawner/random/maintenance/no_decals
 
+/obj/effect/spawner/random/maintenance/no_decals/can_spawn(loot)
+	if(ispath(loot, /obj/effect/decal))
+		return FALSE
+	return ..()
+
 /obj/effect/spawner/random/maintenance/examine(mob/user)
 	. = ..()
 	. += span_info("This spawner has an effective loot count of [get_effective_lootcount()].")


### PR DESCRIPTION
## About The Pull Request
Accidentally removed the can_spawn proc definition at some point.

## Why It's Good For The Game
Fixing the CI.

## Changelog
N/A