### PR TITLE
Make storage datums actually send `COMSIG_ATOM_STORED_ITEM` on the parent atom instead of `COMSIG_STORAGE_STORED_ITEM`

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -444,7 +444,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(!can_insert(to_insert, user, messages = messages, force = force))
 		return FALSE
 
-	SEND_SIGNAL(parent, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
+	SEND_SIGNAL(parent, COMSIG_ATOM_STORED_ITEM, to_insert, user, force)
 	SEND_SIGNAL(src, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)
 	to_insert.forceMove(real_location)
 	item_insertion_feedback(user, to_insert, override)


### PR DESCRIPTION

## About The Pull Request

We have a bunch of signals for storage datums, right?
https://github.com/tgstation/tgstation/blob/0eef56495487ca592a522df74aadcd1049457c62/code/__DEFINES/dcs/signals/signals_storage.dm#L8-L18
As the comments say, we send the atom ones on the parent and the storage ones on the storage:
https://github.com/tgstation/tgstation/blob/0eef56495487ca592a522df74aadcd1049457c62/code/datums/storage/storage.dm#L544-L545
Howeeeeeeeever, we don't actually do this for storing stuff:
https://github.com/tgstation/tgstation/blob/0eef56495487ca592a522df74aadcd1049457c62/code/datums/storage/storage.dm#L447-L448
So this just swaps such over to using the right signal on the parent atom, `COMSIG_ATOM_STORED_ITEM`.

This is technically used by the bloody spreader component, but the one example we have of such on a storage item (the meat backpack) doesn't seem to have a difference in functionality from this change.
So no changelog as this is not player-visible.
## Why It's Good For The Game

Should proooooobably use the right signals for the right things.
