### PR TITLE
Justice mech invisibility fix

### DIFF
--- a/code/modules/vehicles/mecha/combat/justice.dm
+++ b/code/modules/vehicles/mecha/combat/justice.dm
@@ -57,8 +57,9 @@
 
 /obj/vehicle/sealed/mecha/justice/update_icon_state()
 	. = ..()
-	if(LAZYLEN(occupants))
-		icon_state = weapons_safety ? "[base_icon_state]" : "[base_icon_state]-angry"
+	if(!LAZYLEN(occupants))
+		return
+	icon_state = weapons_safety ? "[base_icon_state]" : "[base_icon_state]-angry"
 	if(!has_gravity())
 		icon_state = "[icon_state]-fly"
 


### PR DESCRIPTION
## About The Pull Request
Closes: https://github.com/tgstation/tgstation/issues/84894

Fixes a bug if you exited the mech and it was in “stealth mode” at the time.

This will make your Mech completely unusable.

Originally bug found on Massmeta server.

## Why It's Good For The Game

Have you spent a lot of TC on your new car and forgotten where you parked it? - Skill Isuue.

## Changelog

:cl:
fix: Justice mech invisibility fix
/:cl: