### PR TITLE
Adds colored caps to vendors, removes most of them from loadout.

### DIFF
--- a/code/modules/loadout/categories/heads.dm
+++ b/code/modules/loadout/categories/heads.dm
@@ -40,21 +40,9 @@
 	name = "Cap (Delinquent)"
 	item_path = /obj/item/clothing/head/costume/delinquent
 
-/datum/loadout_item/head/green_cap
-	name = "Cap (Green)"
-	item_path = /obj/item/clothing/head/soft/green
-
 /datum/loadout_item/head/grey_cap
 	name = "Cap (Grey)"
 	item_path = /obj/item/clothing/head/soft/grey
-
-/datum/loadout_item/head/orange_cap
-	name = "Cap (Orange)"
-	item_path = /obj/item/clothing/head/soft/orange
-
-/datum/loadout_item/head/purple_cap
-	name = "Cap (Purple)"
-	item_path = /obj/item/clothing/head/soft/purple
 
 /datum/loadout_item/head/rainbow_cap
 	name = "Cap (Rainbow)"
@@ -67,10 +55,6 @@
 /datum/loadout_item/head/white_cap
 	name = "Cap (White)"
 	item_path = /obj/item/clothing/head/soft
-
-/datum/loadout_item/head/yellow_cap
-	name = "Cap (Yellow)"
-	item_path = /obj/item/clothing/head/soft/yellow
 
 /datum/loadout_item/head/flatcap
 	name = "Cap (Flat)"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -281,7 +281,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	machine_name = "SciDrobe"
 
 /obj/machinery/vending/wardrobe/hydro_wardrobe
-	name = "Hydrobe"
+	name = "HyDrobe"
 	desc = "A machine with a catchy name. It dispenses botany related clothing and gear."
 	icon_state = "hydrobe"
 	product_ads = "Do you love soil? Then buy our clothes!;Get outfits to match your green thumb here!"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -86,6 +86,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/clothing/head/utility/surgerycap/purple = 4,
 		/obj/item/clothing/head/utility/surgerycap/green = 4,
 		/obj/item/clothing/head/beret/medical/paramedic = 4,
+		/obj/item/clothing/head/soft/blue = 4,
 		/obj/item/clothing/head/soft/paramedic = 4,
 		/obj/item/clothing/head/utility/head_mirror = 4,
 		/obj/item/clothing/mask/bandana/striped/medical = 4,
@@ -129,6 +130,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/clothing/head/utility/hardhat = 3,
 		/obj/item/clothing/head/utility/hardhat/welding = 3,
 		/obj/item/clothing/head/beret/engi = 3,
+		/obj/item/clothing/head/soft/yellow = 3,
 		/obj/item/clothing/mask/bandana/striped/engineering = 3,
 		/obj/item/clothing/under/rank/engineering/engineer = 3,
 		/obj/item/clothing/under/rank/engineering/engineer/skirt = 3,
@@ -156,6 +158,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	vend_reply = "Thank you for using the AtmosDrobe!"
 	products = list(
 		/obj/item/clothing/accessory/pocketprotector = 3,
+		/obj/item/clothing/head/soft/yellow = 3,
 		/obj/item/clothing/under/rank/engineering/atmospheric_technician = 3,
 		/obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt = 3,
 		/obj/item/clothing/suit/atmos_overalls = 3,
@@ -222,6 +225,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	products = list(
 		/obj/item/clothing/glasses/hud/diagnostic = 2,
 		/obj/item/clothing/head/soft/black = 2,
+		/obj/item/clothing/head/soft/blue = 2,
 		/obj/item/clothing/mask/bandana/skull/black = 2,
 		/obj/item/clothing/under/rank/rnd/roboticist = 2,
 		/obj/item/clothing/under/rank/rnd/roboticist/skirt = 2,
@@ -256,6 +260,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	products = list(
 		/obj/item/clothing/accessory/pocketprotector = 3,
 		/obj/item/clothing/head/beret/science = 3,
+		/obj/item/clothing/head/soft/purple = 3,
 		/obj/item/clothing/mask/gas = 3,
 		/obj/item/clothing/mask/bandana/striped/science = 3,
 		/obj/item/clothing/under/rank/rnd/scientist = 3,
@@ -283,6 +288,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	vend_reply = "Thank you for using the Hydrobe!"
 	products = list(
 		/obj/item/clothing/accessory/armband/hydro = 3,
+		/obj/item/clothing/head/soft/green = 3,
+		/obj/item/clothing/head/soft/blue = 3,
 		/obj/item/clothing/mask/bandana/striped/botany = 3,
 		/obj/item/clothing/under/rank/civilian/hydroponics = 3,
 		/obj/item/clothing/under/rank/civilian/hydroponics/skirt = 3,
@@ -346,6 +353,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/cautery/cruel = 1,
 		/obj/item/clothing/gloves/latex/coroner = 1,
 		/obj/item/clothing/head/utility/surgerycap/black = 1,
+		/obj/item/clothing/head/soft/black = 1,
 		/obj/item/clothing/mask/surgical = 1,
 		/obj/item/clothing/shoes/sneakers/black = 1,
 		/obj/item/clothing/suit/apron/surgical = 1,
@@ -542,6 +550,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/clothing/shoes/sneakers/black = 1,
 		/obj/item/clothing/suit/chaplainsuit/nun = 1,
 		/obj/item/clothing/head/chaplain/nun_hood = 1,
+		/obj/item/clothing/head/soft/black = 3,
+		/obj/item/clothing/head/soft/mime = 2,
 		/obj/item/clothing/suit/chaplainsuit/holidaypriest = 1,
 		/obj/item/clothing/suit/hooded/chaplainsuit/monkhabit = 1,
 		/obj/item/clothing/head/chaplain/kippah = 3,
@@ -582,6 +592,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	vend_reply = "Thank you for using the ChemDrobe!"
 	products = list(
 		/obj/item/clothing/head/beret/medical = 2,
+		/obj/item/clothing/head/soft/blue = 2,
+		/obj/item/clothing/head/soft/orange = 2,
 		/obj/item/clothing/under/rank/medical/chemist = 2,
 		/obj/item/clothing/under/rank/medical/chemist/skirt = 2,
 		/obj/item/clothing/suit/toggle/labcoat/chemist = 2,
@@ -612,6 +624,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	product_ads = "Perfect for the mad scientist in you!"
 	vend_reply = "Thank you for using the GeneDrobe!"
 	products = list(
+		/obj/item/clothing/head/soft/purple = 2,
+		/obj/item/clothing/head/soft/blue = 2,
 		/obj/item/clothing/under/rank/rnd/geneticist = 2,
 		/obj/item/clothing/under/rank/rnd/geneticist/skirt = 2,
 		/obj/item/clothing/suit/toggle/labcoat/genetics = 2,
@@ -638,6 +652,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	vend_reply = "Thank you for using the ViroDrobe"
 	products = list(
 		/obj/item/clothing/mask/surgical = 2,
+		/obj/item/clothing/head/soft/blue = 2,
+		/obj/item/clothing/head/soft/green = 2,
 		/obj/item/clothing/under/rank/medical/virologist = 2,
 		/obj/item/clothing/under/rank/medical/virologist/skirt = 2,
 		/obj/item/clothing/head/beret/medical = 2,


### PR DESCRIPTION

## About The Pull Request

Adds the caps to the department's clothesmate, allowing for players to wear accessories of their department's color.
Removes these caps from the loadout system, except for the red, blue, black, white and grey ones.

Also removes a typo from the HyDrobe; every one of the job clothes vendors are [job]Drobe, with the D capitalized - EngiDrobe, JaniDrobe, etc. The HyDrobe was Hydrobe, so fixed that.

PR said to be fine by Melbert on the Discord

## Why It's Good For The Game

Adding caps to vendors: Many of these were unobtainable outside of the loadout system; this makes them more easily obtainable and renewable.

Removing the caps from the loadout system: This is to ensure that the players of specific departments stay within the color pallete of that department, helping with visual identity and cohesion. Furthermore since they're job-locked stealing one of these hats could lead to effective disguises as members of the department; if these caps were open to anyone via loadouts then this aspect would be reduced as people know someone with a yellow hat can be anyone rather than only an engineer.

Removing a typo is always good.

## Changelog

:cl:
qol: You can now find colored caps of your departments in your job's clothes vendor!
del: Removed colored caps from the loadouts menu.
spellcheck: The HyDrobe was incorrectly spelled as "Hydrobe"
/:cl:
