### PR TITLE
Fixes that one alien feature that uses mouse drag

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -43,15 +43,21 @@
 	if(!user.can_perform_action(source, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
 		return
 
-	// Cyborgs buckle people by dragging them onto them, unless in combat mode.
+	// Snowflake for cyborgs buckling people by dragging them onto them, unless in combat mode.
 	if (iscyborg(user))
 		var/mob/living/silicon/robot/cyborg_user = user
 		if (!cyborg_user.combat_mode)
+			return
+	// Snowflake for xeno fetish code
+	if (isalienadult(user))
+		var/mob/living/carbon/alien/adult/alien = user
+		if (alien.grab_state == GRAB_AGGRESSIVE && alien.pulling == source)
 			return
 
 	if (!isnull(should_strip_proc_path) && !call(source, should_strip_proc_path)(user))
 		return
 
+	// Snowflake for mob scooping
 	if (isliving(source))
 		var/mob/living/mob = source
 		if (mob.can_be_held && (user.grab_state == GRAB_AGGRESSIVE) && (user.pulling == source))

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -48,7 +48,7 @@
 		var/mob/living/silicon/robot/cyborg_user = user
 		if (!cyborg_user.combat_mode)
 			return
-	// Snowflake for xeno fetish code
+	// Snowflake for xeno consumption code
 	if (isalienadult(user))
 		var/mob/living/carbon/alien/adult/alien = user
 		if (alien.grab_state == GRAB_AGGRESSIVE && alien.pulling == source)


### PR DESCRIPTION
## About The Pull Request

Fixes that one alien feature that uses mouse drag

Honestly I really hate this fix, I think strippable should be non-blocking, or alternatively, strippable should have some proc `should_strip` to prevent people from opening the ui in some contexts. But whatever

## Changelog

:cl: Melbert
fix: Fixes xenos being able to do that one mechanic that involves mouse-dragging people to you
/:cl:


