### PR TITLE
All lattices make catwalk footsteps (instead of just catwalks)

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -23,6 +23,7 @@
 	if(length(give_turf_traits))
 		give_turf_traits = string_list(give_turf_traits)
 		AddElement(/datum/element/give_turf_traits, give_turf_traits)
+	AddElement(/datum/element/footstep_override, footstep = FOOTSTEP_CATWALK)
 
 /datum/armor/structure_lattice
 	melee = 50
@@ -97,10 +98,6 @@
 	canSmoothWith = SMOOTH_GROUP_CATWALK
 	obj_flags = CAN_BE_HIT | BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
 	give_turf_traits = list(TRAIT_TURF_IGNORE_SLOWDOWN, TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED, TRAIT_IMMERSE_STOPPED, TRAIT_HYPERSPACE_STOPPED)
-
-/obj/structure/lattice/catwalk/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/footstep_override, footstep = FOOTSTEP_CATWALK)
 
 /obj/structure/lattice/catwalk/deconstruction_hints(mob/user)
 	return span_notice("The supporting rods look like they could be <b>cut</b>.")


### PR DESCRIPTION
## About The Pull Request

Lattices make catwalk sounds when walked across, much like their children catwalks do

## Why It's Good For The Game

If you've ever walked across the tramway, it's really jarring to go from catwalk (footstep sound) -> lattice (no footstep sound) -> catwalk (footstep sound) -> lattice (no footstep sound) 

But they'd probably sound the same in practice

## Changelog
:cl: Melbert
qol: Lattices now make the same footstep sound as catwalks
/:cl:

