### PR TITLE
Fixes the clown reinforcement spawning with TC

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -187,7 +187,7 @@
 	desc = "A single-use beacon designed to quickly launch reinforcement clown operatives into the field."
 	special_role_name = ROLE_CLOWN_OPERATIVE
 	outfit = /datum/outfit/syndicate/clownop/no_crystals
-	antag_datum = /datum/antagonist/nukeop/clownop
+	antag_datum = /datum/antagonist/nukeop/reinforcement/clownop
 	pod_style = STYLE_HONK
 	use_subtypes = FALSE
 

--- a/code/modules/antagonists/clown_ops/clownop.dm
+++ b/code/modules/antagonists/clown_ops/clownop.dm
@@ -65,6 +65,11 @@
 	if(liver)
 		ADD_TRAIT(liver, TRAIT_COMEDY_METABOLISM, CLOWNOP_TRAIT)
 
+// Clown op reinforcements
+/datum/antagonist/nukeop/reinforcement/clownop
+	name = "Clown Operative Reinforcement"
+	nukeop_outfit = /datum/outfit/syndicate/clownop/no_crystals
+
 /datum/outfit/clown_operative
 	name = "Clown Operative (Preview only)"
 

--- a/code/modules/antagonists/clown_ops/outfits.dm
+++ b/code/modules/antagonists/clown_ops/outfits.dm
@@ -24,6 +24,7 @@
 	id_trim = /datum/id_trim/chameleon/operative/clown
 
 /datum/outfit/syndicate/clownop/no_crystals
+	name = "Clown Operative - Reinforcement"
 	tc = 0
 
 /datum/outfit/syndicate/clownop/leader

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -52,8 +52,8 @@
 	if(command_radio)
 		radio.command = TRUE
 		radio.use_command = TRUE
-
-	if(ispath(uplink_type, /obj/item/uplink/nuclear) || tc) // /obj/item/uplink/nuclear understands 0 tc
+	// Renamed from /obj/item/uplink/nuclear so it works with other subtypes (ie. clown op reinforcement)
+	if(ispath(uplink_type, /obj/item/uplink) || tc) // /obj/item/uplink understands 0 tc
 		var/obj/item/uplink = new uplink_type(nukie, nukie.key, tc)
 		nukie.equip_to_slot_or_del(uplink, ITEM_SLOT_BACKPACK, indirect_action = TRUE)
 

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -52,7 +52,6 @@
 	if(command_radio)
 		radio.command = TRUE
 		radio.use_command = TRUE
-	// Renamed from /obj/item/uplink/nuclear so it works with other subtypes (ie. clown op reinforcement)
 	if(ispath(uplink_type, /obj/item/uplink) || tc) // /obj/item/uplink understands 0 tc
 		var/obj/item/uplink = new uplink_type(nukie, nukie.key, tc)
 		nukie.equip_to_slot_or_del(uplink, ITEM_SLOT_BACKPACK, indirect_action = TRUE)


### PR DESCRIPTION

## About The Pull Request
Fixes the very hilarious issue of reinforcements spawning with... the same amount of TC a normal clown operative would get, leading to... infinite TC glitch.

Fixes #84915
## Why It's Good For The Game
Fixes a bug which breaks the intended balance of clown op uplink.
## Changelog
:cl: MrDas
fix: Clown operative reinforcements' uplink no longer break the syndicates' economy by creating TC from nothingness.
/:cl:
