### PR TITLE
Justice (a melee-only mech) can no longer have guns attached

### DIFF
--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -148,11 +148,12 @@
 		return FALSE
 	if(equipment_slot == MECHA_WEAPON)
 		if(attach_right)
-			if(mech.equip_by_category[MECHA_R_ARM] && (!special_attaching_interaction(attach_right, mech, user, checkonly = TRUE)))
+			// We need to check for length in case a mech doesn't support any arm attachments at all
+			if((mech.equip_by_category[MECHA_R_ARM] == mech.max_equip_by_category[MECHA_R_ARM]) && (!special_attaching_interaction(attach_right, mech, user, checkonly = TRUE)))
 				to_chat(user, span_warning("\The [mech]'s right arm is full![mech.equip_by_category[MECHA_L_ARM] ? "" : " Try left arm!"]"))
 				return FALSE
 		else
-			if(mech.equip_by_category[MECHA_L_ARM] && (!special_attaching_interaction(attach_right, mech, user, checkonly = TRUE)))
+			if((mech.equip_by_category[MECHA_L_ARM] == mech.max_equip_by_category[MECHA_L_ARM]) && (!special_attaching_interaction(attach_right, mech, user, checkonly = TRUE)))
 				to_chat(user, span_warning("\The [mech]'s left arm is full![mech.equip_by_category[MECHA_R_ARM] ? "" : " Try right arm!"]"))
 				return FALSE
 		return TRUE


### PR DESCRIPTION

## About The Pull Request

In the PR adding it, the justice was explicitly stated to be a melee-only mech. In fact, it was stated to be unable to support any arm-mounted attachments at all. In spite of this, it was possible due to a bug to mount both ranged attachments like guns, and (as pointed out in #84920) melee attachments like drills. Now it can't, as intended.
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: You can't attach guns/drills/etc. to the Justice traitor mech anymore.
/:cl:
