### PR TITLE
You can implant yourself with pathfinder MOD implant while you're wearing the suit

### DIFF
--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -11,6 +11,7 @@
 		Nakamura Engineering swears up and down there's airbrakes."
 	icon_state = "pathfinder"
 	complexity = 1
+	module_type = MODULE_USABLE
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 10
 	incompatible_modules = list(/obj/item/mod/module/pathfinder)
 	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT)
@@ -56,6 +57,21 @@
 	else
 		target.visible_message(span_notice("[user] implants [target]."), span_notice("[user] implants you with [implant]."))
 	playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -6)
+	module_type = MODULE_PASSIVE
+
+/obj/item/mod/module/pathfinder/on_use()
+	. = ..()
+	if (!ishuman(mod.wearer) || !implant)
+		return
+	if(!implant.implant(mod.wearer, mod.wearer))
+		balloon_alert(mod.wearer, "can't implant!")
+		return
+	balloon_alert(mod.wearer, "implanted")
+	playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -6)
+	module_type = MODULE_PASSIVE
+	var/datum/action/item_action/mod/pinnable/module/existing_action = pinned_to[REF(mod.wearer)]
+	if(existing_action)
+		mod.remove_item_action(existing_action)
 
 /obj/item/mod/module/pathfinder/proc/attach(mob/living/user)
 	if(!ishuman(user))


### PR DESCRIPTION

## About The Pull Request
Pathfinder MODule now starts as a usable module which can be triggered in order to implant MOD's wearer.

## Why It's Good For The Game

Its a very cool module which unfortunately is severely hampered by having to open the suit and pull it out to eject. This doesn't have any impact on balance, but does make people more likely to use it in-game as its now not as bothersome to set up. Who even knew that captain's MODsuit has it?

## Changelog
:cl:
qol: Pathfinder MODule can now be triggered while wearing the MODsuit to implant yourself without having to pull it out of the suit.
/:cl:
