### PR TITLE
Fixes ash accretion module applying 10 times less armor than it should

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -378,11 +378,11 @@
 	var/static/list/keep_turfs
 
 /datum/armor/mod_ash_accretion
-	melee = 4
-	bullet = 1
-	laser = 2
-	energy = 2
-	bomb = 4
+	melee = 40
+	bullet = 10
+	laser = 20
+	energy = 20
+	bomb = 40
 
 /obj/item/mod/module/ash_accretion/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Ash accretion module values are missing 0s, making armor it gives when fully covered in ash absolutely minuscule. This is pretty clearly unintentional, as multiplying them by 10 would bring armor up to be roughly equal to what a fully upgraded explorer's suit has.

## Why It's Good For The Game

...mining MODs aren't an outright downgrade compared to roundstart gear? This is pretty clearly an oversight and not a balancing issue, as all armor is usually in multiples of 5 (most of the time 10), and the intent was to make it equal to explorer's suit on lavaland.

## Changelog
:cl:
fix: Ash accretion module for mining MODsuit now applies correct amount of armor.
/:cl:
