### PR TITLE
Fixes a chasm appearing in Tramstation when the jungle grass is destroyed

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5316,7 +5316,7 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /turf/open/misc/dirt/jungle{
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/station
 	},
 /area/station/science/explab)
 "aMM" = (
@@ -6789,7 +6789,9 @@
 /area/station/command/bridge)
 "bpn" = (
 /mob/living/carbon/human/species/monkey,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "bpu" = (
 /obj/structure/cable,
@@ -7177,7 +7179,9 @@
 "bwU" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "bxd" = (
 /obj/structure/table,
@@ -10192,7 +10196,9 @@
 	name = "The Monkey Pit";
 	req_access = list("science")
 	},
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "cxc" = (
 /obj/structure/chair,
@@ -18853,7 +18859,9 @@
 /area/station/engineering/storage/tech)
 "fEM" = (
 /obj/machinery/light/warm/directional/south,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "fEQ" = (
 /obj/structure/cable,
@@ -18985,7 +18993,9 @@
 "fGK" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "fHg" = (
 /obj/structure/chair{
@@ -20544,7 +20554,9 @@
 	name = "The Monkey Pit";
 	req_access = list("science")
 	},
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "gkQ" = (
 /obj/machinery/computer/atmos_control/mix_tank{
@@ -22572,7 +22584,9 @@
 /area/station/security/checkpoint/supply)
 "gXo" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "gXA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -33571,7 +33585,9 @@
 	pixel_x = 5;
 	pixel_y = 16
 	},
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "kQX" = (
 /obj/machinery/computer/security{
@@ -33620,7 +33636,9 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "kRR" = (
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "kRW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37882,7 +37900,9 @@
 /area/station/command/meeting_room)
 "mmy" = (
 /obj/structure/flora/bush/jungle/c/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "mmH" = (
 /obj/effect/turf_decal/delivery,
@@ -41329,7 +41349,7 @@
 "nzO" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/misc/dirt/jungle{
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/station
 	},
 /area/station/science/explab)
 "nzR" = (
@@ -41994,7 +42014,9 @@
 /area/station/engineering/supermatter/room)
 "nNh" = (
 /obj/structure/flora/bush/sunny/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "nNi" = (
 /obj/structure/table/wood,
@@ -42224,7 +42246,9 @@
 "nRd" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "nRw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -44702,7 +44726,9 @@
 /area/station/ai_monitored/command/nuke_storage)
 "oQU" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "oQW" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -47798,7 +47824,7 @@
 "pTj" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/dirt/jungle{
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/station
 	},
 /area/station/science/explab)
 "pTl" = (
@@ -55665,7 +55691,7 @@
 /area/station/cargo/miningdock)
 "sGF" = (
 /turf/open/misc/dirt/jungle{
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/station
 	},
 /area/station/science/explab)
 "sGG" = (
@@ -56951,7 +56977,7 @@
 "tdY" = (
 /obj/structure/flora/bush/jungle/c/style_random,
 /turf/open/misc/dirt/jungle{
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/station
 	},
 /area/station/science/explab)
 "tdZ" = (
@@ -62532,7 +62558,9 @@
 "uVa" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/jungle/c/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "uVb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64486,7 +64514,9 @@
 /area/station/engineering/atmos)
 "vCY" = (
 /obj/structure/flora/tree/palm/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "vCZ" = (
 /turf/closed/wall,
@@ -64526,7 +64556,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/landmark/event_spawn,
 /turf/open/misc/dirt/jungle{
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/station
 	},
 /area/station/science/explab)
 "vDu" = (
@@ -64576,7 +64606,9 @@
 /area/station/maintenance/central/greater)
 "vEl" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "vEq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -66687,7 +66719,9 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/tree/palm/style_random,
 /obj/structure/flora/coconuts,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "wtS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -67992,7 +68026,9 @@
 /area/station/commons/dorms)
 "wSp" = (
 /obj/structure/flora/bush/jungle/b/style_random,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/jungle{
+	baseturfs = /turf/open/misc/dirt/station
+	},
 /area/station/science/explab)
 "wSx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6789,9 +6789,7 @@
 /area/station/command/bridge)
 "bpn" = (
 /mob/living/carbon/human/species/monkey,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "bpu" = (
 /obj/structure/cable,
@@ -7179,9 +7177,7 @@
 "bwU" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "bxd" = (
 /obj/structure/table,
@@ -10196,9 +10192,7 @@
 	name = "The Monkey Pit";
 	req_access = list("science")
 	},
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "cxc" = (
 /obj/structure/chair,
@@ -18859,9 +18853,7 @@
 /area/station/engineering/storage/tech)
 "fEM" = (
 /obj/machinery/light/warm/directional/south,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "fEQ" = (
 /obj/structure/cable,
@@ -18993,9 +18985,7 @@
 "fGK" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "fHg" = (
 /obj/structure/chair{
@@ -20554,9 +20544,7 @@
 	name = "The Monkey Pit";
 	req_access = list("science")
 	},
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "gkQ" = (
 /obj/machinery/computer/atmos_control/mix_tank{
@@ -22584,9 +22572,7 @@
 /area/station/security/checkpoint/supply)
 "gXo" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "gXA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -33585,9 +33571,7 @@
 	pixel_x = 5;
 	pixel_y = 16
 	},
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "kQX" = (
 /obj/machinery/computer/security{
@@ -33636,9 +33620,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "kRR" = (
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "kRW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37900,9 +37882,7 @@
 /area/station/command/meeting_room)
 "mmy" = (
 /obj/structure/flora/bush/jungle/c/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "mmH" = (
 /obj/effect/turf_decal/delivery,
@@ -42014,9 +41994,7 @@
 /area/station/engineering/supermatter/room)
 "nNh" = (
 /obj/structure/flora/bush/sunny/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "nNi" = (
 /obj/structure/table/wood,
@@ -42246,9 +42224,7 @@
 "nRd" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "nRw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -44726,9 +44702,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "oQU" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "oQW" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -62558,9 +62532,7 @@
 "uVa" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/jungle/c/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "uVb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64514,9 +64486,7 @@
 /area/station/engineering/atmos)
 "vCY" = (
 /obj/structure/flora/tree/palm/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "vCZ" = (
 /turf/closed/wall,
@@ -64606,9 +64576,7 @@
 /area/station/maintenance/central/greater)
 "vEl" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "vEq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -66719,9 +66687,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/tree/palm/style_random,
 /obj/structure/flora/coconuts,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "wtS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -68026,9 +67992,7 @@
 /area/station/commons/dorms)
 "wSp" = (
 /obj/structure/flora/bush/jungle/b/style_random,
-/turf/open/misc/grass/jungle{
-	baseturfs = /turf/open/misc/dirt/station
-	},
+/turf/open/misc/grass/jungle/station,
 /area/station/science/explab)
 "wSx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{

--- a/code/game/turfs/open/planet.dm
+++ b/code/game/turfs/open/planet.dm
@@ -78,6 +78,9 @@
 /turf/open/misc/grass/jungle/lavaland
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 
+/turf/open/misc/grass/jungle/station
+	baseturfs = /turf/open/misc/dirt/station
+
 /turf/closed/mineral/random/jungle
 	baseturfs = /turf/open/misc/dirt/dark/jungle
 


### PR DESCRIPTION
## About The Pull Request
Changes the baseturf on a specific section of Tramstation - namely, the jungle grass and dirt in the test subject room - from /turf/open/misc/dirt to /turf/open/misc/dirt/station
The original baseturf had its own baseturf of chasm/jungle, while the new baseturf does not (and should turn to asteroid sand if repeatedly obliterated)
![Tramstation_Monkey_Pit](https://github.com/user-attachments/assets/b7dbaca8-74af-4b20-96ed-26023c39fbc4)
This is the area in question.

Additionally, I have added the jungle grass variant into the turf list as /turf/open/grass/jungle/station so that everyone making a station with jungle turf can use it more easily.

## Why It's Good For The Game
Closes #82932 
Prevents a planetary chasm from appearing on an asteroid, and brings the turf in line with the rest of the station.
Jungle grass is also starting to pop up on other maps, so this should make things a bit less chasm-heavy.

## Changelog
:cl:
fix: Destroying the jungle grass tiles in Tramstation's science wing should no longer open a chasm.
/:cl: