### PR TITLE
Adds holo-fan and two thermomachine and emitters boards to lavaland syndicate base. Attempt #2

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4426,6 +4426,9 @@
 /obj/item/stack/sheet/plastitaniumglass{
 	amount = 15
 	},
+/obj/item/holosign_creator/atmos,
+/obj/item/circuitboard/machine/thermomachine,
+/obj/item/circuitboard/machine/thermomachine,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "YP" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
@@ -211,7 +211,9 @@
 /obj/item/storage/toolbox/syndicate,
 /obj/item/pipe_dispenser,
 /obj/item/rpd_upgrade/unwrench,
+/obj/item/circuitboard/machine/emitter,
 /obj/structure/rack,
+/obj/item/circuitboard/machine/emitter,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "uT" = (


### PR DESCRIPTION
## About The Pull Request
This is my second PR after I goofed up in the first by merging from master.
Adds a holofan and two thermomachine boards to the engineering crate in the lavaland syndie base, and adds two emitter boards to its SM room.
## Why It's Good For The Game
The lavaland syndie base has no holofan and is limited to two thermo machines (four thermomachines and only one emitter if the SM shard room spawns). This limits atmospheric gameplay and restricts the freedom in creating set-ups within the base even though it starts with a surplus of T4 parts and four gas miners. These additions should improve the quality of base as an atmospheric ghost role and make it less frustrating when making burns, coolers, dealing with gas leaks Etc. as well as improve SM shard gameplay when creating high power set ups or tesla.
## Changelog
:cl:
qol: Holofan and two thermomachine and emitter boards in lavaland syndicate base.
/:cl:
