### PR TITLE
Fixes loadout menu bluescreen when recoloring certain items.

### DIFF
--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(can_be_greyscale == DONT_GREYSCALE)
 		can_be_greyscale = FALSE
-	else if(item_path::flags_1 & IS_PLAYER_COLORABLE_1)
+	else if((item_path::flags_1 & IS_PLAYER_COLORABLE_1) && item_path::greyscale_config && item_path::greyscale_colors)
 		can_be_greyscale = TRUE
 
 	if(isnull(name))


### PR DESCRIPTION

## About The Pull Request

Fixes a bug where certain non-recolorable items would have a "recolor" option in the loadout menu, causing a bluescreen. This happened on any non-recolorable subtypes of recolorable items, such as the horrible necktie. Checks identical to those performed by clothing vendors have been added to fix the problem.
## Why It's Good For The Game

Things shouldn't bluescreen.
## Changelog
:cl:
fix: You can no longer cause a bluescreen by attempting to recolor non-recolorable loadout items.
/:cl:
