### PR TITLE
Disabling minigames also disables deathmatch

### DIFF
--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -87,6 +87,9 @@
 			ui.close()
 			create_new_lobby(usr)
 		if ("join")
+			if(!(GLOB.ghost_role_flags & GHOSTROLE_MINIGAME))
+				to_chat(usr, span_warning("Deathmatch has been temporarily disabled by admins."))
+				return
 			if (!lobbies[params["id"]])
 				return
 			var/datum/deathmatch_lobby/playing_lobby = find_lobby_by_user(usr.ckey)

--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -77,7 +77,7 @@
 	switch (action)
 		if ("host")
 			if(!(GLOB.ghost_role_flags & GHOSTROLE_MINIGAME))
-				to_chat(usr, span_warning("Deathmatch has been temporarily disabled by admins."))
+				tgui_alert(usr, "Deathmatch has been temporarily disabled by admins.")
 				return
 			if (lobbies[usr.ckey])
 				return
@@ -88,7 +88,7 @@
 			create_new_lobby(usr)
 		if ("join")
 			if(!(GLOB.ghost_role_flags & GHOSTROLE_MINIGAME))
-				to_chat(usr, span_warning("Deathmatch has been temporarily disabled by admins."))
+				tgui_alert(usr, "Deathmatch has been temporarily disabled by admins.")
 				return
 			if (!lobbies[params["id"]])
 				return

--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -76,6 +76,9 @@
 		return
 	switch (action)
 		if ("host")
+			if(!(GLOB.ghost_role_flags & GHOSTROLE_MINIGAME))
+				to_chat(usr, span_warning("Deathmatch has been temporarily disabled by admins."))
+				return
 			if (lobbies[usr.ckey])
 				return
 			if(!SSticker.HasRoundStarted())


### PR DESCRIPTION

## About The Pull Request

Closes #84935
Prevents ghosts from creating deathmatch lobbies or joining existing ones if minigames are disabled

## Changelog
:cl:
admin: Ghosts can no longer create deathmatch lobbies or join existing ones when admins disable minigames
/:cl:
