### PR TITLE
[THIS DOES NOT AFFECT DAMAGE] [ITS PURELY VISUAL] [TRUST ME] [I CHECKED IT] Accelerator cannon projectiles scale slower and have a size limit now

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -139,12 +139,14 @@
 	icon_state = "scatterlaser"
 	range = 255
 	damage = 6
+	var/size_per_tile = 0.1
+	var/max_scale = 4
 
 /obj/projectile/beam/laser/accelerator/Range()
 	..()
 	damage += 7
 	transform = 0
-	transform *= 1 + (((damage - 6)/7) * 0.2)//20% larger per tile
+	transform *= min(1 + (decayedRange - range) * size_per_tile, max_scale)
 
 ///X-ray gun
 


### PR DESCRIPTION

## About The Pull Request
Closes #81811
Slows their scaling too 10% per tile instead of 20% and adds a 400% scale cap. Also converted damage based size calc to use actual distance passed to prevent further issues

## Changelog
:cl:
fix: Accelerator cannon projectiles no longer grow to absurd sizes after a bit of travel.
/:cl:
