### PR TITLE
Fix Scream emote running the wrong emote

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -66,7 +66,7 @@
 	only_forced_audio = TRUE
 	vary = TRUE
 
-/datum/emote/carbon/human/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
+/datum/emote/living/carbon/human/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
 	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))
 		return
 	return ..()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -357,7 +357,7 @@
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 
 /datum/emote/living/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
-	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))
+	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA) || ishuman(user))
 		return
 	return ..()
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -355,9 +355,10 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
+	mob_type_blacklist_typecache = list(/mob/living/brain, /mob/living/carbon/human)
 
 /datum/emote/living/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
-	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA) || ishuman(user))
+	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))
 		return
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Blacklisted `/datum/emote/living/scream` for humans, since humans have their better version

Also fixes a typo for `/datum/emote/carbon/human/scream`

~~So, we have two emotes for `key = "scream"`, `/datum/emote/living/scream` and `/datum/emote/living/carbon/human/scream`.~~

~~Since `/datum/emote/living/scream` is the first in the GLOB.emote_list, it plays (and successfully) first in the list of two.~~

~~I'm not really sure how to "override" available emotes other than restricting the "lesser" emote. So, any suggestions welcome...~~

## Why It's Good For The Game
Correct emote plays when a human scream

## Changelog
:cl:
fix: Correct emote plays when a human scream. Should have sound now.
/:cl:
