### PR TITLE
Recyclers no longer tear implant tools from your body

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -137,6 +137,7 @@
 /obj/item/organ/internal/cyberimp/arm/proc/Retract()
 	if(!active_item || (active_item in src))
 		return FALSE
+	active_item.resistance_flags = active_item::resistance_flags
 	if(owner)
 		owner.visible_message(
 			span_notice("[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),


### PR DESCRIPTION

## About The Pull Request
Recyclers go out of their way to drag any nested indestructible item out of its container, in order to prevent them from being destroyed. There's a check for if that container is a mob, but not for further nested containers (such as an implant within the mob), which causes retracted tools to be forcefully removed, breaking the implant and leaving an indestructible NO_DROP item around for someone else to pick up. But only if you had deployed the tool previously, otherwise it hadn't yet been marked as indestructible. 
## Why It's Good For The Game
Fix bugs, less characters softlocked from picking up broken items and needing admin intervention
## Changelog
:cl:
fix: Attachment points on toolset implants have been improved, to prevent against recycler related decouplings.
/:cl:
