### PR TITLE
Bandaid fix for blood killing you from high percentages if you are in oxycrit

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -10,6 +10,8 @@
 #define MOVE_INTENT_WALK "walk"
 #define MOVE_INTENT_RUN "run"
 
+/// Amount of oxyloss that KOs a human
+#define OXYLOSS_PASSOUT_THRESHOLD 50
 //Blood levels
 #define BLOOD_VOLUME_MAX_LETHAL 2150
 #define BLOOD_VOLUME_EXCESS 2100

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -545,10 +545,10 @@
 */
 /mob/living/carbon/proc/check_passout()
 	var/mob_oxyloss = getOxyLoss()
-	if(mob_oxyloss >= 50)
+	if(mob_oxyloss >= OXYLOSS_PASSOUT_THRESHOLD)
 		if(!HAS_TRAIT_FROM(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT))
 			ADD_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
-	else if(mob_oxyloss < 50)
+	else if(mob_oxyloss < OXYLOSS_PASSOUT_THRESHOLD)
 		REMOVE_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 
 /mob/living/carbon/get_organic_health()


### PR DESCRIPTION
## About The Pull Request

Closes #84857 

Before:

- If you are unconscious / in hard crit, you always take oxyloss damage from missing blood, even miniscule amounts

After:

- If you are unconscious/ in hard crit, you always take oxyloss damage if the blood volume is below 50% (IE, if oxyloss target damage is 50. IE, if blood is dealing enough oxyloss damage to knock you out.) 

## Why It's Good For The Game

Having the main method of revival kill you again if you don't get an injection of salbutamol is not ideal. 

With the new method, it keeps the intent of the comment (you don't get kept in KO forever) while preventing most methods of oxyloss or sleep from killing you straight up.

## Changelog

:cl: Melbert
qol: If you're in oxycrit (>50 oxy damage) or otherwise made unconscious through other means, blood loss will only kill you if you're *actually* missing a lethal amount of blood.
/:cl:
