### PR TITLE
Adjusts firelock balloons and converts attack_alien to use balloon when failing

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -546,7 +546,7 @@
 
 	if(density)
 		being_held_open = TRUE
-		user.balloon_alert_to_viewers("holding [src] open", "holding [src] open")
+		user.balloon_alert_to_viewers("holding firelock open", "holding firelock open")
 		COOLDOWN_START(src, activation_cooldown, REACTIVATION_DELAY)
 		open()
 		if(QDELETED(user))
@@ -583,7 +583,7 @@
 	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 	UnregisterSignal(user, COMSIG_QDELETING)
 	if(user)
-		user.balloon_alert_to_viewers("released [src]", "released [src]")
+		user.balloon_alert_to_viewers("released firelock", "released firelock")
 
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)
@@ -603,7 +603,7 @@
 /obj/machinery/door/firedoor/attack_alien(mob/user, list/modifiers)
 	add_fingerprint(user)
 	if(welded)
-		to_chat(user, span_warning("[src] refuses to budge!"))
+		balloon_alert(user, "refuses to budge!")
 		return
 	open()
 	if(active)


### PR DESCRIPTION

## About The Pull Request

Currently firelock balloons (when opening/closing them with a crowbar) are using their full name. Full name which includes their area and ID, thus creating a 2 line, 3 tile wide balloon.
Alien failure text (when the firelock is welded) also has been converted to a balloon while I'm at it.

## Why It's Good For The Game

Firelocks spamming your screen with text when trying to hold them open is extremely annoying, and has been a thing for quite some time now. Knowing the full name and ID of the firelock you're holding open isn't really necessary.

## Changelog
:cl:
spellcheck: Firelocks no longer output their full name in their balloon alert.
spellcheck: Failure message when a xenomorph tries to force open a welded firelock is now a balloon alert.
/:cl:
