### PR TITLE
Ghosts once again can see people's true names and roundstart jobs

### DIFF
--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -105,5 +105,6 @@
 	return name_chaser
 
 /// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name. add_id_name will control whether or not we append "(as [id_name])".
-/atom/proc/get_visible_name(add_id_name)
+/// force_real_name will always return real_name and add (as face_name/id_name) if it doesn't match their appearance
+/atom/proc/get_visible_name(add_id_name, force_real_name)
 	return name

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -75,8 +75,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		var/number_of_orbiters = length(mob_poi.get_all_orbiters())
 
 		serialized["ref"] = REF(mob_poi)
-		serialized["name"] = mob_poi.get_visible_name(force_real_name = TRUE)
-		serialized["real_name"] = mob_poi.real_name
+		serialized["full_name"] = mob_poi.name
 		if(number_of_orbiters)
 			serialized["orbiters"] = number_of_orbiters
 
@@ -100,6 +99,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 			continue
 
 		serialized["client"] = !!mob_poi.client
+		serialized["name"] = mob_poi.real_name
 
 		if(isliving(mob_poi))
 			serialized += get_living_data(mob_poi)
@@ -221,14 +221,14 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	if (isnull(job))
 		return serialized
 
-	serialized["job"] = job.title
+	serialized["mind_job"] = job.title
 	var/datum/outfit/outfit = job.get_outfit()
 	if (isnull(outfit))
 		return serialized
 
 	var/datum/id_trim/trim = outfit.id_trim
 	if (!isnull(trim))
-		serialized["icon"] = trim::sechud_icon_state
+		serialized["mind_icon"] = trim::sechud_icon_state
 	return serialized
 
 /// Gets a list: Misc data and whether it's critical. Handles all snowflakey type cases

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -75,7 +75,8 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		var/number_of_orbiters = length(mob_poi.get_all_orbiters())
 
 		serialized["ref"] = REF(mob_poi)
-		serialized["full_name"] = name
+		serialized["name"] = mob_poi.get_visible_name(force_real_name = TRUE)
+		serialized["real_name"] = mob_poi.real_name
 		if(number_of_orbiters)
 			serialized["orbiters"] = number_of_orbiters
 
@@ -99,7 +100,6 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 			continue
 
 		serialized["client"] = !!mob_poi.client
-		serialized["name"] = mob_poi.real_name
 
 		if(isliving(mob_poi))
 			serialized += get_living_data(mob_poi)
@@ -211,13 +211,25 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	if(issilicon(player))
 		serialized["job"] = player.job
 		serialized["icon"] = "borg"
-	else
-		var/obj/item/card/id/id_card = player.get_idcard(hand_first = FALSE)
-		serialized["job"] = id_card?.get_trim_assignment()
-		serialized["icon"] = id_card?.get_trim_sechud_icon_state()
+		return serialized
 
+	var/obj/item/card/id/id_card = player.get_idcard(hand_first = FALSE)
+	serialized["job"] = id_card?.get_trim_assignment()
+	serialized["icon"] = id_card?.get_trim_sechud_icon_state()
+
+	var/datum/job/job = player.mind?.assigned_role
+	if (isnull(job))
+		return serialized
+
+	serialized["job"] = job.title
+	var/datum/outfit/outfit = job.get_outfit()
+	if (isnull(outfit))
+		return serialized
+
+	var/datum/id_trim/trim = outfit.id_trim
+	if (!isnull(trim))
+		serialized["icon"] = trim::sechud_icon_state
 	return serialized
-
 
 /// Gets a list: Misc data and whether it's critical. Handles all snowflakey type cases
 /datum/orbit_menu/proc/get_misc_data(atom/movable/atom_poi) as /list

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -75,7 +75,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		var/number_of_orbiters = length(mob_poi.get_all_orbiters())
 
 		serialized["ref"] = REF(mob_poi)
-		serialized["full_name"] = mob_poi.name
+		serialized["full_name"] = name
 		if(number_of_orbiters)
 			serialized["orbiters"] = number_of_orbiters
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -57,15 +57,27 @@
 	return if_no_id
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere
-/mob/living/carbon/human/get_visible_name(add_id_name = TRUE)
-	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
-		return "Unknown"
+/mob/living/carbon/human/get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
 	var/list/identity = list(null, null)
 	SEND_SIGNAL(src, COMSIG_HUMAN_GET_VISIBLE_NAME, identity)
 	var/signal_face = LAZYACCESS(identity, VISIBLE_NAME_FACE)
 	var/signal_id = LAZYACCESS(identity, VISIBLE_NAME_ID)
 	var/face_name = !isnull(signal_face) ? signal_face : get_face_name("")
 	var/id_name = !isnull(signal_id) ? signal_id : get_id_name("")
+	if (force_real_name)
+		var/fake_name
+		if (face_name && face_name != real_name)
+			fake_name = face_name
+		if(add_id_name && id_name && id_name != real_name)
+			if (!isnull(fake_name) && id_name != face_name)
+				fake_name = "[fake_name]/[id_name]"
+			else
+				fake_name = id_name
+		if (HAS_TRAIT(src, TRAIT_UNKNOWN) || (!face_name && !id_name))
+			fake_name = "Unknown"
+		return "[real_name][fake_name ? " (as [fake_name])" : ""]"
+	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
+		return "Unknown"
 	if(face_name)
 		if(add_id_name && id_name && (id_name != face_name))
 			return "[face_name] (as [id_name])"

--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -4,6 +4,7 @@ import { Antagonist, Observable } from './types';
 
 type Props = {
   item: Observable | Antagonist;
+  realNameDisplay: boolean;
 };
 
 type IconSettings = {
@@ -22,7 +23,7 @@ const antagIcon: IconSettings = {
 };
 
 export function JobIcon(props: Props) {
-  const { item } = props;
+  const { item, realNameDisplay } = props;
 
   let iconSettings: IconSettings;
   if ('antag' in item) {
@@ -32,16 +33,18 @@ export function JobIcon(props: Props) {
   }
 
   // We don't need to cast here but typescript isn't smart enough to know that
-  const { icon = '', job = '' } = item;
+  const { icon = '', job = '', mind_icon = '', mind_job = '' } = item;
+  const usedIcon = realNameDisplay ? mind_icon : icon;
+  const usedJob = realNameDisplay ? mind_job : job;
 
   return (
     <div className="JobIcon">
-      {icon === 'borg' ? (
-        <Icon color="lightblue" name={JOB2ICON[job]} ml={0.3} mt={0.4} />
+      {usedIcon === 'borg' ? (
+        <Icon color="lightblue" name={JOB2ICON[usedJob]} ml={0.3} mt={0.4} />
       ) : (
         <DmIcon
           icon={iconSettings.dmi}
-          icon_state={icon}
+          icon_state={usedIcon}
           style={{
             transform: iconSettings.transform,
           }}

--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -34,12 +34,12 @@ export function JobIcon(props: Props) {
 
   // We don't need to cast here but typescript isn't smart enough to know that
   const { icon = '', job = '', mind_icon = '', mind_job = '' } = item;
-  const usedIcon = realNameDisplay ? mind_icon : icon;
-  const usedJob = realNameDisplay ? mind_job : job;
+  const usedIcon = realNameDisplay ? mind_icon || icon : icon;
+  const usedJob = realNameDisplay ? mind_job || job : job;
 
   return (
     <div className="JobIcon">
-      {usedIcon === 'borg' ? (
+      {icon === 'borg' ? (
         <Icon color="lightblue" name={JOB2ICON[usedJob]} ml={0.3} mt={0.4} />
       ) : (
         <DmIcon

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
@@ -115,7 +115,7 @@ function OrbitInfo(props) {
           <Stack.Item>
             <Stack>
               <Stack.Item>
-                <JobIcon item={orbiting} />
+                <JobIcon item={orbiting} realNameDisplay={false} />
               </Stack.Item>
               <Stack.Item color="label" grow>
                 {job}

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../components';
 import { OrbitContext } from '.';
 import { HEALTH, VIEWMODE } from './constants';
-import { getDepartmentByJob, getDisplayName } from './helpers';
+import { getDepartmentByJob } from './helpers';
 import { JobIcon } from './JobIcon';
 import { OrbitData } from './types';
 
@@ -103,7 +103,7 @@ function OrbitInfo(props) {
     <Section title="Orbiting">
       <Stack fill vertical>
         <Stack.Item>
-          {toTitleCase(getDisplayName(full_name, name))}
+          {toTitleCase(name || full_name)}
           {showAFK && (
             <Tooltip content="Away from keyboard" position="bottom-start">
               <Icon ml={1} color="grey" name="bed" />

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../components';
 import { OrbitContext } from '.';
 import { HEALTH, VIEWMODE } from './constants';
-import { getDepartmentByJob } from './helpers';
+import { getDepartmentByJob, getDisplayName } from './helpers';
 import { JobIcon } from './JobIcon';
 import { OrbitData } from './types';
 
@@ -103,7 +103,7 @@ function OrbitInfo(props) {
     <Section title="Orbiting">
       <Stack fill vertical>
         <Stack.Item>
-          {toTitleCase(name || full_name)}
+          {toTitleCase(getDisplayName(full_name, name))}
           {showAFK && (
             <Tooltip content="Away from keyboard" position="bottom-start">
               <Icon ml={1} color="grey" name="bed" />

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitBlade.tsx
@@ -21,7 +21,8 @@ export function OrbitBlade(props) {
   const { data } = useBackend<OrbitData>();
   const { orbiting } = data;
 
-  const { setBladeOpen } = useContext(OrbitContext);
+  const { setBladeOpen, realNameDisplay, setRealNameDisplay } =
+    useContext(OrbitContext);
 
   return (
     <Stack vertical width="244px">
@@ -43,6 +44,24 @@ export function OrbitBlade(props) {
       </Stack.Item>
       <Stack.Item>
         <ViewModeSelector />
+      </Stack.Item>
+      <Stack.Item>
+        <Section
+          buttons={
+            <Button
+              color="transparent"
+              icon="passport"
+              selected={realNameDisplay}
+              onClick={() => setRealNameDisplay(!realNameDisplay)}
+            />
+          }
+          color="label"
+          title="Real Name Display"
+        >
+          Real Name mode will display actual character names and their
+          roundstart jobs insteas of being based on their worn ID. If the person
+          lacks a roundstart job, it will still display their ID job icon.
+        </Section>
       </Stack.Item>
       {!!orbiting && (
         <Stack.Item>

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitCollapsible.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitCollapsible.tsx
@@ -25,7 +25,8 @@ type Props = {
 export function OrbitCollapsible(props: Props) {
   const { color, section = [], title } = props;
 
-  const { autoObserve, searchQuery, viewMode } = useContext(OrbitContext);
+  const { autoObserve, realNameDisplay, searchQuery, viewMode } =
+    useContext(OrbitContext);
 
   const filteredSection = section.filter((observable) =>
     isJobOrNameMatch(observable, searchQuery),
@@ -53,6 +54,7 @@ export function OrbitCollapsible(props: Props) {
           const content = (
             <OrbitItem
               autoObserve={autoObserve}
+              realNameDisplay={realNameDisplay}
               color={color}
               item={item}
               key={item.ref}

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitCollapsible.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitCollapsible.tsx
@@ -68,7 +68,7 @@ export function OrbitCollapsible(props: Props) {
 
           return (
             <Tooltip
-              content={<OrbitTooltip item={item} />}
+              content={<OrbitTooltip item={item} realNameDisplay={false} />}
               key={item.ref}
               position="bottom-start"
             >

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
@@ -9,13 +9,14 @@ import { Antagonist, Observable, OrbitData, ViewMode } from './types';
 type Props = {
   item: Observable | Antagonist;
   autoObserve: boolean;
+  realNameDisplay: boolean;
   viewMode: ViewMode;
   color: string | undefined;
 };
 
 /** Each button on the observable section */
 export function OrbitItem(props: Props) {
-  const { item, autoObserve, viewMode, color } = props;
+  const { item, autoObserve, realNameDisplay, viewMode, color } = props;
   const { full_name, icon, job, name, orbiters, ref } = item;
 
   const { act, data } = useBackend<OrbitData>();
@@ -33,7 +34,7 @@ export function OrbitItem(props: Props) {
         display: 'flex',
       }}
     >
-      {validIcon && <JobIcon item={item} />}
+      {validIcon && <JobIcon item={item} realNameDisplay={realNameDisplay} />}
 
       <Button
         color={getDisplayColor(item, viewMode, color)}
@@ -41,7 +42,9 @@ export function OrbitItem(props: Props) {
       >
         <Stack>
           <Stack.Item>
-            {capitalizeFirst(getDisplayName(full_name, name))}
+            {realNameDisplay
+              ? capitalizeFirst(name || full_name)
+              : capitalizeFirst(getDisplayName(full_name, name))}
           </Stack.Item>
           {!!orbiters && (
             <Stack.Item>

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
@@ -2,7 +2,7 @@ import { capitalizeFirst } from 'common/string';
 
 import { useBackend } from '../../backend';
 import { Button, Flex, Icon, Stack } from '../../components';
-import { getDisplayColor } from './helpers';
+import { getDisplayColor, getDisplayName } from './helpers';
 import { JobIcon } from './JobIcon';
 import { Antagonist, Observable, OrbitData, ViewMode } from './types';
 
@@ -40,7 +40,9 @@ export function OrbitItem(props: Props) {
         pl={validIcon && 0.5}
       >
         <Stack>
-          <Stack.Item>{capitalizeFirst(name || full_name)}</Stack.Item>
+          <Stack.Item>
+            {capitalizeFirst(getDisplayName(full_name, name))}
+          </Stack.Item>
           {!!orbiters && (
             <Stack.Item>
               <Icon name="ghost" />

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
@@ -2,7 +2,7 @@ import { capitalizeFirst } from 'common/string';
 
 import { useBackend } from '../../backend';
 import { Button, Flex, Icon, Stack } from '../../components';
-import { getDisplayColor, getDisplayName } from './helpers';
+import { getDisplayColor } from './helpers';
 import { JobIcon } from './JobIcon';
 import { Antagonist, Observable, OrbitData, ViewMode } from './types';
 
@@ -40,9 +40,7 @@ export function OrbitItem(props: Props) {
         pl={validIcon && 0.5}
       >
         <Stack>
-          <Stack.Item>
-            {capitalizeFirst(getDisplayName(full_name, name))}
-          </Stack.Item>
+          <Stack.Item>{capitalizeFirst(name || full_name)}</Stack.Item>
           {!!orbiters && (
             <Stack.Item>
               <Icon name="ghost" />

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitSearchBar.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitSearchBar.tsx
@@ -12,10 +12,12 @@ export function OrbitSearchBar(props) {
   const {
     autoObserve,
     bladeOpen,
+    realNameDisplay,
     searchQuery,
     viewMode,
     setAutoObserve,
     setBladeOpen,
+    setRealNameDisplay,
     setSearchQuery,
     setViewMode,
   } = useContext(OrbitContext);
@@ -100,6 +102,17 @@ export function OrbitSearchBar(props) {
             icon="sync-alt"
             onClick={() => act('refresh')}
             tooltip="Refresh"
+            tooltipPosition="bottom-start"
+          />
+        </Stack.Item>
+        <Stack.Item>
+          <Button
+            color="transparent"
+            icon="passport"
+            onClick={() => setRealNameDisplay(!realNameDisplay)}
+            selected={realNameDisplay}
+            tooltip="Toggle real name display. When active, you'll see real
+            names instead of disguises in orbit menu."
             tooltipPosition="bottom-start"
           />
         </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitTooltip.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitTooltip.tsx
@@ -3,12 +3,13 @@ import { Antagonist, Observable } from './types';
 
 type Props = {
   item: Observable | Antagonist;
+  realNameDisplay: boolean;
 };
 
 /** Displays some info on the mob as a tooltip. */
 export function OrbitTooltip(props: Props) {
-  const { item } = props;
-  const { extra, full_name, health, job } = item;
+  const { item, realNameDisplay } = props;
+  const { extra, full_name, health, job, mind_job } = item;
 
   let antag;
   if ('antag' in item) {
@@ -18,6 +19,7 @@ export function OrbitTooltip(props: Props) {
   const extraInfo = extra?.split(':');
   const displayHealth = !!health && health >= 0 ? `${health}%` : 'Critical';
   const showAFK = 'client' in item && !item.client;
+  const displayJob = realNameDisplay ? mind_job : job;
 
   return (
     <>
@@ -34,8 +36,8 @@ export function OrbitTooltip(props: Props) {
             {!!full_name && (
               <LabeledList.Item label="Real ID">{full_name}</LabeledList.Item>
             )}
-            {!!job && !antag && (
-              <LabeledList.Item label="Job">{job}</LabeledList.Item>
+            {!!displayJob && !antag && (
+              <LabeledList.Item label="Job">{displayJob}</LabeledList.Item>
             )}
             {!!antag && (
               <LabeledList.Item label="Threat">{antag}</LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/Orbit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/helpers.ts
@@ -31,17 +31,7 @@ export function getDisplayName(full_name: string, nickname?: string): string {
   if (!nickname) {
     return full_name;
   }
-
-  if (
-    !full_name?.includes('[') ||
-    full_name.match(/\(as /) ||
-    full_name.match(/^Unknown/)
-  ) {
-    return nickname;
-  }
-
-  // return only the name before the first ' [' or ' ('
-  return `"${full_name.split(/ \[| \(/)[0]}"`;
+  return nickname;
 }
 
 /** Returns the department the player is in */
@@ -126,10 +116,11 @@ export function isJobOrNameMatch(
 ): boolean {
   if (!searchQuery) return true;
 
-  const { full_name, job } = observable;
+  const { full_name, job, name } = observable;
 
   return (
     full_name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
+    name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     job?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     false
   );

--- a/tgui/packages/tgui/interfaces/Orbit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/helpers.ts
@@ -31,7 +31,17 @@ export function getDisplayName(full_name: string, nickname?: string): string {
   if (!nickname) {
     return full_name;
   }
-  return nickname;
+
+  if (
+    !full_name?.includes('[') ||
+    full_name.match(/\(as /) ||
+    full_name.match(/^Unknown/)
+  ) {
+    return nickname;
+  }
+
+  // return only the name before the first ' [' or ' ('
+  return `"${full_name.split(/ \[| \(/)[0]}"`;
 }
 
 /** Returns the department the player is in */

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -11,6 +11,7 @@ import { ViewMode } from './types';
 export function Orbit(props) {
   const [autoObserve, setAutoObserve] = useState(false);
   const [bladeOpen, setBladeOpen] = useState(false);
+  const [realNameDisplay, setRealNameDisplay] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState<ViewMode>(VIEWMODE.Health);
 
@@ -23,6 +24,8 @@ export function Orbit(props) {
         setAutoObserve,
         bladeOpen,
         setBladeOpen,
+        realNameDisplay,
+        setRealNameDisplay,
         searchQuery,
         setSearchQuery,
         viewMode,
@@ -59,6 +62,8 @@ type Context = {
   setAutoObserve: Dispatch<SetStateAction<boolean>>;
   bladeOpen: boolean;
   setBladeOpen: Dispatch<SetStateAction<boolean>>;
+  realNameDisplay: boolean;
+  setRealNameDisplay: Dispatch<SetStateAction<boolean>>;
   searchQuery: string;
   setSearchQuery: Dispatch<SetStateAction<string>>;
   viewMode: ViewMode;

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -27,7 +27,9 @@ export type Observable = {
   extra: string;
   health: number;
   icon: string;
+  mind_icon: string;
   job: string;
+  mind_job: string;
   name: string;
   orbiters: number;
 }>;

--- a/tgui/packages/tgui/styles/interfaces/Orbit.scss
+++ b/tgui/packages/tgui/styles/interfaces/Orbit.scss
@@ -1,7 +1,6 @@
 .JobIcon {
   background: black;
   height: 20px;
-  overflow: clip;
   padding: 1px 1px 0 1px;
   overflow: hidden;
   width: 20px;

--- a/tgui/packages/tgui/styles/interfaces/Orbit.scss
+++ b/tgui/packages/tgui/styles/interfaces/Orbit.scss
@@ -3,6 +3,7 @@
   height: 20px;
   overflow: clip;
   padding: 1px 1px 0 1px;
+  overflow: hidden;
   width: 20px;
 }
 


### PR DESCRIPTION

## About The Pull Request

#83186 made it so ghosts are fooled by disguises, like wearing a mask and an ID. This PR fixes that behavior, instead always displaying the person's real name and their face/ID name (if their face name is somehow different from real name) in brackets.

Additionally, this PR makes orbit menu prioritize "real" job name and icon, aka the ones the person spawned with. If they don't have an assigned job, it will fall back to current behavior of looking it up from their ID. Also, searching people includes both their fake and real name.

## Why It's Good For The Game

Ghosts really, really shouldn't be fooled by wearing a gas mask and an ID. **Especially** admin ghosts.

## Changelog
:cl:
qol: Ghost orbit menu now always displays person's real name and their roundstart job and cannot be fooled by disguises.
/:cl:
