### PR TITLE
Fix Tongue Based Speech Modifiers Being Applied To Users Native Languages

### DIFF
--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -54,7 +54,7 @@
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] == "*")
 		return
-	if(!should_modify_speech?.Invoke(source, speech_args))
+	if(!isnull(should_modify_speech) && !should_modify_speech?.Invoke(source, speech_args))
 		return
 
 	for (var/to_replace in replacements)
@@ -128,3 +128,6 @@
 		return
 	UnregisterSignal(targeted, COMSIG_MOB_SAY)
 	targeted = null
+
+/datum/component/speechmod/Destroy()
+	QDEL_NULL(should_modify_speech)

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -13,8 +13,10 @@
 	var/slots
 	/// If set to true, turns all text to uppercase
 	var/uppercase = FALSE
+	/// Any additional checks that we should do before applying the speech modification
+	var/datum/callback/should_modify_speech
 
-/datum/component/speechmod/Initialize(replacements = list(), end_string = "", end_string_chance = 100, slots, uppercase = FALSE)
+/datum/component/speechmod/Initialize(replacements = list(), end_string = "", end_string_chance = 100, slots, uppercase = FALSE, should_modify_speech)
 	if (!ismob(parent) && !isitem(parent) && !istype(parent, /datum/mutation/human))
 		return COMPONENT_INCOMPATIBLE
 
@@ -23,6 +25,7 @@
 	src.end_string_chance = end_string_chance
 	src.slots = slots
 	src.uppercase = uppercase
+	src.should_modify_speech = should_modify_speech
 
 	if (istype(parent, /datum/mutation/human))
 		RegisterSignal(parent, COMSIG_MUTATION_GAINED, PROC_REF(on_mutation_gained))
@@ -50,6 +53,8 @@
 
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] == "*")
+		return
+	if(!should_modify_speech?.Invoke(source, speech_args))
 		return
 
 	for (var/to_replace in replacements)

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -14,7 +14,7 @@
 	/// If set to true, turns all text to uppercase
 	var/uppercase = FALSE
 	/// Any additional checks that we should do before applying the speech modification
-	var/datum/callback/should_modify_speech
+	var/datum/callback/should_modify_speech = null
 
 /datum/component/speechmod/Initialize(replacements = list(), end_string = "", end_string_chance = 100, slots, uppercase = FALSE, should_modify_speech)
 	if (!ismob(parent) && !isitem(parent) && !istype(parent, /datum/mutation/human))

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -131,3 +131,4 @@
 
 /datum/component/speechmod/Destroy()
 	QDEL_NULL(should_modify_speech)
+	return ..()

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -54,7 +54,7 @@
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] == "*")
 		return
-	if(!isnull(should_modify_speech) && !should_modify_speech?.Invoke(source, speech_args))
+	if(!isnull(should_modify_speech) && !should_modify_speech.Invoke(source, speech_args))
 		return
 
 	for (var/to_replace in replacements)

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -130,5 +130,5 @@
 	targeted = null
 
 /datum/component/speechmod/Destroy()
-	QDEL_NULL(should_modify_speech)
+	should_modify_speech = null
 	return ..()

--- a/code/game/machinery/dna_infuser/organ_sets/fly_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fly_organs.dm
@@ -51,7 +51,7 @@
 
 /obj/item/organ/internal/tongue/fly/New(class, timer, datum/mutation/human/copymut)
 	. = ..()
-	AddComponent(/datum/component/speechmod, replacements = speech_replacements)
+	AddComponent(/datum/component/speechmod, replacements = speech_replacements, should_modify_speech = CALLBACK(src, PROC_REF(should_modify_speech)))
 
 /obj/item/organ/internal/tongue/fly/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -94,11 +94,15 @@
 /obj/item/organ/internal/tongue/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
 
+	if(should_modify_speech(source, speech_args))
+		modify_speech(source, speech_args)
+
+/obj/item/organ/internal/tongue/proc/should_modify_speech(datum/source, list/speech_args)
 	if(speech_args[SPEECH_LANGUAGE] in languages_native) // Speaking a native language?
 		return FALSE // Don't modify speech
 	if(HAS_TRAIT(source, TRAIT_SIGN_LANG)) // No modifiers for signers - I hate this but I simply cannot get these to combine into one statement
 		return FALSE // Don't modify speech
-	modify_speech(source, speech_args)
+	return TRUE
 
 /obj/item/organ/internal/tongue/proc/modify_speech(datum/source, list/speech_args)
 	return speech_args[SPEECH_MESSAGE]
@@ -195,7 +199,7 @@
 
 /obj/item/organ/internal/tongue/lizard/New(class, timer, datum/mutation/human/copymut)
 	. = ..()
-	AddComponent(/datum/component/speechmod, replacements = speech_replacements)
+	AddComponent(/datum/component/speechmod, replacements = speech_replacements, should_modify_speech = CALLBACK(src, PROC_REF(should_modify_speech)))
 
 /obj/item/organ/internal/tongue/lizard/silver
 	name = "silver tongue"


### PR DESCRIPTION
## About The Pull Request
This change allows tongue based speech modifications to be ignored if the user is speaking in a native language or using hand signs, putting it back to where it was functionally before moving to speechmod components.
## Why It's Good For The Game
This is correcting some of the speaking code to how it was working prior to speechmods, meaning lizard people won't be elongating there s's in draconic. Fly people are the other species with a tongue based speech modifier and receive the same fix. This also corrects  tongue based speech mods getting applied to sign language. Speech modifiers are still applied if the user is talking in a non-native language, same as it was pre speechmod.

Before:
![speechmod_demo_before](https://github.com/user-attachments/assets/86d9bca0-2d1d-44fe-8448-b8aebde8957e)
After:
![speechmod_demo_after](https://github.com/user-attachments/assets/9f071df5-0a60-4898-9aae-e8b8edd0db9e)

## Changelog

:cl:
fix: fixing speech modifiers being applied to a tongue's native languages.
/:cl: