### PR TITLE
Fixed Icebox ordnance being freezing cold (+ some minor Icebox fixes)

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -29366,6 +29366,10 @@
 	pixel_y = 2
 	},
 /obj/structure/lattice/catwalk,
+/obj/machinery/camera/directional/south{
+	c_tag = "Ordnance Lower Mix Lab";
+	network = list("ss13","rd")
+	},
 /turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "iPP" = (
@@ -54339,6 +54343,13 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"qjs" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Ordnance Lower Mix Lab";
+	network = list("ss13","rd")
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "qjx" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -80707,6 +80718,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Ordnance Lower Mix Lab";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/cytology)
 "ybf" = (
@@ -129259,7 +129274,7 @@ iDt
 iDt
 iDt
 iDt
-iDt
+qjs
 fIt
 fIt
 oSU

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -859,9 +859,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"aoC" = (
-/turf/open/openspace,
-/area/icemoon/underground/explored)
 "apb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1157,7 +1154,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "asM" = (
 /obj/machinery/light/directional/east,
@@ -14249,7 +14246,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "egj" = (
 /obj/structure/rack,
@@ -14569,7 +14566,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "ekW" = (
 /obj/structure/cable,
@@ -29369,8 +29366,8 @@
 	pixel_y = 2
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/science/cytology)
+/turf/open/openspace/icemoon,
+/area/icemoon/underground/explored)
 "iPP" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/landmark/start/bartender,
@@ -33584,7 +33581,7 @@
 	dir = 1
 	},
 /obj/structure/railing,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "kdT" = (
 /obj/machinery/iv_drip,
@@ -38876,10 +38873,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/service)
-"lEc" = (
-/obj/structure/stairs/east,
-/turf/open/misc/asteroid/snow,
-/area/station/science/ordnance)
 "lEg" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "AI Core Door";
@@ -40954,7 +40947,7 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "mnC" = (
 /obj/structure/grille,
@@ -42532,7 +42525,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "mRr" = (
 /obj/structure/cable,
@@ -43352,7 +43345,7 @@
 /area/station/service/hydroponics)
 "nce" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "nci" = (
 /obj/structure/cable,
@@ -46176,7 +46169,7 @@
 	dir = 9
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "nOb" = (
 /obj/machinery/door/airlock/external{
@@ -53787,8 +53780,8 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/science/cytology)
+/turf/open/openspace/icemoon,
+/area/icemoon/underground/explored)
 "qbA" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
@@ -66997,7 +66990,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
 "tTL" = (
 /obj/structure/chair,
@@ -193514,9 +193507,9 @@ thA
 thA
 xMq
 xMq
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 kdJ
 iDt
 iDt
@@ -193771,11 +193764,11 @@ thA
 thA
 xMq
 xMq
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 kdJ
-aoC
+lvt
 wnp
 wnp
 sjD
@@ -194027,10 +194020,10 @@ thA
 thA
 thA
 xMq
-aoC
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
+lvt
 mRp
 qbz
 wnp
@@ -194284,9 +194277,9 @@ thA
 thA
 thA
 rcY
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 nNV
 ege
 iPK
@@ -194541,9 +194534,9 @@ thA
 tjo
 tjo
 rcY
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 ekN
 nce
 qcl
@@ -194798,9 +194791,9 @@ thA
 tjo
 tjo
 rcY
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 mnB
 tTK
 rSZ
@@ -195055,10 +195048,10 @@ thA
 tjo
 tjo
 rcY
-aoC
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
+lvt
 asG
 qcl
 qcl
@@ -195313,12 +195306,12 @@ tjo
 tjo
 qZG
 ebX
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 kdJ
-aoC
-aoC
+lvt
+lvt
 wnp
 wnp
 dqt
@@ -195572,11 +195565,11 @@ tjo
 qZG
 kNC
 ebX
-aoC
+lvt
 kdJ
-aoC
-aoC
-aoC
+lvt
+lvt
+lvt
 wnp
 qcl
 qcl
@@ -195584,7 +195577,7 @@ wnp
 uIf
 odm
 odm
-lEc
+odm
 odm
 nqy
 jGR


### PR DESCRIPTION
## About The Pull Request

Fixes #84954.
Fixes #84961.

Due to a snow tile finding its way under some stairs, Icebox ordnance was a balmy -93 C at roundstart. Regular floor has been put back in.

Additionally, Icebox cytology had no cameras in it, so cameras have been added to the lab itself as well as its outdoor area.

Less player-facingly, all of the open space turfs in the new outdoor cytology area were the wrong type, causing a whole bunch of active turfs. These have been replaced with the proper icemoon type.

Finally, the area for the cytology lab no longer extends outdoors, which was causing some weird sound issues.
## Why It's Good For The Game

You shouldn't instantly freeze to death while going to work.
## Changelog
:cl:
fix: The Icebox ordnance lab is now once again a habitable temperature.
fix: Icebox cytology now has cameras in it.
/:cl:
