### PR TITLE
Necropolis gates block atmos when closed.

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -15,6 +15,7 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	light_range = 8
 	light_color = LIGHT_COLOR_LAVA
+	can_atmos_pass = ATMOS_PASS_DENSITY
 	var/open = FALSE
 	var/changing_openness = FALSE
 	var/locked = FALSE


### PR DESCRIPTION

## About The Pull Request

Per the title, necropolis gates are now solid to atmos as long as they're closed - the same as actual doors.
## Why It's Good For The Game

Fixes a couple of active turfs on the Icebox Lavaland ruin, mostly - it had two different types of atmosphere on either side of a necropolis gate, probably because the mapper thought it would work like an airlock.

It also just makes sense that the heavy stone door would block atmos, if even flimsy wooden ones can.
## Changelog
:cl:
fix: Atmosphere can no longer flow through closed necropolis gates.
/:cl:
