### PR TITLE
Improves pipe pistols, changes their bane effect to an on-hit effect of the projectile, fixes a mild bug with bayonets on pipe pistols

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -309,7 +309,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
-	bolt_type = BOLT_TYPE_STANDARD
 	semi_auto = TRUE
 
 	SET_BASE_PIXEL(0, 0)

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -273,6 +273,7 @@
 	obj_flags = UNIQUE_RENAME
 	can_be_sawn_off = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
+	pb_knockback = 3
 
 	SET_BASE_PIXEL(-8, 0)
 
@@ -303,13 +304,17 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol
 	projectile_damage_multiplier = 0.50
 	spread = 15 //kinda inaccurate
+	burst_size = 3 //but it empties the entire magazine when it fires
+	fire_delay = 0.3 // and by empties, I mean it does it all at once
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
+	bolt_type = BOLT_TYPE_STANDARD
+	semi_auto = TRUE
 
 	SET_BASE_PIXEL(0, 0)
 
-/obj/item/gun/ballistic/rifle/boltaction/pipegun/pipepistol/add_bayonet_point()
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol/add_bayonet_point()
 	return
 
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/prime
@@ -330,6 +335,7 @@
 	inhand_icon_state = "regal_pipepistol"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol/prime
 	projectile_damage_multiplier = 1
+	burst_size = 6 // WHOLE CLIP
 	spread = 0
 
 /// MAGICAL BOLT ACTIONS ///

--- a/code/modules/projectiles/projectile/bullets/junk.dm
+++ b/code/modules/projectiles/projectile/bullets/junk.dm
@@ -5,9 +5,28 @@
 	icon_state = "trashball"
 	damage = 30
 	embed_type = /datum/embed_data/bullet_junk
-	var/bane_mob_biotypes = MOB_ROBOTIC
-	var/bane_multiplier = 1.5
-	var/bane_added_damage = 0
+	/// What biotype does our junk projectile especially harm?
+	var/extra_damage_mob_biotypes = MOB_ROBOTIC
+	/// How much do we multiply our total base damage?
+	var/extra_damage_multiplier = 1.5
+	/// How much extra damage do we do on top of this total damage? Separate from the multiplier and unaffected by it.
+	var/extra_damage_added_damage = 0
+	/// What damage type is our extra damage?
+	var/extra_damage_type = BRUTE
+
+/obj/projectile/bullet/junk/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+
+	if(!isliving(target))
+		return
+	var/mob/living/living_target = target
+
+	var/is_correct_biotype = living_target.mob_biotypes & extra_damage_mob_biotypes
+	if(extra_damage_mob_biotypes && is_correct_biotype)
+		var/multiplied_damage = extra_damage_multiplier ? ((damage * extra_damage_multiplier) - damage) : 0
+		var/finalized_damage = multiplied_damage + extra_damage_added_damage
+		if(finalized_damage)
+			living_target.apply_damage(finalized_damage, damagetype = extra_damage_type, def_zone = BODY_ZONE_CHEST, wound_bonus = wound_bonus)
 
 /datum/embed_data/bullet_junk
 	embed_chance=15
@@ -18,10 +37,6 @@
 	pain_mult=5
 	jostle_pain_mult=6
 	rip_time=10
-
-/obj/projectile/bullet/junk/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/bane, mob_biotypes = bane_mob_biotypes, target_type = /mob/living, damage_multiplier = bane_multiplier, added_damage = bane_added_damage, requires_combat_mode = FALSE)
 
 /obj/projectile/bullet/incendiary/fire/junk
 	name = "burning oil"
@@ -40,7 +55,8 @@
 	damage = 15
 	embed_type = null
 	shrapnel_type = null
-	bane_multiplier = 3
+	extra_damage_added_damage = 30
+	extra_damage_type = BURN
 
 /obj/projectile/bullet/junk/shock/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -51,9 +67,9 @@
 /obj/projectile/bullet/junk/hunter
 	name = "junk hunter bullet"
 	icon_state = "gauss"
-	bane_mob_biotypes = MOB_ROBOTIC | MOB_BEAST | MOB_SPECIAL
-	bane_multiplier = 0
-	bane_added_damage = 50
+	extra_damage_mob_biotypes = MOB_ROBOTIC | MOB_BEAST | MOB_SPECIAL
+	extra_damage_multiplier = 0
+	extra_damage_added_damage = 50
 
 /obj/projectile/bullet/junk/ripper
 	name = "junk ripper bullet"


### PR DESCRIPTION
## About The Pull Request

Pipeguns and all subtypes have a 3 tiles knockback when fired pointblank, much like shotguns.

Pipe pistols unload the entire magazine in a single rapid burst. This feature extends to the (otherwise unobtainable) regal pipe pistol.

Fixes pipe pistols being able to be bayoneted.

Junk rounds have their on-hit effects with regards to particular mob biotype effects.

## Why It's Good For The Game

Pipe pistols aren't quite as useful as their pipegun counterparts. While every shot together would outdamage the pipegun, the pipegun is just generally more reliable and accurate, even at close range. People prefer to use the pipegun's dependable functionality than gamble with trying to land three shots with the pistol in a melee.

So, to encourage the use of pipe pistols up close where they are strongest and make them less of a gamble, the pipe pistol has a much deadlier close range potency while still suffering at long range, which is what the pipegun rifle excels at while having slightly lower damage overall. Also it makes the gun feel more like its a duckfoot gun or something, which is fun.

The knockback effect was something lost from when they were a shotgun subtype. I just never got around to re-adding it to any of the iterations of pipeguns. It's a cool feature that is a bit of a shame to lose.

It has been a few months with no fix in sight for the element, and I'm not particularly hopeful about it either. It's easier to just have this effect baked into the bullets themselves.

## Changelog
:cl:
add: Pipe pistols now magdump their entire magazine when fired.
add: Pipeguns and their subtypes have a knockback effect.
fix: Pipe pistols cannot be bayoneted, as intended.
fix: Junk rounds now actually do their extra damage effects against certain mob types. Borgs across the Spinward tremble at the knowledge that these junk weapons can obliterate them with ease.
/:cl:
