### PR TITLE
Human AIs get a portable crew monitor, loses borg costume and implant

### DIFF
--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -98,18 +98,13 @@
 		/obj/item/door_remote/omni = 1,
 		/obj/item/machine_remote = 1,
 		/obj/item/secure_camera_console_pod = 1,
-	)
-	implants = list(
-		/obj/item/implant/teleport_blocker,
+		/obj/item/sensor_device = 1,
 	)
 
 	uniform = /obj/item/clothing/under/rank/station_trait/human_ai
 	belt = /obj/item/modular_computer/pda/human_ai
 	ears = /obj/item/radio/headset/silicon/human_ai
 	glasses = /obj/item/clothing/glasses/hud/diagnostic
-
-	suit = /obj/item/clothing/suit/costume/cardborg
-	head = /obj/item/clothing/head/costume/cardborg
 
 	l_pocket = /obj/item/laser_pointer/infinite_range //to punish borgs, this works through the camera console.
 	r_pocket = /obj/item/assembly/flash/handheld


### PR DESCRIPTION
## About The Pull Request

Removes Human AI's teleport blocker implant and borg costume and gives them a portable crew monitor in their bag instead.

## Why It's Good For The Game

I originally gave human AIs a teleport blocker so it would be a little harder to leave the SAT, but I don't think it should be impossible. With enough effort and determination, it should be possible for a human AI to go get their own food or go interact with crew and whatnot. Their slowness is meant to be a deterrent and I think it is a fine one that doesn't need this extra implant, not to mention that I'd like to keep cybernetics on the human AI to a minimum.
In the original Human AI PR, I had given them a borg costume before they got their own custom outfit. Now that I gave them that, the borg costume is now just outdated. They shouldn't look like a borg to their borgs, they should stand out.

As for the portable crew monitor, I thought it would be the best way to give human AIs the ability to see people's vitals like AIs could, but only if their sensors are maxed. AIs can only see people's medhuds if the person's sensors are on so they don't necessarily need one, they just won't see things like diseases and such, which I think is fine.

## Changelog

:cl:
balance: Human AIs no longer have a teleport blocking implant or borg costume, but now has a portable crew monitor.
/:cl: