### PR TITLE
Lavaland raptor barn improvements 

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -93,6 +93,13 @@
 /obj/structure/cable,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"aL" = (
+/obj/structure/chair/sofa/middle{
+	dir = 1;
+	color = "#AA4A44"
+	},
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "aM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lavaland_living_east_maint"
@@ -255,6 +262,25 @@
 /obj/machinery/mining_weather_monitor/directional/north,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/mine/production)
+"bZ" = (
+/obj/structure/table/wood,
+/obj/item/plate{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/plate{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/cup/glass/mug/tea{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "cb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -266,6 +292,11 @@
 "cc" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
+"cd" = (
+/turf/open/floor/iron/stairs{
+	dir = 8
+	},
+/area/lavaland/surface/outdoors)
 "ce" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -344,10 +375,7 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "ct" = (
-/obj/structure/railing/wooden_fence{
-	dir = 6
-	},
-/turf/open/misc/hay/lavaland,
+/turf/closed/wall/mineral/iron,
 /area/lavaland/surface)
 "cw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -452,6 +480,10 @@
 	dir = 8
 	},
 /area/mine/production)
+"cT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "cU" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -519,6 +551,11 @@
 /obj/structure/lattice/catwalk/mining,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"dl" = (
+/turf/open/floor/iron/stairs{
+	dir = 4
+	},
+/area/lavaland/surface/outdoors)
 "dq" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -537,6 +574,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
+"du" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "dv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -621,6 +664,15 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"eb" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
 "ee" = (
 /obj/machinery/shower/directional/south,
 /obj/machinery/door/window/right/directional/south,
@@ -636,6 +688,12 @@
 	dir = 8
 	},
 /area/mine/laborcamp/production)
+"eq" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "et" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -794,6 +852,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"fm" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "fo" = (
 /obj/structure/closet/crate,
 /obj/structure/window/spawner/directional/west,
@@ -855,6 +923,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"fJ" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "fL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -916,6 +990,12 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
+"fZ" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "gd" = (
 /obj/structure/marker_beacon/yellow,
 /obj/effect/turf_decal/sand/plating/volcanic,
@@ -1079,6 +1159,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/living_quarters)
+"gH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "gI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1315,8 +1401,11 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "hM" = (
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/lavaland/surface)
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "hR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1435,6 +1524,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ir" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "iu" = (
 /turf/closed/wall,
 /area/mine/living_quarters)
@@ -1500,6 +1595,12 @@
 	},
 /turf/open/floor/iron/edge,
 /area/mine/living_quarters)
+"iQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "iX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/bench{
@@ -1598,6 +1699,15 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"jv" = (
+/obj/structure/table/wood,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "jw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -1692,10 +1802,10 @@
 	},
 /area/mine/production)
 "jX" = (
-/obj/structure/railing/wooden_fence{
-	dir = 1
+/obj/structure/railing{
+	dir = 6
 	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "ka" = (
 /obj/structure/table,
@@ -1707,6 +1817,13 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/cafeteria)
+"ke" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp)
@@ -1716,6 +1833,10 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"kl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "kn" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth,
@@ -1730,6 +1851,13 @@
 	dir = 4
 	},
 /area/mine/laborcamp)
+"ks" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "kt" = (
 /turf/closed/wall,
 /area/mine/laborcamp/security)
@@ -1930,6 +2058,15 @@
 	dir = 1
 	},
 /area/mine/eva)
+"ll" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface)
 "lo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -1959,10 +2096,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "lt" = (
-/obj/structure/railing/wooden_fence{
-	dir = 5
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/turf/open/misc/hay,
 /area/lavaland/surface/outdoors)
 "lv" = (
 /obj/structure/stone_tile/block/cracked{
@@ -2311,6 +2445,10 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
+"mE" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "mJ" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -2586,6 +2724,18 @@
 	dir = 1
 	},
 /area/mine/laborcamp)
+"nH" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/mine/eva)
 "nI" = (
 /obj/structure/sink/kitchen/directional/south{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -2750,6 +2900,12 @@
 	dir = 8
 	},
 /turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"oz" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "oA" = (
 /turf/closed/wall,
@@ -3003,6 +3159,12 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"pX" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "pZ" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -3052,10 +3214,11 @@
 	},
 /area/mine/laborcamp/quarters)
 "qi" = (
-/obj/structure/railing/wooden_fence{
-	dir = 4
+/obj/machinery/microwave{
+	pixel_y = 6
 	},
-/turf/open/misc/hay/lavaland,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
 /area/lavaland/surface)
 "qo" = (
 /obj/machinery/door/airlock/glass{
@@ -3117,6 +3280,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"qz" = (
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "qA" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/east,
@@ -3125,6 +3291,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"qE" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "qH" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningbathroomprivate";
@@ -3184,6 +3356,14 @@
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
+"rl" = (
+/obj/structure/bookcase/random/reference,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "rm" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3197,6 +3377,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"rq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "rv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark/smooth_edge{
@@ -3269,6 +3455,13 @@
 "rU" = (
 /turf/closed/wall,
 /area/mine/storage/public)
+"rV" = (
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	color = "#AA4A44"
+	},
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "rX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3350,6 +3543,13 @@
 	dir = 8
 	},
 /area/mine/medical)
+"sp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface)
 "st" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -3482,6 +3682,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"th" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "ti" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -3595,6 +3802,12 @@
 	dir = 8
 	},
 /area/mine/laborcamp)
+"uf" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "ui" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3685,6 +3898,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
+"uK" = (
+/obj/item/canvas/twentythree_nineteen,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "uN" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -4132,6 +4349,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"xy" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "xz" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -4310,6 +4531,12 @@
 /obj/structure/stone_tile,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"yz" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "yC" = (
 /obj/structure/bed{
 	dir = 4
@@ -4374,6 +4601,9 @@
 /obj/structure/lattice/catwalk/mining,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"yW" = (
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "yX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -4399,8 +4629,7 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "ze" = (
-/obj/effect/spawner/random/lavaland_mob/raptor,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/turf/open/misc/ashplanet/rocky,
 /area/lavaland/surface/outdoors)
 "zf" = (
 /obj/machinery/door/airlock{
@@ -4459,9 +4688,9 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "zs" = (
-/obj/structure/railing/wooden_fence,
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/obj/structure/railing,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "zw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4480,6 +4709,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
+"zB" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "zD" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -4620,6 +4855,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"AD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "AI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4649,6 +4890,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_edge,
 /area/mine/laborcamp/production)
+"AO" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "AQ" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -4679,6 +4929,10 @@
 /obj/structure/railing/corner,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Be" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4797,12 +5051,18 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/cafeteria)
-"Cv" = (
-/obj/structure/railing/wooden_fence{
-	dir = 5
+"Cp" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
+"Cv" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/marker_beacon/purple,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Cz" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -4960,6 +5220,9 @@
 	dir = 4
 	},
 /area/mine/laborcamp)
+"Do" = (
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface)
 "Dx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -4978,11 +5241,9 @@
 /turf/closed/wall,
 /area/mine/medical)
 "DB" = (
-/obj/structure/railing/wooden_fence{
-	dir = 8
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "DF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4994,6 +5255,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/textured_large,
 /area/mine/cafeteria)
+"DJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "DK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -5081,6 +5348,13 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"Es" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Raptor Ranch External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface)
 "Ev" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -5114,6 +5388,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
+"ED" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "EE" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5172,6 +5451,11 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"EV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/lavaland/surface)
 "EX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -5266,6 +5550,13 @@
 /area/lavaland/surface/outdoors)
 "FH" = (
 /turf/closed/wall,
+/area/lavaland/surface/outdoors)
+"FJ" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "FL" = (
 /obj/structure/disposalpipe/segment,
@@ -5388,11 +5679,9 @@
 	},
 /area/mine/production)
 "GG" = (
-/obj/structure/railing/wooden_fence{
-	dir = 9
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface)
 "GH" = (
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Lounge"
@@ -5449,6 +5738,12 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
+"Hc" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "Hd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5464,6 +5759,13 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
+"Hg" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "Hp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -5615,6 +5917,11 @@
 "Ia" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
+"Ib" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Ic" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/wideplating_new{
@@ -5781,6 +6088,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"Jg" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Jh" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
@@ -5822,6 +6136,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/eva)
+"Jr" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Jt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -6238,6 +6558,11 @@
 	dir = 8
 	},
 /area/mine/production)
+"Lt" = (
+/obj/machinery/smartfridge/drying_rack,
+/obj/item/food/cheese/firm_cheese,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "Lu" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -6348,6 +6673,12 @@
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
+"LT" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "LY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6392,6 +6723,9 @@
 	dir = 8
 	},
 /area/mine/lounge)
+"Mh" = (
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
 "Mr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -6418,6 +6752,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"Mx" = (
+/obj/structure/water_source/puddle,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "My" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -6433,6 +6771,11 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"ME" = (
+/obj/structure/bed,
+/obj/effect/spawner/random/bedsheet,
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "MH" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock"
@@ -6496,6 +6839,41 @@
 	dir = 4
 	},
 /area/mine/laborcamp)
+"MX" = (
+/obj/structure/rack,
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?"
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9;
+	pixel_x = 2
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 6
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/obj/item/crowbar/large,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "Nb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6526,6 +6904,13 @@
 	},
 /obj/effect/turf_decal/sand/plating/volcanic,
 /turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
+"Ng" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/item/reagent_containers/cup/bucket/wooden,
+/turf/open/misc/hay,
 /area/lavaland/surface/outdoors)
 "Nh" = (
 /obj/structure/ore_box,
@@ -6627,11 +7012,8 @@
 /turf/open/floor/iron/dark,
 /area/mine/production)
 "NK" = (
-/obj/structure/railing/wooden_fence{
-	dir = 1
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/turf/open/misc/ashplanet/ash,
+/area/lavaland/surface/outdoors)
 "NL" = (
 /obj/structure/railing,
 /obj/structure/lattice/catwalk/mining,
@@ -6641,6 +7023,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
+"NQ" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "NR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6737,6 +7123,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/mechbay)
+"Ol" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/lavaland/surface)
 "Om" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -6751,6 +7141,14 @@
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Or" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "Ot" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -6759,6 +7157,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
+"Ov" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ow" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mine/eva)
 "Oy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -6768,6 +7180,9 @@
 	dir = 4
 	},
 /area/mine/laborcamp/security)
+"Oz" = (
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "OH" = (
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
 	pixel_x = -8;
@@ -6898,6 +7313,12 @@
 /obj/item/toy/beach_ball,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Pu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "PA" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
@@ -6998,6 +7419,10 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
+"PX" = (
+/obj/structure/railing,
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "PY" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/toy,
@@ -7022,6 +7447,13 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"Qc" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Raptor Ranch External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
 "Qe" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
@@ -7040,6 +7472,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/mechbay)
+"Qk" = (
+/obj/structure/easel,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/paint_palette,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "Qq" = (
 /obj/structure/ore_vent/starter_resources{
 	icon_state = "ore_vent_active"
@@ -7107,6 +7547,12 @@
 /obj/effect/turf_decal/sand/plating/volcanic,
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
+"QO" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "QP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7195,6 +7641,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
 /area/mine/production)
+"Rr" = (
+/obj/structure/marker_beacon/purple,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Rs" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -7271,6 +7721,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"RQ" = (
+/obj/structure/table/wood,
+/obj/item/knife,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "RV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -7472,6 +7927,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/mine/eva)
+"Tg" = (
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "Ti" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/table,
@@ -7517,11 +7981,9 @@
 	},
 /area/mine/production)
 "Tt" = (
-/obj/structure/railing/wooden_fence{
-	dir = 10
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/obj/effect/spawner/random/lavaland_mob/raptor,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "Tu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7700,6 +8162,13 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"Uw" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Ux" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -7713,9 +8182,7 @@
 /turf/open/floor/iron/freezer,
 /area/mine/living_quarters)
 "UI" = (
-/obj/structure/railing/wooden_fence{
-	dir = 4
-	},
+/obj/structure/flora/ash/stem_shroom,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "UK" = (
@@ -7725,6 +8192,10 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
+"UL" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "UN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7774,6 +8245,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
+"UX" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "UZ" = (
 /obj/structure/chair/stool/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7788,6 +8265,13 @@
 /obj/structure/fluff/drake_statue/falling,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Vb" = (
+/obj/structure/chair/sofa/corner{
+	dir = 8;
+	color = "#AA4A44"
+	},
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "Vc" = (
 /obj/item/reagent_containers/cup/glass/colocup{
 	pixel_x = -5;
@@ -7796,8 +8280,8 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Vd" = (
-/obj/structure/railing/wooden_fence{
-	dir = 9
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/misc/hay/lavaland,
 /area/lavaland/surface)
@@ -7945,11 +8429,9 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
 "VP" = (
-/obj/structure/railing/wooden_fence{
-	dir = 8
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/obj/structure/flora/ash/fireblossom,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "VS" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -7979,11 +8461,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
+"Wc" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/lighter,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "We" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/storage)
+"Wf" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "Wg" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating/volcanic,
@@ -8235,6 +8729,11 @@
 	dir = 4
 	},
 /area/mine/lounge)
+"XC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
+/area/lavaland/surface)
 "XD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8246,6 +8745,12 @@
 	dir = 1
 	},
 /area/mine/lounge)
+"XF" = (
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "XH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8281,6 +8786,31 @@
 /mob/living/basic/mining/goliath,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"XS" = (
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = -1;
+	pixel_x = 5
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9;
+	pixel_x = 2
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?"
+	},
+/turf/open/misc/hay/lavaland,
+/area/lavaland/surface)
 "XT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8360,8 +8890,14 @@
 /area/mine/lounge)
 "Yg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/eva)
+"Yh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "Yk" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile,
@@ -8423,6 +8959,10 @@
 	dir = 1
 	},
 /area/mine/laborcamp/quarters)
+"YE" = (
+/obj/structure/fireplace,
+/turf/open/floor/wood/parquet,
+/area/lavaland/surface)
 "YF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8567,6 +9107,16 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"ZI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
+"ZJ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "ZM" = (
 /obj/structure/railing{
 	dir = 8
@@ -8584,6 +9134,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
+"ZR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/lavaland/surface)
 "ZT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -41748,8 +42305,8 @@ eA
 eA
 pU
 pU
-aj
-aj
+pU
+pU
 aj
 aj
 aj
@@ -41998,16 +42555,16 @@ MS
 QP
 LE
 os
-SP
+Qc
+Mh
+eb
 pU
-ai
-ai
-ai
 pU
-aj
-aj
-aj
-aj
+pU
+NK
+ze
+pU
+pU
 aj
 aj
 "}
@@ -42255,16 +42812,16 @@ JZ
 PR
 ib
 os
-SP
+ZI
+ZI
+ZI
 pU
 pU
-ai
-ai
+ze
+NK
+ze
 pU
-aj
-aj
-aj
-aj
+pU
 aj
 aj
 "}
@@ -42515,12 +43072,12 @@ Jt
 Zq
 pU
 pU
-ai
 pU
-aj
-aj
-aj
-aj
+pU
+ze
+ze
+pU
+pU
 aj
 aj
 aj
@@ -42773,11 +43330,11 @@ Zq
 pU
 pU
 aj
-aj
-aj
 pU
-aj
-aj
+pU
+Rr
+cd
+Rr
 aj
 aj
 aj
@@ -43032,9 +43589,9 @@ aj
 aj
 pU
 pU
-aj
-aj
-aj
+fJ
+qz
+oz
 aj
 aj
 aj
@@ -43289,9 +43846,9 @@ aj
 aj
 aj
 aj
-aj
-aj
-pU
+yz
+qz
+jX
 aj
 aj
 aj
@@ -43546,9 +44103,9 @@ aj
 aj
 aj
 pU
-aj
-pU
-pU
+Rr
+dl
+Rr
 aj
 aj
 aj
@@ -43803,9 +44360,9 @@ aj
 aj
 aj
 pU
-ad
-ad
-ai
+ze
+ze
+ze
 aj
 aj
 aj
@@ -44059,11 +44616,11 @@ aj
 aj
 aj
 pU
-ai
-ad
-ad
-ai
-aj
+ze
+ze
+NK
+ze
+ze
 aj
 aj
 "}
@@ -44316,10 +44873,10 @@ aj
 aj
 aj
 pU
-ad
-ad
-ad
-ad
+ze
+ze
+NK
+NK
 pU
 aj
 aj
@@ -44573,10 +45130,10 @@ aj
 aj
 aj
 aj
-ad
-ad
-ad
-ad
+ze
+ze
+NK
+ze
 pU
 aj
 aj
@@ -44831,10 +45388,10 @@ aj
 aj
 aj
 pU
-ad
-ad
-ad
-ai
+ze
+ze
+ze
+ze
 aj
 aj
 "}
@@ -45088,11 +45645,11 @@ aj
 aj
 aj
 pU
-ai
-ad
-ad
-ad
-aj
+ze
+ze
+ze
+NK
+NK
 aj
 "}
 (143,1,1) = {"
@@ -45346,9 +45903,9 @@ aj
 aj
 pU
 pU
-ai
-ai
-pU
+ze
+NK
+NK
 aj
 aj
 "}
@@ -45603,9 +46160,9 @@ aj
 aj
 aj
 aj
-pU
-pU
-aj
+Rr
+cd
+Rr
 aj
 aj
 "}
@@ -45860,9 +46417,9 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
+fJ
+qz
+oz
 aj
 aj
 "}
@@ -46116,10 +46673,10 @@ aj
 aj
 aj
 aj
-pU
 aj
-aj
-aj
+yz
+qz
+jX
 aj
 aj
 "}
@@ -46370,13 +46927,13 @@ Lw
 pU
 pU
 aj
-aj
-aj
+pU
 aj
 pU
-ai
-aj
-aj
+ze
+Rr
+dl
+Rr
 aj
 aj
 "}
@@ -46627,13 +47184,13 @@ Lw
 pU
 pU
 aj
-aj
-aj
 pU
-ad
-ad
-pU
-aj
+NK
+NK
+ze
+ze
+ze
+NK
 aj
 aj
 "}
@@ -46883,15 +47440,15 @@ BP
 Lw
 pU
 pU
-aj
-aj
-aj
-aj
-ai
-ad
-aj
-aj
-aj
+pU
+NK
+NK
+ze
+ze
+ze
+NK
+NK
+NK
 aj
 "}
 (150,1,1) = {"
@@ -47140,13 +47697,13 @@ BP
 Lw
 pU
 pU
-aj
-aj
-aj
-aj
-aj
 pU
-aj
+ze
+ze
+ze
+ze
+ze
+NK
 aj
 aj
 aj
@@ -47397,13 +47954,13 @@ BP
 Lw
 pU
 pU
-aj
-aj
-aj
-aj
-aj
-pU
-aj
+NK
+NK
+NK
+NK
+ze
+ze
+ze
 aj
 aj
 aj
@@ -47655,12 +48212,12 @@ Lw
 pU
 pU
 aj
-aj
-aj
-aj
-aj
-aj
-aj
+pU
+NK
+NK
+ze
+ze
+ze
 aj
 aj
 aj
@@ -47912,13 +48469,13 @@ Lw
 pU
 pU
 aj
-aj
-aj
-aj
 pU
-pU
-aj
-aj
+NK
+ze
+ze
+NK
+NK
+NK
 aj
 aj
 "}
@@ -48169,12 +48726,12 @@ ii
 pU
 pU
 aj
-aj
-aj
 pU
 pU
-aj
-aj
+Rr
+cd
+Rr
+NK
 aj
 aj
 aj
@@ -48428,9 +48985,9 @@ pU
 aj
 aj
 aj
-pU
-aj
-aj
+fJ
+qz
+oz
 aj
 aj
 aj
@@ -48661,7 +49218,7 @@ lb
 pK
 Ob
 IL
-IL
+nH
 KV
 pK
 aj
@@ -48685,9 +49242,9 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
+ZJ
+qz
+zs
 aj
 aj
 aj
@@ -48918,7 +49475,7 @@ NU
 pK
 pK
 dK
-dK
+Ow
 pK
 pK
 aj
@@ -48929,22 +49486,22 @@ aj
 aj
 pU
 pU
+Cv
+cd
+Cv
 pU
 pU
 pU
 pU
-pU
-pU
-pU
 aj
 aj
 aj
 aj
 aj
 aj
-aj
-aj
-aj
+yz
+qz
+jX
 aj
 aj
 aj
@@ -49175,33 +49732,33 @@ NU
 ai
 pU
 pU
+iQ
 pU
 aj
 aj
-aj
-pU
-pU
-aj
-aj
-aj
-aj
-aj
-pU
-pU
-pU
 pU
 pU
 aj
 aj
 aj
 aj
+aj
+Uw
+BP
+FJ
 pU
 pU
+aj
+aj
+aj
+aj
 pU
 pU
-pU
-pU
-pU
+aj
+aj
+Rr
+dl
+Rr
 pU
 pU
 aj
@@ -49432,7 +49989,7 @@ pU
 pU
 pU
 pU
-aj
+Ov
 aj
 aj
 pU
@@ -49443,26 +50000,26 @@ aj
 aj
 aj
 aj
+Cp
+BP
+Ib
+pU
 aj
 aj
+aj
+aj
+pU
+pU
+pU
+pU
+aj
+pU
+pU
 pU
 pU
 aj
 aj
 aj
-aj
-GG
-DB
-DB
-hM
-hM
-hM
-hM
-hM
-hM
-hM
-hM
-hM
 "}
 (160,1,1) = {"
 aa
@@ -49689,37 +50246,37 @@ pU
 aj
 aj
 aj
+Ov
+aj
+pU
+pU
+pU
+pU
+aj
+aj
+pU
+aj
+aj
+Cp
+BP
+Ib
+aj
+aj
 aj
 aj
 pU
 pU
 pU
 pU
-aj
-aj
+ze
+ze
+ze
+pU
+pU
 pU
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-pU
-jX
-pU
-pU
-NK
-sQ
-NS
-zs
-NS
-NS
-sQ
-NS
-hM
 "}
 (161,1,1) = {"
 aa
@@ -49946,37 +50503,37 @@ aj
 aj
 aj
 aj
+Ov
+aj
+aj
+pU
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+Cp
+BP
+Ib
+aj
 aj
 aj
 aj
 pU
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-pU
-jX
 pU
 pU
+ze
 NK
-il
-NS
-zs
-NS
-NS
-il
-NS
-hM
+ze
+pU
+pU
+pU
+pU
+aj
+aj
+pU
 "}
 (162,1,1) = {"
 aa
@@ -50203,18 +50760,7 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-pU
-aj
-aj
-aj
-aj
+Ov
 aj
 aj
 aj
@@ -50222,18 +50768,29 @@ aj
 aj
 aj
 pU
-jX
+aj
+aj
+aj
+Cp
+BP
+Ib
+aj
+aj
+aj
+aj
 pU
 pU
+ze
 NK
-NS
-NS
-zs
-NS
-NS
-NS
-NS
-hM
+NK
+ze
+pU
+pU
+pU
+aj
+aj
+pU
+pU
 "}
 (163,1,1) = {"
 aa
@@ -50460,37 +51017,37 @@ ai
 ai
 pU
 pU
-pU
-pU
-aj
-aj
-aj
-aj
-pU
-pU
-aj
+Ov
 aj
 aj
 aj
 aj
 aj
 pU
+pU
+aj
+aj
+aj
+Cp
+BP
+Ib
+pU
 aj
 pU
 pU
 pU
-jX
+ze
+ze
+NK
+ze
 pU
 pU
-Cv
-qi
-NS
-ct
-NS
-NS
-qi
-qi
-hM
+pU
+pU
+aj
+aj
+pU
+pU
 "}
 (164,1,1) = {"
 aa
@@ -50717,37 +51274,37 @@ ai
 ai
 ai
 ai
-pU
-pU
-pU
-pU
-aj
-aj
-pU
-aj
-aj
-aj
-pU
-aj
-aj
+iQ
+Ov
+Ov
+Ov
+Ov
 aj
 pU
 pU
 pU
+aj
 pU
+ke
+BP
+Jg
+pU
+pU
+lt
+uK
 pU
 pU
 ze
+ze
+ze
+ze
 pU
-NS
-NS
-NS
-NS
-NS
-uw
-NS
-NS
-hM
+pU
+aj
+aj
+aj
+pU
+pU
 "}
 (165,1,1) = {"
 aa
@@ -50978,6 +51535,26 @@ ai
 pU
 pU
 pU
+Ov
+qz
+pU
+pU
+pU
+pU
+pU
+Cv
+dl
+Cv
+pU
+lt
+VP
+lt
+pU
+pU
+pU
+pU
+ze
+pU
 pU
 aj
 aj
@@ -50985,26 +51562,6 @@ aj
 aj
 pU
 pU
-aj
-aj
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-NS
-mk
-sa
-NS
-NS
-NS
-OW
-sa
-hM
 "}
 (166,1,1) = {"
 aa
@@ -51232,6 +51789,25 @@ aj
 aj
 ai
 ai
+ct
+ct
+GG
+sp
+GG
+ct
+ct
+ct
+lt
+pU
+pU
+pU
+pU
+pU
+pU
+lt
+pU
+pU
+pU
 pU
 pU
 pU
@@ -51240,28 +51816,9 @@ aj
 aj
 aj
 aj
+aj
+aj
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-NS
-NS
-uw
-NS
-NS
-NS
-NS
-NS
-hM
 "}
 (167,1,1) = {"
 aa
@@ -51488,37 +52045,37 @@ aj
 aj
 aj
 aj
+ct
+ct
+MX
+Lt
+AD
+qi
+Tg
+RQ
+GG
+VP
+lt
+pU
+BP
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+aj
+aj
 aj
 pU
 pU
-pU
-pU
-pU
 aj
 aj
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-jX
-pU
-pU
-Vd
-VP
-NS
-Tt
-NS
-NS
-VP
-VP
-hM
 "}
 (168,1,1) = {"
 aa
@@ -51745,37 +52302,37 @@ aj
 aj
 aj
 aj
-aj
-aj
+ct
+Oz
+ks
+kl
+AD
+cT
+gH
+jv
+GG
+lt
+lt
+lt
 pU
 pU
-pU
-pU
-pU
-aj
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-jX
 pU
 pU
 NK
-NS
-NS
-zs
-NS
-NS
-NS
-NS
-hM
+NK
+ze
+pU
+pU
+pU
+aj
+aj
+aj
+pU
+pU
+pU
+aj
+aj
+aj
 "}
 (169,1,1) = {"
 aa
@@ -52002,37 +52559,37 @@ ai
 pU
 aj
 aj
-aj
-aj
+ct
+Qk
+fm
+Pu
+th
+bZ
+QO
+ct
+ct
+pU
+lt
 pU
 pU
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-jX
-pU
-pU
+ze
 NK
-il
-NS
-zs
-NS
-NS
-il
-NS
-hM
+ze
+pU
+pU
+pU
+pU
+aj
+aj
+aj
+pU
+pU
+aj
+aj
+aj
+aj
 "}
 (170,1,1) = {"
 aa
@@ -52259,37 +52816,37 @@ ai
 ai
 ai
 pU
-aj
-aj
+ct
+Oz
+Hg
+yW
+AD
+ZR
+Oz
+ct
 pU
 pU
 pU
 pU
 pU
+BP
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-jX
-pU
-pU
+ze
 NK
-sQ
-NS
-zs
-NS
-NS
-sQ
-NS
-hM
+pU
+UI
+pU
+pU
+pU
+pU
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 "}
 (171,1,1) = {"
 aa
@@ -52516,37 +53073,37 @@ aj
 ai
 ai
 ai
-ai
+ct
+Oz
+rV
+yW
+AD
+AO
+ct
+ct
+ct
+BP
 pU
 pU
 pU
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
+ze
 pU
 pU
 lt
+lt
+lt
 UI
-UI
-hM
-hM
-hM
-hM
-hM
-hM
-hM
-hM
-hM
+pU
+aj
+pU
+pU
+aj
+pU
+pU
+aj
+aj
 "}
 (172,1,1) = {"
 aa
@@ -52773,7 +53330,28 @@ aj
 aj
 pU
 ai
-ai
+ct
+YE
+aL
+yW
+EV
+ZR
+Es
+Do
+ll
+BP
+pU
+BP
+pU
+pU
+pU
+Cv
+BP
+lt
+lt
+VP
+lt
+lt
 pU
 pU
 pU
@@ -52781,27 +53359,6 @@ pU
 pU
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-aj
-aj
-aj
-aj
 aj
 aj
 "}
@@ -53030,36 +53587,36 @@ aj
 aj
 aj
 aj
+ct
+Oz
+Vb
+yW
+XC
+ZR
+ct
+ct
+ct
+BP
 pU
 pU
 pU
 pU
 pU
+BP
+LT
+DJ
+DJ
+ct
+GG
+GG
+ct
+ct
+GG
+GG
+ct
+ct
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-pU
-aj
-pU
-aj
 aj
 "}
 (174,1,1) = {"
@@ -53287,36 +53844,36 @@ aj
 aj
 aj
 aj
-aj
-aj
+ct
+xy
+UX
+yW
+XC
+ZR
+UL
+ct
+NQ
+pU
+lt
+lt
 pU
 pU
+lt
+lt
+rq
+lt
+pU
+Vd
+sQ
+NS
+PX
+NS
+NS
+sQ
+NS
+ct
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-aj
-aj
-aj
-aj
 aj
 "}
 (175,1,1) = {"
@@ -53544,35 +54101,35 @@ aj
 aj
 aj
 aj
-aj
-aj
+ct
+Wc
+Or
+Yh
+ED
+eq
+du
+ct
+ct
+VP
+lt
 pU
 pU
+lt
+lt
+lt
+rq
 pU
 pU
+Vd
+il
+NS
+PX
+NS
+NS
+il
+NS
+GG
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-pU
-pU
-aj
 aj
 aj
 "}
@@ -53801,36 +54358,36 @@ aj
 aj
 aj
 aj
-aj
+ct
+Ol
+rl
+Oz
+DB
+DB
+DB
+Be
+GG
+lt
+lt
 pU
 pU
 pU
+lt
+pU
+Jr
+UI
+pU
+Vd
+NS
+NS
+PX
+NS
+NS
+NS
+NS
+GG
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-aj
-pU
-aj
-aj
-aj
-aj
-aj
 aj
 "}
 (177,1,1) = {"
@@ -54056,38 +54613,38 @@ pU
 pU
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ct
+ct
+rl
+Oz
+yW
+yW
+ME
+mE
+GG
+lt
+pU
+pU
+pU
+pU
+pU
+pU
+Jr
+pU
+lt
+pX
+uf
+NS
+zB
+NS
+NS
+uf
+uf
+ct
+ct
+pU
 aj
 "}
 (178,1,1) = {"
@@ -54314,37 +54871,37 @@ pU
 pU
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
+ct
+ct
+GG
+GG
+GG
+ct
+ct
+ct
+lt
+pU
+pU
+lt
+pU
+pU
+pU
+XF
+Tt
+lt
+NS
+NS
+NS
+NS
+NS
+uw
+NS
+NS
+NS
+GG
+pU
 aj
 "}
 (179,1,1) = {"
@@ -54572,35 +55129,35 @@ pU
 pU
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
 aj
 aj
 aj
 pU
-aj
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+VP
+lt
+pU
+pU
+lt
+lt
+lt
+NS
+mk
+sa
+NS
+NS
+NS
+OW
+sa
+NS
+GG
 aj
 aj
 "}
@@ -54841,23 +55398,23 @@ pU
 pU
 pU
 pU
+lt
+lt
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+hM
+lt
+lt
+lt
+NS
+NS
+uw
+NS
+NS
+NS
+NS
+NS
+NS
+GG
 pU
 aj
 "}
@@ -55099,22 +55656,22 @@ pU
 pU
 pU
 pU
+lt
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-pU
-pU
-pU
-aj
-aj
+Jr
+lt
+lt
+fZ
+qE
+NS
+Wf
+NS
+NS
+qE
+qE
+ct
+ct
 pU
 aj
 "}
@@ -55359,19 +55916,19 @@ pU
 pU
 pU
 pU
+Jr
 pU
+lt
+Vd
+NS
+XS
+PX
+NS
+NS
+NS
+NS
+GG
 pU
-pU
-pU
-pU
-aj
-aj
-pU
-pU
-pU
-pU
-pU
-aj
 aj
 aj
 "}
@@ -55614,22 +56171,22 @@ pU
 pU
 pU
 pU
+lt
+lt
+Jr
 pU
 pU
+Vd
+il
+NS
+PX
+NS
+NS
+il
+NS
+GG
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-aj
-aj
-aj
 pU
 "}
 (184,1,1) = {"
@@ -55870,23 +56427,23 @@ pU
 pU
 pU
 pU
+lt
+VP
+lt
+rq
+Mx
+pU
+Vd
+sQ
+NS
+PX
+NS
+NS
+sQ
+NS
+ct
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
-pU
-pU
-aj
 aj
 "}
 (185,1,1) = {"
@@ -56127,22 +56684,22 @@ pU
 pU
 pU
 pU
+lt
+lt
+BP
+Ng
+Hc
+ir
+ct
+GG
+GG
+ct
+ct
+GG
+GG
+ct
+ct
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-pU
-aj
-aj
 aj
 aj
 "}
@@ -56386,6 +56943,12 @@ pU
 pU
 pU
 pU
+Cv
+BP
+pU
+pU
+pU
+lt
 pU
 pU
 pU
@@ -56395,12 +56958,6 @@ pU
 pU
 pU
 pU
-aj
-aj
-aj
-aj
-aj
-aj
 aj
 "}
 (187,1,1) = {"
@@ -56644,19 +57201,19 @@ pU
 pU
 pU
 pU
+lt
+pU
+pU
+lt
+VP
+lt
+lt
 pU
 pU
 pU
 pU
 pU
 pU
-pU
-pU
-aj
-aj
-aj
-aj
-aj
 aj
 aj
 "}
@@ -56884,7 +57441,6 @@ ZY
 pU
 pU
 pU
-yc
 pU
 pU
 pU
@@ -56901,16 +57457,17 @@ pU
 pU
 pU
 pU
+lt
+lt
+lt
+pU
+lt
+lt
+lt
+lt
+lt
 pU
 pU
-pU
-pU
-pU
-pU
-pU
-pU
-aj
-aj
 aj
 aj
 aj
@@ -57158,15 +57715,15 @@ pU
 pU
 pU
 pU
+VP
 pU
 pU
+UI
+lt
+lt
+VP
+lt
 pU
-pU
-pU
-pU
-pU
-pU
-aj
 aj
 aj
 aj
@@ -57420,8 +57977,8 @@ pU
 pU
 pU
 pU
-pU
-pU
+lt
+lt
 pU
 aj
 aj
@@ -58430,7 +58987,7 @@ pU
 pU
 pU
 pU
-pU
+yc
 pU
 pU
 pU

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -692,7 +692,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "eo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2080,7 +2080,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "lt" = (
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "lv" = (
 /obj/structure/stone_tile/block/cracked{
@@ -2925,7 +2925,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "oS" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock"
@@ -3198,11 +3198,6 @@
 	dir = 4
 	},
 /area/mine/laborcamp/quarters)
-"qi" = (
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/lavaland/surface/outdoors)
 "qo" = (
 /obj/machinery/door/airlock/glass{
 	name = "Equipment Storage"
@@ -3826,7 +3821,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "uq" = (
 /obj/effect/spawner/structure/window,
@@ -4857,7 +4852,7 @@
 /area/lavaland/surface/outdoors)
 "Az" = (
 /obj/item/flashlight/lantern/on,
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "AA" = (
 /obj/structure/lattice/catwalk,
@@ -5076,8 +5071,11 @@
 /turf/open/floor/wood/large,
 /area/mine/lobby/raptor)
 "Cv" = (
-/turf/closed/wall/mineral/iron,
-/area/lavaland/surface)
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/marker_beacon/purple,
+/obj/effect/turf_decal/sand/plating/volcanic,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Cz" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -6970,7 +6968,7 @@
 /area/mine/laborcamp/production)
 "Ns" = (
 /obj/structure/flora/ash/fireblossom,
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "Nt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7154,7 +7152,7 @@
 	dir = 5
 	},
 /obj/item/reagent_containers/cup/bucket/wooden,
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "Op" = (
 /obj/structure/stone_tile/slab,
@@ -7255,7 +7253,7 @@
 /area/mine/mechbay)
 "Pb" = (
 /obj/structure/water_source/puddle,
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "Pc" = (
 /obj/structure/closet/crate/grave,
@@ -7626,7 +7624,7 @@
 "Ri" = (
 /obj/item/canvas/twentythree_nineteen,
 /obj/structure/easel,
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "Rj" = (
 /obj/machinery/suit_storage_unit/mining,
@@ -8692,7 +8690,7 @@
 /area/mine/production)
 "Xk" = (
 /obj/effect/spawner/random/lavaland_mob/raptor,
-/turf/open/misc/hay,
+/turf/open/misc/hay/lavaland,
 /area/lavaland/surface/outdoors)
 "Xp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9101,9 +9099,9 @@
 /turf/open/floor/wood/large,
 /area/mine/lobby/raptor)
 "ZF" = (
-/turf/open/floor/iron/stairs{
-	dir = 4
-	},
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/effect/turf_decal/sand/plating/volcanic,
+/turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "ZH" = (
 /obj/structure/closet/secure_closet/labor_camp_security,
@@ -43340,7 +43338,7 @@ aj
 pU
 pU
 DB
-qi
+BP
 DB
 aj
 aj
@@ -44111,7 +44109,7 @@ aj
 aj
 pU
 DB
-ZF
+BP
 DB
 aj
 aj
@@ -46168,7 +46166,7 @@ aj
 aj
 aj
 DB
-qi
+BP
 DB
 aj
 aj
@@ -46939,7 +46937,7 @@ aj
 pU
 pU
 DB
-ZF
+BP
 DB
 aj
 aj
@@ -48459,7 +48457,7 @@ mT
 pK
 pU
 BP
-BP
+ZF
 BP
 JD
 BP
@@ -48715,9 +48713,9 @@ Yg
 li
 dK
 pU
-ct
-qi
-ct
+Cv
+BP
+Cv
 zk
 mc
 mc
@@ -48736,7 +48734,7 @@ aj
 aj
 pU
 DB
-qi
+BP
 DB
 pU
 aj
@@ -49764,7 +49762,7 @@ pU
 aj
 aj
 DB
-ZF
+BP
 DB
 pU
 pU
@@ -50772,7 +50770,7 @@ aj
 aj
 aj
 ct
-ZF
+BP
 ct
 pU
 aj
@@ -52824,7 +52822,7 @@ ai
 ai
 pU
 CV
-wa
+GG
 Tt
 fa
 eL
@@ -53081,14 +53079,14 @@ ai
 ai
 ai
 CV
-GG
+wa
 rB
 fa
 eL
 Lv
 CV
 CV
-Cv
+CV
 ct
 pU
 pU
@@ -53602,7 +53600,7 @@ Sj
 ZB
 CV
 CV
-Cv
+CV
 ct
 pU
 pU

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -82,6 +82,12 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/iron/dark,
 /area/mine/storage/public)
+"as" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "av" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
@@ -93,13 +99,16 @@
 /obj/structure/cable,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"aL" = (
-/obj/structure/chair/sofa/middle{
-	dir = 1;
-	color = "#AA4A44"
-	},
+"aF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
+"aH" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "aM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lavaland_living_east_maint"
@@ -144,6 +153,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"aX" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
+"ba" = (
+/obj/structure/chair/sofa/middle{
+	dir = 1;
+	color = "#AA4A44"
+	},
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "bb" = (
 /obj/structure/closet/crate/internals,
 /obj/item/tank/internals/emergency_oxygen,
@@ -161,6 +184,13 @@
 	dir = 4
 	},
 /area/mine/laborcamp/production)
+"be" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Raptor Ranch External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lobby/raptor)
 "bf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
@@ -204,6 +234,10 @@
 	},
 /turf/open/floor/plating,
 /area/mine/maintenance/production)
+"bE" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "bH" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes{
@@ -262,25 +296,6 @@
 /obj/machinery/mining_weather_monitor/directional/north,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/mine/production)
-"bZ" = (
-/obj/structure/table/wood,
-/obj/item/plate{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/item/plate{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/cup/glass/mug/tea{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "cb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -292,11 +307,6 @@
 "cc" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
-"cd" = (
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/lavaland/surface/outdoors)
 "ce" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -375,8 +385,10 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "ct" = (
-/turf/closed/wall/mineral/iron,
-/area/lavaland/surface)
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/marker_beacon/purple,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "cw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -480,10 +492,6 @@
 	dir = 8
 	},
 /area/mine/production)
-"cT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "cU" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -538,6 +546,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/mine/cafeteria)
+"de" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk/mining,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "dh" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -550,11 +565,6 @@
 /obj/structure/cable,
 /obj/structure/lattice/catwalk/mining,
 /turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"dl" = (
-/turf/open/floor/iron/stairs{
-	dir = 4
-	},
 /area/lavaland/surface/outdoors)
 "dq" = (
 /obj/structure/stone_tile{
@@ -574,12 +584,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
-"du" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "dv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -624,6 +628,19 @@
 /obj/structure/lattice/catwalk/mining,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"dF" = (
+/obj/structure/table/wood,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
+"dI" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lobby/raptor)
 "dJ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -664,15 +681,6 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"eb" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/mine/lounge)
 "ee" = (
 /obj/machinery/shower/directional/south,
 /obj/machinery/door/window/right/directional/south,
@@ -680,6 +688,12 @@
 /obj/item/soap/homemade,
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp)
+"ej" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "eo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -688,12 +702,6 @@
 	dir = 8
 	},
 /area/mine/laborcamp/production)
-"eq" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "et" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -771,6 +779,18 @@
 	dir = 8
 	},
 /area/mine/cafeteria)
+"eL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
+"eN" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "eP" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
@@ -812,6 +832,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
+"fa" = (
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "fb" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -852,16 +875,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
-"fm" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "fo" = (
 /obj/structure/closet/crate,
 /obj/structure/window/spawner/directional/west,
@@ -923,10 +936,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
-"fJ" = (
-/obj/structure/railing{
-	dir = 9
-	},
+"fK" = (
+/obj/effect/turf_decal/sand/plating/volcanic,
+/obj/structure/railing,
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "fL" = (
@@ -990,12 +1002,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
-"fZ" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "gd" = (
 /obj/structure/marker_beacon/yellow,
 /obj/effect/turf_decal/sand/plating/volcanic,
@@ -1159,12 +1165,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/living_quarters)
-"gH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "gI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1283,6 +1283,10 @@
 /obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/open/floor/iron/freezer,
 /area/mine/living_quarters)
+"hl" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "hn" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -1401,11 +1405,12 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "hM" = (
-/obj/structure/railing/corner/end{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "hR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1507,7 +1512,7 @@
 "il" = (
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "io" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1522,12 +1527,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"ir" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "iu" = (
@@ -1595,12 +1594,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/mine/living_quarters)
-"iQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "iX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/bench{
@@ -1624,6 +1617,13 @@
 	dir = 1
 	},
 /area/mine/living_quarters)
+"jb" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk/mining,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "jc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1699,15 +1699,10 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"jv" = (
-/obj/structure/table/wood,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab{
-	pixel_x = 6;
-	pixel_y = 5
-	},
+"jt" = (
+/obj/structure/fireplace,
 /turf/open/floor/wood/parquet,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "jw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -1752,6 +1747,11 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"jJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "jL" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -1802,11 +1802,12 @@
 	},
 /area/mine/production)
 "jX" = (
-/obj/structure/railing{
-	dir = 6
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "ka" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/north,
@@ -1817,26 +1818,25 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/cafeteria)
-"ke" = (
-/obj/effect/turf_decal/sand/plating/volcanic,
+"kf" = (
 /obj/structure/railing{
-	dir = 5
+	dir = 9
 	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp)
+"ki" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lobby/raptor)
 "kk" = (
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "kn" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth,
@@ -1851,13 +1851,6 @@
 	dir = 4
 	},
 /area/mine/laborcamp)
-"ks" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "kt" = (
 /turf/closed/wall,
 /area/mine/laborcamp/security)
@@ -2058,15 +2051,6 @@
 	dir = 1
 	},
 /area/mine/eva)
-"ll" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface)
 "lo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -2234,6 +2218,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/mine/lounge)
+"lP" = (
+/obj/item/flashlight/lantern/on,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "lQ" = (
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 6
@@ -2334,7 +2322,7 @@
 	},
 /obj/item/raptor_dex,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "ml" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2445,10 +2433,6 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
-"mE" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "mJ" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -2724,18 +2708,6 @@
 	dir = 1
 	},
 /area/mine/laborcamp)
-"nH" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/mine/eva)
 "nI" = (
 /obj/structure/sink/kitchen/directional/south{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -2763,6 +2735,12 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
+"nO" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "nP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -2901,12 +2879,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"oz" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "oA" = (
 /turf/closed/wall,
 /area/mine/storage)
@@ -2945,6 +2917,15 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
+"oO" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface)
 "oS" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock"
@@ -3091,6 +3072,12 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"pF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "pH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3116,6 +3103,10 @@
 /obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp/quarters)
+"pM" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/mine/lobby/raptor)
 "pO" = (
 /obj/machinery/shower/directional/south,
 /obj/machinery/door/window/left/directional/south,
@@ -3159,12 +3150,6 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"pX" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "pZ" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -3214,12 +3199,10 @@
 	},
 /area/mine/laborcamp/quarters)
 "qi" = (
-/obj/machinery/microwave{
-	pixel_y = 6
+/turf/open/floor/iron/stairs{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
+/area/lavaland/surface/outdoors)
 "qo" = (
 /obj/machinery/door/airlock/glass{
 	name = "Equipment Storage"
@@ -3280,9 +3263,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"qz" = (
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "qA" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/east,
@@ -3291,12 +3271,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"qE" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+"qB" = (
+/obj/machinery/smartfridge/drying_rack,
+/obj/item/food/cheese/firm_cheese,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "qH" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningbathroomprivate";
@@ -3356,14 +3335,35 @@
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
-"rl" = (
-/obj/structure/bookcase/random/reference,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+"rf" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
+"rj" = (
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = -1;
+	pixel_x = 5
 	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9;
+	pixel_x = 2
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?"
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "rm" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3377,12 +3377,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
-"rq" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/misc/hay,
-/area/lavaland/surface/outdoors)
 "rv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark/smooth_edge{
@@ -3411,6 +3405,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"rB" = (
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	color = "#AA4A44"
+	},
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "rF" = (
 /turf/closed/wall/r_wall,
 /area/mine/maintenance/labor)
@@ -3455,13 +3456,6 @@
 "rU" = (
 /turf/closed/wall,
 /area/mine/storage/public)
-"rV" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1;
-	color = "#AA4A44"
-	},
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "rX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3492,7 +3486,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "se" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/eva)
@@ -3543,13 +3537,6 @@
 	dir = 8
 	},
 /area/mine/medical)
-"sp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface)
 "st" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -3599,7 +3586,7 @@
 "sQ" = (
 /obj/structure/ore_container/food_trough/raptor_trough,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "sR" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3673,6 +3660,13 @@
 	dir = 4
 	},
 /area/mine/cafeteria)
+"tf" = (
+/obj/structure/chair/sofa/corner{
+	dir = 8;
+	color = "#AA4A44"
+	},
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "tg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
@@ -3682,13 +3676,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
-"th" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/wood,
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "ti" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -3802,12 +3789,6 @@
 	dir = 8
 	},
 /area/mine/laborcamp)
-"uf" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "ui" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3841,6 +3822,12 @@
 /obj/item/crowbar/large/emergency,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"up" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "uq" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -3867,7 +3854,7 @@
 "uw" = (
 /obj/effect/spawner/random/lavaland_mob/raptor,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "ux" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm1";
@@ -3898,10 +3885,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
-"uK" = (
-/obj/item/canvas/twentythree_nineteen,
-/turf/open/misc/hay,
-/area/lavaland/surface/outdoors)
 "uN" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -4034,6 +4017,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/mine/hydroponics)
+"vr" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "vu" = (
 /obj/structure/bed/medical/emergency,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4102,6 +4091,14 @@
 /obj/item/cigbutt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"vM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "vN" = (
 /obj/machinery/computer/records/security,
 /obj/structure/cable,
@@ -4153,6 +4150,12 @@
 /obj/effect/turf_decal/siding/wideplating_new,
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
+"wa" = (
+/obj/machinery/camera/autoname/directional/north{
+	network = list("mine")
+	},
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "wb" = (
 /obj/structure/chair{
 	dir = 8
@@ -4349,10 +4352,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"xy" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "xz" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -4446,6 +4445,12 @@
 	dir = 1
 	},
 /area/mine/storage/public)
+"xW" = (
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "yc" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4531,12 +4536,6 @@
 /obj/structure/stone_tile,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"yz" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "yC" = (
 /obj/structure/bed{
 	dir = 4
@@ -4601,9 +4600,6 @@
 /obj/structure/lattice/catwalk/mining,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"yW" = (
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "yX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -4688,8 +4684,11 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "zs" = (
-/obj/structure/railing,
-/turf/open/floor/plating/lavaland_atmos,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk/mining,
+/turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zw" = (
 /obj/structure/cable,
@@ -4709,12 +4708,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
-"zB" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "zD" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -4787,6 +4780,13 @@
 /obj/structure/cable,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"zX" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "Ae" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4802,6 +4802,13 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/production)
+"Ah" = (
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "Ai" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -4837,10 +4844,20 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
+"Av" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Ax" = (
 /obj/item/pickaxe,
 /obj/effect/mob_spawn/corpse/human/miner,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Az" = (
+/obj/item/flashlight/lantern/on,
+/turf/open/misc/hay,
 /area/lavaland/surface/outdoors)
 "AA" = (
 /obj/structure/lattice/catwalk,
@@ -4855,12 +4872,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
-"AD" = (
+"AF" = (
+/obj/structure/lattice/catwalk/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "AI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4890,15 +4908,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_edge,
 /area/mine/laborcamp/production)
-"AO" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "AQ" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -4929,10 +4938,6 @@
 /obj/structure/railing/corner,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Be" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5051,18 +5056,28 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/cafeteria)
-"Cp" = (
-/obj/effect/turf_decal/sand/plating/volcanic,
-/obj/structure/railing{
-	dir = 1
+"Cn" = (
+/obj/structure/table/wood,
+/obj/item/plate{
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
+/obj/item/plate{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/cup/glass/mug/tea{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "Cv" = (
-/obj/effect/turf_decal/sand/plating/volcanic,
-/obj/structure/marker_beacon/purple,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
+/turf/closed/wall/mineral/iron,
+/area/lavaland/surface)
 "Cz" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -5161,6 +5176,9 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/mine/living_quarters)
+"CV" = (
+/turf/closed/wall/mineral/iron,
+/area/mine/lobby/raptor)
 "CX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5220,9 +5238,6 @@
 	dir = 4
 	},
 /area/mine/laborcamp)
-"Do" = (
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface)
 "Dx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -5241,9 +5256,10 @@
 /turf/closed/wall,
 /area/mine/medical)
 "DB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
+/obj/structure/marker_beacon/purple,
+/obj/effect/turf_decal/sand/plating/volcanic,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "DF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5255,12 +5271,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/textured_large,
 /area/mine/cafeteria)
-"DJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "DK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -5348,13 +5358,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"Es" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Raptor Ranch External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface)
 "Ev" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -5388,11 +5391,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
-"ED" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "EE" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5428,6 +5426,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"EL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
 "EM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5441,6 +5443,12 @@
 	dir = 1
 	},
 /area/mine/production)
+"EP" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "EQ" = (
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
@@ -5451,11 +5459,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
-"EV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/lavaland/surface)
 "EX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -5500,6 +5503,12 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Fo" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "Fp" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -5508,6 +5517,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"Fr" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron/dark/textured_large,
+/area/mine/production)
 "Fs" = (
 /obj/effect/turf_decal/sand/plating/volcanic,
 /obj/effect/spawner/random/maintenance/two,
@@ -5551,13 +5567,10 @@
 "FH" = (
 /turf/closed/wall,
 /area/lavaland/surface/outdoors)
-"FJ" = (
-/obj/effect/turf_decal/sand/plating/volcanic,
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
+"FI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "FL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
@@ -5679,9 +5692,8 @@
 	},
 /area/mine/production)
 "GG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface)
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "GH" = (
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Lounge"
@@ -5691,6 +5703,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/mine/lounge)
+"GI" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/lighter,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "GL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5738,12 +5756,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
-"Hc" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/misc/hay,
-/area/lavaland/surface/outdoors)
 "Hd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5759,13 +5771,18 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
-"Hg" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 4
+"Hj" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining External Airlock"
 	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
+"Hl" = (
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
 "Hp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -5917,11 +5934,6 @@
 "Ia" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
-"Ib" = (
-/obj/effect/turf_decal/sand/plating/volcanic,
-/obj/structure/railing,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "Ic" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/wideplating_new{
@@ -6091,7 +6103,7 @@
 "Jg" = (
 /obj/effect/turf_decal/sand/plating/volcanic,
 /obj/structure/railing{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
@@ -6136,12 +6148,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/eva)
-"Jr" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "Jt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -6270,6 +6276,13 @@
 	dir = 1
 	},
 /area/mine/living_quarters)
+"JQ" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Raptor Ranch External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lounge)
 "JR" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -6351,6 +6364,41 @@
 /obj/structure/girder,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Km" = (
+/obj/structure/rack,
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?"
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 9;
+	pixel_x = 2
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 6
+	},
+/obj/item/food/grown/grass/fairy{
+	name = "weird hay";
+	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/obj/item/crowbar/large,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "Kn" = (
 /obj/machinery/telecomms/relay/preset/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6443,6 +6491,12 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/cafeteria)
+"KO" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "KV" = (
 /obj/structure/table,
 /obj/machinery/light/directional/east,
@@ -6558,16 +6612,20 @@
 	dir = 8
 	},
 /area/mine/production)
-"Lt" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/item/food/cheese/firm_cheese,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "Lu" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/storage)
+"Lv" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "Lw" = (
 /obj/effect/turf_decal/sand/plating/volcanic,
 /obj/effect/turf_decal/stripes/line{
@@ -6673,11 +6731,12 @@
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
-"LT" = (
+"LV" = (
 /obj/structure/railing{
 	dir = 9
 	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/obj/structure/lattice/catwalk/mining,
+/turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "LY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -6723,9 +6782,10 @@
 	dir = 8
 	},
 /area/mine/lounge)
-"Mh" = (
-/turf/open/floor/plating/lavaland_atmos,
-/area/mine/lounge)
+"Mf" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "Mr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -6752,10 +6812,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"Mx" = (
-/obj/structure/water_source/puddle,
-/turf/open/misc/hay,
-/area/lavaland/surface/outdoors)
 "My" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -6771,11 +6827,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
-"ME" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "MH" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock"
@@ -6839,41 +6890,6 @@
 	dir = 4
 	},
 /area/mine/laborcamp)
-"MX" = (
-/obj/structure/rack,
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?"
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = 9
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = 9;
-	pixel_x = 2
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = 6
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = 6;
-	pixel_x = 9
-	},
-/obj/item/crowbar/large,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "Nb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6904,13 +6920,6 @@
 	},
 /obj/effect/turf_decal/sand/plating/volcanic,
 /turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
-"Ng" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/item/reagent_containers/cup/bucket/wooden,
-/turf/open/misc/hay,
 /area/lavaland/surface/outdoors)
 "Nh" = (
 /obj/structure/ore_box,
@@ -6959,6 +6968,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp/production)
+"Ns" = (
+/obj/structure/flora/ash/fireblossom,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "Nt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
@@ -7023,10 +7036,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
-"NQ" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+"NP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/lavaland_atmos,
+/area/mine/lobby/raptor)
 "NR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -7038,7 +7054,7 @@
 /area/mine/laborcamp/production)
 "NS" = (
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "NT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7123,10 +7139,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/mechbay)
-"Ol" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/lavaland/surface)
 "Om" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -7137,18 +7149,17 @@
 	},
 /turf/open/floor/iron,
 /area/mine/lounge)
+"Oo" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/item/reagent_containers/cup/bucket/wooden,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "Op" = (
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Or" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "Ot" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -7157,20 +7168,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
-"Ov" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"Ow" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/mine/eva)
 "Oy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -7180,9 +7177,16 @@
 	dir = 4
 	},
 /area/mine/laborcamp/security)
-"Oz" = (
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
+"OE" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "OH" = (
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
 	pixel_x = -8;
@@ -7239,7 +7243,7 @@
 	},
 /obj/item/soap/deluxe,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "OZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7249,6 +7253,10 @@
 	dir = 1
 	},
 /area/mine/mechbay)
+"Pb" = (
+/obj/structure/water_source/puddle,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "Pc" = (
 /obj/structure/closet/crate/grave,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -7257,6 +7265,13 @@
 /obj/structure/marker_beacon/teal,
 /obj/effect/turf_decal/sand/plating/volcanic,
 /obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
+"Pe" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
 "Pi" = (
@@ -7296,6 +7311,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/cafeteria)
+"Pn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "Po" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/security/labor_camp,
@@ -7313,12 +7334,6 @@
 /obj/item/toy/beach_ball,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Pu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "PA" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
@@ -7419,10 +7434,6 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
-"PX" = (
-/obj/structure/railing,
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "PY" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/toy,
@@ -7447,13 +7458,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
-"Qc" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Raptor Ranch External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating/lavaland_atmos,
-/area/mine/lounge)
 "Qe" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
@@ -7472,14 +7476,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/mechbay)
-"Qk" = (
-/obj/structure/easel,
-/obj/item/canvas/fortyfive_twentyseven,
-/obj/item/canvas/thirtysix_twentyfour,
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/paint_palette,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "Qq" = (
 /obj/structure/ore_vent/starter_resources{
 	icon_state = "ore_vent_active"
@@ -7547,12 +7543,6 @@
 /obj/effect/turf_decal/sand/plating/volcanic,
 /turf/open/floor/plating/lavaland_atmos,
 /area/lavaland/surface/outdoors)
-"QO" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "QP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7633,6 +7623,28 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/production)
+"Ri" = (
+/obj/item/canvas/twentythree_nineteen,
+/obj/structure/easel,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
+"Rj" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/mine/eva)
+"Rm" = (
+/obj/structure/bed,
+/obj/effect/spawner/random/bedsheet,
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "Ro" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -7641,10 +7653,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
 /area/mine/production)
-"Rr" = (
-/obj/structure/marker_beacon/purple,
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "Rs" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -7721,11 +7729,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"RQ" = (
-/obj/structure/table/wood,
-/obj/item/knife,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
+"RO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mine/eva)
 "RV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -7787,6 +7797,11 @@
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Sj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "Sm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/yellow,
@@ -7800,6 +7815,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/hydroponics)
+"Sp" = (
+/obj/structure/easel,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/paint_palette,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "Sq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -7927,15 +7950,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/mine/eva)
-"Tg" = (
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "Ti" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/table,
@@ -7981,15 +7995,22 @@
 	},
 /area/mine/production)
 "Tt" = (
-/obj/effect/spawner/random/lavaland_mob/raptor,
-/turf/open/misc/hay,
-/area/lavaland/surface/outdoors)
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "Tu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"Tw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "Tx" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -8162,19 +8183,16 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"Uw" = (
-/obj/effect/turf_decal/sand/plating/volcanic,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
 "Ux" = (
 /obj/structure/stone_tile{
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Uz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "UD" = (
 /obj/structure/toilet{
 	dir = 8
@@ -8192,10 +8210,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
-"UL" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "UN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8245,12 +8259,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
-"UX" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "UZ" = (
 /obj/structure/chair/stool/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8265,13 +8273,6 @@
 /obj/structure/fluff/drake_statue/falling,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Vb" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8;
-	color = "#AA4A44"
-	},
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "Vc" = (
 /obj/item/reagent_containers/cup/glass/colocup{
 	pixel_x = -5;
@@ -8280,11 +8281,9 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Vd" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/railing,
 /turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
+/area/mine/lobby/raptor)
 "Ve" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
@@ -8406,6 +8405,15 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
+"VI" = (
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
+/area/mine/lobby/raptor)
 "VJ" = (
 /obj/structure/closet/crate,
 /obj/item/food/mint,
@@ -8429,9 +8437,11 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
 "VP" = (
-/obj/structure/flora/ash/fireblossom,
-/turf/open/misc/hay,
-/area/lavaland/surface/outdoors)
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "VS" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -8441,6 +8451,12 @@
 /obj/item/seeds/potato,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
+"VU" = (
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "VX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -8461,28 +8477,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
-"Wc" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/lighter,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "We" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/storage)
-"Wf" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "Wg" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating/volcanic,
 /turf/open/floor/plating/lavaland_atmos,
 /area/mine/lounge)
+"Wh" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Wk" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Wl" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock"
@@ -8502,6 +8518,12 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
+"Wq" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
 "Wt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
@@ -8668,6 +8690,10 @@
 	dir = 4
 	},
 /area/mine/production)
+"Xk" = (
+/obj/effect/spawner/random/lavaland_mob/raptor,
+/turf/open/misc/hay,
+/area/lavaland/surface/outdoors)
 "Xp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8729,11 +8755,6 @@
 	dir = 4
 	},
 /area/mine/lounge)
-"XC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/lavaland/surface)
 "XD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8745,12 +8766,6 @@
 	dir = 1
 	},
 /area/mine/lounge)
-"XF" = (
-/obj/structure/railing/corner/end{
-	dir = 8
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "XH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8770,7 +8785,7 @@
 /area/mine/laborcamp)
 "XM" = (
 /obj/structure/sign/directions/evac/directional/south{
-	pixel_x = 32;
+	pixel_x = -32;
 	pixel_y = 0
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -8786,31 +8801,6 @@
 /mob/living/basic/mining/goliath,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"XS" = (
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = -1;
-	pixel_x = 5
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = 9;
-	pixel_x = 8
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?";
-	pixel_y = 9;
-	pixel_x = 2
-	},
-/obj/item/food/grown/grass/fairy{
-	name = "weird hay";
-	desc = "Somehow, somewhere, this tells you it should increase your friendship level with your animals. Too bad that doesn't work, right?"
-	},
-/turf/open/misc/hay/lavaland,
-/area/lavaland/surface)
 "XT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8894,10 +8884,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/eva)
-"Yh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "Yk" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile,
@@ -8959,10 +8945,6 @@
 	dir = 1
 	},
 /area/mine/laborcamp/quarters)
-"YE" = (
-/obj/structure/fireplace,
-/turf/open/floor/wood/parquet,
-/area/lavaland/surface)
 "YF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8978,6 +8960,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"YP" = (
+/obj/structure/bookcase/random/reference,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
 "YR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9060,6 +9050,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
+"Zs" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "Zt" = (
 /turf/closed/wall,
 /area/mine/laborcamp)
@@ -9099,6 +9093,18 @@
 	dir = 8
 	},
 /area/mine/lounge)
+"ZB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/mine/lobby/raptor)
+"ZF" = (
+/turf/open/floor/iron/stairs{
+	dir = 4
+	},
+/area/lavaland/surface/outdoors)
 "ZH" = (
 /obj/structure/closet/secure_closet/labor_camp_security,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -9107,16 +9113,13 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"ZI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/lavaland_atmos,
-/area/mine/lounge)
-"ZJ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/lavaland/surface/outdoors)
+"ZL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "ZM" = (
 /obj/structure/railing{
 	dir = 8
@@ -9134,13 +9137,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
-"ZR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
-/area/lavaland/surface)
 "ZT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -9154,6 +9150,17 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
+"ZU" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/misc/hay/lavaland,
+/area/mine/lobby/raptor)
+"ZX" = (
+/obj/structure/table/wood,
+/obj/item/knife,
+/turf/open/floor/wood/parquet,
+/area/mine/lobby/raptor)
 "ZY" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
@@ -42555,11 +42562,11 @@ MS
 QP
 LE
 os
-Qc
-Mh
-eb
+JQ
+Hl
+Hj
 pU
-pU
+BP
 pU
 NK
 ze
@@ -42812,13 +42819,13 @@ JZ
 PR
 ib
 os
-ZI
-ZI
-ZI
+EL
+EL
+EL
 pU
 pU
 ze
-NK
+BP
 ze
 pU
 pU
@@ -43332,9 +43339,9 @@ pU
 aj
 pU
 pU
-Rr
-cd
-Rr
+DB
+qi
+DB
 aj
 aj
 aj
@@ -43587,11 +43594,11 @@ pU
 pU
 aj
 aj
-pU
-pU
-fJ
-qz
-oz
+aj
+aj
+LV
+tF
+jb
 aj
 aj
 aj
@@ -43846,9 +43853,9 @@ aj
 aj
 aj
 aj
-yz
-qz
-jX
+zs
+tF
+de
 aj
 aj
 aj
@@ -44103,9 +44110,9 @@ aj
 aj
 aj
 pU
-Rr
-dl
-Rr
+DB
+ZF
+DB
 aj
 aj
 aj
@@ -44360,9 +44367,9 @@ aj
 aj
 aj
 pU
-ze
-ze
-ze
+pU
+pU
+pU
 aj
 aj
 aj
@@ -44616,11 +44623,11 @@ aj
 aj
 aj
 pU
-ze
-ze
-NK
-ze
-ze
+pU
+pU
+BP
+pU
+pU
 aj
 aj
 "}
@@ -44872,12 +44879,12 @@ aj
 aj
 aj
 aj
-pU
-ze
-ze
+aj
+aj
 NK
 NK
 pU
+aj
 aj
 aj
 "}
@@ -45130,11 +45137,11 @@ aj
 aj
 aj
 aj
-ze
-ze
-NK
+pU
+pU
 ze
 pU
+aj
 aj
 aj
 "}
@@ -45388,10 +45395,10 @@ aj
 aj
 aj
 pU
+BP
 ze
-ze
-ze
-ze
+pU
+pU
 aj
 aj
 "}
@@ -45645,11 +45652,11 @@ aj
 aj
 aj
 pU
-ze
-ze
-ze
 NK
-NK
+pU
+pU
+pU
+pU
 aj
 "}
 (143,1,1) = {"
@@ -45901,11 +45908,11 @@ aj
 aj
 aj
 aj
+aj
 pU
 pU
-ze
-NK
-NK
+pU
+pU
 aj
 aj
 "}
@@ -46160,9 +46167,9 @@ aj
 aj
 aj
 aj
-Rr
-cd
-Rr
+DB
+qi
+DB
 aj
 aj
 "}
@@ -46417,9 +46424,9 @@ aj
 aj
 aj
 aj
-fJ
-qz
-oz
+LV
+tF
+jb
 aj
 aj
 "}
@@ -46674,9 +46681,9 @@ aj
 aj
 aj
 aj
-yz
-qz
-jX
+zs
+tF
+de
 aj
 aj
 "}
@@ -46927,13 +46934,13 @@ Lw
 pU
 pU
 aj
-pU
+aj
 aj
 pU
-ze
-Rr
-dl
-Rr
+pU
+DB
+ZF
+DB
 aj
 aj
 "}
@@ -47184,13 +47191,13 @@ Lw
 pU
 pU
 aj
+aj
 pU
-NK
-NK
-ze
-ze
-ze
-NK
+pU
+pU
+pU
+pU
+pU
 aj
 aj
 "}
@@ -47439,16 +47446,16 @@ BP
 BP
 Lw
 pU
+aj
+aj
+aj
 pU
 pU
 NK
-NK
+BP
 ze
-ze
-ze
-NK
-NK
-NK
+pU
+pU
 aj
 "}
 (150,1,1) = {"
@@ -47696,14 +47703,14 @@ BP
 BP
 Lw
 pU
+aj
+aj
+aj
 pU
-pU
 ze
 ze
 ze
 ze
-ze
-NK
 aj
 aj
 aj
@@ -47938,7 +47945,7 @@ lb
 Yl
 Le
 Le
-NU
+Fr
 Le
 Le
 BP
@@ -47953,14 +47960,14 @@ BP
 BP
 Lw
 pU
+aj
+aj
+aj
 pU
-NK
-NK
-NK
-NK
+BP
 ze
-ze
-ze
+NK
+pU
 aj
 aj
 aj
@@ -48194,9 +48201,9 @@ Ra
 oh
 pK
 NU
-pU
-aj
-aj
+BP
+BP
+BP
 JD
 BP
 BP
@@ -48212,12 +48219,12 @@ Lw
 pU
 pU
 aj
+aj
 pU
 NK
 NK
-ze
-ze
-ze
+pU
+pU
 aj
 aj
 aj
@@ -48451,9 +48458,9 @@ Kc
 mT
 pK
 pU
-aj
-aj
-pU
+BP
+BP
+BP
 JD
 BP
 BP
@@ -48469,13 +48476,13 @@ Lw
 pU
 pU
 aj
+aj
 pU
-NK
-ze
-ze
-NK
-NK
-NK
+pU
+pU
+pU
+pU
+pU
 aj
 aj
 "}
@@ -48708,9 +48715,9 @@ Yg
 li
 dK
 pU
-aj
-aj
-pU
+ct
+qi
+ct
 zk
 mc
 mc
@@ -48726,12 +48733,12 @@ ii
 pU
 pU
 aj
+aj
 pU
+DB
+qi
+DB
 pU
-Rr
-cd
-Rr
-NK
 aj
 aj
 aj
@@ -48965,29 +48972,29 @@ Yg
 TQ
 dK
 pU
+aX
+BP
+Jg
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
+pU
 aj
 aj
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
-pU
 aj
-aj
-aj
-fJ
-qz
-oz
+LV
+tF
+jb
 aj
 aj
 aj
@@ -49218,13 +49225,13 @@ lb
 pK
 Ob
 IL
-nH
+Rj
 KV
 pK
 aj
-aj
-aj
-aj
+yV
+BP
+fK
 pU
 pU
 pU
@@ -49242,9 +49249,9 @@ aj
 aj
 aj
 aj
-ZJ
-qz
-zs
+yV
+tF
+NL
 aj
 aj
 aj
@@ -49475,33 +49482,33 @@ NU
 pK
 pK
 dK
-Ow
+RO
 pK
 pK
 aj
-aj
-aj
-aj
+yV
+tF
+NL
 aj
 aj
 pU
 pU
-Cv
-cd
-Cv
 pU
 pU
 pU
 pU
+pU
+pU
+pU
 aj
 aj
 aj
 aj
 aj
 aj
-yz
-qz
-jX
+zs
+tF
+de
 aj
 aj
 aj
@@ -49732,33 +49739,33 @@ NU
 ai
 pU
 pU
-iQ
+Pn
 pU
 aj
 aj
-pU
-pU
-aj
-aj
-aj
-aj
-aj
-Uw
-BP
-FJ
-pU
-pU
+yV
+tF
+NL
 aj
 aj
 aj
 aj
 pU
 pU
+pU
+pU
+pU
 aj
 aj
-Rr
-dl
-Rr
+aj
+aj
+pU
+pU
+aj
+aj
+DB
+ZF
+DB
 pU
 pU
 aj
@@ -49989,20 +49996,20 @@ pU
 pU
 pU
 pU
-Ov
+AF
 aj
 aj
 pU
-ad
-ad
+yV
+tF
+NL
+aj
+aj
 pU
 aj
 aj
 aj
 aj
-Cp
-BP
-Ib
 pU
 aj
 aj
@@ -50246,20 +50253,20 @@ pU
 aj
 aj
 aj
-Ov
-aj
-pU
-pU
-pU
-pU
-aj
+AF
 aj
 pU
 aj
+yV
+tF
+NL
 aj
-Cp
-BP
-Ib
+pU
+pU
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -50503,20 +50510,20 @@ aj
 aj
 aj
 aj
-Ov
+AF
+aj
+aj
+aj
+zs
+tF
+de
+aj
+aj
+aj
 aj
 aj
 pU
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-Cp
-BP
-Ib
 aj
 aj
 aj
@@ -50527,7 +50534,7 @@ pU
 ze
 NK
 ze
-pU
+BP
 pU
 pU
 pU
@@ -50760,7 +50767,17 @@ aj
 aj
 aj
 aj
-Ov
+AF
+aj
+aj
+aj
+ct
+ZF
+ct
+pU
+aj
+aj
+aj
 aj
 aj
 aj
@@ -50768,20 +50785,10 @@ aj
 aj
 aj
 pU
-aj
-aj
-aj
-Cp
-BP
-Ib
-aj
-aj
-aj
-aj
 pU
 pU
 ze
-NK
+BP
 NK
 ze
 pU
@@ -51017,20 +51024,20 @@ ai
 ai
 pU
 pU
-Ov
+AF
 aj
 aj
 aj
-aj
-aj
-pU
-pU
-aj
-aj
-aj
-Cp
 BP
-Ib
+BP
+BP
+pU
+pU
+aj
+aj
+pU
+pU
+pU
 pU
 aj
 pU
@@ -51040,7 +51047,7 @@ ze
 ze
 NK
 ze
-pU
+lP
 pU
 pU
 pU
@@ -51274,25 +51281,25 @@ ai
 ai
 ai
 ai
-iQ
-Ov
-Ov
-Ov
-Ov
-aj
-pU
-pU
-pU
-aj
-pU
-ke
+Pn
+AF
+AF
+AF
+Pe
 BP
-Jg
+BP
+BP
+BP
+pU
+pU
+pU
+pU
+pU
 pU
 pU
 lt
-uK
-pU
+Ri
+eN
 pU
 ze
 ze
@@ -51535,19 +51542,19 @@ ai
 pU
 pU
 pU
-Ov
-qz
+AF
+BP
+BP
+BP
+BP
+ct
 pU
 pU
 pU
 pU
-pU
-Cv
-dl
-Cv
 pU
 lt
-VP
+Ns
 lt
 pU
 pU
@@ -51789,14 +51796,14 @@ aj
 aj
 ai
 ai
-ct
-ct
-GG
-sp
-GG
-ct
-ct
-ct
+CV
+CV
+ki
+NP
+ki
+CV
+CV
+CV
 lt
 pU
 pU
@@ -51806,9 +51813,9 @@ pU
 pU
 lt
 pU
+lP
 pU
-pU
-pU
+BP
 pU
 pU
 pU
@@ -52045,16 +52052,16 @@ aj
 aj
 aj
 aj
-ct
-ct
-MX
-Lt
-AD
-qi
-Tg
-RQ
-GG
-VP
+CV
+CV
+Km
+qB
+eL
+Ah
+VI
+ZX
+ki
+Ns
 lt
 pU
 BP
@@ -52302,22 +52309,22 @@ aj
 aj
 aj
 aj
-ct
-Oz
-ks
-kl
-AD
-cT
-gH
-jv
+CV
 GG
+jX
+Tw
+eL
+aF
+pF
+dF
+ki
 lt
 lt
 lt
 pU
 pU
 pU
-pU
+BP
 NK
 NK
 ze
@@ -52559,15 +52566,15 @@ ai
 pU
 aj
 aj
-ct
-Qk
-fm
-Pu
-th
-bZ
-QO
-ct
-ct
+CV
+Sp
+OE
+as
+ZL
+Cn
+zX
+CV
+CV
 pU
 lt
 pU
@@ -52577,7 +52584,7 @@ pU
 ze
 NK
 ze
-pU
+BP
 pU
 pU
 pU
@@ -52816,18 +52823,18 @@ ai
 ai
 ai
 pU
-ct
-Oz
-Hg
-yW
-AD
-ZR
-Oz
-ct
+CV
+wa
+Tt
+fa
+eL
+ZB
+GG
+CV
 pU
 pU
 pU
-pU
+lP
 pU
 BP
 pU
@@ -53073,16 +53080,16 @@ aj
 ai
 ai
 ai
+CV
+GG
+rB
+fa
+eL
+Lv
+CV
+CV
+Cv
 ct
-Oz
-rV
-yW
-AD
-AO
-ct
-ct
-ct
-BP
 pU
 pU
 pU
@@ -53330,26 +53337,26 @@ aj
 aj
 pU
 ai
+CV
+jt
+ba
+fa
+jJ
+ZB
+be
+dI
+oO
+BP
+pU
+BP
+pU
+pU
+pU
 ct
-YE
-aL
-yW
-EV
-ZR
-Es
-Do
-ll
-BP
-pU
-BP
-pU
-pU
-pU
-Cv
 BP
 lt
 lt
-VP
+Ns
 lt
 lt
 pU
@@ -53587,34 +53594,34 @@ aj
 aj
 aj
 aj
+CV
+GG
+tf
+fa
+Sj
+ZB
+CV
+CV
+Cv
 ct
-Oz
-Vb
-yW
-XC
-ZR
-ct
-ct
-ct
+pU
+pU
+pU
+pU
+pU
 BP
-pU
-pU
-pU
-pU
-pU
-BP
-LT
-DJ
-DJ
-ct
-GG
-GG
-ct
-ct
-GG
-GG
-ct
-ct
+Av
+Wh
+Wh
+CV
+ki
+ki
+CV
+CV
+ki
+ki
+CV
+CV
 pU
 pU
 aj
@@ -53844,15 +53851,15 @@ aj
 aj
 aj
 aj
-ct
-xy
-UX
-yW
-XC
-ZR
-UL
-ct
-NQ
+CV
+rf
+VP
+fa
+Sj
+ZB
+Mf
+CV
+hl
 pU
 lt
 lt
@@ -53860,18 +53867,18 @@ pU
 pU
 lt
 lt
-rq
+up
 lt
 pU
+vr
+sQ
+NS
 Vd
-sQ
-NS
-PX
 NS
 NS
 sQ
 NS
-ct
+CV
 pU
 pU
 aj
@@ -54101,34 +54108,34 @@ aj
 aj
 aj
 aj
-ct
-Wc
-Or
-Yh
-ED
-eq
-du
-ct
-ct
-VP
+CV
+GI
+vM
+FI
+jJ
+Fo
+hM
+CV
+CV
+Ns
 lt
 pU
 pU
 lt
 lt
 lt
-rq
+up
 pU
 pU
+vr
+il
+NS
 Vd
-il
-NS
-PX
 NS
 NS
 il
 NS
-GG
+ki
 pU
 aj
 aj
@@ -54358,15 +54365,15 @@ aj
 aj
 aj
 aj
-ct
-Ol
-rl
-Oz
-DB
-DB
-DB
-Be
+CV
+pM
+YP
 GG
+Uz
+Uz
+Uz
+Zs
+ki
 lt
 lt
 pU
@@ -54374,18 +54381,18 @@ pU
 pU
 lt
 pU
-Jr
+Wk
 UI
-pU
+ct
+vr
+NS
+NS
 Vd
 NS
 NS
-PX
 NS
 NS
-NS
-NS
-GG
+ki
 pU
 pU
 aj
@@ -54615,15 +54622,15 @@ pU
 pU
 aj
 aj
-ct
-ct
-rl
-Oz
-yW
-yW
-ME
-mE
+CV
+CV
+YP
 GG
+fa
+fa
+Rm
+bE
+ki
 lt
 pU
 pU
@@ -54631,19 +54638,19 @@ pU
 pU
 pU
 pU
-Jr
+Wk
 pU
 lt
-pX
-uf
+Wq
+EP
 NS
-zB
+ZU
 NS
 NS
-uf
-uf
-ct
-ct
+EP
+EP
+CV
+CV
 pU
 aj
 "}
@@ -54873,14 +54880,14 @@ pU
 pU
 aj
 aj
-ct
-ct
-GG
-GG
-GG
-ct
-ct
-ct
+CV
+CV
+ki
+ki
+ki
+CV
+CV
+CV
 lt
 pU
 pU
@@ -54888,8 +54895,8 @@ lt
 pU
 pU
 pU
-XF
-Tt
+VU
+Xk
 lt
 NS
 NS
@@ -54900,7 +54907,7 @@ uw
 NS
 NS
 NS
-GG
+ki
 pU
 aj
 "}
@@ -55141,8 +55148,8 @@ pU
 pU
 pU
 pU
-VP
-lt
+Ns
+Az
 pU
 pU
 lt
@@ -55157,7 +55164,7 @@ NS
 OW
 sa
 NS
-GG
+ki
 aj
 aj
 "}
@@ -55401,7 +55408,7 @@ pU
 lt
 lt
 pU
-hM
+xW
 lt
 lt
 lt
@@ -55414,7 +55421,7 @@ NS
 NS
 NS
 NS
-GG
+ki
 pU
 aj
 "}
@@ -55659,19 +55666,19 @@ pU
 lt
 pU
 pU
-Jr
+Wk
 lt
 lt
-fZ
-qE
+kf
+KO
 NS
-Wf
+aH
 NS
 NS
-qE
-qE
-ct
-ct
+KO
+KO
+CV
+CV
 pU
 aj
 "}
@@ -55916,18 +55923,18 @@ pU
 pU
 pU
 pU
-Jr
+Wk
 pU
-lt
+ct
+vr
+NS
+rj
 Vd
 NS
-XS
-PX
 NS
 NS
 NS
-NS
-GG
+ki
 pU
 aj
 aj
@@ -56173,18 +56180,18 @@ pU
 pU
 lt
 lt
-Jr
+Wk
 pU
 pU
+vr
+il
+NS
 Vd
-il
-NS
-PX
 NS
 NS
 il
 NS
-GG
+ki
 pU
 pU
 pU
@@ -56428,20 +56435,20 @@ pU
 pU
 pU
 lt
-VP
+Ns
 lt
-rq
-Mx
+up
+Pb
 pU
+vr
+sQ
+NS
 Vd
-sQ
-NS
-PX
 NS
 NS
 sQ
 NS
-ct
+CV
 pU
 pU
 aj
@@ -56687,18 +56694,18 @@ pU
 lt
 lt
 BP
-Ng
-Hc
-ir
-ct
-GG
-GG
-ct
-ct
-GG
-GG
-ct
-ct
+Oo
+ej
+nO
+CV
+ki
+ki
+CV
+CV
+ki
+ki
+CV
+CV
 pU
 aj
 aj
@@ -56943,7 +56950,7 @@ pU
 pU
 pU
 pU
-Cv
+ct
 BP
 pU
 pU
@@ -57205,7 +57212,7 @@ lt
 pU
 pU
 lt
-VP
+Ns
 lt
 lt
 pU
@@ -57715,13 +57722,13 @@ pU
 pU
 pU
 pU
-VP
+Ns
 pU
 pU
 UI
 lt
 lt
-VP
+Ns
 lt
 pU
 aj

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -18,6 +18,10 @@
 	name = "Mining Station Public Storage"
 	icon_state = "mining_storage"
 
+/area/mine/lobby/raptor
+	name = "Nanotransen Raptor Farm"
+	icon_state = "mining_storage"
+
 /area/mine/production
 	name = "Mining Station Production Wing"
 	icon_state = "mining_production"

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -19,7 +19,7 @@
 	icon_state = "mining_storage"
 
 /area/mine/lobby/raptor
-	name = "Nanotransen Raptor Farm"
+	name = "Nanotrasen Raptor Farm"
 	icon_state = "mining_storage"
 
 /area/mine/production


### PR DESCRIPTION
## About The Pull Request

This PR re-maps the lavaland raptor barn to:
1. Have bridge access from public and regular mining so people are not forced to build one themselves
2. Give the area a bit of spice to look more visually interesting
3. Gives anyone working on raptors less of a giant walk to go eat

![pee arr](https://github.com/user-attachments/assets/34c44db8-878a-48a4-9888-850a6770d74e)

<details><summary>In game screenshots</summary>

![Merde Stopover Theta 2024-07-14 165108](https://github.com/user-attachments/assets/025157b7-2b6d-4447-8d98-ec3efde4fc10)

![Merde Stopover Theta 2024-07-14 165104](https://github.com/user-attachments/assets/36e98170-977a-4288-8ad1-8684c4510a65)

![Merde Stopover Theta 2024-07-14 165059](https://github.com/user-attachments/assets/1a264fc1-5dbd-4d82-a68b-1b004141429e)

![Merde Stopover Theta 2024-07-14 165036](https://github.com/user-attachments/assets/fa96b5f2-338e-4370-9bcc-8bf4a0f9543f)

![Merde Stopover Theta 2024-07-14 165031](https://github.com/user-attachments/assets/b333df16-38bd-472d-aad0-4f868d4e6a77)

</details>


## Why It's Good For The Game

It seems like a major oversight that there was no reliable walkway to and from the barn. Additionally, the barn currently looks out of place. This PR makes it a cohesive themed area, making it more comfortable and attractive to interact with while fitting better into the overall "on lavaland" theme.

## Changelog


:cl: Thedragmeme
qol: re-maps the raptor barn to not stick out like a sore thumb
fix: Miners and the public both can access the raptor barn without having to make a bridge themselves
/:cl:

