### PR TITLE
You can no longer move chairs as a ghost

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -263,16 +263,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 /obj/structure/chair/stool/narsie_act()
 	return
 
-/obj/structure/chair/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
-	if(over_object == user)
-		if(!item_chair || has_buckled_mobs())
-			return
-		user.visible_message(span_notice("[user] grabs \the [src.name]."), span_notice("You grab \the [src.name]."))
-		var/obj/item/C = new item_chair(loc)
-		C.set_custom_materials(custom_materials)
-		TransferComponents(C)
-		user.put_in_hands(C)
-		qdel(src)
+/obj/structure/chair/mouse_drop_dragged(atom/over_object, mob/living/user, src_location, over_location, params)
+	if(!istype(user) || over_object != user)
+		return
+	if(!item_chair || has_buckled_mobs())
+		return
+	user.visible_message(span_notice("[user] grabs \the [src.name]."), span_notice("You grab \the [src.name]."))
+	var/obj/item/C = new item_chair(loc)
+	C.set_custom_materials(custom_materials)
+	TransferComponents(C)
+	user.put_in_hands(C)
+	qdel(src)
 
 /obj/structure/chair/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
 	return ..()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -263,8 +263,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 /obj/structure/chair/stool/narsie_act()
 	return
 
-/obj/structure/chair/mouse_drop_dragged(atom/over_object, mob/living/user, src_location, over_location, params)
-	if(!istype(user) || over_object != user)
+/obj/structure/chair/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
+	if(!isliving(user) || over_object != user)
 		return
 	if(!item_chair || has_buckled_mobs())
 		return


### PR DESCRIPTION
## About The Pull Request

Partially handles #84971

## Changelog
:cl:
fix: Ghosts can no longer move chairs
/:cl:
