### PR TITLE
You can fire PKAs/plasma cutters point blank at turfs

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -84,6 +84,9 @@
 	else
 		to_chat(user, span_notice("There are no modifications currently installed."))
 
+/obj/item/gun/energy/recharge/kinetic_accelerator/try_fire_gun(atom/target, mob/living/user, params)
+  return fire_gun(target, user, user.Adjacent(target) && !isturf(target), params)
+
 /obj/item/gun/energy/recharge/kinetic_accelerator/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
@@ -192,6 +195,10 @@
 	var/pressure_decrease = 0.25
 	var/obj/item/gun/energy/recharge/kinetic_accelerator/kinetic_gun
 
+/obj/projectile/kinetic/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/parriable_projectile, parry_callback = CALLBACK(src, PROC_REF(on_parry)))
+
 /obj/projectile/kinetic/Destroy()
 	kinetic_gun = null
 	return ..()
@@ -208,6 +215,13 @@
 		name = "weakened [name]"
 		damage = damage * pressure_decrease
 		pressure_decrease_active = TRUE
+
+/obj/projectile/kinetic/proc/on_parry(mob/user)
+	SIGNAL_HANDLER
+
+	// Ensure that if the user doesn't have tracer mod we're still visible
+	icon_state = "ka_tracer"
+	update_appearance()
 
 /obj/projectile/kinetic/on_range()
 	strike_thing()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -195,9 +195,6 @@
 	var/pressure_decrease = 0.25
 	var/obj/item/gun/energy/recharge/kinetic_accelerator/kinetic_gun
 
-/obj/projectile/kinetic/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/parriable_projectile, parry_callback = CALLBACK(src, PROC_REF(on_parry)))
 
 /obj/projectile/kinetic/Destroy()
 	kinetic_gun = null
@@ -215,13 +212,6 @@
 		name = "weakened [name]"
 		damage = damage * pressure_decrease
 		pressure_decrease_active = TRUE
-
-/obj/projectile/kinetic/proc/on_parry(mob/user)
-	SIGNAL_HANDLER
-
-	// Ensure that if the user doesn't have tracer mod we're still visible
-	icon_state = "ka_tracer"
-	update_appearance()
 
 /obj/projectile/kinetic/on_range()
 	strike_thing()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -85,7 +85,7 @@
 		to_chat(user, span_notice("There are no modifications currently installed."))
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/try_fire_gun(atom/target, mob/living/user, params)
-  return fire_gun(target, user, user.Adjacent(target) && !isturf(target), params)
+	return fire_gun(target, user, user.Adjacent(target) && !isturf(target), params)
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -170,7 +170,7 @@
 		. = ..(amount=1)
 
 /obj/item/gun/energy/plasmacutter/try_fire_gun(atom/target, mob/living/user, params)
-  return fire_gun(target, user, user.Adjacent(target) && !isturf(target), params)
+	return fire_gun(target, user, user.Adjacent(target) && !isturf(target), params)
 
 #undef PLASMA_CUTTER_CHARGE_WELD
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -169,6 +169,9 @@
 	else
 		. = ..(amount=1)
 
+/obj/item/gun/energy/plasmacutter/try_fire_gun(atom/target, mob/living/user, params)
+  return fire_gun(target, user, user.Adjacent(target) && !isturf(target), params)
+
 #undef PLASMA_CUTTER_CHARGE_WELD
 
 /obj/item/gun/energy/plasmacutter/adv


### PR DESCRIPTION

## About The Pull Request

Due to point blank checks in guncode you weren't able to fire PKAs or plasma cutters at turfs point blank, requiring you to aim at least 1 tile away - making mining with those annoying without mesons.

## Why It's Good For The Game

If you click at a turf in front of you with a mining tool, you expect it to actually work.

## Changelog
:cl:
qol: You can fire PKAs/plasma cutters point blank at turfs.
/:cl:
