### PR TITLE
Projectiles now can hit border objects on other turfs instead of passing through them

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -565,7 +565,7 @@
  */
 /obj/projectile/proc/select_target(turf/our_turf, atom/target, atom/bumped)
 	// 1. special bumped border object check
-	if((bumped?.flags_1 & ON_BORDER_1) && can_hit_target(bumped, original == bumped, FALSE, TRUE))
+	if((bumped?.flags_1 & ON_BORDER_1) && can_hit_target(bumped, original == bumped, TRUE, TRUE))
 		return bumped
 	// 2. original
 	if(can_hit_target(original, TRUE, FALSE, original == bumped))


### PR DESCRIPTION
## About The Pull Request

Title. Due to Guncode:tm: firing at a directional window/windoor/whatever facing you will make the projectile pass through it due to incorrect arguments (it does not ignore projectile's current loc while it should)

Originally discovered by Kapu

## Changelog
:cl:  SmArtKar, Kapu
balance: Projectiles now can hit border objects on other turfs instead of passing through them
/:cl:
