### PR TITLE
You can now buckle to bar stools

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -282,6 +282,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 	desc = "It has some unsavory stains on it..."
 	icon_state = "bar"
 	item_chair = /obj/item/chair/stool/bar
+	can_buckle = TRUE
+
+/obj/structure/chair/stool/bar/post_buckle_mob(mob/living/M)
+	M.pixel_y += 4
+
+/obj/structure/chair/stool/bar/post_unbuckle_mob(mob/living/M)
+	M.pixel_y -= 4
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 


### PR DESCRIPTION

## About The Pull Request

https://github.com/user-attachments/assets/9184fc20-e114-42ff-b442-a491692a388b
## Why It's Good For The Game
Sitting with a pixel offset on bar stools will further the bar RP experience, it'll also show the barkeep that you're here to drink or talk.
## Changelog
:cl: grungussuss
add: You can now buckle to bar stools
/:cl:
