### PR TITLE
Put possible fixes in the "too many actions" bug message

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			var/msg = "Your previous action was ignored because you've done too many in a minute."
 			if (minute != topiclimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
 				topiclimiter[ADMINSWARNED_AT] = minute
-				msg += " Administrators have been informed. If you think this message is a mistake, possible fixes could be: 1. Disconnecting any controllers 2. upgrading byond version 3. Clearing cache..."
+				msg += "If you think these alerts are a mistake, possible fixes could be: 1. Disconnecting any controllers 2. Upgrading byond version 3. Clearing cache."
 				log_game("[key_name(src)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] [ADMIN_KICK(usr)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
 			to_chat(src, span_danger("[msg]"))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -59,7 +59,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			var/msg = "Your previous action was ignored because you've done too many in a minute."
 			if (minute != topiclimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
 				topiclimiter[ADMINSWARNED_AT] = minute
-				msg += "If you think these alerts are a mistake, possible fixes could be: 1. Disconnecting any controllers 2. Upgrading byond version 3. Clearing cache."
+				message_list += "If you think these alerts are a mistake, possible fixes could be:"
+				message_list += "1. Disconnecting any controllers."
+				message_list += "2. Upgrading your BYOND version."
+				message_list += "3. Clearing your BYOND cache."
 				log_game("[key_name(src)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] [ADMIN_KICK(usr)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
 			to_chat(src, span_danger("[msg]"))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			var/msg = "Your previous action was ignored because you've done too many in a minute."
 			if (minute != topiclimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
 				topiclimiter[ADMINSWARNED_AT] = minute
-				msg += " Administrators have been informed."
+				msg += " Administrators have been informed. If you think this message is a mistake, possible fixes could be: 1. Disconnecting any controllers 2. upgrading byond version 3. Clearing cache..."
 				log_game("[key_name(src)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] [ADMIN_KICK(usr)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
 			to_chat(src, span_danger("[msg]"))


### PR DESCRIPTION
## About The Pull Request
Now:
```php
		if (topiclimiter[MINUTE_COUNT] > mtl)
			var/msg = "Your previous action was ignored because you've done too many in a minute."
			if (minute != topiclimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
				topiclimiter[ADMINSWARNED_AT] = minute
				msg += "If you think these alerts are a mistake, possible fixes could be: 1. Disconnecting any controllers 2. Upgrading byond version 3. Clearing cache."
```
## Why It's Good For The Game
A lot of players have had problems with this bug and asking in the help channel for directions. This should help those users.
## Changelog
:cl:
qol: users encountering the "too many actions" bug will now see possible fixes in the message.
/:cl:
