### PR TITLE
Stopping orbiting now automatically breaks you out of autoobserve

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -506,6 +506,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	. = ..()
 	//restart our floating animation after orbit is done.
 	pixel_y = base_pixel_y
+	// if we were autoobserving, reset perspective
+	if (!isnull(client) && !isnull(client.eye))
+		reset_perspective(null)
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"


### PR DESCRIPTION

## About The Pull Request

If you move off someone you automatically stop autoobserve (stop viewing their UI and seeing from their perspective)

## Why It's Good For The Game

Only way to stop autoobserve right now is via orbit UI, and following in chat does not break you out of it either. And if you have closed your orbit window, you need to open it from ghost tab as you no longer have a button for it, which can be annoying.

## Changelog
:cl:
qol: Stopping orbiting now automatically breaks you out of autoobserve
/:cl:
