### PR TITLE
Xenos have their resist UI element again

### DIFF
--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -79,6 +79,7 @@
 	using = new /atom/movable/screen/resist(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_above_movement
+	using.update_appearance()
 	hotkeybuttons += using
 
 	throw_icon = new /atom/movable/screen/throw_catch(null, src)


### PR DESCRIPTION
## About The Pull Request

This restores the "resist" UI element for xenos.

It's been there the whole time, even having the screen item get made every time a Xeno player occupies a body. It wouldn't render, however, since the actual screen element wouldn't be modified to use the xeno UI theme.

![image](https://github.com/user-attachments/assets/ee6a8ddd-da51-4e58-9485-676f3d7085c2)
## Why It's Good For The Game

Xenos have plenty to be resisting from. Stop-drop-and-rolling, instantly breaking out of handcuffs or straitjackets, buckle-combat.

The thing is, it's been here to whole time too, and even had a sprite already set up, so it leads me to believe that this was somehow just taken out by accident one day and went mostly unnoticed.
## Changelog
:cl: Rhials
fix: Xenos have a "resist" ui element now. Cool!
/:cl:
