### PR TITLE
Fish quality fixes and recipes.

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -89,6 +89,7 @@
 	name = "donkfillet"
 	desc = "The dreaded donkfish fillet. No sane spaceman would eat this, and it does not get better when cooked."
 	icon_state = "donkfillet"
+	starting_reagent_purity = 0.3
 
 /obj/item/food/fishmeat/octopus
 	name = "octopus tentacle"

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -34,6 +34,7 @@
 	foodtypes = SEAFOOD
 	eatverbs = list("bite", "chew", "gnaw", "swallow", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
+	starting_reagent_purity = 1.0
 
 /obj/item/food/fishmeat/carp
 	name = "carp fillet"

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1469,6 +1469,20 @@
 		/datum/reagent/water = 5,
 	)
 
+//Fresh Jellyfish fillet soup!
+/datum/chemical_reaction/food/soup/jellyfish_stew_two
+	required_reagents = list(/datum/reagent/water = 50)
+	required_ingredients = list(
+		/obj/item/food/fishmeat/gunner_jellyfish = 1,
+		/obj/item/food/grown/soybeans = 1,
+		/obj/item/food/grown/redbeet = 1,
+		/obj/item/food/grown/potato = 1
+	)
+	results = list(
+		/datum/reagent/consumable/nutriment/soup/jellyfish = 50,
+	)
+
+
 // Rootbread Soup
 /datum/reagent/consumable/nutriment/soup/rootbread
 	name = "Rootbread Soup"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -480,6 +480,10 @@
 	reaction = /datum/chemical_reaction/food/soup/jellyfish_stew
 	category = CAT_LIZARD
 
+/datum/crafting_recipe/food/reaction/soup/jellyfish_stew_two
+	reaction = /datum/chemical_reaction/food/soup/jellyfish_stew_two
+	category = CAT_LIZARD
+
 /datum/crafting_recipe/food/reaction/soup/rootbread_soup
 	reaction = /datum/chemical_reaction/food/soup/rootbread_soup
 	category = CAT_LIZARD

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -44,11 +44,21 @@
 /obj/item/food/grown/koibeans
 	seed = /obj/item/seeds/soya/koi
 	name = "koibean"
-	desc = "Something about these seems fishy."
+	desc = "Something about these seems fishy, they seem really soft, almost squeezable!"
 	icon_state = "koibeans"
 	foodtypes = VEGETABLES
 	tastes = list("koi" = 1)
 	wine_power = 40
+
+//Now squeezable for imitation carpmeat
+/obj/item/food/grown/koibeans/attack_self(mob/living/user)
+	user.visible_message(span_notice("[user] crushes [src] into a slab of carplike meat."), span_notice("You crush [src] into something that resembles a slab of carplike meat."))
+	playsound(user, 'sound/effects/blobattack.ogg', 50, TRUE)
+	var/obj/item/food/fishmeat/carp/imitation/fishie = new(null)
+	fishie.reagents.set_all_reagents_purity(seed.get_reagent_purity())
+	qdel(src)
+	user.put_in_hands(fishie)
+	return TRUE
 
 //Butterbeans, the beans wid da butta!
 // Butterbeans! - Squeeze for a single butter slice!


### PR DESCRIPTION
## About The Pull Request

In this PR I am adding the ability for freshly caught fish to be of the finest quality (excluding a few exceptions like donkfish, they nasty...) This means you chefs won't be losing quality from fresh fish, That makes no sense to me.

![image](https://github.com/user-attachments/assets/8722c964-7a98-4e78-b145-2398a37b9325)


 I am also adding a recipe to create jellyfish soups with fresh fillets and adding the ability to crush koibeans into fake fish (like butterbeans and meatwheat).

![image](https://github.com/user-attachments/assets/819dccca-c180-4684-8cd3-5059ba66bf18)

![image](https://github.com/user-attachments/assets/765d44f0-92ad-4554-94de-3a1a132092d0)



## Why It's Good For The Game

Fresh food shouldn't bring down the quality of your other ingredients, making more fish accessable for cooking and some usable in the first place.

## Changelog
:cl:
qol: made fish better quality when butchered, smushy koibeans and useable gunner jellyfish.
/:cl:
