### PR TITLE
Fixes hulks being able to activate dualsabers despite not being able to actually do anything with them

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -217,10 +217,11 @@
 	if(SEND_SIGNAL(parent, COMSIG_TWOHANDED_WIELD, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)
 		user.dropItemToGround(parent, force = TRUE)
 		return COMPONENT_EQUIPPED_FAILED // blocked wield from item
+	if (wield_callback?.Invoke(parent, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)
+		return
 	wielded = TRUE
 	ADD_TRAIT(parent, TRAIT_WIELDED, REF(src))
 	RegisterSignal(user, COMSIG_MOB_SWAPPING_HANDS, PROC_REF(on_swapping_hands))
-	wield_callback?.Invoke(parent, user)
 
 	// update item stats and name
 	var/obj/item/parent_item = parent


### PR DESCRIPTION

## About The Pull Request

Closes #85002
This order change shouldn't cause any issues with other uses of on_wield

## Changelog
:cl:
fix: Fixes hulks being able to activate dualsabers despite not being able to actually do anything with them
/:cl:
