### PR TITLE
You can properly aim mining bombs at turfs now

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -560,6 +560,7 @@
 	light_power = 1
 	light_color = COLOR_LIGHT_ORANGE
 	embed_type = null
+	can_hit_turfs = TRUE
 
 /obj/projectile/bullet/mining_bomb/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Due to lacking can_target_turfs mining bombs currently travel until they hit a solid object or reach their range, making aiming often frustrating.

## Why It's Good For The Game

This doesn't have a balance impact but makes mining with them a bit easier as you can actually position them where you want.

## Changelog
:cl:
qol: You can properly aim mining bombs at turfs now
/:cl:
