### PR TITLE
Borgs cant put their integrated tools into the reagent grinder

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -204,7 +204,11 @@
 		if(weapon.w_class + total_weight > maximum_weight)
 			to_chat(user, span_warning("[weapon] is too big to fit into [src]."))
 			continue
-		weapon.forceMove(src)
+
+		//try to remove the right way
+		if(!user.transferItemToLoc(weapon, src))
+			continue
+
 		total_weight += weapon.w_class
 		items_transfered += 1
 		to_chat(user, span_notice("[weapon] was loaded into [src]."))
@@ -212,8 +216,8 @@
 	return items_transfered
 
 /obj/machinery/reagentgrinder/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(user.combat_mode || (tool.item_flags & ABSTRACT) || (tool.flags_1 & HOLOGRAM_1) || !can_interact(user) || !user.can_perform_action(src, ALLOW_SILICON_REACH))
-		return NONE
+	if(user.combat_mode || (tool.item_flags & ABSTRACT) || (tool.flags_1 & HOLOGRAM_1))
+		return ITEM_INTERACT_SKIP_TO_ATTACK
 
 	//add the beaker
 	if (is_reagent_container(tool) && tool.is_open_container())


### PR DESCRIPTION
## About The Pull Request
- Fixes #85004

Dont `forceMove` but `transferItemToLoc` which checks for `TRAIT_NODROP`

## Changelog
:cl:
fix: borgs can't put their integrated tools into the reagent grinder
/:cl:
