### PR TITLE
Supermatter sword craft

### DIFF
--- a/code/datums/components/crafting/melee_weapon.dm
+++ b/code/datums/components/crafting/melee_weapon.dm
@@ -187,7 +187,27 @@
 		/obj/item/assembly/signaler/anomaly/ectoplasm = 1,
 	)
 	machinery = list(
-		/obj/machinery/power/supermatter_crystal = CRAFTING_MACHINERY_CONSUME,
+		/obj/machinery/power/supermatter_crystal/shard = CRAFTING_MACHINERY_CONSUME,
 	)
 	time = 10 SECONDS
+	category = CAT_WEAPON_MELEE
+
+/datum/crafting_recipe/supermatter_sword
+	name = "Supermatter Sword"
+	result = /obj/item/melee/supermatter_sword
+	reqs = list(
+		/obj/item/assembly/signaler/anomaly/pyro = 1,
+		/obj/item/assembly/signaler/anomaly/grav = 1,
+		/obj/item/assembly/signaler/anomaly/flux = 1,
+		/obj/item/assembly/signaler/anomaly/bluespace = 1,
+		/obj/item/assembly/signaler/anomaly/vortex = 1,
+		/obj/item/assembly/signaler/anomaly/bioscrambler = 1,
+		/obj/item/assembly/signaler/anomaly/hallucination = 1,
+		/obj/item/assembly/signaler/anomaly/dimensional = 1,
+		/obj/item/assembly/signaler/anomaly/ectoplasm = 1,
+	)
+	machinery = list(
+		/obj/machinery/power/supermatter_crystal/engine = CRAFTING_MACHINERY_CONSUME,
+	)
+	time = 30 SECONDS
 	category = CAT_WEAPON_MELEE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Singulo hammer uses only sm shard for craft. Now, you can craft SM SWORD if you use every type of anomaly and SM CRYSTAL
SM sword craft time is 30 seconds

(Possible balancing variants, if you think it's to op: 
Craftable SM sword has limited use count, after limit reached it breaks and releases SM crystal on tile, where it was broken; 
You need to make expensive gloves with even more anomaly cores to hold SM sword safely. Without gloves sword'll dust you)

## Why It's Good For The Game

I don't think Singulo Hammer is worthy price for spending only vortex anomaly when you can use it for Anti-existential cannon, that is cheaper and easier to do (You can get illegal tech very fast, if you know how to) and can remove ur enemies from round.
SM sword is a bit harder to get and is worth reward for all used ingredients

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added craft for SM sword: each type of anomaly cores and SM Crystal (engine one)
balance: Singulo Hammer craft accepts only SM shard 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
