### PR TITLE
[NO GBP] Fixes some incorrect reagent operations

### DIFF
--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -190,6 +190,8 @@
 				transfer_amount = reagent.volume * part
 
 		if(reagent.intercept_reagents_transfer(target_holder, amount))
+			update_total()
+			target_holder.update_total()
 			continue
 
 		transfered_amount = target_holder.add_reagent(reagent.type, transfer_amount, copy_data(reagent), chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT) //we only handle reaction after every reagent has been transferred.

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -249,7 +249,7 @@
 		cached_reagent.volume -= remove_amount
 
 		//record the changes
-		removed_reagents += cached_reagent
+		removed_reagents[cached_reagent] = remove_amount
 		total_removed_amount += remove_amount
 
 		//if we reached here means we have found our specific reagent type so break
@@ -257,8 +257,8 @@
 			break
 
 	//inform others about our reagents being removed
-	for(var/datum/reagent/removed_reagent as anything in cached_reagents)
-		SEND_SIGNAL(src, COMSIG_REAGENTS_REM_REAGENT, removed_reagent, amount)
+	for(var/datum/reagent/removed_reagent as anything in removed_reagents)
+		SEND_SIGNAL(src, COMSIG_REAGENTS_REM_REAGENT, removed_reagent, removed_reagents[removed_reagent])
 
 	//update the holder & handle reactions
 	update_total()
@@ -476,6 +476,8 @@
 		if(preserve_data)
 			trans_data = copy_data(reagent)
 		if(reagent.intercept_reagents_transfer(target_holder, amount))
+			update_total()
+			target_holder.update_total()
 			continue
 		transfered_amount = target_holder.add_reagent(reagent.type, transfer_amount * multiplier, trans_data, chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT) //we only handle reaction after every reagent has been transferred.
 		if(!transfered_amount)


### PR DESCRIPTION
## About The Pull Request
- Fixes #85014. buffers use `intercept_reagents_transfer()` but this proc does not automatically call `update_total()` on the target & source reagent holders causing inconsistent results
- `remove_reagent()` was sending signals for all reagents in the holder & not just for the reagents removed leading to false triggers & excess work for objects that hooked on this signal. That's fixed now too 

## Changelog
:cl:
fix: acid/base buffers should update your target & source holder
fix: remove reagent operations won't trigger excessive workload
/:cl:
