### PR TITLE
Point blank shots with piercing weapons no longer make the bullet fly north after hitting the target

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -81,9 +81,7 @@
 	var/direct_target
 	if(target && curloc.Adjacent(targloc, target=targloc, mover=src)) //if the target is right on our location or adjacent (including diagonally if reachable) we'll skip the travelling code in the proj's fire()
 		direct_target = target
-	if(!direct_target)
-		var/modifiers = params2list(params)
-		loaded_projectile.preparePixelProjectile(target, fired_from, modifiers, spread)
+	loaded_projectile.preparePixelProjectile(target, fired_from, params2list(params), spread)
 	var/obj/projectile/loaded_projectile_cache = loaded_projectile
 	loaded_projectile = null
 	loaded_projectile_cache.fire(null, direct_target)


### PR DESCRIPTION

## About The Pull Request

A bug uncovered by #84974. Honestly I am surprised that noone found this yet by point blanking someone with a piercing round, but for cutters this is very frequent behavior. There is no logical reason for this check's existence as its a function that always should be called before firing, no exceptions.  

## Changelog
:cl:
fix: Point blank piercing shots no longer fly directly north after hitting their intended target
/:cl:
