### PR TITLE
Rounds temperature protection to .1% accuracy

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -207,7 +207,7 @@
 		if(thermal_protection_flags & HAND_RIGHT)
 			thermal_protection += THERMAL_PROTECTION_HAND_RIGHT
 
-	return min(1, thermal_protection)
+	return min(1, round(thermal_protection, 0.001))
 
 //See proc/get_heat_protection_flags(temperature) for the description of this proc.
 /mob/living/carbon/human/proc/get_cold_protection_flags(temperature)
@@ -268,7 +268,7 @@
 		if(thermal_protection_flags & HAND_RIGHT)
 			thermal_protection += THERMAL_PROTECTION_HAND_RIGHT
 
-	return min(1, thermal_protection)
+	return min(1, round(thermal_protection, 0.001))
 
 /mob/living/carbon/human/has_smoke_protection()
 	if(isclothing(wear_mask))


### PR DESCRIPTION
## About The Pull Request
Both `get_cold_protection()` and `get_heat_protection()` run into decimal precision issues due to several small percentage additions, which means that even if you have all protection flags present, the value returned will never be 1.
![image](https://github.com/user-attachments/assets/a19097e7-bb07-4bc0-af2d-481d01a7b880)
![image](https://github.com/user-attachments/assets/d453e125-7003-45c1-97fd-e8c8431a1b5a)

This means you cannot check for if protection is at 100% if you wanted to short circuit some proc doing temperature calculations which don't need to be done if you have full protection, aswell as may lead to very minor drift.
(I was doing something like that elsewhere which led me to find this problem and mirror this here).

This rounds to 0.1% accuracy (0.001), which is both the smallest decimal used by the bodypart protection define values and is sufficiently large to rectify precision issues.
## Why It's Good For The Game
This should save some coder from a bad day when they try to see if someone is 100% protected against temperature and it doesn't work.
## Changelog
:cl:
fix: cold- & heat protection no longer have decimal precision issues.
/:cl:
