### PR TITLE
Removes a rogue apostrophe from DeltaStation's monkey pen door

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32151,7 +32151,7 @@
 /area/station/science/research/abandoned)
 "hXQ" = (
 /obj/machinery/door/window/left/directional/east{
-	name = "'Monkey Pen";
+	name = "Monkey Pen";
 	req_access = list("genetics")
 	},
 /obj/structure/flora/bush/lavendergrass,


### PR DESCRIPTION

## About The Pull Request
DeltaStation's monkey pen windoor had the name "'Monkey Pen". This changes it to "Monkey Pen".
## Why It's Good For The Game
That apostrophe shouldn't be there
## Changelog
:cl:
spellcheck: Removed an unnecessary apostrophe in DeltaStation's genetics monkey pen door.
/:cl:
