### PR TITLE
Fixes Plague Doctor Mask not being able to use internals

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT|HIDEHAIR
 	inhand_icon_state = "gas_mask"
 	has_fov = FALSE
-	clothing_flags =  BLOCK_GAS_SMOKE_EFFECT
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT|MASKINTERNALS
 
 /obj/item/clothing/mask/gas/syndicate
 	name = "syndicate mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -255,6 +255,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT|HIDEHAIR
 	inhand_icon_state = "gas_mask"
 	has_fov = FALSE
+	flags_cover = MASKCOVERSEYES|MASKCOVERSMOUTH
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT|MASKINTERNALS
 
 /obj/item/clothing/mask/gas/syndicate

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -255,7 +255,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT|HIDEHAIR
 	inhand_icon_state = "gas_mask"
 	has_fov = FALSE
-	flags_cover = MASKCOVERSEYES|MASKCOVERSMOUTH
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT|MASKINTERNALS
 
 /obj/item/clothing/mask/gas/syndicate


### PR DESCRIPTION
## About The Pull Request

Fixes #85007

## Changelog
:cl:
fix: Plague Doctor Mask can now be used with internals again, and is no longer unintentionally pepperproof.
/:cl:
