### PR TITLE
Datumizes pod types

### DIFF
--- a/code/__DEFINES/cargo.dm
+++ b/code/__DEFINES/cargo.dm
@@ -1,33 +1,9 @@
-#define STYLE_STANDARD 1
-#define STYLE_BLUESPACE 2
-#define STYLE_CENTCOM 3
-#define STYLE_SYNDICATE 4
-#define STYLE_BLUE 5
-#define STYLE_CULT 6
-#define STYLE_MISSILE 7
-#define STYLE_RED_MISSILE 8
-#define STYLE_BOX 9
-#define STYLE_HONK 10
-#define STYLE_FRUIT 11
-#define STYLE_INVISIBLE 12
-#define STYLE_GONDOLA 13
-#define STYLE_SEETHROUGH 14
-
-#define POD_SHAPE 1
-#define POD_BASE 2
-#define POD_DOOR 3
-#define POD_DECAL 4
-#define POD_GLOW 5
-#define POD_RUBBLE_TYPE 6
-#define POD_NAME 7
-#define POD_DESC 8
-
 #define RUBBLE_NONE 1
 #define RUBBLE_NORMAL 2
 #define RUBBLE_WIDE 3
 #define RUBBLE_THIN 4
 
-#define POD_SHAPE_NORML 1
+#define POD_SHAPE_NORMAL 1
 #define POD_SHAPE_OTHER 2
 
 #define POD_TRANSIT "1"

--- a/code/_globalvars/lists/cargo.dm
+++ b/code/_globalvars/lists/cargo.dm
@@ -15,20 +15,3 @@ GLOBAL_LIST_INIT(pack_discount_odds, list(
 ))
 
 GLOBAL_LIST_EMPTY(supplypod_loading_bays)
-
-GLOBAL_LIST_INIT(podstyles, list(\
-	list(POD_SHAPE_NORML, "pod",         TRUE, "default", "yellow",   RUBBLE_NORMAL, "supply pod",     "A Nanotrasen supply drop pod."),\
-	list(POD_SHAPE_NORML, "advpod",      TRUE, "bluespace", "blue",     RUBBLE_NORMAL, "bluespace supply pod" ,     "A Nanotrasen Bluespace supply pod. Teleports back to CentCom after delivery."),\
-	list(POD_SHAPE_NORML, "advpod",      TRUE, "centcom", "blue",     RUBBLE_NORMAL, "\improper CentCom supply pod", "A Nanotrasen supply pod, this one has been marked with Central Command's designations. Teleports back to CentCom after delivery."),\
-	list(POD_SHAPE_NORML, "darkpod",     TRUE, "syndicate", "red",      RUBBLE_NORMAL, "blood-red supply pod", "An intimidating supply pod, covered in the blood-red markings of the Syndicate. It's probably best to stand back from this."),\
-	list(POD_SHAPE_NORML, "darkpod",     TRUE, "deathsquad", "blue",     RUBBLE_NORMAL, "\improper Deathsquad drop pod",     "A Nanotrasen drop pod. This one has been marked the markings of Nanotrasen's elite strike team."),\
-	list(POD_SHAPE_NORML, "pod",         TRUE, "cultist", "red",      RUBBLE_NORMAL, "bloody supply pod",     "A Nanotrasen supply pod covered in scratch-marks, blood, and strange runes."),\
-	list(POD_SHAPE_OTHER, "missile",     FALSE, FALSE, FALSE,   RUBBLE_THIN,     "cruise missile", "A big ass missile that didn't seem to fully detonate. It was likely launched from some far-off deep space missile silo. There appears to be an auxillery payload hatch on the side, though manually opening it is likely impossible."),\
-	list(POD_SHAPE_OTHER, "smissile",    FALSE, FALSE,         FALSE,   RUBBLE_THIN,     "\improper Syndicate cruise missile", "A big ass, blood-red missile that didn't seem to fully detonate. It was likely launched from some deep space Syndicate missile silo. There appears to be an auxillery payload hatch on the side, though manually opening it is likely impossible."),\
-	list(POD_SHAPE_OTHER, "box",         TRUE, FALSE,            FALSE,   RUBBLE_WIDE, "\improper Aussec supply crate", "An incredibly sturdy supply crate, designed to withstand orbital re-entry. Has 'Aussec Armory - 2532' engraved on the side."),\
-	list(POD_SHAPE_NORML, "clownpod",    TRUE, "clown", "green",    RUBBLE_NORMAL, "\improper HONK pod",     "A brightly-colored supply pod. It likely originated from the Clown Federation."),\
-	list(POD_SHAPE_OTHER, "orange",      TRUE, FALSE, FALSE,   RUBBLE_NONE,     "\improper Orange", "An angry orange."),\
-	list(POD_SHAPE_OTHER, FALSE,         FALSE,    FALSE,            FALSE,   RUBBLE_NONE,     "\improper S.T.E.A.L.T.H. pod MKVII", "A supply pod that, under normal circumstances, is completely invisible to conventional methods of detection. How are you even seeing this?"),\
-	list(POD_SHAPE_OTHER, "gondola",     FALSE, FALSE, FALSE,   RUBBLE_NONE,     "gondola",     "The silent walker. This one seems to be part of a delivery agency."),\
-	list(POD_SHAPE_OTHER, FALSE,         FALSE,    FALSE,            FALSE,   RUBBLE_NONE,         FALSE,      FALSE,      "rl_click", "give_po")\
-))

--- a/code/datums/pod_style.dm
+++ b/code/datums/pod_style.dm
@@ -1,0 +1,140 @@
+
+/datum/pod_style
+	var/name = "supply pod"
+	var/ui_name = "Standard"
+	var/desc = "A Nanotrasen supply drop pod"
+	var/shape = POD_SHAPE_NORMAL
+	var/icon_state = "pod"
+	var/has_door = TRUE
+	var/decal_icon = "default"
+	var/glow_color = "yellow"
+	var/rubble_type = RUBBLE_NORMAL
+	var/id = "standard"
+
+/datum/pod_style/advanced
+	name = "bluespace supply pod"
+	ui_name = "Advanced"
+	desc = "A Nanotrasen Bluespace supply pod. Teleports back to CentCom after delivery."
+	decal_icon = "bluespace"
+	glow_color = "blue"
+	id = "bluespace"
+
+/datum/pod_style/centcom
+	name = "\improper CentCom supply pod"
+	ui_name = "Nanotrasen"
+	desc = "A Nanotrasen supply pod, this one has been marked with Central Command's designations. Teleports back to CentCom after delivery."
+	decal_icon = "centcom"
+	glow_color = "blue"
+	id = "centcom"
+
+/datum/pod_style/syndicate
+	name = "blood-red supply pod"
+	ui_name = "Syndicate"
+	desc = "An intimidating supply pod, covered in the blood-red markings of the Syndicate. It's probably best to stand back from this."
+	icon_state = "darkpod"
+	decal_icon = "syndicate"
+	glow_color = "red"
+	id = "syndicate"
+
+/datum/pod_style/deathsquad
+	name = "\improper Deathsquad drop pod"
+	ui_name = "Deathsquad"
+	desc = "A Nanotrasen drop pod. This one has been marked the markings of Nanotrasen's elite strike team."
+	icon_state = "darkpod"
+	decal_icon = "deathsquad"
+	glow_color = "blue"
+	id = "deathsquad"
+
+/datum/pod_style/advanced
+	name = "bloody supply pod"
+	ui_name = "Cultist"
+	desc = "A Nanotrasen supply pod covered in scratch-marks, blood, and strange runes."
+	decal_icon = "cultist"
+	glow_color = "red"
+	id = "cultist"
+
+/datum/pod_style/missile
+	name = "cruise missile"
+	ui_name = "Missile"
+	desc = "A big ass missile that didn't seem to fully detonate. It was likely launched from some far-off deep space missile silo. There appears to be an auxillery payload hatch on the side, though manually opening it is likely impossible."
+	shape = POD_SHAPE_OTHER
+	icon_state = "missile"
+	has_door = FALSE
+	decal_icon = null
+	glow_color = null
+	rubble_type = RUBBLE_THIN
+	id = "missile"
+
+/datum/pod_style/missile/syndicate
+	name = "\improper Syndicate cruise missile"
+	ui_name = "Syndie Missile"
+	desc = "A big ass, blood-red missile that didn't seem to fully detonate. It was likely launched from some deep space Syndicate missile silo. There appears to be an auxillery payload hatch on the side, though manually opening it is likely impossible."
+	icon_state = "smissile"
+	id = "syndie_missile"
+
+/datum/pod_style/box
+	name = "\improper Aussec supply crate"
+	ui_name = "Supply Box"
+	desc = "An incredibly sturdy supply crate, designed to withstand orbital re-entry. Has 'Aussec Armory - 2532' engraved on the side."
+	shape = POD_SHAPE_OTHER
+	icon_state = "box"
+	decal_icon = null
+	glow_color = null
+	rubble_type = RUBBLE_WIDE
+	id = "supply_box"
+
+/datum/pod_style/clown
+	name = "\improper HONK pod"
+	ui_name = "Clown Pod"
+	desc = "A brightly-colored supply pod. It likely originated from the Clown Federation."
+	icon_state = "clownpod"
+	decal_icon = "clown"
+	glow_color = "green"
+	id = "clown"
+
+/datum/pod_style/orange
+	name = "\improper Orange"
+	ui_name = "Fruit"
+	desc = "An angry orange."
+	shape = POD_SHAPE_OTHER
+	icon_state = "orange"
+	decal_icon = null
+	glow_color = null
+	rubble_type = RUBBLE_WIDE
+	id = "orange"
+
+/datum/pod_style/invisible
+	name =  "\improper S.T.E.A.L.T.H. pod MKVII"
+	ui_name = "Invisible"
+	desc = "A supply pod that, under normal circumstances, is completely invisible to conventional methods of detection. How are you even seeing this?"
+	shape = POD_SHAPE_OTHER
+	has_door = FALSE
+	icon_state = null
+	decal_icon = null
+	glow_color = null
+	rubble_type = RUBBLE_NONE
+	id = "invisible"
+
+/datum/pod_style/gondola
+	name = "gondola"
+	ui_name = "Gondola"
+	desc = "The silent walker. This one seems to be part of a delivery agency."
+	shape = POD_SHAPE_OTHER
+	icon_state = "gondola"
+	has_door = FALSE
+	decal_icon = null
+	glow_color = null
+	rubble_type = RUBBLE_NONE
+	id = "gondola"
+
+/datum/pod_style/seethrough
+	name = null
+	ui_name = "Seethrough"
+	desc = null
+	shape = POD_SHAPE_OTHER
+	has_door = FALSE
+	icon_state = null
+	decal_icon = null
+	glow_color = null
+	rubble_type = RUBBLE_NONE
+	id = "seethrough"

--- a/code/datums/pod_style.dm
+++ b/code/datums/pod_style.dm
@@ -1,14 +1,25 @@
-
+/// Datum holding information about pod type visuals, VFX, name and description
+/// These are not created anywhere and thus should not be assigned procs, only being used as data storage
 /datum/pod_style
+	/// Name that pods of this style will be named by default
 	var/name = "supply pod"
+	/// Name that is displayed to admins in pod config panel
 	var/ui_name = "Standard"
-	var/desc = "A Nanotrasen supply drop pod"
+	/// Description assigned to droppods of this style
+	var/desc = "A Nanotrasen supply drop pod."
+	/// Determines if this pod can use animations/masking/overlays
 	var/shape = POD_SHAPE_NORMAL
+	/// Base icon state assigned to this pod
 	var/icon_state = "pod"
+	/// Whenever this pod should have a door overlay added to it. Uses [icon_state]_door sprite
 	var/has_door = TRUE
+	/// Decals added to this pod, if any
 	var/decal_icon = "default"
+	/// Color that this pod glows when landing
 	var/glow_color = "yellow"
+	/// Type of rubble that this pod creates upon landing
 	var/rubble_type = RUBBLE_NORMAL
+	/// ID for TGUI data
 	var/id = "standard"
 
 /datum/pod_style/advanced

--- a/code/datums/quirks/negative_quirks/indebted.dm
+++ b/code/datums/quirks/negative_quirks/indebted.dm
@@ -30,7 +30,7 @@
 		quirk_holder.client.give_award(/datum/award/achievement/misc/debt_extinguished, quirk_holder)
 	podspawn(list(
 		"target" = get_turf(quirk_holder),
-		"style" = STYLE_BLUESPACE,
+		"style" = /datum/pod_style/advanced,
 		"spawn" = /obj/item/clothing/accessory/debt_payer_pin,
 	))
 

--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
 		return
 	podspawn(list(
 		"target" = get_turf(mind.current),
-		"style" = STYLE_BLUESPACE,
+		"style" = /datum/pod_style/advanced,
 		"spawn" = skill_item_path,
 		"delays" = list(POD_TRANSIT = 150, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
 	))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -210,7 +210,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	if(LAZYLEN(our_mind.failed_special_equipment))
 		podspawn(list(
 			"target" = get_turf(owner),
-			"style" = STYLE_SYNDICATE,
+			"style" = /datum/pod_style/syndicate,
 			"spawn" = our_mind.failed_special_equipment,
 		))
 		our_mind.failed_special_equipment = null

--- a/code/game/machinery/botlaunchpad.dm
+++ b/code/game/machinery/botlaunchpad.dm
@@ -49,7 +49,7 @@
 	podspawn(list(
 		"target" = get_turf(src),
 		"path" = /obj/structure/closet/supplypod/botpod,
-		"style" = STYLE_SEETHROUGH,
+		"style" = /datum/pod_style/seethrough,
 		"reverse_dropoff_coords" = list(reverse_turf.x, reverse_turf.y, reverse_turf.z)
 	))
 
@@ -67,7 +67,7 @@
 	simple_bot.call_bot(src,  get_turf(src))
 
 /obj/structure/closet/supplypod/botpod
-	style = STYLE_SEETHROUGH
+	style = /datum/pod_style/seethrough
 	explosionSize = list(0,0,0,0)
 	reversing = TRUE
 	reverse_option_list = list("Mobs"=TRUE,"Objects"=FALSE,"Anchored"=FALSE,"Underfloor"=FALSE,"Wallmounted"=FALSE,"Floors"=FALSE,"Walls"=FALSE,"Mecha"=FALSE)

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -201,7 +201,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
 					ordered_paths += item.item_path
 			podspawn(list(
 				"target" = get_turf(living_user),
-				"style" = STYLE_BLUESPACE,
+				"style" = /datum/pod_style/advanced,
 				"spawn" = ordered_paths,
 			))
 			grocery_list.Cut()

--- a/code/game/machinery/mechlaunchpad.dm
+++ b/code/game/machinery/mechlaunchpad.dm
@@ -56,13 +56,13 @@
 	podspawn(list(
 		"target" = get_turf(src),
 		"path" = /obj/structure/closet/supplypod/mechpod,
-		"style" = STYLE_SEETHROUGH,
+		"style" = /datum/pod_style/seethrough,
 		"reverse_dropoff_coords" = list(reverse_turf.x, reverse_turf.y, reverse_turf.z)
 	))
 	use_energy(active_power_usage)
 
 /obj/structure/closet/supplypod/mechpod
-	style = STYLE_SEETHROUGH
+	style = /datum/pod_style/seethrough
 	explosionSize = list(0,0,0,0)
 	reversing = TRUE
 	reverse_option_list = list("Mobs"=FALSE,"Objects"=FALSE,"Anchored"=FALSE,"Underfloor"=FALSE,"Wallmounted"=FALSE,"Floors"=FALSE,"Walls"=FALSE,"Mecha"=TRUE)

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -64,7 +64,7 @@
 /obj/item/choice_beacon/proc/spawn_option(obj/choice_path, mob/living/user)
 	podspawn(list(
 		"target" = get_turf(src),
-		"style" = STYLE_BLUESPACE,
+		"style" = /datum/pod_style/advanced,
 		"spawn" = choice_path,
 	))
 

--- a/code/game/objects/items/devices/battle_royale.dm
+++ b/code/game/objects/items/devices/battle_royale.dm
@@ -295,7 +295,7 @@ GLOBAL_DATUM_INIT(battle_royale_master, /datum/battle_royale_master, new)
 	if (!isnull(winner))
 		podspawn(list(
 			"target" = get_turf(winner),
-			"style" = STYLE_SYNDICATE,
+			"style" = /datum/pod_style/syndicate,
 			"spawn" = /obj/item/food/roast_dinner,
 		))
 

--- a/code/modules/admin/smites/supply_pod_quick.dm
+++ b/code/modules/admin/smites/supply_pod_quick.dm
@@ -37,7 +37,7 @@
 	podspawn(list(
 		"target" = get_turf(target),
 		"path" = /obj/structure/closet/supplypod/centcompod,
-		"style" = STYLE_CENTCOM,
+		"style" = /datum/pod_style/centcom,
 		"spawn" = target_path,
 		"damage" = SUPPLY_POD_QUICK_DAMAGE,
 		"explosionSize" = list(0, 0, 0, SUPPLY_POD_QUICK_FIRE_RANGE),

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -105,7 +105,7 @@
 	/// The antag datum applied
 	var/antag_datum = /datum/antagonist/nukeop/reinforcement
 	/// Style used by the droppod
-	var/pod_style = STYLE_SYNDICATE
+	var/pod_style = /datum/pod_style/syndicate
 	/// Do we use a random subtype of the outfit?
 	var/use_subtypes = TRUE
 	/// Where do we land our pod?
@@ -188,7 +188,7 @@
 	special_role_name = ROLE_CLOWN_OPERATIVE
 	outfit = /datum/outfit/syndicate/clownop/no_crystals
 	antag_datum = /datum/antagonist/nukeop/reinforcement/clownop
-	pod_style = STYLE_HONK
+	pod_style = /datum/pod_style/clown
 	use_subtypes = FALSE
 
 //////SYNDICATE BORG
@@ -313,7 +313,7 @@
 	/// The antag datum applied
 	var/datum/antagonist/antag_datum
 	/// Style used by the droppod
-	var/pod_style = STYLE_SYNDICATE
+	var/pod_style = /datum/pod_style/syndicate
 	/// Do we use a random subtype of the outfit?
 	var/use_subtypes = TRUE
 	/// The antag role we check if the ghosts have enabled to get the poll.

--- a/code/modules/antagonists/traitor/objectives/final_objective/battle_royale.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battle_royale.dm
@@ -38,6 +38,6 @@
 	equipped = TRUE
 	podspawn(list(
 		"target" = get_turf(user),
-		"style" = STYLE_SYNDICATE,
+		"style" = /datum/pod_style/syndicate,
 		"spawn" = /obj/item/storage/box/syndie_kit/battle_royale,
 	))

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -44,6 +44,6 @@
 			emag_card.team = team
 			podspawn(list(
 				"target" = get_turf(user),
-				"style" = STYLE_SYNDICATE,
+				"style" = /datum/pod_style/syndicate,
 				"spawn" = emag_card,
 			))

--- a/code/modules/antagonists/traitor/objectives/final_objective/infect_ai.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/infect_ai.dm
@@ -51,6 +51,6 @@
 			sent_board = TRUE
 			podspawn(list(
 				"target" = get_turf(user),
-				"style" = STYLE_SYNDICATE,
+				"style" = /datum/pod_style/syndicate,
 				"spawn" = /obj/item/ai_module/malf,
 			))

--- a/code/modules/antagonists/traitor/objectives/final_objective/objective_dark_matteor.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/objective_dark_matteor.dm
@@ -48,7 +48,7 @@
 			sent_satellites = TRUE
 			podspawn(list(
 				"target" = get_turf(user),
-				"style" = STYLE_SYNDICATE,
+				"style" = /datum/pod_style/syndicate,
 				"spawn" = /obj/structure/closet/crate/engineering/smuggled_meteor_shields,
 			))
 

--- a/code/modules/antagonists/traitor/objectives/final_objective/romerol.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/romerol.dm
@@ -41,6 +41,6 @@
 			sent_romerol = TRUE
 			podspawn(list(
 				"target" = get_turf(user),
-				"style" = STYLE_SYNDICATE,
+				"style" = /datum/pod_style/syndicate,
 				"spawn" = /obj/item/storage/box/syndie_kit/romerol,
 			))

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -52,6 +52,6 @@
 			sent_crystal = TRUE
 			podspawn(list(
 				"target" = get_turf(user),
-				"style" = STYLE_SYNDICATE,
+				"style" = /datum/pod_style/syndicate,
 				"spawn" = /obj/item/destabilizing_crystal,
 			))

--- a/code/modules/antagonists/wizard/grand_ritual/grand_side_effect.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_side_effect.dm
@@ -335,7 +335,7 @@
 /obj/effect/abstract/local_food_rain/proc/drop_food(turf/landing_zone)
 	podspawn(list(
 			"target" = landing_zone,
-			"style" = STYLE_SEETHROUGH,
+			"style" = /datum/pod_style/seethrough,
 			"spawn" = get_random_food(),
 			"delays" = list(POD_TRANSIT = 0, POD_FALLING = (3 SECONDS), POD_OPENING = 0, POD_LEAVING = 0),
 			"effectStealth" = TRUE,

--- a/code/modules/asset_cache/assets/supplypods.dm
+++ b/code/modules/asset_cache/assets/supplypods.dm
@@ -2,26 +2,26 @@
 	name = "supplypods"
 
 /datum/asset/spritesheet/supplypods/create_spritesheets()
-	for (var/style in 1 to length(GLOB.podstyles))
-		if (style == STYLE_SEETHROUGH)
-			Insert("pod_asset[style]", icon('icons/obj/supplypods.dmi' , "seethrough-icon"))
+	for (var/datum/pod_style/style as anything in typesof(/datum/pod_style))
+		if (ispath(style, /datum/pod_style/seethrough))
+			Insert("pod_asset[style::id]", icon('icons/obj/supplypods.dmi' , "seethrough-icon"))
 			continue
-		var/base = GLOB.podstyles[style][POD_BASE]
+		var/base = style::icon_state
 		if (!base)
-			Insert("pod_asset[style]", icon('icons/obj/supplypods.dmi', "invisible-icon"))
+			Insert("pod_asset[style::id]", icon('icons/obj/supplypods.dmi', "invisible-icon"))
 			continue
 		var/icon/podIcon = icon('icons/obj/supplypods.dmi', base)
-		var/door = GLOB.podstyles[style][POD_DOOR]
+		var/door = style::has_door
 		if (door)
 			door = "[base]_door"
 			podIcon.Blend(icon('icons/obj/supplypods.dmi', door), ICON_OVERLAY)
-		var/shape = GLOB.podstyles[style][POD_SHAPE]
-		if (shape == POD_SHAPE_NORML)
-			var/decal = GLOB.podstyles[style][POD_DECAL]
+		var/shape = style::shape
+		if (shape == POD_SHAPE_NORMAL)
+			var/decal = style::decal_icon
 			if (decal)
 				podIcon.Blend(icon('icons/obj/supplypods.dmi', decal), ICON_OVERLAY)
-			var/glow = GLOB.podstyles[style][POD_GLOW]
+			var/glow = style::glow_color
 			if (glow)
 				glow = "pod_glow_[glow]"
 				podIcon.Blend(icon('icons/obj/supplypods.dmi', glow), ICON_OVERLAY)
-		Insert("pod_asset[style]", podIcon)
+		Insert("pod_asset[style::id]", podIcon)

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -67,10 +67,19 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 	var/atom/movable/screen/background/cam_background
 	var/tabIndex = 1
 	var/renderLighting = FALSE
+	var/static/list/pod_style_info
+	var/static/list/pod_style_lookup
 
 /datum/centcom_podlauncher/New(user) //user can either be a client or a mob
 	if (user) //Prevents runtimes on datums being made without clients
 		setup(user)
+	if (!isnull(pod_style_info))
+		return
+	pod_style_info = list()
+	pod_style_lookup = list()
+	for (var/datum/pod_style/style as anything in typesof(/datum/pod_style))
+		pod_style_info += list(list("id" = style::id, "title" = style::ui_name))
+		pod_style_lookup[style::id] = style
 
 /datum/centcom_podlauncher/proc/setup(user) //H can either be a client or a mob
 	if (istype(user,/client))
@@ -134,6 +143,7 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 	var/list/data = list()
 	data["mapRef"] = map_name
 	data["defaultSoundVolume"] = initial(temp_pod.soundVolume) //default volume for pods
+	data["podStyles"] = pod_style_info
 	return data
 
 /datum/centcom_podlauncher/ui_data(mob/user) //Sends info about the pod to the UI.
@@ -152,7 +162,7 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 	data["delays"] = temp_pod.delays
 	data["rev_delays"] = temp_pod.reverse_delays
 	data["custom_rev_delay"] = temp_pod.custom_rev_delay
-	data["styleChoice"] = temp_pod.style //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the GLOB.podstyles list in cargo.dm defines to get the proper icon/name/desc for the pod.
+	data["styleChoice"] = temp_pod.style::id //Style is a variable that keeps track of what the pod is supposed to look like.
 	data["effectShrapnel"] = temp_pod.effectShrapnel //If true, creates a cloud of shrapnel of a decided type and magnitude on landing
 	data["shrapnelType"] = "[temp_pod.shrapnel_type]" //Path2String
 	data["shrapnelMagnitude"] = temp_pod.shrapnel_magnitude
@@ -333,10 +343,10 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 				temp_pod.adminNamed = FALSE
 				temp_pod.setStyle(temp_pod.style) //This resets the name of the pod based on it's current style (see supplypod/setStyle() proc)
 				return
-			var/nameInput= tgui_input_text(usr, "Enter a custom name", "Custom name", GLOB.podstyles[temp_pod.style][POD_NAME], MAX_NAME_LEN) //Gather input for name and desc
+			var/nameInput= tgui_input_text(usr, "Enter a custom name", "Custom name", temp_pod.style::name, MAX_NAME_LEN) //Gather input for name and desc
 			if (isnull(nameInput))
 				return
-			var/descInput = tgui_input_text(usr, "Enter a custom desc", "Custom description", GLOB.podstyles[temp_pod.style][POD_DESC])  //The GLOB.podstyles is used to get the name, desc, or icon state based on the pod's style
+			var/descInput = tgui_input_text(usr, "Enter a custom desc", "Custom description", temp_pod.style::desc)
 			if (isnull(descInput))
 				return
 			temp_pod.name = nameInput
@@ -504,7 +514,6 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 			temp_pod.soundVolume = soundInput
 			. = TRUE
 		////////////////////////////STYLE CHANGES//////////////////
-		//Style is a value that is used to keep track of what the pod is supposed to look like. It can be used with the GLOB.podstyles list (in cargo.dm defines)
 		//as a way to get the proper icon state, name, and description of the pod.
 		if("tabSwitch")
 			tabIndex = params["tabIndex"]
@@ -519,7 +528,7 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 			. = TRUE
 		if("setStyle")
 			var/chosenStyle = params["style"]
-			temp_pod.setStyle(chosenStyle+1)
+			temp_pod.setStyle(pod_style_lookup[chosenStyle])
 			. = TRUE
 		if("refresh") //Refresh the Pod bay. User should press this if they spawn something new in the centcom bay. Automatically called whenever the user launches a pod
 			refreshBay()
@@ -657,7 +666,7 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 /area/centcom/central_command_areas/supplypod/pod_storage/Initialize(mapload) //temp_pod holding area
 	. = ..()
 	var/obj/imgbound = locate() in locate(200,SUPPLYPOD_X_OFFSET*-4.5, 1)
-	call(GLOB.podlauncher, "RegisterSignal")(imgbound, "ct[GLOB.podstyles[14][9]]", "[GLOB.podstyles[14][10]]dlauncher")
+	call(GLOB.podlauncher, "RegisterSignal")(imgbound, "ctrl_click", "give_podlauncher")
 
 /datum/centcom_podlauncher/proc/createOrderedArea(area/area_to_order) //This assumes the area passed in is a continuous square
 	if (isnull(area_to_order)) //If theres no supplypod bay mapped into centcom, throw an error
@@ -820,7 +829,7 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 	temp_pod.delays = dataToLoad["delays"]
 	temp_pod.reverse_delays = dataToLoad["rev_delays"]
 	temp_pod.custom_rev_delay = dataToLoad["custom_rev_delay"]
-	temp_pod.setStyle(dataToLoad["styleChoice"])  //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the GLOB.podstyles list in cargo.dm defines to get the proper icon/name/desc for the pod.
+	temp_pod.setStyle(dataToLoad["styleChoice"])  //Style is a variable that keeps track of what the pod is supposed to look like.
 	temp_pod.effectShrapnel = dataToLoad["effectShrapnel"] //If true, creates a cloud of shrapnel of a decided type and magnitude on landing
 	temp_pod.shrapnel_type = text2path(dataToLoad["shrapnelType"])
 	temp_pod.shrapnel_magnitude = dataToLoad["shrapnelMagnitude"]

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -666,7 +666,7 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 /area/centcom/central_command_areas/supplypod/pod_storage/Initialize(mapload) //temp_pod holding area
 	. = ..()
 	var/obj/imgbound = locate() in locate(200,SUPPLYPOD_X_OFFSET*-4.5, 1)
-	call(GLOB.podlauncher, "RegisterSignal")(imgbound, "ctrl_click", "give_podlauncher")
+	GLOB.podlauncher.RegisterSignal(imgbound, COMSIG_CLICK_CTRL, TYPE_PROC_REF(/datum/centcom_podlauncher, give_podlauncher))
 
 /datum/centcom_podlauncher/proc/createOrderedArea(area/area_to_order) //This assumes the area passed in is a continuous square
 	if (isnull(area_to_order)) //If theres no supplypod bay mapped into centcom, throw an error

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -663,11 +663,6 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 	preLaunch() //Fill acceptable turfs from orderedArea, then fill launchList from acceptableTurfs (see proc for more info)
 	refreshView()
 
-/area/centcom/central_command_areas/supplypod/pod_storage/Initialize(mapload) //temp_pod holding area
-	. = ..()
-	var/obj/imgbound = locate() in locate(200,SUPPLYPOD_X_OFFSET*-4.5, 1)
-	GLOB.podlauncher.RegisterSignal(imgbound, COMSIG_CLICK_CTRL, TYPE_PROC_REF(/datum/centcom_podlauncher, give_podlauncher))
-
 /datum/centcom_podlauncher/proc/createOrderedArea(area/area_to_order) //This assumes the area passed in is a continuous square
 	if (isnull(area_to_order)) //If theres no supplypod bay mapped into centcom, throw an error
 		to_chat(holder.mob, "No /area/centcom/central_command_areas/supplypod/loading/one (or /two or /three or /four) in the world! You can make one yourself (then refresh) for now, but yell at a mapper to fix this, today!")
@@ -861,14 +856,6 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 	refreshView()
 
 GLOBAL_DATUM_INIT(podlauncher, /datum/centcom_podlauncher, new)
-//Proc for admins to enable others to use podlauncher after roundend
-/datum/centcom_podlauncher/proc/give_podlauncher(mob/living/user, override)
-	if (SSticker.current_state < GAME_STATE_FINISHED)
-		return
-	if (!istype(user))
-		user = override
-	if (user)
-		setup(user)//setup the datum
 
 //Set the dropoff location and indicator to either a specific turf or somewhere in an area
 /datum/centcom_podlauncher/proc/setDropoff(target)

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -36,7 +36,7 @@
 	var/effectQuiet = FALSE //The female sniper. If true, the pod makes no noise (including related explosions, opening sounds, etc)
 	var/effectMissile = FALSE //If true, the pod deletes the second it lands. If you give it an explosion, it will act like a missile exploding as it hits the ground
 	var/effectCircle = FALSE //If true, allows the pod to come in at any angle. Bit of a weird feature but whatever its here
-	var/style = STYLE_STANDARD //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the GLOB.podstyles list in cargo.dm defines to get the proper icon/name/desc for the pod.
+	var/datum/pod_style/style = /datum/pod_style //Style is a variable that keeps track of what the pod is supposed to look like. Only stores a path, type is set for ease of var access
 	var/reversing = FALSE //If true, the pod will not send any items. Instead, after opening, it will close again (picking up items/mobs) and fly back to centcom
 	var/list/reverse_dropoff_coords //Turf that the reverse pod will drop off it's newly-acquired cargo to
 	var/fallingSoundLength = 11
@@ -61,7 +61,7 @@
 	var/list/turfs_in_cargo = list()
 
 /obj/structure/closet/supplypod/bluespacepod
-	style = STYLE_BLUESPACE
+	style = /datum/pod_style/advanced
 	bluespace = TRUE
 	explosionSize = list(0,0,1,2)
 
@@ -83,7 +83,7 @@
 	name = "Syndicate Extraction Pod"
 	desc = "A specalised, blood-red styled pod for extracting high-value targets out of active mission areas. <b>Targets must be manually stuffed inside the pod for proper delivery.</b>"
 	specialised = TRUE
-	style = STYLE_SYNDICATE
+	style = /datum/pod_style/syndicate
 	bluespace = TRUE
 	explosionSize = list(0,0,1,2)
 	delays = list(POD_TRANSIT = 25, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
@@ -93,7 +93,7 @@
 	reverse_option_list = list("Mobs"=TRUE,"Objects"=FALSE,"Anchored"=FALSE,"Underfloor"=FALSE,"Wallmounted"=FALSE,"Floors"=FALSE,"Walls"=FALSE, "Mecha"=FALSE)
 
 /obj/structure/closet/supplypod/centcompod
-	style = STYLE_CENTCOM
+	style = /datum/pod_style/centcom
 	bluespace = TRUE
 	explosionSize = list(0,0,0,0)
 	delays = list(POD_TRANSIT = 20, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
@@ -121,13 +121,13 @@
 	desc = "An intimidating supply pod, covered in the blood-red markings"
 	bluespace = TRUE
 	explosionSize = list(0,0,0,0)
-	style = STYLE_SYNDICATE
+	style = /datum/pod_style/syndicate
 	specialised = TRUE
 
 /obj/structure/closet/supplypod/deadmatch_missile
 	name = "cruise missile"
 	desc = "A big ass missile, likely launched from some far-off deep space missile silo."
-	style = STYLE_RED_MISSILE
+	style = /datum/pod_style/missile/syndicate
 	explosionSize = list(0,1,2,2)
 	effectShrapnel = TRUE
 	specialised = TRUE
@@ -153,33 +153,32 @@
 		style = customStyle
 	setStyle(style) //Upon initialization, give the supplypod an iconstate, name, and description based on the "style" variable. This system is important for the centcom_podlauncher to function correctly
 
-/obj/structure/closet/supplypod/proc/setStyle(chosenStyle) //Used to give the sprite an icon state, name, and description.
-	style = chosenStyle
-	var/base = GLOB.podstyles[chosenStyle][POD_BASE] //GLOB.podstyles is a 2D array we treat as a dictionary. The style represents the verticle index, with the icon state, name, and desc being stored in the horizontal indexes of the 2D array.
-	icon_state = base
-	decal = GLOB.podstyles[chosenStyle][POD_DECAL]
-	rubble_type = GLOB.podstyles[chosenStyle][POD_RUBBLE_TYPE]
+/obj/structure/closet/supplypod/proc/setStyle(datum/pod_style/chosen_style) //Used to give the sprite an icon state, name, and description.
+	style = chosen_style
+	icon_state = chosen_style::icon_state
+	decal = chosen_style::decal_icon
+	rubble_type = chosen_style::rubble_type
 	if (!adminNamed && !specialised) //We dont want to name it ourselves if it has been specifically named by an admin using the centcom_podlauncher datum
-		name = GLOB.podstyles[chosenStyle][POD_NAME]
-		desc = GLOB.podstyles[chosenStyle][POD_DESC]
-	if (GLOB.podstyles[chosenStyle][POD_DOOR])
-		door = "[base]_door"
+		name = chosen_style::name
+		desc = chosen_style::desc
+	if (chosen_style::has_door)
+		door = "[icon_state]_door"
 	else
 		door = FALSE
 	update_appearance()
 
 /obj/structure/closet/supplypod/proc/SetReverseIcon()
 	fin_mask = "bottomfin"
-	if (GLOB.podstyles[style][POD_SHAPE] == POD_SHAPE_NORML)
-		icon_state = GLOB.podstyles[style][POD_BASE] + "_reverse"
+	if (style::shape == POD_SHAPE_NORMAL)
+		icon_state = style::icon_state + "_reverse"
 	pixel_x = initial(pixel_x)
 	transform = matrix()
 	update_appearance()
 
 /obj/structure/closet/supplypod/proc/backToNonReverseIcon()
 	fin_mask = initial(fin_mask)
-	if (GLOB.podstyles[style][POD_SHAPE] == POD_SHAPE_NORML)
-		icon_state = GLOB.podstyles[style][POD_BASE]
+	if (style::shape == POD_SHAPE_NORMAL)
+		icon_state = style::icon_state
 	pixel_x = initial(pixel_x)
 	transform = matrix()
 	update_appearance()
@@ -189,13 +188,13 @@
 
 /obj/structure/closet/supplypod/update_overlays()
 	. = ..()
-	if(style == STYLE_INVISIBLE)
+	if(ispath(style, /datum/pod_style/invisible))
 		return
 
 	if(rubble)
 		. += rubble.getForeground(src)
 
-	if(style == STYLE_SEETHROUGH)
+	if(ispath(style, /datum/pod_style/seethrough))
 		for(var/atom/A in contents)
 			var/mutable_appearance/itemIcon = new(A)
 			itemIcon.transform = matrix().Translate(-1 * SUPPLYPOD_X_OFFSET, 0)
@@ -227,7 +226,7 @@
 		if(decal)
 			. += decal
 		return
-	else if (GLOB.podstyles[style][POD_SHAPE] != POD_SHAPE_NORML) //If we're not a normal pod shape (aka, if we don't have fins), just add the door without masking
+	else if (style::shape != POD_SHAPE_NORMAL) //If we're not a normal pod shape (aka, if we don't have fins), just add the door without masking
 		. += door
 	else
 		var/icon/masked_door = new(icon, door) //The door we want to apply
@@ -280,7 +279,7 @@
 	reversing = FALSE //Now that we're done reversing, we set this to false (otherwise we would get stuck in an infinite loop of calling the close proc at the bottom of open_pod() )
 	bluespace = TRUE //Make it so that the pod doesn't stay in centcom forever
 	pod_flags &= ~FIRST_SOUNDS //Make it so we play sounds now
-	if (!effectQuiet && style != STYLE_SEETHROUGH)
+	if (!effectQuiet && !ispath(style, /datum/pod_style/seethrough))
 		audible_message(span_notice("The pod hisses, closing and launching itself away from the station."), span_notice("The ground vibrates, and you hear the sound of engines firing."))
 	stay_after_drop = FALSE
 	holder.pixel_z = initial(holder.pixel_z)
@@ -351,14 +350,14 @@
 		opened = TRUE //We set opened to TRUE to avoid spending time trying to open (due to being deleted) during the Destroy() proc
 		qdel(src)
 		return
-	if (style == STYLE_GONDOLA) //Checks if we are supposed to be a gondola pod. If so, create a gondolapod mob, and move this pod to nullspace. I'd like to give a shout out, to my man oranges
+	if (ispath(style, /datum/pod_style/gondola)) //Checks if we are supposed to be a gondola pod. If so, create a gondolapod mob, and move this pod to nullspace. I'd like to give a shout out, to my man oranges
 		var/mob/living/basic/pet/gondola/gondolapod/benis = new(turf_underneath, src)
 		benis.contents |= contents //Move the contents of this supplypod into the gondolapod mob.
 		for (var/mob/living/mob_in_pod in benis.contents)
 			mob_in_pod.reset_perspective(null)
 		moveToNullspace()
 		addtimer(CALLBACK(src, PROC_REF(open_pod), benis), delays[POD_OPENING]) //After the opening delay passes, we use the open proc from this supplyprod while referencing the contents of the "holder", in this case the gondolapod mob
-	else if (style == STYLE_SEETHROUGH)
+	else if (ispath(style, /datum/pod_style/seethrough))
 		open_pod(src)
 	else
 		addtimer(CALLBACK(src, PROC_REF(open_pod), src), delays[POD_OPENING]) //After the opening delay passes, we use the open proc from this supplypod, while referencing this supplypod's contents
@@ -381,11 +380,11 @@
 	for (var/cargo in holder.contents)
 		var/atom/movable/movable_cargo = cargo
 		movable_cargo.forceMove(turf_underneath)
-	if (!effectQuiet && !openingSound && style != STYLE_SEETHROUGH && !(pod_flags & FIRST_SOUNDS)) //If we aren't being quiet, play the default pod open sound
+	if (!effectQuiet && !openingSound && !ispath(style, /datum/pod_style/seethrough) && !(pod_flags & FIRST_SOUNDS)) //If we aren't being quiet, play the default pod open sound
 		playsound(get_turf(holder), open_sound, 15, TRUE, -3)
 	if (broken) //If the pod is opening because it's been destroyed, we end here
 		return
-	if (style == STYLE_SEETHROUGH)
+	if (ispath(style, /datum/pod_style/seethrough))
 		startExitSequence(src)
 	else
 		if (reversing)
@@ -400,7 +399,7 @@
 		close(holder)
 	else if (bluespace) //If we're a bluespace pod, then delete ourselves (along with our holder, if a separate holder exists)
 		deleteRubble()
-		if (!effectQuiet && style != STYLE_INVISIBLE && style != STYLE_SEETHROUGH)
+		if (!effectQuiet && !ispath(style, /datum/pod_style/invisible) && !ispath(style, /datum/pod_style/seethrough))
 			do_sparks(5, TRUE, holder) //Create some sparks right before closing
 		qdel(src) //Delete ourselves and the holder
 		if (holder != src)
@@ -537,10 +536,10 @@
 	update_appearance()
 
 /obj/structure/closet/supplypod/proc/addGlow()
-	if (GLOB.podstyles[style][POD_SHAPE] != POD_SHAPE_NORML)
+	if (style::shape != POD_SHAPE_NORMAL)
 		return
 	glow_effect = new(src)
-	glow_effect.icon_state = "pod_glow_" + GLOB.podstyles[style][POD_GLOW]
+	glow_effect.icon_state = "pod_glow_" + style::glow_color
 	vis_contents += glow_effect
 	glow_effect.layer = GASFIRE_LAYER
 	SET_PLANE_EXPLICIT(glow_effect, ABOVE_GAME_PLANE, src)
@@ -629,7 +628,7 @@
 	if (type == RUBBLE_THIN)
 		icon_state += "_thin"
 		foreground += "_thin"
-	if (pod.style == STYLE_BOX)
+	if (ispath(pod.style, /datum/pod_style/box))
 		verticle_offset = -2
 	else
 		verticle_offset = initial(verticle_offset)
@@ -717,12 +716,12 @@
 	pod.transform = matrix().Turn(rotation)
 	pod.layer = FLY_LAYER
 	SET_PLANE_EXPLICIT(pod, ABOVE_GAME_PLANE, src)
-	if (pod.style != STYLE_INVISIBLE)
+	if (!ispath(pod.style, /datum/pod_style/invisible))
 		animate(pod, pixel_z = -1 * abs(sin(rotation))*4, pixel_x = SUPPLYPOD_X_OFFSET + (sin(rotation) * 20), time = pod.delays[POD_FALLING], easing = LINEAR_EASING) //Make the pod fall! At an angle!
 	addtimer(CALLBACK(src, PROC_REF(endLaunch)), pod.delays[POD_FALLING], TIMER_CLIENT_TIME) //Go onto the last step after a very short falling animation
 
 /obj/effect/pod_landingzone/proc/setupSmoke(rotation)
-	if (pod.style == STYLE_INVISIBLE || pod.style == STYLE_SEETHROUGH)
+	if (ispath(pod.style, /datum/pod_style/invisible) || ispath(pod.style, /datum/pod_style/seethrough))
 		return
 	var/turf/our_turf = get_turf(drop_location())
 	for ( var/i in 1 to length(smoke_effects))
@@ -741,7 +740,7 @@
 		QDEL_IN(smoke_part, pod.delays[POD_FALLING] + 35)
 
 /obj/effect/pod_landingzone/proc/drawSmoke()
-	if (pod.style == STYLE_INVISIBLE || pod.style == STYLE_SEETHROUGH)
+	if (ispath(pod.style, /datum/pod_style/invisible) || ispath(pod.style, /datum/pod_style/seethrough))
 		return
 	for (var/obj/effect/supplypod_smoke/smoke_part in smoke_effects)
 		animate(smoke_part, alpha = 0, time = 20, flags = ANIMATION_PARALLEL)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -183,5 +183,5 @@
 ///Apply the syndicate pod skin
 /datum/round_event/stray_cargo/syndicate/make_pod()
 	var/obj/structure/closet/supplypod/S = new
-	S.setStyle(STYLE_SYNDICATE)
+	S.setStyle(/datum/pod_style/syndicate)
 	return S

--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -135,7 +135,7 @@
 
 	podspawn(list(
 		"target" = get_turf(user),
-		"style" = STYLE_SYNDICATE,
+		"style" = /datum/pod_style/syndicate,
 		"spawn" = surplus_crate,
 	))
 	return source //For log icon

--- a/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
+++ b/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
@@ -332,7 +332,7 @@
 	S_TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_MISSILE_STRIKE, strike_cooldown_time)
 	podspawn(list(
 		"target" = target_turf,
-		"style" = STYLE_MISSILE,
+		"style" = /datum/pod_style/missile,
 		"effectMissile" = TRUE,
 		"explosionSize" = list(0,0,1,2)
 	))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -797,6 +797,7 @@
 #include "code\datums\mutable_appearance.dm"
 #include "code\datums\numbered_display.dm"
 #include "code\datums\outfit.dm"
+#include "code\datums\pod_style.dm"
 #include "code\datums\position_point_vector.dm"
 #include "code\datums\profiling.dm"
 #include "code\datums\progressbar.dm"

--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher/StylePage.tsx
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher/StylePage.tsx
@@ -37,7 +37,7 @@ export function StylePage(props) {
           style={{
             verticalAlign: 'middle',
             marginRight: '5px',
-            borderRadius: '5px',
+            borderRadius: '20px',
           }}
           tooltipPosition={
             i >= podStyles.length - 2

--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher/StylePage.tsx
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher/StylePage.tsx
@@ -2,12 +2,11 @@ import { classes } from 'common/react';
 
 import { useBackend } from '../../backend';
 import { Box, Button, Section } from '../../components';
-import { STYLES } from './constants';
 import { PodLauncherData } from './types';
 
 export function StylePage(props) {
   const { act, data } = useBackend<PodLauncherData>();
-  const { effectName, styleChoice } = data;
+  const { effectName, styleChoice, podStyles } = data;
 
   return (
     <Section
@@ -19,7 +18,7 @@ export function StylePage(props) {
           selected={effectName}
           tooltip={`
             Edit pod's
-            name/desc.`}
+            .id/desc.`}
           tooltipPosition="bottom-start"
         >
           Name
@@ -29,19 +28,19 @@ export function StylePage(props) {
       scrollable
       title="Style"
     >
-      {STYLES.map((page, i) => (
+      {podStyles.map((page, i) => (
         <Button
           height="45px"
-          key={i}
-          onClick={() => act('setStyle', { style: i })}
-          selected={styleChoice - 1 === i}
+          key={page.id}
+          onClick={() => act('setStyle', { style: page.id })}
+          selected={styleChoice === page.id}
           style={{
             verticalAlign: 'middle',
             marginRight: '5px',
-            borderRadius: '20px',
+            borderRadius: '5px',
           }}
           tooltipPosition={
-            i >= STYLES.length - 2
+            i >= podStyles.length - 2
               ? i % 2 === 1
                 ? 'top-start'
                 : 'top-end'
@@ -53,7 +52,7 @@ export function StylePage(props) {
           width="45px"
         >
           <Box
-            className={classes(['supplypods64x64', 'pod_asset' + (i + 1)])}
+            className={classes(['supplypods64x64', 'pod_asset' + page.id])}
             style={{
               pointerEvents: 'none',
               transform: 'rotate(45deg) translate(-25%,-10%)',

--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher/constants.ts
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher/constants.ts
@@ -129,23 +129,6 @@ export const SOUNDS = [
   },
 ];
 
-export const STYLES = [
-  { title: 'Standard' },
-  { title: 'Advanced' },
-  { title: 'Nanotrasen' },
-  { title: 'Syndicate' },
-  { title: 'Deathsquad' },
-  { title: 'Cultist' },
-  { title: 'Missile' },
-  { title: 'Syndie Missile' },
-  { title: 'Supply Box' },
-  { title: 'Clown Pod' },
-  { title: 'Fruit' },
-  { title: 'Invisible' },
-  { title: 'Gondola' },
-  { title: 'Seethrough' },
-] as const;
-
 export const BAYS = [
   { title: '1' },
   { title: '2' },

--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher/types.ts
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher/types.ts
@@ -44,7 +44,8 @@ export type PodLauncherData = {
   shrapnelMagnitude: number;
   shrapnelType: string;
   soundVolume: number;
-  styleChoice: number;
+  styleChoice: string;
+  podStyles: Array<Record<string, string>>;
 };
 
 export type PodDelay = {


### PR DESCRIPTION
## About The Pull Request

Changes supply pods to use datums instead of a massive nested list to store data and index defines as styles. Complete feature parity.

## Why It's Good For The Game
this is nightmare fuel to work with
![image](https://github.com/user-attachments/assets/851ea009-508b-4958-996e-d46a758b2f62)

and this is a sin against nature and god
![image](https://github.com/user-attachments/assets/6b0cd374-1305-4fe6-9ab6-4912c9cb4461)
![image](https://github.com/user-attachments/assets/88c83f60-af9d-4ea9-af5f-c0810a6d9c66)
ends up as
![image](https://github.com/user-attachments/assets/2cb9e264-895d-49b9-b228-e04ac1353ba1)
which is ???

Using a nested list to store pod data is a very bad idea, it has horrible formatting, is unreadable without having index defines open in a second tab and is not extendable. And as you can see above, if someone added another pod type before 14th everything would break because other pod type lists **__only have 8 elements__** instead of 10 like the seethrough one does.

## Changelog
:cl:
refactor: Pod code now uses datums instead of being a huge nested list
/:cl:
