### PR TITLE
Fixes kinesis runtime due to un-unregistering signals

### DIFF
--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -180,6 +180,7 @@
 	if(playsound)
 		playsound(grabbed_atom, 'sound/effects/empulse.ogg', 75, TRUE)
 	STOP_PROCESSING(SSfastprocess, src)
+	UnregisterSignal(grabbed_atom, list(COMSIG_MOB_STATCHANGE, COMSIG_MOVABLE_SET_ANCHORED))
 	kinesis_catcher = null
 	mod.wearer.clear_fullscreen("kinesis")
 	grabbed_atom.cut_overlay(kinesis_icon)


### PR DESCRIPTION

## About The Pull Request

Kinesis MODsuit module currently runtimes if you try to grab an item you already grabbed and released before because the signals aren't unregistered.

## Changelog
:cl:
fix: Fixed kinesis runtime due to un-unregistered signals
/:cl:
