### PR TITLE
Elevator music no longer haunts you endlessly if you step off mid-transit

### DIFF
--- a/code/modules/transport/elevator/elev_music_zone.dm
+++ b/code/modules/transport/elevator/elev_music_zone.dm
@@ -83,8 +83,6 @@ GLOBAL_LIST_EMPTY(elevator_music)
 /datum/proximity_monitor/advanced/elevator_music_area/field_turf_uncrossed(mob/exited, turf/old_location, turf/new_location)
 	if (!(exited in tracked_mobs))
 		return
-	if (exited.z == host.z && get_dist(exited, host) <= current_range)
-		return
 	qdel(tracked_mobs[exited])
 	tracked_mobs -= exited
 	UnregisterSignal(exited, COMSIG_QDELETING)


### PR DESCRIPTION

## About The Pull Request

Closes #76043
Z level check in an elevator backfired. There is no case where this check actually needs to exist, if a mob stepped off the tracked tile it should get freed from elevator music torture no matter what.

## Changelog
:cl:
fix: Elevator music no longer haunts you endlessly if you step off mid-transit
/:cl:
