### PR TITLE
Jetpacks on sec mods are pinned by default

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -171,6 +171,9 @@
 		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/headprotector,
 	)
+	default_pins = list(
+		/obj/item/mod/module/jetpack,
+	)
 
 /obj/item/mod/control/pre_equipped/safeguard
 	theme = /datum/mod_theme/safeguard


### PR DESCRIPTION

## About The Pull Request

Sec mods didn't have their jetpacks pinned by default, like on the rest of the mods

## Why It's Good For The Game

consistency and quality of life is good

## Changelog
:cl:
qol: secmods jetpacks are now pinned by default
/:cl:
