### PR TITLE
Fixes shuttle events sometimes killing everyone

### DIFF
--- a/code/modules/shuttle/shuttle_events/_shuttle_events.dm
+++ b/code/modules/shuttle/shuttle_events/_shuttle_events.dm
@@ -69,6 +69,11 @@
 	var/list/target_corner //Top left or bottom right corner
 	var/list/spawn_offset //bounding_coords is ONLY the shuttle, not the space around it, so offset spawn_tiles or stuff spawns on the walls of the shuttle
 
+	// Bounding coords sticky to either the top right or bottom left corner of the template, depending on proximity to docking port
+	// If we sticky to the bottom right corner, then [1] and [2] will be the bottom right corner, so we need to invert it
+	if(bounding_coords[1] > bounding_coords[3])
+		bounding_coords = list(bounding_coords[3], bounding_coords[4], bounding_coords[1], bounding_coords[2])
+
 	switch(direction)
 		if(NORTH) //we're travelling north (so people get pushed south)
 			step_dir = list(1, 0)
@@ -100,7 +105,6 @@
 			var/corner_delta = list(bounding_coords[3] - bounding_coords[1], bounding_coords[2] - bounding_coords[4])
 			//Get the corner tile, but jump over the shuttle and then continue unto the cordon
 			spawning_turfs_miss.Add(locate(target_corner[1] + corner_delta[1] * step_dir[1] + step_dir[1] * i + spawn_offset[1], target_corner[2] + corner_delta[2] * step_dir[2] + step_dir[2] * i + spawn_offset[2], port.z))
-
 
 /datum/shuttle_event/simple_spawner/event_process()
 	. = ..()


### PR DESCRIPTION
FINALLY, MY ARCH NEMESIS DEFEATED!!

Below is nebula with a docking port close to the top left, where it grabs the closest corner, the top left. The green area is the designated no_hit zone, where stuff spawns when they dont want to hit the shuttle

![image](https://github.com/user-attachments/assets/374b140a-b733-4253-80fc-498967513617)

I lied. Because nebula's docking port is actually here
![image](https://github.com/user-attachments/assets/c0991c0f-1095-4d93-b31b-9f5e28fe53a4)

So the bounds proc snaps to the bottom right, and reports that back as the top left corner, erroneously assuming the entire inside of the shuttle is the place to spawn meteors

![image](https://github.com/user-attachments/assets/e4e5aef8-65f9-488b-a44f-836cf64adda8)

The fix I've added just double checks if the top left is the top left, and corrects itself to the correct corner

Fixes #85030, #84994, #80227 

:cl:
fix: Shuttle events meteors now dont sometimes kill everyone
/:cl:
