### PR TITLE
Removes Deprecated Clock Cult Tcomms Connection

### DIFF
--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -63,7 +63,6 @@
 		"s_relay",
 		"m_relay",
 		"r_relay",
-		"h_relay",
 		"science",
 		"medical",
 		"supply",


### PR DESCRIPTION

## About The Pull Request

Removes an autoconnection for the Telecomms relay (`h_relay`) originally designed for the Clock Cult in #29741, which was not removed when Clock Cult was removed.
## Why It's Good For The Game
Cleans up unused connections in telecomms code, which can be confusing enough without leftover changes from 2017.
## Changelog
No player facing changes.
