### PR TITLE
Bodypart overlays provide emissive blockers

### DIFF
--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -9,11 +9,22 @@
 	///Key of the icon states of all the sprite_datums for easy caching
 	var/cache_key = ""
 
+	/// Whether the overlay blocks emissive light
+	var/blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+
 ///Wrapper for getting the proper image, colored and everything
 /datum/bodypart_overlay/proc/get_overlay(layer, obj/item/bodypart/limb)
 	layer = bitflag_to_layer(layer)
-	. = get_image(layer, limb)
-	color_image(., layer, limb)
+	var/image/main_image = get_image(layer, limb)
+	color_image(main_image, layer, limb)
+	if(blocks_emissive == EMISSIVE_BLOCK_NONE)
+		return main_image
+
+	var/list/all_images = list(
+		main_image,
+		emissive_blocker(main_image.icon, main_image.icon_state, limb, layer = main_image.layer, alpha = main_image.alpha)
+	)
+	return all_images
 
 ///Generate the image. Needs to be overriden
 /datum/bodypart_overlay/proc/get_image(layer, obj/item/bodypart/limb)

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -17,7 +17,7 @@
 	layer = bitflag_to_layer(layer)
 	var/image/main_image = get_image(layer, limb)
 	color_image(main_image, layer, limb)
-	if(blocks_emissive == EMISSIVE_BLOCK_NONE)
+	if(blocks_emissive == EMISSIVE_BLOCK_NONE || !limb)
 		return main_image
 
 	var/list/all_images = list(

--- a/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
@@ -19,5 +19,6 @@
 	return "[type]"
 
 /datum/bodypart_overlay/texture/spacey
+	blocks_emissive = EMISSIVE_BLOCK_NONE
 	texture_icon_state = "spacey"
 	texture_icon = 'icons/mob/human/textures.dmi'


### PR DESCRIPTION
## About The Pull Request

Fixes #85035

`/datum/bodypart_overlay`s provides emissive blockers for their overlays

![image](https://github.com/user-attachments/assets/fcb02219-7209-4f9f-81d9-5380d8588dca)

## Changelog

:cl: Melbert
fix: Non-humans should look less transparent while in space
/:cl:

