### PR TITLE
Fixes immerse holding refs to qdeleted things

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -107,6 +107,8 @@
  */
 /datum/element/immerse/proc/on_init_or_entered(turf/source, atom/movable/movable)
 	SIGNAL_HANDLER
+	if(QDELETED(movable))
+		return
 	if(HAS_TRAIT(movable, TRAIT_IMMERSED))
 		return
 	if(movable.layer >= ABOVE_ALL_MOB_LAYER || !ISINRANGE(movable.plane, MUTATE_PLANE(FLOOR_PLANE, source), MUTATE_PLANE(GAME_PLANE, source)))


### PR DESCRIPTION
## About The Pull Request

Tin, should fix the following hard del and prevent similar instances:

![image](https://github.com/user-attachments/assets/816a9d1f-8590-46cb-a518-5bb2a4f7e2c9)

There was nothing stopping something that was qdeleted from potentially being 'immersed' which is definitely not something that we ever want to be happening.

## Why It's Good For The Game

Spurious CI failures are annoying

## Changelog

Nothing player facing