### PR TITLE
Monkification fixes

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -258,8 +258,8 @@
 /datum/mutation/human/race
 	name = "Monkified"
 	desc = "A strange genome, believing to be what differentiates monkeys from humans."
-	text_gain_indication = "You feel unusually monkey-like."
-	text_lose_indication = "You feel like your old self."
+	text_gain_indication = span_green("You feel unusually monkey-like.")
+	text_lose_indication = span_notice("You feel like your old self.")
 	quality = NEGATIVE
 	instability = NEGATIVE_STABILITY_MAJOR // mmmonky
 	remove_on_aheal = FALSE
@@ -269,18 +269,24 @@
 	var/original_name
 
 /datum/mutation/human/race/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
+	if(ismonkey(owner))
+		return TRUE
+	. = ..()
+	if(.)
 		return
-	if(!ismonkey(owner))
-		original_species = owner.dna.species.type
-		original_name = owner.real_name
-		owner.fully_replace_character_name(null, "monkey ([rand(1,999)])")
-	. = owner.monkeyize()
+	original_species = owner.dna.species.type
+	original_name = owner.real_name
+	owner.monkeyize()
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/human/owner)
-	if(!QDELETED(owner) && owner.stat != DEAD && (owner.dna.mutations.Remove(src)) && ismonkey(owner))
-		owner.fully_replace_character_name(null, original_name)
-		. = owner.humanize(original_species)
+	. = ..()
+	if(.)
+		return
+	if(QDELETED(owner) || owner.stat == DEAD)
+		return
+
+	owner.fully_replace_character_name(null, original_name)
+	owner.humanize(original_species)
 
 /datum/mutation/human/glow
 	name = "Glowy"

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -1,7 +1,7 @@
 #define MONKEY_SPEC_ATTACK_BITE_MISS_CHANCE 25
 
 /datum/species/monkey
-	name = "Monkey"
+	name = "\improper Monkey"
 	id = SPECIES_MONKEY
 	external_organs = list(
 		/obj/item/organ/external/tail/monkey = "Monkey",

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -17,7 +17,7 @@
 
 	//Make mob invisible and spawn animation
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
-	Paralyze(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
+	Stun(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
 
@@ -29,12 +29,12 @@
 
 /mob/living/carbon/proc/finish_monkeyize()
 	transformation_timer = null
-	to_chat(src, span_boldnotice("You are now a monkey."))
 	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	icon = initial(icon)
 	RemoveInvisibility(type)
 	set_species(/datum/species/monkey)
-	name = "monkey"
+	to_chat(src, span_boldnotice("You are now \a [dna.species.name]."))
+	name = LOWER_TEXT(dna.species.name)
 	regenerate_icons()
 	set_name()
 	SEND_SIGNAL(src, COMSIG_HUMAN_MONKEYIZE)
@@ -57,7 +57,7 @@
 
 	//Make mob invisible and spawn animation
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
-	Paralyze(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
+	Stun(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
 
@@ -70,15 +70,15 @@
 
 /mob/living/carbon/proc/finish_humanize(species = /datum/species/human)
 	transformation_timer = null
-	to_chat(src, span_boldnotice("You are now a human."))
 	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	icon = initial(icon)
 	RemoveInvisibility(type)
 	set_species(species)
+	to_chat(src, span_boldnotice("You are now \a [dna.species.name]."))
 	SEND_SIGNAL(src, COMSIG_MONKEY_HUMANIZE)
 	return src
 
-/mob/living/carbon/human/finish_humanize(species = /datum/species/human, instant = FALSE)
+/mob/living/carbon/human/finish_humanize(species = /datum/species/human)
 	underwear = "Nude"
 	undershirt = "Nude"
 	socks = "Nude"


### PR DESCRIPTION
## About The Pull Request

- Being monkified / humanified no longer knocks you down
   - Fairly certain this was one of the consequences of the stun refactors of ages past, using `Paralyze` rather than `Stun`.
- Having monkifiaction cured now gives you the cure text
   - Didn't call parent for some reason
- Monkification grant / cure text now has spans
   - Self evident
- Being humanified now tells you what species you are rather than you're "Human" 
   - Just a small tweak
  
## Changelog

:cl: Melbert
fix: When Monkified or Humanified, you are no longer knocked down.
fix: When cured of Monkified, you get the cure text now. 
fix: The text shown when cured / given Monkification now has color. 
fix: Being humanified now tells you what species you become rather than assuming you are a human.
/:cl:


