### PR TITLE
Cleans up clamp code, makes kill clamp actually work, fixes anchor resetting issues

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -53,13 +53,13 @@
 		return
 
 	if(istype(target, /obj/machinery/door/firedoor))
-		var/obj/machinery/door/firedoor/targetfiredoor = clamptarget
+		var/obj/machinery/door/firedoor/targetfiredoor = target
 		playsound(chassis, clampsound, 50, FALSE, -6)
 		targetfiredoor.try_to_crowbar(src, source)
 		return ..()
 
 	if(istype(target, /obj/machinery/door/airlock))
-		var/obj/machinery/door/airlock/targetairlock = clamptarget
+		var/obj/machinery/door/airlock/targetairlock = target
 		playsound(chassis, clampsound, 50, FALSE, -6)
 		targetairlock.try_to_crowbar(src, source, TRUE)
 		return ..()
@@ -104,10 +104,7 @@
 			span_notice("[chassis] pushes you aside."))
 		return ..()
 
-	if(LAZYACCESS(modifiers, RIGHT_CLICK) && iscarbon(victim))//meme clamp here
-		if(!killer_clamp)
-			to_chat(source, span_notice("You longingly wish to tear [victim]'s arms off."))
-			return
+	if(iscarbon(victim))//meme clamp here
 		var/mob/living/carbon/carbon_victim = target
 		var/torn_off = FALSE
 		var/obj/item/bodypart/affected = carbon_victim.get_bodypart(BODY_ZONE_L_ARM)
@@ -118,14 +115,12 @@
 		if(affected != null)
 			affected.dismember(damtype)
 			torn_off = TRUE
-		if(!torn_off)
-			to_chat(source, span_notice("[carbon_victim]'s arms are already torn off, you must find a challenger worthy of the kill clamp!"))
-			return
-		playsound(src, get_dismember_sound(), 80, TRUE)
-		carbon_victim.visible_message(span_danger("[chassis] rips [carbon_victim]'s arms off!"), \
-					span_userdanger("[chassis] rips your arms off!"))
-		log_combat(source, carbon_victim, "removed both arms with a real clamp,", "[name]", "(COMBAT MODE: [uppertext(source.combat_mode)] (DAMTYPE: [uppertext(damtype)])")
-		return ..()
+		if(torn_off)
+			playsound(src, get_dismember_sound(), 80, TRUE)
+			carbon_victim.visible_message(span_danger("[chassis] rips [carbon_victim]'s arms off!"), \
+						span_userdanger("[chassis] rips your arms off!"))
+			log_combat(source, carbon_victim, "removed both arms with a real clamp,", "[name]", "(COMBAT MODE: [uppertext(source.combat_mode)] (DAMTYPE: [uppertext(damtype)])")
+			return ..()
 
 	victim.take_overall_damage(clamp_damage)
 	if(isnull(victim)) //get gibbed stoopid

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -52,16 +52,10 @@
 			to_chat(source, "No providable supplies found in cargo hold")
 		return
 
-	if(istype(target, /obj/machinery/door/firedoor))
-		var/obj/machinery/door/firedoor/targetfiredoor = target
+	if(istype(target, /obj/machinery/door/firedoor) || istype(target, /obj/machinery/door/airlock))
+		var/obj/machinery/door/target_door = target
 		playsound(chassis, clampsound, 50, FALSE, -6)
-		targetfiredoor.try_to_crowbar(src, source)
-		return ..()
-
-	if(istype(target, /obj/machinery/door/airlock))
-		var/obj/machinery/door/airlock/targetairlock = target
-		playsound(chassis, clampsound, 50, FALSE, -6)
-		targetairlock.try_to_crowbar(src, source, TRUE)
+		target_door.try_to_crowbar(src, source)
 		return ..()
 
 	if(isobj(target))

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -37,6 +37,7 @@
 		return
 	if(!workmech.cargo_hold)
 		CRASH("Mech [chassis] has a clamp device, but no internal storage. This should be impossible.")
+
 	if(ismecha(target))
 		var/obj/vehicle/sealed/mecha/M = target
 		var/have_ammo
@@ -44,24 +45,27 @@
 			if(istype(box, /obj/item/mecha_ammo) && box.rounds)
 				have_ammo = TRUE
 				if(M.ammo_resupply(box, source, TRUE))
-					return
+					return ..()
 		if(have_ammo)
 			to_chat(source, "No further supplies can be provided to [M].")
 		else
 			to_chat(source, "No providable supplies found in cargo hold")
+		return
 
-	else if(isobj(target))
+	if(istype(target, /obj/machinery/door/firedoor))
+		var/obj/machinery/door/firedoor/targetfiredoor = clamptarget
+		playsound(chassis, clampsound, 50, FALSE, -6)
+		targetfiredoor.try_to_crowbar(src, source)
+		return ..()
+
+	if(istype(target, /obj/machinery/door/airlock))
+		var/obj/machinery/door/airlock/targetairlock = clamptarget
+		playsound(chassis, clampsound, 50, FALSE, -6)
+		targetairlock.try_to_crowbar(src, source, TRUE)
+		return ..()
+
+	if(isobj(target))
 		var/obj/clamptarget = target
-		if(istype(clamptarget, /obj/machinery/door/firedoor))
-			var/obj/machinery/door/firedoor/targetfiredoor = clamptarget
-			playsound(chassis, clampsound, 50, FALSE, -6)
-			targetfiredoor.try_to_crowbar(src, source)
-			return
-		if(istype(clamptarget, /obj/machinery/door/airlock/))
-			var/obj/machinery/door/airlock/targetairlock = clamptarget
-			playsound(chassis, clampsound, 50, FALSE, -6)
-			targetairlock.try_to_crowbar(src, source, TRUE)
-			return
 		if(clamptarget.anchored)
 			to_chat(source, "[icon2html(src, source)][span_warning("[target] is firmly secured!")]")
 			return
@@ -72,65 +76,67 @@
 		chassis.visible_message(span_notice("[chassis] lifts [target] and starts to load it into cargo compartment."))
 		clamptarget.set_anchored(TRUE)
 		if(!do_after_cooldown(target, source))
-			clamptarget.set_anchored(initial(clamptarget.anchored))
+			clamptarget.set_anchored(FALSE)
 			return
-		clamptarget.forceMove(workmech.cargo_hold)
 		clamptarget.set_anchored(FALSE)
+		clamptarget.forceMove(workmech.cargo_hold)
 		if(!chassis.ore_box && istype(clamptarget, /obj/structure/ore_box))
 			chassis.ore_box = clamptarget
 		to_chat(source, "[icon2html(src, source)][span_notice("[target] successfully loaded.")]")
 		log_message("Loaded [clamptarget]. Cargo compartment capacity: [workmech.cargo_hold.cargo_capacity - workmech.cargo_hold.contents.len]", LOG_MECHA)
+		return ..()
 
-	else if(isliving(target))
-		var/mob/living/M = target
-		if(M.stat == DEAD)
+	if(!isliving(target))
+		return ..()
+
+	var/mob/living/victim = target
+	if(victim.stat == DEAD)
+		return
+
+	if(!source.combat_mode)
+		step_away(victim, chassis)
+		if(killer_clamp)
+			target.visible_message(span_danger("[chassis] tosses [target] like a piece of paper!"), \
+				span_userdanger("[chassis] tosses you like a piece of paper!"))
+		else
+			to_chat(source, "[icon2html(src, source)][span_notice("You push [target] out of the way.")]")
+			chassis.visible_message(span_notice("[chassis] pushes [target] out of the way."), \
+			span_notice("[chassis] pushes you aside."))
+		return ..()
+
+	if(LAZYACCESS(modifiers, RIGHT_CLICK) && iscarbon(victim))//meme clamp here
+		if(!killer_clamp)
+			to_chat(source, span_notice("You longingly wish to tear [victim]'s arms off."))
 			return
-
-		if(!source.combat_mode)
-			step_away(M,chassis)
-			if(killer_clamp)
-				target.visible_message(span_danger("[chassis] tosses [target] like a piece of paper!"), \
-					span_userdanger("[chassis] tosses you like a piece of paper!"))
-			else
-				to_chat(source, "[icon2html(src, source)][span_notice("You push [target] out of the way.")]")
-				chassis.visible_message(span_notice("[chassis] pushes [target] out of the way."), \
-				span_notice("[chassis] pushes you aside."))
-			return ..()
-		else if(LAZYACCESS(modifiers, RIGHT_CLICK) && iscarbon(M))//meme clamp here
-			if(!killer_clamp)
-				to_chat(source, span_notice("You longingly wish to tear [M]'s arms off."))
-				return
-			var/mob/living/carbon/C = target
-			var/torn_off = FALSE
-			var/obj/item/bodypart/affected = C.get_bodypart(BODY_ZONE_L_ARM)
-			if(affected != null)
-				affected.dismember(damtype)
-				torn_off = TRUE
-			affected = C.get_bodypart(BODY_ZONE_R_ARM)
-			if(affected != null)
-				affected.dismember(damtype)
-				torn_off = TRUE
-			if(!torn_off)
-				to_chat(source, span_notice("[M]'s arms are already torn off, you must find a challenger worthy of the kill clamp!"))
-				return
-			playsound(src, get_dismember_sound(), 80, TRUE)
-			target.visible_message(span_danger("[chassis] rips [target]'s arms off!"), \
-						span_userdanger("[chassis] rips your arms off!"))
-			log_combat(source, M, "removed both arms with a real clamp,", "[name]", "(COMBAT MODE: [uppertext(source.combat_mode)] (DAMTYPE: [uppertext(damtype)])")
-			return ..()
-
-		M.take_overall_damage(clamp_damage)
-		if(!M) //get gibbed stoopid
+		var/mob/living/carbon/carbon_victim = target
+		var/torn_off = FALSE
+		var/obj/item/bodypart/affected = carbon_victim.get_bodypart(BODY_ZONE_L_ARM)
+		if(affected != null)
+			affected.dismember(damtype)
+			torn_off = TRUE
+		affected = carbon_victim.get_bodypart(BODY_ZONE_R_ARM)
+		if(affected != null)
+			affected.dismember(damtype)
+			torn_off = TRUE
+		if(!torn_off)
+			to_chat(source, span_notice("[carbon_victim]'s arms are already torn off, you must find a challenger worthy of the kill clamp!"))
 			return
-		M.adjustOxyLoss(round(clamp_damage/2))
-		M.updatehealth()
-		target.visible_message(span_danger("[chassis] squeezes [target]!"), \
-							span_userdanger("[chassis] squeezes you!"),\
-							span_hear("You hear something crack."))
-		log_combat(source, M, "attacked", "[name]", "(Combat mode: [source.combat_mode ? "On" : "Off"]) (DAMTYPE: [uppertext(damtype)])")
+		playsound(src, get_dismember_sound(), 80, TRUE)
+		carbon_victim.visible_message(span_danger("[chassis] rips [carbon_victim]'s arms off!"), \
+					span_userdanger("[chassis] rips your arms off!"))
+		log_combat(source, carbon_victim, "removed both arms with a real clamp,", "[name]", "(COMBAT MODE: [uppertext(source.combat_mode)] (DAMTYPE: [uppertext(damtype)])")
+		return ..()
+
+	victim.take_overall_damage(clamp_damage)
+	if(isnull(victim)) //get gibbed stoopid
+		return ..()
+	victim.adjustOxyLoss(round(clamp_damage/2))
+	victim.updatehealth()
+	victim.visible_message(span_danger("[chassis] squeezes [victim]!"), \
+						span_userdanger("[chassis] squeezes you!"),\
+						span_hear("You hear something crack."))
+	log_combat(source, victim, "attacked", "[name]", "(Combat mode: [source.combat_mode ? "On" : "Off"]) (DAMTYPE: [uppertext(damtype)])")
 	return ..()
-
-
 
 //This is pretty much just for the death-ripley
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill


### PR DESCRIPTION
## About The Pull Request
Kill clamp tries to squeeze carbons on RMB except LMB/RMB are now responsible for left/right arm equipment, making it only work on right arm. So, now kill clamp always dismembers if possible - doing a normal attack otherwise (funny text had to be sacrificed for it)

Additionally, leans up clamp action() code, added early returns and removed one-letter variables. Ensures that parent calls (for cooldown and comsigs) are called where appropriate (clamp achieved some effect) and changed it so clamped objects are no longer set to their initial anchored value (FALSE instead, as the object has to be unanchored for the clamp to be able to affect it) since that would anchor a lot of things upon failing to pick them up.

Closes #67580

## Changelog
:cl:
code: Cleaned up clamp code.
fix: Clamp no longer anchors down some objects upon failing to pick them up
fix: Deathsquad KILL CLAMP finally works once more
/:cl:
