### PR TITLE
Fixed a signal reg error caused by add_occupant being called twice

### DIFF
--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -41,7 +41,6 @@
 		return FALSE
 	if(ishuman(newoccupant) && !Adjacent(newoccupant))
 		return FALSE
-	add_occupant(newoccupant)
 	mecha_flags &= ~PANEL_OPEN //Close panel if open
 	newoccupant.forceMove(src)
 	newoccupant.update_mouse_pointer()


### PR DESCRIPTION

## About The Pull Request

Parent proc in the chain already calls add_occupant, resulting in signals being assigned twice which threw an error

## Changelog
:cl:
fix: Fixed a signal reg error caused by add_occupant being called twice
/:cl:
