### PR TITLE
Make chem dispenser display units instead of kilowatts

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -211,8 +211,8 @@
 	.["amount"] = amount
 	.["energy"] = cell.charge ? cell.charge : 0 //To prevent NaN in the UI.
 	.["maxEnergy"] = cell.maxcharge
-	.["displayedEnergy"] = display_energy(cell.charge)
-	.["displayedMaxEnergy"] = display_energy(cell.maxcharge)
+	.["displayedUnits"] = cell.charge ? (cell.charge / power_cost) : 0
+	.["displayedMaxUnits"] = cell.maxcharge / power_cost
 	.["showpH"] = isnull(recording_recipe) ? show_ph : FALSE //virtual beakers have no ph to compute & display
 
 	var/list/chemicals = list()

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -30,8 +30,8 @@ type Data = {
   amount: number;
   energy: number;
   maxEnergy: number;
-  displayedEnergy: string;
-  displayedMaxEnergy: string;
+  displayedUnits: string;
+  displayedMaxUnits: string;
   chemicals: DispensableReagent[];
   recipes: string[];
   recordingRecipe: string[];
@@ -93,7 +93,10 @@ export const ChemDispenser = (props) => {
           <LabeledList>
             <LabeledList.Item label="Energy">
               <ProgressBar value={data.energy / data.maxEnergy}>
-                {data.displayedEnergy + ' / ' + data.displayedMaxEnergy}
+                {data.displayedUnits +
+                  ' / ' +
+                  data.displayedMaxUnits +
+                  ' units'}
               </ProgressBar>
             </LabeledList.Item>
           </LabeledList>


### PR DESCRIPTION

## About The Pull Request
Makes the chem dispenser display units instead of kilowatts
![image](https://github.com/user-attachments/assets/d102bf66-3480-4e5c-9f4a-6711c7a6ce57)
## Why It's Good For The Game
Chemists use units in their work instead of kilowatts
## Changelog
:cl:
qol: chem dispenser displays units instead of kilowatts
/:cl:
