### PR TITLE
Blob delta now spawns non-ghost controllable spores

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -206,7 +206,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			if(live_guy.stat != DEAD)
 				live_guy.investigate_log("has died from blob takeover.", INVESTIGATE_DEATHS)
 			live_guy.death()
-			create_spore(guy_turf)
+			create_spore(guy_turf, spore_type = /mob/living/basic/blob_minion/spore)
 		else
 			live_guy.fully_heal()
 


### PR DESCRIPTION

## About The Pull Request

Closes #85075
Everyone is dead, round has ended, no point in spamming screeching to ghosts about a hundred new spore zombies

## Changelog
:cl:
fix: Blob victory no longer spams spore zombie notifications to ghosts
/:cl:
