### PR TITLE
Power cell overlay now updates when exiting an object's contents

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -147,7 +147,6 @@
 	if(!cell || !cell_removable)
 		return FALSE
 
-	cell.update_appearance()
 	cell.forceMove(get_turf(src))
 	balloon_alert(user, "removed [cell]")
 	cell = null

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -504,7 +504,6 @@
 /obj/item/melee/baton/security/Exited(atom/movable/mov_content)
 	. = ..()
 	if(mov_content == cell)
-		cell.update_appearance()
 		cell = null
 		active = FALSE
 		update_appearance()

--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -517,7 +517,6 @@ GLOBAL_LIST_INIT(command_strings, list(
 	if(istype(item_to_drop, /obj/item/stock_parts/power_store/cell))
 		var/obj/item/stock_parts/power_store/cell/dropped_cell = item_to_drop
 		dropped_cell.charge = 0
-		dropped_cell.update_appearance()
 		return
 
 	if(istype(item_to_drop, /obj/item/storage))

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -214,7 +214,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	if(!wiresexposed && !issilicon(user))
 		if(!cell)
 			return
-		cell.update_appearance()
 		cell.add_fingerprint(user)
 		to_chat(user, span_notice("You remove \the [cell]."))
 		user.put_in_active_hand(cell)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -556,7 +556,6 @@
 	if(istype(item_to_drop, /obj/item/stock_parts/power_store/cell))
 		var/obj/item/stock_parts/power_store/cell/dropped_cell = item_to_drop
 		dropped_cell.charge = 0
-		dropped_cell.update_appearance()
 
 	else if(istype(item_to_drop, /obj/item/storage))
 		var/obj/item/storage/storage_to_drop = item_to_drop

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -757,7 +757,6 @@
 	new /obj/item/stack/cable_coil/cut(Tsec)
 	if(cell)
 		cell.forceMove(Tsec)
-		cell.update_appearance()
 		cell = null
 
 	new /obj/effect/decal/cleanable/oil(loc)

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -173,7 +173,6 @@
 /obj/item/mod/core/standard/proc/uninstall_cell()
 	if(!cell)
 		return
-	cell.update_appearance()
 	cell = null
 	mod.update_charge_alert()
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -310,7 +310,6 @@
 /obj/machinery/power/apc/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == cell)
-		cell.update_appearance()
 		cell = null
 		charging = APC_NOT_CHARGING
 		update_appearance()

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -320,7 +320,6 @@
 		balloon_alert(user, "cell removed")
 		var/turf/user_turf = get_turf(user)
 		cell.forceMove(user_turf)
-		cell.update_appearance()
 		cell = null
 		charging = APC_NOT_CHARGING
 		update_appearance()

--- a/code/modules/power/lighting/light_construct.dm
+++ b/code/modules/power/lighting/light_construct.dm
@@ -63,7 +63,6 @@
 		return
 	user.visible_message(span_notice("[user] removes [cell] from [src]!"), span_notice("You remove [cell]."))
 	user.put_in_hands(cell)
-	cell.update_appearance()
 	cell = null
 	add_fingerprint(user)
 

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -60,7 +60,7 @@
 
 /obj/item/stock_parts/power_store/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
-	if(!isobj(loc))
+	if(!isturf(old_loc))
 		update_appearance()
 
 

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -57,6 +57,13 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
+
+/obj/item/stock_parts/power_store/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
+	. = ..()
+	if(!isobj(loc))
+		update_appearance()
+
+
 /**
  * Signal proc for [COMSIG_ITEM_MAGICALLY_CHARGED]
  *
@@ -162,7 +169,6 @@
 	if(!force && charge < used)
 		return 0
 	charge -= power_used
-	update_appearance()
 	if(!istype(loc, /obj/machinery/power/apc))
 		SSblackbox.record_feedback("tally", "cell_used", 1, type)
 	return power_used
@@ -174,7 +180,6 @@
 /obj/item/stock_parts/power_store/proc/give(amount)
 	var/power_used = min(maxcharge-charge,amount)
 	charge += power_used
-	update_appearance()
 	if(rigged && amount > 0)
 		explode()
 	return power_used
@@ -188,7 +193,6 @@
 /obj/item/stock_parts/power_store/proc/change(amount)
 	var/energy_used = clamp(amount, -charge, maxcharge - charge)
 	charge += energy_used
-	update_appearance()
 	if(rigged && energy_used)
 		explode()
 	return energy_used

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -162,6 +162,7 @@
 	if(!force && charge < used)
 		return 0
 	charge -= power_used
+	update_appearance()
 	if(!istype(loc, /obj/machinery/power/apc))
 		SSblackbox.record_feedback("tally", "cell_used", 1, type)
 	return power_used
@@ -173,6 +174,7 @@
 /obj/item/stock_parts/power_store/proc/give(amount)
 	var/power_used = min(maxcharge-charge,amount)
 	charge += power_used
+	update_appearance()
 	if(rigged && amount > 0)
 		explode()
 	return power_used
@@ -186,6 +188,7 @@
 /obj/item/stock_parts/power_store/proc/change(amount)
 	var/energy_used = clamp(amount, -charge, maxcharge - charge)
 	charge += energy_used
+	update_appearance()
 	if(rigged && energy_used)
 		explode()
 	return energy_used

--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -91,7 +91,6 @@
 
 /obj/item/reagent_containers/cup/maunamug/attack_hand(mob/living/user, list/modifiers)
 	if(cell && open)
-		cell.update_appearance()
 		user.put_in_hands(cell)
 		cell = null
 		to_chat(user, span_notice("You remove the power cell from [src]."))

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -100,7 +100,6 @@
 /obj/vehicle/ridden/wheelchair/motorized/attack_hand(mob/living/user, list/modifiers)
 	if(!power_cell || !panel_open)
 		return ..()
-	power_cell.update_appearance()
 	to_chat(user, span_notice("You remove [power_cell] from [src]."))
 	user.put_in_hands(power_cell)
 	power_cell = null


### PR DESCRIPTION
## About The Pull Request
The charge indicator overlay on power cells is now properly updated when the cell is charged/discharged. Before, you could use a power cell until it's empty and the overlay wouldn't change at all.
## Why It's Good For The Game
The overlay is there to indicate the charge of the cell. It should work.
## Changelog
:cl:
fix: The charge indicators on power cells now work properly.
code: Removed some now redundant power cell appearance updates
/:cl:
