### PR TITLE
Fix(?) announcement subheader overlapping on long title

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1028,7 +1028,6 @@ $border-width-px: $border-width * 1px;
   padding-top: 0.25rem;
   line-height: 100%;
   width: 100%;
-  height: 100%;
   text-align: left;
   font-size: 125%;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1055,7 +1055,6 @@ $border-width-px: $border-width * 1px;
   padding-top: 0.25rem;
   line-height: 100%;
   width: 100%;
-  height: 100%;
   text-align: left;
   font-size: 125%;
 }


### PR DESCRIPTION
## About The Pull Request
The title says it all, so I'll just attach a before and after comparison
I'm not sure if removing two lines can be called a fix, but anyway

| Before | After |
| - | - |
| ![dreamseeker_0c1iRuFBJm](https://github.com/user-attachments/assets/cf50a184-76c0-4ddf-9ec7-d76fa8064cb4) | ![dreamseeker_8alIoMF5Mf](https://github.com/user-attachments/assets/9505e94d-6328-499a-9744-e7fb3447b1cc) |


## Why It's Good For The Game
Very long headers will no longer force subheaders to overlap with it

## Changelog

:cl:
fix: Announcement subheader will no longer overlap the header if the second one is very long
/:cl:
