### PR TITLE
[QoL] Transfer TGchat notifications to the top

### DIFF
--- a/tgui/packages/tgui-panel/reconnect.tsx
+++ b/tgui/packages/tgui-panel/reconnect.tsx
@@ -19,7 +19,6 @@ export const ReconnectButton = () => {
     <>
       <Button
         color="white"
-        icon="history"
         onClick={() => {
           Byond.command('.reconnect');
         }}

--- a/tgui/packages/tgui-panel/reconnect.tsx
+++ b/tgui/packages/tgui-panel/reconnect.tsx
@@ -19,6 +19,7 @@ export const ReconnectButton = () => {
     <>
       <Button
         color="white"
+        icon="history"
         onClick={() => {
           Byond.command('.reconnect');
         }}
@@ -27,13 +28,14 @@ export const ReconnectButton = () => {
       </Button>
       <Button
         color="white"
+        icon="power-off"
+        tooltip="Relaunch game"
+        tooltipPosition="bottom-end"
         onClick={() => {
           location.href = `byond://${url}`;
           Byond.command('.quit');
         }}
-      >
-        Relaunch game
-      </Button>
+      />
     </>
   );
 };

--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,7 +5,7 @@
 
 .Notifications {
   position: absolute;
-  bottom: 1em;
+  top: 1em;
   left: 1em;
   right: 2em;
 }


### PR DESCRIPTION
## About The Pull Request
Right now the notifications are not conveniently located, as when the server is initialised, it is quite problematic to communicate OOC
Actually this inconvenience I would like to solve

Also reconnect/restart buttons have been slightly modified
| Before | After |
| - | - |
| ![dreamseeker_aYyT5cewaz](https://github.com/user-attachments/assets/f5c8089c-2c41-4ff9-a480-aa1cd3b430a5) | ![image](https://github.com/user-attachments/assets/d893c2e6-3e3b-476a-85f3-f0f7a2e74e7d) |


## Why It's Good For The Game
Now you can discuss the last round without waiting for the server to fully initialise

## Changelog

:cl:
qol: Chat notifications are now at the top
/:cl:

