### PR TITLE
Makes vending use DMIcon where possible, halving the time it takes to make the vending spritesheet

### DIFF
--- a/code/modules/asset_cache/assets/vending.dm
+++ b/code/modules/asset_cache/assets/vending.dm
@@ -19,12 +19,14 @@
 		var/icon_file
 		var/icon_state = initial(item.icon_state)
 		var/icon_color = initial(item.color)
-		if (initial(item.greyscale_colors) && initial(item.greyscale_config))
+		// GAGS icons must be pregenerated
+		if(initial(item.greyscale_config) && initial(item.greyscale_colors))
 			icon_file = SSgreyscale.GetColoredIconByType(initial(item.greyscale_config), initial(item.greyscale_colors))
+		// Colored atoms must be pregenerated
 		else if(icon_color && icon_state)
 			icon_file = initial(item.icon)
+		// Otherwise we can rely on DMIcon, so skip it to save init time
 		else
-			// We don't need to make an icon of this, we can fallback to DMIcon to save init time
 			continue
 
 		if (PERFORM_ALL_TESTS(focus_only/invalid_vending_machine_icon_states))

--- a/code/modules/asset_cache/assets/vending.dm
+++ b/code/modules/asset_cache/assets/vending.dm
@@ -6,22 +6,26 @@
 	var/target_items = list()
 	for(var/obj/machinery/vending/vendor as anything in typesof(/obj/machinery/vending))
 		vendor = new vendor() // It seems `initial(list var)` has nothing. need to make a type.
-		for(var/each in list(vendor.products, vendor.premium, vendor.contraband))
-			target_items |= each
+		target_items |= vendor.products
+		target_items |= vendor.premium
+		target_items |= vendor.contraband
 		qdel(vendor)
 
 	// building icons for each item
-	for (var/k in target_items)
-		var/atom/item = k
+	for (var/atom/item as anything in target_items)
 		if (!ispath(item, /atom))
 			continue
 
 		var/icon_file
+		var/icon_state = initial(item.icon_state)
+		var/icon_color = initial(item.color)
 		if (initial(item.greyscale_colors) && initial(item.greyscale_config))
 			icon_file = SSgreyscale.GetColoredIconByType(initial(item.greyscale_config), initial(item.greyscale_colors))
-		else
+		else if(icon_color && icon_state)
 			icon_file = initial(item.icon)
-		var/icon_state = initial(item.icon_state)
+		else
+			// We don't need to make an icon of this, we can fallback to DMIcon to save init time
+			continue
 
 		if (PERFORM_ALL_TESTS(focus_only/invalid_vending_machine_icon_states))
 			var/icon_states_list = icon_states(icon_file)
@@ -36,11 +40,10 @@
 				stack_trace("[item] does not have a valid icon state, icon=[icon_file], icon_state=[json_encode(icon_state)]([text_ref(icon_state)]), icon_states=[icon_states_string]")
 				continue
 
-		var/icon/I = icon(icon_file, icon_state, SOUTH)
-		var/c = initial(item.color)
-		if (!isnull(c) && c != COLOR_WHITE)
-			I.Blend(c, ICON_MULTIPLY)
+		var/icon/produced = icon(icon_file, icon_state, SOUTH)
+		if (!isnull(icon_color) && icon_color != COLOR_WHITE)
+			produced.Blend(icon_color, ICON_MULTIPLY)
 
 		var/imgid = replacetext(replacetext("[item]", "/obj/item/", ""), "/", "-")
 
-		Insert(imgid, I)
+		Insert(imgid, produced)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1259,7 +1259,10 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 
 		var/atom/printed = record.product_path
 		// If it's not GAGS and has no innate colors we have to care about, we use DMIcon
-		if(ispath(printed, /atom) && !initial(printed.greyscale_config) && !initial(printed.color))
+		if(ispath(printed, /atom) \
+			&& (!initial(printed.greyscale_config) || !initial(printed.greyscale_colors)) \
+			&& !initial(printed.color) \
+		)
 			static_record["icon"] = initial(printed.icon)
 			static_record["icon_state"] = initial(printed.icon_state)
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1257,6 +1257,12 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 			ref = REF(record),
 		)
 
+		var/atom/printed = record.product_path
+		// If it's not GAGS and has no innate colors we have to care about, we use DMIcon
+		if(ispath(printed, /atom) && !initial(printed.greyscale_config) && !initial(printed.color))
+			static_record["icon"] = initial(printed.icon)
+			static_record["icon_state"] = initial(printed.icon_state)
+
 		var/list/category = record.category || default_category
 		if (!isnull(category))
 			if (!(category["name"] in categories))

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -14,7 +14,7 @@ import {
 
 import { createSearch } from '../../common/string';
 import { useBackend } from '../backend';
-import { Input } from '../components';
+import { DmIcon, Input } from '../components';
 import { Window } from '../layouts';
 
 type VendingData = {
@@ -45,6 +45,8 @@ type ProductRecord = {
   max_amount: number;
   ref: string;
   category: string;
+  icon?: string;
+  icon_state?: string;
 };
 
 type CoinRecord = ProductRecord & {
@@ -288,20 +290,22 @@ const VendingRow = (props) => {
       (discount ? redPrice : product.price) > user?.cash);
 
   return (
-    <Table.Row>
-      <Table.Cell collapsing>
+    <Table.Row height="32px">
+      <Table.Cell collapsing width="36px">
         <ProductImage product={product} />
       </Table.Cell>
-      <Table.Cell bold>{capitalizeAll(product.name)}</Table.Cell>
-      <Table.Cell>
+      <Table.Cell verticalAlign="middle" bold>
+        {capitalizeAll(product.name)}
+      </Table.Cell>
+      <Table.Cell verticalAlign="middle">
         {!!productStock?.colorable && (
           <ProductColorSelect disabled={disabled} product={product} />
         )}
       </Table.Cell>
-      <Table.Cell collapsing textAlign="right">
+      <Table.Cell collapsing textAlign="right" verticalAlign="middle">
         <ProductStock custom={custom} product={product} remaining={remaining} />
       </Table.Cell>
-      <Table.Cell collapsing textAlign="center">
+      <Table.Cell collapsing textAlign="center" verticalAlign="middle">
         <ProductButton
           custom={custom}
           disabled={disabled}
@@ -319,20 +323,30 @@ const VendingRow = (props) => {
 const ProductImage = (props) => {
   const { product } = props;
 
-  return product.img ? (
-    <img
-      src={`data:image/jpeg;base64,${product.img}`}
-      style={{
-        verticalAlign: 'middle',
-      }}
-    />
-  ) : (
-    <span
-      className={classes(['vending32x32', product.path])}
-      style={{
-        verticalAlign: 'middle',
-      }}
-    />
+  return (
+    <Box width="32px" height="32px">
+      {product.img ? (
+        <img
+          src={`data:image/jpeg;base64,${product.img}`}
+          style={{
+            verticalAlign: 'middle',
+          }}
+        />
+      ) : product.icon && product.icon_state ? (
+        <DmIcon
+          icon={product.icon}
+          icon_state={product.icon_state}
+          fallback={<Icon name="spinner" size={2} spin />}
+        />
+      ) : (
+        <span
+          className={classes(['vending32x32', product.path])}
+          style={{
+            verticalAlign: 'middle',
+          }}
+        />
+      )}
+    </Box>
   );
 };
 
@@ -347,6 +361,7 @@ const ProductColorSelect = (props) => {
     <Button
       icon="palette"
       tooltip="Change color"
+      width="24px"
       disabled={disabled}
       onClick={() => act('select_colors', { ref: product.ref })}
     />


### PR DESCRIPTION
## About The Pull Request

Vending machines use DMIcon to render non-gags, non-colored atoms, which cuts down the time it takes to create the spritesheet by like half

before
```
/datum/asset/spritesheet/vending/create_spritesheets   0.087        0.817        0.816        0.087            1
```
after
```
/datum/asset/spritesheet/vending/create_spritesheets   0.037        0.478        0.477        0.037            1
```

visually, pretty much no difference

![image](https://github.com/user-attachments/assets/dcda7625-ea6a-4098-8006-5d7993a70b69)

## Changelog

:cl: Melbert
refactor: Refactored how vending machine icons are displayed, please report if you see any broken icons. Also if all the icons look like missing file icons for you, you gotta update byond man, you're like a year out of date.
/:cl:

