### PR TITLE
Self-respiration no longer sends misleading messages and instead tells about lack of need to breathe once it actually gives you the effect

### DIFF
--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -44,7 +44,7 @@
 				infected_mob.blood_volume += 1
 		else
 			if(prob(base_message_chance))
-				to_chat(infected_mob, span_notice("[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]"))
+				to_chat(infected_mob, span_notice("Your lungs feel great."))
 	return
 
 /datum/symptom/oxygen/on_stage_change(datum/disease/advance/A)
@@ -54,6 +54,7 @@
 	var/mob/living/carbon/M = A.affected_mob
 	if(A.stage >= 4)
 		ADD_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
+		to_chat(infected_mob, span_notice(pick("You realize you haven't been breathing.", "You don't feel the need to breathe.")))
 	else
 		REMOVE_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
 	return TRUE

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -47,20 +47,20 @@
 				to_chat(infected_mob, span_notice("Your lungs feel great."))
 	return
 
-/datum/symptom/oxygen/on_stage_change(datum/disease/advance/A)
+/datum/symptom/oxygen/on_stage_change(datum/disease/advance/advanced_disease)
 	. = ..()
 	if(!.)
 		return FALSE
-	var/mob/living/carbon/M = A.affected_mob
-	if(A.stage >= 4)
-		ADD_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
+	var/mob/living/carbon/infected_mob = advanced_disease.affected_mob
+	if(advanced_disease.stage >= 4)
+		ADD_TRAIT(infected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)
 		to_chat(infected_mob, span_notice(pick("You realize you haven't been breathing.", "You don't feel the need to breathe.")))
 	else
-		REMOVE_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
+		REMOVE_TRAIT(infected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)
 	return TRUE
 
-/datum/symptom/oxygen/End(datum/disease/advance/A)
+/datum/symptom/oxygen/End(datum/disease/advance/advanced_disease)
 	. = ..()
 	if(!.)
 		return
-	REMOVE_TRAIT(A.affected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)
+	REMOVE_TRAIT(advanced_disease.affected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)


### PR DESCRIPTION

## About The Pull Request

"You realize you haven't been breathing." and "You don't feel the need to breathe." are displayed once stage changes past 4th, thus removing your need to breathe.

also why was pick wrapped in "[ ]" what even

## Why It's Good For The Game

Its confusing to new players and blatantly misleading. Its a noobtrap and not a funny one.

## Changelog
:cl:
qol: Self-respiration no longer sends misleading messages and instead tells about lack of need to breathe once it actually gives you the effect
/:cl:
