### PR TITLE
Removed stamina vulnerability from several basic mob types (primarly Dragons)

### DIFF
--- a/code/modules/mob/living/basic/alien/_alien.dm
+++ b/code/modules/mob/living/basic/alien/_alien.dm
@@ -18,6 +18,7 @@
 	bubble_icon = "alien"
 	combat_mode = TRUE
 	faction = list(ROLE_ALIEN)
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 0, OXY = 1)
 
 	// Going for a dark purple here
 	lighting_cutoff_red = 30

--- a/code/modules/mob/living/basic/blob_minions/blob_mob.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_mob.dm
@@ -7,6 +7,7 @@
 	unique_name = TRUE
 	pass_flags = PASSBLOB
 	faction = list(ROLE_BLOB)
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 0, OXY = 1)
 	combat_mode = TRUE
 	bubble_icon = "blob"
 	speak_emote = null

--- a/code/modules/mob/living/basic/jungle/leaper/leaper.dm
+++ b/code/modules/mob/living/basic/jungle/leaper/leaper.dm
@@ -6,6 +6,7 @@
 	icon_living = "leaper"
 	icon_dead = "leaper_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 0, OXY = 1)
 
 	melee_damage_lower = 15
 	melee_damage_upper = 20

--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -7,6 +7,7 @@
 	icon_living = "mining_drone"
 	basic_mob_flags = DEL_ON_DEATH
 	status_flags = CANSTUN|CANKNOCKDOWN|CANPUSH
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 	mouse_opacity = MOUSE_OPACITY_ICON
 	combat_mode = TRUE
 	habitable_atmos = null

--- a/code/modules/mob/living/basic/space_fauna/ghost.dm
+++ b/code/modules/mob/living/basic/space_fauna/ghost.dm
@@ -10,6 +10,7 @@
 	response_help_simple = "pass through"
 	combat_mode = TRUE
 	basic_mob_flags = DEL_ON_DEATH
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 	maxHealth = 40
 	health = 40
 	melee_damage_lower = 15

--- a/code/modules/mob/living/basic/space_fauna/hivebot/_hivebot.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/_hivebot.dm
@@ -8,6 +8,7 @@
 	basic_mob_flags = DEL_ON_DEATH
 	gender = NEUTER
 	mob_biotypes = MOB_ROBOTIC
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 
 	health = 15
 	maxHealth = 15

--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -11,6 +11,7 @@
 	combat_mode = TRUE
 
 	mob_biotypes = MOB_BEAST
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 	pass_flags = PASSTABLE
 
 	maxHealth = 150

--- a/code/modules/mob/living/basic/space_fauna/robot_customer.dm
+++ b/code/modules/mob/living/basic/space_fauna/robot_customer.dm
@@ -13,6 +13,7 @@
 	max_grab = GRAB_AGGRESSIVE
 	basic_mob_flags = DEL_ON_DEATH
 	mob_biotypes = MOB_ROBOTIC|MOB_HUMANOID
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 	sentience_type = SENTIENCE_ARTIFICIAL
 
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -25,7 +25,7 @@
 	unsuitable_cold_damage = 0
 	unsuitable_heat_damage = 0
 	unsuitable_atmos_damage = 0
-	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 0.5, OXY = 1)
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 0, OXY = 1)
 	combat_mode = TRUE
 	speed = 0
 	attack_verb_continuous = "chomps"

--- a/code/modules/mob/living/basic/space_fauna/statue/statue.dm
+++ b/code/modules/mob/living/basic/space_fauna/statue/statue.dm
@@ -11,6 +11,7 @@
 	combat_mode = TRUE
 	mob_biotypes = MOB_HUMANOID
 	gold_core_spawnable = NO_SPAWN
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 
 	response_help_continuous = "touches"
 	response_help_simple = "touch"

--- a/code/modules/mob/living/basic/space_fauna/supermatter_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/supermatter_spider.dm
@@ -10,6 +10,7 @@
 
 	gender = NEUTER
 	mob_biotypes = MOB_BUG|MOB_ROBOTIC
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
 	speak_emote = list("vibrates")
 
 


### PR DESCRIPTION
## About The Pull Request

Removed stamina vulnerability fro various basic mobs.

These:
Aliens
Blob spores/nauts/zombies
Leapers
Minebots
basic ghosts
Hivebots
Morphs
Customers
Dragons
Statues
SM Spiders

## Why It's Good For The Game

These mbos were nto desigend around taking stamina damage. This was added in, seemingly without much thoguht, and it causes important balance problems becuase soemnoe can just run up with a disabler and render hem basically immobile so tehy can have dlasers dumped onto tehm. This is a big problem for Dragons, who othewrise do not get slowed, Leapers, likewise, and the rest are here for consistency and becasue it wouldn't make much sense for a statue to be exhausted.

### Inorganics shouldn't get exhausted
Statues
SM Spiders
Customers
Hivebots
Minebots
basic ghosts
### Utterly breaks their design, speed being a vital part of their kit and gameplay
Aliens
Blob spores/nauts/zombies
Leapers
Dragons
Morphs

## Changelog

:cl:
balance: Removed stamina vulnerability from several basic mob types (primarly Dragons)
/:cl:

