### PR TITLE
correct tgui readme re: yarn and node version

### DIFF
--- a/tgui/README.md
+++ b/tgui/README.md
@@ -35,10 +35,10 @@ If you are using the tooling provided in this repo, everything is included! Feel
 
 However, if you want finer control over the installation or build process, you will need these:
 
-- [Node v16.13+](https://nodejs.org/en/download/)
+- [Node v20.2+](https://nodejs.org/en/download/)
   - **LTS** release is recommended instead of latest
   - **DO NOT install Chocolatey if Node installer asks you to!**
-- [Yarn v1.22.4+](https://yarnpkg.com/getting-started/install)
+- [Yarn v4.1.1+](https://yarnpkg.com/getting-started/install)
   - You can run `npm install -g yarn` to install it.
 
 ## Usage


### PR DESCRIPTION
20.2 due to `NODE_VERSION_COMPAT`

## About The Pull Request
correct tgui readme re: yarn and node version

## Why It's Good For The Game

its good for contributors i dont play the game
