### PR TITLE
Monkification Fixes Fixes

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -400,8 +400,9 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(holder && (human_mutation in mutations))
 		set_se(0, human_mutation)
 		. = human_mutation.on_losing(holder)
-		qdel(human_mutation) // qdel mutations on removal
-		update_instability(FALSE)
+		if(!(human_mutation in mutations))
+			qdel(human_mutation) // qdel mutations on removal
+			update_instability(FALSE)
 		return
 
 /**

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -269,20 +269,22 @@
 	var/original_name
 
 /datum/mutation/human/race/on_acquiring(mob/living/carbon/human/owner)
-	if(ismonkey(owner))
-		return TRUE
 	. = ..()
 	if(.)
+		return
+	if(ismonkey(owner))
 		return
 	original_species = owner.dna.species.type
 	original_name = owner.real_name
 	owner.monkeyize()
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/human/owner)
+	if(owner.stat == DEAD)
+		return
 	. = ..()
 	if(.)
 		return
-	if(QDELETED(owner) || owner.stat == DEAD)
+	if(QDELETED(owner))
 		return
 
 	owner.fully_replace_character_name(null, original_name)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -35,7 +35,7 @@
 #define GENETIC_DAMAGE_ACCURACY_MULTIPLIER 3
 
 /// Special status indicating a scanner occupant is transforming eg. from monkey to human
-#define STATUS_TRANSFORMING 4
+#define STATUS_TRANSFORMING 5
 
 /// Multiplier for how much genetic damage received from DNA Console functionality
 #define GENETIC_DAMAGE_IRGENETIC_DAMAGE_MULTIPLIER 1

--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaScanner.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaScanner.jsx
@@ -10,6 +10,7 @@ import {
 import {
   SUBJECT_CONCIOUS,
   SUBJECT_DEAD,
+  SUBJECT_HARD_CRIT,
   SUBJECT_SOFT_CRIT,
   SUBJECT_TRANSFORMING,
   SUBJECT_UNCONSCIOUS,
@@ -81,7 +82,7 @@ const SubjectStatus = (props) => {
       </Box>
     );
   }
-  if (status === SUBJECT_UNCONSCIOUS) {
+  if (status === SUBJECT_UNCONSCIOUS || status === SUBJECT_HARD_CRIT) {
     return (
       <Box inline color="average">
         Unconscious

--- a/tgui/packages/tgui/interfaces/DnaConsole/constants.ts
+++ b/tgui/packages/tgui/interfaces/DnaConsole/constants.ts
@@ -31,8 +31,9 @@ export const STORAGE_MODE_ADVINJ = 'injector';
 export const SUBJECT_CONCIOUS = 0;
 export const SUBJECT_SOFT_CRIT = 1;
 export const SUBJECT_UNCONSCIOUS = 2;
-export const SUBJECT_DEAD = 3;
-export const SUBJECT_TRANSFORMING = 4;
+export const SUBJECT_HARD_CRIT = 3;
+export const SUBJECT_DEAD = 4;
+export const SUBJECT_TRANSFORMING = 5;
 
 export const PULSE_STRENGTH_MAX = 15;
 export const PULSE_DURATION_MAX = 30;


### PR DESCRIPTION
## About The Pull Request

Fixes #85100 

Roundstart monkeys are monkeys before they're monkeys, whoops.

## Changelog

:cl: Melbert
fix: Fixed roundstart monkeys not having monkified 
fix: Fixed being "de-monkified" while dead making it difficult to actually de-monkey you going forward
fix: Fixed genetic scanner showing dead mobs as "transforming"
/:cl:


