### PR TITLE
Stops cyborgs from runtiming on module change if they had selected modules

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -233,6 +233,7 @@
 	if(!new_model.be_transformed_to(src, forced))
 		qdel(new_model)
 		return
+	cyborg.drop_all_held_items()
 	cyborg.model = new_model
 	cyborg.update_module_innate()
 	new_model.rebuild_modules()


### PR DESCRIPTION

## About The Pull Request
Closes #85101
They need to drop their modules beforehand because else they don't have a model to drop them into

## Changelog
:cl:
fix: Borgs now unequip their equipment upon module change like they should
/:cl:
