### PR TITLE
You can now fish with explosives

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_fish.dm
+++ b/code/__DEFINES/dcs/signals/signals_fish.dm
@@ -21,7 +21,7 @@
 /// Fishing challenge completed
 #define COMSIG_FISHING_CHALLENGE_COMPLETED "fishing_completed"
 /// Sent to the fisherman when the reward is dispensed: (reward)
-#define COMSIG_MOB_FISHING_REWARD_DISPENSED "mob_fishing_reward_dispensed"
+#define COMSIG_FISH_SOURCE_REWARD_DISPENSED "mob_fish_source_reward_dispensed"
 
 /// Called when you try to use fishing rod on anything
 #define COMSIG_PRE_FISHING "pre_fishing"

--- a/code/datums/components/fishing_spot.dm
+++ b/code/datums/components/fishing_spot.dm
@@ -17,6 +17,7 @@
 	RegisterSignal(parent, COMSIG_FISHING_ROD_CAST, PROC_REF(handle_cast))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examined))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examined_more))
+	RegisterSignal(parent, COMSIG_ATOM_EX_ACT, PROC_REF(explosive_fishing))
 	ADD_TRAIT(parent, TRAIT_FISHING_SPOT, REF(src))
 
 /datum/component/fishing_spot/Destroy()
@@ -95,3 +96,7 @@
 	var/datum/fishing_challenge/challenge = new(src, result, rod, user)
 	fish_source.pre_challenge_started(rod, user, challenge)
 	challenge.start(user)
+
+/datum/component/fishing_spot/proc/explosive_fishing(atom/location, severity)
+	SIGNAL_HANDLER
+	fish_source.spawn_reward_from_explosion(location, severity)

--- a/code/datums/elements/lazy_fishing_spot.dm
+++ b/code/datums/elements/lazy_fishing_spot.dm
@@ -21,7 +21,7 @@
 	RegisterSignal(target, COMSIG_ATOM_EX_ACT, PROC_REF(explosive_fishing))
 
 /datum/element/lazy_fishing_spot/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_PRE_FISHING, COMSIG_ATOM_EX_ACT))
+	UnregisterSignal(target, list(COMSIG_PRE_FISHING, COMSIG_ATOM_EXAMINE, COMSIG_ATOM_EXAMINE_MORE, COMSIG_ATOM_EX_ACT))
 	REMOVE_TRAIT(target, TRAIT_FISHING_SPOT, REF(src))
 	return ..()
 

--- a/code/datums/elements/lazy_fishing_spot.dm
+++ b/code/datums/elements/lazy_fishing_spot.dm
@@ -16,9 +16,12 @@
 	src.configuration = configuration
 	ADD_TRAIT(target, TRAIT_FISHING_SPOT, REF(src))
 	RegisterSignal(target, COMSIG_PRE_FISHING, PROC_REF(create_fishing_spot))
+	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examined))
+	RegisterSignal(target, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examined_more))
+	RegisterSignal(target, COMSIG_ATOM_EX_ACT, PROC_REF(explosive_fishing))
 
 /datum/element/lazy_fishing_spot/Detach(datum/target)
-	UnregisterSignal(target, COMSIG_PRE_FISHING)
+	UnregisterSignal(target, list(COMSIG_PRE_FISHING, COMSIG_ATOM_EX_ACT))
 	REMOVE_TRAIT(target, TRAIT_FISHING_SPOT, REF(src))
 	return ..()
 
@@ -27,3 +30,49 @@
 
 	source.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[configuration])
 	Detach(source)
+
+///If the fish source has fishes that are shown in the
+/datum/element/lazy_fishing_spot/proc/on_examined(datum/source, mob/user, list/examine_text)
+	SIGNAL_HANDLER
+	if(!HAS_MIND_TRAIT(user, TRAIT_EXAMINE_FISHING_SPOT))
+		return
+
+	var/datum/fish_source/fish_source = GLOB.preset_fish_sources[configuration]
+
+	var/has_known_fishes = FALSE
+	for(var/reward in fish_source.fish_table)
+		if(!ispath(reward, /obj/item/fish))
+			continue
+		var/obj/item/fish/prototype = reward
+		if(initial(prototype.show_in_catalog))
+			has_known_fishes = TRUE
+			break
+	if(!has_known_fishes)
+		return
+
+	examine_text += span_tinynoticeital("This is a fishing spot. You can look again to list its fishes...")
+
+/datum/element/lazy_fishing_spot/proc/on_examined_more(datum/source, mob/user, list/examine_text)
+	SIGNAL_HANDLER
+	if(!HAS_MIND_TRAIT(user, TRAIT_EXAMINE_FISHING_SPOT))
+		return
+
+	var/datum/fish_source/fish_source = GLOB.preset_fish_sources[configuration]
+
+	var/list/known_fishes = list()
+	for(var/reward in fish_source.fish_table)
+		if(!ispath(reward, /obj/item/fish))
+			continue
+		var/obj/item/fish/prototype = reward
+		if(initial(prototype.show_in_catalog))
+			known_fishes += initial(prototype.name)
+
+	if(!length(known_fishes))
+		return
+
+	examine_text += span_info("You can catch the following fish here: [english_list(known_fishes)].")
+
+/datum/element/lazy_fishing_spot/proc/explosive_fishing(atom/location, severity)
+	SIGNAL_HANDLER
+	var/datum/fish_source/fish_source = GLOB.preset_fish_sources[configuration]
+	fish_source.spawn_reward_from_explosion(location, severity)

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -40,11 +40,11 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 		),
 	)
 
-/datum/chasm_detritus/proc/dispense_detritus(mob/fisherman, turf/fishing_spot)
+/datum/chasm_detritus/proc/dispense_detritus(atom/spawn_location, turf/fishing_spot)
 	if(prob(default_contents_chance))
 		var/default_spawn = pick(default_contents[default_contents_key])
-		return new default_spawn(get_turf(fisherman))
-	return find_chasm_contents(fishing_spot, get_turf(fisherman))
+		return new default_spawn(spawn_location)
+	return find_chasm_contents(fishing_spot, spawn_location)
 
 /// Returns the chosen detritus from the given list of things to choose from
 /datum/chasm_detritus/proc/determine_detritus(list/chasm_stuff)

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -183,7 +183,7 @@
 			special_effects |= FISHING_MINIGAME_RULE_KILL
 
 	if(special_effects & FISHING_MINIGAME_RULE_KILL && ispath(reward_path,/obj/item/fish))
-		RegisterSignal(user, COMSIG_MOB_FISHING_REWARD_DISPENSED, PROC_REF(hurt_fish))
+		RegisterSignal(comp.fish_source, COMSIG_FISH_SOURCE_REWARD_DISPENSED, PROC_REF(hurt_fish))
 
 	difficulty += comp.fish_source.calculate_difficulty(reward_path, rod, user, src)
 	difficulty = clamp(round(difficulty), 1, 100)

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -347,6 +347,7 @@ GLOBAL_LIST(fishing_property_cache)
 	var/multiplier = 1/(length(exploded_turfs)**0.5)
 	for(var/turf/turf as anything in exploded_turfs)
 		explosive_spawn(turf, exploded_turfs[turf], multiplier)
+	exploded_turfs = null
 
 /datum/fish_source/proc/explosive_spawn(location, severity, multiplier = 1)
 	for(var/i in 1 to (severity + 2))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -191,6 +191,8 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 
 ///Simplified version of dispense_reward that doesn't need a fisherman.
 /datum/fish_source/proc/simple_dispense_reward(reward_path, atom/spawn_location, turf/fishing_spot)
+	if(isnull(reward_path))
+		return null
 	if((reward_path in fish_counts)) // This is limited count result
 		fish_counts[reward_path] -= 1
 		if(!fish_counts[reward_path])

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -53,6 +53,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 	var/catalog_description
 	/// Background image name from /datum/asset/simple/fishing_minigame
 	var/background = "background_default"
+	/// It true, repeated and large explosions won't be as efficient. This is usually meant for global fish sources.
+	var/explosive_malus = FALSE
+	/// If explosive_malus is true, this will be used to keep track of the turfs where an explosion happened for when we'll spawn the loot.
+	var/list/exploded_turfs
 
 /datum/fish_source/New()
 	if(!PERFORM_ALL_TESTS(focus_only/fish_sources_tables))
@@ -60,6 +64,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 	for(var/path in fish_counts)
 		if(!(path in fish_table))
 			stack_trace("path [path] found in the 'fish_counts' list but not in the fish_table one of [type]")
+
+/datum/fish_source/Destroy()
+	exploded_turfs = null
+	return ..()
 
 ///Called when src is set as the fish source of a fishing spot component
 /datum/fish_source/proc/on_fishing_spot_init(/datum/component/fishing_spot/spot)
@@ -166,13 +174,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 
 /// Gives out the reward if possible
 /datum/fish_source/proc/dispense_reward(reward_path, mob/fisherman, turf/fishing_spot)
-	if((reward_path in fish_counts)) // This is limited count result
-		fish_counts[reward_path] -= 1
-		if(!fish_counts[reward_path])
-			fish_counts -= reward_path //Ran out of these since rolling (multiple fishermen on same source most likely)
-			fish_table -= reward_path
-
-	var/atom/movable/reward = spawn_reward(reward_path, fisherman, fishing_spot)
+	var/atom/movable/reward = simple_dispense_reward(reward_path, get_turf(fisherman), fishing_spot)
 	if(!reward) //balloon alert instead
 		fisherman.balloon_alert(fisherman, pick(duds))
 		return
@@ -185,18 +187,28 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 		INVOKE_ASYNC(reward, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(fisherman))
 	fisherman.balloon_alert(fisherman, "caught [reward]!")
 
-	SEND_SIGNAL(fisherman, COMSIG_MOB_FISHING_REWARD_DISPENSED, reward)
 	return reward
 
+///Simplified version of dispense_reward that doesn't need a fisherman.
+/datum/fish_source/proc/simple_dispense_reward(reward_path, atom/spawn_location, turf/fishing_spot)
+	if((reward_path in fish_counts)) // This is limited count result
+		fish_counts[reward_path] -= 1
+		if(!fish_counts[reward_path])
+			fish_counts -= reward_path //Ran out of these since rolling (multiple fishermen on same source most likely)
+			fish_table -= reward_path
+
+	var/atom/movable/reward = spawn_reward(reward_path, spawn_location, fishing_spot)
+	SEND_SIGNAL(src, COMSIG_FISH_SOURCE_REWARD_DISPENSED, reward)
+
 /// Spawns a reward from a atom path right where the fisherman is. Part of the dispense_reward() logic.
-/datum/fish_source/proc/spawn_reward(reward_path, mob/fisherman, turf/fishing_spot)
+/datum/fish_source/proc/spawn_reward(reward_path, atom/spawn_location, turf/fishing_spot)
 	if(reward_path == FISHING_DUD)
 		return
 	if(ispath(reward_path, /datum/chasm_detritus))
-		return GLOB.chasm_detritus_types[reward_path].dispense_detritus(fisherman, fishing_spot)
+		return GLOB.chasm_detritus_types[reward_path].dispense_detritus(spawn_location, fishing_spot)
 	if(!ispath(reward_path, /atom/movable))
 		CRASH("Unsupported /datum path [reward_path] passed to fish_source/proc/spawn_reward()")
-	var/atom/movable/reward = new reward_path(get_turf(fisherman))
+	var/atom/movable/reward = new reward_path(spawn_location)
 	if(isfish(reward))
 		var/obj/item/fish/caught_fish = reward
 		caught_fish.randomize_size_and_weight()
@@ -316,3 +328,36 @@ GLOBAL_LIST(fishing_property_cache)
 			final_table[fish] += round(difference**leveling_exponent, 1)
 
 	return final_table
+
+/datum/fish_source/proc/spawn_reward_from_explosion(atom/location, severity)
+	if(!explosive_malus)
+		explosive_spawn(location, severity)
+		return
+	if(isnull(exploded_turfs))
+		exploded_turfs = list()
+		addtimer(CALLBACK(src, PROC_REF(post_explosion_spawn)), 1) //run this the next tick.
+	var/turf/turf = get_turf(location)
+	var/peak_severity = max(exploded_turfs[turf], severity)
+	exploded_turfs[turf] = peak_severity
+
+/datum/fish_source/proc/post_explosion_spawn()
+	var/multiplier = 1/(length(exploded_turfs)**0.5)
+	for(var/turf/turf as anything in exploded_turfs)
+		explosive_spawn(turf, exploded_turfs[turf], multiplier)
+
+/datum/fish_source/proc/explosive_spawn(location, severity, multiplier = 1)
+	for(var/i in 1 to (severity + 2))
+		if(!prob((100 + 100 * severity)/i * multiplier))
+			continue
+		var/reward_loot = pick_weight(fish_table)
+		var/atom/movable/reward = simple_dispense_reward(reward_loot, location, location)
+		if(isnull(reward))
+			continue
+		if(isfish(reward))
+			var/obj/item/fish/fish = reward
+			fish.set_status(FISH_DEAD)
+		if(isitem(reward))
+			reward.pixel_x = rand(-9, 9)
+			reward.pixel_y = rand(-9, 9)
+		if(severity >= EXPLODE_DEVASTATE)
+			reward.ex_act(EXPLODE_LIGHT)

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -199,6 +199,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 
 	var/atom/movable/reward = spawn_reward(reward_path, spawn_location, fishing_spot)
 	SEND_SIGNAL(src, COMSIG_FISH_SOURCE_REWARD_DISPENSED, reward)
+	return reward
 
 /// Spawns a reward from a atom path right where the fisherman is. Part of the dispense_reward() logic.
 /datum/fish_source/proc/spawn_reward(reward_path, atom/spawn_location, turf/fishing_spot)

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -14,6 +14,7 @@
 		/obj/item/fish/clownfish/lube = 2,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
+	explosive_malus = TRUE
 
 /datum/fish_source/ocean/beach
 	catalog_description = "Beach shore water"
@@ -159,7 +160,7 @@
 			challenge.special_effects |= effect
 
 ///Cherry on top, fish caught from the randomizer portal also have (almost completely) random traits
-/datum/fish_source/portal/random/spawn_reward(reward_path, mob/fisherman, turf/fishing_spot)
+/datum/fish_source/portal/random/spawn_reward(reward_path, atom/movable/spawn_location, turf/fishing_spot)
 	if(!ispath(reward_path, /obj/item/fish))
 		return ..()
 
@@ -170,7 +171,7 @@
 			var/datum/fish_trait/trait = GLOB.fish_traits[trait_type]
 			weighted_traits[trait.type] = round(trait.inheritability**2/100)
 
-	var/obj/item/fish/caught_fish = new reward_path(get_turf(fisherman), FALSE)
+	var/obj/item/fish/caught_fish = new reward_path(spawn_location, FALSE)
 	var/list/fixed_traits = list()
 	for(var/trait_type in caught_fish.fish_traits)
 		var/datum/fish_trait/trait = GLOB.fish_traits[trait_type]
@@ -211,7 +212,8 @@
 
 	return rod.hook.chasm_detritus_type
 
-/datum/fish_source/chasm
+/datum/fish_source/chasm/spawn_reward_from_explosion(atom/location, severity)
+	return //Spawned content would immediately fall back into the chasm, so it wouldn't matter.
 
 /datum/fish_source/lavaland
 	catalog_description = "Lava vents"
@@ -228,6 +230,7 @@
 	)
 
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	explosive_malus = TRUE
 
 /datum/fish_source/lavaland/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	. = ..()
@@ -358,6 +361,15 @@
 	if(basin.myseed)
 		return "There's a plant growing in [parent]."
 
+	return ..()
+
+/datum/fish_source/hydro_tray/spawn_reward_from_explosion(atom/location, severity)
+	if(!istype(location, /obj/machinery/hydroponics/constructable))
+		return ..()
+
+	var/obj/machinery/hydroponics/constructable/basin = location
+	if(basin.myseed || basin.waterlevel <= 0)
+		return
 	return ..()
 
 /datum/fish_source/hydro_tray/spawn_reward(reward_path, mob/fisherman, turf/fishing_spot)

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -210,5 +210,21 @@
 	run_loc_floor_bottom_left.ChangeTurf(original_turf_type, original_turf_baseturfs)
 	return ..()
 
+/datum/unit_test/explosive_fishing
+
+/datum/unit_test/explosive_fishing/Run()
+	var/datum/fish_source/source = GLOB.preset_fish_sources[/datum/fish_source/unit_test]
+	source.spawn_reward_from_explosion(run_loc_floor_bottom_left, 1)
+	if(length(source.fish_table))
+		TEST_FAIL("The unit test item wasn't removed/spawned from fish_table during 'spawn_reward_from_explosion'.")
+
+/datum/fish_source/unit_test
+	fish_table = list(
+		/obj/item/wrench = 1,
+	)
+	fish_counts = list(
+		/obj/item/wrench = 1,
+	)
+
 #undef TRAIT_FISH_TESTING
 


### PR DESCRIPTION
## About The Pull Request
Iansdoor suggested this to me earlier (but I already knew it was a thing on Goon), and I said ok. Basically, this PR adds an interaction between explosions and fishing.

At the cost of potential collateral damage, you can too now use a TTV to catch a lot of fishes (and other stuff). Fish spawned this way will be pretty much dead however.

This PR also adds the examine tips already presents in the fishing spot component to the lazy fishing spot element.

## Why It's Good For The Game
This PR adds an interaction between fishing and other mechanics of the game.

## Changelog

:cl:
add: You can now fish with explosives.
fix: Fixed an inconsistency with examining fishing spots with sufficiently high fishing skill (or skillchip).
/:cl:
