### PR TITLE
ID and PDA interacts with cash

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1443,8 +1443,7 @@
 		ui_interact(user)
 		return ITEM_INTERACT_SUCCESS
 	if(iscash(interacting_with))
-		insert_money(interacting_with, user)
-		return ITEM_INTERACT_SUCCESS
+		return insert_money(interacting_with, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
 	return NONE
 
 /obj/item/card/id/advanced/chameleon/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1442,9 +1442,7 @@
 		theft_target = WEAKREF(interacting_with)
 		ui_interact(user)
 		return ITEM_INTERACT_SUCCESS
-	if(iscash(interacting_with))
-		return insert_money(interacting_with, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
-	return NONE
+	return ..()
 
 /obj/item/card/id/advanced/chameleon/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	// If we're attacking a human, we want it to be covert. We're not ATTACKING them, we're trying

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -835,6 +835,12 @@
 /obj/item/card/id/proc/get_trim_sechud_icon_state()
 	return trim?.sechud_icon_state || SECHUD_UNKNOWN
 
+/obj/item/card/id/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(iscash(interacting_with))
+		insert_money(interacting_with, user)
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
 /obj/item/card/id/away
 	name = "\proper a perfectly generic identification card"
 	desc = "A perfectly generic identification card. Looks like it could use some flavor."
@@ -1436,6 +1442,9 @@
 	if(isidcard(interacting_with))
 		theft_target = WEAKREF(interacting_with)
 		ui_interact(user)
+		return ITEM_INTERACT_SUCCESS
+	if(iscash(interacting_with))
+		insert_money(interacting_with, user)
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -837,8 +837,7 @@
 
 /obj/item/card/id/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(iscash(interacting_with))
-		insert_money(interacting_with, user)
-		return ITEM_INTERACT_SUCCESS
+		return insert_money(interacting_with, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
 	return NONE
 
 /obj/item/card/id/away

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -140,6 +140,12 @@
 
 	return . || NONE
 
+/obj/item/modular_computer/pda/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(iscash(interacting_with))
+		money_act(user, interacting_with)
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
 /obj/item/modular_computer/pda/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
 	if(.)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -142,8 +142,7 @@
 
 /obj/item/modular_computer/pda/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(iscash(interacting_with))
-		money_act(user, interacting_with)
-		return ITEM_INTERACT_SUCCESS
+		return money_act(user,interacting_with)
 	return NONE
 
 /obj/item/modular_computer/pda/item_interaction(mob/living/user, obj/item/tool, list/modifiers)


### PR DESCRIPTION
## About The Pull Request

Adding interactions between ID/PDA and money.
So, you can swipe it on cash and get it on your bank.
## Why It's Good For The Game

Now you don't have to constantly insert every coin into the card.

<details>
<summary>GIF and evidence that I tested</summary>

![card_test2](https://github.com/user-attachments/assets/833f7587-0b4c-4357-b4dc-b7f897416058)

</details>

## Changelog
:cl:
qol: Now IDs and PDAs have money-reader module for picking some cash into your bank by swiping on money.
/:cl:
