### PR TITLE
Fix typo in rebar crossbow uplink

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -148,7 +148,7 @@
 
 /datum/uplink_item/role_restricted/rebarxbowsyndie
 	name = "Syndicate Rebar Crossbow"
-	desc = "A much more proffessional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
+	desc = "A much more professional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
 	cost = 10
 	restricted_roles = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)


### PR DESCRIPTION

## About The Pull Request

Changes "A much more prof**f**essional version of the engineer's bootleg rebar crossbow." to "A much more professional version of the engineer's bootleg rebar crossbow." (had an "f" too much in professional)

## Why It's Good For The Game

Less typos is good?

## Changelog
:cl:
spellcheck: Fixed a typo in the description for the Syndicate Rebar Crossbow in the Uplink.
/:cl:
