### PR TITLE
Shield gens delete their wires properly in Destroy()

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -348,6 +348,7 @@
 /obj/machinery/power/shieldwallgen/Destroy()
 	for(var/d in GLOB.cardinals)
 		cleanup_field(d)
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/machinery/power/shieldwallgen/should_have_node()


### PR DESCRIPTION

## About The Pull Request

Closes #85110
Harddels are bad kids

## Changelog
:cl:
fix: Shield gens delete their wires properly in Destroy()
/:cl:
