### PR TITLE
Makes set_basalt_light local

### DIFF
--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -116,3 +116,10 @@
 #define LARGE_TURF_SMOOTHING_X_OFFSET -9
 /// Defines the y offset to apply to larger smoothing turfs (such as grass).
 #define LARGE_TURF_SMOOTHING_Y_OFFSET -9
+
+/// Defines a consistent light power for our various basalt turfs
+#define BASALT_LIGHT_POWER 0.6
+/// Defines a consistent light range for basalt turfs that have a bigger area of lava
+#define BASALT_LIGHT_RANGE_BRIGHT 2
+/// Defines a consistent light range for basalt turfs that have a smaller area of lava
+#define BASALT_LIGHT_RANGE_DIM 1.4

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -2,6 +2,7 @@
 
 #define BASALT_LIGHT_BRIGHT 2
 #define BASALT_LIGHT_DIM 1.4
+#define BASALT_LIGHT_POWER 0.6
 
 /turf/open/misc/asteroid //floor piece
 	gender = PLURAL
@@ -170,9 +171,9 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 /turf/open/misc/asteroid/basalt/proc/set_basalt_light()
 	switch(icon_state)
 		if("basalt1", "basalt2", "basalt3")
-			set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA) //more light
+			set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA) //more light
 		if("basalt5", "basalt9")
-			set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA) //barely anything!
+			set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA) //barely anything!
 
 ///////Surface. The surface is warm, but survivable without a suit. Internals are required. The floors break to chasms, which drop you into the underground.
 

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -1,9 +1,5 @@
 /**********************Asteroid**************************/
 
-#define BASALT_LIGHT_BRIGHT 2
-#define BASALT_LIGHT_DIM 1.4
-#define BASALT_LIGHT_POWER 0.6
-
 /turf/open/misc/asteroid //floor piece
 	gender = PLURAL
 	name = "asteroid sand"
@@ -171,9 +167,9 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 /turf/open/misc/asteroid/basalt/proc/set_basalt_light()
 	switch(icon_state)
 		if("basalt1", "basalt2", "basalt3")
-			set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA) //more light
+			set_light(BASALT_LIGHT_RANGE_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA) //more light
 		if("basalt5", "basalt9")
-			set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA) //barely anything!
+			set_light(BASALT_LIGHT_RANGE_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA) //barely anything!
 
 ///////Surface. The surface is warm, but survivable without a suit. Internals are required. The floors break to chasms, which drop you into the underground.
 

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -1,5 +1,8 @@
 /**********************Asteroid**************************/
 
+#define BASALT_LIGHT_BRIGHT 2
+#define BASALT_LIGHT_DIM 1.4
+
 /turf/open/misc/asteroid //floor piece
 	gender = PLURAL
 	name = "asteroid sand"
@@ -151,7 +154,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 /turf/open/misc/asteroid/basalt/refill_dug()
 	. = ..()
 	GLOB.dug_up_basalt -= src
-	set_basalt_light(src)
+	set_basalt_light()
 
 /turf/open/misc/asteroid/basalt/lava //lava underneath
 	baseturfs = /turf/open/lava/smooth
@@ -162,14 +165,14 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 
 /turf/open/misc/asteroid/basalt/Initialize(mapload)
 	. = ..()
-	set_basalt_light(src)
+	set_basalt_light()
 
-/proc/set_basalt_light(turf/open/floor/B)
-	switch(B.icon_state)
+/turf/open/misc/asteroid/basalt/proc/set_basalt_light()
+	switch(icon_state)
 		if("basalt1", "basalt2", "basalt3")
-			B.set_light(2, 0.6, LIGHT_COLOR_LAVA) //more light
+			set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA) //more light
 		if("basalt5", "basalt9")
-			B.set_light(1.4, 0.6, LIGHT_COLOR_LAVA) //barely anything!
+			set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA) //barely anything!
 
 ///////Surface. The surface is warm, but survivable without a suit. Internals are required. The floors break to chasms, which drop you into the underground.
 

--- a/code/game/turfs/open/basalt.dm
+++ b/code/game/turfs/open/basalt.dm
@@ -13,9 +13,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 
 /turf/open/misc/basalt/safe
 	planetary_atmos = FALSE

--- a/code/game/turfs/open/basalt.dm
+++ b/code/game/turfs/open/basalt.dm
@@ -11,7 +11,11 @@
 	AddElement(/datum/element/diggable, /obj/item/stack/ore/glass/basalt, 2)
 	if(prob(15))
 		icon_state = "basalt[rand(0, 12)]"
-		set_basalt_light(src)
+		switch(icon_state)
+			if("basalt1", "basalt2", "basalt3")
+				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA) //more light
+			if("basalt5", "basalt9")
+				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA) //barely anything!
 
 /turf/open/misc/basalt/safe
 	planetary_atmos = FALSE

--- a/code/game/turfs/open/basalt.dm
+++ b/code/game/turfs/open/basalt.dm
@@ -13,9 +13,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_RANGE_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_RANGE_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 
 /turf/open/misc/basalt/safe
 	planetary_atmos = FALSE

--- a/code/game/turfs/open/basalt.dm
+++ b/code/game/turfs/open/basalt.dm
@@ -13,9 +13,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA) //more light
+				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA) //barely anything!
+				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA)
 
 /turf/open/misc/basalt/safe
 	planetary_atmos = FALSE

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -244,9 +244,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 
 /turf/open/floor/carpet
 	name = "carpet"

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -242,7 +242,11 @@
 	AddElement(/datum/element/diggable, /obj/item/stack/ore/glass/basalt, 2, worm_chance = 0)
 	if(prob(15))
 		icon_state = "basalt[rand(0, 12)]"
-		set_basalt_light(src)
+		switch(icon_state)
+			if("basalt1", "basalt2", "basalt3")
+				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA)
+			if("basalt5", "basalt9")
+				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA)
 
 /turf/open/floor/carpet
 	name = "carpet"

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -244,9 +244,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_RANGE_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_RANGE_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 
 /turf/open/floor/carpet
 	name = "carpet"

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -122,9 +122,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_RANGE_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_RANGE_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 
 /turf/open/floor/holofloor/space
 	name = "\proper space"

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -122,9 +122,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_BRIGHT, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA)
+				set_light(BASALT_LIGHT_DIM, BASALT_LIGHT_POWER, LIGHT_COLOR_LAVA)
 
 /turf/open/floor/holofloor/space
 	name = "\proper space"

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -122,9 +122,9 @@
 		icon_state = "basalt[rand(0, 12)]"
 		switch(icon_state)
 			if("basalt1", "basalt2", "basalt3")
-				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA) //more light
+				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA)
 			if("basalt5", "basalt9")
-				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA) //barely anything!
+				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA)
 
 /turf/open/floor/holofloor/space
 	name = "\proper space"

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -120,7 +120,11 @@
 	. = ..()
 	if(prob(15))
 		icon_state = "basalt[rand(0, 12)]"
-		set_basalt_light(src)
+		switch(icon_state)
+			if("basalt1", "basalt2", "basalt3")
+				set_light(BASALT_LIGHT_BRIGHT, 0.6, LIGHT_COLOR_LAVA) //more light
+			if("basalt5", "basalt9")
+				set_light(BASALT_LIGHT_DIM, 0.6, LIGHT_COLOR_LAVA) //barely anything!
 
 /turf/open/floor/holofloor/space
 	name = "\proper space"


### PR DESCRIPTION
## About The Pull Request
- Converts set_basalt_light() from a global proc to an object proc
- Adds defines for basalt light levels to ensure consistency across real and fake basalt turfs
- Replaces non local usage of set_basalt_light with switches that utilize the light defines 

## Why It's Good For The Game
Global namespace should be reserved for things that truly need it. This isn't one of them. Helps reduces global namespace pollution.

Tested it and confirmed it works on all turfs that were modified

## Changelog
:cl:
refactor: refactored global set_basalt_light proc into object proc
/:cl:
