### PR TITLE
Dropping/picking up skin is no longer metallic

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -6,6 +6,9 @@
 	novariants = TRUE
 	merge_type = /obj/item/stack/sheet/animalhide
 
+	pickup_sound = null
+	drop_sound = null
+
 /obj/item/stack/sheet/animalhide/human
 	name = "human skin"
 	desc = "The by-product of human farming."


### PR DESCRIPTION

## About The Pull Request

Fixes #85056

Just removes the sound for skin. I couldn't find a suitable replacement and I'm not really a sound person

## Changelog
:cl:
fix: Animal/people skin is no longer metallic sounding
/:cl:
