### PR TITLE
Holopads no longer suck in unsuspecting people when crowbared

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -413,6 +413,10 @@
 /obj/machinery/proc/close_machine(atom/movable/target, density_to_set = TRUE)
 	state_open = FALSE
 	set_density(density_to_set)
+	if (!density)
+		update_appearance()
+		return
+
 	if(!target)
 		for(var/atom in loc)
 			if (!(can_be_occupant(atom)))


### PR DESCRIPTION

## About The Pull Request

Closes #80183
This is a generic fix for future cases instead of a holopad-specific one, but for now it only affects holopads. Non-dense machinery no longer sucks people in when closed.

## Changelog
:cl:
fix: Holopads no longer suck in unsuspecting people when crowbared
/:cl:
