### PR TITLE
Removes 8 cases of double indentation

### DIFF
--- a/code/controllers/subsystem/persistence/counter_tram_hits.dm
+++ b/code/controllers/subsystem/persistence/counter_tram_hits.dm
@@ -58,7 +58,7 @@
 	tram_hits_last_round = text2num(file2text(TRAM_COUNT_FILEPATH))
 
 /datum/controller/subsystem/persistence/proc/save_tram_counter()
-		rustg_file_write("[tram_hits_this_round]", TRAM_COUNT_FILEPATH)
+	rustg_file_write("[tram_hits_this_round]", TRAM_COUNT_FILEPATH)
 
 #undef TRAM_COUNT_FILEPATH
 #undef MAX_TRAM_SAVES

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -124,10 +124,10 @@
  * Used when the quirk has been gained and no client is attached to the mob.
  */
 /datum/quirk/proc/on_quirk_holder_first_login(mob/living/source)
-		SIGNAL_HANDLER
+	SIGNAL_HANDLER
 
-		UnregisterSignal(source, COMSIG_MOB_LOGIN)
-		post_add()
+	UnregisterSignal(source, COMSIG_MOB_LOGIN)
+	post_add()
 
 /// Any effect that should be applied every single time the quirk is added to any mob, even when transferred.
 /datum/quirk/proc/add(client/client_source)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -252,7 +252,7 @@
 	update_power()
 
 /obj/item/defibrillator/proc/cooldowncheck()
-		addtimer(CALLBACK(src, PROC_REF(finish_charging)), cooldown_duration)
+	addtimer(CALLBACK(src, PROC_REF(finish_charging)), cooldown_duration)
 
 /obj/item/defibrillator/proc/finish_charging()
 	if(cell)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -199,7 +199,7 @@
 	req_access = list(ACCESS_QM)
 
 /obj/item/storage/lockbox/medal/cargo/PopulateContents()
-		new /obj/item/clothing/accessory/medal/ribbon/cargo(src)
+	new /obj/item/clothing/accessory/medal/ribbon/cargo(src)
 
 /obj/item/storage/lockbox/medal/service
 	name = "service award box"
@@ -207,7 +207,7 @@
 	req_access = list(ACCESS_HOP)
 
 /obj/item/storage/lockbox/medal/service/PopulateContents()
-		new /obj/item/clothing/accessory/medal/silver/excellence(src)
+	new /obj/item/clothing/accessory/medal/silver/excellence(src)
 
 /obj/item/storage/lockbox/medal/sci
 	name = "science medal box"

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -146,7 +146,7 @@
 		set_opacity(TRUE)
 
 /obj/structure/curtain/cloth/fancy/mechanical/attack_hand(mob/user, list/modifiers)
-		return
+	return
 
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed
 	icon_state = "cur_fancy-closed"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -138,11 +138,11 @@
 
 /obj/item/proc/get_volume_by_throwforce_and_or_w_class()
 	if(throwforce && w_class)
-			return clamp((throwforce + w_class) * 5, 30, 100)// Add the item's throwforce to its weight class and multiply by 5, then clamp the value between 30 and 100
+		return clamp((throwforce + w_class) * 5, 30, 100)// Add the item's throwforce to its weight class and multiply by 5, then clamp the value between 30 and 100
 	else if(w_class)
-			return clamp(w_class * 8, 20, 100) // Multiply the item's weight class by 8, then clamp the value between 20 and 100
+		return clamp(w_class * 8, 20, 100) // Multiply the item's weight class by 8, then clamp the value between 20 and 100
 	else
-			return 0
+		return 0
 
 /mob/living/proc/set_combat_mode(new_mode, silent = TRUE)
 	if(combat_mode == new_mode)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -137,12 +137,12 @@
 	return 0
 
 /obj/item/proc/get_volume_by_throwforce_and_or_w_class()
-		if(throwforce && w_class)
-				return clamp((throwforce + w_class) * 5, 30, 100)// Add the item's throwforce to its weight class and multiply by 5, then clamp the value between 30 and 100
-		else if(w_class)
-				return clamp(w_class * 8, 20, 100) // Multiply the item's weight class by 8, then clamp the value between 20 and 100
-		else
-				return 0
+	if(throwforce && w_class)
+			return clamp((throwforce + w_class) * 5, 30, 100)// Add the item's throwforce to its weight class and multiply by 5, then clamp the value between 30 and 100
+	else if(w_class)
+			return clamp(w_class * 8, 20, 100) // Multiply the item's weight class by 8, then clamp the value between 20 and 100
+	else
+			return 0
 
 /mob/living/proc/set_combat_mode(new_mode, silent = TRUE)
 	if(combat_mode == new_mode)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -433,8 +433,8 @@
 		return TRUE
 
 /mob/living/simple_animal/bot/mulebot/post_unbuckle_mob(mob/living/M)
-		load = null
-		return ..()
+	load = null
+	return ..()
 
 // called to unload the bot
 // argument is optional direction to unload


### PR DESCRIPTION

## About The Pull Request

Thanks to Potato (Lemon here) on discord for writing a regex to find these ``^/.*\).*\n\t\t``

## Changelog
:cl:
code: Removed 8 cases of double indentation
/:cl:
