### PR TITLE
Fixes fishing rods not working on adjacent targets

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -588,9 +588,10 @@
 		transform = transform.Scale(1, -1)
 	return ..()
 
-/obj/projectile/fishing_cast/Impact(atom/hit_atom)
+/obj/projectile/fishing_cast/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	owner.hook_hit(hit_atom)
+	if(blocked < 100)
+		owner.hook_hit(target)
 	qdel(src)
 
 /obj/projectile/fishing_cast/fire(angle, atom/direct_target)


### PR DESCRIPTION
## About The Pull Request
`Impact` won't be called if the target is right next to the projectile the moment it's fired. it'll call `process_hit` directly, which in turn calls `target.bullet_act`, and then `projectile.on_hit`, which is the proc we now use to do our nefast fishing deeds.

## Why It's Good For The Game
Fixing an issue with the fishing_cast projectile.

## Changelog

:cl:
fix: Fixes fishing rods not working on adjacent targets.
/:cl:
