### PR TITLE
Removed a janky fish bounty and introduced exporting fish thru cargo.

### DIFF
--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -213,7 +213,7 @@
 /datum/bounty/item/assistant/fish
 	name = "Fish"
 	description = "We need fish to populate our aquariums with. Fishes that are dead or bought from cargo will only be paid half as much."
-	reward = CARGO_CRATE_VALUE * 9
+	reward = CARGO_CRATE_VALUE * 9.5
 	required_count = 4
 	wanted_types = list(/obj/item/fish = TRUE, /obj/item/storage/fish_case = TRUE)
 	///the penalty for shipping dead/bought fish, which can subtract up to half the reward in total.
@@ -249,7 +249,7 @@
 
 ///A subtype of the fish bounty that requires fish with a specific fluid type
 /datum/bounty/item/assistant/fish/fluid
-	reward = CARGO_CRATE_VALUE * 11
+	reward = CARGO_CRATE_VALUE * 12
 	///The required fluid type of the fish for it to be shipped
 	var/fluid_type
 
@@ -261,42 +261,3 @@
 
 /datum/bounty/item/assistant/fish/fluid/can_ship_fish(obj/item/fish/fishie)
 	return compatible_fluid_type(fishie.required_fluid_type, fluid_type)
-
-///A subtype of the fish bounty that requires specific fish types. The higher their rarity, the better the pay.
-/datum/bounty/item/assistant/fish/specific
-	description = "Our prestigious fish collection is currently lacking a few specific species. Fishes that are dead or bought from cargo will only be paid half as much."
-	reward = CARGO_CRATE_VALUE * 16
-	required_count = 3
-	wanted_types = list(/obj/item/storage/fish_case = TRUE)
-
-/datum/bounty/item/assistant/fish/specific/New()
-	var/static/list/choosable_fishes
-	if(isnull(choosable_fishes))
-		choosable_fishes = list()
-		for(var/obj/item/fish/prototype as anything in subtypesof(/obj/item/fish))
-			if(initial(prototype.experisci_scannable) && initial(prototype.show_in_catalog))
-				choosable_fishes += prototype
-
-	var/list/fishes_copylist = choosable_fishes.Copy()
-	///Used to calculate the extra reward
-	var/total_rarity = 0
-	var/list/name_list = list()
-	var/num_paths = rand(2,3)
-	for(var/i in 1 to num_paths)
-		var/obj/item/fish/chosen_path = pick_n_take(fishes_copylist)
-		wanted_types[chosen_path] = TRUE
-		name_list += initial(chosen_path.name)
-		total_rarity += initial(chosen_path.random_case_rarity) / num_paths
-	name = english_list(name_list)
-
-	switch(total_rarity)
-		if(FISH_RARITY_NOPE to FISH_RARITY_GOOD_LUCK_FINDING_THIS)
-			reward += CARGO_CRATE_VALUE * 14
-		if(FISH_RARITY_GOOD_LUCK_FINDING_THIS to FISH_RARITY_VERY_RARE)
-			reward += CARGO_CRATE_VALUE * 6.5
-		if(FISH_RARITY_VERY_RARE to FISH_RARITY_RARE)
-			reward += CARGO_CRATE_VALUE * 3
-		if(FISH_RARITY_RARE to FISH_RARITY_BASIC-1)
-			reward += CARGO_CRATE_VALUE * 1
-
-	..()

--- a/code/modules/cargo/exports/fish.dm
+++ b/code/modules/cargo/exports/fish.dm
@@ -1,0 +1,10 @@
+/datum/export/fish
+	cost = 100
+	unit_name = "fish"
+	export_types = list(/obj/item/fish)
+
+/datum/export/fish/get_cost(obj/item/fish/fish, apply_elastic)
+	var/elastic_cost = ..()
+	var/elastic_percent = elastic_cost / init_cost
+	var/size_weight_exponentation = (fish.size * fish.weight * 0.01)^0.85
+	return round(elastic_cost + size_weight_exponentation * elastic_percent)

--- a/code/modules/cargo/exports/fish.dm
+++ b/code/modules/cargo/exports/fish.dm
@@ -1,5 +1,5 @@
 /datum/export/fish
-	cost = 100
+	cost = 50
 	unit_name = "fish"
 	export_types = list(/obj/item/fish)
 

--- a/code/modules/fishing/fish/fish_evolution.dm
+++ b/code/modules/fishing/fish/fish_evolution.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(fish_evolutions, init_subtypes_w_path_keys(/datum/fish_evolutio
 	conditions_note = "The fish (and its mate) need to be unusually big both in size and weight."
 
 /datum/fish_evolution/mastodon/check_conditions(obj/item/fish/source, obj/item/fish/mate, obj/structure/aquarium/aquarium)
-	if((source.size < 144 || source.weight < 4000) || (mate && (mate.size < 144 || mate.weight < 4000)))
+	if((source.size < 120 || source.weight < 3000) || (mate && (mate.size < 120 || mate.weight < 3000)))
 		return FALSE
 	return ..()
 

--- a/code/modules/fishing/fish/fish_types.dm
+++ b/code/modules/fishing/fish/fish_types.dm
@@ -317,7 +317,7 @@
 	sprite_height = 5
 	stable_population = 12
 	average_size = 110
-	average_weight = 10000
+	average_weight = 6000
 	random_case_rarity = FISH_RARITY_GOOD_LUCK_FINDING_THIS
 	required_temperature_min = MIN_AQUARIUM_TEMP+10
 	required_temperature_max = MIN_AQUARIUM_TEMP+30

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3658,6 +3658,7 @@
 #include "code\modules\cargo\exports\anomaly.dm"
 #include "code\modules\cargo\exports\antiques.dm"
 #include "code\modules\cargo\exports\civilain_bounty.dm"
+#include "code\modules\cargo\exports\fish.dm"
 #include "code\modules\cargo\exports\food_and_drink.dm"
 #include "code\modules\cargo\exports\gear.dm"
 #include "code\modules\cargo\exports\large_objects.dm"


### PR DESCRIPTION
## About The Pull Request
The fish bounty for specific kind of fish has been removed for being a bit janky and relying on RNG way too much. The other two remain, and have had their payout buffed a little to compensate.

To make it make it better, a fish export has been added. Each and every fish can be sold to cargo, with a selling price determined by their size and weight, meaning bigger fish sell for more. A fish of default size and weight generally sells for around 130, rarely goes above 600 for most fish, yet a few can sell for 1k, and it can **theorically** go all the way up to ~11k if you were to reach max size and weight for the biggest fish in the game.

This PR also reduces the weight of the jumpercable a bit for balance reasons. It's a big, self-reproducing fish that requires no care whatsoever so it's quite the cash cow, only offset by its rarity (EMAG or blackmarket RNG). Conversely, I made the bone fish evolution a bit easier (still a useless-ish braggard niche tbh).

## Why It's Good For The Game
The aforementioned fish bounty was janky, complex, relied on RNG too much and the info on it didn't really fit in the bounty console. It's better gone tbh. My fault for adding it in the first place.

As for the fish export, I want something simple, that doesn't require the fish to be alive rather than dead, with a low payout per fish on average, to complete the addition of "bomb fishing" from the other PR, ergo dropping maxcaps in the ocean for shit and giggles, but that can also have the potential to generate a decent income by cultivating big fish.

## Changelog

:cl:
del: Removed a janky fish bounty
add: introduced exporting fish through cargo.
balance: reduced the average weight of the jumpercable. Conversely, eased up the requirements for the bone fish evolution.
/:cl:
