### PR TITLE
Adds in missing lights in Tram's Tool Storage

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -8220,6 +8220,7 @@
 	},
 /obj/machinery/vending/modularpc,
 /obj/structure/table,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bNI" = (
@@ -9748,6 +9749,7 @@
 	pixel_y = 11
 	},
 /obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "cpl" = (
@@ -16425,6 +16427,7 @@
 	},
 /obj/structure/sign/clock/directional/east,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/primary)
 "eHr" = (


### PR DESCRIPTION

## About The Pull Request
Adds in lights that were not placed in #84802, oops!

![image](https://github.com/user-attachments/assets/0ce55ac2-c63c-432f-a54a-6d53814a53f9)
## Why It's Good For The Game
Being able to see is nice!
## Changelog
:cl:
fix: Tram's Tool Storage now has proper lighting
/:cl:
