### PR TITLE
Makes the suit storage icons unit test a failable test

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -266,6 +266,7 @@
 	icon = 'icons/obj/art/statue.dmi'
 	icon_state = "chisel"
 	inhand_icon_state = "screwdriver_nuke"
+	worn_icon_state = "nothing"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	obj_flags = CONDUCTS_ELECTRICITY

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/devices/flash.dmi'
 	icon_state = "flash"
 	inhand_icon_state = "flashtool"
+	worn_icon_state = "nothing"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	throwforce = 0


### PR DESCRIPTION
When I made the unit test I only intended for the warning period to last for a short time so folks could fix stuff before it became a failing test. It's been two years since then, so... time to make it actually enforced that you NEED to make an icon for shit that can go in a suit storage slot.

Grandfathered the remaining items that need to be fixed.


:cl: ShizCalev
code: Suit storage items should be less likely to not have icons in the future. 
/:cl:
