### PR TITLE
You can now put dead mice into mortars/grinders properly

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -369,9 +369,7 @@
 	var/trans_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)
 	if(target_reagents.has_reagent(/datum/reagent/fuel) && target_reagents.trans_to(src, trans_amount))
 		to_chat(user, span_notice("You dip [src] into [interacting_with]."))
-	else
-		to_chat(user, span_warning("That's a terrible idea."))
-	return ITEM_INTERACT_BLOCKING
+		return ITEM_INTERACT_SUCCESS
 
 /obj/item/food/deadmouse/moldy
 	name = "moldy dead mouse"


### PR DESCRIPTION

## About The Pull Request

Closes #85143
Blocking interactions unless you can dip is a pretty bad idea, and leaving the line in wouldn't make much sense anymore.

## Changelog
:cl:
fix: You can now put dead mice into mortars/grinders properly
/:cl:
