### PR TITLE
Fixes reversed isnull check in stacking machine consoles

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -13,7 +13,7 @@
 /obj/machinery/mineral/stacking_unit_console/Initialize(mapload)
 	. = ..()
 	var/area/our_area = get_area(src)
-	if(!isnull(our_area))
+	if(isnull(our_area))
 		return
 	var/list/turf_list = our_area.get_turfs_by_zlevel(z)
 	if(!islist(turf_list))


### PR DESCRIPTION

## About The Pull Request

Mineral stacking machine consoles had a reversed isnull area check, preventing them from linking with stacking machines

## Changelog
:cl:
fix: Stacking machine consoles link to machinery now
/:cl:
