### PR TITLE
Adds TRAITOR_SCALING_MULTIPLIER to config and makes it a float value

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -70,6 +70,7 @@
 /// Determines how fast traitors scale in general.
 /datum/config_entry/number/traitor_scaling_multiplier
 	default = 1
+	integer = FALSE
 	min_val = 0.01
 
 /// Determines how many potential objectives a traitor can have.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -100,6 +100,11 @@ TRAITOR_SCALING_COEFF 6
 BROTHER_SCALING_COEFF 6
 CHANGELING_SCALING_COEFF 6
 
+## Global scaling for traitor progression.
+## Higher values will accelerate traitor progression, while lower values will decrease it.
+## Bypasses an upper limit of 1 MINUTE
+#TRAITOR_SCALING_MULTIPLIER 1
+
 ## Variables calculate how number of open security officer positions will scale to population.
 ## Used as (Officers = Population / Coeff)
 ## Set to 0 to disable scaling and use default numbers instead.


### PR DESCRIPTION

## About The Pull Request
Added a missing entry to game_config.txt
Fixed this entry being an integer, not a float

## Why It's Good For The Game
Config can be used to modify the speed at which the traitors progress. It was missing from the example config.

## Changelog
:cl:
config: Added an entry for TRAITOR_SCALING_MULTIPLIER, disabled by default
/:cl:
