### PR TITLE
Xenomorphs and door pryer basic mobs can now attack airlocks in combat mode

### DIFF
--- a/code/datums/elements/door_pryer.dm
+++ b/code/datums/elements/door_pryer.dm
@@ -35,11 +35,12 @@
 		attacker.balloon_alert(attacker, "busy!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if (airlock_target.locked || airlock_target.welded || airlock_target.seal)
-		if (!attacker.combat_mode)
-			airlock_target.balloon_alert(attacker, "it's sealed!")
-			return COMPONENT_CANCEL_ATTACK_CHAIN
+	if (attacker.combat_mode)
 		return // Attack the door
+
+	if (airlock_target.locked || airlock_target.welded || airlock_target.seal)
+		airlock_target.balloon_alert(attacker, "it's sealed!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	INVOKE_ASYNC(src, PROC_REF(open_door), attacker, airlock_target)
 	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1463,9 +1463,9 @@
 		return
 	if(!density) //Already open
 		return ..()
+	if(user.combat_mode)
+		return ..()
 	if(locked || welded || seal) //Extremely generic, as aliens only understand the basics of how airlocks work.
-		if(user.combat_mode)
-			return ..()
 		to_chat(user, span_warning("[src] refuses to budge!"))
 		return
 	add_fingerprint(user)


### PR DESCRIPTION

## About The Pull Request

Closes #84799

## Changelog
:cl:
fix: Xenomorphs and door pryer basic mobs can now attack airlocks in combat mode
/:cl:
