### PR TITLE
You can no longer microwave kisses, slappers, and other abstract items

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -382,6 +382,9 @@
 	if(operating)
 		return NONE
 
+	if (item.item_flags & ABSTRACT)
+		return NONE
+
 	if(broken > NOT_BROKEN)
 		balloon_alert(user, "it's broken!")
 		return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION

## About The Pull Request
Closes #85178

## Changelog
:cl:
fix: You can no longer microwave kisses, slappers, and other abstract items
/:cl:
