### PR TITLE
Having your liver fail no longer keeps drug traits active without metabolizing them

### DIFF
--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -132,6 +132,7 @@
 	. = ..()
 	//If your liver is failing, then we use the liverless version of metabolize
 	if((organ_flags & ORGAN_FAILING) || HAS_TRAIT(owner, TRAIT_LIVERLESS_METABOLISM))
+		owner.reagents.end_metabolization(keep_liverless = TRUE)
 		owner.reagents.metabolize(owner, seconds_per_tick, times_fired, can_overdose = TRUE, liverless = TRUE)
 		return
 


### PR DESCRIPTION

## About The Pull Request
Closes #78992 by making failing livers call on_mob_end_metabolize just like lacking a liver does.

## Why It's Good For The Game

Lack of metabolization can be exploited by players to stack up all drugs in existence without suffering any downsides (which are usually in metab life), resulting in infinite stun/crit immunity/bath salts martial art/speed boosts. This behavior also is inconsistent with lack of liver, which liver failure roughly replicates.
I am unsure of whenever this should be marked as balance or as a fix (since this is an oversight which leads to an exploit), so I'm gonna leave that up to maintainers.

## Changelog
:cl:
fix: Having your liver fail no longer keeps drug traits active without metabolizing them
/:cl:
