### PR TITLE
Removed rogue CMO screen from icebox medsec

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -29673,7 +29673,6 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/landmark/start/depsec/medical,
-/obj/machinery/computer/security/telescreen/cmo/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "iTJ" = (


### PR DESCRIPTION

## About The Pull Request

Closes #85182

## Changelog
:cl:
fix: Removed rogue CMO screen from icebox medsec
/:cl:
