### PR TITLE
Cyberhearts, rather than injecting a chem into you, instead combat bleed wounds. Upgraded hearts give you a brief moment of soft crit action

### DIFF
--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -256,7 +256,7 @@
 /obj/item/organ/internal/heart/cybernetic/tier3
 	name = "upgraded cybernetic heart"
 	desc = "An electronic device designed to mimic the functions of an organic human heart. In case of physical trauma, the heart has temporary failsafes to maintain patient stability \
-		and mobility for a brief moment. In addition, the heart is able to safely self-replicate blood without the possibility of toxin buildup"
+		and mobility for a brief moment. In addition, the heart is able to safely self-replicate blood without risk of toxin buildup."
 	icon_state = "heart-c-u2-on"
 	base_icon_state = "heart-c-u2"
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -168,19 +168,19 @@
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.75 //This also hits defib timer, so a bit higher than its less important counterparts
 	failing_desc = "seems to be broken."
 
-	// Whether or not we have a stabilization available. This prevents our owner from entering softcrit for an amount of time.
+	/// Whether or not we have a stabilization available. This prevents our owner from entering softcrit for an amount of time.
 	var/stabilization_available = FALSE
 
-	// How long our stabilization lasts for.
+	/// How long our stabilization lasts for.
 	var/stabilization_duration = 10 SECONDS
 
-	// Whether our heart suppresses bleeders and restores blood automatically.
+	/// Whether our heart suppresses bleeders and restores blood automatically.
 	var/bleed_prevention = FALSE
 
-	// THe probability that our blood replication causes toxin damage.
+	/// The probability that our blood replication causes toxin damage.
 	var/toxification_probability = 20
 
-	//Chance of permanent effects if emp-ed.
+	/// Chance of permanent effects if emp-ed.
 	var/emp_vulnerability = 80
 
 /obj/item/organ/internal/heart/cybernetic/emp_act(severity)

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -240,8 +240,8 @@
 // Largely a sanity check
 /obj/item/organ/internal/heart/cybernetic/on_mob_remove(mob/living/carbon/heart_owner, special = FALSE)
 	. = ..()
-	if(HAS_TRAIT_FROM(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT))
-		REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
+	if(HAS_TRAIT_FROM(heart_owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT))
+		REMOVE_TRAIT(heart_owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
 
 /obj/item/organ/internal/heart/cybernetic/tier2
 	name = "cybernetic heart"

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -240,8 +240,8 @@
 // Largely a sanity check
 /obj/item/organ/internal/heart/cybernetic/on_mob_remove(mob/living/carbon/heart_owner, special = FALSE)
 	. = ..()
-
-	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
+	if(HAS_TRAIT_FROM(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT))
+		REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
 
 /obj/item/organ/internal/heart/cybernetic/tier2
 	name = "cybernetic heart"

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -230,7 +230,7 @@
 			bloodiest_wound.adjust_blood_flow(-1 * seconds_per_tick)
 
 /obj/item/organ/internal/heart/cybernetic/proc/stabilize_heart()
-	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
+	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
 	stabilization_available = FALSE
 
 	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT), stabilization_duration)

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -235,7 +235,7 @@
 
 	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT), stabilization_duration)
 
-	addtimer(VARSET_CALLBACK(src, stabilization_available, TRUE), 5 MINUTES)
+	addtimer(VARSET_CALLBACK(src, stabilization_available, TRUE), 5 MINUTES, TIMER_DELETE_ME)
 
 // Largely a sanity check
 /obj/item/organ/internal/heart/cybernetic/on_mob_remove(mob/living/carbon/heart_owner, special = FALSE)

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -212,7 +212,7 @@
 		return
 
 	if(stabilization_available && owner.health <= owner.crit_threshold)
-		stabilizer_heart()
+		stabilize_heart()
 
 	if(bleed_prevention && ishuman(owner) && owner.blood_volume < BLOOD_VOLUME_NORMAL)
 		var/mob/living/carbon/human/wounded_owner = owner
@@ -229,7 +229,7 @@
 		if(bloodiest_wound)
 			bloodiest_wound.adjust_blood_flow(-1 * seconds_per_tick)
 
-/obj/item/organ/internal/heart/cybernetic/proc/stabilizer_heart()
+/obj/item/organ/internal/heart/cybernetic/proc/stabilize_heart()
 	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
 	stabilization_available = FALSE
 

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -165,13 +165,23 @@
 	icon_state = "heart-c-on"
 	base_icon_state = "heart-c"
 	organ_flags = ORGAN_ROBOTIC
-	maxHealth = STANDARD_ORGAN_THRESHOLD*0.75 //This also hits defib timer, so a bit higher than its less important counterparts
+	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.75 //This also hits defib timer, so a bit higher than its less important counterparts
 	failing_desc = "seems to be broken."
 
-	var/dose_available = FALSE
-	var/rid = /datum/reagent/medicine/epinephrine
-	var/ramount = 10
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
+	// Whether or not we have a stabilization available. This prevents our owner from entering softcrit for an amount of time.
+	var/stabilization_available = FALSE
+
+	// How long our stabilization lasts for.
+	var/stabilization_duration = 10 SECONDS
+
+	// Whether our heart suppresses bleeders and restores blood automatically.
+	var/bleed_prevention = FALSE
+
+	// THe probability that our blood replication causes toxin damage.
+	var/toxification_probability = 20
+
+	//Chance of permanent effects if emp-ed.
+	var/emp_vulnerability = 80
 
 /obj/item/organ/internal/heart/cybernetic/emp_act(severity)
 	. = ..()
@@ -197,34 +207,62 @@
 
 /obj/item/organ/internal/heart/cybernetic/on_life(seconds_per_tick, times_fired)
 	. = ..()
-	if(dose_available && owner.health <= owner.crit_threshold && !owner.reagents.has_reagent(rid))
-		used_dose()
 
-/obj/item/organ/internal/heart/cybernetic/proc/used_dose()
-	owner.reagents.add_reagent(rid, ramount)
-	dose_available = FALSE
+	if(organ_flags & ORGAN_EMP)
+		return
+
+	if(stabilization_available && owner.health <= owner.crit_threshold)
+		stabilizer_heart()
+
+	if(bleed_prevention && ishuman(owner) && owner.blood_volume < BLOOD_VOLUME_NORMAL)
+		var/mob/living/carbon/human/wounded_owner = owner
+		wounded_owner.blood_volume += 2 * seconds_per_tick
+		if(toxification_probability && prob(toxification_probability))
+			wounded_owner.adjustToxLoss(1 * seconds_per_tick, updating_health = FALSE)
+
+		var/datum/wound/bloodiest_wound
+
+		for(var/datum/wound/iter_wound as anything in wounded_owner.all_wounds)
+			if(iter_wound.blood_flow && iter_wound.blood_flow > bloodiest_wound?.blood_flow)
+				bloodiest_wound = iter_wound
+
+		if(bloodiest_wound)
+			bloodiest_wound.adjust_blood_flow(-1 * seconds_per_tick)
+
+/obj/item/organ/internal/heart/cybernetic/proc/stabilizer_heart()
+	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
+	stabilization_available = FALSE
+
+	addtimer(TRAIT_CALLBACK_REMOVE(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT), stabilization_duration)
+
+	addtimer(VARSET_CALLBACK(src, stabilization_available, TRUE), 5 MINUTES)
+
+// Largely a sanity check
+/obj/item/organ/internal/heart/cybernetic/on_mob_remove(mob/living/carbon/heart_owner, special = FALSE)
+	. = ..()
+
+	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, ORGAN_TRAIT)
 
 /obj/item/organ/internal/heart/cybernetic/tier2
 	name = "cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. In case of lacerations or haemorrhaging, the heart rapidly begins self-replicating \
+		artificial blood. However, this can cause toxins to build up in the bloodstream to the imperfect replication process."
 	icon_state = "heart-c-u-on"
 	base_icon_state = "heart-c-u"
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
-	dose_available = TRUE
+	bleed_prevention = TRUE
 	emp_vulnerability = 40
 
 /obj/item/organ/internal/heart/cybernetic/tier3
 	name = "upgraded cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma. This upgraded model can regenerate its dose after use."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. In case of physical trauma, the heart has temporary failsafes to maintain patient stability \
+		and mobility for a brief moment. In addition, the heart is able to safely self-replicate blood without the possibility of toxin buildup"
 	icon_state = "heart-c-u2-on"
 	base_icon_state = "heart-c-u2"
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
-	dose_available = TRUE
+	stabilization_available = TRUE
+	toxification_probability = 0
 	emp_vulnerability = 20
-
-/obj/item/organ/internal/heart/cybernetic/tier3/used_dose()
-	. = ..()
-	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 5 MINUTES)
 
 /obj/item/organ/internal/heart/cybernetic/surplus
 	name = "surplus prosthetic heart"

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -7,6 +7,8 @@
 	name = "Voltaic Combat Cyberheart"
 	desc = "A cutting-edge cyberheart, originally designed for Nanotrasen killsquad usage but later declassified for normal research. Voltaic technology allows the heart to keep the body upright in dire circumstances, alongside redirecting anomalous flux energy to fully shield the user from shocks and electro-magnetic pulses. Requires a refined Flux core as a power source."
 	icon_state = "anomalock_heart"
+	bleed_prevention = TRUE
+	toxification_probability = 0
 
 	COOLDOWN_DECLARE(survival_cooldown)
 	///Cooldown for the activation of the organ


### PR DESCRIPTION

## About The Pull Request

Cybernetic (tier 2) and Upgraded Cybernetic hearts (tier 3) actively close bleed wounds while inserted. They also restore blood. Tier 2 hearts have a chance to deal toxin damage to you as a result of this blood restoration. (Not much though)

Tier 3 hearts do not deal this damage, and also give a very brief period of soft crit immunity. At least enough time to medicate yourself if you're not actively taking constant damage, or maybe use some kind of escape tool.

If the heart is permanently damaged from an EMP, these benefits cease to function.

## Why It's Good For The Game

I heavily dislike that the hearts use reagents, and that tier 2 hearts can actually only do their special effect once before requiring total replacement. They're the one cybernetic organ that I generally try to avoid, and they can certainly cause some nasty surprises to a few of their users who aren't aware that it has injected them with epinephrine and a few well meaning doctors have rotated your body around with additional medipen injections.

Hopefully these changes make them more appealing to combat a particular danger that is usually quite difficult for players to deal with under most circumstances; blood loss, that really annoying hidden health bar. It won't be able to keep up perfectly with multiple heavy bleeds, but it will usually prevent some of the nastier ones.

## Changelog
:cl:
balance: Quality cybernetic hearts combat bleeds and restore blood, rather than inject you with epinephrine when you enter crit. This can result in mild toxin buildup, however.
balance: Upgraded cybernetic hearts give an extremely brief amount of action when you enter softcrit (but not hardcrit).
/:cl:
