### PR TITLE
Fixes DDOSing bitrunners

### DIFF
--- a/code/modules/bitrunning/netpod/utils.dm
+++ b/code/modules/bitrunning/netpod/utils.dm
@@ -76,6 +76,11 @@
 		balloon_alert(neo, "nothing loaded!")
 		return
 
+	balloon_alert(neo, "establishing connection...")
+	if(!do_after(neo, 2 SECONDS, src))
+		open_machine()
+		return
+
 	var/mob/living/carbon/current_avatar = avatar_ref?.resolve()
 	if(isnull(current_avatar) || current_avatar.stat != CONSCIOUS) // We need a viable avatar
 		current_avatar = server.start_new_connection(neo, netsuit)
@@ -130,9 +135,6 @@
 
 /// Checks for cases to eject/fail connecting an avatar
 /obj/machinery/netpod/proc/validate_entry(mob/living/neo, mob/living/avatar)
-	if(!do_after(neo, 2 SECONDS, src))
-		return FALSE
-
 	// Very invalid
 	if(QDELETED(neo) || QDELETED(avatar) || QDELETED(src) || !is_operational)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Got a bug reported today on a downstream, turns out it's a thing here. If there's no linked avatar yet and you repeatedly climb in and out of the pod before the do_after finishes, you fill in all three bitrunning slots with unlinked avatars and fill up the bandwidth.

I simply moved the do_after before any of the avatar spawning, making the pod "Try to connect" before it does anything avatar handling worthy.

## Why It's Good For The Game

I will have one less bitrunner in my DMs reporting a bug, and you might too!

Idk I guess bugfixes are good

## Changelog

:cl:
fix: fixes bitrunning breaking upon repeatedly climbing in and out the pod
/:cl:
