### PR TITLE
Makes voidwalker objectives more descriptive

### DIFF
--- a/code/modules/antagonists/voidwalker/voidwalker.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker.dm
@@ -48,7 +48,7 @@
 	var/list/explanation_texts = list(
 		"Show them the beauty of the void. Drag them into the cosmic abyss, then impart the truth of the void unto them. Seek to enlighten, not destroy.",
 		"They must see what you have seen. They must walk where you have walked. Bring them to the void and show them the truth. The dead cannot know what you know.",
-		"Recover what you have lost. Bring your children into the inky black return them to your flock.",
+		"Recover what you have lost. Bring your children into the inky black and return them to your flock.",
 	)
 	if(prob(20))
 		explanation_text += "Man I fucking love glass."

--- a/code/modules/antagonists/voidwalker/voidwalker.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker.dm
@@ -32,7 +32,7 @@
 	return ..()
 
 /datum/antagonist/voidwalker/forge_objectives()
-	var/datum/objective/voidwalker_fluff/objective = new
+	var/datum/objective/voidwalker_objective/objective = new
 	objective.owner = owner
 	objectives += objective
 
@@ -42,20 +42,18 @@
 /datum/outfit/voidwalker/post_equip(mob/living/carbon/human/human, visualsOnly)
 	human.set_species(/datum/species/voidwalker)
 
-/datum/objective/voidwalker_fluff
+/datum/objective/voidwalker_objective
 
-/datum/objective/voidwalker_fluff/New()
+/datum/objective/voidwalker_objective/New()
 	var/list/explanation_texts = list(
-		"Show them the beauty of the void.",
-		"They must see what you have seen. They must walk where you have walked.",
-		"Recover what you have lost.",
-		"Obliterate the tyranny of matter.",
-		"Make them all just like you."
+		"Show them the beauty of the void. Drag them into the cosmic abyss, then impart the truth of the void unto them. Seek to enlighten, not destroy.",
+		"They must see what you have seen. They must walk where you have walked. Bring them to the void and show them the truth. The dead cannot know what you know.",
+		"Recover what you have lost. Bring your children into the inky black return them to your flock.",
 	)
 	if(prob(20))
 		explanation_text += "Man I fucking love glass."
 	explanation_text = pick(explanation_texts)
 	..()
 
-/datum/objective/voidwalker_fluff/check_completion()
+/datum/objective/voidwalker_objective/check_completion()
 	return owner.current.stat != DEAD


### PR DESCRIPTION

## About The Pull Request

Voidwalker's potential objectives now better explain what they should be doing as opposed to just being fluff. I like fluff, but we can have that _and_ give extra guidance while better explaining to others during the end round screen what the role should be doing.
## Why It's Good For The Game

Better objectives will help us focus Voidwalkers into doing what we want them to do as opposed to using their cool glass-walking skills to be a budget Nightmare.
## Changelog
:cl: Vekter
spellcheck: Reworded Voidwalker's objectives to be more descriptive of their actual goals as opposed to just fluff.
/:cl:
