### PR TITLE
add hardware flags for silicons pdas

### DIFF
--- a/code/__DEFINES/modular_computer.dm
+++ b/code/__DEFINES/modular_computer.dm
@@ -12,6 +12,16 @@
 ///Can run on PDAs.
 #define PROGRAM_PDA (1<<2)
 
+// can run on cyborgs
+#define PROGRAM_CYBORG (1<<3)
+
+// can run on ai
+#define PROGRAM_AI (1<<4)
+
+// can run on any silicon
+#define PROGRAM_SILICON (PROGRAM_CYBORG|PROGRAM_AI)
+
+
 /**
  * program_flags
  * Used by programs to tell the ModPC any special functions it has.

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -309,6 +309,8 @@
 		/datum/computer_file/program/messenger,
 	)
 
+	hardware_flag = PROGRAM_AI
+
 	///Ref to the RoboTact app. Important enough to borgs to deserve a ref.
 	var/datum/computer_file/program/robotact/robotact
 	///IC log that borgs can view in their personal management app
@@ -317,6 +319,8 @@
 	var/mob/living/silicon/silicon_owner
 
 /obj/item/modular_computer/pda/silicon/cyborg
+	hardware_flag = PROGRAM_CYBORG
+
 	starting_programs = list(
 		/datum/computer_file/program/filemanager,
 		/datum/computer_file/program/robotact,

--- a/code/modules/modular_computers/file_system/programs/maintenance/spectre_meter.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/spectre_meter.dm
@@ -12,7 +12,7 @@
 	downloader_category = PROGRAM_CATEGORY_EQUIPMENT
 	extended_desc = "A program used to somehow detect nearby spectral presence. Combine with the camera app to take photos of ghosts."
 	size = 7
-	can_run_on_flags = PROGRAM_LAPTOP|PROGRAM_PDA
+	can_run_on_flags = PROGRAM_LAPTOP | PROGRAM_PDA | PROGRAM_SILICON
 	tgui_id = "NtosSpectreMeter"
 	program_icon = "ghost"
 	program_open_overlay = "spectre_meter_0"

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -15,7 +15,7 @@
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
 	power_cell_use = NONE
 	program_flags = PROGRAM_HEADER | PROGRAM_RUNS_WITHOUT_POWER | PROGRAM_CIRCUITS_RUN_WHEN_CLOSED
-	can_run_on_flags = PROGRAM_PDA
+	can_run_on_flags = PROGRAM_PDA | PROGRAM_AI
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"
 	program_icon = "comment-alt"

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -7,7 +7,7 @@
 	program_open_overlay = "crew"
 	tgui_id = "NtosRecords"
 	size = 4
-	can_run_on_flags = PROGRAM_PDA | PROGRAM_LAPTOP
+	can_run_on_flags = PROGRAM_PDA | PROGRAM_LAPTOP | PROGRAM_SILICON
 	program_flags = NONE
 	detomatix_resistance = DETOMATIX_RESIST_MINOR
 

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -7,7 +7,7 @@
 	program_open_overlay = "command"
 	program_flags = NONE
 	undeletable = TRUE
-	can_run_on_flags = PROGRAM_PDA
+	can_run_on_flags = PROGRAM_SILICON // it's restricted to silicons
 	size = 5
 	tgui_id = "NtosRobotact"
 	program_icon = "terminal"

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -9,7 +9,7 @@
 	extended_desc = "This program allows access to standard security camera networks."
 	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	download_access = list(ACCESS_SECURITY)
-	can_run_on_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
+	can_run_on_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_SILICON
 	size = 5
 	tgui_id = "NtosSecurEye"
 	program_icon = "eye"

--- a/code/modules/modular_computers/file_system/programs/signalcommander.dm
+++ b/code/modules/modular_computers/file_system/programs/signalcommander.dm
@@ -7,7 +7,7 @@
 	size = 2
 	tgui_id = "NtosSignaler"
 	program_icon = "satellite-dish"
-	can_run_on_flags = PROGRAM_PDA | PROGRAM_LAPTOP
+	can_run_on_flags = PROGRAM_PDA | PROGRAM_LAPTOP | PROGRAM_SILICON
 	program_flags = /datum/computer_file/program::program_flags | PROGRAM_CIRCUITS_RUN_WHEN_CLOSED
 	circuit_comp_type = /obj/item/circuit_component/mod_program/signaler
 	///What is the saved signal frequency?

--- a/code/modules/modular_computers/file_system/programs/virtual_pet.dm
+++ b/code/modules/modular_computers/file_system/programs/virtual_pet.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(virtual_pets_list)
 	size = 3
 	tgui_id = "NtosVirtualPet"
 	program_icon = "paw"
-	can_run_on_flags = PROGRAM_PDA
+	can_run_on_flags = PROGRAM_PDA | PROGRAM_SILICON
 	detomatix_resistance = DETOMATIX_RESIST_MALUS
 	///how many steps have we walked
 	var/steps_counter = 0


### PR DESCRIPTION

## About The Pull Request
adds PROGRAM_CYBORG and PROGRAM_AI hardware_flag and tags programs correctly.

## Why It's Good For The Game

a lot of apps are restricted to or from borgs. this pr makes it clean to do so.
tweaks borgs internal pda to be more like a laptop instead of a pda (with addition of NtosVirtualPet becuse it sounds adorable for a borg to have a virtual pet )

## Changelog
:cl:
code: add hardware flags for silicons pdas
balance: borgs are now able to view cameras via internal pda if someone uploads the app to them
code: apps borgs can't use are marked as such.
balance: borgs can't use lifeline app anymore
/:cl:
