### PR TITLE
Made borgs and AI able to use research queue [NO GBP]

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -332,16 +332,16 @@
 	return techweb_point_display_generic(research_points)
 
 /datum/techweb/proc/enqueue_node(id, mob/user)
-	var/mob/living/carbon/human/human_user = user
-	var/is_rd = FALSE
-	if(human_user.wear_id)
-		var/list/access = human_user.wear_id.GetAccess()
+	var/queue_first = FALSE
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/human_user = user
+		var/list/access = human_user.wear_id?.GetAccess()
 		if(ACCESS_RD in access)
-			is_rd = TRUE
+			queue_first = TRUE
 
 	if(id in research_queue_nodes)
-		if(is_rd)
-			research_queue_nodes.Remove(id)
+		if(queue_first)
+			research_queue_nodes.Remove(id) // Remove to be able to place first
 		else
 			return FALSE
 
@@ -349,7 +349,7 @@
 		if(research_queue_nodes[node_id] == user)
 			research_queue_nodes.Remove(node_id)
 
-	if (is_rd)
+	if (queue_first)
 		research_queue_nodes.Insert(1, id)
 	research_queue_nodes[id] = user
 


### PR DESCRIPTION
## About The Pull Request

Interaction with the queue didn't work for mobs of a type different from `/mob/living/carbon/human`

Fixed this.

## Why It's Good For The Game

Fixes #85049 

## Changelog

:cl:
fix: Borgs and AI can now use research queue
/:cl:
