### PR TITLE
Fix clicking on a table through the lootpanel with an item forcing it to be placed in the very corner

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -316,9 +316,11 @@
 		return NONE
 	if(!user.transferItemToLoc(tool, drop_location(), silent = FALSE))
 		return ITEM_INTERACT_BLOCKING
-	//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
-	tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(world.icon_size/2), world.icon_size/2)
-	tool.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(world.icon_size/2), world.icon_size/2)
+	// Items are centered by default, but we move them if click ICON_X and ICON_Y are available
+	if(LAZYACCESS(modifiers, ICON_X) && LAZYACCESS(modifiers, ICON_Y))
+		// Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
+		tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(world.icon_size/2), world.icon_size/2)
+		tool.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(world.icon_size/2), world.icon_size/2)
 	AfterPutItemOnTable(tool, user)
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -319,8 +319,8 @@
 	// Items are centered by default, but we move them if click ICON_X and ICON_Y are available
 	if(LAZYACCESS(modifiers, ICON_X) && LAZYACCESS(modifiers, ICON_Y))
 		// Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
-		tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(world.icon_size/2), world.icon_size/2)
-		tool.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(world.icon_size/2), world.icon_size/2)
+		tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(world.icon_size*0.5), world.icon_size*0.5)
+		tool.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(world.icon_size*0.5), world.icon_size*0.5)
 	AfterPutItemOnTable(tool, user)
 	return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

So apparently, as the title says, placing items on tables through the lootpanel would place them in the very corner.
I learnt about this because of someone telling me it _used_ to always center them.

Looking into it, this seems to be because we ALWAYS set it based on the `modifiers` `ICON_X` and `ICON_Y`:
https://github.com/tgstation/tgstation/blob/0da57e95248924e5aa67b3d329022b7c74146c94/code/game/objects/structures/tables_racks.dm#L319-L321
While those are not set when clicking through the lootpanel, causing these formulas to default to `-16`, and thus placing them in the corner.

Comparing this to crayons/spraycans, which do center, and do this because they only adjust the `pixel_x` and `pixel_y` if `ICON_X` and `ICON_Y` are actually set:
https://github.com/tgstation/tgstation/blob/0da57e95248924e5aa67b3d329022b7c74146c94/code/game/objects/items/crayons.dm#L500-L502

At some point in the past tables also had this check, but it seems it got accidentally removed during the move to `item_interaction(...)` from `attackby(...)`.

We just reintroduce this check, meaning it once again defaults to the item being centered.
## Why It's Good For The Game

Having your item be placed on the very leg of the table is kinda awkward.
## Changelog
:cl:
fix: Clicking on a table in the lootpanel with an item in-hand tries to place it in the center again.
/:cl:
