### PR TITLE
Fixes firelocks not respecting thermal sensors being disabled

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -431,6 +431,10 @@
 	ignore_alarms = FALSE
 	if(!alarm_type || active) // If we have no alarm type, or are already active, go away
 		return
+	// Do we even care about temperature?
+	for(var/area/place in affecting_areas)
+		if(!place.fire_detect) // If any area is set to disable detection
+			return
 	// Otherwise, reactivate ourselves
 	start_activation_process(alarm_type)
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -477,6 +477,9 @@
 	my_area.fire_detect = !my_area.fire_detect
 	for(var/obj/machinery/firealarm/fire_panel in my_area.firealarms)
 		fire_panel.update_icon()
+	// Used to force all the firelocks to update, if the zone is not manually activated
+	if (my_area.fault_status != AREA_FAULT_MANUAL)
+		reset() // Don't send user to prevent double balloon_alert() and the action is already logged in this proc.
 	if (user)
 		balloon_alert(user, "thermal sensors [my_area.fire_detect ? "enabled" : "disabled"]")
 		user.log_message("[ my_area.fire_detect ? "enabled" : "disabled" ] firelock sensors using [src].", LOG_GAME)


### PR DESCRIPTION
## About The Pull Request

### The issue

Firelocks currently do not respect their fire alarm's thermal sensors being disabled, _(the multitool/silicon right-click on a fire alarm feature)_, after the fire alarms are triggered. 

### Why this happens
**Part 1**, of why this happens is that toggling thermal sensors on a fire alarm doesn't actually reset firelocks in the area.

**Part 2**, of this is even if toggling thermal sensing on fire alarms called `firealarm/proc/reset()` _(this is the proc called when you right-click a fire alarm, also why resetting the fire alarm doesn't act as a workaround)_, that proc doesn't actual call `firedoor/proc/reset() ` on all the firelocks in the area and instead calls `firedoor/proc/crack_open()`, which temporarily disables the firelock; however, the callback that re-enables the firelock does not check to see if any areas the firelock is attached to has temperature sensing disabled, resulting in temp sensing being disabling never doing anything after a firelock is triggered.

### What this PR does

- Adds check in the firelock callback to see if any areas the firelock is attached to care about temperature sensing. 
- Makes toggling thermal sensors on fire alarms update attached firelocks.
## Why It's Good For The Game

Fixes a broken feature. Also firelocks suck and being able to disable them is nice.

## Changelog

:cl:
fix: Firelocks will once again respect fire alarm's thermal sensors being disabled.
/:cl: