### PR TITLE
Fixed janicart not transfering items into the trash bag

### DIFF
--- a/code/datums/components/vacuum.dm
+++ b/code/datums/components/vacuum.dm
@@ -53,7 +53,7 @@
 		if (!isitem(potential_item))
 			continue
 		var/obj/item/item = potential_item
-		if (item.Move(vacuum_bag))
+		if (vacuum_bag.atom_storage.attempt_insert(item))
 			sucked = TRUE // track that we successfully sucked up something
 
 	// if we did indeed suck up something, play a funny noise

--- a/code/datums/components/vacuum.dm
+++ b/code/datums/components/vacuum.dm
@@ -53,7 +53,7 @@
 		if (!isitem(potential_item))
 			continue
 		var/obj/item/item = potential_item
-		if (vacuum_bag?.attackby(item))
+		if (item.Move(vacuum_bag))
 			sucked = TRUE // track that we successfully sucked up something
 
 	// if we did indeed suck up something, play a funny noise

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -64,7 +64,7 @@
 		installed_upgrade = null
 		update_appearance()
 	else if(trash_bag && (!is_key(I) || is_key(inserted_key))) // don't put a key in the trash when we need it
-		trash_bag.attackby(I, user)
+		trash_bag.atom_storage.attempt_insert(I, user)
 	else
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

It was trying to put items into a trash bag that doesn't have `CAN_BE_HIT` flag with an `attackby`.

It now works for both the vacuum insert and the manual one.

Fixes #84653 

## Why It's Good For The Game

Bug fix.

## Changelog

:cl:
fix: Janicart inserts items into the attached trash bag again (manual and vacuumed)
/:cl:
