### PR TITLE
Binoculars removed from ritual of knowledge, clipboards made craftable

### DIFF
--- a/code/datums/components/crafting/misc.dm
+++ b/code/datums/components/crafting/misc.dm
@@ -35,6 +35,17 @@
 	tool_paths = list(/obj/item/stamp/head/captain)
 	category = CAT_MISC
 
+/datum/crafting_recipe/clipboard
+	name = "Clipboard"
+	result = /obj/item/clipboard
+	time = 3 SECONDS
+	reqs = list(
+		/obj/item/stack/sheet/mineral/wood = 1,
+		/obj/item/stack/rods = 1,
+	)
+	tool_paths = list(TOOL_WIRECUTTER)
+	category = CAT_MISC
+
 /datum/crafting_recipe/cardboard_id
 	name = "Cardboard ID Card"
 	tool_behaviors = list(TOOL_WIRECUTTER)

--- a/code/datums/components/crafting/misc.dm
+++ b/code/datums/components/crafting/misc.dm
@@ -43,7 +43,7 @@
 		/obj/item/stack/sheet/mineral/wood = 1,
 		/obj/item/stack/rods = 1,
 	)
-	tool_paths = list(TOOL_WIRECUTTER)
+	tool_behaviors = list(TOOL_WIRECUTTER)
 	category = CAT_MISC
 
 /datum/crafting_recipe/cardboard_id

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -632,7 +632,6 @@
 		/obj/item/paper,
 		/obj/item/toy/crayon,
 		/obj/item/flashlight,
-		/obj/item/clipboard,
 	)
 
 	var/static/list/potential_uncommoner_items = list(

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -632,6 +632,7 @@
 		/obj/item/paper,
 		/obj/item/toy/crayon,
 		/obj/item/flashlight,
+		/obj/item/clipboard,
 	)
 
 	var/static/list/potential_uncommoner_items = list(
@@ -639,7 +640,6 @@
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/circular_saw,
 		/obj/item/scalpel,
-		/obj/item/binoculars,
 		/obj/item/clothing/gloves/color/yellow,
 		/obj/item/melee/baton/security,
 		/obj/item/clothing/glasses/sunglasses,


### PR DESCRIPTION
## About The Pull Request

This pull request removes the clipboard from the pool of heretic ritual of knowledge items, specifically the "Easy" ones to obtain. The rest is unchanged. 
## Why It's Good For The Game

Clipboards are substantially harder to obtain than it's fellow objects for the ritual. 

- Shards are able to be made from glass from autolathes, maintenance loot, protolathes, salvaged from structures
- Candles are printable from biomass, plenty of them in the chapel, orderable, sometimes maintenance has them
- Paper is printable from biogen iirc and in huge quantities across the entire station, you can also handcraft some or order it
- Everyone has a pen roundstart, obtainable from library, lathes, maints
- Flashlights are the same as above yet obtainable from most tool closets and even emergency closets
- Crayons are able to be made with xenobiology, ordered, have a few map spawns but are generally in good quantity and are maintenance loot.

The clipboard however is not printable, orders in sets of 2 for an interesting sum in a suspiciously never ordered package, has lackluster map spawns (One or two in cargo, one psychologist's), is sometimes required in pairs if not more and it's severely more difficult to get. I do not think anyone would miss this, as it's just tedious and too low-supply to get. There are more batons on station then there are clipboards, even organs are easier to access.

## Changelog
:cl:
add: The heretic's ritual of knowledge no longer requires binoculars
add: Clipboards are craftable using a wood plank, an iron rod and wirecutters
/:cl:
