### PR TITLE
wheelchair + ridden mobs buff

### DIFF
--- a/code/datums/components/riding/riding.dm
+++ b/code/datums/components/riding/riding.dm
@@ -9,7 +9,6 @@
 /datum/component/riding
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 
-	var/last_move_diagonal = FALSE
 	///tick delay between movements, lower = faster, higher = slower
 	var/vehicle_move_delay = 2
 

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -105,9 +105,7 @@
 			to_chat(user, span_warning("You need a [initial(key.name)] to ride [movable_parent]!"))
 		return COMPONENT_DRIVER_BLOCK_MOVE
 	var/mob/living/living_parent = parent
-	var/turf/next = get_step(living_parent, direction)
 	step(living_parent, direction)
-	last_move_diagonal = ((direction & (direction - 1)) && (living_parent.loc == next))
 	var/modified_move_cooldown = vehicle_move_cooldown
 	var/modified_move_delay = vehicle_move_delay
 	if(ishuman(user) && HAS_TRAIT(user, TRAIT_ROUGHRIDER)) // YEEHAW!
@@ -133,7 +131,7 @@
 			if(SANITY_LEVEL_INSANE)
 				modified_move_cooldown *= 1.2
 				modified_move_delay *= 1.2
-	COOLDOWN_START(src, vehicle_move_cooldown = modified_move_cooldown, (last_move_diagonal ? 2 : 1) * modified_move_delay)
+	COOLDOWN_START(src, vehicle_move_cooldown = modified_move_cooldown, modified_move_delay)
 	return ..()
 
 /// Yeets the rider off, used for animals and cyborgs, redefined for humans who shove their piggyback rider off

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -97,8 +97,7 @@
 		return
 
 	step(movable_parent, direction)
-	last_move_diagonal = ((direction & (direction - 1)) && (movable_parent.loc == next))
-	COOLDOWN_START(src, vehicle_move_cooldown, (last_move_diagonal? 2 : 1) * vehicle_move_delay)
+	COOLDOWN_START(src, vehicle_move_cooldown, vehicle_move_delay)
 
 	if(QDELETED(src))
 		return


### PR DESCRIPTION

## About The Pull Request

wheelchairs + mobs that are ridden no longer double their movement cooldown if you moved diagonally

## Why It's Good For The Game

this times two multiplier i have no clue why it exists and it apparently seems to only be there to fuck you over if you move diagonally
this makes moving in wheelchairs and on ridden mobs slightly easier

## Changelog
:cl:
balance: wheelchairs no longer double your movement cooldown if you moved diagonally
/:cl:
