### PR TITLE
Elevator fixes

### DIFF
--- a/code/modules/transport/elevator/elev_controller.dm
+++ b/code/modules/transport/elevator/elev_controller.dm
@@ -122,7 +122,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/elevator, 32)
 		return FALSE
 
 	// We can't call an elevator that's moving. You may say "you totally can do that", but that's not modelled
-	if(lift.controls_locked == LIFT_PLATFORM_LOCKED)
+	if(lift.controller_status & CONTROLS_LOCKED)
 		loc.balloon_alert(activator, "elevator is moving!")
 		return FALSE
 

--- a/code/modules/transport/elevator/elev_panel.dm
+++ b/code/modules/transport/elevator/elev_panel.dm
@@ -276,7 +276,7 @@
 	var/datum/transport_controller/linear/lift = lift_weakref?.resolve()
 	if(lift)
 		data["lift_exists"] = TRUE
-		data["currently_moving"] = lift.controls_locked == LIFT_PLATFORM_LOCKED
+		data["currently_moving"] = lift.controller_status & CONTROLS_LOCKED
 		data["currently_moving_to_floor"] = last_move_target
 		data["current_floor"] = lift.transport_modules[1].z
 
@@ -319,7 +319,7 @@
 				return TRUE // Something is inaccurate, update UI
 
 			var/datum/transport_controller/linear/lift = lift_weakref?.resolve()
-			if(!lift || lift.controls_locked == LIFT_PLATFORM_LOCKED)
+			if(!lift || lift.controller_status & CONTROLS_LOCKED)
 				return TRUE // We shouldn't be moving anything, update UI
 
 			INVOKE_ASYNC(lift, TYPE_PROC_REF(/datum/transport_controller/linear, move_to_zlevel), desired_z, CALLBACK(src, PROC_REF(check_panel)), usr)

--- a/code/modules/transport/linear_controller.dm
+++ b/code/modules/transport/linear_controller.dm
@@ -1,3 +1,6 @@
+/// If anyone changes the hydraulic sound effect I sure hope they update this...
+#define HYDRAULIC_SFX_DURATION (2 SECONDS)
+
 ///coordinate and control movement across linked transport_controllers. allows moving large single multitile platforms and many 1 tile platforms.
 ///also is capable of linking platforms across linked z levels
 /datum/transport_controller/linear
@@ -31,9 +34,6 @@
 
 	///bitfield of various transport states
 	var/controller_status = NONE
-
-	///if true, the platform cannot be manually moved.
-	var/controls_locked = FALSE
 
 	/// probability of being thrown hard during an emergency stop
 	var/throw_chance = 17.5
@@ -343,10 +343,8 @@
 	// Get the lowest or highest platform according to which direction we're moving
 	var/obj/structure/transport/linear/prime_lift = return_closest_platform_to_z(direction == UP ? world.maxz : 0)
 
-	// If anyone changes the hydraulic sound effect I sure hope they update this variable...
-	var/hydraulic_sfx_duration = 2 SECONDS
 	// ...because we use the duration of the sound effect to make it last for roughly the duration of the lift travel
-	playsound(prime_lift, 'sound/mecha/hydraulic.ogg', 25, vary = TRUE, frequency = clamp(hydraulic_sfx_duration / lift_move_duration, 0.33, 3))
+	playsound(prime_lift, 'sound/mecha/hydraulic.ogg', 25, vary = TRUE, frequency = clamp(HYDRAULIC_SFX_DURATION / lift_move_duration, 0.33, 3))
 
 	// Move the platform after a timer
 	addtimer(CALLBACK(src, PROC_REF(move_lift_vertically), direction, user), lift_move_duration, TIMER_UNIQUE)
@@ -465,6 +463,7 @@
 
 	// Close all lift doors
 	update_lift_doors(action = CYCLE_CLOSED)
+	sleep(1.1 SECONDS)
 	// Approach the desired z-level one step at a time
 	for(var/i in 1 to z_difference)
 		if(!Check_lift_move(direction))
@@ -482,7 +481,7 @@
 		if(QDELETED(src) || QDELETED(prime_lift))
 			return
 
-	addtimer(CALLBACK(src, PROC_REF(open_lift_doors_callback)), 2 SECONDS)
+	update_lift_doors(get_zs_we_are_on(), action = CYCLE_OPEN)
 	SEND_SIGNAL(src, COMSIG_LIFT_SET_DIRECTION, 0)
 	controls_lock(FALSE)
 	return TRUE
@@ -636,3 +635,5 @@
 		lift_to_reset.reset_contents(consider_anything_past, foreign_objects, foreign_non_player_mobs, consider_player_mobs)
 
 	return TRUE
+
+#undef HYDRAULIC_SFX_DURATION


### PR DESCRIPTION
## About The Pull Request

Fixed controls not locking when elevator is moving, allowing people to send conflicting orders. Fixed elevator moving sound being out of sync with the actual movement.

## Changelog

:cl: LT3
fix: Fixed elevator panel allowing conflicting inputs
fix: Fixed elevator sound being out of sync with movement
/:cl: