### PR TITLE
Update tram ignored smashthroughs

### DIFF
--- a/code/modules/transport/linear_controller.dm
+++ b/code/modules/transport/linear_controller.dm
@@ -10,6 +10,7 @@
 		/obj/machinery/power/supermatter_crystal,
 		/obj/structure/holosign,
 		/obj/machinery/field,
+		/obj/structure/fluff/tram_rail,
 	)
 
 	///whether the lift handled by this transport_controller datum is multitile as opposed to nxm platforms per z level

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -379,7 +379,7 @@
 				if(QDELING(victim_structure))
 					continue
 				if(!is_type_in_typecache(victim_structure, transport_controller_datum.ignored_smashthroughs))
-					if((victim_structure.plane == FLOOR_PLANE && victim_structure.layer > CATWALK_LAYER) || (victim_structure.plane == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
+					if((victim_structure.plane == FLOOR_PLANE && victim_structure.layer > TRAM_RAIL_LAYER) || (victim_structure.plane == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
 						if(victim_structure.anchored && initial(victim_structure.anchored) == TRUE)
 							visible_message(span_danger("[src] smashes through [victim_structure]!"))
 							victim_structure.deconstruct(FALSE)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -378,19 +378,19 @@
 			for(var/obj/structure/victim_structure in dest_turf.contents)
 				if(QDELING(victim_structure))
 					continue
-				if(!is_type_in_typecache(victim_structure, transport_controller_datum.ignored_smashthroughs) && victim_structure.layer >= LOW_OBJ_LAYER)
+				if(!is_type_in_typecache(victim_structure, transport_controller_datum.ignored_smashthroughs))
+					if((victim_structure.plane == FLOOR_PLANE && victim_structure.layer > CATWALK_LAYER) || (victim_structure.plane == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
+						if(victim_structure.anchored && initial(victim_structure.anchored) == TRUE)
+							visible_message(span_danger("[src] smashes through [victim_structure]!"))
+							victim_structure.deconstruct(FALSE)
 
-					if(victim_structure.anchored && initial(victim_structure.anchored) == TRUE)
-						visible_message(span_danger("[src] smashes through [victim_structure]!"))
-						victim_structure.deconstruct(FALSE)
-
-					else
-						if(!throw_target)
-							throw_target = get_edge_target_turf(src, turn(travel_direction, pick(45, -45)))
-						visible_message(span_danger("[src] violently rams [victim_structure] out of the way!"))
-						victim_structure.anchored = FALSE
-						victim_structure.take_damage(rand(20, 25) * collision_lethality)
-						victim_structure.throw_at(throw_target, 200 * collision_lethality, 4 * collision_lethality)
+						else
+							if(!throw_target)
+								throw_target = get_edge_target_turf(src, turn(travel_direction, pick(45, -45)))
+							visible_message(span_danger("[src] violently rams [victim_structure] out of the way!"))
+							victim_structure.anchored = FALSE
+							victim_structure.take_damage(rand(20, 25) * collision_lethality)
+							victim_structure.throw_at(throw_target, 200 * collision_lethality, 4 * collision_lethality)
 
 			for(var/obj/machinery/victim_machine in dest_turf.contents)
 				if(QDELING(victim_machine))


### PR DESCRIPTION
## About The Pull Request

Adjusts the tram's ignored smashthroughs to work with the new floor plane numbering. Fixes https://github.com/tgstation/tgstation/issues/85171

## Why It's Good For The Game

Fixes tram smashing through stuff it shouldn't.

## Changelog

:cl: LT3
fix: Tram will no longer eat its own rails as it travels
/:cl:
