### PR TITLE
Fix disease outbreak announcement

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -102,7 +102,7 @@
 	var/list/afflicted = list()
 
 /datum/round_event/disease_outbreak/announce(fake)
-	if(isnull(illness_type))
+	if(!illness_type)
 		var/list/virus_candidates = list(
 			/datum/disease/anxiety,
 			/datum/disease/beesease,


### PR DESCRIPTION
## About The Pull Request

Fixes a bug in the announcement proc that is supposed to generate a disease name for the announcement.

## Changelog

:cl: LT3
fix: Fixed disease outbreak announcement sometimes missing the disease name
/:cl:
