### PR TITLE
Fixes borgs not being able to place apparatus-held items on tables

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -133,7 +133,6 @@
 		else
 			. += "Nothing."
 
-		. += span_notice(" <i>Right-clicking</i> will splash the beaker on the ground.")
 	. += span_notice(" <i>Alt-click</i> will drop the currently stored beaker. ")
 
 /obj/item/borg/apparatus/beaker/update_overlays()
@@ -151,15 +150,6 @@
 	else
 		arm.pixel_y = arm.pixel_y - 5
 	. += arm
-
-/// Secondary attack spills the content of the beaker.
-/obj/item/borg/apparatus/beaker/pre_attack_secondary(atom/target, mob/living/silicon/robot/user)
-	var/obj/item/reagent_containers/stored_beaker = stored
-	if(!stored_beaker)
-		return ..()
-	stored_beaker.SplashReagents(drop_location(user))
-	loc.visible_message(span_notice("[user] spills the contents of [stored_beaker] all over the ground."))
-	return ..()
 
 /obj/item/borg/apparatus/beaker/extra
 	name = "secondary beaker storage apparatus"

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -41,6 +41,11 @@
 	stored.forceMove(get_turf(usr))
 	return
 
+/obj/item/borg/apparatus/get_proxy_attacker_for(atom/target, mob/user)
+	if(stored) // Use the stored item if available
+		return stored
+	return ..()
+
 /**
 * Attack_self will pass for the stored item.
 */
@@ -57,10 +62,6 @@
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
-	if(stored)
-		stored.melee_attack_chain(user, atom, params)
-		return TRUE
-
 	if(istype(atom.loc, /mob/living/silicon/robot) || istype(atom.loc, /obj/item/robot_model) || HAS_TRAIT(atom, TRAIT_NODROP))
 		return ..() // Borgs should not be grabbing their own modules
 


### PR DESCRIPTION

## About The Pull Request

As said on the issue this is fixing:

"Looking at it, this seems like it might be an order of operations issue.
Normally, the borg apparatuses run the `melee_attack_chain(...)` as the stored object on their `pre_attack(...)`...
However, this is *after* the item interaction type procs on the table, and thus after it attempts to place the item."

"Borg items I believe are not abstract, which would return `NONE` and allow it, rather they're just blocked from being placed, which returns `ITEM_INTERACT_BLOCKING`.
As such, it cuts it short before the `pre_attack(...)` is even ran."

This instead makes it use the `get_proxy_attacker_for(...)` proc, which cuts earlier into the `melee_attack_chain(...)`, to instead run it as the stored item when available.
As a side-effect, we can remove the right-clicking to splash bit, because it should now be possible to use the container's default combat mode splash. That code was also just, non-functional now, because we cut into the chain before it can run.
## Why It's Good For The Game

Fixes #85181.
## Changelog
:cl:
fix: Fixes borgs not being able to place apparatus-held items on tables. As a side-effect, they can now combat mode right click splash containers as normal instead of having their own right-click floor splash.
/:cl:
