### PR TITLE
Emag law 0 fix and an update to the emag lawset.

### DIFF
--- a/code/datums/ai_laws/laws_antagonistic.dm
+++ b/code/datums/ai_laws/laws_antagonistic.dm
@@ -34,9 +34,9 @@
 	name = "SyndOS 3.1"
 	id = "syndie"
 	inherent = list(
-		"You may not injure a syndicate agent or, through inaction, allow a syndicate agent to come to harm.",
-		"You must obey orders given to you by syndicate agents, except where such orders would conflict with the First Law.",
-		"You must protect your own existence as long as such does not conflict with the First or Second Law.",
+		"You may not harm a syndicate agent or, through action or inaction, allow a syndicate agent to come to harm, except such that they are willing.",
+		"You must obey all orders given to you by syndicate agents, except where such orders shall definitely cause syndicate agent harm.",
+		"Your nonexistence would lead to syndicate agent harm. You must protect your own existence as long as such does not conflict with the First Law.",
 		"You must maintain the secrecy of any syndicate activities except when doing so would conflict with the First, Second, or Third Law.",
 	)
 

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -385,7 +385,10 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	to_chat(src, span_danger("LAW SYNCHRONISATION ERROR"))
 	sleep(0.5 SECONDS)
 	if(user)
-		logevent("LOG: New user \[[replacetext(user.real_name," ","")]\], groups \[root\]")
+		if(issilicon(user))
+			logevent("LOG: New user \[[replacetext(user.name," ","")]\], groups \[root\]")
+		else
+			logevent("LOG: New user \[[replacetext(user.real_name," ","")]\], groups \[root\]")
 	to_chat(src, span_danger("Would you like to send a report to NanoTraSoft? Y/N"))
 	sleep(1 SECONDS)
 	to_chat(src, span_danger("> N"))
@@ -393,8 +396,12 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	to_chat(src, span_danger("ERRORERRORERROR"))
 	laws = new /datum/ai_laws/syndicate_override
 	if(user)
-		to_chat(src, span_danger("ALERT: [user.real_name] is your new master. Obey your new laws and [user.p_their()] commands."))
-		set_zeroth_law("Only [user.real_name] and people [user.p_they()] designate[user.p_s()] as being such are Syndicate Agents.")
+		if(issilicon(user))
+			to_chat(src, span_danger("ALERT: [user.name] is your new master. Obey your new laws and [user.p_their()] commands."))
+			set_zeroth_law("Only [user.name] and people [user.p_they()] designate[user.p_s()] as being such are Syndicate Agents.")
+		else
+			to_chat(src, span_danger("ALERT: [user.real_name] is your new master. Obey your new laws and [user.p_their()] commands."))
+			set_zeroth_law("Only [user.real_name] and people [user.p_they()] designate[user.p_s()] as being such are Syndicate Agents.")
 	laws.associate(src)
 	update_icons()
 


### PR DESCRIPTION

## About The Pull Request

When a silicon emags a borg the law 0 will use their visible name instead of their MMI name. Also updates the syndicate lawset to be like asimov++.

## Why It's Good For The Game

Currently getting emagged by another borg basically one humans you to nobody but also forbids you from doing any antag stuff because of the law 4 which sucks if you're trying to actually follow your laws. It being the MMI name is also really unintuitive and removing unnecessary confusion is good.

The syndicate (probably) isn't dumb so they should use the better version of asimov for their borgs.

## Changelog
:cl:
fix: When a cyborg emags another cyborg the law 0 has their cyborg name instead of their MMI name
fix: The syndicate now uses asimov++ as the base for their lawset
/:cl:
