### PR TITLE
Revert "Context maptext now properly dynamically adjusts itself instead of using hardcoded pixel values"

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -863,6 +863,7 @@
 		active_hud.screentip_text.maptext = ""
 		return
 
+	active_hud.screentip_text.maptext_y = 10 // 10px lines us up with the action buttons top left corner
 	var/lmb_rmb_line = ""
 	var/ctrl_lmb_ctrl_rmb_line = ""
 	var/alt_lmb_alt_rmb_line = ""
@@ -932,21 +933,14 @@
 
 				if(extra_lines)
 					extra_context = "<br><span class='subcontext'>[lmb_rmb_line][ctrl_lmb_ctrl_rmb_line][alt_lmb_alt_rmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
+					//first extra line pushes atom name line up 11px, subsequent lines push it up 9px, this offsets that and keeps the first line in the same place
+					active_hud.screentip_text.maptext_y = -1 + (extra_lines - 1) * -9
 
-	var/new_maptext
 	if (screentips_enabled == SCREENTIP_PREFERENCE_CONTEXT_ONLY && extra_context == "")
-		new_maptext = ""
+		active_hud.screentip_text.maptext = ""
 	else
 		//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-		new_maptext = "<span class='context' style='text-align: center; color: [active_hud.screentip_color]'>[name][extra_context]</span>"
-
-	INVOKE_ASYNC(src, PROC_REF(set_hover_maptext), client, active_hud, new_maptext)
-
-/atom/proc/set_hover_maptext(client/client, datum/hud/active_hud, new_maptext)
-	var/map_height
-	WXH_TO_HEIGHT(client.MeasureText(new_maptext, null, active_hud.screentip_text.maptext_width), map_height)
-	active_hud.screentip_text.maptext = new_maptext
-	active_hud.screentip_text.maptext_y = 22 - map_height
+		active_hud.screentip_text.maptext = "<span class='context' style='text-align: center; color: [active_hud.screentip_color]'>[name][extra_context]</span>"
 
 /**
  * This proc is used for telling whether something can pass by this atom in a given direction, for use by the pathfinding system.


### PR DESCRIPTION
About The Pull Request

Reverts tgstation/tgstation#85088

Why It's Good For The Game

Calling measuretext on every mouse enter is slowing down visual updates.
This causes mouse hover to take an additional 50+ms to update when hovering over an object.
This doesn't have an effect on combat but it's difficult to see names of fast moving object/players

The problem tgstation/tgstation#85088 fixes is rare enough that it doesn't need to have an affect on gameplay.

Changelog
🆑
revert: reverts Context maptext now properly dynamically adjusts itself instead of using hardcoded pixel values
/:cl:
