### PR TITLE
Self-respiration virus gives less messages now

### DIFF
--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -14,7 +14,7 @@
 	stage_speed = -3
 	transmittable = -4
 	level = 6
-	base_message_chance = 5
+	base_message_chance = 3
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	required_organ = ORGAN_SLOT_LUNGS
@@ -40,6 +40,8 @@
 		if(4, 5)
 			infected_mob.losebreath = max(0, infected_mob.losebreath - 4)
 			infected_mob.adjustOxyLoss(-7)
+			if(prob(base_message_chance))
+				to_chat(infected_mob, span_notice("You realize you haven't been breathing."))
 			if(regenerate_blood && infected_mob.blood_volume < BLOOD_VOLUME_NORMAL)
 				infected_mob.blood_volume += 1
 		else
@@ -54,9 +56,12 @@
 	var/mob/living/carbon/infected_mob = advanced_disease.affected_mob
 	if(advanced_disease.stage >= 4)
 		ADD_TRAIT(infected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)
-		to_chat(infected_mob, span_notice(pick("You realize you haven't been breathing.", "You don't feel the need to breathe.")))
+		if(advanced_disease.stage == 4)
+			to_chat(infected_mob, span_notice("You don't feel the need to breathe anymore."))
 	else
 		REMOVE_TRAIT(infected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)
+		if(advanced_disease.stage_peaked && advanced_disease.stage == 3)
+			to_chat(infected_mob, span_notice("You feel the need to breathe again."))
 	return TRUE
 
 /datum/symptom/oxygen/End(datum/disease/advance/advanced_disease)


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/tgstation/pull/85091 was great in that it no longer said "You don't need to breathe!" before the NOBREATH actually kicked in. 
It now meant though that that it would message "You don't need to breathe!" Every time that the virus hit on_stage_change and it was on stage 4 or 5 
Apparently on_stage_change can and will still be trigger when the virus is at max stage because now the self resp virus was spamming "You don't need to breathe!" every time that the virus tried to change a stage - which was a lot more often than the previous (albeit erroneous) message that was looking for a 5% probability before say its "You don't need to breathe!" message. 
<details>
<summary>For reference; I made the message display the stage during testing, to confirm it was hitting this while at stage 5, and yeah.</summary>

![image](https://github.com/user-attachments/assets/17dc6950-2e58-466f-812c-cfb99cc6ebfe)

</details>
This PR changes it slightly so that the "You don't need to breathe!" only comes up when it reaches stage 4, which in all my tests it passed on its way to stay 5. 
Though for the people that miss that, it also occasionally says "You realize you haven't been breathing" upon activate() though this is with the probability check
In my tests, though, the prob of 5 was still a bit high (maybe because we sit at stage 5 with a healing virus longer than we sit at stage 1-3 which is when the message was triggering before that fix PR) so I changed the probability to 3 

Also, when it reaches stage 3, and it already hit its peak so the virus is on its way to curing, it will send the message "You need to breathe again". This might be helpful when your healing virus starts to self-heal because you don't take care of yourself. Originally I had it on stage<4 and stage_peaked that it would give that message but testing it out, it would bounce between 1 and 2 a lot during self curing and that got spammy as well. When I cured using reagents, on low resistance versions of self resp viruses, it did not trigger this message, though it did when I used low nutrition and spaceacillin to self cure. 
## Why It's Good For The Game

I'd almost rather not get a healing virus than see all this spam. 
Please make it stop. 

![image](https://github.com/user-attachments/assets/92206be7-fa75-402c-826f-f014565f8591)

Fixes: #85237  
## Changelog
:cl: Thlumyn
fix: self-resp viruses don't spam messages as often
/:cl:
