### PR TITLE
Emotes by default will not be heard through walls

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -102,7 +102,7 @@
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
-		playsound(user, tmp_sound, 50, vary, TRUE, FALSE)
+		playsound(source = user,soundin = tmp_sound,vol = 50, vary = vary, ignore_walls = sound_wall_ignore)
 
 	var/is_important = emote_type & EMOTE_IMPORTANT
 	var/is_visual = emote_type & EMOTE_VISIBLE

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -102,7 +102,7 @@
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
-		playsound(user, ignore_walls = sound_wall_ignore, tmp_sound, 50, vary)
+		playsound(user, tmp_sound, 50, vary, TRUE, FALSE)
 
 	var/is_important = emote_type & EMOTE_IMPORTANT
 	var/is_visual = emote_type & EMOTE_VISIBLE

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -60,6 +60,8 @@
 	var/can_message_change = FALSE
 	/// How long is the cooldown on the audio of the emote, if it has one?
 	var/audio_cooldown = 2 SECONDS
+	/// Does this emote's sound ignore walls?
+	var/sound_wall_ignore = FALSE
 
 /datum/emote/New()
 	switch(mob_type_allowed_typecache)
@@ -100,7 +102,7 @@
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
-		playsound(user, tmp_sound, 50, vary)
+		playsound(user, ignore_walls = sound_wall_ignore, tmp_sound, 50, vary)
 
 	var/is_important = emote_type & EMOTE_IMPORTANT
 	var/is_visual = emote_type & EMOTE_VISIBLE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -352,6 +352,7 @@
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 	mob_type_blacklist_typecache = list(/mob/living/brain, /mob/living/carbon/human)
+	sound_wall_ignore = TRUE
 
 /datum/emote/living/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
 	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))


### PR DESCRIPTION

## About The Pull Request
Added a var to emotes for ignoring walls when playing their sound, now only the scream emote can ignore walls.
## Why It's Good For The Game
It's really annoying and stupid that you can hear people crying through walls and doesn't make sense at all.
## Changelog
:cl: grungussuss
sound: only the scream emote can be heard through walls
/:cl:
