### PR TITLE
[NO GBP] Tooltips no longer call MeasureText every time you move your mouse

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -940,13 +940,18 @@
 		//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
 		new_maptext = "<span class='context' style='text-align: center; color: [active_hud.screentip_color]'>[name][extra_context]</span>"
 
-	INVOKE_ASYNC(src, PROC_REF(set_hover_maptext), client, active_hud, new_maptext)
+	if (length(name) * 10 > active_hud.screentip_text.maptext_width)
+		INVOKE_ASYNC(src, PROC_REF(set_hover_maptext), client, active_hud, new_maptext)
+		return
+
+	active_hud.screentip_text.maptext = new_maptext
+	active_hud.screentip_text.maptext_y = 10 - (extra_lines > 0 ? 11 + 9 * (extra_lines - 1): 0)
 
 /atom/proc/set_hover_maptext(client/client, datum/hud/active_hud, new_maptext)
 	var/map_height
 	WXH_TO_HEIGHT(client.MeasureText(new_maptext, null, active_hud.screentip_text.maptext_width), map_height)
 	active_hud.screentip_text.maptext = new_maptext
-	active_hud.screentip_text.maptext_y = 22 - map_height
+	active_hud.screentip_text.maptext_y = 16 - map_height
 
 /**
  * This proc is used for telling whether something can pass by this atom in a given direction, for use by the pathfinding system.

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -951,7 +951,7 @@
 	var/map_height
 	WXH_TO_HEIGHT(client.MeasureText(new_maptext, null, active_hud.screentip_text.maptext_width), map_height)
 	active_hud.screentip_text.maptext = new_maptext
-	active_hud.screentip_text.maptext_y = 16 - map_height
+	active_hud.screentip_text.maptext_y = 26 - map_height
 
 /**
  * This proc is used for telling whether something can pass by this atom in a given direction, for use by the pathfinding system.


### PR DESCRIPTION

## About The Pull Request

MeasureText is now only called when the text is (most likely) wider than your screen, which is rather rare.

## Why It's Good For The Game
I fucked up

## Changelog
:cl:
fix: People with tooltips enabled no longer lag the server when they move their mouse. Oops.
/:cl:
