### PR TITLE
Injector instead of passive in lavaland waste

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3896,11 +3896,11 @@
 /area/mine/lounge)
 "uT" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/mine/maintenance/service)
 "uU" = (
 /turf/closed/mineral/random/labormineral/volcanic,
 /area/lavaland/surface/outdoors)


### PR DESCRIPTION
## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/78413
## Changelog
:cl: grungussuss
fix: lavaland no longer has roundstart atmos processing because of a passive vent
/:cl:
