### PR TITLE
Mafia role help now checks the original description

### DIFF
--- a/code/modules/mafia/roles/roles.dm
+++ b/code/modules/mafia/roles/roles.dm
@@ -189,6 +189,6 @@
 			team_span = "comradio"
 			the = FALSE
 	result += span_notice("The [span_bold("[name]")] is aligned with [the ? "the " : ""]<span class='[team_span]'>[team_desc]</span>")
-	result += "<span class='bold notice'>\"[desc]\"</span>"
+	result += "<span class='bold notice'>\"[initial(desc)]\"</span>"
 	result += span_notice("[name] wins when they [win_condition]")
 	to_chat(clueless, result.Join("</br>"))


### PR DESCRIPTION
## About The Pull Request

I thought I fixed this bug a long time ago but turns out I just never did.
This makes mafia role help get the initial description rather than the current one, allowing us to edit people's descriptions as we need to in-game without this information being metagamed.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/82088
And prevents this again in the future.

## Changelog

:cl:
fix: [Mafia] The show_help button no longer shows you who the Obsessed's target is.
/:cl: