### PR TITLE
Surgery steps no longer fail silently when missing chemicals

### DIFF
--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -155,7 +155,8 @@
 				"next_step" = capitalize(surgery_step.name),
 				"chems_needed" = chems_needed,
 				"alternative_step" = alternative_step,
-				"alt_chems_needed" = alt_chems_needed
+				"alt_chems_needed" = alt_chems_needed,
+				"chems_present" = surgery_step.chem_check(patient)
 			))
 	return data
 

--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -143,11 +143,13 @@
 			var/chems_needed = surgery_step.get_chem_list()
 			var/alternative_step
 			var/alt_chems_needed = ""
+			var/alt_chems_present = FALSE
 			if(surgery_step.repeatable)
 				var/datum/surgery_step/next_step = procedure.get_surgery_next_step()
 				if(next_step)
 					alternative_step = capitalize(next_step.name)
 					alt_chems_needed = next_step.get_chem_list()
+					alt_chems_present = next_step.chem_check(patient)
 				else
 					alternative_step = "Finish operation"
 			data["procedures"] += list(list(
@@ -156,7 +158,8 @@
 				"chems_needed" = chems_needed,
 				"alternative_step" = alternative_step,
 				"alt_chems_needed" = alt_chems_needed,
-				"chems_present" = surgery_step.chem_check(patient)
+				"chems_present" = surgery_step.chem_check(patient),
+				"alt_chems_present" = alt_chems_present
 			))
 	return data
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -96,6 +96,11 @@
 	var/fail_prob = 0//100 - fail_prob = success_prob
 	var/advance = FALSE
 
+	if(!chem_check(target))
+		user.balloon_alert(user, "missing [LOWER_TEXT(get_chem_list())]!")
+		surgery.step_in_progress = FALSE
+		return FALSE
+
 	if(preop(user, target, target_zone, tool, surgery) == SURGERY_STEP_FAIL)
 		update_surgery_mood(target, SURGERY_STATE_FAILURE)
 		surgery.step_in_progress = FALSE
@@ -134,9 +139,7 @@
 
 	if(do_after(user, modded_time, target = target, interaction_key = user.has_status_effect(/datum/status_effect/hippocratic_oath) ? target : DOAFTER_SOURCE_SURGERY)) //If we have the hippocratic oath, we can perform one surgery on each target, otherwise we can only do one surgery in total.
 
-		var/chem_check_result = chem_check(target)
-		if((prob(100-fail_prob) || (iscyborg(user) && !silicons_obey_prob)) && chem_check_result && !try_to_fail)
-
+		if((prob(100-fail_prob) || (iscyborg(user) && !silicons_obey_prob)) && !try_to_fail)
 			if(success(user, target, target_zone, tool, surgery))
 				update_surgery_mood(target, SURGERY_STATE_SUCCESS)
 				play_success_sound(user, target, target_zone, tool, surgery)
@@ -146,8 +149,6 @@
 				play_failure_sound(user, target, target_zone, tool, surgery)
 				update_surgery_mood(target, SURGERY_STATE_FAILURE)
 				advance = TRUE
-			if(chem_check_result)
-				return .(user, target, target_zone, tool, surgery, try_to_fail) //automatically re-attempt if failed for reason other than lack of required chemical
 		if(advance && !repeatable)
 			surgery.status++
 			if(surgery.status > surgery.steps.len)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -98,6 +98,7 @@
 
 	if(!chem_check(target))
 		user.balloon_alert(user, "missing [LOWER_TEXT(get_chem_list())]!")
+		to_chat(user, span_warning("[target] is missing the [LOWER_TEXT(get_chem_list())] required to perform this surgery step!"))
 		surgery.step_in_progress = FALSE
 		return FALSE
 

--- a/tgui/packages/tgui/interfaces/OperatingComputer.jsx
+++ b/tgui/packages/tgui/interfaces/OperatingComputer.jsx
@@ -118,7 +118,7 @@ const PatientStateView = (props) => {
             )}
             {procedure.alt_chems_needed && (
               <LabeledList.Item label="Required Chems">
-                <NoticeBox success={procedure.chems_present ? true : false}>
+                <NoticeBox success={procedure.alt_chems_present ? true : false}>
                   {procedure.alt_chems_needed}
                 </NoticeBox>
               </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/OperatingComputer.jsx
+++ b/tgui/packages/tgui/interfaces/OperatingComputer.jsx
@@ -103,28 +103,24 @@ const PatientStateView = (props) => {
           <LabeledList>
             <LabeledList.Item label="Next Step">
               {procedure.next_step}
-              {procedure.chems_needed && (
-                <>
-                  <br />
-                  <br />
-                  <b>Required Chemicals:</b>
-                  <br />
-                  {procedure.chems_needed}
-                </>
-              )}
             </LabeledList.Item>
+            {procedure.chems_needed && (
+              <LabeledList.Item label="Required Chems">
+                <NoticeBox success={procedure.chems_present ? true : false}>
+                  {procedure.chems_needed}
+                </NoticeBox>
+              </LabeledList.Item>
+            )}
             {procedure.alternative_step && (
               <LabeledList.Item label="Alternative Step">
                 {procedure.alternative_step}
-                {procedure.alt_chems_needed && (
-                  <>
-                    <br />
-                    <br />
-                    <b>Required Chemicals:</b>
-                    <br />
-                    {procedure.alt_chems_needed}
-                  </>
-                )}
+              </LabeledList.Item>
+            )}
+            {procedure.alt_chems_needed && (
+              <LabeledList.Item label="Required Chems">
+                <NoticeBox success={procedure.chems_present ? true : false}>
+                  {procedure.alt_chems_needed}
+                </NoticeBox>
               </LabeledList.Item>
             )}
           </LabeledList>


### PR DESCRIPTION
## About The Pull Request

Fixes surgery steps that require a chemical from failing silently if that chemical is missing. Player receives a bubble notification and the surgery is not performed if the chemical is missing. Operating computer UI tells you if the required chem is present or not.

![dreamseeker_RMO06bKPcV](https://github.com/user-attachments/assets/c57e5615-0786-4e8c-a2ef-d268f1c82f7d)

## Why It's Good For The Game

Having to guess, without feedback, if the chemical was in the target's system at the time surgery completes is bad.

## Changelog

:cl: LT3
fix: Players now receive a notification when trying to perform surgery steps that involve chemicals
/:cl:
