### PR TITLE
nerfs the sneeze suppressive fire

### DIFF
--- a/code/modules/mob/living/sneeze.dm
+++ b/code/modules/mob/living/sneeze.dm
@@ -57,6 +57,7 @@
 	spread = 40
 	damage_type = BRUTE
 	damage = 0
+	hitsound = null
 
 	/// Call this when we hit something
 	var/datum/callback/sneezie_callback


### PR DESCRIPTION
## About The Pull Request
So sneeze projectiles have a hitsound whenever it lands, this leads to very silly immersion breaking situations where a person keeps sneezing, missing and performing "suppressive" sneezing to "combatants" Setting the hitsound to null should fix that
## Why It's Good For The Game
Hearing the same hitsound for the sneeze projectile as bullets and other projectiles is really jarring, better remove it.
## Changelog
:cl: grungussuss
sound: the sneeze projectile no longer makes a sound when making contact.
/:cl:
