### PR TITLE
Adds Voidwalker to the event controller

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -964,6 +964,7 @@
 	cost = 5
 	minimum_players = 40
 	repeatable = TRUE
+	signup_item_path = /obj/item/cosmic_skull
 	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_VOIDWALKER_VOID)
 	/// The space turf we find in acceptable(), cached for ease
 	var/space_turf

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -27,7 +27,7 @@
 	if(isnull(spawn_location))
 		return MAP_ERROR
 
-	var/mob/chosen_one = SSpolling.poll_ghost_candidates(check_jobban = ROLE_VOIDWALKER, role = ROLE_VOIDWALKER, alert_pic = /obj/item/cosmic_skull, jump_target = spawn_location, role_name_text = "Void Walker", amount_to_pick = 1)
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates(check_jobban = ROLE_VOIDWALKER, role = ROLE_VOIDWALKER, alert_pic = /obj/item/cosmic_skull, jump_target = spawn_location, role_name_text = "Voidwalker", amount_to_pick = 1)
 	if(isnull(chosen_one))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -10,18 +10,18 @@
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
 
-/datum/round_event/ghost_role/void_walker
-	minimum_required = 40
-	fakeable = FALSE
-	role_name = "Void Walker"
-
-// Space only antag
-/datum/round_event_control/ghost_role/voidwalker/can_spawn_event()
+// Only run on station maps.
+/datum/round_event_control/ghost_role/voidwalker/can_spawn_event(players_amt, allow_magic = FALSE)
 	. = ..()
 	var/space_check = find_space_spawn()
 	if(!space_check)
 		return FALSE
 	return TRUE
+
+/datum/round_event/ghost_role/void_walker
+	minimum_required = 40
+	fakeable = FALSE
+	role_name = "void walker"
 
 /datum/round_event/ghost_role/void_walker/spawn_role()
 	var/spawn_location = find_space_spawn()

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/voidwalker
-	name = "Spawn Void Walker"
+	name = "Spawn Voidwalker"
 	typepath = /datum/round_event/ghost_role/void_walker
 	max_occurrences = 1
 	weight = 2

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -12,11 +12,10 @@
 
 // Only run on station maps.
 /datum/round_event_control/ghost_role/voidwalker/can_spawn_event(players_amt, allow_magic = FALSE)
-	. = ..()
-	var/space_check = find_space_spawn()
-	if(!space_check)
+	var/space_turf = find_space_spawn()
+	if(!space_turf)
 		return FALSE
-	return TRUE
+	return ..()
 
 /datum/round_event/ghost_role/void_walker
 	minimum_required = 40

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -37,7 +37,6 @@
 	player_mind.transfer_to(walker)
 	player_mind.set_assigned_role(SSjob.GetJobType(/datum/job/voidwalker))
 	player_mind.add_antag_datum(/datum/antagonist/voidwalker)
-	walker.set_species(/datum/species/voidwalker)
 	playsound(walker, 'sound/magic/ethereal_exit.ogg', 50, TRUE, -1)
 	message_admins("[ADMIN_LOOKUPFLW(walker)] has been made into a Voidwalker by the midround event.")
 	walker.log_message("[key_name(walker)] was spawned as a Voidwalker by an event.", LOG_GAME)

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -16,9 +16,9 @@
 	role_name = "Void Walker"
 
 // Space only antag
-/datum/round_event/ghost_role/voidwalker/can_spawn_event()
+/datum/round_event_control/ghost_role/voidwalker/can_spawn_event()
 	. = ..()
-	var/space_check = find_space_spawn
+	var/space_check = find_space_spawn()
 	if(!space_check)
 		return FALSE
 	return TRUE

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -20,7 +20,7 @@
 /datum/round_event/ghost_role/void_walker
 	minimum_required = 40
 	fakeable = FALSE
-	role_name = "void walker"
+	role_name = "voidwalker"
 
 /datum/round_event/ghost_role/void_walker/spawn_role()
 	var/spawn_location = find_space_spawn()

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -1,0 +1,46 @@
+/datum/round_event_control/voidwalker
+	name = "Spawn Void Walker"
+	typepath = /datum/round_event/ghost_role/void_walker
+	max_occurrences = 1
+	weight = 2
+	min_players = 40
+	dynamic_should_hijack = TRUE
+	category = EVENT_CATEGORY_ENTITIES
+	description = "A Void Walker that rips people out of the station and into the abyss"
+	min_wizard_trigger_potency = 6
+	max_wizard_trigger_potency = 7
+
+/datum/round_event/ghost_role/void_walker
+	minimum_required = 40
+	fakeable = FALSE
+	role_name = "Void Walker"
+
+// Space only antag
+/datum/round_event/ghost_role/voidwalker/can_spawn_event()
+	. = ..()
+	var/space_check = find_space_spawn
+	if(!space_check)
+		return FALSE
+	return TRUE
+
+/datum/round_event/ghost_role/void_walker/spawn_role()
+	var/spawn_location = find_space_spawn()
+	if(isnull(spawn_location))
+		return MAP_ERROR
+
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates(check_jobban = ROLE_VOIDWALKER, role = ROLE_VOIDWALKER, alert_pic = /obj/item/cosmic_skull, jump_target = spawn_location, role_name_text = "Void Walker", amount_to_pick = 1)
+	if(isnull(chosen_one))
+		return NOT_ENOUGH_PLAYERS
+
+	var/datum/mind/player_mind = new /datum/mind(chosen_one.key)
+	player_mind.active = TRUE
+	var/mob/living/carbon/human/walker = new (spawn_location)
+	player_mind.transfer_to(walker)
+	player_mind.set_assigned_role(SSjob.GetJobType(/datum/job/voidwalker))
+	player_mind.add_antag_datum(/datum/antagonist/voidwalker)
+	walker.set_species(/datum/species/voidwalker)
+	playsound(walker, 'sound/magic/ethereal_exit.ogg', 50, TRUE, -1)
+	message_admins("[ADMIN_LOOKUPFLW(walker)] has been made into a Voidwalker by the midround event.")
+	walker.log_message("[key_name(walker)] was spawned as a Voidwalker by an event.", LOG_GAME)
+	spawned_mobs += walker
+	return SUCCESSFUL_SPAWN

--- a/code/modules/events/ghost_role/voidwalker.dm
+++ b/code/modules/events/ghost_role/voidwalker.dm
@@ -6,7 +6,7 @@
 	min_players = 40
 	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
-	description = "A Void Walker that rips people out of the station and into the abyss"
+	description = "A Voidwalker that rips people out of the station and into the abyss"
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4052,6 +4052,7 @@
 #include "code\modules\events\ghost_role\slaughter_event.dm"
 #include "code\modules\events\ghost_role\space_dragon.dm"
 #include "code\modules\events\ghost_role\space_ninja.dm"
+#include "code\modules\events\ghost_role\voidwalker.dm"
 #include "code\modules\events\holiday\easter.dm"
 #include "code\modules\events\holiday\halloween.dm"
 #include "code\modules\events\holiday\vday.dm"


### PR DESCRIPTION
## About The Pull Request

Adds an entry into the event controller for Void Walker. I just used the dynamic voidwalker weights and times.

## Why It's Good For The Game

Every other midround off the top of my head is located inside the event controller. Dynamic is an entirely seperate system, yes. It would be nice for it to be able to be inside the event panel aswell. 

## Changelog

:cl:
code: Void Walker has been added to the event controller and given a signup icon.
/:cl:
