### PR TITLE
Fix ssmachinary sleeping

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -286,6 +286,7 @@
 
 ///Early process for machines added to SSmachines.processing_early to prioritize power draw
 /obj/machinery/proc/process_early()
+	set waitfor = FALSE
 	return PROCESS_KILL
 
 /obj/machinery/process()//If you dont use process or power why are you here
@@ -293,9 +294,11 @@
 
 ///Late process for machines added to SSmachines.processing_late to gather accurate recordings
 /obj/machinery/proc/process_late()
+	set waitfor = FALSE
 	return PROCESS_KILL
 
 /obj/machinery/proc/process_atmos()//If you dont use process why are you here
+	set waitfor = FALSE
 	return PROCESS_KILL
 
 ///Called when we want to change the value of the machine_stat variable. Holds bitflags.


### PR DESCRIPTION
`process()` already has this at its base, so it wasn't obvious these would need it too.

Lemon Edit:
Closes (Maybe?) #85170