### PR TITLE
Peg limbs can now be removed via surgery

### DIFF
--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -77,7 +77,6 @@
 		/obj/item/fireaxe = 90,
 		/obj/item/hatchet = 75,
 		TOOL_SCALPEL = 25,
-
 	)
 	time = 30
 	preop_sound = 'sound/surgery/saw.ogg'

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -82,7 +82,6 @@
 	preop_sound = 'sound/surgery/saw.ogg'
 	success_sound = 'sound/items/wood_drop.ogg'
 
-
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(
 		user,

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -27,6 +27,13 @@
 		/datum/surgery_step/sever_limb/mechanic, //The benefit of being robotic; people can pull you apart in an instant! Wait, that's not a benefit...
 	)
 
+/datum/surgery/amputation/peg
+	name = "Detach"
+	requires_bodypart_type = BODYTYPE_PEG
+	steps = list(
+		/datum/surgery_step/sever_limb/peg,	//Easy come, easy go
+	)
+
 /datum/surgery/amputation/can_start(mob/user, mob/living/patient)
 	if(HAS_TRAIT(patient, TRAIT_NODISMEMBER))
 		return FALSE
@@ -61,6 +68,21 @@
 	time = 20 //WAIT I NEED THAT!!
 	preop_sound = 'sound/items/ratchet.ogg'
 	preop_sound = 'sound/machines/doorclick.ogg'
+
+/datum/surgery_step/sever_limb/peg
+	name = "detach limb (circular saw)"
+	implements = list(
+		TOOL_SAW = 100,
+		/obj/item/shovel/serrated = 100,
+		/obj/item/fireaxe = 90,
+		/obj/item/hatchet = 75,
+		TOOL_SCALPEL = 25,
+
+	)
+	time = 30
+	preop_sound = 'sound/surgery/saw.ogg'
+	success_sound = 'sound/items/wood_drop.ogg'
+
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(


### PR DESCRIPTION
## About The Pull Request

Adds amputation surgery for peg limbs

## Why It's Good For The Game

Peg limbs are a funny ghetto solution to replacing a limb in emergency situations. Unfortunately they can only be removed by burning or sawing the limb off.

It's good to have a proper medical solution to getting pegged

## Changelog
:cl:
fix: peg limbs can now be amputated
/:cl:

