### PR TITLE
Justice invisibility now turns off by the safety

### DIFF
--- a/code/modules/vehicles/mecha/combat/justice.dm
+++ b/code/modules/vehicles/mecha/combat/justice.dm
@@ -173,7 +173,7 @@
 /// update button icon when toggle safety.
 /datum/action/vehicle/sealed/mecha/invisibility/proc/on_toggle_safety()
 	SIGNAL_HANDLER
-
+ invisibility_off()
 	build_all_button_icons(UPDATE_BUTTON_STATUS)
 
 /datum/action/vehicle/sealed/mecha/invisibility/Trigger(trigger_flags)

--- a/code/modules/vehicles/mecha/combat/justice.dm
+++ b/code/modules/vehicles/mecha/combat/justice.dm
@@ -170,10 +170,10 @@
 	. = ..()
 	RegisterSignal(chassis, COMSIG_MECH_SAFETIES_TOGGLE, PROC_REF(on_toggle_safety))
 
-/// update button icon when toggle safety.
+/// update button icon when toggle safety and turns invisibility off.
 /datum/action/vehicle/sealed/mecha/invisibility/proc/on_toggle_safety()
 	SIGNAL_HANDLER
- invisibility_off()
+	invisibility_off()
 	build_all_button_icons(UPDATE_BUTTON_STATUS)
 
 /datum/action/vehicle/sealed/mecha/invisibility/Trigger(trigger_flags)


### PR DESCRIPTION

## About The Pull Request
Small change to make justice invisibility turn off when the safety is turned on. Because you could bypass safety check on it by basically turning off mecha safety and turning it on after it went to invicibility.
## Why It's Good For The Game
Now everything works as supposed.
## Changelog
:cl:
fix: now Justice invisibility turns off in non combat mode as it supposed to
/:cl:
