### PR TITLE
Emergency climbing hooks now spawn in emergency boxes if the station has multi-z level.

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -43,7 +43,7 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_RADIOACTIVE_NEBULA))
 		new /obj/item/storage/pill_bottle/potassiodide(src)
 
-	if(SSmapping.is_planetary() && LAZYLEN(SSmapping.multiz_levels))
+	if(LAZYLEN(SSmapping.multiz_levels))
 		new /obj/item/climbing_hook/emergency(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -311,7 +311,7 @@
 
 /datum/supply_pack/goody/climbing_hook
 	name = "Climbing Hook Single-Pack"
-	desc = "A less cheap imported climbing hook. Absolutely no use outside of planetary stations."
+	desc = "A less cheap imported climbing hook. Absolutely no use outside of multi-floor stations."
 	cost = PAYCHECK_CREW * 5
 	contains = list(/obj/item/climbing_hook)
 


### PR DESCRIPTION
## About The Pull Request
Emergency climbing hooks now spawn in emergency boxes not only on Icebox, but also on Northstar and Tram.
## Why It's Good For The Game
Firstly, I think it's funny to see some assistant just casually climbing up from the -1 floor on the sideways of tram, when he fell out of it.

Secondly, trying to get somewhere when the Northstar or Tram got blown up multiple times is an absolute nightmare if you have no good flashlight, or something similar.
## Changelog
:cl:
add: Emergency climbing hooks now spawn in emergency boxes on all of the multi-z level stations.
/:cl:
