### PR TITLE
Makes Voidwalker check SSmapping.is_planetary when spawning

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -969,7 +969,13 @@
 	var/space_turf
 
 /datum/dynamic_ruleset/midround/from_ghosts/voidwalker/acceptable(population = 0, threat_level = 0)
-	if(SSmapping.is_planetary())
+	if(SSmapping.is_planetary()) // Will die on planetary gravity
+		if (ruleset_forced == RULESET_FORCE_ENABLED) // Warning to admins that this antag is not designed for planetary based maps.
+			message_admins("[name] failed to spawn due to planetary gravity and will die inside it!")
+		return FALSE
+	// Checks for space carp landmarks
+	space_turf = find_space_spawn()
+	if(space_turf)
 		return FALSE
 	return ..()
 

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -964,18 +964,15 @@
 	cost = 5
 	minimum_players = 40
 	repeatable = TRUE
+	signup_item_path = /obj/item/cosmic_skull
 	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_VOIDWALKER_VOID)
 	/// The space turf we find in acceptable(), cached for ease
 	var/space_turf
 
 /datum/dynamic_ruleset/midround/from_ghosts/voidwalker/acceptable(population = 0, threat_level = 0)
-	if(SSmapping.is_planetary()) // Will die on planetary gravity
-		if (ruleset_forced == RULESET_FORCE_ENABLED) // Warning to admins that this antag is not designed for planetary based maps.
-			message_admins("[name] failed to spawn due to planetary gravity and will die inside it!")
-		return FALSE
-	// Checks for space carp landmarks
 	space_turf = find_space_spawn()
-	if(space_turf)
+	// Space only antag and will die on planetary gravity.
+	if(SSmapping.is_planetary() || !space_turf)
 		return FALSE
 	return ..()
 

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -969,8 +969,7 @@
 	var/space_turf
 
 /datum/dynamic_ruleset/midround/from_ghosts/voidwalker/acceptable(population = 0, threat_level = 0)
-	space_turf = find_space_spawn()
-	if(!space_turf)
+	if(SSmapping.is_planetary())
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Per title. Dynamic naturally running will not spawn a voidwalker on icebox now. ``find_space_spawn()`` checks only for carp landmarks, and icebox has carp landmarks for the other midround invasion antags. As a bonus, I also made SSpolling use the cosmic skull sprite to alert ghosts with.

## Why It's Good For The Game

Just a lil' bug I found. Plus the skull sprite is cool as hell.

![image](https://github.com/user-attachments/assets/6459db22-f4a4-45b6-b770-8ec0d83bc379)

## Changelog

:cl:
fix: Voidwalker should not run on planetary maps.
/:cl: