### PR TITLE
Fixes planet allergy not killing you on planets.

### DIFF
--- a/code/modules/antagonists/voidwalker/voidwalker_status_effects.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_status_effects.dm
@@ -25,6 +25,7 @@
 
 /datum/status_effect/planet_allergy/tick()
 	owner.adjustBruteLoss(1)
+	return ..()
 
 /datum/status_effect/void_eatered
 	duration = 10 SECONDS


### PR DESCRIPTION
## About The Pull Request

``status_effect/tick()`` was early returning and it needed a return ..() added to it.

## Why It's Good For The Game

Fixes a simple logic error with how the proc is handled.

## Changelog

:cl:
fix: You should now die on a planet as a voidwalker or its victims.
/:cl:

