### PR TITLE
fixes birdshot holodeck area fuckery

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2661,7 +2661,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "baP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4949,7 +4949,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "bWs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -7555,7 +7555,7 @@
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "cUH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -7767,7 +7767,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "cYt" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8400,7 +8400,7 @@
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "diI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
@@ -12629,7 +12629,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "eOY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -16692,7 +16692,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "gjE" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21001,7 +21001,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "hED" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -22215,7 +22215,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "ibI" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -28260,7 +28260,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "jTD" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 8
@@ -38208,10 +38208,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"ngd" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/holodeck/rec_center)
 "ngq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -39118,7 +39114,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "nuY" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/structure/alien/weeds/node,
@@ -45899,9 +45895,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
-"pOT" = (
-/turf/closed/wall,
-/area/station/holodeck/rec_center)
 "pOX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -46151,7 +46144,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "pTq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance"
@@ -46177,7 +46170,7 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "pTZ" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -52948,7 +52941,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "sjl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53636,7 +53629,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "sul" = (
 /obj/effect/turf_decal/siding{
 	dir = 1
@@ -56211,7 +56204,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "tlX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -59975,7 +59968,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
-/area/station/holodeck/rec_center)
+/area/station/commons/fitness/recreation/entertainment)
 "uwB" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
@@ -112298,13 +112291,13 @@ cvk
 nFW
 uvG
 siN
-ngd
+jpp
 nuV
 sue
-ngd
+jpp
 cUB
 baO
-pOT
+pzd
 gMz
 rem
 rQA
@@ -112557,11 +112550,11 @@ pTA
 hEw
 bWp
 gjn
-ngd
+jpp
 ibF
 diG
 baO
-pOT
+pzd
 ycQ
 rem
 nvB
@@ -112810,13 +112803,13 @@ eav
 eav
 nFW
 nFW
-pOT
-pOT
+pzd
+pzd
 tlJ
 cYp
 jTC
 eOX
-pOT
+pzd
 xQJ
 xQJ
 xQJ
@@ -113068,12 +113061,12 @@ tLj
 wOp
 fsq
 iRl
-pOT
-pOT
+pzd
+pzd
 pTk
-pOT
-pOT
-pOT
+pzd
+pzd
+pzd
 xqs
 xMO
 xQJ

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -7763,7 +7763,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -32344,6 +32343,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/engine/atmos)
+"ljc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "ljg" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -46140,7 +46148,6 @@
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -46490,7 +46497,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -56200,9 +56206,7 @@
 "tlJ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/item/kirbyplants/random,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "tlX" = (
@@ -113320,7 +113324,7 @@ fLg
 tHi
 tfc
 wOp
-mTc
+ljc
 xQJ
 ejn
 vJx
@@ -113577,7 +113581,7 @@ pot
 rUq
 lyq
 wOp
-mTc
+ljc
 xQJ
 mbV
 vJx


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/85280
These 2 areas share an APC, no reason for the right side to use the holodeck area.
Works now:
![image](https://github.com/user-attachments/assets/c3d97a3d-e925-49cf-b646-975913b1c1dc)
## Changelog
:cl: grungussuss
fix: birdshot holodeck's lighting has been fixed.
/:cl:
