### PR TITLE
Fish ordered from bought fish cases now sells for 1/20th of the normal price

### DIFF
--- a/code/modules/cargo/exports/fish.dm
+++ b/code/modules/cargo/exports/fish.dm
@@ -1,5 +1,5 @@
 /datum/export/fish
-	cost = 50
+	cost = 30
 	unit_name = "fish"
 	export_types = list(/obj/item/fish)
 
@@ -7,4 +7,7 @@
 	var/elastic_cost = ..()
 	var/elastic_percent = elastic_cost / init_cost
 	var/size_weight_exponentation = (fish.size * fish.weight * 0.01)^0.85
-	return round(elastic_cost + size_weight_exponentation * elastic_percent)
+	var/new_cost = elastic_cost + size_weight_exponentation * elastic_percent
+	if(HAS_TRAIT(fish, TRAIT_FISH_FROM_CASE)) //Avoid printing money by simply ordering fish and sending it back.
+		new_cost *= 0.05
+	return round(new_cost)


### PR DESCRIPTION
## About The Pull Request
Fish money printer goes brrrr...

But yeah, it turns out just buying and sending back fish crates is making cargo lotsa money, which is basically an exploit. Good thing we've the TRAIT_FISH_FROM_CASE trait which we can use to differentiate fishes from cargo from other more natural sources.

## Why It's Good For The Game
This will fix #85284.

## Changelog

:cl:
fix: Centcom technicians have been trained to recognize cargo-bought fish. You will no longer be able to trick the economy system by buying fish and sending it right back. Also nerfed fish selling price very slightly.
/:cl:
