### PR TITLE
[NO GBP] Clown Ops gear is now restricted to clown ops again

### DIFF
--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -48,7 +48,7 @@
 	hidden_uplink.uplink_handler.debug_mode = TRUE
 
 /obj/item/uplink/nuclear
-	uplink_flag = UPLINK_ALL_SYNDIE_OPS
+	uplink_flag = UPLINK_NUKE_OPS
 
 /obj/item/uplink/nuclear/debug
 	name = "debug nuclear uplink"


### PR DESCRIPTION

## About The Pull Request

I messed this up in the loneop gear change. Nukie uplinks got `UPLINK_ALL_SYNDIE_OPS` instead of `UPLINK_NUKE_OPS` for some reason. Whoops!
## Why It's Good For The Game

Fixes something I messed up. Makes clown ops unique again.
## Changelog
:cl: Rhials
fix: Clown Ops gear has been returned to being available only to clown ops. Whoops!
/:cl:
