### PR TITLE
Monkeymancers can interact with runes

### DIFF
--- a/code/__DEFINES/interaction_flags.dm
+++ b/code/__DEFINES/interaction_flags.dm
@@ -26,6 +26,8 @@
 #define INTERACT_ATOM_MOUSEDROP_IGNORE_USABILITY (1<<12)
 /// Bypass all adjacency and other checks for mouse drop
 #define INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS (INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT | INTERACT_ATOM_MOUSEDROP_IGNORE_USABILITY)
+/// calls try_interact() on attack_paw() and returns that.
+#define INTERACT_ATOM_ATTACK_PAW (1<<13)
 
 /// attempt pickup on attack_hand for items
 #define INTERACT_ITEM_ATTACK_HAND_PICKUP (1<<0)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -200,7 +200,8 @@
 /atom/proc/attack_paw(mob/user, list/modifiers)
 	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_PAW, user, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
-	return FALSE
+	if(interaction_flags_atom & INTERACT_ATOM_ATTACK_PAW)
+		. = _try_interact(user)
 
 
 /*

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -19,7 +19,7 @@
 	pixel_y = 16
 	pixel_z = -48
 	anchored = TRUE
-	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_ATTACK_PAW
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = SIGIL_LAYER
 	/// How many prior grand rituals have been completed?

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -159,7 +159,9 @@
 
 	var/duration = (total_time / rating_speed)
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, Shake), 1, 0, duration)
-	sleep(duration)
+	addtimer(CALLBACK(src, PROC_REF(complete_processing)), duration)
+
+/obj/machinery/processor/proc/complete_processing()
 	for(var/atom/movable/content_item in processor_contents)
 		var/datum/food_processor_process/recipe = PROCESSOR_SELECT_RECIPE(content_item)
 		if (!recipe)


### PR DESCRIPTION
## About The Pull Request

Hey hey party people. I watched a monkeymancer round last night. It was hilarious, but the guy couldn't activate his ritual rune. Sucks!

Turns out, monkies don't call `attack_hand()`, they call `attack_paw()`. This means that monkey dexterity was never the problem stopping the rune from activating, but the fact that the attack chain was never even trying to interact with the rune effect in the first place.

I've added a new atom interaction flag that routes through attack_paw, so now monkies can be given their own specific interaction behaviors for cases like this.

![image](https://github.com/user-attachments/assets/db5bab0e-30ab-4e3b-b1a6-ae392b23fcab)
## Why It's Good For The Game

Closes #85267.

Also makes it a bit easier to make interact behaviors scalable to monkies in the future.
## Changelog
:cl: Rhials
fix: Monkey wizards can now interact with grand ritual runes.
/:cl:
