### PR TITLE
Allows RPD to place atmos meters on layer 1 and 5

### DIFF
--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -142,6 +142,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /datum/pipe_info/meter
 	icon_state = "meter"
 	dirtype = PIPE_ONEDIR
+	all_layers = TRUE
 
 /datum/pipe_info/meter/New(label)
 	name = label


### PR DESCRIPTION

## About The Pull Request
Why are we restricting atmos techs from doing this?
## Why It's Good For The Game
atmos meters are very useful and there is no reason to restrict them from layer 1 and 5
## Changelog
:cl:
qol: atmos meters can now be attached to layer 1 and 5
/:cl:
