### PR TITLE
Optimizes hunger appearance work

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -869,9 +869,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 /atom/movable/screen/hunger/update_appearance(updates)
 	var/old_state = state
 	update_hunger_state() // Do this before we call all the other update procs
-	. = ..()
 	if(state == old_state) // Let's not be wasteful
 		return
+	. = ..()
 	if(state == HUNGER_STATE_FINE)
 		SetInvisibility(INVISIBILITY_ABSTRACT, name)
 		return
@@ -889,9 +889,10 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 		remove_filter("hunger_outline")
 
 	// Update color of the food
-	underlays -= food_image
-	food_image.color = state == HUNGER_STATE_FAT ? COLOR_DARK : null
-	underlays += food_image
+	if((state == HUNGER_STATE_FAT) != (old_state == HUNGER_STATE_FAT))
+		underlays -= food_image
+		food_image.color = state == HUNGER_STATE_FAT ? COLOR_DARK : null
+		underlays += food_image
 
 /atom/movable/screen/hunger/update_icon_state()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

If our appearance is fully dependant on hunger state, there's no reason to do ANY work if the state hasn't changed, also don't churn underlays for no reason.

## Why It's Good For The Game

This has relatively high cost and it's an easy win