### PR TITLE
If you have auto fit viewport enabled, it will trigger upon entering or exiting fullscreen

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1206,6 +1206,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		winset(usr, "mainwindow", "can-resize=true")
 		winset(usr, "mainwindow", "is-maximized=false")
 		winset(usr, "mainwindow", "on-size=attempt_auto_fit_viewport")
+	attempt_auto_fit_viewport()
 
 /client/verb/toggle_status_bar()
 	set name = "Toggle Status Bar"


### PR DESCRIPTION

## About The Pull Request

Automatically calls attempt_auto_fit_viewport() upon toggling fullscreen

## Why It's Good For The Game

Fullscreen changes your viewport height but not width so if you're running stretch to fit (which is probably used by most of our players as fullhd does not integer scale) you have to manually use Fit Viewport verb every time you join the game and enter fullscreen which is rather annoying to do.

## Changelog
:cl:
qol: If you have auto fit viewport enabled, it will trigger upon entering or exiting fullscreen
/:cl:
