### PR TITLE
Fixes planet gravity not crushing and void eater not refreshing

### DIFF
--- a/code/modules/antagonists/voidwalker/voidwalker_status_effects.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_status_effects.dm
@@ -21,10 +21,15 @@
 /datum/status_effect/planet_allergy
 	id = "planet_allergy"
 	duration = INFINITE
-	alert_type = /atom/movable/screen/alert/veryhighgravity
+	alert_type = /atom/movable/screen/alert/status_effect/veryhighgravity
 
 /datum/status_effect/planet_allergy/tick()
 	owner.adjustBruteLoss(1)
+
+/atom/movable/screen/alert/status_effect/veryhighgravity
+	name = "Crushing Gravity"
+	desc = "You're getting crushed by high gravity, picking up items and movement will be slowed. You'll also accumulate brute damage!"
+	icon_state = "paralysis"
 
 /datum/status_effect/void_eatered
 	duration = 10 SECONDS

--- a/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
@@ -31,7 +31,7 @@
 
 	AddComponent(/datum/component/temporary_glass_shatterer)
 
-/obj/item/void_eater/on_equipped(mob/user)
+/obj/item/void_eater/equipped(mob/user)
 	. = ..()
 
 	RegisterSignal(user, COMSIG_VOIDWALKER_SUCCESFUL_KIDNAP, PROC_REF(refresh))

--- a/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
@@ -31,7 +31,7 @@
 
 	AddComponent(/datum/component/temporary_glass_shatterer)
 
-/obj/item/void_eater/pickup(mob/user)
+/obj/item/void_eater/on_equipped(mob/user)
 	. = ..()
 
 	RegisterSignal(user, COMSIG_VOIDWALKER_SUCCESFUL_KIDNAP, PROC_REF(refresh))


### PR DESCRIPTION
Fixes #85303, fixes #85278 

Fixes planetary gravity not killing voidwalkers and voided people. I used a screen alert but I shouldve used a status effect screen alert (apparently it matters), causing runtimes and breaking it aaaa

Also someone refactored how pickup() works so it no longer gets called if you dont pick it up by clicking it. I think it's a little dumb but I can't find the PR that did it so whatever. Anyway it's not my fault woohoo!!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes void eater not refreshing
fix: Fixes planetary gravity not killing voidwalkers and voideds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
