### PR TITLE
Grass sheath now holds parsnip sabres, fixed grammar for the latter

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -167,7 +167,7 @@
 
 /obj/item/melee/parsnip_sabre
 	name = "parsnip sabre"
-	desc = "An elegant weapon, if weird weapon. Suprisingly sharp for being made from a parsnip."
+	desc = "A weird, yet elegant weapon. Suprisingly sharp for something made from a parsnip."
 	icon = 'icons/obj/weapons/sword.dmi'
 	icon_state = "parsnip_sabre"
 	inhand_icon_state = "parsnip_sabre"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -857,7 +857,7 @@
 
 /obj/item/storage/belt/grass_sabre
 	name = "sabre sheath"
-	desc = "An simple grass sheath designed to hold a sabre of... some sorts. Actual metal one might be too sharp, though..."
+	desc = "An simple grass sheath designed to hold a sabre of... some sort. Actual metal one might be too sharp, though..."
 	icon_state = "grass_sheath"
 	inhand_icon_state = "grass_sheath"
 	worn_icon_state = "grass_sheath"
@@ -871,7 +871,7 @@
 	atom_storage.max_slots = 1
 	atom_storage.rustle_sound = FALSE
 	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
-	atom_storage.set_holdable(/obj/item/melee/sabre)
+	atom_storage.set_holdable(/obj/item/melee/parsnip_sabre)
 	atom_storage.click_alt_open = FALSE
 
 /obj/item/storage/belt/grass_sabre/examine(mob/user)


### PR DESCRIPTION

## About The Pull Request

Closes #85306

## Changelog
:cl:
fix: Grass sheath now holds parsnip sabres like its supposed to
spellcheck: Fixed up parsnip sabre description grammar
/:cl:
