### PR TITLE
[no gbp] Assorted birdshot engineering feedback

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -72341,7 +72341,7 @@
 /area/station/hallway/primary/starboard)
 "yei" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Transit Tube Station"
+	name = "Atmospherics Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -4399,6 +4399,7 @@
 	cycle_id = "atmos_airlock_1"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bJK" = (
@@ -4958,8 +4959,9 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bXb" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "bXi" = (
@@ -5135,6 +5137,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "cam" = (
@@ -5721,7 +5724,7 @@
 	dir = 1;
 	name = "Plasma to Pure"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -7336,6 +7339,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /turf/open/floor/iron/smooth_half{
 	dir = 8
 	},
@@ -9248,6 +9252,7 @@
 /area/station/maintenance/starboard/aft)
 "dzH" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "dAn" = (
@@ -10739,6 +10744,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"efn" = (
+/obj/effect/spawner/random/structure/crate_loot,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "efy" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/machinery/status_display/ai/directional/west,
@@ -12469,9 +12478,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"eKU" = (
-/turf/closed/wall/r_wall/rust,
-/area/station/engineering/atmos/pumproom)
 "eKW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bathroom"
@@ -14389,9 +14395,7 @@
 /area/station/science/xenobiology)
 "fxp" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/orange{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "fxF" = (
@@ -16495,6 +16499,10 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"ggr" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "ggw" = (
 /obj/effect/turf_decal/stripes/white/end{
 	dir = 1
@@ -18857,7 +18865,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos/pumproom)
+/area/station/maintenance/department/engine/atmos)
 "gUV" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/south{
@@ -19681,7 +19689,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos/pumproom)
+/area/station/maintenance/department/engine/atmos)
 "hhL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21075,6 +21083,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
+"hGa" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Atmospherics Tank - Mix"
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "hGb" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/storage)
@@ -21884,7 +21898,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hWk" = (
@@ -23321,7 +23335,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "itw" = (
@@ -25639,13 +25653,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"jbE" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "jbV" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
@@ -26700,6 +26707,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
+"jvm" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "jvB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27837,7 +27855,7 @@
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "O2 To Pure"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -30993,9 +31011,6 @@
 /area/station/maintenance/starboard/fore)
 "kNv" = (
 /obj/machinery/air_sensor/mix_tank,
-/obj/machinery/camera/directional/east{
-	c_tag = "Atmospherics Tank - Mix"
-	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "kNx" = (
@@ -33234,9 +33249,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"lwK" = (
-/turf/closed/wall/r_wall/rust,
-/area/station/engineering/atmos/storage)
 "lwO" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Engine Room"
@@ -36648,13 +36660,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"mDb" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "mDf" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -37284,10 +37289,6 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"mMF" = (
-/obj/structure/sign/warning/pods/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "mMN" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -38042,6 +38043,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"nbN" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "ncb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -39961,9 +39966,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nKj" = (
@@ -40915,6 +40918,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
 "odh" = (
@@ -44574,6 +44578,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"prd" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/supermatter/room)
 "prf" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46984,7 +46992,7 @@
 	dir = 1;
 	name = "CO2 to Pure"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -50683,6 +50691,7 @@
 	name = "Engine Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ruS" = (
@@ -53462,7 +53471,7 @@
 /area/station/maintenance/port/greater)
 "srw" = (
 /turf/closed/wall/r_wall/rust,
-/area/station/engineering/atmospherics_engine)
+/area/station/maintenance/department/electrical)
 "srx" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/bot{
@@ -56535,6 +56544,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
+"tqn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
 "tqo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -58697,6 +58712,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"uct" = (
+/turf/open/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "ucy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/red{
@@ -60118,19 +60136,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
-"uAM" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "uAY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
@@ -61738,10 +61743,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"vcm" = (
-/obj/item/pickaxe,
-/turf/open/misc/asteroid,
-/area/station/maintenance/department/electrical)
 "vcB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63923,7 +63924,7 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Office"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /turf/open/floor/iron/smooth_half{
 	dir = 8
 	},
@@ -65457,14 +65458,6 @@
 "wfr" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
-"wfB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "wfG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
@@ -67714,10 +67707,10 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "O2 to Airmix"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green{
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wPP" = (
@@ -70300,6 +70293,10 @@
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
 	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
@@ -83995,7 +83992,7 @@ kjW
 fcE
 ceN
 cDV
-kUN
+bNq
 ybs
 knv
 knv
@@ -84221,8 +84218,8 @@ wzv
 wzv
 fjh
 dfd
-ybO
-jbE
+pnl
+ooo
 ukP
 ooo
 jZl
@@ -84233,7 +84230,7 @@ wmq
 vMI
 pKW
 kiP
-wmq
+tqn
 dYv
 jZl
 feu
@@ -84252,7 +84249,7 @@ tKn
 eWr
 xcW
 prP
-kUN
+bNq
 ybs
 knv
 aJq
@@ -84478,7 +84475,7 @@ wzv
 wzv
 fjh
 wzv
-ybO
+pnl
 dpH
 kNv
 gAy
@@ -84509,7 +84506,7 @@ hBi
 bzF
 gzM
 svd
-kUN
+bNq
 liX
 jqd
 lxP
@@ -84735,10 +84732,10 @@ pWm
 pWm
 uEH
 dfd
-ybO
-ybO
-ybO
-ybO
+pnl
+uct
+uct
+uct
 jZl
 bEG
 rCk
@@ -84766,7 +84763,7 @@ isC
 bPd
 vDG
 rry
-kUN
+bNq
 olj
 cmf
 gBh
@@ -84991,11 +84988,11 @@ wzv
 wzv
 wzv
 yil
-yil
-wfB
-kNn
-yil
-kNn
+wzv
+pnl
+uct
+hGa
+uct
 jZl
 oqq
 tmK
@@ -85023,7 +85020,7 @@ uqg
 cjS
 gqS
 kmL
-eKU
+ecq
 olj
 gBh
 gBh
@@ -85244,15 +85241,15 @@ dDB
 aWx
 tdY
 qcF
-wzv
+kNn
 yil
 xnL
 yil
-pWm
-pWm
-pWm
-mMF
-mDb
+bXb
+pnl
+pnl
+pnl
+pnl
 srw
 tXF
 qaU
@@ -85280,7 +85277,7 @@ hMQ
 tNm
 nWa
 iua
-kUN
+bNq
 bJK
 dez
 gBh
@@ -85501,13 +85498,13 @@ pWm
 pWm
 pWm
 pWm
-pWm
 rjo
 pWm
 pWm
 pWm
-bvt
-bvt
+bXb
+bXb
+bXb
 bXb
 yil
 fTJ
@@ -85537,7 +85534,7 @@ kti
 iwR
 oQK
 dFG
-kUN
+bNq
 cvJ
 olj
 knv
@@ -85756,18 +85753,18 @@ dDB
 dDB
 tYT
 aJq
-aJq
-pWm
+gcs
 ako
 mmT
 vtJ
 acg
 pWm
-bvt
-bvt
-vcm
+efn
+wzv
+wzv
+wzv
 oii
-jZl
+pnl
 sZP
 wvZ
 mDS
@@ -85794,7 +85791,7 @@ lkN
 rjw
 vSt
 kOH
-kUN
+bNq
 cvJ
 aIk
 knv
@@ -86013,8 +86010,7 @@ dDB
 dDB
 tYT
 aJq
-aJq
-pWm
+gcs
 arN
 wOz
 viE
@@ -86022,9 +86018,10 @@ bOa
 pWm
 bvt
 bvt
-bvt
+nbN
+ggr
 oii
-jZl
+pnl
 gmv
 jrD
 jrD
@@ -86051,7 +86048,7 @@ vuV
 xLS
 lfq
 cHt
-kUN
+bNq
 xxt
 liX
 knv
@@ -86270,8 +86267,7 @@ dDB
 dDB
 tYT
 aJq
-aJq
-pWm
+gcs
 pWm
 hDg
 qMG
@@ -86280,17 +86276,18 @@ bvt
 bvt
 bvt
 bvt
+bvt
 yil
-jZl
+pnl
 wFZ
 oLc
 jDi
 jDi
 jDi
-jZl
+pnl
 srw
-jZl
-jZl
+pnl
+pnl
 jZl
 xck
 cag
@@ -86298,17 +86295,17 @@ xck
 bJH
 xck
 cGV
-cGV
-cGV
-lwK
-cGV
-kUN
+bNq
+bNq
+ecq
+bNq
+bNq
 hhr
-kUN
+bNq
 gUQ
-kUN
-kUN
-kUN
+bNq
+bNq
+bNq
 knv
 tZE
 knv
@@ -86529,22 +86526,22 @@ dDB
 tYT
 aJq
 bvt
-bvt
 fiw
 oIf
 pWm
 bvt
 bvt
 bvt
+bvt
 pWm
 oii
-jZl
+pnl
 jDi
 jDi
 jDi
 jDi
 jDi
-jZl
+pnl
 oCE
 oCE
 lYH
@@ -86795,13 +86792,13 @@ bvt
 bvt
 pWm
 yil
-jZl
+pnl
 urP
 kLr
 wkj
 tuu
 kHd
-jZl
+pnl
 oCE
 pWm
 pWm
@@ -87053,11 +87050,11 @@ bvt
 pWm
 qjp
 kNn
-jZl
-jZl
-jZl
+pnl
+pnl
+pnl
 srw
-jZl
+pnl
 tOc
 oCE
 pWm
@@ -90396,7 +90393,7 @@ szg
 tpW
 pUM
 kMe
-kMe
+prd
 fGf
 ayK
 izf
@@ -91673,7 +91670,7 @@ cBd
 cBd
 dyI
 ozQ
-xAx
+jvm
 brA
 dyI
 oer
@@ -92704,7 +92701,7 @@ buI
 kjs
 xUK
 vni
-uAM
+nHH
 lHd
 nHH
 xTr

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -160,6 +160,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/airlock_controller/incinerator_atmos{
+	pixel_x = -40;
+	pixel_y = -8
+	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "aem" = (
@@ -205,8 +209,15 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/layer2{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 8;
+	pixel_y = 36
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "aeX" = (
@@ -12448,6 +12459,9 @@
 "eKd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_y = -20
+	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "eKf" = (
@@ -43441,6 +43455,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"oYf" = (
+/obj/machinery/button/ignition/incinerator/atmos,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/disposal/incinerator)
 "oYi" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -44352,6 +44370,7 @@
 /area/station/service/chapel)
 "pnO" = (
 /obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "pnQ" = (
@@ -81899,7 +81918,7 @@ wBo
 sRf
 wBo
 hFO
-wBo
+oYf
 mPB
 wWm
 nlR


### PR DESCRIPTION
## About The Pull Request
I made some mistakes in the original birdshot engineering re-rework, fixing them here.
Changes:
- added missing access helpers to new doors
- added cycling to SM airlocks
- bridge pipes for filter in atmos are now visible
- added missing controls to the incinerator
- added air alarm in incinerator room
- added missing pipes for the plasma storage chamber
- expanded the mixing chamber in atmos because apparently it's important to be big
- fixed the unconnected pipe in the mixing chamber
- changed the name of a maintenance door that said "transit tube station" when it was supposed to be "atmospherics maintenance"
## Changelog
:cl:
fix: birdshot engineering feedback has been applied
/:cl:
