### PR TITLE
Fixes a typo in military javelins

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -221,7 +221,7 @@
 	icon_state = "military_spear0"
 	base_icon_state = "military_spear0"
 	icon_prefix = "military_spear"
-	name = "military Javelin"
+	name = "military javelin"
 	desc = "A stick with a seemingly blunt spearhead on its end. Looks like it might break bones easily."
 	attack_verb_continuous = list("attacks", "pokes", "jabs")
 	attack_verb_simple = list("attack", "poke", "jab")


### PR DESCRIPTION

## About The Pull Request
Changes "military Javelin" to "military javelin"
## Why It's Good For The Game
Consistent capitalisation. Makes the name look better.
## Changelog
:cl:
spellcheck: military javelin's name is now fully uncapitalised
/:cl:
