### PR TITLE
Players can now reorder items inside storages by dragging them

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -482,8 +482,26 @@
 
 	return TRUE
 
+/atom/movable/screen/storage/cell
+
+/atom/movable/screen/storage/cell/mouse_drop_receive(atom/target, mob/living/user, params)
+	var/datum/storage/storage = master_ref?.resolve()
+
+	if (isnull(storage) || !istype(user) || storage != user.active_storage)
+		return
+
+	if (!user.can_perform_action(storage.parent, FORBID_TELEKINESIS_REACH))
+		return
+
+	if (target.loc != storage.real_location)
+		return
+
+	/// Due to items in storage ignoring transparency for click hitboxes, this only can happen if we drag onto a free cell - aka after all current contents
+	storage.real_location.contents -= target
+	storage.real_location.contents += target
+	storage.refresh_views()
+
 /atom/movable/screen/storage/corner
-	name = "storage"
 	icon_state = "storage_corner_topleft"
 
 /atom/movable/screen/storage/corner/top_right

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -469,6 +469,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		UnregisterSignal(target, COMSIG_MOUSEDROPPED_ONTO)
 		return
 
+	if(numerical_stacking)
+		return
+
 	var/drop_index = real_location.contents.Find(dropped_onto)
 	real_location.contents -= target
 	// Use an empty list if we're dropping onto the last item

--- a/code/datums/storage/storage_interface.dm
+++ b/code/datums/storage/storage_interface.dm
@@ -2,7 +2,7 @@
 /datum/storage_interface
 	/// UI elements for this theme
 	var/atom/movable/screen/close/closer
-	var/atom/movable/screen/storage/cells
+	var/atom/movable/screen/storage/cell/cells
 	var/atom/movable/screen/storage/corner/corner_top_left
 	var/atom/movable/screen/storage/corner/top_right/corner_top_right
 	var/atom/movable/screen/storage/corner/bottom_left/corner_bottom_left


### PR DESCRIPTION

## About The Pull Request

https://github.com/user-attachments/assets/8949965f-a78a-4f3d-b528-afcdfe5c4e72

Drag'n'dropping items inside of an open storage that you can access will reorder them. I had to register dropping onto items themselves instead of cells as they ignore icon transparency when in storage for QOL reasons, so bear with that.
## Why It's Good For The Game

Reordering your storage currently requires taking out all items in front of position that you want a certain item to be and putting them back in which could be rather annoying with large storages.

## Changelog
:cl:
qol: You can now reorder items inside storages by dragging them
/:cl:
