### PR TITLE
allows to disable sliders again

### DIFF
--- a/tgui/packages/tgui/components/Slider.tsx
+++ b/tgui/packages/tgui/components/Slider.tsx
@@ -19,6 +19,8 @@ type Props = {
   /** Value itself, controls the position of the cursor. */
   value: number;
 } & Partial<{
+  /** Allows to disable the slider */
+  disabled: boolean;
   /** Animates the value if it was changed externally. */
   animated: boolean;
   /** Custom css */


### PR DESCRIPTION
## About The Pull Request
Before the  typescript update, the slider element could be disabled without issues, but as the prop was missing, the compiler rejected to accept disabling sliders any longer. This ensures that sliders once again can be disabled as the prop will be accepted and properly forwarded.

## Why It's Good For The Game

