### PR TITLE
allows implanting TTVs into chest once again

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -19,6 +19,7 @@
 	preop_sound = 'sound/surgery/organ1.ogg'
 	success_sound = 'sound/surgery/organ2.ogg'
 	var/obj/item/item_for_cavity
+	var/list/heavy_weight_whitelist = list(/obj/item/transfer_valve = TRUE)
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
 	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser))
@@ -49,7 +50,7 @@
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery = FALSE)
 	var/obj/item/bodypart/chest/target_chest = target.get_bodypart(BODY_ZONE_CHEST)
 	if(tool)
-		if(item_for_cavity || tool.w_class > WEIGHT_CLASS_NORMAL || HAS_TRAIT(tool, TRAIT_NODROP) || isorgan(tool))
+		if(item_for_cavity || ((tool.w_class > WEIGHT_CLASS_NORMAL) && !is_type_in_typecache(tool, heavy_weight_whitelist)) || HAS_TRAIT(tool, TRAIT_NODROP) || isorgan(tool))
 			to_chat(user, span_warning("You can't seem to fit [tool] in [target]'s [target_zone]!"))
 			return FALSE
 		else

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -9,6 +9,8 @@
 		/datum/surgery_step/handle_cavity,
 		/datum/surgery_step/close)
 
+GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valve)))
+
 //handle cavity
 /datum/surgery_step/handle_cavity
 	name = "implant item"
@@ -19,7 +21,6 @@
 	preop_sound = 'sound/surgery/organ1.ogg'
 	success_sound = 'sound/surgery/organ2.ogg'
 	var/obj/item/item_for_cavity
-	var/list/heavy_weight_whitelist = list(/obj/item/transfer_valve = TRUE)
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
 	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser))
@@ -50,7 +51,7 @@
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery = FALSE)
 	var/obj/item/bodypart/chest/target_chest = target.get_bodypart(BODY_ZONE_CHEST)
 	if(tool)
-		if(item_for_cavity || ((tool.w_class > WEIGHT_CLASS_NORMAL) && !is_type_in_typecache(tool, heavy_weight_whitelist)) || HAS_TRAIT(tool, TRAIT_NODROP) || isorgan(tool))
+		if(item_for_cavity || ((tool.w_class > WEIGHT_CLASS_NORMAL) && !is_type_in_typecache(tool, GLOB.heavy_cavity_implants)) || HAS_TRAIT(tool, TRAIT_NODROP) || isorgan(tool))
 			to_chat(user, span_warning("You can't seem to fit [tool] in [target]'s [target_zone]!"))
 			return FALSE
 		else


### PR DESCRIPTION

## About The Pull Request
TTVs can be implanted into the chest again. They still function inside people, and can be detonated.
## Why It's Good For The Game
TTVs were made bulky years ago so you couldn't have a backpack full of bombs. This also had the side effect of implanting bombs into people made impossible because any items with weight above normal can't be implanted

You can still implant chembombs now so you should be able to do TTVs as well. Allows for cool hostage scenario RP. TTV implants were always meant to be part of the game
![Screenshot 2024-07-28 155926](https://github.com/user-attachments/assets/71ec283a-c246-420a-b943-fb0f154ccb37)


Codewise added a whitelist for heavy items in cavity implant
## Changelog
:cl:
balance: TTV bombs can be implanted into people's chest once again
/:cl:
