### PR TITLE
Added a config to override the def gateway delay for specific start points.

### DIFF
--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -598,7 +598,7 @@
 /turf/open/floor/iron/freezer,
 /area/awaymission/cabin)
 "cH" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowcabin,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/awaymission/cabin)
@@ -660,7 +660,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/cabin)
 "cQ" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowcabin,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
@@ -2904,7 +2904,7 @@
 /area/awaymission/cabin/snowforest)
 "rk" = (
 /obj/machinery/light/directional/south,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowcabin,
 /obj/structure/sign/poster/official/report_crimes/directional/south,
 /obj/structure/cable,
 /turf/open/floor/carpet,

--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -1688,7 +1688,7 @@
 "vq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/beach,
 /turf/open/floor/plating,
 /area/awaymission/beach)
 "vx" = (
@@ -3586,7 +3586,7 @@
 /area/awaymission/beach)
 "SB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/beach,
 /turf/open/floor/plating,
 /area/awaymission/beach)
 "SI" = (

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -480,7 +480,7 @@
 /turf/open/floor/plating,
 /area/awaymission/caves/research)
 "cR" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/floor/plating,
 /area/awaymission/caves/research)
 "cS" = (
@@ -610,7 +610,7 @@
 "dw" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid/level_two)
 "dx" = (
@@ -653,7 +653,7 @@
 "dH" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/floor/wood,
 /area/awaymission/caves/northblock)
 "dI" = (
@@ -705,7 +705,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/floor/wood,
 /area/awaymission/caves/northblock)
 "ea" = (
@@ -714,7 +714,7 @@
 /area/awaymission/caves/northblock)
 "ed" = (
 /obj/structure/bed,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/floor/wood,
 /area/awaymission/caves/northblock)
 "ee" = (
@@ -849,7 +849,7 @@
 /turf/open/floor/iron,
 /area/awaymission/caves/listeningpost)
 "eO" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/floor/iron,
 /area/awaymission/caves/listeningpost)
 "eP" = (
@@ -1584,7 +1584,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
 "Bs" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/caves,
 /turf/open/misc/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1903,14 +1903,14 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaymission/moonoutpost19/arrivals)
 "ms" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/moonoutpost,
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/moonoutpost19/arrivals)
 "mt" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/moonoutpost,
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/moonoutpost19/arrivals)
 "mu" = (
@@ -1955,7 +1955,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaymission/moonoutpost19/arrivals)
 "mI" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/moonoutpost,
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaymission/moonoutpost19/arrivals)
 "mJ" = (
@@ -1965,7 +1965,7 @@
 	icon_state = "beacon";
 	name = "tracking beacon"
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/moonoutpost,
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaymission/moonoutpost19/arrivals)
 "mK" = (

--- a/_maps/RandomZLevels/museum.dmm
+++ b/_maps/RandomZLevels/museum.dmm
@@ -1426,7 +1426,7 @@
 /turf/open/indestructible/plating,
 /area/awaymission/museum)
 "lz" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/museum,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/awaymission/museum)
@@ -3095,7 +3095,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/awaymission/museum)
 "zd" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/museum,
 /turf/open/floor/grass,
 /area/awaymission/museum)
 "zg" = (
@@ -4503,7 +4503,7 @@
 	},
 /area/awaymission/museum)
 "KN" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/museum,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -389,7 +389,7 @@
 /turf/open/floor/iron/dark,
 /area/awaymission/research/interior/gateway)
 "bR" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /turf/open/floor/iron/dark,
 /area/awaymission/research/interior/gateway)
 "bS" = (
@@ -438,7 +438,7 @@
 /turf/open/floor/iron/dark,
 /area/awaymission/research/interior/gateway)
 "bZ" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -481,12 +481,12 @@
 /area/awaymission/research/interior/gateway)
 "cj" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /turf/open/floor/iron/dark,
 /area/awaymission/research/interior/gateway)
 "ck" = (
 /obj/machinery/door/window/right/directional/south,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/awaymission/research/interior/gateway)
@@ -1761,7 +1761,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/awaymission/research/interior/bathroom)
@@ -2007,7 +2007,7 @@
 "jU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "jV" = (
@@ -2505,7 +2505,7 @@
 "lT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/patriot,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lX" = (
@@ -2976,7 +2976,7 @@
 /area/awaymission/research/interior)
 "sM" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/research,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/awaymission/research/interior/gateway)

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -181,7 +181,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/item/bedsheet/purple,
 /turf/open/floor/wood,
 /area/awaymission/snowdin/post/dorm)
@@ -213,7 +213,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /turf/open/floor/wood,
 /area/awaymission/snowdin/post/dorm)
 "aY" = (
@@ -239,7 +239,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/item/paper/crumpled/ruins/snowdin/dontdeadopeninside,
 /obj/item/bedsheet/green,
 /turf/open/floor/wood,
@@ -414,7 +414,7 @@
 /turf/open/floor/iron/freezer,
 /area/awaymission/snowdin/post/kitchen)
 "bM" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/freezer,
 /area/awaymission/snowdin/post/kitchen)
@@ -1092,7 +1092,7 @@
 "eh" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/item/bedsheet/red,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
@@ -2073,12 +2073,12 @@
 /area/awaymission/snowdin/post/gateway)
 "hR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/gateway)
 "hS" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2086,7 +2086,7 @@
 /area/awaymission/snowdin/post/gateway)
 "hT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/gateway)
@@ -2302,7 +2302,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/gateway)
 "iB" = (
@@ -2310,7 +2310,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 10
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2318,7 +2318,7 @@
 /area/awaymission/snowdin/post/gateway)
 "iC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/gateway)
 "iD" = (
@@ -2579,14 +2579,14 @@
 /turf/open/floor/iron/white,
 /area/awaymission/snowdin/post/minipost)
 "ju" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/gateway)
 "jv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2650,7 +2650,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
@@ -3523,7 +3523,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/garage)
@@ -7044,7 +7044,7 @@
 	},
 /area/awaymission/snowdin/cave)
 "Be" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
@@ -7500,7 +7500,7 @@
 /obj/structure/bed{
 	dir = 4
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/snowdin,
 /obj/item/bedsheet/nanotrasen{
 	dir = 4
 	},

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -101,14 +101,14 @@
 /turf/open/floor/iron/dark,
 /area/awaymission/undergroundoutpost45/central)
 "ax" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/underground,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/central)
 "ay" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/underground,
 /turf/open/floor/iron/grimy,
 /area/awaymission/undergroundoutpost45/central)
 "az" = (
@@ -118,7 +118,7 @@
 	icon_state = "beacon";
 	name = "tracking beacon"
 	},
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/underground,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
@@ -126,7 +126,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "aB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/underground,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
@@ -218,7 +218,7 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/central)
 "aT" = (
-/obj/effect/landmark/awaystart,
+/obj/effect/landmark/awaystart/underground,
 /turf/open/floor/iron/grimy,
 /area/awaymission/undergroundoutpost45/central)
 "aU" = (

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -222,3 +222,13 @@ Always compile, always use that verb, and always make sure that it works for wha
 
 /// Checks the job changes in the map config for the passed change key.
 #define CHECK_MAP_JOB_CHANGE(job, change) SSmapping.config.job_changes?[job]?[change]
+
+///Identifiers for away mission spawnpoints
+#define AWAYSTART_BEACH "AWAYSTART_BEACH"
+#define AWAYSTART_MUSEUM "AWAYSTART_MUSEUM"
+#define AWAYSTART_RESEARCH "AWAYSTART_RESEARCH"
+#define AWAYSTART_CAVES "AWAYSTART_CAVES"
+#define AWAYSTART_MOONOUTPOST "AWAYSTART_MOONOUTPOST"
+#define AWAYSTART_SNOWCABIN "AWAYSTART_SNOWCABIN"
+#define AWAYSTART_SNOWDIN "AWAYSTART_SNOWDIN"
+#define AWAYSTART_UNDERGROUND "AWAYSTART_UNDERGROUND"

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -278,8 +278,8 @@
 ///An override to gateway_delay for specific maps or start points
 /datum/config_entry/keyed_list/gateway_delays_by_id
 	default = list(
-		AWAYSTART_BEACH = 10 MINUTES,
-		AWAYSTART_MUSEUM = 15 MINUTES,
+		AWAYSTART_BEACH = 5 MINUTES, //Chill RP zone
+		AWAYSTART_MUSEUM = 12 MINUTES, //Chill place with some cool puzzles and effects.
 	)
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -266,7 +266,7 @@
 /datum/config_entry/flag/roundstart_away //Will random away mission be loaded.
 
 /datum/config_entry/number/gateway_delay //How long the gateway takes before it activates. Default is half an hour. Only matters if roundstart_away is enabled.
-	default = 18000
+	default = 30 MINUTES
 	integer = FALSE
 	min_val = 0
 
@@ -274,6 +274,16 @@
 	integer = FALSE
 	min_val = 0
 	max_val = 100
+
+///An override to gateway_delay for specific maps or start points
+/datum/config_entry/keyed_list/gateway_delays_by_id
+	default = list(
+		AWAYSTART_BEACH = 10 MINUTES,
+		AWAYSTART_MUSEUM = 15 MINUTES,
+	)
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_NUM
+	lowercase_key = FALSE //The macros are written the exact same way as their values, only without the quotation marks.
 
 /datum/config_entry/flag/ghost_interaction
 

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -32,14 +32,50 @@ GLOBAL_LIST_INIT(potentialConfigRandomZlevels, generate_map_list_from_directory(
 			current = D
 	if(!current)
 		current = new
+		current.name = name
 		current.id = id
 		if(delay)
-			current.wait = CONFIG_GET(number/gateway_delay)
+			var/list/waits_by_id = CONFIG_GET(keyed_list/gateway_delays_by_id)
+			var/wait_to_use = !isnull(waits_by_id[id]) ? waits_by_id[id] : CONFIG_GET(number/gateway_delay)
+			current.wait = wait_to_use
 		GLOB.gateway_destinations += current
 	current.target_turfs += get_turf(src)
+	return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/awaystart/nodelay
 	delay = FALSE
+
+/obj/effect/landmark/awaystart/beach
+	name = "beach away spawn"
+	id = AWAYSTART_BEACH
+
+/obj/effect/landmark/awaystart/museum
+	name = "buseum away spawn"
+	id = AWAYSTART_MUSEUM
+
+/obj/effect/landmark/awaystart/research
+	name = "research outpost away spawn"
+	id = AWAYSTART_RESEARCH
+
+/obj/effect/landmark/awaystart/caves
+	name = "caves away spawn"
+	id = AWAYSTART_CAVES
+
+/obj/effect/landmark/awaystart/moonoutpost
+	name = "Moon Outpost 19 away spawn"
+	id = AWAYSTART_MOONOUTPOST
+
+/obj/effect/landmark/awaystart/snowcabin
+	name = "snow cabin away spawn"
+	id = AWAYSTART_SNOWCABIN
+
+/obj/effect/landmark/awaystart/snowdin
+	name = "Snowdin away spawn"
+	id = AWAYSTART_SNOWDIN
+
+/obj/effect/landmark/awaystart/underground
+	name = "Underground Outpost 45 away spawn"
+	id = AWAYSTART_UNDERGROUND
 
 /proc/generateMapList(filename)
 	. = list()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -185,6 +185,10 @@ ALLOW_AI_MULTICAM
 ## 600 is one minute.
 GATEWAY_DELAY 18000
 
+## Overrides to gateway delay for specific away mission start points.
+GATEWAY_DELAYS_BY_ID AWAYSTART_BEACH 6000
+GATEWAY_DELAYS_BY_ID AWAYSTART_MUSEUM 9000
+
 ## The probability of the gateway mission being a config one
 CONFIG_GATEWAY_CHANCE 0
 


### PR DESCRIPTION
## About The Pull Request
I've a few gripes with start points and the gateway delay. First of all, there's no way to discriminate peaceful away locations that do not need a with a 30 minutes timegate from the rest. Places like the beach and the museum hardly have anything OP that could tip the scales.

Second, none of the awaystart landmarks have identifiers of their own, which means all awaystart landmarks from all away missions are linked under the same destination point datum. This is hardly an issue in the current state where only one map is ever loaded and all maps have only one way in that directs you to one of several locations at least until the gateways are linked, but it's nevertheless something that I have to take care of, since the config requires it.

## Why It's Good For The Game
See above.

## Changelog

:cl:
config: Added a config for specific gateway delays so locations like the beach and the museum don't have to take 30 minutes to become available like the rest.
/:cl:
