### PR TITLE
Fixes mining MODsuit suit storage

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -533,7 +533,7 @@
 		),
 	)
 
-/datum/mod_theme/loader/New()
+/datum/mod_theme/mining/New()
 	.=..()
 	allowed_suit_storage = GLOB.mining_suit_allowed
 


### PR DESCRIPTION

## About The Pull Request

Closes #85332
#83437 had a copypasting error and ended up giving mining MOD suit storage to loaders instead of mining MODs

## Changelog
:cl:
fix: Mining MODsuits now can store everything that explorer suits can
/:cl:
