### PR TITLE
Fixes some mining mobs not becoming hostile to ashwalker attacks [no gbp]

### DIFF
--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -36,6 +36,9 @@
 			drop_immediately = basic_mob_flags & DEL_ON_DEATH,\
 		)
 	RegisterSignal(src, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(check_ashwalker_peace_violation))
+	// We add this to ensure that mobs will actually receive the above signal, as some will lack AI
+	// handling for retaliation and attack special cases
+	AddElement(/datum/element/relay_attackers)
 
 /mob/living/basic/mining/proc/add_ranged_armour(list/vulnerable_projectiles)
 	AddElement(\


### PR DESCRIPTION

## About The Pull Request

Some mining mobs didn't have signal registrations to respond to ashwalkers breaking the peace. This fixes that by giving all mining mobs a signal listener to being attacked if their AI handler doesn't give them one already.
## Why It's Good For The Game

Fixes an exploit where people would drag legion to the ashwalker nest to kill them for free egg spawning because legion don't have a signal listener for being attacked.
Future proofs any other mining mobs that might be missing this signal through AI.
## Changelog
:cl: Bisar
fix: All mining mobs now properly listen to the signals sent by attackers and will respond appropriately.
/:cl:
