### PR TITLE
Fixed NT Frontier discounts not applying

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -11,9 +11,6 @@
 #define TECHWEB_TIER_4_POINTS 160
 #define TECHWEB_TIER_5_POINTS 200
 
-/// Minimal amount of points that a node can be reduced to by research paper boosts
-#define TECHWEB_MIN_BOOST_POINTS 10
-
 //! Amount of points gained per second by a single R&D server, see: [research][code/controllers/subsystem/research.dm]
 #define TECHWEB_SINGLE_SERVER_INCOME 1
 

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -11,6 +11,9 @@
 #define TECHWEB_TIER_4_POINTS 160
 #define TECHWEB_TIER_5_POINTS 200
 
+/// Minimal amount of points that a node can be reduced to by research paper boosts
+#define TECHWEB_MIN_BOOST_POINTS 10
+
 //! Amount of points gained per second by a single R&D server, see: [research][code/controllers/subsystem/research.dm]
 #define TECHWEB_SINGLE_SERVER_INCOME 1
 

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -90,7 +90,7 @@
 		var/list/boostlist = host.boosted_nodes[id]
 		for(var/booster in boostlist)
 			if(actual_costs[booster])
-				var/delta = max(0, actual_costs[booster] - 250)
+				var/delta = max(0, actual_costs[booster] - TECHWEB_MIN_BOOST_POINTS)
 				actual_costs[booster] -= min(boostlist[booster], delta)
 
 	return actual_costs

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -90,8 +90,7 @@
 		var/list/boostlist = host.boosted_nodes[id]
 		for(var/booster in boostlist)
 			if(actual_costs[booster])
-				var/delta = max(0, actual_costs[booster] - TECHWEB_MIN_BOOST_POINTS)
-				actual_costs[booster] -= min(boostlist[booster], delta)
+				actual_costs[booster] = max(actual_costs[booster] - boostlist[booster], 0)
 
 	return actual_costs
 


### PR DESCRIPTION
## About The Pull Request

Closes #85234

There was a check in place to ensure that no node gets reduced below 250 cost. It made sense when nodes costed up to 10000 points... but now the maximum cost is 200. Into the recycler it goes.

## Changelog
:cl:
fix: Fixed NT Frontier discounts not applying
/:cl:
