### PR TITLE
Fixes AI Mech Control GBJing the AI

### DIFF
--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -12,7 +12,7 @@
 		to_chat(user, "<a href='?src=[REF(user)];ai_take_control=[REF(src)]'>[span_userdanger("ASSUME DIRECT CONTROL?")]</a><br>")
 		return
 	examine(user)
-	if(length(return_drivers()) > 0)
+	if(length(return_occupants()) >= max_occupants)
 		to_chat(user, span_warning("This exosuit has a pilot and cannot be controlled."))
 		return
 	var/can_control_mech = FALSE

--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -103,6 +103,7 @@
 	AI.controlled_equipment = src
 	AI.remote_control = src
 	AI.ShutOffDoomsdayDevice()
+	add_occupant(AI)
 	to_chat(AI, AI.can_dominate_mechs ? span_greenannounce("Takeover of [name] complete! You are now loaded onto the onboard computer. Do not attempt to leave the station sector!") :\
 		span_notice("You have been uploaded to a mech's onboard computer."))
 	to_chat(AI, "<span class='reallybig boldnotice'>Use Middle-Mouse or the action button in your HUD to toggle equipment safety. Clicks with safety enabled will pass AI commands.</span>")


### PR DESCRIPTION

## About The Pull Request

So when an AI entered a mech it wasnt considered an occupant it was just there, so it didnt get controls or UI or anything (cuz the add_control_flags proc only gives the controls to mobs in the occupants list) it was just there stuck unable to move or do anything really. I put this proc in so the AI can do stuff now.

I dunno if this is cleanest of fixes but it's 5am and in my testing it makes it go from not working to working so I'm claiming it is good enough (tm)

I cant really convey how it works in image form so I will go over the steps I did to implement this fix:
On master, mess about with AI dominating mechs or controlling mechs with a beacon. See how none of the AI buttons appear, WASD stops moving the camera around. The mouse changes to the correct mech style but nothing else works.

Call a bunch of procs on the AI to see what does something, add_occupant with the AI marked as the only argument works and makes everything function as intended.

Tell the code to do that.
## Why It's Good For The Game

I don't like mechs but I know some people do so it's cool for those people that it works :)
## Changelog
:cl:
fix: AI mech control beacons and malf AI dominate mech work again.
/:cl:
