### PR TITLE
[no gbp] Fixes rods not having sound_vary on

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	merge_type = /obj/item/stack/rods
 	pickup_sound = 'sound/items/iron_rod_pick_up.ogg'
 	drop_sound = 'sound/items/metal_drop.ogg'
+	sound_vary = TRUE
 
 /datum/embed_data/rods
 	embed_chance = 50


### PR DESCRIPTION

## About The Pull Request
rods are an item subtype, not a sheet. naturally I only applied `sound_vary` to the sheet parent
## Changelog
:cl:
fix: rod sounds will now vary in pitch
/:cl:
