### PR TITLE
Fridge UI adjustments [NO GBP]

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -32,6 +32,8 @@
 	var/welded_down = FALSE
 	/// The sound of item retrieval
 	var/vend_sound = 'sound/machines/machine_vend.ogg'
+	/// Whether the UI should be set to list view by default
+	var/default_list_view = FALSE
 
 /obj/machinery/smartfridge/Initialize(mapload)
 	. = ..()
@@ -383,6 +385,7 @@
 	.["contents"] = sort_list(listofitems)
 	.["name"] = name
 	.["isdryer"] = FALSE
+	.["default_list_view"] = default_list_view
 
 /obj/machinery/smartfridge/Exited(atom/movable/gone, direction) // Update the UIs in case something inside is removed
 	. = ..()
@@ -728,6 +731,7 @@
 	desc = "A refrigerated storage unit for medicine storage."
 	base_build_path = /obj/machinery/smartfridge/chemistry
 	contents_overlay_icon = "chem"
+	default_list_view = TRUE
 
 /obj/machinery/smartfridge/chemistry/accept_check(obj/item/weapon)
 	// not an item or reagent container
@@ -778,6 +782,7 @@
 	desc = "A refrigerated storage unit for volatile sample storage."
 	base_build_path = /obj/machinery/smartfridge/chemistry/virology
 	contents_overlay_icon = "viro"
+	default_list_view = TRUE
 
 /obj/machinery/smartfridge/chemistry/virology/preloaded
 	initial_contents = list(

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -400,6 +400,7 @@
 		if("Release")
 			var/amount = text2num(params["amount"])
 			var/desired = 1
+			var/dispensed_amount = 0
 
 			if(isAI(living_mob))
 				to_chat(living_mob, span_warning("[src] does not respect your authority!"))
@@ -420,11 +421,11 @@
 					if(!living_mob.put_in_hands(dispensed_item))
 						dispensed_item.forceMove(drop_location())
 						adjust_item_drop_location(dispensed_item)
-					if(vend_sound)
-						playsound(src, vend_sound, 50, TRUE, extrarange = -3)
 					use_energy(active_power_usage)
+					dispensed_amount++
 					desired--
-
+			if(dispensed_amount && vend_sound)
+				playsound(src, vend_sound, 50, TRUE, extrarange = -3)
 			if (visible_contents)
 				update_appearance()
 			return

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -369,7 +369,7 @@
 
 		var/atom/movable/atom = item
 		if (!QDELETED(atom))
-			var/key = "[atom.type]"
+			var/key = "[atom.type]-[atom.name]"
 			if (listofitems[key])
 				listofitems[key]["amount"]++
 			else
@@ -414,7 +414,7 @@
 			for(var/obj/item/dispensed_item in src)
 				if(desired <= 0)
 					break
-				if(istype(dispensed_item, text2path(params["path"])))
+				if(params["path"] == "[dispensed_item.type]-[dispensed_item.name]")
 					if(dispensed_item in component_parts)
 						CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
 					//dispense the item

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -214,7 +214,7 @@ const ItemList = ({ item }) => {
         <Box
           style={{
             marginTop: '20px',
-            border: '1px dotted gray',
+            borderBottom: '1px dotted gray',
           }}
         />
       </Stack.Item>

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -65,6 +65,7 @@ export const SmartVend = (props) => {
             contents.map((item) => (
               <Box key={item.path} m={1} p={0} inline width="64px">
                 <Button
+                  p={0}
                   height="64px"
                   width="64px"
                   tooltip={item.name}

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { DmIcon, Icon } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
-import { Box, Button, Input, NoticeBox, Section } from '../components';
+import { Box, Button, Input, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 type Item = {
@@ -20,20 +20,25 @@ type Data = {
   name: string;
   isdryer: BooleanLike;
   drying: BooleanLike;
+  default_list_view: BooleanLike;
 };
+
+enum MODE {
+  tile,
+  list,
+}
 
 export const SmartVend = (props) => {
   const { act, data } = useBackend<Data>();
   const [searchText, setSearchText] = useState('');
+  const [displayMode, setDisplayMode] = useState(
+    data.default_list_view ? MODE.list : MODE.tile,
+  );
   const search = createSearch(searchText, (item: Item) => item.name);
   const contents =
     searchText.length > 0
       ? Object.values(data.contents).filter(search)
       : Object.values(data.contents);
-
-  const fallback = (
-    <Icon name="spinner" lineHeight="64px" size={3} spin color="gray" />
-  );
   return (
     <Window width={498} height={550}>
       <Window.Content>
@@ -50,81 +55,211 @@ export const SmartVend = (props) => {
                 {data.drying ? 'Stop drying' : 'Dry'}
               </Button>
             ) : (
-              <Input
-                autoFocus
-                placeholder={'Search...'}
-                value={searchText}
-                onInput={(e, value) => setSearchText(value)}
-              />
+              <>
+                <Input
+                  autoFocus
+                  placeholder={'Search...'}
+                  value={searchText}
+                  onInput={(e, value) => setSearchText(value)}
+                />
+                <Button
+                  icon={displayMode === MODE.tile ? 'list' : 'border-all'}
+                  tooltip={
+                    displayMode === MODE.tile
+                      ? 'Display as a list'
+                      : 'Display as a grid'
+                  }
+                  tooltipPosition="bottom"
+                  onClick={() =>
+                    setDisplayMode(
+                      displayMode === MODE.tile ? MODE.list : MODE.tile,
+                    )
+                  }
+                />
+              </>
             )
           }
         >
           {!contents.length ? (
             <NoticeBox>Nothing found.</NoticeBox>
           ) : (
-            contents.map((item) => (
-              <Box key={item.path} m={1} p={0} inline width="64px">
-                <Button
-                  p={0}
-                  height="64px"
-                  width="64px"
-                  tooltip={item.name}
-                  tooltipPosition="bottom"
-                  textAlign="right"
-                  disabled={item.amount < 1}
-                  onClick={() =>
-                    act('Release', {
-                      path: item.path,
-                      amount: 1,
-                    })
-                  }
-                >
-                  <DmIcon
-                    fallback={fallback}
-                    icon={item.icon}
-                    icon_state={item.icon_state}
-                    height="64px"
-                    width="64px"
-                  />
-                  {item.amount > 1 && (
-                    <Button
-                      color="transparent"
-                      minWidth="24px"
-                      height="24px"
-                      lineHeight="24px"
-                      textAlign="center"
-                      position="absolute"
-                      left="0"
-                      bottom="0"
-                      fontWeight="bold"
-                      fontSize="14px"
-                      onClick={(e) => {
-                        act('Release', {
-                          path: item.path,
-                          amount: item.amount,
-                        });
-                        e.stopPropagation();
-                      }}
-                    >
-                      {item.amount}
-                    </Button>
-                  )}
-                </Button>
-                <Box
-                  style={{
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                    textAlign: 'center',
-                  }}
-                >
-                  {item.name}
-                </Box>
-              </Box>
-            ))
+            contents.map((item) =>
+              displayMode === MODE.tile ? (
+                <ItemTile key={item.path} item={item} />
+              ) : (
+                <ItemList key={item.path} item={item} />
+              ),
+            )
           )}
         </Section>
       </Window.Content>
     </Window>
   );
+};
+
+const ItemTile = ({ item }) => {
+  const { act } = useBackend<Data>();
+  const fallback = (
+    <Icon name="spinner" lineHeight="64px" size={3} spin color="gray" />
+  );
+  return (
+    <Box m={1} p={0} inline width="64px">
+      <Button
+        p={0}
+        height="64px"
+        width="64px"
+        tooltip={item.name}
+        tooltipPosition="bottom"
+        textAlign="right"
+        disabled={item.amount < 1}
+        onClick={() =>
+          act('Release', {
+            path: item.path,
+            amount: 1,
+          })
+        }
+      >
+        <DmIcon
+          fallback={fallback}
+          icon={item.icon}
+          icon_state={item.icon_state}
+          height="64px"
+          width="64px"
+        />
+        {item.amount > 1 && (
+          <Button
+            color="transparent"
+            minWidth="24px"
+            height="24px"
+            lineHeight="24px"
+            textAlign="center"
+            position="absolute"
+            left="0"
+            bottom="0"
+            fontWeight="bold"
+            fontSize="14px"
+            onClick={(e) => {
+              act('Release', {
+                path: item.path,
+                amount: item.amount,
+              });
+              e.stopPropagation();
+            }}
+          >
+            {item.amount}
+          </Button>
+        )}
+      </Button>
+      <Box
+        style={{
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          textAlign: 'center',
+        }}
+      >
+        {item.name}
+      </Box>
+    </Box>
+  ) as any;
+};
+
+const ItemList = ({ item }) => {
+  const { act } = useBackend<Data>();
+  const fallback = (
+    <Icon name="spinner" lineHeight="32px" size={3} spin color="gray" />
+  );
+  return (
+    <Stack>
+      <Stack.Item>
+        <Button
+          p={0}
+          m={0}
+          color="transparent"
+          width="32px"
+          height="32px"
+          onClick={() =>
+            act('Release', {
+              path: item.path,
+              amount: 1,
+            })
+          }
+        >
+          <DmIcon
+            fallback={fallback}
+            icon={item.icon}
+            icon_state={item.icon_state}
+          />
+        </Button>
+      </Stack.Item>
+      <Stack.Item
+        style={{
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          lineHeight: '32px',
+        }}
+      >
+        {item.name}
+      </Stack.Item>
+      <Stack.Item
+        grow
+        style={{
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          lineHeight: '32px',
+        }}
+      >
+        <Box
+          style={{
+            marginTop: '20px',
+            border: '1px dotted gray',
+          }}
+        />
+      </Stack.Item>
+      {item.amount > 1 && (
+        <Stack.Item
+          style={{
+            lineHeight: '32px',
+          }}
+        >
+          {`x${item.amount}`}
+        </Stack.Item>
+      )}
+      <Stack.Item>
+        <Button
+          py="4px"
+          mt="4px"
+          height="24px"
+          lineHeight="16px"
+          onClick={() =>
+            act('Release', {
+              path: item.path,
+              amount: 1,
+            })
+          }
+        >
+          Vend
+        </Button>
+      </Stack.Item>
+      <Stack.Item>
+        <Button
+          py="4px"
+          mt="4px"
+          height="24px"
+          lineHeight="16px"
+          disabled={item.amount <= 1}
+          onClick={(e) => {
+            act('Release', {
+              path: item.path,
+              amount: item.amount,
+            });
+          }}
+        >
+          Amount
+        </Button>
+      </Stack.Item>
+    </Stack>
+  ) as any;
 };

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { DmIcon, Icon } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
-import { Button, Input, NoticeBox, Section } from '../components';
+import { Box, Button, Input, NoticeBox, Section } from '../components';
 import { Window } from '../layouts';
 
 type Item = {
@@ -40,9 +40,6 @@ export const SmartVend = (props) => {
         <Section
           fill
           scrollable
-          style={{
-            textTransform: 'capitalize',
-          }}
           title="Storage"
           buttons={
             data.isdryer ? (
@@ -66,54 +63,63 @@ export const SmartVend = (props) => {
             <NoticeBox>Nothing found.</NoticeBox>
           ) : (
             contents.map((item) => (
-              <Button
-                key={item.path}
-                m={1}
-                p={0}
-                height="64px"
-                width="64px"
-                tooltip={item.name}
-                tooltipPosition="bottom"
-                textAlign="right"
-                disabled={item.amount < 1}
-                onClick={() =>
-                  act('Release', {
-                    path: item.path,
-                    amount: 1,
-                  })
-                }
-              >
-                <DmIcon
-                  fallback={fallback}
-                  icon={item.icon}
-                  icon_state={item.icon_state}
+              <Box key={item.path} m={1} p={0} inline width="64px">
+                <Button
                   height="64px"
                   width="64px"
-                />
-                {item.amount > 1 && (
-                  <Button
-                    color="transparent"
-                    minWidth="24px"
-                    height="24px"
-                    lineHeight="24px"
-                    textAlign="center"
-                    position="absolute"
-                    left="0"
-                    bottom="0"
-                    fontWeight="bold"
-                    fontSize="14px"
-                    onClick={(e) => {
-                      act('Release', {
-                        path: item.path,
-                        amount: item.amount,
-                      });
-                      e.stopPropagation();
-                    }}
-                  >
-                    {item.amount}
-                  </Button>
-                )}
-              </Button>
+                  tooltip={item.name}
+                  tooltipPosition="bottom"
+                  textAlign="right"
+                  disabled={item.amount < 1}
+                  onClick={() =>
+                    act('Release', {
+                      path: item.path,
+                      amount: 1,
+                    })
+                  }
+                >
+                  <DmIcon
+                    fallback={fallback}
+                    icon={item.icon}
+                    icon_state={item.icon_state}
+                    height="64px"
+                    width="64px"
+                  />
+                  {item.amount > 1 && (
+                    <Button
+                      color="transparent"
+                      minWidth="24px"
+                      height="24px"
+                      lineHeight="24px"
+                      textAlign="center"
+                      position="absolute"
+                      left="0"
+                      bottom="0"
+                      fontWeight="bold"
+                      fontSize="14px"
+                      onClick={(e) => {
+                        act('Release', {
+                          path: item.path,
+                          amount: item.amount,
+                        });
+                        e.stopPropagation();
+                      }}
+                    >
+                      {item.amount}
+                    </Button>
+                  )}
+                </Button>
+                <Box
+                  style={{
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                    textAlign: 'center',
+                  }}
+                >
+                  {item.name}
+                </Box>
+              </Box>
             ))
           )}
         </Section>


### PR DESCRIPTION
## About The Pull Request

Made a few adjustments to the Smart Fridge UI per feedback. See CL for the list of changes.

<img  width="100%" alt="eZXChptv1X" src="https://github.com/user-attachments/assets/17695373-4e42-4dd3-b21a-db9fa2811042">

![image](https://github.com/user-attachments/assets/f81e30c2-6e42-4f4c-84f6-1b294e935cbf)

## Why It's Good For The Game

Better UX

## Changelog

:cl:
qol: smart fridge UI now groups items by type+name instead of just type
qol: smart fridge UI now shows item names next to the images
qol: smart fridge UI has a list view option (default for chem and viro versions)
fix: fixed smart fridge stacking sounds when dispensing multiple items
/:cl:

