### PR TITLE
Heart eater wizard perk no longer works activates on organs that haven't been used before

### DIFF
--- a/code/__DEFINES/traits/declarations.dm
+++ b/code/__DEFINES/traits/declarations.dm
@@ -1123,6 +1123,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///Trait given to limb by /mob/living/basic/living_limb_flesh
 #define TRAIT_IGNORED_BY_LIVING_FLESH "livingflesh_ignored"
 
+///Trait given to organs that have been inside a living being previously
+#define TRAIT_USED_ORGAN "used_organ"
+
 /// Trait given while using /datum/action/cooldown/mob_cooldown/wing_buffet
 #define TRAIT_WING_BUFFET "wing_buffet"
 /// Trait given while tired after using /datum/action/cooldown/mob_cooldown/wing_buffet

--- a/code/_globalvars/traits/_traits.dm
+++ b/code/_globalvars/traits/_traits.dm
@@ -610,6 +610,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 	),
 	/obj/item/organ = list(
 		"TRAIT_LIVING_HEART" = TRAIT_LIVING_HEART,
+		"TRAIT_USED_ORGAN" = TRAIT_USED_ORGAN,
 	),
 	/obj/item/organ/internal/liver = list(
 		"TRAIT_BALLMER_SCIENTIST" = TRAIT_BALLMER_SCIENTIST,

--- a/code/datums/components/heart_eater.dm
+++ b/code/datums/components/heart_eater.dm
@@ -65,6 +65,8 @@
 	if(!istype(what_we_ate, /obj/item/organ/internal/heart))
 		return
 	var/obj/item/organ/internal/heart/we_ate_heart = what_we_ate
+	if (we_ate_heart.organ_flags & ORGAN_ROBOTIC)
+		return
 	var/obj/item/organ/internal/heart/previous_heart = last_heart_we_ate?.resolve()
 	if(we_ate_heart == previous_heart)
 		return

--- a/code/datums/components/heart_eater.dm
+++ b/code/datums/components/heart_eater.dm
@@ -65,7 +65,7 @@
 	if(!istype(what_we_ate, /obj/item/organ/internal/heart))
 		return
 	var/obj/item/organ/internal/heart/we_ate_heart = what_we_ate
-	if (we_ate_heart.organ_flags & ORGAN_ROBOTIC)
+	if (!HAS_TRAIT(we_ate_heart, TRAIT_USED_ORGAN))
 		return
 	var/obj/item/organ/internal/heart/previous_heart = last_heart_we_ate?.resolve()
 	if(we_ate_heart == previous_heart)

--- a/code/datums/components/heart_eater.dm
+++ b/code/datums/components/heart_eater.dm
@@ -65,10 +65,11 @@
 	if(!istype(what_we_ate, /obj/item/organ/internal/heart))
 		return
 	var/obj/item/organ/internal/heart/we_ate_heart = what_we_ate
-	if (!HAS_TRAIT(we_ate_heart, TRAIT_USED_ORGAN))
-		return
 	var/obj/item/organ/internal/heart/previous_heart = last_heart_we_ate?.resolve()
 	if(we_ate_heart == previous_heart)
+		return
+	if (!HAS_TRAIT(we_ate_heart, TRAIT_USED_ORGAN))
+		to_chat(eater, span_warning("This heart is utterly lifeless, you won't receive any boons from consuming it!"))
 		return
 	bites_taken = 0
 

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -161,6 +161,7 @@
 	UnregisterSignal(organ_owner, COMSIG_ATOM_EXAMINE)
 	SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED, organ_owner)
 	SEND_SIGNAL(organ_owner, COMSIG_CARBON_LOSE_ORGAN, src, special)
+	ADD_TRAIT(src, TRAIT_USED_ORGAN, ORGAN_TRAIT)
 
 	var/list/diseases = organ_owner.get_static_viruses()
 	if(!LAZYLEN(diseases))


### PR DESCRIPTION
## About The Pull Request

Closes #85364
Organs now mark themselves after being removed from someone, which is that the perk checks for

## Changelog
:cl:
fix: Heart eater wizard perk no longer works activates on organs that haven't been used before
/:cl:
