### PR TITLE
Renamed "Pack of *** seeds" to "*** seed pack"

### DIFF
--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -192,7 +192,7 @@
 //BOMBANANA
 
 /obj/item/seeds/banana/bombanana
-	name = "pack of bombanana seeds"
+	name = "bombanana seed pack"
 	desc = "They're seeds that grow into bombanana trees. When grown, give to the clown."
 	plantname = "Bombanana Tree"
 	product = /obj/item/food/grown/banana/bombanana

--- a/code/modules/hydroponics/grown/aloe.dm
+++ b/code/modules/hydroponics/grown/aloe.dm
@@ -1,7 +1,7 @@
 
 // aloe
 /obj/item/seeds/aloe
-	name = "pack of aloe seeds"
+	name = "aloe seed pack"
 	desc = "These seeds grow into aloe."
 	icon_state = "seed-aloe"
 	species = "aloe"

--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -11,7 +11,7 @@
 
 // Ambrosia Vulgaris
 /obj/item/seeds/ambrosia
-	name = "pack of ambrosia vulgaris seeds"
+	name = "ambrosia vulgaris seed pack"
 	desc = "These seeds grow into common ambrosia, a plant grown by and from medicine."
 	icon_state = "seed-ambrosiavulgaris"
 	plant_icon_offset = 0
@@ -36,7 +36,7 @@
 
 // Ambrosia Deus
 /obj/item/seeds/ambrosia/deus
-	name = "pack of ambrosia deus seeds"
+	name = "ambrosia deus seed pack"
 	desc = "These seeds grow into ambrosia deus. Could it be the food of the gods..?"
 	icon_state = "seed-ambrosiadeus"
 	species = "ambrosiadeus"
@@ -55,7 +55,7 @@
 
 //Ambrosia Gaia
 /obj/item/seeds/ambrosia/gaia
-	name = "pack of ambrosia gaia seeds"
+	name = "ambrosia gaia seed pack"
 	desc = "These seeds grow into ambrosia gaia, filled with infinite potential."
 	icon_state = "seed-ambrosia_gaia"
 	species = "ambrosia_gaia"

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -1,6 +1,6 @@
 // Apple
 /obj/item/seeds/apple
-	name = "pack of apple seeds"
+	name = "apple seed pack"
 	desc = "These seeds grow into apple trees."
 	icon_state = "seed-apple"
 	species = "apple"
@@ -31,7 +31,7 @@
 
 // Gold Apple
 /obj/item/seeds/apple/gold
-	name = "pack of golden apple seeds"
+	name = "golden apple seed pack"
 	desc = "These seeds grow into golden apple trees. Good thing there are no firebirds in space."
 	icon_state = "seed-goldapple"
 	species = "goldapple"

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -1,6 +1,6 @@
 // Banana
 /obj/item/seeds/banana
-	name = "pack of banana seeds"
+	name = "banana seed pack"
 	desc = "They're seeds that grow into banana trees. When grown, keep away from clown."
 	icon_state = "seed-banana"
 	species = "banana"
@@ -91,7 +91,7 @@
 
 // Mimana - invisible sprites are totally a feature!
 /obj/item/seeds/banana/mime
-	name = "pack of mimana seeds"
+	name = "mimana seed pack"
 	desc = "They're seeds that grow into mimana trees. When grown, keep away from mime."
 	icon_state = "seed-mimana"
 	species = "mimana"
@@ -119,7 +119,7 @@
 
 // Bluespace Banana
 /obj/item/seeds/banana/bluespace
-	name = "pack of bluespace banana seeds"
+	name = "bluespace banana seed pack"
 	desc = "They're seeds that grow into bluespace banana trees. When grown, keep away from bluespace clown."
 	icon_state = "seed-banana-blue"
 	species = "bluespacebanana"

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -1,6 +1,6 @@
 // Soybeans
 /obj/item/seeds/soya
-	name = "pack of soybean seeds"
+	name = "soybean seed pack"
 	desc = "These seeds grow into soybean plants."
 	icon_state = "seed-soybean"
 	species = "soybean"
@@ -30,7 +30,7 @@
 
 // Koibean
 /obj/item/seeds/soya/koi
-	name = "pack of koibean seeds"
+	name = "koibean seed pack"
 	desc = "These seeds grow into koibean plants."
 	icon_state = "seed-koibean"
 	species = "koibean"
@@ -63,7 +63,7 @@
 //Butterbeans, the beans wid da butta!
 // Butterbeans! - Squeeze for a single butter slice!
 /obj/item/seeds/soya/butter
-	name = "pack of butterbean seeds"
+	name = "butterbean seed pack"
 	desc = "These seeds grow into butterbean plants."
 	icon_state = "seed-butterbean"
 	species = "butterbean"
@@ -94,7 +94,7 @@
 
 // Green Beans
 /obj/item/seeds/greenbean
-	name = "pack of green bean seeds"
+	name = "green bean seed pack"
 	desc = "These seeds grow into green bean plants."
 	icon_state = "seed-greenbean"
 	species = "greenbean"
@@ -123,7 +123,7 @@
 
 // Jumping Bean
 /obj/item/seeds/greenbean/jump
-	name = "pack of jumping bean seeds"
+	name = "jumping bean seed pack"
 	desc = "These seeds grow into jumping bean plants."
 	icon_state = "seed-jumpingbean"
 	species = "jumpingbean"

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -1,6 +1,6 @@
 // Berries
 /obj/item/seeds/berry
-	name = "pack of berry seeds"
+	name = "berry seed pack"
 	desc = "These seeds grow into berry bushes."
 	icon_state = "seed-berry"
 	species = "berry"
@@ -31,7 +31,7 @@
 
 // Poison Berries
 /obj/item/seeds/berry/poison
-	name = "pack of poison-berry seeds"
+	name = "poison-berry seed pack"
 	desc = "These seeds grow into poison-berry bushes."
 	icon_state = "seed-poisonberry"
 	species = "poisonberry"
@@ -55,7 +55,7 @@
 
 // Death Berries
 /obj/item/seeds/berry/death
-	name = "pack of death-berry seeds"
+	name = "death-berry seed pack"
 	desc = "These seeds grow into death berries."
 	icon_state = "seed-deathberry"
 	species = "deathberry"
@@ -81,7 +81,7 @@
 
 // Glow Berries
 /obj/item/seeds/berry/glow
-	name = "pack of glow-berry seeds"
+	name = "glow-berry seed pack"
 	desc = "These seeds grow into glow-berry bushes."
 	icon_state = "seed-glowberry"
 	species = "glowberry"
@@ -108,7 +108,7 @@
 
 // Grapes
 /obj/item/seeds/grape
-	name = "pack of grape seeds"
+	name = "grape seed pack"
 	desc = "These seeds grow into grape vines."
 	icon_state = "seed-grapes"
 	species = "grape"
@@ -143,7 +143,7 @@
 
 // Green Grapes
 /obj/item/seeds/grape/green
-	name = "pack of green grape seeds"
+	name = "green grape seed pack"
 	desc = "These seeds grow into green-grape vines."
 	icon_state = "seed-greengrapes"
 	species = "greengrape"
@@ -162,7 +162,7 @@
 
 // Toechtauese Berries
 /obj/item/seeds/toechtauese
-	name = "pack of töchtaüse berry seeds"
+	name = "töchtaüse berry seed pack"
 	desc = "These seeds grow into töchtaüse bushes."
 	icon_state = "seed-toechtauese"
 	species = "toechtauese"
@@ -190,7 +190,7 @@
 	distill_reagent = /datum/reagent/toxin/itching_powder
 
 /obj/item/seeds/lanternfruit
-	name = "pack of lanternfruit seeds"
+	name = "lanternfruit seed pack"
 	desc = "These seeds grow into lanternfruit pods."
 	icon_state = "seed-lanternfruit"
 	species = "lanternfruit"

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -1,6 +1,6 @@
 // Cannabis
 /obj/item/seeds/cannabis
-	name = "pack of cannabis seeds"
+	name = "cannabis seed pack"
 	desc = "Taxable."
 	icon_state = "seed-cannabis"
 	plant_icon_offset = 6
@@ -24,7 +24,7 @@
 
 
 /obj/item/seeds/cannabis/rainbow
-	name = "pack of rainbow weed seeds"
+	name = "rainbow weed seed pack"
 	desc = "These seeds grow into rainbow weed. Groovy... and also highly addictive."
 	icon_state = "seed-megacannabis"
 	icon_grow = "megacannabis-grow"
@@ -36,7 +36,7 @@
 	rarity = 40
 
 /obj/item/seeds/cannabis/death
-	name = "pack of deathweed seeds"
+	name = "deathweed seed pack"
 	desc = "These seeds grow into deathweed. Not groovy."
 	icon_state = "seed-blackcannabis"
 	icon_grow = "blackcannabis-grow"
@@ -48,7 +48,7 @@
 	rarity = 40
 
 /obj/item/seeds/cannabis/white
-	name = "pack of lifeweed seeds"
+	name = "lifeweed seed pack"
 	desc = "I will give unto him that is munchies of the fountain of the cravings of life, freely."
 	icon_state = "seed-whitecannabis"
 	icon_grow = "whitecannabis-grow"
@@ -62,7 +62,7 @@
 
 
 /obj/item/seeds/cannabis/ultimate
-	name = "pack of omega weed seeds"
+	name = "omega weed seed pack"
 	desc = "These seeds grow into omega weed."
 	icon_state = "seed-ocannabis"
 	plant_icon_offset = 0

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -1,6 +1,6 @@
 // Wheat
 /obj/item/seeds/wheat
-	name = "pack of wheat seeds"
+	name = "wheat seed pack"
 	desc = "These may, or may not, grow into wheat."
 	icon_state = "seed-wheat"
 	species = "wheat"
@@ -30,7 +30,7 @@
 
 // Oat
 /obj/item/seeds/wheat/oat
-	name = "pack of oat seeds"
+	name = "oat seed pack"
 	desc = "These may, or may not, grow into oat."
 	icon_state = "seed-oat"
 	species = "oat"
@@ -52,7 +52,7 @@
 
 // Rice
 /obj/item/seeds/wheat/rice
-	name = "pack of rice seeds"
+	name = "rice seed pack"
 	desc = "These may, or may not, grow into rice."
 	icon_state = "seed-rice"
 	species = "rice"
@@ -76,7 +76,7 @@
 
 //Meatwheat - grows into synthetic meat
 /obj/item/seeds/wheat/meat
-	name = "pack of meatwheat seeds"
+	name = "meatwheat seed pack"
 	desc = "If you ever wanted to drive a vegetarian to insanity, here's how."
 	icon_state = "seed-meatwheat"
 	species = "meatwheat"

--- a/code/modules/hydroponics/grown/cherries.dm
+++ b/code/modules/hydroponics/grown/cherries.dm
@@ -1,6 +1,6 @@
 // Cherries
 /obj/item/seeds/cherry
-	name = "pack of cherry pits"
+	name = "cherry pit pack"
 	desc = "Careful not to crack a tooth on one... That'd be the pits."
 	icon_state = "seed-cherry"
 	species = "cherry"
@@ -34,7 +34,7 @@
 
 // Blue Cherries
 /obj/item/seeds/cherry/blue
-	name = "pack of blue cherry pits"
+	name = "blue cherry pit pack"
 	desc = "The blue kind of cherries."
 	icon_state = "seed-bluecherry"
 	species = "bluecherry"
@@ -57,7 +57,7 @@
 
 //Cherry Bulbs
 /obj/item/seeds/cherry/bulb
-	name = "pack of cherry bulb pits"
+	name = "cherry bulb pit pack"
 	desc = "The glowy kind of cherries."
 	icon_state = "seed-cherrybulb"
 	species = "cherrybulb"
@@ -82,7 +82,7 @@
 
 //Cherry Bombs
 /obj/item/seeds/cherry/bomb
-	name = "pack of cherry bomb pits"
+	name = "cherry bomb pit pack"
 	desc = "They give you vibes of dread and frustration."
 	icon_state = "seed-cherry_bomb"
 	species = "cherry_bomb"

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -1,6 +1,6 @@
 // Chili
 /obj/item/seeds/chili
-	name = "pack of chili seeds"
+	name = "chili seed pack"
 	desc = "These seeds grow into chili plants. HOT! HOT! HOT!"
 	icon_state = "seed-chili"
 	species = "chili"
@@ -30,7 +30,7 @@
 
 // Ice Chili
 /obj/item/seeds/chili/ice
-	name = "pack of chilly pepper seeds"
+	name = "chilly pepper seed pack"
 	desc = "These seeds grow into chilly pepper plants."
 	icon_state = "seed-icepepper"
 	species = "chiliice"
@@ -56,7 +56,7 @@
 
 // Ghost Chili
 /obj/item/seeds/chili/ghost
-	name = "pack of ghost chili seeds"
+	name = "ghost chili seed pack"
 	desc = "These seeds grow into a chili said to be the hottest in the galaxy."
 	icon_state = "seed-chilighost"
 	species = "chilighost"
@@ -83,7 +83,7 @@
 
 // Bell Pepper
 /obj/item/seeds/chili/bell_pepper
-	name = "pack of bell pepper seeds"
+	name = "bell pepper seed pack"
 	desc = "These seeds grow into bell pepper plants. MILD! MILD! MILD!"
 	icon_state = "seed-bell-pepper"
 	species = "bellpepper"

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -9,7 +9,7 @@
 
 // Lime
 /obj/item/seeds/lime
-	name = "pack of lime seeds"
+	name = "lime seed pack"
 	desc = "These are very sour seeds."
 	icon_state = "seed-lime"
 	species = "lime"
@@ -33,7 +33,7 @@
 
 // Orange
 /obj/item/seeds/orange
-	name = "pack of orange seeds"
+	name = "orange seed pack"
 	desc = "Sour seeds."
 	icon_state = "seed-orange"
 	species = "orange"
@@ -61,7 +61,7 @@
 
 // Lemon
 /obj/item/seeds/lemon
-	name = "pack of lemon seeds"
+	name = "lemon seed pack"
 	desc = "These are sour seeds."
 	icon_state = "seed-lemon"
 	species = "lemon"
@@ -86,7 +86,7 @@
 
 // Combustible lemon
 /obj/item/seeds/firelemon //combustible lemon is too long so firelemon
-	name = "pack of combustible lemon seeds"
+	name = "combustible lemon seed pack"
 	desc = "When life gives you lemons, don't make lemonade. Make life take the lemons back! Get mad! I don't want your damn lemons!"
 	icon_state = "seed-firelemon"
 	species = "firelemon"
@@ -112,7 +112,7 @@
 
 //3D Orange
 /obj/item/seeds/orange_3d
-	name = "pack of extradimensional orange seeds"
+	name = "extradimensional orange seed pack"
 	desc = "Polygonal seeds."
 	icon_state = "seed-orange"
 	species = "orange"

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -1,6 +1,6 @@
 // Cocoa Pod
 /obj/item/seeds/cocoapod
-	name = "pack of cocoa pod seeds"
+	name = "cocoa pod seed pack"
 	desc = "These seeds grow into cacao trees. They look fattening." //SIC: cocoa is the seeds. The trees are spelled cacao.
 	icon_state = "seed-cocoapod"
 	species = "cocoapod"
@@ -31,7 +31,7 @@
 
 // Vanilla Pod
 /obj/item/seeds/cocoapod/vanillapod
-	name = "pack of vanilla pod seeds"
+	name = "vanilla pod seed pack"
 	desc = "These seeds grow into vanilla trees. They look fattening."
 	icon_state = "seed-vanillapod"
 	species = "vanillapod"
@@ -52,7 +52,7 @@
 	distill_reagent = /datum/reagent/consumable/vanilla //Takes longer, but you can get even more vanilla from it.
 
 /obj/item/seeds/cocoapod/bungotree
-	name = "pack of bungo tree seeds"
+	name = "bungo tree seed pack"
 	desc = "These seeds grow into bungo trees. They appear to be heavy and almost perfectly spherical."
 	icon_state = "seed-bungotree"
 	plant_icon_offset = 4

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -1,6 +1,6 @@
 // Corn
 /obj/item/seeds/corn
-	name = "pack of corn seeds"
+	name = "corn seed pack"
 	desc = "I don't mean to sound corny..."
 	icon_state = "seed-corn"
 	species = "corn"
@@ -57,7 +57,7 @@
 
 // Snapcorn
 /obj/item/seeds/corn/snapcorn
-	name = "pack of snapcorn seeds"
+	name = "snapcorn seed pack"
 	desc = "Oh snap!"
 	icon_state = "seed-snapcorn"
 	species = "snapcorn"
@@ -100,7 +100,7 @@
 
 //Pepper-corn - Heh funny.
 /obj/item/seeds/corn/pepper
-	name = "pack of pepper-corn seeds"
+	name = "pepper-corn seed pack"
 	desc = "If Peter picked a pack of pepper-corn..."
 	icon_state = "seed-peppercorn"
 	species = "peppercorn"

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/cotton
-	name = "pack of cotton seeds"
+	name = "cotton seed pack"
 	desc = "A pack of seeds that'll grow into a cotton plant. Assistants make good free labor if neccesary."
 	icon_state = "seed-cotton"
 	species = "cotton"
@@ -45,7 +45,7 @@
 
 //reinforced mutated variant
 /obj/item/seeds/cotton/durathread
-	name = "pack of durathread seeds"
+	name = "durathread seed pack"
 	desc = "A pack of seeds that'll grow into an extremely durable thread that could easily rival plasteel if woven properly."
 	icon_state = "seed-durathread"
 	species = "durathread"

--- a/code/modules/hydroponics/grown/cucumber.dm
+++ b/code/modules/hydroponics/grown/cucumber.dm
@@ -1,6 +1,6 @@
 // CUCUMBERS YEAH
 /obj/item/seeds/cucumber
-	name = "pack of cucumber seeds"
+	name = "cucumber seed pack"
 	desc = "These seeds grow into cucumber plants."
 	icon_state = "seed-cucumber"
 	species = "cucumber"

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -1,6 +1,6 @@
 // Eggplant
 /obj/item/seeds/eggplant
-	name = "pack of eggplant seeds"
+	name = "eggplant seed pack"
 	desc = "These seeds grow to produce berries that look nothing like eggs."
 	icon_state = "seed-eggplant"
 	species = "eggplant"
@@ -25,7 +25,7 @@
 
 // Egg-Plant
 /obj/item/seeds/eggplant/eggy
-	name = "pack of egg-plant seeds"
+	name = "egg-plant seed pack"
 	desc = "These seeds grow to produce berries that look a lot like eggs."
 	icon_state = "seed-eggy"
 	species = "eggy"

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -1,6 +1,6 @@
 // Poppy
 /obj/item/seeds/poppy
-	name = "pack of poppy seeds"
+	name = "poppy seed pack"
 	desc = "These seeds grow into poppies."
 	icon_state = "seed-poppy"
 	species = "poppy"
@@ -32,7 +32,7 @@
 
 // Lily
 /obj/item/seeds/poppy/lily
-	name = "pack of lily seeds"
+	name = "lily seed pack"
 	desc = "These seeds grow into lilies."
 	icon_state = "seed-lily"
 	species = "lily"
@@ -52,7 +52,7 @@
 
 	//Spacemans's Trumpet
 /obj/item/seeds/poppy/lily/trumpet
-	name = "pack of spaceman's trumpet seeds"
+	name = "spaceman's trumpet seed pack"
 	desc = "A plant sculped by extensive genetic engineering. The spaceman's trumpet is said to bear no resemblance to its wild ancestors. Inside NT AgriSci circles it is better known as NTPW-0372."
 	icon_state = "seed-trumpet"
 	species = "spacemanstrumpet"
@@ -86,7 +86,7 @@
 
 // Geranium
 /obj/item/seeds/poppy/geranium
-	name = "pack of geranium seeds"
+	name = "geranium seed pack"
 	desc = "These seeds grow into geranium."
 	icon_state = "seed-geranium"
 	species = "geranium"
@@ -106,7 +106,7 @@
 
 ///Fraxinella seeds.
 /obj/item/seeds/poppy/geranium/fraxinella
-	name = "pack of fraxinella seeds"
+	name = "fraxinella seed pack"
 	desc = "These seeds grow into fraxinella."
 	icon_state = "seed-fraxinella"
 	species = "fraxinella"
@@ -130,7 +130,7 @@
 
 // Harebell
 /obj/item/seeds/harebell
-	name = "pack of harebell seeds"
+	name = "harebell seed pack"
 	desc = "These seeds grow into pretty little flowers."
 	icon_state = "seed-harebell"
 	plant_icon_offset = 1
@@ -162,7 +162,7 @@
 
 // Sunflower
 /obj/item/seeds/sunflower
-	name = "pack of sunflower seeds"
+	name = "sunflower seed pack"
 	desc = "These seeds grow into sunflowers."
 	icon_state = "seed-sunflower"
 	species = "sunflower"
@@ -203,7 +203,7 @@
 
 // Moonflower
 /obj/item/seeds/sunflower/moonflower
-	name = "pack of moonflower seeds"
+	name = "moonflower seed pack"
 	desc = "These seeds grow into moonflowers."
 	icon_state = "seed-moonflower"
 	lefthand_file = 'icons/mob/inhands/items/food_lefthand.dmi'
@@ -231,7 +231,7 @@
 
 // Novaflower
 /obj/item/seeds/sunflower/novaflower
-	name = "pack of novaflower seeds"
+	name = "novaflower seed pack"
 	desc = "These seeds grow into novaflowers."
 	icon_state = "seed-novaflower"
 	species = "novaflower"
@@ -266,7 +266,7 @@
 
 // Rose
 /obj/item/seeds/rose
-	name = "pack of rose seeds"
+	name = "rose seed pack"
 	desc = "These seeds grow into roses."
 	icon_state = "seed-rose"
 	species = "rose"
@@ -311,7 +311,7 @@
 
 // Carbon Rose
 /obj/item/seeds/carbon_rose
-	name = "pack of carbon rose seeds"
+	name = "carbon rose seed pack"
 	desc = "These seeds grow into carbon roses."
 	icon_state = "seed-carbonrose"
 	species = "carbonrose"

--- a/code/modules/hydroponics/grown/garlic.dm
+++ b/code/modules/hydroponics/grown/garlic.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/garlic
-	name = "pack of garlic seeds"
+	name = "garlic seed pack"
 	desc = "A packet of extremely pungent seeds."
 	icon_state = "seed-garlic"
 	species = "garlic"

--- a/code/modules/hydroponics/grown/gatfruit.dm
+++ b/code/modules/hydroponics/grown/gatfruit.dm
@@ -1,7 +1,7 @@
 
 // Gatfruit
 /obj/item/seeds/gatfruit
-	name = "pack of gatfruit seeds"
+	name = "gatfruit seed pack"
 	desc = "These seeds grow into .357 revolvers."
 	icon_state = "seed-gatfruit"
 	species = "gatfruit"

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -1,6 +1,6 @@
 // Grass
 /obj/item/seeds/grass
-	name = "pack of grass seeds"
+	name = "grass seed pack"
 	desc = "These seeds grow into grass. Yummy!"
 	icon_state = "seed-grass"
 	species = "grass"
@@ -42,7 +42,7 @@
 
 //Fairygrass
 /obj/item/seeds/grass/fairy
-	name = "pack of fairygrass seeds"
+	name = "fairygrass seed pack"
 	desc = "These seeds grow into a more mystical grass."
 	icon_state = "seed-fairygrass"
 	species = "fairygrass"
@@ -65,7 +65,7 @@
 
 // Carpet
 /obj/item/seeds/grass/carpet
-	name = "pack of carpet seeds"
+	name = "carpet seed pack"
 	desc = "These seeds grow into stylish carpet samples."
 	icon_state = "seed-carpet"
 	species = "carpet"

--- a/code/modules/hydroponics/grown/hedges.dm
+++ b/code/modules/hydroponics/grown/hedges.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/shrub
-	name = "pack of shrub seeds"
+	name = "shrub seed pack"
 	desc = "These seeds grow into hedge shrubs."
 	icon_state = "seed-shrub"
 	species = "shrub"

--- a/code/modules/hydroponics/grown/herbs.dm
+++ b/code/modules/hydroponics/grown/herbs.dm
@@ -1,6 +1,6 @@
 // Herbs
 /obj/item/seeds/herbs
-	name = "pack of herb seeds"
+	name = "herb seed pack"
 	desc = "These seeds grow to produce an assortment of herbs and seasonings."
 	icon_state = "seed-herbs"
 	species = "herbs"

--- a/code/modules/hydroponics/grown/korta_nut.dm
+++ b/code/modules/hydroponics/grown/korta_nut.dm
@@ -1,6 +1,6 @@
 //Korta Nut
 /obj/item/seeds/korta_nut
-	name = "pack of korta nut seeds"
+	name = "korta nut seed pack"
 	desc = "These seeds grow into korta nut bushes, native to Tizira."
 	icon_state = "seed-korta"
 	species = "kortanut"
@@ -29,7 +29,7 @@
 
 //Sweet Korta Nut
 /obj/item/seeds/korta_nut/sweet
-	name = "pack of sweet korta nut seeds"
+	name = "sweet korta nut seed pack"
 	desc = "These seeds grow into sweet korta nuts, a mutation of the original species that produces a thick syrup that Tizirans use for desserts."
 	icon_state = "seed-sweetkorta"
 	species = "kortanut"

--- a/code/modules/hydroponics/grown/kronkus.dm
+++ b/code/modules/hydroponics/grown/kronkus.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/kronkus
-	name = "pack of kronkus seeds"
+	name = "kronkus seed pack"
 	desc = "A pack of highly illegal kronkus seeds.\nPossession of these seeds carries the death penalty in 7 sectors."
 	icon_state = "seed-kronkus"
 	plant_icon_offset = 6

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -1,6 +1,6 @@
 // Watermelon
 /obj/item/seeds/watermelon
-	name = "pack of watermelon seeds"
+	name = "watermelon seed pack"
 	desc = "These seeds grow into watermelon plants."
 	icon_state = "seed-watermelon"
 	species = "watermelon"
@@ -74,7 +74,7 @@
 
 // Holymelon
 /obj/item/seeds/watermelon/holy
-	name = "pack of holymelon seeds"
+	name = "holymelon seed pack"
 	desc = "These seeds grow into holymelon plants."
 	icon_state = "seed-holymelon"
 	species = "holymelon"
@@ -159,7 +159,7 @@
 
 /// Barrel melon Seeds
 /obj/item/seeds/watermelon/barrel
-	name = "pack of barrelmelon seeds"
+	name = "barrelmelon seed pack"
 	desc = "These seeds grow into barrelmelon plants."
 	icon_state = "seed-barrelmelon"
 	species = "barrelmelon"

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -11,7 +11,7 @@
 
 // Reishi
 /obj/item/seeds/reishi
-	name = "pack of reishi mycelium"
+	name = "reishi mycelium pack"
 	desc = "This mycelium grows into something medicinal and relaxing."
 	icon_state = "mycelium-reishi"
 	species = "reishi"
@@ -38,7 +38,7 @@
 
 // Fly Amanita
 /obj/item/seeds/amanita
-	name = "pack of fly amanita mycelium"
+	name = "fly amanita mycelium pack"
 	desc = "This mycelium grows into something horrible."
 	icon_state = "mycelium-amanita"
 	species = "amanita"
@@ -65,7 +65,7 @@
 
 // Destroying Angel
 /obj/item/seeds/angel
-	name = "pack of destroying angel mycelium"
+	name = "destroying angel mycelium pack"
 	desc = "This mycelium grows into something devastating."
 	icon_state = "mycelium-angel"
 	species = "angel"
@@ -93,7 +93,7 @@
 
 // Liberty Cap
 /obj/item/seeds/liberty
-	name = "pack of liberty-cap mycelium"
+	name = "liberty-cap mycelium pack"
 	desc = "This mycelium grows into liberty-cap mushrooms."
 	icon_state = "mycelium-liberty"
 	species = "liberty"
@@ -119,7 +119,7 @@
 
 // Plump Helmet
 /obj/item/seeds/plump
-	name = "pack of plump-helmet mycelium"
+	name = "plump-helmet mycelium pack"
 	desc = "This mycelium grows into helmets... maybe."
 	icon_state = "mycelium-plump"
 	species = "plump"
@@ -145,7 +145,7 @@
 
 // Walking Mushroom
 /obj/item/seeds/plump/walkingmushroom
-	name = "pack of walking mushroom mycelium"
+	name = "walking mushroom mycelium pack"
 	desc = "This mycelium will grow into huge stuff!"
 	icon_state = "mycelium-walkingmushroom"
 	species = "walkingmushroom"
@@ -171,7 +171,7 @@
 
 // Chanterelle
 /obj/item/seeds/chanter
-	name = "pack of chanterelle mycelium"
+	name = "chanterelle mycelium pack"
 	desc = "This mycelium grows into chanterelle mushrooms."
 	icon_state = "mycelium-chanter"
 	species = "chanter"
@@ -213,7 +213,7 @@
 
 //Jupiter Cup
 /obj/item/seeds/chanter/jupitercup
-	name = "pack of jupiter cup mycelium"
+	name = "jupiter cup mycelium pack"
 	desc = "This mycelium grows into jupiter cups. Zeus would be envious at the power at your fingertips."
 	icon_state = "mycelium-jupitercup"
 	species = "jupitercup"
@@ -238,7 +238,7 @@
 
 // Glowshroom
 /obj/item/seeds/glowshroom
-	name = "pack of glowshroom mycelium"
+	name = "glowshroom mycelium pack"
 	desc = "This mycelium -glows- into mushrooms!"
 	icon_state = "mycelium-glowshroom"
 	species = "glowshroom"
@@ -293,7 +293,7 @@
 
 // Glowcap
 /obj/item/seeds/glowshroom/glowcap
-	name = "pack of glowcap mycelium"
+	name = "glowcap mycelium pack"
 	desc = "This mycelium -powers- into mushrooms!"
 	icon_state = "mycelium-glowcap"
 	species = "glowcap"
@@ -317,7 +317,7 @@
 
 //Shadowshroom
 /obj/item/seeds/glowshroom/shadowshroom
-	name = "pack of shadowshroom mycelium"
+	name = "shadowshroom mycelium pack"
 	desc = "This mycelium will grow into something shadowy."
 	icon_state = "mycelium-shadowshroom"
 	species = "shadowshroom"
@@ -346,7 +346,7 @@
 		investigate_log("was planted by [key_name(user)] at [AREACOORD(user)]", INVESTIGATE_BOTANY)
 
 /obj/item/seeds/odious_puffball
-	name = "pack of odious pullball spores"
+	name = "odious pullball spore pack"
 	desc = "These spores reek! Disgusting."
 	icon_state = "seed-odiouspuffball"
 	species = "odiouspuffball"

--- a/code/modules/hydroponics/grown/olive.dm
+++ b/code/modules/hydroponics/grown/olive.dm
@@ -1,6 +1,6 @@
 // Olive
 /obj/item/seeds/olive
-	name = "pack of olive seeds"
+	name = "olive seed pack"
 	desc = "These seeds grow into olive trees."
 	icon_state = "seed-olive"
 	species = "olive"

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/onion
-	name = "pack of onion seeds"
+	name = "onion seed pack"
 	desc = "These seeds grow into onions."
 	icon_state = "seed-onion"
 	species = "onion"
@@ -29,7 +29,7 @@
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/onion_slice, 2, 15, screentip_verb = "Cut")
 
 /obj/item/seeds/onion/red
-	name = "pack of red onion seeds"
+	name = "red onion seed pack"
 	desc = "For growing exceptionally potent onions."
 	icon_state = "seed-onionred"
 	species = "onion_red"

--- a/code/modules/hydroponics/grown/peanut.dm
+++ b/code/modules/hydroponics/grown/peanut.dm
@@ -1,6 +1,6 @@
 // Peanuts!
 /obj/item/seeds/peanut
-	name = "pack of peanut seeds"
+	name = "peanut seed pack"
 	desc = "These seeds grow into peanut plants."
 	icon_state = "seed-peanut"
 	species = "peanut"

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -1,6 +1,6 @@
 // Finally, peas. Base plant.
 /obj/item/seeds/peas
-	name = "pack of pea pods"
+	name = "pea pod pack"
 	desc = "These seeds grows into vitamin rich peas!"
 	icon_state = "seed-peas"
 	species = "peas"
@@ -29,7 +29,7 @@
 
 // Laughin' Peas
 /obj/item/seeds/peas/laugh
-	name = "pack of laughin' peas"
+	name = "laughin' pea pack"
 	desc = "These seeds give off a very soft purple glow.. they should grow into Laughin' Peas."
 	icon_state = "seed-laughpeas"
 	species = "laughpeas"
@@ -61,7 +61,7 @@
 
 // World Peas - Peace at last, peace at last...
 /obj/item/seeds/peas/laugh/peace
-	name = "pack of world peas"
+	name = "world pea pack"
 	desc = "These rather large seeds give off a soothing blue glow..."
 	icon_state = "seed-worldpeas"
 	species = "worldpeas"

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -1,6 +1,6 @@
 // Pineapple!
 /obj/item/seeds/pineapple
-	name = "pack of pineapple seeds"
+	name = "pineapple seed pack"
 	desc = "Oooooooooooooh!"
 	icon_state = "seed-pineapple"
 	species = "pineapple"

--- a/code/modules/hydroponics/grown/plum.dm
+++ b/code/modules/hydroponics/grown/plum.dm
@@ -1,6 +1,6 @@
 // Plum
 /obj/item/seeds/plum
-	name = "pack of plum seeds"
+	name = "plum seed pack"
 	desc = "These seeds grow into plum trees."
 	icon_state = "seed-plum"
 	species = "plum"
@@ -28,7 +28,7 @@
 
 // Plumb
 /obj/item/seeds/plum/plumb
-	name = "pack of plumb seeds"
+	name = "plumb seed pack"
 	desc = "These seeds grow into plumb trees."
 	icon_state = "seed-plumb"
 	species = "plumb"

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -1,6 +1,6 @@
 // Potato
 /obj/item/seeds/potato
-	name = "pack of potato seeds"
+	name = "potato seed pack"
 	desc = "Boil 'em! Mash 'em! Stick 'em in a stew!"
 	icon_state = "seed-potato"
 	species = "potato"
@@ -50,7 +50,7 @@
 
 // Sweet Potato
 /obj/item/seeds/potato/sweet
-	name = "pack of sweet potato seeds"
+	name = "sweet potato seed pack"
 	desc = "These seeds grow into sweet potato plants."
 	icon_state = "seed-sweetpotato"
 	species = "sweetpotato"

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -1,6 +1,6 @@
 // Pumpkin
 /obj/item/seeds/pumpkin
-	name = "pack of pumpkin seeds"
+	name = "pumpkin seed pack"
 	desc = "These seeds grow into pumpkin vines."
 	icon_state = "seed-pumpkin"
 	plant_icon_offset = 4
@@ -40,7 +40,7 @@
 
 // Blumpkin
 /obj/item/seeds/pumpkin/blumpkin
-	name = "pack of blumpkin seeds"
+	name = "blumpkin seed pack"
 	desc = "These seeds grow into blumpkin vines."
 	icon_state = "seed-blumpkin"
 	species = "blumpkin"

--- a/code/modules/hydroponics/grown/rainbow_bunch.dm
+++ b/code/modules/hydroponics/grown/rainbow_bunch.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/rainbow_bunch
-	name = "pack of rainbow bunch seeds"
+	name = "rainbow bunch seed pack"
 	desc = "A pack of seeds that'll grow into a beautiful bush of various colored flowers."
 	icon_state = "seed-rainbowbunch"
 	species = "rainbowbunch"

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -1,7 +1,7 @@
 //Random seeds; stats, traits, and plant type are randomized for each seed.
 
 /obj/item/seeds/random
-	name = "pack of strange seeds"
+	name = "strange seed pack"
 	desc = "Mysterious seeds as strange as their name implies. Spooky."
 	icon_state = "seed-x"
 	species = "?????"

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -2,7 +2,7 @@
 
 // Yes, i'm talking about cabbage, baby! No, just kidding, but cabbages are the precursor to replica pods, so they are here as well.
 /obj/item/seeds/cabbage
-	name = "pack of cabbage seeds"
+	name = "cabbage seed pack"
 	desc = "These seeds grow into cabbages."
 	icon_state = "seed-cabbage"
 	species = "cabbage"
@@ -31,7 +31,7 @@
 
 ///The actual replica pods themselves!
 /obj/item/seeds/replicapod
-	name = "pack of replica pod seeds"
+	name = "replica pod seed pack"
 	desc = "These seeds grow into replica pods. They say these are used to harvest humans."
 	icon_state = "seed-replicapod"
 	plant_icon_offset = 2

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -1,6 +1,6 @@
 // Carrot
 /obj/item/seeds/carrot
-	name = "pack of carrot seeds"
+	name = "carrot seed pack"
 	desc = "These seeds grow into carrots."
 	icon_state = "seed-carrot"
 	species = "carrot"
@@ -45,7 +45,7 @@
 
 // Parsnip
 /obj/item/seeds/carrot/parsnip
-	name = "pack of parsnip seeds"
+	name = "parsnip seed pack"
 	desc = "These seeds grow into parsnips."
 	icon_state = "seed-parsnip"
 	species = "parsnip"
@@ -85,7 +85,7 @@
 
 // Cahn'root
 /obj/item/seeds/carrot/cahnroot
-	name = "pack of cahn'root seeds"
+	name = "cahn'root seed pack"
 	desc = "These seeds grow into cahn'roots."
 	icon_state = "seed-cahn'root"
 	species = "cahn'root"
@@ -130,7 +130,7 @@
 
 // White-Beet
 /obj/item/seeds/whitebeet
-	name = "pack of white-beet seeds"
+	name = "white-beet seed pack"
 	desc = "These seeds grow into sugary beet producing plants."
 	icon_state = "seed-whitebeet"
 	species = "whitebeet"
@@ -156,7 +156,7 @@
 
 // Red Beet
 /obj/item/seeds/redbeet
-	name = "pack of redbeet seeds"
+	name = "redbeet seed pack"
 	desc = "These seeds grow into red beet producing plants."
 	icon_state = "seed-redbeet"
 	species = "redbeet"

--- a/code/modules/hydroponics/grown/seedling.dm
+++ b/code/modules/hydroponics/grown/seedling.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/seedling
-	name = "pack of seedling seeds"
+	name = "seedling seed pack"
 	desc = "These seeds grow into a floral assistant which can help look after other plants!"
 	icon_state = "seed-seedling"
 	growing_icon = 'icons/obj/service/hydroponics/growing_fruits.dmi'

--- a/code/modules/hydroponics/grown/sugarcane.dm
+++ b/code/modules/hydroponics/grown/sugarcane.dm
@@ -1,7 +1,7 @@
 
 // Sugarcane
 /obj/item/seeds/sugarcane
-	name = "pack of sugarcane seeds"
+	name = "sugarcane seed pack"
 	desc = "These seeds grow into sugarcane."
 	icon_state = "seed-sugarcane"
 	species = "sugarcane"
@@ -28,7 +28,7 @@
 
 ///and bamboo!
 /obj/item/seeds/bamboo
-	name = "pack of bamboo seeds"
+	name = "bamboo seed pack"
 	desc = "A plant known for its flexible and resistant logs."
 	icon_state = "seed-bamboo"
 	species = "bamboo"
@@ -59,7 +59,7 @@
 
 //Saltcane - Gross, salty shafts!
 /obj/item/seeds/sugarcane/saltcane
-	name = "pack of saltcane seeds"
+	name = "saltcane seed pack"
 	desc = "These seeds grow into saltcane."
 	icon_state = "seed-saltcane"
 	species = "saltcane"

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -1,6 +1,6 @@
 // Tea
 /obj/item/seeds/tea
-	name = "pack of tea aspera seeds"
+	name = "tea aspera seed pack"
 	desc = "These seeds grow into tea plants."
 	icon_state = "seed-teaaspera"
 	species = "teaaspera"
@@ -27,7 +27,7 @@
 
 // Tea Astra
 /obj/item/seeds/tea/astra
-	name = "pack of tea astra seeds"
+	name = "tea astra seed pack"
 	icon_state = "seed-teaastra"
 	species = "teaastra"
 	plantname = "Tea Astra Plant"
@@ -46,7 +46,7 @@
 
 // Coffee
 /obj/item/seeds/coffee
-	name = "pack of coffee arabica seeds"
+	name = "coffee arabica seed pack"
 	desc = "These seeds grow into coffee arabica bushes."
 	icon_state = "seed-coffeea"
 	species = "coffeea"
@@ -75,7 +75,7 @@
 
 // Coffee Robusta
 /obj/item/seeds/coffee/robusta
-	name = "pack of coffee robusta seeds"
+	name = "coffee robusta seed pack"
 	desc = "These seeds grow into coffee robusta bushes."
 	icon_state = "seed-coffeer"
 	species = "coffeer"

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -1,6 +1,6 @@
 // Tobacco
 /obj/item/seeds/tobacco
-	name = "pack of tobacco seeds"
+	name = "tobacco seed pack"
 	desc = "These seeds grow into tobacco plants."
 	icon_state = "seed-tobacco"
 	species = "tobacco"
@@ -24,7 +24,7 @@
 
 // Space Tobacco
 /obj/item/seeds/tobacco/space
-	name = "pack of space tobacco seeds"
+	name = "space tobacco seed pack"
 	desc = "These seeds grow into space tobacco plants."
 	icon_state = "seed-stobacco"
 	species = "stobacco"

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -1,6 +1,6 @@
 // Tomato
 /obj/item/seeds/tomato
-	name = "pack of tomato seeds"
+	name = "tomato seed pack"
 	desc = "These seeds grow into tomato plants."
 	icon_state = "seed-tomato"
 	species = "tomato"
@@ -29,7 +29,7 @@
 
 // Blood Tomato
 /obj/item/seeds/tomato/blood
-	name = "pack of blood-tomato seeds"
+	name = "blood-tomato seed pack"
 	desc = "These seeds grow into blood-tomato plants."
 	icon_state = "seed-bloodtomato"
 	species = "bloodtomato"
@@ -52,7 +52,7 @@
 
 // Blue Tomato
 /obj/item/seeds/tomato/blue
-	name = "pack of blue-tomato seeds"
+	name = "blue-tomato seed pack"
 	desc = "These seeds grow into blue-tomato plants."
 	icon_state = "seed-bluetomato"
 	species = "bluetomato"
@@ -77,7 +77,7 @@
 
 // Bluespace Tomato
 /obj/item/seeds/tomato/blue/bluespace
-	name = "pack of bluespace tomato seeds"
+	name = "bluespace tomato seed pack"
 	desc = "These seeds grow into bluespace tomato plants."
 	icon_state = "seed-bluespacetomato"
 	species = "bluespacetomato"
@@ -101,7 +101,7 @@
 
 // Killer Tomato
 /obj/item/seeds/tomato/killer
-	name = "pack of killer-tomato seeds"
+	name = "killer-tomato seed pack"
 	desc = "These seeds grow into killer-tomato plants."
 	icon_state = "seed-killertomato"
 	species = "killertomato"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/tower
-	name = "pack of tower-cap mycelium"
+	name = "tower-cap mycelium pack"
 	desc = "This mycelium grows into tower-cap mushrooms."
 	icon_state = "mycelium-tower"
 	species = "towercap"
@@ -20,7 +20,7 @@
 	graft_gene = /datum/plant_gene/trait/plant_type/fungal_metabolism
 
 /obj/item/seeds/tower/steel
-	name = "pack of steel-cap mycelium"
+	name = "steel-cap mycelium pack"
 	desc = "This mycelium grows into steel logs."
 	icon_state = "mycelium-steelcap"
 	species = "steelcap"

--- a/code/modules/hydroponics/grown/weeds/kudzu.dm
+++ b/code/modules/hydroponics/grown/weeds/kudzu.dm
@@ -1,7 +1,7 @@
 // A very special plant, deserving its own file.
 
 /obj/item/seeds/kudzu
-	name = "pack of kudzu seeds"
+	name = "kudzu seed pack"
 	desc = "These seeds grow into a weed that grows incredibly fast."
 	icon_state = "seed-kudzu"
 	plant_icon_offset = 2

--- a/code/modules/hydroponics/grown/weeds/nettle.dm
+++ b/code/modules/hydroponics/grown/weeds/nettle.dm
@@ -1,5 +1,5 @@
 /obj/item/seeds/nettle
-	name = "pack of nettle seeds"
+	name = "nettle seed pack"
 	desc = "These seeds grow into nettles."
 	icon_state = "seed-nettle"
 	plant_icon_offset = 0
@@ -17,7 +17,7 @@
 	graft_gene = /datum/plant_gene/trait/plant_type/weed_hardy
 
 /obj/item/seeds/nettle/death
-	name = "pack of death-nettle seeds"
+	name = "death-nettle seed pack"
 	desc = "These seeds grow into death-nettles."
 	icon_state = "seed-deathnettle"
 	species = "deathnettle"

--- a/code/modules/hydroponics/grown/weeds/starthistle.dm
+++ b/code/modules/hydroponics/grown/weeds/starthistle.dm
@@ -1,6 +1,6 @@
 // Starthistle
 /obj/item/seeds/starthistle
-	name = "pack of starthistle seeds"
+	name = "starthistle seed pack"
 	desc = "A robust species of weed that often springs up in-between the cracks of spaceship parking lots."
 	icon_state = "seed-starthistle"
 	plant_icon_offset = 3
@@ -33,7 +33,7 @@
 
 // Corpse flower
 /obj/item/seeds/starthistle/corpse_flower
-	name = "pack of corpse flower seeds"
+	name = "corpse flower seed pack"
 	desc = "A species of plant that emits a horrible odor. The odor stops being produced in difficult atmospheric conditions."
 	icon_state = "seed-corpse-flower"
 	species = "corpse-flower"
@@ -46,7 +46,7 @@
 
 //Galaxy Thistle
 /obj/item/seeds/galaxythistle
-	name = "pack of galaxythistle seeds"
+	name = "galaxythistle seed pack"
 	desc = "An impressive species of weed that is thought to have evolved from the simple milk thistle. Contains flavolignans that can help repair a damaged liver."
 	icon_state = "seed-galaxythistle"
 	species = "galaxythistle"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -261,7 +261,7 @@
 	graft_gene = /datum/plant_gene/trait/fire_resistance
 
 /obj/item/seeds/lavaland/cactus
-	name = "pack of fruiting cactus seeds"
+	name = "fruiting cactus seed pack"
 	desc = "These seeds grow into fruiting cacti."
 	icon_state = "seed-cactus"
 	species = "cactus"
@@ -275,7 +275,7 @@
 
 ///Star Cactus seeds, mutation of lavaland cactus.
 /obj/item/seeds/star_cactus
-	name = "pack of star cacti seeds"
+	name = "star cacti seed pack"
 	desc = "These seeds grow into star cacti."
 	icon_state = "seed-starcactus"
 	species = "starcactus"
@@ -358,7 +358,7 @@
 	reagents_add = list(/datum/reagent/toxin/mushroom_powder = 0.1, /datum/reagent/medicine/coagulant/seraka_extract = 0.02)
 
 /obj/item/seeds/lavaland/fireblossom
-	name = "pack of fire blossom seeds"
+	name = "fire blossom seed pack"
 	desc = "These seeds grow into fire blossoms."
 	plantname = "Fire Blossom"
 	icon_state = "seed-fireblossom"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -303,7 +303,7 @@
 	distill_reagent = /datum/reagent/consumable/ethanol/tequila
 
 /obj/item/seeds/lavaland/polypore
-	name = "pack of polypore mycelium"
+	name = "polypore mycelium pack"
 	desc = "This mycelium grows into bracket mushrooms, also known as polypores. Woody and firm, shaft miners often use them for makeshift crafts."
 	icon_state = "mycelium-polypore"
 	species = "polypore"
@@ -314,7 +314,7 @@
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02)
 
 /obj/item/seeds/lavaland/porcini
-	name = "pack of porcini mycelium"
+	name = "porcini mycelium pack"
 	desc = "This mycelium grows into Boletus edulus, also known as porcini. Native to the late Earth, but discovered on Lavaland. Has culinary, medicinal and relaxant effects."
 	icon_state = "mycelium-porcini"
 	species = "porcini"
@@ -325,7 +325,7 @@
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.06,  /datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04)
 
 /obj/item/seeds/lavaland/inocybe
-	name = "pack of inocybe mycelium"
+	name = "inocybe mycelium pack"
 	desc = "This mycelium grows into an inocybe mushroom, a species of Lavaland origin with hallucinatory and toxic effects."
 	icon_state = "mycelium-inocybe"
 	species = "inocybe"
@@ -336,7 +336,7 @@
 	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.04, /datum/reagent/consumable/entpoly = 0.08, /datum/reagent/drug/mushroomhallucinogen = 0.04)
 
 /obj/item/seeds/lavaland/ember
-	name = "pack of embershroom mycelium"
+	name = "embershroom mycelium pack"
 	desc = "This mycelium grows into embershrooms, a species of bioluminescent mushrooms native to Lavaland."
 	icon_state = "mycelium-ember"
 	species = "ember"
@@ -347,7 +347,7 @@
 	reagents_add = list(/datum/reagent/consumable/tinlux = 0.04, /datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/drug/space_drugs = 0.02)
 
 /obj/item/seeds/lavaland/seraka
-	name = "pack of seraka mycelium"
+	name = "seraka mycelium pack"
 	desc = "This mycelium grows into seraka mushrooms, a species of savoury mushrooms originally native to Tizira used in food and traditional medicine."
 	icon_state = "mycelium-seraka"
 	species = "seraka"


### PR DESCRIPTION
## About The Pull Request

<img alt="0Jva48mReD" src="https://github.com/user-attachments/assets/8b5ef2a2-c1dd-4561-89ef-15c0ca199e5d">

Renamed all seed packs to say "Apple seed pack" instead of "Pack of apple seeds.

## Why It's Good For The Game

Shorter and better for UIs.

Easier to find the needed items in a list, the important part of the name won't be truncated by ellipsis.

## Changelog

:cl:
qol: Renamed seed packs to have the plant name at the beginning
/:cl:
