### PR TITLE
[TM only] Roundstart Traitors will not have side objectives

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/traitor
 	name = "Traitors"
 	antag_flag = ROLE_TRAITOR
-	antag_datum = /datum/antagonist/traitor
+	antag_datum = /datum/antagonist/traitor/infiltrator
 	minimum_required_age = 0
 	protected_roles = list(
 		JOB_CAPTAIN,

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -56,7 +56,6 @@
 	// Used to denote traitors who have joined midround and therefore have no access to secondary objectives.
 	// Progression elements are best left to the roundstart antagonists
 	// There will still be a timelock on uplink items
-	name = "\improper Infiltrator"
 	give_secondary_objectives = FALSE
 	uplink_flag_given = UPLINK_INFILTRATORS
 


### PR DESCRIPTION
## About The Pull Request

By headmin request, they wanted to try out "what if we just didn't have traitor progression" in an attempt to validate or invalidate various views about antagonist gameplay that the admin team have but don't necessarily have firm agreement about.
We will not merge this PR. This is intended in an investigative fashion to see what, if any, player changes you might see if this incentive wasn't in the game.
Any actual change following this will depend on how it goes on servers.

This basically just removes the side objectives tab. Timelocks still exist, and removing those would be a separate discussion.

## Why It's Good For The Game

Plausibly, the FOMO pressure of having side objectives drives player behaviours in ways we don't like. It's unclear if we could establish this for or against in a short-term testmerge trial run, but might as well try.

## Changelog

:cl:
balance: Traitors cannot perform side objectives to fast-forward their progression and obtain additional telecrystals.
/:cl:
