### PR TITLE
Fix some wonky anchored_tabletop_offset rendering

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -12,7 +12,7 @@
 	/// Icon to use as a 32x32 preview in crafting menus and such
 	var/icon_preview
 	var/icon_state_preview
-	/// The vertical pixel offset applied when the object is anchored on a tile with table
+	/// The vertical pixel_z offset applied when the object is anchored on a tile with table
 	/// Ignored when set to 0 - to avoid shifting directional wall-mounted objects above tables
 	var/anchored_tabletop_offset = 0
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -278,7 +278,7 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 		return FALSE
 	return TRUE
 
-/// Adjusts the vertical pixel offset when the object is anchored on a tile with table
+/// Adjusts the vertical pixel_z offset when the object is anchored on a tile with table
 /obj/proc/check_on_table()
 	if(anchored_tabletop_offset == 0)
 		return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -280,5 +280,12 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 
 /// Adjusts the vertical pixel offset when the object is anchored on a tile with table
 /obj/proc/check_on_table()
-	if(anchored_tabletop_offset != 0 && !istype(src, /obj/structure/table) && locate(/obj/structure/table) in loc)
-		pixel_y = anchored ? anchored_tabletop_offset : initial(pixel_y)
+	if(anchored_tabletop_offset == 0)
+		return
+	if(istype(src, /obj/structure/table))
+		return
+
+	if(anchored && locate(/obj/structure/table) in loc)
+		pixel_z = anchored_tabletop_offset
+	else
+		pixel_z = initial(pixel_z)


### PR DESCRIPTION

## About The Pull Request

While working out railing layering rank, I noticed this issue:
![image](https://github.com/user-attachments/assets/d6a21016-23c1-48f7-821f-fdb38a351232)
This seems to be because we allow objects to have their `pixel_y` be offset when anchored on top of a table, which causes it to peek into the next tile up, thus layering us on top of it.
Making it use `pixel_z` instead such that it's only visually offset fixes this:
![image](https://github.com/user-attachments/assets/21051291-424a-422c-ad9c-aa71cb58c5ee)

Additionally, while we're touching the `check_on_table()` proc, we make it remove the `pixel_z` offset whenever it gets unanchored instead of only whenever it gets unanchored _on a table_.

Ideally we would also make such vertically offset objects remove their offset when the table they're on gets destroyed, but that's not the point of this pr.
## Why It's Good For The Game

Tends to be better to not look like you're standing on something you're not.
It's a bit annoying when you destroy the table under a vertically offset object and now can't remove that offset until you put it on a table again.
## Changelog
:cl:
fix: You no longer render on top of tall enough objects that get vertically offset when anchored to a table when standing on the tile directly to the north of them. Examples are soda and booze dispensers.
fix: Removing the vertical offset some objects get when anchored to a table can be done by unanchoring it at any point, rather than only on a table.
/:cl:
