### PR TITLE
Fixing one way of duplicating iron sheets

### DIFF
--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -137,6 +137,7 @@
 	icon = 'icons/obj/wallmounts.dmi'
 	icon_state = "migniter"
 	result_path = /obj/machinery/sparker
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)
 	pixel_shift = 26
 
 /obj/machinery/sparker

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -119,6 +119,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	icon = 'icons/obj/machines/wallmounts.dmi'
 	icon_state = "light-nopower"
 	result_path = /obj/machinery/light_switch
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)
 	pixel_shift = 26
 
 /obj/item/circuit_component/light_switch


### PR DESCRIPTION
## About The Pull Request
You actually could duplicate iron by assembling and disassembling wallmounted sparklers or light switch. Well, now you can't.
## Why It's Good For The Game
I cannot make a cassle out of one iron sheet :(
## Changelog
:cl:
fix: fixes a way of duplicating iron with wallmounted sparklers and light switches
/:cl:
