### PR TITLE
Replaces the "eyelight" with a "flashlight" in an ice ruin

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
@@ -25,9 +25,6 @@
 /obj/item/clothing/shoes/galoshes{
 	pixel_y = -5
 	},
-/obj/item/flashlight/eyelight{
-	pixel_y = 11
-	},
 /turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/operations)
 "ap" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
@@ -25,6 +25,9 @@
 /obj/item/clothing/shoes/galoshes{
 	pixel_y = -5
 	},
+/obj/item/flashlight{
+	pixel_y = 8
+	},
 /turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/operations)
 "ap" = (


### PR DESCRIPTION

## About The Pull Request
```php
/obj/item/flashlight/eyelight
	name = "eyelight"
	desc = "This shouldn't exist outside of someone's head, how are you seeing this?"
	obj_flags = CONDUCTS_ELECTRICITY
	item_flags = DROPDEL
	actions_types = list()
```
## Why It's Good For The Game
## Changelog
:cl: grungussuss
fix: the abandoned plasma research facility on icemoon no longer has an item that shouldn't exist
/:cl:
