### PR TITLE
Fixed spray can face spraying logic

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -860,7 +860,7 @@
 		if(carbon_target.client)
 			carbon_target.set_eye_blur_if_lower(6 SECONDS)
 			carbon_target.adjust_temp_blindness(2 SECONDS)
-		if(carbon_target.get_eye_protection() <= 0) // no eye protection? ARGH IT BURNS. Warning: don't add a stun here. It's a roundstart item with some quirks.
+		if(carbon_target.get_eye_protection() <= 0 || carbon_target.is_eyes_covered()) // no eye protection? ARGH IT BURNS. Warning: don't add a stun here. It's a roundstart item with some quirks. added redundancy because gas masks don't give you eye protection
 			carbon_target.adjust_jitter(1 SECONDS)
 			carbon_target.adjust_eye_blur(0.5 SECONDS)
 			flash_color(carbon_target, flash_color=paint_color, flash_time=40)


### PR DESCRIPTION

## About The Pull Request
It was only checking for eye protection, since light-sensitives can have 0 or less eye protection even with sunglasses on, this doesn't make sense.
There is now more redundancy, the same check for blind carbons and another check for `is_eyes_covered` which takes in account if your eyes are covered by eyewear or masks.
## Changelog
:cl:
fix: spray can face spraying will no longer work on light-sensitives with eyewear and people wearing eye covering masks
/:cl:
