### PR TITLE
The clown planet domain is now completable

### DIFF
--- a/_maps/virtual_domains/clown_planet.dmm
+++ b/_maps/virtual_domains/clown_planet.dmm
@@ -759,7 +759,9 @@
 /turf/open/indestructible/white,
 /area/lavaland/surface/outdoors/virtual_domain)
 "WT" = (
-/obj/machinery/door/airlock/bananium,
+/obj/machinery/door/airlock/bananium{
+	use_power = 0
+	},
 /turf/open/floor/carpet,
 /area/lavaland/surface/outdoors/virtual_domain)
 "WX" = (


### PR DESCRIPTION

## About The Pull Request
The airlock to the loot room was unpowered and there was no way to open it, now it doesn't require power
## Changelog
:cl:
fix: The clown planet domain is now completable
/:cl:
