### PR TITLE
[NO GBP] Fixes emergency climbing hooks spawning on not multi-z stations.

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -43,7 +43,7 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_RADIOACTIVE_NEBULA))
 		new /obj/item/storage/pill_bottle/potassiodide(src)
 
-	if(LAZYLEN(SSmapping.multiz_levels))
+	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) > 1)
 		new /obj/item/climbing_hook/emergency(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()


### PR DESCRIPTION
## About The Pull Request
I naively assumed that `if(LAZYLEN(SSmapping.multiz_levels))` which was already present was doing something and didn't proceed with testing stuff further, well turns out it doesn't.
## Changelog
:cl:
fix: Emergency climbing hooks now shouldn't spawn on non multi-z stations.
/:cl:
