### PR TITLE
[NO GBP] Fixed advanced pods showing up as cultist pods

### DIFF
--- a/code/datums/pod_style.dm
+++ b/code/datums/pod_style.dm
@@ -56,7 +56,7 @@
 	glow_color = "blue"
 	id = "deathsquad"
 
-/datum/pod_style/advanced
+/datum/pod_style/cultist
 	name = "bloody supply pod"
 	ui_name = "Cultist"
 	desc = "A Nanotrasen supply pod covered in scratch-marks, blood, and strange runes."


### PR DESCRIPTION

## About The Pull Request

Closes #85385

## Changelog
:cl:
fix: Fixed advanced pods showing up as cultist pods
/:cl:
