### PR TITLE
Attempting to fix search_object hard dels

### DIFF
--- a/code/modules/lootpanel/contents.dm
+++ b/code/modules/lootpanel/contents.dm
@@ -21,6 +21,8 @@
 		if(!istype(thing))
 			stack_trace("Non-atom in the contents of [source_turf]!")
 			continue
+		if(QDELETED(thing))
+			continue
 		if(thing.mouse_opacity == MOUSE_OPACITY_TRANSPARENT)
 			continue
 		if(thing.IsObscured())

--- a/code/modules/lootpanel/search_object.dm
+++ b/code/modules/lootpanel/search_object.dm
@@ -86,4 +86,4 @@
 /datum/search_object/proc/on_turf_change(turf/source, path, list/new_baseturfs, flags, list/post_change_callbacks)
 	SIGNAL_HANDLER
 
-	post_change_callbacks += CALLBACK(src, GLOBAL_PROC_REF(qdel), src)
+	post_change_callbacks += CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), src)

--- a/code/modules/lootpanel/search_object.dm
+++ b/code/modules/lootpanel/search_object.dm
@@ -62,6 +62,7 @@
 
 /datum/search_object/Destroy(force)
 	item = null
+	icon = null
 
 	return ..()
 
@@ -74,6 +75,9 @@
 /// Parent item has been altered, search object no longer valid
 /datum/search_object/proc/on_item_moved(atom/source)
 	SIGNAL_HANDLER
+
+	if(QDELETED(src))
+		return
 
 	qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/b4cd5369-06c4-4e01-98f4-343030e28199)

These were coming up often, had a hunch that the callback may have been hanging their refs. It seems to be true from my testing, they should be passing GLOBAL_PROC as the `object` arg, not `src`, since qdel is not a `search_object` proc. (Thanks Melbert for noticing that detail!)

Also just tidies up the code a bit, adding checks to prevent redundant qdel calls and preventing a potential race condition with qdeleted atoms.

## Why It's Good For The Game

Hard dels here in particular have potential to cause significant lag and issues.

## Changelog

Not player-facing really