### PR TITLE
Discounts now pick 4-6 items each from a unique category. Items that cost below 4 TC cannot get discounted anymore

### DIFF
--- a/code/__DEFINES/uplink.dm
+++ b/code/__DEFINES/uplink.dm
@@ -42,3 +42,6 @@
 #define SPY_LOWER_COST_THRESHOLD 5
 /// Upper threshold for which an uplink items's TC cost is considered "high" for spy bounties picking rewards
 #define SPY_UPPER_COST_THRESHOLD 12
+
+/// Minimal cost for an item to be eligible for a discount
+#define TRAITOR_DISCOUNT_MIN_PRICE 4

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -47,7 +47,8 @@
 	/// The uplink handler that this traitor belongs to.
 	var/datum/uplink_handler/uplink_handler
 
-	var/uplink_sale_count = 3
+	var/uplink_sales_min = 4
+	var/uplink_sales_max = 6
 
 	///the final objective the traitor has to accomplish, be it escaping, hijacking, or just martyrdom.
 	var/datum/objective/ending_objective
@@ -98,14 +99,14 @@
 
 		var/list/uplink_items = list()
 		for(var/datum/uplink_item/item as anything in SStraitor.uplink_items)
-			if(item.item && !item.cant_discount && (item.purchasable_from & uplink_handler.uplink_flag) && item.cost > 1)
+			if(item.item && !item.cant_discount && (item.purchasable_from & uplink_handler.uplink_flag) && item.cost >= TRAITOR_DISCOUNT_MIN_PRICE)
 				if(!length(item.restricted_roles) && !length(item.restricted_species))
 					uplink_items += item
 					continue
 				if((uplink_handler.assigned_role in item.restricted_roles) || (uplink_handler.assigned_species in item.restricted_species))
 					uplink_items += item
 					continue
-		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, 1, uplink_items)
+		uplink_handler.extra_purchasable += create_uplink_sales(rand(uplink_sales_min, uplink_sales_max), /datum/uplink_category/discounts, 1, uplink_items)
 
 	if(give_objectives)
 		forge_traitor_objectives()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2,9 +2,17 @@
 /// Selects a set number of unique items from the uplink, and deducts a percentage discount from them
 /proc/create_uplink_sales(num, datum/uplink_category/category, limited_stock, list/sale_items)
 	var/list/sales = list()
-	var/list/sale_items_copy = sale_items.Copy()
+	var/list/per_category = list()
+
+	for (var/datum/uplink_item/possible_sale as anything in sale_items)
+		if (!(possible_sale.category in per_category))
+			per_category[possible_sale.category] = list()
+		per_category[possible_sale.category] += possible_sale
+
 	for (var/i in 1 to num)
-		var/datum/uplink_item/taken_item = pick_n_take(sale_items_copy)
+		var/datum/uplink_category/item_category = pick(per_category)
+		var/datum/uplink_item/taken_item = pick(per_category[item_category])
+		per_category -= item_category
 		var/datum/uplink_item/uplink_item = new taken_item.type()
 		var/discount = uplink_item.get_discount()
 		var/static/list/disclaimer = list(

--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -79,3 +79,4 @@
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 	progression_minimum = 90 MINUTES
 	cost = 16
+	cant_discount = TRUE


### PR DESCRIPTION
## About The Pull Request

Currently discounts pick 3 random items, often resulting in low-cost useless items being discounted due to the amount of junk in our uplinks. This PR changes the number of discounts to be random between 4~6, and makes sure that cheap items cannot get discounted anymore. Additionally, each discount now is from a unique category as to ensure that you don't get an uplink full of discounted gadgets and no weapons. This translates to roughly half the categories having a discount, giving you a decent chance of getting at least one weapon and gadget discount. Due to this, traitor version of elite MOD no longer can be discounted.

Approved by Watermelon on discord. 

## Why It's Good For The Game
Discounts are rather useless and act more as a lottery with a very small chance of you actually rolling anything worthwhile. This will change this into discounts being a "softer" version of bundles, giving you a cheap loadout that you can opt into and allow it to shape your playstyle. Only item really worth anything below 4 TC is airlock auth card priced at 3, but 1 TC discount off of that won't change much for you.

## Changelog
:cl:
balance: Discounts now pick 4-6 items each from a unique category
balance: Items that cost below 4 TC cannot get discounted anymore
balance: Elite syndicate MODs for traitors can no longer get discounted
/:cl:
