### PR TITLE
[NO GBP] Return wrap for stat panel tabs

### DIFF
--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -35,9 +35,35 @@ img {
 
 #menu {
 	display: flex;
-	flex-wrap: wrap-reverse;
+	overflow: hidden;
+	overflow-x: auto;
 	padding: 0.25em 0.25em 0;
 	background-color: #ffffff;
+}
+
+.menu-wrap {
+	flex-wrap: wrap-reverse;
+}
+
+#menu.tabs-classic {
+	padding: 0.15em;
+}
+
+#menu.tabs-classic .button {
+	min-width: 2em;
+	margin: 0.1em;
+	padding: 0.25em 0.4em;
+	border: 0;
+	border-radius: 0.25em;
+}
+
+#menu.tabs-classic .button.active {
+	background-color: #20b142;
+	color: white;
+}
+
+#menu.tabs-classic .button.active:hover {
+	background-color: #32c154;
 }
 
 .button {

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -35,8 +35,7 @@ img {
 
 #menu {
 	display: flex;
-	overflow-x: auto;
-	overflow-y: hidden;
+	flex-wrap: wrap-reverse;
 	padding: 0.25em 0.25em 0;
 	background-color: #ffffff;
 }

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -16,7 +16,7 @@ a:hover {
 }
 
 h3 {
-	margin: 0 -0.5em 0.25em;
+	margin: 0 -0.5em 0.5em;
 	padding: 1em 0.66em 0.5em;
 	border-bottom: 0.1667em solid;
 }
@@ -102,7 +102,7 @@ img {
 }
 
 .grid-container {
-	margin: 0;
+	margin: -0.25em;
 }
 
 .grid-item {
@@ -111,13 +111,14 @@ img {
 	user-select: none;
 	-ms-user-select: none; /* Remove after Byond 516 */
 	width: 100%;
-	box-sizing: border-box;
+	max-height: 1.85em;
 	text-decoration: none;
 	background-color: transparent;
 	color: black;
 }
 
-.grid-item:hover {
+.grid-item:hover,
+.grid-item:active {
 	color: #003399;
 	z-index: 1;
 }
@@ -126,21 +127,20 @@ img {
 	display: inline-block;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	box-sizing: border-box;
 	white-space: nowrap;
+	pointer-events: none;
 	width: 100%;
 	padding: 0.33em 0.5em;
 	border-radius: 0.25em;
 }
 
-.grid-item-text:hover {
-	position: absolute;
-	top: -1.33em;
+.grid-item:hover .grid-item-text {
+	overflow: visible;
 	white-space: normal;
 	background-color: #ececec;
 }
 
-.grid-item-text:active {
+.grid-item:active .grid-item-text  {
 	background-color: #dfdfdf;
 }
 
@@ -195,7 +195,8 @@ body.dark {
 }
 
 .dark a:hover,
-.dark .grid-item:hover {
+.dark .grid-item:hover,
+.dark .grid-item:active {
 	color: #80bfff;
 }
 
@@ -229,10 +230,10 @@ body.dark {
 	color: #b2c4dd;
 }
 
-.dark .grid-item-text:hover {
+.dark .grid-item:hover .grid-item-text {
 	background-color: #252525;
 }
 
-.dark  .grid-item-text:active {
+.dark .grid-item:active .grid-item-text {
 	background-color: #313131;
 }

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -58,12 +58,8 @@ img {
 }
 
 #menu.tabs-classic .button.active {
-	background-color: #20b142;
+	background-color: #0668b8;
 	color: white;
-}
-
-#menu.tabs-classic .button.active:hover {
-	background-color: #32c154;
 }
 
 .button {
@@ -87,6 +83,7 @@ img {
 }
 
 .button.active {
+	cursor: default;
 	background-color: #dfdfdf;
 	color: black;
 	border-bottom-color: #000000;
@@ -204,6 +201,10 @@ body.dark {
 
 .dark #menu {
 	background-color: #131313;
+}
+
+.dark #menu.tabs-classic .button.active {
+	background-color: #20b142;
 }
 
 .dark .button {

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -35,8 +35,8 @@ img {
 
 #menu {
 	display: flex;
-	overflow: hidden;
 	overflow-x: auto;
+	overflow-y: hidden;
 	padding: 0.25em 0.25em 0;
 	background-color: #ffffff;
 }

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -719,13 +719,11 @@ function set_font_size(size) {
 function set_tabs_style(style) {
 	if (style == "default") {
 		menu.classList.add('menu-wrap');
-		menu.classList.remove('menu-nowrap');
 		menu.classList.remove('tabs-classic');
 	} else if (style == "classic") {
 		menu.classList.add('menu-wrap');
 		menu.classList.add('tabs-classic');
-		menu.classList.remove('menu-nowrap');
-	} else if (style == "nowrap") {
+	} else if (style == "scrollable") {
 		menu.classList.remove('menu-wrap');
 		menu.classList.remove('tabs-classic');
 	}

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -716,6 +716,21 @@ function set_font_size(size) {
 	document.body.style.setProperty('font-size', size);
 }
 
+function set_tabs_style(style) {
+	if (style == "default") {
+		menu.classList.add('menu-wrap');
+		menu.classList.remove('menu-nowrap');
+		menu.classList.remove('tabs-classic');
+	} else if (style == "classic") {
+		menu.classList.add('menu-wrap');
+		menu.classList.add('tabs-classic');
+		menu.classList.remove('menu-nowrap');
+	} else if (style == "nowrap") {
+		menu.classList.remove('menu-wrap');
+		menu.classList.remove('tabs-classic');
+	}
+}
+
 function set_style_sheet(sheet) {
 	if (document.getElementById("goonStyle")) {
 		var currentSheet = document.getElementById("goonStyle");

--- a/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
@@ -20,11 +20,10 @@ import { FONTS } from './constants';
 import { selectSettings } from './selectors';
 
 export function SettingsGeneral(props) {
-  const { theme, fontFamily, fontSize, lineHeight, statLinked, statFontSize } =
+  const { theme, fontFamily, fontSize, lineHeight } =
     useSelector(selectSettings);
   const dispatch = useDispatch();
   const [freeFont, setFreeFont] = useState(false);
-  const [statFont, setStatFont] = useState(false);
 
   return (
     <Section>
@@ -119,46 +118,14 @@ export function SettingsGeneral(props) {
                 stepPixelSize={20}
                 minValue={8}
                 maxValue={32}
-                value={statFont ? statFontSize : fontSize}
+                value={fontSize}
                 unit="px"
                 format={(value) => toFixed(value)}
                 onChange={(e, value) =>
-                  dispatch(
-                    updateSettings({
-                      [statFont ? 'statFontSize' : 'fontSize']: value,
-                    }),
-                  )
+                  dispatch(updateSettings({ fontSize: value }))
                 }
               />
             </Stack.Item>
-            <Stack.Item>
-              <Button
-                width={statFont ? 7.3 : 10}
-                onClick={() => setStatFont(!statFont)}
-              >
-                {statFont ? 'Stat Panel' : 'Chat'}
-              </Button>
-            </Stack.Item>
-            {!!statFont && (
-              <Stack.Item>
-                <Button
-                  tooltip={
-                    statLinked
-                      ? 'Unlink Stat Panel settings from chat'
-                      : 'Link Stat Panel settings to chat'
-                  }
-                  icon={statLinked ? 'link' : 'link-slash'}
-                  color={statLinked ? 'bad' : 'good'}
-                  onClick={() =>
-                    dispatch(
-                      updateSettings({
-                        statLinked: !statLinked,
-                      }),
-                    )
-                  }
-                />
-              </Stack.Item>
-            )}
           </Stack>
         </LabeledList.Item>
         <LabeledList.Item label="Line height">

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.tsx
@@ -12,8 +12,8 @@ import { changeSettingsTab } from './actions';
 import { SETTINGS_TABS } from './constants';
 import { selectActiveTab } from './selectors';
 import { SettingsGeneral } from './SettingsGeneral';
-import { TextHighlightSettings } from './TextHighlight';
 import { SettingsStatPanel } from './SettingsStatPanel';
+import { TextHighlightSettings } from './TextHighlight';
 
 export function SettingsPanel(props) {
   const activeTab = useSelector(selectActiveTab);

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.tsx
@@ -13,6 +13,7 @@ import { SETTINGS_TABS } from './constants';
 import { selectActiveTab } from './selectors';
 import { SettingsGeneral } from './SettingsGeneral';
 import { TextHighlightSettings } from './TextHighlight';
+import { SettingsStatPanel } from './SettingsStatPanel';
 
 export function SettingsPanel(props) {
   const activeTab = useSelector(selectActiveTab);
@@ -45,6 +46,7 @@ export function SettingsPanel(props) {
         {activeTab === 'general' && <SettingsGeneral />}
         {activeTab === 'chatPage' && <ChatPageSettings />}
         {activeTab === 'textHighlight' && <TextHighlightSettings />}
+        {activeTab === 'statPanel' && <SettingsStatPanel />}
       </Stack.Item>
     </Stack>
   );

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -24,65 +24,61 @@ export function SettingsStatPanel(props) {
   const dispatch = useDispatch();
 
   return (
-    <Stack fill vertical>
-      <Section fill>
-        <Stack fill vertical>
-          <Stack.Item grow>
-            <LabeledList>
-              <LabeledList.Item label="Tabs" verticalAlign="middle">
-                <Stack.Item grow>
-                  {TabsViews.map((view) => (
-                    <Button
-                      key={view}
-                      color="transparent"
-                      selected={statTabsStyle === view}
-                      onClick={() =>
-                        dispatch(updateSettings({ statTabsStyle: view }))
-                      }
-                    >
-                      {capitalize(view)}
-                    </Button>
-                  ))}
-                </Stack.Item>
-              </LabeledList.Item>
-              <LabeledList.Item label="Font size">
-                <Stack.Item grow>
-                  {statLinked ? (
-                    <LinkedToChat />
-                  ) : (
-                    <Slider
-                      width="100%"
-                      step={1}
-                      stepPixelSize={20}
-                      minValue={8}
-                      maxValue={32}
-                      value={statFontSize}
-                      unit="px"
-                      format={(value) => toFixed(value)}
-                      onChange={(e, value) =>
-                        dispatch(updateSettings({ statFontSize: value }))
-                      }
-                    />
-                  )}
-                </Stack.Item>
-              </LabeledList.Item>
-            </LabeledList>
-          </Stack.Item>
-          <Stack.Divider />
-          <Stack.Item textAlign="center">
-            <Button
-              fluid
-              icon="link"
-              color={statLinked ? 'bad' : 'good'}
-              onClick={() =>
-                dispatch(updateSettings({ statLinked: !statLinked }))
-              }
-            >
-              {statLinked ? 'Unlink from chat' : 'Link to chat'}
-            </Button>
-          </Stack.Item>
-        </Stack>
-      </Section>
-    </Stack>
+    <Section fill>
+      <Stack fill vertical>
+        <Stack.Item>
+          <LabeledList>
+            <LabeledList.Item label="Tabs" verticalAlign="middle">
+              {TabsViews.map((view) => (
+                <Button
+                  key={view}
+                  color="transparent"
+                  selected={statTabsStyle === view}
+                  onClick={() =>
+                    dispatch(updateSettings({ statTabsStyle: view }))
+                  }
+                >
+                  {capitalize(view)}
+                </Button>
+              ))}
+            </LabeledList.Item>
+            <LabeledList.Item label="Font size">
+              <Stack.Item grow>
+                {statLinked ? (
+                  <LinkedToChat />
+                ) : (
+                  <Slider
+                    width="100%"
+                    step={1}
+                    stepPixelSize={20}
+                    minValue={8}
+                    maxValue={32}
+                    value={statFontSize}
+                    unit="px"
+                    format={(value) => toFixed(value)}
+                    onChange={(e, value) =>
+                      dispatch(updateSettings({ statFontSize: value }))
+                    }
+                  />
+                )}
+              </Stack.Item>
+            </LabeledList.Item>
+          </LabeledList>
+        </Stack.Item>
+        <Stack.Divider />
+        <Stack.Item textAlign="center">
+          <Button
+            fluid
+            icon="link"
+            color={statLinked ? 'bad' : 'good'}
+            onClick={() =>
+              dispatch(updateSettings({ statLinked: !statLinked }))
+            }
+          >
+            {statLinked ? 'Unlink from chat' : 'Link to chat'}
+          </Button>
+        </Stack.Item>
+      </Stack>
+    </Section>
   );
 }

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { updateSettings } from './actions';
 import { selectSettings } from './selectors';
 
-const TabsViews = ['default', 'classic', 'nowrap'];
+const TabsViews = ['default', 'classic', 'scrollable'];
 const LinkedToChat = () => (
   <NoticeBox color="red">Unlink Stat Panel from chat!</NoticeBox>
 );

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -65,7 +65,7 @@ export function SettingsStatPanel(props) {
             </LabeledList.Item>
           </LabeledList>
         </Stack.Item>
-        <Stack.Divider />
+        <Stack.Divider mt={2.5} />
         <Stack.Item textAlign="center">
           <Button
             fluid

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -4,10 +4,10 @@ import { useDispatch, useSelector } from 'tgui/backend';
 import {
   Button,
   LabeledList,
+  NoticeBox,
   Section,
   Slider,
   Stack,
-  NoticeBox,
 } from 'tgui/components';
 
 import { updateSettings } from './actions';

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -1,0 +1,87 @@
+import { toFixed } from 'common/math';
+import { capitalize } from 'common/string';
+import { useDispatch, useSelector } from 'tgui/backend';
+import {
+  Button,
+  LabeledList,
+  Section,
+  Slider,
+  Stack,
+  NoticeBox,
+} from 'tgui/components';
+
+import { updateSettings } from './actions';
+import { selectSettings } from './selectors';
+
+const TabsViews = ['default', 'classic', 'nowrap'];
+
+export function SettingsStatPanel(props) {
+  const { statLinked, statFontSize, statTabsStyle } =
+    useSelector(selectSettings);
+  const dispatch = useDispatch();
+
+  return (
+    <Stack fill vertical>
+      <Section fill>
+        <Stack fill vertical>
+          <Stack.Item grow>
+            <LabeledList>
+              <LabeledList.Item label="Tabs" verticalAlign="middle">
+                <Stack.Item grow>
+                  {TabsViews.map((view) => (
+                    <Button
+                      key={view}
+                      color="transparent"
+                      selected={statTabsStyle === view}
+                      onClick={() =>
+                        dispatch(updateSettings({ statTabsStyle: view }))
+                      }
+                    >
+                      {capitalize(view)}
+                    </Button>
+                  ))}
+                </Stack.Item>
+              </LabeledList.Item>
+              <LabeledList.Item label="Font size">
+                <Stack.Item grow>
+                  {statLinked ? (
+                    <NoticeBox color="red" fontSize={0.95}>
+                      Unlink Stat Panel from chat!
+                    </NoticeBox>
+                  ) : (
+                    <Slider
+                      width="100%"
+                      step={1}
+                      stepPixelSize={20}
+                      minValue={8}
+                      maxValue={32}
+                      value={statFontSize}
+                      unit="px"
+                      format={(value) => toFixed(value)}
+                      onChange={(e, value) =>
+                        dispatch(updateSettings({ statFontSize: value }))
+                      }
+                    />
+                  )}
+                </Stack.Item>
+              </LabeledList.Item>
+            </LabeledList>
+          </Stack.Item>
+          <Stack.Divider />
+          <Stack.Item textAlign="center">
+            <Button
+              fluid
+              icon="link"
+              color={statLinked ? 'bad' : 'good'}
+              onClick={() =>
+                dispatch(updateSettings({ statLinked: !statLinked }))
+              }
+            >
+              {statLinked ? 'Unlink from chat' : 'Link to chat'}
+            </Button>
+          </Stack.Item>
+        </Stack>
+      </Section>
+    </Stack>
+  );
+}

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -69,7 +69,7 @@ export function SettingsStatPanel(props) {
         <Stack.Item textAlign="center">
           <Button
             fluid
-            icon="link"
+            icon={statLinked ? 'unlink' : 'link'}
             color={statLinked ? 'bad' : 'good'}
             onClick={() =>
               dispatch(updateSettings({ statLinked: !statLinked }))

--- a/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsStatPanel.tsx
@@ -14,6 +14,9 @@ import { updateSettings } from './actions';
 import { selectSettings } from './selectors';
 
 const TabsViews = ['default', 'classic', 'nowrap'];
+const LinkedToChat = () => (
+  <NoticeBox color="red">Unlink Stat Panel from chat!</NoticeBox>
+);
 
 export function SettingsStatPanel(props) {
   const { statLinked, statFontSize, statTabsStyle } =
@@ -45,9 +48,7 @@ export function SettingsStatPanel(props) {
               <LabeledList.Item label="Font size">
                 <Stack.Item grow>
                   {statLinked ? (
-                    <NoticeBox color="red" fontSize={0.95}>
-                      Unlink Stat Panel from chat!
-                    </NoticeBox>
+                    <LinkedToChat />
                   ) : (
                     <Slider
                       width="100%"

--- a/tgui/packages/tgui-panel/settings/constants.ts
+++ b/tgui/packages/tgui-panel/settings/constants.ts
@@ -18,6 +18,10 @@ export const SETTINGS_TABS = [
     id: 'chatPage',
     name: 'Chat Tabs',
   },
+  {
+    id: 'statPanel',
+    name: 'Stat Panel',
+  },
 ];
 
 export const FONTS_DISABLED = 'Default';

--- a/tgui/packages/tgui-panel/settings/middleware.ts
+++ b/tgui/packages/tgui-panel/settings/middleware.ts
@@ -17,7 +17,8 @@ import {
 import { FONTS_DISABLED } from './constants';
 import { selectSettings } from './selectors';
 
-let setStatFontTimer: NodeJS.Timeout;
+let statFontTimer: NodeJS.Timeout;
+let statTabsTimer: NodeJS.Timeout;
 let overrideRule: HTMLStyleElement;
 let overrideFontFamily: string | undefined;
 let overrideFontSize: string;
@@ -53,11 +54,11 @@ function setGlobalFontSize(
   overrideFontSize = `${fontSize}px`;
 
   // Used solution from theme.ts
-  clearInterval(setStatFontTimer);
+  clearInterval(statFontTimer);
   Byond.command(
     `.output statbrowser:set_font_size ${statLinked ? fontSize : statFontSize}px`,
   );
-  setStatFontTimer = setTimeout(() => {
+  statFontTimer = setTimeout(() => {
     Byond.command(
       `.output statbrowser:set_font_size ${statLinked ? fontSize : statFontSize}px`,
     );
@@ -66,6 +67,14 @@ function setGlobalFontSize(
 
 function setGlobalFontFamily(fontFamily: string) {
   overrideFontFamily = fontFamily === FONTS_DISABLED ? undefined : fontFamily;
+}
+
+function setStatTabsStyle(style: string) {
+  clearInterval(statTabsTimer);
+  Byond.command(`.output statbrowser:set_tabs_style ${style}`);
+  statTabsTimer = setTimeout(() => {
+    Byond.command(`.output statbrowser:set_tabs_style ${style}`);
+  }, 1500);
 }
 
 export function settingsMiddleware(store) {
@@ -100,6 +109,9 @@ export function settingsMiddleware(store) {
     next(action);
 
     const settings = selectSettings(store.getState());
+
+    // Update stat panel settings
+    setStatTabsStyle(settings.statTabsStyle);
 
     // Update global UI font size
     setGlobalFontSize(

--- a/tgui/packages/tgui-panel/settings/reducer.ts
+++ b/tgui/packages/tgui-panel/settings/reducer.ts
@@ -40,6 +40,7 @@ const initialState = {
   },
   statLinked: true,
   statFontSize: 12,
+  statTabsStyle: 'default',
 } as const;
 
 export function settingsReducer(


### PR DESCRIPTION
## About The Pull Request
Tabs in Stat Panel wraps again instead of creating a horizontal scroll bar by default
BUT. Added 2 more options for tabs look, and created special setting tabs for Stat Panel settings...

![image](https://github.com/user-attachments/assets/934d590b-3dd3-4ed5-a11c-c77838990dc3)

Idk if it is necessary to put a feature tag for this and remove `[NO GBP]`
If need to, please tell me, I'm still new into this system

Fixes #85437

## Images of changes
<details>
<summary>Screenshots</summary>
Tabs look

| Default | Classic | Scrollable |
| - | - | - |
| ![image](https://github.com/user-attachments/assets/6b1dc400-8cf4-42d4-8667-bd89e7f6db9b) | ![image](https://github.com/user-attachments/assets/64d83ce8-eb25-4ea1-ae18-1c2fa4b216bd) | ![image](https://github.com/user-attachments/assets/07afbe95-d8d8-4fc7-8d51-7fce2ea1478f) |

</details>
<details>
<summary>Video</summary>

https://github.com/user-attachments/assets/77839c27-60c8-45c2-ad92-8add59f9ba38

</details>

:cl:
qol: Stat Panel settings moved to personal tab
fix: Stat Panel tabs no longer create horizontal scrollbar by default, but you can return it into the settings
fix: Hovering over a truncated statpanel button, doesn't blocks the button below it anymore
/:cl:
