### PR TITLE
Fixes temperature getting stuck in offset equalibrium causing lizards to die if wearing thermal insulation

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1195,9 +1195,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	// Get the insulation value based on the area's temp
 	var/thermal_protection = humi.get_insulation_protection(area_temp)
+	var/original_bodytemp = humi.bodytemperature
 
 	// Changes to the skin temperature based on the area
-	var/area_skin_diff = area_temp - humi.bodytemperature
+	var/area_skin_diff = area_temp - original_bodytemp
 	if(!humi.on_fire || area_skin_diff > 0)
 		// change rate of 0.05 as area temp has large impact on the surface
 		var/area_skin_change = get_temp_change_amount(area_skin_diff, 0.05 * seconds_per_tick)
@@ -1217,7 +1218,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Core to skin temp transfer, when not on fire
 	if(!humi.on_fire)
 		// Get the changes to the skin from the core temp
-		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
+		var/core_skin_diff = humi.coretemperature - original_bodytemp
 		// change rate of 0.045 to reflect temp back to the skin at the slight higher rate then core to skin
 		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, 0.045 * seconds_per_tick)
 


### PR DESCRIPTION
## About The Pull Request

When returning to thermal equilibrium, the core temperature and body temperature seem to get stuck in a feedback loop, causing them to sometimes get stuck below or above safe limits and kill the player unless they remove their armor. This fixes that.

Here's a pic of slowly returning to safe temperature after being shot a bunch by watcher, whereas originally this would kill you if you had too much thermal insulation.
![image](https://github.com/user-attachments/assets/72236ff6-2444-4872-a19c-92d8788f660d)
(Ignore the duplicate var prints, one should be core_skin_change, but messed it up)
## Why It's Good For The Game
You don't have to remove your armor to stop from being permanently frozen/hot.
## Changelog
:cl:
fix: Fixes getting permanently hot or cold if wearing thermal insulation as a lizard
/:cl:
