### PR TITLE
Fixes echolocation creating the wrong screen overlay state when used with default arguments

### DIFF
--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -32,7 +32,7 @@
 	/// Cooldown for the echolocation.
 	COOLDOWN_DECLARE(cooldown_last)
 
-/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon = "echo", color_path)
+/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path)
 	. = ..()
 	var/mob/living/echolocator = parent
 	if(!istype(echolocator))


### PR DESCRIPTION
## About The Pull Request

Discovered this whilst porting some stuff from one downstream to another. The default echo_icon Initialize variable is "echo", which makes the screen overlay use the icon_state of "echoecho", an overlay state that doesnt exist.

Before
![image](https://github.com/user-attachments/assets/b818a4ad-4b69-4293-a824-6015270f1a0a)
![image](https://github.com/user-attachments/assets/2ffb5ec8-5fb4-47f0-a58f-3c6ab879d053)

After
![image](https://github.com/user-attachments/assets/89ec9e1d-5562-409d-b2f1-6422daf9cef9)

## Why It's Good For The Game

Fixes an overlay not appearing when it should. I don't think this actually affects anything on here though

## Changelog

:cl:
fix: Fixes the echolocation screen overlay not appearing with default arguments due to using the wrong icon state
/:cl: