### PR TITLE
Portable atmos machine circuit boards fixes [NO GBP]

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -36,11 +36,11 @@ Buildable meters
 	icon_state_preview = "junction"
 	pipe_type = /obj/machinery/atmospherics/pipe/heat_exchanging/junction
 /obj/item/pipe/directional/vent
-	name = "air vent"
+	name = "air vent fitting"
 	icon_state_preview = "uvent"
 	pipe_type = /obj/machinery/atmospherics/components/unary/vent_pump
 /obj/item/pipe/directional/scrubber
-	name = "air scrubber"
+	name = "air scrubber fitting"
 	icon_state_preview = "scrubber"
 	pipe_type = /obj/machinery/atmospherics/components/unary/vent_scrubber
 /obj/item/pipe/directional/connector
@@ -80,7 +80,7 @@ Buildable meters
 	RPD_type = PIPE_TRIN_M
 	var/flipped = FALSE
 /obj/item/pipe/trinary/flippable/filter
-	name = "gas filter"
+	name = "gas filter fitting"
 	icon_state_preview = "filter"
 	pipe_type = /obj/machinery/atmospherics/components/trinary/filter
 /obj/item/pipe/trinary/flippable/mixer

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -36,9 +36,11 @@ Buildable meters
 	icon_state_preview = "junction"
 	pipe_type = /obj/machinery/atmospherics/pipe/heat_exchanging/junction
 /obj/item/pipe/directional/vent
+	name = "air vent"
 	icon_state_preview = "uvent"
 	pipe_type = /obj/machinery/atmospherics/components/unary/vent_pump
 /obj/item/pipe/directional/scrubber
+	name = "air scrubber"
 	icon_state_preview = "scrubber"
 	pipe_type = /obj/machinery/atmospherics/components/unary/vent_scrubber
 /obj/item/pipe/directional/connector
@@ -78,6 +80,7 @@ Buildable meters
 	RPD_type = PIPE_TRIN_M
 	var/flipped = FALSE
 /obj/item/pipe/trinary/flippable/filter
+	name = "gas filter"
 	icon_state_preview = "filter"
 	pipe_type = /obj/machinery/atmospherics/components/trinary/filter
 /obj/item/pipe/trinary/flippable/mixer

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -6,7 +6,7 @@
 	desc = "Very useful for filtering gasses."
 
 	can_unwrench = TRUE
-	construction_type = /obj/item/pipe/trinary/flippable
+	construction_type = /obj/item/pipe/trinary/flippable/filter
 	pipe_state = "filter"
 
 	///Rate of transfer of the gases to the outputs

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -5,7 +5,7 @@
 
 	name = "air vent"
 	desc = "Has a valve and pump attached to it."
-
+	construction_type = /obj/item/pipe/directional/vent
 	use_power = IDLE_POWER_USE
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.15
 	can_unwrench = TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -3,6 +3,7 @@
 
 	name = "air scrubber"
 	desc = "Has a valve and pump attached to it."
+	construction_type = /obj/item/pipe/directional/scrubber
 	use_power = IDLE_POWER_USE
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.15

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -51,6 +51,10 @@
 	AddElement(/datum/element/elevation, pixel_shift = 8)
 	register_context()
 
+/obj/machinery/portable_atmospherics/on_construction(mob/user)
+	. = ..()
+	set_anchored(FALSE)
+
 /obj/machinery/portable_atmospherics/on_deconstruction(disassembled)
 	if(nob_crystal_inserted)
 		new /obj/item/hypernoblium_crystal(src)


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/8c7247c3-ecf8-4598-a5d3-8db9cbef8921)

I didn't check the examine text on the circuit boards when I was adding them. 

The pipe fitting items didn't have a proper name and the examine text was saying "pipe", confusing players.

Also the machines remained wrenched down on construction if the frame was wrenched.

And the fittings that people get from the RPD didn't have the correct typepath.

## Why It's Good For The Game

Fixes #85384
Fixes #85409
Fixes #84778

## Changelog

:cl:
fix: Portable atmos machine circuit boards list correct components
fix: Portable atmos machine circuit boards accept unwrenched fittings
fix: Portable atmos machines are movable on construction
/:cl:

