### PR TITLE
Revert "Heretic spell invocations now use one dead language per path"

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -1,7 +1,5 @@
 /**
  * # The path of Ash.
- * Spell names are in this language: OLD NORDIC
- * Both are related: Nordic Mythology-Yggdrassil-Ash Tree Genus-Ash
  *
  * Goes as follows:
  *
@@ -233,7 +231,7 @@
 		text = "[generate_heretic_text()] Fear the blaze, for the Ashlord, [user.real_name] has ascended! The flames shall consume all! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_ash.ogg',
-		color_override = "white",
+		color_override = "pink",
 	)
 
 	var/datum/action/cooldown/spell/fire_sworn/circle_spell = new(user.mind)

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -1,7 +1,5 @@
 /**
  * # The path of Blades. Stab stab.
- * Spell names are in this language: ARAMAIC
- * Both are related: Aramaic-Damascus-Blade
  *
  * Goes as follows:
  *

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -1,7 +1,5 @@
 /**
  * # The path of Cosmos.
- * Spell names are in this language: SUMERIAN
- * Both are related: Sumerian-Original-Primordial-Cosmic
  *
  * Goes as follows:
  *
@@ -285,7 +283,7 @@
 		text = "[generate_heretic_text()] A Star Gazer has arrived into the station, [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_cosmic.ogg',
-		color_override = "purple",
+		color_override = "pink",
 	)
 	var/mob/living/basic/heretic_summon/star_gazer/star_gazer_mob = new /mob/living/basic/heretic_summon/star_gazer(loc)
 	star_gazer_mob.maxHealth = INFINITY

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -5,8 +5,6 @@
 
 /**
  * # The path of Flesh.
- * Spell names are in this language: LATIN
- * Both are related: Latin-Rome-Hedonism-Flesh
  *
  * Goes as follows:
  *
@@ -332,7 +330,7 @@
 		text = "[generate_heretic_text()] Ever coiling vortex. Reality unfolded. ARMS OUTREACHED, THE LORD OF THE NIGHT, [user.real_name] has ascended! Fear the ever twisting hand! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_flesh.ogg',
-		color_override = "red",
+		color_override = "pink",
 	)
 
 	var/datum/action/cooldown/spell/shapeshift/shed_human_form/worm_spell = new(user.mind)

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -1,7 +1,5 @@
 /**
  * # The path of Lock.
- * Spell names are in this language: EGYPTIAN
- * Both are related: Egyptian-Mysteries-Secrets-Lock
  *
  * Goes as follows:
  *
@@ -243,7 +241,7 @@
 		text = "Delta-class dimensional anomaly detec[generate_heretic_text()] Reality rended, torn. Gates open, doors open, [user.real_name] has ascended! Fear the tide! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_knock.ogg',
-		color_override = "yellow",
+		color_override = "pink",
 	)
 
 	// buffs

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -1,7 +1,5 @@
 /**
  * # The path of Moon.
- * Spell names are in this language: ANCIENT HEBREW
- * Both are related: Ancient Hebrew-Moon Mysticism-Moon
  *
  * Goes as follows:
  *
@@ -211,7 +209,7 @@
 				The truth shall finally devour the lie! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_moon.ogg',
-		color_override = "blue",
+		color_override = "pink",
 	)
 
 	ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, REF(src))

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -1,6 +1,5 @@
 /**
  * # The path of Rust.
- * Spell names are in this language: OLD SLAVIC
  *
  * Goes as follows:
  *
@@ -257,7 +256,7 @@
 		text = "[generate_heretic_text()] Fear the decay, for the Rustbringer, [user.real_name] has ascended! None shall escape the corrosion! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_rust.ogg',
-		color_override = "brown",
+		color_override = "pink",
 	)
 	trigger(loc)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -1,5 +1,4 @@
 // Heretic starting knowledge.
-// Default heretic language is Ancient Greek, because, uh, they're like ancient and shit.
 
 /// Global list of all heretic knowledge that have route = PATH_START. List of PATHS.
 GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -1,7 +1,5 @@
 /**
  * # The path of VOID.
- * Spell names are in this language: PALI
- * Both are related: Pali-Buddhism-Nothingness-Void
  *
  * Goes as follows:
  *
@@ -221,7 +219,7 @@
 		text = "[generate_heretic_text()] The nobleman of void [user.real_name] has arrived, stepping along the Waltz that ends worlds! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/ambience/antag/heretic/ascend_void.ogg',
-		color_override = "blue",
+		color_override = "pink",
 	)
 	ADD_TRAIT(user, TRAIT_RESISTLOWPRESSURE, MAGIC_TRAIT)
 

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -10,8 +10,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Agresiv'noe rasprostra-neniye!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "A'GRSV SPR'D"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	aoe_radius = 2

--- a/code/modules/antagonists/heretic/magic/apetravulnera.dm
+++ b/code/modules/antagonists/heretic/magic/apetravulnera.dm
@@ -10,8 +10,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "Shea' shen-eh!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "AP'TRA VULN'RA!"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	cast_range = 4

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 70 SECONDS
 
-	invocation = "EID'R-ELDR!!!"
+	invocation = "FL'MS"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -72,8 +72,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "ILLA-LASARA'FOSS!!!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "C'SC'DE"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	/// The radius the flames will go around the caster.
@@ -112,7 +112,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 300
 
-	invocation = "Eld'sky!"
+	invocation = "F'RE"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/ash_jaunt.dm
+++ b/code/modules/antagonists/heretic/magic/ash_jaunt.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "Askgraar' goetur!"
+	invocation = "ASH'N P'SSG'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "Fer're!"
+	invocation = "CL'VE!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "Sanguis suctio!"
+	invocation = "FL'MS O'ET'RN'ITY."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/burglar_finesse.dm
+++ b/code/modules/antagonists/heretic/magic/burglar_finesse.dm
@@ -9,7 +9,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 40 SECONDS
 
-	invocation = "Khenem"
+	invocation = "Y'O'K!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "An'gar baltil!"
+	invocation = "C'SM'S 'XP'ND"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/cosmic_runes.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_runes.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "Is'zara-runen"
+	invocation = "ST'R R'N'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/eldritch_blind.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_blind.dm
@@ -5,7 +5,7 @@
 	overlay_icon_state = "bg_heretic_border"
 
 	school = SCHOOL_FORBIDDEN
-	invocation = "Caecus"
+	invocation = "E'E'S"
 	spell_requirements = NONE
 
 	cast_range = 10

--- a/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
@@ -8,7 +8,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Pulsus Energiae"
+	invocation = "E'P"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
@@ -7,7 +7,7 @@
 	overlay_icon_state = "bg_heretic_border"
 
 	school = SCHOOL_FORBIDDEN
-	invocation = "Forma"
+	invocation = "SH'PE"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/fire_blast.dm
+++ b/code/modules/antagonists/heretic/magic/fire_blast.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "Eld'fjall!"
+	invocation = "V'LC'N!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	channel_time = 5 SECONDS

--- a/code/modules/antagonists/heretic/magic/flesh_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_ascension.dm
@@ -9,7 +9,7 @@
 
 	school = SCHOOL_FORBIDDEN
 
-	invocation = "REALITAS EXSERPAT!!"
+	invocation = "REALITY UNCOIL!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -11,8 +11,8 @@
 
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
-	invocation = "Carnis chirurgia"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "CL'M M'N!" // "CLAIM MINE", but also almost "KALI MA"
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 	hand_path = /obj/item/melee/touch_attack/flesh_surgery

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -11,7 +11,7 @@
 
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 60 SECONDS
-	invocation = "Ham'sana-qasep!"
+	invocation = "F'LSH'NG S'LV'R!"
 	invocation_type = INVOCATION_SHOUT
 
 	spell_requirements = NONE

--- a/code/modules/antagonists/heretic/magic/manse_link.dm
+++ b/code/modules/antagonists/heretic/magic/manse_link.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Diaperaste' to-myalo!"
+	invocation = "PI'RC' TH' M'ND."
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_EVOCATION
 	cooldown_time = 10 SECONDS
 
-	invocation = "Ad verum per aspera!"
+	invocation = "R'CH T'H TR'TH!"
 	invocation_type = INVOCATION_SHOUT
 	// Mimes can cast it. Chaplains can cast it. Anyone can cast it, so long as they have a hand.
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION

--- a/code/modules/antagonists/heretic/magic/mind_gate.dm
+++ b/code/modules/antagonists/heretic/magic/mind_gate.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Sha'ar ha-da'at"
+	invocation = "Op' 'oY 'Mi'd"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 	cast_range = 6

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Tsiyun' levani!"
+	invocation = "L'N'R P'RAD"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 
-	invocation = "Manahel-qomem!"
+	invocation = "R''S 'E"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/moon_smile.dm
+++ b/code/modules/antagonists/heretic/magic/moon_smile.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Hiyuk-levana!"
+	invocation = "Mo'N S'M'LE"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	cast_range = 6

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 
-	invocation = "Dyrth-a Vaktry'ggjandi"
+	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_HUMAN
 

--- a/code/modules/antagonists/heretic/magic/realignment.dm
+++ b/code/modules/antagonists/heretic/magic/realignment.dm
@@ -14,8 +14,8 @@
 	cooldown_reduction_per_rank = -6 SECONDS // we're not a wizard spell but we use the levelling mechanic
 	spell_max_level = 10 // we can get up to / over a minute duration cd time
 
-	invocation = "Rasut"
-	invocation_type = INVOCATION_WHISPER
+	invocation = "R'S'T."
+	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 
 /datum/action/cooldown/spell/realignment/is_valid_target(atom/cast_on)

--- a/code/modules/antagonists/heretic/magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_wave.dm
@@ -13,8 +13,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Entro'pichniy-plim!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "'NTR'P'C PL'M'"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	cone_levels = 5
@@ -78,8 +78,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 35 SECONDS
 
-	invocation = "Diffunde' verbum!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "SPR'D TH' WO'D"
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	projectile_type = /obj/projectile/magic/aoe/rust_wave

--- a/code/modules/antagonists/heretic/magic/star_blast.dm
+++ b/code/modules/antagonists/heretic/magic/star_blast.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Pi-rig is'zara!"
+	invocation = "R'T'T' ST'R!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -13,7 +13,7 @@
 	sound = 'sound/items/welder.ogg'
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
-	invocation = "An'gar sig!"
+	invocation = "ST'R 'N'RG'!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	antimagic_flags = MAGIC_RESISTANCE

--- a/code/modules/antagonists/heretic/magic/void_cold_cone.dm
+++ b/code/modules/antagonists/heretic/magic/void_cold_cone.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Sunya'kop!"
+	invocation = "FR'ZE!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -12,8 +12,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "Sunya'sthiti!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "RE'L'TY PH'S'E."
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	cast_range = 9

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -11,8 +11,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 40 SECONDS
 
-	invocation = "Sunya'apamkti!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "BR'NG F'RTH TH'M T' M'."
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	aoe_radius = 7

--- a/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
+++ b/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
@@ -11,8 +11,8 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 5 MINUTES
 
-	invocation = "Kher' Sekh-em waaef'k!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = "F'K 'FF."
+	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	aoe_radius = 3


### PR DESCRIPTION

## About The Pull Request

Reverts spell invocation changes.
## Why It's Good For The Game

After seeing this on live for a while, I think it isn't quite worth it. A lot of the spells sound better, but the most common ones don't, so it just ends up being silly overall.
## Changelog
:cl:
del: Revert "Heretic spell invocations now use one dead language per path"
/:cl:
