### PR TITLE
[NO GBP] Minor quality of life change to ice box

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -19776,6 +19776,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"fUv" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "fUx" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -51117,7 +51121,7 @@
 /area/station/maintenance/port/greater)
 "ply" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/caution_sign,
+/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "plN" = (
@@ -52976,14 +52980,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "pOC" = (
-/obj/machinery/computer/order_console/cook{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/west,
+/obj/machinery/computer/order_console/cook{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "pOK" = (
@@ -250557,7 +250561,7 @@ knl
 dGO
 xPf
 lRs
-tml
+fUv
 kKL
 kKL
 aft

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -31468,7 +31468,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/ladder,
+/obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "jwj" = (
@@ -79954,7 +79954,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xPu" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -31464,6 +31464,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "jwj" = (
@@ -79949,6 +79950,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xPu" = (


### PR DESCRIPTION

## About The Pull Request
adds a single ladder in bar maints on zlevel 2 and 3
![image](https://github.com/user-attachments/assets/d99fc238-c0a9-47e5-8e51-556a1ac95f98)
![image](https://github.com/user-attachments/assets/60fae0ce-855e-4b73-b348-ab39b7610c2c)
ladders circled in red are the ladders that were added
## Why It's Good For The Game
you are basically trapped on the second zlevel if you dont have any maints access
and you can also grab the loot if you climb down from the 3rd zlevel to the 2nd
## Changelog
:cl:
qol: Adds ladder to IceBox's bar maints, both on the second zlevel and the third
/:cl:
