### PR TITLE
Chem master containers use DMIcon

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -247,11 +247,6 @@
 /obj/machinery/chem_master/attack_ai_secondary(mob/user, list/modifiers)
 	return attack_hand_secondary(user, modifiers)
 
-/obj/machinery/chem_master/ui_assets(mob/user)
-	return list(
-		get_asset_datum(/datum/asset/spritesheet/chemmaster)
-	)
-
 /obj/machinery/chem_master/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
@@ -273,9 +268,10 @@
 		//add containers to this category
 		for(var/obj/item/reagent_containers/container as anything in printable_containers[category])
 			category_list["containers"] += list(list(
-				"icon" = sanitize_css_class_name("[container]"),
 				"ref" = REF(container),
 				"name" = initial(container.name),
+				"icon" = initial(container.icon),
+				"icon_state" = initial(container.icon_state),
 				"volume" = initial(container.volume),
 			))
 

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   ColorBox,
   Divider,
+  DmIcon,
+  Icon,
   LabeledList,
   NumberInput,
   ProgressBar,
@@ -13,7 +15,7 @@ import {
   Table,
   Tooltip,
 } from 'tgui-core/components';
-import { BooleanLike, classes } from 'tgui-core/react';
+import { BooleanLike } from 'tgui-core/react';
 import { capitalize } from 'tgui-core/string';
 
 import { useBackend } from '../backend';
@@ -22,6 +24,7 @@ import { Beaker, BeakerReagent } from './common/BeakerDisplay';
 
 type Container = {
   icon: string;
+  icon_state: string;
   ref: string;
   name: string;
   volume: number;
@@ -375,6 +378,8 @@ const ContainerButton = (props: CategoryButtonProps) => {
   const { isPrinting, selectedContainerRef, suggestedContainerRef } = data;
   const { category, container, showPreferredContainer } = props;
   const isPillPatch = ['pills', 'patches'].includes(category.name);
+  const fallback = <Icon m="18px" name="spinner" spin />;
+  const fallbackPillPatch = <Icon m="10px" name="spinner" spin />;
 
   return (
     <Tooltip
@@ -402,12 +407,13 @@ const ContainerButton = (props: CategoryButtonProps) => {
           });
         }}
       >
-        <Box
-          m={isPillPatch ? '0' : '8px'}
-          style={{
-            transform: 'scale(2)',
-          }}
-          className={classes(['chemmaster32x32', container.icon])}
+        <DmIcon
+          m={isPillPatch ? '-16px' : '-8px'}
+          fallback={isPillPatch ? fallbackPillPatch : fallback}
+          icon={container.icon}
+          icon_state={container.icon_state}
+          height="64px"
+          width="64px"
         />
       </Button>
     </Tooltip>


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/5964f6f6-5485-48a9-a346-54490c5ce1b4)

Makes Chem and Condi master machines use DMIcon instead of stylesheets to render icons.

## Why It's Good For The Game

Crisp icons, cleaner code.

## Changelog

:cl:
image: Made chem master container icons not blurry
/:cl:

