### PR TITLE
Fixes lua function SS13.wait.

### DIFF
--- a/lua/timer.lua
+++ b/lua/timer.lua
@@ -60,8 +60,9 @@ __Timer_timer_process = function(seconds_per_tick)
 end
 
 function Timer.wait(time)
+	local yieldIndex = _exec.next_yield_index
 	__add_internal_timer(function()
-		SSlua:queue_resume(state.state, _exec.next_yield_index)
+		SSlua:queue_resume(state.state, yieldIndex)
 	end, time * 10, false)
 	coroutine.yield()
 end


### PR DESCRIPTION

## About The Pull Request
See title. It's broken because it's not resuming the proper yielded coroutine, it's getting the global next yield index.

## Why It's Good For The Game
Fixes SS13.wait breaking if called more than once.

## Changelog
:cl:
fix: Fixes SS13.wait not working when called multiple times before it finishes waiting.
/:cl:
