### PR TITLE
Turfs in lua will no longer null out their reference on deletion.

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -11,6 +11,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define DF_USE_TAG (1<<0)
 #define DF_VAR_EDITED (1<<1)
 #define DF_ISPROCESSING (1<<2)
+/// Placed on datums that have a static, constant reference. Primarily only used for turfs.
+#define DF_STATIC_OBJECT (1<<3)
 
 //FLAGS BITMASK
 // scroll down before changing the numbers on these

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -111,8 +111,9 @@
 	tag = null
 	datum_flags &= ~DF_USE_TAG //In case something tries to REF us
 	weak_reference = null //ensure prompt GCing of weakref.
-	DREAMLUAU_CLEAR_REF_USERDATA(vars) // vars ceases existing when src does, so we need to clear any lua refs to it that exist.
-	DREAMLUAU_CLEAR_REF_USERDATA(src)
+	if(!(datum_flags & DF_STATIC_OBJECT))
+		DREAMLUAU_CLEAR_REF_USERDATA(vars) // vars ceases existing when src does, so we need to clear any lua refs to it that exist.
+		DREAMLUAU_CLEAR_REF_USERDATA(src)
 
 	if(_active_timers)
 		var/list/timers = _active_timers

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -187,10 +187,11 @@
 		SSicon_smooth.remove_from_queues(src)
 
 	// These lists cease existing when src does, so we need to clear any lua refs to them that exist.
-	DREAMLUAU_CLEAR_REF_USERDATA(contents)
-	DREAMLUAU_CLEAR_REF_USERDATA(filters)
-	DREAMLUAU_CLEAR_REF_USERDATA(overlays)
-	DREAMLUAU_CLEAR_REF_USERDATA(underlays)
+	if(!(datum_flags & DF_STATIC_OBJECT))
+		DREAMLUAU_CLEAR_REF_USERDATA(contents)
+		DREAMLUAU_CLEAR_REF_USERDATA(filters)
+		DREAMLUAU_CLEAR_REF_USERDATA(overlays)
+		DREAMLUAU_CLEAR_REF_USERDATA(underlays)
 
 	return ..()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /// Any floor or wall. What makes up the station and the rest of the map.
 /turf
 	icon = 'icons/turf/floors.dmi'
+	datum_flags = DF_STATIC_OBJECT
 	vis_flags = VIS_INHERIT_ID // Important for interaction with and visualization of openspace.
 	luminosity = 1
 	light_height = LIGHTING_HEIGHT_FLOOR


### PR DESCRIPTION

## About The Pull Request
Turfs are static objects and you can safely hold reference to them because their reference does not change on deletion.

## Why It's Good For The Game
Makes lua scripts more stable since signals don't get unregistered on turf deletion.

## Changelog
:cl:
admin: Turfs in lua will no longer become invalid on deletion.
/:cl:
