### PR TITLE
Scanner gate fixes

### DIFF
--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -244,11 +244,14 @@
 				beep = TRUE
 			else if(ishuman(thing))
 				var/mob/living/carbon/human/scanned_human = thing
-				if(!HAS_TRAIT(scanned_human, TRAIT_MINDSHIELD))
-					for(var/scanned_item in scanned_human.get_contents())
-						if(isgun(scanned_item))
+				var/obj/item/card/id/idcard = scanned_human.get_idcard(hand_first = FALSE)
+				for(var/obj/item/scanned_item in scanned_human.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
+					if(isgun(scanned_item))
+						if((!HAS_TRAIT(scanned_human, TRAIT_MINDSHIELD)) && (isnull(idcard) || !(ACCESS_WEAPONS in idcard.access))) // mindshield or ID card with weapons access, like bartender
 							beep = TRUE
 							break
+						say("[detected_thing] detection bypassed.")
+						break
 			else
 				for(var/obj/item/content in thing.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
 					if(isgun(content))

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -189,8 +189,8 @@
 				if(!target || (target.wanted_status == WANTED_ARREST))
 					beep = TRUE
 		if(SCANGATE_MINDSHIELD)
+			detected_thing = "Mindshield"
 			if(ishuman(thing))
-				detected_thing = "Mindshield"
 				var/mob/living/carbon/human/scanned_human = thing
 				if(HAS_TRAIT(scanned_human, TRAIT_MINDSHIELD))
 					beep = TRUE
@@ -250,8 +250,8 @@
 							beep = TRUE
 							break
 			else
-				for(var/scanned_item in thing.contents)
-					if(isgun(scanned_item))
+				for(var/obj/item/content in thing.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
+					if(isgun(content))
 						beep = TRUE
 						break
 		if(SCANGATE_NUTRITION)

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -244,10 +244,11 @@
 				beep = TRUE
 			else if(ishuman(thing))
 				var/mob/living/carbon/human/scanned_human = thing
-				for(var/scanned_item in scanned_human.get_contents())
-					if(isgun(scanned_item))
-						beep = TRUE
-						break
+				if(!HAS_TRAIT(scanned_human, TRAIT_MINDSHIELD))
+					for(var/scanned_item in scanned_human.get_contents())
+						if(isgun(scanned_item))
+							beep = TRUE
+							break
 			else
 				for(var/scanned_item in thing.contents)
 					if(isgun(scanned_item))
@@ -302,7 +303,7 @@
 		say("[detected_thing][reverse ? " not " : " "]detected!!")
 
 	COOLDOWN_START(src, next_beep, 2 SECONDS)
-	playsound(src, 'sound/machines/scanbuzz.ogg', 100, FALSE)
+	playsound(src, 'sound/machines/scanbuzz.ogg', 30, FALSE)
 	set_scanline("alarm", 2 SECONDS)
 
 /obj/machinery/scanner_gate/can_interact(mob/user)

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -303,7 +303,7 @@
 		say("[detected_thing][reverse ? " not " : " "]detected!!")
 
 	COOLDOWN_START(src, next_beep, 2 SECONDS)
-	playsound(src, 'sound/machines/scanbuzz.ogg', 30, FALSE)
+	playsound(source = src, soundin = 'sound/machines/scanbuzz.ogg', vol = 30, vary = FALSE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE, falloff_distance = 4)
 	set_scanline("alarm", 2 SECONDS)
 
 /obj/machinery/scanner_gate/can_interact(mob/user)

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -96,13 +96,13 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 
-/obj/machinery/scanner_gate/proc/on_entered(datum/source, atom/movable/AM)
+/obj/machinery/scanner_gate/proc/on_entered(datum/source, atom/movable/thing)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(auto_scan), AM)
+	INVOKE_ASYNC(src, PROC_REF(auto_scan), thing)
 
-/obj/machinery/scanner_gate/proc/auto_scan(atom/movable/AM)
-	if(!(machine_stat & (BROKEN|NOPOWER)) && isliving(AM) & (!panel_open))
-		perform_scan(AM)
+/obj/machinery/scanner_gate/proc/auto_scan(atom/movable/thing)
+	if(!(machine_stat & (BROKEN|NOPOWER)) && anchored && !panel_open)
+		perform_scan(thing)
 
 /obj/machinery/scanner_gate/proc/set_scanline(type, duration)
 	cut_overlays()
@@ -124,8 +124,8 @@
 			return ITEM_INTERACT_SUCCESS
 	return NONE
 
-/obj/machinery/scanner_gate/attackby(obj/item/W, mob/user, params)
-	var/obj/item/card/id/card = W.GetID()
+/obj/machinery/scanner_gate/attackby(obj/item/attacking_item, mob/user, params)
+	var/obj/item/card/id/card = attacking_item.GetID()
 	if(card)
 		if(locked)
 			if(allowed(user))
@@ -133,16 +133,16 @@
 				req_access = list()
 				to_chat(user, span_notice("You unlock [src]."))
 		else if(!(obj_flags & EMAGGED))
-			to_chat(user, span_notice("You lock [src] with [W]."))
-			var/list/access = W.GetAccess()
+			to_chat(user, span_notice("You lock [src] with [attacking_item]."))
+			var/list/access = attacking_item.GetAccess()
 			req_access = access
 			locked = TRUE
 		else
-			to_chat(user, span_warning("You try to lock [src] with [W], but nothing happens."))
+			to_chat(user, span_warning("You try to lock [src] with [attacking_item], but nothing happens."))
 	else
-		if(!locked && default_deconstruction_screwdriver(user, "[initial(icon_state)]_open", initial(icon_state), W))
+		if(!locked && default_deconstruction_screwdriver(user, "[initial(icon_state)]_open", initial(icon_state), attacking_item))
 			return
-		if(panel_open && is_wire_tool(W))
+		if(panel_open && is_wire_tool(attacking_item))
 			wires.interact(user)
 	return ..()
 
@@ -173,7 +173,7 @@
 	balloon_alert(user, "id checker disabled")
 	return TRUE
 
-/obj/machinery/scanner_gate/proc/perform_scan(mob/living/M)
+/obj/machinery/scanner_gate/proc/perform_scan(atom/movable/thing)
 	var/beep = FALSE
 	var/color = null
 	var/detected_thing = null
@@ -181,26 +181,28 @@
 		if(SCANGATE_NONE)
 			return
 		if(SCANGATE_WANTED)
-			if(ishuman(M))
+			if(ishuman(thing))
 				detected_thing = "Warrant"
-				var/mob/living/carbon/human/H = M
-				var/perpname = H.get_face_name(H.get_id_name())
+				var/mob/living/carbon/human/scanned_human = thing
+				var/perpname = scanned_human.get_face_name(scanned_human.get_id_name())
 				var/datum/record/crew/target = find_record(perpname)
 				if(!target || (target.wanted_status == WANTED_ARREST))
 					beep = TRUE
 		if(SCANGATE_MINDSHIELD)
-			detected_thing = "Mindshield"
-			if(HAS_TRAIT(M, TRAIT_MINDSHIELD))
-				beep = TRUE
+			if(ishuman(thing))
+				detected_thing = "Mindshield"
+				var/mob/living/carbon/human/scanned_human = thing
+				if(HAS_TRAIT(scanned_human, TRAIT_MINDSHIELD))
+					beep = TRUE
 		if(SCANGATE_DISEASE)
 			detected_thing = "[disease_threshold] infection"
-			if(iscarbon(M))
-				var/mob/living/carbon/C = M
-				if(get_disease_severity_value(C.check_virus()) >= get_disease_severity_value(disease_threshold))
+			if(iscarbon(thing))
+				var/mob/living/carbon/scanned_carbon = thing
+				if(get_disease_severity_value(scanned_carbon.check_virus()) >= get_disease_severity_value(disease_threshold))
 					beep = TRUE
 		if(SCANGATE_SPECIES)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
+			if(ishuman(thing))
+				var/mob/living/carbon/human/scanned_human = thing
 				var/datum/species/scan_species = /datum/species/human
 				switch(detect_species)
 					if(SCANGATE_LIZARD)
@@ -230,29 +232,38 @@
 					if(SCANGATE_ZOMBIE)
 						detected_thing = "Zombie"
 						scan_species = /datum/species/zombie
-				if(is_species(H, scan_species))
+				if(is_species(scanned_human, scan_species))
 					beep = TRUE
 				if(detect_species == SCANGATE_ZOMBIE) //Can detect dormant zombies
 					detected_thing = "Romerol infection"
-					if(H.get_organ_slot(ORGAN_SLOT_ZOMBIE))
+					if(scanned_human.get_organ_slot(ORGAN_SLOT_ZOMBIE))
 						beep = TRUE
 		if(SCANGATE_GUNS)
-			for(var/I in M.get_contents())
-				detected_thing = "Weapons"
-				if(isgun(I))
-					beep = TRUE
-					break
+			detected_thing = "Weapons"
+			if(isgun(thing))
+				beep = TRUE
+			else if(ishuman(thing))
+				var/mob/living/carbon/human/scanned_human = thing
+				for(var/scanned_item in scanned_human.get_contents())
+					if(isgun(scanned_item))
+						beep = TRUE
+						break
+			else
+				for(var/scanned_item in thing.contents)
+					if(isgun(scanned_item))
+						beep = TRUE
+						break
 		if(SCANGATE_NUTRITION)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.nutrition <= detect_nutrition && detect_nutrition == NUTRITION_LEVEL_STARVING)
+			if(ishuman(thing))
+				var/mob/living/carbon/human/scanned_human = thing
+				if(scanned_human.nutrition <= detect_nutrition && detect_nutrition == NUTRITION_LEVEL_STARVING)
 					beep = TRUE
 					detected_thing = "Starvation"
-				if(H.nutrition >= detect_nutrition && detect_nutrition == NUTRITION_LEVEL_FAT)
+				if(scanned_human.nutrition >= detect_nutrition && detect_nutrition == NUTRITION_LEVEL_FAT)
 					beep = TRUE
 					detected_thing = "Obesity"
 		if(SCANGATE_CONTRABAND)
-			for(var/obj/item/content in M.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
+			for(var/obj/item/content in thing.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
 				detected_thing = "Contraband"
 				if(content.is_contraband())
 					beep = TRUE
@@ -268,13 +279,13 @@
 
 	if(beep)
 		alarm_beep(detected_thing)
-		SEND_SIGNAL(src, COMSIG_SCANGATE_PASS_TRIGGER, M)
+		SEND_SIGNAL(src, COMSIG_SCANGATE_PASS_TRIGGER, thing)
 		if(!ignore_signals)
 			color = wires.get_color_of_wire(WIRE_ACCEPT)
 			var/obj/item/assembly/assembly = wires.get_attached(color)
 			assembly?.activate()
 	else
-		SEND_SIGNAL(src, COMSIG_SCANGATE_PASS_NO_TRIGGER, M)
+		SEND_SIGNAL(src, COMSIG_SCANGATE_PASS_NO_TRIGGER, thing)
 		if(!ignore_signals)
 			color = wires.get_color_of_wire(WIRE_DENY)
 			var/obj/item/assembly/assembly = wires.get_attached(color)

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -291,7 +291,7 @@
 			color = wires.get_color_of_wire(WIRE_DENY)
 			var/obj/item/assembly/assembly = wires.get_attached(color)
 			assembly?.activate()
-		set_scanline("scanning", 10)
+		set_scanline("scanning", 1 SECONDS)
 
 	use_energy(active_power_usage)
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/85424
Reduces the volume of the alarm buzz
Scanner on guns mode doesn't trigger for mindshielded players

## Changelog

:cl: LT3
fix: Scanner gate now detects items thrown through it
fix: Scanner gate does not alarm for guns on players with mindshield
fix: Scanner gate does not alarm for guns on players with weapons ID card access
sound: Reduced volume of scanner gate alarm
/:cl: