### PR TITLE
Spies can now set their own custom objectives

### DIFF
--- a/code/modules/antagonists/spy/spy.dm
+++ b/code/modules/antagonists/spy/spy.dm
@@ -8,6 +8,8 @@
 	hijack_speed = 1
 	ui_name = "AntagInfoSpy"
 	preview_outfit = /datum/outfit/spy
+	can_assign_self_objectives = TRUE
+	default_custom_objective = "Rob the station blind."
 	/// Whether an uplink has been created (successfully or at all)
 	var/uplink_created = FALSE
 	/// String displayed in the antag panel pointing the spy to where their uplink is.

--- a/tgui/packages/tgui/interfaces/AntagInfoSpy.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoSpy.tsx
@@ -1,8 +1,13 @@
 import { Section, Stack } from 'tgui-core/components';
+import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
-import { Objective, ObjectivePrintout } from './common/Objectives';
+import {
+  Objective,
+  ObjectivePrintout,
+  ReplaceObjectivesButton,
+} from './common/Objectives';
 
 const greenText = {
   fontWeight: 'italics',
@@ -18,13 +23,15 @@ type Data = {
   antag_name: string;
   uplink_location: string | null;
   objectives: Objective[];
+  can_change_objective: BooleanLike;
 };
 
 export const AntagInfoSpy = () => {
   const { data } = useBackend<Data>();
-  const { antag_name, uplink_location, objectives } = data;
+  const { antag_name, uplink_location, objectives, can_change_objective } =
+    data;
   return (
-    <Window width={380} height={420} theme="ntos_darkmode">
+    <Window width={380} height={450} theme="ntos_darkmode">
       <Window.Content
         style={{
           backgroundImage: 'none',
@@ -57,6 +64,16 @@ export const AntagInfoSpy = () => {
                 titleMessage={'Your mission, should you choose to accept it'}
                 objectives={objectives}
               />
+            </Stack.Item>
+            <Stack.Divider />
+            <Stack.Item textAlign="center">
+              {
+                <ReplaceObjectivesButton
+                  can_change_objective={can_change_objective}
+                  button_title={'Make Your Own Plan'}
+                  button_colour={'green'}
+                />
+              }
             </Stack.Item>
           </Stack>
         </Section>


### PR DESCRIPTION

## About The Pull Request

Spies can now pick a custom objective to override their auto-generated ones.

![image](https://github.com/user-attachments/assets/71556d71-e2e2-4b32-b628-d057df974f02)

Here's how it looks at roundend:

![image](https://github.com/user-attachments/assets/d6e029af-2cdc-4246-b8e5-48863cfee40b)

By default, the custom objective is set to "Rob the station blind."

Honestly I'm surprised they couldn't do this already.
## Why It's Good For The Game

Spies are a very low-stakes antag, they can lend themselves to letting people pull low-stakes shenanigans. They should have the freedom to declare their intent, so people reading the roundend report can understand why they painted the entire station orange or slaughtered that farm of innocent orphan mothroaches.

I am, of course, doing this all under the assumption that the administration team (of which I am a part of) will not let people setting their objective to "kill people for fun" fly when murderbone otherwise wouldn't. It feels like that detail is a given but it warrants addressing regardless -- I have to say it here or else someone will in the comments.
## Changelog
:cl: Rhials
add: Spies can now pick their own custom objectives, if they so choose.
/:cl:
