### PR TITLE
Skills are passed down to bitrunning avatars and then back to the original body.

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -66,6 +66,9 @@
 	if(alias && avatar.real_name != alias)
 		avatar.fully_replace_character_name(avatar.real_name, alias)
 
+	for(var/skill_type in old_mind?.known_skills)
+		avatar.mind.set_experience(skill_type, old_mind.get_skill_exp(skill_type), silent = TRUE)
+
 	avatar.playsound_local(avatar, 'sound/magic/blink.ogg', 25, TRUE)
 	avatar.set_static_vision(2 SECONDS)
 	avatar.set_temp_blindness(1 SECONDS) // I'm in
@@ -280,6 +283,9 @@
 
 	if(isnull(old_mind) || isnull(old_body))
 		return
+
+	for(var/skill_type in avatar.mind.known_skills)
+		old_mind.set_experience(skill_type, avatar.mind.get_skill_exp(skill_type), silent = TRUE)
 
 	ghost.mind = old_mind
 	if(old_body.stat != DEAD)

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -286,6 +286,7 @@
 
 	for(var/skill_type in avatar.mind.known_skills)
 		old_mind.set_experience(skill_type, avatar.mind.get_skill_exp(skill_type), silent = TRUE)
+		avatar.mind.set_experience(skill_type, 0, silent = TRUE)
 
 	ghost.mind = old_mind
 	if(old_body.stat != DEAD)

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -20,7 +20,7 @@
 	help_text,
 	)
 
-	if(!isliving(parent) || !isliving(old_body) || !server.is_operational || !pod.is_operational)
+	if(!isliving(parent) || !isliving(old_body) || !old_mind || !server.is_operational || !pod.is_operational)
 		return COMPONENT_INCOMPATIBLE
 
 	var/mob/living/avatar = parent
@@ -66,7 +66,7 @@
 	if(alias && avatar.real_name != alias)
 		avatar.fully_replace_character_name(avatar.real_name, alias)
 
-	for(var/skill_type in old_mind?.known_skills)
+	for(var/skill_type in old_mind.known_skills)
 		avatar.mind.set_experience(skill_type, old_mind.get_skill_exp(skill_type), silent = TRUE)
 
 	avatar.playsound_local(avatar, 'sound/magic/blink.ogg', 25, TRUE)


### PR DESCRIPTION
## About The Pull Request
Skills are now passed down to the mind of the bitrunning avatar, and then back to the real body once disconnected, allowing for skills to be leveled up (and theorically down) in the simulation.

## Why It's Good For The Game
Skills improved in a simulation should be passed back to the real body.

## Changelog

:cl:
qol: Skills are passed down to bitrunning avatars and then back to the original body.
/:cl:
