### PR TITLE
Bamboo staffs can now be wielded, bostaff no longer disappears forever when wielded

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -518,12 +518,13 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb_simple = list("smash", "slam", "whack", "thwack")
 	icon = 'icons/obj/weapons/staff.dmi'
 	icon_state = "bambostaff0"
+	base_icon_state = "bambostaff"
 	inhand_icon_state = "bambostaff0"
 	worn_icon_state = "bambostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 
-/obj/item/nullrod/bostaff/Initialize(mapload)
+/obj/item/bambostaff/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/two_handed, \
 		force_unwielded = 10, \
@@ -531,7 +532,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		icon_wielded = "[base_icon_state]1", \
 	)
 
-/obj/item/nullrod/bostaff/update_icon_state()
+/obj/item/bambostaff/update_icon_state()
 	icon_state = "[base_icon_state]0"
 	return ..()
 

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -574,6 +574,7 @@
 	attack_verb_simple = list("smash", "slam", "whack", "thwack")
 	icon = 'icons/obj/weapons/staff.dmi'
 	icon_state = "bostaff0"
+	base_icon_state = "bostaff"
 	inhand_icon_state = "bostaff0"
 	worn_icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'


### PR DESCRIPTION
## About The Pull Request

Closes #85431

## Changelog
:cl:
fix: Bamboo staves can now be wielded
fix: Bostaff no longer disappears forever when wielded
/:cl:
