### PR TITLE
Fix disease outbreak spread modifier

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -40,6 +40,7 @@
 	var/cure_chance = 4
 	var/carrier = FALSE //If our host is only a carrier
 	var/bypasses_immunity = FALSE //Does it skip species virus immunity check? Some things may diseases and not viruses
+	/// How quickly the disease spreads between mobs. Lower is faster.
 	var/spreading_modifier = 1
 	var/severity = DISEASE_SEVERITY_NONTHREAT
 	/// If the disease requires an organ for the effects to function, robotic organs are immune to disease unless inorganic biology symptom is present

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -431,7 +431,7 @@
 
 	incubation_time = round(world.time + (((ADV_ANNOUNCE_DELAY * 2) - 10) SECONDS))
 	properties["transmittable"] = rand(4,7)
-	spreading_modifier = max(CEILING(0.4 * properties["transmittable"], 1), 1)
+	spreading_modifier = rand(75, 100) / 100
 	cure_chance = clamp(7.5 - (0.5 * properties["resistance"]), 5, 10) // Can be between 5 and 10
 	stage_prob = max(0.4 * properties["stage_rate"], 1)
 	set_severity(properties["severity"])

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -430,8 +430,8 @@
 		return
 
 	incubation_time = round(world.time + (((ADV_ANNOUNCE_DELAY * 2) - 10) SECONDS))
-	properties["transmittable"] = rand(4,7)
-	spreading_modifier = rand(75, 100) / 100
+	properties["transmittable"] = rand(4,7) // Only used to decide symptom effects, not transmssibility
+	spreading_modifier = rand(75, 100) / 100 // Between 0.75 and 1
 	cure_chance = clamp(7.5 - (0.5 * properties["resistance"]), 5, 10) // Can be between 5 and 10
 	stage_prob = max(0.4 * properties["stage_rate"], 1)
 	set_severity(properties["severity"])

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -431,7 +431,7 @@
 
 	incubation_time = round(world.time + (((ADV_ANNOUNCE_DELAY * 2) - 10) SECONDS))
 	properties["transmittable"] = rand(4,7) // Only used to decide symptom effects, not transmssibility
-	spreading_modifier = rand(75, 100) / 100 // Between 0.75 and 1
+	spreading_modifier = rand(50, 100) / 100 // Between 0.5 and 1
 	cure_chance = clamp(7.5 - (0.5 * properties["resistance"]), 5, 10) // Can be between 5 and 10
 	stage_prob = max(0.4 * properties["stage_rate"], 1)
 	set_severity(properties["severity"])


### PR DESCRIPTION
## About The Pull Request

Fixes advanced disease outbreak generation to set a spread_modifier between 0.5 and 1, like normal disease outbreaks.

Event diseases have their transmissibility randomly assigned, so we can't assign a spread_modifier based on the symptom values.

## Changelog

:cl: LT3
fix: Advanced disease outbreaks correctly have spread modifiers in line with regular disease outbreaks
/:cl: