### PR TITLE
Sentience potions can now be used without a summon reason

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -715,13 +715,10 @@
 	if(!dumb_mob.compare_sentience_type(sentience_type)) // Will also return false if not a basic or simple mob, which are the only two we want anyway
 		balloon_alert(user, "invalid creature!")
 		return
-	if(isnull(potion_reason))
-		balloon_alert(user, "no reason for offering set!")
-		return
 	balloon_alert(user, "offering...")
 	being_used = TRUE
 	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
-		question = "[span_danger(user.name)] is offering [span_notice(dumb_mob.name)] an intelligence potion! Reason: [span_boldnotice(potion_reason)]",
+		question = "[span_danger(user.name)] is offering [span_notice(dumb_mob.name)] an intelligence potion![potion_reason ? " Reason: [span_boldnotice(potion_reason)]" : ""]",
 		check_jobban = ROLE_SENTIENCE,
 		poll_time = 20 SECONDS,
 		checked_target = dumb_mob,


### PR DESCRIPTION

## About The Pull Request

Sentience Potions will poll for ghosts with no provided reason, if no reason is set.
## Why It's Good For The Game

People might not think/consider how to set a reason for providing sentience to a mob. I've seen at least one person get confused by this and that's enough to warrant a QOL change. It really boils down to "why shouldn't people be able to do this?".

It's simpler this way. Sometimes we don't need a reason to do things.
## Changelog
:cl: Rhials
qol: Sentience potions can now be used without a provided summon reason.
/:cl:
