### PR TITLE
Fixes/improves the Lua UI Slightly

### DIFF
--- a/code/modules/admin/verbs/lua/lua_editor.dm
+++ b/code/modules/admin/verbs/lua/lua_editor.dm
@@ -75,6 +75,7 @@
 		if(last_error)
 			data["lastError"] = last_error
 			last_error = null
+		data["supressRuntimes"] = current_state.supress_runtimes
 	data["states"] = list()
 	for(var/datum/lua_state/state as anything in SSlua.states)
 		data["states"] += state.display_name
@@ -228,7 +229,7 @@
 			if(result["status"] == "error")
 				last_error = result["message"]
 			arguments.Cut()
-			return TRUE
+			return
 		if("resumeTask")
 			var/task_index = params["index"]
 			SSlua.queue_resume(current_state, task_index, arguments)
@@ -260,6 +261,9 @@
 			return TRUE
 		if("toggleShowGlobalTable")
 			show_global_table = !show_global_table
+			return TRUE
+		if("toggleSupressRuntimes")
+			current_state.supress_runtimes = !current_state.supress_runtimes
 			return TRUE
 		if("nextPage")
 			page = min(page+1, CEILING(current_state.log.len/50, 1)-1)

--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -24,6 +24,9 @@ GLOBAL_PROTECT(lua_state_stack)
 	/// Whether the timer.lua script has been included into this lua context state.
 	var/timer_enabled = FALSE
 
+	/// Whether to supress logging BYOND runtimes for this state.
+	var/supress_runtimes = FALSE
+
 	/// Callbacks that need to be ran on next tick
 	var/list/functions_to_execute = list()
 

--- a/tgui/packages/tgui/interfaces/LuaEditor/Log.tsx
+++ b/tgui/packages/tgui/interfaces/LuaEditor/Log.tsx
@@ -120,8 +120,8 @@ export const Log = (props: LogProps) => {
                 }`
               : ''}
             .
-            <Box color="default">
-              {return_values.length ? (
+            {return_values.length ? (
+              <Box color="default">
                 <ListMapper
                   list={return_values}
                   variants={variants}
@@ -135,10 +135,10 @@ export const Log = (props: LogProps) => {
                     })
                   }
                 />
-              ) : (
-                <br />
-              )}
-            </Box>
+              </Box>
+            ) : (
+              <br />
+            )}
           </>
         );
         messageColor = 'green';
@@ -187,7 +187,7 @@ export const Log = (props: LogProps) => {
     if (chunk) {
       output = (
         <>
-          {output}
+          <Box>{output}</Box>
           <Button
             onClick={() => {
               setViewedChunk(chunk);

--- a/tgui/packages/tgui/interfaces/LuaEditor/types.ts
+++ b/tgui/packages/tgui/interfaces/LuaEditor/types.ts
@@ -89,6 +89,7 @@ export type LuaEditorData = {
   pageCount: number;
   lastError?: string;
   showGlobalTable: boolean;
+  supressRuntimes: boolean;
   globals: LuaGlobals;
   tasks: LuaTasks;
   stateLog: LogEntry[];


### PR DESCRIPTION
## About The Pull Request

A couple of fixes/updates watermelon asked for. Of particular note is the ability to suppress logging runtimes that the state was involved in causing.

## Why It's Good For The Game

There were a few formatting issues caused by converting the UI to React Typescript. As for suppressing runtime logging, sometimes the runtimes being logged aren't important to the lua code being run, so it would make sense to toggle whether such runtimes should be saved to a state's log.

## Changelog

:cl:
admin: The layout of the lua editor has been tweaked slightly.
admin: In the lua editor, you can now toggle whether to log runtimes the viewed state is involved in.
/:cl:
