### PR TITLE
Fixed rice hat toggling, now toggle uses alt click

### DIFF
--- a/code/modules/clothing/head/hat.dm
+++ b/code/modules/clothing/head/hat.dm
@@ -210,19 +210,14 @@
 	name = "rice hat"
 	desc = "Welcome to the rice fields, motherfucker."
 	icon_state = "rice_hat"
+	base_icon_state = "rice_hat"
 	var/reversed = FALSE
-	///Sprite while worn normaly.
-	var/frontsprite = "rice_hat"
-	///Sprite while worn in reverse
-	var/reversesprite = "rice_hat_kim"
 
-/obj/item/clothing/head/costume/rice_hat/attack_self(mob/user)
-	if(reversed)
-		icon_state = frontsprite
-		to_chat(user, span_notice("You raise the hat."))
-	else
-		icon_state = reversesprite
-		to_chat(user, span_notice("You lower the hat."))
+/obj/item/clothing/head/costume/rice_hat/click_alt(mob/user)
+	reversed = !reversed
+	worn_icon_state = "[base_icon_state][reversed ? "_kim" : ""]"
+	to_chat(user, span_notice("You [reversed ? "lower" : "raise"] the hat."))
+	update_appearance()
 
 /obj/item/clothing/head/costume/lizard
 	name = "lizardskin cloche hat"


### PR DESCRIPTION
## About The Pull Request
Closes #85434
Closes #85435
Closes #85432

## Changelog
:cl:
fix: Rice hat no longer disappears upon being toggled and can be raised back up. Toggling sprites is now done by alt-clicking
/:cl:
