### PR TITLE
Gives sec jackboots shoelaces you can untie and/or knot

### DIFF
--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -48,7 +48,7 @@
 	equip_delay_other = 50
 	resistance_flags = NONE
 	armor_type = /datum/armor/shoes_jackboots
-	can_be_tied = FALSE
+	lace_time = 10 SECONDS
 
 /datum/armor/shoes_jackboots
 	bio = 90


### PR DESCRIPTION

## About The Pull Request

I really, really want to be able to untie unassuming secoffs' shoes and after consulting the discord, I believe others do too.
## Why It's Good For The Game

Funny
## Changelog
:cl:
add: Security jackboots now have shoelaces which may be untied and/or knotted.
/:cl:
