### PR TITLE
Stuffing people into contractor pods now unbuckles them first

### DIFF
--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -421,17 +421,21 @@
 	insert(turf_underneath, holder)
 
 /obj/structure/closet/supplypod/insert(atom/to_insert, atom/movable/holder)
-	if(insertion_allowed(to_insert))
-		if(isturf(to_insert))
-			var/turf/turf_to_insert = to_insert
-			turfs_in_cargo += turf_to_insert.type
-			turf_to_insert.ScrapeAway()
-		else
-			var/atom/movable/movable_to_insert = to_insert
-			movable_to_insert.forceMove(holder)
-		return TRUE
-	else
+	if(!insertion_allowed(to_insert))
 		return FALSE
+
+	if(isturf(to_insert))
+		var/turf/turf_to_insert = to_insert
+		turfs_in_cargo += turf_to_insert.type
+		turf_to_insert.ScrapeAway()
+		return TRUE
+
+	var/atom/movable/movable_to_insert = to_insert
+	if (ismob(movable_to_insert))
+		var/mob/mob_to_insert = movable_to_insert
+		if (!isnull(mob_to_insert.buckled))
+			mob_to_insert.buckled.unbuckle_mob(mob_to_insert, force = TRUE)
+	movable_to_insert.forceMove(holder)
 
 /obj/structure/closet/supplypod/insertion_allowed(atom/to_insert)
 	if(to_insert.invisibility == INVISIBILITY_ABSTRACT)


### PR DESCRIPTION

## About The Pull Request
Closes #85451

## Changelog
:cl:
fix: Putting people you're fireman carrying into contractor pods no longer sends both of you to zelda's shadow realm
/:cl:
