### PR TITLE
Fix advanced disease runtiming with invalid severity

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -146,6 +146,8 @@
 				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_HARMFUL)
 			if(DISEASE_SEVERITY_BIOHAZARD)
 				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_BIOHAZARD)
+			else
+				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_NONTHREAT)
 		peaked_cycles += stage/max_stages //every cycle we spend sick counts towards eventually curing the virus, faster at higher stages
 		recovery_prob += DISEASE_RECOVERY_CONSTANT + (peaked_cycles / (cycles_to_beat / DISEASE_RECOVERY_SCALING)) //more severe viruses are beaten back more aggressively after the peak
 		if(stage_peaked)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -265,7 +265,7 @@
 		properties["severity"] += round((properties["transmittable"] / 8), 1)
 		properties["severity"] = round((properties["severity"] / 2), 1)
 		properties["severity"] *= (symptoms.len / VIRUS_SYMPTOM_LIMIT) //fewer symptoms, less severity
-		properties["severity"] = clamp(properties["severity"], 1, 7)
+		properties["severity"] = round(clamp(properties["severity"], 1, 7), 1)
 	properties["capacity"] = get_symptom_weights()
 
 // Assign the properties that are in the list.


### PR DESCRIPTION
## About The Pull Request

Fixes runtime in  /mob/living/carbon/human/Life() proc when a mob has a disease that failed to have a severity string assigned.

## Why It's Good For The Game

Runtime in life proc bad

## Changelog

:cl: LT3
fix: Fixed players being incorrectly immune to certain virus severities
/:cl: