### PR TITLE
Slimes no longer can feed when they're inside of objects or attacking a target that became invalid after they chose their dinner

### DIFF
--- a/code/modules/mob/living/basic/slime/ai/behaviours.dm
+++ b/code/modules/mob/living/basic/slime/ai/behaviours.dm
@@ -57,6 +57,10 @@
 /datum/ai_behavior/hunt_target/unarmed_attack_target/slime
 
 /datum/ai_behavior/hunt_target/unarmed_attack_target/slime/target_caught(mob/living/basic/slime/hunter, mob/living/hunted)
+	if (!hunter.can_feed_on(hunted)) // Target is no longer edible
+		hunter.UnarmedAttack(hunted, TRUE)
+		return
+
 	if((hunted.body_position != STANDING_UP) || prob(20)) //Not standing, or we rolled well? Feed.
 		hunter.start_feeding(hunted)
 		return

--- a/code/modules/mob/living/basic/slime/feeding.dm
+++ b/code/modules/mob/living/basic/slime/feeding.dm
@@ -20,7 +20,7 @@
 	if(check_friendship && (REF(meal) in faction))
 		return FALSE
 
-	if(check_adjacent && !Adjacent(meal))
+	if(check_adjacent && (!Adjacent(meal) || !isturf(loc)))
 		return FALSE
 
 	if(meal.stat == DEAD)


### PR DESCRIPTION

## About The Pull Request

Closes #85466

## Changelog
:cl:
fix: Slimes no longer can feed when they're inside of objects or attacking a target that became invalid after they chose their dinner
/:cl:
