### PR TITLE
Jarvis, add buckshot to the blackmarket.

### DIFF
--- a/code/game/objects/items/storage/boxes/security_boxes.dm
+++ b/code/game/objects/items/storage/boxes/security_boxes.dm
@@ -174,6 +174,12 @@
 	for(var/i in 1 to 7)
 		new /obj/item/ammo_casing/shotgun/buckshot(src)
 
+/obj/item/storage/box/lethalshot/old
+
+/obj/item/storage/box/lethalshot/old/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/ammo_casing/shotgun/buckshot/old(src)
+
 /obj/item/storage/box/slugs
 	name = "box of shotgun shells (Lethal - Slugs)"
 	desc = "A box full of lethal shotgun slugs, designed for shotguns."

--- a/code/modules/cargo/markets/market_items/weapons.dm
+++ b/code/modules/cargo/markets/market_items/weapons.dm
@@ -31,8 +31,8 @@
 	stock_max = 3
 	availability_prob = 35
 	item = /obj/item/storage/box/lethalshot/old
-	price_min = CARGO_CRATE_VALUE * 3.375
-	price_max = CARGO_CRATE_VALUE * 5.25
+	price_min = CARGO_CRATE_VALUE * 3
+	price_max = CARGO_CRATE_VALUE * 4.5
 
 /datum/market_item/weapon/bone_spear
 	name = "Bone Spear"

--- a/code/modules/cargo/markets/market_items/weapons.dm
+++ b/code/modules/cargo/markets/market_items/weapons.dm
@@ -26,13 +26,13 @@
 
 /datum/market_item/weapon/buckshot
 	name = "Box of Buckshot Shells"
-	desc = "It wasn't easy since buckshot has been made illegal all over the sector of space, but \
+	desc = "It wasn't easy since buckshot has been made illegal all over this sector of space, but \
 	we managed to find a large cache of it... somewhere. A word of caution, the stuff may be a tad old."
 	stock_max = 3
 	availability_prob = 35
 	item = /obj/item/storage/box/lethalshot/old
 	price_min = CARGO_CRATE_VALUE * 3.375
-	price_max = CARGO_CRATE_VALUE * 5.5
+	price_max = CARGO_CRATE_VALUE * 5.25
 
 /datum/market_item/weapon/bone_spear
 	name = "Bone Spear"

--- a/code/modules/cargo/markets/market_items/weapons.dm
+++ b/code/modules/cargo/markets/market_items/weapons.dm
@@ -24,6 +24,16 @@
 	stock_max = 4
 	availability_prob = 40
 
+/datum/market_item/weapon/buckshot
+	name = "Box of Buckshot Shells"
+	desc = "It wasn't easy since buckshot has been made illegal all over the sector of space, but \
+	we managed to find a large cache of it... somewhere. A word of caution, the stuff may be a tad old."
+	stock_max = 3
+	availability_prob = 35
+	item = /obj/item/storage/box/lethalshot/old
+	price_min = CARGO_CRATE_VALUE * 3.375
+	price_max = CARGO_CRATE_VALUE * 5.5
+
 /datum/market_item/weapon/bone_spear
 	name = "Bone Spear"
 	desc = "Authentic tribal spear, made from real bones! A steal at any price, especially if you're a caveman."

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -36,6 +36,8 @@
 	var/can_misfire = null
 	///This is how much misfire probability is added to the gun when it fires this casing.
 	var/misfire_increment = 0
+	///If set, this casing will damage any gun it's fired from by the specified amount
+	var/integrity_damage = 0
 
 /obj/item/ammo_casing/spent
 	name = "spent bullet casing"

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -32,6 +32,10 @@
 	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect
 	///pacifism check for boolet, set to FALSE if bullet is non-lethal
 	var/harmful = TRUE
+	///If set to true or false, this ammunition can or cannot misfire, regardless the gun can_misfire setting
+	var/can_misfire = null
+	///This is how much misfire probability is added to the gun when it fires this casing.
+	var/misfire_increment = 0
 
 /obj/item/ammo_casing/spent
 	name = "spent bullet casing"

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -54,7 +54,7 @@
 	if(isgun(fired_from))
 		var/obj/item/gun/gun = fired_from
 
-		var/integrity_mult = 1 - (gun.atom_integrity/gun.max_integrity) * 0.5
+		var/integrity_mult = 0.5 + gun.get_integrity_percentage() * 0.5
 		if(integrity_mult >= 0.95) //Guns that are only mildly smudged don't debuff projectiles.
 			integrity_mult = 1
 

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -52,12 +52,19 @@
 	loaded_projectile.suppressed = quiet
 
 	if(isgun(fired_from))
-		var/obj/item/gun/G = fired_from
-		loaded_projectile.damage *= G.projectile_damage_multiplier
-		loaded_projectile.stamina *= G.projectile_damage_multiplier
+		var/obj/item/gun/gun = fired_from
 
-		loaded_projectile.wound_bonus += G.projectile_wound_bonus
-		loaded_projectile.bare_wound_bonus += G.projectile_wound_bonus
+		var/integrity_mult = 1 - (gun.atom_integrity/gun.max_integrity) * 0.5
+		if(integrity_mult >= 0.95) //Guns that are only mildly smudged don't debuff projectiles.
+			integrity_mult = 1
+
+		loaded_projectile.damage *= gun.projectile_damage_multiplier * integrity_mult
+		loaded_projectile.stamina *= gun.projectile_damage_multiplier * integrity_mult
+
+		loaded_projectile.wound_bonus += gun.projectile_wound_bonus
+		loaded_projectile.wound_bonus *= loaded_projectile.wound_bonus >= 0 ? 1 : 2 - integrity_mult
+		loaded_projectile.bare_wound_bonus += gun.projectile_wound_bonus
+		loaded_projectile.bare_wound_bonus *= loaded_projectile.bare_wound_bonus >= 0 ? 1 : 2 - integrity_mult
 
 	if(tk_firing(user, fired_from))
 		loaded_projectile.ignore_source_check = TRUE

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -85,7 +85,8 @@
 /obj/item/ammo_casing/shotgun/buckshot/old
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot/old
 	can_misfire = TRUE
-	misfire_increment = 7
+	misfire_increment = 2
+	integrity_damage = 4
 
 /obj/item/ammo_casing/shotgun/buckshot/old/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
 	. = ..()

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -82,6 +82,19 @@
 	pellets = 6
 	variance = 25
 
+/obj/item/ammo_casing/shotgun/buckshot/old
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot/old
+	can_misfire = TRUE
+	misfire_increment = 7
+
+/obj/item/ammo_casing/shotgun/buckshot/old/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
+	. = ..()
+	if(!fired_from)
+		return
+
+	var/datum/effect_system/fluid_spread/smoke/smoke = new
+	smoke.set_up(0, holder = fired_from, location = fired_from)
+
 /obj/item/ammo_casing/shotgun/buckshot/spent
 	projectile_type = null
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -228,7 +228,7 @@
 		return ..()
 	var/mob/living/holder = loc
 	if(holder.is_holding(src) && holder.owner.stat < UNCONSCIOUS)
-		to_chat(holder, span_boldwarning("[src] breaks down!")
+		to_chat(holder, span_boldwarning("[src] breaks down!"))
 		holder.playsound_local(get_turf(src), 'sound/weapons/smash.ogg', 50, TRUE)
 	return ..()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -220,14 +220,13 @@
 		)
 
 	if(chambered.integrity_damage)
-		var/gun_name = name
-		fired_from.take_damage(integrity_damage, sound_effect = FALSE)
+		take_damage(chambered.integrity_damage, sound_effect = FALSE)
 
 /obj/item/gun/atom_destruction(damage_flag)
 	if(!isliving(loc))
 		return ..()
 	var/mob/living/holder = loc
-	if(holder.is_holding(src) && holder.owner.stat < UNCONSCIOUS)
+	if(holder.is_holding(src) && holder.stat < UNCONSCIOUS)
 		to_chat(holder, span_boldwarning("[src] breaks down!"))
 		holder.playsound_local(get_turf(src), 'sound/weapons/smash.ogg', 50, TRUE)
 	return ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -153,6 +153,15 @@
 		else
 			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 
+	var/healthpercent = (atom_integrity/max_integrity) * 100
+	switch(healthpercent)
+		if(60 to 95)
+			. += span_info("It looks slightly damaged.")
+		if(25 to 60)
+			. += span_warning("It appears heavily damaged.")
+		if(0 to 25)
+			. += span_boldwarning("It's falling apart!")
+
 //called after the gun has successfully fired its chambered ammo.
 /obj/item/gun/proc/process_chamber(empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE)
 	handle_chamber(empty_chamber, from_firing, chamber_next_round)
@@ -179,36 +188,49 @@
 	else
 		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound)
 
-/obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
+/obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
 	if(recoil && !tk_firing(user))
 		shake_camera(user, recoil + 1, recoil)
 	fire_sounds()
-	if(!suppressed)
-		if(message)
-			if(tk_firing(user))
-				visible_message(
-						span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
-						blind_message = span_hear("You hear a gunshot!"),
-						vision_distance = COMBAT_MESSAGE_RANGE
-				)
-			else if(pointblank)
-				user.visible_message(
-						span_danger("[user] fires [src] point blank at [pbtarget]!"),
-						span_danger("You fire [src] point blank at [pbtarget]!"),
-						span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
-				)
-				to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
-				if(pb_knockback > 0 && ismob(pbtarget))
-					var/mob/PBT = pbtarget
-					var/atom/throw_target = get_edge_target_turf(PBT, user.dir)
-					PBT.throw_at(throw_target, pb_knockback, 2)
-			else if(!tk_firing(user))
-				user.visible_message(
-						span_danger("[user] fires [src]!"),
-						blind_message = span_hear("You hear a gunshot!"),
-						vision_distance = COMBAT_MESSAGE_RANGE,
-						ignored_mobs = user
-				)
+	if(suppressed || !message)
+		return
+	if(tk_firing(user))
+		visible_message(
+				span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
+				blind_message = span_hear("You hear a gunshot!"),
+				vision_distance = COMBAT_MESSAGE_RANGE
+		)
+	else if(pointblank)
+		user.visible_message(
+				span_danger("[user] fires [src] point blank at [pbtarget]!"),
+				span_danger("You fire [src] point blank at [pbtarget]!"),
+				span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
+		)
+		to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
+		if(pb_knockback > 0 && ismob(pbtarget))
+			var/mob/PBT = pbtarget
+			var/atom/throw_target = get_edge_target_turf(PBT, user.dir)
+			PBT.throw_at(throw_target, pb_knockback, 2)
+	else if(!tk_firing(user))
+		user.visible_message(
+				span_danger("[user] fires [src]!"),
+				blind_message = span_hear("You hear a gunshot!"),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+		)
+
+	if(chambered.integrity_damage)
+		var/gun_name = name
+		fired_from.take_damage(integrity_damage, sound_effect = FALSE)
+
+/obj/item/gun/atom_destruction(damage_flag)
+	if(!isliving(loc))
+		return ..()
+	var/mob/living/holder = loc
+	if(holder.is_holding(src) && holder.owner.stat < UNCONSCIOUS)
+		to_chat(holder, span_boldwarning("[src] breaks down!")
+		holder.playsound_local(get_turf(src), 'sound/weapons/smash.ogg', 50, TRUE)
+	return ..()
 
 /obj/item/gun/emp_act(severity)
 	. = ..()
@@ -403,9 +425,9 @@
 			return FALSE
 		else
 			if(get_dist(user, target) <= 1) //Making sure whether the target is in vicinity for the pointblank shot
-				shoot_live_shot(user, 1, target, message)
+				shoot_live_shot(user, TRUE, target, message)
 			else
-				shoot_live_shot(user, 0, target, message)
+				shoot_live_shot(user, FALSE, target, message)
 			if (iteration >= burst_size)
 				firing_burst = FALSE
 	else
@@ -459,9 +481,9 @@
 				return
 			else
 				if(get_dist(user, target) <= 1) //Making sure whether the target is in vicinity for the pointblank shot
-					shoot_live_shot(user, 1, target, message)
+					shoot_live_shot(user, TRUE, target, message)
 				else
-					shoot_live_shot(user, 0, target, message)
+					shoot_live_shot(user, FALSE, target, message)
 		else
 			shoot_with_empty_chamber(user)
 			return

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -449,7 +449,7 @@
 		if (sawoff(user, A))
 			return
 
-	if(can_misfire && istype(A, /obj/item/stack/sheet/cloth))
+	if(misfire_probability && istype(A, /obj/item/stack/sheet/cloth))
 		if(guncleaning(user, A))
 			return
 
@@ -461,7 +461,8 @@
 	return TRUE
 
 /obj/item/gun/ballistic/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	if(target != user && chambered.loaded_projectile && can_misfire && prob(misfire_probability) && blow_up(user))
+	var/could_it_misfire = (can_misfire && chambered.can_misfire != FALSE) || chambered.can_misfire
+	if(target != user && chambered.loaded_projectile && could_it_misfire && prob(misfire_probability) && blow_up(user))
 		to_chat(user, span_userdanger("[src] misfires!"))
 		return
 
@@ -471,8 +472,11 @@
 	return ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
-	if(can_misfire)
+	if(can_misfire && chambered.can_misfire != FALSE)
 		misfire_probability += misfire_percentage_increment
+		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
+	if(chambered.can_misfire)
+		misfire_probability += chambered.misfire_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
 	return ..()
 
@@ -577,6 +581,9 @@
 		. += span_danger("You get the feeling this might explode if you fire it...")
 		if(misfire_probability > 0)
 			. += span_danger("Given the state of the gun, there is a [misfire_probability]% chance it'll misfire.")
+	else if(misfire_probability > 0)
+		. += span_warning("You get a feeling, however safe, may explode if loaded with the wrong munitions...")
+		. += span_warning("Given the state of the gun, there is a [EXAMINE_HINT("[misfire_probability]%")] chance it'll misfire.")
 
 ///Gets the number of bullets in the gun
 /obj/item/gun/ballistic/proc/get_ammo(countchambered = TRUE)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -582,7 +582,7 @@
 		if(misfire_probability > 0)
 			. += span_danger("Given the state of the gun, there is a [misfire_probability]% chance it'll misfire.")
 	else if(misfire_probability > 0)
-		. += span_warning("You get a feeling, however safe, may explode if loaded with the wrong munitions...")
+		. += span_warning("You get a feeling this might explode if you fire it with the wrong ammunitions...")
 		. += span_warning("Given the state of the gun, there is a [EXAMINE_HINT("[misfire_probability]%")] chance it'll misfire.")
 
 ///Gets the number of bullets in the gun

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -24,6 +24,7 @@
 	cartridge_wording = "shell"
 	tac_reloads = FALSE
 	weapon_weight = WEAPON_HEAVY
+	misfire_probability_cap = 35 // Even if the misfire probability and increment are both zero, we've some shots that may do that.
 
 	pb_knockback = 2
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -79,7 +79,10 @@
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
-//A slightly weaker version of the buckshot, available from the blackmarket. The casings they're in have a small chance to misfire.
+/**
+ * A slightly weaker version of the buckshot, available from the blackmarket.
+ * The casings they're in have a very small chance to misfire and will gradually damage the firearm, making it weaker.
+ */
 /obj/projectile/bullet/pellet/shotgun_buckshot/old
 	damage_falloff_tile = -0.47
 	wound_bonus = -100

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -79,9 +79,10 @@
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
+//A slightly weaker version of the buckshot, available from the blackmarket. The casings they're in have a small chance to misfire.
 /obj/projectile/bullet/pellet/shotgun_buckshot/old
 	damage_falloff_tile = -0.47
-	wound_bonus = -100 ///wounds weren't a thing back in the day.
+	wound_bonus = -100
 	bare_wound_bonus = -100
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -80,9 +80,9 @@
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/old
-	damage_falloff_tile = -0.5
-	wound_bonus = 0 ///wounds weren't a thing back in the day.
-	bare_wound_bonus = 0
+	damage_falloff_tile = -0.47
+	wound_bonus = -100 ///wounds weren't a thing back in the day.
+	bare_wound_bonus = -100
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubber shot pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -79,6 +79,11 @@
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
+/obj/projectile/bullet/pellet/shotgun_buckshot/old
+	damage_falloff_tile = -0.5
+	wound_bonus = 0 ///wounds weren't a thing back in the day.
+	bare_wound_bonus = 0
+
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubber shot pellet"
 	damage = 3


### PR DESCRIPTION
## About The Pull Request
![immagine](https://github.com/user-attachments/assets/82a41ea7-9951-43d5-a553-7c9884058bf2)

~discord light-theme big L.~

By the by, these are slightly nerfed buckshots, create big puffs of powder smoke when fired, damage your gun, and MIGHT blow you up in the same style of using a detective revolver loaded with .357 if you fire too many.

Also, the integrity of the firearm now counts towards the damage of bullets it's fired from.

## Why It's Good For The Game
The blackmarket is a place where you can find illegally illegal, evil items, along with other trinkets. I thought it'd be a nice place to reintroduce buckshot with a little downgrading twist after it has been nerfed (it used to do 60 damage without falloff) AFTER it was removed from the lathes and the station.

## Changelog

:cl:
add: Buckshot is back on the menu, on the blackmarket.
balance: the integrity of firearms now counts toward projectile damage. A gun that's on the very verge of breaking down will deal half as much damage.
/:cl:
