### PR TITLE
Fix TGUI notepad with various small fixes

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -309,6 +309,7 @@ class NotePadTextArea extends Component<NotePadTextAreaProps> {
         nowrap={!wordWrap}
         value={text}
         scrollbar
+        autoFocus
       />
     );
   }

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -308,6 +308,7 @@ class NotePadTextArea extends Component<NotePadTextAreaProps> {
         className="NtosNotepad__textarea"
         nowrap={!wordWrap}
         value={text}
+        scrollbar
       />
     );
   }

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -10,6 +10,7 @@ import { useBackend } from '../backend';
 import { Box, Divider, MenuBar, Section, TextArea } from '../components';
 import { Dialog, UnsavedChangesDialog } from '../components/Dialog';
 import { NtosWindow } from '../layouts';
+import { NTOSData } from '../layouts/NtosWindow';
 import { createLogger } from '../logging';
 
 const logger = createLogger('NtosNotepad');
@@ -317,11 +318,12 @@ class NotePadTextArea extends Component<NotePadTextAreaProps> {
 
 type AboutDialogProps = {
   close: () => void;
-  clientName: string;
 };
 
 const AboutDialog = (props: AboutDialogProps) => {
-  const { close, clientName } = props;
+  const { close } = props;
+  const { act, data } = useBackend<NTOSData>();
+  const { login } = data;
   const paragraphStyle = { padding: '.5rem 1rem 0 2rem' };
   return (
     <Dialog title="About Notepad" onClose={close} width={'500px'}>
@@ -349,7 +351,7 @@ const AboutDialog = (props: AboutDialogProps) => {
           >
             This product is licensed under the NT Corporation Terms to:
           </span>
-          <span style={{ padding: '0 1rem 0 4rem' }}>{clientName}</span>
+          <span style={{ padding: '0 1rem 0 4rem' }}>{login.IDName}</span>
         </Box>
       </div>
       <div className="Dialog__footer">
@@ -365,7 +367,7 @@ type NoteData = {
 type RetryActionType = (retrying?: boolean) => void;
 
 export const NtosNotepad = (props) => {
-  const { act, data, config } = useBackend<NoteData>();
+  const { act, data } = useBackend<NoteData>();
   const { note } = data;
   const [documentName, setDocumentName] = useState(DEFAULT_DOCUMENT_NAME);
   const [originalText, setOriginalText] = useState(note);
@@ -479,7 +481,7 @@ export const NtosNotepad = (props) => {
         />
       )}
       {activeDialog === Dialogs.ABOUT && (
-        <AboutDialog close={handleCloseDialog} clientName={config.user.name} />
+        <AboutDialog close={handleCloseDialog} />
       )}
     </NtosWindow>
   );

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -304,7 +304,7 @@ class NotePadTextArea extends Component<NotePadTextAreaProps> {
     return (
       <TextArea
         ref={this.innerRef}
-        onChange={(_, value) => setText(value)}
+        onInput={(_, value) => setText(value)}
         className="NtosNotepad__textarea"
         nowrap={!wordWrap}
         value={text}

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -325,7 +325,7 @@ type AboutDialogProps = {
 const AboutDialog = (props: AboutDialogProps) => {
   const { close } = props;
   const { act, data } = useBackend<NTOSData>();
-  const { login } = data;
+  const { show_imprint, login } = data;
   const paragraphStyle = { padding: '.5rem 1rem 0 2rem' };
   return (
     <Dialog title="About Notepad" onClose={close} width={'500px'}>
@@ -353,7 +353,9 @@ const AboutDialog = (props: AboutDialogProps) => {
           >
             This product is licensed under the NT Corporation Terms to:
           </span>
-          <span style={{ padding: '0 1rem 0 4rem' }}>{login.IDName}</span>
+          <span style={{ padding: '0 1rem 0 4rem' }}>
+            {show_imprint ? login.IDName : 'Unknown'}
+          </span>
         </Box>
       </div>
       <div className="Dialog__footer">

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -239,7 +239,7 @@ interface NotePadTextAreaProps {
   maintainFocus: boolean;
   text: string;
   wordWrap: boolean;
-  setText: (string) => void;
+  setText: (text: string) => void;
   setStatuses: (statuses: Statuses) => void;
 }
 

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -263,10 +263,7 @@ class NotePadTextArea extends Component<NotePadTextAreaProps> {
 
     if (this.props.maintainFocus) {
       this.innerRef.current.focus();
-      return false;
     }
-
-    return true;
   }
 
   // eslint-disable-next-line react/no-deprecated

--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -195,6 +195,9 @@ const StatusBar = (props: StatusBarProps) => {
   const { statuses } = props;
   return (
     <Box className="NtosNotepad__StatusBar">
+      <Box className="NtosNotepad__StatusBar__entry" minWidth="25rem">
+        Press shift-enter to insert new line
+      </Box>
       <Box className="NtosNotepad__StatusBar__entry" minWidth="15rem">
         Ln {statuses.line}, Col {statuses.column}
       </Box>

--- a/tgui/packages/tgui/styles/interfaces/NtosNotepad.scss
+++ b/tgui/packages/tgui/styles/interfaces/NtosNotepad.scss
@@ -28,7 +28,6 @@ $background-color: base.$color-bg !default;
 .NtosNotepad__textarea {
   background-color: base.$color-bg-section;
   height: 100%;
-  overflow-y: scroll;
 }
 
 .NtosNotepad__StatusBar {


### PR DESCRIPTION

## About The Pull Request

Back from my hiatus and playing ss13 again!  A few fixes for this component I wrote back in 2022. Hopefully the commit messages are self-explanatory.

There's one fix to TextArea that needs extra scrutiny. I removed the `blur()` call as it prevents newline input (unless holding shift).
@jlsnow301 Could you check this one-liner change?

## Why It's Good For The Game

Fixes incorrect prop usage, uses new props on TextArea, uses `login.IDName` instead of `clientName` and so on.
The most important fix would be restoring state change on text input as that's quite important for other bits to work.

## Changelog
:cl:
fix: Various fixes to TGUI notepad
/:cl:
