### PR TITLE
Ensures that capture zones are actually indestructible

### DIFF
--- a/_maps/safehouses/bathroom.dmm
+++ b/_maps/safehouses/bathroom.dmm
@@ -27,7 +27,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/blacklight/directional/east,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "v" = (
 /obj/machinery/light/small/blacklight/directional/east,
@@ -68,7 +68,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "M" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/safehouses/den.dmm
+++ b/_maps/safehouses/den.dmm
@@ -18,7 +18,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "e" = (
 /obj/structure/table/reinforced/plastitaniumglass,
@@ -59,7 +59,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "z" = (
 /obj/effect/turf_decal/trimline/yellow/corner{

--- a/_maps/safehouses/dig.dmm
+++ b/_maps/safehouses/dig.dmm
@@ -20,7 +20,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/bitrunning/cache_goal_turf,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "i" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -98,7 +98,7 @@
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/box/corners,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "T" = (
 /obj/effect/landmark/bitrunning/hololadder_spawn,

--- a/_maps/safehouses/ice.dmm
+++ b/_maps/safehouses/ice.dmm
@@ -60,7 +60,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "p" = (
 /obj/structure/railing,
@@ -69,7 +69,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "u" = (
 /obj/effect/decal/cleanable/dirt/dust,

--- a/_maps/safehouses/lavaland_boss.dmm
+++ b/_maps/safehouses/lavaland_boss.dmm
@@ -63,7 +63,7 @@
 /obj/machinery/light/directional/east,
 /obj/structure/railing,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "A" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{

--- a/_maps/safehouses/mine.dmm
+++ b/_maps/safehouses/mine.dmm
@@ -26,7 +26,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "B" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -52,7 +52,7 @@
 	},
 /obj/structure/railing,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "H" = (
 /obj/machinery/door/airlock/external/glass{

--- a/_maps/safehouses/shuttle.dmm
+++ b/_maps/safehouses/shuttle.dmm
@@ -16,7 +16,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "i" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41,7 +41,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "m" = (
 /obj/modular_map_connector,

--- a/_maps/safehouses/shuttle_space.dmm
+++ b/_maps/safehouses/shuttle_space.dmm
@@ -67,7 +67,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "z" = (
 /obj/effect/turf_decal/stripes/line{
@@ -98,7 +98,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "E" = (
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/safehouses/wood.dmm
+++ b/_maps/safehouses/wood.dmm
@@ -19,7 +19,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "v" = (
 /obj/machinery/light/small/directional/east,
@@ -50,7 +50,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/safehouse)
 "T" = (
 /obj/effect/landmark/bitrunning/hololadder_spawn,

--- a/_maps/virtual_domains/island_brawl.dmm
+++ b/_maps/virtual_domains/island_brawl.dmm
@@ -2540,7 +2540,7 @@
 /area/virtual_domain)
 "GD" = (
 /obj/effect/landmark/bitrunning/permanent_exit,
-/turf/open/floor/bitrunning_transport,
+/turf/open/indestructible/bitrunning_transport,
 /area/virtual_domain/protected_space/fullbright)
 "GI" = (
 /turf/open/floor/iron/dark/textured_large,

--- a/code/datums/components/reskinnable.dm
+++ b/code/datums/components/reskinnable.dm
@@ -1,0 +1,4 @@
+/// Allows an item to be retextured when alt-clicked
+/datum/component/reskinnable
+	/// List of reskin options we provide, name -> icon_state
+	var/list/reskin_options

--- a/code/datums/components/reskinnable.dm
+++ b/code/datums/components/reskinnable.dm
@@ -1,4 +1,0 @@
-/// Allows an item to be retextured when alt-clicked
-/datum/component/reskinnable
-	/// List of reskin options we provide, name -> icon_state
-	var/list/reskin_options

--- a/code/modules/bitrunning/turfs.dm
+++ b/code/modules/bitrunning/turfs.dm
@@ -1,4 +1,4 @@
-/turf/open/floor/bitrunning_transport
+/turf/open/indestructible/bitrunning_transport
 	name = "circuit floor"
 	desc = "Looks complex. You can see the circuits running through the floor."
 	icon_state = "bitrunning"


### PR DESCRIPTION

## About The Pull Request

Closes #85469
These should probably never be destroyed, not sure if comsigs are passed down to the new turf but players get confused either way if the turf is broken.

## Changelog
:cl:
fix: Bitrunning crate capture zones can no longer be destroyed
/:cl:
