### PR TITLE
Add a janitorial 'borg plunger

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -208,6 +208,16 @@
 
 	items_to_add = list(/obj/item/cautery/prt)
 
+/obj/item/borg/upgrade/plunger
+	name = "janitor cyborg plating repair tool"
+	desc = "An integrated cyborg retractable plunger. It's meant for plunging things, duh."
+	icon_state = "module_janitor"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/janitor)
+	model_flags = BORG_MODEL_JANITOR
+
+	items_to_add = list(/obj/item/plunger/cyborg)
+
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -209,7 +209,7 @@
 	items_to_add = list(/obj/item/cautery/prt)
 
 /obj/item/borg/upgrade/plunger
-	name = "janitor cyborg plating repair tool"
+	name = "janitor cyborg plunging tool"
 	desc = "An integrated cyborg retractable plunger. It's meant for plunging things, duh."
 	icon_state = "module_janitor"
 	require_model = TRUE

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -185,3 +185,7 @@
 	layer_mode_sprite = "reinforced_plunger_layer"
 
 	custom_premium_price = PAYCHECK_CREW * 8
+
+/obj/item/plunger/cyborg/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1578,6 +1578,20 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
 	)
 
+/datum/design/borg_upgrade_plunger
+	name = "Integrated Plunger"
+	id = "borg_upgrade_plunger"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/plunger
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT*1.125,
+		/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*0.75,
+	)
+	construction_time = 4 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
+	)
+
 /datum/design/borg_upgrade_rolling_table
 	name = "Rolling Table Dock"
 	id = "borg_upgrade_rolling_table"

--- a/code/modules/research/techweb/nodes/cyborg_nodes.dm
+++ b/code/modules/research/techweb/nodes/cyborg_nodes.dm
@@ -98,6 +98,7 @@
 		"borg_upgrade_broomer",
 		"borg_upgrade_expand",
 		"borg_upgrade_prt",
+		"borg_upgrade_plunger",
 		"borg_upgrade_selfrepair",
 		"borg_upgrade_thrusters",
 		"borg_upgrade_trashofholding",


### PR DESCRIPTION

## About The Pull Request
I got annoyed at not being able to plung vents when there's a clog. This PR corrects that. I copied all of the cyborg mop attributes to make this. This is my first PR on this server, but I did test it on a local server, and it indeed, plungs. 

## Why It's Good For The Game
More content for janitorial cyborg. They really should have a plunger, to be honest. It just makes sense to me. 

## Changelog
:cl:
add: Added a cyborg plunger for janitorial modules
/:cl:
