### PR TITLE
Fix inventory item interactions sometimes being blocked due to not counting as adjacent when not on a turf

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -68,6 +68,8 @@
 /atom/movable/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
 	if(neighbor == loc)
 		return TRUE
+	if(neighbor?.loc == src)
+		return TRUE
 	var/turf/T = loc
 	if(!istype(T))
 		return FALSE
@@ -78,6 +80,8 @@
 // This is necessary for storage items not on your person.
 /obj/item/Adjacent(atom/neighbor, atom/target, atom/movable/mover, recurse = 1)
 	if(neighbor == loc)
+		return TRUE
+	if(neighbor?.loc == src)
 		return TRUE
 	if(isitem(loc))
 		if(recurse > 0)


### PR DESCRIPTION

## About The Pull Request

So it seems that currently `can_perform_action(target, ...)` being called for an inventory item while you're inside of another object, say a closet or a pAI card, blocks with the message "You are too far away!".
Looking into this, it seemed to be due to `CanReach(target)` failing, which seemed to be due to `Adjacent(target)` not actually recognizing these as being adjacent when not on a turf.
This seemed to be because it only really passes when either on a turf or if the object we're checking adjacency with is the loc of the object we're checking adjacency from.

After talking about it in the code channel, we decided to go for adding a simple inverse check to make it symmetric.
Being, we add a second `neighbor?.loc == src` check parallel to our existing `neighbor == loc` check.
This seems to fix the issue.
## Why It's Good For The Game

Kinda weird if being in a closet means somehow your inventory is no longer adjacent to you for interactions, saying you're too far away.
Especially for pAIs, whom are always in this situation when not in holoform (pAI in card, PDA in pAI).
## Changelog
:cl:
fix: Fixes getting a "You are too far away!" interaction block on inventory items when inside of another object. This includes accessing storage or using your PDA from a closet, or as pAI using your digital messenger while inside of your card.
/:cl:
