### PR TITLE
remove narsie and ratvar plushies from loadout

### DIFF
--- a/code/modules/loadout/categories/pocket.dm
+++ b/code/modules/loadout/categories/pocket.dm
@@ -106,10 +106,6 @@
 	name = "Plush (Moth)"
 	item_path = /obj/item/toy/plush/moth
 
-/datum/loadout_item/pocket_items/plush/narsie
-	name = "Plush (Nar'sie)"
-	item_path = /obj/item/toy/plush/narplush
-
 /datum/loadout_item/pocket_items/plush/nukie
 	name = "Plush (Nukie)"
 	item_path = /obj/item/toy/plush/nukeplushie
@@ -121,10 +117,6 @@
 /datum/loadout_item/pocket_items/plush/plasmaman
 	name = "Plush (Plasmaman)"
 	item_path = /obj/item/toy/plush/plasmamanplushie
-
-/datum/loadout_item/pocket_items/plush/ratvar
-	name = "Plush (Ratvar)"
-	item_path = /obj/item/toy/plush/ratplush
 
 /datum/loadout_item/pocket_items/plush/rouny
 	name = "Plush (Rouny)"


### PR DESCRIPTION
## About The Pull Request

Remove narsie and ratvar plushies from loadout

Originally this were added in this [pull request](https://github.com/tgstation/tgstation/issues/83521)

@MrMelbert was this intended or where  you just adding all the plushies and didn't know of their rarity and special feature?Thanks for loadout btw.

Also, should I write a migration script to update preferences? Loadouts are sanitized on load, so there will be no bugs, but If I have to, I will do it.

## Why It's Good For The Game

Those plushies are meant to be rare and only are accessible in hacked chaplain wardrobe, received in mail by chaplain or spawn very infrequently by `/obj/effect/spawner/random/entertainment/plushie_delux` spawner.

But this is not the main problem, the main one is, that everyone can have roundstart small bomb, because ratvar and narsie have special feature - they fight and explosion occurs when one of them wins. This is fun and interesting feature for sure, but not when this happens frequently.

## Changelog

:cl:
del: Remove narsie and ratvar plushies from loadout
/:cl:
