### PR TITLE
Circuits can now be stored between rounds per-user in module duplicator

### DIFF
--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -20,6 +20,8 @@ SUBSYSTEM_DEF(persistence)
 	var/list/blocked_maps = list()
 	var/list/saved_trophies = list()
 	var/list/picture_logging_information = list()
+	///List of all stored circuit designs
+	var/list/circuit_designs = list()
 
 	/// A json_database linking to data/photo_frames.json.
 	/// Schema is persistence_id => array of photo names.
@@ -62,6 +64,7 @@ SUBSYSTEM_DEF(persistence)
 	load_delamination_counter()
 	load_tram_counter()
 	load_adventures()
+	load_circuits()
 	return SS_INIT_SUCCESS
 
 ///Collects all data to persist.
@@ -74,6 +77,7 @@ SUBSYSTEM_DEF(persistence)
 	save_scars()
 	save_custom_outfits()
 	save_delamination_counter()
+	save_circuits()
 	if(SStransport.can_fire)
 		for(var/datum/transport_controller/linear/tram/transport as anything in SStransport.transports_by_type[TRANSPORT_TYPE_TRAM])
 			save_tram_history(transport.specific_transport_id)

--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(persistence)
 	var/list/blocked_maps = list()
 	var/list/saved_trophies = list()
 	var/list/picture_logging_information = list()
-	///List of all stored circuit designs
+	///Associated list of all saved circuits, ckey -> list of designs
 	var/list/circuit_designs = list()
 
 	/// A json_database linking to data/photo_frames.json.
@@ -64,7 +64,6 @@ SUBSYSTEM_DEF(persistence)
 	load_delamination_counter()
 	load_tram_counter()
 	load_adventures()
-	load_circuits()
 	return SS_INIT_SUCCESS
 
 ///Collects all data to persist.

--- a/code/controllers/subsystem/persistence/circuits.dm
+++ b/code/controllers/subsystem/persistence/circuits.dm
@@ -21,7 +21,8 @@
 	for (var/user in circuit_designs)
 		var/json_file = file("[CIRCUITS_DATA_FILEPATH][user].json")
 		var/file_data = list()
-		var/designs_to_store = circuit_designs[user].Copy()
+		var/list/user_designs = circuit_designs[user]
+		var/list/designs_to_store = user_designs.Copy()
 
 		for (var/list/design in designs_to_store)
 			var/list/new_materials = list()

--- a/code/controllers/subsystem/persistence/circuits.dm
+++ b/code/controllers/subsystem/persistence/circuits.dm
@@ -1,32 +1,36 @@
-#define CIRCUITS_DATA_FILEPATH "data/circuit_designs.json"
+#define CIRCUITS_DATA_FILEPATH "data/circuit_designs/"
 
-/datum/controller/subsystem/persistence/proc/load_circuits()
-	var/json_file = file(CIRCUITS_DATA_FILEPATH)
+/datum/controller/subsystem/persistence/proc/load_circuits_by_ckey(user)
+	var/json_file = file("[CIRCUITS_DATA_FILEPATH][user].json")
 	if(!fexists(json_file))
+		circuit_designs[user] = list()
 		return
 	var/list/json = json_decode(file2text(json_file))
 	if(!json)
+		circuit_designs[user] = list()
 		return
-	circuit_designs = json["data"]
-	for (var/list/design in circuit_designs)
+	var/list/new_circuit_designs = json["data"]
+	for (var/list/design in new_circuit_designs)
 		var/list/new_materials = list()
 		for (var/material in design["materials"])
 			new_materials[GET_MATERIAL_REF(text2path(material))] = design["materials"][material]
 		design["materials"] = new_materials
+	circuit_designs[user] = new_circuit_designs
 
 /datum/controller/subsystem/persistence/proc/save_circuits()
-	var/json_file = file(CIRCUITS_DATA_FILEPATH)
-	var/file_data = list()
-	var/designs_to_store = circuit_designs.Copy()
+	for (var/user in circuit_designs)
+		var/json_file = file("[CIRCUITS_DATA_FILEPATH][user].json")
+		var/file_data = list()
+		var/designs_to_store = circuit_designs[user].Copy()
 
-	for (var/list/design in designs_to_store)
-		var/list/new_materials = list()
-		for (var/datum/material/material in design["materials"])
-			new_materials["[material.type]"] = design["materials"][material]
-		design["materials"] = new_materials
+		for (var/list/design in designs_to_store)
+			var/list/new_materials = list()
+			for (var/datum/material/material in design["materials"])
+				new_materials["[material.type]"] = design["materials"][material]
+			design["materials"] = new_materials
 
-	file_data["data"] = designs_to_store
-	fdel(json_file)
-	WRITE_FILE(json_file, json_encode(file_data))
+		file_data["data"] = designs_to_store
+		fdel(json_file)
+		WRITE_FILE(json_file, json_encode(file_data))
 
 #undef CIRCUITS_DATA_FILEPATH

--- a/code/controllers/subsystem/persistence/circuits.dm
+++ b/code/controllers/subsystem/persistence/circuits.dm
@@ -1,0 +1,32 @@
+#define CIRCUITS_DATA_FILEPATH "data/circuit_designs.json"
+
+/datum/controller/subsystem/persistence/proc/load_circuits()
+	var/json_file = file(CIRCUITS_DATA_FILEPATH)
+	if(!fexists(json_file))
+		return
+	var/list/json = json_decode(file2text(json_file))
+	if(!json)
+		return
+	circuit_designs = json["data"]
+	for (var/list/design in circuit_designs)
+		var/list/new_materials = list()
+		for (var/material in design["materials"])
+			new_materials[GET_MATERIAL_REF(text2path(material))] = design["materials"][material]
+		design["materials"] = new_materials
+
+/datum/controller/subsystem/persistence/proc/save_circuits()
+	var/json_file = file(CIRCUITS_DATA_FILEPATH)
+	var/file_data = list()
+	var/designs_to_store = circuit_designs.Copy()
+
+	for (var/list/design in designs_to_store)
+		var/list/new_materials = list()
+		for (var/datum/material/material in design["materials"])
+			new_materials["[material.type]"] = design["materials"][material]
+		design["materials"] = new_materials
+
+	file_data["data"] = designs_to_store
+	fdel(json_file)
+	WRITE_FILE(json_file, json_encode(file_data))
+
+#undef CIRCUITS_DATA_FILEPATH

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -462,6 +462,7 @@
 
 			SSpersistence.circuit_designs -= list(design)
 			scanned_designs -= list(design)
+			update_static_data_for_all_viewers()
 
 		if ("remove_mat")
 			var/datum/material/material = locate(params["ref"])

--- a/code/modules/wiremod/core/duplicator.dm
+++ b/code/modules/wiremod/core/duplicator.dm
@@ -150,6 +150,7 @@ GLOBAL_LIST_INIT(circuit_dupe_whitelisted_types, list(
 		var/list/component_data = list()
 
 		component_data["type"] = component.type
+		component_data["name"] = component.name
 
 		var/list/connections = list()
 		var/list/input_ports_stored_data = list()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -730,6 +730,7 @@
 #include "code\controllers\subsystem\movement\movement_types.dm"
 #include "code\controllers\subsystem\movement\spacedrift.dm"
 #include "code\controllers\subsystem\persistence\_persistence.dm"
+#include "code\controllers\subsystem\persistence\circuits.dm"
 #include "code\controllers\subsystem\persistence\counter_delamination.dm"
 #include "code\controllers\subsystem\persistence\counter_tram_hits.dm"
 #include "code\controllers\subsystem\persistence\custom_outfits.dm"

--- a/tgui/packages/tgui/interfaces/ComponentPrinter.tsx
+++ b/tgui/packages/tgui/interfaces/ComponentPrinter.tsx
@@ -77,7 +77,9 @@ const Recipe = (props: RecipeProps) => {
 
   const canPrint = !Object.entries(design.cost).some(
     ([material, amount]) =>
-      !available[material] || amount > (available[material] ?? 0),
+      !available[material] ||
+      amount > (available[material] ?? 0) ||
+      !!design.print_error,
   );
 
   return (
@@ -93,6 +95,31 @@ const Recipe = (props: RecipeProps) => {
           <Icon name="question-circle" />
         </div>
       </Tooltip>
+      {!!design.print_error && (
+        <Tooltip content={design.print_error} position="right">
+          <div
+            className={classes([
+              'FabricatorRecipe__Button',
+              'FabricatorRecipe__Button--icon',
+            ])}
+          >
+            <Icon name="circle-exclamation" />
+          </div>
+        </Tooltip>
+      )}
+      {design.can_delete && (
+        <div
+          onClick={() =>
+            design.can_delete && act('delete', { designId: design.id })
+          }
+          className={classes([
+            'FabricatorRecipe__Button',
+            'FabricatorRecipe__Button--icon',
+          ])}
+        >
+          <Icon name="circle-xmark" />
+        </div>
+      )}
       <Tooltip
         content={
           <MaterialCostSequence

--- a/tgui/packages/tgui/interfaces/Fabrication/Types.ts
+++ b/tgui/packages/tgui/interfaces/Fabrication/Types.ts
@@ -68,6 +68,16 @@ export type Design = {
    * 32x32.**
    */
   icon: string;
+
+  /**
+   * Whenever this design can be deleted
+   */
+  can_delete: boolean;
+
+  /**
+   * Error displayed next to this design
+   */
+  print_error: string;
 };
 
 /**


### PR DESCRIPTION

## About The Pull Request
Allows circuit designs to be saved between rounds by scanning them with a module duplicator. You will be able to see and print designs you saved in previous rounds as long as all components that they use are researched.

This does not allow designs to be shared between players outside the game as there are no exposed imports/exports and data is stored per ckey.

Approved by Watermelon on discord.

## Why It's Good For The Game

Circuits are highly bothersome to set up, even if you know a design by memory due to our UI it still takes considerable time to make the circuit from scratch. This allows players to continue developing their designs between rounds, but prevents formation of metacords/metadocs for circuits like with previous iteration of exporting.

## Changelog
:cl:
add: Circuits can now be stored between rounds per-user in module duplicator
/:cl:
