### PR TITLE
Fixes the missing voidwalker glass eater objective message

### DIFF
--- a/code/modules/antagonists/voidwalker/voidwalker.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker.dm
@@ -50,9 +50,10 @@
 		"They must see what you have seen. They must walk where you have walked. Bring them to the void and show them the truth. The dead cannot know what you know.",
 		"Recover what you have lost. Bring your children into the inky black and return them to your flock.",
 	)
-	if(prob(20))
-		explanation_text += "Man I fucking love glass."
 	explanation_text = pick(explanation_texts)
+
+	if(prob(5))
+		explanation_text = "Man I fucking love glass."
 	..()
 
 /datum/objective/voidwalker_objective/check_completion()

--- a/code/modules/antagonists/voidwalker/voidwalker.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker.dm
@@ -52,8 +52,8 @@
 	)
 	explanation_text = pick(explanation_texts)
 
-	if(prob(20))
-		explanation_text += " Man I fucking love glass."
+	if(prob(5))
+		explanation_text = "Man I fucking love glass."
 	..()
 
 /datum/objective/voidwalker_objective/check_completion()

--- a/code/modules/antagonists/voidwalker/voidwalker.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker.dm
@@ -52,8 +52,8 @@
 	)
 	explanation_text = pick(explanation_texts)
 
-	if(prob(5))
-		explanation_text = "Man I fucking love glass."
+	if(prob(20))
+		explanation_text += " Man I fucking love glass."
 	..()
 
 /datum/objective/voidwalker_objective/check_completion()


### PR DESCRIPTION

## About The Pull Request

This makes the "Man I fucking love glass." voidwalker meme objective line actually show up now. Rather than being appended to the end of your objective, it can roll as its own objective line at a 5% chance.
## Why It's Good For The Game

It's funny, and wasn't meant to be inaccessible in the first place.
## Changelog
:cl: Rhials
grammar: The "man I love glass" voidwalker message can show up in your objectives now.
/:cl:
