### PR TITLE
[NO GBP] Actually makes the runtime logging suppression for lua states suppress logging runtimes

### DIFF
--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -55,6 +55,8 @@ GLOBAL_PROTECT(lua_state_stack)
 	var/status = result["status"]
 	if(!verbose && status != "error" && status != "panic" && status != "runtime" && !(result["name"] == "input" && (status == "finished" || length(result["return_values"]))))
 		return
+	if(status == "runtime" && supress_runtimes)
+		return
 	var/append_to_log = TRUE
 	var/index_of_log
 	if(log.len)


### PR DESCRIPTION
## About The Pull Request

I was so focused on the ui code that I forgot that I didn't make the `supress_runtimes` var do anything.

## Why It's Good For The Game

Things should do what they were made to do.

## Changelog

:cl:
admin: The "Suppress Runtime Logging" toggle in the lua editor actually does what it says
/:cl:
