### PR TITLE
Hydraulic clamps can force doors open again

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -55,7 +55,7 @@
 	if(istype(target, /obj/machinery/door/firedoor) || istype(target, /obj/machinery/door/airlock))
 		var/obj/machinery/door/target_door = target
 		playsound(chassis, clampsound, 50, FALSE, -6)
-		target_door.try_to_crowbar(src, source)
+		target_door.try_to_crowbar(src, source, TRUE)
 		return ..()
 
 	if(isobj(target))


### PR DESCRIPTION

## About The Pull Request

What the title says. This behavior seems to have been removed by accident in a previous PR, so I just put it back. Fixes #85506 
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: Hydraulic clamps (the mech tool) can force powered doors open again.
/:cl:
