### PR TITLE
fixes lobstrosity ai constant runtimes

### DIFF
--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -41,8 +41,6 @@
 
 /mob/living/basic/mining/lobstrosity/Initialize(mapload)
 	. = ..()
-	var/static/list/food_types = list(/obj/item/fish/lavaloop)
-	ai_controller.set_blackboard_key(BB_BASIC_FOODS, typecacheof(food_types))
 	AddComponent(/datum/component/profound_fisher)
 	AddElement(/datum/element/mob_grabber)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
@@ -34,6 +34,14 @@
 		/datum/ai_planning_subtree/find_and_hunt_target/lobster_fishing,
 		/datum/ai_planning_subtree/find_fingers,
 	)
+
+/datum/ai_controller/basic_controller/lobstrosity/TryPossessPawn(atom/new_pawn)
+	. = ..()
+	if(. & AI_CONTROLLER_INCOMPATIBLE)
+		return
+	var/static/list/food_types = list(/obj/item/fish/lavaloop)
+	set_blackboard_key(BB_BASIC_FOODS, typecacheof(food_types))
+
 ///Ensure that juveline lobstrosities witll charge at things they can reach.
 /datum/ai_controller/basic_controller/lobstrosity/juvenile
 	blackboard = list(

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity_ai.dm
@@ -39,8 +39,8 @@
 	. = ..()
 	if(. & AI_CONTROLLER_INCOMPATIBLE)
 		return
-	var/static/list/food_types = list(/obj/item/fish/lavaloop)
-	set_blackboard_key(BB_BASIC_FOODS, typecacheof(food_types))
+	var/static/list/food_types = typecacheof(list(/obj/item/fish/lavaloop))
+	set_blackboard_key(BB_BASIC_FOODS, food_types)
 
 ///Ensure that juveline lobstrosities witll charge at things they can reach.
 /datum/ai_controller/basic_controller/lobstrosity/juvenile


### PR DESCRIPTION
## About The Pull Request
juvenile lobstrosities would constantly runtime as chasm crabs delete their ai after growth and replace it with a new one, meaning blackboard keys arent set correctly

## Why It's Good For The Game
fixes lobsrosity ai runtimes

## Changelog
:cl:
fix: juvenile lobstrosities will now look for food
/:cl:
