### PR TITLE
Fixed handyman assistants spawning without a PDA

### DIFF
--- a/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
+++ b/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
@@ -167,6 +167,7 @@
 	belt = /obj/item/storage/belt/utility/full
 	head = /obj/item/clothing/head/utility/hardhat
 	uniform = /obj/item/clothing/under/color/yellow
+	l_pocket = /obj/item/modular_computer/pda/assistant
 
 	outfit_weight = 6
 


### PR DESCRIPTION

## About The Pull Request

Closes #85517

## Changelog
:cl:
fix: Fixed handyman assistants spawning without a PDA
/:cl:
