### PR TITLE
Integrated circuit modules now can be linked to component printers

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -192,12 +192,22 @@
 	return data
 
 /obj/machinery/component_printer/attackby(obj/item/weapon, mob/living/user, params)
-	if(istype(weapon, /obj/item/integrated_circuit) && !user.combat_mode)
-		var/obj/item/integrated_circuit/circuit = weapon
+	if (user.combat_mode)
+		return ..()
+	var/obj/item/integrated_circuit/circuit
+
+	if(istype(weapon, /obj/item/integrated_circuit))
+		circuit = weapon
+	else if (istype(weapon, /obj/item/circuit_component/module))
+		var/obj/item/circuit_component/module/module = weapon
+		circuit = module.internal_circuit
+
+	if (!isnull(circuit))
 		circuit.linked_component_printer = WEAKREF(src)
 		circuit.update_static_data_for_all_viewers()
 		balloon_alert(user, "successfully linked to the integrated circuit")
 		return
+
 	return ..()
 
 /obj/machinery/component_printer/crowbar_act(mob/living/user, obj/item/tool)

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -201,14 +201,13 @@
 	else if (istype(weapon, /obj/item/circuit_component/module))
 		var/obj/item/circuit_component/module/module = weapon
 		circuit = module.internal_circuit
+	if (isnull(circuit))
+		return ..()
 
-	if (!isnull(circuit))
-		circuit.linked_component_printer = WEAKREF(src)
-		circuit.update_static_data_for_all_viewers()
-		balloon_alert(user, "successfully linked to the integrated circuit")
-		return
+	circuit.linked_component_printer = WEAKREF(src)
+	circuit.update_static_data_for_all_viewers()
+	balloon_alert(user, "successfully linked to the integrated circuit")
 
-	return ..()
 
 /obj/machinery/component_printer/crowbar_act(mob/living/user, obj/item/tool)
 	if(..())

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -194,8 +194,8 @@
 /obj/machinery/component_printer/attackby(obj/item/weapon, mob/living/user, params)
 	if (user.combat_mode)
 		return ..()
-	var/obj/item/integrated_circuit/circuit
 
+	var/obj/item/integrated_circuit/circuit
 	if(istype(weapon, /obj/item/integrated_circuit))
 		circuit = weapon
 	else if (istype(weapon, /obj/item/circuit_component/module))


### PR DESCRIPTION
## About The Pull Request
Title. They've been missing quick component addition functionality due to an oversight and were rather annoying to use.

## Why It's Good For The Game

Simple QOL, you no longer need to add every piece manually and can develop circuits as actually intended (fully from their UI, as you can do with primary circuits themselves)

## Changelog
:cl:
qol: Integrated circuit modules now can be linked to component printers
/:cl:
