### PR TITLE
Chameleon gun counts as harmless and can be fired by pacifists

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -53,6 +53,7 @@
 /obj/item/ammo_casing/energy/chameleon
 	projectile_type = /obj/projectile/energy/chameleon
 	e_cost = 0 // Can't really use the macro here, unfortunately
+	harmful = FALSE
 	var/projectile_vars = list()
 
 /obj/item/ammo_casing/energy/chameleon/ready_proj()


### PR DESCRIPTION

## About The Pull Request

Closes #85496

## Changelog
:cl:
fix: Chameleon gun counts as harmless and can be fired by pacifists
/:cl:
