### PR TITLE
Magicarps no longer fire their projectiles while out of combat mode

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/carp/carp_abilities.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp_abilities.dm
@@ -28,6 +28,11 @@
 	projectile_type = pick(permitted_projectiles)
 	return ..()
 
+/datum/action/cooldown/mob_cooldown/projectile_attack/magicarp_bolt/InterceptClickOn(mob/living/caller, params, atom/target)
+	if (!caller.combat_mode)
+		return FALSE
+	return ..()
+
 /**
  * # Lesser Carp Rift
  * Teleport a short distance and leave a short-lived portal for people to follow through


### PR DESCRIPTION

## About The Pull Request

Closes #85504
Not a bug but you could do a lot of unintentional friendly fire

## Changelog
:cl:
qol: Magicarps no longer fire their projectiles while out of combat mode
/:cl:
