### PR TITLE
Fixed Creatures not being able to use non-jaunt actions when seen

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -79,7 +79,7 @@
 	. = ..()
 	if (!owner)
 		return
-	observed_blocker = owner.AddComponent(/datum/component/unobserved_actor, unobserved_flags = NO_OBSERVED_ACTIONS)
+	observed_blocker = owner.AddComponent(/datum/component/unobserved_actor, unobserved_flags = NO_OBSERVED_ACTIONS, affected_actions = list(type))
 
 /datum/action/cooldown/spell/jaunt/creature_teleport/Remove(mob/living/remove_from)
 	QDEL_NULL(observed_blocker)


### PR DESCRIPTION

## About The Pull Request

Closes #85500
you can now specify what types of actions are affected, not sure if I should make this a typecache instead tbh

## Changelog
:cl:
fix: Fixed Creatures not being able to use non-jaunt actions when seen
/:cl:
