### PR TITLE
replaces the unusable energy cannon in mystery boxes to the new smartgun

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -19,7 +19,6 @@
 #define MBOX_DURATION_STANDBY (2.7 SECONDS)
 
 GLOBAL_LIST_INIT(mystery_box_guns, list(
-	/obj/item/gun/energy/lasercannon,
 	/obj/item/gun/energy/recharge/ebow/large,
 	/obj/item/gun/energy/e_gun,
 	/obj/item/gun/energy/e_gun/nuclear,
@@ -45,6 +44,7 @@ GLOBAL_LIST_INIT(mystery_box_guns, list(
 	/obj/item/gun/ballistic/automatic/m90/unrestricted,
 	/obj/item/gun/ballistic/automatic/tommygun,
 	/obj/item/gun/ballistic/automatic/wt550,
+	/obj/item/gun/ballistic/automatic/smartgun,
 	/obj/item/gun/ballistic/rifle/sniper_rifle,
 	/obj/item/gun/ballistic/rifle/boltaction,
 ))


### PR DESCRIPTION

## About The Pull Request

see title
## Why It's Good For The Game

It's been a really long time since anyone other than a turret could shoot the energy cannon (free tasers for everyone!!) so it's an entirely useless weapon roll. I'm replacing it with the new smartgun because the smartgun is cool and more importantly you can actually shoot it.
## Changelog
:cl:
add: The new smartgun has replaced the unusable energy cannon in mystery boxes
/:cl:
