### PR TITLE
Reduced pathfinding circuit component cooldown to 5 seconds

### DIFF
--- a/code/modules/wiremod/components/action/pathfind.dm
+++ b/code/modules/wiremod/components/action/pathfind.dm
@@ -24,7 +24,7 @@
 
 	// Cooldown to limit how frequently we can path to the same location.
 	var/same_path_cooldown = 5 SECONDS
-	var/different_path_cooldown = 30 SECONDS
+	var/different_path_cooldown = 5 SECONDS
 
 	var/max_range = 60
 


### PR DESCRIPTION

## About The Pull Request
The cooldown length for pathfinding to a position with circuits is reduced from 30 seconds to 5 seconds, the same time when pathfinding to a previously located position.

## Why It's Good For The Game
This allows the moving drone and other circuit related operations to be able to track moving targets, as the 30 second cooldown would render the component practically pointless.

https://github.com/user-attachments/assets/cba8742c-7e98-411e-931d-4d74f51f6be0

## Changelog
:cl:
balance: Reduced pathfinding circuit component cooldown from 30 seconds to 5 seconds
/:cl:
