### PR TITLE
Fixed things with \improper name not dispensing from smartfridge [NO GBP]

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -417,7 +417,8 @@
 			for(var/obj/item/dispensed_item in src)
 				if(desired <= 0)
 					break
-				if(params["path"] == "[dispensed_item.type]-[dispensed_item.name]")
+				var/item_name = "[dispensed_item.type]-[replacetext(replacetext(dispensed_item.name, "\proper", ""), "\improper", "")]"
+				if(params["path"] == item_name)
 					if(dispensed_item in component_parts)
 						CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
 					//dispense the item


### PR DESCRIPTION
## About The Pull Request

Added `replacetext` to clean it up before the comparison.

## Why It's Good For The Game

Fix

## Changelog

:cl:
fix: Smartfridges properly dispense `\Improper` items
/:cl:
