### PR TITLE
Elevator music no longer restarts when you take a step

### DIFF
--- a/code/modules/transport/elevator/elev_music_zone.dm
+++ b/code/modules/transport/elevator/elev_music_zone.dm
@@ -83,6 +83,8 @@ GLOBAL_LIST_EMPTY(elevator_music)
 /datum/proximity_monitor/advanced/elevator_music_area/field_turf_uncrossed(mob/exited, turf/old_location, turf/new_location)
 	if (!(exited in tracked_mobs))
 		return
+	if ((new_location in field_turfs) || (new_location in edge_turfs))
+		return
 	qdel(tracked_mobs[exited])
 	tracked_mobs -= exited
 	UnregisterSignal(exited, COMSIG_QDELETING)


### PR DESCRIPTION

## About The Pull Request

Closes #85533
in 2564 dubstep isn't the hype it used to be

## Changelog
:cl:
fix: Elevator music no longer restarts when you take a step
/:cl:
