### PR TITLE
Fixed being able to activate BCI actions whilst not conscious

### DIFF
--- a/code/modules/wiremod/components/bci/hud/target_intercept.dm
+++ b/code/modules/wiremod/components/bci/hud/target_intercept.dm
@@ -39,7 +39,7 @@
 		return
 
 	var/mob/living/owner = bci.owner
-	if(!owner || !istype(owner) || !owner.client)
+	if(!owner || !istype(owner) || !owner.client || owner.stat >= UNCONSCIOUS)
 		return
 
 	if(TIMER_COOLDOWN_RUNNING(parent.shell, COOLDOWN_CIRCUIT_TARGET_INTERCEPT))

--- a/code/modules/wiremod/components/bci/hud/target_intercept.dm
+++ b/code/modules/wiremod/components/bci/hud/target_intercept.dm
@@ -39,7 +39,7 @@
 		return
 
 	var/mob/living/owner = bci.owner
-	if(!owner || !istype(owner) || !owner.client || owner.stat >= UNCONSCIOUS)
+	if(!owner || !istype(owner) || !owner.client || owner.stat >= SOFT_CRIT)
 		return
 
 	if(TIMER_COOLDOWN_RUNNING(parent.shell, COOLDOWN_CIRCUIT_TARGET_INTERCEPT))

--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -57,6 +57,9 @@
 
 /obj/item/circuit_component/thought_listener/proc/thought_listen(mob/living/owner)
 	var/message = tgui_input_text(owner, input_desc.value ? input_desc.value : "", input_name.value ? input_name.value : "Thought Listener", "")
+	if(QDELETED(owner) || owner.stat >= UNCONSCIOUS)
+		failure.set_output(COMPONENT_SIGNAL)
+		return
 	output.set_output(message)
 	trigger_output.set_output(COMPONENT_SIGNAL)
 	ready = TRUE

--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -58,7 +58,6 @@
 /obj/item/circuit_component/thought_listener/proc/thought_listen(mob/living/owner)
 	var/message = tgui_input_text(owner, input_desc.value ? input_desc.value : "", input_name.value ? input_name.value : "Thought Listener", "")
 	if(QDELETED(owner) || owner.stat >= UNCONSCIOUS)
-		failure.set_output(COMPONENT_SIGNAL)
 		return
 	output.set_output(message)
 	trigger_output.set_output(COMPONENT_SIGNAL)

--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -48,7 +48,7 @@
 
 	var/mob/living/owner = bci.owner
 
-	if(!owner || !istype(owner) || !owner.client || (owner.stat >= UNCONSCIOUS))
+	if(!owner || !istype(owner) || !owner.client || (owner.stat >= SOFT_CRIT))
 		failure.set_output(COMPONENT_SIGNAL)
 		return
 
@@ -57,7 +57,7 @@
 
 /obj/item/circuit_component/thought_listener/proc/thought_listen(mob/living/owner)
 	var/message = tgui_input_text(owner, input_desc.value ? input_desc.value : "", input_name.value ? input_name.value : "Thought Listener", "")
-	if(QDELETED(owner) || owner.stat >= UNCONSCIOUS)
+	if(QDELETED(owner) || owner.stat >= SOFT_CRIT)
 		return
 	output.set_output(message)
 	trigger_output.set_output(COMPONENT_SIGNAL)


### PR DESCRIPTION
## About The Pull Request
As the title says

## Why It's Good For The Game
Shouldn't be able to activate these whilst unconscious, or stall activation to activate at a convenient time whilst unconsious.

## Changelog
:cl:
fix: Fixed activating specific BCI actions whilst unconsious
/:cl:
