### PR TITLE
Metastation Camera Move - T-Comms

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -27838,10 +27838,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jNZ" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Telecomms - Server Room - Aft-Port";
-	network = list("ss13","tcomms")
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron/dark/telecomms,
@@ -40195,6 +40191,10 @@
 /area/station/maintenance/starboard/lesser)
 "oln" = (
 /obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/camera/directional/east{
+	c_tag = "Telecomms - Server Room - Aft-Starboard";
+	network = list("ss13","tcomms")
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "olq" = (
@@ -59246,6 +59246,10 @@
 /area/station/security/office)
 "uRp" = (
 /obj/machinery/telecomms/server/presets/common,
+/obj/machinery/camera/directional/west{
+	c_tag = "Telecomms - Server Room - Aft-Port";
+	network = list("ss13","tcomms")
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "uRw" = (
@@ -66453,14 +66457,10 @@
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
 "xpZ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Telecomms - Server Room - Aft-Starboard";
-	network = list("ss13","tcomms")
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/area)
 "xqc" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 4


### PR DESCRIPTION
…blocking machine frames but it was cameras - Moved cameras 1x tile north so that when APC needs repairing in T-comms room, can attach APC back to wall. - On asking a staff member what is a simple annoyance that comes up often for my first change this was suggested.
## About The Pull Request

Slowly but surely getting into mapping and contributing.

Was having a chat with an admin about consistent frustrations for newer players and one of them was about t-comms failing or sabotage on meta-station, if the APC needs fixing you cannot place the wallframe due to the camera being present on the same wall. This just moves the camera 1x tile up, I did the same for the air alarm on the other side for consistency. Tested as AI player and used mapping tools camera view to check range.

The image below shows camera placement on same wall as air alarm on the left and the moved camera from APC wall on the right 1x tile up, to give an idea of before and after.

![Screenshot 2024-08-03 021729](https://github.com/user-attachments/assets/30d5585a-0ffc-4c1d-9ff9-6632e6b0b8c8)
## Why It's Good For The Game

Currently if you need to repair APC by re-installing wall-frame in T-Comms room, you cannot due to a camera being present on that wall.

This PR makes it easier for newbie engineers to repair t-comms power on metastation map without needing to remove the camera.

I suppose balance wise as it makes it easier to repair comms the value of sabotage is decreased so may be a potential downside.

![Screenshot 2024-08-03 023332](https://github.com/user-attachments/assets/3d2ca0fd-b02b-4bf9-84ef-fa79f83cf1d3)
## Changelog
:cl:
qol: made something easier to use
/:cl:
