### PR TITLE
Makes upgraded soda dispensers actually upgraded

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -572,6 +572,7 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Contains a large reservoir of soft drinks. This model has had its safeties shorted out."
 	obj_flags = CAN_BE_HIT | EMAGGED
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/drinks/fullupgrade
 
 /obj/machinery/chem_dispenser/drinks/fullupgrade/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Makes the `drinks/fullupgrade` actually have the fullupgrade circuit board, which is responsible for upgrading the parts in the machine. Matches the booze dispenser, which currently works.

https://github.com/tgstation/tgstation/blob/6847e9203500e2c6e3c138d8102254cc08a018bb/code/modules/reagents/chemistry/machinery/chem_dispenser.dm#L632-L635
## Why It's Good For The Game
bugn't
## Changelog
:cl:
fix: pre-upgraded soda dispensers are actually pre-upgraded again
/:cl:
