### PR TITLE
Supermatter bioscrambler anomalies are docile

### DIFF
--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -173,7 +173,7 @@
 		if(VORTEX_ANOMALY)
 			new /obj/effect/anomaly/bhole(local_turf, 20, FALSE)
 		if(BIOSCRAMBLER_ANOMALY)
-			new /obj/effect/anomaly/bioscrambler(local_turf, null, FALSE)
+			new /obj/effect/anomaly/bioscrambler/docile(local_turf, null, FALSE)
 
 #undef CHANCE_EQUATION_SLOPE
 #undef INTEGRITY_EXPONENTIAL_DEGREE


### PR DESCRIPTION

## About The Pull Request

Supermatter bioscrambler anomalies are now docile.

## Why It's Good For The Game

It is extremely frustrating for you to be trying to handle the usual crises caused by a round chaotic enough to have an anomalous SM while two bioscramblers are orbiting around you in the brig or god knows where. I don't know, I just don't think this is worth keeping. Mantainers can decide one way or the other.

## Changelog

:cl:
balance: Supermatter bioscrambler anomalies are now docile.
/:cl:

