### PR TITLE
Holding someone at gunpoint no longer makes all shots count as point blank

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -48,7 +48,7 @@
 	RegisterSignals(targ, list(COMSIG_LIVING_DISARM_HIT, COMSIG_LIVING_GET_PULLED), PROC_REF(cancel))
 	RegisterSignals(weapon, list(COMSIG_ITEM_DROPPED, COMSIG_ITEM_EQUIPPED), PROC_REF(cancel))
 
-	var/distance = min(get_dist(shooter, target), 1) // treat 0 distance as adjacent
+	var/distance = max(get_dist(shooter, target), 1) // treat 0 distance as adjacent
 	var/distance_description = (distance <= 1 ? "point blank " : "")
 
 	shooter.visible_message(span_danger("[shooter] aims [weapon] [distance_description]at [target]!"),


### PR DESCRIPTION

## About The Pull Request
because of a mixup between min and max all gunpoint shots are currently point blank. Point blank code is a nightmare.
guns were a mistake can we return to toolbox-only days

thanks to Melbert for finding this

## Changelog
:cl: MrMelbert, SmArtKar
fix: Holding someone at gunpoint no longer makes all shots count as point blank
/:cl:
