### PR TITLE
Soulscythe now deletes the soul mob when destroyed

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -602,10 +602,9 @@
 	SpinAnimation(15)
 
 /obj/item/soulscythe/Destroy(force)
-	. = ..()
 	soul.ghostize()
 	QDEL_NULL(soul)
-
+	. = ..()
 /mob/living/simple_animal/soulscythe
 	name = "mysterious spirit"
 	maxHealth = 200

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -601,6 +601,11 @@
 	animate(src)
 	SpinAnimation(15)
 
+/obj/item/soulscythe/Destroy(force)
+	. = ..()
+	soul.ghostize()
+	QDEL_NULL(soul)
+
 /mob/living/simple_animal/soulscythe
 	name = "mysterious spirit"
 	maxHealth = 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mob remains alive when it is metalgenned into glass and then shattered currently, here's a preview of what it causes

![image](https://github.com/user-attachments/assets/8d6671dd-1b77-4f0c-a263-31a84f8791f0)

Reported on discord

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Soulscythe now deletes the soul mob when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
