### PR TITLE
Heretic sacrifice area no longer modifies global ambience lists

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_EMPTY(heretic_sacrifice_landmarks)
 /area/centcom/heretic_sacrifice/Initialize(mapload)
 	if(!ambientsounds)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]
-		ambientsounds += 'sound/ambience/ambiatm1.ogg'
+		ambientsounds = ambientsounds + 'sound/ambience/ambiatm1.ogg'
 	return ..()
 
 /area/centcom/heretic_sacrifice/ash //also, the default

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
@@ -91,8 +91,7 @@ GLOBAL_LIST_EMPTY(heretic_sacrifice_landmarks)
 
 /area/centcom/heretic_sacrifice/Initialize(mapload)
 	if(!ambientsounds)
-		ambientsounds = GLOB.ambience_assoc[ambience_index]
-		ambientsounds = ambientsounds + 'sound/ambience/ambiatm1.ogg'
+		ambientsounds = GLOB.ambience_assoc[ambience_index] + 'sound/ambience/ambiatm1.ogg'
 	return ..()
 
 /area/centcom/heretic_sacrifice/ash //also, the default


### PR DESCRIPTION

## About The Pull Request

Since it +=d a new sound it ended up modifying a global ambience list, applying the sound to 5 other lists (5 areas had this behavior)

Equating it to a new list created by summing up the old one and the sound should fix this behavior

## Changelog
:cl:
fix: Heretic sacrifice area no longer modifies global ambience lists
/:cl:
