### PR TITLE
Gives Janitor ERT no slips

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -493,7 +493,7 @@
 
 /obj/item/mod/control/pre_equipped/responsory/janitor
 	insignia_type = /obj/item/mod/module/insignia/janitor
-	additional_module = /obj/item/mod/module/clamp
+	additional_module = /obj/item/mod/module/noslip
 
 /obj/item/mod/control/pre_equipped/responsory/clown
 	insignia_type = /obj/item/mod/module/insignia/clown


### PR DESCRIPTION

## About The Pull Request

Gives janitor ERT no slips instead of a clamp

## Why It's Good For The Game

Quite silly for the top of the top janitors from NT losing in a slip battle with the regular station janny. I'm pretty sure no slip modules weren't a thing when the ERT modsuits were made

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Nanotrasen has fitted the Janitorial Emergency Response Team with equipment better suited for the job.
/:cl:

