### PR TITLE
Fix first tab selection on ore redemption machine

### DIFF
--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
@@ -21,7 +21,7 @@ import { Window } from '../layouts';
 export const OreRedemptionMachine = (props) => {
   const { act, data } = useBackend();
   const { disconnected, unclaimedPoints, materials, user } = data;
-  const [tab, setTab] = useSharedState('tab', 1);
+  const [tab, setTab] = useSharedState('tab', 'material');
   const [searchItem, setSearchItem] = useState('');
   const [compact, setCompact] = useState(false);
   const search = createSearch(searchItem, (materials) => materials.name);


### PR DESCRIPTION
## About The Pull Request
`1` is never going to select the first tab as `1 === 'material'` is always false.
To test this PR, spawn the `/obj/machinery/mineral/ore_redemption` atom. Upon opening the interface the first tab is now selected.

## Why It's Good For The Game
Less bugs!

## Changelog
:cl:
fix: The first tab is now selected with ore redemption machines when opened for the first time
/:cl:
