### PR TITLE
Re-fix insulation jank. Give lizards homeostasis

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1195,9 +1195,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	// Get the insulation value based on the area's temp
 	var/thermal_protection = humi.get_insulation_protection(area_temp)
+	var/original_bodytemp = humi.bodytemperature
 
 	// Changes to the skin temperature based on the area
-	var/area_skin_diff = area_temp - humi.bodytemperature
+	var/area_skin_diff = area_temp - original_bodytemp
 	if(!humi.on_fire || area_skin_diff > 0)
 		// change rate of 0.05 as area temp has large impact on the surface
 		var/area_skin_change = get_temp_change_amount(area_skin_diff, 0.05 * seconds_per_tick)
@@ -1217,7 +1218,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Core to skin temp transfer, when not on fire
 	if(!humi.on_fire)
 		// Get the changes to the skin from the core temp
-		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
+		var/core_skin_diff = humi.coretemperature - original_bodytemp
 		// change rate of 0.045 to reflect temp back to the skin at the slight higher rate then core to skin
 		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, 0.045 * seconds_per_tick)
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -133,6 +133,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	/// The natural temperature for a body
 	var/bodytemp_normal = BODYTEMP_NORMAL
+	/// Multiplier for amount of kelvin moved toward normal body temperature per tick.
+	var/bodytemp_homeostasis = 1
 	/// Minimum amount of kelvin moved toward normal body temperature per tick.
 	var/bodytemp_autorecovery_min = BODYTEMP_AUTORECOVERY_MINIMUM
 	/// The body temperature limit the body can take before it starts taking damage from heat.
@@ -1164,7 +1166,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
  */
 /datum/species/proc/body_temperature_core(mob/living/carbon/human/humi, seconds_per_tick, times_fired)
 	var/natural_change = get_temp_change_amount(humi.get_body_temp_normal() - humi.coretemperature, 0.06 * seconds_per_tick)
-	humi.adjust_coretemperature(humi.metabolism_efficiency * natural_change)
+	humi.adjust_coretemperature(humi.metabolism_efficiency * bodytemp_homeostasis * natural_change)
 
 /**
  * Used to normalize the skin temperature on living mobs

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -18,6 +18,7 @@
 		/obj/item/organ/external/tail/lizard = "Smooth",
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/lizard
+	bodytemp_homeostasis = 0.7 // Lizards regulate body temperature weaker
 	coldmod = 1.5
 	heatmod = 0.67
 	payday_modifier = 1.0
@@ -43,10 +44,6 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/lizard,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/lizard,
 	)
-
-/// Lizards are cold blooded and do not stabilize body temperature naturally
-/datum/species/lizard/body_temperature_core(mob/living/carbon/human/humi, seconds_per_tick, times_fired)
-	return
 
 /datum/species/lizard/randomize_features()
 	var/list/features = ..()


### PR DESCRIPTION
## About The Pull Request
Apparently we want lizards to survive outside in icebox with passive winter clothes despite not having the ability to regulate body temperature. They were able to do this before since insulation code was janked and prevented their temp from reaching the outside temperature.

This PR gives lizards some homeostasis so they can survive with passive winter clothes in the cold of icebox and fixes the insulation jank again.
## Why It's Good For The Game
Insulation works correctly again and lizards don't freeze to death while wearing winter clothes.
## Changelog
:cl:
fix: Fixes insulation jank again
balance: Gives lizards weak bodytemp regulation so they can survive cold environments with passive insulation.
/:cl:
