### PR TITLE
Plasmamen helmets now display their smiles + can be painted with spraycans

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -119,24 +119,24 @@
 	if(!up)
 		. += visor_icon
 	if(smile)
-		var/mutable_appearance/slimey = mutable_appearance(icon, smile_state)
-		slimey.color = smile_color
-		. += slimey
+		var/mutable_appearance/smiley = mutable_appearance(icon, smile_state)
+		smiley.color = smile_color
+		. += smiley
 
 /obj/item/clothing/head/helmet/space/plasmaman/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(istype(tool, /obj/item/toy/crayon))
 		if(smile)
-			to_chat(user, span_warning("Seems like someone already drew something on this helmet's visor!"))
+			to_chat(user, span_warning("Seems like someone already drew something on [src]'s visor!"))
 			return ITEM_INTERACT_BLOCKING
 
 		var/obj/item/toy/crayon/crayon = tool
-		to_chat(user, span_notice("You start drawing a smiley face on the helmet's visor..."))
+		to_chat(user, span_notice("You start drawing a smiley face on [src]'s visor..."))
 		if(!do_after(user, 2.5 SECONDS, target = src))
 			return ITEM_INTERACT_BLOCKING
 
 		smile = TRUE
 		smile_color = crayon.paint_color
-		to_chat(user, "You draw a smiley on the helmet visor.")
+		to_chat(user, "You draw a smiley on [src] visor.")
 		update_appearance()
 		return ITEM_INTERACT_SUCCESS
 
@@ -145,15 +145,15 @@
 
 	var/obj/item/clothing/hitting_clothing = tool
 	if(hitting_clothing.clothing_flags & STACKABLE_HELMET_EXEMPT)
-		to_chat(user, span_notice("You cannot place [hitting_clothing.name] on helmet!"))
+		to_chat(user, span_notice("You cannot place [hitting_clothing.name] on [src]!"))
 		return ITEM_INTERACT_BLOCKING
 
 	if(attached_hat)
-		to_chat(user, span_notice("There's already something placed on helmet!"))
+		to_chat(user, span_notice("There's already something placed on [src]!"))
 		return ITEM_INTERACT_BLOCKING
 
 	attached_hat = hitting_clothing
-	to_chat(user, span_notice("You placed [hitting_clothing.name] on helmet!"))
+	to_chat(user, span_notice("You placed [hitting_clothing.name] on [src]!"))
 	hitting_clothing.forceMove(src)
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -118,33 +118,45 @@
 	. = ..()
 	if(!up)
 		. += visor_icon
+	if(smile)
+		var/mutable_appearance/slimey = mutable_appearance(icon, smile_state)
+		slimey.color = smile_color
+		. += slimey
 
-/obj/item/clothing/head/helmet/space/plasmaman/attackby(obj/item/hitting_item, mob/living/user)
-	. = ..()
-	if(istype(hitting_item, /obj/item/toy/crayon))
-		if(smile == FALSE)
-			var/obj/item/toy/crayon/CR = hitting_item
-			to_chat(user, span_notice("You start drawing a smiley face on the helmet's visor.."))
-			if(do_after(user, 2.5 SECONDS, target = src))
-				smile = TRUE
-				smile_color = CR.paint_color
-				to_chat(user, "You draw a smiley on the helmet visor.")
-				update_appearance()
-		else
+/obj/item/clothing/head/helmet/space/plasmaman/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/toy/crayon))
+		if(smile)
 			to_chat(user, span_warning("Seems like someone already drew something on this helmet's visor!"))
-		return
-	if(istype(hitting_item, /obj/item/clothing/head))
-		var/obj/item/clothing/hitting_clothing = hitting_item
-		if(hitting_clothing.clothing_flags & STACKABLE_HELMET_EXEMPT)
-			to_chat(user, span_notice("You cannot place [hitting_clothing.name] on helmet!"))
-			return
-		if(attached_hat)
-			to_chat(user, span_notice("There's already something placed on helmet!"))
-			return
-		attached_hat = hitting_clothing
-		to_chat(user, span_notice("You placed [hitting_clothing.name] on helmet!"))
-		hitting_clothing.forceMove(src)
+			return ITEM_INTERACT_BLOCKING
+
+		var/obj/item/toy/crayon/crayon = tool
+		to_chat(user, span_notice("You start drawing a smiley face on the helmet's visor..."))
+		if(!do_after(user, 2.5 SECONDS, target = src))
+			return ITEM_INTERACT_BLOCKING
+
+		smile = TRUE
+		smile_color = crayon.paint_color
+		to_chat(user, "You draw a smiley on the helmet visor.")
 		update_appearance()
+		return ITEM_INTERACT_SUCCESS
+
+	if(!istype(tool, /obj/item/clothing/head))
+		return NONE
+
+	var/obj/item/clothing/hitting_clothing = tool
+	if(hitting_clothing.clothing_flags & STACKABLE_HELMET_EXEMPT)
+		to_chat(user, span_notice("You cannot place [hitting_clothing.name] on helmet!"))
+		return ITEM_INTERACT_BLOCKING
+
+	if(attached_hat)
+		to_chat(user, span_notice("There's already something placed on helmet!"))
+		return ITEM_INTERACT_BLOCKING
+
+	attached_hat = hitting_clothing
+	to_chat(user, span_notice("You placed [hitting_clothing.name] on helmet!"))
+	hitting_clothing.forceMove(src)
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 ///By the by, helmets have the update_icon_updates_onmob element, so we don't have to call mob.update_worn_head()
 /obj/item/clothing/head/helmet/space/plasmaman/worn_overlays(mutable_appearance/standing, isinhands)


### PR DESCRIPTION

## About The Pull Request

Closes #85610

They lacked code to add smiles to their sprite despite having those textures, resulting in them only displaying on-mob. Also converted it to use item_interact so spraycans also can be used to paint the smileys.

## Changelog
:cl:
fix: Plasmamen helmets now display their smiles + can be painted with spraycans
/:cl:
