### PR TITLE
Adds cargo gorka internals

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -225,6 +225,10 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
 	allowed = list(
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/tank/internals/plasmaman,
+		/obj/item/boxcutter,
+		/obj/item/dest_tagger,
 		/obj/item/stamp,
 		/obj/item/storage/bag/mail,
 		/obj/item/universal_scanner,


### PR DESCRIPTION
## About The Pull Request

Allows small internals and a few other cargo related items for the Cargo Gorka suit slot.
Extra items are dest_tagger, and boxcutter.  
## Why It's Good For The Game

Literally every other suit I’ve seen allows emergency/plasmaman internals, also the Gorka only supports 3 items which is really low compared to hazard vests or jackets. Not adding radios or flashlight as they are covered with the hazard vest which techs can buy, makes Gorka more suited to use in department work rather than maints.
Alternatively could make the Gorka a jacket subtype similar to Qm's.

## Changelog



:cl:
qol: Cargo Gorka suit slot now allows emergency/plasmaman internals.

/:cl:
