### PR TITLE
Allows AI players to operate the Boulder Retrival Matrix (BRM) machine

### DIFF
--- a/code/modules/mining/boulder_processing/brm.dm
+++ b/code/modules/mining/boulder_processing/brm.dm
@@ -153,6 +153,23 @@
 	playsound(src, MANUAL_TELEPORT_SOUND, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return TRUE
 
+/obj/machinery/brm/attack_ai(mob/user)
+	. = ..()
+	if(. || panel_open)
+		return
+	if(!handle_teleport_conditions(user))
+		return
+
+	var/result = pre_collect_boulder()
+	if(result == TURF_BLOCKED_BY_BOULDER)
+		balloon_alert(user, "no space")
+	else if(result)
+		balloon_alert(user, "teleporting")
+
+	COOLDOWN_START(src, manual_teleport_cooldown, TELEPORTATION_TIME)
+
+	return TRUE
+
 /obj/machinery/brm/attack_robot(mob/user)
 	. = ..()
 	if(. || panel_open)
@@ -205,6 +222,17 @@
 	else
 		end_processing()
 	update_appearance(UPDATE_ICON_STATE)
+
+/obj/machinery/brm/attack_ai_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || panel_open)
+		return
+	if(!anchored)
+		balloon_alert(user, "anchor first!")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	toggle_auto_on(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/brm/attack_robot_secondary(mob/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This change allows AI Sillicon players to use the BRM - 6 months ago this PR did a refactor https://github.com/tgstation/tgstation/pull/81358 - Whilst it added the ability for Cyborgs to interact with it - Nothing was added for AI. This PR just corrects that and changes nothing else.
![image](https://github.com/user-attachments/assets/b5b8aa51-d5c1-4c41-8bac-32a925b6d862)
**The addition of the below matching attack_robot with identical functions depending on left or right click**
`/obj/machinery/brm/attack_ai(mob/user)`
`/obj/machinery/brm/attack_ai_secondary(mob/user, list/modifiers)`
## Why It's Good For The Game

On many low pop scenarios with AI players, It allows them to begin generating basic resources (Iron and Glass) for the station. Gives AI players another task they can do to assist the crew and adds to the value of an AI even in low pop.

I believe the original PR from six months ago meant to include AI but it was an oversight, this PR corrects that oversight.
## Changelog
:cl:
fix: AI Players can now operate the BRM (Boulder Retrival Matrix) 
/:cl:
