### PR TITLE
[NO GBP]Fixes supermatter zaps getting called with 0 zap_cutoff.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -896,10 +896,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 3.2 MEGA JOULES, zap_flags = ZAP_SUPERMATTER_FLAGS, list/targets_hit = list(), zap_cutoff = 1.2 MEGA JOULES, power_level = 0, zap_icon = DEFAULT_ZAP_ICON_STATE, color = null)
 	if(QDELETED(zapstart))
 		return
-	if(!zap_str || zap_str < 0) // Just in case something scales zap_str and zap_cutoff to 0.
+	if(zap_cutoff <= 0)
+		stack_trace("/obj/machinery/supermatter_zap() was called with a non-positive value")
 		return
-	if(!zap_cutoff || zap_cutoff < 0)
-		stack_trace("/obj/machinery/supermatter_zap() was called with a non-positive value. This causes a recursion that will hit the recursion limit.")
+	if(zap_str <= 0) // Just in case something scales zap_str and zap_cutoff to 0.
 		return
 	. = zapstart.dir
 	//If the strength of the zap decays past the cutoff, we stop

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -896,6 +896,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 3.2 MEGA JOULES, zap_flags = ZAP_SUPERMATTER_FLAGS, list/targets_hit = list(), zap_cutoff = 1.2 MEGA JOULES, power_level = 0, zap_icon = DEFAULT_ZAP_ICON_STATE, color = null)
 	if(QDELETED(zapstart))
 		return
+	if(!zap_str || zap_str < 0) // Just in case something scales zap_str and zap_cutoff to 0.
+		return
+	if(!zap_cutoff || zap_cutoff < 0)
+		stack_trace("/obj/machinery/supermatter_zap() was called with a non-positive value. This causes a recursion that will hit the recursion limit.")
+		return
 	. = zapstart.dir
 	//If the strength of the zap decays past the cutoff, we stop
 	if(zap_str < zap_cutoff)

--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -130,9 +130,10 @@
 	if(zap_count >= 1)
 		playsound(loc, 'sound/weapons/emitter2.ogg', 100, TRUE, extrarange = 10)
 		var/delta_time = (SSmachines.times_fired - last_high_energy_zap_perspective_machines) * SSmachines.wait / (1 SECONDS)
-		for(var/i in 1 to zap_count)
-			supermatter_zap(src, range, clamp(internal_energy * 3200, 6.4e6, 3.2e7) * delta_time, flags, zap_cutoff = src.zap_cutoff * delta_time, power_level = internal_energy, zap_icon = src.zap_icon)
-		last_high_energy_zap_perspective_machines = SSmachines.times_fired
+		if(delta_time)
+			for(var/i in 1 to zap_count)
+				supermatter_zap(src, range, clamp(internal_energy * 3200, 6.4e6, 3.2e7) * delta_time, flags, zap_cutoff = src.zap_cutoff * delta_time, power_level = internal_energy, zap_icon = src.zap_icon)
+			last_high_energy_zap_perspective_machines = SSmachines.times_fired
 	if(prob(5))
 		supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
 	if(prob(5))


### PR DESCRIPTION
Supermatter high energy processing no longer calls supermatter_zap() if delta_time is 0. Also early returns in supermatter_zap() if zap_str or zap_cutoff are invalid.
## Changelog
:cl:
fix: Fixes high energy supermatter zaps arcing through an unusually high amount of objects and ignoring grounding rods.
/:cl:
