### PR TITLE
Fixes ziptie pickup/drop sounds

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -200,6 +200,8 @@
 	custom_materials = list(/datum/material/iron= SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/glass= SMALL_MATERIAL_AMOUNT * 0.75)
 	breakouttime = 30 SECONDS
 	cuffsound = 'sound/weapons/cablecuff.ogg'
+	pickup_sound = null
+	drop_sound = null
 	restraint_strength = HANDCUFFS_TYPE_WEAK
 
 /obj/item/restraints/handcuffs/cable/Initialize(mapload, new_color)


### PR DESCRIPTION

## About The Pull Request

This removes the pickup/drop sounds from zipties, inherited from handcuffs.

I elected to keep the `cuffsuccesssound` the same, as I feel like the sound is appropriate for conveying zipties being tightened off.
## Why It's Good For The Game

Closes #85616, I hope. The issue report wasn't very descriptive so I'm not sure if I've missed anything here.
## Changelog
:cl: Rhials
sound: Zipties no longer make handcuff noises when picked up or dropped.
/:cl:
