### PR TITLE
ERTs no longer humanize plasmamen

### DIFF
--- a/code/modules/admin/verbs/ert.dm
+++ b/code/modules/admin/verbs/ert.dm
@@ -226,7 +226,7 @@
 			chosen_candidate.client.prefs.safe_transfer_prefs_to(ert_operative, is_antag = TRUE)
 			ert_operative.key = chosen_candidate.key
 
-			if(ertemplate.enforce_human || !(ert_operative.dna.species.changesource_flags & ERT_SPAWN)) // Don't want any exploding plasmemes
+			if(ertemplate.enforce_human || !(ert_operative.dna.species.changesource_flags & ERT_SPAWN))
 				ert_operative.set_species(/datum/species/human)
 
 			//Give antag datum

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -238,6 +238,10 @@
 		H.open_internals(H.get_item_for_held_index(2))
 	H.equipOutfit(outfit)
 
+	if(isplasmaman(H))
+		var/obj/item/mod/control/our_modsuit = locate() in H.get_equipped_items()
+		if(our_modsuit)
+			our_modsuit.install(new /obj/item/mod/module/plasma_stabilizer)
 
 /datum/antagonist/ert/greet()
 	if(!ert_team)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -27,7 +27,7 @@
 	heatmod = 1.5
 	payday_modifier = 1.0
 	breathid = GAS_PLASMA
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN
 	species_cookie = /obj/item/reagent_containers/condiment/milk
 	outfit_important_for_life = /datum/outfit/plasmaman
 	species_language_holder = /datum/language_holder/skeleton


### PR DESCRIPTION
## About The Pull Request

This one's a bit complex, stay with me here.

So, the ERT system has support for enforcing all ERT members to be human, or if they will be spawned as their selected species.

![image](https://github.com/user-attachments/assets/14aeaabc-ac47-44dd-811d-a25525d926ea)

This addresses plasmamen by including plasmamen outfits that are equipped prior to the actual outfit they're given, added in #56987.

![image](https://github.com/user-attachments/assets/2b3192f9-2aa7-48eb-8ce3-ff58fa0883e8)

Despite this support, plasmamen never spawn as plasmamen, as they are missing the `ERT_SPAWN` changeflag. This is because as the body is created, the ERT spawning system human-ifies them to prevent them from exploding. This system existed in place prior to #56987, but it didn't work.

![image](https://github.com/user-attachments/assets/6b803c80-ded6-48d6-94a6-781efda89642)

Fortunately(?) #58870 fixed it, but in doing so nullified the work done in #56987 as plasmamen could no longer be plasmamen when the `plasmaman_outfit` check was reached. They had already become human.

If this reads a bit weirdly its because this was originally just going to be an issue report. I finished writing it and decided "well why not just fix it instead dorkus".

![image](https://github.com/user-attachments/assets/dd4b74af-b89e-4ecf-8bb4-0d3199a52649)
## Why It's Good For The Game

Fixes a problem caused by, ironically, a logic fix.
## Changelog
:cl: Rhials
fix: Centcom ERT hiring standards have been expanded to include plasmamen, again.
/:cl:
