### PR TITLE
Circuit health analyzer/state components now work on targets inside lockers

### DIFF
--- a/code/modules/wiremod/components/atom/health.dm
+++ b/code/modules/wiremod/components/atom/health.dm
@@ -43,7 +43,8 @@
 
 	var/mob/living/organism = input_port.value
 	var/turf/current_turf = get_location()
-	if(!istype(organism) || get_dist(current_turf, organism) > max_range || current_turf.z != organism.z)
+	var/turf/target_location = get_turf(organism)
+	if(!istype(organism) || get_dist(current_turf, target_location) > max_range || current_turf.z != target_location.z)
 		brute.set_output(null)
 		burn.set_output(null)
 		toxin.set_output(null)

--- a/code/modules/wiremod/components/atom/health_state.dm
+++ b/code/modules/wiremod/components/atom/health_state.dm
@@ -37,7 +37,7 @@
 	var/mob/living/organism = input_port.value
 	var/turf/current_turf = get_location()
 	var/turf/target_location = get_turf(organism)
-	if(!istype(organism) || current_turf.z != target_location.z || get_dist(current_turf, target_location)s > max_range)
+	if(!istype(organism) || current_turf.z != target_location.z || get_dist(current_turf, target_location) > max_range)
 		return FALSE
 
 	var/current_option = state_option.value

--- a/code/modules/wiremod/components/atom/health_state.dm
+++ b/code/modules/wiremod/components/atom/health_state.dm
@@ -36,7 +36,8 @@
 /obj/item/circuit_component/compare/health_state/do_comparisons()
 	var/mob/living/organism = input_port.value
 	var/turf/current_turf = get_location()
-	if(!istype(organism) || current_turf.z != organism.z || get_dist(current_turf, organism) > max_range)
+	var/turf/target_location = get_turf(organism)
+	if(!istype(organism) || current_turf.z != target_location.z || get_dist(current_turf, target_location)s > max_range)
 		return FALSE
 
 	var/current_option = state_option.value


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes circuit health analyzer/scanner components check distance to target turf instead of target itself similarly to (most) other components. (There are exceptions, presumably due to balancing? concerns, but this feels like it should not have been one)

This doesn't feel intentional so I marked it as a fix, given that BCIs stopping being able to scan their occupant is rather nonsensical

## Why It's Good For The Game

Currently BCIs with health analyzer components stop working if the owner goes into a locker which is pretty stupid. Most components also only check for turf distance, and while this could theoretically be used to pinpoint someone's hiding spot there are far better ways to do so with circuits

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Circuit health analyzer/state components now work on targets inside lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
