### PR TITLE
ERTs can now be summoned as a set species

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -1,5 +1,4 @@
 /datum/ert
-	var/mobtype = /mob/living/carbon/human
 	var/team = /datum/team/ert
 	var/opendoors = TRUE
 	var/leader_role = /datum/antagonist/ert/commander
@@ -20,6 +19,8 @@
 	var/datum/map_template/ert_template
 	/// If we should actually _use_ the ert_template custom shuttle
 	var/use_custom_shuttle = TRUE
+	/// Used for spawning bodies for your ERT. Unless customized in the Summon-ERT verb settings, will be overridden and should not be defined at the datum level.
+	var/mob/living/carbon/human/mob_type
 
 /datum/ert/New()
 	if (!polldesc)

--- a/code/modules/admin/verbs/ert.dm
+++ b/code/modules/admin/verbs/ert.dm
@@ -84,7 +84,7 @@
 		"teamsize" = list("desc" = "Team Size", "type" = "number", "value" = ertemplate.teamsize),
 		"mission" = list("desc" = "Mission", "type" = "string", "value" = ertemplate.mission),
 		"polldesc" = list("desc" = "Ghost poll description", "type" = "string", "value" = ertemplate.polldesc),
-		"enforce_human" = list("desc" = "Enforce human authority", "type" = "boolean", "value" = "[(ertemplate.enforce_human ? "Yes" : "No")]"),
+		"enforce_human" = list("desc" = "Enforce human authority", "type" = "boolean", "value" = "[(CONFIG_GET(flag/enforce_human_authority) ? "Yes" : "No")]"),
 		"open_armory" = list("desc" = "Open armory doors", "type" = "boolean", "value" = "[(ertemplate.opendoors ? "Yes" : "No")]"),
 		"leader_experience" = list("desc" = "Pick an experienced leader", "type" = "boolean", "value" = "[(ertemplate.leader_experience ? "Yes" : "No")]"),
 		"random_names" = list("desc" = "Randomize names", "type" = "boolean", "value" = "[(ertemplate.random_names ? "Yes" : "No")]"),

--- a/code/modules/admin/verbs/ert.dm
+++ b/code/modules/admin/verbs/ert.dm
@@ -84,7 +84,7 @@
 		"teamsize" = list("desc" = "Team Size", "type" = "number", "value" = ertemplate.teamsize),
 		"mission" = list("desc" = "Mission", "type" = "string", "value" = ertemplate.mission),
 		"polldesc" = list("desc" = "Ghost poll description", "type" = "string", "value" = ertemplate.polldesc),
-		"enforce_human" = list("desc" = "Enforce human authority", "type" = "boolean", "value" = "[(CONFIG_GET(flag/enforce_human_authority) ? "Yes" : "No")]"),
+		"enforce_human" = list("desc" = "Enforce human authority", "type" = "boolean", "value" = "[(ertemplate.enforce_human ? "Yes" : "No")]"),
 		"open_armory" = list("desc" = "Open armory doors", "type" = "boolean", "value" = "[(ertemplate.opendoors ? "Yes" : "No")]"),
 		"leader_experience" = list("desc" = "Pick an experienced leader", "type" = "boolean", "value" = "[(ertemplate.leader_experience ? "Yes" : "No")]"),
 		"random_names" = list("desc" = "Randomize names", "type" = "boolean", "value" = "[(ertemplate.random_names ? "Yes" : "No")]"),

--- a/code/modules/admin/verbs/ert.dm
+++ b/code/modules/admin/verbs/ert.dm
@@ -90,6 +90,7 @@
 		"random_names" = list("desc" = "Randomize names", "type" = "boolean", "value" = "[(ertemplate.random_names ? "Yes" : "No")]"),
 		"spawn_admin" = list("desc" = "Spawn yourself as briefing officer", "type" = "boolean", "value" = "[(ertemplate.spawn_admin ? "Yes" : "No")]"),
 		"use_custom_shuttle" = list("desc" = "Use the ERT's custom shuttle (if it has one)", "type" = "boolean", "value" = "[(ertemplate.use_custom_shuttle ? "Yes" : "No")]"),
+		"mob_type" = list("desc" = "Base Species", "callback" = CALLBACK(src, PROC_REF(makeERTTemplateModified)), "type" = "datum", "path" = "/mob/living/carbon/human", "subtypesonly" = TRUE, "value" = ertemplate.mob_type),
 		)
 	)
 
@@ -117,6 +118,7 @@
 		ertemplate.random_names = prefs["random_names"]["value"] == "Yes"
 		ertemplate.spawn_admin = prefs["spawn_admin"]["value"] == "Yes"
 		ertemplate.use_custom_shuttle = prefs["use_custom_shuttle"]["value"] == "Yes"
+		ertemplate.mob_type = prefs["mob_type"]["value"]
 
 		var/list/spawnpoints = GLOB.emergencyresponseteamspawn
 		var/index = 0
@@ -222,8 +224,12 @@
 				continue
 
 			//Spawn the body
-			var/mob/living/carbon/human/ert_operative = new ertemplate.mobtype(spawnloc)
-			chosen_candidate.client.prefs.safe_transfer_prefs_to(ert_operative, is_antag = TRUE)
+			var/mob/living/carbon/human/ert_operative
+			if(ertemplate.mob_type)
+				ert_operative = new ertemplate.mob_type(spawnloc)
+			else
+				ert_operative = new /mob/living/carbon/human(spawnloc)
+				chosen_candidate.client.prefs.safe_transfer_prefs_to(ert_operative, is_antag = TRUE)
 			ert_operative.key = chosen_candidate.key
 
 			if(ertemplate.enforce_human || !(ert_operative.dna.species.changesource_flags & ERT_SPAWN)) // Don't want any exploding plasmemes


### PR DESCRIPTION
## About The Pull Request

This repurposes the redundant `mobtype` var on the ERT datum. Originally used to store the typepath for what mob the ERT would spawn (which was unchanged on any of the other datums), it is now null by default and can be modified in the summon_ert verb menu. If left blank, it will default to humans, but it can be set to any humanoid species.

![image](https://github.com/user-attachments/assets/8caa01e3-dabf-4971-ba38-68138fb66eae)
## Why It's Good For The Game

As stated previously, mobtype was redundant, as it would either always spawn humans (human authority would immediately humanize the spawned mob) or be overridden by the preferences of the player being spawned. Rather than making it a hardcoded value and deleting the var, I've elected to repurpose it for further ERT customization.

Moth ERT, Moth ERT, Moth ERT.
## Changelog
:cl: Rhials
admin: You can now choose the humanoid species spawned by an ERT summon in the summon menu.
/:cl:
