### PR TITLE
Reduced caltrop default paralyze timer from 6 to 2

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -30,7 +30,7 @@
 	///So we can update ant damage
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
-/datum/component/caltrop/Initialize(min_damage = 0, max_damage = 0, probability = 100, paralyze_duration = 6 SECONDS, flags = NONE, soundfile = null)
+/datum/component/caltrop/Initialize(min_damage = 0, max_damage = 0, probability = 100, paralyze_duration = 2 SECONDS, flags = NONE, soundfile = null)
 	. = ..()
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE


### PR DESCRIPTION

## About The Pull Request

Reduced caltrop default paralyze timer from 6 to 2. In practice, this means glass shards, broken glasses, etc.

## Why It's Good For The Game

As time goes on, the game has sped up. stuns are smaller, attacks are more volatile, the pace has generally gone up. Six seconds for stepping on some broken shards is, frankly, rather ridiculous in 2024 /tg/. It made more sense in the past, but I think it's time to reduce it. Two seconds is plenty of time in an active situation to get screwed over for being weird and not having shoes, six is overkill and just frustrating when you lose a leg.

## Changelog

:cl:
balance: Reduced caltrop default paralyze timer from 6 to 2
/:cl:

