### PR TITLE
Fixed chanterelles runtiming upon being hollowed out with a spoon and not spawning a hat

### DIFF
--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -205,11 +205,11 @@
 
 	to_chat(user, span_notice("You hollow up the chanterelle with [I]."))
 	remove_item_from_storage(user)
-	qdel(src)
 	if(seed.resistance_flags & FIRE_PROOF)
 		user.put_in_hands(new /obj/item/clothing/head/wizard/chanterelle/fr())
 	else
 		user.put_in_hands(new /obj/item/clothing/head/wizard/chanterelle())
+	qdel(src)
 
 //Jupiter Cup
 /obj/item/seeds/chanter/jupitercup


### PR DESCRIPTION

## About The Pull Request

Closes #85659

Not, in fact, attack chain heck. Just seed getting deleted too soon.

## Changelog
:cl:
fix: Fixed chanterelles runtiming upon being hollowed out with a spoon and not spawning a hat
/:cl:
