### PR TITLE
Materials now attempt to merge other stacks into their own instead of doing the opposite

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -669,7 +669,10 @@
 		return
 
 	if(!arrived.throwing && can_merge(arrived))
-		INVOKE_ASYNC(src, PROC_REF(merge), arrived)
+		if (istype(arrived, /obj/item/stack))
+			INVOKE_ASYNC(arrived, TYPE_PROC_REF(/obj/item/stack, merge), src)
+		else
+			INVOKE_ASYNC(src, PROC_REF(merge), arrived)
 
 /obj/item/stack/hitby(atom/movable/hitting, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(can_merge(hitting, inhand = TRUE))


### PR DESCRIPTION

## About The Pull Request

Closes #85658
God I hate the fact that merge merges *the parent object* into the target instead of vise versa

## Changelog
:cl:
fix: Materials now attempt to merge other stacks into their own instead of doing the opposite
/:cl:
