### PR TITLE
Adds arms/legs coverage to armored gloves/shoes, adds a unit test to check for former

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -386,6 +386,7 @@
 	icon_state = "crusader"
 	w_class = WEIGHT_CLASS_NORMAL
 	armor_type = /datum/armor/shoes_plate
+	body_parts_covered = FEET|LEGS
 	clothing_traits = list(TRAIT_NO_SLIP_WATER)
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -17,6 +17,7 @@
 	desc = "advanced clown shoes that protect the wearer and render them nearly immune to slipping on their own peels. They also squeak at 100% capacity."
 	clothing_traits = list(TRAIT_NO_SLIP_WATER)
 	slowdown = SHOES_SLOWDOWN
+	body_parts_covered = FEET|LEGS
 	armor_type = /datum/armor/clown_shoes_combat
 	strip_delay = 70
 	resistance_flags = NONE

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -50,6 +50,7 @@
 	strip_delay = 70
 	resistance_flags = NONE
 	always_noslip = TRUE
+	body_parts_covered = FEET|LEGS
 
 /datum/armor/banana_shoes_combat
 	melee = 25

--- a/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
+++ b/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
@@ -107,6 +107,7 @@ do { \
 	greyscale_colors = null
 
 	resistance_flags = NONE
+	body_parts_covered = HANDS|ARMS
 	armor_type = /datum/armor/gloves_chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/gloves)
 	clothing_traits = list(TRAIT_FAST_CUFFING)
@@ -218,6 +219,7 @@ do { \
 	desc = "A pair of black shoes."
 	icon_state = "sneakers"
 	inhand_icon_state = "sneakers_back"
+	body_parts_covered = FEET|LEGS
 	greyscale_colors = "#545454#ffffff"
 	greyscale_config = /datum/greyscale_config/sneakers
 	greyscale_config_worn = /datum/greyscale_config/sneakers/worn

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -50,6 +50,7 @@
 	resistance_flags = NONE
 	armor_type = /datum/armor/shoes_jackboots
 	can_be_tied = FALSE
+	body_parts_covered = FEET|LEGS
 
 /datum/armor/shoes_jackboots
 	bio = 90

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -3,6 +3,7 @@
 	desc = "High speed, low drag combat boots."
 	icon_state = "jackboots"
 	inhand_icon_state = "jackboots"
+	body_parts_covered = FEET|LEGS
 	armor_type = /datum/armor/shoes_combat
 	strip_delay = 40
 	resistance_flags = NONE
@@ -108,6 +109,7 @@
 	strip_delay = 4 SECONDS
 	equip_delay_other = 4 SECONDS
 	clothing_flags = THICKMATERIAL
+	body_parts_covered = FEET|LEGS
 	resistance_flags = NONE
 
 /datum/armor/ice_boots_eva
@@ -177,6 +179,7 @@
 	strip_delay = 40
 	resistance_flags = NONE
 	lace_time = 12 SECONDS
+	body_parts_covered = FEET|LEGS
 
 /datum/armor/shoes_pirate
 	melee = 25

--- a/code/modules/clothing/shoes/cowboy.dm
+++ b/code/modules/clothing/shoes/cowboy.dm
@@ -109,3 +109,4 @@
 	desc = "And they sing, oh, ain't you glad you're single? And that song ain't so very far from wrong."
 	armor_type = /datum/armor/shoes_combat
 	has_spurs = TRUE
+	body_parts_covered = FEET|LEGS

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -622,6 +622,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	body_parts_covered = HANDS|ARMS
 	resistance_flags = LAVA_PROOF | FIRE_PROOF //they are from lavaland after all
 	armor_type = /datum/armor/gloves_gauntlets
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -150,6 +150,7 @@
 #include "gas_transfer.dm"
 #include "get_turf_pixel.dm"
 #include "geyser.dm"
+#include "gloves_and_shoes_armor.dm"
 #include "greyscale_config.dm"
 #include "hallucination_icons.dm"
 #include "heretic_knowledge.dm"

--- a/code/modules/unit_tests/gloves_and_shoes_armor.dm
+++ b/code/modules/unit_tests/gloves_and_shoes_armor.dm
@@ -1,0 +1,25 @@
+/// Checks if any gloves or shoes that have non bio/fire/acid armor haven't been marked with ARMS or LEGS coverage respectively
+/datum/unit_test/gloves_and_shoes_armor
+
+/datum/unit_test/gloves_and_shoes_armor/Run()
+	for (var/obj/item/clothing/gloves/gloves as anything in subtypesof(/obj/item/clothing/gloves))
+		var/datum/armor/armor = gloves::armor_type
+		if (!armor)
+			continue
+
+		if (gloves::body_parts_covered != HANDS)
+			continue
+
+		if (armor::melee || armor::bomb || armor::energy || armor::laser || armor::bullet || armor::wound)
+			TEST_FAIL("[gloves] has non-bio/acid/fire armor but doesn't cover non-hand bodyparts.")
+
+	for (var/obj/item/clothing/shoes/shoes as anything in subtypesof(/obj/item/clothing/shoes))
+		var/datum/armor/armor = shoes::armor_type
+		if (!armor)
+			continue
+
+		if (shoes::body_parts_covered != FEET)
+			continue
+
+		if (armor::melee || armor::bomb || armor::energy || armor::laser || armor::bullet || armor::wound)
+			TEST_FAIL("[shoes] has non-bio/acid/fire armor but doesn't cover non-feet bodyparts.")


### PR DESCRIPTION

## About The Pull Request
Turns out HANDS and FEET coverage doesn't actually apply armor to the body, at all, making it entirely useless. Despite this, a lot of clothing still does it! So I added ARMS and LEGS flags to gloves/shoes that do it respectively and wrote a unit test for it that will yell out a list of all items missing coverage while having non acid/bio/fire armor (three snowflake types)

as discusses with melbert on discord

## Why It's Good For The Game
...features working as intended?

## Changelog
:cl:
balance: Multiple gloves/shoes that had armor values but failed to apply them got fixed
/:cl:
