### PR TITLE
Fixed Charlie MOD installer not installing MODsuits unless you have a backpack to drop

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/oldstation/oldstation_mod.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/oldstation/oldstation_mod.dm
@@ -64,7 +64,7 @@
 	var/mob/living/carbon/human/human_occupant = occupant
 	if(!istype(human_occupant))
 		return
-	if(!human_occupant.dropItemToGround(human_occupant.back))
+	if(!isnull(human_occupant.back) && !human_occupant.dropItemToGround(human_occupant.back))
 		return
 	if(!human_occupant.equip_to_slot_if_possible(mod_unit, mod_unit.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
 		return


### PR DESCRIPTION

## About The Pull Request

Closes #85669

## Changelog
:cl:
fix: Fixed Charlie MOD installer not installing MODsuit unless you have a backpack to drop
/:cl:
