### PR TITLE
Rainbow jumpsuits are fireproof

### DIFF
--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -226,6 +226,7 @@
 	greyscale_config_worn = null
 	can_adjust = FALSE
 	flags_1 = NONE
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/under/color/jumpskirt/rainbow
 	name = "rainbow jumpskirt"


### PR DESCRIPTION

## About The Pull Request

Rainbow jumpsuits are now fireproof.

## Why It's Good For The Game

Burning jumpsuits is pretty close to SS13'S version of burning flags. Burning a rainbow jumpsuit, often a symbol of LGBT pride, is heavily associated with the equivalent action of burning an LGBT flag, which is hate speech we don't want to encourage in our game. This ensures that won't be an issue.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Rainbow jumpsuits are fireproof
/:cl:

