### PR TITLE
Fix a spot of shitcode

### DIFF
--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -44,9 +44,9 @@
 	speed /= segments
 
 	if(parallel)
-		animate(src, transform = matrices[1], time = speed, loops , flags = ANIMATION_PARALLEL)
+		animate(src, transform = matrices[1], time = speed, loop = loops, flags = ANIMATION_PARALLEL)
 	else
-		animate(src, transform = matrices[1], time = speed, loops)
+		animate(src, transform = matrices[1], time = speed, loop = loops)
 	for(var/i in 2 to segments) //2 because 1 is covered above
 		animate(transform = matrices[i], time = speed)
 		//doesn't have an object argument because this is "Stacking" with the animate call above

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -360,7 +360,7 @@
 
 /obj/effect/abstract/gas_visual/Initialize(mapload)
 	. = ..()
-	color_filter = filter(type="color", color=matrix())
+	color_filter = filter(type="color", color="white")
 	filters += color_filter
 	color_filter = filters[filters.len]
 	if(current_color)


### PR DESCRIPTION
## About The Pull Request
OD errors on invalid values for `color` in a color filter def, BYOND just fails silently and gives a white color matrix. I'm guessing this was going for identity matrix == white, but `/matrix` is not a color matrix.

OD also errors on invalid values for `easing` in `animate`, which this also fixes an instance of
## Why It's Good For The Game
Fix shitcode
