### PR TITLE
Fixes a hard del with island_brawl spawners

### DIFF
--- a/code/modules/bitrunning/virtual_domain/domains/island_brawl.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/island_brawl.dm
@@ -29,6 +29,7 @@
 	SIGNAL_HANDLER
 
 	custom_spawns -= source
+	UnregisterSignal(source, COMSIG_QDELETING)
 
 
 /// Someone has spawned in, so we check for their death

--- a/code/modules/bitrunning/virtual_domain/domains/island_brawl.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/island_brawl.dm
@@ -21,7 +21,14 @@
 	for(var/obj/effect/mob_spawn/ghost_role/human/virtual_domain/islander/spawner in created_atoms)
 		custom_spawns += spawner
 
+		RegisterSignal(spawner, COMSIG_QDELETING, PROC_REF(on_spawner_qdeleted))
 		RegisterSignals(spawner, list(COMSIG_GHOSTROLE_SPAWNED, COMSIG_BITRUNNER_SPAWNED), PROC_REF(on_spawn))
+
+
+/datum/lazy_template/virtual_domain/island_brawl/proc/on_spawner_qdeleted(obj/effect/mob_spawn/ghost_role/human/virtual_domain/islander/source)
+	SIGNAL_HANDLER
+
+	custom_spawns -= source
 
 
 /// Someone has spawned in, so we check for their death


### PR DESCRIPTION
## About The Pull Request

![yN86RRrD0h](https://github.com/user-attachments/assets/2aaa23c8-1fcb-4a40-ad54-c71306a2f430)

Tin, just aims to fix this hard del by releasing the refs when the spawners get qdeleted.

## Why It's Good For The Game

Fixes a hard del---also, there were some issues with this domain not clearing itself properly under certain cases and this may resolve that.

## Changelog

Nothing player facing