### PR TITLE
Removes an unused var from SSpersistence

### DIFF
--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -43,8 +43,6 @@ SUBSYSTEM_DEF(persistence)
 	/// List of persistene ids which piggy banks.
 	var/list/queued_broken_piggy_ids
 
-	var/list/broken_piggy_banks
-
 	var/rounds_since_engine_exploded = 0
 	var/delam_highscore = 0
 	var/tram_hits_this_round = 0


### PR DESCRIPTION
## About The Pull Request
I think I may have forgotten to remove it from the final version of the persistent piggy banks PR (museum cafeteria yadda yadda)

## Why It's Good For The Game
Unused var.

## Changelog
N/A