### PR TITLE
Fixes an oversight with EVA helmets having no FOV despite blocking pepperspray and hiding your identity.

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -25,6 +25,10 @@
 	resistance_flags = NONE
 	dog_fashion = null
 
+/obj/item/clothing/head/helmet/space/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+
 /datum/armor/helmet_space
 	bio = 100
 	fire = 80


### PR DESCRIPTION
## About The Pull Request

Fixes an oversight with EVA helmets having no FOV despite blocking pepperspray and hiding your identity.

## Why It's Good For The Game

![Discord_p4MEgJG8OU](https://github.com/user-attachments/assets/67f3d03c-aa6b-439d-8992-d3be114f4465)
![Discord_0xhGl7sh99](https://github.com/user-attachments/assets/ceb85300-d631-40a7-91cf-b85ba06dd2e8)

i see all, players, nice try
## Changelog

:cl:
balance: Fixes an oversight with EVA helmets having no FOV despite blocking pepperspray and hiding your identity.
/:cl: