### PR TITLE
Splits the slowdown between the space helmet and the space suit

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -24,6 +24,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	dog_fashion = null
+	slowdown = 0.5
 
 /datum/armor/helmet_space
 	bio = 100
@@ -47,7 +48,7 @@
 		/obj/item/tank/internals,
 		/obj/item/tank/jetpack/oxygen/captain,
 		)
-	slowdown = 1
+	slowdown = 0.5
 	armor_type = /datum/armor/suit_space
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS

--- a/code/modules/clothing/spacesuits/pirate.dm
+++ b/code/modules/clothing/spacesuits/pirate.dm
@@ -3,6 +3,7 @@
 	desc = "A modified helmet to allow space pirates to intimidate their customers whilst staying safe from the void. Comes with some additional protection."
 	icon_state = "spacepirate"
 	inhand_icon_state = "space_pirate_helmet"
+	slowdown = 0
 	armor_type = /datum/armor/space_pirate
 	strip_delay = 40
 	equip_delay_other = 20

--- a/code/modules/clothing/spacesuits/santa.dm
+++ b/code/modules/clothing/spacesuits/santa.dm
@@ -7,6 +7,7 @@
 	inhand_icon_state = "santahat"
 	flags_cover = HEADCOVERSEYES
 	dog_fashion = /datum/dog_fashion/head/santa
+	slowdown = 0
 
 /obj/item/clothing/head/helmet/space/santahat/beardless
 	icon = 'icons/obj/clothing/head/costume.dmi'
@@ -14,6 +15,7 @@
 	icon_state = "santahatnorm"
 	inhand_icon_state = "that"
 	flags_inv = NONE
+	slowdown = 0
 
 /obj/item/clothing/suit/space/santa
 	name = "Santa's suit"

--- a/code/modules/clothing/spacesuits/softsuit.dm
+++ b/code/modules/clothing/spacesuits/softsuit.dm
@@ -16,13 +16,14 @@
 	name = "Engineering Void Helmet"
 	desc = "A CentCom engineering dark red space suit helmet. While old and dusty, it still gets the job done."
 	icon_state = "void"
+	slowdown = 2
 
 /obj/item/clothing/suit/space/nasavoid/old
 	name = "Engineering Voidsuit"
 	icon_state = "void"
 	inhand_icon_state = "void_suit"
 	desc = "A CentCom engineering dark red space suit. Age has degraded the suit making it difficult to move around in."
-	slowdown = 4
+	slowdown = 2
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
 
 	//EVA suit
@@ -72,6 +73,7 @@
 	inhand_icon_state = "syndicate-helm-orange" //resprite?
 	armor_type = /datum/armor/space_fragile
 	strip_delay = 65
+	slowdown = 1
 
 /obj/item/clothing/suit/space/fragile
 	name = "emergency space suit"
@@ -79,7 +81,7 @@
 	var/torn = FALSE
 	icon_state = "syndicate-orange"
 	inhand_icon_state = "syndicate-orange"
-	slowdown = 2
+	slowdown = 1
 	armor_type = /datum/armor/space_fragile
 	strip_delay = 65
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -755,12 +755,13 @@
 	name = "emergency space helmet"
 	icon_state = "syndicate-helm-orange"
 	inhand_icon_state = "syndicate-helm-orange"
+	slowdown = 1.5
 
 /obj/item/clothing/suit/space/orange
 	name = "emergency space suit"
 	icon_state = "syndicate-orange"
 	inhand_icon_state = "syndicate-orange"
-	slowdown = 3
+	slowdown = 1.5
 
 /obj/item/pickaxe/emergency
 	name = "emergency disembarkation tool"


### PR DESCRIPTION
## About The Pull Request
As the title says. Instead of space suits providing all of the slowdown, it provides half of the slowdown and the other half is given to the space helmet as slowdown too.

Closes #85702

## Why It's Good For The Game
By splitting the slowdown cost between the two components that make a traditional space suit, players will no longer gain pepperspray immunity with no downside.

This also does provide the benefit of moving a bit faster if you aren't wearing a bulky space suit helmet and I think it does just add to the immersion a lot more if it were the two components of the space suit that slowed you down together rather than one or the other.

## Changelog
:cl:
balance: Space suits no longer provide all of the slowdown when wearing space gear. Helmets now share the burden and you can now move faster when wearing only a space suit. Helmets now provide a bit of slowdown when worn alone as a result.
/:cl:
