### PR TITLE
Buff to MODsuit deployment time

### DIFF
--- a/code/__DEFINES/mod.dm
+++ b/code/__DEFINES/mod.dm
@@ -5,7 +5,7 @@
 #define DEFAULT_CHARGE_DRAIN (0.005 * STANDARD_CELL_CHARGE) // A standard cell lasts 200 seconds with this on active power usage, while a high power one lasts 2,000 seconds.
 
 /// Default time for a part of the suit to seal.
-#define MOD_ACTIVATION_STEP_TIME (2 SECONDS)
+#define MOD_ACTIVATION_STEP_TIME (1 SECONDS)
 
 /// Passive module, just acts when put in naturally.
 #define MODULE_PASSIVE 0

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1351,6 +1351,7 @@
 	siemens_coefficient = 0
 	slowdown_inactive = 0
 	slowdown_active = 0
+	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.5
 	ui_theme = "syndicate"
 	slot_flags = ITEM_SLOT_BELT
 	inbuilt_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/storage/belt, /obj/item/mod/module/demoralizer)


### PR DESCRIPTION

## About The Pull Request
Before it took 12 seconds to fully deploy (2 seconds per part) so it's just an awkward standing around moment while you wait for your MOD to activate in front of the airlock.
- Increased speed of MODsuit deploy time by 2 times
- Increased speed of infiltrator MODsuit deploy time by 4 times
## Why It's Good For The Game
One of the reasons why so many players are deterred from MODsuits is how long the deployment or undeployment takes. 
This change should increase the desire for players to use MODsuits and will raise their value, giving more incentive to produce more, which roboticists barely ever do.

The infiltrator MODsuit is supposed to be a sneaky sleek and quick (infiltrating) device, allowing you to quickly disguise your identity and then quickly become inconspicuous. This change allows it to execute that purpose better.
## Changelog
:cl: grungussuss
balance: MODsuits now deploy 2 times faster
balance: The infiltrator MODsuit now deploys 4 times faster
/:cl:
