### PR TITLE
Fixed bileworms not having a deaggro range

### DIFF
--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -29,6 +29,9 @@
 		if(M.status_flags & GODMODE)
 			return FALSE
 
+	if (vision_range && get_dist(living_mob, the_target) > vision_range)
+		return FALSE
+
 	if(!ignore_sight && !can_see(living_mob, the_target, vision_range)) //Target has moved behind cover and we have lost line of sight to it
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Closes #69244
Bileworms use standard 9 tiles of vision but also have the ignore_sight flag, which prevents can_see check from running. Check, which is the only place where deaggro range check exists. Vision range may need bumping up based on player feedback if they seem to be deaggroing too easily due to slow movement speed now that they actually do so

## Changelog
:cl:
fix: Fixed bileworms not having a deaggro range
/:cl:
