### PR TITLE
Adds attack_dir to multiple common damage sources, fixes mechs' directional armor

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -275,7 +275,7 @@
 	if(!attacking_item.force)
 		return
 
-	var/damage = take_damage(attacking_item.force, attacking_item.damtype, MELEE, 1)
+	var/damage = take_damage(attacking_item.force, attacking_item.damtype, MELEE, 1, get_dir(src, user))
 	//only witnesses close by and the victim see a hit message.
 	user.visible_message(span_danger("[user] hits [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]"), \
 		span_danger("You hit [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]"), null, COMBAT_MESSAGE_RANGE)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -96,7 +96,7 @@
 
 /obj/proc/collision_damage(atom/movable/pusher, force = MOVE_FORCE_DEFAULT, direction)
 	var/amt = max(0, ((force - (move_resist * MOVE_FORCE_CRUSH_RATIO)) / (move_resist * MOVE_FORCE_CRUSH_RATIO)) * 10)
-	take_damage(amt, BRUTE)
+	take_damage(amt, BRUTE, attack_dir = REVERSE_DIR(direction))
 
 /obj/singularity_act()
 	SSexplosions.high_mov_atom += src

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 
 	var/total_force = (attacking_item.force * attacking_item.demolition_mod)
 
-	var/damage = take_damage(total_force, attacking_item.damtype, MELEE, 1)
+	var/damage = take_damage(total_force, attacking_item.damtype, MELEE, 1, get_dir(src, user))
 
 	var/damage_verb = "hit"
 

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -25,7 +25,7 @@
 	// Get a sample "melee" weapon.
 	// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
 	var/obj/item/dummy_melee = allocate(/obj/item/melee/energy/axe)
-	dummy_melee.force = dummy_melee.active_force
+	dummy_melee.force = 150
 	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * dummy_melee.demolition_mod * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
 
 	// Get a sample laser weapon.

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -25,6 +25,7 @@
 	// Get a sample "melee" weapon.
 	// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
 	var/obj/item/dummy_melee = allocate(/obj/item/melee/energy/axe)
+	dummy_melee.force = dummy_melee.active_force
 	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * dummy_melee.demolition_mod * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
 
 	// Get a sample laser weapon.

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -25,7 +25,7 @@
 	// Get a sample "melee" weapon.
 	// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
 	var/obj/item/dummy_melee = allocate(/obj/item/melee/energy/axe)
-	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * dummy_melee.demolition_mod, DAMAGE_PRECISION)
+	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * dummy_melee.demolition_mod * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
 
 	// Get a sample laser weapon.
 	// The captain's laser gun here is chosen primarily because it deals more damage than normal lasers.

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -317,7 +317,7 @@
 	if(!attacking_item.force)
 		return
 
-	var/damage_taken = take_damage(attacking_item.force * attacking_item.demolition_mod, attacking_item.damtype, MELEE, 1)
+	var/damage_taken = take_damage(attacking_item.force * attacking_item.demolition_mod, attacking_item.damtype, MELEE, 1, get_dir(src, user))
 	try_damage_component(damage_taken, user.zone_selected)
 
 	var/hit_verb = length(attacking_item.attack_verb_simple) ? "[pick(attacking_item.attack_verb_simple)]" : "hit"


### PR DESCRIPTION
## About The Pull Request

Closes #81260
Closes #74022
Currently mechs are the only atoms utilizing attack_dir but I added it in multiple other places that were missing it to ensure that if something else uses it it won't break in those scenarios

## Changelog
:cl:
fix: Mechs' directional armor now actually works
/:cl:
