### PR TITLE
Clarify what the Medical Cyborg Omnitool Upgrade does

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -420,7 +420,7 @@
 /obj/item/borg/upgrade/surgery_omnitool
 	name = "cyborg surgical omni-tool upgrade"
 	desc = "An upgrade to the Medical model, upgrading the built-in \
-		surgical omnitool, to be on par with advanced surgical tools"
+		surgical omnitool, to be on par with advanced surgical tools, allowing for faster surgery. It also upgrades their scanner."
 	icon_state = "module_medical"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/medical,  /obj/item/robot_model/syndicate_medical)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -420,7 +420,8 @@
 /obj/item/borg/upgrade/surgery_omnitool
 	name = "cyborg surgical omni-tool upgrade"
 	desc = "An upgrade to the Medical model, upgrading the built-in \
-		surgical omnitool, to be on par with advanced surgical tools, allowing for faster surgery. It also upgrades their scanner."
+		surgical omnitool, to be on par with advanced surgical tools, allowing for faster surgery. \
+		It also upgrades their scanner."
 	icon_state = "module_medical"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/medical,  /obj/item/robot_model/syndicate_medical)


### PR DESCRIPTION
## About The Pull Request
Changed the text of the medical cyborg omnitool upgrade to specify it increases surgery speed, and adds the advanced scanner. 


## Why It's Good For The Game
I had a hard time figuring what this upgrade does. This should make it clearer for everyone why it is good, given it has not much visual feedback. 

## Changelog
:cl:
qol: Clarified what the Medical Cyborg Omnitool Upgrade does
/:cl:
