### PR TITLE
Some crime and citations fixes

### DIFF
--- a/code/datums/records/crime.dm
+++ b/code/datums/records/crime.dm
@@ -12,6 +12,8 @@
 	var/time
 	/// Whether the crime is active or not
 	var/valid = TRUE
+	/// Player that marked the crime as invalid
+	var/voider
 
 /datum/crime/New(name = "Crime", details = "No details provided.", author = "Anonymous")
 	src.author = author

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -102,6 +102,7 @@
 				paid = warrant.paid,
 				time = warrant.time,
 				valid = warrant.valid,
+				voider = warrant.voider,
 			))
 
 		var/list/crimes = list()
@@ -113,6 +114,7 @@
 				name = crime.name,
 				time = crime.time,
 				valid = crime.valid,
+				voider = crime.voider,
 			))
 
 		records += list(list(
@@ -250,8 +252,8 @@
 		editing_crime.name = new_name
 		return TRUE
 
-	if(params["details"] && length(params["description"]) > 2 && params["name"] != editing_crime.name)
-		var/new_details = strip_html_full(params["details"], MAX_MESSAGE_LEN)
+	if(params["description"] && length(params["description"]) > 2 && params["name"] != editing_crime.name)
+		var/new_details = strip_html_full(params["description"], MAX_MESSAGE_LEN)
 		investigate_log("[user] edited crime \"[editing_crime.name]\" for target: \"[target.name]\", changing the details to: \"[new_details]\" from: \"[editing_crime.details]\".", INVESTIGATE_RECORDS)
 		editing_crime.details = new_details
 		return TRUE
@@ -269,6 +271,9 @@
 
 /// Only qualified personnel can edit records.
 /obj/machinery/computer/records/security/proc/has_armory_access(mob/user)
+	if (HAS_SILICON_ACCESS(user))
+		return TRUE
+
 	if(!isliving(user))
 		return FALSE
 	var/mob/living/player = user
@@ -284,16 +289,22 @@
 
 /// Voids crimes, or sets someone to discharged if they have none left.
 /obj/machinery/computer/records/security/proc/invalidate_crime(mob/user, datum/record/crew/target, list/params)
-	if(!has_armory_access(user))
-		return FALSE
 	var/datum/crime/to_void = locate(params["crime_ref"]) in target.crimes
+	var/acquitted = TRUE
 	if(!to_void)
+		to_void = locate(params["crime_ref"]) in target.citations
+		// No need to change status after invalidatation of citation
+		acquitted = FALSE
+		if(!to_void)
+			return FALSE
+
+	if(user != to_void.author && !has_armory_access(user))
 		return FALSE
 
 	to_void.valid = FALSE
+	to_void.voider = user
 	investigate_log("[key_name(user)] has invalidated [target.name]'s crime: [to_void.name]", INVESTIGATE_RECORDS)
 
-	var/acquitted = TRUE
 	for(var/datum/crime/incident in target.crimes)
 		if(!incident.valid)
 			continue

--- a/code/game/machinery/computer/warrant.dm
+++ b/code/game/machinery/computer/warrant.dm
@@ -133,6 +133,7 @@
 		return TRUE
 
 	warrant.alert_owner(user, src, target.name, "One of your outstanding warrants has been completely paid.")
+	warrant.valid = FALSE
 	return TRUE
 
 /// Finishes printing, resets the printer.

--- a/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
@@ -102,8 +102,9 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
   const { crew_ref } = foundRecord;
   const { act, data } = useBackend<SecurityRecordsData>();
   const { current_user, higher_access } = data;
-  const { author, crime_ref, details, fine, name, paid, time, valid } = item;
-  const showFine = !!fine && fine > 0 ? `: ${fine} cr` : '';
+  const { author, crime_ref, details, fine, name, paid, time, valid, voider } =
+    item;
+  const showFine = !!fine && fine > 0 ? `: ${fine} cr` : ': PAID OFF';
 
   let collapsibleColor = '';
   if (!valid) {
@@ -113,7 +114,7 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
   }
 
   let displayTitle = name;
-  if (fine && fine > 0) {
+  if (fine !== undefined) {
     displayTitle = name.slice(0, 18) + showFine;
   }
 
@@ -128,7 +129,15 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
           <LabeledList.Item color={!valid ? 'bad' : 'good'} label="Status">
             {!valid ? 'Void' : 'Active'}
           </LabeledList.Item>
-          {fine && (
+          {!valid && (
+            <LabeledList.Item
+              color={voider ? 'gold' : 'good'}
+              label="Voided by"
+            >
+              {!voider ? 'Automation' : voider}
+            </LabeledList.Item>
+          )}
+          {!!fine && fine > 0 && (
             <>
               <LabeledList.Item color="bad" label="Fine">
                 {fine}cr <Icon color="gold" name="coins" />
@@ -155,7 +164,7 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
             </Button>
             <Button.Confirm
               content="Invalidate"
-              disabled={!higher_access || !valid}
+              disabled={!valid || (!higher_access && author !== current_user)}
               icon="ban"
               onClick={() =>
                 act('invalidate_crime', {

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -37,6 +37,7 @@ export type Crime = {
   paid: number;
   time: number;
   valid: BooleanLike;
+  voider: string;
 };
 
 export enum SECURETAB {


### PR DESCRIPTION

## About The Pull Request

1. Silicons now able to invalidate crimes, because... they have armory access too.
2. After citation being paid off there will be no more broken 0 in sec records
3. After citation being paid off it will be invalidated automticaly
4. Crime authors can invalidate crimes, issued by them.
5. In case of invalidation, crime now shows who voided it
6. Also fixing bug with editing crime description
<details>
<summary>Screenshots</summary>
![image](https://github.com/user-attachments/assets/d6635dd2-87a8-47d6-a7eb-269c08fbdcf5)
![image](https://github.com/user-attachments/assets/8d739e57-24a5-4d58-8a87-47344a04b46c)
![image](https://github.com/user-attachments/assets/c000caff-76c7-484d-bf8f-57a2946e93c4)

</details>

## Why It's Good For The Game

Thats few fixes and QoLs features.
If someone want to argue about:
1. Synths: man they was able to issue crimes which is more impactfull + now voiding is recorded
2. Authors: they had ability to edit name and description, why can't delete?
3. Voiders: how offen do you use invalidate button? How many of those uses you wanna hide from sec?
## Changelog
:cl:
fix: Strange zeros in paid off citations on sec records
fix: Now invalidating citations works
fix: You can change crimes description
fix: Synths have 'armory access' for sec records logic
qol: Paying off citation now automaticaly voiding it
qol: Crime issuer can void the crime without armory access
qol: In case of invalidation crime shows who voided it
/:cl:
