### PR TITLE
Makes the Ansem implant locked

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -609,7 +609,7 @@
 	uniform = /obj/item/clothing/under/syndicate/tacticool
 	back = /obj/item/mod/control/pre_equipped/nuclear
 	r_hand = /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
-	belt = /obj/item/gun/ballistic/automatic/pistol/clandestine
+	belt = /obj/item/gun/ballistic/automatic/pistol/clandestine/unrestricted
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/stimulants
 	l_pocket = /obj/item/grenade/syndieminibomb
 	implants = list(/obj/item/implant/explosive)

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -71,6 +71,7 @@
 	can_suppress = FALSE
 	can_unsuppress = FALSE
 	var/obj/item/gun/energy/recharge/fisher/underbarrel
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/ballistic/automatic/pistol/clandestine/fisher/examine_more(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -56,6 +56,10 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m10mm
 	empty_indicator = TRUE
 	suppressor_x_offset = 12
+	pin = /obj/item/firing_pin/implant/pindicate
+
+/obj/item/gun/ballistic/automatic/pistol/clandestine/unrestricted
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/ballistic/automatic/pistol/clandestine/fisher
 	name = "\improper Ansem/SC pistol"

--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -87,7 +87,7 @@
 /datum/uplink_item/spy_unique/ansem_pistol
 	name = "Ansem Pistol"
 	desc = "A pistol that's really good at making people sleep."
-	item = /obj/item/gun/ballistic/automatic/pistol/clandestine
+	item = /obj/item/gun/ballistic/automatic/pistol/clandestine/unrestricted
 	cost = SPY_UPPER_COST_THRESHOLD
 	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
 


### PR DESCRIPTION

## About The Pull Request

The pistol nukies start with (including uplink spawned ones) is now implant locked like their other guns.

## Why It's Good For The Game

Every other gun they get is implant locked. The pistol is pretty underwhelming anyway so I don't think it should be an exception.

## Changelog

:cl:
fix: The Ansem (nuke op pistol) is implant locked like other nukie guns
/:cl:
