### PR TITLE
Wizard's Deja Vu tweaks

### DIFF
--- a/code/datums/components/dejavu.dm
+++ b/code/datums/components/dejavu.dm
@@ -2,6 +2,7 @@
  * A component to reset the parent to its previous state after some time passes
  */
 /datum/component/dejavu
+	dupe_mode = COMPONENT_DUPE_ALLOWED
 
 	///message sent when dejavu rewinds
 	var/rewind_message = "You remember a time not so long ago..."

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -44,7 +44,7 @@
 
 	if(istype(new_area, /area/centcom))
 		return
-	wizard.AddComponent(/datum/component/dejavu/wizard, -1, 60 SECONDS, 60 SECONDS)
+	wizard.AddComponent(/datum/component/dejavu/wizard, -1, 60 SECONDS, TRUE)
 	UnregisterSignal(wizard, COMSIG_ENTER_AREA)
 
 /datum/spellbook_entry/perks/spell_lottery

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -44,7 +44,7 @@
 
 	if(istype(new_area, /area/centcom))
 		return
-	wizard.AddComponent(/datum/component/dejavu/wizard, -1, 60 SECONDS, TRUE)
+	wizard.AddComponent(/datum/component/dejavu/wizard, 1, 60 SECONDS, TRUE)
 	UnregisterSignal(wizard, COMSIG_ENTER_AREA)
 
 /datum/spellbook_entry/perks/spell_lottery

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -42,9 +42,9 @@
 /datum/spellbook_entry/perks/dejavu/proc/give_dejavu(mob/living/carbon/human/wizard, area/new_area)
 	SIGNAL_HANDLER
 
-	if(new_area == GLOB.areas_by_type[/area/centcom/wizard_station])
+	if(istype(new_area, /area/centcom))
 		return
-	wizard.AddComponent(/datum/component/dejavu/timeline, -1, 60 SECONDS)
+	wizard.AddComponent(/datum/component/dejavu/wizard, -1, 60 SECONDS, 60 SECONDS)
 	UnregisterSignal(wizard, COMSIG_ENTER_AREA)
 
 /datum/spellbook_entry/perks/spell_lottery


### PR DESCRIPTION

## About The Pull Request
Deja Vu perk now blacklists all centcom areas, not just the ship itself. It also now teleports you to where you were before the teleport, instead of teleporting you to the same spot every time.

Closes #85737

## Why It's Good For The Game

In its current implementation it makes you borderline immortal as it stores your health, but also makes it impossible to escape the station as you will be teleported to where you first arrived on the station, stealing your greentext. This way its gives the player a more balanced, but riskier experience

## Changelog
:cl:
balance: Deja Vu perk now teleports you to where you were before the last teleport, instead of where you arrived on the station
fix: Deja Vu can no longer be used to return to the wizard ship
/:cl:
