### PR TITLE
Fixes multiple admin verbs using incorrect search, updates them to TGUI

### DIFF
--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -218,9 +218,15 @@ ADMIN_VERB(hostile_environment, R_ADMIN, "Hostile Environment", "Disable the shu
 			SSshuttle.hostile_environments.Cut()
 			SSshuttle.checkHostileEnvironment()
 
-ADMIN_VERB(toggle_nuke, R_DEBUG|R_ADMIN, "Toggle Nuke", "Arm or disarm a nuke.", ADMIN_CATEGORY_EVENTS, obj/machinery/nuclearbomb/nuke in world)
+ADMIN_VERB(toggle_nuke, R_DEBUG|R_ADMIN, "Toggle Nuke", "Arm or disarm a nuke.", ADMIN_CATEGORY_EVENTS)
+	var/list/nukes = list()
+	for (var/obj/machinery/nuclearbomb/bomb in world)
+		nukes += bomb
+	var/obj/machinery/nuclearbomb/nuke = tgui_input_list(user, "", "Toggle Nuke", nukes)
+	if (isnull(nuke))
+		return
 	if(!nuke.timing)
-		var/newtime = input(user, "Set activation timer.", "Activate Nuke", "[nuke.timer_set]") as num|null
+		var/newtime = tgui_input_number(user, "Set activation timer.", "Activate Nuke", nuke.timer_set)
 		if(!newtime)
 			return
 		nuke.timer_set = newtime

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -153,16 +153,7 @@ ADMIN_VERB(polymorph_all, R_ADMIN, "Polymorph All", "Applies the effects of the 
 
 	message_admins("Mass polymorph started by [who_did_it] is complete.")
 
-ADMIN_VERB(admin_smite, R_ADMIN|R_FUN, "Smite", "Smite a player with divine power.", ADMIN_CATEGORY_FUN)
-	var/list/victims = list()
-	for (var/mob/living/victim in world)
-		victims += victim
-
-	var/mob/living/target = tgui_input_list(user, "", "Smite", victims)
-
-	if (isnull(target))
-		return
-
+ADMIN_VERB_AND_CONTEXT_MENU(admin_smite, R_ADMIN|R_FUN, "Smite", "Smite a player with divine power.", ADMIN_CATEGORY_FUN, mob/living/target in world)
 	var/punishment = tgui_input_list(user, "Choose a punishment", "DIVINE SMITING", GLOB.smites)
 
 	if(QDELETED(target) || !punishment)

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -153,8 +153,17 @@ ADMIN_VERB(polymorph_all, R_ADMIN, "Polymorph All", "Applies the effects of the 
 
 	message_admins("Mass polymorph started by [who_did_it] is complete.")
 
-ADMIN_VERB_AND_CONTEXT_MENU(admin_smite, R_ADMIN|R_FUN, "Smite", "Smite a player with divine power.", ADMIN_CATEGORY_FUN, mob/living/target in world)
-	var/punishment = input(user, "Choose a punishment", "DIVINE SMITING") as null|anything in GLOB.smites
+ADMIN_VERB_AND_CONTEXT_MENU(admin_smite, R_ADMIN|R_FUN, "Smite", "Smite a player with divine power.", ADMIN_CATEGORY_FUN)
+	var/list/victims = list()
+	for (var/mob/living/victim in world)
+		victims += victim
+
+	var/mob/living/target = tgui_input_list(user, "", "Smite", victims)
+
+	if (isnull(target))
+		return
+
+	var/punishment = tgui_input_list(user, "Choose a punishment", "DIVINE SMITING", GLOB.smites)
 
 	if(QDELETED(target) || !punishment)
 		return

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -153,7 +153,7 @@ ADMIN_VERB(polymorph_all, R_ADMIN, "Polymorph All", "Applies the effects of the 
 
 	message_admins("Mass polymorph started by [who_did_it] is complete.")
 
-ADMIN_VERB_AND_CONTEXT_MENU(admin_smite, R_ADMIN|R_FUN, "Smite", "Smite a player with divine power.", ADMIN_CATEGORY_FUN)
+ADMIN_VERB(admin_smite, R_ADMIN|R_FUN, "Smite", "Smite a player with divine power.", ADMIN_CATEGORY_FUN)
 	var/list/victims = list()
 	for (var/mob/living/victim in world)
 		victims += victim

--- a/code/modules/admin/verbs/machine_upgrade.dm
+++ b/code/modules/admin/verbs/machine_upgrade.dm
@@ -1,5 +1,13 @@
-ADMIN_VERB(machine_upgrade, R_DEBUG, "Tweak Component Ratings", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, obj/machinery/machine in world)
-	var/new_rating = input(user, "Enter new rating:","Num") as num|null
+ADMIN_VERB(machine_upgrade, R_DEBUG, "Tweak Component Ratings", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN)
+	var/list/machines = list()
+	for (var/obj/machinery/target in world)
+		machines += target
+
+	var/obj/machinery/machine = tgui_input_list(user, "", "Tweak Component Ratings", machines)
+	if (isnull(machine))
+		return
+
+	var/new_rating = tgui_input_number(user, "", "Enter new rating:")
 	if(new_rating && machine.component_parts)
 		for(var/obj/item/stock_parts/P in machine.component_parts)
 			P.rating = new_rating

--- a/code/modules/admin/verbs/machine_upgrade.dm
+++ b/code/modules/admin/verbs/machine_upgrade.dm
@@ -1,12 +1,4 @@
-ADMIN_VERB(machine_upgrade, R_DEBUG, "Tweak Component Ratings", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN)
-	var/list/machines = list()
-	for (var/obj/machinery/target in world)
-		machines += target
-
-	var/obj/machinery/machine = tgui_input_list(user, "", "Tweak Component Ratings", machines)
-	if (isnull(machine))
-		return
-
+ADMIN_VERB_AND_CONTEXT_MENU(machine_upgrade, R_DEBUG, "Tweak Component Ratings", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, obj/machinery/machine in world)
 	var/new_rating = tgui_input_number(user, "", "Enter new rating:")
 	if(new_rating && machine.component_parts)
 		for(var/obj/item/stock_parts/P in machine.component_parts)


### PR DESCRIPTION

## About The Pull Request

Closes #85740
BYOND doesn't support this sort of type picking, these are the 3 last admin verbs to use it

## Changelog
:cl:
fix: Fixed nuke toggle, smite and machine upgrade admin verbs using incorrect sorting
admin: Updated nuke toggle, smite and machine upgrade admin verbs to use TGUI
/:cl:
