### PR TITLE
turf reservations may set whether they should override baseturfs, off for deathmatch

### DIFF
--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -1,6 +1,7 @@
-/datum/lazy_template/deathmatch //deathmatch maps that have any possibility of the walls being destroyed should use indestructible walls, because baseturf moment
+/datum/lazy_template/deathmatch
 	map_dir = "_maps/deathmatch"
 	place_on_top = TRUE
+	turf_reservation_type = /datum/turf_reservation/turf_not_baseturf
 	/// Map UI Name
 	var/name
 	/// Map Description

--- a/code/modules/mapping/space_management/space_reservation.dm
+++ b/code/modules/mapping/space_management/space_reservation.dm
@@ -28,6 +28,9 @@
 	/// The turf type the reservation is initially made with
 	var/turf_type = /turf/open/space
 
+	/// Do we override baseturfs with turf_type?
+	var/turf_type_is_baseturf = TRUE
+
 	///Distance away from the cordon where we can put a "sort-cordon" and run some extra code (see make_repel). 0 makes nothing happen
 	var/pre_cordon_distance = 0
 
@@ -138,6 +141,9 @@
 	if(!HAS_TRAIT(enterer, TRAIT_FREE_HYPERSPACE_SOFTCORDON_MOVEMENT))
 		space_dump(source, enterer)
 
+/datum/turf_reservation/turf_not_baseturf
+	turf_type_is_baseturf = FALSE
+
 /// Internal proc which handles reserving the area for the reservation.
 /datum/turf_reservation/proc/_reserve_area(width, height, zlevel)
 	src.width = width
@@ -181,7 +187,7 @@
 		SSmapping.unused_turfs["[T.z]"] -= T
 		SSmapping.used_turfs[T] = src
 		T.turf_flags = (T.turf_flags | RESERVATION_TURF) & ~UNUSED_RESERVATION_TURF
-		T.ChangeTurf(turf_type, turf_type)
+		T.ChangeTurf(turf_type, turf_type_is_baseturf ? turf_type : null)
 
 	bottom_left_turfs += BL
 	top_right_turfs += TR


### PR DESCRIPTION
## About The Pull Request

uhh laymans terms; break wall, turf under wall not space now plating

turf reservations may set to not override baseturfs with turf_type, created a subtype with that set, and deathmatch templates use this for default

essentially for whoever wants to build a deathmatch map:
set turf_reservation_type (on the template) to
1. **(default)** /datum/turf_reservation/turf_not_baseturf - preserves baseturfs of what you map in, eg. plating under normal flooring and space under that plating, etc. Turf used to fill in the template is still space
2. /datum/turf_reservation/indestructible_plating - fills in the noop spots before loading with indestructible plating, and also is the baseturf for everything there, so break any turf = indestructible plating (you may still map in space)

## Why It's Good For The Game
makes sense for normal walls in deathmatch to not break into space immediately and that allows more destructible deathmatch maps
i encourage whoever makes new maps to include non indestructible turfs

## Changelog
:cl:
fix: breaking certain terrain in deathmatch doesnt instantly breach to space
/:cl:
