### PR TITLE
Prevents people from being shoved into closets/crates/bins through directional glass

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1193,6 +1193,8 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	if(!toggle())
 		return
 	if(was_opened)
+		if (!target.Move(get_turf(src), get_dir(target, src)))
+			return
 		target.forceMove(src)
 	else
 		target.Knockdown(SHOVE_KNOCKDOWN_SOLID)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -624,6 +624,11 @@
 	SIGNAL_HANDLER
 	if((shove_flags & SHOVE_KNOCKDOWN_BLOCKED) || !(shove_flags & SHOVE_BLOCKED))
 		return
+	var/cur_density = density
+	density = FALSE
+	if (!target.Move(get_turf(src), get_dir(target, src)))
+		return
+	density = cur_density
 	target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
 	target.forceMove(src)
 	target.visible_message(span_danger("[shover.name] shoves [target.name] into \the [src]!"),

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -627,6 +627,7 @@
 	var/cur_density = density
 	density = FALSE
 	if (!target.Move(get_turf(src), get_dir(target, src)))
+		density = cur_density
 		return
 	density = cur_density
 	target.Knockdown(SHOVE_KNOCKDOWN_SOLID)


### PR DESCRIPTION

## About The Pull Request

forceMove made it possible for someone to get shoved into a closet/crate/disposals bin through a piece of directional glass that was located on said objects tile, resulting in a very cheesy way to GBJ people.

## Changelog
:cl:
fix: You can no longer shove people into closets through directional glass
/:cl:
