### PR TITLE
Wawastation Science distro fix and a missing cable mended

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -53709,6 +53709,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"sUD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/central/lesser)
 "sUI" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room"
@@ -67028,6 +67034,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "xFt" = (
@@ -93566,7 +93573,7 @@ dTU
 pMD
 acc
 kYl
-jUd
+sUD
 dGc
 fDN
 enu


### PR DESCRIPTION

## About The Pull Request

Adds a missing distro pipe in science maint needed to Science to have atmos distro 
Adds a missing cable in the Electrical Relay connected to Service Maint that acts as a redundency 
## Why It's Good For The Game

Noticed Ordenence burn chamber wasnt cycling due to no distro.. then found all of science had no distro.. oh no. Tracked missing pipe in maint.

Also spotted a missing cable above service maint due to the catwalk bug.
## Changelog
:cl:
fix: Wawastation Science is connected to distro,Floor Electrical Relay cable fixed
/:cl:
