### PR TITLE
Fixed improvised shield crafting recipe being overriden by moonflowers

### DIFF
--- a/code/datums/components/crafting/equipment.dm
+++ b/code/datums/components/crafting/equipment.dm
@@ -23,7 +23,7 @@
 	time = 4 SECONDS
 	category = CAT_EQUIPMENT
 
-/datum/crafting_recipe/improvisedshield
+/datum/crafting_recipe/moonflowershield
 	name = "Moonflower Shield"
 	result = /obj/item/shield/buckler/moonflower
 	reqs = list(


### PR DESCRIPTION

## About The Pull Request
Copypasted code prevented improvised shields from being crafting due to moonflower shields having the same path. Found by ncarlarc on discord

## Changelog
:cl:
fix: Fixed improvised shield crafting recipe being overriden by moonflowers
/:cl:
