### PR TITLE
Fixes blade heretic ascension runtiming and not granting you blades

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -232,6 +232,7 @@
 	blade_orbit_radius = 20,
 	time_between_initial_blades = 0.25 SECONDS,
 	blade_recharge_time = 1 MINUTES,
+	blade_type = /obj/effect/floating_blade,
 )
 
 	src.blade_recharge_time = blade_recharge_time


### PR DESCRIPTION

## About The Pull Request
Closes #84603 
It overrode one of its parent args, resulting in parent code not assigning a var and runtiming when trying to spawn a blade

## Changelog
:cl:
fix: Blade heretic ascension now gives you floating blades once again
/:cl:
