### PR TITLE
Undoes my test code

### DIFF
--- a/code/modules/unit_tests/changeling.dm
+++ b/code/modules/unit_tests/changeling.dm
@@ -70,7 +70,7 @@
 	return victim
 
 /datum/unit_test/transformation_sting/proc/setup_ling()
-	var/mob/living/carbon/human/ling = allocate(/mob/living/carbon/human/consistent/rotate)
+	var/mob/living/carbon/human/ling = allocate(/mob/living/carbon/human/consistent)
 	// Because we use two consistent humans, we need to change some of the features to know they're actually updating to new values.
 	// The more DNA features and random things we change, the more likely we are to catch something not updating correctly.
 	// Yeah guess who/what this is, I dare you.
@@ -97,9 +97,3 @@
 	ling.mind.add_antag_datum(/datum/antagonist/changeling)
 
 	return ling
-
-/mob/living/carbon/human/consistent/rotate
-
-/mob/living/carbon/human/consistent/rotate/setDir(newdir)
-	. = ..()
-	stack_trace("WHAT HOW WHO WOULD DO THIS TO ME ON THE EVENING OF MY SON'S WEDDING")


### PR DESCRIPTION
Changling screenshot test mobs are somehow being shifted around by atmos during their waiting period. This code made that clear but unfortunately it doesn't appear to happen consistently so screenshot tests fail intermittently.

Anyway this wasn't intended to be merged but moth pressed automerge and it saw blood.

We need to figure out what causes atmos diffs in the testing room randomly, but I am too tired rn to do that

