### PR TITLE
Clean up blood brother teams if all members are removed

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -221,6 +221,9 @@
 		return
 	. = ..()
 	member.remove_antag_datum(/datum/antagonist/brother)
+	if (!length(members))
+		qdel(src)
+		return
 	if (isnull(member.current))
 		return
 	for (var/datum/mind/brother_mind as anything in members)


### PR DESCRIPTION

## About The Pull Request

Currently, if you remove someone's BB status, and there's no more members on the team - the empty BB team will still exist, and appear on the roundend report.

## Why It's Good For The Game

No reason for empty teams to exist, and they clog up the roundend report.

## Changelog
:cl:
fix: Empty blood brother teams will now be cleaned up, instead of clogging up the roundend report.
/:cl:
