### PR TITLE
Metastation Wallening update part 1

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1420,10 +1420,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"aBW" = (
-/obj/machinery/button/ignition/incinerator/atmos,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/disposal/incinerator)
 "aBX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -24232,10 +24228,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/airlock_controller/incinerator_atmos{
-	pixel_x = 40;
-	pixel_y = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /turf/open/floor/engine,
@@ -25558,6 +25550,13 @@
 	chamber_id = "ordnanceburn"
 	},
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/structure/table,
+/obj/machinery/button/ignition/incinerator/ordmix/table{
+	pixel_y = 3
+	},
+/obj/machinery/button/door/incinerator_vent_ordmix/table{
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "iYG" = (
@@ -26999,6 +26998,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/power/apc/auto_name/directional/east{
+	areastring = "/area/station/science/ordnance/burnchamber"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jwp" = (
@@ -29764,10 +29766,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/ordnance/burnchamber"
-	},
 /obj/structure/cable,
+/obj/machinery/airlock_controller/incinerator_ordmix{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "kqm" = (
@@ -35806,6 +35808,34 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north{
 	pixel_x = -5
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/cable,
+/obj/structure/table/wood/fancy/black,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = 3;
+	pixel_y = 22
+	},
+/obj/item/reagent_containers/cup/glass/bottle/champagne{
+	pixel_x = -7;
+	pixel_y = 16
+	},
+/obj/item/cigarette/cigar{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/cigarette/cigar{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/keycard_auth/wall_mounted/directional/north{
+	pixel_y = 0
+	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "mCj" = (
@@ -39987,17 +40017,6 @@
 "nWe" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/airlock_controller/incinerator_ordmix{
-	pixel_x = -24
-	},
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = 24;
-	pixel_y = 8
-	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
@@ -48807,7 +48826,6 @@
 /area/station/science/ordnance)
 "rbF" = (
 /obj/machinery/mass_driver/chapelgun,
-/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/machinery/light/small/directional/north,
 /obj/item/gps,
 /obj/effect/turf_decal/stripes/line{
@@ -52643,7 +52661,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 6
 	},
-/obj/structure/sign/warning/fire/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "svQ" = (
@@ -56443,14 +56460,6 @@
 "tLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = -8;
-	pixel_y = -24
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = -8;
-	pixel_y = -36
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -62410,8 +62419,22 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/electrolyzer,
 /obj/machinery/atmospherics/components/binary/pump/on/supply/hidden/layer4,
+/obj/machinery/airlock_controller/incinerator_atmos{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/button/ignition/incinerator/atmos/table{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 16
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_main/table,
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "vPy" = (
@@ -65046,6 +65069,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/structure/cable,
 /obj/machinery/computer/security/telescreen/turbine/directional/east,
+/obj/machinery/electrolyzer,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wHd" = (
@@ -109390,7 +109414,7 @@ nmR
 dQO
 fIZ
 ydj
-aBW
+pnH
 vQh
 pnH
 lZk

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2883,7 +2883,7 @@
 	pixel_y = 12;
 	id = "outerbrig";
 	name = "Brig Exterior Door Control";
-	req_access = s;
+	req_access = list("security");
 	normaldoorcontrol = 1
 	},
 /obj/machinery/button/door/table{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1795,7 +1795,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "aHW" = (
@@ -2951,7 +2950,7 @@
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
 	icon_state = "control_stun";
 	name = "AI Upload Turret Control";
-	pixel_y = 28
+	pixel_y = -7
 	},
 /obj/item/radio/intercom/directional/north{
 	broadcasting = 1;
@@ -4867,6 +4866,10 @@
 	pixel_x = -7;
 	name = "Privacy Shutters Control";
 	req_access = "hop"
+	},
+/obj/machinery/button/flasher{
+	id = "hopflash";
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -23189,12 +23192,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
-"ilD" = (
-/obj/machinery/button/flasher{
-	id = "hopflash"
-	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/hop)
 "ilJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -23702,6 +23699,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"itV" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "itW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -61431,9 +61434,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/digital_clock/directional/north{
-	pixel_y = 0
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vxJ" = (
@@ -93689,7 +93689,7 @@ iiE
 rGj
 rJr
 jTg
-wMx
+itV
 qRI
 urA
 nIR
@@ -94716,7 +94716,7 @@ lJn
 eRC
 htG
 bIq
-ilD
+pJR
 mQq
 ndS
 urA

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -565,7 +565,9 @@
 	id = "AI"
 	},
 /obj/structure/table/wood/fancy/blue,
-/obj/effect/spawner/random/aimodule/neutral,
+/obj/effect/spawner/random/aimodule/neutral{
+	pixel_y = 8
+	},
 /obj/machinery/door/window/right/directional/east{
 	name = "Core Modules";
 	req_access = list("captain")
@@ -786,6 +788,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "xeno_airlock_exterior";
+	idSelf = "xeno_airlock_control";
+	name = "Access Button";
+	req_access = list("xenobiology");
+	pixel_y = -7
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "apT" = (
@@ -821,16 +830,20 @@
 /area/space/nearstation)
 "aqt" = (
 /obj/structure/table,
-/obj/item/folder/yellow,
+/obj/item/folder/yellow{
+	pixel_y = 8
+	},
 /obj/item/storage/medkit/regular{
 	pixel_x = 3;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aqu" = (
@@ -899,7 +912,6 @@
 	pixel_y = 5
 	},
 /obj/item/stack/cable_coil,
-/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "asm" = (
@@ -1257,21 +1269,24 @@
 	},
 /obj/item/folder/yellow{
 	pixel_x = 8;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/item/ammo_casing/rocket{
 	pixel_x = -2;
-	pixel_y = 19;
+	pixel_y = 27;
 	name = "Dud Rocket";
 	desc = "An 84mm High Explosive rocket. This one's a dud. Pretty sure."
 	},
 /obj/item/computer_disk/quartermaster{
 	pixel_x = 9;
-	pixel_y = 13
+	pixel_y = 20
 	},
 /obj/effect/spawner/random/entertainment/lighter{
 	pixel_x = -7;
-	pixel_y = -4
+	pixel_y = 3
+	},
+/obj/machinery/button/door/directional/east{
+	id = "qmroom"
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
@@ -1305,15 +1320,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
-"aAb" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 8
-	},
-/area/station/medical/morgue)
 "aAg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
@@ -1405,10 +1411,12 @@
 /area/station/maintenance/starboard/greater)
 "aBQ" = (
 /obj/structure/cable,
-/obj/structure/sign/warning/secure_area/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
+	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
@@ -1591,8 +1599,12 @@
 /area/station/cargo/sorting)
 "aEA" = (
 /obj/structure/table/wood,
-/obj/item/staff/broom,
-/obj/item/wrench,
+/obj/item/staff/broom{
+	pixel_y = 8
+	},
+/obj/item/wrench{
+	pixel_y = 8
+	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -1635,25 +1647,22 @@
 "aFG" = (
 /obj/item/storage/box/matches{
 	pixel_x = -2;
-	pixel_y = 3
+	pixel_y = 8
 	},
 /obj/item/cigarette/cigar{
 	pixel_x = 4;
-	pixel_y = 1
+	pixel_y = 8
 	},
 /obj/item/cigarette/cigar{
 	pixel_x = -4;
-	pixel_y = 1
+	pixel_y = 8
 	},
-/obj/item/cigarette/cigar/cohiba,
+/obj/item/cigarette/cigar/cohiba{
+	pixel_y = 7
+	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
-"aFW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/mirror/directional/west,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "aFZ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -1683,11 +1692,11 @@
 "aGA" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed{
-	pixel_y = 9;
+	pixel_y = 17;
 	pixel_x = 8
 	},
 /obj/item/storage/box/lights/mixed{
-	pixel_y = 5;
+	pixel_y = 13;
 	pixel_x = -6
 	},
 /turf/open/floor/iron,
@@ -1711,7 +1720,7 @@
 "aGQ" = (
 /obj/item/storage/medkit/regular{
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
@@ -1789,10 +1798,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"aHR" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/station/science/research)
 "aHW" = (
 /obj/machinery/door/airlock/mining{
 	name = "Drone Bay"
@@ -1941,11 +1946,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/button/door/directional/west{
-	id = "qmroom";
-	name = "Privacy Blast Doors Control";
-	pixel_y = -7
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -1953,8 +1953,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_x = -22;
-	pixel_y = 5
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
@@ -2213,9 +2213,15 @@
 /area/station/service/kitchen)
 "aNQ" = (
 /obj/structure/table,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/mesh,
-/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze{
+	pixel_y = 8
+	},
+/obj/item/stack/medical/mesh{
+	pixel_y = 8
+	},
+/obj/item/stack/medical/suture{
+	pixel_y = 8
+	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -2533,12 +2539,15 @@
 	},
 /obj/structure/table/wood,
 /obj/structure/desk_bell{
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/obj/item/reagent_containers/cup/rag,
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = -3;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
@@ -2931,10 +2940,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bac" = (
-/obj/machinery/turretid/directional/south{
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the ai_upload.";
+	dir = 4;
+	name = "AI Upload Monitor";
+	network = list("aiupload");
+	pixel_x = -29
+	},
+/obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
 	icon_state = "control_stun";
-	name = "AI Upload Turret Control"
+	name = "AI Upload Turret Control";
+	pixel_y = 28
 	},
 /obj/item/radio/intercom/directional/north{
 	broadcasting = 1;
@@ -3071,12 +3088,11 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"bcb" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/science/research)
 "bcf" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -3093,7 +3109,6 @@
 /area/station/hallway/primary/central)
 "bcw" = (
 /obj/structure/cable,
-/obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
@@ -3101,16 +3116,40 @@
 /area/station/commons/fitness/recreation)
 "bcx" = (
 /obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 10
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 6
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 14
+	},
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/window/spawner/directional/south,
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"bcH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "xeno_airlock_exterior";
+	idSelf = "xeno_airlock_control";
+	name = "Access Button";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology/hallway)
 "bcT" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -3130,17 +3169,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"bdb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/random/directional/east,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "bdv" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk,
@@ -3316,6 +3344,12 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/computer/security/telescreen/med_sec/directional/west,
+/obj/machinery/button/door/directional/west{
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_y = -8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bgS" = (
@@ -3537,6 +3571,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bjP" = (
@@ -3839,10 +3874,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 8
 	},
 /obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 8
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
@@ -3882,14 +3919,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"bqg" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/official/random/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/entry)
 "bqk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -4092,8 +4121,12 @@
 "btG" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/table,
-/obj/item/storage/belt/utility/full,
-/obj/item/borg/upgrade/rename,
+/obj/item/storage/belt/utility/full{
+	pixel_y = 8
+	},
+/obj/item/borg/upgrade/rename{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "btL" = (
@@ -4144,7 +4177,6 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "buv" = (
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -4191,6 +4223,9 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -4401,6 +4436,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar,
+/obj/structure/sign/directions/medical/right,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byR" = (
@@ -4785,10 +4821,6 @@
 /obj/structure/aquarium/lawyer,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"bIa" = (
-/obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "bIi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4800,9 +4832,6 @@
 /area/station/commons/lounge)
 "bIq" = (
 /obj/structure/table/wood,
-/obj/machinery/button/ticket_machine{
-	pixel_x = 38
-	},
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 6;
 	pixel_y = -34
@@ -4814,26 +4843,30 @@
 	req_access = list("hop")
 	},
 /obj/item/paper_bin/carbon{
-	pixel_x = -2;
-	pixel_y = 4
+	pixel_x = 5;
+	pixel_y = 11
 	},
 /obj/item/stamp/head/hop{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/machinery/button/door/directional/south{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = -6;
-	pixel_y = -34;
-	req_access = list("hop")
+	pixel_x = 5;
+	pixel_y = 18
 	},
 /obj/item/pen{
-	pixel_x = -4;
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/machinery/button/ticket_machine/table{
+	pixel_x = -7;
 	pixel_y = 3
 	},
-/obj/machinery/button/photobooth{
-	pixel_x = 26
+/obj/machinery/button/photobooth/table{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 17;
+	pixel_x = -7;
+	name = "Privacy Shutters Control";
+	req_access = "hop"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -4917,7 +4950,6 @@
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
@@ -4935,16 +4967,20 @@
 /obj/item/pen,
 /obj/structure/table/reinforced,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 8
+	},
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/machinery/newscaster/directional/north,
 /obj/item/screwdriver{
-	pixel_y = 10
+	pixel_y = 18
 	},
-/obj/item/radio/off,
+/obj/item/radio/off{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
@@ -4955,7 +4991,7 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -4982,19 +5018,19 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/korta_nectar{
 	pixel_x = 5;
-	pixel_y = 16
+	pixel_y = 24
 	},
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/liqueur{
 	pixel_x = -5;
-	pixel_y = 16
+	pixel_y = 24
 	},
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/caramel{
 	pixel_x = 15;
-	pixel_y = 16
+	pixel_y = 24
 	},
 /obj/item/storage/fancy/coffee_condi_display{
 	pixel_x = 4;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -5251,7 +5287,7 @@
 "bRp" = (
 /obj/effect/spawner/random/decoration/microwave{
 	dir = 1;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -5360,15 +5396,27 @@
 	dir = 5
 	},
 /obj/structure/table/glass,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
+/obj/item/grenade/chem_grenade{
+	pixel_y = 8
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_y = 8
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_y = 8
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil{
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil{
+	pixel_y = 8
+	},
 /obj/item/screwdriver{
 	pixel_x = -2;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/requests_console/directional/west{
@@ -5404,11 +5452,13 @@
 "bTm" = (
 /obj/structure/table/reinforced,
 /obj/item/wheelchair{
-	pixel_y = -3
+	pixel_y = 5
 	},
-/obj/item/wheelchair,
 /obj/item/wheelchair{
-	pixel_y = 3
+	pixel_y = 8
+	},
+/obj/item/wheelchair{
+	pixel_y = 13
 	},
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/west,
@@ -5450,10 +5500,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 8
 	},
 /obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 8
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
@@ -5466,11 +5518,12 @@
 "bUo" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plasteel{
-	amount = 15
+	amount = 15;
+	pixel_y = 8
 	},
 /obj/item/assembly/prox_sensor{
 	pixel_x = 5;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /obj/machinery/light/small/directional/north,
@@ -5480,8 +5533,12 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/item/radio/intercom/directional/west,
-/obj/item/pinpointer/nuke,
-/obj/item/disk/nuclear,
+/obj/item/pinpointer/nuke{
+	pixel_y = 8
+	},
+/obj/item/disk/nuclear{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "bUC" = (
@@ -5680,7 +5737,9 @@
 /area/station/commons/fitness/recreation)
 "bXc" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
 /obj/machinery/requests_console/directional/east{
 	department = "Research Lab";
 	name = "Research Requests Console"
@@ -5888,9 +5947,12 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/small/directional/east,
-/obj/structure/bed,
-/obj/item/bedsheet/qm,
+/obj/structure/bed{
+	pixel_z = 0
+	},
+/obj/item/bedsheet/qm{
+	dir = 8
+	},
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
@@ -5934,7 +5996,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	pixel_x = 1;
-	pixel_y = 5
+	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -6107,7 +6169,6 @@
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
 "chn" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
@@ -6432,9 +6493,11 @@
 /obj/machinery/newscaster/directional/north,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 4
+	pixel_y = 8
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -6510,20 +6573,20 @@
 "cqm" = (
 /obj/item/disk/data{
 	pixel_x = 9;
-	pixel_y = -1
+	pixel_y = 6
 	},
 /obj/item/disk/tech_disk{
 	pixel_x = -2;
-	pixel_y = -3
+	pixel_y = 4
 	},
 /obj/item/disk/design_disk{
 	name = "component design disk";
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/structure/table/wood,
 /obj/item/toy/talking/ai{
 	name = "\improper Nanotrasen-brand toy AI";
-	pixel_y = 6
+	pixel_y = 14
 	},
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
@@ -6641,13 +6704,15 @@
 /obj/structure/table,
 /obj/item/raw_anomaly_core/random{
 	pixel_x = -5;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/item/raw_anomaly_core/random{
 	pixel_x = 7;
-	pixel_y = 9
+	pixel_y = 17
 	},
-/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -6743,6 +6808,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"cuJ" = (
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "cuM" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/bar,
@@ -6751,13 +6823,16 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/structure/table,
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 8;
-	pixel_y = 2
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/cup/rag{
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 12
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -6766,7 +6841,6 @@
 	dir = 1
 	},
 /obj/structure/closet/firecloset,
-/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "cuZ" = (
@@ -6975,13 +7049,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"cwP" = (
-/obj/structure/sign/poster/random/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "cwX" = (
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Command Desk";
@@ -7118,7 +7185,8 @@
 /obj/structure/table/wood,
 /obj/item/toy/plush/carpplushie{
 	greyscale_colors = "#ff5050#000000";
-	name = "\improper Nanotrasen wildlife department space carp plushie"
+	name = "\improper Nanotrasen wildlife department space carp plushie";
+	pixel_y = 8
 	},
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
@@ -7254,20 +7322,33 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cCN" = (
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 8
+	},
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
-	amount = 10
+	amount = 10;
+	pixel_y = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/crowbar,
-/obj/item/wrench,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 8
+	},
+/obj/item/crowbar{
+	pixel_y = 8
+	},
+/obj/item/wrench{
+	pixel_y = 8
+	},
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7298,11 +7379,11 @@
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/item/pen{
 	pixel_x = -2;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -7334,10 +7415,18 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "cEv" = (
-/obj/item/food/grown/wheat,
-/obj/item/food/grown/watermelon,
-/obj/item/food/grown/citrus/orange,
-/obj/item/food/grown/grapes,
+/obj/item/food/grown/wheat{
+	pixel_y = 8
+	},
+/obj/item/food/grown/watermelon{
+	pixel_y = 8
+	},
+/obj/item/food/grown/citrus/orange{
+	pixel_y = 8
+	},
+/obj/item/food/grown/grapes{
+	pixel_y = 8
+	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -7347,6 +7436,10 @@
 /area/station/hallway/primary/central)
 "cEx" = (
 /obj/structure/dresser,
+/obj/structure/mirror/directional/west{
+	pixel_x = 0;
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/service/theater)
 "cFa" = (
@@ -7362,7 +7455,9 @@
 "cFl" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/rollingpin{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cFp" = (
@@ -7375,7 +7470,9 @@
 /obj/machinery/flasher/directional/south{
 	id = "AI"
 	},
-/obj/effect/spawner/round_default_module,
+/obj/effect/spawner/round_default_module{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "cFu" = (
@@ -7537,10 +7634,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"cJL" = (
-/obj/structure/sign/directions/evac,
-/turf/closed/wall/r_wall,
-/area/station/medical/chemistry)
 "cKd" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -7578,10 +7671,14 @@
 /obj/structure/cable,
 /obj/item/storage/backpack/satchel/leather/withwallet{
 	pixel_x = -1;
-	pixel_y = 4
+	pixel_y = 14
 	},
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "cKW" = (
@@ -7709,10 +7806,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"cOj" = (
-/obj/structure/sign/chalkboard_menu,
-/turf/closed/wall,
-/area/station/commons/storage/primary)
 "cOl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7812,11 +7905,11 @@
 /obj/machinery/light_switch/directional/north,
 /obj/item/storage/briefcase/secure{
 	pixel_x = 3;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/item/storage/medkit/regular{
 	pixel_x = -3;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -8039,11 +8132,19 @@
 /area/station/commons/dorms)
 "cUX" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 8
+	},
 /obj/machinery/light/small/directional/west,
-/obj/item/paper/fluff/gateway,
-/obj/item/coin/plasma,
-/obj/item/melee/chainofcommand,
+/obj/item/paper/fluff/gateway{
+	pixel_y = 8
+	},
+/obj/item/coin/plasma{
+	pixel_y = 8
+	},
+/obj/item/melee/chainofcommand{
+	pixel_y = 8
+	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
@@ -8068,25 +8169,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/button/door/directional/north{
-	id = "rdrnd";
-	name = "Research and Development Containment Control";
-	pixel_x = -6;
-	req_access = list("rd")
-	},
-/obj/machinery/button/door/directional/north{
-	id = "rdordnance";
-	name = "Ordnance Containment Control";
-	pixel_x = 6;
-	req_access = list("rd")
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/button/door/directional/north{
 	id = "rdoffice";
 	name = "Privacy Control";
-	pixel_y = 34;
+	pixel_y = -6;
 	req_access = list("rd")
 	},
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "cVJ" = (
@@ -8101,8 +8190,12 @@
 /area/station/maintenance/port/fore)
 "cWa" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -8169,7 +8262,9 @@
 /area/station/hallway/primary/central)
 "cXc" = (
 /obj/structure/table,
-/obj/item/food/grown/poppy/lily,
+/obj/item/food/grown/poppy/lily{
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -8204,13 +8299,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"cXH" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/safety_eye_protection/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "cXP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
@@ -8250,12 +8338,12 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 8
 	},
 /obj/machinery/door/firedoor,
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
@@ -8263,7 +8351,8 @@
 	name = "Pharmacy Shutters"
 	},
 /obj/structure/desk_bell{
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 8
 	},
 /obj/machinery/door/window/left/directional/north{
 	name = "Pharmacy Desk";
@@ -8289,7 +8378,6 @@
 /area/station/hallway/primary/central)
 "cYY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -8341,6 +8429,7 @@
 "daa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/records/medical/laptop,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dac" = (
@@ -9112,8 +9201,12 @@
 	id = "roboticsprivacy2";
 	name = "Robotics Shutters"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/left/directional/north{
 	name = "Robotics Desk";
@@ -9126,10 +9219,10 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
 	pixel_x = 2;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
@@ -9211,13 +9304,18 @@
 "dqu" = (
 /obj/item/book/manual/wiki/security_space_law{
 	name = "space law";
-	pixel_y = 2
+	pixel_y = 10
 	},
-/obj/item/toy/gun,
-/obj/item/restraints/handcuffs,
+/obj/item/toy/gun{
+	pixel_y = 8
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 8
+	},
 /obj/structure/table/wood,
 /obj/item/clothing/head/collectable/hos{
-	name = "novelty HoS hat"
+	name = "novelty HoS hat";
+	pixel_y = 8
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
@@ -9254,7 +9352,6 @@
 /area/station/engineering/storage/tech)
 "dqX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "drm" = (
@@ -10006,16 +10103,15 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dIr" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_x = 5;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/iron,
@@ -10118,10 +10214,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"dKl" = (
-/obj/structure/sign/warning/pods,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/engine)
 "dKm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -10325,7 +10417,6 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin/tagger,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -10481,7 +10572,6 @@
 /area/station/maintenance/department/science/central)
 "dQy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/east,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/modular_computer/preset/cargochat/service{
 	dir = 8
@@ -10721,11 +10811,11 @@
 /area/station/security/checkpoint/science)
 "dTV" = (
 /obj/item/folder/red{
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/structure/table/glass,
 /obj/item/folder/red{
-	pixel_y = 3
+	pixel_y = 6
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -10840,13 +10930,17 @@
 	network = list("aiupload")
 	},
 /obj/structure/table/wood/fancy/green,
-/obj/effect/spawner/random/aimodule/harmless,
+/obj/effect/spawner/random/aimodule/harmless{
+	pixel_y = 8
+	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dWg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/food/pie/cream,
+/obj/item/food/pie/cream{
+	pixel_y = 8
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "kitchen_counter";
@@ -11009,11 +11103,11 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "dYG" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint/directional/north,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/periodic_table,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dYK" = (
@@ -11109,6 +11203,20 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"eaK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "eaN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11475,8 +11583,12 @@
 /obj/item/storage/briefcase/secure,
 /obj/structure/table/wood,
 /obj/item/folder/blue,
-/obj/item/storage/briefcase/secure,
-/obj/item/assembly/flash/handheld,
+/obj/item/storage/briefcase/secure{
+	pixel_y = 8
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "egs" = (
@@ -11961,7 +12073,9 @@
 /area/station/command/heads_quarters/qm)
 "enF" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_y = 8
+	},
 /obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Security Post - Research Division";
@@ -11995,9 +12109,15 @@
 "enS" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
+/obj/item/controller{
+	pixel_y = 8
+	},
+/obj/item/compact_remote{
+	pixel_y = 8
+	},
+/obj/item/compact_remote{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "eoj" = (
@@ -12135,13 +12255,6 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"eqt" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "eqS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12468,7 +12581,7 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/cup/glass/waterbottle{
-	pixel_y = 48;
+	pixel_y = 56;
 	pixel_x = 9
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -12492,8 +12605,12 @@
 /area/station/commons/fitness/recreation)
 "ewh" = (
 /obj/structure/table,
-/obj/item/clipboard,
-/obj/item/wrench,
+/obj/item/clipboard{
+	pixel_y = 8
+	},
+/obj/item/wrench{
+	pixel_y = 8
+	},
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -12797,10 +12914,13 @@
 	c_tag = "Bar - Backroom"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror/directional/north,
 /obj/structure/sink/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/mirror/directional/west{
+	pixel_x = 0;
+	pixel_y = 8
 	},
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
@@ -12995,6 +13115,13 @@
 "eIO" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/central)
+"eIT" = (
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "eIV" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
@@ -13087,7 +13214,6 @@
 /obj/machinery/modular_computer/preset/civilian{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -13116,7 +13242,7 @@
 /obj/item/storage/briefcase/secure{
 	desc = "A large briefcase with a digital locking system, and the Nanotrasen logo emblazoned on the sides.";
 	name = "\improper Nanotrasen-brand secure briefcase exhibit";
-	pixel_y = 2
+	pixel_y = 10
 	},
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
@@ -13573,7 +13699,9 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/effect/spawner/random/entertainment/musical_instrument{
+	pixel_y = 8
+	},
 /obj/item/clothing/glasses/regular/hipster{
 	name = "Hipster Glasses"
 	},
@@ -13693,7 +13821,9 @@
 /area/station/construction/mining/aux_base)
 "eVy" = (
 /obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/effect/spawner/random/food_or_drink/cake_ingredients{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "eVz" = (
@@ -14061,16 +14191,18 @@
 	},
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = -3;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = 5;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/item/modular_computer/laptop/preset/civilian,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "fbI" = (
@@ -14112,9 +14244,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/secure_area/directional/west{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
@@ -14238,16 +14367,22 @@
 /area/station/hallway/primary/port)
 "ffL" = (
 /obj/structure/table,
-/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/rollingpin{
+	pixel_y = 5
+	},
 /obj/effect/turf_decal/trimline/brown/warning,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 5
+	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/aquarium_kit,
+/obj/item/aquarium_kit{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "ffP" = (
@@ -15139,16 +15274,23 @@
 "fvK" = (
 /obj/structure/table,
 /obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = -5
+	pixel_x = 5;
+	pixel_y = 8
 	},
 /obj/item/transfer_valve{
-	pixel_x = 5
+	pixel_y = 8
 	},
-/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/transfer_valve{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -15479,12 +15621,12 @@
 /obj/structure/table/wood,
 /obj/item/cigbutt/cigarbutt{
 	pixel_x = 5;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/item/reagent_containers/cup/glass/mug{
 	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -15616,7 +15758,6 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "fGv" = (
@@ -16030,10 +16171,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"fNI" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/wood,
-/area/station/maintenance/port/aft)
 "fNR" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16570,13 +16707,21 @@
 /area/station/service/library)
 "fZw" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 8
+	},
+/obj/item/clothing/gloves/latex{
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -10;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -17024,10 +17169,10 @@
 /area/station/service/hydroponics)
 "gkD" = (
 /obj/machinery/recharger{
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/restraints/handcuffs{
-	pixel_y = 3
+	pixel_y = 8
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -17079,7 +17224,6 @@
 /area/station/engineering/break_room)
 "glP" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -17133,10 +17277,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"gmH" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/command/bridge)
 "gmI" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -17611,9 +17751,11 @@
 /obj/machinery/light_switch/directional/west,
 /obj/item/storage/briefcase/secure{
 	pixel_x = -2;
-	pixel_y = 4
+	pixel_y = 12
 	},
-/obj/item/storage/lockbox/medal,
+/obj/item/storage/lockbox/medal{
+	pixel_y = 10
+	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -17677,6 +17819,7 @@
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/bed/dogbed/ian,
 /mob/living/basic/pet/dog/corgi/ian,
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "gvm" = (
@@ -17922,7 +18065,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -12;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -18241,7 +18384,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gGf" = (
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -18611,8 +18753,12 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera/directional/north{
 	c_tag = "Science Mechbay";
@@ -18767,11 +18913,12 @@
 /area/station/maintenance/starboard/lesser)
 "gOa" = (
 /obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/book/manual/hydroponics_pod_people{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gOp" = (
@@ -18845,7 +18992,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "gPh" = (
-/obj/item/clothing/head/fedora,
+/obj/item/clothing/head/fedora{
+	pixel_y = 13
+	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -19449,7 +19598,6 @@
 	pixel_x = -7
 	},
 /obj/machinery/camera/directional/north,
-/obj/machinery/digital_clock/directional/east,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/poster/traitor,
 /turf/open/floor/wood/large,
@@ -19775,22 +19923,23 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/shipping{
 	pixel_x = -6;
-	pixel_y = 15
+	pixel_y = 23
 	},
 /obj/item/multitool{
 	pixel_x = -3;
-	pixel_y = -4
+	pixel_y = 4
 	},
 /obj/item/storage/box/lights/mixed{
 	pixel_x = 8;
-	pixel_y = 11
+	pixel_y = 19
 	},
 /obj/item/flashlight/lamp{
 	pixel_x = -7;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/item/storage/box/shipping{
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -19825,6 +19974,7 @@
 "hhN" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/barsign/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "hif" = (
@@ -19878,10 +20028,12 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	pixel_x = 1;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/bikehorn/rubberducky,
+/obj/item/bikehorn/rubberducky{
+	pixel_y = 8
+	},
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20073,7 +20225,9 @@
 /obj/machinery/flasher/directional/north{
 	id = "AI"
 	},
-/obj/effect/spawner/random/aimodule/harmful,
+/obj/effect/spawner/random/aimodule/harmful{
+	pixel_y = 8
+	},
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	name = "High-Risk Modules";
@@ -20326,10 +20480,18 @@
 /area/station/science/ordnance/freezerchamber)
 "hrw" = (
 /obj/structure/table/glass,
-/obj/machinery/cell_charger,
-/obj/item/stack/cable_coil,
-/obj/item/assembly/igniter,
-/obj/item/stock_parts/power_store/cell,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil{
+	pixel_y = 8
+	},
+/obj/item/assembly/igniter{
+	pixel_y = 16
+	},
+/obj/item/stock_parts/power_store/cell{
+	pixel_y = 8
+	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -20345,9 +20507,6 @@
 /area/station/service/chapel/office)
 "hrM" = (
 /obj/machinery/vending/boozeomat,
-/obj/structure/sign/picture_frame/portrait/bar{
-	pixel_y = -28
-	},
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -20531,10 +20690,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"hux" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/command/teleporter)
 "huy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -20767,18 +20922,22 @@
 /area/station/service/hydroponics)
 "hxz" = (
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_x = 8;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_x = 13;
-	pixel_y = 5
+	pixel_y = 13
 	},
-/obj/item/watertank,
-/obj/item/grenade/chem_grenade/antiweed,
+/obj/item/watertank{
+	pixel_y = 8
+	},
+/obj/item/grenade/chem_grenade/antiweed{
+	pixel_y = 8
+	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20786,7 +20945,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "hxB" = (
@@ -21013,12 +21171,6 @@
 /area/station/command/heads_quarters/rd)
 "hBb" = (
 /obj/machinery/chem_dispenser,
-/obj/machinery/button/door/directional/north{
-	id = "pharmacy_shutters";
-	name = "pharmacy shutters control";
-	pixel_x = 24;
-	req_access = list("medical")
-	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -21067,19 +21219,19 @@
 	c_tag = "Science Ordnance Test Lab"
 	},
 /obj/item/assembly/prox_sensor{
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/assembly/prox_sensor{
 	pixel_x = 9;
-	pixel_y = -2
+	pixel_y = 6
 	},
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
-	pixel_y = 1
+	pixel_y = 9
 	},
 /obj/item/assembly/prox_sensor{
 	pixel_x = 8;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /obj/machinery/requests_console/directional/west{
 	department = "Ordnance Test Range";
@@ -21175,6 +21327,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"hDG" = (
+/obj/machinery/digital_clock/directional/north{
+	pixel_y = 7
+	},
+/turf/closed/wall/r_wall,
+/area/station/command/bridge)
 "hDX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21773,20 +21931,19 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap{
 	pixel_x = 2;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/stack/package_wrap{
 	pixel_x = -2;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/item/pen{
 	pixel_x = -7;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/reagent_containers/cup/glass/waterbottle{
-	pixel_y = 16
+	pixel_y = 24
 	},
-/obj/machinery/digital_clock/directional/north,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -21899,7 +22056,6 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/structure/sign/poster/official/moth_piping/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "hSr" = (
@@ -22120,7 +22276,6 @@
 /turf/open/floor/plating,
 /area/station/command/teleporter)
 "hWD" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -22222,40 +22377,40 @@
 "hYA" = (
 /obj/item/assembly/timer{
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/assembly/timer{
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/assembly/igniter{
 	pixel_x = 3;
-	pixel_y = -7
+	pixel_y = 1
 	},
 /obj/item/assembly/igniter{
 	pixel_x = 3;
-	pixel_y = -7
+	pixel_y = 1
 	},
 /obj/item/assembly/igniter{
 	pixel_x = 3;
-	pixel_y = -7
+	pixel_y = 1
 	},
 /obj/item/assembly/igniter{
 	pixel_x = 3;
-	pixel_y = -7
+	pixel_y = 1
 	},
 /obj/item/assembly/timer{
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/assembly/timer{
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/structure/table/glass,
 /obj/item/storage/pill_bottle/epinephrine{
 	pixel_x = 8;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
@@ -22307,8 +22462,12 @@
 /area/station/maintenance/port/fore)
 "hZT" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -22512,25 +22671,26 @@
 /obj/structure/cable,
 /obj/item/storage/medkit/regular{
 	pixel_x = -3;
-	pixel_y = 10
+	pixel_y = 15
 	},
 /obj/item/pen/blue{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/pen/fountain{
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 16
 	},
 /obj/item/pen/red{
 	pixel_x = 8;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/stamp/denied{
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/item/stamp{
 	pixel_x = -9;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/storage)
@@ -22542,7 +22702,9 @@
 /area/station/medical/morgue)
 "idR" = (
 /obj/structure/table,
-/obj/item/food/dough,
+/obj/item/food/dough{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "idT" = (
@@ -22820,7 +22982,8 @@
 /obj/structure/table/wood,
 /obj/machinery/fax{
 	fax_name = "Head of Personnel's Office";
-	name = "Head of Personnel's Fax Machine"
+	name = "Head of Personnel's Fax Machine";
+	pixel_y = 11
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
@@ -22977,10 +23140,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"ikY" = (
-/obj/structure/sign/warning/secure_area/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/greater)
 "ikZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -23030,6 +23189,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"ilD" = (
+/obj/machinery/button/flasher{
+	id = "hopflash"
+	},
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/hop)
 "ilJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -23358,25 +23523,27 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap{
 	pixel_x = 2;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/stack/package_wrap{
 	pixel_x = 1;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/stack/package_wrap{
 	pixel_x = -4;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/dest_tagger{
 	pixel_x = -9;
-	pixel_y = 12
+	pixel_y = 16
 	},
 /obj/item/hand_labeler_refill{
 	pixel_x = -11;
-	pixel_y = -3
+	pixel_y = 5
 	},
-/obj/item/stack/wrapping_paper,
+/obj/item/stack/wrapping_paper{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "irz" = (
@@ -23940,7 +24107,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "iAk" = (
@@ -23983,7 +24149,7 @@
 /area/station/medical/surgery/aft)
 "iAA" = (
 /obj/item/toy/beach_ball/branded{
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -24122,6 +24288,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"iDe" = (
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
+/turf/open/space/basic,
+/area/space)
 "iDq" = (
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
@@ -24275,6 +24447,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/pdapainter/supply,
+/obj/structure/noticeboard/qm,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "iGA" = (
@@ -24551,7 +24724,9 @@
 /area/station/maintenance/starboard/lesser)
 "iMi" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
 "iMk" = (
@@ -24685,7 +24860,9 @@
 "iNB" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/table/glass,
-/obj/item/papercutter,
+/obj/item/papercutter{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "iNC" = (
@@ -24770,7 +24947,8 @@
 /obj/structure/table,
 /obj/machinery/fax{
 	fax_name = "Cargo Office";
-	name = "Cargo Office Fax Machine"
+	name = "Cargo Office Fax Machine";
+	pixel_y = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -25101,8 +25279,9 @@
 /obj/item/lipstick{
 	pixel_y = 5
 	},
-/obj/effect/spawner/random/entertainment/musical_instrument,
-/obj/structure/sign/poster/random/directional/east,
+/obj/effect/spawner/random/entertainment/musical_instrument{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -25272,9 +25451,15 @@
 	dir = 6
 	},
 /obj/structure/table,
-/obj/item/clipboard,
-/obj/item/holosign_creator/atmos,
-/obj/item/holosign_creator/atmos,
+/obj/item/clipboard{
+	pixel_y = 8
+	},
+/obj/item/holosign_creator/atmos{
+	pixel_y = 8
+	},
+/obj/item/holosign_creator/atmos{
+	pixel_y = 8
+	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
@@ -25292,7 +25477,9 @@
 /area/station/hallway/primary/central)
 "iXp" = (
 /obj/structure/table,
-/obj/item/analyzer,
+/obj/item/analyzer{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
 	},
@@ -25379,9 +25566,11 @@
 /area/station/commons/fitness/recreation)
 "iYO" = (
 /obj/structure/table,
-/obj/item/circular_saw,
+/obj/item/circular_saw{
+	pixel_y = 8
+	},
 /obj/item/scalpel{
-	pixel_y = 16
+	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
@@ -25711,9 +25900,15 @@
 /area/station/science/ordnance/storage)
 "jeL" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/wiki/medicine,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/wrench/medical,
+/obj/item/book/manual/wiki/medicine{
+	pixel_y = 8
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 8
+	},
+/obj/item/wrench/medical{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -25852,14 +26047,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"jgK" = (
-/obj/structure/sign/poster/random/directional/south,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "jgT" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -26022,7 +26209,9 @@
 /area/station/science/cytology)
 "jjF" = (
 /obj/structure/table/reinforced,
-/obj/item/holosign_creator/robot_seat/bar,
+/obj/item/holosign_creator/robot_seat/bar{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
@@ -26299,7 +26488,6 @@
 	pixel_x = -9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -26466,18 +26654,26 @@
 "jsh" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/screwdriver{
 	pixel_x = -2;
-	pixel_y = 6
+	pixel_y = 14
 	},
-/obj/item/radio/headset/headset_med,
+/obj/item/radio/headset/headset_med{
+	pixel_y = 8
+	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/firealarm/directional/south,
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
+/obj/item/hand_labeler{
+	pixel_y = 6
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -26600,12 +26796,24 @@
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/circuitboard/mecha/ripley/main,
-/obj/item/circuitboard/mecha/ripley/peripherals,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 12
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 12
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 13
+	},
+/obj/item/circuitboard/mecha/ripley/main{
+	pixel_y = 8
+	},
+/obj/item/circuitboard/mecha/ripley/peripherals{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "juf" = (
@@ -26683,9 +26891,15 @@
 /area/station/maintenance/disposal/incinerator)
 "jvr" = (
 /obj/structure/table/glass,
-/obj/item/folder/blue,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/glasses/hud/health,
+/obj/item/folder/blue{
+	pixel_y = 8
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -26790,36 +27004,39 @@
 /obj/structure/cable,
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
 	pixel_x = -6;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
 	pixel_x = 6;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
 	pixel_x = -6;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
 	pixel_x = 6;
-	pixel_y = 6
+	pixel_y = 14
 	},
-/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/dropper{
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "jws" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = 3;
-	pixel_y = -2
+	pixel_y = 5
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
@@ -26861,8 +27078,12 @@
 /area/station/service/library)
 "jwP" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple{
@@ -26893,10 +27114,18 @@
 /area/station/science/ordnance/freezerchamber)
 "jxm" = (
 /obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 6
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 8
+	},
+/obj/item/construction/plumbing{
+	pixel_y = 6
+	},
+/obj/item/construction/plumbing{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -26912,7 +27141,8 @@
 /obj/structure/table/wood,
 /obj/machinery/fax{
 	fax_name = "Captain's Office";
-	name = "Captain's Fax Machine"
+	name = "Captain's Fax Machine";
+	pixel_y = 10
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood,
@@ -27168,7 +27398,6 @@
 	dir = 9
 	},
 /obj/structure/light_construct/small/directional/south,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jBU" = (
@@ -27386,9 +27615,34 @@
 /area/station/maintenance/starboard/lesser)
 "jGw" = (
 /obj/structure/table/glass,
-/obj/machinery/computer/records/medical/laptop,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/button/door/table{
+	pixel_x = -8;
+	pixel_y = 10;
+	id = "cmoprivacy";
+	name = "CMO Privacy Shutters"
+	},
+/obj/item/pen{
+	pixel_x = -7;
+	pixel_y = 16
+	},
+/obj/item/folder/blue{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/obj/item/folder/white{
+	pixel_y = 10;
+	pixel_x = 6
+	},
+/obj/item/computer_disk/medical{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/computer_disk/medical{
+	pixel_y = 8;
+	pixel_x = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -27490,13 +27744,27 @@
 /area/station/science/cytology)
 "jIg" = (
 /obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/multitool,
+/obj/item/storage/belt/utility{
+	pixel_y = 8
+	},
+/obj/item/storage/belt/utility{
+	pixel_y = 8
+	},
+/obj/item/radio/off{
+	pixel_y = 8
+	},
+/obj/item/radio/off{
+	pixel_y = 8
+	},
+/obj/item/radio/off{
+	pixel_y = 8
+	},
+/obj/item/radio/off{
+	pixel_y = 8
+	},
+/obj/item/multitool{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "jIk" = (
@@ -27824,9 +28092,11 @@
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
 	pixel_x = 4;
-	pixel_y = 4
+	pixel_y = 12
 	},
-/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/regular{
+	pixel_y = 8
+	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/light/cold/directional/south,
@@ -27945,6 +28215,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"jPj" = (
+/obj/structure/sign/directions/evac,
+/obj/structure/sign/directions/medical{
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/station/commons/storage/tools)
 "jPm" = (
 /obj/machinery/atmospherics/components/tank/air,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -28060,26 +28340,27 @@
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = 8;
-	pixel_y = 1
+	pixel_y = 9
 	},
 /obj/item/paper_bin{
 	pixel_x = 8;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/paper_bin{
 	pixel_x = 8;
-	pixel_y = 11
+	pixel_y = 19
 	},
 /obj/item/folder/yellow{
 	pixel_x = -6;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/folder/yellow{
 	pixel_x = -9;
-	pixel_y = 1
+	pixel_y = 9
 	},
 /obj/item/paper{
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -28097,13 +28378,18 @@
 /area/station/hallway/primary/central)
 "jRO" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Science Research Office";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "jRZ" = (
@@ -28162,6 +28448,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"jTg" = (
+/obj/machinery/digital_clock/directional/north{
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/hop)
 "jTi" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/camera/directional/west{
@@ -28545,8 +28837,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "jYL" = (
-/obj/machinery/recharger,
-/obj/item/restraints/handcuffs,
+/obj/machinery/recharger{
+	pixel_y = 8
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 8
+	},
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -28659,26 +28955,25 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/mousetraps{
 	pixel_x = -5;
-	pixel_y = 14
+	pixel_y = 18
 	},
 /obj/structure/table,
 /obj/item/storage/box/mousetraps{
 	pixel_x = 12;
-	pixel_y = 15
+	pixel_y = 12
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/item/grenade/chem_grenade/cleaner{
 	pixel_x = -7;
-	pixel_y = 6
+	pixel_y = 10
 	},
 /obj/item/grenade/chem_grenade/cleaner{
 	pixel_x = -1;
-	pixel_y = 3
+	pixel_y = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "kbR" = (
-/obj/structure/sign/poster/official/cleanliness/directional/east,
 /obj/machinery/door/window/right/directional/north{
 	name = "Hydroponics Delivery";
 	req_access = list("hydroponics")
@@ -29150,20 +29445,22 @@
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = 7;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = -4;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/reagent_containers/syringe/epinephrine{
 	pixel_x = 3;
-	pixel_y = -2
+	pixel_y = 6
 	},
-/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 8;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/sign/warning/no_smoking{
 	pixel_y = 28
@@ -29215,7 +29512,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 7
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
@@ -29254,6 +29551,17 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/station/commons/lounge)
+"kmd" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "kmN" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
@@ -29484,7 +29792,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -29508,7 +29815,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/assembly/timer{
 	pixel_x = -4;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/assembly/timer{
 	pixel_x = 5;
@@ -29516,9 +29823,11 @@
 	},
 /obj/item/assembly/timer{
 	pixel_x = 6;
-	pixel_y = -4
+	pixel_y = 4
 	},
-/obj/item/assembly/timer,
+/obj/item/assembly/timer{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
@@ -29550,7 +29859,7 @@
 /area/station/maintenance/starboard/greater)
 "ksZ" = (
 /obj/machinery/recharger{
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Security Post - Medbay";
@@ -29653,6 +29962,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/fireaxecabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "kvv" = (
@@ -29750,7 +30060,6 @@
 /area/station/engineering/atmos)
 "kxa" = (
 /obj/machinery/chem_master,
-/obj/structure/noticeboard/directional/south,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -29792,7 +30101,6 @@
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
 	},
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
@@ -29906,7 +30214,6 @@
 "kzZ" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
@@ -30004,11 +30311,11 @@
 	},
 /obj/item/storage/box/bodybags{
 	pixel_x = -4;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /obj/item/storage/box/disks{
 	pixel_x = 6;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/clothing/gloves/latex{
 	pixel_x = 4;
@@ -30243,7 +30550,6 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/maintenance,
 /obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "kFK" = (
@@ -30478,13 +30784,15 @@
 "kKT" = (
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = 7;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = -4;
-	pixel_y = 12
+	pixel_y = 20
 	},
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 8;
 	pixel_y = 2
@@ -30581,23 +30889,28 @@
 "kMk" = (
 /obj/item/book/manual/wiki/chemistry{
 	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 12
 	},
-/obj/item/book/manual/wiki/grenades,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
+/obj/item/book/manual/wiki/grenades{
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil{
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil{
+	pixel_y = 8
+	},
 /obj/item/book/manual/wiki/plumbing{
 	pixel_x = 4;
-	pixel_y = -4
+	pixel_y = 4
 	},
-/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
+	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/periodic_table/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kMl" = (
@@ -30627,13 +30940,15 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = 1;
-	pixel_y = 9
+	pixel_y = 14
 	},
 /obj/item/pen{
 	pixel_x = 1;
 	pixel_y = 9
 	},
-/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 8
+	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Security Post - Cargo"
 	},
@@ -30768,8 +31083,12 @@
 /area/station/security/checkpoint/engineering)
 "kPy" = (
 /obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/cautery,
+/obj/item/surgical_drapes{
+	pixel_y = 8
+	},
+/obj/item/cautery{
+	pixel_y = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -31072,7 +31391,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "kVq" = (
-/obj/structure/sign/warning/secure_area/directional/east,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -31150,12 +31468,6 @@
 	},
 /turf/closed/wall,
 /area/station/hallway/secondary/command)
-"kWO" = (
-/obj/structure/sign/directions/medical{
-	pixel_y = -7
-	},
-/turf/closed/wall,
-/area/station/medical/pharmacy)
 "kWP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31670,6 +31982,12 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"lgR" = (
+/obj/structure/sign/poster/official/moth_piping/directional/north{
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance)
 "lgS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31838,15 +32156,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
-"lkc" = (
-/obj/machinery/barsign,
-/turf/closed/wall,
-/area/station/commons/lounge)
-"lku" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "lkv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31941,22 +32250,22 @@
 /obj/structure/table/reinforced,
 /obj/item/stamp/denied{
 	pixel_x = 4;
-	pixel_y = -2
+	pixel_y = 6
 	},
 /obj/item/stamp{
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/pen/red{
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/dest_tagger{
 	pixel_x = 9;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/pen/screwdriver{
 	pixel_x = -7;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -32012,8 +32321,12 @@
 /area/station/hallway/primary/central)
 "lnu" = (
 /obj/structure/table,
-/obj/item/clipboard,
-/obj/item/toy/figure/scientist,
+/obj/item/clipboard{
+	pixel_y = 8
+	},
+/obj/item/toy/figure/scientist{
+	pixel_y = 8
+	},
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -32123,9 +32436,17 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/item/computer_disk/ordnance,
-/obj/item/computer_disk/ordnance,
-/obj/item/computer_disk/ordnance,
+/obj/item/computer_disk/ordnance{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/computer_disk/ordnance{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/item/computer_disk/ordnance{
+	pixel_y = 12
+	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
@@ -32333,13 +32654,17 @@
 "ltW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/paper,
+/obj/item/paper{
+	pixel_y = 8
+	},
 /obj/machinery/door/window/left/directional/south{
 	name = "Hydroponics Window";
 	req_access = list("hydroponics")
 	},
 /obj/effect/turf_decal/delivery,
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "hydro_service";
@@ -32457,10 +32782,13 @@
 "lwt" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law{
-	pixel_y = 3
+	pixel_y = 8
 	},
 /obj/item/radio/intercom/command/directional/north,
-/obj/item/paper/fluff/jobs/engineering/frequencies,
+/obj/item/paper/fluff/jobs/engineering/frequencies{
+	pixel_y = 5;
+	pixel_x = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lwx" = (
@@ -32717,7 +33045,6 @@
 /area/station/engineering/supermatter/room)
 "lEl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/directional/south,
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
 	},
@@ -32833,7 +33160,7 @@
 /area/station/hallway/primary/aft)
 "lHe" = (
 /obj/machinery/reagentgrinder{
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -32896,7 +33223,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -33409,7 +33738,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "packageExternal"
@@ -33440,10 +33768,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"lRT" = (
-/obj/structure/sign/directions/evac,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/medical/central)
 "lSw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33916,7 +34240,9 @@
 /area/station/maintenance/disposal/incinerator)
 "lZM" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/shaker,
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
@@ -34224,9 +34550,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/gambling,
-/obj/effect/spawner/random/entertainment/gambling,
-/obj/effect/spawner/random/entertainment/gambling,
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_y = 12
+	},
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_y = 12
+	},
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_y = 12
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "mgv" = (
@@ -34432,16 +34764,18 @@
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/item/radio/off{
 	pixel_x = -11;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/item/binoculars,
+/obj/item/binoculars{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "mkr" = (
@@ -34509,10 +34843,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"mlH" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "mlK" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -34843,8 +35173,12 @@
 /area/station/maintenance/starboard/lesser)
 "mrG" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/lighter,
+/obj/item/folder/blue{
+	pixel_y = 8
+	},
+/obj/item/lighter{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
 "mrJ" = (
@@ -34922,7 +35256,9 @@
 /area/station/medical/surgery/aft)
 "msJ" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 8
+	},
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/south{
 	department = "Security";
@@ -34952,7 +35288,9 @@
 "msT" = (
 /obj/structure/table,
 /obj/item/food/mint,
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "mta" = (
@@ -34973,9 +35311,12 @@
 "mtb" = (
 /obj/structure/table/wood,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/folder/blue,
+/obj/item/folder/blue{
+	pixel_y = 8
+	},
 /obj/item/clothing/head/collectable/hop{
-	name = "novelty HoP hat"
+	name = "novelty HoP hat";
+	pixel_y = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -35053,7 +35394,7 @@
 /obj/structure/showcase/machinery/tv{
 	dir = 1;
 	pixel_x = 2;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -35111,7 +35452,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mvg" = (
@@ -35257,16 +35597,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
-"myG" = (
-/obj/structure/sign/directions/evac,
-/obj/structure/sign/directions/medical{
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/science{
-	pixel_y = -8
-	},
-/turf/closed/wall,
-/area/station/commons/lounge)
 "myH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -35453,18 +35783,19 @@
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
 	pixel_x = 3;
-	pixel_y = 14
+	pixel_y = 22
 	},
 /obj/item/reagent_containers/cup/glass/bottle/champagne{
 	pixel_x = -7;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/cigarette/cigar{
 	pixel_x = 4;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/cigarette/cigar{
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -36583,19 +36914,23 @@
 /area/station/engineering/atmospherics_engine)
 "mVf" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 8;
-	pixel_y = 2
+	pixel_y = 10
 	},
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = -4;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = 7;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -36710,11 +37045,11 @@
 "mWY" = (
 /obj/item/bodypart/chest/robot{
 	pixel_x = -2;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/bodypart/head/robot{
 	pixel_x = 3;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/table/wood,
 /obj/structure/cable,
@@ -36848,8 +37183,9 @@
 /area/station/security/office)
 "mZc" = (
 /obj/structure/table/wood,
-/obj/item/clothing/head/costume/sombrero/green,
-/obj/structure/sign/poster/random/directional/east,
+/obj/item/clothing/head/costume/sombrero/green{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -36862,17 +37198,18 @@
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/smart_metal_foam{
 	pixel_x = -4;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/grenade/chem_grenade/smart_metal_foam{
 	pixel_x = 4;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 8
 	},
 /obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/evac/directional/west,
@@ -37326,10 +37663,14 @@
 /area/station/security/courtroom)
 "nhr" = (
 /obj/structure/table,
-/obj/item/folder/white,
-/obj/item/stamp/head/rd,
-/obj/item/toy/figure/rd{
-	pixel_y = 10
+/obj/item/aicard{
+	pixel_y = 8
+	},
+/obj/item/circuitboard/aicore{
+	pixel_y = 8
+	},
+/obj/item/pai_card{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
@@ -37338,7 +37679,6 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nhS" = (
 /obj/machinery/vending/cigarette,
-/obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "nib" = (
@@ -37602,7 +37942,6 @@
 /obj/item/clothing/under/color/blue,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/neck/tie/blue,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -37674,11 +38013,15 @@
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table,
 /obj/machinery/firealarm/directional/north,
-/obj/item/stack/sheet/iron/five,
+/obj/item/stack/sheet/iron/five{
+	pixel_y = 8
+	},
 /obj/item/radio/intercom/directional/east{
 	pixel_y = 8
 	},
-/obj/item/stack/cable_coil/five,
+/obj/item/stack/cable_coil/five{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -38221,6 +38564,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/side,
 /area/station/science/lobby)
+"nuZ" = (
+/obj/machinery/digital_clock/directional/north{
+	pixel_y = 2;
+	pixel_z = 8
+	},
+/turf/closed/wall,
+/area/station/cargo/sorting)
 "nvc" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -38255,13 +38605,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"nwa" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/effect/landmark/start/hangover/closet,
-/obj/structure/sign/poster/official/random/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
 "nwl" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Medical Deliveries";
@@ -38357,7 +38700,9 @@
 /obj/effect/landmark/navigate_destination/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 8
+	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -38411,6 +38756,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"nyB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "nyF" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/camera/directional/east{
@@ -38771,7 +39130,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "nEB" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/machinery/requests_console/directional/south{
 	department = "Kitchen";
 	name = "Kitchen Requests Console"
@@ -38913,7 +39271,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -38926,16 +39283,17 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/reagent_containers/cup/soda_cans/random{
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 8
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/storage)
@@ -38995,9 +39353,11 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 6
+	pixel_y = 14
 	},
-/obj/item/pai_card,
+/obj/item/pai_card{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
@@ -39186,8 +39546,12 @@
 "nMz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
 /obj/machinery/button/door/directional/west{
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control"
@@ -39219,7 +39583,6 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "nMY" = (
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -39956,7 +40319,6 @@
 	c_tag = "Cargo Bay - Drone Launch Room";
 	pixel_x = 14
 	},
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "obG" = (
@@ -39977,11 +40339,15 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/item/taperecorder{
 	pixel_x = 6;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
@@ -40011,9 +40377,8 @@
 /obj/structure/table/wood,
 /obj/machinery/microwave{
 	pixel_x = 1;
-	pixel_y = 6
+	pixel_y = 14
 	},
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
 "ocC" = (
@@ -40167,7 +40532,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ogL" = (
-/obj/structure/mirror/directional/north,
+/obj/structure/mirror/directional/north{
+	pixel_y = 8
+	},
 /obj/structure/sink/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/soap{
@@ -40427,7 +40794,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "ome" = (
@@ -40518,7 +40884,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "onN" = (
 /obj/structure/table/wood,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/spawner/random/bureaucracy/paper,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
@@ -40727,10 +41092,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "osH" = (
-/obj/structure/secure_safe/hos{
-	pixel_x = 36;
-	pixel_y = 28
-	},
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -40765,18 +41126,19 @@
 /obj/structure/table,
 /obj/item/computer_disk{
 	pixel_x = -8;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/computer_disk{
 	pixel_x = -5;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/item/computer_disk/ordnance{
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
@@ -41036,9 +41398,11 @@
 /obj/structure/table,
 /obj/item/pipe_dispenser{
 	pixel_x = 3;
-	pixel_y = 7
+	pixel_y = 15
 	},
-/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -41130,6 +41494,12 @@
 /obj/structure/flora/bush/fullgrass,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"ozl" = (
+/obj/structure/sign/poster/official/cleanliness/directional/north{
+	pixel_y = 0
+	},
+/turf/closed/wall,
+/area/station/hallway/secondary/service)
 "ozm" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -41153,7 +41523,6 @@
 /obj/machinery/airalarm/directional/south,
 /obj/item/cigarette/pipe,
 /obj/item/clothing/mask/fakemoustache,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "ozX" = (
@@ -41244,11 +41613,11 @@
 	},
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 7
 	},
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 10
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron,
@@ -41303,10 +41672,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"oCX" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology/hallway)
 "oDc" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -41469,10 +41834,14 @@
 	},
 /obj/item/folder/red{
 	pixel_x = 4;
-	pixel_y = 2
+	pixel_y = 10
 	},
-/obj/item/paper,
-/obj/item/pen,
+/obj/item/paper{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "oFH" = (
@@ -41520,9 +41889,11 @@
 /area/station/maintenance/starboard/aft)
 "oFT" = (
 /obj/structure/table,
-/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/speech_relay{
+	pixel_y = 8
+	},
 /obj/item/integrated_circuit/loaded/hello_world{
-	pixel_y = 2;
+	pixel_y = 10;
 	pixel_x = 3
 	},
 /turf/open/floor/iron,
@@ -42114,7 +42485,7 @@
 "oRn" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
-	pixel_y = 4
+	pixel_y = 7
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -42267,12 +42638,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"oUB" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/digital_clock/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "oUE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42363,7 +42728,6 @@
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/iron/twenty,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "oWT" = (
@@ -42578,7 +42942,9 @@
 /area/station/cargo/bitrunning/den)
 "pbb" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -42945,7 +43311,9 @@
 /area/station/service/kitchen/coldroom)
 "pic" = (
 /obj/structure/table,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -43262,7 +43630,9 @@
 /area/station/engineering/main)
 "pof" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
@@ -43511,21 +43881,27 @@
 /area/station/science/xenobiology)
 "psv" = (
 /obj/item/stack/sheet/rglass{
-	amount = 50
+	amount = 50;
+	pixel_y = 8
 	},
 /obj/item/stack/sheet/rglass{
-	amount = 50
+	amount = 50;
+	pixel_y = 8
 	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty{
+	pixel_y = 8
+	},
+/obj/item/stack/rods/fifty{
+	pixel_y = 8
+	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -43626,7 +44002,9 @@
 /area/station/engineering/atmos)
 "pur" = (
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/gambling,
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "puG" = (
@@ -43685,12 +44063,6 @@
 	},
 /obj/machinery/keycard_auth/wall_mounted/directional/south{
 	pixel_x = 6
-	},
-/obj/machinery/button/door/directional/south{
-	id = "cmoprivacy";
-	name = "CMO Privacy Shutters";
-	pixel_x = -8;
-	req_access = list("cmo")
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
@@ -43988,10 +44360,10 @@
 /area/station/commons/lounge)
 "pBs" = (
 /obj/structure/sign/warning/cold_temp/directional/north{
-	name = "\improper CRYOGENICS"
+	name = "\improper CRYOGENICS";
+	pixel_y = -4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "pBG" = (
@@ -44079,7 +44451,6 @@
 "pCL" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sink/directional/east,
-/obj/structure/sign/poster/official/cleanliness/directional/south,
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -44720,18 +45091,18 @@
 	},
 /obj/item/assembly/signaler{
 	pixel_x = 6;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/item/assembly/signaler{
 	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -8;
 	pixel_y = 5
 	},
 /obj/item/assembly/signaler{
-	pixel_y = 8
+	pixel_x = -8;
+	pixel_y = 13
+	},
+/obj/item/assembly/signaler{
+	pixel_y = 16
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -44765,7 +45136,9 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -44826,7 +45199,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "pPU" = (
-/obj/structure/noticeboard/qm,
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/command/heads_quarters/qm)
@@ -44883,7 +45255,9 @@
 "pQC" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/south,
-/obj/item/storage/photo_album/bar,
+/obj/item/storage/photo_album/bar{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -44907,7 +45281,6 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
 "pQO" = (
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -44974,14 +45347,16 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/table,
 /obj/item/storage/box/bandages{
-	pixel_y = 6;
+	pixel_y = 14;
 	pixel_x = 4
 	},
 /obj/effect/spawner/random/entertainment/cigarette_pack{
 	pixel_x = -6;
+	pixel_y = 16
+	},
+/obj/effect/spawner/random/entertainment/deck{
 	pixel_y = 8
 	},
-/obj/effect/spawner/random/entertainment/deck,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "pSa" = (
@@ -45126,10 +45501,16 @@
 /obj/structure/table,
 /obj/effect/turf_decal/siding/white/corner,
 /obj/machinery/firealarm/directional/north,
-/obj/item/clipboard,
-/obj/item/paper,
-/obj/item/pen,
-/obj/machinery/light/small/directional/north,
+/obj/item/clipboard{
+	pixel_y = 8
+	},
+/obj/item/paper{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "pUS" = (
@@ -45275,10 +45656,12 @@
 /area/station/security/brig)
 "pXF" = (
 /obj/machinery/cell_charger{
-	pixel_y = 4
+	pixel_y = 9
 	},
 /obj/structure/table/glass,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -45881,9 +46264,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/sign/poster/random/directional/east,
 /obj/structure/table/wood,
-/obj/item/food/pie/cream,
+/obj/item/food/pie/cream{
+	pixel_y = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "qjf" = (
@@ -46077,7 +46461,6 @@
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qnt" = (
@@ -46219,22 +46602,22 @@
 /obj/structure/table/wood,
 /obj/item/stamp/head/qm{
 	pixel_x = 1;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/item/stamp/granted{
 	pixel_x = -7;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/item/stamp/denied{
 	pixel_x = -7;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/item/stamp/void{
 	pixel_x = 1;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/effect/spawner/random/entertainment/money_medium{
-	pixel_y = -6;
+	pixel_y = 2;
 	pixel_x = -3
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -46242,10 +46625,10 @@
 	},
 /obj/item/clipboard{
 	pixel_x = 10;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/coin/gold{
-	pixel_y = -5;
+	pixel_y = 3;
 	pixel_x = 10
 	},
 /turf/open/floor/wood/large,
@@ -46265,7 +46648,8 @@
 /area/station/cargo/bitrunning/den)
 "qrO" = (
 /obj/machinery/chem_dispenser/drinks{
-	dir = 1
+	dir = 1;
+	pixel_y = 8
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/structure/table,
@@ -46497,10 +46881,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
-"qwI" = (
-/obj/structure/sign/departments/chemistry/pharmacy,
-/turf/closed/wall,
-/area/station/medical/pharmacy)
 "qwK" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
@@ -46833,10 +47213,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
-"qCY" = (
-/obj/structure/sign/directions/evac,
-/turf/closed/wall,
-/area/station/maintenance/department/science/central)
 "qDa" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
@@ -46964,9 +47340,15 @@
 /area/station/hallway/primary/aft)
 "qFR" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
@@ -47066,7 +47448,6 @@
 /turf/closed/wall,
 /area/station/hallway/secondary/command)
 "qIp" = (
-/obj/structure/sign/poster/official/cleanliness/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/directional/north{
 	c_tag = "Jim Norton's Quebecois Coffee"
@@ -47084,6 +47465,7 @@
 /obj/item/reagent_containers/condiment/soymilk,
 /obj/item/reagent_containers/condiment/milk,
 /obj/structure/closet/secure_closet/freezer/empty/open,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
 "qIq" = (
@@ -47112,7 +47494,6 @@
 "qIF" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qIL" = (
@@ -47170,9 +47551,12 @@
 /area/station/security/prison/visit)
 "qJn" = (
 /obj/machinery/chem_master,
-/obj/structure/noticeboard/directional/east,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/button/door/directional/east{
+	name = "pharmacy shutters control";
+	id = "pharmacy_shutters"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "qJt" = (
@@ -47218,7 +47602,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qKD" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -47249,11 +47632,16 @@
 "qLk" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/obj/item/clipboard,
-/obj/item/toy/figure/cmo,
+/obj/item/clipboard{
+	pixel_y = 8
+	},
+/obj/item/toy/figure/cmo{
+	pixel_y = 8
+	},
 /obj/structure/cable,
 /obj/item/stamp/head/cmo{
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -47272,7 +47660,6 @@
 	pixel_y = 2
 	},
 /obj/item/lipstick/black,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -47602,14 +47989,15 @@
 /obj/structure/table,
 /obj/item/papercutter{
 	pixel_x = 9;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/item/stamp/denied{
 	pixel_x = -7;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/item/stamp/granted{
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
@@ -47908,15 +48296,15 @@
 	},
 /obj/structure/table/wood,
 /obj/item/food/cherrycupcake{
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/food/muffin/berry{
 	pixel_x = 18;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /obj/item/food/cakeslice/pound_cake_slice{
 	pixel_x = 4;
-	pixel_y = -5
+	pixel_y = 3
 	},
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/west,
@@ -47957,9 +48345,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "qTU" = (
-/obj/item/retractor,
+/obj/item/retractor{
+	pixel_y = 8
+	},
 /obj/item/hemostat{
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 8
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
@@ -48020,12 +48411,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "qVB" = (
-/obj/structure/sign/warning/secure_area/directional/north,
-/turf/open/space/basic,
-/area/space/nearstation)
-"qWg" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/secure_area/directional/east,
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "qWm" = (
@@ -48210,7 +48598,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
@@ -48249,7 +48637,7 @@
 /obj/machinery/button/door/directional/north{
 	id = "hosspace";
 	name = "Space Shutters Control";
-	pixel_x = -24
+	pixel_y = -5
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -48350,7 +48738,9 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
 "raJ" = (
-/obj/structure/secure_safe/caps_spare,
+/obj/structure/secure_safe/caps_spare{
+	pixel_y = 7
+	},
 /obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -48376,9 +48766,15 @@
 "rbs" = (
 /obj/structure/cable,
 /obj/structure/table,
-/obj/item/stack/medical/mesh,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/suture,
+/obj/item/stack/medical/mesh{
+	pixel_y = 8
+	},
+/obj/item/stack/medical/gauze{
+	pixel_y = 8
+	},
+/obj/item/stack/medical/suture{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -48404,7 +48800,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/wtf_is_co2/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "rbF" = (
@@ -48525,7 +48920,8 @@
 /obj/structure/table,
 /obj/machinery/fax{
 	fax_name = "Service Hallway";
-	name = "Service Fax Machine"
+	name = "Service Fax Machine";
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -48703,6 +49099,17 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"rir" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/sign/directions/engineering/left,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "riz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -48836,8 +49243,12 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
 /obj/structure/table/glass,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science{
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = 8
+	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -49119,12 +49530,12 @@
 /area/station/security/checkpoint/supply)
 "rrz" = (
 /obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
+	dir = 1;
+	pixel_y = 8
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/light/small/directional/south,
-/obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "rrL" = (
@@ -49231,7 +49642,9 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "rtd" = (
@@ -49421,8 +49834,12 @@
 /area/station/security/courtroom)
 "rwa" = (
 /obj/structure/table,
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/cup/watering_can,
+/obj/item/storage/bag/plants{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/watering_can{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 10
 	},
@@ -49510,7 +49927,7 @@
 	},
 /obj/structure/desk_bell{
 	pixel_x = -3;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
@@ -49669,13 +50086,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"rzB" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "rzJ" = (
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/iron,
@@ -49759,6 +50169,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"rAB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rAG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50045,28 +50464,18 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 9;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/structure/cable,
 /obj/item/radio{
 	pixel_x = -6;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "rHk" = (
 /obj/structure/table/glass,
-/obj/item/folder/blue{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/folder/white,
-/obj/item/pen{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/item/computer_disk/medical,
-/obj/item/computer_disk/medical,
+/obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "rHn" = (
@@ -50077,9 +50486,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 6
-	},
-/obj/structure/sign/warning/secure_area/directional/east{
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 6
@@ -50189,9 +50595,12 @@
 /obj/structure/table/wood,
 /obj/machinery/light/directional/south,
 /obj/item/papercutter{
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/item/paper/fluff/ids_for_dummies,
+/obj/item/paper/fluff/ids_for_dummies{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "rJA" = (
@@ -50373,13 +50782,13 @@
 "rMr" = (
 /obj/structure/table/glass,
 /obj/item/experi_scanner{
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/item/experi_scanner{
-	pixel_y = 1
+	pixel_y = 9
 	},
 /obj/item/experi_scanner{
-	pixel_y = 6
+	pixel_y = 14
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -50595,8 +51004,12 @@
 	name = "Genetics Desk";
 	req_access = list("genetics")
 	},
-/obj/item/folder,
-/obj/item/pen,
+/obj/item/folder{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/genetics)
@@ -50640,7 +51053,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/cigarette,
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_y = 13
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "rRB" = (
@@ -50664,7 +51079,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "rRR" = (
-/obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50873,21 +51287,21 @@
 /obj/structure/table,
 /obj/item/folder/white{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/cup/beaker/large{
 	pixel_x = -4;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/cup/beaker{
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 8
 	},
 /obj/item/reagent_containers/dropper{
 	pixel_x = -3;
-	pixel_y = -6
+	pixel_y = 2
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron,
 /area/station/science/lab)
@@ -50999,9 +51413,11 @@
 	},
 /obj/item/book/manual/wiki/chemistry{
 	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 12
 	},
-/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/grenades{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
@@ -51195,25 +51611,26 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/mug{
 	pixel_x = 13;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/cup/glass/mug{
 	pixel_x = 6;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/reagent_containers/cup/glass/mug{
 	pixel_x = 13;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/item/reagent_containers/cup/glass/shaker{
 	pixel_x = -2;
-	pixel_y = 12
+	pixel_y = 18
 	},
 /obj/item/reagent_containers/cup/glass/ice{
 	pixel_x = -4;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/window/spawner/directional/west,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
 "saN" = (
@@ -51521,7 +51938,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
@@ -51849,7 +52266,9 @@
 	pixel_x = 1;
 	pixel_y = 9
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 10
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "snB" = (
@@ -51870,7 +52289,6 @@
 /area/station/science/ordnance/testlab)
 "soa" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "soi" = (
@@ -52117,7 +52535,9 @@
 "stI" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/table,
-/obj/item/binoculars,
+/obj/item/binoculars{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
@@ -52315,9 +52735,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/item/aicard,
-/obj/item/pai_card,
-/obj/item/circuitboard/aicore,
 /obj/machinery/keycard_auth/wall_mounted/directional/north{
 	pixel_x = -5
 	},
@@ -52326,6 +52743,32 @@
 	name = "Xenobiology Containment Control";
 	pixel_x = 8;
 	req_access = list("rd")
+	},
+/obj/machinery/button/door/table{
+	id = "rdrnd";
+	name = "Research and Development Containment Control";
+	pixel_y = 4;
+	pixel_x = 6;
+	req_access = list("rd")
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 12;
+	name = "Ordnance Containment Control";
+	id = "rdordnance";
+	pixel_x = 6;
+	req_access = list("rd")
+	},
+/obj/item/toy/figure/rd{
+	pixel_y = 16;
+	pixel_x = -6
+	},
+/obj/item/folder/white{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/stamp/head/rd{
+	pixel_y = 8;
+	pixel_x = -6
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
@@ -52383,9 +52826,15 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/table/wood,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/toy/crayon/spraycan,
-/obj/item/stack/rods/ten,
+/obj/item/stack/sheet/cloth/ten{
+	pixel_y = 8
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_y = 8
+	},
+/obj/item/stack/rods/ten{
+	pixel_y = 8
+	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
@@ -52847,11 +53296,11 @@
 /obj/machinery/airalarm/directional/east,
 /obj/item/food/poppypretzel{
 	pixel_x = -5;
-	pixel_y = -2
+	pixel_y = 5
 	},
 /obj/item/food/hotcrossbun{
 	pixel_x = 5;
-	pixel_y = 7
+	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 1
@@ -53121,9 +53570,6 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/light/small/directional/south,
-/obj/structure/noticeboard/rd{
-	pixel_y = -32
-	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -53713,7 +54159,7 @@
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 8
 	},
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
@@ -53960,7 +54406,9 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood,
-/obj/item/storage/backpack/duffelbag/drone,
+/obj/item/storage/backpack/duffelbag/drone{
+	pixel_y = 8
+	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
@@ -54151,13 +54599,14 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/coffeepack{
 	pixel_x = 15;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/item/reagent_containers/cup/glass/bottle/juice/cream{
 	pixel_x = 15;
 	pixel_y = 2
 	},
 /obj/machinery/coffeemaker/impressa,
+/obj/structure/sign/chalkboard_menu,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
 "tcu" = (
@@ -54239,10 +54688,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "teq" = (
-/obj/item/cultivator,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/cup/watering_can,
+/obj/item/cultivator{
+	pixel_y = 8
+	},
+/obj/item/crowbar{
+	pixel_y = 8
+	},
+/obj/item/plant_analyzer{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/watering_can{
+	pixel_y = 8
+	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -54450,7 +54907,6 @@
 /area/station/cargo/miningoffice)
 "tit" = (
 /obj/structure/sink/directional/east,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "tiA" = (
@@ -55167,9 +55623,13 @@
 /area/station/maintenance/port)
 "twl" = (
 /obj/structure/table,
-/obj/item/hand_tele,
+/obj/item/hand_tele{
+	pixel_y = 8
+	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/spawner/random/engineering/tracking_beacon{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
@@ -55343,12 +55803,14 @@
 /area/station/medical/medbay/central)
 "tzI" = (
 /obj/structure/table/reinforced,
-/obj/item/emergency_bed,
 /obj/item/emergency_bed{
-	pixel_y = 3
+	pixel_y = 8
 	},
 /obj/item/emergency_bed{
-	pixel_y = 6
+	pixel_y = 11
+	},
+/obj/item/emergency_bed{
+	pixel_y = 14
 	},
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -55389,18 +55851,22 @@
 /obj/structure/table,
 /obj/item/hand_labeler_refill{
 	pixel_x = 12;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/effect/spawner/random/bureaucracy/birthday_wrap{
 	pixel_x = -2;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/stack/package_wrap{
 	pixel_x = -6;
-	pixel_y = 18
+	pixel_y = 26
 	},
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "tAx" = (
@@ -55561,7 +56027,6 @@
 	},
 /obj/structure/window/spawner/directional/west,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/directional/west,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "tDN" = (
@@ -55757,6 +56222,7 @@
 	c_tag = "Science Maintenance Corridor";
 	network = list("ss13","rd")
 	},
+/obj/structure/sign/warning/secure_area,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "tIe" = (
@@ -55815,10 +56281,10 @@
 "tIR" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album{
-	pixel_y = -4
+	pixel_y = 4
 	},
 /obj/item/camera{
-	pixel_y = 4
+	pixel_y = 11
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet,
@@ -55935,7 +56401,8 @@
 /obj/machinery/fax{
 	fax_name = "Research Division";
 	name = "Research Division Fax Machine";
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -55951,9 +56418,10 @@
 	idInterior = "xeno_airlock_interior";
 	idSelf = "xeno_airlock_control";
 	name = "Access Console";
-	pixel_x = -25;
-	pixel_y = -25;
-	req_access = list("xenobiology")
+	pixel_x = -12;
+	pixel_y = -30;
+	req_access = list("xenobiology");
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -56012,13 +56480,15 @@
 /obj/structure/table,
 /obj/structure/cable,
 /obj/item/disk/tech_disk{
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 8
 	},
 /obj/item/disk/tech_disk{
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 8
 	},
 /obj/item/disk/tech_disk{
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -56090,13 +56560,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"tMS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "tMX" = (
 /obj/effect/turf_decal/trimline/brown/filled/shrink_cw{
 	dir = 8
@@ -56139,7 +56602,8 @@
 	},
 /obj/item/pai_card{
 	desc = "A real Nanotrasen success, these personal AIs provide all of the companionship of an AI without any law related red-tape.";
-	name = "\improper Nanotrasen-brand personal AI device exhibit"
+	name = "\improper Nanotrasen-brand personal AI device exhibit";
+	pixel_y = 8
 	},
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
@@ -56471,11 +56935,11 @@
 /obj/effect/turf_decal/bot,
 /obj/item/computer_disk{
 	pixel_x = 7;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/item/computer_disk{
 	pixel_x = -5;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -56500,9 +56964,15 @@
 /area/station/maintenance/starboard/lesser)
 "tUt" = (
 /obj/structure/table/glass,
-/obj/item/clothing/accessory/armband/hydro,
-/obj/item/clothing/suit/apron,
-/obj/item/wrench,
+/obj/item/clothing/accessory/armband/hydro{
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/apron{
+	pixel_y = 8
+	},
+/obj/item/wrench{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -56717,10 +57187,14 @@
 /obj/structure/table/wood,
 /obj/item/razor{
 	pixel_x = -4;
-	pixel_y = 2
+	pixel_y = 8
 	},
-/obj/item/cigarette/cigar,
-/obj/item/reagent_containers/cup/glass/flask/gold,
+/obj/item/cigarette/cigar{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/glass/flask/gold{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "tXU" = (
@@ -56942,6 +57416,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "uaR" = (
@@ -57034,17 +57511,21 @@
 /obj/structure/table,
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 8;
-	pixel_y = 2
+	pixel_y = 10
 	},
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = -4;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = 7;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/light/small/directional/south,
@@ -57523,12 +58004,6 @@
 /obj/machinery/computer/records/security{
 	dir = 4
 	},
-/obj/machinery/button/door/directional/west{
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_y = -9
-	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
@@ -57726,11 +58201,15 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/item/multitool/circuit{
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/obj/item/multitool/circuit,
 /obj/item/multitool/circuit{
-	pixel_x = -8
+	pixel_y = 8
+	},
+/obj/item/multitool/circuit{
+	pixel_x = -8;
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
@@ -57808,9 +58287,15 @@
 "usg" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/table/reinforced,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/obj/item/clothing/head/utility/welding,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/utility/welding{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "ush" = (
@@ -57897,7 +58382,7 @@
 "usQ" = (
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 7
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -57964,8 +58449,9 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/structure/table/wood,
-/obj/item/clothing/glasses/monocle,
-/obj/structure/sign/poster/random/directional/south,
+/obj/item/clothing/glasses/monocle{
+	pixel_y = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "utG" = (
@@ -59286,7 +59772,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "uUb" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
@@ -59412,10 +59900,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"uWk" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology/hallway)
 "uWn" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -59633,7 +60117,8 @@
 	name = "Kitchen Counter Shutters"
 	},
 /obj/structure/desk_bell{
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -59926,7 +60411,8 @@
 /obj/structure/cable,
 /obj/machinery/fax{
 	fax_name = "Chief Medical Officer's Office";
-	name = "Chief Medical Officer's Fax Machine"
+	name = "Chief Medical Officer's Fax Machine";
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -60103,9 +60589,11 @@
 /obj/machinery/door/firedoor,
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 5
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 8
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "pharmacy_shutters_2";
@@ -60234,19 +60722,19 @@
 /obj/item/radio/intercom/directional/north,
 /obj/item/storage/medkit{
 	pixel_x = 7;
-	pixel_y = -3
+	pixel_y = 6
 	},
 /obj/item/storage/medkit{
 	pixel_x = -5;
-	pixel_y = -1
+	pixel_y = 7
 	},
 /obj/item/healthanalyzer{
 	pixel_x = 4;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/healthanalyzer{
 	pixel_x = -3;
-	pixel_y = -4
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
@@ -60618,9 +61106,15 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/item/stack/sheet/glass,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/signaler,
+/obj/item/stack/sheet/glass{
+	pixel_y = 8
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
 /obj/item/assembly/timer{
 	pixel_x = 3;
 	pixel_y = 3
@@ -60644,9 +61138,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 4
+	pixel_y = 10
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 6
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "vth" = (
@@ -60725,11 +61221,11 @@
 	},
 /obj/item/storage/box/lights/mixed{
 	pixel_x = 6;
-	pixel_y = 12
+	pixel_y = 20
 	},
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/grenade/chem_grenade/cleaner{
 	pixel_x = -7;
@@ -60741,10 +61237,11 @@
 "vtK" = (
 /obj/machinery/reagentgrinder{
 	pixel_x = 6;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/reagent_containers/cup/glass/shaker{
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 13
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Bar - Counter"
@@ -60934,7 +61431,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/digital_clock/directional/north,
+/obj/machinery/digital_clock/directional/north{
+	pixel_y = 0
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vxJ" = (
@@ -60961,10 +61460,6 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
-"vyi" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/command/corporate_showroom)
 "vyv" = (
 /obj/structure/table,
 /obj/machinery/status_display/ai/directional/west,
@@ -60973,9 +61468,11 @@
 	},
 /obj/item/ai_module/reset{
 	pixel_x = 2;
+	pixel_y = 16
+	},
+/obj/item/ai_module/supplied/freeform{
 	pixel_y = 8
 	},
-/obj/item/ai_module/supplied/freeform,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "vyy" = (
@@ -61013,7 +61510,6 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/north,
 /obj/item/surgery_tray/full/morgue,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
@@ -61028,7 +61524,6 @@
 /area/station/science/ordnance/storage)
 "vzG" = (
 /obj/item/radio/intercom/directional/north,
-/obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -61179,16 +61674,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"vCC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "vCN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -61311,18 +61796,19 @@
 	},
 /obj/item/radio/headset/headset_medsci{
 	pixel_x = -7;
-	pixel_y = 4
+	pixel_y = 12
 	},
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 6;
-	pixel_y = 9
+	pixel_y = 17
 	},
 /obj/item/storage/box/gloves{
 	pixel_x = 5;
-	pixel_y = 1
+	pixel_y = 9
 	},
 /obj/item/storage/box/monkeycubes{
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/east,
@@ -61489,7 +61975,8 @@
 /obj/structure/table/wood,
 /obj/machinery/fax{
 	fax_name = "Quartermaster";
-	name = "Quartermaster's Fax Machine"
+	name = "Quartermaster's Fax Machine";
+	pixel_y = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -61742,7 +62229,9 @@
 /area/station/commons/locker)
 "vLM" = (
 /obj/structure/table/wood/poker,
-/obj/item/storage/dice,
+/obj/item/storage/dice{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "vLX" = (
@@ -62137,13 +62626,13 @@
 /obj/machinery/status_display/ai/directional/north,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -1;
-	pixel_y = 4
+	pixel_y = 9
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vSo" = (
@@ -62503,10 +62992,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"vYl" = (
-/obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "vYD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62612,11 +63097,15 @@
 /obj/machinery/airalarm/directional/south,
 /obj/item/stack/package_wrap{
 	pixel_x = -4;
-	pixel_y = 6
+	pixel_y = 11
 	},
-/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/item/gun/ballistic/shotgun/doublebarrel{
+	pixel_y = 8
+	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
@@ -62790,8 +63279,12 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -62929,13 +63422,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"weq" = (
-/obj/structure/sign/warning/secure_area{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/wall,
-/area/station/science/ordnance/bomb)
 "wev" = (
 /obj/structure/rack,
 /obj/item/storage/box,
@@ -63017,13 +63503,12 @@
 	},
 /area/station/engineering/atmos/storage/gas)
 "wfD" = (
-/obj/structure/fireaxecabinet/directional/south,
 /obj/item/paper_bin{
 	pixel_x = -2;
-	pixel_y = 7
+	pixel_y = 10
 	},
 /obj/item/pen{
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table/glass,
@@ -63073,7 +63558,6 @@
 	spawn_random_offset = 1
 	},
 /obj/effect/spawner/random/entertainment/musical_instrument,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wgs" = (
@@ -63217,7 +63701,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "wjK" = (
-/obj/item/clothing/head/hats/tophat,
+/obj/item/clothing/head/hats/tophat{
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
@@ -63308,9 +63794,15 @@
 "wll" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/east,
-/obj/item/folder/blue,
-/obj/item/hand_tele,
-/obj/item/stamp/head/captain,
+/obj/item/folder/blue{
+	pixel_y = 8
+	},
+/obj/item/hand_tele{
+	pixel_y = 7
+	},
+/obj/item/stamp/head/captain{
+	pixel_y = 8
+	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -63628,7 +64120,7 @@
 "wss" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/item/folder/yellow{
-	pixel_y = 4
+	pixel_y = 9
 	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Bridge - Central"
@@ -63637,7 +64129,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "wst" = (
@@ -63789,7 +64281,9 @@
 /area/station/command/heads_quarters/rd)
 "wtX" = (
 /obj/structure/table/wood,
-/obj/item/folder/yellow,
+/obj/item/folder/yellow{
+	pixel_y = 8
+	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -64017,9 +64511,15 @@
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/wood,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/under/suit/black_really,
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 8
+	},
+/obj/item/clothing/under/suit/black_really{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 8
+	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Corporate Showroom"
 	},
@@ -64145,8 +64645,9 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/effect/spawner/random/trash/soap,
-/obj/structure/sign/poster/random/directional/east,
+/obj/effect/spawner/random/trash/soap{
+	pixel_y = 8
+	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
@@ -64182,10 +64683,13 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
 	},
-/obj/item/toy/figure/geneticist,
+/obj/item/toy/figure/geneticist{
+	pixel_y = 8
+	},
 /obj/item/radio/intercom/directional/west,
 /obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -64197,15 +64701,6 @@
 "wBu" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/head_of_personnel,
-/obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -35
-	},
-/obj/machinery/button/flasher{
-	id = "hopflash";
-	pixel_x = 38;
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -64258,7 +64753,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "wCb" = (
 /obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
@@ -64355,7 +64852,9 @@
 	},
 /area/station/engineering/atmos/pumproom)
 "wDH" = (
-/obj/machinery/digital_clock/directional/north,
+/obj/machinery/digital_clock/directional/north{
+	pixel_y = 0
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "wEf" = (
@@ -64521,7 +65020,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/sign/departments/rndserver/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wGP" = (
@@ -64940,12 +65438,18 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "wPH" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/utility/welding,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -65083,13 +65587,20 @@
 	dir = 6
 	},
 /obj/structure/dresser,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "wRD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi,
+/obj/item/mmi{
+	pixel_y = 8
+	},
+/obj/item/mmi{
+	pixel_y = 8
+	},
+/obj/item/mmi{
+	pixel_y = 8
+	},
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -65140,7 +65651,9 @@
 /area/station/command/heads_quarters/hos)
 "wSs" = (
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/deck,
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_y = 7
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wSv" = (
@@ -65159,7 +65672,7 @@
 	},
 /obj/structure/desk_bell{
 	pixel_x = 6;
-	pixel_y = 10
+	pixel_y = 18
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron,
@@ -65830,36 +66343,38 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
 /obj/item/bodypart/arm/right/robot{
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 8
 	},
 /obj/item/bodypart/arm/left/robot{
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/firealarm/directional/west,
 /obj/item/assembly/flash/handheld{
 	pixel_x = 6;
-	pixel_y = 13
+	pixel_y = 21
 	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 6;
-	pixel_y = 13
+	pixel_y = 21
 	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 6;
-	pixel_y = 13
+	pixel_y = 21
 	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 6;
-	pixel_y = 13
+	pixel_y = 21
 	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 6;
-	pixel_y = 13
+	pixel_y = 21
 	},
 /obj/machinery/ecto_sniffer{
 	pixel_x = -6;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
@@ -66049,11 +66564,11 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap{
 	pixel_x = -2;
-	pixel_y = 1
+	pixel_y = 7
 	},
 /obj/effect/spawner/random/bureaucracy/birthday_wrap{
 	pixel_x = -2;
-	pixel_y = 8
+	pixel_y = 16
 	},
 /obj/item/dest_tagger{
 	pixel_x = 7;
@@ -66061,7 +66576,7 @@
 	},
 /obj/item/stack/wrapping_paper{
 	pixel_x = -4;
-	pixel_y = -7
+	pixel_y = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -66442,7 +66957,9 @@
 "xqv" = (
 /obj/structure/cable,
 /obj/structure/table,
-/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xqI" = (
@@ -66563,7 +67080,7 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/reinforced,
 /obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
+	pixel_y = 15
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -66837,7 +67354,7 @@
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/reagent_containers/cup/glass/mug/britcup{
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/light/small/directional/south,
@@ -66861,7 +67378,6 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "xyd" = (
@@ -66917,10 +67433,17 @@
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
-/obj/item/plunger,
-/obj/item/plunger,
+/obj/item/plunger{
+	pixel_y = 6
+	},
+/obj/item/plunger{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
+	},
+/obj/item/clothing/head/utility/welding{
+	pixel_y = 16
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -67024,7 +67547,6 @@
 /area/station/service/hydroponics)
 "xAi" = (
 /obj/machinery/vending/autodrobe,
-/obj/structure/sign/poster/contraband/clown/directional/east,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -67206,7 +67728,7 @@
 "xCR" = (
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 5
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -67278,10 +67800,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xEe" = (
-/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes{
+	pixel_y = 8
+	},
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
-	pixel_y = 2
+	pixel_y = 10
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -67492,7 +68016,6 @@
 	dir = 6
 	},
 /obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -67524,21 +68047,26 @@
 "xJI" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/table/glass,
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 10
 	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
+	},
 /obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 10
+	pixel_y = 18
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 18
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/noticeboard/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xJK" = (
@@ -67564,8 +68092,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "xJT" = (
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/crap,
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/crap{
+	pixel_y = 8
+	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
@@ -67810,7 +68342,8 @@
 /obj/structure/table,
 /obj/machinery/fax{
 	fax_name = "Research Director's Office";
-	name = "Research Director's Fax Machine"
+	name = "Research Director's Fax Machine";
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
@@ -68013,7 +68546,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/clock/directional/west,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
@@ -68204,11 +68736,11 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
 	pixel_x = 6;
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/reagent_containers/condiment/enzyme{
 	pixel_x = -6;
-	pixel_y = 5
+	pixel_y = 15
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -68653,14 +69185,18 @@
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/power_store/cell/high{
 	pixel_x = 4;
-	pixel_y = 5
+	pixel_y = 13
 	},
 /obj/item/stock_parts/power_store/cell/high{
 	pixel_x = -8;
-	pixel_y = 9
+	pixel_y = 17
 	},
-/obj/item/stock_parts/power_store/cell/high,
-/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "yec" = (
@@ -68716,6 +69252,12 @@
 	c_tag = "Head of Security's Office"
 	},
 /obj/structure/cable,
+/obj/machinery/button/door/directional/north{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_y = 0
+	},
+/obj/structure/secure_safe/hos,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "yfg" = (
@@ -68799,11 +69341,21 @@
 /area/station/engineering/transit_tube)
 "ygt" = (
 /obj/structure/table/wood,
-/obj/item/poster/random_official,
-/obj/item/poster/random_official,
-/obj/item/poster/random_official,
-/obj/item/poster/random_official,
-/obj/item/poster/random_official,
+/obj/item/poster/random_official{
+	pixel_y = 2
+	},
+/obj/item/poster/random_official{
+	pixel_y = 6
+	},
+/obj/item/poster/random_official{
+	pixel_y = 18
+	},
+/obj/item/poster/random_official{
+	pixel_y = 14
+	},
+/obj/item/poster/random_official{
+	pixel_y = 10
+	},
 /obj/structure/cable,
 /obj/machinery/button/door/directional/east{
 	id = "corporate_privacy";
@@ -68820,6 +69372,18 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"ygG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/warning/secure_area/directional/north{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "ygR" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -68920,10 +69484,10 @@
 	},
 /obj/machinery/fax{
 	fax_name = "Medical";
-	name = "Medical Fax Machine"
+	name = "Medical Fax Machine";
+	pixel_y = 8
 	},
 /obj/structure/noticeboard/directional/north,
-/obj/structure/sign/clock/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "yiJ" = (
@@ -69031,15 +69595,21 @@
 	req_access = list("medical")
 	},
 /obj/item/clothing/glasses/blindfold{
-	pixel_y = 3
+	pixel_y = 11
 	},
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/ears/earmuffs{
-	pixel_y = 3
+	pixel_y = 11
 	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/glasses/eyepatch,
-/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/eyepatch{
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/jacket/straight_jacket{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "ylt" = (
@@ -82329,7 +82899,7 @@ cUd
 sCz
 oHw
 xOO
-bqg
+slD
 ahe
 slD
 nyF
@@ -82621,7 +83191,7 @@ aox
 lMJ
 aaa
 aaa
-qWg
+lMJ
 aaa
 aaa
 aaa
@@ -82633,7 +83203,7 @@ aaa
 lZV
 aaa
 aaa
-qWg
+lMJ
 aaa
 aaa
 aaa
@@ -82811,7 +83381,7 @@ nmg
 jXu
 kBS
 rOz
-mlH
+sHu
 sHu
 cVL
 jZW
@@ -84145,7 +84715,7 @@ jUb
 hWj
 coJ
 uxS
-fNI
+uxS
 uxS
 bCE
 wGz
@@ -84917,7 +85487,7 @@ aZL
 jgk
 qnr
 pAe
-rzB
+jgk
 pAe
 jUb
 cBc
@@ -85139,7 +85709,7 @@ aaa
 fcq
 fcq
 pck
-lku
+fxQ
 uEw
 nJG
 wSb
@@ -86981,7 +87551,7 @@ xUu
 mue
 xUu
 kIR
-tMS
+xUu
 xUu
 gjk
 kIR
@@ -88013,7 +88583,7 @@ oZO
 bMS
 jUb
 dqN
-vCC
+kym
 jUb
 jdH
 oBv
@@ -88551,7 +89121,7 @@ tSw
 gOp
 bCM
 vKd
-ikY
+drm
 tSw
 lMJ
 aaa
@@ -90536,7 +91106,7 @@ iRR
 faA
 nKn
 bzH
-bzH
+nuZ
 nco
 cvX
 qNn
@@ -91554,7 +92124,7 @@ nZh
 hSf
 pID
 qSp
-cOj
+guX
 tcr
 jfX
 aUC
@@ -92866,7 +93436,7 @@ lxp
 qRI
 urA
 nIR
-hyN
+tOh
 uaN
 jIg
 dTr
@@ -93118,8 +93688,8 @@ pJR
 iiE
 rGj
 rJr
-pJR
-oUB
+jTg
+wMx
 qRI
 urA
 nIR
@@ -94146,7 +94716,7 @@ lJn
 eRC
 htG
 bIq
-pJR
+ilD
 mQq
 ndS
 urA
@@ -94426,7 +94996,7 @@ asm
 kqm
 vLf
 kXD
-kWO
+rvE
 rvE
 whx
 cIK
@@ -94665,7 +95235,7 @@ tNg
 vpg
 ebx
 aks
-hux
+gBD
 bbT
 ilq
 kAp
@@ -94683,7 +95253,7 @@ xEX
 hYr
 qAf
 lrR
-qwI
+rvE
 xJI
 tIx
 wmT
@@ -94909,7 +95479,7 @@ tKN
 aaf
 dsQ
 dsQ
-dho
+hDG
 dhp
 kcn
 qXF
@@ -95227,7 +95797,7 @@ jLy
 kgx
 hKB
 vLo
-aAb
+wnW
 tSw
 dbX
 iUm
@@ -95444,8 +96014,8 @@ sYh
 qeZ
 nBs
 eLa
-vyi
-nNY
+jzN
+ygG
 htd
 tHR
 sTz
@@ -95474,7 +96044,7 @@ iqz
 iqz
 sTW
 cYx
-cXH
+pbz
 joj
 dWI
 hZV
@@ -95690,8 +96260,8 @@ duI
 lwt
 ddm
 vKL
-gmH
-lSz
+dho
+eaK
 aks
 qzz
 qRV
@@ -95979,7 +96549,7 @@ lLq
 lLq
 eIO
 qbZ
-lRT
+fvE
 bqX
 bqX
 bqX
@@ -95987,7 +96557,7 @@ pJV
 bqX
 bqX
 bqX
-cJL
+bqX
 fjq
 wvh
 iEv
@@ -97015,7 +97585,7 @@ fma
 fma
 kor
 aQS
-qCY
+kor
 kQe
 qYt
 qDa
@@ -97232,8 +97802,8 @@ duI
 wtX
 ppB
 nEC
-gmH
-ebx
+dho
+nyB
 vQe
 kHn
 gUP
@@ -97500,8 +98070,8 @@ aAI
 gzi
 krL
 cqm
-vyi
-wpx
+jzN
+rAB
 htd
 tHR
 udN
@@ -98263,7 +98833,7 @@ eoD
 bcT
 xPN
 vQe
-kmZ
+tvE
 buL
 pha
 sdp
@@ -101086,7 +101656,7 @@ vLb
 jmT
 jZR
 mJN
-cwP
+sqM
 sqM
 hBr
 jef
@@ -101134,7 +101704,7 @@ jTN
 vAH
 kIY
 iaF
-gyQ
+lgR
 rbD
 jwj
 ujk
@@ -101601,13 +102171,13 @@ eaF
 xCD
 xCD
 xCD
-xCD
+rir
 byQ
 hio
 vtu
 cWT
 xBx
-bdb
+smG
 smG
 smG
 gtU
@@ -101850,7 +102420,7 @@ uZj
 ghl
 xZW
 uOX
-myG
+rac
 rac
 bvJ
 bvJ
@@ -101915,8 +102485,8 @@ dpN
 dpN
 egk
 mwY
-bIa
-vYl
+nFa
+nFa
 nFa
 nFa
 rDB
@@ -102103,11 +102673,11 @@ qXB
 eFR
 ubD
 usK
-dZm
+jPj
 vFB
 fRS
 twN
-lkc
+rac
 hhN
 pBi
 hkG
@@ -103190,7 +103760,7 @@ oFS
 aqh
 uGX
 oWk
-jNp
+kmd
 lPC
 guG
 iAs
@@ -103675,7 +104245,7 @@ oxd
 xlF
 xlF
 aWg
-jgK
+eur
 tUn
 dQT
 wXF
@@ -103757,14 +104327,14 @@ lMJ
 dxK
 aaf
 aaf
-weq
+cxz
 kJi
 pgU
 qRS
 pnk
 kJi
-weq
-aaa
+cxz
+iDe
 aaa
 aaa
 aaa
@@ -103909,7 +104479,7 @@ aeb
 bvJ
 lWm
 kdN
-wSs
+eIT
 jGA
 mgo
 fGH
@@ -104785,14 +105355,14 @@ lMJ
 dxK
 aaf
 aaf
-weq
+cxz
 kJi
 vpl
 cDb
 xOI
 kJi
-weq
-aaa
+cxz
+iDe
 aaa
 aaa
 aaa
@@ -104960,7 +105530,7 @@ soU
 gkx
 gkx
 nbJ
-jgK
+eur
 tUn
 eLh
 lQI
@@ -105170,7 +105740,7 @@ hJv
 iEE
 ejl
 pFd
-nwa
+xUh
 lqQ
 sdt
 geV
@@ -105708,7 +106278,7 @@ lje
 klZ
 oCq
 fqD
-wSs
+cuJ
 pur
 oEu
 gZV
@@ -105748,9 +106318,9 @@ wXF
 wXF
 wXF
 wXF
-bcb
+gFQ
 gMQ
-bcb
+gFQ
 oWk
 clj
 fwP
@@ -106496,7 +107066,7 @@ wPU
 gKS
 huG
 olP
-wYB
+ozl
 gAx
 siz
 hxz
@@ -106744,7 +107314,7 @@ iEZ
 uWK
 gFO
 rHz
-aFW
+dqX
 dqX
 qLp
 ozF
@@ -107484,7 +108054,7 @@ psZ
 bSY
 kbo
 kbo
-eqt
+tjo
 psZ
 psZ
 psZ
@@ -107547,9 +108117,9 @@ tUn
 gFQ
 gFQ
 gFQ
-aHR
+gFQ
 ejH
-aHR
+gFQ
 gFQ
 aaa
 aaa
@@ -109353,7 +109923,7 @@ tOg
 tOg
 tOg
 gUS
-gLr
+bcH
 tOg
 aaa
 aaa
@@ -109865,7 +110435,7 @@ aaa
 aaa
 aaa
 aaa
-oCX
+wmL
 wmL
 kLC
 wmL
@@ -110383,8 +110953,8 @@ wmL
 cvO
 uNO
 hUd
-uWk
-aaa
+wmL
+iDe
 aaa
 aaa
 aaa
@@ -112899,7 +113469,7 @@ fJy
 fJy
 fJy
 pnJ
-dKl
+fJy
 fJy
 byR
 iFh

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1676,6 +1676,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"aGk" = (
+/obj/machinery/button/door/directional/south{
+	id = "bridge blast";
+	name = "Bridge Access Blast Door Control";
+	req_access = list("command")
+	},
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/captain/private)
 "aGm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -1721,6 +1729,10 @@
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = 7
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -2863,32 +2875,29 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/button/door{
-	desc = "A door remote control switch for the exterior brig doors.";
-	id = "outerbrig";
-	name = "Brig Exterior Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = 6;
-	pixel_y = 7;
-	req_access = list("security")
-	},
-/obj/machinery/button/flasher{
-	id = "secentranceflasher";
-	name = "Brig Entrance Flasher";
-	pixel_y = -3;
-	req_access = list("security")
-	},
-/obj/machinery/button/door{
-	desc = "A door remote control switch for the interior brig doors.";
-	id = "innerbrig";
-	name = "Brig Interior Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	pixel_y = 7;
-	req_access = list("security")
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/button/door/table{
+	pixel_x = 6;
+	pixel_y = 12;
+	id = "outerbrig";
+	name = "Brig Exterior Door Control";
+	req_access = s;
+	normaldoorcontrol = 1
+	},
+/obj/machinery/button/door/table{
+	pixel_x = -6;
+	pixel_y = 12;
+	id = "innerbrig";
+	name = "Brig Interior Door Control";
+	req_access = list("security");
+	normaldoorcontrol = 1
+	},
+/obj/machinery/button/flasher/table{
+	pixel_y = 3;
+	id = "secentranceflasher";
+	req_access = list("security")
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
@@ -2937,7 +2946,6 @@
 "bac" = (
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
-	icon_state = "control_stun";
 	name = "AI Upload Turret Control";
 	pixel_y = -7
 	},
@@ -4467,7 +4475,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
-	name = "Brig"
+	name = "Brig";
+	id = "innerbrig";
+	normalspeed = 0
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -5615,14 +5625,6 @@
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock"
 	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = 8;
-	pixel_y = -24;
-	req_access = list("virology")
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -6449,6 +6451,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"cov" = (
+/obj/structure/sign/poster/official/cleanliness/directional/north{
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/station/medical/virology)
 "coE" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -10693,6 +10701,11 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/effect/spawner/random/armory/riot_shield,
+/obj/machinery/button/door/directional/north{
+	id = "armory";
+	name = "Armory Shutters";
+	req_access = list("armory")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "dRY" = (
@@ -12642,36 +12655,32 @@
 	dir = 10
 	},
 /obj/structure/table,
-/obj/machinery/button/door{
-	desc = "Controls the shutters over the cell windows.";
-	id = "Secure Gate";
-	name = "Cell Window Control";
-	pixel_x = -6;
-	pixel_y = 7;
-	req_access = list("security");
-	specialfunctions = 4
-	},
-/obj/machinery/button/door{
-	desc = "Controls the shutters over the brig windows.";
-	id = "briglockdown";
-	name = "Brig Lockdown Control";
-	pixel_x = 6;
-	pixel_y = 7;
-	req_access = list("security")
-	},
-/obj/machinery/button/door{
-	desc = "Controls the blast doors in front of the prison wing.";
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_y = -3;
-	req_access = list("brig")
-	},
 /obj/item/key/security,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/button/door/table{
+	pixel_x = -6;
+	pixel_y = 12;
+	id = "Secure Gate";
+	name = "Cell Window Control";
+	req_access = list("security")
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 3;
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	req_access = list("brig")
+	},
+/obj/machinery/button/door/table{
+	pixel_x = 6;
+	pixel_y = 12;
+	id = "briglockdown";
+	name = "Brig Lockdown Control";
+	req_access = list("security")
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
@@ -19215,7 +19224,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
-	name = "Brig"
+	name = "Brig";
+	id = "outerbrig"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -23985,24 +23995,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"iyC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = 24;
-	pixel_y = -24;
-	req_access = list("virology")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "iyV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon{
@@ -36531,7 +36523,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
-	name = "Brig"
+	name = "Brig";
+	id = "outerbrig"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -43777,12 +43770,16 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "prx" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Airlock";
-	network = list("ss13","medbay")
-	},
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access = list("virology");
+	dir = 8;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pry" = (
@@ -44874,17 +44871,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/button/door/directional/south{
-	id = "bridge blast";
-	name = "Bridge Access Blast Door Control";
-	req_access = list("command")
-	},
-/obj/machinery/button/door/directional/south{
-	id = "council blast";
-	name = "Council Chamber Blast Door Control";
-	pixel_y = -34;
-	req_access = list("command")
-	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
 "pKa" = (
@@ -45632,14 +45618,28 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pXF" = (
-/obj/machinery/cell_charger{
-	pixel_y = 9
-	},
 /obj/structure/table/glass,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_y = 8
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/button/door/table{
+	pixel_x = -6;
+	pixel_y = 12;
+	id = "bridge blast";
+	name = "Bridge Access Blast Door Control";
+	req_access = list("command")
+	},
+/obj/machinery/button/door/table{
+	pixel_x = 6;
+	pixel_y = 12;
+	id = "gateshutter";
+	name = "Gateway Shutter Control";
+	req_access = list("command")
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 3;
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter Control";
+	req_access = list("command")
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "pXM" = (
@@ -47731,17 +47731,6 @@
 "qMf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/machinery/button/door/directional/south{
-	id = "gateshutter";
-	name = "Gateway Shutter Control";
-	pixel_y = -34;
-	req_access = list("command")
-	},
-/obj/machinery/button/door/directional/south{
-	id = "evashutter";
-	name = "E.V.A. Storage Shutter Control";
-	req_access = list("command")
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
@@ -53617,12 +53606,18 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "sMo" = (
-/obj/structure/sign/poster/official/cleanliness/directional/west,
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
 /obj/structure/mirror/directional/north,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access = list("virology");
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sMB" = (
@@ -53805,6 +53800,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access = list("virology");
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -54817,6 +54819,14 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"tgU" = (
+/obj/machinery/button/door/directional/north{
+	id = "council blast";
+	name = "Council Chamber Blast Door Control";
+	req_access = list("command")
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "thc" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Gravity Generator Room"
@@ -54881,6 +54891,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"tim" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "tit" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/plating,
@@ -58348,13 +58364,15 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "usQ" = (
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = 7
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 9
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -59032,6 +59050,15 @@
 	},
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	req_access = list("virology");
+	dir = 8;
+	pixel_x = 11
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -62988,7 +63015,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
-	name = "Brig"
+	name = "Brig";
+	id = "innerbrig";
+	normalspeed = 0
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64043,6 +64072,10 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Airlock";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wrc" = (
@@ -64766,6 +64799,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/server)
+"wCK" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/east,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "wCL" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -85485,9 +85524,9 @@ uCG
 jUb
 aaa
 aaa
-rKQ
-eSR
-rKQ
+tim
+sOM
+gqI
 aaa
 aaa
 xjH
@@ -85742,9 +85781,9 @@ shK
 jUb
 aaa
 aaa
-rKQ
+gqI
 eSR
-rKQ
+gqI
 aaa
 aaa
 xjH
@@ -85999,9 +86038,9 @@ shK
 jUb
 aaa
 aaa
-rKQ
-iyC
-rKQ
+gqI
+ark
+wCK
 aaa
 aaa
 xjH
@@ -86769,7 +86808,7 @@ gsn
 shK
 jUb
 huF
-xjH
+cov
 rUU
 eSR
 vYJ
@@ -96751,7 +96790,7 @@ gGy
 nEC
 pJY
 duI
-gGy
+tgU
 oLD
 klI
 lPZ
@@ -99063,7 +99102,7 @@ dho
 iNB
 wfD
 dho
-syo
+aGk
 syo
 sSx
 syo

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6452,9 +6452,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cov" = (
-/obj/structure/sign/poster/official/cleanliness/directional/north{
-	pixel_y = 0
-	},
+/obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
 "coE" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2935,13 +2935,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bac" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the ai_upload.";
-	dir = 4;
-	name = "AI Upload Monitor";
-	network = list("aiupload");
-	pixel_x = -29
-	},
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
 	icon_state = "control_stun";
@@ -24291,12 +24284,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"iDe" = (
-/obj/structure/sign/warning/secure_area/directional/north{
-	pixel_y = 32
-	},
-/turf/open/space/basic,
-/area/space)
 "iDq" = (
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
@@ -104327,7 +104314,7 @@ qRS
 pnk
 kJi
 cxz
-iDe
+aaa
 aaa
 aaa
 aaa
@@ -105355,7 +105342,7 @@ cDb
 xOI
 kJi
 cxz
-iDe
+aaa
 aaa
 aaa
 aaa
@@ -110947,7 +110934,7 @@ cvO
 uNO
 hUd
 wmL
-iDe
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2956,13 +2956,13 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/light/small/directional/west,
-/obj/machinery/computer/security/telescreen/aiupload/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/computer/security/telescreen/aiupload/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "bah" = (
@@ -10886,6 +10886,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"dVQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmroom"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "dVT" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -18087,6 +18094,7 @@
 "gAx" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gAB" = (
@@ -31987,12 +31995,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"lgR" = (
-/obj/structure/sign/poster/official/moth_piping/directional/north{
-	pixel_y = 8
-	},
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance)
 "lgS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35784,34 +35786,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "mCg" = (
-/obj/structure/cable,
-/obj/structure/table/wood/fancy/black,
-/obj/item/storage/fancy/cigarettes/cigars/cohiba{
-	pixel_x = 3;
-	pixel_y = 22
-	},
-/obj/item/reagent_containers/cup/glass/bottle/champagne{
-	pixel_x = -7;
-	pixel_y = 16
-	},
-/obj/item/cigarette/cigar{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/cigarette/cigar{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/keycard_auth/wall_mounted/directional/north{
-	pixel_x = -5
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/structure/cable,
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
@@ -41516,12 +41490,6 @@
 /obj/structure/flora/bush/fullgrass,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"ozl" = (
-/obj/structure/sign/poster/official/cleanliness/directional/north{
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/station/hallway/secondary/service)
 "ozm" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -48822,6 +48790,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/moth_piping/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "rbF" = (
@@ -89578,7 +89547,7 @@ ufm
 qtu
 tcY
 oAt
-ixt
+dVQ
 ixt
 oAt
 kQP
@@ -101728,7 +101697,7 @@ jTN
 vAH
 kIY
 iaF
-lgR
+gyQ
 rbD
 jwj
 ujk
@@ -107090,7 +107059,7 @@ wPU
 gKS
 huG
 olP
-ozl
+wYB
 gAx
 siz
 hxz


### PR DESCRIPTION
## About The Pull Request

Fixes Metastation's Wallening issues, including:

- Adjusting buttons, including moving a few to tables as stacking multiple on one wall is a little iffy rn
- Fixing a merge conflict indicator near the AI upload
- Fixing access to Xenobiology
- Fixing mapping issues with burn mix chambers in Atmos and Toxins

This is not actually finished at this time - there are still some visual updates the map needs, but I want to get this out there so we can play on Meta again for now.

## Why It's Good For The Game

Map broke by Wallening, unbreaking map good
## Changelog
:cl: TheVekter
fix: Updated Metastation for Wallening
/:cl:
