### PR TITLE
Adds examine balloons to light switches

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -36,6 +36,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/machinery/light_switch)
 	find_and_hang_on_wall(custom_drop_callback = CALLBACK(src, PROC_REF(deconstruct), TRUE))
 	register_context()
 	update_appearance()
+	AddComponent(/datum/component/examine_balloon, pixel_y_offset = 24, pixel_y_offset_arrow = 8)
 
 /obj/machinery/light_switch/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/a5de50da-45c9-4a71-9cc4-a7894f009733)
No idea why they've been missing these
## Why It's Good For The Game
Makes them easier to notice on sideways walls
## Changelog
:cl:
qol: Added examine balloons to light switches
/:cl:
