### PR TITLE
Deoffset screen alert mobs

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1239,6 +1239,8 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	var/mutable_appearance/alert_overlay = new(source)
 	alert_overlay.pixel_x = 0
 	alert_overlay.pixel_y = 0
+	alert_overlay.pixel_z = 0
+	alert_overlay.pixel_w = 0
 
 	var/scale = 1
 	var/list/icon_dimensions = get_icon_dimensions(source.icon)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -349,6 +349,7 @@
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	flags = HIGH_IMPACT_RULESET
 	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_WIZARDDEN)
+	signup_item_path = /obj/item/clothing/head/wizard
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/ready(forced = FALSE)
 	if(!check_candidates())
@@ -388,6 +389,7 @@
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NUKIEBASE)
 	flags = HIGH_IMPACT_RULESET
+	signup_item_path = /obj/machinery/nuclearbomb
 
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 
@@ -433,6 +435,7 @@
 	cost = 8
 	minimum_players = 25
 	repeatable = TRUE
+	signup_item_path = /obj/structure/blob/normal
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
 	var/body = applicant.become_overmind()
@@ -506,6 +509,7 @@
 	cost = 10
 	minimum_players = 25
 	repeatable = TRUE
+	signup_item_path = /mob/living/basic/alien
 	var/list/vents = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/forget_startup()
@@ -554,6 +558,7 @@
 	cost = 5
 	minimum_players = 15
 	repeatable = TRUE
+	signup_item_path = /obj/item/light_eater
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/acceptable(population = 0, threat_level = 0)
 	var/turf/spawn_loc = find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE) //Checks if there's a single safe, dark tile on station.
@@ -590,6 +595,7 @@
 	cost = 7
 	minimum_players = 25
 	repeatable = TRUE
+	signup_item_path = /mob/living/basic/space_dragon
 	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/space_dragon/forget_startup()
@@ -669,6 +675,7 @@
 	minimum_players = 30
 	repeatable = TRUE
 	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NINJA_HOLDING_FACILITY) // I mean, no one uses the nets anymore but whateva
+	signup_item_path = /obj/item/energy_katana
 
 	var/list/spawn_locs = list()
 
@@ -728,6 +735,7 @@
 	cost = 5
 	minimum_players = 15
 	repeatable = TRUE
+	signup_item_path = /mob/living/basic/revenant
 	var/dead_mobs_required = 20
 	var/need_extra_spawns_value = 15
 	var/list/spawn_locs = list()
@@ -870,6 +878,7 @@
 	cost = 7
 	minimum_players = 15
 	repeatable = TRUE
+	signup_item_path = /obj/effect/meteor/meaty/changeling
 
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_midround/generate_ruleset_body(mob/applicant)
 	var/body = generate_changeling_meteor(applicant)

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -130,10 +130,9 @@ SUBSYSTEM_DEF(polling)
 
 		// Image to display
 		var/image/poll_image
-		if(ispath(alert_pic, /atom))
-			poll_image = image(alert_pic)
-		else if(isatom(alert_pic))
+		if(ispath(alert_pic, /atom) || isatom(alert_pic))
 			poll_image = new /mutable_appearance(alert_pic)
+			poll_image.pixel_z = 0
 		else if(!isnull(alert_pic))
 			poll_image = alert_pic
 		else


### PR DESCRIPTION
## About The Pull Request

Fixes #85528
![image](https://github.com/user-attachments/assets/88342802-1b4b-464b-b5ca-62fb16a9d7f0)
Atoms shown in screen alerts have their pixel_z set to 0. This means they won't inherit the mob offset in the world.

The drop shadow is still there but I'm uh, not sure I can get rid of it.

For a more opinionated change I also changed a bunch of the atom references for midround alerts to stop referencing the default poster, which now looks bad and ugly.
Most of them didn't make sense with that icon anyway.

## Why It's Good For The Game

Looks better.

## Changelog

:cl:
fix: Mobs shown in ghost alerts shouldn't be offset out of the box
image: Several midround dynamic alert icons should be more demonstrative of what is spawning
/:cl:
