### PR TITLE
Updated anomaly dimensional themes to use new walls

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -236,12 +236,14 @@
 	icon = 'icons/obj/stack_objects.dmi'
 	icon_state = "sheet-gold_2"
 	material = /datum/material/gold
+	replace_walls = /turf/closed/wall/mineral/gold
 
 /datum/dimension_theme/plasma
 	name = "Plasma"
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "gas_alt"
 	material = /datum/material/plasma
+	replace_walls = /turf/closed/wall/mineral/plasma
 
 /datum/dimension_theme/clown
 	name = "Clown"
@@ -249,6 +251,7 @@
 	icon_state = "clown"
 	material = /datum/material/bananium
 	sound = 'sound/items/bikehorn.ogg'
+	replace_walls = /turf/closed/wall/mineral/bananium
 
 /datum/dimension_theme/radioactive
 	name = "Radioactive"
@@ -256,6 +259,7 @@
 	icon_state = "uranium"
 	material = /datum/material/uranium
 	sound = 'sound/items/welder.ogg'
+	replace_walls = /turf/closed/wall/mineral/uranium
 
 /datum/dimension_theme/meat
 	name = "Meat"
@@ -263,6 +267,7 @@
 	icon_state = "meat"
 	material = /datum/material/meat
 	sound = 'sound/items/eatfood.ogg'
+	replace_walls = /turf/closed/wall/mineral/meat
 
 /datum/dimension_theme/pizza
 	name = "Pizza"
@@ -270,6 +275,7 @@
 	icon_state = "pizzamargherita"
 	material = /datum/material/pizza
 	sound = 'sound/items/eatfood.ogg'
+	replace_walls = /turf/closed/wall/mineral/pizza
 
 /datum/dimension_theme/natural
 	name = "Natural"
@@ -316,7 +322,7 @@
 	name = "Winter Cabin"
 	icon = 'icons/obj/clothing/shoes.dmi'
 	icon_state = "iceboots"
-	replace_walls = /turf/closed/wall/mineral/wood
+	replace_walls = /turf/closed/wall/mineral/wood/nonmetal
 	replace_objs = list(
 		/obj/structure/chair = list(/obj/structure/chair/wood = 1),
 		/obj/machinery/door/airlock = list(/obj/machinery/door/airlock/wood = 1),
@@ -349,6 +355,7 @@
 	icon = 'icons/obj/debris.dmi'
 	icon_state = "small"
 	material = /datum/material/glass
+	replace_walls = /turf/closed/wall/mineral/titanium/survival // Until we decide what glass walls actually do
 	replace_floors = list(/turf/open/floor/glass = 1)
 	sound = SFX_SHATTER
 
@@ -402,6 +409,7 @@
 	name = "Disco"
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "lbulb"
+	replace_walls = /turf/closed/wall/fake_hierophant
 	material = /datum/material/glass
 	replace_floors = list(/turf/open/floor/light = 1)
 
@@ -419,7 +427,7 @@
 	icon_state = "tile_grass"
 	sound = SFX_CRUNCHY_BUSH_WHACK
 	replace_floors = list(/turf/open/floor/grass = 1)
-	replace_walls = /turf/closed/wall/mineral/wood
+	replace_walls = /turf/closed/wall/mineral/wood/nonmetal
 	replace_objs = list(
 		/obj/structure/chair = list(/obj/structure/chair/wood = 1),
 		/obj/machinery/door/airlock = list(/obj/machinery/door/airlock/wood = 1),

--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -344,6 +344,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	underlay_appearance.icon_state = "basalt"
 	return TRUE
 
+
 /turf/closed/indestructible/riveted/hierophant
 	name = "wall"
 	desc = "A wall made out of a strange metal. The squares on it pulse in a predictable pattern."

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -105,3 +105,16 @@
 	icon = 'icons/turf/walls/hierophant_wall.dmi'
 	smoothing_groups = SMOOTH_GROUP_HIERO_WALL + SMOOTH_GROUP_TALL_WALLS
 	canSmoothWith = SMOOTH_GROUP_HIERO_WALL
+
+/turf/closed/wall/material/meat
+	name = "living wall"
+	baseturfs = /turf/open/floor/material/meat
+	girder_type = null
+	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+
+/turf/closed/wall/material/meat/Initialize(mapload)
+	. = ..()
+	set_custom_materials(list(GET_MATERIAL_REF(/datum/material/meat) = SHEET_MATERIAL_AMOUNT))
+
+/turf/closed/wall/material/meat/airless
+	baseturfs = /turf/open/floor/material/meat/airless

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -99,15 +99,9 @@
 	smoothing_groups = null
 	use_splitvis = FALSE
 
-/turf/closed/wall/material/meat
-	name = "living wall"
-	baseturfs = /turf/open/floor/material/meat
-	girder_type = null
-	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-
-/turf/closed/wall/material/meat/Initialize(mapload)
-	. = ..()
-	set_custom_materials(list(GET_MATERIAL_REF(/datum/material/meat) = SHEET_MATERIAL_AMOUNT))
-
-/turf/closed/wall/material/meat/airless
-	baseturfs = /turf/open/floor/material/meat/airless
+/turf/closed/wall/fake_hierophant
+	name = "vibrant wall"
+	desc = "A wall made out of a strange metal. The squares on it pulse in a predictable pattern."
+	icon = 'icons/turf/walls/hierophant_wall.dmi'
+	smoothing_groups = SMOOTH_GROUP_HIERO_WALL + SMOOTH_GROUP_TALL_WALLS
+	canSmoothWith = SMOOTH_GROUP_HIERO_WALL

--- a/code/modules/clothing/suits/reactive_armour_dimensional_themes.dm
+++ b/code/modules/clothing/suits/reactive_armour_dimensional_themes.dm
@@ -155,21 +155,25 @@
 	barricade = /obj/structure/holosign/barrier
 
 /datum/armour_dimensional_theme/safe/meat
+	replace_wall = /turf/closed/wall/mineral/meat
 	material = /datum/material/meat
 
 /// Dangerous themes can potentially impede the user as much as people pursuing them
 /datum/armour_dimensional_theme/dangerous
 
 /datum/armour_dimensional_theme/dangerous/clown
+	replace_wall = /turf/closed/wall/mineral/bananium
 	material = /datum/material/bananium
 	barricade = /obj/item/restraints/legcuffs/beartrap/prearmed
 	barricade_anchored = FALSE
 
 /datum/armour_dimensional_theme/dangerous/radioactive
+	replace_wall = /turf/closed/wall/mineral/uranium
 	material = /datum/material/uranium
 	barricade = /obj/structure/statue/uranium/nuke
 
 /datum/armour_dimensional_theme/dangerous/plasma
+	replace_wall = /turf/closed/wall/mineral/plasma
 	material = /datum/material/plasma
 	barricade = /obj/structure/statue/plasma/xeno
 


### PR DESCRIPTION
## About The Pull Request

Fixes #85546
We added a bunch of new walls which were not being referenced by the dimensional anomaly.
It was just creating material turfs, which also seem to just not work. I updated them to use the cooler-looking sprites.

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/b9ffacfd-bec2-4c01-af16-12f03f2fe801)
Now once again works as god intended

Observant eyes may notice that the disco theme is spawning hierophant walls now, but these are a subtype which isn't invincible don't worry.

## Changelog

:cl:
fix: Dimensional anomalies should once again create cool walls, not boring grey ones
/:cl:
