### PR TITLE
reticence require progression

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -389,6 +389,6 @@
 	restricted_roles = list(JOB_MIME)
 	restricted = TRUE
 	refundable = FALSE
-	progression_minimum = 45 MINUTES
+	progression_minimum = 30 MINUTES
 	purchasable_from = parent_type::purchasable_from & ~UPLINK_SPY
 

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -389,5 +389,6 @@
 	restricted_roles = list(JOB_MIME)
 	restricted = TRUE
 	refundable = FALSE
+	progression_minimum = 45 MINUTES
 	purchasable_from = parent_type::purchasable_from & ~UPLINK_SPY
 


### PR DESCRIPTION

## About The Pull Request
people murder bone with it way too often. this sets a min progression level for it to give crew to prepare.
## Why It's Good For The Game

round start low pop reticence very frequently murder bones.
it is very powerful weapon  and extremely rare people use it for not just gunning down the crew

## Changelog
:cl:

balance: reticence requires progression

/:cl:
