### PR TITLE
Adds a light switch to the science hallway in metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28626,6 +28626,7 @@
 /obj/effect/turf_decal/siding/purple/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kaS" = (


### PR DESCRIPTION

## About The Pull Request
Adds a light switch to the science hallway in metastation
## Why It's Good For The Game
Now the lights in the science hallway in metastation can actually be turned on woo
## Changelog
:cl:
fix: Added a light switch to the science hallway in Metastation
/:cl:
