### PR TITLE
Adjust shadow position for secbots and mice

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -1,10 +1,13 @@
 /mob/living/basic/mouse
+	SET_BASE_VISUAL_PIXEL(0, 10)
 	name = "mouse"
 	desc = "This cute little guy just loves the taste of uninsulated electrical cables. Isn't he adorable?"
 	icon_state = "mouse_gray"
 	icon_living = "mouse_gray"
 	icon_dead = "mouse_gray_dead"
 	held_state = "mouse_gray"
+	shadow_type = SHADOW_SMALL
+	shadow_offset_y = 2
 
 	maxHealth = 5
 	health = 5

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -1,7 +1,10 @@
 /mob/living/simple_animal/bot/secbot/ed209
+	SET_BASE_VISUAL_PIXEL(0, 9)
 	name = "\improper ED-209 Security Robot"
 	desc = "A security robot. He looks less than thrilled."
 	icon_state = "ed209"
+	shadow_type = SHADOW_LARGE
+	shadow_offset_y = 1
 	light_color = "#f84e4e"
 	density = TRUE
 	health = 100

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -1,10 +1,12 @@
 /mob/living/simple_animal/bot/secbot
+	SET_BASE_VISUAL_PIXEL(0, 9)
 	name = "\improper Securitron"
 	desc = "A little security robot. He looks less than thrilled."
 	icon = 'icons/mob/silicon/aibots.dmi'
 	icon_state = "secbot"
 	light_color = "#f56275"
 	light_power = 0.8
+	shadow_offset_y = 3
 	density = FALSE
 	anchored = FALSE
 	health = 25


### PR DESCRIPTION
## About The Pull Request

Fixes #85802
![image](https://github.com/user-attachments/assets/1fdc25e2-3db5-4eb4-9291-119745c87a9c)

Secbots were sort of awkwardly above their shadow, mice I noticed someone complaining that they had human-sized shadows and I guess I just forgot about them when I was auditing shadow positions on mobs.

Edit: also the bigger secbots
![image](https://github.com/user-attachments/assets/fd50f212-c333-47a4-8860-3ba87728774d)

## Why It's Good For The Game

Looks nicer.

## Changelog

:cl:
fix: Beepsky and Mice have more appropriately positioned shadows.
/:cl:
