### PR TITLE
Fixes indestructible reinforced walls being the wrong icon state

### DIFF
--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -110,9 +110,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 /turf/closed/indestructible/reinforced
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/riveted_wall.dmi'
-	smoothing_groups = SMOOTH_GROUP_WALLS + SMOOTH_GROUP_TALL_WALLS + SMOOTH_GROUP_CLOSED_TURFS
-	canSmoothWith = SMOOTH_GROUP_WALLS
+	icon = 'icons/turf/walls/reinforced_wall.dmi'
 
 /turf/closed/indestructible/reinforced/titanium
 	name = "reinforced titanium imitation wall"


### PR DESCRIPTION

## About The Pull Request
These were set to look like the CC walls instead of the reinforced walls for whatever reason. Addresses that and culls two extra lines there were just duplicating behavior already present on the parent type.
## Why It's Good For The Game
Clamps a visual issue before mappers get confused by it.
## Changelog
:cl:
fix: Indestructible reinforced walls now mimic their destructible counterparts as intended.
/:cl:
