### PR TITLE
Fixes a runtime caused by incorrect arguments

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -60,7 +60,7 @@ SUBSYSTEM_DEF(title)
 	for(var/thing in GLOB.clients)
 		if(!thing)
 			continue
-		var/atom/movable/screen/splash/S = new(thing, FALSE)
+		var/atom/movable/screen/splash/S = new(null, thing, FALSE)
 		S.Fade(FALSE,FALSE)
 
 /datum/controller/subsystem/title/Recover()


### PR DESCRIPTION
`FALSE` was being passed in where a client is expected, down the line causing some code to try registering for a signal on a 0. This was intermittently causing errors on startup.