### PR TITLE
Makes map view hiding a bit more robust against unusual circumstances

### DIFF
--- a/code/_onclick/hud/map_view.dm
+++ b/code/_onclick/hud/map_view.dm
@@ -19,7 +19,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/map_view)
 		var/client/our_client = client_ref.resolve()
 		if(!our_client)
 			continue
-		hide_from(our_client.mob)
+		hide_from_client(our_client)
 
 	return ..()
 
@@ -55,15 +55,23 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/map_view)
 	return pop_planes
 
 /atom/movable/screen/map_view/proc/hide_from(mob/hide_from)
-	hide_from?.canon_client.clear_map(assigned_map)
-	var/client_ref = WEAKREF(hide_from?.canon_client)
+	var/client/target = hide_from?.canon_client
+	if(!target)
+		return
 
+	hide_from_client(target)
+
+/atom/movable/screen/map_view/proc/hide_from_client(client/hide_from)
+	if(!hide_from)
+		return
+	hide_from.clear_map(assigned_map)
+
+	var/datum/weakref/client_ref = WEAKREF(hide_from)
 	// Make sure we clear the *right* hud
-	var/datum/weakref/hud_ref = viewers_to_huds[client_ref]
-	viewers_to_huds -= client_ref
-	var/datum/hud/clear_from = hud_ref?.resolve()
+	var/datum/hud/clear_from = viewers_to_huds[client_ref]?.resolve()
 	if(!clear_from)
 		return
 
+	viewers_to_huds -= client_ref
 	var/datum/plane_master_group/popup/pop_planes = clear_from.get_plane_group(PLANE_GROUP_POPUP_WINDOW(src))
 	qdel(pop_planes)

--- a/code/_onclick/hud/map_view.dm
+++ b/code/_onclick/hud/map_view.dm
@@ -16,10 +16,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/map_view)
 
 /atom/movable/screen/map_view/Destroy()
 	for(var/datum/weakref/client_ref in viewers_to_huds)
-		var/client/our_client = client_ref.resolve()
-		if(!our_client)
-			continue
-		hide_from_client(our_client)
+		hide_from_client(client_ref.resolve())
 
 	return ..()
 
@@ -55,11 +52,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/map_view)
 	return pop_planes
 
 /atom/movable/screen/map_view/proc/hide_from(mob/hide_from)
-	var/client/target = hide_from?.canon_client
-	if(!target)
-		return
-
-	hide_from_client(target)
+	hide_from_client(hide_from?.canon_client)
 
 /atom/movable/screen/map_view/proc/hide_from_client(client/hide_from)
 	if(!hide_from)
@@ -68,10 +61,12 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/map_view)
 
 	var/datum/weakref/client_ref = WEAKREF(hide_from)
 	// Make sure we clear the *right* hud
-	var/datum/hud/clear_from = viewers_to_huds[client_ref]?.resolve()
+	var/datum/weakref/hud_ref = viewers_to_huds[client_ref]
+	viewers_to_huds -= client_ref
+
+	var/datum/hud/clear_from = hud_ref?.resolve()
 	if(!clear_from)
 		return
 
-	viewers_to_huds -= client_ref
 	var/datum/plane_master_group/popup/pop_planes = clear_from.get_plane_group(PLANE_GROUP_POPUP_WINDOW(src))
 	qdel(pop_planes)

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -20,7 +20,7 @@
 
 /obj/item/clothing/glasses/sunglasses/spy/proc/on_screen_clear(client/source, window)
 	SIGNAL_HANDLER
-	linked_bug.cam_screen.hide_from(source.mob)
+	linked_bug.cam_screen.hide_from_client(source)
 
 /obj/item/clothing/glasses/sunglasses/spy/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION
While in the middle of a destroy chain the mob can no longer be associated with the client you need to clear huds from. This allows you to just pass a client into a different proc and has some more error checking to hopefully avoid visible issues for players if something goes wrong.

This fixes a runtime I cam across while working on something else.