### PR TITLE
Splits wall layer into three

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -205,7 +205,9 @@
 #define WALL_LAYER 2.67
 #define ABOVE_WALL_LAYER 2.68
 #define WALL_CLICKCATCH_LAYER 2.69
-#define ON_WALL_LAYER 2.7
+#define FLAT_ON_WALL_LAYER 2.70 // wall mounts that lie flat against the wall or are generally less important gameplay-wise (such as signs)
+#define ON_WALL_LAYER 2.71 // normal wall mounts
+#define HIGH_ON_WALL_LAYER 2.72 // wall mounts that hang high on the wall (light fixtures)
 
 #define BELOW_OPEN_DOOR_LAYER 2.74
 ///Anything below this layer is to be considered completely (visually) under water by the immerse layer.

--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -92,8 +92,8 @@
  * 	@param directional If TRUE, will use the direction of the object to determine the wall to attach to. If FALSE, will use the object's loc.
  *	@param custom_drop_callback If set, will use this callback instead of the default deconstruct callback.
  */
-/obj/proc/find_and_hang_on_wall(directional = TRUE, custom_drop_callback)
-	AddElement(/datum/element/wall_mount)
+/obj/proc/find_and_hang_on_wall(directional = TRUE, custom_drop_callback, wall_layer = ON_WALL_LAYER)
+	AddElement(/datum/element/wall_mount, wall_layer)
 	if(istype(get_area(src), /area/shuttle))
 		return FALSE //For now, we're going to keep the component off of shuttles to avoid the turf changing issue. We'll hit that later really;
 	var/turf/attachable_wall

--- a/code/datums/elements/render_over_keep_hitbox.dm
+++ b/code/datums/elements/render_over_keep_hitbox.dm
@@ -147,6 +147,3 @@
 	// Make it clickable, and direct all clicks to the source object
 	click_catch.mouse_opacity = MOUSE_OPACITY_ICON
 	click_catch.vis_flags |= VIS_INHERIT_ID
-
-
-

--- a/code/datums/elements/wall_mount.dm
+++ b/code/datums/elements/wall_mount.dm
@@ -1,24 +1,33 @@
 /datum/element/wall_mount
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// What layer the object should be on when wall-mounted
+	var/wall_layer
 
-/datum/element/wall_mount/Attach(datum/target)
+/datum/element/wall_mount/Attach(datum/target, wall_layer)
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 	. = ..()
 	var/atom/movable/real_target = target
+	src.wall_layer = wall_layer
 	RegisterSignal(target, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_dir_changed))
-	on_dir_changed(real_target, real_target.dir, real_target.dir)
+	on_dir_changed(real_target, null, real_target.dir)
 
 /datum/element/wall_mount/Detach(datum/source)
 	. = ..()
 	UnregisterSignal(source, COMSIG_ATOM_DIR_CHANGE)
 
 /datum/element/wall_mount/proc/on_dir_changed(datum/target, olddir, newdir)
+	SIGNAL_HANDLER
+
+	if(olddir == newdir)
+		return
+
 	var/atom/movable/real_target = target
 	var/new_plane = OVER_FRILL_PLANE
 	if(real_target.wall_mount_common_plane(newdir))
 		new_plane = initial(real_target.plane)
 	SET_PLANE_EXPLICIT(real_target, new_plane, real_target)
-	real_target.layer = ON_WALL_LAYER
+	real_target.layer = wall_layer || ON_WALL_LAYER
 	real_target.wall_mount_offset(newdir)
 	real_target.update_appearance()
-

--- a/code/game/machinery/barsigns.dm
+++ b/code/game/machinery/barsigns.dm
@@ -30,7 +30,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/barsign, 32)
 	//Roundstart/map specific barsigns "belong" in their area and should be renaming it, signs created from wallmounts will not.
 	change_area_name = mapload
 	set_sign(new /datum/barsign/hiddensigns/signoff)
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 
 /obj/machinery/barsign/proc/set_sign(datum/barsign/sign)
 	if(!istype(sign))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -133,8 +133,7 @@ CAMERA_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray)
 
 	alarm_manager = new(src)
 	if(should_wallmount)
-		find_and_hang_on_wall(directional = TRUE, \
-			custom_drop_callback = CALLBACK(src, PROC_REF(deconstruct), FALSE))
+		find_and_hang_on_wall(directional = TRUE, custom_drop_callback = CALLBACK(src, PROC_REF(deconstruct), FALSE), wall_layer = HIGH_ON_WALL_LAYER)
 
 	RegisterSignal(src, COMSIG_HIT_BY_SABOTEUR, PROC_REF(on_saboteur))
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -32,7 +32,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/machinery/flasher)
 	name = "Thunderdome Flash"
 
 /obj/machinery/flasher/Initialize(mapload, ndir = 0, built = 0)
-	. = ..() // ..() is EXTREMELY IMPORTANT, never forget to add it
+	. = ..()
 	if(!built)
 		bulb = new(src)
 	if(should_wallmount)

--- a/code/game/machinery/incident_display.dm
+++ b/code/game/machinery/incident_display.dm
@@ -94,6 +94,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/incident_display/tram, 32)
 /obj/machinery/incident_display/Initialize(mapload)
 	..()
 	register_context()
+	find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/incident_display/post_machine_initialize()

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -98,7 +98,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/glowshroom/single)
 	setDir(calc_dir())
 	base_icon_state = initial(icon_state)
 	if(!floor)
-		find_and_hang_on_wall()
+		find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 		icon_state = "[base_icon_state][rand(1,3)]"
 	else //if on the floor, glowshroom on-floor sprite
 		icon_state = base_icon_state

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -73,9 +73,9 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/mirror)
 		return FALSE
 	return TRUE
 
-/obj/structure/mirrr/Initialize(mapload)
+/obj/structure/mirror/Initialize(mapload)
 	. = ..()
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 
 /obj/structure/mirror/broken
 	icon_state = "mirror_broke"

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -26,7 +26,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/noticeboard)
 			I.forceMove(src)
 			notices++
 	update_appearance(UPDATE_ICON)
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 
 //attaching papers!!
 /obj/structure/noticeboard/attackby(obj/item/O, mob/user, params)

--- a/code/game/objects/structures/plaques/_plaques.dm
+++ b/code/game/objects/structures/plaques/_plaques.dm
@@ -22,7 +22,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/plaque)
 
 /obj/structure/plaque/Initialize(mapload)
 	. = ..()
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 	register_context()
 
 /obj/structure/plaque/add_context(atom/source, list/context, obj/item/held_item, mob/user)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -33,7 +33,7 @@
 	. = ..()
 	register_context()
 	knock_down_callback = CALLBACK(src, PROC_REF(knock_down))
-	find_and_hang_on_wall(custom_drop_callback = knock_down_callback)
+	find_and_hang_on_wall(custom_drop_callback = knock_down_callback, wall_layer = FLAT_ON_WALL_LAYER)
 
 /obj/structure/sign/Destroy()
 	. = ..()

--- a/code/game/objects/structures/water_structures/urinal.dm
+++ b/code/game/objects/structures/water_structures/urinal.dm
@@ -16,7 +16,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/urinal)
 	. = ..()
 	if(mapload)
 		hidden_item = new /obj/item/food/urinalcake(src)
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = FLAT_ON_WALL_LAYER)
 
 /obj/structure/urinal/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -128,7 +128,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/machinery/airalarm)
 
 	GLOB.air_alarms += src
 	update_appearance()
-	find_and_hang_on_wall(wall_layer = HIGH_ON_WALL_LAYER)
+	find_and_hang_on_wall()
 	register_context()
 
 /obj/machinery/airalarm/process()

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -128,7 +128,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/machinery/airalarm)
 
 	GLOB.air_alarms += src
 	update_appearance()
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = HIGH_ON_WALL_LAYER)
 	register_context()
 
 /obj/machinery/airalarm/process()

--- a/code/modules/atmospherics/machinery/bluespace_vendor.dm
+++ b/code/modules/atmospherics/machinery/bluespace_vendor.dm
@@ -68,7 +68,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/machinery/bluespace_vendor)
 /obj/machinery/bluespace_vendor/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/payment, tank_cost, SSeconomy.get_dep_account(ACCOUNT_ENG), PAYMENT_ANGRY)
-	find_and_hang_on_wall( FALSE)
+	find_and_hang_on_wall(directional = FALSE)
 
 /obj/machinery/bluespace_vendor/post_machine_initialize()
 	. = ..()

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -90,11 +90,11 @@
 	dispensedreagent = /datum/reagent/fuel/oil
 
 // This is a hole
-/obj/structure/sink/oil_well/find_and_hang_on_wall()
+/obj/structure/sink/oil_well/find_and_hang_on_wall(directional, custom_drop_callback, wall_layer)
 	return
 
 /obj/structure/sink/oil_well/Initialize(mapload)
-	.=..()
+	. = ..()
 	create_reagents(20)
 	reagents.add_reagent(dispensedreagent, 20)
 	//I'm pretty much aware that, because how oil wells and sinks work, attackby() won't work unless in combat mode.

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -120,7 +120,7 @@
 	AddElement(/datum/element/atmos_sensitive, mapload)
 	AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text = "Remove bulb")
 	if(break_if_moved)
-		find_and_hang_on_wall(custom_drop_callback = CALLBACK(src, PROC_REF(knock_down)))
+		find_and_hang_on_wall(custom_drop_callback = CALLBACK(src, PROC_REF(knock_down)), wall_layer = HIGH_ON_WALL_LAYER)
 
 /obj/machinery/light/post_machine_initialize()
 	. = ..()
@@ -737,7 +737,7 @@
 	fire_brightness = 4.5
 
 // No hanging for us brother
-/obj/machinery/light/floor/find_and_hang_on_wall(directional, custom_drop_callback)
+/obj/machinery/light/floor/find_and_hang_on_wall(directional, custom_drop_callback, wall_layer)
 	return
 
 /obj/machinery/light/floor/get_light_offset()

--- a/code/modules/power/lighting/light_construct.dm
+++ b/code/modules/power/lighting/light_construct.dm
@@ -32,7 +32,7 @@
 	. = ..()
 	if(building)
 		setDir(ndir)
-	find_and_hang_on_wall()
+	find_and_hang_on_wall(wall_layer = HIGH_ON_WALL_LAYER)
 
 /obj/structure/light_construct/Destroy()
 	QDEL_NULL(cell)


### PR DESCRIPTION
## About The Pull Request

Turns 
`ON_WALL_LAYER`
into
`FLAT_ON_WALL_LAYER`
`ON_WALL_LAYER`
`HIGH_ON_WALL_LAYER`

Where `FLAT_ON_WALL_LAYER` is meant for lower-priority wall mounts like signs and posters
`ON_WALL_LAYER` is default
and `HIGH_ON_WALL_LAYER` is for stuff that "hang over" the wall

Also makes the incident display actually wall mounted

## Why It's Good For The Game

I noticed this while doing mapping and I thought it was a really cool effect

![image](https://github.com/user-attachments/assets/93f33d54-2cda-41d1-abe6-d2035e0284c7)

Unfortunately this effect was a coinflip because all wall mounts were on the same layer. Sometimes it'd look like this

![image](https://github.com/user-attachments/assets/59c3c6a7-561f-4ef6-813b-3cd06b295372)

So this allows us to do this kinda stuff consistently. 
Also has the added effect of letting us "de-prioritize" stuff like posters, so we can hang stuff *over* posters and signs, which could be useful.

## Changelog

:cl: Melbert
qol: Some wall mounts will now consistently layer over others (light switches and cameras, notably, should always layer above other mounts like signs and status displays)
/:cl:

