### PR TITLE
Autopsies now reveal the cadaver's last words.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1097,7 +1097,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 /proc/scramble_message_replace_chars(original, replaceprob = 25, list/replacementchars = list("$", "@", "!", "#", "%", "^", "&", "*"), replace_letters_only = FALSE, replace_whitespace = FALSE)
 	var/list/out = list()
 	var/static/list/whitespace = list(" ", "\n", "\t")
-	for(var/i in 1 to length(original))
+	for(var/i in 1 to length_char(original))
 		var/char = original[i]
 		if(!replace_whitespace && (char in whitespace))
 			out += char

--- a/code/game/objects/items/devices/scanners/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/scanners/autopsy_scanner.dm
@@ -1,3 +1,5 @@
+#define AUTOPSY_RECENT_SPEECH 5
+
 /obj/item/autopsy_scanner
 	name = "autopsy scanner"
 	desc = "Used in surgery to extract information from a cadaver. Can also scan the health of cadavers like an advanced health analyzer!"
@@ -108,6 +110,24 @@
 		for(var/datum/symptom/symptom as anything in advanced_disease.symptoms)
 			autopsy_information += "[symptom.name] - [symptom.desc]<br>"
 
+	var/cannot_reason
+	var/obj/item/organ/internal/brain/brain = scanned.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!brain)
+		cannot_reason = "brain missing!"
+	else if(brain.organ_flags & ORGAN_FAILING)
+		cannot_reason = "brain too damaged!"
+
+	if(cannot_reason)
+		autopsy_information += "<b>Last Words:</b> ERROR: [cannot_reason]<br>"
+	else
+		var/list/last_words = scanned.copy_recent_speech(AUTOPSY_RECENT_SPEECH, line_chance = 95, line_chance_affect_amount = FALSE)
+		if(length(last_words))
+			autopsy_information += "<b>Last Words:</b><br>"
+			var/scramble_prob = 1
+			for(var/message in last_words)
+				autopsy_information += "[scramble_message_replace_chars(message, scramble_prob)]<br>"
+				scramble_prob += 3
+
 	var/obj/item/paper/autopsy_report = new(user.loc)
 	autopsy_report.name = "Autopsy Report ([scanned.name])"
 	autopsy_report.add_raw_text(autopsy_information.Join("\n"))
@@ -115,3 +135,5 @@
 	user.put_in_hands(autopsy_report)
 	user.balloon_alert(user, "report printed")
 	return TRUE
+
+#undef AUTOPSY_RECENT_SPEECH

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -546,8 +546,9 @@
  * Returns an associative list of the logs of a certain amount of lines spoken recently by this mob
  * copy_amount - number of lines to return
  * line_chance - chance to return a line, if you don't want just the most recent x lines
+ * line_chance_affect_amount - if FALSE, we add 1 to copy_amount to ensure the amount of returned messages is kept the same
  */
-/mob/proc/copy_recent_speech(copy_amount = LING_ABSORB_RECENT_SPEECH, line_chance = 100)
+/mob/proc/copy_recent_speech(copy_amount = LING_ABSORB_RECENT_SPEECH, line_chance = 100, line_chance_affect_amount = TRUE)
 	var/list/recent_speech = list()
 	var/list/say_log = list()
 	var/log_source = logging
@@ -563,6 +564,8 @@
 		if(recent_speech.len >= copy_amount)
 			break
 		if(!prob(line_chance))
+			if(!line_chance_affect_amount)
+				copy_amount += 1
 			continue
 		recent_speech[spoken_memory] = splittext(say_log[spoken_memory], "\"", 1, 0, TRUE)[3]
 


### PR DESCRIPTION
## About The Pull Request
Ok, so, I originally came with the idea of adding this to the forensics scanner, but upon speaking with other contributors, the general idea was that it's better to detach it from security to avoid making it all more powerful, so I've added it to autopsy scanners instead.

Anyway, autopsies now reveal the cadaver's last five spoken message. That is, IF they have a brain that isn't failing.

## Why It's Good For The Game
More content for autopsies. It's a little neat thing for to the coroner, and perhaps something that security MIGHT benefit from if they can cooperate, but at least it isn't as immediate as going around and scanning every dead body for a possible "George Melons Bad!".

## Changelog

:cl:
add: Autopsies now reveal the cadaver's last words, if the brain is still functioning.
/:cl:
