### PR TITLE
Random spraypaint setting now properly paints large decals

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -458,6 +458,12 @@
 		if(RANDOM_ANY)
 			drawing = pick(all_drawables)
 
+	if(drawing in graffiti_large_h)
+		paint_mode = PAINT_LARGE_HORIZONTAL
+		text_buffer = ""
+	else
+		paint_mode = PAINT_NORMAL
+
 	var/istagger = HAS_TRAIT(user, TRAIT_TAGGER)
 	var/cost = all_drawables[drawing] || CRAYON_COST_DEFAULT
 	if(istype(target, /obj/item/canvas))


### PR DESCRIPTION

## About The Pull Request

Found by Melbert on discord, caused by paint mode not applying when painting random decals.

## Changelog
:cl:
fix: Random spraypaint setting now properly paints large decals
/:cl:
