### PR TITLE
Rewires the runtime APC on the map [NO GBP]

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -473,6 +473,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "de" = (
@@ -1068,10 +1069,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"gZ" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "hl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1356,7 +1353,6 @@
 /area/station/cargo/storage)
 "qD" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron,
@@ -7482,7 +7478,7 @@ dJ
 dJ
 dJ
 dJ
-gZ
+dJ
 cS
 Tt
 bL


### PR DESCRIPTION
## About The Pull Request
Oops! A minor mapping change made it's way through on runtime unwiring the APC on runtime as a consequence of some directional wallmount changes I did. This moves the APC back to the top left corner with a wire connection yet again.
![image](https://github.com/user-attachments/assets/7aa8a5ff-4ffd-4e61-8810-654679c3d6fe)


## Why It's Good For The Game

Prevents runtime station from running out of power during standard testing.

## Changelog

:cl:
fix: Runtimestation's APC is now connected to the grid again.
/:cl:
