### PR TITLE
Removes the slowdown from the CentCom officer's beret

### DIFF
--- a/code/modules/clothing/spacesuits/specialops.dm
+++ b/code/modules/clothing/spacesuits/specialops.dm
@@ -7,6 +7,7 @@
 	inhand_icon_state = null
 	greyscale_colors = "#397F3F#FFCE5B"
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT
+	slowdown = 0
 	flags_inv = 0
 	armor_type = /datum/armor/space_beret
 	strip_delay = 130


### PR DESCRIPTION

## About The Pull Request
Following the PR that split the slowdown between spacesuits and helmets, the CentCom special ops 'space suit' (officer's beret and winter coat), which previously had no slowdown, gained a slowdown on the beret only. Considering it is an adminspawned outfit and cannot be found anywhere, there shouldn't be any balance issues with it.
## Why It's Good For The Game
The CentCom winter coat had its slowdown removed, why wouldn't the beret? Seemed like an oversight from the original PR.
## Changelog
:cl:
qol: The CentCom officer's beret has had its slowdown removed to be in line with the winter coat.
/:cl:
