### PR TITLE
Fixes Clarke ore box breaking upon collecting boulders

### DIFF
--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -22,6 +22,8 @@
 	var/boulder_size = BOULDER_SIZE_SMALL
 	/// Used in inheriting the icon_state from our parent vent in update_icon.
 	var/boulder_string = "boulder"
+	// There is one boulder per boulder (this is required for the Clarke UI as it treats ores and boulders in the same fashion and needs an amount for both)
+	var/amount = 1
 
 /obj/item/boulder/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -78,14 +78,14 @@
 	var/list/contents = chassis.ore_box?.contents
 	var/list/contents_grouped = list()
 	for(var/obj/item/stack/ore/item as anything in contents)
-		if(isnull(contents_grouped[item.icon_state]))
+		if(isnull(contents_grouped[item.name]))
 			var/ore_data = list()
 			ore_data["name"] = item.name
 			ore_data["icon"] = item.icon_state
 			ore_data["amount"] = item.amount
-			contents_grouped[item.icon_state] = ore_data
+			contents_grouped[item.name] = ore_data
 		else
-			contents_grouped[item.icon_state]["amount"] += item.amount
+			contents_grouped[item.name]["amount"] += item.amount
 	var/list/data = list(
 		"snowflake_id" = MECHA_SNOWFLAKE_ID_OREBOX_MANAGER,
 		"contents" = contents_grouped,


### PR DESCRIPTION
## About The Pull Request

Ever since Clarkes could pick up boulders they've been broken if you ever collected one. The UI would break and all your precious minerals would be trapped inside the Clarke, only being obtainable if you broke the Clarke itself.

This also updates the Clarke Storage to differentiate by ore name rather than icon, as otherwise the lower quality boulders would be mixed with normal boulders with no way to differentiate them in the UI.


## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/84364
Before:
<details>
  <summary>Before</summary> 

https://github.com/user-attachments/assets/f90daf35-733a-42bd-8af5-7e6712f09fba

</details>
<details>
<summary>After</summary> 

https://github.com/user-attachments/assets/4510803c-6dee-403e-a051-966a8a66c17c



</details>


## Changelog

:cl: TwistedSilicon
fix: Clarkes will no longer become unable to dump ores upon picking a boulder up. Mine away.
/:cl:
