### PR TITLE
Makes the Start Screen Look Better

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -707,7 +707,7 @@
 /area/centcom/central_command_areas/admin)
 "de" = (
 /obj/effect/landmark/start/new_player,
-/turf/closed/indestructible/start_area,
+/turf/cordon,
 /area/misc/start)
 "df" = (
 /obj/structure/table/wood,
@@ -1292,7 +1292,7 @@
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
 "fX" = (
-/turf/closed/indestructible/start_area,
+/turf/cordon,
 /area/misc/start)
 "fZ" = (
 /obj/effect/landmark/ctf,

--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -58,6 +58,7 @@
 /turf/closed/indestructible/splashscreen
 	name = "Space Station 13"
 	desc = null
+	baseturfs = /turf/cordon
 	icon = 'icons/blanks/blank_title.png'
 	icon_state = ""
 	pixel_x = -64
@@ -97,15 +98,6 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 /turf/closed/indestructible/splashscreen/examine()
 	desc = pick(strings(SPLASH_FILE, "splashes"))
 	return ..()
-
-/turf/closed/indestructible/start_area
-	name = null
-	desc = null
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	use_splitvis = FALSE
-	smoothing_flags = NONE
-	smoothing_groups = null
-	canSmoothWith = null
 
 /turf/closed/indestructible/reinforced
 	name = "reinforced wall"


### PR DESCRIPTION
## About The Pull Request

I think it's been related to the recent DDOS's but looking at the non-connected wall turf overlay while loading into the game and waiting for the config-loaded start screen to load is just ugly as hell on production servers. So, let's fix this in a way that we really should have done pre-wallening: using cordons.

Cordons just give us a fully solid white background and are probably faster to load than the indestructible turfs (claim unverified), but visually it just looks better if an admin deletes the start screen for a laugh or just having a nice solid black background while the lobby screen loads in instead of the weird noncongruous turf type we made.

<details>
<summary>
Photos
</summary>

This is what the lobby screen looks like if the image is deleted/while it's loading in:
![image](https://github.com/user-attachments/assets/e435a454-6b12-41f2-8283-9141e6328bc7)

This is what it looks like when zoomed out on the map after deleting the sprite. will just appear as world border to any mobs that venture out into the wastes.
![image](https://github.com/user-attachments/assets/c1545153-cb01-41f4-9403-3fdebd764f1c)
</details>

## Why It's Good For The Game

Looks way cleaner than the current solution, can discard a needless turf type for something that looks nice. We were already punching a hole in the CentCom z-level so why not just make it fully more obvious.

I left the `misc/start` area as-is in case admins still want to plop down schenanigan meme buildings in the lobby. I also made it so that deleting the lobby screen baseturfs to the cordon type, so you aren't left with an ugly hole to space in the title screen.
## Changelog
:cl:
fix: The area of the CentCom Z-Level dedicated to the Lobby Screen should look far better now, with a solid black title screen should the lobby image not load in/get deleted.
/:cl:
