### PR TITLE
Grounds cockroaches

### DIFF
--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -14,6 +14,8 @@
 	can_be_held = TRUE
 	gold_core_spawnable = FRIENDLY_SPAWN
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	shadow_type = SHADOW_SMALL
+	shadow_offset_y = 12
 
 	verb_say = "chitters"
 	verb_ask = "chitters inquisitively"


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/5bef1cc3-c01e-426c-af41-de48c306dc2b)
Moves the cockroach shadow to be right under it

## Why It's Good For The Game

While technically cockroaches _can_ fly, they don't in our game.
Cockroaches are the ultimate survivor organism and have even managed to evade the 12 pixel offset all other creatures are labouring under.

## Changelog

:cl:
fix: Whatever the roaches were getting into which made them hover above the ground seems to have worn off.
/:cl:
