### PR TITLE
Fixes active turfs on crashsite ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_crashsite.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_crashsite.dmm
@@ -59,10 +59,10 @@
 /area/ruin/unpowered)
 "k" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/unpowered)
 "l" = (
-/turf/open/water,
+/turf/open/water/lavaland_atmos,
 /area/lavaland/surface)
 "m" = (
 /obj/machinery/door/airlock/survival_pod/glass,
@@ -84,6 +84,12 @@
 /area/ruin/powered)
 "q" = (
 /turf/closed/wall/mineral/titanium/interior,
+/area/ruin/unpowered)
+"r" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/turf/open/floor/mineral/titanium/blue/lavaland_atmos,
 /area/ruin/unpowered)
 "s" = (
 /turf/open/floor/pod/dark,
@@ -119,7 +125,7 @@
 	dir = 1
 	},
 /obj/effect/mob_spawn/corpse/human/engineer,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/blue/lavaland_atmos,
 /area/ruin/unpowered)
 "z" = (
 /obj/item/book/manual/fish_catalog,
@@ -154,7 +160,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/blue/lavaland_atmos,
 /area/ruin/unpowered)
 "J" = (
 /obj/machinery/smartfridge/survival_pod{
@@ -476,7 +482,7 @@ o
 O
 y
 I
-b
+r
 a
 a
 R

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -97,6 +97,10 @@
 /turf/open/floor/mineral/titanium/blue/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
+/turf/open/floor/mineral/titanium/blue/lavaland_atmos
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+
 /turf/open/floor/mineral/titanium/white
 	icon_state = "titanium_white"
 	floor_tile = /obj/item/stack/tile/mineral/titanium/white

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -42,3 +42,7 @@
 	baseturfs = /turf/open/water/beach
 	immerse_overlay_color = "#7799AA"
 	fishing_datum = /datum/fish_source/ocean/beach
+
+/turf/open/water/lavaland_atmos
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	planetary_atmos = TRUE


### PR DESCRIPTION

## About The Pull Request

Water and breached pod had stationside atmos and were creating a ton of active turfs roundstart

## Changelog
:cl:
fix: Fixed active turfs on crashsite ruin
/:cl:
