### PR TITLE
Fixes soapbox component sometimes runtiming roundstart due to not unregistering signals

### DIFF
--- a/code/datums/components/soapbox.dm
+++ b/code/datums/components/soapbox.dm
@@ -33,7 +33,7 @@
 	SIGNAL_HANDLER
 	for(var/atom/movable/loud as anything in soapboxers)
 		UnregisterSignal(loud, COMSIG_MOB_SAY)
-		soapboxers = list()
+	soapboxers.Cut()
 
 ///Gives a mob a unique say span
 /datum/component/soapbox/proc/soapbox_speech(datum/source, list/speech_args)


### PR DESCRIPTION

## About The Pull Request

sometimes runtimed due to reassigning signals and it has been driving me insane

## Changelog
:cl:
fix: Fixed soapbox component sometimes runtiming roundstart
/:cl:
