### PR TITLE
Vomiting from disgust now removes 50 disgust from you

### DIFF
--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -217,6 +217,7 @@
 				disgusted.adjust_confusion(2.5 SECONDS)
 				disgusted.adjust_stutter(2 SECONDS)
 				disgusted.vomit(VOMIT_CATEGORY_KNOCKDOWN, distance = 0)
+				disgusted.adjust_disgust(-50)
 			disgusted.set_dizzy_if_lower(10 SECONDS)
 		if(disgust >= DISGUST_LEVEL_DISGUSTED)
 			if(SPT_PROB(13, seconds_per_tick))


### PR DESCRIPTION
## About The Pull Request

Vomiting caused by disgust now deducts 50 disgust from you. This should prevent chainvomiting causing infinite knockdowns and slowdowns.

## Why It's Good For The Game
This is primarily intended as a nerf to rust heretics, although it also serves as semi-balance/qol to other sources of disgust. Rust tiles apply 10 disgust per tick with blade applying 50/100 on detonation, which leads to chain vomiting resulting in endless knockdown.

![изображение](https://github.com/user-attachments/assets/5f184435-85e2-4c55-8fb5-ad24fec191a7)

Statistics also support this, as rust is currently the strongest heretic path to go down, both pickrate and (almost) win % wise. Initial rework's author also supports this change, as chain vomit knockdowns were not intended to be this prevalent or strong.

## Changelog
:cl:
balance: Vomiting from disgust now removes 50 of it from you.
/:cl:
