### PR TITLE
Doubles PACMAN power output, triples their sheet efficiency. Inducers can now be recharged with plasma.

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -95,6 +95,15 @@
 				to_chat(user, span_warning("[src] already has \a [our_cell] installed!"))
 				return
 
+	if (istype(used_item, /obj/item/stack/sheet/mineral/plasma))
+		if(cell.charge == cell.maxcharge)
+			balloon_alert(user, "already fully charged!")
+			return
+		used_item.use(1)
+		cell.give(0.5 * STANDARD_CELL_CHARGE)
+		balloon_alert(user, "cell recharged")
+		return
+
 	if(cantbeused(user))
 		return
 

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -100,7 +100,7 @@
 			balloon_alert(user, "already fully charged!")
 			return
 		used_item.use(1)
-		cell.give(2.5 * STANDARD_CELL_CHARGE)
+		cell.give(2 * STANDARD_CELL_CHARGE)
 		balloon_alert(user, "cell recharged")
 		return
 

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -81,9 +81,9 @@
 		return
 
 /obj/item/inducer/attackby(obj/item/used_item, mob/user)
+	var/obj/item/stock_parts/power_store/our_cell = get_cell()
 	if(istype(used_item, /obj/item/stock_parts/power_store))
 		if(opened)
-			var/obj/item/stock_parts/power_store/our_cell = get_cell()
 			if(isnull(our_cell))
 				if(!user.transferItemToLoc(used_item, src))
 					return
@@ -95,12 +95,12 @@
 				to_chat(user, span_warning("[src] already has \a [our_cell] installed!"))
 				return
 
-	if (istype(used_item, /obj/item/stack/sheet/mineral/plasma))
-		if(cell.charge == cell.maxcharge)
+	if (istype(used_item, /obj/item/stack/sheet/mineral/plasma) && !isnull(our_cell))
+		if(our_cell.charge == our_cell.maxcharge)
 			balloon_alert(user, "already fully charged!")
 			return
 		used_item.use(1)
-		cell.give(1.5 * STANDARD_CELL_CHARGE)
+		our_cell.give(1.5 * STANDARD_CELL_CHARGE)
 		balloon_alert(user, "cell recharged")
 		return
 

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -100,7 +100,7 @@
 			balloon_alert(user, "already fully charged!")
 			return
 		used_item.use(1)
-		cell.give(2 * STANDARD_CELL_CHARGE)
+		cell.give(1.5 * STANDARD_CELL_CHARGE)
 		balloon_alert(user, "cell recharged")
 		return
 

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -100,7 +100,7 @@
 			balloon_alert(user, "already fully charged!")
 			return
 		used_item.use(1)
-		cell.give(0.5 * STANDARD_CELL_CHARGE)
+		cell.give(2.5 * STANDARD_CELL_CHARGE)
 		balloon_alert(user, "cell recharged")
 		return
 
@@ -196,7 +196,7 @@
 	opened = TRUE
 
 /obj/item/inducer/orderable
-	cell_type = /obj/item/stock_parts/power_store/cell/inducer_supply
+	cell_type = /obj/item/stock_parts/power_store/battery/upgraded
 	opened = FALSE
 
 /obj/item/inducer/sci

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -221,9 +221,6 @@
 	custom_materials = null
 	grind_results = null
 
-/obj/item/stock_parts/power_store/cell/inducer_supply
-	maxcharge = STANDARD_CELL_CHARGE * 5
-
 /obj/item/stock_parts/power_store/cell/ethereal
 	name = "ahelp it"
 	desc = "you sohuldn't see this"

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -82,7 +82,7 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
-	power_gen = 5000
+	power_gen = 10000
 	var/sheets = 0
 	var/max_sheets = 50
 	var/sheet_name = ""
@@ -110,7 +110,7 @@
 		base_icon_state = "portgen1"
 		max_sheets = 20
 		time_per_sheet = 20
-		power_gen = 15000
+		power_gen *= 3
 		sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
@@ -276,7 +276,7 @@
 	base_icon_state = "portgen1"
 	max_sheets = 20
 	time_per_sheet = 20
-	power_gen = 15000
+	power_gen = 30000
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/pre_loaded

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -11,7 +11,7 @@
 	use_power = NO_POWER_USE
 
 	var/active = FALSE
-	var/power_gen = 5000
+	var/power_gen = 5 KILO JOULES
 	var/power_output = 1
 	var/consumption = 0
 	var/datum/looping_sound/generator/soundloop
@@ -82,7 +82,7 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
-	power_gen = 10000
+	power_gen = 10 KILO JOULES
 	var/sheets = 0
 	var/max_sheets = 50
 	var/sheet_name = ""
@@ -110,7 +110,7 @@
 		base_icon_state = "portgen1"
 		max_sheets = 20
 		time_per_sheet = 60
-		power_gen = 30000
+		power_gen = 30 KILO JOULES
 		sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
@@ -276,7 +276,7 @@
 	base_icon_state = "portgen1"
 	max_sheets = 20
 	time_per_sheet = 60
-	power_gen = 30000
+	power_gen = 30 KILO JOULES
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/pre_loaded

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -82,13 +82,13 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
-	power_gen = 10000
+	power_gen = 20000
 	var/sheets = 0
 	var/max_sheets = 50
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/plasma
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 60
+	var/time_per_sheet = 120
 	var/current_heat = 0
 
 /obj/machinery/power/port_gen/pacman/Initialize(mapload)
@@ -109,8 +109,8 @@
 		icon_state = "portgen1_0"
 		base_icon_state = "portgen1"
 		max_sheets = 20
-		time_per_sheet = 20
-		power_gen *= 3
+		time_per_sheet = 40
+		power_gen = 60000
 		sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
@@ -275,8 +275,8 @@
 	icon_state = "portgen1_0"
 	base_icon_state = "portgen1"
 	max_sheets = 20
-	time_per_sheet = 20
-	power_gen = 30000
+	time_per_sheet = 40
+	power_gen = 60000
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/pre_loaded

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -82,13 +82,13 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
-	power_gen = 20000
+	power_gen = 10000
 	var/sheets = 0
 	var/max_sheets = 50
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/plasma
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 120
+	var/time_per_sheet = 180
 	var/current_heat = 0
 
 /obj/machinery/power/port_gen/pacman/Initialize(mapload)
@@ -109,8 +109,8 @@
 		icon_state = "portgen1_0"
 		base_icon_state = "portgen1"
 		max_sheets = 20
-		time_per_sheet = 40
-		power_gen = 60000
+		time_per_sheet = 60
+		power_gen = 30000
 		sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
@@ -275,8 +275,8 @@
 	icon_state = "portgen1_0"
 	base_icon_state = "portgen1"
 	max_sheets = 20
-	time_per_sheet = 40
-	power_gen = 60000
+	time_per_sheet = 60
+	power_gen = 30000
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/pre_loaded


### PR DESCRIPTION

## About The Pull Request

PACMANs now can produce 10-40kW of power and take 180 ticks to go through a sheet instead of 60. This does not allow them to power the station on their own like in the good ole days, but they're still capable of powering a section of a department(maybe even all of it if it doesn't eat too much power)

Inducers can be recharged with plasma, 15kJ per sheet. Cargo-ordered inducers now also start with an upgraded megacell (x2.5 of a normal one) instead of a regular upgraded battery (x5 of a normal one and half of a megacell) (it barely can charge anything)

## Why It's Good For The Game

PACMANs are currently in a very sad state as they are borderline useless after power changes, and don't see much use beyond kickstarting the SM if emitters don't have enough juice. This should bring them a bit into action while not allowing them to power the entire station like before.
As for emitter changes, introduction of megacells rendered them almost entirely useless as you cannot charge megacells you print and using normal batteries for charging APCs is a joke. This should allow people to recharge their APCs and machinery in a pinch. Inducer change has been approved by Watermelon a while ago, while PACMAN buffs have been mentioned but these are significantly smaller than discussed with him.

## Changelog
:cl:
balance: PACMANs now have significantly increased power output and take longer to consume a single sheet
balance: Inducers can now be recharged with plasma
balance: Inducers ordered from cargo now start with upgraded megacells instead of upgraded batteries
/:cl:
