### PR TITLE
[TM Only] Revert "Wallmount balloons are now clickable"

### DIFF
--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -584,6 +584,7 @@
 	name = "Examine Balloons"
 	documentation = "The balloons that appear above objects (often wallmounts) when holding shift."
 	plane = EXAMINE_BALLOONS_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
 	alpha = 0

--- a/code/datums/components/examine_balloon.dm
+++ b/code/datums/components/examine_balloon.dm
@@ -1,5 +1,7 @@
 /// Adds clickable balloons whenever someone holds the examine key (is it still shift in the future?)
 /datum/component/examine_balloon
+	/// Store the overlays applied in the previous turn and clean them up (because of how managed_overlays checks for changes we need to do this manually)
+	var/list/previous_overlays
 	/// Offset applied on the hologram
 	var/pixel_y_offset
 	/// Our x and y size is multiplied by this, for small sprites like buttons
@@ -11,8 +13,6 @@
 	var/hologram_alpha = 200
 	/// Add a hologram when we're in these directions
 	var/draw_in_dirs = NORTH | EAST | WEST
-	/// Balloon holo that is actually displayed to players
-	var/obj/effect/abstract/balloon_hologram/balloon
 
 /datum/component/examine_balloon/Initialize(pixel_y_offset = 28, pixel_y_offset_arrow = 16, size_upscaling = 1)
 	. = ..()
@@ -24,71 +24,57 @@
 	src.size_upscaling = size_upscaling
 	src.pixel_y_offset_arrow = pixel_y_offset_arrow
 
-	var/atom/movable/atom_parent = parent
-	balloon = new(atom_parent, atom_parent, pixel_y_offset_arrow - pixel_y_offset)
-	balloon.pixel_y = pixel_y_offset
-	atom_parent.vis_contents += balloon
+	var/atom/atom_parent = parent
 
 	// We use UPDATED_ICON specifically because we need to be last in the icon chain, even if UPDATE_OVERLAYS would otherwise be more apt
 	RegisterSignal(atom_parent, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_updated_icon))
-	atom_parent.update_appearance()
 
-/datum/component/examine_balloon/UnregisterFromParent()
-	var/atom/movable/atom_parent = parent
-	atom_parent.vis_contents -= balloon
-	qdel(balloon)
+	atom_parent.update_icon(UPDATE_OVERLAYS)
 
-/datum/component/examine_balloon/proc/on_updated_icon(atom/movable/source, updates)
+/datum/component/examine_balloon/proc/on_updated_icon(atom/movable/parent, updates)
 	SIGNAL_HANDLER
 
-	// Generally south facing directions are already obvious, so we dont add a hologram (south is the default exception dont shoot me)
-	if(!(source.dir & draw_in_dirs))
-		balloon.invisibility = INVISIBILITY_MAXIMUM
+	if(!(updates & UPDATE_OVERLAYS))
 		return
 
-	balloon.invisibility = INVISIBILITY_NONE
-	balloon.icon = source.icon
-	balloon.icon_state = source.icon_state
-	balloon.pixel_y = pixel_y_offset
+	// Generally south facing directions are already obvious, so we dont add a hologram (south is the default exception dont shoot me)
+	if(!(parent.dir & draw_in_dirs))
+		return
+
+	parent.cut_overlay(previous_overlays)
+
+	// Make a copy of the wallmount and force it south
+	var/mutable_appearance/hologram = make_mutable_appearance_directional(new /mutable_appearance(parent), SOUTH)
+	SET_PLANE_EXPLICIT(hologram, EXAMINE_BALLOONS_PLANE, parent)
+
+	hologram.pixel_w = 0
+	hologram.pixel_x = 0
+	hologram.pixel_y = pixel_y_offset
+	hologram.pixel_z = 0
 
 	// We need to set all our overlay's planes to the wallmount balloons plane, or we get stuff like emissives sticking through the lighting plane
 	var/list/new_overlays = list()
-	for(var/mutable_appearance/immutable_appearance as anything in source.overlays)
+	for(var/mutable_appearance/immutable_appearance as anything in parent.overlays)
 		var/mutable_appearance/actually_mutable_appearance = new(immutable_appearance)
 		if(PLANE_TO_TRUE(actually_mutable_appearance.plane) != FLOAT_PLANE)
 			continue
 		new_overlays += actually_mutable_appearance
 
-	var/mutable_appearance/examine_arrow = mutable_appearance('icons/effects/effects.dmi', "examine_arrow")
-	examine_arrow.pixel_y = pixel_y_offset_arrow - balloon.pixel_y
-	new_overlays += examine_arrow
+	hologram.overlays = new_overlays
 
-	balloon.overlays = new_overlays
-	balloon.transform = balloon.transform.Scale(size_upscaling, size_upscaling)
-	balloon.alpha = hologram_alpha
+	hologram.transform = hologram.transform.Scale(size_upscaling, size_upscaling)
+	hologram.alpha = hologram_alpha
 
-/obj/effect/abstract/balloon_hologram
-	plane = EXAMINE_BALLOONS_PLANE
-	/// Atom that we're copying
-	var/atom/original
-	/// Y offset for our arrow
-	var/arrow_offset
+	var/mutable_appearance/examine_arrow = mutable_appearance(
+		'icons/effects/effects.dmi',
+		"examine_arrow",
+	)
 
-/obj/effect/abstract/balloon_hologram/Initialize(mapload, atom/to_copy, arrow_y)
-	. = ..()
-	if (isnull(to_copy))
-		return
-	original = to_copy
-	name = original.name
-	desc = original.desc
-	arrow_offset = arrow_y
-	update_appearance()
+	examine_arrow.pixel_y = pixel_y_offset_arrow
 
-/obj/effect/abstract/balloon_hologram/Destroy(force)
-	original = null
-	return ..()
+	SET_PLANE_EXPLICIT(examine_arrow, EXAMINE_BALLOONS_PLANE, parent)
 
-/obj/effect/abstract/balloon_hologram/Click(location, control, params)
-	var/list/modifiers = params2list(params)
-	LAZYREMOVE(modifiers, SHIFT_CLICK)
-	original.Click(location, control, list2params(modifiers))
+	previous_overlays = list(hologram, examine_arrow)
+
+	parent.add_overlay(previous_overlays)
+


### PR DESCRIPTION
Reverts tgstation/tgstation#85887

Infinitely expanding button examine balloons turn areas of the station into uninteractable wastelands over time.

For testmerge pending the merge of #85949