### PR TITLE
fixes elevation being permanent if you spawn on it

### DIFF
--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -151,7 +151,7 @@
 
 /datum/element/elevation_core/proc/on_initialized_on(turf/source, atom/movable/spawned)
 	SIGNAL_HANDLER
-	if(isliving(spawned) && isturf(spawned.loc))
+	if(isliving(spawned) && !HAS_TRAIT(spawned, TRAIT_ON_ELEVATED_SURFACE))
 		on_entered(entered = spawned)
 
 /datum/element/elevation_core/proc/on_exited(turf/source, atom/movable/gone)

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -152,7 +152,7 @@
 /datum/element/elevation_core/proc/on_initialized_on(turf/source, atom/movable/spawned)
 	SIGNAL_HANDLER
 	if(isliving(spawned))
-		elevate_mob(spawned)
+		on_entered(entered = spawned)
 
 /datum/element/elevation_core/proc/on_exited(turf/source, atom/movable/gone)
 	SIGNAL_HANDLER

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -151,7 +151,7 @@
 
 /datum/element/elevation_core/proc/on_initialized_on(turf/source, atom/movable/spawned)
 	SIGNAL_HANDLER
-	if(isliving(spawned))
+	if(isliving(spawned) && isturf(spawned.loc))
 		on_entered(entered = spawned)
 
 /datum/element/elevation_core/proc/on_exited(turf/source, atom/movable/gone)


### PR DESCRIPTION

## About The Pull Request

1 line change that makes spawning on stuff such as table not offset you forever

## Why It's Good For The Game

fixes #84121

## Changelog
:cl:
fix: spawning on a table or other elevated object does not offset you forever
/:cl:
