### PR TITLE
Use yt-dlp by default instead of youtube-dl

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -54,13 +54,13 @@ ADMIN_VERB(play_direct_mob_sound, R_SOUND, "Play Direct Mob Sound", "Play a soun
 	SEND_SOUND(target, sound)
 	BLACKBOX_LOG_ADMIN_VERB("Play Direct Mob Sound")
 
-///Takes an input from either proc/play_web_sound or the request manager and runs it through youtube-dl and prompts the user before playing it to the server.
+///Takes an input from either proc/play_web_sound or the request manager and runs it through yt-dlp and prompts the user before playing it to the server.
 /proc/web_sound(mob/user, input, credit)
 	if(!check_rights(R_SOUND))
 		return
 	var/ytdl = CONFIG_GET(string/invoke_youtubedl)
 	if(!ytdl)
-		to_chat(user, span_boldwarning("Youtube-dl was not configured, action unavailable"), confidential = TRUE) //Check config.txt for the INVOKE_YOUTUBEDL value
+		to_chat(user, span_boldwarning("yt-dlp was not configured, action unavailable"), confidential = TRUE) //Check config.txt for the INVOKE_YOUTUBEDL value
 		return
 	var/web_sound_url = ""
 	var/stop_web_sounds = FALSE
@@ -73,14 +73,14 @@ ADMIN_VERB(play_direct_mob_sound, R_SOUND, "Play Direct Mob Sound", "Play a soun
 		var/stdout = output[SHELLEO_STDOUT]
 		var/stderr = output[SHELLEO_STDERR]
 		if(errorlevel)
-			to_chat(user, span_boldwarning("Youtube-dl URL retrieval FAILED:"), confidential = TRUE)
+			to_chat(user, span_boldwarning("yt-dlp URL retrieval FAILED:"), confidential = TRUE)
 			to_chat(user, span_warning("[stderr]"), confidential = TRUE)
 			return
 		var/list/data
 		try
 			data = json_decode(stdout)
 		catch(var/exception/e)
-			to_chat(user, span_boldwarning("Youtube-dl JSON parsing FAILED:"), confidential = TRUE)
+			to_chat(user, span_boldwarning("yt-dlp JSON parsing FAILED:"), confidential = TRUE)
 			to_chat(user, span_warning("[e]: [stdout]"), confidential = TRUE)
 			return
 		if (data["url"])

--- a/config/config.txt
+++ b/config/config.txt
@@ -208,19 +208,19 @@ IPINTEL_REJECT_BAD
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://justanotherday.example.com
 
-## System command that invokes youtube-dl, used by Play Internet Sound.
-## You can install youtube-dl with
-## "pip install youtube-dl" if you have pip installed
-## from https://github.com/rg3/youtube-dl/releases
+## System command that invokes yt-dlp, used by Play Internet Sound.
+## You can install yt-dlp with
+## "pip install yt-dlp" if you have pip installed
+## from https://github.com/yt-dlp/yt-dlp/releases
 ## or your package manager
-## The default value assumes youtube-dl is in your system PATH
-# INVOKE_YOUTUBEDL youtube-dl
+## The default value assumes yt-dlp is in your system PATH
+# INVOKE_YOUTUBEDL yt-dlp
 
 ## Comment this out to disable users ability to use the request internet sounds to be played.
 REQUEST_INTERNET_SOUND
 
 ## Request Internet Sound Allowed URL'S comma separated, urls here are the only sites allowed through Request Internet Sound, Add more to allow more, or remove to disallow.
-## The Defaults here are all supported by youtube-dl
+## The Defaults here are all supported by yt-dlp
 ## Ensure . and / are escaped with \
 REQUEST_INTERNET_ALLOWED youtube\.com\/watch?v=,youtu\.be\/,soundcloud\.com\/,bandcamp\.com\/track\/
 

--- a/tools/tgs_scripts/InstallDeps.sh
+++ b/tools/tgs_scripts/InstallDeps.sh
@@ -6,7 +6,7 @@ has_git="$(command -v git)"
 has_curl="$(command -v curl)"
 has_cargo="$(command -v ~/.cargo/bin/cargo)"
 has_sudo="$(command -v sudo)"
-has_youtubedl="$(command -v youtube-dl)"
+has_ytdlp="$(command -v yt-dlp)"
 has_pip3="$(command -v pip3)"
 set -e
 set -x
@@ -40,12 +40,12 @@ if ! [ -x "$has_cargo" ]; then
 	. ~/.profile
 fi
 
-# install or update youtube-dl when not present, or if it is present with pip3,
+# install or update yt-dlp when not present, or if it is present with pip3,
 # which we assume was used to install it
-if ! [ -x "$has_youtubedl" ]; then
-	echo "Installing youtube-dl with pip3..."
-	pip3 install youtube-dl --break-system-packages
+if ! [ -x "$has_ytdlp" ]; then
+	echo "Installing yt-dlp with pip3..."
+	pip3 install yt-dlp --break-system-packages
 else
-	echo "Ensuring youtube-dl is up-to-date with pip3..."
-	pip3 install youtube-dl -U --break-system-packages
+	echo "Ensuring yt-dlp is up-to-date with pip3..."
+	pip3 install yt-dlp -U --break-system-packages
 fi


### PR DESCRIPTION

## About The Pull Request

This replaces references to youtube-dl in the config, pre-compile script, and error messages with yt-dlp.

also wow yt-dlp seems like gibberish after seeing it so much lol

## Why It's Good For The Game

yt-dlp is more reliable and updated more frequently than youtube-dl, and works as a drop-in replacement for the purposes of Play-Internet-Sound.

## Changelog

No player-facing changes
