### PR TITLE
Cooldown for radio "message received" sound effects

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -91,6 +91,11 @@
 	/// If TRUE, will set the icon in initializations.
 	VAR_PRIVATE/should_update_icon = FALSE
 
+	/// A very brief cooldown to prevent regular radio sounds from overlapping.
+	COOLDOWN_DECLARE(audio_cooldown)
+	/// A very brief cooldown to prevent "important" radio sounds from overlapping.
+	COOLDOWN_DECLARE(important_audio_cooldown)
+
 /obj/item/radio/Initialize(mapload)
 	set_wires(new /datum/wires/radio(src))
 	secure_radio_connections = list()
@@ -439,8 +444,11 @@
 		return
 
 	var/list/spans = data["spans"]
-	SEND_SOUND(holder, 'sound/misc/radio_receive.ogg')
-	if(SPAN_COMMAND in spans)
+	if(COOLDOWN_FINISHED(src, audio_cooldown))
+		COOLDOWN_START(src, audio_cooldown, 0.5 SECONDS)
+		SEND_SOUND(holder, 'sound/misc/radio_receive.ogg')
+	if((SPAN_COMMAND in spans) && COOLDOWN_FINISHED(src, important_audio_cooldown))
+		COOLDOWN_START(src, important_audio_cooldown, 0.5 SECONDS)
 		SEND_SOUND(holder, 'sound/misc/radio_important.ogg')
 
 /obj/item/radio/ui_state(mob/user)


### PR DESCRIPTION

## About The Pull Request

Radio message sounds now have cooldowns on when they play. The timer is separate for "important" and regular messages. 

The cooldown is half a second long, approximately the length of the default message noise.
## Why It's Good For The Game

Closes #85817

Reduced audio spam means less people getting overwhelmed by the aforementioned audio spam.
## Changelog
:cl: Rhials
sound: "radio message received" audio now has a brief cooldown. 
/:cl:
