### PR TITLE
Unarmed attacks with carp jaws now uses the bite attack effect

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -58,11 +58,12 @@
 	var/datum/species/rec_species = human_receiver.dna.species
 	rec_species.update_no_equip_flags(tongue_owner, rec_species.no_equip_flags | ITEM_SLOT_MASK)
 
-/obj/item/organ/internal/tongue/carp/on_bodypart_insert(obj/item/bodypart/limb)
+/obj/item/organ/internal/tongue/carp/on_bodypart_insert(obj/item/bodypart/head)
 	. = ..()
-	limb.unarmed_damage_low = 10
-	limb.unarmed_damage_high = 15
-	limb.unarmed_effectiveness = 15
+	head.unarmed_damage_low = 10
+	head.unarmed_damage_high = 15
+	head.unarmed_effectiveness = 15
+	head.unarmed_attack_effect = ATTACK_EFFECT_BITE
 
 /obj/item/organ/internal/tongue/carp/on_mob_remove(mob/living/carbon/tongue_owner)
 	. = ..()
@@ -76,10 +77,10 @@
 
 /obj/item/organ/internal/tongue/carp/on_bodypart_remove(obj/item/bodypart/head)
 	. = ..()
-
 	head.unarmed_damage_low = initial(head.unarmed_damage_low)
 	head.unarmed_damage_high = initial(head.unarmed_damage_high)
 	head.unarmed_effectiveness = initial(head.unarmed_effectiveness)
+	head.unarmed_attack_effect = initial(head.unarmed_attack_effect)
 
 /obj/item/organ/internal/tongue/carp/on_life(seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

The carp organ set gives your head 10-15 unarmed damage, alongside making you attack with your head... Which is, well, you're biting them with your carp jaws. So, let's make it actually use the bite effect.

## Why It's Good For The Game

Makes more sense - if you're biting using carp jaws, then the effect should be a bite.

## Changelog
:cl:
qol: Unarmed attacks with carp jaws now uses a bite effect rather than a punch effect.
/:cl:
