### PR TITLE
Fixes black fences and layering issues

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -169,6 +169,7 @@
 	icon_state = "wooden_railing"
 	item_deconstruct = /obj/item/stack/sheet/mineral/wood
 	layer = ABOVE_MOB_LAYER
+	plane = GAME_PLANE
 
 /obj/structure/railing/wooden_fence/Initialize(mapload)
 	. = ..()
@@ -181,7 +182,6 @@
 
 /obj/structure/railing/wooden_fence/proc/adjust_dir_layer(direction)
 	layer = (direction & NORTH) ? MOB_LAYER : initial(layer)
-	plane = (direction & NORTH) ? GAME_PLANE : initial(plane)
 
 
 /obj/structure/railing/corner/end/wooden_fence


### PR DESCRIPTION

## About The Pull Request
fixes wooden fences appearing pitch black on lower levels of icebox. also fixes layering issues with them appearing on top of players

## Why It's Good For The Game
Fixes black fences and layering issues

## Changelog
:cl:
fix: fences will no longer appear pitch black and they will layer properly 
/:cl:
