### PR TITLE
Icemoon cliffside bench area adjustments (very small)

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5756,7 +5756,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/waffles,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bGm" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5756,6 +5756,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/trash/waffles,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bGm" = (
@@ -56205,9 +56206,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
-"qtv" = (
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "qtw" = (
 /obj/machinery/door/airlock/security{
 	name = "Prison Forestry"
@@ -270718,7 +270716,7 @@ wNO
 tkU
 tkU
 tkU
-qtv
+bln
 hHG
 hHG
 hHG

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -77715,12 +77715,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"wLI" = (
-/obj/structure/flora/tree/pine/style_random,
-/obj/structure/marker_beacon/cerulean,
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "wLK" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -269180,8 +269174,8 @@ wNO
 wNO
 wNO
 wNO
-wNO
-wLI
+bln
+fwx
 kDs
 kDs
 kDs
@@ -269437,8 +269431,8 @@ wNO
 wNO
 wNO
 wNO
-wNO
-wNO
+bln
+bln
 kDs
 kDs
 kDs
@@ -269694,8 +269688,8 @@ wNO
 wNO
 wNO
 wNO
-wNO
-wNO
+bln
+bln
 bln
 hHG
 hHG


### PR DESCRIPTION

## About The Pull Request

This makes a tiny adjustment to the upper area of Icebox, by the cliffside bench.

Since the area around this last tree wasn't a `/nospawn` icemoon area, it would generate terrain over it leading to the dreaded walltree:

![image](https://github.com/user-attachments/assets/eb5cb6ea-bc7a-4ae0-8509-74ab0a528459)

This also changes a single area tile nearby, which seems to have been a `no_monsters` area instead of `nospawn` for no discernible reason.

Before:

![image](https://github.com/user-attachments/assets/5561dc7c-8007-48e5-b9c7-ba073e2f3069)

![image](https://github.com/user-attachments/assets/1d9b0cb3-90e8-4b36-a6ea-4eb777896c1c)

After:

![image](https://github.com/user-attachments/assets/69705d2a-e19a-40fb-b0ca-772e49d4eb49)

![image](https://github.com/user-attachments/assets/2f3a47d2-547b-4f2f-b177-e695b6f8cdf6)
## Why It's Good For The Game

Tiny adjustments to areas that make generation make a little more sense. Also kills the walltree because it sucks and I hate it.
## Changelog
:cl:
fix: Adjusts some areas by the Icebox Cliffside Bench to generate a bit less weirdly.  
/:cl:
