### PR TITLE
Captain no longer requires hours played or command experience, as they teach new players how to pick up items and put them in their backpack or pockets.

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -10,6 +10,7 @@
 	spawn_positions = 1
 	supervisors = "Nanotrasen officials and Space Law"
 	req_admin_notify = 1
+	minimal_player_age = 2
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CAPTAIN"
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -10,10 +10,6 @@
 	spawn_positions = 1
 	supervisors = "Nanotrasen officials and Space Law"
 	req_admin_notify = 1
-	minimal_player_age = 14
-	exp_requirements = 180
-	exp_required_type = EXP_TYPE_CREW
-	exp_required_type_department = EXP_TYPE_COMMAND
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CAPTAIN"
 


### PR DESCRIPTION
## About The Pull Request

Captain no longer requires hours played or command experience, as they teach new players how to pick up items and put them in their backpack or pockets.

## Why It's Good For The Game

Captain is the best job for brand new players.
It teaches you how to pick up items.
It teaches you how to put items in your inventory, aka using items on other items.
it teaches you about the station because you can walk anywhere and people won't tell you to leave because you're the Captain.

It's basically perfect for new players. Why didn't we do this sooner?

## Changelog
:cl:
qol: Captain no longer requires hours played or command experience, as they teach new players how to pick up items and put them in their backpack or pockets.
qol: Captain now only requires 2 days down from 14 days.
/:cl: