### PR TITLE
[NO GBP] Fixes examine balloons not being click transparent even while inactive

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -108,6 +108,7 @@
 #define BALLOON_CHAT_PLANE 31
 /// Plane for the wallmount balloons
 #define EXAMINE_BALLOONS_PLANE 32
+#define EXAMINE_BALLOONS_RENDER_TARGET "*EXAMINE_BALLOONS_RENDER_TARGET"
 
 //-------------------- HUD ---------------------
 //HUD layer defines

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -584,6 +584,18 @@
 	name = "Examine Balloons"
 	documentation = "The balloons that appear above objects (often wallmounts) when holding shift."
 	plane = EXAMINE_BALLOONS_PLANE
+	invisibility = INVISIBILITY_ABSTRACT
+	render_target = EXAMINE_BALLOONS_RENDER_TARGET
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
 	alpha = 0
+	var/invis_timer
+
+/atom/movable/screen/plane_master/examine_balloons/proc/fade_in()
+	animate(src, 0.2 SECONDS, alpha = 255)
+	invisibility = INVISIBILITY_NONE
+	deltimer(invis_timer)
+
+/atom/movable/screen/plane_master/examine_balloons/proc/fade_out()
+	animate(src, 0.2 SECONDS, alpha = 0)
+	invis_timer = addtimer(VARSET_CALLBACK(src, invisibility, INVISIBILITY_ABSTRACT), 0.2 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -584,18 +584,17 @@
 	name = "Examine Balloons"
 	documentation = "The balloons that appear above objects (often wallmounts) when holding shift."
 	plane = EXAMINE_BALLOONS_PLANE
-	invisibility = INVISIBILITY_ABSTRACT
 	render_target = EXAMINE_BALLOONS_RENDER_TARGET
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
+	render_relay_planes = list()
 	alpha = 0
 	var/invis_timer
 
 /atom/movable/screen/plane_master/examine_balloons/proc/fade_in()
 	animate(src, 0.2 SECONDS, alpha = 255)
-	invisibility = INVISIBILITY_NONE
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_WORLD, offset))
 	deltimer(invis_timer)
 
 /atom/movable/screen/plane_master/examine_balloons/proc/fade_out()
 	animate(src, 0.2 SECONDS, alpha = 0)
-	invis_timer = addtimer(VARSET_CALLBACK(src, invisibility, INVISIBILITY_ABSTRACT), 0.2 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
+	invis_timer = addtimer(CALLBACK(src, PROC_REF(remove_relay_from), GET_NEW_PLANE(RENDER_PLANE_GAME_WORLD, offset)), 0.2 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -588,12 +588,13 @@
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	render_relay_planes = list()
 	alpha = 0
-	var/invis_timer
+	var/invis_timer = TIMER_ID_NULL
 
 /atom/movable/screen/plane_master/examine_balloons/proc/fade_in()
 	animate(src, 0.2 SECONDS, alpha = 255)
 	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_WORLD, offset))
 	deltimer(invis_timer)
+	invis_timer = TIMER_ID_NULL
 
 /atom/movable/screen/plane_master/examine_balloons/proc/fade_out()
 	animate(src, 0.2 SECONDS, alpha = 0)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -164,12 +164,12 @@
 	. = ..()
 
 	var/datum/hud/our_hud = user.mob.hud_used
-	for(var/atom/movable/screen/plane_master/balloons in our_hud.get_true_plane_masters(EXAMINE_BALLOONS_PLANE))
-		animate(balloons, 0.2 SECONDS, alpha = 255)
+	for(var/atom/movable/screen/plane_master/examine_balloons/balloons in our_hud.get_true_plane_masters(EXAMINE_BALLOONS_PLANE))
+		balloons.fade_in()
 
 /datum/keybinding/living/toggle_examine_balloons/up(client/user)
 	. = ..()
 
 	var/datum/hud/our_hud = user.mob.hud_used
-	for(var/atom/movable/screen/plane_master/balloons in our_hud.get_true_plane_masters(EXAMINE_BALLOONS_PLANE))
-		animate(balloons, 0.2 SECONDS, alpha = 0)
+	for(var/atom/movable/screen/plane_master/examine_balloons/balloons in our_hud.get_true_plane_masters(EXAMINE_BALLOONS_PLANE))
+		balloons.fade_out()


### PR DESCRIPTION
## About The Pull Request
This solution sucks, but byond is after our mortal souls and I wasn't able to find anything better. Something is very wrong with mouse_opacity and the only working solution was making the plane master invisible while its inactive.

Closes #85968

## Why It's Good For The Game

They no longer eat your clicks while invisible

## Changelog
:cl:
fix: Fixed examine balloons not being click transparent even while inactive
/:cl:
