### PR TITLE
Smartfridge no longer pops open a separate tgui input to vend several items

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -396,43 +396,39 @@
 	if(. || !ui.user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
 
-	. = TRUE
 	var/mob/living_mob = ui.user
 
 	switch(action)
 		if("Release")
 			var/amount = text2num(params["amount"])
-			var/desired = 1
+			if(isnull(amount) || !isnum(amount))
+				return TRUE
 			var/dispensed_amount = 0
 
 			if(isAI(living_mob))
 				to_chat(living_mob, span_warning("[src] does not respect your authority!"))
-				return
+				return TRUE
 
-			if (amount > 1)
-				desired = tgui_input_number(living_mob, "How many items would you like to take out?", "Release", default = min(amount, 50), max_value = min(amount, 50))
-				if(!desired)
-					return
-
-			for(var/obj/item/dispensed_item in src)
-				if(desired <= 0)
+			for(var/obj/item/dispensed_item in contents)
+				if(amount <= 0)
 					break
 				var/item_name = "[dispensed_item.type]-[replacetext(replacetext(dispensed_item.name, "\proper", ""), "\improper", "")]"
-				if(params["path"] == item_name)
-					if(dispensed_item in component_parts)
-						CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
-					//dispense the item
-					if(!living_mob.put_in_hands(dispensed_item))
-						dispensed_item.forceMove(drop_location())
-						adjust_item_drop_location(dispensed_item)
-					use_energy(active_power_usage)
-					dispensed_amount++
-					desired--
+				if(params["path"] != item_name)
+					continue
+				if(dispensed_item in component_parts)
+					CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
+				//dispense the item
+				if(!living_mob.put_in_hands(dispensed_item))
+					dispensed_item.forceMove(drop_location())
+					adjust_item_drop_location(dispensed_item)
+				use_energy(active_power_usage)
+				dispensed_amount++
+				amount--
 			if(dispensed_amount && vend_sound)
 				playsound(src, vend_sound, 50, TRUE, extrarange = -3)
 			if (visible_contents)
 				update_appearance()
-			return
+			return TRUE
 
 	return FALSE
 

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -4,7 +4,15 @@ import { useState } from 'react';
 import { DmIcon, Icon } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
-import { Box, Button, Input, NoticeBox, Section, Stack } from '../components';
+import {
+  Box,
+  Button,
+  Input,
+  NoticeBox,
+  NumberInput,
+  Section,
+  Stack,
+} from '../components';
 import { Window } from '../layouts';
 
 type Item = {
@@ -169,6 +177,7 @@ const ItemList = ({ item }) => {
   const fallback = (
     <Icon name="spinner" lineHeight="32px" size={3} spin color="gray" />
   );
+  const [itemCount, setItemCount] = useState<number>(1);
   return (
     <Stack>
       <Stack.Item>
@@ -236,29 +245,20 @@ const ItemList = ({ item }) => {
           onClick={() =>
             act('Release', {
               path: item.path,
-              amount: 1,
+              amount: itemCount,
             })
           }
         >
           Vend
         </Button>
-      </Stack.Item>
-      <Stack.Item>
-        <Button
-          py="4px"
-          mt="4px"
-          height="24px"
-          lineHeight="16px"
-          disabled={item.amount <= 1}
-          onClick={(e) => {
-            act('Release', {
-              path: item.path,
-              amount: item.amount,
-            });
-          }}
-        >
-          Amount
-        </Button>
+        <NumberInput
+          width="25px"
+          minValue={1}
+          maxValue={item.amount}
+          step={1}
+          value={itemCount}
+          onChange={(value) => setItemCount(value)}
+        />
       </Stack.Item>
     </Stack>
   ) as any;

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -177,7 +177,7 @@ const ItemList = ({ item }) => {
   const fallback = (
     <Icon name="spinner" lineHeight="32px" size={3} spin color="gray" />
   );
-  const [itemCount, setItemCount] = useState<number>(1);
+  const [itemCount, setItemCount] = useState(1);
   return (
     <Stack>
       <Stack.Item>


### PR DESCRIPTION
## About The Pull Request

Now uses Number input in the tgui panel directly.

https://github.com/user-attachments/assets/e76f62c7-56f7-486e-b8a4-62582f54e263

## Why It's Good For The Game

Having a TGUI window pop up cause you clicked on a TGUI window is kinda bad, keep them to the page theyre already on.

## Changelog

:cl:
qol: Smartfridges now lets you set how many pills you want to vend, rather than popping out a second separate tgui window.
/:cl: