### PR TITLE
Fix typo in CRUSH_CRIT_PARAPLEGIC

### DIFF
--- a/code/__DEFINES/crushing.dm
+++ b/code/__DEFINES/crushing.dm
@@ -8,7 +8,7 @@
 #define SUCCESSFULLY_FELL_OVER (1<<2)
 
 #define CRUSH_CRIT_SHATTER_LEGS "crush_crit_shatter_legs"
-#define CRUSH_CRIT_PARAPALEGIC "crush_crit_parapalegic"
+#define CRUSH_CRIT_PARAPLEGIC "crush_crit_paraplegic"
 #define CRUSH_CRIT_SQUISH_LIMB "crush_crit_pin"
 #define CRUSH_CRIT_HEADGIB "crush_crit_headgib"
 #define VENDOR_CRUSH_CRIT_PIN "vendor_crush_crit_pin"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -989,7 +989,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	var/list/weighted_crits = list()
 
 	weighted_crits[CRUSH_CRIT_SHATTER_LEGS] = 100
-	weighted_crits[CRUSH_CRIT_PARAPALEGIC] = 80
+	weighted_crits[CRUSH_CRIT_PARAPLEGIC] = 80
 	weighted_crits[CRUSH_CRIT_HEADGIB] = 20
 	weighted_crits[CRUSH_CRIT_SQUISH_LIMB] = 100
 
@@ -1028,7 +1028,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 			if(left_leg || right_leg)
 				carbon_target.visible_message(span_danger("[carbon_target]'s legs shatter with a sickening crunch!"), span_userdanger("Your legs shatter with a sickening crunch!"))
 			return TRUE
-		if(CRUSH_CRIT_PARAPALEGIC) // paralyze this binch
+		if(CRUSH_CRIT_PARAPLEGIC) // paralyze this binch
 			// the new paraplegic gets like 4 lines of losing their legs so skip them
 			if (!iscarbon(atom_target))
 				return FALSE


### PR DESCRIPTION
## About The Pull Request
```diff
- CRUSH_CRIT_PARAPALEGIC
+ CRUSH_CRIT_PARAPLEGIC
```

## Why It's Good For The Game
While I was fixing another error in the code with paralytics, I accidentally made a typo and found this "new" word. So if you look for a "paraplegic", you won't find one everywhere.

## Changelog

:cl:
fix: typo in CRUSH_CRIT_PARAPLEGIC
/:cl: