### PR TITLE
More Tramstation Map Fixes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15793,14 +15793,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/button/door/directional/north{
-	pixel_x = -6;
-	id = "QMLoaddoor"
-	},
-/obj/machinery/button/door/directional/north{
-	pixel_x = 6;
-	id = "QMLoaddoor2"
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Cargo - Warehouse North"
 	},
@@ -18463,6 +18455,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"frz" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	pixel_x = 6;
+	id = "QMLoaddoor2"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "frB" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/light/warm/directional/east,
@@ -57936,6 +57943,10 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
+	},
+/obj/machinery/button/door/directional/north{
+	pixel_x = -6;
+	id = "QMLoaddoor"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -182530,7 +182541,7 @@ aac
 aac
 aaa
 aaa
-akr
+cTU
 tjS
 hFV
 mmi
@@ -184586,8 +184597,8 @@ aac
 aac
 aac
 aac
-akr
-xAJ
+cTU
+frz
 bYR
 haS
 udQ

--- a/_maps/shuttles/emergency_tram.dmm
+++ b/_maps/shuttles/emergency_tram.dmm
@@ -149,10 +149,11 @@
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "aM" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "aO" = (
@@ -163,11 +164,12 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aQ" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
 /obj/docking_port/mobile/emergency{
 	name = "Tram emergency shuttle"
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -197,7 +199,8 @@
 /area/shuttle/escape)
 "aW" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+	name = "Emergency Shuttle Airlock";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)


### PR DESCRIPTION
## About The Pull Request
Moves the cargo conveyor buttons to the far sides of each airlock so they don't overlap once in-game. Fixes the tram emergency shuttle airlocks so they face the right way.

## Why It's Good For The Game
let players hit both buttons like intended

## Changelog
:cl:
fix: More various Tramstation-adjacent wallening fixes.
/:cl:
this will probably get more fixes but this is the only new issue i've heard about so far

Closes #85872