### PR TITLE
Indestructible windows now use proper sprites in mapping editors

### DIFF
--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -201,8 +201,8 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 
 /turf/closed/indestructible/opsglass
 	name = "window"
-	icon = MAP_SWITCH('icons/obj/structures/smooth/windows/plastitanium_window.dmi', 'icons/obj/structures/smooth/plastitanium_window.dmi')
-	icon_state = MAP_SWITCH("0-lower", "plastitanium_window-0")
+	icon = MAP_SWITCH('icons/obj/structures/smooth/windows/plastitanium_window.dmi', 'icons/obj/structures_spawners.dmi')
+	icon_state = MAP_SWITCH("0-lower", "plastitaniumwindow_spawner")
 	layer = ABOVE_OBJ_LAYER
 	opacity = FALSE
 	use_splitvis = FALSE


### PR DESCRIPTION

## About The Pull Request
Replaces old flat plastitanium glass sprite with the one that window spawners use for map editors

## Why It's Good For The Game

Mappers have a rough idea of what they'll see in-game

## Changelog
Nothing player-facing
