### PR TITLE
Replaces a locked cabinet that you cannot open in ninja den with an unlocked one

### DIFF
--- a/_maps/templates/lazy_templates/ninja_den.dmm
+++ b/_maps/templates/lazy_templates/ninja_den.dmm
@@ -1585,7 +1585,6 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
 "JV" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/item/food/grown/rice,
 /obj/item/food/grown/rice,
 /obj/item/food/grown/rice,
@@ -1601,6 +1600,9 @@
 /obj/item/food/grown/onion/red,
 /obj/item/food/grown/onion/red,
 /obj/item/food/grown/coffee,
+/obj/structure/closet/secure_closet/freezer/fridge/open{
+	name = "kitchen cabinet"
+	},
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
 "Kb" = (


### PR DESCRIPTION

## About The Pull Request

Title, ninja den had all refrigerators/cabinets unlocked by default except one, and you have no access while in there.

## Why It's Good For The Game

If you wanna cook something you'd usually want to have vegetables be accessible to you

## Changelog
:cl:
fix: Replaced a locked cabinet that you cannot open in ninja den with an unlocked one
/:cl:
