### PR TITLE
Installs bot pathing/delivery nodes on Runtimestation

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1181,6 +1181,13 @@
 /obj/structure/server,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"kK" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=4-Southeast";
+	location = "3-Northeast"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "kS" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
@@ -1436,6 +1443,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"tw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Center"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "tE" = (
 /obj/machinery/door/airlock/research,
 /turf/open/floor/iron/dark,
@@ -1708,6 +1722,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"AE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=2-Northwest";
+	location = "1-Southwest"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "Bp" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -2091,6 +2112,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"Kw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1-Southwest";
+	location = "4-Southeast"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "Kx" = (
 /obj/structure/table,
 /obj/item/analyzer{
@@ -2545,6 +2573,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"VB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=3-Northeast";
+	location = "2-Northwest"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "VJ" = (
 /obj/structure/sign/warning/docking/directional/north,
 /turf/open/floor/iron,
@@ -7469,14 +7504,14 @@ bE
 cS
 qv
 dJ
+VB
+dJ
+dJ
+tw
 dJ
 dJ
 dJ
-dJ
-dJ
-dJ
-dJ
-dJ
+AE
 dJ
 dJ
 cS
@@ -8113,14 +8148,14 @@ cJ
 by
 Pc
 dw
-dJ
+kK
 dJ
 dJ
 dI
 dJ
 dJ
 dJ
-dJ
+Kw
 dJ
 kf
 cS


### PR DESCRIPTION

## About The Pull Request

This adds some cargo delivery/simplebot pathing nodes to the center of Runtimestation.

![image](https://github.com/user-attachments/assets/bedc2d2d-183b-4a04-b384-cafef156fbbb)

The bot pathing goes clockwise, with the first node being at the bottom left.
## Why It's Good For The Game

Helpful for testing out bots and delivery pathing. Manually setting up these nodes is a pain.
## Changelog
:cl: Rhials
qol: Delivery/Bot pathing nodes have been added to the middle room of Runtime station.
/:cl:
