### PR TITLE
Clicking floor tiles now also closes curator/morgue doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -623,6 +623,10 @@
 	icon = 'icons/obj/doors/doormorgue.dmi'
 	icon_state = "closed"
 
+/obj/machinery/door/morgue/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/redirect_attack_hand_from_turf)
+
 /obj/machinery/door/morgue/update_icon_state()
 	. = ..()
 	if(animation && animation != "deny")


### PR DESCRIPTION

## About The Pull Request

This makes it so the "morgue doors" (more often seen on the curator's study or chaplain confession booth, tbh) also have `/datum/component/redirect_attack_hand_from_turf`.

## Why It's Good For The Game

Consistency, and just nice to have.

## Changelog
:cl:
qol: Clicking floor tiles now also closes curator/morgue doors, like with normal airlocks.
/:cl:
