### PR TITLE
[NO GBP] CytoPro Price Adjustment

### DIFF
--- a/code/modules/vending/cytopro.dm
+++ b/code/modules/vending/cytopro.dm
@@ -19,15 +19,15 @@
 		/obj/item/clothing/suit/bio_suit = 3,
 		/obj/item/clothing/head/bio_hood = 3,
 		/obj/item/reagent_containers/dropper = 5,
-		/obj/item/reagent_containers/syringe = 5
+		/obj/item/reagent_containers/syringe = 5,
+		/obj/item/petri_dish/random = 6
 	)
 	contraband = list(
 		/obj/item/knife/kitchen = 3,
-		/obj/item/petri_dish/random = 6
 	)
 	refill_canister = /obj/item/vending_refill/cytopro
-	default_price = PAYCHECK_CREW * 0.6
-	extra_price = PAYCHECK_COMMAND * 0.5
+	default_price = PAYCHECK_CREW * 1
+	extra_price = PAYCHECK_COMMAND * 0.75
 	payment_department = ACCOUNT_SCI
 
 /obj/item/vending_refill/cytopro

--- a/code/modules/vending/cytopro.dm
+++ b/code/modules/vending/cytopro.dm
@@ -27,7 +27,7 @@
 	)
 	refill_canister = /obj/item/vending_refill/cytopro
 	default_price = PAYCHECK_CREW * 1
-	extra_price = PAYCHECK_COMMAND * 0.75
+	extra_price = PAYCHECK_COMMAND * 0.5
 	payment_department = ACCOUNT_SCI
 
 /obj/item/vending_refill/cytopro


### PR DESCRIPTION

## About The Pull Request

Increases the default price of CytoPro items from 30 credits to 50 credits.
Also moves the pre-filled petri dish from contraband to the regular tab

## Why It's Good For The Game

When I originally made the CytoPro I didn't realize that departmental discounts were a thing that existed. So, I put a 30 credit price tag on the regular items only to find out that they actually only cost 6 credits in practice, a LOT cheaper than I was intending and lower than pretty much all the other departmental vendors. This should increase the price from 6 credits to 10 credits for scientists, which is still quite inexpensive but no longer absurdly so.
Also, the petri dishes don't really need to be in contraband since apparently they're the same ones that start in the smartfridge nearby, so there wasn't much point in hiding them.

## Changelog
:cl:
balance: The CytoPro has had prices raised to slightly more reasonable levels.
/:cl:
