### PR TITLE
[NO GBP] Fixes the chainsaw evolution for goldfishes

### DIFF
--- a/code/modules/fishing/fish/fish_evolution.dm
+++ b/code/modules/fishing/fish/fish_evolution.dm
@@ -119,6 +119,8 @@ GLOBAL_LIST_INIT(fish_evolutions, init_subtypes_w_path_keys(/datum/fish_evolutio
 	conditions_note = "The fish needs to be unusually big and aggressive"
 
 /datum/fish_evolution/chainsawfish/check_conditions(obj/item/fish/source, obj/item/fish/mate, obj/structure/aquarium/aquarium)
-	if(source.size >= 60 && source.size >= 1000 && (/datum/fish_trait/aggressive in source.fish_traits))
+	var/double_avg_size = /obj/item/fish/goldfish::average_size * 2
+	var/double_avg_weight = /obj/item/fish/goldfish::average_weight * 2
+	if(source.size >= double_avg_size && source.weight >= double_avg_weight && (/datum/fish_trait/aggressive in source.fish_traits))
 		return ..()
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
It was checking if the size was over 1000 instead of the weight. Also I'm changing the code to use the initial values of the average size and weight of goldfish, since I'm shrinking the lil' fella a bit in an upcoming PR.

## Why It's Good For The Game
Fixing an oopsie.

## Changelog

:cl:
fix: Fixes the chainsaw evolution for goldfishes.
/:cl:
