### PR TITLE
Fixes buckling to beds in some situations making you use the pillow as a footrest

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -881,6 +881,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 
 /// Possible value of [/atom/movable/buckle_lying]. If set to a different (positive-or-zero) value than this, the buckling thing will force a lying angle on the buckled.
 #define NO_BUCKLE_LYING -1
+/// Possible value of [/atom/movable/buckle_dir]. If set to a different (positive-or-zero) value than this, the buckling thing will force a dir on the buckled.
+#define BUCKLE_MATCH_DIR -1
 
 // Flags for fully_heal().
 

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -10,6 +10,7 @@
 	obj_flags = BLOCKS_CONSTRUCTION
 	can_buckle = TRUE
 	buckle_lying = 90
+	buckle_dir = WEST
 	circuit = /obj/item/circuitboard/machine/stasis
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
@@ -23,6 +24,7 @@
 /obj/machinery/stasis/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/elevation, pixel_shift = 6)
+	update_buckle_vars(dir)
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()
@@ -57,6 +59,14 @@
 		if(HAS_TRAIT(L, TRAIT_STASIS))
 			thaw_them(L)
 	return ..()
+
+/obj/machinery/stasis/setDir(newdir)
+	. = ..()
+	update_buckle_vars(newdir)
+
+/obj/machinery/stasis/proc/update_buckle_vars(newdir)
+	buckle_lying = newdir & NORTHEAST ? 270 : 90
+	buckle_dir = newdir & NORTHEAST ? EAST : WEST
 
 /obj/machinery/stasis/proc/stasis_running()
 	return stasis_enabled && is_operational

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -10,7 +10,7 @@
 	obj_flags = BLOCKS_CONSTRUCTION
 	can_buckle = TRUE
 	buckle_lying = 90
-	buckle_dir = WEST
+	buckle_dir = SOUTH
 	circuit = /obj/item/circuitboard/machine/stasis
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
@@ -66,7 +66,6 @@
 
 /obj/machinery/stasis/proc/update_buckle_vars(newdir)
 	buckle_lying = newdir & NORTHEAST ? 270 : 90
-	buckle_dir = newdir & NORTHEAST ? EAST : WEST
 
 /obj/machinery/stasis/proc/stasis_running()
 	return stasis_enabled && is_operational

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -3,6 +3,8 @@
 	var/can_buckle = FALSE
 	/// Bed-like behaviour, forces mob.lying = buckle_lying if not set to [NO_BUCKLE_LYING].
 	var/buckle_lying = NO_BUCKLE_LYING
+	/// Bed-like behaviour, sets mob dir to buckle_dir if not set to [BUCKLE_MATCH_DIR]. If set to [BUCKLE_MATCH_DIR], makes mob dir match ours.
+	var/buckle_dir = BUCKLE_MATCH_DIR
 	/// Require people to be handcuffed before being able to buckle. eg: pipes
 	var/buckle_requires_restraints = FALSE
 	/// The mobs currently buckled to this atom
@@ -106,7 +108,10 @@
 	M.set_glide_size(glide_size)
 
 	M.Move(loc)
-	M.setDir(dir)
+	if(buckle_dir == BUCKLE_MATCH_DIR)
+		M.setDir(dir)
+	else
+		M.setDir(buckle_dir)
 
 	//Something has unbuckled us in reaction to the above movement
 	if(!M.buckled)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -16,6 +16,7 @@
 	anchored = TRUE
 	can_buckle = TRUE
 	buckle_lying = 90
+	buckle_dir = WEST
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	integrity_failure = 0.35
@@ -33,6 +34,7 @@
 	AddElement(/datum/element/soft_landing)
 	if(elevation)
 		AddElement(/datum/element/elevation, pixel_shift = elevation)
+	update_buckle_vars(dir)
 	register_context()
 
 /obj/structure/bed/examine(mob/user)
@@ -51,6 +53,14 @@
 	else if(has_buckled_mobs())
 		context[SCREENTIP_CONTEXT_LMB] = "Unbuckle"
 		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/structure/bed/setDir(newdir)
+	. = ..()
+	update_buckle_vars(newdir)
+
+/obj/structure/bed/proc/update_buckle_vars(newdir)
+	buckle_lying = newdir & NORTHEAST ? 270 : 90
+	buckle_dir = newdir & NORTHEAST ? EAST : WEST
 
 /obj/structure/bed/atom_deconstruct(disassembled = TRUE)
 	if(build_stack_type)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -16,7 +16,7 @@
 	anchored = TRUE
 	can_buckle = TRUE
 	buckle_lying = 90
-	buckle_dir = WEST
+	buckle_dir = SOUTH
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	integrity_failure = 0.35
@@ -60,7 +60,6 @@
 
 /obj/structure/bed/proc/update_buckle_vars(newdir)
 	buckle_lying = newdir & NORTHEAST ? 270 : 90
-	buckle_dir = newdir & NORTHEAST ? EAST : WEST
 
 /obj/structure/bed/atom_deconstruct(disassembled = TRUE)
 	if(build_stack_type)


### PR DESCRIPTION
## About The Pull Request

Previously, buckling yourself to a bed would always tilt you by 90 degrees, meaning you would always have your head to the east regardless of the actual position of the pillow.
We fix this by updating `buckle_lying` to 270 degrees when in the `NORTH` or `EAST` positions.

Then, I noticed being buckled to a bed sets your dir to that of the bed, which just unintuitively rotates you. _Especially_ so given there's only two visual directions, but building a bed may grant it any of the four directions.
We resolve this by adding a `buckle_dir` parallel to `buckle_lying`, which allows objects to override what dir we should be set to face when buckling. This defaults to `BUCKLE_MATCH_DIR`, being the current behaviour of matching the atom dir.

This fixes our issues.

<details>
  <summary>Images</summary>
  
![image](https://github.com/user-attachments/assets/0053c5f8-b64d-459d-a626-00c43e896ded)
![image](https://github.com/user-attachments/assets/164371b8-5fbe-4973-839a-d96972ad45b8)
![image](https://github.com/user-attachments/assets/dc86797e-50ff-49e9-afd0-87c1c3c6f205)
![image](https://github.com/user-attachments/assets/46468b0a-af77-4249-a05f-3bc0a56d9fe2)
  
</details>

## Why It's Good For The Game


Looks a bit awkward to be forced to use your pillow like a footrest if your bed's a certain direction.
Also, awkward to have your dir upon being buckled be dependent on the direction it was built in, when this is not intuitive at all.

Fixes #84017.

## Changelog
:cl:
fix: Buckling yourself to a bed or stasis bed will now make you actually use the headrest/pillow and face up.
/:cl:
