### PR TITLE
Hides no longer clang like metal

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -346,6 +346,8 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	icon_state = "sheet-hairlesshide"
 	inhand_icon_state = null
 	merge_type = /obj/item/stack/sheet/hairlesshide
+	pickup_sound = 'sound/items/skin_pick_up.ogg'
+	drop_sound = 'sound/items/skin_drop.ogg'
 
 /obj/item/stack/sheet/hairlesshide/examine(mob/user)
 	. = ..()
@@ -359,6 +361,8 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	icon_state = "sheet-wetleather"
 	inhand_icon_state = null
 	merge_type = /obj/item/stack/sheet/wethide
+	pickup_sound = 'sound/items/skin_pick_up.ogg'
+	drop_sound = 'sound/items/skin_drop.ogg'
 	/// Reduced when exposed to high temperatures
 	var/wetness = 30
 	/// Kelvin to start drying


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4241

Just simply reuses the sound effects for dropping leather goods that was added here: https://github.com/tgstation/tgstation/pull/85254

## Why It's Good For The Game

Muh immersion

## Changelog

:cl:
fix: wet hides and hairless hides no longer make metal clanging noises when picked up/dropped
/:cl:

