### PR TITLE
Deletes teleport subtype of deathmatch area, removes consoles and gascanisters from species deathmatch. Changes some loadouts.

### DIFF
--- a/_maps/deathmatch/ragin_mages.dmm
+++ b/_maps/deathmatch/ragin_mages.dmm
@@ -8,7 +8,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "aT" = (
 /obj/item/cardboard_cutout/adaptive{
 	pixel_y = 14;
@@ -17,7 +17,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "bb" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -28,15 +28,15 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "bg" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "bv" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating/airless,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "co" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/carbon{
@@ -44,7 +44,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ct" = (
 /obj/structure/flora/bush/grassy/style_random,
 /mob/living/basic/pet/gondola{
@@ -52,24 +52,24 @@
 	faction = list("gondola", "Wizard")
 	},
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "cU" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "dj" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ds" = (
 /turf/open/floor/carpet/purple,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ez" = (
 /obj/structure/closet/crate,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "fH" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/griddle,
@@ -82,19 +82,19 @@
 	pixel_x = 9
 	},
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "fI" = (
 /turf/open/lava,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "gn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "gr" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/chair/wood,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "hg" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -104,14 +104,14 @@
 	dir = 8
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "hk" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 21;
 	pixel_x = -7
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "hK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/light_emitter{
@@ -120,20 +120,20 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ig" = (
 /obj/structure/table/wood,
 /obj/item/stack/medical/bruise_pack{
 	pixel_x = -12
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "iz" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "iL" = (
 /obj/effect/light_emitter{
 	set_cap = 2;
@@ -141,7 +141,7 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "iQ" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin{
@@ -149,42 +149,42 @@
 	pixel_x = 3
 	},
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "iZ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "jb" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/railing/corner/end/flip,
 /obj/structure/railing/corner/end,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "jg" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "jm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/mystery_box/wands,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "js" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "jM" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "jV" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "kl" = (
 /obj/structure/flora/bush/grassy/style_random,
 /obj/machinery/light/floor,
@@ -194,7 +194,7 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "li" = (
 /obj/structure/table,
 /obj/item/extinguisher{
@@ -206,7 +206,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "lM" = (
 /obj/structure/bed{
 	dir = 1
@@ -220,19 +220,19 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "lO" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "mu" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "mV" = (
 /obj/structure/railing{
 	dir = 4
@@ -242,40 +242,40 @@
 	},
 /obj/structure/mystery_box/tdome,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "nk" = (
 /obj/item/gun/magic/wand/death,
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "nx" = (
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "nQ" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "on" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "oP" = (
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "pe" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 21;
 	pixel_x = -7
 	},
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ph" = (
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "pv" = (
 /obj/effect/light_emitter{
 	set_cap = 2;
@@ -283,18 +283,18 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "pL" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /obj/structure/mystery_box/wands,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "pV" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "qx" = (
 /obj/effect/light_emitter{
 	set_cap = 2;
@@ -302,15 +302,15 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/carpet/purple,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "qY" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "rj" = (
 /obj/machinery/door/window/right/directional/east,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "rD" = (
 /obj/structure/railing{
 	dir = 4
@@ -319,11 +319,11 @@
 	dir = 8
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "sf" = (
 /obj/structure/mirror/directional/east,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "tL" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /mob/living/simple_animal/hostile/ooze/gelatinous{
@@ -331,7 +331,7 @@
 	faction = list("slime", "Wizard")
 	},
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ue" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/item/food/burger/yellow{
@@ -347,14 +347,14 @@
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ui" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "uz" = (
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "uR" = (
 /obj/item/clothing/shoes/sandal/magic{
 	pixel_y = 16
@@ -365,82 +365,82 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "vh" = (
 /obj/structure/mystery_box/wands,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "vv" = (
 /obj/vehicle/ridden/scooter/skateboard{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "vR" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "wd" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/mystery_box/wands,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "wl" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 1;
 	pixel_x = -6
 	},
 /turf/open/floor/carpet/purple,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "wL" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/gibber/autogibber,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "xk" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north{
 	pixel_y = 36
 	},
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "xs" = (
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "yA" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "zN" = (
 /obj/structure/mystery_box/wands,
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth/directional/north,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "zO" = (
 /obj/structure/closet,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Au" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "AD" = (
 /obj/structure/sign/departments/restroom/directional/west,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Bm" = (
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Cb" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/wood,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Cj" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs{
@@ -456,10 +456,10 @@
 	pixel_y = -10
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Cq" = (
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "CM" = (
 /obj/structure/railing/corner,
 /obj/structure/railing/corner{
@@ -477,7 +477,7 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "DK" = (
 /obj/structure/railing{
 	dir = 8
@@ -489,11 +489,11 @@
 	dir = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "DW" = (
 /obj/machinery/computer,
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Eh" = (
 /obj/effect/light_emitter{
 	set_cap = 2;
@@ -501,64 +501,64 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Fb" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Fm" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Fv" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Fx" = (
 /obj/item/target,
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "FL" = (
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Ge" = (
 /obj/item/flashlight/flare{
 	pixel_x = -5;
 	pixel_y = -12
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Gv" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 2;
 	pixel_x = 5
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "GC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "GZ" = (
 /obj/structure/curtain,
 /obj/machinery/shower/directional/north,
 /obj/item/soap/syndie,
 /turf/open/floor/noslip,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Hf" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 1;
 	pixel_x = -6
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Hs" = (
 /turf/template_noop,
 /area/template_noop)
@@ -572,17 +572,17 @@
 	pixel_y = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "HP" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "HS" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "IE" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/wizrobe/black{
@@ -594,40 +594,40 @@
 	pixel_x = 6
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "IM" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 2;
 	pixel_x = 5
 	},
 /turf/open/floor/carpet/purple,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Jm" = (
 /turf/closed/wall/mineral/wood,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Jo" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Kr" = (
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "KW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Le" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Mg" = (
 /obj/machinery/computer,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Nl" = (
 /obj/machinery/power/shuttle_engine/heater{
 	resistance_flags = 3
@@ -636,21 +636,21 @@
 	resistance_flags = 3
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Nm" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 21;
 	pixel_x = 6
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Nt" = (
 /obj/item/target{
 	pixel_y = 11
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "NW" = (
 /obj/structure/railing{
 	dir = 4
@@ -659,30 +659,30 @@
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Ok" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "OD" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "OK" = (
 /obj/item/kirbyplants/organic/plant10{
 	pixel_y = 21;
 	pixel_x = 6
 	},
 /turf/open/floor/carpet/red,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "PD" = (
 /obj/structure/table/wood,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Qj" = (
 /obj/structure/dresser,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "QH" = (
 /obj/structure/table,
 /obj/item/clothing/head/wizard{
@@ -690,19 +690,19 @@
 	pixel_x = 4
 	},
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "QT" = (
 /obj/structure/mystery_box/wands,
 /turf/open/floor/plastic,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "RB" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "RI" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "RT" = (
 /obj/machinery/power/shuttle_engine/heater{
 	resistance_flags = 3
@@ -711,14 +711,14 @@
 	resistance_flags = 3
 	},
 /turf/open/lava,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Sa" = (
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "SK" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Th" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/reinforced,
@@ -736,15 +736,15 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Vk" = (
 /obj/machinery/door/window/left/directional/east,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "VM" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Wl" = (
 /obj/structure/railing{
 	dir = 4
@@ -755,37 +755,37 @@
 	set_luminosity = 4
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "WX" = (
 /obj/machinery/vending/magivend,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Xv" = (
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "YP" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "YS" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "Zo" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/deathmatch/teleport)
+/area/deathmatch)
 "ZS" = (
 /obj/structure/railing/corner/end/flip,
 /turf/open/floor/iron,
-/area/deathmatch/teleport)
+/area/deathmatch)
 
 (1,1,1) = {"
 Hs

--- a/_maps/deathmatch/species_warfare.dmm
+++ b/_maps/deathmatch/species_warfare.dmm
@@ -34,10 +34,10 @@
 /area/deathmatch)
 "cd" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
-/obj/machinery/computer/crew{
+/obj/machinery/light/built/directional/south,
+/obj/machinery/computer{
 	dir = 4
 	},
-/obj/machinery/light/built/directional/south,
 /turf/open/indestructible/dark/smooth_large,
 /area/deathmatch)
 "cl" = (
@@ -71,18 +71,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/indestructible/white,
 /area/deathmatch)
 "dB" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/indestructible,
-/area/deathmatch)
-"dX" = (
-/obj/effect/turf_decal/tile/dark_blue/full,
-/obj/machinery/computer/communications,
-/turf/open/indestructible/dark/smooth_large,
 /area/deathmatch)
 "ee" = (
 /obj/effect/turf_decal/tile/green{
@@ -365,7 +359,6 @@
 /area/deathmatch)
 "oy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/indestructible,
 /area/deathmatch)
 "oD" = (
@@ -380,7 +373,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/nitrium,
 /turf/open/indestructible,
 /area/deathmatch)
 "pD" = (
@@ -420,7 +412,7 @@
 /area/deathmatch)
 "qV" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer{
 	dir = 8
 	},
 /turf/open/indestructible/dark/smooth_large,
@@ -495,7 +487,7 @@
 /area/deathmatch)
 "sx" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/machinery/computer/message_monitor{
+/obj/machinery/computer{
 	dir = 4
 	},
 /turf/open/indestructible/dark,
@@ -520,7 +512,7 @@
 /area/deathmatch)
 "tR" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer{
 	dir = 4
 	},
 /turf/open/indestructible/dark/smooth_large,
@@ -582,7 +574,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/nob,
 /obj/machinery/light/built/directional/south,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -709,10 +700,10 @@
 /area/deathmatch)
 "zt" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
-/obj/machinery/computer/crew{
+/obj/machinery/light/built/directional/south,
+/obj/machinery/computer{
 	dir = 8
 	},
-/obj/machinery/light/built/directional/south,
 /turf/open/indestructible/dark/smooth_large,
 /area/deathmatch)
 "zw" = (
@@ -1013,11 +1004,6 @@
 	},
 /turf/open/indestructible/plating,
 /area/deathmatch)
-"IU" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/indestructible,
-/area/deathmatch)
 "JL" = (
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
 /obj/structure/table/glass,
@@ -1034,11 +1020,6 @@
 "JX" = (
 /obj/item/melee/chainofcommand/tailwhip/kitty,
 /turf/open/floor/wood,
-/area/deathmatch)
-"JZ" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/indestructible,
 /area/deathmatch)
 "Ka" = (
 /obj/machinery/door/airlock{
@@ -1064,7 +1045,7 @@
 /area/deathmatch)
 "Lq" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
-/obj/machinery/computer/monitor,
+/obj/machinery/computer,
 /turf/open/indestructible/dark/smooth_large,
 /area/deathmatch)
 "Lr" = (
@@ -1087,8 +1068,6 @@
 "Mi" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
-/obj/item/grenade/gas_crystal/proto_nitrate_crystal,
-/obj/item/grenade/gas_crystal/nitrous_oxide_crystal,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -1152,7 +1131,7 @@
 /area/deathmatch)
 "ND" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/machinery/computer/message_monitor{
+/obj/machinery/computer{
 	dir = 8
 	},
 /turf/open/indestructible/dark,
@@ -1197,8 +1176,6 @@
 /area/deathmatch)
 "Ps" = (
 /obj/structure/table/reinforced,
-/obj/item/grenade/gas_crystal/healium_crystal,
-/obj/item/nitrium_crystal,
 /turf/open/indestructible,
 /area/deathmatch)
 "Qo" = (
@@ -1243,7 +1220,6 @@
 /area/deathmatch)
 "Sm" = (
 /obj/structure/table/reinforced,
-/obj/item/hypernoblium_crystal,
 /obj/item/grenade/gas_crystal/crystal_foam,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -1260,13 +1236,8 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/computer/rdconsole,
+/obj/machinery/computer,
 /turf/open/indestructible/white,
-/area/deathmatch)
-"Tl" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/turf/open/indestructible,
 /area/deathmatch)
 "To" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -1278,9 +1249,8 @@
 /turf/open/indestructible/dark,
 /area/deathmatch)
 "TZ" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/portable_atmospherics/canister/zauker,
-/turf/open/indestructible,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
 /area/deathmatch)
 "Uj" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -1411,7 +1381,7 @@ jw
 jw
 jw
 jw
-fA
+TZ
 rV
 jw
 jw
@@ -1664,7 +1634,7 @@ zJ
 wM
 BV
 pL
-Tl
+dv
 Za
 rV
 jw
@@ -1846,7 +1816,7 @@ jw
 (14,1,1) = {"
 rV
 Za
-dX
+Lq
 BL
 gI
 Vp
@@ -2005,9 +1975,9 @@ XZ
 XZ
 XZ
 Os
-IU
-JZ
-TZ
+dB
+dB
+dB
 dB
 zJ
 rV
@@ -2039,9 +2009,9 @@ Vl
 Vl
 Vl
 EC
-IU
-JZ
-TZ
+dB
+dB
+dB
 dB
 zJ
 jw
@@ -2409,7 +2379,7 @@ jw
 jw
 jw
 rV
-fA
+TZ
 rV
 jw
 jw

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -402,7 +402,7 @@
 	spells_to_add = list(
 		/datum/action/cooldown/spell/aoe/magic_missile,
 		/datum/action/cooldown/spell/forcewall,
-		/datum/action/cooldown/spell/jaunt/ethereal_jaunt,
+		/datum/action/cooldown/spell/pointed/projectile/fireball,
 	)
 
 /datum/outfit/deathmatch_loadout/wizard/pyro
@@ -1106,10 +1106,10 @@
 
 	spells_to_add = list(
 		/datum/action/cooldown/spell/touch/mansus_grasp,
-		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash,
+		/datum/action/cooldown/spell/conjure/cosmic_expansion,
 		/datum/action/cooldown/spell/pointed/projectile/star_blast,
 		/datum/action/cooldown/spell/touch/star_touch,
-		/datum/action/cooldown/spell/pointed/void_phase,
+		/datum/action/cooldown/spell/cone/staggered/cone_of_cold/void,
 		/datum/action/cooldown/spell/aoe/void_pull,
 	)
 

--- a/code/modules/deathmatch/deathmatch_mapping.dm
+++ b/code/modules/deathmatch/deathmatch_mapping.dm
@@ -11,13 +11,6 @@
 /obj/effect/landmark/deathmatch_player_spawn
 	name = "Deathmatch Player Spawner"
 
-/area/deathmatch/teleport //Prevent access to cross-z teleportation in the map itself (no wands of safety/teleportation scrolls). Cordons should prevent same-z teleportations outside of the arena.
-	area_flags = /area/deathmatch::area_flags & ~NOTELEPORT
-
-/area/deathmatch/teleport/fullbright
-	static_lighting = FALSE
-	base_lighting_alpha = 255
-
 // for the illusion of a moving train
 /turf/open/chasm/true/no_smooth/fake_motion_sand
 	name = "air"


### PR DESCRIPTION

## About The Pull Request

Deletes /area/deathmatch/teleport to prevent possible fuckups from mappers in the future, this only affects Ragin' Mages as Ragnarok already got its share of punishment. Species Warfare had ***functional*** robotics, RD and comms consoles so now all consoles have been replaced with base /obj/machinery/computer which does nothing. Additionally, removes all atmos-related things from it (canisters left in atmos are cosmetic and fully empty) - we do not need additional performance losses from already bad enough deathmatch.

To compensate for the changes, base wizard loadout had their jaunt replaced with fireball and heretics got cone of cold and cosmic expansion instead of ash jaunt and void phase.

## Why It's Good For The Game

Deathmatch already has a hefty performance impact on the server and we do not need to worsen it with atmos stuff. Teleport areas are a nightmare to deal with and leave a possibility of people either getting stuck in walls or escaping the area entirely which is a nightmare scenario. And being able to interact with the station through functional consoles is almost as bad.

## Changelog
:cl:
fix: Removed all ways of teleportation from deathmatch and replaced all consoles on a certain map with non-functional variants. Loadouts have been adjusted to account for this.
del: Species Warfare no longer has atmospherics-related equipment on it.
/:cl:
