### PR TITLE
Fixes polling returning a list full of nulls when not enough candidates are available

### DIFF
--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -175,6 +175,8 @@ SUBSYSTEM_DEF(polling)
 	UNTIL(new_poll.finished)
 	if(!(amount_to_pick > 0))
 		return new_poll.signed_up
+	if(length(new_poll.signed_up) < amount_to_pick)
+		return new_poll.signed_up
 	for(var/pick in 1 to amount_to_pick)
 		new_poll.chosen_candidates += pick_n_take(new_poll.signed_up)
 	if(announce_chosen)


### PR DESCRIPTION
## About The Pull Request

I was trying to fix an unrelated bug with abductors on a downstream that I'm not even sure exists on here and found another unrelated bug.

Turns out polling always returns the list of a requested size, except it fills in the empty spots with nulls.
![image](https://github.com/user-attachments/assets/9a9c8f0f-32eb-4106-98a6-2c61960960ca)

This makes this check completely broken, and runtimes abductors trying to spawn with null clients, making the one lone abductor spawn naked on the shuttle.
![image](https://github.com/user-attachments/assets/67707002-5898-4b40-99fd-24f8c8b9a167)

There might be an issue open for this but I was unable to find one

## Why It's Good For The Game

Uuuuh bugfix good.

See it working here
![image](https://github.com/user-attachments/assets/3be58814-ce4e-4b0f-a8d5-ec1efffb46df)
![image](https://github.com/user-attachments/assets/bd5ed3d0-60cf-44ac-88bd-822f1a2ea7e7)

## Changelog

:cl:
fix: SSPolling no longer fills in the candidate list with empty entries to guarantee it returns a list size of amount_to_pick
/:cl:

