### PR TITLE
New maintenance hazard: Smokey Remains

### DIFF
--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -180,14 +180,23 @@
 	else
 		return null
 
-///Returns a random reagent object minus blacklisted reagents
-/proc/get_random_reagent_id()
-	var/static/list/random_reagents = list()
-	if(!random_reagents.len)
+///Returns a random reagent object, with the option to blacklist reagents.
+/proc/get_random_reagent_id(list/blacklist)
+	var/static/list/reagent_static_list = list() //This is static, and will be used by default if a blacklist is not passed.
+	var/list/reagent_list_to_process
+	if(blacklist) //If we do have a blacklist, we recompile a new list with the excluded reagents not present and pick from there.
+		reagent_list_to_process = list()
+	else
+		reagent_list_to_process = reagent_static_list
+
+	if(!reagent_list_to_process.len)
 		for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
+			if(is_path_in_list(reagent_path, blacklist))
+				continue
 			if(initial(reagent_path.chemical_flags) & REAGENT_CAN_BE_SYNTHESIZED)
-				random_reagents += reagent_path
-	var/picked_reagent = pick(random_reagents)
+				reagent_list_to_process += reagent_path
+
+	var/picked_reagent = pick(reagent_list_to_process)
 	return picked_reagent
 
 ///Returns a random reagent consumable ethanol object minus blacklisted reagents

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -33,10 +33,7 @@
 	. = ..()
 
 	proximity_monitor = new(src, 1)
-	var/list/blocked_reagents = list()
-	for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
-		if(ispath(reagent_path, /datum/reagent/medicine) || ispath(reagent_path, /datum/reagent/consumable)) //Boooooriiiiing
-			blocked_reagents += reagent_path
+	var/list/blocked_reagents = subtypesof(/datum/reagent/medicine) + subtypesof(/datum/reagent/consumable) //Boooooriiiiing
 	that_shit_that_killed_saddam = get_random_reagent_id(blacklist = blocked_reagents)
 
 /obj/effect/decal/remains/human/smokey/HasProximity(atom/movable/tomb_raider)

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -41,7 +41,7 @@
 
 	if(iscarbon(tomb_raider))
 		var/mob/living/carbon/nearby_carbon = tomb_raider
-		if (nearby_carbon.move_intent != MOVE_INTENT_WALK || prob(15))
+		if(nearby_carbon.move_intent != MOVE_INTENT_WALK || prob(5))
 			release_smoke(nearby_carbon)
 			COOLDOWN_START(src, gas_cooldown, gas_cooldown_length)
 

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -33,7 +33,11 @@
 	. = ..()
 
 	proximity_monitor = new(src, 1)
-	that_shit_that_killed_saddam = generate_reagent()
+	var/list/blocked_reagents = list()
+	for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
+		if(ispath(reagent_path, /datum/reagent/medicine) || ispath(reagent_path, /datum/reagent/consumable)) //Boooooriiiiing
+			blocked_reagents += reagent_path
+	that_shit_that_killed_saddam = get_random_reagent_id(blacklist = blocked_reagents)
 
 /obj/effect/decal/remains/human/smokey/HasProximity(atom/movable/tomb_raider)
 	if(!COOLDOWN_FINISHED(src, gas_cooldown))
@@ -53,19 +57,6 @@
 	cigarette_puff.attach(get_turf(src))
 	cigarette_puff.set_up(range = 2, amount = DIAMOND_AREA(2), holder = src, location = get_turf(src), silent = TRUE)
 	cigarette_puff.start()
-
-///Returns a random reagent object minus blacklisted reagents and with other blocking conditions to make the potential choices more interesting.
-/obj/effect/decal/remains/human/smokey/proc/generate_reagent()
-	var/static/list/random_reagents = list()
-	if(!length(random_reagents))
-		for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
-			if(!(initial(reagent_path.chemical_flags) & REAGENT_CAN_BE_SYNTHESIZED))
-				continue
-			if(istype(reagent_path, /datum/reagent/medicine) || istype(reagent_path, /datum/reagent/consumable)) //Boooooriiiiing
-				continue
-			random_reagents += reagent_path
-	var/picked_reagent = pick(random_reagents)
-	return picked_reagent
 
 ///Subtype of smokey remains used for rare maintenance spawns.
 /obj/effect/decal/remains/human/smokey/maintenance

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -74,7 +74,7 @@
 
 /obj/effect/decal/remains/human/smokey/maintenance/Initialize(mapload)
 	. = ..()
-	gas_cooldown_length = rand(3 MINUTES, 5 MINUTES)
+	gas_cooldown_length = rand(4 MINUTES, 6 MINUTES)
 
 /obj/effect/decal/remains/plasma
 	icon_state = "remainsplasma"

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -23,6 +23,7 @@
 		/obj/effect/spawner/random/trash/mess = 30,
 		/obj/item/kirbyplants/fern = 20,
 		/obj/structure/closet/crate/decorations = 15,
+		/obj/effect/decal/remains/human/smokey/maintenance = 7,
 		/obj/structure/destructible/cult/pants_altar = 1,
 	)
 


### PR DESCRIPTION

## About The Pull Request

![tboi unlock](https://github.com/user-attachments/assets/c1cc3d10-85b1-450b-b404-1b00eeb5715b)

This implements a new rare maintenance spawn, smokey remains. Piles of bones that used to be Nanotrasen employees, still packed with whatever reagent finally did them in.

Rarely replacing a crate spawn (7/1007 chance per crate spawn if I'm doing the math right), these act as landmines for uncareful travelers in maintenance. When you get too close, one will release a cloud of a randomly generated reagents into the air (the same reagent every time, unique to the instance of remains). You can (mostly) avoid this by walking instead of running. These will "re-arm" themselves after 4-6 minutes. They're decals, so you can just sweep them away if they're a problem.

This also slightly tweaks the original iteration of this, which I used in my Smoking Room ruin. Don't worry about it.

I'm open to adjusting the rarity, cooldown, and selection of reagents if need be.
## Why It's Good For The Game

Makes maintenance a bit more spicy. Maybe dangerous, maybe beneficial, maybe it's baldium. Who knows! Better be careful just in case!

There's plenty of boring chemicals that could roll, but an interesting one could be a nice injection of uniqueness into an otherwise dull round. It's an infinite supply, but can only be dispensed infrequently (at a fixed location) and would be extremely difficult to harvest.

The rarity, combined with the variety of reagents that can be picked, make it unlikely that these will have any serious impact on a round (it's still possible, but rarely, which is good).
## Changelog
:cl: Rhials
add: Smokey remains have appeared in maintenance. Make sure to walk when near them!
/:cl:
