### PR TITLE
Refactor some usages of `get_step_towards` in loops to use `get_steps_to` instead

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -63,17 +63,17 @@
 	var/turf/target_turf = get_turf(target)
 	if(get_dist(source, target) > length)
 		return FALSE
-	var/steps = 1
 	if(current == target_turf)//they are on the same turf, source can see the target
 		return TRUE
-	current = get_step_towards(current, target_turf)
-	while(current != target_turf)
-		if(steps > length)
-			return FALSE
+	var/list/steps = get_steps_to(current, target_turf)
+	if(isnull(steps) || length(steps) > length)
+		return FALSE
+	for(var/direction in steps)
+		current = get_step(current, direction)
+		if(current == target_turf)
+			break
 		if(IS_OPAQUE_TURF(current))
 			return FALSE
-		current = get_step_towards(current, target_turf)
-		steps++
 	return TRUE
 
 ///Get the cardinal direction between two atoms

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -195,8 +195,12 @@
 		var/turf/inbetween_turf = center_turf
 
 		//this is the lowest overhead way of doing a loop in dm other than a goto. distance is guaranteed to be >= steps taken to target by this algorithm
-		for(var/step_counter in 1 to distance)
-			inbetween_turf = get_step_towards(inbetween_turf, target_turf)
+		var/list/steps = get_steps_to(inbetween_turf, target_turf)
+		if(isnull(steps))
+			return
+		steps.Cut(distance + 1)
+		for(var/direction in steps)
+			inbetween_turf = get_step(inbetween_turf, direction)
 
 			if(inbetween_turf == target_turf)//we've gotten to target's turf without returning due to turf opacity, so we must be able to see target
 				break

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -246,7 +246,8 @@
 	return TRUE
 
 /proc/CheckToolReach(atom/movable/here, atom/movable/there, reach)
-	if(!here || !there)
+	. = FALSE
+	if(QDELETED(here) || QDELETED(there))
 		return
 	switch(reach)
 		if(0)
@@ -257,14 +258,18 @@
 			var/obj/dummy = new(get_turf(here))
 			dummy.pass_flags |= PASSTABLE
 			dummy.SetInvisibility(INVISIBILITY_ABSTRACT)
-			for(var/i in 1 to reach) //Limit it to that many tries
-				var/turf/T = get_step(dummy, get_dir(dummy, there))
+			var/list/steps = get_steps_to(dummy, there)
+			if(isnull(steps) || length(steps) > reach) // If the path is further than the reach, no way we can reach it anyways.
+				qdel(dummy)
+				return FALSE
+			for(var/direction in steps)
+				var/turf/next_step = get_step(dummy, direction)
 				if(dummy.CanReach(there))
 					qdel(dummy)
 					return TRUE
-				if(!dummy.Move(T)) //we're blocked!
+				if(!dummy.Move(next_step)) // We're blocked, nope.
 					qdel(dummy)
-					return
+					return FALSE
 			qdel(dummy)
 
 /// Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)


### PR DESCRIPTION
## About The Pull Request

BYOND 515 added a new proc called `get_steps_to` - which is basically `get_step_towards`, but instead it returns a list of directions! Ain't that nifty and useful? So we can just calculate the path once.

Several helper procs - `can_see`, `CheckToolReach`, and `get_hearers_in_LOS`, use `get_step_towards` in a loop, so I've refactored them to just calculate the path once using `get_steps_to`, and then loop through the returned path of directions.

## Why It's Good For The Game

In theory, should micro-optimize performance, by only calculating the pathfinding once.

## Changelog
:cl:
refactor: Refactored some functions related to line-of-sight and reach to improve performance.
/:cl:
