### PR TITLE
Revolver in roundstart holsters is on the last slot and not on first

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -113,8 +113,8 @@
 
 /obj/item/storage/belt/holster/detective/full/PopulateContents()
 	generate_items_inside(list(
-		/obj/item/gun/ballistic/revolver/c38/detective = 1,
 		/obj/item/ammo_box/c38 = 2,
+		/obj/item/gun/ballistic/revolver/c38/detective = 1,
 	), src)
 
 /obj/item/storage/belt/holster/detective/full/ert
@@ -126,8 +126,8 @@
 
 /obj/item/storage/belt/holster/detective/full/ert/PopulateContents()
 	generate_items_inside(list(
-		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
 		/obj/item/ammo_box/magazine/m45 = 2,
+		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
 	),src)
 
 /obj/item/storage/belt/holster/chameleon
@@ -197,8 +197,8 @@
 
 /obj/item/storage/belt/holster/nukie/cowboy/full/PopulateContents()
 	generate_items_inside(list(
-		/obj/item/gun/ballistic/revolver/syndicate/cowboy/nuclear = 1,
 		/obj/item/ammo_box/a357 = 2,
+		/obj/item/gun/ballistic/revolver/syndicate/cowboy/nuclear = 1,
 	), src)
 
 


### PR DESCRIPTION
## Why It's Good For The Game
Always have to move revolver to the last slot, and if you don't, the hotkey will give you a speedloader instead, which is very annoying sometimes(especially in deathmatch).

:cl:
qol: revolver in roundstart holsters is on the last slot and not on first
/:cl:
