### PR TITLE
Stagger animation is no longer horrilbly jittery

### DIFF
--- a/code/datums/status_effects/debuffs/staggered.dm
+++ b/code/datums/status_effects/debuffs/staggered.dm
@@ -25,7 +25,7 @@
 	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/staggered)
 	// Resetting both X on remove so we're back to normal
-	animate(owner, pixel_x = owner.base_pixel_x, time = 0.2 SECONDS)
+	animate(owner, pixel_x = owner.base_pixel_x, time = 0.2 SECONDS, flags = ANIMATION_PARALLEL)
 
 /// Signal proc that self deletes our staggered effect
 /datum/status_effect/staggered/proc/clear_staggered(datum/source)
@@ -40,14 +40,16 @@
 		return
 	if(HAS_TRAIT(owner, TRAIT_FAKEDEATH))
 		return
-	owner.do_stagger_animation()
+	INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob/living, do_stagger_animation))
 
 /// Helper proc that causes the mob to do a stagger animation.
 /// Doesn't change significantly, just meant to represent swaying back and forth
 /mob/living/proc/do_stagger_animation()
-	animate(src, pixel_x = 4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
-	animate(pixel_x = -8, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
-	animate(pixel_x = 4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
+	animate(src, pixel_x = 4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
+	sleep(0.2 SECONDS)
+	animate(src, pixel_x = -8, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
+	sleep(0.2 SECONDS)
+	animate(src, pixel_x = 4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 
 /// Status effect specifically for instances where someone is vulnerable to being stunned when shoved.
 /datum/status_effect/next_shove_stuns

--- a/code/datums/status_effects/debuffs/staggered.dm
+++ b/code/datums/status_effects/debuffs/staggered.dm
@@ -4,7 +4,7 @@
 /// Staggered can occur most often via shoving, but can also occur in other places too.
 /datum/status_effect/staggered
 	id = "staggered"
-	tick_interval = 0.5 SECONDS
+	tick_interval = 0.8 SECONDS
 	alert_type = null
 	remove_on_fullheal = TRUE
 
@@ -25,7 +25,7 @@
 	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/staggered)
 	// Resetting both X on remove so we're back to normal
-	owner.pixel_x = owner.base_pixel_x
+	animate(owner, pixel_x = owner.base_pixel_x, time = 0.2 SECONDS)
 
 /// Signal proc that self deletes our staggered effect
 /datum/status_effect/staggered/proc/clear_staggered(datum/source)
@@ -45,8 +45,9 @@
 /// Helper proc that causes the mob to do a stagger animation.
 /// Doesn't change significantly, just meant to represent swaying back and forth
 /mob/living/proc/do_stagger_animation()
-	animate(src, pixel_x = 4, time = 0.2 SECONDS, loop = 6, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
-	animate(pixel_x = -4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
+	animate(src, pixel_x = 4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = -8, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = 4, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
 
 /// Status effect specifically for instances where someone is vulnerable to being stunned when shoved.
 /datum/status_effect/next_shove_stuns


### PR DESCRIPTION

## About The Pull Request

ANIMATION_PARALLEL and random loop was messing it up heavily, plus you only swayed to one side. Now its smoother, no longer teleports you around and you don't snap to the center of the tile the moment you unstagger

## Why It's Good For The Game

Current stagger animation is rather ugly and jittery, this should help fix its visuals.

## Changelog
:cl:
fix: Stagger animation is no longer horrilbly jittery
/:cl:
