### PR TITLE
Nanotrasen Delamination Crackdown Act - New Negative Station Trait, Supermatter Ban

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -119,6 +119,19 @@
 		if(is_station_level(apc.z) && prob(60))
 			apc.overload_lighting()
 
+/datum/station_trait/supermatter_ban
+	name = "Supermatter Ban"
+	trait_type = STATION_TRAIT_NEGATIVE
+	weight = 1
+	show_in_report = TRUE
+	report_message = "Recent delaminations in other stations have raised safety concerns over our Supermatter engine, please use alternative power sources while we sort things out."
+
+/datum/station_trait/supermatter_ban/on_round_start()
+	. = ..()
+	for(var/obj/machinery/power/supermatter_crystal/sm as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/supermatter_crystal))
+		if(is_station_level(sm.z))
+			qdel(sm)
+
 /datum/station_trait/empty_maint
 	name = "Cleaned out maintenance"
 	trait_type = STATION_TRAIT_NEGATIVE


### PR DESCRIPTION

## About The Pull Request

Adds a new negative station trait the "Supermatter Ban", which remove's the Supermatter crystal at the start of the round, forcing alternative power generation methods. I'm not super familiar with traits so if anything looks off, or unbalanced please let me know!

## Why It's Good For The Game

We have some pretty cool methods of generating power at the disposal of engineers and atmospheric techs that are rarely used because the SM can pretty much handle the station on it's own. This trait forces the engineering department to get creative into how they can power the station in other ways, be it solar panels, gas turbine (which is upgrade-able but I feel like rarely ever gets utilized), a bunch of Pac-Mans, whatever.

Engineer's can coordinate with cargo to order additional solar panels if the round start setup's are insufficient, cargo can order Pac-Mans to supplement power in important areas like med-bay, atmospheric techs can contribute to the station rather than doing their own thing, stuff like that.

Also more traits are cool, even the negative ones.

## Additional Note
Could be interesting if Supermatter shards from cargo were considered contraband cargo while this trait is active, but I want feedback on this idea before I spend more time on this.

## Changelog
:cl:
add: Adds new negative station trait "Supermatter Ban"
/:cl:
