### PR TITLE
Adds a second detective slot.

### DIFF
--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -5,8 +5,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_HEAD_OF_SECURITY)
 	faction = FACTION_STATION
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = SUPERVISOR_HOS
 	minimal_player_age = 7
 	exp_requirements = 300


### PR DESCRIPTION
## About The Pull Request
Adds a second detective slot.

## Why It's Good For The Game

As someone who's played a lot of detective on many different servers from LRP to MRP to HRP, the number one most boring thing as a detective is having nobody to bounce ideas and theories off of. This usually ends up being the Warden because he's the only person in Security who's not constantly busy.

Opening a second detective slot will play right into typical detective media, where the detective has a comrade or buddy or assistant that works with him to crack the case.

It'll drastically improve the feel of Detective, and will allow for more interesting Detective cases and stories and roleplaying to occur.

Look at these famous detective duos:

![Sam_ _Max](https://github.com/user-attachments/assets/25f0a2ac-d008-43be-8ec4-7d11abdb0c8d)
![breaking-bad-bryan-cranston-steven-michael-quezada](https://github.com/user-attachments/assets/0d81e844-f373-43bc-8162-948a52491176)
![x_files](https://github.com/user-attachments/assets/503938ae-344b-49e1-8456-080d623c8a2f)
![Disco-Elysium-Kim-and-Harry](https://github.com/user-attachments/assets/915e3d9e-b60a-4d97-b8eb-b4e2c0ab2b9c)


## Changelog
:cl:
add: Adds a second detective slot.
/:cl:
