### PR TITLE
Fixing three fishing issues in one PR.

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -262,12 +262,12 @@ GLOBAL_LIST_EMPTY(chasm_fallen_mobs)
 	. = ..()
 	if(isliving(gone))
 		UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
-		LAZYREMOVE(GLOB.chasm_fallen_mobs[get_chasm_category(loc)], arrived)
+		LAZYREMOVE(GLOB.chasm_fallen_mobs[get_chasm_category(loc)], gone)
 
 /obj/effect/abstract/chasm_storage/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	. = ..()
 	var/old_cat = get_chasm_category(old_turf)
-	var/new_cat = get_chasm_categeory(new_turf)
+	var/new_cat = get_chasm_category(new_turf)
 	var/list/mobs = list()
 	for(var/mob/fallen in src)
 		mobs += fallen
@@ -284,15 +284,15 @@ GLOBAL_LIST_EMPTY(chasm_fallen_mobs)
 	if(istype(area, /area/shuttle)) //shuttle move between z-levels, so they're a special case.
 		return area
 
-	if(is_away_level(turf))
+	if(is_away_level(z_level))
 		return ZTRAIT_AWAY
-	if(is_mining_level(turf))
+	if(is_mining_level(z_level))
 		return ZTRAIT_MINING
-	if(is_station_level(turf))
+	if(is_station_level(z_level))
 		return ZTRAIT_STATION
-	if(is_centcom_level(turf))
+	if(is_centcom_level(z_level))
 		return ZTRAIT_CENTCOM
-	if(is_reserved_level(turf))
+	if(is_reserved_level(z_level))
 		return ZTRAIT_RESERVED
 
 	return ZTRAIT_SPACE_RUINS

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -251,14 +251,51 @@ GLOBAL_LIST_EMPTY(chasm_fallen_mobs)
 /obj/effect/abstract/chasm_storage/Entered(atom/movable/arrived)
 	. = ..()
 	if(isliving(arrived))
+		 //Mobs that have fallen in reserved area should be deleted to avoid fishing stuff from the deathmatch or VR.
+		if(is_reserved_level(loc) && !istype(get_area(loc), /area/shuttle))
+			qdel(arrived)
+			return
 		RegisterSignal(arrived, COMSIG_LIVING_REVIVE, PROC_REF(on_revive))
-		GLOB.chasm_fallen_mobs += arrived
+		LAZYADD(GLOB.chasm_fallen_mobs[get_chasm_category(loc)], arrived)
 
 /obj/effect/abstract/chasm_storage/Exited(atom/movable/gone)
 	. = ..()
 	if(isliving(gone))
 		UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
-		GLOB.chasm_fallen_mobs -= gone
+		LAZYREMOVE(GLOB.chasm_fallen_mobs[get_chasm_category(loc)], arrived)
+
+/obj/effect/abstract/chasm_storage/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
+	. = ..()
+	var/old_cat = get_chasm_category(old_turf)
+	var/new_cat = get_chasm_categeory(new_turf)
+	var/list/mobs = list()
+	for(var/mob/fallen in src)
+		mobs += fallen
+	LAZYREMOVE(GLOB.chasm_fallen_mobs[old_cat], mobs)
+	LAZYADD(GLOB.chasm_fallen_mobs[new_cat], mobs)
+
+/**
+ * Returns a key to store, remove and access fallen mobs depending on the z-level.
+ * This stops rescuing people from places that are waaaaaaaay too far-fetched.
+ */
+/proc/get_chasm_category(turf/turf)
+	var/z_level = turf?.z
+	var/area/area = get_area(turf)
+	if(istype(area, /area/shuttle)) //shuttle move between z-levels, so they're a special case.
+		return area
+
+	if(is_away_level(turf))
+		return ZTRAIT_AWAY
+	if(is_mining_level(turf))
+		return ZTRAIT_MINING
+	if(is_station_level(turf))
+		return ZTRAIT_STATION
+	if(is_centcom_level(turf))
+		return ZTRAIT_CENTCOM
+	if(is_reserved_level(turf))
+		return ZTRAIT_RESERVED
+
+	return ZTRAIT_SPACE_RUINS
 
 #define CHASM_TRAIT "chasm trait"
 /**

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -252,7 +252,7 @@ GLOBAL_LIST_EMPTY(chasm_fallen_mobs)
 	. = ..()
 	if(isliving(arrived))
 		 //Mobs that have fallen in reserved area should be deleted to avoid fishing stuff from the deathmatch or VR.
-		if(is_reserved_level(loc) && !istype(get_area(loc), /area/shuttle))
+		if(is_reserved_level(loc.z) && !istype(get_area(loc), /area/shuttle))
 			qdel(arrived)
 			return
 		RegisterSignal(arrived, COMSIG_LIVING_REVIVE, PROC_REF(on_revive))

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -251,7 +251,7 @@ GLOBAL_LIST_EMPTY(chasm_fallen_mobs)
 /obj/effect/abstract/chasm_storage/Entered(atom/movable/arrived)
 	. = ..()
 	if(isliving(arrived))
-		 //Mobs that have fallen in reserved area should be deleted to avoid fishing stuff from the deathmatch or VR.
+		//Mobs that have fallen in reserved area should be deleted to avoid fishing stuff from the deathmatch or VR.
 		if(is_reserved_level(loc.z) && !istype(get_area(loc), /area/shuttle))
 			qdel(arrived)
 			return

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 /// This also includes all mobs fallen into chasms, regardless of distance
 /datum/chasm_detritus/restricted/bodies/get_chasm_contents(turf/fishing_spot)
 	. = ..()
-	. |= GLOB.chasm_fallen_mobs
+	. |= GLOB.chasm_fallen_mobs[get_chasm_category(fishing_spot)]
 
 /// Body detritus is selected in favor of bodies belonging to sentient mobs
 /// The first sentient body found in the list of contents is returned, otherwise

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -138,9 +138,10 @@
 		return
 	//Try to move it 'till it's under the user's feet, then try to pick it up
 	if(isitem(currently_hooked))
-		step_towards(currently_hooked, get_turf(src))
-		if(currently_hooked.loc == user.loc)
-			user.put_in_inactive_hand(currently_hooked)
+		var/obj/item/item = currently_hooked
+		step_towards(item, get_turf(src))
+		if(item.loc == user.loc && (item.interaction_flags_item & INTERACT_ITEM_ATTACK_HAND_PICKUP))
+			user.put_in_inactive_hand(item)
 			QDEL_NULL(fishing_line)
 	//Not an item, so just delete the line if it's adjacent to the user.
 	else if(get_dist(currently_hooked,get_turf(src)) > 1)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -38,6 +38,12 @@
 	if(faction)
 		faction = string_list(faction)
 
+/obj/effect/mob_spawn/Destroy()
+	spawned_mob_ref = null
+	if(istype(outfit))
+		QDEL_NULL(outfit)
+	return ..()
+
 /// Creates whatever mob the spawner makes. Return FALSE if we want to exit from here without doing that, returning NULL will be logged to admins.
 /obj/effect/mob_spawn/proc/create(mob/mob_possessor, newname)
 	var/mob/living/spawned_mob = new mob_type(get_turf(src)) //living mobs only
@@ -137,7 +143,7 @@
 	SSpoints_of_interest.make_point_of_interest(src)
 	LAZYADD(GLOB.mob_spawners[name], src)
 
-/obj/effect/mob_spawn/Destroy()
+/obj/effect/mob_spawn/ghost_role/Destroy()
 	var/list/spawners = GLOB.mob_spawners[name]
 	LAZYREMOVE(spawners, src)
 	if(!LAZYLEN(spawners))
@@ -261,6 +267,7 @@
 
 ///these mob spawn subtypes trigger immediately (New or Initialize) and are not player controlled... since they're dead, you know?
 /obj/effect/mob_spawn/corpse
+	density = FALSE //these are pretty much abstract objects that leave a corpse in their place.
 	///when this mob spawn should auto trigger.
 	var/spawn_when = CORPSE_INSTANT
 


### PR DESCRIPTION
## About The Pull Request
This will fix #83730, fix #85985 and fix #86033.

## Why It's Good For The Game
See above.

## Changelog

:cl:
fix: You can no longer pickup closets and crates wrapped in a package with a fishing rod.
fix: Fixed a few harddel issues with mob spawns that caused charred corpses fished from lavaland to create an invisible blockade.
fix: Fixed being able to fish up mobs that have fallen in totally different z-levels with a rescue hook (i.e. from bitrunning domains to lavaland).
/:cl:
