### PR TITLE
Blackbox logging for remaining time on anomaly defusal

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -95,7 +95,15 @@
 
 /obj/effect/anomaly/proc/anomalyNeutralize()
 	new /obj/effect/particle_effect/fluid/smoke/bad(loc)
-	SSblackbox.record_feedback("nested tally", "anomaly_defused", 1, list("[type]", "[immortal ? "N/A" : round((death_time - world.time) / 10)]"))
+	SSblackbox.record_feedback(
+		"nested tally",
+		"anomaly_defused",
+		1,
+		list(
+			"[type]",
+			immortal ? "immortal" : "[round((death_time - world.time) / 10)]ds time left",
+		)
+	)
 
 	if(drops_core)
 		if(isnull(anomaly_core))

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -95,6 +95,7 @@
 
 /obj/effect/anomaly/proc/anomalyNeutralize()
 	new /obj/effect/particle_effect/fluid/smoke/bad(loc)
+	SSblackbox.record_feedback("nested tally", "anomaly_defused", 1, list("[type]", "[immortal ? "N/A" : round((death_time - world.time) / 10)]"))
 
 	if(drops_core)
 		if(isnull(anomaly_core))


### PR DESCRIPTION
## About The Pull Request

Back in 2023 in PR #74666 Mothblocks said:
`We really should collect data on how many people collect anomalies and how much time they had left.`
Now here in 2024 it occurs to me that I don't think we actually log that information anywhere. So I added it.

Please note: I don't remember how blackbox logging works so while I think this works it might not be the correct way to format the data. Please tell me if it isn't.

## Why It's Good For The Game

`We really should collect data on how many people collect anomalies and how much time they had left.`

## Changelog

Not player facing