### PR TITLE
Adds randomly missing cables in Birdshot SM + brings filters inline with other SMs

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -9615,6 +9615,7 @@
 	cycle_id = "engine_airlock_1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/main)
 "dLQ" = (
@@ -12437,6 +12438,14 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"eKa" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 1;
+	filter_type = list(/datum/gas/nitrogen)
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "eKf" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets/donkpocketpizza,
@@ -29642,6 +29651,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/supermatter/room)
 "kse" = (
@@ -29794,6 +29804,13 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/dock)
+"ktY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/engineering/supermatter/room)
 "kua" = (
 /obj/structure/table,
 /obj/item/disk/cargo{
@@ -88573,7 +88590,7 @@ fXd
 fXd
 qrX
 pyj
-bag
+ktY
 bag
 fEW
 ugF
@@ -88831,7 +88848,7 @@ sxK
 qrX
 pyj
 ksd
-fXd
+kEf
 xgW
 nor
 oPa
@@ -90107,7 +90124,7 @@ mER
 ujm
 gqx
 qEL
-dAd
+eKa
 toE
 hqU
 dla


### PR DESCRIPTION

## About The Pull Request

There's some missing cables on Birdshot that power the emitters and secure storage. Which might explain why there are so many delaminations on this map.

Also changed the first filter in the SM waste cooling loop to have N2 on by default on mapload as they are in most other maps. 

<details>
  <summary>Before</summary> 
 
![Capture](https://github.com/user-attachments/assets/f9c8a5aa-97d9-43e8-b20b-6839d3b50f46)


</details>
<details>
  <summary>After</summary> 
 
![Capture1](https://github.com/user-attachments/assets/64383db0-a15b-4b04-b01d-53848d78878f)

</details>

Also! This is my first time using strongDMM to edit maps for a PR. I've manually setup the SM twice on the updated version and no holes in reality have formed but please- Inspect my changes closely. If something was wrong I wouldn't know the difference.

## Why It's Good For The Game

Setting the SM up is both vital for the stations survival, confusing for new engineers and a chore for experienced engineers. These changes bring Birdshot's SM more in line with the others. Here's hoping this reduces the amount of instant delam-shuttle rounds on Birdshot.

## Changelog

:cl:TwistedSilicon
qol: Updated Birdshot's SM first waste filter to be on N2 by default as to prevent engineering dumping their entire supply into space roundstart.
fix: Added a few missing cables that powered the emitters and secure storage on Birdshot.
/:cl:

