### PR TITLE
Fixes Light Overload draining almost no power and Powersinks draining almost no APC charge. Also rebalances powersinks

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -171,7 +171,7 @@
 		if(istype(terminal.master, /obj/machinery/power/apc))
 			var/obj/machinery/power/apc/apc = terminal.master
 			if(apc.operating && apc.cell)
-				drained += 0.001 * apc.cell.use(0.05 * STANDARD_BATTERY_CHARGE, force = TRUE)
+				drained += 0.001 * apc.cell.use(0.1 * STANDARD_BATTERY_CHARGE, force = TRUE)
 	internal_heat += drained
 
 /obj/item/powersink/process()

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -23,7 +23,7 @@
 	throw_speed = 1
 	throw_range = 2
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT* 7.5)
-	var/max_heat = 5e7 // Maximum contained heat before exploding. Not actual temperature.
+	var/max_heat = 100 * STANDARD_BATTERY_CHARGE // Maximum contained heat before exploding. Not actual temperature.
 	var/internal_heat = 0 // Contained heat, goes down every tick.
 	var/mode = DISCONNECTED // DISCONNECTED, CLAMPED_OFF, OPERATING
 	var/warning_given = FALSE //! Stop warning spam, only warn the admins/deadchat once that we are about to boom.
@@ -145,7 +145,7 @@
 	var/temp_to_give = internal_heat / FRACTION_TO_RELEASE
 	internal_heat -= temp_to_give
 	var/datum/gas_mixture/environment = our_turf.return_air()
-	var/delta_temperature = temp_to_give / environment.heat_capacity()
+	var/delta_temperature = (temp_to_give / 100) / environment.heat_capacity()
 	if(delta_temperature)
 		environment.temperature += delta_temperature
 		air_update_turf(FALSE, FALSE)
@@ -171,7 +171,7 @@
 		if(istype(terminal.master, /obj/machinery/power/apc))
 			var/obj/machinery/power/apc/apc = terminal.master
 			if(apc.operating && apc.cell)
-				drained += 0.001 * apc.cell.use(0.05 * STANDARD_CELL_CHARGE, force = TRUE)
+				drained += 0.001 * apc.cell.use(0.05 * STANDARD_BATTERY_CHARGE, force = TRUE)
 	internal_heat += drained
 
 /obj/item/powersink/process()

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -2,9 +2,9 @@
 #define CLAMPED_OFF 1
 #define OPERATING 2
 
-#define FRACTION_TO_RELEASE 50
+#define FRACTION_TO_RELEASE 25
 #define ALERT 90
-#define MINIMUM_HEAT 10000
+#define MINIMUM_HEAT 20000
 
 // Powersink - used to drain station power
 
@@ -145,7 +145,7 @@
 	var/temp_to_give = internal_heat / FRACTION_TO_RELEASE
 	internal_heat -= temp_to_give
 	var/datum/gas_mixture/environment = our_turf.return_air()
-	var/delta_temperature = (temp_to_give / 100) / environment.heat_capacity()
+	var/delta_temperature = temp_to_give / environment.heat_capacity()
 	if(delta_temperature)
 		environment.temperature += delta_temperature
 		air_update_turf(FALSE, FALSE)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -670,7 +670,7 @@
 /obj/machinery/power/apc/proc/overload_lighting()
 	if(!operating || shorted)
 		return
-	if(cell && cell.use(0.02 * STANDARD_CELL_CHARGE))
+	if(cell && cell.use(0.02 * STANDARD_BATTERY_CHARGE))
 		INVOKE_ASYNC(src, PROC_REF(break_lights))
 
 /obj/machinery/power/apc/proc/break_lights()


### PR DESCRIPTION
## About The Pull Request

Fixes #85779,
Fixes #86041
APCs use batteries instead of cells now, and overload and power sink APC drain were made to scale off of cell capacity instead of battery capacity. Power sinks were not adjusted at all to match the new power changes. 

## Why It's Good For The Game
## Changelog
:cl:
fix: Fixed light overloads not draining significant amounts of energy.
fix: Power sinks now drain APCs at a significant rate instead of glacially slow.
balance: Power sinks are adjusted to not explode within 30 seconds of the average power output a station produces.
/:cl:
