### PR TITLE
fixes blob spore and slime AI endlessly attacking the dead

### DIFF
--- a/code/modules/mob/living/basic/blob_minions/blob_ai.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_ai.dm
@@ -46,7 +46,7 @@
 	ai_movement = /datum/ai_movement/jps
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
-		/datum/ai_planning_subtree/find_and_hunt_target/corpses,
+		/datum/ai_planning_subtree/find_and_hunt_target/corpses/human,
 		/datum/ai_planning_subtree/travel_to_point/and_clear_target,
 		/datum/ai_planning_subtree/simple_find_target,
 		/datum/ai_planning_subtree/attack_obstacle_in_path,

--- a/code/modules/mob/living/basic/slime/ai/behaviours.dm
+++ b/code/modules/mob/living/basic/slime/ai/behaviours.dm
@@ -30,14 +30,14 @@
 /datum/ai_behavior/find_hunt_target/find_slime_food/valid_dinner(mob/living/basic/slime/hunter, mob/living/dinner, radius, datum/ai_controller/controller, seconds_per_tick)
 
 	if(REF(dinner) in hunter.faction) //Don't eat our friends...
-		return
+		return FALSE
 
 	var/static/list/slime_faction = list(FACTION_SLIME)
 	if(faction_check(slime_faction, dinner.faction)) //Don't try to eat slimy things, no matter how hungry we are. Anyone else can be betrayed.
-		return
+		return FALSE
 
 	if(!hunter.can_feed_on(dinner, check_adjacent = FALSE)) //Are they tasty to slimes?
-		return
+		return FALSE
 
 	//If we are retaliating on someone edible, lets eat them instead
 	if(dinner == controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET])
@@ -73,6 +73,6 @@
 
 /datum/ai_behavior/hunt_target/unarmed_attack_target/slime/finish_action(datum/ai_controller/controller, succeeded, hunting_target_key, hunting_cooldown_key)
 	. = ..()
-	var/mob/living/living_pawn = controller.pawn
-	if(living_pawn.buckled)
+	var/mob/living/basic/slime/slime_pawn = controller.pawn
+	if(!slime_pawn.can_feed_on(hunted))
 		controller.clear_blackboard_key(hunting_target_key)

--- a/code/modules/mob/living/basic/slime/ai/behaviours.dm
+++ b/code/modules/mob/living/basic/slime/ai/behaviours.dm
@@ -74,5 +74,6 @@
 /datum/ai_behavior/hunt_target/unarmed_attack_target/slime/finish_action(datum/ai_controller/controller, succeeded, hunting_target_key, hunting_cooldown_key)
 	. = ..()
 	var/mob/living/basic/slime/slime_pawn = controller.pawn
-	if(!slime_pawn.can_feed_on(hunted))
+	var/atom/target = controller.blackboard[hunting_target_key]
+	if(!slime_pawn.can_feed_on(target))
 		controller.clear_blackboard_key(hunting_target_key)

--- a/code/modules/mob/living/basic/slime/ai/subtrees.dm
+++ b/code/modules/mob/living/basic/slime/ai/subtrees.dm
@@ -31,11 +31,11 @@
 /datum/ai_planning_subtree/find_and_hunt_target/find_slime_food/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	var/mob/living/living_pawn = controller.pawn
 	if(living_pawn.buckled)
-		return FALSE
+		return
 
 	//Slimes don't want to hunt if they are neither rabid, hungry or feeling attack right now
 	if( (controller.blackboard[BB_SLIME_HUNGER_LEVEL] == SLIME_HUNGER_NONE) && !controller.blackboard[BB_SLIME_RABID] && isnull(controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET]))
-		return FALSE
+		return
 
 	return ..()
 

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -288,7 +288,7 @@
 /mob/living/basic/slime/proc/on_slime_pre_attack(mob/living/basic/slime/our_slime, atom/target, proximity, modifiers)
 	SIGNAL_HANDLER
 
-	if(LAZYACCESS(modifiers, RIGHT_CLICK) && isliving(target) && target != src && usr == src)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK) && isliving(target) && target != src)
 		if(our_slime.can_feed_on(target))
 			our_slime.start_feeding(target)
 		return COMPONENT_HOSTILE_NO_ATTACK


### PR DESCRIPTION

## About The Pull Request
these were 2 seperate issues to do with each's AI. spores should only be looking for corpses they can infect and slimes would endlesly attack people they can no longer feed on

## Why It's Good For The Game
closes #86000

## Changelog
:cl:
fix: fixes blob spore and slime AI endlessly attacking the dead
/:cl:
