### PR TITLE
Prevents persistence from trying to load more engravings than exists

### DIFF
--- a/code/controllers/subsystem/persistence/engravings.dm
+++ b/code/controllers/subsystem/persistence/engravings.dm
@@ -27,7 +27,7 @@
 
 	var/successfully_loaded_engravings = 0
 
-	for(var/iteration in 1 to rand(MIN_PERSISTENT_ENGRAVINGS, MAX_PERSISTENT_ENGRAVINGS))
+	for(var/iteration in 1 to min(rand(MIN_PERSISTENT_ENGRAVINGS, MAX_PERSISTENT_ENGRAVINGS), saved_engravings.len))
 		var/engraving = pick_n_take(saved_engravings)
 		if(!islist(engraving))
 			stack_trace("something's wrong with the engraving data! one of the saved engravings wasn't a list!")


### PR DESCRIPTION

## About The Pull Request

During initializing persistent wall engravings, the game picked a number between 15 and 25, and attempted to load that many. However, if there were less engravings than that, the loop went on even after the list it was calling `pick_n_take` on was empty, and multiple times it has logged a runtime claiming that the engraving was in an incorrect format when it tried to parse the returned nulls. 

This PR ensures that the game will not attempt to load more engravings than the amount that exists in the persistence files, ensuring less incorrect error messages during initialization.

## Why It's Good For The Game

Less incorrect lines during initialization on maps that have not received enough engravings.

## Changelog

Nothing player facing.
