### PR TITLE
Moves deletion for dreamluau objects to happen at the very end of the Destroy proc.

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -111,9 +111,6 @@
 	tag = null
 	datum_flags &= ~DF_USE_TAG //In case something tries to REF us
 	weak_reference = null //ensure prompt GCing of weakref.
-	if(!(datum_flags & DF_STATIC_OBJECT))
-		DREAMLUAU_CLEAR_REF_USERDATA(vars) // vars ceases existing when src does, so we need to clear any lua refs to it that exist.
-		DREAMLUAU_CLEAR_REF_USERDATA(src)
 
 	if(_active_timers)
 		var/list/timers = _active_timers
@@ -144,6 +141,10 @@
 
 	_clear_signal_refs()
 	//END: ECS SHIT
+
+	if(!(datum_flags & DF_STATIC_OBJECT))
+		DREAMLUAU_CLEAR_REF_USERDATA(vars) // vars ceases existing when src does, so we need to clear any lua refs to it that exist.
+		DREAMLUAU_CLEAR_REF_USERDATA(src)
 
 	return QDEL_HINT_QUEUE
 


### PR DESCRIPTION

## About The Pull Request
As the title says

## Why It's Good For The Game
Dreamluau objects should only really be nulled out right before deletion handling is complete, since it makes logical sense for lua to have a handle on these objects up until they're queued for deletion. It's slightly different from weakrefs in the fact that a weakref is not going to handle signals, but a lua script can, so it makes sense for the nulling out to happen after ECS cleanup is complete.

No changelog necessary since it's not fixing any particular bug
