### PR TITLE
When silicons use their radio they don't whisper

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -25,7 +25,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		return
+		return .
 	if(message_mods[MODE_HEADSET])
 		if(radio)
 			radio.talk_into(src, message, , spans, language, message_mods)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -23,7 +23,18 @@
 	if(!radio_enabled) //AI cannot speak if radio is disabled (via intellicard) or depowered.
 		to_chat(src, span_danger("Your radio transmitter is offline!"))
 		return FALSE
-	..()
+	. = ..()
+	if(.)
+		return
+	if(message_mods[MODE_HEADSET])
+		if(radio)
+			radio.talk_into(src, message, , spans, language, message_mods)
+		return NOPASS
+	else if(message_mods[RADIO_EXTENSION] in GLOB.radiochannels)
+		if(radio)
+			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return NOPASS
+	return FALSE
 
 //For holopads only. Usable by AI.
 /mob/living/silicon/ai/proc/holopad_talk(message, language)

--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -82,10 +82,10 @@
 	if(message_mods[MODE_HEADSET])
 		if(radio)
 			radio.talk_into(src, message, , spans, language, message_mods)
-		return REDUCE_RANGE
+		return NOPASS
 	else if(message_mods[RADIO_EXTENSION] in GLOB.radiochannels)
 		if(radio)
 			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
+			return NOPASS
 
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

If a borg or AI uses their internal radio they won't whisper

## Why It's Good For The Game

It's the internal radio of a robot duh. Makes them feel more robotic and it's cool

## Changelog
:cl:
balance: When silicons use their radio they will not whisper out loud anymore
/:cl:
