### PR TITLE
Introduces the ability to send legally distinct spam mail over fax (and cookies, please accept them)

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -43,6 +43,8 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 		/obj/item/card,
 		/obj/item/folder/biscuit,
 		/obj/item/food/breadslice,
+		/obj/item/food/chapslice,
+		/obj/item/food/grilled_chapslice,
 		/obj/item/food/pizza/flatbread,
 		/obj/item/food/pizzaslice,
 		/obj/item/food/root_flatbread,

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -44,6 +44,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 		/obj/item/folder/biscuit,
 		/obj/item/food/breadslice,
 		/obj/item/food/chapslice,
+		/obj/item/food/cookie,
 		/obj/item/food/grilled_chapslice,
 		/obj/item/food/pizza/flatbread,
 		/obj/item/food/pizzaslice,


### PR DESCRIPTION

## About The Pull Request

I joked about faxing spam (the food), and later cookies, and then remembered the hacked input servos and made this pr.
This just adds slices of chap and cookies to the list of items that can be faxed by fax machines with hacked input servos.
## Why It's Good For The Game

They're flat shapes like the other exotic fax items, and most importantly I think it's incredibly funny to send spam (chap, the food, legally distinct) over the fax. Same with cookies, accept cookies joke.
## Changelog
:cl:
balance: Fax machines with hacked input servos can now send chap slices and cookies. Please accept them.
/:cl:
