### PR TITLE
Plexagon Crew Manifest is accessible and free to everyone.

### DIFF
--- a/code/modules/modular_computers/computers/item/disks/role_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/role_disks.dm
@@ -6,7 +6,6 @@
 	max_capacity = 32
 	///Static list of programss ALL command tablets have.
 	var/static/list/datum/computer_file/command_programs = list(
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/status,
 	)
@@ -74,7 +73,6 @@
 	icon_state = "datadisk9"
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-		/datum/computer_file/program/crew_manifest,
 	)
 
 /**

--- a/code/modules/modular_computers/computers/item/disks/unique_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/unique_disks.dm
@@ -23,7 +23,6 @@
 		/datum/computer_file/program/supermatter_monitor,
 		/datum/computer_file/program/newscaster,
 		/datum/computer_file/program/secureye,
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 	)
 	potential_programs += subtypesof(/datum/computer_file/program/maintenance) - /datum/computer_file/program/maintenance/theme

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -38,6 +38,7 @@
 		/datum/computer_file/program/messenger,
 		/datum/computer_file/program/nt_pay,
 		/datum/computer_file/program/notepad,
+		/datum/computer_file/program/crew_manifest,
 	)
 	///List of items that can be stored in a PDA
 	var/static/list/contained_item = list(

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -7,7 +7,6 @@
 	greyscale_colors = "#67A364#a92323"
 	max_capacity = parent_type::max_capacity * 2
 	var/static/list/datum/computer_file/head_programs = list(
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -105,7 +104,6 @@
 	inserted_item = /obj/item/pen/red/security
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
 	)
 
@@ -115,7 +113,6 @@
 	inserted_item = /obj/item/pen/red/security
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
 	)
 
@@ -126,7 +123,6 @@
 	inserted_item = /obj/item/pen/red/security
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
 	)
 
@@ -220,7 +216,6 @@
 	greyscale_colors = "#FAFAFA#000099#1f2026"
 	starting_programs = list(
 		/datum/computer_file/program/records/medical,
-		/datum/computer_file/program/crew_manifest,
 	)
 
 /**
@@ -381,7 +376,6 @@
 	greyscale_colors = "#333333#000099#3F96CC"
 	starting_programs = list(
 		/datum/computer_file/program/records/medical,
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/robocontrol,
 	)
 
@@ -398,7 +392,6 @@
 	name = "bridge assistant PDA"
 	greyscale_colors = "#374f7e#a92323"
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
 	)
 
@@ -408,7 +401,6 @@
 	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/coupon, //veteran discount
 		/datum/computer_file/program/skill_tracker,
 	)

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -1,15 +1,13 @@
 /datum/computer_file/program/crew_manifest
 	filename = "plexagoncrew"
 	filedesc = "Plexagon Crew List"
-	downloader_category = PROGRAM_CATEGORY_SECURITY
+	downloader_category = PROGRAM_CATEGORY_DEVICE
 	program_open_overlay = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
-	download_access = list(ACCESS_SECURITY, ACCESS_COMMAND)
 	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
-	size = 4
+	size = 2
 	tgui_id = "NtosCrewManifest"
 	program_icon = "clipboard-list"
-	detomatix_resistance = DETOMATIX_RESIST_MAJOR
 
 /datum/computer_file/program/crew_manifest/ui_static_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -5,7 +5,7 @@
 	program_open_overlay = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
 	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
-	size = 2
+	size = 0
 	tgui_id = "NtosCrewManifest"
 	program_icon = "clipboard-list"
 

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -29,6 +29,7 @@
 	download_access = list(ACCESS_SECURITY, ACCESS_FLAG_COMMAND)
 	program_flags = PROGRAM_ON_NTNET_STORE
 	mode = "security"
+	detomatix_resistance = DETOMATIX_RESIST_MINOR
 
 /datum/computer_file/program/records/proc/GetRecordsReadable()
 	var/list/all_records = list()

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -11,6 +11,7 @@
 
 	can_run_on_flags = PROGRAM_ALL
 	program_flags = PROGRAM_REQUIRES_NTNET
+	detomatix_resistance = DETOMATIX_RESIST_MAJOR
 
 	var/upper_text = ""
 	var/lower_text = ""


### PR DESCRIPTION
## About The Pull Request

Plexagon Crew Manifest has been made into a publicly accessible and roundstart installed PDA app instead of being restricted to heads, security and a few odd medical jobs. For this, it lost its major Detomatix resistance which has been added to security records (minor resistance) and status display control (major resistance)

To ensure that noone has to wipe their PDAs roundstart, its size on PDA drives has been halved.

## Why It's Good For The Game

Crew manifest can be easily accessed from the messenger app, but without nice formatting that plexagon has. The app itself does not have any capabilities beyond reading crew manifest and printing it out on paper from consoles, neither of which are something that cannot be already done with ease. I believe this is a remnant from old PDA days and doesn't really deserve to stay.

## Changelog
:cl:
balance: Plexagon Crew Manifest is now a default PDA app for everyone, and is free.
balance: Plexagon Crew Manifest no longer provides Detomatix resistance, but security records and status display control now do.
/:cl:
