### PR TITLE
Pride mirror yeets you into space once again. Mirrors also now use tooltips for their radials

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -98,7 +98,7 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken)
 	return display_radial_menu(user)
 
 /obj/structure/mirror/proc/display_radial_menu(mob/living/carbon/human/user)
-	var/pick = show_radial_menu(user, src, mirror_options, user, radius = 36, require_near = TRUE)
+	var/pick = show_radial_menu(user, src, mirror_options, user, radius = 36, require_near = TRUE, tooltips = TRUE)
 	if(!pick)
 		return TRUE //get out
 
@@ -393,12 +393,36 @@ WALL_MOUNT_DIRECTIONAL_HELPERS(/obj/structure/mirror/magic)
 	desc = "Pride cometh before the..."
 	race_flags = MIRROR_PRIDE
 	mirror_options = PRIDE_MIRROR_OPTIONS
+	/// If the last user has altered anything about themselves
+	var/changed = FALSE
+
+/obj/structure/mirror/magic/pride/display_radial_menu(mob/living/carbon/human/user)
+	var/pick = show_radial_menu(user, src, mirror_options, user, radius = 36, require_near = TRUE, tooltips = TRUE)
+	if(!pick)
+		return TRUE //get out
+
+	changed = TRUE
+	switch(pick)
+		if(CHANGE_HAIR)
+			change_hair(user)
+		if(CHANGE_BEARD)
+			change_beard(user)
+		if(CHANGE_RACE)
+			change_race(user)
+		if(CHANGE_SEX) // sex: yes
+			change_sex(user)
+		if(CHANGE_NAME)
+			change_name(user)
+		if(CHANGE_EYES)
+			change_eyes(user)
+
+	return display_radial_menu(user)
 
 /obj/structure/mirror/magic/pride/attack_hand(mob/living/carbon/human/user)
+	changed = FALSE
 	. = ..()
-	if(.)
-		return TRUE
-
+	if (!changed)
+		return
 	user.visible_message(
 		span_bolddanger("The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!"),
 		span_notice("Perfect. Much better! Now <i>nobody</i> will be able to resist yo-"),


### PR DESCRIPTION

## About The Pull Request

Pride mirrors haven't been dropping people into chasms for the past 10 months and nobody noticed. Now they drop you if you actually changed something about yourself instead of doing so even if you just opened and closed the menu.

Additionally, menus now use tooltips for their radials as they lack sprites for those.

## Why It's Good For The Game
Pride mirror is a free species swap right now without requiring a jacob's ladder/jaunter/whatever funny shenanigans you can think of. Dumping people for just opening the menu is a bit dumb, and tooltips allow you to use magic mirrors without having to look into the bottom left corner of your screen all the time.

## Changelog
:cl:
qol: Mirrors now have text tooltips for their radial menus
fix: Fixed pride mirrors not dumping you into space after use
/:cl:
