### PR TITLE
Fix screwing radio headset in combat mode don't do anything

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -536,6 +536,11 @@
 	if(listening && overlay_speaker_idle)
 		. += overlay_speaker_idle
 
+/obj/item/radio/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode && tool.tool_behaviour == TOOL_SCREWDRIVER)
+		return screwdriver_act(user, tool)
+	return ..()
+
 /obj/item/radio/screwdriver_act(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
 	unscrewed = !unscrewed


### PR DESCRIPTION
## About The Pull Request

Fix that screwing radio headset in combat mode don't give you encryption key and also don't do anything.

## Changelog
:cl:
fix: fixed that screwdriwing radio headset in combat mode don't do anything.
/:cl:
