### PR TITLE
Fix spy rewards runtiming

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -172,6 +172,8 @@
 		ADD_TRAIT(created, TRAIT_CONTRABAND, INNATE_TRAIT)
 		for(var/obj/contained as anything in created.get_all_contents())
 			ADD_TRAIT(contained, TRAIT_CONTRABAND, INNATE_TRAIT)
+
+	if(isgun(created))
 		replace_pin(created)
 	else if(istype(created, /obj/item/storage/toolbox/guncase))
 		for(var/obj/item/gun/gun in created)


### PR DESCRIPTION
## About The Pull Request

We lost an `isgun` check with the contraband PR so this runtimes (`replace_pin` asserts it is a passed a gun)

## Changelog

:cl: Melbert
fix: Some spy items should spawn less broken
/:cl:
