### PR TITLE
Syndie Sleepers now drop appropriate circuitboards and are aptly named.

### DIFF
--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -300,17 +300,21 @@
  * Can be controlled from the inside and can be deconstructed.
  */
 /obj/machinery/sleeper/syndie
+	name = "syndicate sleeper"
 	icon_state = "sleeper_s"
 	base_icon_state = "sleeper_s"
 	controls_inside = TRUE
 	deconstructable = TRUE
+	circuit = /obj/item/circuitboard/machine/sleeper/syndie
 
 ///Fully upgraded variant, the circuit using tier 4 parts.
 /obj/machinery/sleeper/syndie/fullupgrade
+	name = "upgraded syndicate sleeper"
 	circuit = /obj/item/circuitboard/machine/sleeper/fullupgrade
 
 ///Fully upgraded, not deconstructable, while using the normal sprite.
 /obj/machinery/sleeper/syndie/fullupgrade/nt
+	name = "\improper Nanotrasen sleeper"
 	icon_state = "sleeper"
 	base_icon_state = "sleeper"
 	deconstructable = FALSE

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -923,6 +923,9 @@
 		/obj/item/stack/cable_coil = 1,
 		/obj/item/stack/sheet/glass = 2)
 
+/obj/item/circuitboard/machine/sleeper/syndie
+	build_path = /obj/machinery/sleeper/syndie
+
 /obj/item/circuitboard/machine/sleeper/fullupgrade
 	build_path = /obj/machinery/sleeper/syndie/fullupgrade
 	req_components = list(


### PR DESCRIPTION
## About The Pull Request
Syndicate Sleepers are only found on syndicate bases and shuttles, as well as one Interdyne-themed space ruin with zombies, however when deconstructed, they drop a generic sleeper board. This PR fixes that.

Syndicate Sleeper have also been aptly renamed so that it shows on the circuit board, otherwise it'd be named just like the normal sleeper board.

## Why It's Good For The Game
Consistency foremost. Balance is not an issue as sleepers weren't as great as they once were. They don't cure wounds and several other ailments that medical can with its starting tools, plus the syndie version is fairly rare to find and get your hands on.

## Changelog

:cl:
fix: Syndie sleepers now drop the appropriate syndicate sleeper boards.
/:cl:
