### PR TITLE
TguiPrettierTarget now uses the '--write' parameter outside of CI

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -371,8 +371,9 @@ export const TguiEslintTarget = new Juke.Target({
 });
 
 export const TguiPrettierTarget = new Juke.Target({
+  parameters: [CiParameter],
   dependsOn: [YarnTarget],
-  executes: () => yarn('tgui:prettier'),
+  executes: ({ get }) => yarn('tgui:prettier', !get(CiParameter) && '--write'),
 });
 
 export const TguiSonarTarget = new Juke.Target({


### PR DESCRIPTION
## About The Pull Request
TguiEslintTarget already does this with the '--fix' parameter. I don't know why we shouldn't do the same with prettier, especially if you're building without an editor because you're probably a bit lazy and just want to click the tgui-build bat. ~~now replace "you're" with "I'm"~~

## Why It's Good For The Game
See above.

No CL.