### PR TITLE
Borgs buckle people to themselves instantly (not dumb this time)

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -294,9 +294,9 @@
 
 	add_fingerprint(user)
 
-	// If the mob we're attempting to buckle is not stood on this atom's turf and it isn't the user buckling themselves,
+	// If the mob we're attempting to buckle is not stood on this atom's turf and it isn't the user buckling themselves and the user isn't a borg buckling to themselves,
 	// we'll try it with a 2 second do_after delay.
-	if(M != user && (get_turf(M) != get_turf(src)))
+	if(M != user && (get_turf(M) != get_turf(src)) && !(iscyborg(src) && user == src))
 		M.visible_message(span_warning("[user] starts buckling [M] to [src]!"),\
 			span_userdanger("[user] starts buckling you to [src]!"),\
 			span_hear("You hear metal clanking."))


### PR DESCRIPTION

## About The Pull Request

When a borg buckles someone to themselves it's instant. Buckling another person to a borg still takes time

## Why It's Good For The Game

Being able to save the hoomans without pixel hunting while your metal ass covers half their sprite is good actually.
It's pretty useless for combat since all you need to do to avoid it is hold two items (also means borgs can't annoy sec by stealing cuffed people more easily).

## Changelog
:cl:
balance: cyborgs instantly buckle people to themselves again
/:cl:
