### PR TITLE
(prev grey bull only) Soda and beer cans fit on tool belts - honoring the age-old tradition of drinking on the job

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -76,6 +76,7 @@
 		/obj/item/wrench,
 		/obj/item/spess_knife,
 		/obj/item/melee/sickly_blade/lock,
+		/obj/item/reagent_containers/cup/soda_cans/grey_bull,
 	))
 
 /obj/item/storage/belt/utility/chief

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -76,7 +76,7 @@
 		/obj/item/wrench,
 		/obj/item/spess_knife,
 		/obj/item/melee/sickly_blade/lock,
-		/obj/item/reagent_containers/cup/soda_cans/grey_bull,
+		/obj/item/reagent_containers/cup/soda_cans,
 	))
 
 /obj/item/storage/belt/utility/chief


### PR DESCRIPTION
## About The Pull Request
The grey bull can fits on storage belts. There's so little value to be had from using it to store other reagents that it's not worth it, but grey bull on a belt lets people do more micro in backpacks. Yes, I could do it without this, yes, it'd be easier if I didn't have to juggle to have my kidney stone juice. Really small change, really neat, not game breaking or anything, plenty of people would be happy *if you count assistant players as people

## Why It's Good For The Game

Look, it fits! 

![361471076-c53bbf46-cc30-411b-bd12-1c0ad1ea87f3](https://github.com/user-attachments/assets/6d2bb404-6889-44b4-b105-6500589db454)


## Changelog

:cl:
qol: All cans (soda cans etc) fit on utility belts now. Drink on the job!
/:cl:
