### PR TITLE
Gives Plumbing Constructors and RTDs pick up and UI sounds

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -82,10 +82,6 @@
 	GLOB.rcd_list -= src
 	. = ..()
 
-/obj/item/construction/rcd/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
-	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
-
 /obj/item/construction/rcd/ui_action_click(mob/user, actiontype)
 	if (!COOLDOWN_FINISHED(src, destructive_scan_cooldown))
 		to_chat(user, span_warning("[src] lets out a low buzz."))
@@ -354,6 +350,7 @@
 	return data
 
 /obj/item/construction/rcd/handle_ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
+	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
 
 	switch(action)
 		if("root_category")

--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -363,9 +363,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
-	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
 	if(.)
 		return
+
+	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
 
 	var/playeffect = TRUE
 	switch(action)

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -155,11 +155,9 @@
 
 	return data
 
-/obj/item/construction/plumbing/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
+/obj/item/construction/plumbing/handle_ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
 
-/obj/item/construction/plumbing/handle_ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("color")
 			var/color = params["paint_color"]

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -12,6 +12,9 @@
 	banned_upgrades = RCD_ALL_UPGRADES & ~RCD_UPGRADE_SILO_LINK
 	matter = 200
 	max_matter = 200
+	drop_sound = 'sound/items/handling/rcd_drop.ogg'
+	pickup_sound = 'sound/items/handling/rcd_pickup.ogg'
+	sound_vary = TRUE
 
 	///category of design selected
 	var/selected_category

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -24,6 +24,9 @@
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON
 	has_ammobar = TRUE
 	banned_upgrades = RCD_ALL_UPGRADES & ~RCD_UPGRADE_SILO_LINK
+	drop_sound = 'sound/items/handling/rcd_drop.ogg'
+	pickup_sound = 'sound/items/handling/rcd_pickup.ogg'
+	sound_vary = TRUE
 
 	/// main category for tile design
 	var/root_category = "Conventional"
@@ -193,6 +196,11 @@
 	selected_design.fill_ui_data(data)
 
 	return data
+
+/obj/item/construction/rtd/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
+
 
 /obj/item/construction/rtd/handle_ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -197,12 +197,8 @@
 
 	return data
 
-/obj/item/construction/rtd/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
-	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
-
-
 /obj/item/construction/rtd/handle_ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
+	playsound(src, SFX_TOOL_SWITCH, 20, TRUE)
 
 	var/floor_designs = GLOB.floor_designs
 	switch(action)


### PR DESCRIPTION
## About The Pull Request
Gives the Plumbing Constructor and Rapid-Tiling-Device the same pick up and UI interaction sounds as the RCD's (Plumbing Constructor already had the UI one actually)

Additionally fixes an issue where ghosts could interact with the RCD, Plumbing Constructors and RPDs

https://github.com/user-attachments/assets/c743981c-0231-45c4-b003-e8aa89b8fc12


https://github.com/user-attachments/assets/4dc51f6d-eb4d-40c7-bf4e-ed29053796d9



## Why It's Good For The Game
Both of them are meant to be modified RCDs, so it makes sense to give them the same sounds.


## Changelog
:cl: Hardly
sound: Plumbing Constructor and Rapid-Tiling-Device now has RCD's pick up and UI sounds
fix: Fixes ghosts being able to interact with the RCD, RPLD and RPDs
/:cl:
