### PR TITLE
Removes a no longer used fish variable.

### DIFF
--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -84,8 +84,6 @@
 	var/list/compatible_types
 	/// A list of possible evolutions. If set, offsprings may be of a different, new fish type if conditions are met.
 	var/list/evolution_types
-	/// The species' name(s) of the parents of the fish. Shown by the fish analyzer.
-	var/progenitors
 
 	// Fishing related properties
 
@@ -165,7 +163,6 @@
 	if(apply_qualities)
 		apply_traits() //Make sure traits are applied before size and weight.
 		update_size_and_weight()
-		progenitors = full_capitalize(name) //default value
 
 	register_evolutions()
 
@@ -662,12 +659,6 @@
 		partner.breeding_wait = world.time + breeding_timeout
 	else //Make a close of this fish.
 		new_fish.update_size_and_weight(size, weight, TRUE)
-		new_fish.progenitors = initial(name)
-	if(partner && type != partner.type)
-		var/string = "[initial(name)] - [initial(partner.name)]"
-		new_fish.progenitors = full_capitalize(string)
-	else
-		new_fish.progenitors = full_capitalize(initial(name))
 
 	breeding_wait = world.time + breeding_timeout
 

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -269,7 +269,6 @@
 		new_traits |= pick_weight(weighted_traits)
 	caught_fish.inherit_traits(new_traits)
 	caught_fish.randomize_size_and_weight(deviation = 0.3)
-	caught_fish.progenitors = full_capitalize(caught_fish.name)
 	return caught_fish
 
 


### PR DESCRIPTION
## About The Pull Request
Since Ben revamped the fish analyzer, this variable is no longer used. Frankly it could as well be removed. Knowing the family history of a fish really isn't in the top 100 things to do before being robusted in maints.

## Why It's Good For The Game
Unused var.

## Changelog
N/A.