### PR TITLE
Nerfs Justice Mech blocking all damage, buffs health

### DIFF
--- a/code/modules/vehicles/mecha/combat/justice.dm
+++ b/code/modules/vehicles/mecha/combat/justice.dm
@@ -11,7 +11,7 @@
 	icon_state = "justice"
 	base_icon_state = "justice"
 	movedelay = MOVEDELAY_SAFETY // fast
-	max_integrity = 200 // but weak
+	max_integrity = 300 // but weak
 	accesses = list(ACCESS_SYNDICATE)
 	armor_type = /datum/armor/mecha_justice
 	max_temperature = 40000
@@ -147,7 +147,6 @@
 		if(prob(60))
 			new /obj/effect/temp_visual/mech_sparks(get_turf(src))
 			playsound(src, 'sound/mecha/mech_stealth_effect.ogg' , 75, FALSE)
-			return
 	return ..()
 
 /datum/action/vehicle/sealed/mecha/invisibility


### PR DESCRIPTION
## About The Pull Request
I have removed the 60% chance to block all damage from the justice mech, and increased it's HP from 200 to 300. 

## Why It's Good For The Game

First off, this is indeed an ided PR. I had the honor of empting multiple revolver clips into it for a total of 60 damage before it teleported into me and removed my head

The Justice mech (new traitor mech) has a 60% chance to block all damage. This was advertised as a glass cannon mech, but a 200 integrity mech with a 60% block chance equates to a 500hp mech, giving it more health than a DURAND (which is at 400hp). 

I don't think the blocking is a good mechanic, it advertised to the world that it was immune to all forms of damage (because it was blocking melee, bullets, lasers, emp's). It's entire survival mechanic is also based on RNG, which is not enjoyable for people fighting against it, since a diceroll determined that their entire assault did nothing, or rider when they roll bad RNG and have their mech go down in 1 second. 

It can still teleport, it still turns completely invisible, it still deals 60 melee, it still delimbs on every hit, it still has armor and it still has a 100% chance to behead on people in softcrit or lower

## Changelog
:cl:
balance: Removes Justice mechs 60% block chance, increases HP from 200 to 300
/:cl:
