### PR TITLE
Voidwalker 'Unsettle' doesn't immediately go on cooldown if line of sight is broken

### DIFF
--- a/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
@@ -37,7 +37,7 @@
 		spookify(cast_on)
 		return
 	owner.balloon_alert(owner, "line of sight broken!")
-	return SPELL_CANCEL_CAST
+	return SPELL_NO_IMMEDIATE_COOLDOWN
 
 /datum/action/cooldown/spell/pointed/unsettle/proc/check_if_in_view(mob/living/carbon/human/target)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
This was an oversight. If someone breaks line of sight (which you need to maintain for 8 seconds) it immediately goes back on cooldown, which is kinda ass

## Why It's Good For The Game

I saw the voidwalker I was playing against was Livrah so I checked the stream afterwards. Not that I can understand a word but the Unsettle going on cooldown seemed frustrating, and is not something I intended

Also this is me we're so cute toghether :heart:
![image](https://github.com/user-attachments/assets/5f079bbb-a693-4a0e-ab97-9979bc19c150)

## Changelog
:cl:
qol: Unsettle (Voidwalker) doesn't go on cooldown if line of sight is broken
/:cl:

