### PR TITLE
[NO GBP] Fixing fishing code not caring whether a reward is limited or not.

### DIFF
--- a/code/datums/elements/lazy_fishing_spot.dm
+++ b/code/datums/elements/lazy_fishing_spot.dm
@@ -22,8 +22,13 @@
 	RegisterSignal(target, COMSIG_ATOM_EX_ACT, PROC_REF(explosive_fishing))
 
 /datum/element/lazy_fishing_spot/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_PRE_FISHING, COMSIG_ATOM_EXAMINE, COMSIG_ATOM_EXAMINE_MORE, COMSIG_ATOM_EX_ACT))
-	UnregisterSignal(target, list(COMSIG_PRE_FISHING, COMSIG_NPC_FISHING))
+	UnregisterSignal(target, list(
+		COMSIG_PRE_FISHING,
+		COMSIG_NPC_FISHING,
+		COMSIG_ATOM_EXAMINE,
+		COMSIG_ATOM_EXAMINE_MORE,
+		COMSIG_ATOM_EX_ACT,
+	))
 	REMOVE_TRAIT(target, TRAIT_FISHING_SPOT, REF(src))
 	return ..()
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	var/catalog_description
 	/// Background image name from /datum/asset/simple/fishing_minigame
 	var/background = "background_default"
-	/// It true, repeated and large explosions won't be as efficient. This is usually meant for global fish sources.
+	/// It true, repeated and large explosions won't be as efficient. This is usually for fish sources that cover multiple turfs (i.e. rivers, oceans).
 	var/explosive_malus = FALSE
 	/// If explosive_malus is true, this will be used to keep track of the turfs where an explosion happened for when we'll spawn the loot.
 	var/list/exploded_turfs
@@ -226,6 +226,9 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	if(isnull(reward_path))
 		return null
 	if(reward_path in fish_counts) // This is limited count result
+		//Somehow, we're trying to spawn an expended reward.
+		if(fish_counts[reward_path] <= 0)
+			return null
 		fish_counts[reward_path] -= 1
 		var/regen_time = fish_count_regen?[reward_path]
 		if(regen_time)
@@ -280,7 +283,7 @@ GLOBAL_LIST(fishing_property_cache)
 /datum/fish_source/proc/get_fish_table()
 	var/list/table = fish_table.Copy()
 	for(var/result in table)
-		if(fish_counts[result] == 0)
+		if(fish_counts[result] <= 0)
 			table -= result
 	return table
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 		return
 	for(var/path in fish_counts)
 		if(!(path in fish_table))
-			stack_trace("path [path] found in the 'fish_counts' list but not in the fish_table one of [type]")
+			stack_trace("path [path] found in the 'fish_counts' list but not in the 'fish_table'")
 
 /datum/fish_source/Destroy()
 	exploded_turfs = null
@@ -296,7 +296,7 @@ GLOBAL_LIST(fishing_property_cache)
 	var/result_multiplier = 1
 
 
-	var/list/final_table = fish_table.Copy()
+	var/list/final_table = get_fish_table()
 
 	if(bait)
 		if(HAS_TRAIT(bait, TRAIT_GREAT_QUALITY_BAIT))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -225,7 +225,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 /datum/fish_source/proc/simple_dispense_reward(reward_path, atom/spawn_location, turf/fishing_spot)
 	if(isnull(reward_path))
 		return null
-	if(reward_path in fish_counts) // This is limited count result
+	if(!isnull(fish_counts[reward_path])) // This is limited count result
 		//Somehow, we're trying to spawn an expended reward.
 		if(fish_counts[reward_path] <= 0)
 			return null
@@ -283,7 +283,7 @@ GLOBAL_LIST(fishing_property_cache)
 /datum/fish_source/proc/get_fish_table()
 	var/list/table = fish_table.Copy()
 	for(var/result in table)
-		if((result in fish_counts) && fish_counts[result] <= 0)
+		if(!isnull(fish_counts[result]) && fish_counts[result] <= 0)
 			table -= result
 	return table
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -283,7 +283,7 @@ GLOBAL_LIST(fishing_property_cache)
 /datum/fish_source/proc/get_fish_table()
 	var/list/table = fish_table.Copy()
 	for(var/result in table)
-		if(fish_counts[result] <= 0)
+		if((result in fish_counts) && fish_counts[result] <= 0)
 			table -= result
 	return table
 

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -54,6 +54,7 @@
 		/obj/item/fish/three_eyes = 1,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
+	explosive_malus = TRUE
 
 /datum/fish_source/sand
 	catalog_description = "Sand"
@@ -65,6 +66,7 @@
 		/obj/item/coin/gold = 3,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
+	explosive_malus = TRUE
 
 /datum/fish_source/cursed_spring
 	catalog_description = null //it's a secret (sorta, I know you're reading this)
@@ -78,6 +80,7 @@
 		/obj/item/fishing_rod/telescopic/master = 1,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 25
+	explosive_malus = TRUE
 
 /datum/fish_source/portal
 	fish_table = list(


### PR DESCRIPTION
## About The Pull Request
At some point, I must have removed the check for limited items from `get_modified_fish_table()` and never replaced the `fish_table.Copy()` call with `get_fish_table()` (which has it), causing limited rewards to be yet `again` unlimited. This extends to explosive and lobstrosities (clientless mobs with the profound fisher comp) once the associated value of the reward in the `fish_counts` list (the list of keeps track of these limited rewards) reaches a negative value, because the code only checks if the value is equal to zero where it frankly it should check if the value is equal or less than zero.

Also I've set `explosion_malus` to true for a few fish sources that cover multiple turfs, revisited a few comments and a redundant UnregisterSignal call in lazy_fishing_spot

## Why It's Good For The Game
Fixing an oversight.

## Changelog

:cl:
fix: Fixing fishing not caring whether a reward is limited or not.
/:cl:
