### PR TITLE
Bumps Icon Cutter to v4.0.0

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -31,4 +31,4 @@ export DREAMLUAU_VERSION=0.1.1
 export CUTTER_REPO=spacestation13/hypnagogic
 
 #hypnagogic git tag
-export CUTTER_VERSION=v3.1.0
+export CUTTER_VERSION=v4.0.0


### PR DESCRIPTION

## About The Pull Request

Exposes the rewind byond var, one guy had a problem with this and I had flashbacks to manually setting repeat info on airlock animations and decided to do the right thing.

Adds support for multiple target input folders by space separating them. This should hopefully make integrating the cutter easier for downsteams and servers with weird fucked up icon stuff.

This is a major release because I am being anal about SemVer and TECHNICALLY I'm removing an unused (and unchanged) public version constant

Also the input change is maybe sorta breaking so might as well

For more detail please see https://github.com/spacestation13/hypnagogic/releases/tag/v4.0.0