### PR TITLE
Fixes the die of fate deleting all your organs when rolling a 4

### DIFF
--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -360,10 +360,8 @@
 		if(4)
 			//Destroy Equipment
 			selected_turf.visible_message(span_userdanger("Everything [user] is holding and wearing disappears!"))
-			for(var/obj/item/non_implant in user)
-				if(istype(non_implant, /obj/item/implant))
-					continue
-				qdel(non_implant)
+			var/list/belongings = get_all_gear()
+			QDEL_LIST(belongings)
 		if(5)
 			//Monkeying
 			selected_turf.visible_message(span_userdanger("[user] transforms into a monkey!"))

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -360,7 +360,7 @@
 		if(4)
 			//Destroy Equipment
 			selected_turf.visible_message(span_userdanger("Everything [user] is holding and wearing disappears!"))
-			var/list/belongings = get_all_gear()
+			var/list/belongings = user.get_all_gear()
 			QDEL_LIST(belongings)
 		if(5)
 			//Monkeying

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -393,9 +393,9 @@
 		if(11)
 			//Cookie
 			selected_turf.visible_message(span_userdanger("A cookie appears out of thin air!"))
-			var/obj/item/food/cookie/C = new(drop_location())
+			var/obj/item/food/cookie/ooh_a_cookie = new(drop_location())
 			do_smoke(0, holder = src, location = drop_location())
-			C.name = "Cookie of Fate"
+			ooh_a_cookie.name = "Cookie of Fate"
 		if(12)
 			//Healing
 			selected_turf.visible_message(span_userdanger("[user] looks very healthy!"))


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/86133

Rolling a 4 is supposed to destroy 'everything you are holding and wearing'. At the time this was coded, this worked as intended, because organs were in nullspace. In modern times, however, our organs now fall under the category of 'holding and wearing' according to the code. Always read the fine print...

This PR swaps over to a more safe method of getting all equipped and held items that does not include vital organs.

## Why It's Good For The Game

Your fate is sealed the moment you step foot on the station but this was just excessive.

## Changelog

:cl:
fix: fixed the die of fate deleting all your organs when rolling a 4
/:cl: