### PR TITLE
Add a build target that doesn't run the icon cutter

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -238,6 +238,40 @@ export const DmTarget = new Juke.Target({
   },
 });
 
+export const JustDmTarget = new Juke.Target({
+  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
+  dependsOn: ({ get }) => [
+    get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
+  ],
+  inputs: [
+    '_maps/map_files/generic/**',
+    'maps/**/*.dm',
+    'code/**',
+    'html/**',
+    'icons/**',
+    'interface/**',
+    `${DME_NAME}.dme`,
+    NamedVersionFile,
+  ],
+  outputs: ({ get }) => {
+    if (get(DmVersionParameter)) {
+      return []; // Always rebuild when dm version is provided
+    }
+    return [
+      `${DME_NAME}.dmb`,
+      `${DME_NAME}.rsc`,
+    ]
+  },
+  executes: async ({ get }) => {
+    await DreamMaker(`${DME_NAME}.dme`, {
+      defines: ['CBT', ...get(DefineParameter)],
+      warningsAsErrors: get(WarningParameter).includes('error'),
+      ignoreWarningCodes: get(NoWarningParameter),
+      namedDmVersion: get(DmVersionParameter),
+    });
+  },
+});
+
 export const DmTestTarget = new Juke.Target({
   parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
   dependsOn: ({ get }) => [


### PR DESCRIPTION
## About The Pull Request
This isn't prebuilt for linux so i can't compile the game with the normal build target, even when i'm not touching any icons
## Why It's Good For The Game
This is nice to have, but not a requirement
