### PR TITLE
Let ghosts use the jump emote

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -142,3 +142,27 @@
 #undef BEYBLADE_DIZZINESS_DURATION
 #undef BEYBLADE_CONFUSION_INCREMENT
 #undef BEYBLADE_CONFUSION_LIMIT
+
+
+/datum/emote/jump
+	key = "jump"
+	key_third_person = "jumps"
+	message = "jumps!"
+	// Allows ghosts to jump
+	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+
+/datum/emote/jump/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+
+	var/original_transform = user.transform
+	animate(user, transform = user.transform.Translate(0, 4), time = 0.1 SECONDS, flags = ANIMATION_PARALLEL)
+	animate(transform = original_transform, time = 0.1 SECONDS)
+
+/datum/emote/jump/get_sound(mob/user)
+	return 'sound/weapons/thudswoosh.ogg'
+
+// Avoids playing sounds if we're a ghost
+/datum/emote/jump/should_play_sound(mob/user, intentional)
+	if ishuman(user)
+		return ..()
+	return FALSE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -235,20 +235,6 @@
 	key_third_person = "grimaces"
 	message = "grimaces."
 
-/datum/emote/living/jump
-	key = "jump"
-	key_third_person = "jumps"
-	message = "jumps!"
-	hands_use_check = TRUE
-
-/datum/emote/living/jump/run_emote(mob/living/user, params, type_override, intentional)
-	. = ..()
-	animate(user, pixel_y = user.pixel_y + 4, time = 0.1 SECONDS)
-	animate(pixel_y = user.pixel_y - 4, time = 0.1 SECONDS)
-
-/datum/emote/living/jump/get_sound(mob/living/user)
-	return 'sound/weapons/thudswoosh.ogg'
-
 /datum/emote/living/kiss
 	key = "kiss"
 	key_third_person = "kisses"

--- a/code/modules/modular_computers/file_system/programs/virtual_pet.dm
+++ b/code/modules/modular_computers/file_system/programs/virtual_pet.dm
@@ -429,7 +429,7 @@ GLOBAL_LIST_EMPTY(virtual_pets_list)
 
 	var/static/list/possible_emotes = list(
 		/datum/emote/flip,
-		/datum/emote/living/jump,
+		/datum/emote/jump,
 		/datum/emote/living/shiver,
 		/datum/emote/spin,
 		/datum/emote/silicon/beep,


### PR DESCRIPTION

## About The Pull Request
This lets ghosts use the jump emote (but they can't play sounds)
## Why It's Good For The Game
There's no reason to not let them jump and there's no harm, this was requested by someone in dchat
## Changelog

:cl: oranges
add: ghosts can now jump, bhop your way to life
/:cl:
