### PR TITLE
Fixes runtimes caused by dreamluau's absence

### DIFF
--- a/code/__HELPERS/_dreamluau.dm
+++ b/code/__HELPERS/_dreamluau.dm
@@ -1,8 +1,12 @@
 /* This comment bypasses grep checks */ /var/__dreamluau
 
-#define DREAMLUAU (world.system_type == MS_WINDOWS ? "dreamluau.dll" : (__dreamluau || (__dreamluau = __detect_auxtools("dreamluau"))))
+/* This comment also bypasses grep checks */ /var/__dreamluau_exists
 
-#define DREAMLUAU_CALL(func) call_ext(DREAMLUAU, "byond:[#func]")
+#define DREAMLUAU_EXISTS (__dreamluau_exists ||= fexists(DREAMLUAU))
+
+#define DREAMLUAU (world.system_type == MS_WINDOWS ? "dreamluau.dll" : (__dreamluau ||= __detect_auxtools("dreamluau")))
+
+#define DREAMLUAU_CALL(func) (!DREAMLUAU_EXISTS) ? null : call_ext(DREAMLUAU, "byond:[#func]")
 
 /**
  * All of the following functions will return a string if the underlying rust code returns an error or a wrapped panic.

--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -41,7 +41,10 @@ GLOBAL_PROTECT(lua_state_stack)
 		return
 	display_name = _name
 	internal_id = DREAMLUAU_NEW_STATE()
-	if(!isnum(internal_id))
+	if(isnull(internal_id))
+		stack_trace("dreamluau is not loaded")
+		qdel(src)
+	else if(!isnum(internal_id))
 		stack_trace(internal_id)
 		qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

Currently, if dreamluau is absent (which it might be on linux instances that don't automatically download it), every `call_ext` call runtimes, crashing the calling proc. This fixes that by using a flag that skips calling `call_ext` if unset.

## Why It's Good For The Game

Apparently this could really bork the garbage collection subsystem, so fixing it is a really good idea.

## Changelog

Does this even count as a player-facing change?
