### PR TITLE
Fix detective board building

### DIFF
--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -25,7 +25,7 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 
-/obj/structure/detectiveboard/Initialize(mapload,  ndir, building)
+/obj/structure/detectiveboard/Initialize(mapload)
 	. = ..()
 
 	if(mapload)
@@ -36,8 +36,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 
 	register_context()
 	find_and_hang_on_wall()
-
-/obj/structure/detectiveboard/
 
 /// Attaching evidences: photo and papers
 

--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -25,23 +25,28 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 
-/obj/structure/detectiveboard/Initialize(mapload)
+/obj/structure/detectiveboard/Initialize(mapload,  ndir, building)
 	. = ..()
 
-	if(!mapload)
-		return
-	for(var/obj/item/item in loc)
-		if(istype(item, /obj/item/paper) || istype(item, /obj/item/photo))
-			item.forceMove(src)
-			cases[current_case].notices++
+	if(mapload)
+		for(var/obj/item/item in loc)
+			if(istype(item, /obj/item/paper) || istype(item, /obj/item/photo))
+				item.forceMove(src)
+				cases[current_case].notices++
+
+	register_context()
+	find_and_hang_on_wall()
+
+/obj/structure/detectiveboard/
 
 /// Attaching evidences: photo and papers
 
 /obj/structure/detectiveboard/attackby(obj/item/item, mob/user, params)
-	if(!cases.len)
-		to_chat(user, "There are no cases!")
-		return
 	if(istype(item, /obj/item/paper) || istype(item, /obj/item/photo))
+		if(!cases.len)
+			to_chat(user, "There are no cases!")
+			return
+
 		if(attaching_evidence)
 			to_chat(user, "You already attaching evidence!")
 			return
@@ -224,6 +229,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 
 /obj/structure/detectiveboard/update_overlays()
 	. = ..()
+	if(!cases.len)
+		return
 	if(cases[current_case].notices < MAX_ICON_NOTICES)
 		. += "notices_[cases[current_case].notices]"
 	else
@@ -261,6 +268,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 	)
 	resistance_flags = FLAMMABLE
 	result_path = /obj/structure/detectiveboard
+	inverse_dir = FALSE
 
 /datum/evidence
 	var/name = "None"


### PR DESCRIPTION
Due to the reverse construction, the detective board was placed incorrectly:
![fix1](https://github.com/user-attachments/assets/ac41a76f-873b-4f3e-bf32-d966b135244a)

Now its correct.
Also if you try attach not paper or photo, you will not recieve messages

🆑 FeudedyTF
fix: problems with detective board placing
/:cl: