### PR TITLE
Allows drones to understand galactic common (but not speak it)

### DIFF
--- a/code/modules/language/_language_holder.dm
+++ b/code/modules/language/_language_holder.dm
@@ -270,9 +270,9 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 	)
 
 /datum/language_holder/drone
-	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM)),
+				    /datum/language/drone = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate
 	blocked_languages = null

--- a/code/modules/language/_language_holder.dm
+++ b/code/modules/language/_language_holder.dm
@@ -270,8 +270,10 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 	)
 
 /datum/language_holder/drone
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM)),
-				    /datum/language/drone = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/drone = list(LANGUAGE_ATOM),
+	)
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate

--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -165,6 +165,7 @@
 		/obj/item/storage/part_replacer,
 		/obj/item/soap,
 		/obj/item/holosign_creator,
+		/obj/item/radio,
 	)
 	/// machines whitelisted from being shy with
 	var/list/shy_machine_whitelist = list(


### PR DESCRIPTION

## About The Pull Request
As per title, and also lets drones pickup and use station bounced radios. This will let drones understand what nearby humans are saying, and also understand the common radio if they want to by picking up a radio or through intercoms **(understand, not speak).** 

Also, this was previously closed in #70818, but I disagree with the reason for closing it.

## Why It's Good For The Game
The way I see it, maintenance drones are meant to be the ghost role you go to when you want something to do while still being somewhat involved with the main station itself. If someone doesn't want to be a part of the main station at all, they choose the derelict drones or any other ghost role that isolates them from the station. Being able to understand the radio simply makes the drone experience more enjoyable by also allowing you to hear the stations ongoing story while you're busy maintaining the station.

Secondly, this also has a function beyond increasing fun. It lets drones follow their law of non-involvement MUCH better. There are many situations where a drone can get confused on what it should and should not repair, and listening to the radio solves this problem. For example, hearing "AI is milf" on the radio lets the drone know that it should not fix/repair randomly bolted or shocked doors, as they were most likely intentionally sabotaged by the silicon's. Hearing "Blob in Chapel" will let it know to avoid the chapel and repair things on the opposite side of the station. Hearing "Nightmare in dorms" will let it know that the lights being broken isn't due to collateral/accidental damage, and it shouldn't fix them. Hearing "Revs" will let it know that it needs to always close any doors it opens, and to never accidentally give free access to the crew as its passing through (or use vents more). And so on. 

I don't think this change will make it easier to grief either, as any information acquired from radio can also be acquired by ghosting, observing, and then respawning as drone. It simply makes drone gameplay a little more enjoyable and makes it easier to not accidentally mess with the crew for the 3 or so drone players that exist.

## Changelog

:cl:
balance: Drones can now understand galactic common
balance: Drones can now pickup and use station bounced radios
/:cl:
