### PR TITLE
You can kill germs by actually cooking the food now (or by setting it on fire).

### DIFF
--- a/code/datums/components/food/germ_sensitive.dm
+++ b/code/datums/components/food/germ_sensitive.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_INIT(floor_diseases, list(
 
 /datum/component/germ_sensitive/proc/delete_germs()
 	SIGNAL_HANDLER
-	if(!infective)
+	if(infective)
 		infective = FALSE
 		qdel(parent.GetComponent(/datum/component/infective))
 		return COMPONENT_CLEANED

--- a/code/datums/components/food/germ_sensitive.dm
+++ b/code/datums/components/food/germ_sensitive.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(floor_diseases, list(
 
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(handle_movement))
-	RegisterSignals(parent, list(COMSIG_COMPONENT_CLEAN_ACT, COMSIG_ITEM_FRIED, COMSIG_ITEM_BARBEQUE_GRILLED), PROC_REF(delete_germs))
+	RegisterSignals(parent, list(COMSIG_COMPONENT_CLEAN_ACT, COMSIG_ITEM_FRIED, COMSIG_ITEM_BARBEQUE_GRILLED, COMSIG_ATOM_FIRE_ACT), PROC_REF(delete_germs))
 
 	RegisterSignals(parent, list(
 		COMSIG_ITEM_DROPPED, //Dropped into the world
@@ -52,6 +52,7 @@ GLOBAL_LIST_INIT(floor_diseases, list(
 		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_ITEM_FRIED,
 		COMSIG_ITEM_BARBEQUE_GRILLED,
+		COMSIG_ATOM_FIRE_ACT,
 		COMSIG_ITEM_DROPPED,
 		COMSIG_ITEM_PICKUP,
 		COMSIG_MOVABLE_MOVED,
@@ -118,9 +119,9 @@ GLOBAL_LIST_INIT(floor_diseases, list(
 	var/random_disease = pick_weight(GLOB.floor_diseases)
 	parent.AddComponent(/datum/component/infective, new random_disease, weak = TRUE)
 
-/datum/component/germ_sensitive/proc/wash()
+/datum/component/germ_sensitive/proc/delete_germs()
 	SIGNAL_HANDLER
-	if(infective)
+	if(!infective)
 		infective = FALSE
 		qdel(parent.GetComponent(/datum/component/infective))
 		return COMPONENT_CLEANED

--- a/code/datums/components/food/germ_sensitive.dm
+++ b/code/datums/components/food/germ_sensitive.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(floor_diseases, list(
 
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(handle_movement))
-	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(wash)) //Wash germs off dirty things
+	RegisterSignals(parent, list(COMSIG_COMPONENT_CLEAN_ACT, COMSIG_ITEM_FRIED, COMSIG_ITEM_BARBEQUE_GRILLED), PROC_REF(delete_germs))
 
 	RegisterSignals(parent, list(
 		COMSIG_ITEM_DROPPED, //Dropped into the world
@@ -50,6 +50,8 @@ GLOBAL_LIST_INIT(floor_diseases, list(
 		COMSIG_ATOM_EXAMINE,
 		COMSIG_ATOM_EXITED,
 		COMSIG_COMPONENT_CLEAN_ACT,
+		COMSIG_ITEM_FRIED,
+		COMSIG_ITEM_BARBEQUE_GRILLED,
 		COMSIG_ITEM_DROPPED,
 		COMSIG_ITEM_PICKUP,
 		COMSIG_MOVABLE_MOVED,


### PR DESCRIPTION
## About The Pull Request
It always seemed weird to me that you can kill germs by washing the food in a sink but not by cooking it to be frank. Also fire should work too, though that's not a worksafe strategy.

## Why It's Good For The Game
It makes perfect sense for heat to kill germs. It can also be a fun alternative to using a sink.

## Changelog

:cl:
qol: You can kill germs by actually cooking the food (i.e. frying and grilling) now, or by setting it on fire.
/:cl:
