### PR TITLE
Fixes ice cream vat refilling

### DIFF
--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -1,5 +1,5 @@
 ///How many units of a reagent is needed to make a cone.
-#define CONE_REAGENET_NEEDED 1
+#define CONE_REAGENT_NEEDED 1
 
 ///The vat is set to dispense ice cream.
 #define VAT_MODE_ICECREAM "ice cream"
@@ -242,7 +242,7 @@
 ///Makes an ice cream cone of the make_type, using ingredients list as reagents used to make it. Puts in user's hand if possible.
 /obj/machinery/icecream_vat/proc/make_cone(mob/user, make_type, list/ingredients)
 	for(var/reagents_needed in ingredients)
-		if(!reagents.has_reagent(reagents_needed, CONE_REAGENET_NEEDED))
+		if(!reagents.has_reagent(reagents_needed, CONE_REAGENT_NEEDED))
 			balloon_alert(user, "not enough ingredients!")
 			return
 	var/cone_type = cone_prototypes[make_type].type
@@ -251,7 +251,7 @@
 	var/obj/item/food/icecream/cone = new cone_type(src)
 
 	for(var/reagents_used in ingredients)
-		reagents.remove_reagent(reagents_used, CONE_REAGENET_NEEDED)
+		reagents.remove_reagent(reagents_used, CONE_REAGENT_NEEDED)
 	balloon_alert_to_viewers("cooks up [cone.name]", "cooks up [cone.name]")
 	try_put_in_hand(cone, user)
 
@@ -262,14 +262,14 @@
 		CRASH("[user] was making ice cream of [selected_flavour] but had no flavor datum for it!")
 
 	for(var/reagents_needed in flavor.ingredients)
-		if(!reagents.has_reagent(reagents_needed, CONE_REAGENET_NEEDED))
+		if(!reagents.has_reagent(reagents_needed, CONE_REAGENT_NEEDED))
 			balloon_alert(user, "not enough ingredients!")
 			return
 
 	var/should_use_custom_ingredients = (flavor.takes_custom_ingredients && custom_ice_cream_beaker && custom_ice_cream_beaker.reagents.total_volume)
 	if(flavor.add_flavour(source, should_use_custom_ingredients ? custom_ice_cream_beaker.reagents : null))
 		for(var/reagents_used in flavor.ingredients)
-			reagents.remove_reagent(reagents_used, CONE_REAGENET_NEEDED)
+			reagents.remove_reagent(reagents_used, CONE_REAGENT_NEEDED)
 		balloon_alert_to_viewers("scoops [selected_flavour]", "scoops [selected_flavour]")
 
 	if(istype(cone))
@@ -297,4 +297,4 @@
 
 #undef VAT_MODE_ICECREAM
 #undef VAT_MODE_CONES
-#undef CONE_REAGENET_NEEDED
+#undef CONE_REAGENT_NEEDED

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -161,7 +161,7 @@
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
 
 	target.update_appearance()
-	return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /obj/item/reagent_containers/cup/attackby(obj/item/attacking_item, mob/user, params)
 	var/hotness = attacking_item.get_temperature()


### PR DESCRIPTION
## About The Pull Request

3 months ago in <https://github.com/tgstation/tgstation/pull/83818> beakers were set to always cancel attack chain, so beakers werent calling attackby secondary on ice cream vats

![image](https://github.com/user-attachments/assets/2472377a-8076-45c7-aa8d-aacf9f0d20d2)

Reverted it back to how it was before, ice cream vat works again
![image](https://github.com/user-attachments/assets/8b11dbcd-530d-4168-87ef-60e292444ac2)

## Why It's Good For The Game

Fixes ice cream vat refilling, and anything else this might've broke.

## Changelog

:cl:
fix: Ice cream vats can be refilled with beakers again.
/:cl: