### PR TITLE
sec helmet now block pepperspray

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -69,9 +69,9 @@
 	base_icon_state = "[initial(base_icon_state)][flipped_visor ? "-novisor" : ""]"
 	icon_state = base_icon_state
 	if (flipped_visor)
-		flags_cover &= ~HEADCOVERSEYES
+		flags_cover &= ~HEADCOVERSEYES | PEPPERPROOF
 	else
-		flags_cover |= HEADCOVERSEYES
+		flags_cover |= HEADCOVERSEYES | PEPPERPROOF
 	update_appearance()
 	return CLICK_ACTION_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request
I was playing around as sec on sybil and was understandably not pleased about not having pepperspray protecton on my helmet
## Why It's Good For The Game
I think, in my honest to god opinion. That it's honestly silly sec helmet don't protect ya from pepperspray, especially as it's a roundstart equipment in your belt. considering you have the flash which can be blocked by the sunglasses, the bang which is blocked by your bowman headset. why doesn't the helmet protect you from spray? seems. counterintuitive
## Changelog
:cl:
balance: After fending off against the gorlex marauder, we have restored the helmet factory and now it should protect you from pepperspray
/:cl:
