### PR TITLE
Fixes ballistic weapons not making any firing sound

### DIFF
--- a/code/datums/components/face_decal.dm
+++ b/code/datums/components/face_decal.dm
@@ -118,7 +118,8 @@
 GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	/mob/living/carbon/human,
 	/mob/living/basic/pet/dog/corgi,
-	/mob/living/silicon/ai)))
+	/mob/living/silicon/ai,
+)))
 
 /datum/component/face_decal/creampie/Initialize()
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -219,7 +219,7 @@
 				ignored_mobs = user
 		)
 
-	if(chambered.integrity_damage)
+	if(chambered?.integrity_damage)
 		take_damage(chambered.integrity_damage, sound_effect = FALSE)
 
 /obj/item/gun/atom_destruction(damage_flag)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -474,10 +474,10 @@
 	return ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
-	if(can_misfire && chambered.can_misfire != FALSE)
+	if(can_misfire && chambered?.can_misfire != FALSE)
 		misfire_probability += misfire_percentage_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
-	if(chambered.can_misfire)
+	if(chambered?.can_misfire)
 		misfire_probability += chambered.misfire_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
 	return ..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -474,10 +474,12 @@
 	return ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
-	if(can_misfire && chambered?.can_misfire != FALSE)
+	if(!chambered)
+		return ..()
+	if(can_misfire && chambered.can_misfire != FALSE)
 		misfire_probability += misfire_percentage_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
-	if(chambered?.can_misfire)
+	if(chambered.can_misfire)
 		misfire_probability += chambered.misfire_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
 	return ..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -474,7 +474,7 @@
 	return ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
-	if(!chambered)
+	if(isnull(chambered))
 		return ..()
 	if(can_misfire && chambered.can_misfire != FALSE)
 		misfire_probability += misfire_percentage_increment


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4337

https://github.com/tgstation/tgstation/pull/85470 added some checks in `/obj/item/gun/ballistic/shoot_live_shot()` that were causing runtimes in probably most of the ballistic gun types. To see for yourself just take out a revolver and shoot it a few times, then check the runtimes log. 

The runtime was preventing the parent `/obj/item/gun/ballistic/shoot_live_shot()` from being called, which is where the firing sound gets played.

Fix is just acknowledging that `chambered` can be null at this point in the call chain and adding a quick check in there for good measure. Also fixes the runtime here, though that one didn't cause any functional bugs apart from polluting the log since it occurs at the end of the proc.

![KZXgDrEAnV](https://github.com/user-attachments/assets/f22dcc6a-fffd-4d10-abdd-e5d98856939b)
 
Also adds a missing multiline list comma that I noticed cough.

## Why It's Good For The Game

Guns go boom again.

## Changelog

:cl:
fix: due to a clerical error, all ballistic guns were shipping with built-in silencers. this has been resolved-they will now make noise once again when fired.
/:cl: