### PR TITLE
Fixes anomaly suicides and a grammar mishap in the suicide message

### DIFF
--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -20,8 +20,9 @@
 		A.anomalyNeutralize()
 	return TRUE
 
-/obj/item/assembly/signaler/anomaly/manual_suicide(mob/living/carbon/user)
-	user.visible_message(span_suicide("[user]'s [src] is reacting to the radio signal, warping [user.p_their()] body!"))
+/obj/item/assembly/signaler/anomaly/manual_suicide(datum/mind/suicidee)
+	var/mob/living/user = suicidee.current
+	user.visible_message(span_suicide("[user]'s [name] is reacting to the radio signal, warping [user.p_their()] body!"))
 	user.set_suicide(TRUE)
 	user.gib(DROP_ALL_REMAINS)
 


### PR DESCRIPTION

## About The Pull Request

This fixes anomaly suicides (which is among my favorite suicides, right next to airtank and volumetric pump).

The issue was a runtime occurring because the anomaly-level suicide act would expect a living mob to be passed, when `suicide_act()` passes a mind instead.

This also includes a grammar fix. Now removing an extraneous "the" in the anomaly suicide message.

![image](https://github.com/user-attachments/assets/de36e073-e50c-4779-a1c3-ec7f528f685d)
## Why It's Good For The Game

Closes #86062.

The Curse of Thanos has been broken...
## Changelog
:cl: Rhials
spellcheck: Anomaly suicides now use proper grammar.
fix: Anomaly suicides work again.
/:cl:
