### PR TITLE
Fixes consistency issue in crafting

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -365,8 +365,8 @@
 						if(!locate(S.type) in Deletion)
 							Deletion += S
 						else
-							SD = locate(S.type) in Deletion
-							SD.add(S.amount) // add to our tally stack, SD
+							SD = SD || locate(S.type) in Deletion
+							SD.add(S.amount) // add the amount to our tally stack, SD
 							qdel(S) // We can just delete it straight away as it's going to be fully consumed anyway
 						surroundings -= S
 			else

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -308,7 +308,6 @@
 	var/datum/reagents/holder
 	var/list/surroundings
 	var/list/Deletion = list()
-	var/data
 	var/amt
 	var/list/requirements = list()
 	if(R.reqs)
@@ -358,7 +357,7 @@
 							SD = new S.type()
 							Deletion += SD
 						S.use(amt)
-						SD = locate(S.type) in Deletion
+						SD = SD || locate(S.type) in Deletion // SD might be already set here, no sense in searching for it again
 						SD.amount += amt
 						continue main_loop
 					else
@@ -366,10 +365,9 @@
 						if(!locate(S.type) in Deletion)
 							Deletion += S
 						else
-							data = S.amount
-							S = locate(S.type) in Deletion
-							S.add(data)
-							S.use(data)
+							SD = locate(S.type) in Deletion
+							SD.add(S.amount) // add to our tally stack, SD
+							qdel(S) // We can just delete it straight away as it's going to be fully consumed anyway
 						surroundings -= S
 			else
 				var/atom/movable/I

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -367,7 +367,7 @@
 						else
 							SD = SD || locate(S.type) in Deletion
 							SD.add(S.amount) // add the amount to our tally stack, SD
-							qdel(S) // We can just delete it straight away as it's going to be fully consumed anyway
+							qdel(S) // We can just delete it straight away as it's going to be fully consumed anyway, saving some overhead from calling use()
 						surroundings -= S
 			else
 				var/atom/movable/I

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -369,6 +369,7 @@
 							data = S.amount
 							S = locate(S.type) in Deletion
 							S.add(data)
+							S.use(data)
 						surroundings -= S
 			else
 				var/atom/movable/I


### PR DESCRIPTION
## About The Pull Request

So I am keeping the PR title a bit vague as this is exploitable, and I will leave the specific steps to reproduce out for sake of preventing more people from using it...

But basically under certain conditions when crafting a recipe using the crafting menu, the requirements were not actually being consumed in the correct amounts. 

With knowledge of this exploit, you could take something that needs x amount of resources, and only spend a fraction of that. Then disassembling the item yields the full amount, granting you extra resources out of thin air.

## Why It's Good For The Game

Patches an economy breaking crafting exploit

## Changelog

:cl:
fix: fixes a crafting exploit that allowed you to get more resources back from disassembling than you put into the recipe
/:cl:

