### PR TITLE
Reverts an unintended change to Leeching Walk.

### DIFF
--- a/code/datums/elements/leeching_walk.dm
+++ b/code/datums/elements/leeching_walk.dm
@@ -55,3 +55,5 @@
 	// Heals blood loss
 	if(source.blood_volume < BLOOD_VOLUME_NORMAL)
 		source.blood_volume += 2.5 * seconds_per_tick
+	// Slowly regulates your body temp
+	source.adjust_bodytemperature((source.get_body_temp_normal() - source.bodytemperature)/5)


### PR DESCRIPTION

## About The Pull Request

Reverts an accidental change to leeching walk.

## Why It's Good For The Game
Few months ago, i reworked Rust Heretic and most of its skills.

https://github.com/tgstation/tgstation/pull/83006

One of the changes i pushed was a minor temperature regulation effect being added to leeching walk.

This was accidentally reverted by Carlactg in his pr on Cult Vs Heretic

https://github.com/tgstation/tgstation/pull/82877

This change was not discussed  nor alluded in the pr, and it wasn't even remotely related to it, Carlact themsleves admitted it was their mistake.

So i'm reverting it.

## Changelog

:cl:
revert: Leeching walk has been granted it's intended temp regulation effect back.
/:cl:

