### PR TITLE
All jaunts now kick you out if you are KO'd mid-jaunt

### DIFF
--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -23,6 +23,7 @@
 	jaunter.forceMove(src)
 	if(ismob(jaunter))
 		var/mob/mob_jaunter = jaunter
+		RegisterSignal(mob_jaunter, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 		mob_jaunter.reset_perspective(src)
 
 /obj/effect/dummy/phased_mob/Destroy()
@@ -55,6 +56,7 @@
 /obj/effect/dummy/phased_mob/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == jaunter)
+		UnregisterSignal(jaunter, COMSIG_MOB_STATCHANGE)
 		SEND_SIGNAL(src, COMSIG_MOB_EJECTED_FROM_JAUNT, jaunter)
 		jaunter = null
 
@@ -98,3 +100,9 @@
 		newloc = can_z_move(direction, get_turf(src), newloc, ZMOVE_INCAPACITATED_CHECKS | ZMOVE_FEEDBACK | ZMOVE_ALLOW_ANCHORED, user)
 
 	return newloc
+
+/// Signal proc for [COMSIG_MOB_STATCHANGE], to throw us out of the jaunt if we lose consciousness.
+/obj/effect/dummy/phased_mob/proc/on_stat_change(mob/living/source, new_stat, old_stat)
+	SIGNAL_HANDLER
+	if(source == jaunter && source.stat != CONSCIOUS)
+		eject_jaunter()

--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -83,7 +83,6 @@
 		jaunter.put_in_hands(right_hand)
 
 	RegisterSignal(jaunter, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), PROC_REF(on_focus_lost))
-	RegisterSignal(jaunter, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 	playsound(our_turf, 'sound/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	our_turf.visible_message(span_warning("[jaunter] sinks into [our_turf]!"))
 	new /obj/effect/temp_visual/space_explosion(our_turf)
@@ -107,7 +106,7 @@
 
 /datum/action/cooldown/spell/jaunt/space_crawl/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	UnregisterSignal(jaunt, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(unjaunter, list(SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), COMSIG_MOB_STATCHANGE))
+	UnregisterSignal(unjaunter, list(SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING)))
 	playsound(get_turf(unjaunter), 'sound/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	new /obj/effect/temp_visual/space_explosion(get_turf(unjaunter))
 	if(iscarbon(unjaunter))
@@ -121,13 +120,6 @@
 	SIGNAL_HANDLER
 	var/turf/our_turf = get_turf(source)
 	try_exit_jaunt(our_turf, source, TRUE)
-
-/// Signal proc for [COMSIG_MOB_STATCHANGE], to throw us out of the jaunt if we lose consciousness.
-/datum/action/cooldown/spell/jaunt/space_crawl/proc/on_stat_change(mob/living/source, new_stat, old_stat)
-	SIGNAL_HANDLER
-	if(new_stat != CONSCIOUS)
-		var/turf/our_turf = get_turf(source)
-		try_exit_jaunt(our_turf, source, TRUE)
 
 /// Spacecrawl "hands", prevent the user from holding items in spacecrawl
 /obj/item/space_crawl

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -62,7 +62,6 @@
 
 	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter)
 	RegisterSignal(jaunt, COMSIG_MOB_EJECTED_FROM_JAUNT, PROC_REF(on_jaunt_exited))
-	RegisterSignal(jaunter, COMSIG_MOB_STATCHANGE, PROC_REF(on_jaunt_exited))
 	check_flags &= ~AB_CHECK_PHASED
 	jaunter.add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
 	// Don't do the feedback until we have runechat hidden.
@@ -107,7 +106,6 @@
  */
 /datum/action/cooldown/spell/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	SHOULD_CALL_PARENT(TRUE)
-	UnregisterSignal(unjaunter, COMSIG_MOB_STATCHANGE)
 	check_flags |= AB_CHECK_PHASED
 	unjaunter.remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
 	// This needs to happen at the end, after all the traits and stuff is handled
@@ -120,12 +118,3 @@
 	var/obj/effect/dummy/phased_mob/jaunt = remove_from.loc
 	jaunt.eject_jaunter()
 	return ..()
-
-/// Signal proc for [COMSIG_MOB_STATCHANGE], to throw us out of the jaunt if we lose consciousness.
-/datum/action/cooldown/spell/jaunt/proc/on_stat_change(mob/living/source, new_stat, old_stat)
-	SIGNAL_HANDLER
-	exit_jaunt(source)
-	if(!is_jaunting(source))
-		return
-	var/obj/effect/dummy/phased_mob/jaunt = source.loc
-	jaunt.eject_jaunter()


### PR DESCRIPTION

## About The Pull Request

Basically, this is https://github.com/tgstation/tgstation/pull/83241 extended to all jaunts, like bloodcrawl and such

## Why It's Good For The Game

Kinda sucks getting RR'd if you die for some stupid reason mid-bloodcrawl (i.e accidentally suffocating while jaunting)

## Changelog
:cl:
 fix: You will now be ejected from any jaunt (i.e bloodcrawl or shadow walk) if you lose consciousness somehow during the jaunt.
/:cl:
