### PR TITLE
Green Star shifts will now show a random threat between yellow and red in the status report

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -393,16 +393,16 @@ SUBSYSTEM_DEF(dynamic)
 
 	switch(round(shown_threat))
 		if(0 to 19)
-			var/show_core_territory = (GLOB.current_living_antags.len > 0)
-			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))
-				show_core_territory = !show_core_territory
-
-			if (show_core_territory)
-				advisory_string += "Advisory Level: <b>Blue Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Blue Star. At this threat advisory, the risk of attacks on Nanotrasen assets within the sector is minor but cannot be ruled out entirely. Remain vigilant."
-			else
-				advisory_string += "Advisory Level: <b>Green Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department of Intelligence advises maintaining vigilance against potential threats, regardless of a lack of known threats."
+			switch(rand(1,3))
+				if(1)
+					advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
+					advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
+				if(2)
+					advisory_string += "Advisory Level: <b>Orange Star</b></center><BR>"
+					advisory_string += "Your sector's advisory level is Orange Star. Upon reviewing your sector's intelligence, the Department has determined that the risk of enemy activity is moderate to severe. At this advisory, we recommend maintaining a higher degree of security and reviewing red alert protocols with command and the crew."
+				if(3)
+					advisory_string += "Advisory Level: <b>Red Star</b></center><BR>"
+					advisory_string += "Your sector's advisory level is Red Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
 		if(20 to 39)
 			advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
 			advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -391,18 +391,11 @@ SUBSYSTEM_DEF(dynamic)
 		advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
 		return advisory_string
 
+	//Green shifts won't show on the status report so players won't suicide because >no valids
+	if(shown_threat <= 20)
+		shown_threat = rand(21, 79)
+
 	switch(round(shown_threat))
-		if(0 to 19)
-			switch(rand(1,3))
-				if(1)
-					advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
-					advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
-				if(2)
-					advisory_string += "Advisory Level: <b>Orange Star</b></center><BR>"
-					advisory_string += "Your sector's advisory level is Orange Star. Upon reviewing your sector's intelligence, the Department has determined that the risk of enemy activity is moderate to severe. At this advisory, we recommend maintaining a higher degree of security and reviewing red alert protocols with command and the crew."
-				if(3)
-					advisory_string += "Advisory Level: <b>Red Star</b></center><BR>"
-					advisory_string += "Your sector's advisory level is Red Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
 		if(20 to 39)
 			advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
 			advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."


### PR DESCRIPTION

## About The Pull Request

Any threat below 20 will now show either a yellow, orange, or red star alert in the status report.

![image](https://github.com/user-attachments/assets/191bed74-aac2-400a-888e-d33ee065ca1e)

For clarification, this does **not** remove green shifts from the game; it just makes the status report lie about what the actual threat is in cases where the threat is lower than a normal yellow star shift.
## Why It's Good For The Game

I think there's a bad mentality in the game right now surrounding the idea of a green shift. I've seen instances of players suiciding upon hearing it's a green shift. While this might not cut down on the behavior completely, I'm hoping players will be more willing to stick around for a round with less going on instead of leaving it due to a preconception about there not being any threats.

I considered a few other alternatives but didn't think they would really get done what I wanted done here:

- Removing the threat aspect of the report entirely sounds good on paper, and is probably my next step if this doesn't help, but I like the dread that comes with a potential high-threat round and I think it's a fun aspect that adds a fair bit of paranoia.
- Removing green shifts is a non-starter IMO; if every round is going to have the shit hit the fan, the paranoia goes down a fair bit. I also actually really like slower shifts from time to time, as I think they're important to help players cool off after a particularly eventful one.
- It was also recommended to just have the game tell people on the lobby that it's a green shift, but I'm not a fan of how this pulls the threat level further into a kind of meta warning about the state of the round and not an in-game representation of Nanotrasen's threat assessment. I feel like this is just going to result in players not playing if the threat level isn't high enough for them, and I would rather they at least contribute something and see if the round is going somewhere than just bail because not enough antags are going to exist.
## Changelog
:cl: Vekter
add: Green Star shifts will no longer show on the status report and will instead be replaced with either a yellow, orange, or red star report.
/:cl:
