### PR TITLE
Makes big manipulator hands move smoothly with the base when it's moved

### DIFF
--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -58,7 +58,6 @@
 		return
 	if(!manipulator_hand)
 		create_manipulator_hand()
-	manipulator_hand.forceMove(get_turf(src))
 
 /obj/machinery/big_manipulator/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -103,8 +102,9 @@
 
 /// Creat manipulator hand effect on manipulator core.
 /obj/machinery/big_manipulator/proc/create_manipulator_hand()
-	manipulator_hand = new/obj/effect/big_manipulator_hand(get_turf(src))
+	manipulator_hand = new/obj/effect/big_manipulator_hand(src)
 	manipulator_hand.dir = take_here
+	vis_contents += manipulator_hand
 
 /// Check servo tier and change manipulator speed, power_use and colour.
 /obj/machinery/big_manipulator/proc/manipulator_lvl()


### PR DESCRIPTION

## About The Pull Request

So when one were to move a big manipulator, the big manipulator hands would move choppily along with the smoothly moving base.
Looking into it, this seemed to be because it just made the hand effect on its turf, and then forcemoved it with itself as it moved.
To resolve the choppy movement, we just put the hand effect in the `contents` and `vis_contents` instead, meaning it moves and glides along with the arm automatically, while still letting us do all the hand animation stuff as is.

This resolves our choppy hand movement issue.
## Why It's Good For The Game

The choppy movement of the hand looked awful with the smooth movement of the big manipulator base.
## Changelog
:cl:
fix: Big manipulator hands now move smoothly with the base when it's moved.
/:cl:
