### PR TITLE
Detective board UI fixes

### DIFF
--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -167,7 +167,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 			cases -= case
 			current_case = cases.len
 			update_appearance(UPDATE_ICON)
-			. = TRUE
 			return TRUE
 		if("rename_case")
 			var/new_name = tgui_input_text(user, "Please ender the case new name",  "Detective's Board")

--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -114,12 +114,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 						data_evidence["text"] = paper.raw_text_inputs[1].raw_text
 			data_evidences += list(data_evidence)
 		data_case["evidences"] = data_evidences
-		data_cases += list(data_case)
-
-	data["data_connections"] = list()
-	if(cases.len > 0)
 		var/list/connections = list()
-		for(var/datum/evidence/evidence in cases[current_case].evidences)
+		for(var/datum/evidence/evidence in case.evidences)
 			for(var/datum/evidence/connection in evidence.connections)
 				var/list/from_pos = get_pin_position(evidence)
 				var/list/to_pos = get_pin_position(connection)
@@ -130,13 +126,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 				if(!found_in_connections)
 					var/list/data_connection = list("color" = "red", "from" = from_pos, "to" = to_pos)
 					connections += list(data_connection)
-		data["data_connections"] = connections
+		data_case["connections"] = connections
+		data_cases += list(data_case)
+
 	data["cases"] = data_cases
 	data["current_case"] = current_case
 	return data
 
 /obj/structure/detectiveboard/proc/get_pin_position(datum/evidence/evidence)
-	return list("x" =  evidence.x + 15, "y" =  evidence.y + 45)
+	return list("x" =  evidence.x + 15, "y" =  evidence.y + 15)
 
 /obj/structure/detectiveboard/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -147,10 +145,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 		if("add_case")
 			var/new_case = tgui_input_text(user, "Please enter the case name", "Detective's Board")
 			if(!new_case)
-				return
+				return FALSE
 			var/case_color = tgui_input_list(user, "Please choose case color", "Detective's Board", case_colors)
 			if(!case_color)
-				return
+				return FALSE
 
 			var/datum/case/case = new (new_case, case_color)
 			cases += case
@@ -169,6 +167,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 			cases -= case
 			current_case = cases.len
 			update_appearance(UPDATE_ICON)
+			. = TRUE
 			return TRUE
 		if("rename_case")
 			var/new_name = tgui_input_text(user, "Please ender the case new name",  "Detective's Board")
@@ -266,6 +265,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 	)
 	resistance_flags = FLAMMABLE
 	result_path = /obj/structure/detectiveboard
+	pixel_shift = 32
 
 /datum/evidence
 	var/name = "None"

--- a/tgui/packages/tgui/interfaces/DetectiveBoard/DataTypes.tsx
+++ b/tgui/packages/tgui/interfaces/DetectiveBoard/DataTypes.tsx
@@ -1,8 +1,11 @@
+import { Connection } from '../common/Connections';
+
 export type DataCase = {
   ref: string;
   name: string;
   color: string;
   evidences: DataEvidence[];
+  connections: Connection[];
 };
 
 export type DataEvidence = {

--- a/tgui/packages/tgui/interfaces/DetectiveBoard/Evidence.tsx
+++ b/tgui/packages/tgui/interfaces/DetectiveBoard/Evidence.tsx
@@ -115,7 +115,7 @@ export function Evidence(props: EvidenceProps) {
       <Stack vertical>
         <Stack.Item>
           <Box className="Evidence__Box">
-            <Flex justify="space-between" align="center">
+            <Flex justify="space-between" mt={0.5} align="top">
               <Flex.Item align="left">
                 <Pin
                   evidence={evidence}

--- a/tgui/packages/tgui/interfaces/DetectiveBoard/Pin.tsx
+++ b/tgui/packages/tgui/interfaces/DetectiveBoard/Pin.tsx
@@ -3,8 +3,6 @@ import { useEffect, useState } from 'react';
 import { Box, Stack } from '../../components';
 import { DataEvidence } from './DataTypes';
 
-const Y_OFFSET = -45;
-
 type PinProps = {
   evidence: DataEvidence;
   onStartConnecting: Function;
@@ -20,7 +18,7 @@ export function Pin(props: PinProps) {
     setCreatingRope(true);
     onStartConnecting(evidence, {
       x: args.clientX,
-      y: args.clientY + Y_OFFSET,
+      y: args.clientY,
     });
   }
 
@@ -35,7 +33,7 @@ export function Pin(props: PinProps) {
           evidence_ref: 'not used',
           position: {
             x: args.clientX,
-            y: args.clientY + Y_OFFSET,
+            y: args.clientY,
           },
         });
       }

--- a/tgui/packages/tgui/styles/interfaces/DetectiveBoard.scss
+++ b/tgui/packages/tgui/styles/interfaces/DetectiveBoard.scss
@@ -49,18 +49,22 @@
   padding: 5px;
   color: black;
   min-width: 200px;
+  max-width: 300px;
   background-color: white;
   border: 2px solid grey;
   -ms-user-select: none;
   user-select: none;
+  text-wrap: wrap;
   cursor: pointer;
 }
 
 .Evidence__Box__TextBox {
   border-top: 1px solid #eaeaea;
-  word-wrap: break-word;
+  text-wrap: wrap;
   padding: 5px 0;
   margin-top: 5px;
+  max-width: 240px;
+  text-align: center;
 
   &.title {
     border-top: none;
@@ -72,8 +76,8 @@
   position: relative;
   background-color: #edcf64;
   padding: 5px;
-  min-height: 730px;
   overflow: hidden;
+  height: 95%;
 }
 
 .Evidence__Icon {


### PR DESCRIPTION
## About The Pull Request

If you switch case, the ropes will stay, untill you reenter in the interface. Now it will change to new case's ropes ☑
If you scroll down with linked evidences, ropes will stay on the screen. Now it will move with evidences ☑
If you try put big content in paper, evidence wil be VERY big. Now max width is 300px ☑
Title will wrap, if it too big. Content of evidence too. ☑

Also i again fixed placement problem, because of wallening revert ☑

## Why It's Good For The Game

Fixes

## Changelog

:cl: FeudeyTF
fix: fixed an UI problems of evidence board
/:cl:
