### PR TITLE
Exodrones can now have a custom name assigned by mappers

### DIFF
--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 
 /obj/item/exodrone/Initialize(mapload)
 	. = ..()
-	if(name == initial(name))
+	if(name == /obj/item/exodrone::name)
 		name = pick(strings(EXODRONE_FILE,"probe_names"))
 		if(name_counter[name])
 			name_counter[name]++

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -63,12 +63,15 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 
 /obj/item/exodrone/Initialize(mapload)
 	. = ..()
-	name = pick(strings(EXODRONE_FILE,"probe_names"))
-	if(name_counter[name])
-		name_counter[name]++
-		name = "[name] \Roman[name_counter[name]]"
+	if(name == "exploration drone")
+		name = pick(strings(EXODRONE_FILE,"probe_names"))
+		if(name_counter[name])
+			name_counter[name]++
+			name = "[name] \Roman[name_counter[name]]"
+		else
+			name_counter[name] = 1
 	else
-		name_counter[name] = 1
+		name = name
 	GLOB.exodrones += src
 	// Cargo storage
 	create_storage(max_slots = EXODRONE_CARGO_SLOTS, canthold = GLOB.blacklisted_cargo_types)

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 
 /obj/item/exodrone/Initialize(mapload)
 	. = ..()
-	if(name == "exploration drone")
+	if(name == initial(name))
 		name = pick(strings(EXODRONE_FILE,"probe_names"))
 		if(name_counter[name])
 			name_counter[name]++


### PR DESCRIPTION

## About The Pull Request
This adds a simple check to see if an exploration drone has had a unique name set when designing a map. Previously, there was no check, and the name would be overridden by the name generator.
I've only done basic testing, and it seems like it works perfectly fine. The unedited drones received their random names, and the edited drone kept its special name.
## Why It's Good For The Game
More freedom for mappers, if they want to include an exploration drone that has a not randomly generated name.
## Changelog
Nothing player facing.
