### PR TITLE
adds the emergency workplace relocation station trait

### DIFF
--- a/code/__HELPERS/clients.dm
+++ b/code/__HELPERS/clients.dm
@@ -16,3 +16,4 @@
 /proc/unvalidated_client_error(client/target)
 	to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."))
 	log_access("Client [key_name(target)] attempted to execute a verb before being fully initialized.")
+link()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -540,3 +540,22 @@
 	dynamic_category = RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
 	threat_reduction = 15
 	dynamic_threat_id = "Background Checks"
+
+/datum/station_trait/to_terry
+	name = "Emergency Workplace Relocation"
+	report_message = "Right before you all boarded your shuttles to travel to your expected worksite, Syndicate threat actors disclosed the location of the site on several malicious channels, thus you will be relocated to an alternative workplace to continue your duties to the company. Glory to NanoTranesen"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 0.3
+	show_in_report = TRUE
+	can_revert = TRUE
+	var/destination = ""
+
+/datum/station_trait/to_terry/New()
+	destination = pick(
+	"bagil.tgstation13.org:2337",
+	"sybil.tgstation13.org:1337",
+	"terry.tgstation13.org:3336",
+	"campbell.tgstation13.org:6337",)
+
+/datum/station_trait/to_terry/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
+	player_client << link(destination)


### PR DESCRIPTION

## About The Pull Request
adds a station trait that will randomly pick a new server and send all players there

this PR adds the station event "emergency workplace relocation". it is a very low weight (0.3) and can be reverted by admins. it will select a main TG server and send all players there when they attempt to spawn in as any job
## Why It's Good For The Game
will push players to (very rarely) expierence different server cultures and make for some fun shennanigans

## Changelog

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

!!TODO!!

add config and unhardcode the servers