### PR TITLE
Fixes an oversight with jump boots

### DIFF
--- a/code/modules/clothing/shoes/jumpboots.dm
+++ b/code/modules/clothing/shoes/jumpboots.dm
@@ -36,6 +36,7 @@
 		user.visible_message(span_warning("[usr] dashes forward into the air!"))
 		recharging_time = world.time + recharging_rate
 	else
+		REMOVE_TRAIT(user, TRAIT_MOVE_FLOATING, LEAPING_TRAIT)
 		to_chat(user, span_warning("Something prevents you from dashing forward!"))
 
 /obj/item/clothing/shoes/bhop/rocket


### PR DESCRIPTION
## About The Pull Request

Tin, the trait doesn't get removed under certain circumstances (not going to say what they are because it can be exploited easily).

This leads to permanent noslip and zooming around like the gravity generator is dead.

## Why It's Good For The Game

Fixes an exploitable bug.

## Changelog

:cl:
fix: fixed a bug that could sometimes cause jump boots users to retain the floating trait indefinitely when using the ability
/:cl:
