### PR TITLE
Changed `BUILD.cmd` in the RUNNING_A_SERVER.MD instructions to the correct file extension

### DIFF
--- a/.github/guides/RUNNING_A_SERVER.md
+++ b/.github/guides/RUNNING_A_SERVER.md
@@ -4,7 +4,7 @@ BYOND installed. You can get it from https://www.byond.com/download. Once you've
 that, extract the game files to wherever you want to keep them. This is a
 sourcecode-only release, so the next step is to compile the server files.
 
-Double-click `BUILD.bat` in the root directory of the source code. This'll take
+Double-click `BUILD.cmd` in the root directory of the source code. This'll take
 a little while, and if everything's done right you'll get a message like this:
 
 ```


### PR DESCRIPTION

## About The Pull Request

File was named `BUILD.bat`  in the instructions for running a server (RUNNING_A_SERVER.md) but in the directory it is named `BUILD.cmd`. A small change, but it makes it clearer which file is the correct one for the reader.
## Why It's Good For The Game

It doesn't affect the game.
## Changelog
:cl:
spellcheck: fixed a wrong extension in the RUNNING_A_SERVER.md
/:cl:
