### PR TITLE
Changes Brimdemon Trophy Text

### DIFF
--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
@@ -8,7 +8,7 @@
 	var/static/list/comic_phrases = list("BOOM", "BANG", "KABLOW", "KAPOW", "OUCH", "BAM", "KAPOW", "WHAM", "POW", "KABOOM")
 
 /obj/item/crusher_trophy/brimdemon_fang/effect_desc()
-	return "mark detonation creates visual and audiosensory effects on the target"
+	return "visual and audiosensory effects on the target upon mark detonation"
 
 /obj/item/crusher_trophy/brimdemon_fang/on_mark_detonation(mob/living/target, mob/living/user)
 	target.balloon_alert_to_viewers("[pick(comic_phrases)]!")

--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
@@ -8,7 +8,7 @@
 	var/static/list/comic_phrases = list("BOOM", "BANG", "KABLOW", "KAPOW", "OUCH", "BAM", "KAPOW", "WHAM", "POW", "KABOOM")
 
 /obj/item/crusher_trophy/brimdemon_fang/effect_desc()
-	return "visual and audiosensory effects on the target upon mark detonation"
+	return "mark detonation to inflict visual and audiosensory effects on the target"
 
 /obj/item/crusher_trophy/brimdemon_fang/on_mark_detonation(mob/living/target, mob/living/user)
 	target.balloon_alert_to_viewers("[pick(comic_phrases)]!")

--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
@@ -8,7 +8,7 @@
 	var/static/list/comic_phrases = list("BOOM", "BANG", "KABLOW", "KAPOW", "OUCH", "BAM", "KAPOW", "WHAM", "POW", "KABOOM")
 
 /obj/item/crusher_trophy/brimdemon_fang/effect_desc()
-	return "mark detonation to inflict visual and audiosensory effects on the target"
+	return "mark detonation to create visual and audiosensory effects at the target"
 
 /obj/item/crusher_trophy/brimdemon_fang/on_mark_detonation(mob/living/target, mob/living/user)
 	target.balloon_alert_to_viewers("[pick(comic_phrases)]!")


### PR DESCRIPTION
## About The Pull Request

Changes the message on the brimdemon horn from "It has a brimdemon's fang attached, which causes mark detonation creates visual and audiosensory effects on the target." to "It has a brimdemon's fang attached, which causes mark detonation to create visual and audiosensory effects at the target.

## Why It's Good For The Game

Closes #86460
Makes the trophy read better

## Changelog
:cl:
spellcheck: made the grammar on the brimdemon horn crusher trophy nicer
/:cl:
