### PR TITLE
Fixes the forgotten_ship captain having a normal makarov instead of a stetchkin APS

### DIFF
--- a/_maps/virtual_domains/syndicate_assault.dmm
+++ b/_maps/virtual_domains/syndicate_assault.dmm
@@ -693,7 +693,7 @@
 /obj/item/crowbar/red,
 /obj/item/ammo_box/magazine/m9mm_aps,
 /obj/item/ammo_box/magazine/m9mm_aps,
-/obj/item/gun/ballistic/automatic/pistol,
+/obj/item/gun/ballistic/automatic/pistol/aps,
 /turf/open/floor/carpet/royalblack,
 /area/virtual_domain)
 "Cn" = (


### PR DESCRIPTION
## About The Pull Request
Replaces the normal automatic makarov with the stechkin APS
## Why It's Good For The Game
I'm super sure back then the captain had a stechkin aps, probably a botched updatepaths job.
## Changelog
:cl:
fix: Fixes makarov-stechkin mix up on forgotten ship virtual domain.
/:cl:

fixes #86287