### PR TITLE
You don't need two hands to stream with broadcast camera

### DIFF
--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -21,7 +21,7 @@
 	light_power = 0.3
 	light_on = FALSE
 	/// Is camera streaming
-	var/activate = FALSE
+	var/active = FALSE
 	/// The name of the broadcast
 	var/broadcast_name = "Curator News"
 	/// The networks it broadcasts to, default is CAMERANET_NETWORK_CURATOR
@@ -43,8 +43,8 @@
 
 /obj/item/broadcast_camera/attack_self(mob/user, modifiers)
 	. = ..()
-	activate = !activate
-	if(activate)
+	active = !active
+	if(active)
 		on_activating()
 	else
 		on_deactivating()
@@ -59,15 +59,15 @@
 
 /obj/item/broadcast_camera/on_enter_storage(datum/storage/master_storage)
 	. = ..()
-	if(activate)
+	if(active)
 		on_deactivating()
 
 /// When activating the camera
 /obj/item/broadcast_camera/proc/on_activating()
 	if(!iscarbon(loc))
 		return
-	activate = TRUE
-	icon_state = "[base_icon_state][activate]"
+	active = TRUE
+	icon_state = "[base_icon_state][active]"
 	/// The carbon who wielded the camera, allegedly
 	var/mob/living/carbon/wielding_carbon = loc
 
@@ -87,8 +87,8 @@
 
 /// When deactivating the camera
 /obj/item/broadcast_camera/proc/on_deactivating()
-	activate = FALSE
-	icon_state = "[base_icon_state][activate]"
+	active = FALSE
+	icon_state = "[base_icon_state][active]"
 	QDEL_NULL(internal_camera)
 	QDEL_NULL(internal_radio)
 

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -62,6 +62,11 @@
 	if(active)
 		on_deactivating()
 
+/obj/item/broadcast_camera/dropped(mob/user, silent)
+	. = ..()
+	if(active)
+		on_deactivating()
+
 /// When activating the camera
 /obj/item/broadcast_camera/proc/on_activating()
 	if(!iscarbon(loc))

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -44,13 +44,10 @@
 /obj/item/broadcast_camera/attack_self(mob/user, modifiers)
 	. = ..()
 	activate = !activate
-	icon_state = "[base_icon_state][activate]"
 	if(activate)
 		on_activating()
-		playsound(src, 'sound/misc/radio_talk.ogg', 100, TRUE)
 	else
 		on_deactivating()
-		playsound(src, 'sound/misc/radio_receive.ogg', 100, TRUE)
 
 /obj/item/broadcast_camera/attack_self_secondary(mob/user, modifiers)
 	. = ..()
@@ -60,10 +57,17 @@
 	. = ..()
 	. += span_notice("Broadcast name is <b>[broadcast_name]</b>")
 
+/obj/item/broadcast_camera/on_enter_storage(datum/storage/master_storage)
+	. = ..()
+	if(activate)
+		on_deactivating()
+
 /// When activating the camera
 /obj/item/broadcast_camera/proc/on_activating()
 	if(!iscarbon(loc))
 		return
+	activate = TRUE
+	icon_state = "[base_icon_state][activate]"
 	/// The carbon who wielded the camera, allegedly
 	var/mob/living/carbon/wielding_carbon = loc
 
@@ -83,6 +87,8 @@
 
 /// When deactivating the camera
 /obj/item/broadcast_camera/proc/on_deactivating()
+	activate = FALSE
+	icon_state = "[base_icon_state][activate]"
 	QDEL_NULL(internal_camera)
 	QDEL_NULL(internal_radio)
 

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -20,6 +20,8 @@
 	light_range = 1
 	light_power = 0.3
 	light_on = FALSE
+	/// Is camera streaming
+	var/activate = FALSE
 	/// The name of the broadcast
 	var/broadcast_name = "Curator News"
 	/// The networks it broadcasts to, default is CAMERANET_NETWORK_CURATOR
@@ -28,16 +30,6 @@
 	var/obj/machinery/camera/internal_camera
 	/// The "virtual" radio inside of the the physical camera, a la microphone
 	var/obj/item/radio/entertainment/microphone/internal_radio
-
-/obj/item/broadcast_camera/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/two_handed, \
-		force_unwielded = 8, \
-		force_wielded = 12, \
-		icon_wielded = "[base_icon_state]1", \
-		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
-		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
-	)
 
 /obj/item/broadcast_camera/Destroy(force)
 	QDEL_NULL(internal_radio)
@@ -49,6 +41,17 @@
 	icon_state = "[base_icon_state]0"
 	return ..()
 
+/obj/item/broadcast_camera/attack_self(mob/user, modifiers)
+	. = ..()
+	activate = !activate
+	icon_state = "[base_icon_state][activate]"
+	if(activate)
+		on_activating()
+		playsound(src, 'sound/misc/radio_talk.ogg', 100, TRUE)
+	else
+		on_deactivating()
+		playsound(src, 'sound/misc/radio_receive.ogg', 100, TRUE)
+
 /obj/item/broadcast_camera/attack_self_secondary(mob/user, modifiers)
 	. = ..()
 	broadcast_name = tgui_input_text(user = user, title = "Broadcast Name", message = "What will be the name of your broadcast?", default = "[broadcast_name]", max_length = MAX_CHARTER_LEN)
@@ -57,8 +60,8 @@
 	. = ..()
 	. += span_notice("Broadcast name is <b>[broadcast_name]</b>")
 
-/// When wielding the camera
-/obj/item/broadcast_camera/proc/on_wield()
+/// When activating the camera
+/obj/item/broadcast_camera/proc/on_activating()
 	if(!iscarbon(loc))
 		return
 	/// The carbon who wielded the camera, allegedly
@@ -78,8 +81,8 @@
 	playsound(source = src, soundin = 'sound/machines/terminal_processing.ogg', vol = 20, vary = FALSE, ignore_walls = FALSE)
 	balloon_alert_to_viewers("live!")
 
-/// When unwielding the camera
-/obj/item/broadcast_camera/proc/on_unwield()
+/// When deactivating the camera
+/obj/item/broadcast_camera/proc/on_deactivating()
 	QDEL_NULL(internal_camera)
 	QDEL_NULL(internal_radio)
 


### PR DESCRIPTION
## About Pull Request
 You don't need two hands to stream with broadcast camera. Insteed you need just click on camera to start streaming and click again to finish.

## Why It's Good For The Game

It’s very inconvenient when camera takes two hands and to take something you need to turn off the stream because the stream only works when the camera is in two hands.

## Changelog

:cl:
qol: You don't need two hands to stream with broadcast camera.
/:cl:
