### PR TITLE
Reformats rebar crossbow description, removes nonexistent misfire warning.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -193,8 +193,8 @@
 
 /obj/item/gun/ballistic/rifle/rebarxbow
 	name = "Heated Rebar Crossbow"
-	desc = "Made from an inducer, iron rods, and some wire, this crossbow fires sharpened iron rods, made from the plentiful iron rods found stationwide. \
-		   Additionally, can fire specialty ammo made from the materials in the atmos crystalizer - zaukerite, metallic hydrogen, and healium crytals all work. \
+	desc = "A handcrafted crossbow. \
+		   Aside from conventional sharpened iron rods, it can also fire specialty ammo made from the atmos crystalizer - zaukerite, metallic hydrogen, and healium rods all work. \
 		   Very slow to reload - you can craft the crossbow with a crowbar to try loosen the crossbar, but risks a misfire, or worse..."
 	icon = 'icons/obj/weapons/guns/ballistic.dmi'
 	icon_state = "rebarxbow"
@@ -211,7 +211,6 @@
 	bolt_wording = "bowstring"
 	magazine_wording = "rod"
 	cartridge_wording = "rod"
-	misfire_probability = 25
 	weapon_weight = WEAPON_HEAVY
 	initial_caliber = CALIBER_REBAR
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/normal
@@ -277,7 +276,7 @@
 /obj/item/gun/ballistic/rifle/rebarxbow/syndie
 	name = "Syndicate Rebar Crossbow"
 	desc = "The syndicate liked the bootleg rebar crossbow NT engineers made, so they showed what it could be if properly developed. \
-			Holds three shots without a chance of exploding, and features a built in scope. Compatable with all known crossbow ammunition."
+			Holds three shots without a chance of exploding, and features a built in scope. Compatible with all known crossbow ammunition."
 	icon_state = "rebarxbowsyndie"
 	inhand_icon_state = "rebarxbowsyndie"
 	worn_icon_state = "rebarxbowsyndie"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -195,7 +195,7 @@
 	name = "Heated Rebar Crossbow"
 	desc = "A handcrafted crossbow. \
 		   Aside from conventional sharpened iron rods, it can also fire specialty ammo made from the atmos crystalizer - zaukerite, metallic hydrogen, and healium rods all work. \
-		   Very slow to reload - you can craft the crossbow with a crowbar to try loosen the crossbar, but risks a misfire, or worse..."
+		   Very slow to reload - you can craft the crossbow with a crowbar to loosen the crossbar, but risk a misfire, or worse..."
 	icon = 'icons/obj/weapons/guns/ballistic.dmi'
 	icon_state = "rebarxbow"
 	inhand_icon_state = "rebarxbow"


### PR DESCRIPTION
Reworked description of rebarxbow, and rebarxbow/syndie. Removed incorrect missfire label on rebarxbow regular variant.
## About The Pull Request

The description for the rebar crossbow is too long-winded, so I made it succinct.
Fixes a few typos too, and removes a warning about misfire for regular crossbows that has no business for being there.

What this PR does **not** fix are the recent changes in gun code lowering the reserve ammo count for all crossbows by one, thanks to some off-by-one shenanigans that crossbows formerly exploited.
I chose to not include a fix for it in this PR, as it could be considered a balance change.


## Why It's Good For The Game

Good grammar good, Bad grammar bad. Long text bad, shorter text good.

## Changelog


:cl:
spellcheck: Changed description of Rebar crossbow.
fix: Rebar crossbow description will no longer lie about it's missfire potential.
/:cl:
