### PR TITLE
Fixes an faulty message when a AI controlled mech is destroyed

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -61,7 +61,6 @@
 
 /obj/structure/ai_core/Destroy()
 	if(istype(remote_ai))
-		remote_ai.break_core_link()
 		remote_ai = null
 	QDEL_NULL(circuit)
 	QDEL_NULL(core_mmi)
@@ -72,7 +71,7 @@
 	. = ..()
 	if(. > 0 && istype(remote_ai))
 		to_chat(remote_ai, span_danger("Your core is under attack!"))
-	
+
 
 /obj/structure/ai_core/deactivated
 	icon_state = "ai-empty"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/86127

## Changelog
:cl:
fix: Fixes an faulty message when a AI controlled mech is destroyed
/:cl:
