### PR TITLE
fixes an if statement from the jump emote

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -163,6 +163,6 @@
 
 // Avoids playing sounds if we're a ghost
 /datum/emote/jump/should_play_sound(mob/user, intentional)
-	if ishuman(user)
+	if(isliving(user))
 		return ..()
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
An if statement without parenthetis slipped through the cracks after optimumtact resolved the conflicts in his latest PR, discarding the previous reviews. I'm not sure if functionally it works the same, but it sure doesn't fit the coding style either way.

This also changes the condition from `ishuman(user)` to `isliving(user)`, there's no reason to restrict the sound to human mobs, we only need to exclude observers from playing it.

## Why It's Good For The Game
See above.

## Changelog
N/A ?