### PR TITLE
Allows people to skip the icon cutter on a DMTARGET, but properly this time

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -63,6 +63,7 @@ export const DefineParameter = new Juke.Parameter({
   alias: 'D',
 });
 
+
 export const PortParameter = new Juke.Parameter({
   type: 'string',
   alias: 'p',
@@ -77,6 +78,10 @@ export const CiParameter = new Juke.Parameter({ type: 'boolean' });
 export const ForceRecutParameter = new Juke.Parameter({
   type: 'boolean',
   name: "force-recut",
+});
+export const SkipIconCutter = new Juke.Parameter({
+  type: 'boolean',
+  name: "skip-icon-cutter",
 });
 
 export const WarningParameter = new Juke.Parameter({
@@ -204,10 +209,10 @@ export const DmMapsIncludeTarget = new Juke.Target({
 });
 
 export const DmTarget = new Juke.Target({
-  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
+  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter, SkipIconCutter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
-    IconCutterTarget,
+    !get(SkipIconCutter) && IconCutterTarget,
   ],
   inputs: [
     '_maps/map_files/generic/**',

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -63,7 +63,6 @@ export const DefineParameter = new Juke.Parameter({
   alias: 'D',
 });
 
-
 export const PortParameter = new Juke.Parameter({
   type: 'string',
   alias: 'p',

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -79,6 +79,7 @@ export const ForceRecutParameter = new Juke.Parameter({
   type: 'boolean',
   name: "force-recut",
 });
+
 export const SkipIconCutter = new Juke.Parameter({
   type: 'boolean',
   name: "skip-icon-cutter",


### PR DESCRIPTION
Adds a new build parameter to skip icon cutting, this build parameter is --skip-icon-cutter

This allows users like myself who don't have a working hypnagogic to build the game when we are trying to debug code issues and don't care about icons being cut or not
