### PR TITLE
Fix the task bar icon for the client

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -65,7 +65,7 @@ window "mainwindow"
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
 		statusbar = false
-		icon = 'icons\\ui_icons\\common\\tg_32.png'
+		icon = 'icons\\ui\\common\\tg_32.png'
 		macro = "default"
 		menu = "menu"
 	elem "split"


### PR DESCRIPTION
This got renamed in a icons folder rework some time ago but this reference isn't enforced at compile time like it should be. (also likely a byond bug) so when the file was renamed this never came up as a reference to it.

:cl:
fix: Fixed the taskbar/menu bar icon showing the virgin orange byond icon instead of the chad blue ss13 icon.
/:cl:
