### PR TITLE
Add start and completion gates to CI

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -19,9 +19,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_linters:
+  start_gate:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
+    name: Start Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mandatory Empty Step
+        run: exit 0
+
+  run_linters:
     name: Run Linters
+    needs: start_gate
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
@@ -130,9 +138,8 @@ jobs:
         run: tools/build/build --ci lint tgui-test
 
   compile_all_maps:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Compile Maps
-    needs: [collect_data]
+    needs: collect_data
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
@@ -155,8 +162,8 @@ jobs:
           max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}
 
   collect_data:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Collect data for other tasks
+    needs: start_gate
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -185,9 +192,8 @@ jobs:
           echo "max_required_byond_client=$(grep -Ev '^[[:blank:]]{0,}#{1,}|^[[:blank:]]{0,}$' .github/max_required_byond_client.txt | tail -n1)" >> $GITHUB_OUTPUT
 
   run_all_tests:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
-    needs: [collect_data]
+    needs: collect_data
 
     strategy:
       fail-fast: false
@@ -200,9 +206,9 @@ jobs:
       max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
 
   run_alternate_tests:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') && needs.collect_data.outputs.alternate_tests != '[]' )
+    if: needs.collect_data.outputs.alternate_tests != '[]'
     name: Alternate Tests
-    needs: [collect_data]
+    needs: collect_data
     strategy:
       fail-fast: false
       matrix:
@@ -216,16 +222,15 @@ jobs:
       max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
 
   check_alternate_tests:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') && needs.collect_data.outputs.alternate_tests != '[]' )
     name: Check Alternate Tests
-    needs: [run_alternate_tests]
+    needs: run_alternate_tests
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - run: echo Alternate tests passed.
 
   compare_screenshots:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') && (always() && (!failure() && !cancelled())) )
+    if: (!failure() && !cancelled())
     needs: [run_all_tests, run_alternate_tests]
     name: Compare Screenshot Tests
     timeout-minutes: 15
@@ -263,7 +268,6 @@ jobs:
           path: artifacts/screenshot_comparisons
 
   test_windows:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Windows Build
     needs: [collect_data]
     runs-on: windows-latest
@@ -287,3 +291,11 @@ jobs:
         with:
           dmb-location: tgstation.dmb
           max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}
+
+  completion_gate: # Serves as a non-moving target for branch rulesets
+    name: Completion Gate
+    needs: [ test_windows, compare_screenshots ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mandatory Empty Step
+        run: exit 0


### PR DESCRIPTION
Start gate means we only need to check `[ci skip]` once

Completion gate means we need only one status check in our rulesets.