### PR TITLE
Circuitboards track station level association

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -159,10 +159,18 @@
 	fire = 50
 	acid = 70
 
-/obj/machinery/Initialize(mapload)
+/obj/machinery/Initialize(mapload, obj/structure/frame/machine/frame_with_parts = null, mob/living/builder = null, obj/item/building_tool = null)
 	. = ..()
 	SSmachines.register_machine(src)
 
+	if(frame_with_parts && istype(frame_with_parts, /obj/structure/frame/machine))
+		circuit = frame_with_parts.circuit
+		component_parts = frame_with_parts?.components
+		for (var/obj/new_part in component_parts)
+			new_part.forceMove(src)
+		//Inform machine that its finished & cleanup
+		RefreshParts()
+		on_construction(builder)
 	if(ispath(circuit, /obj/item/circuitboard))
 		circuit = new circuit(src)
 		circuit.apply_default_parts(src)

--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -445,23 +445,10 @@
 			return FALSE
 
 	tool.play_tool_sound(src)
-	var/obj/machinery/new_machine = new circuit.build_path(loc)
+	var/obj/machinery/new_machine = new circuit.build_path(loc, /* frame_with_parts = */src, /*builder = */user, /*building_tool = */tool)
 	if(istype(new_machine))
-		new_machine.clear_components()
-		// Set anchor state
 		new_machine.set_anchored(anchored)
-		// Prevent us from dropping stuff thanks to /Exited
-		var/obj/item/circuitboard/machine/leaving_circuit = circuit
 		circuit = null
-		// Assign the circuit & parts & move them all at once into the machine
-		// no need to separately move circuit board as its already part of the components list
-		new_machine.circuit = leaving_circuit
-		new_machine.component_parts = components
-		for (var/obj/new_part in components)
-			new_part.forceMove(new_machine)
-		//Inform machine that its finished & cleanup
-		new_machine.RefreshParts()
-		new_machine.on_construction(user)
 		components = null
 	qdel(src)
 	return TRUE

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -27,9 +27,10 @@
 		name = "[initial(name)] [name_extension]"
 	if(icon_state == "circuit_map") // some circuitboards have cool custom sprites
 		set_greyscale(new_config = /datum/greyscale_config/circuit)
-	var/turf/my_turf = get_turf(src)
-	if(mapload && !is_station_level(my_turf.z))
-		onstation = FALSE
+	if(mapload)
+		var/turf/my_turf = get_turf(src)
+		if(!is_station_level(my_turf.z))
+			onstation = FALSE
 	return ..()
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/machine)

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -27,6 +27,9 @@
 		name = "[initial(name)] [name_extension]"
 	if(icon_state == "circuit_map") // some circuitboards have cool custom sprites
 		set_greyscale(new_config = /datum/greyscale_config/circuit)
+	var/turf/my_turf = get_turf(src)
+	if(mapload && !is_station_level(my_turf.z))
+		onstation = FALSE
 	return ..()
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/machine)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -258,13 +258,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	power_change()
 
 	if(mapload) //check if it was initially created off station during mapload.
-		if(!is_station_level(z))
-			if(!onstation_override)
-				onstation = FALSE
-			if(circuit)
-				circuit.onstation = onstation //sync up the circuit so the pricing schema is carried over if it's reconstructed.
-
-		else if(HAS_TRAIT(SSstation, STATION_TRAIT_VENDING_SHORTAGE))
+		if(HAS_TRAIT(SSstation, STATION_TRAIT_VENDING_SHORTAGE))
 			for (var/datum/data/vending_product/product_record as anything in product_records + coin_records + hidden_records)
 				/**
 				 * in average, it should be 37.5% of the max amount, rounded up to the nearest int,
@@ -276,8 +270,6 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 			if(tiltable && prob(6)) // 1 in 17 chance to start tilted (as an additional hint to the station trait behind it)
 				INVOKE_ASYNC(src, PROC_REF(tilt), loc)
 				credits_contained = 0 // If it's tilted, it's been looted, so no credits for you.
-	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
-		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
 	if(onstation && !onstation_override)
 		AddComponent(/datum/component/payment, 0, SSeconomy.get_dep_account(payment_department), PAYMENT_VENDING)
 		GLOB.vending_machines_to_restock += src //We need to keep track of the final onstation vending machines so we can keep them restocked.


### PR DESCRIPTION

## About The Pull Request

Vendors currently determine their pricing (and probably some other behaviors) via a few things, and one of them is it they were initialized off-station during mapload.

Currently, however, this breaks if they get reconstructed because circuitboards inside them don't also check for this.

This fixes that.
## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/86514
Allows us to accurately track if a machine is from the station or somewhere else(I am planning to use this, might be useful for others)
## Changelog
:cl: Bisar
fix: Circuitboards now properly keep track of their origin regarding on or off-station map placement.
/:cl:
