### PR TITLE
Fixes broken malf AI shunting, fixes AI dying when they move a controlled mech into the SM, undoes mech domination cancelling delta, makes mech destruction during control cause a massive EMP instead

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_silicon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_silicon.dm
@@ -8,3 +8,12 @@
 	#define COMSIG_BORG_HUG_HANDLED 1
 ///called from /mob/living/silicon/attack_hand proc
 #define COMSIG_MOB_PAT_BORG "mob_pat_borg"
+///called when someone is inquiring about an AI's linked core
+#define COMSIG_SILICON_AI_CORE_STATUS "AI_core_status"
+	#define	COMPONENT_CORE_ALL_GOOD (1<<0)
+	#define	COMPONENT_CORE_DISCONNECTED (1<<1)
+///called when an AI (malf or perhaps combat upgraded or some other circumstance that has them inhabit
+///an APC) enters an APC
+#define COMSIG_SILICON_AI_OCCUPY_APC "AI_occupy_apc"
+///called when an AI vacates an APC
+#define COMSIG_SILICON_AI_VACATE_APC "AI_vacate_apc"

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -41,6 +41,7 @@
 	malfunction_flavor = strings(MALFUNCTION_FLAVOR_FILE, employer)
 
 	add_law_zero()
+	RegisterSignal(owner.current, COMSIG_SILICON_AI_CORE_STATUS, PROC_REF(core_status))
 	if(malf_sound)
 		owner.current.playsound_local(get_turf(owner.current), malf_sound, 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	owner.current.grant_language(/datum/language/codespeak, source = LANGUAGE_MALF)
@@ -58,7 +59,7 @@
 		QDEL_NULL(malf_ai.malf_picker)
 
 	owner.special_role = null
-
+	UnregisterSignal(owner, COMSIG_SILICON_AI_CORE_STATUS)
 	return ..()
 
 /// Generates a complete set of malf AI objectives up to the traitor objective limit.
@@ -270,6 +271,14 @@
 	malf_ai_icon.Scale(ANTAGONIST_PREVIEW_ICON_SIZE, ANTAGONIST_PREVIEW_ICON_SIZE)
 
 	return malf_ai_icon
+
+/datum/antagonist/malf_ai/proc/core_status(datum/source)
+	SIGNAL_HANDLER
+
+	var/mob/living/silicon/ai/malf_owner = owner.current
+	if(malf_owner.linked_core)
+		return COMPONENT_CORE_ALL_GOOD
+	return COMPONENT_CORE_DISCONNECTED
 
 //Subtype of Malf AI datum, used for one of the traitor final objectives
 /datum/antagonist/malf_ai/infected

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -778,12 +778,26 @@
 	button_icon = 'icons/mob/actions/actions_AI.dmi'
 	button_icon_state = "ai_malf_core"
 
+/datum/action/innate/core_return/Grant(mob/new_owner)
+	. = ..()
+	RegisterSignal(new_owner, COMSIG_SILICON_AI_VACATE_APC, PROC_REF(returned_to_core))
+
+/datum/action/innate/core_return/proc/returned_to_core(datum/source)
+	SIGNAL_HANDLER
+
+	Remove(source)
+	UnregisterSignal(source, COMSIG_SILICON_AI_VACATE_APC)
+
 /datum/action/innate/core_return/Activate()
 	var/obj/machinery/power/apc/apc = owner.loc
 	if(!istype(apc))
 		to_chat(owner, span_notice("You are already in your Main Core."))
 		return
-	apc.malfvacate()
+	if(SEND_SIGNAL(owner, COMSIG_SILICON_AI_CORE_STATUS) & COMPONENT_CORE_ALL_GOOD)
+		apc.malfvacate()
+	else
+		to_chat(owner, span_danger("Linked core not detected!"))
+		return
 	qdel(src)
 
 /mob/living/silicon/ai/proc/toggle_camera_light()

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -45,7 +45,7 @@
 	malf.ShutOffDoomsdayDevice()
 	occupier = malf
 	if (isturf(malf.loc)) // create a deactivated AI core if the AI isn't coming from an emergency mech shunt
-		malf.linked_core = new /obj/structure/ai_core/deactivated
+		malf.linked_core = new /obj/structure/ai_core/deactivated(malf.loc)
 		malf.linked_core.remote_ai = malf // note that we do not set the deactivated core's core_mmi.brainmob
 	malf.forceMove(src) // move INTO the APC, not to its tile
 	if(!findtext(occupier.name, "APC Copy"))
@@ -57,22 +57,29 @@
 		disk_pinpointers.switch_mode_to(TRACK_MALF_AI) //Pinpointer will track the shunted AI
 	var/datum/action/innate/core_return/return_action = new
 	return_action.Grant(occupier)
+	SEND_SIGNAL(src, COMSIG_SILICON_AI_OCCUPY_APC, occupier)
+	SEND_SIGNAL(occupier, COMSIG_SILICON_AI_OCCUPY_APC, occupier)
 	occupier.cancel_camera()
 
 /obj/machinery/power/apc/proc/malfvacate(forced)
 	if(!occupier)
+		return
+	SEND_SIGNAL(occupier, COMSIG_SILICON_AI_VACATE_APC, occupier)
+	SEND_SIGNAL(src, COMSIG_SILICON_AI_VACATE_APC, occupier)
+	if(forced)
+		occupier.forceMove(drop_location())
+		INVOKE_ASYNC(occupier, TYPE_PROC_REF(/mob/living, death))
+		occupier.gib(DROP_ALL_REMAINS)
+		occupier = null
 		return
 	if(occupier.linked_core)
 		occupier.shunted = FALSE
 		occupier.forceMove(occupier.linked_core.loc)
 		qdel(occupier.linked_core)
 		occupier.cancel_camera()
-		return
-	to_chat(occupier, span_danger("Primary core damaged, unable to return core processes."))
-	if(forced)
-		occupier.forceMove(drop_location())
-		INVOKE_ASYNC(occupier, TYPE_PROC_REF(/mob/living, death))
-		occupier.gib(DROP_ALL_REMAINS)
+		occupier = null
+	else
+		stack_trace("An AI: [occupier] has vacated an APC with no linked core and without being gibbed.")
 
 	if(!occupier.nuking) //Pinpointers go back to tracking the nuke disk, as long as the AI (somehow) isn't mid-nuking.
 		for(var/obj/item/pinpointer/nuke/disk_pinpointers in GLOB.pinpointer_list)

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -138,6 +138,7 @@
 	remove_control_flags(M, ALL)
 	remove_passenger_actions(M)
 	LAZYREMOVE(occupants, M)
+//	LAZYREMOVE(contents, M)
 	cleanup_actions_for_mob(M)
 	after_remove_occupant(M)
 	return TRUE

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -340,11 +340,12 @@
 				ai.investigate_log("has been gibbed by having their mech destroyed.", INVESTIGATE_DEATHS)
 				ai.gib(DROP_ALL_REMAINS) //No wreck, no AI to recover
 			else
-				mob_exit(ai,silent = TRUE, forced = TRUE) // so we dont ghost the AI
+				mob_exit(ai, silent = TRUE, forced = TRUE) // so we dont ghost the AI
 			continue
-		mob_exit(occupant, forced = TRUE)
-		if(!isbrain(occupant)) // who would win.. 1 brain vs 1 sleep proc..
-			occupant.SetSleeping(destruction_sleep_duration)
+		else
+			mob_exit(occupant, forced = TRUE)
+			if(!isbrain(occupant)) // who would win.. 1 brain vs 1 sleep proc..
+				occupant.SetSleeping(destruction_sleep_duration)
 
 	if(wreckage)
 		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, unlucky_ai)

--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -102,7 +102,6 @@
 	AI.eyeobj?.RegisterSignal(src, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/mob/camera/ai_eye, update_visibility))
 	AI.controlled_equipment = src
 	AI.remote_control = src
-	AI.ShutOffDoomsdayDevice()
 	add_occupant(AI)
 	to_chat(AI, AI.can_dominate_mechs ? span_greenannounce("Takeover of [name] complete! You are now loaded onto the onboard computer. Do not attempt to leave the station sector!") :\
 		span_notice("You have been uploaded to a mech's onboard computer."))

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -115,12 +115,13 @@
 		mob_container = brain.container
 	else if(isAI(M))
 		var/mob/living/silicon/ai/AI = M
+		mob_container = AI
 		//stop listening to this signal, as the static update is now handled by the eyeobj's setLoc
 		AI.eyeobj?.UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 		AI.eyeobj?.forceMove(newloc) //kick the eye out as well
+		AI.controlled_equipment = null
+		AI.remote_control = null
 		if(forced)
-			AI.controlled_equipment = null
-			AI.remote_control = null
 			if(!AI.linked_core) //if the victim AI has no core
 				if (!AI.can_shunt || !length(AI.hacked_apcs))
 					AI.investigate_log("has been gibbed by being forced out of their mech.", INVESTIGATE_DEATHS)
@@ -130,31 +131,30 @@
 					AI.gib(DROP_ALL_REMAINS)
 					AI = null
 					mecha_flags &= ~SILICON_PILOT
-					return
+					return ..()
 				else
 					var/obj/machinery/power/apc/emergency_shunt_apc = pick(AI.hacked_apcs)
 					emergency_shunt_apc.malfoccupy(AI) //get shunted into a random APC (you don't get to choose which)
 					AI = null
 					mecha_flags &= ~SILICON_PILOT
-					return
-			newloc = get_turf(AI.linked_core)
-			qdel(AI.linked_core)
-			AI.forceMove(newloc)
-		else
-			if(!silent)
-				to_chat(AI, span_notice("Returning to core..."))
-			AI.controlled_equipment = null
-			AI.remote_control = null
-			mob_container = AI
-			newloc = get_turf(AI.linked_core)
-			qdel(AI.linked_core)
-			AI.forceMove(newloc)
+					return ..()
+		if(!forced && !silent)
+			to_chat(AI, span_notice("Returning to core..."))
+		mecha_flags &= ~SILICON_PILOT
+		newloc = get_turf(AI.linked_core)
+		qdel(AI.linked_core)
+		AI.forceMove(newloc)
+		if(forced)
+			to_chat(AI, span_danger("ZZUZULU.ERR--ERRR-NEUROLOG-- PERCEP--- DIST-B**@"))
+			for(var/count in 1 to 5)
+				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_sparks), rand(10, 20), FALSE, AI), count SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(empulse), get_turf(AI), /*heavy_range = */10, /*light_range = */20), 10 SECONDS)
+		return ..()
 	else if(isliving(M))
 		mob_container = M
 	else
 		return ..()
 	var/mob/living/ejector = M
-	mecha_flags  &= ~SILICON_PILOT
 	mob_container.forceMove(newloc)//ejecting mob container
 	log_message("[mob_container] moved out.", LOG_MECHA)
 	SStgui.close_user_uis(M, src)

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -94,6 +94,8 @@
 	remove_occupant(M)
 	if(!isAI(M))//This is the ONE mob we dont want to be moved to the vehicle that should be handeled when used
 		M.forceMove(exit_location(M))
+	else
+		return TRUE
 	if(randomstep)
 		var/turf/target_turf = get_step(exit_location(M), pick(GLOB.cardinals))
 		M.throw_at(target_turf, 5, 10)
@@ -169,4 +171,5 @@
 /obj/vehicle/sealed/proc/on_entered_supermatter(atom/movable/vehicle, atom/movable/supermatter)
 	SIGNAL_HANDLER
 	for (var/mob/passenger as anything in occupants)
-		passenger.Bump(supermatter)
+		if(!isAI(passenger))
+			passenger.Bump(supermatter)


### PR DESCRIPTION

## About The Pull Request

This fixes a couple of bugs that are still lurking for malf AI, primarily, and reverts an unintentional balance change I did by making mech domination cancel the delta activation.

There's a balance change instead; previously mech domination death killed you (seemingly because of badly formed callstacks assuming you never had a core or APCs available); I replaced this by causing the AI to produce a massive EMP centered at their location if their mech gets destroyed while they're piloting it.
## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/86107
Fixes https://github.com/tgstation/tgstation/issues/83753
Undoes unintentional balance change and adds  with something that is still quite debilitating, especially if you're currently under attack as a malf AI.
## Changelog
:cl: Bisar
balance: AIs piloting mechs no longer die if they hit the supermatter, nor do they harmlessly snap back to their core. The shock now causes them to produce a massive EMP.
balance: Undid a balance change I did during the malf AI refactor. The doomsday countdown will no longer stop if a malf AI dominates a mech.
fix: Fixed a few bugs with AI shunting and AI mech death.
/:cl:
