### PR TITLE
Fixes binary conversion circuit component so that it does conversion into binary

### DIFF
--- a/code/modules/wiremod/components/math/binary_conversion.dm
+++ b/code/modules/wiremod/components/math/binary_conversion.dm
@@ -37,14 +37,15 @@
 	if(!length(bit_array))
 		return
 
+	var/to_convert = number.value
 	var/is_negative
 	if(number.value < 0)
 		is_negative = TRUE
+		to_convert = -to_convert
 
-	var/binary_representation = num2text((is_negative ? -number.value : number.value), length(bit_array), 2)
 	for(var/iteration in 1 to length(bit_array))
 		var/datum/port/output/bit = bit_array[iteration]
-		if(is_negative && iteration == 1)
+		if(iteration == 1 && is_negative)
 			bit.set_output(1)
 			continue
-		bit.set_output(text2num(binary_representation[iteration]))
+		bit.set_output(!!(to_convert & (1<<(length(bit_array) - iteration))))

--- a/code/modules/wiremod/components/math/binary_conversion.dm
+++ b/code/modules/wiremod/components/math/binary_conversion.dm
@@ -37,6 +37,14 @@
 	if(!length(bit_array))
 		return
 
+	var/is_negative
+	if(number.value < 0)
+		is_negative = TRUE
+
+	var/binary_representation = num2text((is_negative ? -number.value : number.value), length(bit_array), 2)
 	for(var/iteration in 1 to length(bit_array))
 		var/datum/port/output/bit = bit_array[iteration]
-		bit.set_output(number.value & (2 ** (iteration - 1)))
+		if(is_negative && iteration == 1)
+			bit.set_output(1)
+			continue
+		bit.set_output(text2num(binary_representation[iteration]))

--- a/code/modules/wiremod/components/math/binary_conversion.dm
+++ b/code/modules/wiremod/components/math/binary_conversion.dm
@@ -42,10 +42,10 @@
 	if(number.value < 0)
 		is_negative = TRUE
 		to_convert = -to_convert
-
-	for(var/iteration in 1 to length(bit_array))
+	var/len = length(bit_array)
+	for(var/iteration in 1 to len)
 		var/datum/port/output/bit = bit_array[iteration]
 		if(iteration == 1 && is_negative)
 			bit.set_output(1)
 			continue
-		bit.set_output(!!(to_convert & (1<<(length(bit_array) - iteration))))
+		bit.set_output(!!(to_convert & (1<< (len - iteration))))


### PR DESCRIPTION

## About The Pull Request

The binary conversion circuit component is totally busted at the moment, so I redid the logic and now it actually outputs a series of bits to represent whatever number you feed it. Additionally, it supports representing a negative number by setting the leftmost bit of your bit array to 1.
## Why It's Good For The Game

Fixes a broken circuit component and makes it able to represent negative numbers
## Changelog
:cl: Bisar
fix: The binary conversion circuit component should work again.
code: The component also now supports representing negative numbers.
/:cl:
