### PR TITLE
Fixes EMPs not disabling turrets: 6 months edition

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -143,7 +143,7 @@ DEFINE_BITFIELD(turret_flags, list(
 /obj/machinery/porta_turret/proc/toggle_on(turn_on = TRUE)
 	if(on == turn_on)
 		return
-	if(on && !COOLDOWN_FINISHED(src, disabled_time))
+	if(turn_on && !COOLDOWN_FINISHED(src, disabled_time))
 		return
 	on = turn_on
 	check_should_process()


### PR DESCRIPTION

## About The Pull Request

Closes #86503, somehow went unnoticed for half a year.

## Changelog
:cl:
fix: EMPing turrets temporarily disables them once again
/:cl:
