### PR TITLE
You no longer return to the station cuffed after being sacrificed by a heretic

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -501,6 +501,7 @@
 	sac_target.remove_status_effect(/datum/status_effect/necropolis_curse)
 	sac_target.remove_status_effect(/datum/status_effect/unholy_determination)
 	sac_target.reagents?.del_reagent(/datum/reagent/inverse/helgrasp/heretic)
+	sac_target.uncuff()
 	sac_target.clear_mood_event("shadow_realm")
 	if(IS_HERETIC(sac_target))
 		var/datum/antagonist/heretic/victim_heretic = sac_target.mind?.has_antag_datum(/datum/antagonist/heretic)


### PR DESCRIPTION

## About The Pull Request
Closes #86083

## Why It's Good For The Game

Being teleported to a random place, often without an ID as heretics frequently loot their victims first, almost guarantees a death with some of the new organs unless someone can notice and quickly save you, and due to heavy slurring you cannot broadcast your position either.

## Changelog
:cl:
fix: You no longer return to the station cuffed after being sacrificed by a heretic
/:cl:
