### PR TITLE
Sorts iceruinblacklist.txt and adds missing entries

### DIFF
--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -5,28 +5,32 @@
 
 ##RESPAWN
 #_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
 
 ##MEGAFAUNA
 #_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_wendigo_cave.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_wendigo_cave.dmm
 
 ##MISC
+#_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_gas.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
-#_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
-#_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_phonebooth.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_smoking_room.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_puzzle.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_wrath.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_bathhouse.dmm
-#_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_hotsprings.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_homestead.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_bathhouse.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_hotsprings.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_puzzle.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_wrath.dmm


### PR DESCRIPTION

## About The Pull Request
Adds all ice ruin maps to the config file iceruinblacklist.txt
Alphabetises that file.
## Why It's Good For The Game
File is disorderly and missing entries. Some ruins can't be blacklisted by server runners as a result.
## Changelog
:cl:
fix: Added missing entries to server config file iceruinblacklist.txt
/:cl:
