### PR TITLE
Allow beds to define what side their headrest is on, fixing medical/roller bed buckling and bed_tuckable directions

### DIFF
--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -53,11 +53,11 @@
 	return COMPONENT_NO_AFTERATTACK
 
 /datum/element/bed_tuckable/proc/tuck(obj/item/tucked, obj/structure/bed/target_bed)
-	tucked.dir = target_bed.dir
-	tucked.pixel_x = target_bed.dir & EAST ? -x_offset : x_offset
+	tucked.dir = target_bed.dir & target_bed.left_headrest_dirs ? EAST : WEST
+	tucked.pixel_x = target_bed.dir & target_bed.left_headrest_dirs ? -x_offset : x_offset
 	tucked.pixel_y = y_offset
 	if(starting_angle)
-		rotation_degree = target_bed.dir & EAST ? starting_angle + 180 : starting_angle
+		rotation_degree = target_bed.dir & target_bed.left_headrest_dirs ? starting_angle + 180 : starting_angle
 		tucked.transform = turn(tucked.transform, rotation_degree)
 		RegisterSignal(tucked, COMSIG_ITEM_PICKUP, PROC_REF(untuck))
 

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -27,6 +27,8 @@
 	var/elevation = 8
 	/// If this bed can be deconstructed using a wrench
 	var/can_deconstruct = TRUE
+	/// Directions in which the bed has its headrest on the left side.
+	var/left_headrest_dirs = NORTHEAST
 
 /obj/structure/bed/Initialize(mapload)
 	. = ..()
@@ -58,7 +60,7 @@
 	update_buckle_vars(newdir)
 
 /obj/structure/bed/proc/update_buckle_vars(newdir)
-	buckle_lying = newdir & NORTHEAST ? 270 : 90
+	buckle_lying = newdir & left_headrest_dirs ? 270 : 90
 
 /obj/structure/bed/atom_deconstruct(disassembled = TRUE)
 	if(build_stack_type)
@@ -83,7 +85,8 @@
 	icon_state = "med_down"
 	base_icon_state = "med"
 	anchored = FALSE
-	buckle_lying = 270 // Flipped from regular beds because the sprites are flipped
+	left_headrest_dirs = SOUTHWEST
+	buckle_lying = 270
 	resistance_flags = NONE
 	build_stack_type = /obj/item/stack/sheet/mineral/titanium
 	build_stack_amount = 1
@@ -106,9 +109,6 @@
 	AddElement(/datum/element/noisy_movement)
 	if(anchored)
 		update_appearance()
-
-/obj/structure/bed/medical/update_buckle_vars(newdir)
-	buckle_lying = newdir & NORTHEAST ? 90 : 270 // Flipped from regular beds because the sprites are flipped
 
 /obj/structure/bed/medical/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -83,6 +83,7 @@
 	icon_state = "med_down"
 	base_icon_state = "med"
 	anchored = FALSE
+	buckle_lying = 270 // Flipped from regular beds because the sprites are flipped
 	resistance_flags = NONE
 	build_stack_type = /obj/item/stack/sheet/mineral/titanium
 	build_stack_amount = 1
@@ -105,6 +106,9 @@
 	AddElement(/datum/element/noisy_movement)
 	if(anchored)
 		update_appearance()
+
+/obj/structure/bed/medical/update_buckle_vars(newdir)
+	buckle_lying = newdir & NORTHEAST ? 90 : 270 // Flipped from regular beds because the sprites are flipped
 
 /obj/structure/bed/medical/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

So previously I put out a pr that made beds alternate their `buckle_lying` angle based on their current direction, such that you would always use the headrest as a headrest.
However, the medical/roller beds have their sprites flipped, and so these would instead always use the headrest as a footrest.
This wasn't obvious before as both regular and medical/roller beds would use the headrest on half their directions, just different halves.

While we could have fixed this by flipping the sprites on the medical/roller beds, I think it's better to flip their buckling angles instead so that the medical/roller beds maintain how they look while being pulled, so my first thought was to override the `update_buckle_vars(...)` proc with the other directions.

However, during testing I realized that these flipped sprites would also affect the `bed_tuckable` element interactions with the code, used to work out how to place certain items onto beds.
So instead of just overriding the proc, we add a new var `left_headrest_dirs` that defines the directions for which the headrest faces left, change its value for medical/roller beds, and use this for the `update_buckle_vars(...)` proc and `bed_tuckle` element.

This fixes our issues.
As a side-effect, this also fixes an issue where `bed_tuckable` would consider north-facing regular beds as if their headrest was on the right rather than on the left.

<details>
  <summary>Images</summary>
  
![image](https://github.com/user-attachments/assets/450a3cd5-eed9-4fd1-9d19-ab155d47efaa)
![image](https://github.com/user-attachments/assets/864b28a7-b073-4291-8c21-fcf49c012894)

![image](https://github.com/user-attachments/assets/27016b04-2daa-4cb6-b9c9-5b0557a50a45)
![image](https://github.com/user-attachments/assets/e8af12ce-ad89-4844-b331-478dc0f4ba0d)
</details>

## Why It's Good For The Game

Fixes part of #86521.
Good to not use the headrest as a footrest all the time.
## Changelog
:cl:
fix: Fixed being buckled to medical/roller beds making you always use the headrest as a footrest.
fix: Fixed bedsheets/diskies/plushies/etc put on medical/roller beds facing the wrong direction.
fix: Fixed bedsheets/diskies/plushies/etc put on any bed facing the wrong direction on some beds.
/:cl:
