### PR TITLE
[Birdshot]Tool Storage Supply Drop

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1680,17 +1680,17 @@
 "aGI" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can/food/pine_nuts{
-	pixel_x = 16;
-	pixel_y = 6
-	},
 /obj/machinery/cell_charger{
 	pixel_x = -1;
-	pixel_y = 2
+	pixel_y = 4
 	},
 /obj/item/stock_parts/power_store/cell/high{
 	pixel_x = -1;
-	pixel_y = 1
+	pixel_y = 4
+	},
+/obj/item/assembly/timer{
+	pixel_x = 14;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
@@ -18623,6 +18623,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot_white,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/stack/package_wrap{
 	pixel_y = 5
 	},
@@ -18633,6 +18634,12 @@
 	desc = "It smells of monkey business...";
 	name = "Empty Gorillacube Box"
 	},
+/obj/item/weldingtool,
+/obj/item/radio{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/assembly/signaler,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
 "gRm" = (
@@ -19580,17 +19587,11 @@
 /area/station/commons/storage/tools)
 "hgd" = (
 /obj/structure/table,
-/obj/item/clothing/head/collectable/paper{
-	pixel_x = -6;
-	pixel_y = -2
+/obj/item/screwdriver{
+	pixel_y = -6
 	},
-/obj/item/paper/crumpled{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/trash/candle{
-	pixel_x = 7;
-	pixel_y = 1
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
@@ -19953,6 +19954,10 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
+/obj/item/gps{
+	pixel_y = 5;
+	pixel_x = 13
+	},
 /obj/item/storage/toolbox/emergency/old,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
@@ -20005,20 +20010,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/mechanical/old{
-	pixel_x = 15;
-	pixel_y = 15
-	},
 /obj/item/crowbar/large{
 	pixel_y = 18
 	},
 /obj/item/clothing/head/costume/pirate{
-	pixel_x = 17;
-	pixel_y = -10
+	pixel_x = 15;
+	pixel_y = -3
 	},
 /obj/item/clothing/suit/hazardvest{
 	pixel_x = -3;
 	pixel_y = -2
+	},
+/obj/item/wrench{
+	pixel_y = 15
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
@@ -20399,6 +20403,7 @@
 	},
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/rack,
+/obj/item/hand_labeler,
 /obj/item/stack/cable_coil/five,
 /obj/item/pickaxe,
 /obj/item/wrench,
@@ -34445,6 +34450,10 @@
 "lNN" = (
 /obj/structure/table,
 /obj/item/toy/foamblade,
+/obj/item/analyzer{
+	pixel_y = 8;
+	pixel_x = -9
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/commons/fitness/locker_room)
 "lNQ" = (
@@ -35237,12 +35246,12 @@
 /area/station/hallway/secondary/dock)
 "lZP" = (
 /obj/structure/table,
-/obj/item/clothing/head/fedora/det_hat/minor{
-	pixel_x = 7;
-	pixel_y = 9
-	},
 /obj/item/toy/eightball{
 	pixel_x = -4
+	},
+/obj/item/wirecutters{
+	pixel_y = 17;
+	pixel_x = 4
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/commons/fitness/locker_room)
@@ -36170,7 +36179,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 3
+	},
 /obj/item/food/monkeycube/bee{
 	name = "monkey cube";
 	pixel_y = 17
@@ -36180,6 +36191,9 @@
 	pixel_x = 6;
 	name = "monkey cube";
 	desc = "A new Nanotrasen classic, the monkey cube. Tastes like everything!"
+	},
+/obj/item/wirecutters{
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
@@ -46988,6 +47002,7 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/south,
+/obj/item/storage/belt/utility,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
 "qhh" = (
@@ -67671,6 +67686,20 @@
 /obj/effect/decal/cleanable/molten_object,
 /obj/effect/landmark/event_spawn,
 /obj/structure/table,
+/obj/item/reagent_containers/cup/bottle/welding_fuel{
+	pixel_y = -3;
+	pixel_x = 13
+	},
+/obj/item/stack/sheet/iron/ten{
+	pixel_y = -6;
+	pixel_x = -2
+	},
+/obj/item/hand_labeler{
+	pixel_y = -15
+	},
+/obj/item/reagent_containers/cup/watering_can{
+	pixel_y = 12
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
 "wPd" = (


### PR DESCRIPTION
## About The Pull Request

The Birdshot Quartermaster has finally restocked Birdshot's tool storage and cleaned up some of the leftover garbage. 

## Why It's Good For The Game

Should add some freebie tools for the initial assistant rush. Basically there's stuff worth fighting over in there now. Like Fortnite. 

Also this is a continuation of an earlier topic on discord. Birdshot gets actionable feedback, I fix. Repeat. etc.etc. 

## Changelog

:cl:
qol: The Birdshot Tool Storage has been resupplied. New tools are at the crews displosal. 
/:cl:
