### PR TITLE
fixes leaper polymorph outbreak

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -52,6 +52,8 @@
 
 	/// Toggles whether this action is usable or not
 	var/action_disabled = FALSE
+	/// Can this action be shared with our rider?
+	var/can_be_shared = TRUE
 
 /datum/action/New(Target)
 	link_to(Target)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -7,7 +7,9 @@
 	var/can_use_abilities = FALSE
 	/// shall we require riders to go through the riding minigame if they arent in our friends list
 	var/require_minigame = FALSE
-	/// list of blacklisted abilities that cant be shared
+	/// unsharable abilities that we will force to be shared anyway
+	var/list/override_unsharable_abilities = list()
+	/// abilities that are always blacklisted from sharing
 	var/list/blacklist_abilities = list()
 
 /datum/component/riding/creature/Initialize(mob/living/riding_mob, force = FALSE, ride_check_flags = NONE, potion_boost = FALSE)
@@ -167,6 +169,8 @@
 
 	for(var/datum/action/action as anything in ridden_creature.actions)
 		if(is_type_in_list(action, blacklist_abilities))
+			continue
+		if(!action.can_be_shared && !is_type_in_list(action, override_unsharable_abilities))
 			continue
 		action.GiveAction(rider)
 
@@ -504,7 +508,6 @@
 /datum/component/riding/creature/leaper
 	can_force_unbuckle = FALSE
 	can_use_abilities = TRUE
-	blacklist_abilities = list(/datum/action/cooldown/toggle_seethrough)
 	ride_check_flags = JUST_FRIEND_RIDERS
 
 /datum/component/riding/creature/leaper/handle_specials()

--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -122,6 +122,7 @@
 	background_icon_state = "bg_alien"
 	cooldown_time = 1 SECONDS
 	melee_cooldown_time = 0
+	can_be_shared = FALSE
 
 /datum/action/cooldown/toggle_seethrough/Remove(mob/remove_from)
 	var/datum/component/seethrough_mob/transparency = target

--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -108,6 +108,10 @@
 	/// Amount of time it takes us to transform back or forth
 	var/channel_time = 3 SECONDS
 
+/datum/action/cooldown/spell/shapeshift/polymorph_belt/cast(mob/living/cast_on)
+	cast_on = owner //make sure this is only affecting the wearer of the belt
+	return ..()
+
 /datum/action/cooldown/spell/shapeshift/polymorph_belt/Remove(mob/remove_from)
 	var/datum/status_effect/shapechange_mob/shapechange = remove_from.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
 	var/atom/changer = shapechange?.caster_mob || remove_from
@@ -115,6 +119,7 @@
 	return ..()
 
 /datum/action/cooldown/spell/shapeshift/polymorph_belt/before_cast(mob/living/cast_on)
+	cast_on = owner
 	. = ..()
 	if (. & SPELL_CANCEL_CAST)
 		return

--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -104,6 +104,7 @@
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 	possible_shapes = list(/mob/living/basic/cockroach)
+	can_be_shared = FALSE
 	/// Amount of time it takes us to transform back or forth
 	var/channel_time = 3 SECONDS
 


### PR DESCRIPTION

## About The Pull Request
fixes a bug where if people ride animals that share abilities with their rider, and this animal happens to be polymorphed, players would be able to turn into it by clicking that ability. this pr makes it so riders are unable to use the ridden mob's polymorph ability, or if they are, it will only transform the ridden.

## Why It's Good For The Game
closes #85114 , closes #85122

## Changelog
:cl:
fix: fixes being able to transform into polymorphed mobs by riding them 
/:cl:
