### PR TITLE
Makes meteor shields buyable during any round, not just meteor shield station goal

### DIFF
--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -199,7 +199,6 @@
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. \
 		Contains three Shield Generator Satellites."
 	cost = CARGO_CRATE_VALUE * 6
-	special = TRUE
 	access_view = ACCESS_COMMAND
 	contains = list(/obj/machinery/satellite/meteor_shield = 3)
 	crate_name= "shield sat crate"
@@ -209,7 +208,6 @@
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
 	cost = CARGO_CRATE_VALUE * 10
-	special = TRUE
 	access_view = ACCESS_COMMAND
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"


### PR DESCRIPTION

## About The Pull Request

Meteors range from pain in the ass to an apocalyptic annihilator of the station, depending solely on RNG. Meteor shield network is the only way to buy meteor shields, which are incidentally the singular counter to meteors, especially bluespace meteors.

Even if you buy them, they're arduous to set up, so a lot of times people just... don't. They also don't know how they work, which I'll explain here; they destroy meteors within fourteen tiles.

In any case, this changes the meteor shield crates to be buyable during any round, not just the meteor shield network station goal.
## Why It's Good For The Game

Letting people choose to go to the lengths to set up meteor shielding even if it's not the station goal is another avenue for them to prevent a random event from ending the round -- if they do it right, anyway.
## Changelog
:cl: Bisar
balance: Meteor shielding is now purchasable at cargo even if it isn't the current station goal.
/:cl:
