### PR TITLE
You can now bloodcrawl into/out of tomato smudges

### DIFF
--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -10,6 +10,9 @@
 	icon_state = "tomato_floor1"
 	random_icon_states = list("tomato_floor1", "tomato_floor2", "tomato_floor3")
 
+/obj/effect/decal/cleanable/food/tomato_smudge/can_bloodcrawl_in()
+	return TRUE // why? why not.
+
 /obj/effect/decal/cleanable/food/plant_smudge
 	name = "plant smudge"
 	desc = "Chlorophyll? More like borophyll!"


### PR DESCRIPTION

## About The Pull Request

This makes tomato smudges on the floor valid for bloodcrawl. Pretty simple.

## Why It's Good For The Game

Why not? It's funny, and ketchup = fake blood.

## Changelog
:cl:
add: Tomato smudges on the floor are now considered valid to bloodcrawl into and out of.
/:cl:
