### PR TITLE
Fix trash cannons being unusable / Only food crafting recipes transfer reagents to target

### DIFF
--- a/code/__DEFINES/crafting.dm
+++ b/code/__DEFINES/crafting.dm
@@ -28,6 +28,10 @@
 #define CRAFT_CHECK_DENSITY (1<<5)
 /// If the created atom will gain custom mat datums
 #define CRAFT_APPLIES_MATS (1<<6)
+/// Crafting passes reagents of components to the finished product
+#define CRAFT_TRANSFERS_REAGENTS (1<<7)
+/// Crafting clears all reagents present in the finished product
+#define CRAFT_CLEARS_REAGENTS (1<<8)
 
 //food/drink crafting defines
 //When adding new defines, please make sure to also add them to the encompassing list

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -268,9 +268,11 @@
 				qdel(thing)
 	var/datum/reagents/holder = locate() in parts
 	if(holder) //transfer reagents from ingredients to result
-		if(!ispath(recipe.result,  /obj/item/reagent_containers) && result.reagents)
-			result.reagents.clear_reagents()
-			holder.trans_to(result.reagents, holder.total_volume, no_react = TRUE)
+		if(!ispath(recipe.result, /obj/item/reagent_containers) && result.reagents)
+			if(recipe.crafting_flags & CRAFT_CLEARS_REAGENTS)
+				result.reagents.clear_reagents()
+			if(recipe.crafting_flags & CRAFT_TRANSFERS_REAGENTS)
+				holder.trans_to(result.reagents, holder.total_volume, no_react = TRUE)
 		parts -= holder
 		qdel(holder)
 	result.CheckParts(parts, recipe)

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -1,5 +1,6 @@
 /datum/crafting_recipe/food
 	mass_craftable = TRUE
+	crafting_flags = parent_type::crafting_flags | CRAFT_TRANSFERS_REAGENTS | CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/on_craft_completion(mob/user, atom/result)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
## About The Pull Request

Adds a crafting flag for clearing and transferring reagents on craft, only applies it to food recipes.

This makes it a partial fix to #81226

## Changelog

:cl: Melbert
fix: Trash cannons can be filled with fuel and fired again
/:cl:

