### PR TITLE
[NO GBP] Fixes the icemoon genturf causing unit tests to fail

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -56941,9 +56941,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
-"qtv" = (
-/turf/open/genturf,
-/area/icemoon/surface/outdoors/nospawn)
 "qtw" = (
 /obj/machinery/door/airlock/security{
 	name = "Prison Forestry"
@@ -269753,7 +269750,7 @@ wNO
 wNO
 wNO
 bln
-qtv
+bln
 fwx
 kDs
 kDs


### PR DESCRIPTION

## About The Pull Request

I missed a tile and had a genturf under an icemoon nospawn area. Unit tests didn't like that.
## Why It's Good For The Game

Unit tests work again.
## Changelog
