### PR TITLE
Clears out a double railing on the wizard den/ragin' mages maps

### DIFF
--- a/_maps/deathmatch/ragin_mages.dmm
+++ b/_maps/deathmatch/ragin_mages.dmm
@@ -483,9 +483,6 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/engine/cult,

--- a/_maps/templates/lazy_templates/wizard_den.dmm
+++ b/_maps/templates/lazy_templates/wizard_den.dmm
@@ -669,9 +669,6 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/engine/cult,


### PR DESCRIPTION

## About The Pull Request

This removes an erroneous double railing from the wizard den.

![image](https://github.com/user-attachments/assets/60e20adb-1775-4c4e-ae16-5b9075d9cba7)

I discovered this while experimenting with changing the ragin' mages map (shortly before giving up on the idea). Since the map is a carbon copy of the actual den, I check and, wouldn't you know it, the error was on the OG den too.
## Why It's Good For The Game

One railing is enough. Two is completely absurd.
## Changelog
:cl: Rhials
fix: Removes some doubled-up railings on the wizard den/ragin' mages shuttle.
/:cl:
