### PR TITLE
Teleport blocker security implants prevent jaunting

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -68,6 +68,9 @@
 #define COMSIG_SPELL_TOUCH_HAND_HIT "spell_touch_hand_cast"
 
 // Jaunt Spells
+/// Sent from datum/action/cooldown/spell/jaunt/before_cast, before the mob enters jaunting as a pre-check: (datum/action/cooldown/spell/spell)
+#define COMSIG_MOB_PRE_JAUNT "spell_mob_pre_jaunt"
+	#define COMPONENT_BLOCK_JAUNT (1<<0)
 /// Sent from datum/action/cooldown/spell/jaunt/enter_jaunt, to the mob jaunting: (obj/effect/dummy/phased_mob/jaunt, datum/action/cooldown/spell/spell)
 #define COMSIG_MOB_ENTER_JAUNT "spell_mob_enter_jaunt"
 /// Set from /obj/effect/dummy/phased_mob after the mob is ejected from its contents: (obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)

--- a/code/game/objects/items/implants/security/implant_noteleport.dm
+++ b/code/game/objects/items/implants/security/implant_noteleport.dm
@@ -17,6 +17,7 @@
 	if(!. || !isliving(target))
 		return FALSE
 	RegisterSignal(target, COMSIG_MOVABLE_TELEPORTING, PROC_REF(on_teleport))
+	RegisterSignal(target, COMSIG_MOB_PRE_JAUNT, PROC_REF(on_jaunt))
 	return TRUE
 
 /obj/item/implant/teleport_blocker/removed(mob/target, silent = FALSE, special = FALSE)
@@ -24,6 +25,7 @@
 	if(!. || !isliving(target))
 		return FALSE
 	UnregisterSignal(target, COMSIG_MOVABLE_TELEPORTING)
+	UnregisterSignal(target, COMSIG_MOB_PRE_JAUNT)
 	return TRUE
 
 /// Signal for COMSIG_MOVABLE_TELEPORTED that blocks teleports and stuns the would-be-teleportee.
@@ -37,6 +39,18 @@
 	spark_system.set_up(5, TRUE, teleportee)
 	spark_system.start()
 	return COMPONENT_BLOCK_TELEPORT
+
+/// Signal for COMSIG_MOB_PRE_JAUNT that prevents a user from entering a jaunt.
+/obj/item/implant/teleport_blocker/proc/on_jaunt(mob/living/jaunter)
+	SIGNAL_HANDLER
+
+	to_chat(jaunter, span_holoparasite("As you attempt to jaunt, you slam directly into the barrier between realities and are sent crashing back into corporeality!"))
+
+	jaunter.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 5 SECONDS)
+	var/datum/effect_system/spark_spread/quantum/spark_system = new()
+	spark_system.set_up(5, TRUE, jaunter)
+	spark_system.start()
+	return COMPONENT_BLOCK_JAUNT
 
 /obj/item/implantcase/teleport_blocker
 	name = "implant case - 'Bluespace Grounding'"

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -25,6 +25,11 @@
 
 	return ..()
 
+/datum/action/cooldown/spell/jaunt/PreActivate(atom/target)
+	if(SEND_SIGNAL(target, COMSIG_MOB_PRE_JAUNT, target) & COMPONENT_BLOCK_JAUNT)
+		return FALSE
+	. = ..()
+
 /datum/action/cooldown/spell/jaunt/before_cast(atom/cast_on)
 	return ..() | SPELL_NO_FEEDBACK // Don't do the feedback until after we're jaunting
 


### PR DESCRIPTION

## About The Pull Request

This extends the teleport blocker security implant's capabilities to block jaunts. All jaunt subtypes (ethereal, ashen passage, shadow walk) are blocked and stun you upon attempting to use them.

This took way more trial and error than it should have. 
## Why It's Good For The Game

This was my initial vision when I added these. I even marketed them as being useful for keeping a wizard or heretic contained, but that turned out to be false advertising. After being served a civil claim under Section 43(a) of the Lanham Act, I have been fined an undisclosed amount of money and am being forced to rectify this.

Jokes aside, this was my intent from the get-go, and I'm only just now getting around to making it so. It also just makes sense, because jaunting is basically just teleporting with extra steps.
## Changelog
:cl: Rhials
balance: Teleport blocker implants now prevent implantees from jaunting.
/:cl:
