### PR TITLE
Some echolocation fixes & fulton runtime

### DIFF
--- a/code/__HELPERS/dynamic_human_icon_gen.dm
+++ b/code/__HELPERS/dynamic_human_icon_gen.dm
@@ -57,6 +57,7 @@ GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 /proc/set_dynamic_human_appearance(list/arguments)
 	var/atom/target = arguments[1] //1st argument is the target
 	var/dynamic_appearance = get_dynamic_human_appearance(arglist(arguments.Copy(2))) //the rest of the arguments starting from 2 matter to the proc
-	target.icon = 'icons/blanks/32x32.dmi'
-	target.icon_state = "nothing"
+	target.icon = 'icons/mob/human/human.dmi'
+	target.icon_state = ""
+	target.appearance_flags |= KEEP_TOGETHER
 	target.copy_overlays(dynamic_appearance, cut_old = TRUE)

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -156,7 +156,7 @@
 		copied_appearance.pixel_x = 0
 		copied_appearance.pixel_y = 0
 		copied_appearance.transform = matrix()
-	if(!iscarbon(input)) //wacky overlay people get generated everytime
+	if(input.icon && input.icon_state)
 		saved_appearances["[input.icon]-[input.icon_state]"] = copied_appearance
 	return copied_appearance
 

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		var/obj/structure/extraction_point/extraction_point = point_ref.resolve()
 		if(isnull(extraction_point))
 			GLOB.total_extraction_beacons.Remove(point_ref)
+			continue
 		if(extraction_point.beacon_network in beacon_networks)
 			possible_beacons += extraction_point
 	if(!length(possible_beacons))


### PR DESCRIPTION

## About The Pull Request
Fixes psyker echolocation permanently breaking when in the vicinity of holopad holograms or someone being fulton'd
Also fixes non humans that have human appearances (eg syndicate commandos) being invisible to psykers.
Also also fixes a runtime related to fulton extraction that I found while testing the above
## Why It's Good For The Game
My eyes!
## Changelog
:cl:
fix: Echolocation no longer breaks when witnessing a hologram
fix: Echolocation no longer breaks when witnessing a fulton extraction
fix: Humanoid NPCs are no longer invisible to echolocation users
/:cl:
