### PR TITLE
Ragnarok/Lattice/Species post-merge tune-up

### DIFF
--- a/_maps/deathmatch/lattice_battles.dmm
+++ b/_maps/deathmatch/lattice_battles.dmm
@@ -9,28 +9,17 @@
 	dir = 1
 	},
 /obj/item/clothing/head/cone,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "cN" = (
 /obj/structure/railing/unbreakable{
 	dir = 8
 	},
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
-"df" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/chasm,
-/area/deathmatch/fullbright)
 "dM" = (
-/turf/open/chasm,
-/area/deathmatch/fullbright)
-"eK" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/chasm,
 /area/deathmatch/fullbright)
 "gz" = (
@@ -45,12 +34,12 @@
 	dir = 1
 	},
 /obj/structure/flora/lunar_plant/style_1,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "ho" = (
 /obj/structure/flora/lunar_plant/style_1,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /obj/structure/railing/unbreakable{
 	dir = 6
 	},
@@ -62,7 +51,7 @@
 	},
 /obj/structure/flora/rock/pile/style_random,
 /obj/structure/flora/lunar_plant/style_3,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "jb" = (
@@ -75,7 +64,7 @@
 	},
 /obj/structure/flora/rock/pile/style_random,
 /obj/structure/flora/lunar_plant/style_3,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "rE" = (
@@ -96,12 +85,12 @@
 /obj/structure/railing/unbreakable{
 	dir = 4
 	},
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "tL" = (
 /obj/structure/railing/unbreakable,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "uJ" = (
@@ -109,7 +98,7 @@
 	dir = 4
 	},
 /obj/item/clothing/head/cone,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "uO" = (
@@ -139,7 +128,7 @@
 	dir = 8
 	},
 /obj/structure/flora/lunar_plant/style_1,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "AS" = (
@@ -150,7 +139,7 @@
 /obj/structure/railing/unbreakable{
 	dir = 1
 	},
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "Cf" = (
@@ -190,7 +179,7 @@
 	dir = 10
 	},
 /obj/structure/flora/lunar_plant/style_1,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "KO" = (
@@ -199,7 +188,7 @@
 /area/deathmatch/fullbright)
 "LN" = (
 /obj/structure/railing/corner,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "MF" = (
@@ -217,12 +206,11 @@
 /area/deathmatch/fullbright)
 "NA" = (
 /obj/structure/flora/lunar_plant/style_2,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "NG" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/cardboard,
 /obj/item/statuebust,
 /turf/open/chasm,
@@ -233,7 +221,7 @@
 /turf/open/chasm,
 /area/deathmatch/fullbright)
 "NY" = (
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /obj/structure/railing/unbreakable,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
@@ -245,21 +233,15 @@
 /mob/living/basic/spider/giant/nurse/away_caves,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
-"Sv" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/chasm,
-/area/deathmatch/fullbright)
 "SL" = (
 /obj/structure/flora/rock/pile/style_random,
 /obj/structure/flora/lunar_plant/style_3,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "Uy" = (
 /obj/item/clothing/head/cone,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /obj/structure/railing/corner/unbreakable{
 	dir = 1
 	},
@@ -270,7 +252,7 @@
 	dir = 9
 	},
 /obj/structure/flora/rock/style_random,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "Xf" = (
@@ -285,7 +267,7 @@
 /area/deathmatch/fullbright)
 "Xo" = (
 /obj/structure/flora/rock/style_random,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "Yu" = (
@@ -294,11 +276,11 @@
 	dir = 6
 	},
 /obj/structure/flora/lunar_plant/style_3,
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "YH" = (
-/obj/effect/playeronly_barrier,
+/obj/effect/invisible_wall,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch/fullbright)
 "YV" = (
@@ -466,9 +448,9 @@ MF
 MF
 MF
 vk
-df
 vk
-df
+vk
+vk
 vk
 MF
 dM
@@ -571,12 +553,12 @@ vk
 MF
 MF
 vk
-df
-Sv
+vk
+NI
 vk
 MF
 vk
-df
+vk
 MF
 vk
 vk
@@ -595,18 +577,18 @@ CI
 tL
 MF
 vk
-df
-MF
-MF
-vk
 vk
 MF
 MF
 vk
-df
+vk
+MF
+MF
 vk
 vk
-df
+vk
+vk
+vk
 vk
 hH
 gN
@@ -633,7 +615,7 @@ vk
 vk
 vk
 vk
-df
+vk
 NG
 gN
 gN
@@ -649,7 +631,7 @@ gN
 Yu
 MF
 MF
-eK
+wb
 vk
 vk
 vk
@@ -703,7 +685,7 @@ gN
 gN
 gN
 bm
-df
+vk
 vk
 vk
 vk
@@ -738,7 +720,7 @@ MF
 vk
 vk
 vk
-df
+vk
 MF
 vk
 vk
@@ -795,7 +777,7 @@ vk
 vk
 vk
 vk
-df
+vk
 gN
 gN
 gN

--- a/_maps/deathmatch/ragnarok.dmm
+++ b/_maps/deathmatch/ragnarok.dmm
@@ -7,13 +7,17 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch)
+"aR" = (
+/obj/structure/bonfire/dense/prelit,
+/turf/open/misc/grass/jungle,
+/area/deathmatch)
 "bb" = (
 /obj/structure/flora/coconuts,
 /turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "bj" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/structure/bonfire/prelit,
+/obj/structure/bonfire/dense/prelit,
 /turf/open/floor/wood/large,
 /area/deathmatch)
 "bn" = (
@@ -24,7 +28,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "bI" = (
 /turf/open/misc/asteroid/moon,
@@ -122,7 +126,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "fO" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -224,7 +228,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "jv" = (
 /obj/structure/flora/grass/jungle/b/style_random,
@@ -263,7 +267,7 @@
 /area/deathmatch)
 "lr" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/bonfire/prelit,
+/obj/structure/bonfire/dense/prelit,
 /turf/open/floor/wood/large,
 /area/deathmatch)
 "lx" = (
@@ -321,7 +325,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "ox" = (
 /obj/effect/cosmic_rune,
@@ -344,7 +348,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "pr" = (
 /obj/structure/flora/bush/jungle/a/style_random,
@@ -426,7 +430,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "rH" = (
 /obj/effect/turf_decal/siding/wood{
@@ -522,6 +526,12 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/large,
 /area/deathmatch)
+"wJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/misc/dirt/jungle,
+/area/deathmatch)
 "wP" = (
 /obj/structure/flora/rock/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -563,6 +573,11 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/spawner/random/decoration/glowstick/on,
 /turf/open/floor/plating/heretic_rust,
+/area/deathmatch)
+"yZ" = (
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/effect/landmark/deathmatch_player_spawn,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "zo" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
@@ -616,8 +631,10 @@
 /turf/open/floor/wood/tile,
 /area/deathmatch)
 "AO" = (
-/obj/effect/decal/cleanable/ants,
-/turf/closed/wall/heretic_rust,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Ba" = (
 /obj/structure/destructible/cult/pylon,
@@ -648,7 +665,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "CB" = (
 /obj/structure/destructible/eldritch_crucible,
@@ -664,7 +681,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "CR" = (
 /mob/living/carbon/human/species/monkey,
@@ -681,14 +698,14 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Ds" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Du" = (
 /obj/structure/flora/rock/pile/style_random,
@@ -705,7 +722,13 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
+/area/deathmatch)
+"Ed" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "EF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -731,7 +754,6 @@
 /area/deathmatch)
 "FQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ants,
 /turf/open/misc/grass/jungle,
 /area/deathmatch)
 "FS" = (
@@ -785,7 +807,9 @@
 /turf/open/floor/cult,
 /area/deathmatch)
 "Ic" = (
-/obj/effect/decal/cleanable/ants,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
 /turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Ig" = (
@@ -827,7 +851,8 @@
 /turf/open/misc/grass/jungle,
 /area/deathmatch)
 "Kg" = (
-/turf/open/water/jungle,
+/obj/structure/flora/rock/style_4,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Kl" = (
 /obj/effect/spawner/structure/window/bronze,
@@ -854,6 +879,15 @@
 "LU" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /turf/open/misc/grass/jungle,
+/area/deathmatch)
+"LW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/water/jungle,
 /area/deathmatch)
 "My" = (
 /obj/structure/table/wood,
@@ -883,7 +917,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/water/jungle,
+/obj/structure/flora/rock/style_4,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Or" = (
 /obj/structure/flora/tree/jungle/style_random,
@@ -899,11 +934,17 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "Px" = (
 /obj/structure/flora/tree/jungle/style_random,
 /turf/open/misc/grass/jungle,
+/area/deathmatch)
+"PC" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "PH" = (
 /obj/effect/visible_heretic_influence,
@@ -939,10 +980,6 @@
 "Rm" = (
 /obj/effect/forcefield/cult/permanent,
 /turf/open/misc/dirt/jungle/dark,
-/area/deathmatch)
-"RE" = (
-/obj/structure/bonfire/prelit,
-/turf/open/misc/grass/jungle,
 /area/deathmatch)
 "RL" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1057,7 +1094,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/water/jungle,
+/turf/open/misc/dirt/jungle,
 /area/deathmatch)
 "VF" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1098,6 +1135,15 @@
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/dirt/jungle/dark,
 /area/deathmatch)
+"Ww" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/water/jungle,
+/area/deathmatch)
 "Xa" = (
 /obj/structure/rack/skeletal,
 /obj/item/clothing/head/helmet/chaplain/ancient{
@@ -1114,8 +1160,13 @@
 /turf/closed/wall/mineral/cult/artificer,
 /area/deathmatch)
 "Yn" = (
-/obj/effect/decal/cleanable/ants,
-/turf/open/misc/grass/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/water/jungle,
 /area/deathmatch)
 "Ys" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1193,7 +1244,7 @@
 /turf/open/misc/grass/jungle,
 /area/deathmatch)
 "ZY" = (
-/obj/structure/bonfire/prelit,
+/obj/structure/bonfire/dense/prelit,
 /turf/open/misc/dirt/jungle,
 /area/deathmatch)
 
@@ -1362,7 +1413,7 @@ jL
 jv
 CR
 LU
-Yn
+qa
 Sw
 Sw
 yY
@@ -1464,7 +1515,7 @@ eL
 Be
 XL
 VP
-AO
+SC
 tm
 qa
 vI
@@ -1515,7 +1566,7 @@ GD
 qa
 LU
 Fn
-qa
+aR
 Sw
 Sw
 oC
@@ -1528,7 +1579,7 @@ dI
 lx
 PI
 Vm
-iJ
+Ic
 TN
 qh
 FK
@@ -1543,7 +1594,7 @@ Ig
 Ig
 wR
 ZY
-Ic
+FK
 FK
 FK
 sC
@@ -1561,8 +1612,8 @@ PI
 NX
 NQ
 NQ
-NQ
-TN
+Ed
+AO
 CE
 DA
 Ig
@@ -1576,7 +1627,7 @@ iJ
 TN
 TN
 TN
-qh
+Ww
 FK
 FK
 FK
@@ -1586,16 +1637,16 @@ eB
 SC
 FK
 sC
-iJ
+Ic
 Ds
 PI
 Bp
 FK
 FK
 wR
-SE
+wJ
 FK
-sC
+yZ
 Ig
 Ig
 Ig
@@ -1606,18 +1657,18 @@ Ig
 SE
 NQ
 NQ
-NQ
+LW
 Kg
-TN
-qh
+AO
+PC
 FK
 FK
-iJ
-qh
+Yn
+PC
 RL
 PI
 Do
-Kg
+FK
 Pi
 PI
 gx
@@ -1638,24 +1689,24 @@ sC
 sC
 FK
 bb
-SE
-NQ
+wJ
+Ed
 bv
 PI
 ou
-NQ
-Kg
+Ed
+FK
 Ds
 ft
 Vv
 oO
 FK
-ZY
-qa
+FK
+aR
 GD
 qa
 jv
-Yn
+qa
 GD
 RW
 jL
@@ -1675,7 +1726,7 @@ RL
 PI
 Bp
 bb
-SE
+wJ
 rD
 YI
 jb
@@ -1770,7 +1821,7 @@ QO
 Jf
 Yv
 qa
-RE
+aR
 Ov
 qg
 qg
@@ -1954,7 +2005,7 @@ YN
 Wp
 qa
 qa
-Yn
+qa
 qa
 qa
 qa
@@ -1982,7 +2033,7 @@ KL
 Nf
 Sf
 Jf
-RE
+aR
 Px
 Ik
 GO

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -185,6 +185,13 @@
 /obj/structure/bonfire/dense
 	density = TRUE
 
+/obj/structure/bonfire/dense/prelit/Initialize(mapload)
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/bonfire/dense/prelit/LateInitialize()
+	start_burning()
+
 /obj/structure/bonfire/prelit/Initialize(mapload)
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -101,6 +101,10 @@
 
 /obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
+	if(resistance_flags & INDESTRUCTIBLE)
+		to_chat(user, span_warning("You try to cut apart the railing, but it's too hard!"))
+		I.play_tool_sound(src, 100)
+		return TRUE
 	to_chat(user, span_warning("You cut apart the railing."))
 	I.play_tool_sound(src, 100)
 	deconstruct()

--- a/code/modules/antagonists/heretic/items/unfathomable_curio.dm
+++ b/code/modules/antagonists/heretic/items/unfathomable_curio.dm
@@ -21,6 +21,7 @@
 	atom_storage.max_total_storage = 21
 	atom_storage.set_holdable(list(
 		/obj/item/ammo_box/strilka310/lionhunter,
+		/obj/item/heretic_labyrinth_handbook,
 		/obj/item/bodypart, // Bodyparts are often used in rituals.
 		/obj/item/clothing/neck/eldritch_amulet,
 		/obj/item/clothing/neck/heretic_focus,

--- a/code/modules/awaymissions/away_props.dm
+++ b/code/modules/awaymissions/away_props.dm
@@ -137,3 +137,16 @@
 	if(!istype(mover))
 		return
 	return isnull(mover.ckey) == reverse
+
+/obj/effect/invisible_wall // why didnt we have this already
+	name = "invisible wall"
+	desc = "You shall not pass"
+	icon = 'icons/effects/mapping_helpers.dmi'
+	icon_state = "blocker"
+	color = COLOR_BLUE_LIGHT
+	invisibility = INVISIBILITY_MAXIMUM
+	anchored = TRUE
+
+/obj/effect/invisible_wall/CanAllowThrough(mob/living/mover, border_dir)
+	..()
+	return FALSE // NO

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -768,7 +768,7 @@
 	id_trim = /datum/id_trim/job/bridge_assistant // half tider half command
 	id = /obj/item/card/id/advanced/chameleon
 	uniform = /obj/item/clothing/under/trek/command/next
-	l_pocket = /obj/item/gun/energy/e_gun/mini
+	l_pocket = /obj/item/gun/energy/e_gun/mini // they are thej best race in the end. not as impactful as you may think
 	r_pocket = /obj/item/extinguisher/mini
 	gloves = /obj/item/clothing/gloves/fingerless
 	belt = /obj/item/storage/belt/utility/full/inducer
@@ -846,9 +846,10 @@
 	back = /obj/item/storage/backpack/science
 
 	backpack_contents = list(
-		/obj/item/dnainjector/shock,
 		/obj/item/etherealballdeployer,
 	)
+
+	mutations_to_add = list(/obj/item/dnainjector/shock) // pretend ethereals are interesting
 
 /datum/outfit/deathmatch_loadout/plasmamen
 	name = "Deathmatch: Plasmaman Species"
@@ -907,15 +908,9 @@
 
 	uniform = /obj/item/clothing/under/pants/jeans
 	suit = /obj/item/clothing/suit/costume/wellworn_shirt/graphic
-	back = /obj/item/storage/backpack
+	r_pocket = /obj/item/stack/rods/twentyfive
+	l_pocket = /obj/item/stack/rods/twentyfive
 	r_hand = /obj/item/wirecutters
-
-	backpack_contents = list(
-		/obj/item/stack/rods/fifty,
-		/obj/item/stack/rods/fifty,
-		/obj/item/stack/rods/fifty,
-		/obj/item/stack/rods/fifty,
-	)
 
 // We don't want them to just punch each other to death
 
@@ -983,14 +978,12 @@
 	back = /obj/item/storage/backpack/cultpack
 
 	backpack_contents = list(
-		/obj/item/cult_shift,
 		/obj/item/reagent_containers/cup/beaker/unholywater,
 		/obj/item/reagent_containers/cup/beaker/unholywater,
 		/obj/item/reagent_containers/cup/beaker/unholywater,
 	)
 
 	spells_to_add = list(
-		/datum/action/innate/cult/blood_spell/horror,
 		/datum/action/innate/cult/blood_spell/horror,
 		/datum/action/innate/cult/blood_spell/stun,
 		/datum/action/innate/cult/blood_spell/stun,
@@ -999,7 +992,7 @@
 
 /datum/outfit/deathmatch_loadout/cultish/artificer/post_equip(mob/living/carbon/human/user, visualsOnly)
 	. = ..()
-	var/datum/action/innate/cult/blood_spell/manipulation/magick = locate() in user
+	var/datum/action/innate/cult/blood_spell/manipulation/magick = locate() in user.get_all_contents()
 	magick.charges = 300
 
 /datum/outfit/deathmatch_loadout/heresy
@@ -1018,13 +1011,10 @@
 
 // Heretic Warrior
 
-// Has spells of Ash, Blade, and Rust. Overall aggressive
-
 /datum/outfit/deathmatch_loadout/heresy/warrior
 	name = "Deathmatch: Heretic Warrior"
 	display_name = "Heretic Warrior"
-	desc = "Prove the furious strength of the Mansus."
-	//species_override = /datum/species/plasmaman
+	desc = "Prove the furious strength of the Mansus!"
 
 	head = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	neck = /obj/item/clothing/neck/heretic_focus
@@ -1032,7 +1022,7 @@
 	suit_store = /obj/item/melee/sickly_blade/dark
 	uniform = /obj/item/clothing/under/color/darkgreen
 	id_trim = null
-	belt = /obj/item/melee/sickly_blade/ash
+	belt = /obj/item/melee/sickly_blade/rust
 	gloves = null
 	shoes = /obj/item/clothing/shoes/sandal
 	l_pocket = /obj/item/flashlight/lantern/jade/on
@@ -1061,15 +1051,11 @@
 		/datum/action/cooldown/spell/touch/mansus_grasp,
 		/datum/action/cooldown/spell/realignment,
 		/datum/action/cooldown/spell/pointed/projectile/furious_steel,
-		/datum/action/cooldown/spell/charged/beam/fire_blast,
-		/datum/action/cooldown/spell/aoe/fiery_rebirth,
 		/datum/action/cooldown/spell/cone/staggered/entropic_plume,
 		/datum/action/cooldown/spell/pointed/rust_construction,
 	)
 
 // Heretic Scribe
-
-// Has spells of Void, Moon, and Cosmos. Overall defensive/mobile
 
 /datum/outfit/deathmatch_loadout/heresy/scribe
 	name = "Deathmatch: Heretic Scribe"
@@ -1087,29 +1073,27 @@
 	gloves = null
 	shoes = /obj/item/clothing/shoes/winterboots/ice_boots
 	l_pocket = /obj/item/ammo_box/strilka310/lionhunter
-	r_pocket = /obj/item/codex_cicatrix
+	r_pocket = /obj/item/ammo_box/strilka310/lionhunter
 
 	back = /obj/item/gun/ballistic/rifle/lionhunter // for his neutral b, he wields a gun
 
 	belt_contents = list(
 		/obj/item/heretic_labyrinth_handbook,
 		/obj/item/heretic_labyrinth_handbook,
-		/obj/item/eldritch_potion/crucible_soul,
-		/obj/item/clothing/neck/heretic_focus/moon_amulet = 3,
+		/obj/item/eldritch_potion/duskndawn,
+		/obj/item/eldritch_potion/duskndawn,
 	)
 
 	knowledge_to_grant = list(
 		/datum/heretic_knowledge/cosmic_grasp,
 		/datum/heretic_knowledge/moon_grasp,
-		/datum/heretic_knowledge/mark/moon_mark,
 	)
 
 	spells_to_add = list(
 		/datum/action/cooldown/spell/touch/mansus_grasp,
-		/datum/action/cooldown/spell/conjure/cosmic_expansion,
 		/datum/action/cooldown/spell/pointed/projectile/star_blast,
 		/datum/action/cooldown/spell/touch/star_touch,
-		/datum/action/cooldown/spell/cone/staggered/cone_of_cold/void,
+		/datum/action/cooldown/spell/pointed/mind_gate,
 		/datum/action/cooldown/spell/aoe/void_pull,
 	)
 
@@ -1127,7 +1111,7 @@
 	suit_store = /obj/item/book/bible/booze
 	uniform = /obj/item/clothing/under/rank/civilian/chaplain
 	id_trim = null
-	belt = /obj/item/nullrod // choose any!
+	belt = /obj/item/nullrod/non_station // choose any!
 	gloves = /obj/item/clothing/gloves/plate
 	shoes = /obj/item/clothing/shoes/plate
 	l_pocket = /obj/item/flashlight/lantern/on
@@ -1150,7 +1134,6 @@
 	name = "Deathmatch: Clock Cultist"
 	display_name = "Rat'var Apostate"
 	desc = "You're in a fight between the servants of gods, and yours is dead. Good luck?"
-	//species_override = /datum/species/plasmaman
 
 	head = /obj/item/clothing/head/costume/bronze
 	suit = /obj/item/clothing/suit/costume/bronze
@@ -1160,5 +1143,5 @@
 	belt = /obj/item/brass_spear
 	gloves = /obj/item/clothing/gloves/tinkerer
 	shoes = /obj/item/clothing/shoes/bronze
-	l_pocket = /obj/item/reagent_containers/cup/beaker/synthflesh // they used to turn their dmg into tox with a spell. close enough
-	r_pocket = /obj/item/reagent_containers/cup/beaker/synthflesh
+	l_pocket = /obj/item/reagent_containers/cup/beaker/synthflesh/named // they used to turn their dmg into tox with a spell. close enough
+	r_pocket = /obj/item/reagent_containers/cup/beaker/synthflesh/named

--- a/code/modules/deathmatch/deathmatch_mapping.dm
+++ b/code/modules/deathmatch/deathmatch_mapping.dm
@@ -31,3 +31,4 @@
 	icon_state = /turf/open/floor/wood::icon_state
 	base_icon_state = /turf/open/floor/wood::base_icon_state
 	icon = /turf/open/floor/wood::icon
+	smoothing_flags = NONE

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -22,6 +22,8 @@
 	var/menu_description = "A standard chaplain's weapon. Fits in pockets. Can be worn on the belt."
 	/// Lazylist, tracks refs()s to all cultists which have been crit or killed by this nullrod.
 	var/list/cultists_slain
+	/// Affects GLOB.holy_weapon_type. Disable to allow null rods to change at will and without affecting the station's type.
+	var/station_holy_item = TRUE
 
 /obj/item/nullrod/Initialize(mapload)
 	. = ..()
@@ -35,7 +37,7 @@
 	)
 	AddElement(/datum/element/bane, target_type = /mob/living/basic/revenant, damage_multiplier = 0, added_damage = 25, requires_combat_mode = FALSE)
 
-	if(!GLOB.holy_weapon_type && type == /obj/item/nullrod)
+	if((!GLOB.holy_weapon_type || !station_holy_item) && type == /obj/item/nullrod)
 		var/list/rods = list()
 		for(var/obj/item/nullrod/nullrod_type as anything in typesof(/obj/item/nullrod))
 			if(!initial(nullrod_type.chaplain_spawnable))
@@ -52,6 +54,8 @@
 		AddComponent(/datum/component/subtype_picker, rods, CALLBACK(src, PROC_REF(on_holy_weapon_picked)))
 
 /obj/item/nullrod/proc/on_holy_weapon_picked(obj/item/nullrod/holy_weapon_type)
+	if(!station_holy_item)
+		return
 	GLOB.holy_weapon_type = holy_weapon_type
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NULLROD_PICKED)
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[initial(holy_weapon_type.name)]")
@@ -89,6 +93,9 @@
 	var/num_slain = LAZYLEN(cultists_slain)
 	. += span_cult_italic("It has the blood of [num_slain] fallen cultist[num_slain == 1 ? "" : "s"] on it. \
 		<b>Offering</b> it to Nar'sie will transform it into a [num_slain >= 3 ? "powerful" : "standard"] cult weapon.")
+
+/obj/item/nullrod/non_station
+	station_holy_item = FALSE
 
 /// Claymore Variant
 /// This subtype possesses a block chance and is sharp.

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -345,6 +345,9 @@
 /obj/item/reagent_containers/cup/beaker/synthflesh
 	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 50)
 
+/obj/item/reagent_containers/cup/beaker/synthflesh/named
+	name = "synthflesh beaker"
+
 /obj/item/reagent_containers/cup/bucket
 	name = "bucket"
 	desc = "It's a bucket."


### PR DESCRIPTION
## About The Pull Request

### Ragnarok

- Uncomplicated the arena. The center area's river has been muddied over, the bonfires have been made dense, the ants on the ground everywhere have been removed.
- The Warrior's loadout has been simplified, removing any Ash aspects and making it more concise and understandable.
- The Scribe's loadout has also been simplified, and given an additional rifle clip. (Yes, it's a clip.) It lost cosmic expansion and the pacifism mansus, but gained mind gate and some formerly bugged labyrinth handbooks.
- The Crusader should be able to adjust their nullrod now.
- The Rat'var Apostate's beakers are now named so people other than me can get the joke.

### Lattice
- Unbreakable lattices are now actually unbreakable and can't be snipped into nothingness.
- Added true invis walls to the edges.
- Moved spare rods to the pockets.

### Species
- Added no_smoothing to the funny, so it's actually hidden now.
## Why It's Good For The Game

Time playing these ingame has shown some oversights and imbalances. Ragnarok in particular was far too overcomplicated and indulgent to the detriment of gameplay. Too many things - ants, rivers, bonfires, spells, it was cloying. I toned this down a lot here to make the arena more fun. We still do need a way to pre-bind spells but out of scope.
## Changelog
:cl:
balance: - Uncomplicated the Ragnarok arena. The center area's river has been muddied over, the bonfires have been made dense, the ants on the ground everywhere have been removed. The Warrior and Scribe have had their loadouts simplified. 
qol: - The Rat'var Apostate's beakers are now named so people other than me can get the joke.
fix: - Unbreakable lattices are now actually unbreakable and can't be snipped into nothingness.
fix: - Added true invis walls to the edges of Lattice Battles. Moved spare rods to the pockets.
fix: - Species Warfare: Added no_smoothing to the funny, so it's actually hidden now.
/:cl:
