### PR TITLE
Fixes uniforms with no/broken sensors sending basic medical HUD data

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -28,6 +28,8 @@
 	var/obj/item/clothing/under/U = H.w_uniform
 	if(!istype(U))
 		return FALSE
+	if(U.has_sensor < HAS_SENSORS)
+		return FALSE
 	if(U.sensor_mode <= SENSOR_VITALS)
 		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Checks the uniform for the presence of suit sensors entirely before caring about the mode they're set to.

Uniforms spawn with a random sensor_mode regardless if they have sensors or not, so currently a piece of clothing that spawns SENSOR_COORDS will be added to the basic medical HUD even though its has_sensor var is NO_SENSORS

:cl: LT3
fix: Fixed certain clothing sending suit sensor data when it shouldn't be capable
/:cl: