### PR TITLE
[no gbp] basic ai pauses during do afters

### DIFF
--- a/code/datums/ai/basic_mobs/base_basic_controller.dm
+++ b/code/datums/ai/basic_mobs/base_basic_controller.dm
@@ -19,9 +19,12 @@
 /datum/ai_controller/basic_controller/setup_able_to_run()
 	. = ..()
 	RegisterSignal(pawn, COMSIG_MOB_INCAPACITATE_CHANGED, PROC_REF(update_able_to_run))
+	if(ai_traits & PAUSE_DURING_DO_AFTER)
+		RegisterSignals(pawn, list(COMSIG_DO_AFTER_BEGAN, COMSIG_DO_AFTER_ENDED), PROC_REF(update_able_to_run))
+
 
 /datum/ai_controller/basic_controller/clear_able_to_run()
-	UnregisterSignal(pawn, list(COMSIG_MOB_INCAPACITATE_CHANGED, COMSIG_MOB_STATCHANGE))
+	UnregisterSignal(pawn, list(COMSIG_MOB_INCAPACITATE_CHANGED, COMSIG_MOB_STATCHANGE, COMSIG_DO_AFTER_BEGAN, COMSIG_DO_AFTER_ENDED))
 	return ..()
 
 /datum/ai_controller/basic_controller/get_able_to_run()


### PR DESCRIPTION

## About The Pull Request
when making able_to_run event based, we forgot to account for this!

## Why It's Good For The Game
closes #86614

## Changelog
:cl:
fix: fixes basic AI that are supposed to pause during actions not pausing
/:cl:
