### PR TITLE
[NO GBP] Fixes aquarium props not showing up in the aquarium.

### DIFF
--- a/code/modules/fishing/aquarium/aquarium_kit.dm
+++ b/code/modules/fishing/aquarium/aquarium_kit.dm
@@ -123,7 +123,7 @@
 /obj/item/aquarium_prop/Initialize(mapload)
 	. = ..()
 	//It's important that we register the signals before the component is attached.
-	RegisterSignals(src, COMSIG_AQUARIUM_CONTENT_GENERATE_APPEARANCE, PROC_REF(generate_aquarium_appearance))
+	RegisterSignal(src, COMSIG_AQUARIUM_CONTENT_GENERATE_APPEARANCE, PROC_REF(generate_aquarium_appearance))
 	AddComponent(/datum/component/aquarium_content, beauty = beauty)
 	ADD_TRAIT(src, TRAIT_UNIQUE_AQUARIUM_CONTENT, INNATE_TRAIT)
 


### PR DESCRIPTION
## About The Pull Request
RegisterSignals apparently doesn't throw warnings when the signals arg is not a list and just silently fails.

## Why It's Good For The Game
Fixing stuff.

## Changelog

:cl:
fix: Fixed aquarium props not showing up inside the aquarium.
/:cl:
