### PR TITLE
STATION TRAIT GAMEMODE: Naval Patrol (No exterior threats, only internal threats)

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -44,3 +44,5 @@
 #define RULESET_CATEGORY_DEFAULT (1 << 0)
 /// Rulesets not including crew antagonists, non-witting referring to antags like obsessed which aren't really enemies of the station
 #define RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS (1 << 1)
+/// Rulesets not including outside antagonists or infestations like Nuke Ops, Aliens or etc. Blob infection is a exception.
+#define RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS (1 << 2)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
@@ -55,6 +55,7 @@
 	antag_datum = /datum/antagonist/traitor/infiltrator
 	antag_flag = ROLE_SYNDICATE_INFILTRATOR
 	antag_flag_override = ROLE_TRAITOR
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
@@ -85,6 +86,7 @@
 	antag_datum = /datum/antagonist/rev/head
 	antag_flag = ROLE_PROVOCATEUR
 	antag_flag_override = ROLE_REV_HEAD
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,
@@ -185,6 +187,7 @@
 	antag_datum = /datum/antagonist/heretic
 	antag_flag = ROLE_HERETIC_SMUGGLER
 	antag_flag_override = ROLE_HERETIC
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
@@ -227,6 +230,7 @@
 	antag_datum = /datum/antagonist/changeling
 	antag_flag = ROLE_STOWAWAY_CHANGELING
 	antag_flag_override = ROLE_CHANGELING
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -233,6 +233,7 @@
 	antag_datum = /datum/antagonist/traitor/infiltrator/sleeper_agent
 	antag_flag = ROLE_SLEEPER_AGENT
 	antag_flag_override = ROLE_TRAITOR
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
@@ -281,6 +282,7 @@
 	antag_datum = /datum/antagonist/malf_ai
 	antag_flag = ROLE_MALF_MIDROUND
 	antag_flag_override = ROLE_MALF
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	enemy_roles = list(
 		JOB_CHEMIST,
 		JOB_CHIEF_ENGINEER,
@@ -448,7 +450,7 @@
 	antag_datum = /datum/antagonist/blob/infection
 	antag_flag = ROLE_BLOB_INFECTION
 	antag_flag_override = ROLE_BLOB
-	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
@@ -826,7 +828,7 @@
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
 	antag_datum = /datum/antagonist/obsessed
 	antag_flag = ROLE_OBSESSED
-	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CYBORG,
@@ -892,7 +894,7 @@
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
 	antag_datum = /datum/antagonist/paradox_clone
 	antag_flag = ROLE_PARADOX_CLONE
-	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	enemy_roles = list(
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -10,6 +10,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	name = "Traitors"
 	antag_flag = ROLE_TRAITOR
 	antag_datum = /datum/antagonist/traitor
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	minimum_required_age = 0
 	protected_roles = list(
 		JOB_CAPTAIN,
@@ -52,6 +53,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/malf_ai
 	name = "Malfunctioning AI"
 	antag_flag = ROLE_MALF
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	antag_datum = /datum/antagonist/malf_ai
 	minimum_required_age = 14
 	exclusive_roles = list(JOB_AI)
@@ -98,6 +100,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/traitorbro
 	name = "Blood Brothers"
 	antag_flag = ROLE_BROTHER
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	antag_datum = /datum/antagonist/brother
 	protected_roles = list(
 		JOB_CAPTAIN,
@@ -148,6 +151,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/changeling
 	name = "Changelings"
 	antag_flag = ROLE_CHANGELING
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	antag_datum = /datum/antagonist/changeling
 	protected_roles = list(
 		JOB_CAPTAIN,
@@ -196,6 +200,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/heretics
 	name = "Heretics"
 	antag_flag = ROLE_HERETIC
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	antag_datum = /datum/antagonist/heretic
 	protected_roles = list(
 		JOB_CAPTAIN,
@@ -316,6 +321,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/bloodcult
 	name = "Blood Cult"
 	antag_flag = ROLE_CULTIST
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	antag_datum = /datum/antagonist/cult
 	minimum_required_age = 14
 	restricted_roles = list(
@@ -491,6 +497,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	persistent = TRUE
 	antag_flag = ROLE_REV_HEAD
 	antag_flag_override = ROLE_REV_HEAD
+	ruleset_category = parent_type::ruleset_category |  RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	antag_datum = /datum/antagonist/rev/head
 	minimum_required_age = 14
 	restricted_roles = list(

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	if(threat_reduction)
 		GLOB.dynamic_station_traits[src] = threat_reduction
 	if(dynamic_category)
-		GLOB.dynamic_ruleset_categories = dynamic_category
+		GLOB.dynamic_ruleset_categories |= dynamic_category
 	if(sign_up_button)
 		GLOB.lobby_station_traits += src
 	if(trait_processes)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -555,5 +555,5 @@
 	can_revert = FALSE
 
 	dynamic_category = RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
-	threat_reduction = 10
+	threat_reduction = 15
 	dynamic_threat_id = "Naval Patrol"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -544,3 +544,16 @@
 	dynamic_category = RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
 	threat_reduction = 15
 	dynamic_threat_id = "Background Checks"
+
+/// Outside threats or infestations like Nuclear Operatives, Aliens or etc can't spawn. Blob infection is a exception.
+/datum/station_trait/naval_patrol
+	name = "Naval Patrol"
+	report_message = "Your sector falls within the patrol route of our corporate Naval fleet. While no external threats or infestations can breach this perimeter - internal issues on station will still remain your concern."
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 1
+	show_in_report = TRUE
+	can_revert = FALSE
+
+	dynamic_category = RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
+	threat_reduction = 10
+	dynamic_threat_id = "Naval Patrol"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -540,6 +540,7 @@
 	weight = 1
 	show_in_report = TRUE
 	can_revert = FALSE
+	blacklist = list(/datum/station_trait/naval_patrol)
 
 	dynamic_category = RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
 	threat_reduction = 15
@@ -550,9 +551,10 @@
 	name = "Naval Patrol"
 	report_message = "Your sector falls within the patrol route of our corporate Naval fleet. While no external threats or infestations can breach this perimeter - internal issues on station will still remain your concern."
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1
+	weight = 2
 	show_in_report = TRUE
 	can_revert = FALSE
+	blacklist = list(/datum/station_trait/background_checks)
 
 	dynamic_category = RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS
 	threat_reduction = 15

--- a/code/modules/events/ghost_role/operative.dm
+++ b/code/modules/events/ghost_role/operative.dm
@@ -32,6 +32,13 @@
 
 	Mind.add_antag_datum(/datum/antagonist/nukeop/lone)
 
+	// If we have a Station Trait "Naval Patrol" it will not prevent the Lone Ops but just announce it presence
+	// You should've secured that disk! Not even Navy will stop a disk-sniffing-determined Lone Operative
+	if(GLOB.dynamic_ruleset_categories == RULESET_CATEGORY_NO_OUTSIDE_ANTAGONISTS)
+		minor_announce(
+			message = "We've detected a fast-moving, human-sized, blood-red blip on radar heading towards [GLOB.station_name]. It somehow evaded our engagement protocols and is now within your proximity. The situation is yours to handle, no reply.",
+			title = "Nanotrasen Navy Update",
+		)
 	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone operative by an event.")
 	operative.log_message("was spawned as a lone operative by an event.", LOG_GAME)
 	spawned_mobs += operative

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -156,6 +156,8 @@
 		"Radioactive Nebula": {
 		},
 		"Background Checks": {
+		},
+		"Naval Patrol": {
 		}
 	}
 }


### PR DESCRIPTION
## About The Pull Request

The opposite version of #83307

This very rare station trait (1 point less rare as Station-Wide Background Checks) does not allow any exterior antagonists like Nuclear Operatives, Wizards, Space Dragons, Aliens, etc to spawn, the only exception is Blob Infection.

Internal threats like Traitors, Changelings, Heretic, Cults, Revolutionaries, etc can still spawn while the Station Trait is active.
## Why It's Good For The Game
When #83307 only appeared, I immediately thought it would be neat to have the opposite: only internal threats and no outside threats.
And after the success of #83307, this will work out well. Especially that more "Station Trait Gamemodes" would be neat to have.

This would allow the Station to be fully submerged only in internal paranoia threats without being at risk of getting all of that atmosphere broken by a sudden Space Dragon or similar that everyone must murder and abandon whatever they did before.
Rare rounds with this threat would be refreshing for Crew and Security as they have no stress of getting randomly under heavy fire in the middle of the round, without just being a Green Start/White Dwarf with 0 threats.

Paranoia and investigations will be more plausible when the Station Trait is active.
## Changelog
:cl: DrDiasyl aka DrTuxedo
add: NEW STATION TRAIT "GAMEMODE": Naval Patrol! The station sector is being crossed by a Naval fleet patrol, due to this NO external threats or infestations can board the station. But internal threats remain, so stay vigilant and paranoid without getting distracted...
/:cl:
