### PR TITLE
Small refactor on station trait lobby buttons.

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -419,6 +419,11 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 		return
 	update_robot_modules_display()
 
+/datum/hud/new_player/show_hud(version = 0, mob/viewmob)
+	. = ..()
+	if(.)
+		show_station_trait_buttons()
+
 /datum/hud/proc/hidden_inventory_update()
 	return
 

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -28,7 +28,7 @@
 			lobbyscreen.RegisterSignal(src, COMSIG_HUD_LOBBY_COLLAPSED, TYPE_PROC_REF(/atom/movable/screen/lobby, collapse_button))
 			lobbyscreen.RegisterSignal(src, COMSIG_HUD_LOBBY_EXPANDED, TYPE_PROC_REF(/atom/movable/screen/lobby, expand_button))
 
-/// Display buttons for relevant station traits
+/// Load and then display the buttons for relevant station traits
 /datum/hud/new_player/proc/show_station_trait_buttons()
 	if (!mymob?.client || mymob.client.interviewee || !length(GLOB.lobby_station_traits))
 		return
@@ -45,26 +45,33 @@
 		LAZYSET(shown_station_trait_buttons, trait, sign_up_button)
 		RegisterSignal(trait, COMSIG_QDELETING, PROC_REF(remove_station_trait_button))
 
-	if(hud_version != HUD_STYLE_STANDARD)
+	place_station_trait_buttons()
+
+/// Display the buttosn for relevant station traits.
+/datum/hud/new_player/proc/place_station_trait_buttons()
+	if(hud_version != HUD_STYLE_STANDARD || !mymob?.client)
 		return
 
 	var/y_offset = 397
 	var/x_offset = 233
 	var/y_button_offset = 27
-	var/x_button_offset = 27
+	var/x_button_offset = -27
 	var/iteration = 0
 	for(var/trait in shown_station_trait_buttons)
 		var/atom/movable/screen/lobby/button/sign_up/sign_up_button = shown_station_trait_buttons[trait]
 		iteration++
 		sign_up_button.screen_loc = offset_to_screen_loc(x_offset, y_offset, mymob.client.view)
-		y_offset += y_button_offset
 		mymob.client.screen |= sign_up_button
 		if (iteration >= MAX_STATION_TRAIT_BUTTONS_VERTICAL)
 			iteration = 0
 			y_offset = 397
-			x_offset -= x_button_offset
+			x_offset += x_button_offset
+		else
+			y_offset += y_button_offset
 
+/// Remove a station trait button, then re-order the rest.
 /datum/hud/new_player/proc/remove_station_trait_button(datum/station_trait/trait)
+	SIGNAL_HANDLER
 	var/atom/movable/screen/lobby/button/sign_up/remove_me = LAZYACCESS(shown_station_trait_buttons, trait)
 	if(!remove_me)
 		return
@@ -72,7 +79,7 @@
 	UnregisterSignal(trait, COMSIG_QDELETING)
 	static_inventory -= remove_me
 	qdel(remove_me)
-	show_station_trait_buttons()
+	place_station_trait_buttons()
 
 /atom/movable/screen/lobby
 	plane = SPLASHSCREEN_PLANE

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -6,6 +6,7 @@
 /datum/hud/new_player
 	///Whether the menu is currently on the client's screen or not
 	var/menu_hud_status = TRUE
+	var/list/shown_station_trait_buttons
 
 /datum/hud/new_player/New(mob/owner)
 	. = ..()
@@ -26,31 +27,52 @@
 		if (!lobbyscreen.always_shown)
 			lobbyscreen.RegisterSignal(src, COMSIG_HUD_LOBBY_COLLAPSED, TYPE_PROC_REF(/atom/movable/screen/lobby, collapse_button))
 			lobbyscreen.RegisterSignal(src, COMSIG_HUD_LOBBY_EXPANDED, TYPE_PROC_REF(/atom/movable/screen/lobby, expand_button))
-		if (istype(lobbyscreen, /atom/movable/screen/lobby/button))
-			var/atom/movable/screen/lobby/button/lobby_button = lobbyscreen
-			lobby_button.owner = REF(owner)
-	add_station_trait_buttons()
 
 /// Display buttons for relevant station traits
-/datum/hud/new_player/proc/add_station_trait_buttons()
+/datum/hud/new_player/proc/show_station_trait_buttons()
 	if (!mymob?.client || mymob.client.interviewee || !length(GLOB.lobby_station_traits))
 		return
-	var/buttons_created = 0
-	var/y_offset = 397
-	var/y_button_offset = 27
 	for (var/datum/station_trait/trait as anything in GLOB.lobby_station_traits)
 		if (!trait.can_display_lobby_button(mymob.client))
+			remove_station_trait_button(trait)
 			continue
+		if(LAZYACCESS(shown_station_trait_buttons, trait))
+			return
 		var/atom/movable/screen/lobby/button/sign_up/sign_up_button = new(our_hud = src)
 		sign_up_button.SlowInit()
-		sign_up_button.owner = REF(mymob)
-		sign_up_button.screen_loc = offset_to_screen_loc(233, y_offset, mymob.client.view)
-		y_offset += y_button_offset
-		static_inventory += sign_up_button
 		trait.setup_lobby_button(sign_up_button)
-		buttons_created++
-		if (buttons_created >= MAX_STATION_TRAIT_BUTTONS_VERTICAL)
-			return
+		static_inventory += sign_up_button
+		LAZYSET(shown_station_trait_buttons, trait, sign_up_button)
+		RegisterSignal(trait, COMSIG_QDELETING, PROC_REF(remove_station_trait_button))
+
+	if(hud_version != HUD_STYLE_STANDARD)
+		return
+
+	var/y_offset = 397
+	var/x_offset = 233
+	var/y_button_offset = 27
+	var/x_button_offset = 27
+	var/iteration = 0
+	for(var/trait in shown_station_trait_buttons)
+		var/atom/movable/screen/lobby/button/sign_up/sign_up_button = shown_station_trait_buttons[trait]
+		iteration++
+		sign_up_button.screen_loc = offset_to_screen_loc(x_offset, y_offset, mymob.client.view)
+		y_offset += y_button_offset
+		mymob.client.screen |= sign_up_button
+		if (iteration >= MAX_STATION_TRAIT_BUTTONS_VERTICAL)
+			iteration = 0
+			y_offset = 397
+			x_offset -= x_button_offset
+
+/datum/hud/new_player/proc/remove_station_trait_button(datum/station_trait/trait)
+	var/atom/movable/screen/lobby/button/sign_up/remove_me = LAZYACCESS(shown_station_trait_buttons, trait)
+	if(!remove_me)
+		return
+	LAZYREMOVE(shown_station_trait_buttons, trait)
+	UnregisterSignal(trait, COMSIG_QDELETING)
+	static_inventory -= remove_me
+	qdel(remove_me)
+	show_station_trait_buttons()
 
 /atom/movable/screen/lobby
 	plane = SPLASHSCREEN_PLANE
@@ -94,11 +116,9 @@
 	var/enabled = TRUE
 	///Is the button currently being hovered over with the mouse?
 	var/highlighted = FALSE
-	/// The ref of the mob that owns this button. Only the owner can click on it.
-	var/owner
 
 /atom/movable/screen/lobby/button/Click(location, control, params)
-	if(owner != REF(usr))
+	if(usr != get_mob())
 		return
 
 	if(!usr.client || usr.client.interviewee)
@@ -113,7 +133,7 @@
 	return TRUE
 
 /atom/movable/screen/lobby/button/MouseEntered(location,control,params)
-	if(owner != REF(usr))
+	if(usr != get_mob())
 		return
 
 	if(!usr.client || usr.client.interviewee)
@@ -124,7 +144,7 @@
 	update_appearance(UPDATE_ICON)
 
 /atom/movable/screen/lobby/button/MouseExited()
-	if(owner != REF(usr))
+	if(usr != get_mob())
 		return
 
 	if(!usr.client || usr.client.interviewee)

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -33,15 +33,14 @@
 	if (!mymob?.client || mymob.client.interviewee || !length(GLOB.lobby_station_traits))
 		return
 	for (var/datum/station_trait/trait as anything in GLOB.lobby_station_traits)
-		if (!trait.can_display_lobby_button(mymob.client))
+		if (QDELETED(trait) || !trait.can_display_lobby_button(mymob.client))
 			remove_station_trait_button(trait)
 			continue
 		if(LAZYACCESS(shown_station_trait_buttons, trait))
-			return
+			continue
 		var/atom/movable/screen/lobby/button/sign_up/sign_up_button = new(our_hud = src)
-		sign_up_button.SlowInit()
 		trait.setup_lobby_button(sign_up_button)
-		static_inventory += sign_up_button
+		static_inventory |= sign_up_button
 		LAZYSET(shown_station_trait_buttons, trait, sign_up_button)
 		RegisterSignal(trait, COMSIG_QDELETING, PROC_REF(remove_station_trait_button))
 
@@ -72,13 +71,13 @@
 /// Remove a station trait button, then re-order the rest.
 /datum/hud/new_player/proc/remove_station_trait_button(datum/station_trait/trait)
 	SIGNAL_HANDLER
-	var/atom/movable/screen/lobby/button/sign_up/remove_me = LAZYACCESS(shown_station_trait_buttons, trait)
-	if(!remove_me)
+	var/atom/movable/screen/lobby/button/sign_up/button = LAZYACCESS(shown_station_trait_buttons, trait)
+	if(!button)
 		return
 	LAZYREMOVE(shown_station_trait_buttons, trait)
 	UnregisterSignal(trait, COMSIG_QDELETING)
-	static_inventory -= remove_me
-	qdel(remove_me)
+	static_inventory -= button
+	qdel(button)
 	place_station_trait_buttons()
 
 /atom/movable/screen/lobby

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -181,5 +181,4 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		var/datum/hud/new_player/observer_hud = player.hud_used
 		if (!istype(observer_hud))
 			continue
-		observer_hud.add_station_trait_buttons()
-		observer_hud.show_hud(observer_hud.hud_version)
+		observer_hud.show_station_trait_buttons()

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	var/dynamic_threat_id
 	/// If ran during dynamic, do we reduce the total threat? Will be overridden by config if set
 	var/threat_reduction = 0
-	/// Which ruleset flags to allow dynamic to use. null to disregard
+	/// Which ruleset flags to allow dynamic to use. NONE to disregard
 	var/dynamic_category = NONE
 	/// Trait should not be instantiated in a round if its type matches this type
 	var/abstract_type = /datum/station_trait

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	/// If ran during dynamic, do we reduce the total threat? Will be overridden by config if set
 	var/threat_reduction = 0
 	/// Which ruleset flags to allow dynamic to use. null to disregard
-	var/dynamic_category = null
+	var/dynamic_category = NONE
 	/// Trait should not be instantiated in a round if its type matches this type
 	var/abstract_type = /datum/station_trait
 
@@ -48,8 +48,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	if(threat_reduction)
 		GLOB.dynamic_station_traits[src] = threat_reduction
 	if(dynamic_category)
-		GLOB.dynamic_ruleset_categories &= ~RULESET_CATEGORY_DEFAULT
-		GLOB.dynamic_ruleset_categories |= dynamic_category
+		GLOB.dynamic_ruleset_categories = dynamic_category
 	if(sign_up_button)
 		GLOB.lobby_station_traits += src
 		if(SSstation.initialized)
@@ -60,15 +59,11 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 		ADD_TRAIT(SSstation, trait_to_give, STATION_TRAIT)
 
 /datum/station_trait/Destroy()
+	destroy_lobby_buttons()
 	SSstation.station_traits -= src
 	GLOB.lobby_station_traits -= src
-	REMOVE_TRAIT(SSstation, trait_to_give, STATION_TRAIT)
 	GLOB.dynamic_station_traits -= src
-	if(dynamic_category)
-		GLOB.dynamic_ruleset_categories &= ~dynamic_category
-		if(GLOB.dynamic_ruleset_categories == NONE)
-			GLOB.dynamic_ruleset_categories = RULESET_CATEGORY_DEFAULT
-	destroy_lobby_buttons()
+	REMOVE_TRAIT(SSstation, trait_to_give, STATION_TRAIT)
 	return ..()
 
 /// Returns the type of info the centcom report has on this trait, if any.

--- a/code/datums/station_traits/job_traits.dm
+++ b/code/datums/station_traits/job_traits.dm
@@ -41,6 +41,10 @@
 	else
 		LAZYADD(lobby_candidates, user)
 
+/datum/station_trait/job/on_lobby_button_destroyed(atom/movable/screen/lobby/button/sign_up/lobby_button)
+	. = ..()
+	LAZYREMOVE(lobby_candidates, lobby_button.get_mob())
+
 /datum/station_trait/job/on_lobby_button_update_icon(atom/movable/screen/lobby/button/sign_up/lobby_button, updates)
 	if (LAZYFIND(lobby_candidates, lobby_button.get_mob()))
 		lobby_button.base_icon_state = "signup_on"
@@ -251,6 +255,13 @@
 	show_in_report = TRUE
 	can_roll_antag = CAN_ROLL_ALWAYS
 	job_to_add = /datum/job/pun_pun
+
+/datum/station_trait/job/pun_pun/New()
+	. = ..()
+	if(SSticker.HasRoundStarted() || !GLOB.the_one_and_only_punpun) //Make sure we don't have two Pun Puns if loaded before the start of the round.
+		return
+	new /obj/effect/landmark/start/pun_pun(GLOB.the_one_and_only_punpun.loc)
+	qdel(GLOB.the_one_and_only_punpun)
 
 /datum/station_trait/job/pun_pun/on_lobby_button_update_overlays(atom/movable/screen/lobby/button/sign_up/lobby_button, list/overlays)
 	. = ..()

--- a/code/datums/station_traits/job_traits.dm
+++ b/code/datums/station_traits/job_traits.dm
@@ -84,7 +84,7 @@
 /datum/station_trait/job/cargorilla
 	name = "Cargo Gorilla"
 	button_desc = "Sign up to become the Cargo Gorilla, a peaceful shepherd of boxes."
-	weight = 1
+	weight = 0
 	show_in_report = FALSE // Selective attention test. Did you spot the gorilla?
 	can_roll_antag = CAN_ROLL_NEVER
 	job_to_add = /datum/job/cargo_gorilla
@@ -258,7 +258,7 @@
 
 /datum/station_trait/job/pun_pun/New()
 	. = ..()
-	if(SSticker.HasRoundStarted() || !GLOB.the_one_and_only_punpun) //Make sure we don't have two Pun Puns if loaded before the start of the round.
+	if(!SSticker.HasRoundStarted() || !GLOB.the_one_and_only_punpun) //Make sure we don't have two Pun Puns if loaded before the start of the round.
 		return
 	new /obj/effect/landmark/start/pun_pun(GLOB.the_one_and_only_punpun.loc)
 	qdel(GLOB.the_one_and_only_punpun)

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -697,10 +697,6 @@
 /datum/holiday/monkey/celebrate()
 	. = ..()
 	SSstation.setup_trait(/datum/station_trait/job/pun_pun)
-	//SSevents should initialize before SSatoms but who knows if it'll ever change.
-	if(GLOB.the_one_and_only_punpun)
-		new /obj/effect/landmark/start/pun_pun(GLOB.the_one_and_only_punpun.loc)
-		qdel(GLOB.the_one_and_only_punpun)
 
 /datum/holiday/doomsday
 	name = "Mayan Doomsday Anniversary"


### PR DESCRIPTION
## About The Pull Request
So, I've been looking into manually loading job traits today, and it seems the buttons don't appear until you reconnect. Upon further investigations, it turns out that the code doesn't support showing lobby buttons outside of SSstation init. To add injury only up to three buttons can be displayed for some stupid reason (the lack of code for x offsets), plus the buttons aren't relocated when one is removed, thus possibly leaving behind an empty gap.

This PR fixes all of that, while removing some crumbs of shitcode from new players' HUDs and making sure to remove datum traits and references are removed when the trait is deleted (usually never the case outside VV).

![immagine](https://github.com/user-attachments/assets/c7e0c481-df7c-41fc-a98c-bee15f0d9ce7)


## Why It's Good For The Game
Lobby buttons should ALWAYS be shown to the player if the relative trait is loaded, the only exception being the conditions set by the trait itself (for job traits is the job age and whether the game has started or not), while the offsets of the lobby buttons should stay synced with how many are being displayed to the new player at any given time, so if a button is deleted, the others are relocated to avoid having leaving an empty gap behind.

Beside, this is necessary for the lobby button for the playable pun pun to show up during Monkey Day.


## Changelog
N/A, all backend.