### PR TITLE
Fixes a typo in DeForest medical crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -224,7 +224,7 @@
 
 /obj/structure/closet/crate/deforest
 	name = "deforest medical crate"
-	desc = "A DeFortest brand crate of medical supplies."
+	desc = "A DeForest brand crate of medical supplies."
 	icon_state = "deforest"
 	base_icon_state = "deforest"
 


### PR DESCRIPTION

## About The Pull Request

Closes #86628 

## Changelog
:cl:
spellcheck: Fixed a typo in DeForest medical crates
/:cl:
