### PR TITLE
Replaces HAS_TRAIT_FROM with HAS_TRAIT in engraving checks

### DIFF
--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -301,3 +301,6 @@
 
 /// Trait added by style component
 #define STYLE_TRAIT "style"
+
+/// Trait from an engraving
+#define ENGRAVED_TRAIT "engraved"

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -67,13 +67,13 @@
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	//supporting component transfer means putting these here instead of initialize
 	SSpersistence.wall_engravings += src
-	ADD_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC)
+	ADD_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, ENGRAVED_TRAIT)
 
 /datum/component/engraved/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ATOM_EXAMINE)
 	//supporting component transfer means putting these here instead of destroy
 	SSpersistence.wall_engravings -= src
-	REMOVE_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC)
+	REMOVE_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, ENGRAVED_TRAIT)
 
 /// Used to maintain the acid overlay on the parent [/atom].
 /datum/component/engraved/proc/on_update_overlays(atom/parent_atom, list/overlays)

--- a/code/datums/elements/wall_engraver.dm
+++ b/code/datums/elements/wall_engraver.dm
@@ -31,11 +31,11 @@
 /datum/element/wall_engraver/proc/try_chisel(obj/item/item, turf/closed/wall, mob/living/user)
 	if(!istype(wall) || !user.mind)
 		return
-	if(HAS_TRAIT_FROM(wall, TRAIT_NOT_ENGRAVABLE, INNATE_TRAIT))
-		user.balloon_alert(user, "wall cannot be engraved!")
-		return
-	if(HAS_TRAIT_FROM(wall, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC))
+	if(HAS_TRAIT_FROM(wall, TRAIT_NOT_ENGRAVABLE, ENGRAVED_TRAIT))
 		user.balloon_alert(user, "wall has already been engraved!")
+		return
+	if(HAS_TRAIT(wall, TRAIT_NOT_ENGRAVABLE))
+		user.balloon_alert(user, "wall cannot be engraved!")
 		return
 	if(!length(user.mind?.memories))
 		user.balloon_alert(user, "nothing memorable to engrave!")

--- a/code/datums/memory/tattoo_kit.dm
+++ b/code/datums/memory/tattoo_kit.dm
@@ -47,10 +47,10 @@
 		balloon_alert(tattoo_artist, "no limb to tattoo!")
 		return
 	if(HAS_TRAIT_FROM(tattoo_target, TRAIT_NOT_ENGRAVABLE, ENGRAVED_TRAIT))
-		balloon_alert(tattoo_artist, "bodypart has already been engraved!")
+		balloon_alert(tattoo_artist, "bodypart already tattooed!")
 		return
 	if(HAS_TRAIT(tattoo_target, TRAIT_NOT_ENGRAVABLE))
-		balloon_alert(tattoo_artist, "bodypart cannot be engraved!")
+		balloon_alert(tattoo_artist, "bodypart cannot be tattooed!")
 		return
 	var/datum/memory/memory_to_tattoo = tattoo_artist.mind.select_memory("tattoo")
 	if(!memory_to_tattoo || !tattoo_artist.Adjacent(tattoo_holder) || !tattoo_holder.get_bodypart(selected_zone))

--- a/code/datums/memory/tattoo_kit.dm
+++ b/code/datums/memory/tattoo_kit.dm
@@ -46,11 +46,11 @@
 	if(!tattoo_target)
 		balloon_alert(tattoo_artist, "no limb to tattoo!")
 		return
-	if(HAS_TRAIT_FROM(tattoo_target, TRAIT_NOT_ENGRAVABLE, INNATE_TRAIT))
-		balloon_alert(tattoo_artist, "bodypart cannot be engraved!")
-		return
-	if(HAS_TRAIT_FROM(tattoo_target, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC))
+	if(HAS_TRAIT_FROM(tattoo_target, TRAIT_NOT_ENGRAVABLE, ENGRAVED_TRAIT))
 		balloon_alert(tattoo_artist, "bodypart has already been engraved!")
+		return
+	if(HAS_TRAIT(tattoo_target, TRAIT_NOT_ENGRAVABLE))
+		balloon_alert(tattoo_artist, "bodypart cannot be engraved!")
 		return
 	var/datum/memory/memory_to_tattoo = tattoo_artist.mind.select_memory("tattoo")
 	if(!memory_to_tattoo || !tattoo_artist.Adjacent(tattoo_holder) || !tattoo_holder.get_bodypart(selected_zone))


### PR DESCRIPTION

## About The Pull Request

Stumbled upon this by accident. If you add a trait that **should** prevent engraving from a source other than INNATE_TRAIT you'd probably want it to actually work. This doesn't actually do anything at the moment but could save someone a few hours in the future.

## Changelog
:cl:
code: Non-innate engraving blockers should work now (none as of now)
/:cl:
