### PR TITLE
Humans that never had a player controlling them no longer count towards changeling absorption counter

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -42,6 +42,9 @@
 	to_chat(target, span_userdanger("You are absorbed by the changeling!"))
 
 	var/true_absorbtion = (!isnull(target.client) || !isnull(target.mind) || !isnull(target.last_mind))
+	if (!true_absorbtion)
+		to_chat(owner, span_changeling(span_bold("You absorb [target], but their weak DNA is not enough to satisfy your hunger.")))
+
 	if(!changeling.has_profile_with_dna(target.dna))
 		changeling.add_new_profile(target)
 		if (true_absorbtion)

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -41,9 +41,11 @@
 	owner.visible_message(span_danger("[owner] sucks the fluids from [target]!"), span_notice("We have absorbed [target]."))
 	to_chat(target, span_userdanger("You are absorbed by the changeling!"))
 
+	var/true_absorbtion = (!isnull(target.client) || !isnull(target.mind) || !isnull(target.last_mind))
 	if(!changeling.has_profile_with_dna(target.dna))
 		changeling.add_new_profile(target)
-		changeling.true_absorbs++
+		if (true_absorbtion)
+			changeling.true_absorbs++
 
 	if(owner.nutrition < NUTRITION_LEVEL_WELL_FED)
 		owner.set_nutrition(min((owner.nutrition + target.nutrition), NUTRITION_LEVEL_WELL_FED))
@@ -57,7 +59,8 @@
 	is_absorbing = FALSE
 
 	changeling.adjust_chemicals(10)
-	changeling.can_respec = TRUE
+	if (true_absorbtion)
+		changeling.can_respec = TRUE
 
 	if(target.stat != DEAD)
 		target.investigate_log("has died from being changeling absorbed.", INVESTIGATE_DEATHS)


### PR DESCRIPTION

## About The Pull Request

If a DNA absorption victim doesn't have a client/mind (i.e. monkey or spawned corpse, most of the time) they no longer count towards the absorption counter / refresh your respec. This affects only one ability, that being bloody spiders which requires you to succ 3 people in order to buy it.

## Why It's Good For The Game

Blood spiders is a potent tool in right hands and I don't think that it should be acquirable by just visiting genetics/xenobiology/virology/cargo for some monkey cubes. This will force antags who want to get a strong ability to interact with the crew a bit more instead of spending first 15 minutes "powering up"

## Changelog
:cl:
balance: Humans that never had a player controlling them no longer count towards changeling absorption counter
/:cl:
