### PR TITLE
Adds 'required_neighbors' to maplint and conditional lints

### DIFF
--- a/tools/maplint/README.md
+++ b/tools/maplint/README.md
@@ -130,3 +130,68 @@ help: Pugs haven't existed on Sol since 2450.
 /mob/dog/pug:
   banned: true
 ```
+
+### `disabled`
+
+The disabled flag can be set in the root if the rule should be skipped. This is convenient if you have lints for a feature which is not ready to be linted against.
+
+```yml
+disabled: true
+/mob/dog/pug:
+  banned: true
+```
+
+### `when` - Conditional Rules
+
+Sometimes it may be necessary for a rule to be given conditions which have to be met before it needs to be applied. All children of the when node must be satisfied for the rule to execute.
+
+If we wanted to create a rule which disallows the placement of access helpers when an airlock's access has been manually set via a variable edit, then we could make the following rule:
+
+```yml
+/obj/machinery/door/airlock:
+	when:
+	- req_access_txt is set
+	banned_neighbors:
+	- /obj/effect/mapping_helper/airlock/access
+```
+
+The following conditions are valid:
+- **{var_name} is set**: The variable named *var_name* has been modified.
+- **{var_name} is not set**: The variable named *var_name* has not been modified.
+- **{var_name} is '{value}'**: The variable named *var_name* has a specific value.
+- **{var_name} is not '{value}'**: The variable named *var_name* does not have a specific value.
+- **{var_name} like '{regex}'**: The variable named *var_name* matches the provided regex.
+- **{var_name} not like '{regex}'**: The variable named *var_name* does not match the provided regex.
+
+#### `any`
+
+The any node may be added as a child to the when node to specify that it will be satisfied if any of its child conditions are met.
+
+```yml
+/mob/dog:
+	# Rule only applies when the dog is any of the following breeds
+	when:
+	- any:
+		- breed is 'labrador'
+		- breed is 'pug'
+		- breed is 'corgi'
+	# These breeds of dogs must have a dogbed
+	required_neighbors:
+	- /obj/dogbed
+```
+
+#### `all`
+
+The all node may be added as a child to the when node to specify that it will be satisfied only when all of its child conditions are met. Note that the `all` node only makes sense to use when the parent node is an `any` node, as the default behaviour of `when` is to require all conditions to be met.
+
+```yml
+/mob/dog:
+	# Rule only applies if the dog breed is capitalised and has an owner
+	when:
+	- all:
+		- breed like '[A-Z][a-z]*'
+		- owner is set
+	# These dogs must have a dogbed for their owner
+	required_neighbors:
+	- /obj/dogbed
+```

--- a/tools/maplint/README.md
+++ b/tools/maplint/README.md
@@ -131,16 +131,6 @@ help: Pugs haven't existed on Sol since 2450.
   banned: true
 ```
 
-### `disabled`
-
-The disabled flag can be set in the root if the rule should be skipped. This is convenient if you have lints for a feature which is not ready to be linted against.
-
-```yml
-disabled: true
-/mob/dog/pug:
-  banned: true
-```
-
 ### `when` - Conditional Rules
 
 Sometimes it may be necessary for a rule to be given conditions which have to be met before it needs to be applied. All children of the when node must be satisfied for the rule to execute.

--- a/tools/maplint/README.md
+++ b/tools/maplint/README.md
@@ -161,7 +161,6 @@ The following conditions are valid:
 - **{var_name} is '{value}'**: The variable named *var_name* has a specific value.
 - **{var_name} is not '{value}'**: The variable named *var_name* does not have a specific value.
 - **{var_name} like '{regex}'**: The variable named *var_name* matches the provided regex.
-- **{var_name} not like '{regex}'**: The variable named *var_name* does not match the provided regex.
 
 #### `any`
 

--- a/tools/maplint/source/common.py
+++ b/tools/maplint/source/common.py
@@ -29,8 +29,12 @@ class Typepath:
 class Filename:
     path: str
 
+    def __str__(self) -> str:
+        return self.path
+
 @dataclass
 class Null:
-    pass
+    def __str__(self) -> str:
+        return "null"
 
 Constant = str | float | Filename | Typepath | Null | list['Constant'] | dict['Constant', 'Constant']

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Optional, Union
 
 from .common import Constant, Typepath
 from .dmm import DMM, Content
@@ -41,7 +41,7 @@ class TypepathExtra:
 
         return self.typepath.segments == path.segments[:len(self.typepath.segments)]
 
-class BannedNeighbor:
+class AtomNeighbor:
     identical: bool = False
     typepath: Optional[TypepathExtra] = None
     pattern: Optional[re.Pattern] = None
@@ -83,6 +83,12 @@ class BannedNeighbor:
                 return True
 
         return False
+
+    def to_string(self) -> str:
+        if (self.typepath is not None):
+            return self.typepath.typepath.path
+        elif (self.pattern is not None):
+            return self.pattern.pattern
 
 Choices = list[Constant] | re.Pattern
 
@@ -153,10 +159,121 @@ class BannedVariable:
 
         return f"This variable is not allowed for this type."
 
+# Base class for conditional rules
+class ConditionalRule:
+    def is_met(self, identified: Content) -> bool:
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+    def match_string(self, parent_intersection: bool) -> str:
+        raise NotImplementedError("This method should be implemented by subclasses")
+
+# A single conditional expression
+class WhenCondition(ConditionalRule):
+    condition: str
+    match_set: Optional[re.Match]
+    match_not_set: Optional[re.Match]
+    match_equal: Optional[re.Match]
+    match_not_equal: Optional[re.Match]
+    match_like: Optional[re.Match]
+
+    def __init__(self, condition: str):
+        self.condition = condition
+        self.match_set = re.match(r"(.+) is set", condition)
+        self.match_not_set = re.match(r"(.+) is not set", condition)
+        self.match_equal = re.match(r"(.+) is '(.+)'", condition)
+        self.match_not_equal = re.match(r"(.+) is not '(.+)'", condition)
+        self.match_like = re.match(r"(.+) like '(.+)'", condition)
+
+    def is_met(self, identified: Content) -> bool:
+        var_edits = identified.var_edits
+
+        if self.match_set:
+            var_name = self.match_set.group(1)
+            return var_name in var_edits
+
+        elif self.match_not_set:
+            var_name = self.match_not_set.group(1)
+            return var_name not in var_edits
+
+        elif self.match_equal:
+            var_name, expected_value = self.match_equal.groups()
+            return var_name in var_edits and var_edits[var_name] == expected_value
+
+        elif self.match_not_equal:
+            var_name, unexpected_value = self.match_not_equal.groups()
+            return var_name not in var_edits or var_edits[var_name] != unexpected_value
+
+        elif self.match_like:
+            var_name, pattern = self.match_like.groups()
+            return var_name in var_edits and re.match(pattern, var_edits[var_name])
+
+        return False
+
+    def match_string(self, parent_intersection: bool) -> str:
+        return self.condition
+
+# A conditional group (Joining with AND and OR)
+class WhenGroup(ConditionalRule):
+    conditions: list[ConditionalRule]
+    all_group: bool
+
+    def __init__(self, conditions: list[Union[dict, str]], all_group: bool = True):
+        self.conditions = [self.parse_condition(condition) for condition in conditions]
+        self.all_group = all_group
+
+    def parse_condition(self, condition: Union[dict, str]) -> ConditionalRule:
+        if isinstance(condition, dict):
+            if "all" in condition:
+                return WhenGroup(condition["all"], all_group=True)
+            elif "any" in condition:
+                return WhenGroup(condition["any"], all_group=False)
+            else:
+                raise MapParseError(f"Unknown conditional group in when clause: {list(condition.keys())[0]}")
+        elif isinstance(condition, str):
+            return WhenCondition(condition)
+        else:
+            raise MapParseError(f"Invalid condition type: {type(condition)}")
+
+    def is_met(self, identified: Content) -> bool:
+        if self.all_group:
+            # For `all` group, all conditions must be met
+            return all(condition.is_met(identified) for condition in self.conditions)
+        else:
+            # For `any` group, only one condition must be met
+            return any(condition.is_met(identified) for condition in self.conditions)
+
+    # Add parenthesis where required
+    def match_string(self, parent_intersection: bool) -> str:
+        match_symbol = " and " if self.all_group else " or "
+        match_text = match_symbol.join(condition.match_string(self.all_group) for condition in self.conditions);
+        if (self.all_group == False and parent_intersection == True and len(self.conditions) > 1):
+            return f"({match_text})"
+        else:
+            return match_text
+
+class When:
+    root_group: WhenGroup
+
+    def __init__(self, conditions: list[Union[dict, str]]):
+        expect(isinstance(conditions, list), "when must be a list of conditions.")
+        # Default to 'all' group if there are multiple conditions with no explicit 'any' or 'all'
+        if len(conditions) > 1 and not any(isinstance(cond, dict) for cond in conditions):
+            self.root_group = WhenGroup(conditions, all_group=True)
+        else:
+            self.root_group = WhenGroup(conditions)
+
+    def evaluate(self, identified: Content) -> bool:
+        return self.root_group.is_met(identified)
+
+    def match_string(self) -> str:
+        return f" when {self.root_group.match_string(True)}";
+
 class Rules:
     banned: bool = False
-    banned_neighbors: list[BannedNeighbor] = []
+    banned_neighbors: list[AtomNeighbor] = []
     banned_variables: bool | list[BannedVariable] = []
+    required_neighbors: list[AtomNeighbor] = []
+    when: Optional[When] = None
 
     def __init__(self, data):
         expect(isinstance(data, dict), "Lint rules must be a dictionary.")
@@ -171,9 +288,19 @@ class Rules:
             expect(isinstance(banned_neighbors_data, list) or isinstance(banned_neighbors_data, dict), "banned_neighbors must be a list, or a dictionary keyed by type.")
 
             if isinstance(banned_neighbors_data, dict):
-                self.banned_neighbors = [BannedNeighbor(typepath, data) for typepath, data in banned_neighbors_data.items()]
+                self.banned_neighbors = [AtomNeighbor(typepath, data) for typepath, data in banned_neighbors_data.items()]
             else:
-                self.banned_neighbors = [BannedNeighbor(typepath) for typepath in banned_neighbors_data]
+                self.banned_neighbors = [AtomNeighbor(typepath) for typepath in banned_neighbors_data]
+
+        if "required_neighbors" in data:
+            required_neighbors_data = data.pop("required_neighbors")
+
+            expect(isinstance(required_neighbors_data, list) or isinstance(required_neighbors_data, dict), "required_neighbors must be a list, or a dictionary keyed by type.")
+
+            if isinstance(required_neighbors_data, dict):
+                self.required_neighbors = [AtomNeighbor(typepath, data) for typepath, data in required_neighbors_data.items()]
+            else:
+                self.required_neighbors = [AtomNeighbor(typepath) for typepath in required_neighbors_data]
 
         if "banned_variables" in data:
             banned_variables_data = data.pop("banned_variables")
@@ -187,24 +314,41 @@ class Rules:
                 else:
                     self.banned_variables = [BannedVariable(variable) for variable in banned_variables_data]
 
+        if "when" in data:
+            self.when = When(data.pop("when"))
+
         expect(len(data) == 0, f"Unknown lint rules: {', '.join(data.keys())}.")
 
     def run(self, identified: Content, contents: list[Content], identified_index) -> list[MaplintError]:
         failures: list[MaplintError] = []
+        when_text = self.when.match_string() if self.when is not None else ""
+
+        # If a when is present and is unmet, skip evaluation of this rule
+        if self.when and not self.when.evaluate(identified):
+            return failures
 
         if self.banned:
-            failures.append(fail_content(identified, f"Typepath {identified.path} is banned."))
+            failures.append(fail_content(identified, f"Typepath {identified.path} is banned{when_text}."))
 
         for banned_neighbor in self.banned_neighbors:
             for neighbor in contents[:identified_index] + contents[identified_index + 1:]:
                 if not banned_neighbor.matches(identified, neighbor):
                     continue
 
-                failures.append(fail_content(identified, f"Typepath {identified.path} has a banned neighbor: {neighbor.path}"))
+                failures.append(fail_content(identified, f"Typepath {identified.path} has a banned neighbor{when_text}: {neighbor.path}"))
+
+        for required_neighbor in self.required_neighbors:
+            found = False
+            for neighbor in contents[:identified_index] + contents[identified_index + 1:]:
+                if required_neighbor.matches(identified, neighbor):
+                    found = True
+                    break
+            if found == False:
+                failures.append(fail_content(identified, f"Typepath {identified.path} is missing a required neighbor{when_text}: {required_neighbor.to_string()}"))
 
         if self.banned_variables == True:
             if len(identified.var_edits) > 0:
-                failures.append(fail_content(identified, f"Typepath {identified.path} should not have any variable edits."))
+                failures.append(fail_content(identified, f"Typepath {identified.path} should not have any variable edits{when_text}."))
         else:
             assert isinstance(self.banned_variables, list)
             for banned_variable in self.banned_variables:
@@ -212,19 +356,23 @@ class Rules:
                     ban_reason = banned_variable.run(identified)
                     if ban_reason is None:
                         continue
-                    failures.append(fail_content(identified, f"Typepath {identified.path} has a banned variable (set to {identified.var_edits[banned_variable.variable]}): {banned_variable.variable}. {ban_reason}"))
+                    failures.append(fail_content(identified, f"Typepath {identified.path} has a banned variable (set to {identified.var_edits[banned_variable.variable]}){when_text}: {banned_variable.variable}. {ban_reason}"))
 
         return failures
 
 class Lint:
     help: Optional[str] = None
     rules: dict[TypepathExtra, Rules]
+    disabled: bool = False
 
     def __init__(self, data):
         expect(isinstance(data, dict), "Lint must be a dictionary.")
 
         if "help" in data:
             self.help = data.pop("help")
+
+        if "disabled" in data:
+            self.disabled = data.pop("disabled")
 
         expect(isinstance(self.help, str) or self.help is None, "Lint help must be a string.")
 
@@ -234,6 +382,9 @@ class Lint:
             self.rules[TypepathExtra(typepath)] = Rules(rules)
 
     def run(self, map_data: DMM) -> list[MaplintError]:
+        if self.disabled:
+            return list()
+
         all_failures: list[MaplintError] = []
         (width, height) = map_data.size()
 

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -401,9 +401,6 @@ class Lint:
         if "help" in data:
             self.help = data.pop("help")
 
-        if "disabled" in data:
-            self.disabled = data.pop("disabled")
-
         expect(isinstance(self.help, str) or self.help is None, "Lint help must be a string.")
 
         self.rules = {}
@@ -412,9 +409,6 @@ class Lint:
             self.rules[TypepathExtra(typepath)] = Rules(rules)
 
     def run(self, map_data: DMM) -> list[MaplintError]:
-        if self.disabled:
-            return list()
-
         all_failures: list[MaplintError] = []
         (width, height) = map_data.size()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows us to test for atoms that are required to be placed alongside another atom, such as APCs to cables.
There are many situations where a structure spawner is not good enough:
- APC cables need to be in any colour or any direction
- Airlock mapping helpers may be any access to any airlock and would create too many subtypes.

## Why It's Good For The Game

This allows us to have more comprehensive linting added to future mapping changes.

This is needed to support the following lints:
- Airlocks should not have an access helper if they have access requirement variables set.
- Access requirement helpers MUST have an airlock placed on their tile.

Needed to satisfy the following review: https://github.com/BeeStation/BeeStation-Hornet/pull/11469#discussion_r1757608360

## Testing Photographs and Procedure

### Test required neighbors

![image](https://github.com/user-attachments/assets/ea79aa85-048f-40ca-b27b-2a1da0e1ba2e)

### Conditional Rulesets

(I know this rule is useless since it mimics banned_variables, but we can make more complex rules with the other ones and with banned_neighbors)

![image](https://github.com/user-attachments/assets/a607a4cd-0e97-4557-8129-7cf5875a2ebd)

![image](https://github.com/user-attachments/assets/81e43bb6-acc8-441f-97a3-936f5bc88203)

Test a more complex query with set operations:

![image](https://github.com/user-attachments/assets/2d309060-8360-4b55-a4d2-2a5d11d7bad5)

![image](https://github.com/user-attachments/assets/33b30d70-3971-40d8-97d5-2f610d73cf86)

![image](https://github.com/user-attachments/assets/50e564eb-9b82-413f-99c3-4655e6c23c75)

Super complex query:

![image](https://github.com/user-attachments/assets/0d12c56f-6ff5-4663-bd5b-738c12c3f085)

![image](https://github.com/user-attachments/assets/a46afaa8-4385-4017-a452-a3a624d968c4)

![image](https://github.com/user-attachments/assets/7a6f5fe5-9a0c-4f55-afc9-2fb1777c8a7d)

Test like:

![image](https://github.com/user-attachments/assets/2f0187e2-c7f1-4631-8f40-c8d8ae68942b)

![image](https://github.com/user-attachments/assets/1d63faf1-934f-4d6d-8091-f484fcd44c7a)

![image](https://github.com/user-attachments/assets/86dd3593-a3de-47bf-8061-ff206366d387)

Not set:
![image](https://github.com/user-attachments/assets/2ae61dfe-4214-42a5-96a9-37ae5e91e6b0)

Test is:

![image](https://github.com/user-attachments/assets/ace87258-f9cd-4898-86ba-1cf86bf52a3a)

![image](https://github.com/user-attachments/assets/067acb26-1bf7-4038-9d2f-3e304810fadd)


## Changelog
:cl:
add: Implements the ability to lint for required neighbors in maplint.
add: Adds conditional linting rules in maplint, allowing a lint to apply only if certain conditions are met (Variable is/isn't set, Variable is/isn't a value, Variable matches a regex).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
