### PR TITLE
Water turfs are now properly named

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -1,4 +1,5 @@
 /turf/open/water
+	name = "water"
 	gender = PLURAL
 	desc = "Shallow water."
 	icon = 'icons/turf/floors.dmi'

--- a/code/modules/mapfluff/ruins/icemoonruin_code/hotsprings.dm
+++ b/code/modules/mapfluff/ruins/icemoonruin_code/hotsprings.dm
@@ -11,6 +11,7 @@
  */
 
 /turf/open/water/cursed_spring
+	name = "cursed spring"
 	baseturfs = /turf/open/water/cursed_spring
 	planetary_atmos = TRUE
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS


### PR DESCRIPTION
## About The Pull Request
Because water turfs were unnamed on compile-time, they defaulted to the last section of their path.

## Why It's Good For The Game
This will fix #86638

## Changelog

:cl:
fix: Water turfs from the crashed site ruin on lavaland are no longer named "lavaland atmos".
/:cl:
