### PR TITLE
Fix disposal bin label on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -40898,10 +40898,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "lOV" = (
-/obj/machinery/disposal/bin{
-	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
-	name = "corpse disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request

Fixes a mislabelled disposal bin on Icebox

## Why It's Good For The Game

Less cargo yelling at medbay for flushing dead bodies down disposals. Less coroner yelling at medbay wondering where the bodies are.

## Changelog

:cl: LT3
fix: Fixed a mislabelled corpse disposal in Icebox medbay, probably less dead bodies showing up in cargo
/:cl:
