### PR TITLE
Tiny fix for phonebooth ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_phonebooth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_phonebooth.dmm
@@ -13,7 +13,7 @@
 /area/ruin/powered/lavaland_phone_booth)
 "k" = (
 /obj/machinery/vending/snack/green{
-	all_products_free = 0;
+	all_products_free = 0
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/lavaland_atmos,
@@ -66,7 +66,7 @@
 /area/ruin/powered/lavaland_phone_booth)
 "W" = (
 /obj/machinery/vending/cigarette{
-	all_products_free = 0;
+	all_products_free = 0
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/lavaland_atmos,


### PR DESCRIPTION
## About The Pull Request

This is just so UpdatePaths doesn't annoyingly keep adding space after the varedits, because it likes to do that when you have a semicolon on a single varedit.

## Changelog

Nothing whatsoever player-facing