### PR TITLE
Fixes being able to shout chuunibyou phrases while mute

### DIFF
--- a/code/datums/components/chuunibyou.dm
+++ b/code/datums/components/chuunibyou.dm
@@ -64,7 +64,7 @@
 /datum/component/chuunibyou/proc/on_try_speech(datum/source, message, ignore_spam, forced)
 	SIGNAL_HANDLER
 
-	if(casting_spell)
+	if(casting_spell && !HAS_TRAIT(src, TRAIT_MUTE))
 		return COMPONENT_IGNORE_CAN_SPEAK
 
 ///signal sent when the parent casts a spell that has a projectile


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4391

It was an easy fix so why not. This override was in place specifically to allow mimes to use the spell but did not take into consideration the mute trait.

Mimes use `TRAIT_MIMING` not `TRAIT_MUTE`, so this should not have any effect on the original intent.

## Why It's Good For The Game

Fixes an oversight.

## Changelog

:cl:
fix: fixes being able to use chuunibyou shouts while mute
/:cl:
