### PR TITLE
Adds IGNORE_DENSITY flag to windoors and railings to allow crafting on their tile

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -6,7 +6,7 @@
 	layer = ABOVE_WINDOW_LAYER
 	closingLayer = ABOVE_WINDOW_LAYER
 	resistance_flags = ACID_PROOF
-	obj_flags = CAN_BE_HIT | BLOCKS_CONSTRUCTION_DIR
+	obj_flags = CAN_BE_HIT | IGNORE_DENSITY | BLOCKS_CONSTRUCTION_DIR
 	var/base_state = "left"
 	max_integrity = 150 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
 	integrity_failure = 0

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/railings.dmi'
 	icon_state = "railing"
 	flags_1 = ON_BORDER_1
-	obj_flags = CAN_BE_HIT | BLOCKS_CONSTRUCTION_DIR
+	obj_flags = CAN_BE_HIT | BLOCKS_CONSTRUCTION_DIR | IGNORE_DENSITY
 	density = TRUE
 	anchored = TRUE
 	pass_flags_self = LETPASSTHROW|PASSSTRUCTURE


### PR DESCRIPTION
## About The Pull Request

I am bored enough to the point where I'm diving into downstream github issues.
Thindows have IGNORE_DENSITY but windoors and railings do not, preventing crafting on their tiles. This ***should not*** cause any side effects as I went through all the recipes and they still have BLOCKS_CONSTRUCTION_DIR which should block duplicates or windows from being constructed on the same tile, but ideally this needs another pair of eyes.

## Why It's Good For The Game
Windoors/railings should not be preventing you from crafting sprears and boxes on their tiles. Also parity with thindows.

## Changelog
:cl:
fix: You can now craft things on tiles with windoors and railings on them.
/:cl:
