### PR TITLE
Fixes crafted donuts never, ever getting their sprinkles

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -21,7 +21,6 @@
 	if(donut_result.is_decorated)
 		donut_result.reagents.add_reagent(/datum/reagent/consumable/sprinkles, 1)
 
-
 /datum/crafting_recipe/food/donut/chaos
 	name = "Chaos donut"
 	reqs = list(

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -17,6 +17,7 @@
 // here we are adding it again (but only for crafting, maploaded and spawned donuts work fine).
 // Until the issues with crafted items' reagents are resolved this will have to do
 /datum/crafting_recipe/food/donut/on_craft_completion(mob/user, atom/result)
+	. = ..()
 	var/obj/item/food/donut/donut_result = result
 	if(donut_result.is_decorated)
 		donut_result.reagents.add_reagent(/datum/reagent/consumable/sprinkles, 1)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -13,6 +13,14 @@
 	result = /obj/item/food/donut/plain
 	category = CAT_PASTRY
 
+// It is so stupid that we have to do this but because food crafting clears all reagents that got added during init,
+// here we are adding it again (but only for crafting, maploaded and spawned donuts work fine).
+// Until the issues with crafted items' reagents are resolved this will have to do
+/datum/crafting_recipe/food/donut/on_craft_completion(mob/user, atom/result)
+	var/obj/item/food/donut/donut_result = result
+	if(donut_result.is_decorated)
+		donut_result.reagents.add_reagent(/datum/reagent/consumable/sprinkles, 1)
+
 
 /datum/crafting_recipe/food/donut/chaos
 	name = "Chaos donut"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4380

Sprinkles are supposed to be added as a reagent during `Initialize()`, but whenever you craft a food item the `reagents` get cleared, and then reagents from the ingredients get transferred into the resulting food item. Since sprinkles do not come from any particular ingredient (they are hand-waved to be made from the 1unit of sugar) they just never get re-added by anything.

Basically it comes down to a race condition of donut spawned by crafting->1unit sprinkles gets added->crafting tries to do its clearing reagents + transferring reagents thing, losing the sprinkles in the process.

The solution I came up with is to just...readd them in `on_craft_completion()`.

## Why It's Good For The Game

I want my mother*****ing sprinkles!!

<details><summary>Works</summary>

![dreamseeker_T1AfkW6M8t](https://github.com/user-attachments/assets/c2e3b997-e71a-4cb0-935a-3b0625de0f53)

</details>

## Changelog

:cl:
fix: fixed crafted donuts not getting any sprinkles, ever
/:cl:
