### PR TITLE
Lesser gorillas (And gutlunchers' grubs) now use the `current_size` variable instead of directly scaling the transform matrix

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -146,10 +146,7 @@
 	obj_damage = 15
 	ai_controller = /datum/ai_controller/basic_controller/gorilla/lesser
 	butcher_results = list(/obj/item/food/meat/slab/gorilla = 2)
-
-/mob/living/basic/gorilla/lesser/Initialize(mapload)
-	. = ..()
-	transform *= 0.75
+	current_size = 0.75
 
 /// Cargo's wonderful mascot, the tranquil box-carrying ape
 /mob/living/basic/gorilla/cargorilla

--- a/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
+++ b/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
@@ -139,12 +139,12 @@
 	can_breed = FALSE
 	gender = NEUTER
 	ai_controller = /datum/ai_controller/basic_controller/gutlunch/gutlunch_baby
+	current_size = 0.6
 	///list of stats we inherited
 	var/datum/gutlunch_inherited_stats/inherited_stats
 
 /mob/living/basic/mining/gutlunch/grub/Initialize(mapload)
 	. = ..()
-	transform = transform.Scale(0.6, 0.6)
 	AddComponent(\
 		/datum/component/growth_and_differentiation,\
 		growth_time = 3 MINUTES,\


### PR DESCRIPTION
## About The Pull Request
Yeah, as I suspected, lab gorillas from the Self-Gorillafication Nerf weren't the only mobs to be resized without the `current_size` var or the `update_transform` proc. The other one that does this (at least on init) is, drum roll, yet another gorilla subtype. Wow, the apple doesn't fall far from the tree. EDIT: I was wrong... there's another mob who does this too.

## Why It's Good For The Game
For those of you who care but don't know what the difference is: the transform matrix of an object works around the center of the icon, which means that if you multiply the transform matrix a 32x32 icon by 0.5, the icon will then appear roughly 8 px above the lower edge of the turf. For most objects, we don't care about it, but for mobs, this is a small visual issue because the lower end of the icon should be aligned with the floor (or the shadow in the case of the wallening for non-floating mobs). This where the `update_transform` comes handy, since it offsets the icon by that amount to compensate for the scaled transform matrix. Alas, the transform matrix is used for a lot of things and it's perhaps impossible to have the CI look into it.


## Changelog
It's a very subtle nit, people won't notice.