### PR TITLE
Being abducted by a contractor no longer recursively dumps contents of all of your boxes and belts, nor does it break your UI anymore

### DIFF
--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -102,14 +102,14 @@
 		if(traitor_data.uplink_handler.contractor_hub.current_contract == src)
 			traitor_data.uplink_handler.contractor_hub.current_contract = null
 
-	for(var/obj/item/person_contents as anything in person_sent.gather_belongings())
+	for(var/obj/item/person_contents as anything in person_sent.gather_belongings(FALSE, FALSE))
 		if(ishuman(person_sent))
 			var/mob/living/carbon/human/human_sent = person_sent
 			if(person_contents == human_sent.w_uniform)
 				continue //So all they're left with are shoes and uniform.
 			if(person_contents == human_sent.shoes)
 				continue
-		person_sent.transferItemToLoc(person_contents)
+		person_sent.transferItemToLoc(person_contents, idrop = TRUE)
 		victim_belongings.Add(WEAKREF(person_contents))
 
 	var/obj/structure/closet/supplypod/extractionpod/pod = source

--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -110,6 +110,8 @@
 			if(person_contents == human_sent.shoes)
 				continue
 		person_sent.temporarilyRemoveItemFromInventory(person_contents)
+		if (!person_contents)
+			continue
 		person_contents.moveToNullspace()
 		victim_belongings.Add(WEAKREF(person_contents))
 

--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -109,7 +109,8 @@
 				continue //So all they're left with are shoes and uniform.
 			if(person_contents == human_sent.shoes)
 				continue
-		person_sent.transferItemToLoc(person_contents, idrop = TRUE)
+		person_sent.temporarilyRemoveItemFromInventory(person_contents)
+		person_contents.moveToNullspace()
 		victim_belongings.Add(WEAKREF(person_contents))
 
 	var/obj/structure/closet/supplypod/extractionpod/pod = source

--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -109,8 +109,8 @@
 				continue //So all they're left with are shoes and uniform.
 			if(person_contents == human_sent.shoes)
 				continue
-		person_sent.temporarilyRemoveItemFromInventory(person_contents)
-		if (!person_contents)
+		var/unequipped = person_sent.temporarilyRemoveItemFromInventory(person_contents)
+		if (!unequipped)
 			continue
 		person_contents.moveToNullspace()
 		victim_belongings.Add(WEAKREF(person_contents))

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -228,11 +228,11 @@
 
 	var/mob/living/carbon/human/sent_mob = entered_atom
 
-	for(var/obj/item/belonging in sent_mob.gather_belongings())
+	for(var/obj/item/belonging in sent_mob.gather_belongings(FALSE, FALSE))
 		if(belonging == sent_mob.get_item_by_slot(ITEM_SLOT_ICLOTHING) || belonging == sent_mob.get_item_by_slot(ITEM_SLOT_FEET))
 			continue
 
-		var/unequipped = sent_mob.transferItemToLoc(belonging)
+		var/unequipped = sent_mob.transferItemToLoc(belonging, idrop = TRUE)
 		if (!unequipped)
 			continue
 		target_belongings.Add(WEAKREF(belonging))

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -232,9 +232,10 @@
 		if(belonging == sent_mob.get_item_by_slot(ITEM_SLOT_ICLOTHING) || belonging == sent_mob.get_item_by_slot(ITEM_SLOT_FEET))
 			continue
 
-		var/unequipped = sent_mob.transferItemToLoc(belonging, idrop = TRUE)
+		var/unequipped = sent_mob.temporarilyRemoveItemFromInventory(belonging)
 		if (!unequipped)
 			continue
+		unequipped.moveToNullspace()
 		target_belongings.Add(WEAKREF(belonging))
 
 	var/datum/market_item/hostage/market_item = sent_mob.process_capture(rand(1000, 3000))

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -235,7 +235,7 @@
 		var/unequipped = sent_mob.temporarilyRemoveItemFromInventory(belonging)
 		if (!unequipped)
 			continue
-		unequipped.moveToNullspace()
+		belonging.moveToNullspace()
 		target_belongings.Add(WEAKREF(belonging))
 
 	var/datum/market_item/hostage/market_item = sent_mob.process_capture(rand(1000, 3000))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -344,8 +344,8 @@
 	return I
 
 //for when the item will be immediately placed in a loc other than the ground
-/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, silent = TRUE, idrop = FALSE)
-	. = doUnEquip(I, force, newloc, FALSE, idrop, silent = silent)
+/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, silent = TRUE)
+	. = doUnEquip(I, force, newloc, FALSE, silent = silent)
 	I.do_drop_animation(src)
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -344,8 +344,8 @@
 	return I
 
 //for when the item will be immediately placed in a loc other than the ground
-/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, silent = TRUE)
-	. = doUnEquip(I, force, newloc, FALSE, silent = silent)
+/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, silent = TRUE, idrop = FALSE)
+	. = doUnEquip(I, force, newloc, FALSE, idrop, silent = silent)
 	I.do_drop_animation(src)
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC
@@ -586,19 +586,19 @@
 		hud_used.build_hand_slots()
 
 //GetAllContents that is reasonable and not stupid
-/mob/living/proc/get_all_gear()
-	var/list/processing_list = get_equipped_items(INCLUDE_POCKETS | INCLUDE_ACCESSORIES | INCLUDE_HELD)
+/mob/living/proc/get_all_gear(accessories = TRUE, recursive = TRUE)
+	var/list/processing_list = get_equipped_items(INCLUDE_POCKETS | INCLUDE_HELD | (accessories ? INCLUDE_ACCESSORIES : NONE))
 	list_clear_nulls(processing_list) // handles empty hands
 	var/i = 0
 	while(i < length(processing_list))
 		var/atom/A = processing_list[++i]
-		if(A.atom_storage)
+		if(A.atom_storage && recursive)
 			processing_list += A.atom_storage.return_inv()
 	return processing_list
 
 /// Returns a list of things that the provided mob has, including any storage-capable implants.
-/mob/living/proc/gather_belongings()
-	var/list/belongings = get_all_gear()
+/mob/living/proc/gather_belongings(accessories = TRUE, recursive = TRUE)
+	var/list/belongings = get_all_gear(accessories, recursive)
 	for (var/obj/item/implant/storage/internal_bag in implants)
 		belongings += internal_bag.contents
 	return belongings


### PR DESCRIPTION

## About The Pull Request

Contractor abductions no longer recursively dump all of your items on the ground, instead only doing a single depth loop. Also fixed storage UI getting broken after being kidnapped due to using a wrong proc

## Why It's Good For The Game

There's zero reason as for why it should behave like that other than just making recovery far more annoying.

## Changelog
:cl:
fix: Your UI no longer breaks after being kidnapped by a contractor
qol: Being kidnapped by a contractor no longer dumps all of your boxes and belts
/:cl:
