### PR TITLE
[NO GBP] The fishing line and float are now actually offset to match the fishing spot

### DIFF
--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -758,8 +758,12 @@
 
 /obj/effect/fishing_float/Initialize(mapload, atom/spot)
 	. = ..()
+	if(!spot)
+		return
 	if(ismovable(spot)) // we want the float and therefore the fishing line to stay connected with the fishing spot.
 		RegisterSignal(spot, COMSIG_MOVABLE_MOVED, PROC_REF(follow_movable))
+	SET_BASE_PIXEL(spot.pixel_x, spot.pixel_y)
+	SET_BASE_VISUAL_PIXEL(spot.pixel_w, spot.pixel_z)
 
 /obj/effect/fishing_float/proc/follow_movable(atom/movable/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
I've made a PR before so that beam datum (and therefore the fishing line) would take pixel_w/z into account, but what I didn't consider is that the fishing line is actually attached to the float (as it should be), so it did basically nothing on the other end of fishing lines while fishing. This PR fixes that.

## Why It's Good For The Game
Fixing a small visual inconsistency.

## Changelog
N/A