### PR TITLE
Adds a small vertical margin to ID card image in new examine panel to ensure that it doesn't collide with text

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1012,6 +1012,7 @@ em {
   width: 3em; // a css guru can probably dehardcode this later
   height: auto;
   margin-right: 12px;
+  margin-top: 6px;
 }
 
 .img_by_text_container .img_text {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1030,6 +1030,7 @@ h2.alert {
   width: 2.5em; // a css guru can probably dehardcode this later
   height: auto;
   margin-right: 12px;
+  margin-top: 6px;
 }
 
 .img_by_text_container .img_text {


### PR DESCRIPTION

## About The Pull Request
This is how it currently looks, the distance between the card and font is minimal and highlight collides with it

![image](https://github.com/user-attachments/assets/8929b246-9712-4aed-b786-832574f07316)

After adding a 6 px margin

![image](https://github.com/user-attachments/assets/1d2de75f-1994-45b0-8fee-8db2ae346a11)

and without highlights

![image](https://github.com/user-attachments/assets/a36e273f-0422-4d92-b7ee-34c3558581c8)

This is intentionally in px and not em to prevent the same issue from occuring with smaller font sizes
## Why It's Good For The Game

Visual jank bad

## Changelog
:cl:
qol: Added a small vertical margin to ID card image in new examine panel to ensure that it doesn't collide with text
/:cl:
