### PR TITLE
Once again re-assigns tackling to r-clicks

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -71,6 +71,9 @@
 /datum/component/tackler/proc/checkTackle(mob/living/carbon/user, atom/clicked_atom, list/modifiers)
 	SIGNAL_HANDLER
 
+	if(!modifiers[RIGHT_CLICK])
+		return
+
 	if(modifiers[ALT_CLICK] || modifiers[SHIFT_CLICK] || modifiers[CTRL_CLICK] || modifiers[MIDDLE_CLICK])
 		return
 

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -71,10 +71,7 @@
 /datum/component/tackler/proc/checkTackle(mob/living/carbon/user, atom/clicked_atom, list/modifiers)
 	SIGNAL_HANDLER
 
-	if(!modifiers[RIGHT_CLICK])
-		return
-
-	if(modifiers[ALT_CLICK] || modifiers[SHIFT_CLICK] || modifiers[CTRL_CLICK] || modifiers[MIDDLE_CLICK])
+	if(!modifiers[RIGHT_CLICK] || modifiers[ALT_CLICK] || modifiers[SHIFT_CLICK] || modifiers[CTRL_CLICK] || modifiers[MIDDLE_CLICK])
 		return
 
 	if(!user.throw_mode || user.get_active_held_item() || user.pulling || user.buckled || user.incapacitated)


### PR DESCRIPTION
## About The Pull Request
This will fix #86668, caused by #86031

## Why It's Good For The Game
This will fix #86668, caused by #86031

## Changelog

:cl:
fix: You once again need to right click to use tackling gloves.
/:cl:
