### PR TITLE
Fixes autochangelog just dying if fed an invalid changelog entry

### DIFF
--- a/tools/pull_request_hooks/changelogParser.js
+++ b/tools/pull_request_hooks/changelogParser.js
@@ -42,7 +42,7 @@ function parseChangelogBody(lines, openTag) {
 
 			const entry = CHANGELOG_KEYS_TO_ENTRY[type];
 
-			if (entry.placeholders.includes(description)) {
+			if (!entry || entry.placeholders.includes(description)) {
 				continue;
 			}
 


### PR DESCRIPTION
## About The Pull Request

Something that really has annoyed me for a while, if a user puts something invalid in their changelog body like:
`tweak: something something` (a common one I encounter)

then this results in the autochangelog script crashing and not creating a changelog at all. So many changelogs get dumpstered because of this and it is stupid.

This PR changes it so the changelog parser is able to continue past the invalid lines and complete the action.

It would be nice to have the ci bot comment on the user's pr if it detects bad input to inform them of it but that's beyond what I have the time and skills for right now.

This was tested downstream and confirmed to work.

## Why It's Good For The Game

<details><summary>Less changelogs getting lost to the void.</summary>

![image](https://github.com/user-attachments/assets/a82e746f-d6ea-4234-af79-e432be5d21af)

</details>

## Changelog

Nothing player-facing
