### PR TITLE
[Birdshot] Fixes for kitchen tables, doors & shutters

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1759,12 +1759,15 @@
 /area/station/maintenance/department/engine/atmos)
 "aIr" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
 	name = "Kitchen Shutters"
 	},
-/turf/open/floor/iron/kitchen/small,
+/obj/effect/turf_decal/siding/end{
+	dir = 8
+	},
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "aIu" = (
 /obj/structure/bookcase/random/reference,
@@ -11105,9 +11108,11 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/end,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "elc" = (
 /obj/structure/cable,
@@ -14993,9 +14998,13 @@
 /obj/machinery/smartfridge,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
-/turf/open/floor/iron/kitchen/small,
+/obj/effect/turf_decal/siding/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "fGT" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -20217,9 +20226,11 @@
 /obj/machinery/door/window/right/directional/west,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/end,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "hrx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35175,6 +35186,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"lZs" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenshutters";
+	name = "Kitchen Shutters"
+	},
+/obj/effect/turf_decal/siding/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/kitchen)
 "lZt" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -40240,9 +40263,16 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "nQa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52253,12 +52283,19 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/spawner/random/food_or_drink/condiment,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
-/obj/effect/spawner/random/food_or_drink/condiment,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "rVy" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -55500,12 +55537,19 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/spawner/random/food_or_drink/donuts,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
-/obj/effect/spawner/random/food_or_drink/donuts,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "sZo" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -98461,7 +98505,7 @@ sJL
 sne
 aTg
 aTg
-aIr
+lZs
 bIN
 nUd
 bmY


### PR DESCRIPTION

## About The Pull Request
![Before](https://i.imgur.com/Znl82fL.png)
Before

![After](https://i.imgur.com/hLkKOM6.png)
After

Rotates the privacy shutters so they face in/out of the kitchen. Now they don't take up space on the table when not in use.
Fixes the windoor to the corridor, now uses a right door and a left door (previously two rights).
Makes all the floors under the tables large black textured tiles with white outlines. They are now consistant and match the flooring under the kitchen's other tables and appliances.
## Why It's Good For The Game
Shutters change is needed because the closed shutters take up valuable counter space (see pictures)
Other two changes are fixes to sloppy design I noticed when fixing the shutters. Two right windoors is an obvious mistake and inconsistant floors under tables looked bad when tables were removed.
## Changelog
:cl:
qol: [Birdshot] Kitchen's privacy shutters no longer cover parts of the cafeteria table when open.
fix: [Birdshot] Kitchen's corridor windoor is now rotated correctly.
/:cl:
