### PR TITLE
Adds linebreaks to smartfridge examine

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -199,11 +199,11 @@
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: This unit can hold a maximum of <b>[max_n_of_items]</b> items.")
 
-	. += structure_examine()
+	. += jointext(structure_examine(), "<br>")
 
 /// Returns details related to the fridge structure
 /obj/machinery/smartfridge/proc/structure_examine()
-	. = ""
+	. = list()
 
 	if(welded_down)
 		. += span_info("It's moorings are firmly [EXAMINE_HINT("welded")] to the floor.")

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -199,7 +199,7 @@
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: This unit can hold a maximum of <b>[max_n_of_items]</b> items.")
 
-	. += jointext(structure_examine(), "<br>")
+	. += structure_examine()
 
 /// Returns details related to the fridge structure
 /obj/machinery/smartfridge/proc/structure_examine()


### PR DESCRIPTION
## About The Pull Request

Tin. Smartfridges have a nonstandard way of arranging their examine text printout. This just puts it in line with the rest of examines so it will display multiline and get line breaks added.

## Why It's Good For The Game

Further standardizes examine text.

Before:

![image](https://github.com/user-attachments/assets/85805e36-3733-42c1-850b-cf5e87d550b4)

After:

![ShareX_x7nCaw74BH](https://github.com/user-attachments/assets/2f539109-9601-4688-9cd8-77f29467114f)

## Changelog

:cl:
fix: smartfridges and drying racks will now display their examine text information mutlilined
/:cl:
