### PR TITLE
Lets you dump bodybags (with people in them) down disposals

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -116,8 +116,22 @@
 		*/
 /obj/structure/closet/body_bag/proc/perform_fold(mob/living/carbon/human/the_folder)
 	visible_message(span_notice("[the_folder] folds up [src]."))
-	var/obj/item/bodybag/folding_bodybag = foldedbag_instance || new foldedbag_path
-	the_folder.put_in_hands(folding_bodybag)
+	the_folder.put_in_hands(undeploy_bodybag(the_folder.loc))
+
+/// Makes the bag into an item, returns that item
+/obj/structure/closet/body_bag/proc/undeploy_bodybag(atom/fold_loc)
+	var/obj/item/bodybag/folding_bodybag = foldedbag_instance || new foldedbag_path()
+	if(fold_loc)
+		folding_bodybag.forceMove(fold_loc)
+	return folding_bodybag
+
+/obj/structure/closet/body_bag/container_resist_act(mob/living/user, loc_required = TRUE)
+	// ideally we support this natively but i guess that's for a later time
+	if(!istype(loc, /obj/machinery/disposal))
+		return ..()
+	for(var/atom/movable/thing as anything in src)
+		thing.forceMove(loc)
+	undeploy_bodybag(loc)
 
 /obj/structure/closet/body_bag/bluespace
 	name = "bluespace body bag"
@@ -152,7 +166,7 @@
 
 /obj/structure/closet/body_bag/bluespace/perform_fold(mob/living/carbon/human/the_folder)
 	visible_message(span_notice("[the_folder] folds up [src]."))
-	var/obj/item/bodybag/folding_bodybag = foldedbag_instance || new foldedbag_path
+	var/obj/item/bodybag/folding_bodybag = undeploy_bodybag(the_folder.loc)
 	var/max_weight_of_contents = initial(folding_bodybag.w_class)
 	for(var/am in contents)
 		var/atom/movable/content = am
@@ -277,18 +291,9 @@
 		icon_state = initial(icon_state)
 
 /obj/structure/closet/body_bag/environmental/prisoner/container_resist_act(mob/living/user, loc_required = TRUE)
-	/// copy-pasted with changes because flavor text as well as some other misc stuff
-	if(opened)
-		return
-	if(ismovable(loc))
-		user.changeNext_move(CLICK_CD_BREAKOUT)
-		user.last_special = world.time + CLICK_CD_BREAKOUT
-		var/atom/movable/location = loc
-		location.relay_container_resist_act(user, src)
-		return
-	if(!sinched)
-		open(user)
-		return
+	// copy-pasted with changes because flavor text as well as some other misc stuff
+	if(opened || ismovable(loc) || !sinched)
+		return ..()
 
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
@@ -301,6 +306,8 @@
 		//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
 		user.visible_message(span_danger("[user] successfully broke out of [src]!"),
 							span_notice("You successfully break out of [src]!"))
+		if(istype(loc, /obj/machinery/disposal))
+			return ..()
 		bust_open()
 	else
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -165,9 +165,11 @@
 	user.visible_message(span_notice("[user.name] places \the [I] into \the [src]."), span_notice("You place \the [I] into \the [src]."))
 
 /// Mouse drop another mob or self
-/obj/machinery/disposal/mouse_drop_receive(mob/living/target, mob/living/user, params)
-	if(istype(target))
+/obj/machinery/disposal/mouse_drop_receive(atom/target, mob/living/user, params)
+	if(isliving(target))
 		stuff_mob_in(target, user)
+	if(istype(target, /obj/structure/closet/body_bag) && (user.mobility_flags & (MOBILITY_PICKUP|MOBILITY_STAND) == (MOBILITY_PICKUP|MOBILITY_STAND)))
+		stuff_bodybag_in(target, user)
 
 /// Handles stuffing a grabbed mob into the disposal
 /obj/machinery/disposal/proc/stuff_mob_in(mob/living/target, mob/living/user)
@@ -176,33 +178,65 @@
 		if (iscyborg(user))
 			var/mob/living/silicon/robot/borg = user
 			if (!borg.model || !borg.model.canDispose)
-				return
+				return FALSE
 		else
-			return
+			return FALSE
 	if(!isturf(user.loc)) //No magically doing it from inside closets
-		return
+		return FALSE
 	if(target.buckled || target.has_buckled_mobs())
-		return
+		return FALSE
 	if(target.mob_size > MOB_SIZE_HUMAN)
 		to_chat(user, span_warning("[target] doesn't fit inside [src]!"))
-		return
+		return FALSE
 	add_fingerprint(user)
 	if(user == target)
 		user.visible_message(span_warning("[user] starts climbing into [src]."), span_notice("You start climbing into [src]..."))
 	else
 		target.visible_message(span_danger("[user] starts putting [target] into [src]."), span_userdanger("[user] starts putting you into [src]!"))
-	if(do_after(user, 2 SECONDS, target))
-		if (!loc)
-			return
-		target.forceMove(src)
-		if(user == target)
-			user.visible_message(span_warning("[user] climbs into [src]."), span_notice("You climb into [src]."))
-			. = TRUE
-		else
-			target.visible_message(span_danger("[user] places [target] in [src]."), span_userdanger("[user] places you in [src]."))
-			log_combat(user, target, "stuffed", addition="into [src]")
-			. = TRUE
-		update_appearance()
+	if(!do_after(user, 2 SECONDS, target) || QDELETED(src))
+		return FALSE
+	target.forceMove(src)
+	if(user == target)
+		user.visible_message(span_warning("[user] climbs into [src]."), span_notice("You climb into [src]."))
+	else
+		target.visible_message(span_danger("[user] places [target] in [src]."), span_userdanger("[user] places you in [src]."))
+		log_combat(user, target, "stuffed", addition="into [src]")
+	update_appearance()
+	return TRUE
+
+/obj/machinery/disposal/proc/stuff_bodybag_in(obj/structure/closet/body_bag/bag, mob/living/user)
+	if(!length(bag.contents))
+		bag.undeploy_bodybag(src)
+		qdel(bag)
+		user.visible_message(
+			span_warning("[user] stuffs the empty [bag.name] into [src]."),
+			span_notice("You stuff the empty [bag.name] into [src].")
+		)
+		return TRUE
+
+	user.visible_message(
+		span_warning("[user] starts putting [bag] into [src]."),
+		span_notice("You start putting [bag] into [src]...")
+	)
+
+	if(!do_after(user, 4 SECONDS, bag) || QDELETED(src))
+		return FALSE
+
+	user.visible_message(
+		span_warning("[user] places [bag] in [src]."),
+		span_notice("You place [bag] in [src].")
+	)
+
+	if(!length(bag.contents))
+		bag.undeploy_bodybag(src)
+		qdel(bag)
+	else
+		bag.add_fingerprint(user)
+		bag.forceMove(src)
+
+	add_fingerprint(user)
+	update_appearance()
+	return TRUE
 
 /obj/machinery/disposal/relaymove(mob/living/user, direction)
 	attempt_escape(user)


### PR DESCRIPTION
## About The Pull Request

Bodybags (with people inside them) can be click+dragged to disposals, so you can dump bodybags down disposals

## Why It's Good For The Game

It's a classic crime trope, so I thought it'd be funny to represent.

## Changelog

:cl: Melbert
qol: You can dump bodybags (with people inside them) down disposals
/:cl:


