### PR TITLE
Fix plasmamen having all feature preferences

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1469,8 +1469,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	mut_organs += mutantliver
 	mut_organs += mutantstomach
 	mut_organs += mutantappendix
-	list_clear_nulls(mut_organs)
-	return mut_organs
+	return list_clear_nulls(mut_organs)
 
 /datum/species/proc/get_types_to_preload()
 	return get_mut_organs(FALSE)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1469,6 +1469,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	mut_organs += mutantliver
 	mut_organs += mutantstomach
 	mut_organs += mutantappendix
+	list_clear_nulls()
 	return mut_organs
 
 /datum/species/proc/get_types_to_preload()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1469,7 +1469,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	mut_organs += mutantliver
 	mut_organs += mutantstomach
 	mut_organs += mutantappendix
-	return list_clear_nulls(mut_organs)
+	list_clear_nulls(mut_organs)
+	return mut_organs
 
 /datum/species/proc/get_types_to_preload()
 	return get_mut_organs(FALSE)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1469,7 +1469,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	mut_organs += mutantliver
 	mut_organs += mutantstomach
 	mut_organs += mutantappendix
-	list_clear_nulls()
+	list_clear_nulls(mut_organs)
 	return mut_organs
 
 /datum/species/proc/get_types_to_preload()


### PR DESCRIPTION

## About The Pull Request

Fixes #86622 

Plasmamen relevant_external_organ is null, and it then checks if relevant_external_organ is in a list containing nulls
I cleared the nulls from get_mut_organs to fix it

:cl:
fix: Fixes plasmamen having all external organ species preferences
/:cl:
