### PR TITLE
Fixes veteran advisor not spawning on security officer landmarks

### DIFF
--- a/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
+++ b/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
@@ -38,7 +38,6 @@
 	job_flags = STATION_JOB_FLAGS | STATION_TRAIT_JOB_FLAGS
 
 /datum/job/veteran_advisor/get_default_roundstart_spawn_point()
-	. = ..()
 	for(var/obj/effect/landmark/start/spawn_point as anything in GLOB.start_landmarks_list)
 		if(spawn_point.name != "Security Officer")
 			continue
@@ -47,6 +46,8 @@
 			continue
 		spawn_point.used = TRUE
 		break
+	if(!.) // Try to fall back to "our" landmark
+		. = ..()
 	if(!.)
 		log_mapping("Job [title] ([type]) couldn't find a round start spawn point.")
 

--- a/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
+++ b/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
@@ -37,10 +37,18 @@
 	allow_bureaucratic_error = FALSE
 	job_flags = STATION_JOB_FLAGS | STATION_TRAIT_JOB_FLAGS
 
-/datum/job/veteran_advisor/get_roundstart_spawn_point() //Spawning at Brig where Officers spawn
-	if (length(GLOB.start_landmarks_list["Security Officer"]))
-		return pick(GLOB.start_landmarks_list["Security Officer"])
-	return ..()
+/datum/job/veteran_advisor/get_default_roundstart_spawn_point()
+	. = ..()
+	for(var/obj/effect/landmark/start/spawn_point as anything in GLOB.start_landmarks_list)
+		if(spawn_point.name != "Security Officer")
+			continue
+		. = spawn_point
+		if(spawn_point.used) //so we can revert to spawning them on top of eachother if something goes wrong
+			continue
+		spawn_point.used = TRUE
+		break
+	if(!.)
+		log_mapping("Job [title] ([type]) couldn't find a round start spawn point.")
 
 /datum/job/veteran_advisor/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Potato found it in discord, landmarks aren't an assoc list and we already have a proc for finding spawnpoints.

## Changelog
:cl:
fix: Fixed veteran advisor not spawning on security officer landmarks
/:cl:
