### PR TITLE
[NO GBP] Fixing a runtime with examining fishing spots while wielding a rod

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -421,7 +421,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 					if(weight/init_weight >= 3.5)
 						init_name = "<u>init_name</u>"
 				else if(weight < init_weight)
-					init_name = span_small(reward)
+					init_name = span_small(init_name)
 			known_fishes += init_name
 
 	if(!length(known_fishes))


### PR DESCRIPTION
## About The Pull Request
Well, it seems examining a fishing spot (with sufficient skill) while wielding a rod is borked because of a bad line. It should be `init_name` and not `reward`. Thanks to vinylspider for informing me about it.

## Why It's Good For The Game
Fixing stuff I made and then broke.

## Changelog

:cl:
fix: examining fishing spots while wielding a rod (with sufficient skill) now works.
/:cl:
