### PR TITLE
Fixes downstream species joining ERT not getting internals they need

### DIFF
--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -233,11 +233,11 @@
 	var/mob/living/carbon/human/H = owner.current
 	if(!istype(H))
 		return
+
 	if(isplasmaman(H))
-		H.equipOutfit(plasmaman_outfit)
-		H.open_internals(H.get_item_for_held_index(2))
-	else
-		H.dna.species.give_important_for_life(H)
+		H.dna.species.outfit_important_for_life = plasmaman_outfit
+
+	H.dna.species.give_important_for_life(H)
 	H.equipOutfit(outfit)
 
 	if(isplasmaman(H))

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -236,6 +236,8 @@
 	if(isplasmaman(H))
 		H.equipOutfit(plasmaman_outfit)
 		H.open_internals(H.get_item_for_held_index(2))
+	else
+		H.dna.species.give_important_for_life(H)
 	H.equipOutfit(outfit)
 
 	if(isplasmaman(H))


### PR DESCRIPTION

## About The Pull Request
Some species weren't getting their needed internals when joining ERT. Now they do
![image](https://github.com/user-attachments/assets/200a1397-a32e-43ef-9f75-18c20affde60)
## Why It's Good For The Game
Allows other species to safety join ERT
## Changelog
:cl:
fix: Downstream species not getting internals they need when joining ERT
/:cl:
