### PR TITLE
Implement functionality to toggle broadcast camera microphone on and off, independent of camera state.

### DIFF
--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -58,10 +58,7 @@
 /obj/item/broadcast_camera/examine(mob/user)
 	. = ..()
 	. += span_notice("Broadcast name is <b>[broadcast_name]</b>")
-	if (active_microphone)
-		. += span_notice("The microphone is <b>On</b>")
-	else
-		. += span_notice("The microphone is <b>Off</b>")
+	. += span_notice("The microphone is <b>[active_microphone ? "On" : "Off"]</b>")
 
 /obj/item/broadcast_camera/on_enter_storage(datum/storage/master_storage)
 	. = ..()
@@ -124,7 +121,4 @@
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/broadcast_camera/proc/set_microphone_state()
-	if(!active_microphone)
-		internal_radio.set_broadcasting(FALSE)
-	else
-		internal_radio.set_broadcasting(TRUE)
+	internal_radio.set_broadcasting(active_microphone)

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -115,10 +115,7 @@
 	active_microphone = !active_microphone
 
 	/// Text popup for letting the user know that the microphone has changed state
-	if(!active_microphone)
-		balloon_alert(user, "turned off the microphone.")
-	else
-		balloon_alert(user, "turned on the microphone.")
+	balloon_alert(user, "turned [active_microphone ? "on" : "off"] the microphone.")
 
 	///If the radio exists as an object, set its state accordingly
 	if(active)

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -47,7 +47,7 @@
 	. = ..()
 	active = !active
 	if(active)
-		on_activating(user)
+		on_activating()
 	else
 		on_deactivating()
 
@@ -74,7 +74,7 @@
 		on_deactivating()
 
 /// When activating the camera
-/obj/item/broadcast_camera/proc/on_activating(mob/user)
+/obj/item/broadcast_camera/proc/on_activating()
 	if(!iscarbon(loc))
 		return
 	active = TRUE
@@ -92,7 +92,7 @@
 	// INTERNAL RADIO
 	internal_radio = new(src)
 	/// Sets the state of the microphone
-	set_microphone_state(user)
+	set_microphone_state()
 
 	set_light_on(TRUE)
 	playsound(source = src, soundin = 'sound/machines/terminal_processing.ogg', vol = 20, vary = FALSE, ignore_walls = FALSE)
@@ -122,11 +122,11 @@
 
 	///If the radio exists as an object, set its state accordingly
 	if(active)
-		set_microphone_state(user)
+		set_microphone_state()
 
 	return CLICK_ACTION_SUCCESS
 
-/obj/item/broadcast_camera/proc/set_microphone_state(mob/user)
+/obj/item/broadcast_camera/proc/set_microphone_state()
 	if(!active_microphone)
 		internal_radio.set_broadcasting(FALSE)
 	else


### PR DESCRIPTION
## About The Pull Request

Implements the ability to toggle the broadcast camera's microphone on and off, independently of the camera's operational state. The microphone's current status (on or off) is also displayed when examining the camera.

The text describing the action for toggling the microphone state already existed, but the actual ability to change the microphone's state did not. This pull request addresses that gap by implementing the functionality. See issue #86660 for more details.

Fixes #86660.

## Why It's Good For The Game

It enriches the role-playing experience by allowing more intricate use of the broadcast camera, enabling players to create unique and dynamic scenarios. For example, the microphone can be turned off temporarily during a broadcast to allow the broadcaster to discuss details with others on set without the audience hearing it. This opens up creative possibilities for secret planning, behind-the-scenes coordination, or dramatic reveals, depending on the player's creativity.
## Changelog
:cl:
add: Added ability to turn broadcast microphone on or off
/:cl:
