### PR TITLE
removes non syndicate aligned traitor flavors

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -165,33 +165,20 @@ GLOBAL_LIST_INIT(syndicate_employers, list(
 	"Waffle Corporation Terrorist",
 	"Waffle Corporation",
 ))
-///employers that are from Nanotrasen
-GLOBAL_LIST_INIT(nanotrasen_employers, list(
-	"Champions of Evil",
-	"Corporate Climber",
-	"Gone Postal",
-	"Internal Affairs Agent",
-	"Legal Trouble",
-))
 
 ///employers who hire agents to do the hijack
 GLOBAL_LIST_INIT(hijack_employers, list(
 	"Animal Rights Consortium",
 	"Bee Liberation Front",
-	"Gone Postal",
 	"Tiger Cooperative Fanatic",
 	"Waffle Corporation Terrorist",
 ))
 
 ///employers who hire agents to do a task and escape... or martyrdom. whatever
 GLOBAL_LIST_INIT(normal_employers, list(
-	"Champions of Evil",
-	"Corporate Climber",
 	"Cybersun Industries",
 	"Donk Corporation",
 	"Gorlex Marauders",
-	"Internal Affairs Agent",
-	"Legal Trouble",
 	"MI13",
 	"Waffle Corporation",
 ))

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -1,8 +1,3 @@
-///all the employers that are syndicate
-#define FLAVOR_FACTION_SYNDICATE "syndicate"
-///all the employers that are Nanotrasen
-#define FLAVOR_FACTION_NANOTRASEN "nanotrasen"
-
 /datum/antagonist/traitor
 	name = "\improper Traitor"
 	roundend_category = "traitors"
@@ -187,21 +182,15 @@
 
 /datum/antagonist/traitor/proc/pick_employer()
 	if(!employer)
-		var/faction = prob(75) ? FLAVOR_FACTION_SYNDICATE : FLAVOR_FACTION_NANOTRASEN
 		var/list/possible_employers = list()
 
-		possible_employers.Add(GLOB.syndicate_employers, GLOB.nanotrasen_employers)
+		possible_employers.Add(GLOB.syndicate_employers)
 
 		if(istype(ending_objective, /datum/objective/hijack))
 			possible_employers -= GLOB.normal_employers
 		else //escape or martyrdom
 			possible_employers -= GLOB.hijack_employers
 
-		switch(faction)
-			if(FLAVOR_FACTION_SYNDICATE)
-				possible_employers -= GLOB.nanotrasen_employers
-			if(FLAVOR_FACTION_NANOTRASEN)
-				possible_employers -= GLOB.syndicate_employers
 		employer = pick(possible_employers)
 	traitor_flavor = strings(TRAITOR_FLAVOR_FILE, employer)
 
@@ -418,6 +407,3 @@
 		sword.worn_icon_state = "e_sword_on_red"
 
 		H.update_held_items()
-
-#undef FLAVOR_FACTION_SYNDICATE
-#undef FLAVOR_FACTION_NANOTRASEN

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -15,22 +15,6 @@
 		"ui_theme": "syndicate",
 		"uplink": "The Syndicate have graciously given one of their uplinks to see if we are worthy."
 	},
-	"Champions of Evil": {
-		"allies": "Anyone who sees as you see, feels as you feel, may join the Champions of Evil! That means the Syndicate, the self-serving, or even the insane, as long as it has a heart of darkness, it's cool with the Champions!",
-		"goal": "You've got some napkin-note-plans for some EVIL to do today. On the side, the Champions of Evil are always looking for more morally malodorous malefactors! Get some recruiting done!",
-		"introduction": "You are the Champion of Evil.",
-		"roundend_report": "was a Champion of Evil!",
-		"ui_theme": "neutral",
-		"uplink": "The Champions of Evil is well connected to the black market. Your uplink has been provided for utmost evil!"
-	},
-	"Corporate Climber": {
-		"allies": "Death to the Syndicate.",
-		"goal": "Killing needlessly would make you some kind of traitor, or at least definitely seen as one. This is all just a means to an end.",
-		"introduction": "You are the Corporate Climber.",
-		"roundend_report": "was a corporate climber.",
-		"ui_theme": "neutral",
-		"uplink": "You have connections to the black market for the deeds. Knock off a few loose weights, and your climb will be so much smoother."
-	},
 	"Cybersun Industries": {
 		"allies": "Fellow Cybersun operatives are to be trusted. Members of the MI13 organization can be trusted. All other syndicate operatives are not to be trusted.",
 		"goal": "Do not establish substantial presence on the designated facility, as larger incidents are harder to cover up.",
@@ -47,14 +31,6 @@
 		"ui_theme": "syndicate",
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
 	},
-	"Gone Postal": {
-		"allies": "If the syndicate learns of your plan, they're going to kill you and take your uplink. Take no chances.",
-		"goal": "The preparations are finally complete. Today is the day you go postal. You're going to hijack the emergency shuttle and live a new life free of Nanotrasen.",
-		"introduction": "You're going postal today.",
-		"roundend_report": "simply went completely postal!",
-		"ui_theme": "neutral",
-		"uplink": "You've actually managed to steal a full uplink a month ago. This should certainly help accomplish your goals."
-	},
 	"Gorlex Marauders": {
 		"allies": "You may collaborate with any friends of the Syndicate coalition, but keep an eye on any of those Tiger punks if they do show up.",
 		"goal": "Getting noticed is not an issue, and you may use any level of ordinance to get the job done. That being said, do not make this sloppy by dragging in random slaughter.",
@@ -62,22 +38,6 @@
 		"roundend_report": "was a Gorlex Marauder.",
 		"ui_theme": "syndicate",
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
-	},
-	"Internal Affairs Agent": {
-		"allies": "Do NOT reveal your agent status, to anyone. Work to root out corruption from the station from the shadows.",
-		"goal": "While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.",
-		"introduction": "You are the Internal Affairs Agent.",
-		"roundend_report": "was part of Nanotrasen Internal Affairs.",
-		"ui_theme": "ntos",
-		"uplink": "For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink."
-	},
-	"Legal Trouble": {
-		"allies": "Death to the Syndicate.",
-		"goal": "Try to finish your to-do list, and don't get caught. If they find out what you're actually doing, this scandal will go galactic.",
-		"introduction": "You are in legal trouble.",
-		"roundend_report": "was in legal trouble.",
-		"ui_theme": "neutral",
-		"uplink": "You've connected to the black market to clean this mess up. If there's no evidence, there's no crime."
 	},
 	"MI13": {
 		"allies": "You are the only operative we are sending, any others are fake. All other syndicate operatives are not to be trusted, with the exception of Cybersun operatives.",


### PR DESCRIPTION

## About The Pull Request
Removes the non syndicate aligned traitor flavors
## Why It's Good For The Game
While these are fun ideas, these flavors are at direct odds with many of the traitor mechanics, including code words, side objectives, final objectives, and how people interact with the traitor role. They do not make sense in the realm of progtot.
## Changelog
:cl: itseasytosee
del: All traitors are now syndicate aligned.
/:cl:
