### PR TITLE
adds fishing category to games vendor

### DIFF
--- a/code/modules/fishing/aquarium/fish_analyzer.dm
+++ b/code/modules/fishing/aquarium/fish_analyzer.dm
@@ -8,6 +8,7 @@
 	worn_icon_state = "fish_analyzer"
 	desc = "A fish-shaped scanner used to monitor fish's status and evolutionary traits."
 	obj_flags = CONDUCTS_ELECTRICITY
+	custom_price = PAYCHECK_CREW * 3
 	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 3

--- a/code/modules/fishing/fish_catalog.dm
+++ b/code/modules/fishing/fish_catalog.dm
@@ -3,6 +3,7 @@
 	name = "Fish Encyclopedia"
 	desc = "Indexes all fish known to mankind (and related species)."
 	icon_state = "fishbook"
+	custom_price = PAYCHECK_CREW * 2
 	starting_content = "Lot of fish stuff" //book wrappers could use cleaning so this is not necessary
 
 /obj/item/book/manual/fish_catalog/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -287,7 +287,7 @@
 	icon_state = "fishing"
 	inhand_icon_state = "artistic_toolbox"
 	material_flags = NONE
-	custom_price = PAYCHECK_CREW * 2.5
+	custom_price = PAYCHECK_CREW * 3
 
 /obj/item/storage/toolbox/fishing/Initialize(mapload)
 	. = ..()

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -287,6 +287,7 @@
 	icon_state = "fishing"
 	inhand_icon_state = "artistic_toolbox"
 	material_flags = NONE
+	custom_price = PAYCHECK_CREW * 2.5
 
 /obj/item/storage/toolbox/fishing/Initialize(mapload)
 	. = ..()
@@ -339,6 +340,7 @@
 /obj/item/storage/box/fishing_hooks
 	name = "fishing hook set"
 	illustration = "fish"
+	custom_price = PAYCHECK_CREW * 2
 
 /obj/item/storage/box/fishing_hooks/PopulateContents()
 	new /obj/item/fishing_hook/magnet(src)
@@ -355,6 +357,7 @@
 /obj/item/storage/box/fishing_lines
 	name = "fishing line set"
 	illustration = "fish"
+	custom_price = PAYCHECK_CREW * 2
 
 /obj/item/storage/box/fishing_lines/PopulateContents()
 	new /obj/item/fishing_line/bouncy(src)
@@ -403,6 +406,7 @@
 	icon_state = "plasticbox"
 	foldable_result = null
 	illustration = "fish"
+	custom_price = PAYCHECK_CREW * 9
 
 /obj/item/storage/box/fishing_lures/PopulateContents()
 	new /obj/item/paper/lures_instructions(src)

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -502,6 +502,7 @@
 	icon_state = "fishing_rod_telescopic"
 	desc = "A lightweight, ergonomic, easy to store telescopic fishing rod. "
 	inhand_icon_state = null
+	custom_price = PAYCHECK_CREW * 9
 	force = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	ui_description = "A collapsible fishing rod that can fit within a backpack."

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -45,6 +45,19 @@
 				/obj/item/stack/pipe_cleaner_coil/random = 10,
 			),
 		),
+		list(		
+			"name" = "Fishing",
+			"icon" = "fish",
+			"products" = list(
+				/obj/item/storage/toolbox/fishing = 2,
+				/obj/item/storage/box/fishing_hooks = 2,
+				/obj/item/storage/box/fishing_lines = 2,
+				/obj/item/storage/box/fishing_lures = 2,
+				/obj/item/book/manual/fish_catalog = 5,
+				/obj/item/fish_analyzer = 2,
+				/obj/item/fishing_rod/telescopic = 1,
+			),
+		),
 		list(
 			"name" = "Skillchips",
 			"icon" = "floppy-disk",

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -9,7 +9,8 @@
 			"name" = "Cards",
 			"icon" = "diamond",
 			"products" = list(
-				/obj/item/toy/cards/deck = 5,
+				/obj/item/toy/cards/deck = 5
+				custom_price = PAYCHECK_COMMAND * 5 ,
 				/obj/item/toy/cards/deck/blank = 3,
 				/obj/item/toy/cards/deck/blank/black = 3,
 				/obj/item/toy/cards/deck/cas = 3,

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -9,8 +9,7 @@
 			"name" = "Cards",
 			"icon" = "diamond",
 			"products" = list(
-				/obj/item/toy/cards/deck = 5
-				custom_price = PAYCHECK_COMMAND * 5 ,
+				/obj/item/toy/cards/deck = 5,
 				/obj/item/toy/cards/deck/blank = 3,
 				/obj/item/toy/cards/deck/blank/black = 3,
 				/obj/item/toy/cards/deck/cas = 3,


### PR DESCRIPTION
## About The Pull Request
this pull request adds a fishing category to the games vendor with items that cost 50 credits more than their goodie alternatives.
## Why It's Good For The Game
this allows people to start their fishing goals earlier without waiting 20 minutes for cargo at the caveat of the items costing 50 credits extra than normal
## Changelog
:cl:
add: Added new fishing category to games vendor
/:cl:
