### PR TITLE
Fixes penlights not being able to look at peoples' eyes and mouth

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -254,7 +254,7 @@
 	if(!scanning.get_bodypart(BODY_ZONE_HEAD))
 		to_chat(user, span_warning("[scanning] doesn't have a head!"))
 		return
-	if(light_power < 1)
+	if(light_power < 0.5)
 		to_chat(user, span_warning("[src] isn't bright enough to see anything!"))
 		return
 


### PR DESCRIPTION

## About The Pull Request

Currently, flashlights need a minimum light_power of 1 to be able to look at peoples' eyes and mouth. Penlights have a light_power of 0.8, so they don't work.

This PR bumps the minimum light_power required down to 0.5 so penlights can be used to diagnose patients again.
## Why It's Good For The Game

Items should function as intended
## Changelog
:cl: Bumtickley00
fix: Penlights can once again be used to look at people's eyes and mouth.
/:cl:
