### PR TITLE
Fixes mobs without dexterity being able to remove pens from PDAs

### DIFF
--- a/code/game/objects/items/stickers.dm
+++ b/code/game/objects/items/stickers.dm
@@ -25,7 +25,7 @@
 	throw_range = 3
 	pressure_resistance = 0
 
-	item_flags = NOBLUDGEON | XENOMORPH_HOLDABLE //funny ~Jimmyl
+	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_TINY
 
 	/// `list` or `null`, contains possible alternate `icon_states`.

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1134,7 +1134,6 @@
 	name = "xenomorph action figure"
 	desc = "MEGA presents the new Xenos Isolated action figure! Comes complete with realistic sounds! Pull back string to use."
 	w_class = WEIGHT_CLASS_SMALL
-	item_flags = XENOMORPH_HOLDABLE
 	var/cooldown = 0
 
 /obj/item/toy/toy_xeno/attack_self(mob/user)

--- a/code/modules/basketball/basketball.dm
+++ b/code/modules/basketball/basketball.dm
@@ -8,7 +8,6 @@
 	inhand_icon_state = "basketball"
 	desc = "Here's your chance, do your dance at the Space Jam."
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
-	item_flags = XENOMORPH_HOLDABLE // playing ball against a xeno is rigged since they cannot be disarmed
 	/// The person dribbling the basketball
 	var/mob/living/wielder
 	/// So the basketball doesn't make sound every step

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -23,6 +23,13 @@
 	unique_name = TRUE
 
 	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
+	var/static/list/xeno_allowed_items = typecacheof(list(
+		/obj/item/clothing/mask/facehugger,
+		/obj/item/toy/basketball, // playing ball against a xeno is rigged since they cannot be disarmed, their game is out of this world
+		/obj/item/toy/toy_xeno,
+		/obj/item/sticker, //funny ~Jimmyl
+		/obj/item/toy/plush/rouny,
+	))
 
 /mob/living/carbon/alien/Initialize(mapload)
 	add_verb(src, /mob/living/proc/mob_sleep)
@@ -37,6 +44,9 @@
 	. = ..()
 	if(alien_speed)
 		update_alien_speed()
+	LoadComponent(/datum/component/itempicky, xeno_allowed_items, \
+	span_alien("Your claws lack the dexterity to hold %TARGET."), \
+	CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_has_trait), src, TRAIT_ADVANCEDTOOLUSER))
 
 /mob/living/carbon/alien/create_internal_organs()
 	organs += new /obj/item/organ/internal/brain/alien
@@ -149,8 +159,8 @@ Des: Removes all infected images from the alien.
 
 	set_name()
 
-/mob/living/carbon/alien/can_hold_items(obj/item/I)
-	return (I && (I.item_flags & XENOMORPH_HOLDABLE || ISADVANCEDTOOLUSER(src)) && ..())
+///mob/living/carbon/alien/can_hold_items(obj/item/I)
+//	return (I && (I.item_flags & XENOMORPH_HOLDABLE || ISADVANCEDTOOLUSER(src)) && ..())
 
 /mob/living/carbon/alien/on_lying_down(new_lying_angle)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -23,7 +23,6 @@
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	layer = MOB_LAYER
 	max_integrity = 100
-	item_flags = XENOMORPH_HOLDABLE
 	slowdown = 2
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -181,7 +181,7 @@
 
 /obj/item/modular_computer/pda/proc/remove_pen(mob/user)
 
-	if(issilicon(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH)) //TK doesn't work even with this removed but here for readability
+	if(issilicon(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH | NEED_DEXTERITY)) //TK doesn't work even with this removed but here for readability
 		return
 
 	if(inserted_item)


### PR DESCRIPTION

## About The Pull Request
Bugfix for non dextrous mobs being able to use the PDA Ctrl click interaction 

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/86703 and similar 
## Changelog
:cl: Bisar
fix: fixed PDA Ctrl click not checking for dexterity 
/:cl:
