### PR TITLE
Agent ID cards no longer display broken text when you put non-letter symbols as your name

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1700,11 +1700,11 @@
 		return
 
 	///forge the ID if not forged.
-	var/input_name = tgui_input_text(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN)
+	var/input_name = tgui_input_text(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN, encode = FALSE)
 	if(!after_input_check(user))
 		return TRUE
 	if(input_name)
-		input_name = sanitize_name(input_name, allow_numbers = TRUE)
+		input_name = reject_bad_name(input_name, allow_numbers = TRUE)
 	if(!input_name)
 		// Invalid/blank names give a randomly generated one.
 		if(user.gender == MALE)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1704,7 +1704,7 @@
 	if(!after_input_check(user))
 		return TRUE
 	if(input_name)
-		input_name = reject_bad_name(input_name, allow_numbers = TRUE)
+		input_name = sanitize_name(input_name, allow_numbers = TRUE)
 	if(!input_name)
 		// Invalid/blank names give a randomly generated one.
 		if(user.gender == MALE)


### PR DESCRIPTION

## About The Pull Request

Thanks to Kapu for figuring this one out

## Changelog
:cl: SmArtKar, Kapu
fix: Agent ID cards no longer display broken text when you put non-letter symbols as your name
/:cl:
