### PR TITLE
Changing ID card's trim now properly adjusts linked bank account's job

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -409,6 +409,10 @@ SUBSYSTEM_DEF(id_access)
 	if(trim.assignment)
 		id_card.assignment = trim.assignment
 
+	var/datum/job/trim_job = trim.find_job()
+	if (!isnull(trim_job) && !isnull(id_card.registered_account))
+		id_card.registered_account.account_job = trim_job
+
 	id_card.update_label()
 	id_card.update_icon()
 

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -29,6 +29,12 @@
 	///If set, IDs with this trim will give wearers arrows of different colors when pointing
 	var/pointer_color
 
+/datum/id_trim/proc/find_job()
+	for (var/datum/job/job as anything in SSjob.all_occupations)
+		if (job.title == assignment)
+			return job
+	return null
+
 /// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.
 /obj/item/proc/get_sechud_job_icon_state()
 	var/obj/item/card/id/id_card = GetID()


### PR DESCRIPTION

## About The Pull Request

Closes #61216
Closes #57516

Arcane gave greenlight on this PR as its unlikely that this'll be cheesed or affect balance in any way, and in worst case scenario mass account changes will just summon space IRS on the offending HoP

## Changelog
:cl:
fix: Changing ID card's trim now properly adjusts linked bank account's job, allowing you to receive bounties for your new job
/:cl:
