### PR TITLE
Fixes xenos being able to pick up items that they shouldn't by most means, expands itempicky component functionality

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -809,13 +809,16 @@
 ///return first thing in L which has var/varname == value
 ///this is typecaste as list/L, but you could actually feed it an atom instead.
 ///completely safe to use
-/proc/get_element_by_var(list/inserted_list, varname, value)
+/proc/get_element_by_var(list/inserted_list, varname, value, poll_value = FALSE)
 	varname = "[varname]"
 	for(var/datum/checked_datum in inserted_list)
 		if(!checked_datum.vars.Find(varname))
 			continue
 		if(checked_datum.vars[varname] == value)
-			return checked_datum
+			if(poll_value)
+				return list(checked_datum, checked_datum.vars[varname])
+			else
+				return checked_datum
 
 
 ///Copies a list, and all lists inside it recusively

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -809,16 +809,13 @@
 ///return first thing in L which has var/varname == value
 ///this is typecaste as list/L, but you could actually feed it an atom instead.
 ///completely safe to use
-/proc/get_element_by_var(list/inserted_list, varname, value, poll_value = FALSE)
+/proc/get_element_by_var(list/inserted_list, varname, value)
 	varname = "[varname]"
 	for(var/datum/checked_datum in inserted_list)
 		if(!checked_datum.vars.Find(varname))
 			continue
 		if(checked_datum.vars[varname] == value)
-			if(poll_value)
-				return list(checked_datum, checked_datum.vars[varname])
-			else
-				return checked_datum
+			return checked_datum
 
 
 ///Copies a list, and all lists inside it recusively

--- a/code/datums/components/itempicky.dm
+++ b/code/datums/components/itempicky.dm
@@ -17,6 +17,10 @@
 	if(tertiary_condition)
 		src.tertiary_condition = tertiary_condition
 
+/datum/component/itempicky/Destroy(force)
+	. = ..()
+	tertiary_condition = null
+
 /datum/component/itempicky/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_LIVING_TRY_PUT_IN_HAND, PROC_REF(particularly))
 

--- a/code/datums/components/itempicky.dm
+++ b/code/datums/components/itempicky.dm
@@ -5,9 +5,8 @@
 	var/whitelist
 	/// Message shown if you try to pick up an item not in the whitelist
 	var/message = "You don't like %TARGET, why would you hold it?"
-	/// An optional condition we check for overriding our whitelist;
-	/// can be a var or a callback
-	var/tertiary_condition = null
+	/// An optional callback we check for overriding our whitelist
+	var/datum/callback/tertiary_condition = null
 
 /datum/component/itempicky/Initialize(whitelist, message, tertiary_condition)
 	if(!ismob(parent))
@@ -16,12 +15,7 @@
 	if(message)
 		src.message = message
 	if(tertiary_condition)
-		if(istype(tertiary_condition, /datum/callback))
-			// if we're tracking some value that we won't be changing and
-			// isn't resolved logically by a callback, we'll resolve our reference to it instead
-			src.tertiary_condition = tertiary_condition
-		else
-			src.tertiary_condition = &tertiary_condition
+		src.tertiary_condition = tertiary_condition
 
 /datum/component/itempicky/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_LIVING_TRY_PUT_IN_HAND, PROC_REF(particularly))
@@ -42,7 +36,7 @@
 	SIGNAL_HANDLER
 	// if we were passed the output of a callback, check against that
 	// otherwise resolve our pointer
-	var/tertiary_result = (istype(tertiary_condition, /datum/callback) ? tertiary_condition?:Invoke() : *tertiary_condition)
+	var/tertiary_result = tertiary_condition?.Invoke()
 	if(!tertiary_result && !is_type_in_typecache(pickingup, whitelist))
 		to_chat(source, span_warning("[replacetext(message, "%TARGET", pickingup)]"))
 		return COMPONENT_LIVING_CANT_PUT_IN_HAND

--- a/code/datums/components/itempicky.dm
+++ b/code/datums/components/itempicky.dm
@@ -18,8 +18,8 @@
 		src.tertiary_condition = tertiary_condition
 
 /datum/component/itempicky/Destroy(force)
-	. = ..()
 	tertiary_condition = null
+	return ..()
 
 /datum/component/itempicky/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_LIVING_TRY_PUT_IN_HAND, PROC_REF(particularly))

--- a/code/datums/components/itempicky.dm
+++ b/code/datums/components/itempicky.dm
@@ -35,8 +35,6 @@
 /datum/component/itempicky/proc/particularly(datum/source, obj/item/pickingup)
 	SIGNAL_HANDLER
 	// if we were passed the output of a callback, check against that
-	// otherwise resolve our pointer
-	var/tertiary_result = tertiary_condition?.Invoke()
-	if(!tertiary_result && !is_type_in_typecache(pickingup, whitelist))
+	if(!tertiary_condition?.Invoke() && !is_type_in_typecache(pickingup, whitelist))
 		to_chat(source, span_warning("[replacetext(message, "%TARGET", pickingup)]"))
 		return COMPONENT_LIVING_CANT_PUT_IN_HAND

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -633,7 +633,7 @@
 /obj/item/attack_alien(mob/user, list/modifiers)
 	var/mob/living/carbon/alien/ayy = user
 
-	if(!user.can_hold_items(src))
+	if(!ayy.can_hold_items(src))
 		if(src in ayy.contents) // To stop Aliens having items stuck in their pockets
 			ayy.dropItemToGround(src)
 		to_chat(user, span_warning("Your claws aren't capable of such fine manipulation!"))

--- a/code/game/objects/items/stickers.dm
+++ b/code/game/objects/items/stickers.dm
@@ -25,7 +25,7 @@
 	throw_range = 3
 	pressure_resistance = 0
 
-	item_flags = NOBLUDGEON | XENOMORPH_HOLDABLE //funny ~Jimmyl
+	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_TINY
 
 	/// `list` or `null`, contains possible alternate `icon_states`.

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1134,7 +1134,6 @@
 	name = "xenomorph action figure"
 	desc = "MEGA presents the new Xenos Isolated action figure! Comes complete with realistic sounds! Pull back string to use."
 	w_class = WEIGHT_CLASS_SMALL
-	item_flags = XENOMORPH_HOLDABLE
 	var/cooldown = 0
 
 /obj/item/toy/toy_xeno/attack_self(mob/user)

--- a/code/modules/basketball/basketball.dm
+++ b/code/modules/basketball/basketball.dm
@@ -8,7 +8,6 @@
 	inhand_icon_state = "basketball"
 	desc = "Here's your chance, do your dance at the Space Jam."
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
-	item_flags = XENOMORPH_HOLDABLE // playing ball against a xeno is rigged since they cannot be disarmed
 	/// The person dribbling the basketball
 	var/mob/living/wielder
 	/// So the basketball doesn't make sound every step

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -44,9 +44,11 @@
 	. = ..()
 	if(alien_speed)
 		update_alien_speed()
-	LoadComponent(/datum/component/itempicky, xeno_allowed_items, \
-	span_alien("Your claws lack the dexterity to hold %TARGET."), \
-	CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_has_trait), src, TRAIT_ADVANCEDTOOLUSER))
+	LoadComponent( \
+		/datum/component/itempicky, \
+		xeno_allowed_items, \
+		span_alien("Your claws lack the dexterity to hold %TARGET."), \
+		CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_has_trait), src, TRAIT_ADVANCEDTOOLUSER))
 
 /mob/living/carbon/alien/create_internal_organs()
 	organs += new /obj/item/organ/internal/brain/alien

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -23,6 +23,13 @@
 	unique_name = TRUE
 
 	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
+	var/static/list/xeno_allowed_items = typecacheof(list(
+		/obj/item/clothing/mask/facehugger,
+		/obj/item/toy/basketball, // playing ball against a xeno is rigged since they cannot be disarmed, their game is out of this world
+		/obj/item/toy/toy_xeno,
+		/obj/item/sticker, //funny ~Jimmyl
+		/obj/item/toy/plush/rouny,
+	))
 
 /mob/living/carbon/alien/Initialize(mapload)
 	add_verb(src, /mob/living/proc/mob_sleep)
@@ -37,6 +44,9 @@
 	. = ..()
 	if(alien_speed)
 		update_alien_speed()
+	LoadComponent(/datum/component/itempicky, xeno_allowed_items, \
+	span_alien("Your claws lack the dexterity to hold %TARGET."), \
+	CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_has_trait), src, TRAIT_ADVANCEDTOOLUSER))
 
 /mob/living/carbon/alien/create_internal_organs()
 	organs += new /obj/item/organ/internal/brain/alien
@@ -149,8 +159,8 @@ Des: Removes all infected images from the alien.
 
 	set_name()
 
-/mob/living/carbon/alien/can_hold_items(obj/item/I)
-	return (I && (I.item_flags & XENOMORPH_HOLDABLE || ISADVANCEDTOOLUSER(src)) && ..())
+///mob/living/carbon/alien/can_hold_items(obj/item/I)
+//	return (I && (I.item_flags & XENOMORPH_HOLDABLE || ISADVANCEDTOOLUSER(src)) && ..())
 
 /mob/living/carbon/alien/on_lying_down(new_lying_angle)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -159,9 +159,6 @@ Des: Removes all infected images from the alien.
 
 	set_name()
 
-///mob/living/carbon/alien/can_hold_items(obj/item/I)
-//	return (I && (I.item_flags & XENOMORPH_HOLDABLE || ISADVANCEDTOOLUSER(src)) && ..())
-
 /mob/living/carbon/alien/on_lying_down(new_lying_angle)
 	. = ..()
 	update_icons()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -23,7 +23,6 @@
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	layer = MOB_LAYER
 	max_integrity = 100
-	item_flags = XENOMORPH_HOLDABLE
 	slowdown = 2
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -181,7 +181,7 @@
 
 /obj/item/modular_computer/pda/proc/remove_pen(mob/user)
 
-	if(issilicon(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH)) //TK doesn't work even with this removed but here for readability
+	if(issilicon(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH | NEED_DEXTERITY)) //TK doesn't work even with this removed but here for readability
 		return
 
 	if(inserted_item)


### PR DESCRIPTION
## About The Pull Request

Xenos can apparently use shenanigans such as https://github.com/tgstation/tgstation/issues/86703 to put some items in their hand, and there are likely methods like this dotted around the codebase. However, the signal to put something in their hand is called consistently across any process that would cause them to pick up or otherwise have something to put in their hand, so instead I added /datum/component/itempicky to xenos.

While I was in there, I expanded the functionality of itempicky; it can run a callback to determine a condition that needs to be met now. 

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/86703
Expands a component's usefulness
## Changelog
:cl: Bisar
fix: Xenomorph restrictions on items they can pick up have had their determining logic made more _robust_.
code: The itempicky component (restricts what can be picked up via a whitelist) can now, optionally, have a callback fed to it to determine cases of bypassing that whitelist.
/:cl:
