### PR TITLE
Fix lack of blob reagent description

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/_reagent.dm
+++ b/code/modules/antagonists/blob/blobstrains/_reagent.dm
@@ -26,11 +26,20 @@
 // These can only be applied by blobs. They are what (reagent) blobs are made out of.
 /datum/reagent/blob
 	name = "Unknown"
-	description = "shouldn't exist and you should adminhelp immediately."
+	description = ""
 	color = COLOR_WHITE
 	taste_description = "bad code and slime"
 	chemical_flags = NONE
 	penetrates_skin = NONE
+
+
+/datum/reagent/blob/New()
+	..()
+
+	if(name == "Unknown")
+		description = "shouldn't exist and you should adminhelp immediately."
+	else if(description == "")
+		description = "[name] is the reagent created by that type of blob."
 
 /// Used by blob reagents to calculate the reaction volume they should use when exposing mobs.
 /datum/reagent/blob/proc/return_mob_expose_reac_volume(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/overmind)

--- a/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
+++ b/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
@@ -12,7 +12,7 @@
 
 /datum/reagent/blob/cryogenic_poison
 	name = "Cryogenic Poison"
-	description = "will inject targets with a freezing poison that does high damage over time."
+	description = "A freezing poison that does high damage over time. Cryogenic poison blobs inject this into their victims."
 	color = "#8BA6E9"
 	taste_description = "brain freeze"
 

--- a/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
+++ b/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
@@ -12,6 +12,7 @@
 
 /datum/reagent/blob/regenerative_materia
 	name = "Regenerative Materia"
+	description = "Chemical that inflicts toxin damage and makes the target believe they are fully healed. Regenerative materia blobs inject this into their victims."
 	taste_description = "heaven"
 	color = "#A88FB7"
 


### PR DESCRIPTION

## About The Pull Request

This PR addresses the lack of descriptions for blob reagents. Previously, the description for these reagents stated: "shouldn't exist and you should adminhelp immediately." This has been changed to automatically generate a basic description when a reagent's name exists. The confusion caused by the previous description is exemplified in issue #85363 (does not fix the issue itself).

For example, if the reagent is named *Blazing Oil*, the new description will read: "Blazing Oil is the reagent created by that type of blob.". See the example below:

![image](https://github.com/user-attachments/assets/ab7c10cf-9306-404d-a232-b16115dab894)

If the reagent name is *Unknown*, the description will revert to the original message, prompting players to adminhelp.

![image](https://github.com/user-attachments/assets/09036d34-9c69-4688-90d6-9b1f2a7a4722)

In addition, two specific blob chemicals used to inject players, *Regenerative Materia* and *Cryogenic Poison*, will now include more detailed descriptions, specifying their purposes.

![image](https://github.com/user-attachments/assets/7299b679-f55e-491c-95c8-07fecb9a075c)

![image](https://github.com/user-attachments/assets/4737b748-5409-4e34-b420-0a46df654b80)
## Why It's Good For The Game

This change makes it easier for players to understand the origin of blob chemicals, reducing confusion when they are detected.
## Changelog
:cl:
fix: fixes description for blob reagents
/:cl:
