### PR TITLE
Allows lockers & crates with no electronics to be renamed

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -823,19 +823,19 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			balloon_alert(user, "unlock first!")
 			return
 
-		if(isnull(id_card))
+		if(isnull(id_card) && secure)
 			balloon_alert(user, "not yours to rename!")
 			return
 
 		var/name_set = FALSE
 		var/desc_set = FALSE
 
-		var/str = tgui_input_text(user, "Personal Locker Name", "Locker Name")
+		var/str = tgui_input_text(user, "Locker Name", "Locker Name")
 		if(!isnull(str))
 			name = str
 			name_set = TRUE
 
-		str = tgui_input_text(user, "Personal Locker Description", "Locker Description")
+		str = tgui_input_text(user, "Locker Description", "Locker Description")
 		if(!isnull(str))
 			desc = str
 			desc_set = TRUE


### PR DESCRIPTION
## About The Pull Request
Adds a `secure` check to `ifnull(id_card)`, this allows crates without airlock electronics or card readers to be renamed by anyone. Also removes the 'personal' in the TGUI as it doesn't make sense anymore.
## Why It's Good For The Game
Allows any random crate to be renamed and re described. Communal lockers, like departmental lockers, cannot be renamed because that would be RUDE. 
fix #85628
## Changelog
:cl: Goat
fix: lockers and crates with no access requirements can now be renamed by anyone
/:cl:
