### PR TITLE
Collars can no longer be used to null a pet's name

### DIFF
--- a/code/datums/elements/pet_collar.dm
+++ b/code/datums/elements/pet_collar.dm
@@ -54,7 +54,7 @@
 /datum/element/wears_collar/proc/on_content_enter(mob/living/source, obj/item/clothing/neck/petcollar/new_collar)
 	SIGNAL_HANDLER
 
-	if(!istype(new_collar))
+	if(!istype(new_collar) || !new_collar.tagname)
 		return
 
 	source.fully_replace_character_name(null, "\proper [new_collar.tagname]")

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -452,6 +452,10 @@
 
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
 	tagname = sanitize_name(tgui_input_text(user, "Would you like to change the name on the tag?", "Pet Naming", "Spot", MAX_NAME_LEN))
+	if (!tagname || !length(tagname))
+		name = initial(name)
+		tagname = null
+		return
 	name = "[initial(name)] - [tagname]"
 
 //////////////


### PR DESCRIPTION

## About The Pull Request

Closes #86716

## Changelog
:cl:
fix: Collars can no longer be used to null a pet's name
/:cl:
