### PR TITLE
Vore victims no longer get digested instantly when you evolve

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -168,10 +168,9 @@
 		span_noticealien("The queen has granted you a promotion to Praetorian!"),
 	)
 
-	var/mob/living/carbon/alien/adult/royal/praetorian/new_prae = new(to_promote.loc)
-	to_promote.mind.transfer_to(new_prae)
-
-	qdel(to_promote)
+	var/mob/living/carbon/alien/lucky_winner = to_promote
+	var/mob/living/carbon/alien/adult/royal/praetorian/new_prae = new(lucky_winner.loc)
+	lucky_winner.alien_evolve(new_prae)
 	qdel(src)
 	return TRUE
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -134,8 +134,8 @@ Des: Removes all infected images from the alien.
 	var/obj/item/organ/internal/stomach/alien/melting_pot = get_organ_slot(ORGAN_SLOT_STOMACH)
 	var/obj/item/organ/internal/stomach/alien/frying_pan = new_xeno.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(istype(melting_pot) && istype(frying_pan))
-		while (length(melting_pot.stomach_contents))
-			frying_pan.consume_thing(melting_pot.stomach_contents[1])
+		for (var/atom/movable/poor_sod as anything in melting_pot.stomach_contents)
+			frying_pan.consume_thing(poor_sod)
 	qdel(src)
 
 /// Changes the name of the xeno we are evolving into in order to keep the same numerical identifier the old xeno had.

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -131,6 +131,11 @@ Des: Removes all infected images from the alien.
 		mind.name = new_xeno.real_name
 		mind.transfer_to(new_xeno)
 
+	var/obj/item/organ/internal/stomach/alien/melting_pot = get_organ_slot(ORGAN_SLOT_STOMACH)
+	var/obj/item/organ/internal/stomach/alien/frying_pan = new_xeno.get_organ_slot(ORGAN_SLOT_STOMACH)
+	if(istype(melting_pot) && istype(frying_pan))
+		while (length(melting_pot.stomach_contents))
+			frying_pan.consume_thing(melting_pot.stomach_contents[1])
 	qdel(src)
 
 /// Changes the name of the xeno we are evolving into in order to keep the same numerical identifier the old xeno had.


### PR DESCRIPTION

## About The Pull Request
Partially handles #86685
Moving all organs/contents is a pretty bad idea and I'm not sure if there's a cleaner way to do it for the first point in the issue.

## Changelog
:cl:
fix: Vore victims no longer get digested instantly when you evolve
/:cl:
