### PR TITLE
Implement fix for hydroponics tray allowing autogrow while no power

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1090,10 +1090,14 @@
 /obj/machinery/hydroponics/click_ctrl(mob/user)
 	if(!anchored)
 		return NONE
+
+	update_use_power(ACTIVE_POWER_USE)
+
 	if(!powered())
 		to_chat(user, span_warning("[name] has no power."))
 		update_use_power(NO_POWER_USE)
 		return CLICK_ACTION_BLOCKING
+
 	set_self_sustaining(!self_sustaining)
 	to_chat(user, span_notice("You [self_sustaining ? "activate" : "deactivated"] [src]'s autogrow function[self_sustaining ? ", maintaining the tray's health while using high amounts of power" : ""]."))
 	return CLICK_ACTION_SUCCESS


### PR DESCRIPTION

## About The Pull Request

Fixes #83539.

The code was structured in such a way that the check for power usage did not work correctly, and this allowed for someone to double press ctrl click on the hydroponics tray while there is no power, turning it on forever regardless.
## Why It's Good For The Game

Fixes a bug that allows autogrow to be turned on with no power.
## Changelog
:cl:
fix: fixed a bug that allows autogrow to be turned on with no power.
/:cl:
