### PR TITLE
Adds three useful PDA programs to Cyborg's default PDA loadout

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -329,9 +329,6 @@
 		/datum/computer_file/program/borg_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/crew_manifest,
-		// /datum/computer_file/program/records/medical, //read only/unable to edit (good). Could add this to Mediborgs
-		// /datum/computer_file/program/records/security, //read only/unable to edit (good). Could add this to Peacekeepers
-		// /datum/computer_file/program/supermatter_monitor, //read only/unable to edit (good). Could add this to Engiborgs
 	)
 
 /obj/item/modular_computer/pda/silicon/Initialize(mapload)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -326,6 +326,12 @@
 	starting_programs = list(
 		/datum/computer_file/program/filemanager,
 		/datum/computer_file/program/robotact,
+		/datum/computer_file/program/borg_monitor,
+		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/crew_manifest,
+		// /datum/computer_file/program/records/medical, //read only/unable to edit (good). Could add this to Mediborgs
+		// /datum/computer_file/program/records/security, //read only/unable to edit (good). Could add this to Peacekeepers
+		// /datum/computer_file/program/supermatter_monitor, //read only/unable to edit (good). Could add this to Engiborgs
 	)
 
 /obj/item/modular_computer/pda/silicon/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

![overview](https://i.imgur.com/elfIbWM.png)
For a long time borgs have only had two PDA programs: `filemanager` and `robotact`, but there are other simple programs with useful information for gameplay. This PR remedies this by including three other programs to borgs by default: `borg_monitor`, `atmosscan`, and `crew_manifest`. In the interest of transparency, I've included possible negatives in the form of disclaimers below.

`borg_monitor`: 
![monitor](https://i.imgur.com/7NzfvSO.png) 
This is the "SiliConnect" program in-game, and allows showing a brief overview to cyborg players who else is connected as a cyborg and what their model is, which allows for informed decisions on which module to choose for themselves, among other minor useful data.

**_Disclaimer: I'm pretty sure the "Send message" button on this program is unusable for borgs due to how it's coded [here](https://github.com/tgstation/tgstation/blob/ab222330ef3b05f512d9b0a87c3292377ce91271/code/modules/modular_computers/file_system/programs/borg_monitor.dm#L116), but I'm unable to test it with another player. Looks like it requires an ID, which borgs don't have, so I'm assuming this is a non-issue._**

`atmosscan`: 
![atmos](https://i.imgur.com/Vie1Cud.png) 
The AtmoZsphere program, which shows local oxygen/nitrogen data to help make informed decisions on protecting humans.

`crew_manifest`: 
![crew](https://i.imgur.com/7OWeM4i.png) 
The Plexagon Crew List - A simple window that shows an updated list of current crew members and their jobs.

**_Disclaimer: The "print" button on this program allows borgs to spam printed crew manifests on the ground if they choose to do so, which may have the potential to be overused, however they've also had the ability to spam-print photos using the Robotact program and I don't know of any issues this has caused (correct me if I'm mistaken)._**
## Why It's Good For The Game / Potential additional changes

Currently cyborg gameplay can become a walking simulator if they need simple information that a crew manifest computer would have, or an air alarm (which might've just been blown up, disabled, or out of power), or if they just got borgified at a Roboticist and would like to know which other cyborgs are currently in play but don't want to pick  a model already being used. All humans have this data and more on their handheld PDAs. Cyborgs should at least have these three as a bare minimum.

There are other useful programs: `records/medical`, `records/security`, `custodial_locator`, and `supermatter_monitor` (NT CIMS), which could go into Mediborgs, Peacekeepers, Janiborgs, and Engiborgs respectively. I've tested these and am unable to change these records as a borg, only view them, so this is purely informational data that could be useful for various RP reasons. It could be fun for a cyborg buddy to patrol with a Sec officer (or Paramedic) and give them up-to-date info on a crew member's status just by having the human ask about them. Or, Engiborgs are given the ability to keep an eye on the Supermatter using NT CIMS and can inform engineers out in the field of its status. 

Just having this general information available only to humans feels a bit silly when cyborgs are meant to be connected to the station in a way that allows them to interact with doors from a distance but not something simpler like viewing a crew manifest. This still keeps the power in human's hands since this data cannot be manipulated by borgs, only humans (ID required).
## Changelog
:cl:
add: Added three programs to cyborg PDAs: SiliConnect, AtmoZphere, and Crew Manifest
/:cl:
