### PR TITLE
Removed 80% chance to waste resources when expanding into space

### DIFF
--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -172,10 +172,6 @@
 		return
 	var/make_blob = TRUE //can we make a blob?
 
-	if(isspaceturf(T) && !(locate(/obj/structure/lattice) in T) && prob(80))
-		make_blob = FALSE
-		playsound(src.loc, 'sound/effects/splat.ogg', 50, TRUE) //Let's give some feedback that we DID try to spawn in space, since players are used to it
-
 	ConsumeTile() //hit the tile we're in, making sure there are no border objects blocking us
 	if(!T.CanPass(src, get_dir(T, src))) //is the target turf impassable
 		make_blob = FALSE


### PR DESCRIPTION

## About The Pull Request
Blob had a hard-coded 0.8 probability to waste resources and do nothing when you manually expand into space. This PR removes that.
## Why It's Good For The Game
If you are a blob and you are adjacent to space (most likely because blob nodes auto-expansion broke the outer station walls), you will be easily gunned down with 10 000 lasers from space, and there's nothing you can do (literally). This has to change.
To put this into perspective, consider: with how things currently are, you can spend 100 resource (maximum storage) to:
A) make a blobbernaut
B) make 2-3 resource nodes
C) make 2 blob nodes that auto expand or
D) expand 5 tiles into space (on average)
One of these things is not like the other.
P. S. expanding into space still doesn't count towards the goal
## Changelog
:cl:
balance: removed 80% chance to waste resources when expanding into space
/:cl:
