### PR TITLE
Minor rewording in mouse description

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -1,6 +1,6 @@
 /mob/living/basic/mouse
 	name = "mouse"
-	desc = "This cute little guy just loves the taste of uninsulated electrical cables. Isn't he adorable?"
+	desc = "This cute little guy just loves the taste of insulated electrical cables. Isn't he adorable?"
 	icon_state = "mouse_gray"
 	icon_living = "mouse_gray"
 	icon_dead = "mouse_gray_dead"


### PR DESCRIPTION

## About The Pull Request
Description states they eat uninsulated cable. This has been changed to say they love eating *insulated* electrical cables.
## Why It's Good For The Game
All cables in the game are insulated, so this keeps things consistant. It's also more realistic, mice don't bite into electrical cables to get at the wires inside - they do it because gnawing the soft rubber or plastic insulation sharpens and maintains their teeth.
## Changelog
:cl:
spellcheck: Mice now love the taste of insulated electrical cables, not uninsulated ones.
/:cl:
