### PR TITLE
Add the broken sensor status to medical HUD text [NO GBP]

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -242,7 +242,7 @@
  */
 /obj/item/clothing/under/proc/get_sensor_text(silent = TRUE)
 	if(has_sensor == BROKEN_SENSORS)
-		return "<font color='#cc3333'>Non-Functional. Repair with cable coil</font>"
+		return "<font color='#cc3333'>Non-Functional: Repair with cable coil</font>"
 
 	if(silent)
 		return ""

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -242,7 +242,7 @@
  */
 /obj/item/clothing/under/proc/get_sensor_text(silent = TRUE)
 	if(has_sensor == BROKEN_SENSORS)
-		return "<font color='#cc3333'>Non-Functional: Repair with cable coil</font>"
+		return "<font color='#ffcc33'>Non-Functional: Repair with cable coil</font>"
 
 	if(silent)
 		return ""

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -234,6 +234,29 @@
 
 	update_wearer_status()
 
+/**
+ * Called by medical scanners a simple summary of the status
+ *
+ * Arguments:
+ * * silent: If TRUE, will return blank if everything is fine
+ */
+/obj/item/clothing/under/proc/get_sensor_text(silent = TRUE)
+	if(has_sensor == BROKEN_SENSORS)
+		return "<font color='#cc3333'>Non-Functional. Repair with cable coil</font>"
+
+	if(silent)
+		return ""
+
+	switch(has_sensor)
+		if(NO_SENSORS)
+			return "Not Present"
+
+		if(LOCKED_SENSORS)
+			return "Functional, Locked"
+
+		if(HAS_SENSORS)
+			return "Functional"
+
 // End suit sensor handling
 
 /// Attach the passed accessory to the clothing item

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -519,13 +519,15 @@
 	. += "<a href='?src=[REF(src)];hud=m;evaluation=1;examine_time=[world.time]'>\[Medical evaluation\]</a>"
 	. += "<a href='?src=[REF(src)];hud=m;quirk=1;examine_time=[world.time]'>\[See quirks\]</a>"
 
-	if(ishuman(src))
-		var/mob/living/carbon/human/human_mob = src
-		if(istype(human_mob.w_uniform, /obj/item/clothing/under))
-			var/obj/item/clothing/under/undershirt = human_mob.w_uniform
-			var/sensor_text = undershirt.get_sensor_text()
-			if(sensor_text)
-				. += "Sensor Status: [sensor_text]"
+/// Collects information displayed about src when examined by a user with a medical HUD.
+/mob/living/carbon/human/get_medhud_examine_info(mob/living/user, datum/record/crew/target_record)
+	. = ..()
+
+	if(istype(w_uniform, /obj/item/clothing/under))
+		var/obj/item/clothing/under/undershirt = w_uniform
+		var/sensor_text = undershirt.get_sensor_text()
+		if(sensor_text)
+			. += "Sensor Status: [sensor_text]"
 
 /// Collects information displayed about src when examined by a user with a security HUD.
 /mob/living/carbon/proc/get_sechud_examine_info(mob/living/user, datum/record/crew/target_record)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -519,16 +519,6 @@
 	. += "<a href='?src=[REF(src)];hud=m;evaluation=1;examine_time=[world.time]'>\[Medical evaluation\]</a>"
 	. += "<a href='?src=[REF(src)];hud=m;quirk=1;examine_time=[world.time]'>\[See quirks\]</a>"
 
-/// Collects information displayed about src when examined by a user with a medical HUD.
-/mob/living/carbon/human/get_medhud_examine_info(mob/living/user, datum/record/crew/target_record)
-	. = ..()
-
-	if(istype(w_uniform, /obj/item/clothing/under))
-		var/obj/item/clothing/under/undershirt = w_uniform
-		var/sensor_text = undershirt.get_sensor_text()
-		if(sensor_text)
-			. += "Sensor Status: [sensor_text]"
-
 /// Collects information displayed about src when examined by a user with a security HUD.
 /mob/living/carbon/proc/get_sechud_examine_info(mob/living/user, datum/record/crew/target_record)
 	. = list()

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -519,6 +519,14 @@
 	. += "<a href='?src=[REF(src)];hud=m;evaluation=1;examine_time=[world.time]'>\[Medical evaluation\]</a>"
 	. += "<a href='?src=[REF(src)];hud=m;quirk=1;examine_time=[world.time]'>\[See quirks\]</a>"
 
+	if(ishuman(src))
+		var/mob/living/carbon/human/human_mob = src
+		if(istype(human_mob.w_uniform, /obj/item/clothing/under))
+			var/obj/item/clothing/under/undershirt = human_mob.w_uniform
+			var/sensor_text = undershirt.get_sensor_text()
+			if(sensor_text)
+				. += "Sensor Status: [sensor_text]"
+
 /// Collects information displayed about src when examined by a user with a security HUD.
 /mob/living/carbon/proc/get_sechud_examine_info(mob/living/user, datum/record/crew/target_record)
 	. = list()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,0 +1,9 @@
+/// Collects information displayed about src when examined by a user with a medical HUD.
+/mob/living/carbon/human/get_medhud_examine_info(mob/living/user, datum/record/crew/target_record)
+	. = ..()
+
+	if(istype(w_uniform, /obj/item/clothing/under))
+		var/obj/item/clothing/under/undershirt = w_uniform
+		var/sensor_text = undershirt.get_sensor_text()
+		if(sensor_text)
+			. += "Sensor Status: [sensor_text]"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5144,6 +5144,7 @@
 #include "code\modules\mob\living\carbon\human\death.dm"
 #include "code\modules\mob\living\carbon\human\dummy.dm"
 #include "code\modules\mob\living\carbon\human\emote.dm"
+#include "code\modules\mob\living\carbon\human\examine.dm"
 #include "code\modules\mob\living\carbon\human\human.dm"
 #include "code\modules\mob\living\carbon\human\human_context.dm"
 #include "code\modules\mob\living\carbon\human\human_defense.dm"


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/86523 added the yellow border for broken suit sensors on the medical HUD, but I forgot to put the actual text back in the appropriate examine proc after the recent examine box refactor.

![image](https://github.com/user-attachments/assets/b6547d31-ad10-4f69-8880-622041f0cc5b)

## Why It's Good For The Game

Less asking 'what does this mean?' because there's a new HUD status but no accompanying information about it.

## Changelog

:cl: LT3
fix: Fixed missing examine text for the yellow medical HUD border regarding suit sensors
/:cl: