### PR TITLE
Fix icebox's virology airlock

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -38494,6 +38494,7 @@
 	pixel_y = 32;
 	idExterior = "virology_airlock_exterior";
 	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
 	interior_airlock = "virology_airlock_control";
 	name = "Virology Access Controller";
 	req_access = list("virology")


### PR DESCRIPTION

## About The Pull Request
Arlock controller's ID got left out at some point which bricked the entire cycling airlock, fixes that
## Why It's Good For The Game
door stuck
## Changelog
:cl:
fix: Icebox's virology airlock cycles properly again
/:cl:
