### PR TITLE
Account job changes account for curator patronage, including VVedit job changes

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -411,7 +411,9 @@ SUBSYSTEM_DEF(id_access)
 
 	var/datum/job/trim_job = trim.find_job()
 	if (!isnull(trim_job) && !isnull(id_card.registered_account))
+		var/datum/job/old_job = id_card.registered_account.account_job
 		id_card.registered_account.account_job = trim_job
+		id_card.registered_account.update_account_job_lists(trim_job, old_job)
 
 	id_card.update_label()
 	id_card.update_icon()

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -44,6 +44,7 @@
 	payday_modifier = modifier
 	add_to_accounts = player_account
 	setup_unique_account_id()
+	update_account_job_lists(job)
 	pay_token = uppertext("[copytext(newname, 1, 2)][copytext(newname, -1)]-[random_capital_letter()]-[rand(1111,9999)]")
 
 /datum/bank_account/Destroy()
@@ -71,11 +72,22 @@
 	if(SSeconomy.bank_accounts_by_id["[account_id]"])
 		stack_trace("Unable to find a unique account ID, substituting currently existing account of id [account_id].")
 	SSeconomy.bank_accounts_by_id["[account_id]"] = src
-	if(account_job)
-		LAZYADD(SSeconomy.bank_accounts_by_job[account_job.type], src)
+
+/**
+ * Proc places this account into the right place in the `SSeconomy.bank_accounts_by_job` list, if needed.
+ * If an old job is given, it removes it from its previous place first.
+ */
+/datum/bank_account/proc/update_account_job_lists(datum/job/new_job, datum/job/old_job)
+	if(!add_to_accounts)
+		return
+
+	if(old_job)
+		SSeconomy.bank_accounts_by_job[old_job.type] -= src
+	LAZYADD(SSeconomy.bank_accounts_by_job[new_job.type], src)
 
 /datum/bank_account/vv_edit_var(var_name, var_value) // just so you don't have to do it manually
 	var/old_id = account_id
+	var/datum/job/old_job = account_job
 	var/old_balance = account_balance
 	. = ..()
 	switch(var_name)
@@ -83,11 +95,15 @@
 			if(add_to_accounts)
 				SSeconomy.bank_accounts_by_id -= "[old_id]"
 				setup_unique_account_id()
+		if(NAMEOF(src, account_job))
+			update_account_job_lists(account_job, old_job)
 		if(NAMEOF(src, add_to_accounts))
 			if(add_to_accounts)
 				setup_unique_account_id()
+				update_account_job_lists(account_job)
 			else
 				SSeconomy.bank_accounts_by_id -= "[account_id]"
+				SSeconomy.bank_accounts_by_job[account_job.type] -= src
 		if(NAMEOF(src, account_balance))
 			add_log_to_history(var_value - old_balance, "Nanotrasen: Moderator Action")
 


### PR DESCRIPTION

## About The Pull Request

In #86711 we made it so adjusting the trim of an id card also updated the job on the associated bank account to match, but we forgot to update `bank_accounts_by_job` to match this.
This made it so Curator painting patronage cuts wouldn't get updated to match the trim, and would risk issues with removing it from `bank_accounts_by_job` if the bank account were to get deleted.

In this pr we add a `update_account_job_lists(...)` proc that updated `bank_accounts_by_job` to match.
This fixes our issues.

Additionally, we update `vv_edit_var(...)` to also run this when changing related values, such that it actually removes and adds the values when needed.
## Why It's Good For The Game

Fixes a bug, helps with VVediting bank account jobs.
## Changelog
:cl:
fix: Changing a bank account's job to or from Curator actually changes whether they get a cut from painting patronage.
admin: VVediting a bank account's account_job actually updates what job the account is associated with. Currently only matters for Curators.
admin: VVediting a bank account's add_to_accounts actually removes it from or adds it to the job to account associations. Currently only matters for Curators.
/:cl:
