### PR TITLE
Fixes some nonhuman surgery oversights

### DIFF
--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -195,7 +195,7 @@
 
 /obj/projectile/organ/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	if(!ishuman(target))
+	if(!isliving(target))
 		organ.forceMove(drop_location())
 		organ = null
 		return

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -178,7 +178,7 @@
 		target.clear_mood_event(SURGERY_MOOD_CATEGORY) //incase they gained the trait mid-surgery. has the added side effect that if someone has a bad surgical memory/mood and gets drunk & goes back to surgery, they'll forget they hated it, which is kinda funny imo.
 		return
 	if(target.stat >= UNCONSCIOUS)
-		var/datum/mood_event/surgery/target_mood_event = target.mob_mood.mood_events[SURGERY_MOOD_CATEGORY]
+		var/datum/mood_event/surgery/target_mood_event = target.mob_mood?.mood_events[SURGERY_MOOD_CATEGORY]
 		if(!target_mood_event || target_mood_event.surgery_completed) //don't give sleeping mobs trauma. that said, if they fell asleep mid-surgery after already getting the bad mood, lets make sure they wake up to a (hopefully) happy memory.
 			return
 	switch(surgery_state)


### PR DESCRIPTION

## About The Pull Request

Added a null check to mood, because it caused runtimes. Nonhumans have mood, but they never initialize it, yet surgery mood assumes it is.

Removed unnecessary ishuman check in the organizer, allowing it to work on xenomorphs and other theoretical carbons.
## Why It's Good For The Game

> Added a null check to mood, because it caused runtimes. Nonhumans have mood, but they never initialize it, yet surgery mood assumes it is.

Bug bad

> Removed unnecessary ishuman check in the organizer, allowing it to work on xenomorphs and other theoretical carbons.

Oversight bad
## Changelog
:cl:
fix: Added a null check to mood, because it caused runtimes. Nonhumans have mood, but they never initialize it, yet surgery mood assumes it is.
fix: Removed unnecessary ishuman check in the organizer, allowing it to work on xenomorphs and other theoretical carbons.
/:cl:
