### PR TITLE
Fix crew manifest not having colour

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewManifest.jsx
+++ b/tgui/packages/tgui/interfaces/CrewManifest.jsx
@@ -1,5 +1,5 @@
 import { Icon, Section, Table, Tooltip } from 'tgui-core/components';
-import { classes } from 'tgui-core/react';
+import { classes } from '../../common/react';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';


### PR DESCRIPTION

## About The Pull Request

Adds color back to the lobby crew manifest.

Fixes #84768.
## Why It's Good For The Game

Adds colour back to the lobby crew manifest, fixing a previous issue.
## Changelog
:cl:
fix: Lobby crew manifest has colour again
/:cl:
