### PR TITLE
Replaces the security NVGs in Metastation Central bitrunner domain with generic ones

### DIFF
--- a/_maps/virtual_domains/meta_central.dmm
+++ b/_maps/virtual_domains/meta_central.dmm
@@ -4413,14 +4413,14 @@
 /area/virtual_domain)
 "Lq" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/glasses/hud/security/night{
-	pixel_x = -8;
-	pixel_y = -6
+/obj/item/clothing/glasses/night/colorless{
+	pixel_x = 5;
+	pixel_y = 7
 	},
-/obj/item/clothing/glasses/hud/security/night,
-/obj/item/clothing/glasses/hud/security/night{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/item/clothing/glasses/night/colorless,
+/obj/item/clothing/glasses/night/colorless{
+	pixel_x = -5;
+	pixel_y = -3
 	},
 /turf/template_noop,
 /area/virtual_domain/safehouse)


### PR DESCRIPTION

## About The Pull Request

This swaps out the security NVGs in the Metastation Central bitrunner domain with regular ones.

These NVGs are the colorless variant, so nothing is changed beyond not being able to access sec records.
## Why It's Good For The Game

Closes #86645.
## Changelog
:cl: Rhials
fix: You can no longer backdoor security records using the Metastation Central bitrunner domain.
/:cl:
