### PR TITLE
A better fix for robotic revival surgeries showing on basic mobs

### DIFF
--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -47,6 +47,13 @@
 		return FALSE
 	return TRUE
 
+/datum/surgery/revival/mechanic/is_valid_target(mob/living/patient)
+	if (iscarbon(patient))
+		return FALSE
+	if (!(patient.mob_biotypes & (MOB_ROBOTIC|MOB_HUMANOID)))
+		return FALSE
+	return TRUE
+
 /datum/surgery_step/revive
 	name = "shock brain (defibrillator)"
 	implements = list(


### PR DESCRIPTION

## About The Pull Request

Prevents robotic revival from appearing on non-robotic basic mobs. Better fix, thanks to Melbert.

## Changelog
:cl:
fix: Fixed robotic revival surgery showing up for simplemobs
/:cl:
