### PR TITLE
New traitor flavors

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -153,46 +153,54 @@
 /// JSON file containing spy objectives
 #define SPY_OBJECTIVE_FILE "antagonist_flavor/spy_objective.json"
 
-///employers that are from the syndicate
+///traitors that are from the syndicate or alligned with the syndicate
 GLOBAL_LIST_INIT(syndicate_employers, list(
 	"Animal Rights Consortium",
 	"Bee Liberation Front",
 	"Cybersun Industries",
+	"Defector",
 	"Donk Corporation",
 	"Gorlex Marauders",
+	"Hired Mercenary",
 	"MI13",
+	"Radicalized",
 	"Tiger Cooperative Fanatic",
 	"Waffle Corporation Terrorist",
 	"Waffle Corporation",
 ))
-///employers that are from Nanotrasen
-GLOBAL_LIST_INIT(nanotrasen_employers, list(
+///traitors that are not from the syndicate
+GLOBAL_LIST_INIT(neutral_employers, list(
 	"Champions of Evil",
 	"Corporate Climber",
 	"Gone Postal",
-	"Internal Affairs Agent",
+	"Rival Saboteur",
 	"Legal Trouble",
 ))
 
-///employers who hire agents to do the hijack
+///employers who only hire agents to do the hijack
 GLOBAL_LIST_INIT(hijack_employers, list(
-	"Animal Rights Consortium",
-	"Bee Liberation Front",
 	"Gone Postal",
-	"Tiger Cooperative Fanatic",
 	"Waffle Corporation Terrorist",
 ))
 
-///employers who hire agents to do a task and escape... or martyrdom. whatever
-GLOBAL_LIST_INIT(normal_employers, list(
+///employers who might be hire agents to hyjack
+GLOBAL_LIST_INIT(maybe_hijack_employers, list(
+	"Animal Rights Consortium",
+	"Bee Liberation Front",
+	"Tiger Cooperative Fanatic",
+	"Radicalized",
+))
+
+///employers who will never hire agents to hyjack
+GLOBAL_LIST_INIT(never_hijack_employers, list(
 	"Champions of Evil",
 	"Corporate Climber",
 	"Cybersun Industries",
+	"Defector",
 	"Donk Corporation",
-	"Gorlex Marauders",
-	"Internal Affairs Agent",
 	"Legal Trouble",
 	"MI13",
+	"Rival Saboteur",
 	"Waffle Corporation",
 ))
 

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -153,7 +153,7 @@
 /// JSON file containing spy objectives
 #define SPY_OBJECTIVE_FILE "antagonist_flavor/spy_objective.json"
 
-///traitors that are from the syndicate or alligned with the syndicate
+///traitors that are from the syndicate or aligned with the syndicate
 GLOBAL_LIST_INIT(syndicate_employers, list(
 	"Animal Rights Consortium",
 	"Bee Liberation Front",
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(maybe_hijack_employers, list(
 	"Radicalized",
 ))
 
-///employers who will never hire agents to hyjack
+///employers who will never hire agents to hijack
 GLOBAL_LIST_INIT(never_hijack_employers, list(
 	"Champions of Evil",
 	"Corporate Climber",

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -187,21 +187,14 @@
 
 /datum/antagonist/traitor/proc/pick_employer()
 	if(!employer)
-		var/faction = prob(75) ? FLAVOR_FACTION_SYNDICATE : FLAVOR_FACTION_NANOTRASEN
 		var/list/possible_employers = list()
 
-		possible_employers.Add(GLOB.syndicate_employers, GLOB.nanotrasen_employers)
+		possible_employers.Add(GLOB.syndicate_employers, GLOB.neutral_employers)
 
 		if(istype(ending_objective, /datum/objective/hijack))
-			possible_employers -= GLOB.normal_employers
+			possible_employers -= GLOB.never_hijack_employers
 		else //escape or martyrdom
 			possible_employers -= GLOB.hijack_employers
-
-		switch(faction)
-			if(FLAVOR_FACTION_SYNDICATE)
-				possible_employers -= GLOB.nanotrasen_employers
-			if(FLAVOR_FACTION_NANOTRASEN)
-				possible_employers -= GLOB.syndicate_employers
 		employer = pick(possible_employers)
 	traitor_flavor = strings(TRAITOR_FLAVOR_FILE, employer)
 
@@ -209,7 +202,7 @@
 /datum/antagonist/traitor/proc/forge_traitor_objectives()
 	var/objective_count = 0
 
-	if((GLOB.joined_player_list.len >= HIJACK_MIN_PLAYERS) && prob(HIJACK_PROB))
+	if(/*(GLOB.joined_player_list.len >= HIJACK_MIN_PLAYERS) && */prob(HIJACK_PROB))
 		is_hijacker = TRUE
 		objective_count++
 

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -24,7 +24,10 @@
 		nuke.r_code = random_nukecode()
 	team.nuke = nuke
 	team.update_objectives()
-	handler.owner.add_antag_datum(/datum/antagonist/battlecruiser/ally, team)
+	var/datum/antagonist/traitor/traitor_datum = handler.owner.has_antag_datum(/datum/antagonist/traitor)
+	for(var/employers in GLOB.syndicate_employers)
+		if(traitor_datum.employer == employers)
+			handler.owner.add_antag_datum(/datum/antagonist/battlecruiser/ally, team)
 
 
 /datum/traitor_objective/ultimate/battlecruiser/generate_ui_buttons(mob/user)

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -1,6 +1,6 @@
 {
 	"Animal Rights Consortium": {
-		"allies": "You may cooperate with other syndicate operatives if they support our cause. Maybe you can convince the Bee Liberation Front operatives to cooperate for once?",
+		"allies": "You may cooperate with other Syndicate operatives if they support our cause. Maybe you can convince the Bee Liberation Front operatives to cooperate for once?",
 		"goal": "The creatures of this world must be freed from the iron grasp of Nanotrasen, and you are their only hope!",
 		"introduction": "You are the ARC Terrorist.",
 		"roundend_report": "was an activist from the Animal Rights Consortium.",
@@ -8,7 +8,7 @@
 		"uplink": "The Syndicate have graciously given one of their uplinks for your task."
 	},
 	"Bee Liberation Front": {
-		"allies": "You may cooperate with other syndicate operatives if they support our cause. Maybe you can recruit an Animal Rights Consort to be useful for once?",
+		"allies": "You may cooperate with other Syndicate operatives if they support our cause. Maybe you can recruit an Animal Rights Consort to be useful for once?",
 		"goal": "We must prove ourselves to the Syndicate or we will not be able to join. Animal Rights Consort will roll us!",
 		"introduction": "You are the Bee Liberation Front Operative.",
 		"roundend_report": "was an activist of the Bee Liberation Front.",
@@ -32,12 +32,20 @@
 		"uplink": "You have connections to the black market for the deeds. Knock off a few loose weights, and your climb will be so much smoother."
 	},
 	"Cybersun Industries": {
-		"allies": "Fellow Cybersun operatives are to be trusted. Members of the MI13 organization can be trusted. All other syndicate operatives are not to be trusted.",
+		"allies": "Fellow Cybersun operatives are to be trusted. Members of the MI13 organization can be trusted. All other Syndicate operatives are not to be trusted.",
 		"goal": "Do not establish substantial presence on the designated facility, as larger incidents are harder to cover up.",
 		"introduction": "You are from Cybersun Industries.",
 		"roundend_report": "was a specialist from Cybersun Industries.",
 		"ui_theme": "syndicate",
-		"uplink": "You have been supplied the tools for the job in the form of a standard syndicate uplink."
+		"uplink": "You have been supplied the tools for the job in the form of a standard Syndicate uplink."
+	},
+	"Defector": {
+		"allies": "You are new to the secret agent business, be wary of others and look out for yourself.",
+		"goal": "The Syndicate picked the right time to offer you money. Do their dirty work for them and get paid.",
+		"introduction": "You are the Syndicate Defector.",
+		"roundend_report": "was a Syndicate defector.",
+		"ui_theme": "syndicate",
+		"uplink": "Last week you picked up a Syndicate uplink from a dead-drop. Now is the time to use it."
 	},
 	"Donk Corporation": {
 		"allies": "Members of Waffle Corp. are to be killed on sight; they are not allowed to be on the station while we're around.",
@@ -48,7 +56,7 @@
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
 	},
 	"Gone Postal": {
-		"allies": "If the syndicate learns of your plan, they're going to kill you and take your uplink. Take no chances.",
+		"allies": "If the Syndicate learns of your plan, they're going to kill you and take your uplink. Take no chances.",
 		"goal": "The preparations are finally complete. Today is the day you go postal. You're going to hijack the emergency shuttle and live a new life free of Nanotrasen.",
 		"introduction": "You're going postal today.",
 		"roundend_report": "simply went completely postal!",
@@ -63,14 +71,6 @@
 		"ui_theme": "syndicate",
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
 	},
-	"Internal Affairs Agent": {
-		"allies": "Do NOT reveal your agent status, to anyone. Work to root out corruption from the station from the shadows.",
-		"goal": "While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.",
-		"introduction": "You are the Internal Affairs Agent.",
-		"roundend_report": "was part of Nanotrasen Internal Affairs.",
-		"ui_theme": "ntos",
-		"uplink": "For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink."
-	},
 	"Legal Trouble": {
 		"allies": "Death to the Syndicate.",
 		"goal": "Try to finish your to-do list, and don't get caught. If they find out what you're actually doing, this scandal will go galactic.",
@@ -79,13 +79,37 @@
 		"ui_theme": "neutral",
 		"uplink": "You've connected to the black market to clean this mess up. If there's no evidence, there's no crime."
 	},
+	"Hired Mercenary": {
+		"allies": "The Syndicate hired you, but their agents are notoriously twitchy. Use your own judgment to decide who can be trusted.",
+		"goal": "This job pays enough to finally get out of the business. Complete your work, and you'll be sipping drinks on the beach in no time.",
+		"introduction": "You are the Syndicate Hired Mercenary.",
+		"roundend_report": "was a Syndicate hired mercenary.",
+		"ui_theme": "syndicate",
+		"uplink": "You've been supplied a Syndicate uplink for this mission."
+	},
 	"MI13": {
-		"allies": "You are the only operative we are sending, any others are fake. All other syndicate operatives are not to be trusted, with the exception of Cybersun operatives.",
+		"allies": "You are the only operative we are sending, any others are fake. All other Syndicate operatives are not to be trusted, with the exception of Cybersun operatives.",
 		"goal": "Avoid killing innocent personnel at all costs. You are not here to mindlessly kill people, as that would attract too much attention and is not our goal. Avoid detection at all costs.",
 		"introduction": "You are the MI13 Agent.",
 		"roundend_report": "was an MI13 agent.",
 		"ui_theme": "syndicate",
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
+	},
+	"Rival Saboteur": {
+		"allies": "Don't make your true alligences obvious. Syndicate agents could make unlikely allies if you could trick them into thinking you are one of them.",
+		"goal": "Sabotage the station to make this division look bad. Make this look like a Syndicate job, you can't let it be traced back to your sector.",
+		"introduction": "You are a saboteur from a rival division of nanotrasen.",
+		"roundend_report": "was a Rival Saboteur.",
+		"ui_theme": "ntos",
+		"uplink": "You have been given a captured Syndicate uplink to get your task done."
+	},
+	"Radicalized": {
+		"allies": "Down with Nanotrasen's tyrany! Surround yourself with likeminded indivduals.",
+		"goal": "Bring down the nanotrasen's establishment! You've got a list of targets in mind.",
+		"introduction": "You have been radicalized by the Syndicate.",
+		"roundend_report": "was radicalized by the Syndicate.",
+		"ui_theme": "syndicate",
+		"uplink": "After weeks of sending messages, the Syndicate has finally sent you your own personal uplink. So rad!"
 	},
 	"Tiger Cooperative Fanatic": {
 		"allies": "Only the enlightened Tiger brethren can be trusted; all others must be expelled from this mortal realm!",
@@ -105,7 +129,7 @@
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
 	},
 	"Waffle Corporation Terrorist": {
-		"allies": "Most other syndicate operatives are not to be trusted, except for members of the Gorlex Marauders. Do not trust fellow members of the Waffle.co (but try not to rat them out), as they might have been assigned opposing objectives.",
+		"allies": "Most other Syndicate operatives are not to be trusted, except for members of the Gorlex Marauders. Do not trust fellow members of the Waffle.co (but try not to rat them out), as they might have been assigned opposing objectives.",
 		"goal": "Our investors need a demonstration of our pledge to destroying Nanotrasen. Let's give them a loud one!",
 		"introduction": "You are the Waffle Corporation Terrorist.",
 		"roundend_report": "was a terrorist from Waffle Corporation.",

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -42,7 +42,7 @@
 	"Defector": {
 		"allies": "You are new to the secret agent business, be wary of others and look out for yourself.",
 		"goal": "The Syndicate picked the right time to offer you money. Do their dirty work for them and get paid.",
-		"introduction": "You are the Syndicate Defector.",
+		"introduction": "You are a Syndicate Defector.",
 		"roundend_report": "was a Syndicate defector.",
 		"ui_theme": "syndicate",
 		"uplink": "Last week you picked up a Syndicate uplink from a dead-drop. Now is the time to use it."
@@ -82,7 +82,7 @@
 	"Hired Mercenary": {
 		"allies": "The Syndicate hired you, but their agents are notoriously twitchy. Use your own judgment to decide who can be trusted.",
 		"goal": "This job pays enough to finally get out of the business. Complete your work, and you'll be sipping drinks on the beach in no time.",
-		"introduction": "You are the Syndicate Hired Mercenary.",
+		"introduction": "You are a Syndicate Hired Mercenary.",
 		"roundend_report": "was a Syndicate hired mercenary.",
 		"ui_theme": "syndicate",
 		"uplink": "You've been supplied a Syndicate uplink for this mission."
@@ -96,7 +96,7 @@
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
 	},
 	"Rival Saboteur": {
-		"allies": "Don't make your true alligences obvious. Syndicate agents could make unlikely allies if you could trick them into thinking you are one of them.",
+		"allies": "Don't make your true allegiances obvious. Syndicate agents could make unlikely allies if you could trick them into thinking you are one of them.",
 		"goal": "Sabotage the station to make this division look bad. Make this look like a Syndicate job, you can't let it be traced back to your sector.",
 		"introduction": "You are a saboteur from a rival division of nanotrasen.",
 		"roundend_report": "was a Rival Saboteur.",
@@ -104,7 +104,7 @@
 		"uplink": "You have been given a captured Syndicate uplink to get your task done."
 	},
 	"Radicalized": {
-		"allies": "Down with Nanotrasen's tyrany! Surround yourself with likeminded indivduals.",
+		"allies": "Down with Nanotrasen! Surround yourself with like-minded individuals.",
 		"goal": "Bring down the nanotrasen's establishment! You've got a list of targets in mind.",
 		"introduction": "You have been radicalized by the Syndicate.",
 		"roundend_report": "was radicalized by the Syndicate.",

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -96,7 +96,7 @@
 		"uplink": "You have been provided with a standard uplink to accomplish your task."
 	},
 	"Rival Saboteur": {
-		"allies": "Don't make your true alligences obvious. Syndicate agents could make unlikely allies if you could trick them into thinking you are one of them.",
+		"allies": "Don't make your true alligences obvious. The Syndicate are scum, but you might be able to work them to your advantage.",
 		"goal": "Sabotage the station to make this division look bad. Make this look like a Syndicate job, you can't let it be traced back to your sector.",
 		"introduction": "You are a saboteur from a rival division of nanotrasen.",
 		"roundend_report": "was a Rival Saboteur.",
@@ -109,7 +109,7 @@
 		"introduction": "You have been radicalized by the Syndicate.",
 		"roundend_report": "was radicalized by the Syndicate.",
 		"ui_theme": "syndicate",
-		"uplink": "After weeks of sending messages, the Syndicate has finally sent you your own personal uplink. So rad!"
+		"uplink": "After a lot of work and studying surfing underbelly web forums, you've pieced together your very own Syndicate uplink."
 	},
 	"Tiger Cooperative Fanatic": {
 		"allies": "Only the enlightened Tiger brethren can be trusted; all others must be expelled from this mortal realm!",


### PR DESCRIPTION

## About The Pull Request
Adds new traitor flavors:

Defector: A Nanotrasen employee bribed to achieve syndicate interests
Radicalized: a Nanotrasen employee who has been radicalized by syndicate ideology (maybe all those posters they have been hanging up)
Hired Mercenary: A high profile mercenary hired by the syndicate to get their dirty work done.

Internal affair agent has been changed to Rival Saboteur

Rival Saboteur: A member of a different rival Nanotrasen division, sent to the station to sabotage and make it look like a syndicate job. Maybe they are jealous of ss13's high funding.

Additionally:
Traitors who are not directly affiliated with the syndicate no longer get added to the battle cruiser team if they summon it.
Some traitors are now on the "maybe hijack" list, as opposed to being devided into traitors that only hijack and traitors that never hijack. Because hijack is pretty rare, this lets some of those traitors show up more often.
## Why It's Good For The Game
New flavors are fun. Internal affairs agent has some particularly bad clashes with how traitor is played, like calling cards and the battle cruiser and all that, so this is a bit of a twist on it to make it work.
## Changelog
:cl: itseasytosee
del: Non-syndicate aligned flavors will not be added to the battlecrusier team if they summon it.
spellcheck: replaced IAA with 4 other traitor flavors
/:cl:
