### PR TITLE
Removes caps from many improper items

### DIFF
--- a/code/game/objects/items/etherealdiscoball.dm
+++ b/code/game/objects/items/etherealdiscoball.dm
@@ -1,5 +1,5 @@
 /obj/item/etherealballdeployer
-	name = "Portable Ethereal Disco Ball"
+	name = "portable ethereal disco ball"
 	desc = "Press the button for a deployment of slightly-unethical PARTY!"
 	icon = 'icons/obj/devices/remote.dmi'
 	icon_state = "ethdisco"
@@ -11,7 +11,7 @@
 	qdel(src)
 
 /obj/structure/etherealball
-	name = "Ethereal Disco Ball"
+	name = "ethereal disco ball"
 	desc = "The ethics of this discoball are questionable."
 	icon = 'icons/obj/machines/floor.dmi'
 	icon_state = "ethdisco_head_0"

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -79,7 +79,7 @@
 	reagents.add_reagent(extra_reagent, 3)
 
 /obj/item/food/donut/meat
-	name = "Meat Donut"
+	name = "meat donut"
 	desc = "Tastes as gross as it looks."
 	icon_state = "donut_meat"
 	food_reagents = list(

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -339,7 +339,7 @@
 	crafting_complexity = FOOD_COMPLEXITY_5
 
 /obj/item/food/branrequests
-	name = "Bran Requests Cereal"
+	name = "bran requests cereal"
 	desc = "A dry cereal that satiates your requests for bran. Tastes uniquely like raisins and salt."
 	icon_state = "bran_requests"
 	food_reagents = list(
@@ -422,7 +422,7 @@
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/crab_rangoon
-	name = "Crab Rangoon"
+	name = "crab rangoon"
 	desc = "Has many names, like crab puffs, cheese won'tons, crab dumplings? Whatever you call them, they're a fabulous blast of cream cheesy crab."
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "crabrangoon"

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -575,7 +575,7 @@
 		new /obj/item/ammo_casing/harpoon(src)
 
 /obj/item/storage/bag/rebar_quiver
-	name = "Rebar Storage Quiver"
+	name = "rebar quiver"
 	icon = 'icons/obj/weapons/bows/quivers.dmi'
 	icon_state = "rebar_quiver"
 	worn_icon_state = "rebar_quiver"

--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/neck/heretic_focus
-	name = "Amber Focus"
+	name = "amber focus"
 	desc = "An amber focusing glass that provides a link to the world beyond. The necklace seems to twitch, but only when you look at it from the corner of your eye."
 	icon_state = "eldritch_necklace"
 	w_class = WEIGHT_CLASS_SMALL
@@ -10,7 +10,7 @@
 	AddElement(/datum/element/heretic_focus)
 
 /obj/item/clothing/neck/heretic_focus/crimson_medallion
-	name = "Crimson Medallion"
+	name = "crimson medallion"
 	desc = "A blood-red focusing glass that provides a link to the world beyond, and worse. Its eye is constantly twitching and gazing in all directions. It almost seems to be silently screaming..."
 	icon_state = "crimson_medallion"
 	/// The aura healing component. Used to delete it when taken off.
@@ -105,7 +105,7 @@
 		. += span_red("You can also squeeze it to recover a large amount of health quickly, at a cost...")
 
 /obj/item/clothing/neck/eldritch_amulet
-	name = "Warm Eldritch Medallion"
+	name = "warm eldritch medallion"
 	desc = "A strange medallion. Peering through the crystalline surface, the world around you melts away. You see your own beating heart, and the pulsing of a thousand others."
 	icon = 'icons/obj/antags/eldritch.dmi'
 	icon_state = "eye_medalion"
@@ -134,7 +134,7 @@
 	user.update_sight()
 
 /obj/item/clothing/neck/eldritch_amulet/piercing
-	name = "Piercing Eldritch Medallion"
+	name = "piercing eldritch medallion"
 	desc = "A strange medallion. Peering through the crystalline surface, the light refracts into new and terrifying spectrums of color. You see yourself, reflected off cascading mirrors, warped into impossible shapes."
 	heretic_only_trait = TRAIT_XRAY_VISION
 
@@ -149,7 +149,7 @@
 
 // The amulet conversion tool used by moon heretics
 /obj/item/clothing/neck/heretic_focus/moon_amulet
-	name = "Moonlight Amulet"
+	name = "moonlight amulet"
 	desc = "A piece of the mind, the soul and the moon. Gazing into it makes your head spin and hear whispers of laughter and joy."
 	icon = 'icons/obj/antags/eldritch.dmi'
 	icon_state = "moon_amulette"

--- a/code/modules/clothing/under/accessories/tribal.dm
+++ b/code/modules/clothing/under/accessories/tribal.dm
@@ -12,7 +12,7 @@
 	attachment_slot = GROIN
 
 /obj/item/clothing/accessory/skilt
-	name = "Sinew Skirt"
+	name = "sinew skirt"
 	desc = "For the last time. IT'S A KILT not a skirt."
 	icon_state = "skilt"
 	minimize_when_attached = FALSE

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -417,7 +417,7 @@
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/gi
-	name = "Martial Artist Gi"
+	name = "martial gi"
 	desc = "Assistant, nukie, whatever. You can beat anyone; it's called hard work!"
 	icon_state = "martial_arts_gi"
 	greyscale_config = /datum/greyscale_config/gi
@@ -434,13 +434,13 @@
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/item/clothing/under/costume/gi/goku
-	name = "Sacred Gi"
+	name = "sacred gi"
 	desc = "Created by a man who touched the hearts and lives of many."
 	icon_state = "martial_arts_gi_goku"
 	greyscale_colors = "#f89925#3e6dd7"
 
 /obj/item/clothing/under/costume/traditional
-	name = "Traditional Suit"
+	name = "traditional suit"
 	desc = "A full, vibrantly coloured suit. Likely with traditional purposes. Maybe the colours represent a familly, clan, or rank, who knows."
 	icon_state = "tradition"
 	inhand_icon_state = null
@@ -448,7 +448,7 @@
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/loincloth
-	name = "Leather Loincloth"
+	name = "leather loincloth"
 	desc = "Just a piece of leather to cover private areas. Itchy to the touch. Whoever made this must have been desperate, or savage."
 	icon_state = "loincloth"
 	inhand_icon_state = null

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -15,7 +15,7 @@
 	icon_state = "blue_pyjamas"
 
 /obj/item/clothing/under/misc/patriotsuit
-	name = "Patriotic Suit"
+	name = "patriotic suit"
 	desc = "Motorcycle not included."
 	icon_state = "ek"
 	inhand_icon_state = null

--- a/code/modules/events/holiday/easter.dm
+++ b/code/modules/events/holiday/easter.dm
@@ -75,7 +75,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/suit/costume/bunnysuit
-	name = "Easter Bunny suit"
+	name = "easter bunny suit"
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
@@ -88,7 +88,7 @@
 
 //Bunny bag!
 /obj/item/storage/backpack/satchel/bunnysatchel
-	name = "Easter Bunny satchel"
+	name = "easter bunny satchel"
 	desc = "Good for your eyes."
 	icon_state = "satchel_carrot"
 	inhand_icon_state = null

--- a/code/modules/events/holiday/easter.dm
+++ b/code/modules/events/holiday/easter.dm
@@ -66,7 +66,7 @@
 
 //Bunny Suit
 /obj/item/clothing/head/costume/bunnyhead
-	name = "Easter Bunny Head"
+	name = "Easter Bunny head"
 	icon_state = "bunnyhead"
 	inhand_icon_state = null
 	desc = "Considerably more cute than 'Frank'."
@@ -75,7 +75,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/suit/costume/bunnysuit
-	name = "Easter Bunny Suit"
+	name = "Easter Bunny suit"
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
@@ -88,7 +88,7 @@
 
 //Bunny bag!
 /obj/item/storage/backpack/satchel/bunnysatchel
-	name = "Easter Bunny Satchel"
+	name = "Easter Bunny satchel"
 	desc = "Good for your eyes."
 	icon_state = "satchel_carrot"
 	inhand_icon_state = null

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -603,7 +603,7 @@
 	SEND_SIGNAL(target, COMSIG_ATOM_RESTYLE, user, target, user.zone_selected, EXTERNAL_RESTYLE_PLANT, 6 SECONDS)
 
 /obj/item/geneshears
-	name = "Botanogenetic Plant Shears"
+	name = "botanogenetic plant shears"
 	desc = "A high tech, high fidelity pair of plant shears, capable of cutting genetic traits out of a plant."
 	icon = 'icons/obj/service/hydroponics/equipment.dmi'
 	icon_state = "genesheers"

--- a/code/modules/jobs/job_types/chaplain/chaplain_costumes.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_costumes.dm
@@ -222,7 +222,7 @@
 	inhand_icon_state = null
 
 /obj/item/clothing/suit/chaplainsuit/armor/crusader
-	name = "Crusader's Armour"
+	name = "crusader's armour"
 	desc = "Armour that's comprised of metal and cloth."
 	icon_state = "crusader"
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 	new /obj/item/reagent_containers/cup/glass/bottle/whiskey(src)
 
 /obj/item/book/bible/syndicate
-	name = "Syndicate Tome"
+	name = "syndicate tome"
 	desc = "A very ominous tome resembling a bible."
 	icon_state ="ebook"
 	item_flags = NO_BLOOD_ON_ITEM

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -319,7 +319,7 @@
 // Old Semi-Auto Rifle //
 
 /obj/item/gun/ballistic/automatic/surplus
-	name = "Surplus Rifle"
+	name = "surplus rifle"
 	desc = "One of countless obsolete ballistic rifles that still sees use as a cheap deterrent. Uses 10mm ammo and its bulky frame prevents one-hand firing."
 	icon_state = "surplus"
 	worn_icon_state = null

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -192,7 +192,7 @@
 		spread = 50
 
 /obj/item/gun/ballistic/rifle/rebarxbow
-	name = "Heated Rebar Crossbow"
+	name = "heated rebar Crossbow"
 	desc = "A handcrafted crossbow. \
 		   Aside from conventional sharpened iron rods, it can also fire specialty ammo made from the atmos crystalizer - zaukerite, metallic hydrogen, and healium rods all work. \
 		   Very slow to reload - you can craft the crossbow with a crowbar to loosen the crossbar, but risk a misfire, or worse..."
@@ -265,7 +265,7 @@
 		. += "[initial(icon_state)]" + "_bolt_locked"
 
 /obj/item/gun/ballistic/rifle/rebarxbow/forced
-	name = "Stressed Rebar Crossbow"
+	name = "stressed rebar crossbow"
 	desc = "Some idiot decided that they would risk shooting themselves in the face if it meant they could have a draw this crossbow a bit faster. Hopefully, it was worth it."
 	// Feel free to add a recipe to allow you to change it back if you would like, I just wasn't sure if you could have two recipes for the same thing.
 	can_misfire = TRUE
@@ -274,7 +274,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/force
 
 /obj/item/gun/ballistic/rifle/rebarxbow/syndie
-	name = "Syndicate Rebar Crossbow"
+	name = "syndicate rebar crossbow"
 	desc = "The syndicate liked the bootleg rebar crossbow NT engineers made, so they showed what it could be if properly developed. \
 			Holds three shots without a chance of exploding, and features a built in scope. Compatible with all known crossbow ammunition."
 	icon_state = "rebarxbowsyndie"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -192,7 +192,7 @@
 		spread = 50
 
 /obj/item/gun/ballistic/rifle/rebarxbow
-	name = "heated rebar Crossbow"
+	name = "heated rebar crossbow"
 	desc = "A handcrafted crossbow. \
 		   Aside from conventional sharpened iron rods, it can also fire specialty ammo made from the atmos crystalizer - zaukerite, metallic hydrogen, and healium rods all work. \
 		   Very slow to reload - you can craft the crossbow with a crowbar to loosen the crossbar, but risk a misfire, or worse..."

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -4,7 +4,7 @@
 #define DOAFTER_IMPLANTING_HEART "implanting"
 
 /obj/item/organ/internal/heart/cybernetic/anomalock
-	name = "Voltaic Combat Cyberheart"
+	name = "voltaic combat cyberheart"
 	desc = "A cutting-edge cyberheart, originally designed for Nanotrasen killsquad usage but later declassified for normal research. Voltaic technology allows the heart to keep the body upright in dire circumstances, alongside redirecting anomalous flux energy to fully shield the user from shocks and electro-magnetic pulses. Requires a refined Flux core as a power source."
 	icon_state = "anomalock_heart"
 	bleed_prevention = TRUE


### PR DESCRIPTION

## About The Pull Request

Removes caps from many improper items.
For example - Heated Rebar Crossbow -> heated rebar crossbow

I've kept a lot of items untouched because for some reason or another it felt nicer to me that they be, uh, capsed. For example Hat of the Honkmother, anything that has 'weight' to it.

There's also some minor name changes that I think fit better, such as Rebar Storage Quiver -> rebar quiver. I mean, we already know it's for storage. That's the whole point of quivers.
## Why It's Good For The Game

This is one of my biggest pet peeves, Randomly Capitalized Items For No Reason. It looks sloppy, awkward, and half-assed. This PR brings a lot of the worst offenders in line. if your name isn't a proper noun it almost never should have caps. 
## Changelog
:cl:
spellcheck: Removes caps from many improper items
/:cl:
