### PR TITLE
Makes PDAs just as robust as IDs

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -14,7 +14,8 @@
 	steel_sheet_cost = 2
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT * 3, /datum/material/glass=SMALL_MATERIAL_AMOUNT, /datum/material/plastic=SMALL_MATERIAL_AMOUNT)
 	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_ALLOW_USER_LOCATION | INTERACT_ATOM_IGNORE_MOBILITY
-
+	armor_type = /datum/armor/pda
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	icon_state_menu = "menu"
 	max_capacity = 64
 	allow_chunky = TRUE
@@ -49,6 +50,10 @@
 		/obj/item/reagent_containers/hypospray/medipen,
 		/obj/item/cigarette,
 	)
+
+/datum/armor/pda
+	fire = 100
+	acid = 100
 
 /obj/item/modular_computer/pda/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

As it turns out, IDs are totally fireproof and acidproof, which makes a lot of sense, because your ID getting melted by being caught on fire (which takes about 10-15 seconds, cumulatively, over every single time you get caught on fire forever because you can't repair most of your items). This is crippling, and we in fact have rules about stealing someone's ID as a non-antag because of how crippling of a disadvantage it is.

Well, PDAs have no armor at all, and they have no special deconstruction handling to drop IDs when they get destroyed. That's something that I'll save for another PR going over PDAs, but I instead have made PDAs just as robust as IDs; that is, acid and fireproof.
## Why It's Good For The Game

PDAs are just as important as IDs, and this prevents PDAs getting destroyed by something that wouldn't destroy the ID inside.
## Changelog
:cl:
qol: Like ID cards, PDAs are now acidproof and fireproof.

/:cl:
