### PR TITLE
Adds a warning and single retry to byond membership lookup

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -105,15 +105,19 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		load_path(parent.ckey)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
+
 		var/byond_member = parent.IsByondMember()
 		if(isnull(byond_member)) // Connection failure, retry once
 			byond_member = parent.IsByondMember()
 			var/static/admins_warned = FALSE
 			if(!admins_warned)
 				admins_warned = TRUE
-				message_admins("Byond membership lookup had a connection failure for a user. This is most likely an issue on the byond side but if this consistently happens you should bother your server operator to look into it.")
+				message_admins("BYOND membership lookup had a connection failure for a user. This is most likely an issue on the BYOND side but if this consistently happens you should bother your server operator to look into it.")
 			if(isnull(byond_member)) // Retrying didn't work, warn the user
-				to_chat(parent, span_warning("There's been a connection failure while trying to check the status of your byond membership. Reconnecting may fix the issue, or byond could be experiencing downtime."))
+				log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error.")
+				to_chat(parent, span_warning("There's been a connection failure while trying to check the status of your BYOND membership. Reconnecting may fix the issue, or BYOND could be experiencing downtime."))
+			else
+				log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error but succeeded after retry.")
 		unlock_content = !!byond_member
 		if(unlock_content)
 			max_save_slots = 8

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -568,12 +568,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/url_membership_lookup()
 	var/uri = "https://www.byond.com/members/[html_encode(parent.ckey)]?format=text"
 	var/outfile = "tmp/[parent.ckey].txt"
-	var/output
 	switch(world.system_type)
 		if(MS_WINDOWS)
-			output = world.shelleo("powershell Invoke-WebRequest -Uri '[uri]' -OutFile '[outfile]'")
+			world.shelleo("powershell Invoke-WebRequest -Uri '[uri]' -OutFile '[outfile]'")
 		if(UNIX)
-			output = world.shelleo("curl -o '[outfile]' '[uri]'")
+			world.shelleo("curl -o '[outfile]' '[uri]'")
 	if(!fexists(outfile))
 		CRASH("No file downloaded from url membership lookup.")
 	var/savefile/data = new

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -549,37 +549,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		else
 			log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error but succeeded after retry.")
 
-	if(!byond_member)
-		var/url_lookup = url_membership_lookup()
-		if(url_lookup)
-			if(isnull(byond_member))
-				log_game("Normal BYOND membership lookup for [parent.ckey] had a connection failure but url lookup succeeded.")
-			else
-				log_game("Normal BYOND membership lookup for [parent.ckey] indicated they were not a member but url lookup said they are.")
-		byond_member = url_lookup
-
 	if(isnull(byond_member))
 		to_chat(parent, span_warning("There's been a connection failure while trying to check the status of your BYOND membership. Reconnecting may fix the issue, or BYOND could be experiencing downtime."))
 
 	unlock_content = !!byond_member
 	if(unlock_content)
 		max_save_slots = 8
-
-/datum/preferences/proc/url_membership_lookup()
-	var/uri = "https://www.byond.com/members/[html_encode(parent.ckey)]?format=text"
-	var/outfile = "tmp/[parent.ckey].txt"
-	switch(world.system_type)
-		if(MS_WINDOWS)
-			world.shelleo("powershell Invoke-WebRequest -Uri '[uri]' -OutFile '[outfile]'")
-		if(UNIX)
-			world.shelleo("curl -o '[outfile]' '[uri]'")
-	if(!fexists(outfile))
-		CRASH("No file downloaded from url membership lookup.")
-	var/savefile/data = new
-	data.ImportText("/", file(outfile))
-	if(!data.dir.Find("general"))
-		CRASH("File downloaded from url membership lookup was malformed.")
-	data.cd = "general"
-	var/url_membership
-	data["is_member"] >> url_membership
-	return !!url_membership

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -106,21 +106,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
 
-		var/byond_member = parent.IsByondMember()
-		if(isnull(byond_member)) // Connection failure, retry once
-			byond_member = parent.IsByondMember()
-			var/static/admins_warned = FALSE
-			if(!admins_warned)
-				admins_warned = TRUE
-				message_admins("BYOND membership lookup had a connection failure for a user. This is most likely an issue on the BYOND side but if this consistently happens you should bother your server operator to look into it.")
-			if(isnull(byond_member)) // Retrying didn't work, warn the user
-				log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error.")
-				to_chat(parent, span_warning("There's been a connection failure while trying to check the status of your BYOND membership. Reconnecting may fix the issue, or BYOND could be experiencing downtime."))
-			else
-				log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error but succeeded after retry.")
-		unlock_content = !!byond_member
-		if(unlock_content)
-			max_save_slots = 8
+		refresh_membership()
 	else
 		CRASH("attempted to create a preferences datum without a client or mock!")
 	load_savefile()
@@ -549,3 +535,52 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			default_randomization[preference_key] = RANDOM_ENABLED
 
 	return default_randomization
+
+/datum/preferences/proc/refresh_membership()
+	var/byond_member = parent.IsByondMember()
+	if(isnull(byond_member)) // Connection failure, retry once
+		byond_member = parent.IsByondMember()
+		var/static/admins_warned = FALSE
+		if(!admins_warned)
+			admins_warned = TRUE
+			message_admins("BYOND membership lookup had a connection failure for a user. This is most likely an issue on the BYOND side but if this consistently happens you should bother your server operator to look into it.")
+		if(isnull(byond_member)) // Retrying didn't work, warn the user
+			log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error.")
+		else
+			log_game("BYOND membership lookup for [parent.ckey] failed due to a connection error but succeeded after retry.")
+
+	if(!byond_member)
+		var/url_lookup = url_membership_lookup()
+		if(url_lookup)
+			if(isnull(byond_member))
+				log_game("Normal BYOND membership lookup for [parent.ckey] had a connection failure but url lookup succeeded.")
+			else
+				log_game("Normal BYOND membership lookup for [parent.ckey] indicated they were not a member but url lookup said they are.")
+		byond_member = url_lookup
+
+	if(isnull(byond_member))
+		to_chat(parent, span_warning("There's been a connection failure while trying to check the status of your BYOND membership. Reconnecting may fix the issue, or BYOND could be experiencing downtime."))
+
+	unlock_content = !!byond_member
+	if(unlock_content)
+		max_save_slots = 8
+
+/datum/preferences/proc/url_membership_lookup()
+	var/uri = "https://www.byond.com/members/[html_encode(parent.ckey)]?format=text"
+	var/outfile = "tmp/[parent.ckey].txt"
+	var/output
+	switch(world.system_type)
+		if(MS_WINDOWS)
+			output = world.shelleo("powershell Invoke-WebRequest -Uri '[uri]' -OutFile '[outfile]'")
+		if(UNIX)
+			output = world.shelleo("curl -o '[outfile]' '[uri]'")
+	if(!fexists(outfile))
+		CRASH("No file downloaded from url membership lookup.")
+	var/savefile/data = new
+	data.ImportText("/", file(outfile))
+	if(!data.dir.Find("general"))
+		CRASH("File downloaded from url membership lookup was malformed.")
+	data.cd = "general"
+	var/url_membership
+	data["is_member"] >> url_membership
+	return !!url_membership

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -105,7 +105,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		load_path(parent.ckey)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
-		unlock_content = !!parent.IsByondMember()
+		var/byond_member = parent.IsByondMember()
+		if(isnull(byond_member)) // Connection failure, retry once
+			byond_member = parent.IsByondMember()
+			var/static/admins_warned = FALSE
+			if(!admins_warned)
+				admins_warned = TRUE
+				message_admins("Byond membership lookup had a connection failure for a user. This is most likely an issue on the byond side but if this consistently happens you should bother your server operator to look into it.")
+			if(isnull(byond_member)) // Retrying didn't work, warn the user
+				to_chat(parent, span_warning("There's been a connection failure while trying to check the status of your byond membership. Reconnecting may fix the issue, or byond could be experiencing downtime."))
+		unlock_content = !!byond_member
 		if(unlock_content)
 			max_save_slots = 8
 	else


### PR DESCRIPTION
## About The Pull Request

A few people are having issues getting byond membership features disabled even though they're a byond member. This is *likely* due to byond server troubles, and according to lummox the lookup proc should return null when a connection issue happens. So I've put some handling in there for that case as well as a single retry.

:cl:
fix: Byond membership lookup should now warn you when it fails due to a connection failure.
/:cl:
