### PR TITLE
Fix: museum keycard spawns in toilet but you can't pick it from cistern.

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
@@ -199,6 +199,6 @@
 	var/obj/structure/toilet/destination = pick(partners)
 	forceMove(destination)
 	destination.w_items += w_class
-	destination.contents += src
+	LAZYADD(destination.cistern_items, src)
 
 #undef CAFE_KEYCARD_TOILETS


### PR DESCRIPTION
## About The Pull Request

Keycard is spawning in one of gateway museum toilets contents but you can't get it. Destroying the toilet also does not give the keycard.

## Changelog

:cl:
fix: Gateway museum keycard now spawns in toilet properly.
/:cl: