### PR TITLE
Makes shipping containers hitbox match sprite

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/garbagetruck2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck2.dmm
@@ -209,10 +209,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)
-"tI" = (
-/obj/structure/tank_holder/anesthetic,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/garbagetruck/medicalwaste)
 "uo" = (
 /obj/machinery/computer/terminal{
 	content = list("Property of Spinward-Upsilon Sanitation Department. Authorised employees only.");
@@ -240,14 +236,6 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/power_store/cell/lead,
 /turf/open/floor/iron/smooth,
-/area/ruin/space/has_grav/garbagetruck/medicalwaste)
-"vM" = (
-/obj/structure/closet/cardboard,
-/obj/item/toy/plush/snakeplushie,
-/obj/item/bodypart/arm/left/robot/surplus,
-/obj/item/clothing/glasses/eyepatch,
-/obj/item/toy/nuke,
-/turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)
 "wh" = (
 /mob/living/basic/trooper/syndicate/ranged,
@@ -405,28 +393,11 @@
 /obj/item/wrench/medical,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)
-"EJ" = (
-/obj/item/stack/sticky_tape/surgical,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/garbagetruck/medicalwaste)
 "Go" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/pill/cyanide{
 	pixel_y = 8
 	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/garbagetruck/medicalwaste)
-"Gp" = (
-/obj/item/organ/internal/eyes/robotic/basic,
-/obj/item/kitchen/spoon,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/garbagetruck/medicalwaste)
-"Hx" = (
-/obj/effect/decal/cleanable/plastic,
-/obj/structure/closet/crate/freezer,
-/obj/item/skillchip/entrails_reader,
-/obj/item/mod/module/health_analyzer,
-/obj/item/shovel,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)
 "HE" = (
@@ -456,12 +427,6 @@
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)
 "Ka" = (
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/garbagetruck/medicalwaste)
-"Kk" = (
-/obj/item/wheelchair,
-/obj/item/screwdriver,
-/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)
 "Ky" = (
@@ -756,7 +721,7 @@ HE
 PM
 zZ
 hu
-vM
+CJ
 AB
 py
 io
@@ -778,7 +743,7 @@ QK
 CJ
 Um
 zb
-tI
+CJ
 CJ
 uG
 CJ
@@ -800,7 +765,7 @@ CJ
 eO
 qV
 CJ
-Kk
+CJ
 CJ
 zj
 Go
@@ -844,7 +809,7 @@ Dv
 rB
 JW
 CJ
-EJ
+CJ
 AB
 xw
 CJ
@@ -866,7 +831,7 @@ hv
 Ka
 CJ
 CJ
-Gp
+CJ
 CJ
 pD
 CJ
@@ -888,7 +853,7 @@ UJ
 RT
 Lh
 CJ
-Hx
+CJ
 CJ
 zu
 IS

--- a/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
@@ -5136,37 +5136,12 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hauntedtradingpost/office/meetingroom)
-"SF" = (
-/obj/item/target/clown{
-	pixel_y = 3
-	},
-/obj/item/bikehorn,
-/obj/item/soap/syndie{
-	pixel_y = -9
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hauntedtradingpost/maint/toystorage)
 "SK" = (
 /obj/structure/cable/layer1,
 /obj/machinery/light/red/dim/directional/east,
 /obj/structure/holosign/barrier/cyborg/cybersun_ai_shield,
 /turf/open/floor/circuit/red,
 /area/ruin/space/has_grav/hauntedtradingpost/aicore)
-"SO" = (
-/obj/item/ammo_box/foambox{
-	pixel_x = -10;
-	pixel_y = 7
-	},
-/obj/item/mod/module/recycler/donk/safe{
-	pixel_y = -3;
-	pixel_x = 7
-	},
-/obj/item/gun/ballistic/automatic/pistol/toy{
-	pixel_y = -6;
-	pixel_x = -5
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hauntedtradingpost/maint/toystorage)
 "SQ" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hauntedtradingpost/maint/toystorage)
@@ -7384,7 +7359,7 @@ ap
 YF
 yF
 HV
-SF
+SQ
 HV
 KG
 SQ
@@ -7474,7 +7449,7 @@ DX
 iz
 yF
 SQ
-SO
+SQ
 SQ
 fW
 SQ

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -209,6 +209,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "kg" = (
+/obj/effect/mapping_helpers/broken_floor,
 /obj/item/toy/plush/beeplushie{
 	desc = "How did this get here?";
 	name = "Secret bee plushie"
@@ -2081,9 +2082,9 @@ Me
 Rn
 Rn
 Zi
-kg
 QD
-aF
+QD
+kg
 QD
 Eh
 Zi

--- a/_maps/RandomZLevels/museum.dmm
+++ b/_maps/RandomZLevels/museum.dmm
@@ -2377,6 +2377,9 @@
 "tl" = (
 /obj/item/food/cake/mothmallow,
 /obj/structure/table,
+/obj/item/keycard/blue{
+	puzzle_id = "museum_secret"
+	},
 /turf/open/floor/carpet/executive,
 /area/awaymission/museum)
 "tq" = (
@@ -4343,8 +4346,8 @@
 /turf/open/floor/mineral/gold,
 /area/awaymission/museum/mothroachvoid)
 "Jk" = (
-/obj/item/toy/plush/moth,
 /obj/machinery/light/small/dim/directional/west,
+/obj/item/toy/plush/moth,
 /turf/open/floor/carpet/executive,
 /area/awaymission/museum)
 "Jl" = (
@@ -4456,13 +4459,6 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/chasm/true/no_smooth,
-/area/awaymission/museum)
-"Ks" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/item/keycard/blue{
-	puzzle_id = "museum_secret"
-	},
-/turf/open/floor/carpet/executive,
 /area/awaymission/museum)
 "Kt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36716,7 +36712,7 @@ FK
 FK
 FK
 FK
-Ks
+CL
 aw
 XK
 aK

--- a/_maps/deathmatch/backalley.dmm
+++ b/_maps/deathmatch/backalley.dmm
@@ -213,10 +213,6 @@
 /obj/structure/barricade/security/murderdome,
 /turf/open/indestructible/stone,
 /area/deathmatch)
-"uB" = (
-/obj/structure/fence/end,
-/turf/open/indestructible/rockyground,
-/area/deathmatch)
 "uW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -482,10 +478,6 @@
 "Pi" = (
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/random/maintenance/four,
-/turf/open/indestructible/rockyground,
-/area/deathmatch)
-"Ps" = (
-/obj/structure/fence/corner,
 /turf/open/indestructible/rockyground,
 /area/deathmatch)
 "PB" = (
@@ -948,7 +940,7 @@ xy
 Oz
 PN
 uY
-uB
+Oz
 Mh
 Oz
 Qa
@@ -1024,7 +1016,7 @@ Oz
 kc
 iQ
 Oz
-Ps
+Oz
 fT
 Oz
 sR

--- a/_maps/deathmatch/train.dmm
+++ b/_maps/deathmatch/train.dmm
@@ -329,14 +329,16 @@
 /turf/open/indestructible/plating,
 /area/deathmatch)
 "rM" = (
-/obj/structure/shipping_container/deforest,
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/fuel_pool/hivis,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/shipping_container/deforest,
 /turf/open/indestructible/plating,
 /area/deathmatch)
 "rZ" = (
@@ -391,12 +393,6 @@
 /obj/effect/decal/fakelattice{
 	density = 0
 	},
-/turf/open/indestructible/plating,
-/area/deathmatch)
-"vV" = (
-/obj/effect/decal/cleanable/fuel_pool/hivis,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/bag/money,
 /turf/open/indestructible/plating,
 /area/deathmatch)
 "vW" = (
@@ -607,12 +603,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/indestructible/plating,
-/area/deathmatch)
-"EU" = (
-/obj/item/stack/rods/ten,
-/obj/effect/decal/cleanable/fuel_pool/hivis,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/plating,
 /area/deathmatch)
 "EX" = (
@@ -1619,11 +1609,11 @@ Sy
 Sy
 Sy
 Fa
-rM
+pO
 EH
 ry
 gN
-pO
+rM
 CX
 Ht
 Sy
@@ -1663,8 +1653,8 @@ yR
 Sm
 HV
 Sm
-EU
-vV
+AR
+AR
 Mq
 Js
 Se
@@ -1701,11 +1691,11 @@ Mt
 Mt
 Mt
 YR
-Sm
+Yt
 ii
 Sm
 Mq
-Yt
+AR
 AR
 xN
 Mt

--- a/_maps/map_files/CTF/turbine.dmm
+++ b/_maps/map_files/CTF/turbine.dmm
@@ -610,6 +610,13 @@
 	dir = 1
 	},
 /area/centcom/ctf)
+"Wr" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/shipping_container/nanotrasen{
+	resistance_flags = 115
+	},
+/turf/open/floor/iron/large,
+/area/centcom/ctf)
 "XC" = (
 /obj/machinery/rnd/server{
 	resistance_flags = 115
@@ -1205,11 +1212,6 @@ MP
 yA
 Zp
 Zp
-no
-QO
-no
-QO
-no
 QO
 no
 no
@@ -1217,8 +1219,13 @@ QO
 no
 QO
 no
+no
 QO
 no
+QO
+no
+no
+QO
 no
 yA
 yA
@@ -2143,11 +2150,6 @@ zd
 yA
 no
 no
-no
-dx
-no
-dx
-no
 dx
 no
 no
@@ -2155,8 +2157,13 @@ dx
 no
 dx
 no
+no
 dx
-qH
+no
+dx
+no
+no
+Wr
 qH
 yA
 yA

--- a/code/game/objects/structures/containers.dm
+++ b/code/game/objects/structures/containers.dm
@@ -5,7 +5,7 @@
 	icon_state = "container_blank"
 	max_integrity = 1000
 	bound_width = 96
-	bound_height = 32
+	bound_height = 64
 	density = TRUE
 	anchored = TRUE
 	layer = ABOVE_ALL_MOB_LAYER


### PR DESCRIPTION

## About The Pull Request
Changes the `bound_height` of shipping containers to 64. I looked at all maps using shipping containers to make sure nothing would break. Moved a shipping container on the train deathmatch map, removed some stuff hidden behind a container on a garbage truck. Moved a bee plush. Tell me if these map changes are FUCKED UP and they're BAD.
## Why It's Good For The Game
The sprite of the shipping container suggests that they're taking up two tiles but, they only take up one. Huge ass shipping containers are not the width of one person. 
fix: #86443
## Changelog
:cl: Goat
fix: Shipping containers are now much taller and cannot hide stuff behind them. Minor map edits to accommodate these taller containers.
/:cl:
