### PR TITLE
Enable dependabot updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: master
+    schedule:
+      interval: daily
+    labels:
+      - GitHub
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Makes sure we're on the latest versions of the stuff we never check (i.e. actions/checkout).