### PR TITLE
Adds shorthand alt-click for removing tanks from TTVs and adds context for it

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -25,10 +25,37 @@
 /obj/item/transfer_valve/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_FRIED, PROC_REF(on_fried))
+	register_context()
 
 /obj/item/transfer_valve/Destroy()
 	attached_device = null
+	tank_one = null
+	tank_two = null
 	return ..()
+
+/obj/item/transfer_valve/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(tank_one || tank_two)
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Remove [tank_one || tank_two]"
+		. = CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item) && is_type_in_list(held_item, list(/obj/item/tank, /obj/item/assembly)))
+		context[SCREENTIP_CONTEXT_LMB] = "Attach [held_item]"
+		. = CONTEXTUAL_SCREENTIP_SET
+
+	return . || NONE
+
+/obj/item/transfer_valve/item_ctrl_click(mob/user)
+	if(tank_one)
+		split_gases()
+		valve_open = FALSE
+		tank_one.forceMove(drop_location())
+	else if(tank_two)
+		split_gases()
+		valve_open = FALSE
+		tank_two.forceMove(drop_location())
+
+	return CLICK_ACTION_SUCCESS
 
 /obj/item/transfer_valve/IsAssemblyHolder()
 	return TRUE

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -37,7 +37,7 @@
 	. = ..()
 
 	if(tank_one || tank_two)
-		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Remove [tank_one || tank_two]"
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove [tank_one || tank_two]"
 		. = CONTEXTUAL_SCREENTIP_SET
 	if(istype(held_item) && is_type_in_list(held_item, list(/obj/item/tank, /obj/item/assembly)))
 		context[SCREENTIP_CONTEXT_LMB] = "Attach [held_item]"
@@ -45,7 +45,7 @@
 
 	return . || NONE
 
-/obj/item/transfer_valve/item_ctrl_click(mob/user)
+/obj/item/transfer_valve/alt_click(mob/user)
 	if(tank_one)
 		split_gases()
 		valve_open = FALSE

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -29,8 +29,6 @@
 
 /obj/item/transfer_valve/Destroy()
 	attached_device = null
-	tank_one = null
-	tank_two = null
 	return ..()
 
 /obj/item/transfer_valve/add_context(atom/source, list/context, obj/item/held_item, mob/user)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -45,7 +45,7 @@
 
 	return . || NONE
 
-/obj/item/transfer_valve/alt_click(mob/user)
+/obj/item/transfer_valve/click_alt(mob/user)
 	if(tank_one)
 		split_gases()
 		valve_open = FALSE


### PR DESCRIPTION
## About The Pull Request

Adds shorthand alt-click for removing tanks from TTVs and adds context for it.

## Why It's Good For The Game

Hate removing these manually when refining anoms

## Changelog

:cl:
qol: Adds shorthand alt-click for removing tanks from TTVs and adds context for it
/:cl:

