### PR TITLE
Legions borne from mimes can no longer talk

### DIFF
--- a/code/modules/mob/living/basic/lavaland/legion/legion_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_ai.dm
@@ -66,6 +66,9 @@
 	if (QDELETED(victim) || prob(30))
 		return ..()
 
+	if(HAS_MIND_TRAIT(victim, TRAIT_MIMING)) // mimes cant talk
+		return
+
 	var/list/remembered_speech = controller.blackboard[BB_LEGION_RECENT_LINES] || list()
 
 	if (length(remembered_speech) && prob(50)) // Don't spam the radio


### PR DESCRIPTION

## About The Pull Request

Legions borne from mimes can no longer talk

## Why It's Good For The Game

Immersion breaking oversight. Just as dwarves make tiny legions mimes make mute legions

## Changelog

:cl:
fix: Legions borne from mimes can no longer talk
/:cl:

