### PR TITLE
Various syndicate crossbow adjustments

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -605,7 +605,7 @@
 	desc = "A specialized quiver meant to hold any kind of bolts intended for use with the rebar crossbow. \
 		Clearly a better design than a cut up oxygen tank..."
 	slot_flags = ITEM_SLOT_NECK
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/reload_rebar)
 
@@ -647,7 +647,7 @@
 	if(held_crossbow.magazine.contents.len >= held_crossbow.magazine.max_ammo)
 		user.balloon_alert(user, "no more room!")
 		return
-	if(!do_after(user, 0.8 SECONDS, user, IGNORE_USER_LOC_CHANGE))
+	if(!do_after(user, 0.8 SECONDS, user))
 		return
 
 	var/obj/item/ammo_casing/rebar/ammo_to_load = contents[1]

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -647,7 +647,7 @@
 	if(held_crossbow.magazine.contents.len >= held_crossbow.magazine.max_ammo)
 		user.balloon_alert(user, "no more room!")
 		return
-	if(!do_after(user, 0.8 SECONDS, user))
+	if(!do_after(user, 1.2 SECONDS, user))
 		return
 
 	var/obj/item/ammo_casing/rebar/ammo_to_load = contents[1]

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -92,7 +92,7 @@
 /obj/projectile/bullet/rebar/syndie
 	name = "rebar"
 	icon_state = "rebar"
-	damage = 49
+	damage = 45
 	speed = 0.4
 	dismemberment = 2 //It's a budget sniper rifle.
 	armour_penetration = 20 //A bit better versus armor. Gets past anti laser armor or a vest, but doesnt wound proc on sec armor.
@@ -140,7 +140,7 @@
 /obj/projectile/bullet/rebar/hydrogen
 	name = "metallic hydrogen bolt"
 	icon_state = "rebar_hydrogen"
-	damage = 35
+	damage = 30
 	speed = 0.6
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
@@ -148,8 +148,8 @@
 	dismemberment = 0 //goes through clean.
 	damage_type = BRUTE
 	armour_penetration = 30 //very pointy.
-	wound_bonus = -15
-	bare_wound_bonus = 10
+	wound_bonus = -100
+	bare_wound_bonus = 0
 	shrapnel_type = /obj/item/ammo_casing/rebar/hydrogen
 	embed_type = /datum/embed_data/rebar_hydrogen
 	embed_falloff_tile = -3

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -92,7 +92,7 @@
 /obj/projectile/bullet/rebar/syndie
 	name = "rebar"
 	icon_state = "rebar"
-	damage = 55
+	damage = 49
 	speed = 0.4
 	dismemberment = 2 //It's a budget sniper rifle.
 	armour_penetration = 20 //A bit better versus armor. Gets past anti laser armor or a vest, but doesnt wound proc on sec armor.
@@ -140,7 +140,7 @@
 /obj/projectile/bullet/rebar/hydrogen
 	name = "metallic hydrogen bolt"
 	icon_state = "rebar_hydrogen"
-	damage = 55
+	damage = 35
 	speed = 0.6
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
@@ -153,7 +153,6 @@
 	shrapnel_type = /obj/item/ammo_casing/rebar/hydrogen
 	embed_type = /datum/embed_data/rebar_hydrogen
 	embed_falloff_tile = -3
-	shrapnel_type = /obj/item/ammo_casing/rebar/hydrogen
 	accurate_range = 205 //15 tiles before falloff starts to kick in
 
 /obj/projectile/bullet/rebar/hydrogen/Impact(atom/A)

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -140,7 +140,7 @@
 /obj/projectile/bullet/rebar/hydrogen
 	name = "metallic hydrogen bolt"
 	icon_state = "rebar_hydrogen"
-	damage = 30
+	damage = 35
 	speed = 0.6
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -150,7 +150,7 @@
 	name = "Syndicate Rebar Crossbow"
 	desc = "A much more professional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
-	cost = 11
+	cost = 13
 	restricted_roles = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 
 /datum/uplink_item/role_restricted/magillitis_serum

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -150,7 +150,7 @@
 	name = "Syndicate Rebar Crossbow"
 	desc = "A much more professional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
-	cost = 10
+	cost = 11
 	restricted_roles = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 
 /datum/uplink_item/role_restricted/magillitis_serum

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -150,7 +150,7 @@
 	name = "Syndicate Rebar Crossbow"
 	desc = "A much more professional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
-	cost = 13
+	cost = 12
 	restricted_roles = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 
 /datum/uplink_item/role_restricted/magillitis_serum


### PR DESCRIPTION
## About The Pull Request
Adjustments have been made to the Syndicate Crossbow to address its current strength and balance issues. The weapon is being heavily abused due to its overpowering combination of damage and utility. These changes aim to reduce its effectiveness while maintaining its role in the game.

List of Changes:
    Syndicate Rebar Bolt Damage: Reduced to 45 from 55.
    Hydrogen Bolt Damage: Reduced 35 from 55.
    Hydrogen Bolt Wound chance: reduced to 0 to prevent delimbing.
    Quiver Reload: Reload is now interrupted by movement.
    Quiver Reload: Reload increased 1.2 seconds from 0.8 seconds.
    Crossbow TC Cost Increased to 12 from 10.
    Quiver size: Increased to normal from small.

Edit : after some more thought and looking at the original creator's ideal, i've made some more changes. I've adjusted damage slightly to still fit in damage breakpoints but not rely on mood. Syndicate crossbow was meant to be a sidegrade to the syndicate revolver, it is currently an upgrade, even with these changes.

## Why It's Good For The Game
The Syndicate Crossbow’s high damage output, especially with hydrogen bolts, makes it overly powerful, leading to imbalanced gameplay. Reducing the damage brings it more in line with other weapons like the syndicate revolver while ensuring it still remains useful in certain situations.

We should consider this weapon as a sidegrade to the syndicate revolver, we should look at what armor does to the damage. With these changes, we kill both a security officer and an unarmored crew member in 3 shots. The revolver kills an unarmored crew member in 2 shots but an armored security officer in 3 or 4, depending on their mood. 

Comparing the Syndicate crossbow to the Syndicate Revolver, it is easier to find ammo for, has higher armor pen, is easier to store ammo for, easier to reload, has a scope, and the ammo is reusable. The crossbow needs a bit more of a trade-off than some reduced ammo capacity.

Metal hydrogen bolts fill a niche for silently killing pets across the map, not killing the entire station from a 1x1 hole in maintenance. They have no reason to be doing as much damage as syndicate rebar bolt damage or close to zaukerite bolts which are significantly more difficult to make.

With the introduction of the syndicate quiver, the syndicate crossbow has gotten significantly more powerful. Much of the clunkiness that made it 'worse' than the syndicate revolver has been removed (similar TC cost, damage, utility. 13 TC for revolver, 10 TC for crossbow). The increase in power deserves an increase in TC cost. The syndicate crossbow was meant to be a sidegrade to the syndicate revolver, we can adjust the price so balance between them is more cut and dry.

The ability to reload the crossbow with the quiver while moving is also a bit too strong. It effectively gives you a magazine of 20 shots while in active combat. You can spam your reload keybind and left mouse button while moving to continue firing at a rate of one shot per 0.8 seconds. I feel like this kind of defeats the entire idea behind the crossbow. 
Edit : I found while testing that I could still reload while moving at 0.8 second reload if i stutter step, I could still reload during combat. I've increased it to 1.2 seconds.

Quiver size was increased because it's silly for a quiver with 20 bolts to be able to fit in a box

## Changelog
:cl:
balance: Syndicate Rebar Bolt damage reduced to 45 from 55.
balance: Hydrogen Bolt damage reduced to 35 from 55.
balance: Syndicate Quiver reload is now interrupted by movement.
balance: Syndicate Quiver reload increased to 1.2 seconds from 0.8 seconds.
balance: Crossbow TC cost increased to 12 from 10.
balance: Quiver size increased to normal from small.
/:cl:
