### PR TITLE
Intentional *scream is audible again, now w/ 5s cooldown

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -63,7 +63,7 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
-	cooldown = (5 SECONDS)
+	audio_cooldown = 5 SECONDS
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/can_run_emote(mob/user, status_check = TRUE , intentional, params)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -63,7 +63,6 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
-	only_forced_audio = TRUE
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/can_run_emote(mob/user, status_check = TRUE , intentional, params)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -63,6 +63,7 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
+	cooldown = (5 SECONDS)
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/can_run_emote(mob/user, status_check = TRUE , intentional, params)


### PR DESCRIPTION
Removed the only instance of `only_forced_audio = TRUE` in /tg/, replaced with `cooldown = (5 SECONDS)`.
The variable is still there in case someone needs it.
## About The Pull Request
The variable was introduced in https://github.com/tgstation/tgstation/pull/42216
to prevent it from getting annoying.

I discussed this change on the forums, previously assuming it was server config
https://tgstation13.org/phpBB/viewtopic.php?f=9&t=37131
and people seemed receptive to the idea, spam being the only concern.
## Why It's Good For The Game

There are better ways to prevent spam.
Extending the cooldown is more favorable than being blocked completely 
(this is the treatment cyborg *deathgasp received, which is a longer, more jarring sound).

Audible emotes help you grab the attention of others (for better or worse).
I genuinely find them amusing at times & they remind me of the person on the other side.

There is some limit to play-pretend. These emotes enabled some interactions with players I would not have had otherwise.
As long as we stop the spam, it breathes some life into a game full of clicking, pointing at people and typing indicators.
## Changelog
:cl:
del: Intentional screaming has been unmuted. Now has a 5s cooldown instead.
/:cl:
