### PR TITLE
Fixes spacesuit slowdown applying to plasmamen helmets

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -70,6 +70,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSMOUTH|HEADCOVERSEYES|PEPPERPROOF
 	visor_flags_inv = HIDEEYES|HIDEFACE
+	slowdown = 0
 
 /datum/armor/space_plasmaman
 	bio = 100


### PR DESCRIPTION

#85855 without the extra balance changes, just the fix.
## About The Pull Request
When slowdown was split between spacesuit helmets and suits (idk why exactly)
it accidentally applied the slowdown to plasmamen enviro helmets.
The ones they wear by default and really need to live.
## Why It's Good For The Game
All plasmamen had an extra slowdown applied to them ever since the PR.
There were attempts to fix it, like the one mentioned at the start, but it included some questionable extra check that seemingly lead to it going stale and closing.

I really want the fix to happen, because I'm one of the 5 people who play plasmamen.
## Changelog
:cl:
fix: Plasmamen envirohelmets no longer erroneously apply a slowdown.
/:cl:
