### PR TITLE
fixes botkeeper displaying wrong states

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_ai.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_ai.dm
@@ -11,3 +11,6 @@
 #define COMSIG_BOT_RESET "bot_reset"
 ///Sent off /mob/living/basic/bot/proc/set_mode_flags() : (new_flags)
 #define COMSIG_BOT_MODE_FLAGS_SET "bot_mode_flags_set"
+
+///Signal sent off of ai/movement/proc/start_moving_towards
+#define COMSIG_MOB_AI_MOVEMENT_STARTED "mob_ai_movement_started"

--- a/code/datums/ai/movement/_ai_movement.dm
+++ b/code/datums/ai/movement/_ai_movement.dm
@@ -11,6 +11,7 @@
 	controller.consecutive_pathing_attempts = 0
 	controller.set_blackboard_key(BB_CURRENT_MIN_MOVE_DISTANCE, min_distance)
 	moving_controllers[controller] = current_movement_target
+	SEND_SIGNAL(controller.pawn, COMSIG_MOB_AI_MOVEMENT_STARTED, current_movement_target)
 
 /datum/ai_movement/proc/stop_moving_towards(datum/ai_controller/controller)
 	controller.consecutive_pathing_attempts = 0

--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -538,6 +538,7 @@ GLOBAL_LIST_INIT(command_strings, list(
 /mob/living/basic/bot/proc/bot_reset(bypass_ai_reset = FALSE)
 	SEND_SIGNAL(src, COMSIG_BOT_RESET)
 	access_card.set_access(initial_access)
+	update_bot_mode(new_mode = src::mode)
 	diag_hud_set_botstat()
 	diag_hud_set_botmode()
 	clear_path_hud()
@@ -558,8 +559,7 @@ GLOBAL_LIST_INIT(command_strings, list(
 	// process control input
 	switch(command)
 		if("patroloff")
-			bot_reset() //HOLD IT!! //OBJECTION!!
-			set_mode_flags(bot_mode_flags & ~BOT_MODE_AUTOPATROL)
+			set_patrol_off()
 		if("patrolon")
 			set_mode_flags(bot_mode_flags | BOT_MODE_AUTOPATROL)
 		if("summon")
@@ -567,6 +567,9 @@ GLOBAL_LIST_INIT(command_strings, list(
 		if("ejectpai")
 			eject_pai_remote(user)
 
+/mob/living/basic/bot/proc/set_patrol_off()
+	bot_reset()
+	set_mode_flags(bot_mode_flags & ~BOT_MODE_AUTOPATROL)
 
 /mob/living/basic/bot/proc/bot_control_message(command, user)
 	if(command == "summon")

--- a/code/modules/mob/living/basic/bots/bot_ai.dm
+++ b/code/modules/mob/living/basic/bots/bot_ai.dm
@@ -48,6 +48,12 @@
 		return
 	RegisterSignal(new_pawn, COMSIG_BOT_RESET, PROC_REF(reset_bot))
 	RegisterSignal(new_pawn, COMSIG_AI_BLACKBOARD_KEY_CLEARED(BB_BOT_SUMMON_TARGET), PROC_REF(clear_summon))
+	RegisterSignal(new_pawn, COMSIG_MOB_AI_MOVEMENT_STARTED, PROC_REF(on_movement_start))
+
+/datum/ai_controller/basic_controller/bot/proc/on_movement_start(mob/living/basic/bot/source, atom/target)
+	SIGNAL_HANDLER
+	if(current_movement_target == blackboard[BB_BEACON_TARGET])
+		source.update_bot_mode(new_mode = BOT_PATROL)
 
 /datum/ai_controller/basic_controller/bot/proc/clear_summon()
 	SIGNAL_HANDLER
@@ -75,7 +81,7 @@
 
 /datum/ai_controller/basic_controller/bot/proc/reset_bot()
 	SIGNAL_HANDLER
-
+	CancelActions()
 	if(!length(reset_keys))
 		return
 	for(var/key in reset_keys)
@@ -130,7 +136,6 @@
 		return
 
 	if(controller.blackboard_key_exists(BB_BEACON_TARGET))
-		bot_pawn.update_bot_mode(new_mode = BOT_PATROL)
 		controller.queue_behavior(travel_behavior, BB_BEACON_TARGET)
 		return
 
@@ -195,8 +200,6 @@
 /datum/ai_planning_subtree/respond_to_summon/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	if(!controller.blackboard_key_exists(BB_BOT_SUMMON_TARGET))
 		return
-	controller.clear_blackboard_key(BB_PREVIOUS_BEACON_TARGET)
-	controller.clear_blackboard_key(BB_BEACON_TARGET)
 	controller.queue_behavior(/datum/ai_behavior/travel_towards/bot_summon, BB_BOT_SUMMON_TARGET)
 	return SUBTREE_RETURN_FINISH_PLANNING
 


### PR DESCRIPTION

## About The Pull Request
bot modes werent correctly reflecting the bot's AI states. this pr fixes that. also fixes some issues where the bot's AI might get stuck inbetween switching modes

## Why It's Good For The Game
closes #86771

## Changelog
:cl:
fix: botkeeper now displays bot's correct states!
/:cl:
