### PR TITLE
Syndicate Crossbow Rebalance (NO GBP)

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -647,7 +647,7 @@
 	if(held_crossbow.magazine.contents.len >= held_crossbow.magazine.max_ammo)
 		user.balloon_alert(user, "no more room!")
 		return
-	if(!do_after(user, 0.8 SECONDS, user))
+	if(!do_after(user, 1.5 SECONDS, user))
 		return
 
 	var/obj/item/ammo_casing/rebar/ammo_to_load = contents[1]

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -647,7 +647,7 @@
 	if(held_crossbow.magazine.contents.len >= held_crossbow.magazine.max_ammo)
 		user.balloon_alert(user, "no more room!")
 		return
-	if(!do_after(user, 0.8 SECONDS, user, IGNORE_USER_LOC_CHANGE))
+	if(!do_after(user, 0.8 SECONDS, user))
 		return
 
 	var/obj/item/ammo_casing/rebar/ammo_to_load = contents[1]

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -46,14 +46,14 @@
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/normal
-	name = "single round magazine"
-	max_ammo = 1
+	name = "two round magazine"
+	max_ammo = 2
 	caliber = CALIBER_REBAR
 	ammo_type = /obj/item/ammo_casing/rebar
 
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/force
-	name = "two round magazine"
-	max_ammo = 2
+	name = "three round magazine"
+	max_ammo = 3
 	caliber = CALIBER_REBAR_FORCED
 	ammo_type = /obj/item/ammo_casing/rebar
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -148,8 +148,8 @@
 	dismemberment = 0 //goes through clean.
 	damage_type = BRUTE
 	armour_penetration = 30 //very pointy.
-	wound_bonus = -15
-	bare_wound_bonus = 10
+	wound_bonus = -100
+	bare_wound_bonus = 0
 	shrapnel_type = /obj/item/ammo_casing/rebar/hydrogen
 	embed_type = /datum/embed_data/rebar_hydrogen
 	embed_falloff_tile = -3

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -140,7 +140,7 @@
 /obj/projectile/bullet/rebar/hydrogen
 	name = "metallic hydrogen bolt"
 	icon_state = "rebar_hydrogen"
-	damage = 55
+	damage = 40
 	speed = 0.6
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
@@ -231,7 +231,7 @@
 
 /obj/projectile/bullet/paperball
 	desc = "Doink!"
-	damage = 1 // It's a damn toy.
+	damage = 0 // It's a damn toy.
 	range = 10
 	shrapnel_type = null
 	embed_type = null

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -150,7 +150,7 @@
 	name = "Syndicate Rebar Crossbow"
 	desc = "A much more professional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
-	cost = 10
+	cost = 12
 	restricted_roles = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 
 /datum/uplink_item/role_restricted/magillitis_serum


### PR DESCRIPTION

## About The Pull Request

So i've seen some talk about the recent buff to the rebar crossbow via #86116, and I will say, I do feel it does deserve a a once-over. I'm not going to beat around the bush here - pr #86781 is basically the reason I'm making this (and as someone not familiar with the customs of the github, apologies if making a dueling PR like this is considered poor form as the original author), but I felt giving it an attempt couldnt hurt.

So what does it change? Well, as stated above, I agree with most of #86781's points, namely the ones from the quiver PR - but I disagree on the damage reduction of the basic syndicate ammo type. There's also a few changes to things that got altered in #86116 by accident, namely with the station sided crossbows.

## Why It's Good For The Game

The crossbow was originally designed as an alpha strike high damage weapon that suffers in prolonged combat - its a sidegrade to the revolver, not an equivalent. As #86781 states, the quiver massively buffed its usefulness in this regard, and I agree it's a bit overtuned, but I feel nerfing the base ammo itself, rather than the quiver, might have unintended consequences.

## Changelog

:cl: WebcomicArtist
balance: Hydrogen Bolt Damage reduced from 55 to 40. It's always a 3 shot, rather than being 2 or 3 if mood is high.
balance: Quiver Reload: Reload is now interrupted by movement. Reload lasts 1.5 seconds rather than 0.8. 
balance: Engi Crossbow TC Cost Increased from 10 to 12. 
balance: Syndicate quiver size: Increased from small to normal.

Fix: Metal Hydrogen doesn't wound proc anymore, as intended.
Fix: Station sided crossbows (the basic and forced) now hold 2 and 3 rods instead of 1 and 2, respectively.
Fix: Paper balls no longer do blood splats when fired from crossbow.
/:cl:

