### PR TITLE
Show a feedback message for whispers you cannot hear

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -293,8 +293,15 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/dist = get_dist(speaker, src) - message_range
 	if(dist > 0 && dist <= EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src)) // ghosts can hear all messages clearly
 		raw_message = stars(raw_message)
-	if (message_range != INFINITY && dist > EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src))
-		return FALSE // Too far away and don't have good hearing, you can't hear anything
+    if(message_range != INFINITY && dist > EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src))
+        // Too far away and don't have good hearing, you can't hear anything
+        if(is_blind()) // Can't see them speak either
+            return FALSE
+        if(can_hear() || HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) // If we can't hear we want to continue to the default deaf message, except for signing
+            deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something, but you are too far away to understand [speaker.p_them()]."
+            deaf_type = MSG_VISUAL
+            message = deaf_message
+            return show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
 
 	// we need to send this signal before compose_message() is used since other signals need to modify
 	// the raw_message first. After the raw_message is passed through the various signals, it's ready to be formatted

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -310,7 +310,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			var/mob/living/living_speaker = speaker
 			if(istype(living_speaker) && living_speaker.is_mouth_covered()) // Can't see them speak if their mouth is covered
 				return FALSE
-			deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something, but you are too far away to understand [speaker.p_them()]."
+			deaf_message = "[span_name("[speaker]")] [speaker.verb_whisper] something, but you are too far away to hear [speaker.p_them()]."
 
 		if(deaf_message)
 			deaf_type = MSG_VISUAL

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -293,15 +293,15 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/dist = get_dist(speaker, src) - message_range
 	if(dist > 0 && dist <= EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src)) // ghosts can hear all messages clearly
 		raw_message = stars(raw_message)
-    if(message_range != INFINITY && dist > EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src))
-        // Too far away and don't have good hearing, you can't hear anything
-        if(is_blind()) // Can't see them speak either
-            return FALSE
-        if(can_hear() || HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) // If we can't hear we want to continue to the default deaf message, except for signing
-            deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something, but you are too far away to understand [speaker.p_them()]."
-            deaf_type = MSG_VISUAL
-            message = deaf_message
-            return show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
+	if(message_range != INFINITY && dist > EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src))
+		// Too far away and don't have good hearing, you can't hear anything
+		if(is_blind()) // Can't see them speak either
+			return FALSE
+		if(can_hear() || HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) // If we can't hear we want to continue to the default deaf message, except for signing
+			deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something, but you are too far away to understand [speaker.p_them()]."
+			deaf_type = MSG_VISUAL
+			message = deaf_message
+			return show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
 
 	// we need to send this signal before compose_message() is used since other signals need to modify
 	// the raw_message first. After the raw_message is passed through the various signals, it's ready to be formatted

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -287,6 +287,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		if(raw_message != untranslated_raw_message)
 			understood = FALSE
 
+	var/speaker_is_signing = HAS_TRAIT(speaker, TRAIT_SIGN_LANG)
+
+
 	// if someone is whispering we make an extra type of message that is obfuscated for people out of range
 	// Less than or equal to 0 means normal hearing. More than 0 and less than or equal to EAVESDROP_EXTRA_RANGE means
 	// partial hearing. More than EAVESDROP_EXTRA_RANGE means no hearing. Exception for GOOD_HEARING trait
@@ -295,20 +298,32 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		raw_message = stars(raw_message)
 	if(message_range != INFINITY && dist > EAVESDROP_EXTRA_RANGE && !HAS_TRAIT(src, TRAIT_GOOD_HEARING) && !isobserver(src))
 		// Too far away and don't have good hearing, you can't hear anything
-		if(is_blind()) // Can't see them speak either
+		if(is_blind() || HAS_TRAIT(speaker, TRAIT_INVISIBLE_MAN)) // Can't see them speak either
 			return FALSE
-		if(can_hear() || HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) // If we can't hear we want to continue to the default deaf message, except for signing
+		if(!isturf(speaker.loc)) // If they're inside of something, probably can't see them speak
+			return FALSE
+
+		// But we can still see them speak
+		if(speaker_is_signing)
+			deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something, but the motions are too subtle to make out from afar."
+		else if(can_hear()) // If we can't hear we want to continue to the default deaf message
+			var/mob/living/living_speaker = speaker
+			if(istype(living_speaker) && living_speaker.is_mouth_covered()) // Can't see them speak if their mouth is covered
+				return FALSE
 			deaf_message = "[span_name("[speaker]")] [speaker.get_default_say_verb()] something, but you are too far away to understand [speaker.p_them()]."
+
+		if(deaf_message)
 			deaf_type = MSG_VISUAL
 			message = deaf_message
 			return show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
+
 
 	// we need to send this signal before compose_message() is used since other signals need to modify
 	// the raw_message first. After the raw_message is passed through the various signals, it's ready to be formatted
 	// by compose_message() to be displayed in chat boxes for to_chat or runechat
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
-	if(HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) //Checks if speaker is using sign language
+	if(speaker_is_signing) //Checks if speaker is using sign language
 		deaf_message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods, TRUE)
 
 		if(speaker != src)


### PR DESCRIPTION
## About The Pull Request

In this pr we make it so, instead of doing an early return, whispers you cannot hear will display a feedback message along the lines of:
`Angel Randolph says something, but you are too far away to understand him.`
As long as you are capable of seeing them say something.

This includes signing, as it uses the same logic.
If they're not signing and you cannot hear at all, then it skips to the normal deaf messages.


<details>
  <summary>Example Test Images</summary>

### explanation:

The number after each message denotes the distance between speaker and listener.
The first image is from the speaker's pov, the second from the listener's.
 
 
### no blindfold, no earmuffs:

no signing
![image](https://github.com/user-attachments/assets/eaf271e6-3174-40e5-8eec-647aba239e55)
![image](https://github.com/user-attachments/assets/272ef988-46ea-4c40-91a4-f55df2404d5b)

signing
![image](https://github.com/user-attachments/assets/9ef54ff9-9a63-4291-800b-9adce2e00727)
![image](https://github.com/user-attachments/assets/acd76a99-8395-4e10-90c4-dc28aaf3d888)


### no blindfold, earmuffs:

no signing
![image](https://github.com/user-attachments/assets/bf839a0e-8a0e-433c-b60e-d3e0677f6f39)
![image](https://github.com/user-attachments/assets/6da2e226-2149-45a5-9214-3e80bdd71c30)

signing
![image](https://github.com/user-attachments/assets/3fcf08ea-81fb-4e1f-a3d7-4037c9d75635)
![image](https://github.com/user-attachments/assets/e20a4e7b-4fcd-4f2c-9bee-b1bf8cdd9e5d)


### blindfold, no earmuffs:

no signing
![image](https://github.com/user-attachments/assets/963467b7-8cca-44d8-94f5-3f75d86f5e3a)
![image](https://github.com/user-attachments/assets/83793e34-b386-4595-8063-164915ff43e2)


signing
![image](https://github.com/user-attachments/assets/1a8f220d-02f2-4def-826a-a313a35f4894)
![image](https://github.com/user-attachments/assets/248c5e46-ed9d-4f87-b1da-ed6a361228e4)


### blindfold, earmuffs:

no signing
![image](https://github.com/user-attachments/assets/d084a21b-c050-44ba-b16a-86a7b3d2aa4c)
![image](https://github.com/user-attachments/assets/7b797034-7b0d-4238-b2eb-135193cab5c7)




</details>

## Why It's Good For The Game

Currently, someone whispering grants zero feedback to listeners who are beyond 2 tiles (without good hearing), all they get is that the speaker's typing indicator disappeared. This makes it look indistinguishable from the speaker just having backspaced their message.
This is _especially_ annoying with soft-spoken, as it tends to cause other players to disengage, because to them you just didn't press enter if they left your immediate range before you finished speaking.

But even outside of that, arguably, even if you couldn't _hear_ it, you should be able to _see_ the movements of them speaking.
And really, I just think that it'd lead to fun interactions if you could grumble to yourself or whisper amongst each other and have people actually know you're up to _something_.

## Changelog
:cl:
add: You can now see people whispering, even if you cannot hear what they're saying, unless you are blind (obviously). The speaker wearing something that covers their mouth, being invisible, or being inside of something counteracts this.
/:cl:
