### PR TITLE
Apply jetpack nerf to implantable thrusters

### DIFF
--- a/code/modules/movespeed/modifiers/items.dm
+++ b/code/modules/movespeed/modifiers/items.dm
@@ -2,9 +2,6 @@
 	conflicts_with = MOVE_CONFLICT_JETPACK
 	movetypes = FLOATING
 
-/datum/movespeed_modifier/jetpack/cybernetic
-	multiplicative_slowdown = -0.5
-
 /datum/movespeed_modifier/die_of_fate
 	multiplicative_slowdown = 1
 

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -201,7 +201,6 @@
 		return
 
 	on = TRUE
-	owner.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/cybernetic)
 	if(!silent)
 		to_chat(owner, span_notice("You turn your thrusters set on."))
 	update_appearance()
@@ -210,7 +209,6 @@
 	if(!on)
 		return
 	SEND_SIGNAL(src, COMSIG_THRUSTER_DEACTIVATED, owner)
-	owner.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/cybernetic)
 	if(!silent)
 		to_chat(owner, span_notice("You turn your thrusters set off."))
 	on = FALSE


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/85165.
## Changelog
:cl:
fix: jetpack nerf is now applied to implantable thrusters
/:cl:
