### PR TITLE
Fixes surprise lemons in fruit crate

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -101,8 +101,8 @@
 
 /datum/supply_pack/organic/randomized/chef/fruits
 	name = "Fruit Crate"
-	desc = "Rich of vitamins. Contains a lime, orange, watermelon, apple, \
-		berries and a lime."
+	desc = "Rich in vitamins. Contains a lime, orange, watermelon, apple, \
+		berries and a lemon."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/food/grown/citrus/lime,
 					/obj/item/food/grown/citrus/orange,


### PR DESCRIPTION
## About The Pull Request

No, the shipping manifest isn't wrong. When life gives you lemons, shut up and eat your damn lemons.

## Changelog

:cl: LT3
spellcheck: Fruit crate description now correctly warns that it contains lemons
/:cl:
