### PR TITLE
Removes syndicate headset from virtual pirates

### DIFF
--- a/code/modules/bitrunning/spawners.dm
+++ b/code/modules/bitrunning/spawners.dm
@@ -1,5 +1,5 @@
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain
-	outfit = /datum/outfit/pirate
+	outfit = /datum/outfit/virtual_pirate
 	prompt_name = "a virtual domain debug entity"
 	flavour_text = "You probably shouldn't be seeing this, contact a coder!"
 	you_are_text = "You are NOT supposed to be here. How did you let this happen?"
@@ -31,6 +31,17 @@
 	prompt_name = "a virtual skeleton pirate"
 	you_are_text = "You are a virtual pirate. Yarrr!"
 	flavour_text = " There's a LANDLUBBER after yer booty. Stop them!"
+
+/datum/outfit/virtual_pirate
+	name = "Virtual Pirate"
+	id = /obj/item/card/id/advanced
+	id_trim = /datum/id_trim/pirate
+	uniform = /obj/item/clothing/under/costume/pirate
+	suit = /obj/item/clothing/suit/costume/pirate/armored
+	ears = null
+	glasses = /obj/item/clothing/glasses/eyepatch
+	head = /obj/item/clothing/head/costume/pirate/bandana/armored
+	shoes = /obj/item/clothing/shoes/pirate/armored
 
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/pirate/special(mob/living/spawned_mob, mob/mob_possessor)

--- a/code/modules/bitrunning/spawners.dm
+++ b/code/modules/bitrunning/spawners.dm
@@ -38,7 +38,6 @@
 	id_trim = /datum/id_trim/pirate
 	uniform = /obj/item/clothing/under/costume/pirate
 	suit = /obj/item/clothing/suit/costume/pirate/armored
-	ears = null
 	glasses = /obj/item/clothing/glasses/eyepatch
 	head = /obj/item/clothing/head/costume/pirate/bandana/armored
 	shoes = /obj/item/clothing/shoes/pirate/armored


### PR DESCRIPTION

## About The Pull Request
Adds `/datum/outfit/virtual_pirate` that's the pirate outfit minus the headset
## Why It's Good For The Game
Virtual pirates shouldn't have syndicate headsets because that might cause problems for if a bitrunner kills them and loots the headset, gaining access to syndicate channels.
Fix: #86785
## Changelog
:cl: Goat
fix: Virtual pirates were yelled at by the virtual syndicate and no longer have virtual syndicate headsets.
/:cl:
