### PR TITLE
Meta Central Virtual Domain spawner fixes and announce_to_ghosts adjustment

### DIFF
--- a/_maps/virtual_domains/meta_central.dmm
+++ b/_maps/virtual_domains/meta_central.dmm
@@ -112,7 +112,7 @@
 /turf/open/floor/iron/dark,
 /area/virtual_domain)
 "aT" = (
-/obj/effect/mob_spawn/ghost_role/human/pirate/skeleton/captain,
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/pirate,
 /turf/open/floor/plating,
 /area/virtual_domain)
 "aV" = (

--- a/code/controllers/subsystem/bitrunning.dm
+++ b/code/controllers/subsystem/bitrunning.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(bitrunning)
 		var/can_view_reward = domain.difficulty < (scanner_tier + 1) && domain.cost <= points + 3
 
 		UNTYPED_LIST_ADD(levels, list(
-			"announce_ghosts"= domain.announce_to_ghosts,
+			"announce_ghosts" = domain.announce_to_ghosts,
 			"cost" = domain.cost,
 			"desc" = can_view ? domain.desc : "Limited scanning capabilities. Cannot infer domain details.",
 			"difficulty" = domain.difficulty,

--- a/code/modules/bitrunning/virtual_domain/domains/meta_central.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/meta_central.dm
@@ -10,3 +10,4 @@
 	map_name = "meta_central"
 	mob_modules = list(/datum/modular_mob_segment/revolutionary)
 	reward_points = BITRUNNER_REWARD_LOW
+	announce_to_ghosts = TRUE


### PR DESCRIPTION
## About The Pull Request

This swaps out the pirate spawner on the Meta Central VDOM with the subtype specifically meant for virtual domains. That thing wasn't actually a virtual domain spawner, it was just a regular one.

This applies the necessary restrictions/roles being applied to pirates who spawn on that map. It will also make #86794 work on the Metastation Central map, rather than only affect the Corsair Cove map (which used the correct spawner type).

This also adds the Announce to Ghosts flag to Meta Central, as is uniform for maps with ghost roles. Doing so also enables the VDOM selector UI indicator that ghost roles can spawn on the map.

This whole thing started as an attempt to fix #86785 but I was too slow and someone beat me too it. Darn.
## Why It's Good For The Game

Ensures #86785 will be closed properly.
## Changelog
:cl: Rhials
fix: The Meta Central Virtual Domain now uses the proper ghost role spawner, meaning you can't eavesdrop on syndie comms using their headset.
/:cl:
