### PR TITLE
Fixes spears -- SHARP_POINTY not SHARP_EDGE

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -18,7 +18,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
-	sharpness = SHARP_EDGED // i know the whole point of spears is that they're pointy, but edged is more devastating at the moment so
+	sharpness = SHARP_POINTY
 	max_integrity = 200
 	armor_type = /datum/armor/item_spear
 	wound_bonus = -15


### PR DESCRIPTION

## About The Pull Request

A 4 year old comment was left about sharp edge being "more devastating" than sharp_pointy so they made spears that. Well, there have been like, 5 or 6 updates and 2 refactors to wounding since then, so it doesn't make sense for spears to be edged anymore. Seems like an oversight that didn't get fixed, but don't worry, I'll save you.
## Why It's Good For The Game

Amends an oversight
## Changelog
:cl:
fix: Spears are actually pointy as one would expect.
/:cl:
