### PR TITLE
Replaces QDEL_NULL with QDEL_LIST in infective component

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -37,7 +37,7 @@
 	src.weak_infection_chance = weak_infection_chance
 
 /datum/component/infective/Destroy()
-	QDEL_NULL(diseases)
+	QDEL_LIST(diseases)
 	return ..()
 
 /datum/component/infective/RegisterWithParent()


### PR DESCRIPTION

## About The Pull Request

Diseases copy their instances, so they should be cleaned up afterwards
Closes #86800

## Changelog
:cl:
fix: Fixed infective components not cleaning up disease datums after themselves
/:cl:
