### PR TITLE
Fix fireproof and lavaproof objects receiving burn integrity damage

### DIFF
--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -25,7 +25,7 @@
 		play_attack_sound(damage_amount, damage_type, damage_flag)
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
-	if(damage_type == BURN && resistance_flags & FIRE_PROOF || resistance_flags & LAVA_PROOF)
+	if(damage_type == BURN && damage_flag != "laser" && resistance_flags & FIRE_PROOF || resistance_flags & LAVA_PROOF)
 		return
 	damage_amount = run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
 	if(damage_amount < DAMAGE_PRECISION)

--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -25,6 +25,8 @@
 		play_attack_sound(damage_amount, damage_type, damage_flag)
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
+	if(damage_type == BURN && resistance_flags & FIRE_PROOF || resistance_flags & LAVA_PROOF)
+		return
 	damage_amount = run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
 	if(damage_amount < DAMAGE_PRECISION)
 		return


### PR DESCRIPTION

## About The Pull Request

Adds checks for if an object is fire proof or lava proof before applying integrity damage from burn type.
## Why It's Good For The Game

Makes fire proof and lava proof objects immune to burn type damage.
## Changelog
:cl:
fix: fix items taking burn damage even if fire proof or lava proof
/:cl:
