### PR TITLE
Add NTNRC client to pAIs digital messenger

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -322,6 +322,12 @@
 	///Ref to the silicon we're installed in. Set by the silicon itself during its creation.
 	var/mob/living/silicon/silicon_owner
 
+/obj/item/modular_computer/pda/silicon/pai
+	starting_programs = list(
+		/datum/computer_file/program/messenger,
+		/datum/computer_file/program/chatclient,
+	)
+
 /obj/item/modular_computer/pda/silicon/cyborg
 	starting_programs = list(
 		/datum/computer_file/program/filemanager,

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -240,6 +240,11 @@
 	RegisterSignals(src, list(COMSIG_LIVING_ADJUST_BRUTE_DAMAGE, COMSIG_LIVING_ADJUST_BURN_DAMAGE), PROC_REF(on_shell_damaged))
 	RegisterSignal(src, COMSIG_LIVING_ADJUST_STAMINA_DAMAGE, PROC_REF(on_shell_weakened))
 
+/mob/living/silicon/pai/create_modularInterface()
+	if(!modularInterface)
+		modularInterface = new /obj/item/modular_computer/pda/silicon/pai(src)
+	return ..()
+
 /mob/living/silicon/pai/make_laws()
 	laws = new /datum/ai_laws/pai()
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Just adds the NTNRC client to the pAI digital messenger software's starting programs.
To avoid also giving this to the AI, creates a new silicon PDA subtype for pAIs and applies it similarly to borgs.
## Why It's Good For The Game

It's already barely ever used, and I just think it'd be fun to let pAIs talk to the never-checked department consoles or open chatrooms with each other or their hosts.
Currently you can do this by being in your host's PDA, but this means they couldn't use their PDA at the same time as you just... chatting. Nor could you share a chatroom with them, due to sharing the same account.
Also the pAI cabal using the bootleg IRC client to plot their next move is just incredibly funny to me.
## Changelog
:cl:
balance: The pAI digital messenger software now includes the NTNRC client.
/:cl:
