### PR TITLE
you can now use the toy codex cicatrix as base for the codex ritual

### DIFF
--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -10,20 +10,19 @@
 #define LIMB_MAX_HP_ADVANCED 75 //Used by advanced robotic limbs.
 #define LIMB_MAX_HP_CORE 200 //Only use this for heads and torsos.
 
-#define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 2.5 //Used by surplus prosthesis limbs
-#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.5 //Used by advanced robotic limbs.
-#define LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT 0.75 //Used by all limbs by default.
-
 /// Xenomorph Limbs
 #define LIMB_MAX_HP_ALIEN_LARVA 50 //Used by the weird larva chest and head. Did you know they have those?
 #define LIMB_MAX_HP_ALIEN_LIMBS 100 //Used by xenomorph limbs.
 #define LIMB_MAX_HP_ALIEN_CORE 500 //Used by xenomorph chests and heads
 
 /// Limb Body Damage Coefficient
-/// A mutiplication of the burn and brute damage that the limb's stored damage contributes to its attached mob's overall wellbeing.
+/// A multiplication of the burn and brute damage that the limb's stored damage contributes to its attached mob's overall wellbeing.
 /// For instance, if a limb has 50 damage, and has a coefficient of 50%, the human is considered to have suffered 25 damage to their total health.
 
+#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.5 //Used by advanced robotic limbs.
+#define LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT 0.75 //Used by all limbs by default.
 #define LIMB_BODY_DAMAGE_COEFFICIENT_TOTAL 1 //Used by heads and torsos
+#define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 2.5 //Used by surplus prosthesis limbs
 
 // EMP
 // Note most of these values are doubled on heavy EMP

--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -10,6 +10,10 @@
 #define LIMB_MAX_HP_ADVANCED 75 //Used by advanced robotic limbs.
 #define LIMB_MAX_HP_CORE 200 //Only use this for heads and torsos.
 
+#define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 2.5 //Used by surplus prosthesis limbs
+#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.5 //Used by advanced robotic limbs.
+#define LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT 0.75 //Used by all limbs by default.
+
 /// Xenomorph Limbs
 #define LIMB_MAX_HP_ALIEN_LARVA 50 //Used by the weird larva chest and head. Did you know they have those?
 #define LIMB_MAX_HP_ALIEN_LIMBS 100 //Used by xenomorph limbs.
@@ -19,10 +23,7 @@
 /// A mutiplication of the burn and brute damage that the limb's stored damage contributes to its attached mob's overall wellbeing.
 /// For instance, if a limb has 50 damage, and has a coefficient of 50%, the human is considered to have suffered 25 damage to their total health.
 
-#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.5 //Used by advanced robotic limbs.
-#define LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT 0.75 //Used by all limbs by default.
 #define LIMB_BODY_DAMAGE_COEFFICIENT_TOTAL 1 //Used by heads and torsos
-#define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 2.5 //Used by surplus prosthesis limbs
 
 // EMP
 // Note most of these values are doubled on heavy EMP

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	gain_text = "The occult leaves fragments of knowledge and power anywhere and everywhere. The Codex Cicatrix is one such example. \
 		Within the leather-bound faces and age old pages, a path into the Mansus is revealed."
 	required_atoms = list(
-		/obj/item/book = 1,
+		list(/obj/item/toy/eldritch_book, /obj/item/book) = 1,
 		/obj/item/pen = 1,
 		list(/mob/living, /obj/item/stack/sheet/leather, /obj/item/stack/sheet/animalhide) = 1,
 	)


### PR DESCRIPTION

## About The Pull Request

you can now use the toy codex cicatrix as base for the codex ritual

## Why It's Good For The Game

the ritual uses books as a base and this is a book

## Changelog

:cl:
qol: you can now use the toy codex cicatrix as base for the codex ritual
/:cl:

