### PR TITLE
add lead pipes to hacked autolathe recipes

### DIFF
--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -399,6 +399,18 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE,
 	)
 
+/datum/design/lead_pipe
+	name = "Lead Pipe"
+	id = "lead_pipe"
+	desc = "Yes, there's enough lead contamination in the iron you've provided to print a lead pipe."
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 9)
+	build_path = /obj/item/lead_pipe
+	category = list(
+		RND_CATEGORY_HACKED,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_JOKE,
+	)
+
 /datum/design/spraycan
 	name = "Spraycan"
 	id = "spraycan"


### PR DESCRIPTION

## About The Pull Request

adds lead pipes to autolathes when they are hacked
## Why It's Good For The Game

they have the same force as a butcher's cleaver but instead of bleeding they go CLONG, so they're clearly a sidegrade that should be just as difficult to access

also it's funny that the most reliable way to get the lead reagent is to print and then grind down lead pipes

iron can be made into tin for tinfoil hats so this transmutation also definitely applies
## Changelog
:cl:
add: you can now print lead pipes from hacked autolathes (CLANG)
/:cl:
