### PR TITLE
Fixes some stuff with the Living Heart ritual

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -109,27 +109,24 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 /datum/heretic_knowledge/living_heart/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/our_heretic = GET_HERETIC(user)
 	var/obj/item/organ/our_living_heart = user.get_organ_slot(our_heretic.living_heart_organ_slot)
-	// Obviously you need a heart in your chest to do a ritual on your... heart
-	if(!our_living_heart)
-		loc.balloon_alert(user, "ritual failed, you have no [our_heretic.living_heart_organ_slot]!") // "you have no heart!"
-		return FALSE
-	// For sanity's sake, check if they've got a heart -
+	// For sanity's sake, check if they've got a living heart -
 	// even though it's not invokable if you already have one,
 	// they may have gained one unexpectantly in between now and then
-	if(HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
-		loc.balloon_alert(user, "ritual failed, already have a living heart!")
-		return FALSE
+	if(!QDELETED(our_living_heart))
+		if(HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
+			loc.balloon_alert(user, "ritual failed, already have a living heart!")
+			return FALSE
 
-	// By this point they are making a new heart
-	// If their current heart is organic / not synthetic, we can continue the ritual as normal
-	if(is_valid_heart(our_living_heart))
-		return TRUE
+		// By this point they are making a new heart
+		// If their current heart is organic / not synthetic, we can continue the ritual as normal
+		if(is_valid_heart(our_living_heart))
+			return TRUE
 
-	// If their current heart is not organic / is synthetic, they need an organic replacement
-	// ...But if our organ-to-be-replaced is unremovable, we're screwed
-	if(our_living_heart.organ_flags & ORGAN_UNREMOVABLE)
-		loc.balloon_alert(user, "ritual failed, [our_heretic.living_heart_organ_slot] unremovable!") // "heart unremovable!"
-		return FALSE
+		// If their current heart is not organic / is synthetic, they need an organic replacement
+		// ...But if our organ-to-be-replaced is unremovable, we're screwed
+		if(our_living_heart.organ_flags & ORGAN_UNREMOVABLE)
+			loc.balloon_alert(user, "ritual failed, [our_heretic.living_heart_organ_slot] unremovable!") // "heart unremovable!"
+			return FALSE
 
 	// Otherwise, seek out a replacement in our atoms
 	for(var/obj/item/organ/nearby_organ in atoms)
@@ -151,17 +148,21 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	// Our heart is robotic or synthetic - we need to replace it, and we fortunately should have one by here
 	if(!is_valid_heart(our_new_heart))
 		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms
-		if(our_replacement_heart)
+		if(!our_replacement_heart)
+			CRASH("[type] required a replacement organic heart in on_finished_recipe, but did not find one.")
+		// Repair the organic heart, if needed, to just below the high threshold
+		if(our_replacement_heart.damage >= our_replacement_heart.high_threshold)
+			our_replacement_heart.set_organ_damage(our_replacement_heart.high_threshold - 1)
+		// And now, put our organic heart in its place
+		our_replacement_heart.Insert(user, TRUE, TRUE)
+		if(our_new_heart)
 			// Throw our current heart out of our chest, violently
 			user.visible_message(span_boldwarning("[user]'s [our_new_heart.name] bursts suddenly out of [user.p_their()] chest!"))
 			INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, emote), "scream")
 			user.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
-			// And put our organic heart in its place
-			our_replacement_heart.Insert(user, TRUE, TRUE)
+			selected_atoms -= our_new_heart // so we don't delete our old heart while we dramatically toss is out
 			our_new_heart.throw_at(get_edge_target_turf(user, pick(GLOB.alldirs)), 2, 2)
-			our_new_heart = our_replacement_heart
-		else
-			CRASH("[type] required a replacement organic heart in on_finished_recipe, but did not find one.")
+		our_new_heart = our_replacement_heart
 
 	if(!our_new_heart)
 		CRASH("[type] somehow made it to on_finished_recipe without a heart. What?")
@@ -182,7 +183,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 /// Checks if the passed heart is a valid heart to become a living heart
 /datum/heretic_knowledge/living_heart/proc/is_valid_heart(obj/item/organ/new_heart)
-	if(!new_heart)
+	if(QDELETED(new_heart))
 		return FALSE
 	if(!new_heart.useable)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

This fixes and improves some stuff with the living heart ritual:
- If you don't have any heart at all - i.e, you're a species without a heart, or have no heart due to vein muscle membrane surgery, you can still use the ritual to *put* a living heart into your chest.
- Fixed a "qdeleted thing being thrown around" runtime from the ritual unintentionally deleting your old heart while dramatically throwing it out of your chest.
- The ritual, when its replacing/adding a new heart to your chest, will now heal the heart to just below the "severe organ damage" threshold, if needed. It's very easy for a heart to accidentally decay without you realizing if you're butchering a monkey in maints to hastily replace your heart, especially if you accidentally forget the poppy or something and have to go sprint to get one.

Fixes https://github.com/tgstation/tgstation/issues/71451

## Why It's Good For The Game

Consistency for edge cases is good, as well as avoiding runtimes.

## Changelog
:cl:
fix: Fixed the Living Heart ritual deleting your old heart when replacing it instead of having it dramatically burst out of your chest like it should.
qol: The Living Heart ritual will now work if you don't have one at all for some reason, in the same way that'd you use an organic heart in the ritual to replace a cybernetic heart.
qol: The Living Heart ritual, when putting a new heart into your chest, will now heal the heart enough to be just under the "severe damage" threshold, if needed.
/:cl:
