### PR TITLE
Change thermomachine temperature upgrades to only use parabola formulas (instead of linear)

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -1,4 +1,6 @@
 #define THERMOMACHINE_POWER_CONVERSION 0.01
+#define BASE_COOLING (T0C - 192)
+#define BASE_HEATING (T20C + 271)
 
 /obj/machinery/atmospherics/components/unary/thermomachine
 	icon = 'icons/obj/machines/atmospherics/thermomachine.dmi'
@@ -30,8 +32,8 @@
 	var/target_temperature = T20C
 	var/heat_capacity = 0
 	var/interactive = TRUE // So mapmakers can disable interaction.
-	var/base_heating = 140
-	var/base_cooling = 170
+	var/base_heating = BASE_HEATING
+	var/base_cooling = BASE_COOLING
 	var/color_index = 1
 
 /datum/armor/unary_thermomachine
@@ -91,8 +93,13 @@
 	var/calculated_laser_rating = 0
 	for(var/datum/stock_part/micro_laser/laser in component_parts)
 		calculated_laser_rating += laser.tier
-	min_temperature = max(T0C - (base_cooling + calculated_laser_rating * 15), TCMB) //73.15K with T1 stock parts
-	max_temperature = T20C + (base_heating * calculated_laser_rating) //573.15K with T1 stock parts
+
+	// 73.15K with T1 stock parts
+	min_temperature = base_cooling - ((calculated_laser_rating * 2) + (calculated_laser_rating ** 2))
+	min_temperature = max(min_temperature, TCMB) // No going below 2.7K
+
+	// 573.15K with T1 stock parts
+	max_temperature = base_heating + (floor(calculated_laser_rating ** 3.25))
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon_state()
 	var/colors_to_use = ""
@@ -381,3 +388,5 @@
 	icon_state = "thermo_base_1"
 
 #undef THERMOMACHINE_POWER_CONVERSION
+#undef BASE_COOLING
+#undef BASE_HEATING


### PR DESCRIPTION

## About The Pull Request
Thermomachines currently use a mixture of linear and parabola formulas to determine their stats for upgrades. (heat capacity, min temp, max temp) I changed the formulas to include only parabola functions.

In the graphs below:

- The black curvy lines are the new parabola formulas
- The orange straight lines are the old linear formulas
- The purple dotted line is the absolute minimum temp cutoff for everything atmos-related. (2.7K) 
- Thermomachines have 2 lasers, so the minimum part tier starts at 2. (T1 + T1 = 2) The maximum part tier is 8. (T4 + T4 = 8) You can mix/match different part tiers to reach different ratings. (T1 + T3 = 4)

The old equation for the minimum setting hits its temperature cap before you fully upgrade it. (T3 + T4 = 7) My new formula accounts for this and makes sure the temperature cap is only fully reached when fully upgraded. (T4 + T4 = 8) 

<details>
<summary>Max Temparture Changes</summary>

![chrome_e5tHgrRVT6](https://github.com/user-attachments/assets/bdd10449-0983-443e-b642-28bf71e14477)

</details>

<details>
<summary>Min Temparture Changes</summary>

![chrome_Jqi0hDytA3](https://github.com/user-attachments/assets/8005b821-33cb-45ef-a09f-b0b16e42305e)

</details>

The starting temps for min/max are the same. The final min is the same but the final max is slightly increased. (from 1413.15 to 1425.15)

## Why It's Good For The Game
Thermomachine upgrades already use a parabola formula to determine heat capacity. This aims to be consistent and make all the temperature settings follow that. 

You might wonder, why is a linear formula bad?

The technology jump from a T1, T2, T3, etc. are supposed to be a massive leap and bounds over the previous tech. Using a linear formula a T4 part is the equivalent to 4 T1 parts. Using a parabola formula a T4 part is the equivalent to 15 T1 parts. They are supposed to be super efficient when compared to previous technologies. 

## Changelog
:cl:
balance: Change thermomachine temperature upgrades to use a parabola formula to determine the rate of max/min. It now has a slightly higher max ceiling at 1425.15 (before was 1413.15)
/:cl:
