### PR TITLE
A smattering of boulder-related QOL and fixes.

### DIFF
--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -257,6 +257,8 @@
 		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/card/id))
+		if(machine_stat & NOPOWER)
+			return ITEM_INTERACT_BLOCKING
 		if(points_held <= 0)
 			balloon_alert_to_viewers("no points to claim!")
 			if(!COOLDOWN_FINISHED(src, sound_cooldown))

--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -81,7 +81,7 @@
 	for(var/obj/item/boulder/potential_boulder in contents)
 		boulder_count += 1
 	. += span_notice("Storage capacity = <b>[boulder_count]/[boulders_held_max] boulders</b>.")
-	. += span_notice("Can process upto <b>[boulders_processing_count] boulders</b> at a time.")
+	. += span_notice("Can process up to <b>[boulders_processing_count] boulders</b> at a time.")
 
 	if(anchored)
 		. += span_notice("Its [EXAMINE_HINT("anchored")] in place.")
@@ -127,7 +127,7 @@
 	if(!istype(new_boulder) || QDELETED(new_boulder))
 		return FALSE
 
-	//someone just processed this
+	//someone is still processing this
 	if(new_boulder.processed_by)
 		return FALSE
 
@@ -149,7 +149,6 @@
  */
 /obj/machinery/bouldertech/proc/accept_boulder(obj/item/boulder/new_boulder)
 	PRIVATE_PROC(TRUE)
-
 	if(!can_process_boulder(new_boulder))
 		return FALSE
 
@@ -257,8 +256,6 @@
 		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/card/id))
-		if(machine_stat & NOPOWER)
-			return ITEM_INTERACT_BLOCKING
 		if(points_held <= 0)
 			balloon_alert_to_viewers("no points to claim!")
 			if(!COOLDOWN_FINISHED(src, sound_cooldown))
@@ -410,9 +407,12 @@
 		return TRUE
 	if(locate(/obj/item/boulder) in loc) //There is an boulder in our loc. it has be removed so we don't clog up our loc with even more boulders
 		return FALSE
+	if(!length(specific_boulder.custom_materials))
+		specific_boulder.break_apart()
+		return TRUE
 
 	//Reset durability to little random lower value cause we have crushed it so many times
-	var/size = specific_boulder.boulder_size
+	var/size = specific_boulder::boulder_size
 	if(size == BOULDER_SIZE_SMALL)
 		specific_boulder.durability = rand(2, BOULDER_SIZE_SMALL - 1)
 	else

--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -412,7 +412,7 @@
 		return TRUE
 
 	//Reset durability to little random lower value cause we have crushed it so many times
-	var/size = specific_boulder::boulder_size
+	var/size = specific_boulder.boulder_size
 	if(size == BOULDER_SIZE_SMALL)
 		specific_boulder.durability = rand(2, BOULDER_SIZE_SMALL - 1)
 	else

--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -62,9 +62,9 @@
 			icon_state = "[boulder_string]_small"
 
 /obj/item/boulder/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
 	if(istype(mover, /obj/item/boulder)) //This way, boulders can only go one at a time on conveyor belts, but everyone else can go through.
 		return FALSE
+	return ..()
 
 /obj/item/boulder/attack_self(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/mining/boulder_processing/boulder_types.dm
+++ b/code/modules/mining/boulder_processing/boulder_types.dm
@@ -25,6 +25,10 @@
 	artifact_inside = null
 	return ..()
 
+/obj/item/boulder/artifact/update_icon_state()
+	. = ..()
+	icon_state = "boulder_artifact" // Hardset to artifact sprites for consistency
+
 ///Boulders usually spawned in lavaland labour camp area
 /obj/item/boulder/gulag
 	name = "low-quality boulder"


### PR DESCRIPTION
## About The Pull Request

This pull request does a little bit of cleanup that I came across awhile ago while looking at #85081, then forgot about, then came back up when I was looking at some additional cleanup that needed to be done.

Reorganizes the handle_wave_conclusion function such that it can take a force arg, to force a ore vent to be completed for debug purposes.
This also fixes a minor bug where vents, when successfully completed, will still show a warning alert that the waves were failed, and that the vent has closed up.

Grammar fix to the examine of boulder processing machines.

Moves the can-move behavior of boulders on conveyor belts and during regular stacking to an early return over a late return (Thank you Goofball for pointing that out).

Artifact boulders will now default to their artifact icon_state whenever possible.

Finally, adds an additional sanity check to boulder processing to check for custom material length, to attempt to avoid zero-content boulders existing and running into the afforementioned #85081

## Why It's Good For The Game

Largely applies cleanup to several aspects of the boulder processing system, and a handful of (hopefully) performance related rearrangements to the existing layout of boulder processing code.

I can't for sure say that it'll fix the linked issue, due to the fact that I could not for some reason re-create the issue in local testing, but I'm hopeful that it's some kind of nebulous sanity-related issue.

Cleans up grammar in some spots, and provides a useful debug tool for admin purposes when you just want a vent to flip. Might be a good justification for a ore-manager admin panel later? 🤷 

## Changelog

:cl:
fix: Artifact boulders should keep their alien icon even after a first round of processing.
fix: Boulders are less likely to exist with zero materials after processing.
fix: Boulders should be slightly less laggy on conveyor belts.
fix: Grammar of refinery/smeltery examine is corrected.
/:cl:
