### PR TITLE
Fix TGS Test

### DIFF
--- a/tools/tgs_test/Program.cs
+++ b/tools/tgs_test/Program.cs
@@ -1,6 +1,6 @@
 // Simple app meant to test tgstation's TGS integration given a fresh TGS install with the default account
 //
-// Args: Repository Owner/Name, TGS instance path, TGS API port, Pushed commit hash (For .tgs.yml access), GitHub Token, (OPTIONAL) PR Number 
+// Args: Repository Owner/Name, TGS instance path, TGS API port, Pushed commit hash (For .tgs.yml access), GitHub Token, (OPTIONAL) PR Number
 
 using System.Reflection;
 using System.Text;
@@ -197,8 +197,6 @@ try
 		{
 			Origin = new Uri($"http://github.com/{repoSlug}"),
 			UpdateSubmodules = true,
-			AccessUser = "Testing",
-			AccessToken = gitHubToken
 		},
 		default);
 


### PR DESCRIPTION
TGS now does some validation of the access token you give it, which doesn't work well in an actions environment. Just don't give it a token unless absolutely necessary.

Private repos can eat shit cause this is AGPL code.

Okay, fr, they'd have to just use a PAT and set the `AccessUser` name appropriately