### PR TITLE
Fixes storage UI breaking upon an observer detaching while having your storage UI open under odd circumstances

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1088,7 +1088,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	var/columns = clamp(max_slots, 1, screen_max_columns)
 	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + additional_row, 1, screen_max_rows)
 
-	for (var/ui_user in storage_interfaces)
+	for (var/mob/ui_user as anything in storage_interfaces)
 		if (isnull(storage_interfaces[ui_user]))
 			var/observer_string = ""
 			if (LAZYLEN(ui_user.observers))

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1047,17 +1047,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(to_hide.client)
 		to_hide.client.screen -= storage_interfaces[to_hide].list_ui_elements()
 		to_hide.client.screen -= real_location.contents
-	if (isnull(storage_interfaces[to_hide]))
-		var/observer_string = ""
-		if (LAZYLEN(to_hide.observers))
-			observer_string = "while they had [length(to_hide.observers)] observers "
-			var/viewing_us = 0
-			for (var/mob/potential_bad_evil_guy in to_hide.observers)
-				if (potential_bad_evil_guy in is_using)
-					viewing_us += 1
-			if (viewing_us)
-				observer_string += "[viewing_us] of whom had this storage open "
-		WARNING("[parent] had a null storage interface for [to_hide] ([isobserver(to_hide) ? "observer" : "player"]) during closing [observer_string]- this is a TM issue, yell at smartkar")
 	QDEL_NULL(storage_interfaces[to_hide])
 	storage_interfaces -= to_hide
 
@@ -1090,17 +1079,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	for (var/mob/ui_user as anything in storage_interfaces)
 		if (isnull(storage_interfaces[ui_user]))
-			var/observer_string = ""
-			if (LAZYLEN(ui_user.observers))
-				observer_string = "while they had [length(ui_user.observers)] observers "
-				var/viewing_us = 0
-				for (var/mob/potential_bad_evil_guy in ui_user.observers)
-					if (potential_bad_evil_guy in is_using)
-						viewing_us += 1
-				if (viewing_us)
-					observer_string += "[viewing_us] of whom had this storage open "
-			WARNING("[parent] had a null storage interface for [ui_user] ([isobserver(ui_user) ? "observer" : "player"]) during orient_storage [observer_string]- this is a TM issue, yell at smartkar")
-			storage_interfaces -= ui_user
 			continue
 		storage_interfaces[ui_user].update_position(screen_start_x, screen_pixel_x, screen_start_y, screen_pixel_y, columns, rows)
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1057,7 +1057,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 					viewing_us += 1
 			if (viewing_us)
 				observer_string += "[viewing_us] of whom had this storage open "
-		WARNING("[parent] had a null storage interface for [ui_user] during closing [observer_string]- this is a TM issue, yell at smartkar")
+		WARNING("[parent] had a null storage interface for [to_hide] ([isobserver(to_hide) ? "observer" : "player"]) during closing [observer_string]- this is a TM issue, yell at smartkar")
 	QDEL_NULL(storage_interfaces[to_hide])
 	storage_interfaces -= to_hide
 
@@ -1099,7 +1099,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 						viewing_us += 1
 				if (viewing_us)
 					observer_string += "[viewing_us] of whom had this storage open "
-			WARNING("[parent] had a null storage interface for [ui_user] during orient_storage [observer_string]- this is a TM issue, yell at smartkar")
+			WARNING("[parent] had a null storage interface for [ui_user] ([isobserver(ui_user) ? "observer" : "player"]) during orient_storage [observer_string]- this is a TM issue, yell at smartkar")
 			storage_interfaces -= ui_user
 			continue
 		storage_interfaces[ui_user].update_position(screen_start_x, screen_pixel_x, screen_start_y, screen_pixel_y, columns, rows)


### PR DESCRIPTION
## About The Pull Request
This is one of the stupidest issues I had the displeasure of working with and I still do not know concrete details behind the issue because some of the code introduced in this (supposed-to-be) debug PR accidentally fixed said issue. Essentially, under odd circumstances of the user either being SSD or having their storage focus stolen by something else, an observer who had their storage UI open via autoobserve could break their UI by moving away because that improperly removed the user from some lists. This is the primary theory judging from what fixed the issue, but sadly there is no concrete info behind it as all attempts to reproduce the bug, both locally and on live, have failed.

Closes #85259

## Changelog
:cl:
fix: Storage UI should no longer (not so much) randomly disappear, hooray!
/:cl: