### PR TITLE
[NO GBP] Fixes the fishing experience gain from reeling objects

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -153,7 +153,7 @@
 		return
 
 	//About thirty minutes of non-stop reeling to get from zero to master... not worth it but hey, you do what you do.
-	user.mind?.adjust_experience(/datum/skill/fishing, time * 1.3)
+	user.mind?.adjust_experience(/datum/skill/fishing, time * 0.13)
 
 	//Try to move it 'till it's under the user's feet, then try to pick it up
 	if(isitem(currently_hooked))


### PR DESCRIPTION
## About The Pull Request
Little oopsie since I've forgot that time is in deciseconds for a moment there, therefore it should be multiplied by 0.13 and not 1.3

## Why It's Good For The Game
I made a mistake.

## Changelog
Too small to add to the CL.