### PR TITLE
Fix link for rules button

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -319,7 +319,7 @@
 	default = "http://tgstation13.org/phpBB/index.php"
 
 /datum/config_entry/string/rulesurl
-	default = "http://www.tgstation13.org/wiki/Rules"
+	default = "http://tgstation13.org/wiki/Rules"
 
 /datum/config_entry/string/githuburl
 	default = "https://www.github.com/tgstation/tgstation"


### PR DESCRIPTION

## About The Pull Request

This pull request fixes the link you get redirected to when you click the "Rules" button on the top right of the game. Before it redirected to http://www.tgstation13.org/wiki/Rules but the correct link is http://tgstation13.org/wiki/rules (the www part is the problem).
## Why It's Good For The Game

Makes the rules button direct you to the correct link, making it easier for someone to view the rules of the server.
## Changelog
:cl:
fix: fixed link for the rules button
/:cl:
