### PR TITLE
Fix imaginary friends not being able to hear their host, some minor adjustments

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -100,8 +100,7 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	if(owner)
-		greet()
+	greet()
 	Show()
 
 /mob/camera/imaginary_friend/proc/greet()
@@ -128,7 +127,6 @@
 	if(!owner.imaginary_group)
 		owner.imaginary_group = list(owner)
 	owner.imaginary_group += src
-	greet()
 
 /// Copies appearance from passed player prefs, or randomises them if none are provided
 /mob/camera/imaginary_friend/proc/setup_appearance(datum/preferences/appearance_from_prefs = null)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -1,3 +1,8 @@
+
+#define IMAGINARY_FRIEND_RANGE 9
+#define IMAGINARY_FRIEND_SPEECH_RANGE IMAGINARY_FRIEND_RANGE
+#define IMAGINARY_FRIEND_EXTENDED_SPEECH_RANGE 999
+
 /datum/brain_trauma/special/imaginary_friend
 	name = "Imaginary Friend"
 	desc = "Patient can see and hear an imaginary person."
@@ -87,6 +92,9 @@
 	var/move_delay = 0
 	var/mob/living/owner
 	var/bubble_icon = "default"
+
+	// Whether our host and other imaginary friends can hear us only when nearby or practically anywhere.
+	var/extended_message_range = TRUE
 
 /mob/camera/imaginary_friend/Login()
 	. = ..()
@@ -212,7 +220,7 @@
 		create_chat_message(speaker, message_language, raw_message, spans)
 	to_chat(src, compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods))
 
-/mob/camera/imaginary_friend/send_speech(message, range = 7, obj/source = src, bubble_type = bubble_icon, list/spans = list(), datum/language/message_language = null, list/message_mods = list(), forced = null)
+/mob/camera/imaginary_friend/send_speech(message, range = IMAGINARY_FRIEND_SPEECH_RANGE, obj/source = src, bubble_type = bubble_icon, list/spans = list(), datum/language/message_language = null, list/message_mods = list(), forced = null)
 	message = get_message_mods(message, message_mods)
 	message = capitalize(message)
 
@@ -231,6 +239,9 @@
 		var/randomnote = pick("♩", "♪", "♫")
 		message = "[randomnote] [capitalize(message)] [randomnote]"
 		spans |= SPAN_SINGING
+
+	if(extended_message_range)
+		range = IMAGINARY_FRIEND_EXTENDED_SPEECH_RANGE
 
 	var/eavesdrop_range = 0
 
@@ -528,3 +539,7 @@
 	real_name = "[owner.real_name]?"
 	name = real_name
 	human_image = icon('icons/mob/simple/lavaland/lavaland_monsters.dmi', icon_state = "curseblob")
+
+#undef IMAGINARY_FRIEND_RANGE
+#undef IMAGINARY_FRIEND_SPEECH_RANGE
+#undef IMAGINARY_FRIEND_EXTENDED_SPEECH_RANGE

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -93,7 +93,7 @@
 	var/mob/living/owner
 	var/bubble_icon = "default"
 
-	// Whether our host and other imaginary friends can hear us only when nearby or practically anywhere.
+	/// Whether our host and other imaginary friends can hear us only when nearby or practically anywhere.
 	var/extended_message_range = TRUE
 
 /mob/camera/imaginary_friend/Login()

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -100,7 +100,8 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	greet()
+	if(owner)
+		greet()
 	Show()
 
 /mob/camera/imaginary_friend/proc/greet()
@@ -127,6 +128,7 @@
 	if(!owner.imaginary_group)
 		owner.imaginary_group = list(owner)
 	owner.imaginary_group += src
+	greet()
 
 /// Copies appearance from passed player prefs, or randomises them if none are provided
 /mob/camera/imaginary_friend/proc/setup_appearance(datum/preferences/appearance_from_prefs = null)

--- a/code/modules/admin/smites/imaginary_friend_special.dm
+++ b/code/modules/admin/smites/imaginary_friend_special.dm
@@ -1,6 +1,8 @@
 #define CHOICE_RANDOM_APPEARANCE "Random"
 #define CHOICE_PREFS_APPEARANCE "Look-a-like"
+#define CHOICE_PICK_PLAYER "Pick player"
 #define CHOICE_POLL_GHOSTS "Offer to ghosts"
+#define CHOICE_END_THEM "Do it!"
 #define CHOICE_CANCEL "Cancel"
 
 /**
@@ -15,10 +17,12 @@
  **/
 /datum/smite/custom_imaginary_friend
 	name = "Imaginary Friend (Special)"
-	/// Who are we going to add to your head today?
-	var/list/friend_candidates
 	/// Do we randomise friend appearances or not?
 	var/random_appearance
+	/// Are we polling for ghosts
+	var/ghost_polling
+	/// How many imaginary friends should be added when polling
+	var/polled_friend_count
 
 /datum/smite/custom_imaginary_friend/configure(client/user)
 	var/appearance_choice = tgui_alert(user,
@@ -29,69 +33,99 @@
 		return FALSE
 	random_appearance = appearance_choice == CHOICE_RANDOM_APPEARANCE
 
-	var/picked_client = tgui_input_list(user, "Pick the player to put in control", "New Imaginary Friend", list(CHOICE_POLL_GHOSTS) + sort_list(GLOB.clients))
-	if(isnull(picked_client))
+	var/client_selection_choice = tgui_alert(user,
+		"Do you want to pick a specific player, or poll for ghosts?",
+		"Imaginary Friend Selection?",
+		list(CHOICE_PICK_PLAYER, CHOICE_POLL_GHOSTS, CHOICE_CANCEL))
+
+	if(isnull(client_selection_choice) || client_selection_choice == CHOICE_CANCEL)
 		return FALSE
+	ghost_polling = client_selection_choice == CHOICE_POLL_GHOSTS
 
-	if(picked_client == CHOICE_POLL_GHOSTS)
-		return poll_ghosts(user)
+	if(ghost_polling)
+		var/how_many = tgui_input_number(user, "How many imaginary friends should be added?", "Imaginary friend count", default = 1, min_value = 1)
+		if(isnull(how_many) || how_many < 1)
+			return FALSE
+		polled_friend_count = how_many
 
-	var/client/friend_candidate_client = picked_client
-	if(QDELETED(friend_candidate_client))
-		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
-		return FALSE
-
-	if(isliving(friend_candidate_client.mob) && (tgui_alert(user, "This player already has a living mob ([friend_candidate_client.mob]). Do you still want to turn them into an Imaginary Friend?", "Remove player from mob?", list("Do it!", "Cancel")) != "Do it!"))
-		return FALSE
-
-	if(QDELETED(friend_candidate_client))
-		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
-		return FALSE
-
-	friend_candidates = list(friend_candidate_client)
 	return TRUE
 
-/// Try to offer the role to ghosts
-/datum/smite/custom_imaginary_friend/proc/poll_ghosts(client/user)
-	var/how_many = tgui_input_number(user, "How many imaginary friends should be added?", "Imaginary friend count", default = 1, min_value = 1)
-	if (isnull(how_many) || how_many < 1)
-		return FALSE
 
+/// Try to offer the role to ghosts
+/datum/smite/custom_imaginary_friend/proc/poll_ghosts(client/user, mob/living/target)
 	var/list/volunteers = SSpolling.poll_ghost_candidates(
 		check_jobban = ROLE_PAI,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_IMAGINARYFRIEND,
-		role_name_text = "imaginary friend",
+		jump_target = target,
+		role_name_text = "an imaginary friend for [target.real_name]",
 	)
 	var/volunteer_count = length(volunteers)
-	if (volunteer_count == 0)
+	if(volunteer_count == 0)
 		to_chat(user, span_warning("No candidates volunteered, aborting."))
-		return FALSE
+		return
 
 	shuffle_inplace(volunteers)
-	friend_candidates = list()
-	while (how_many > 0 && length(volunteers) > 0)
+	var/list/friend_candidates = list()
+	while(polled_friend_count > 0 && length(volunteers) > 0)
 		var/mob/dead/observer/lucky_ghost = pop(volunteers)
 		if (!lucky_ghost.client)
 			continue
-		how_many--
+		polled_friend_count--
 		friend_candidates += lucky_ghost.client
-	return TRUE
+	return friend_candidates
+
+/// Pick client manually
+/datum/smite/custom_imaginary_friend/proc/pick_client(client/user)
+	var/picked_client = tgui_input_list(user, "Pick the player to put in control", "New Imaginary Friend", sort_list(GLOB.clients))
+	if(isnull(picked_client))
+		return
+
+	var/client/friend_candidate_client = picked_client
+	if(QDELETED(friend_candidate_client))
+		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
+		return
+
+	if(isliving(friend_candidate_client.mob))
+		var/end_them_choice = tgui_alert(user,
+			"This player already has a living mob ([friend_candidate_client.mob]). Do you still want to turn them into an Imaginary Friend?",
+			"Remove player from mob?",
+			list(CHOICE_END_THEM, CHOICE_CANCEL))
+		if(end_them_choice == CHOICE_CANCEL)
+			return
+
+	if(QDELETED(friend_candidate_client))
+		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
+		return
+
+	return list(friend_candidate_client)
+
 
 /datum/smite/custom_imaginary_friend/effect(client/user, mob/living/target)
 	. = ..()
+
+	// Run this check before and after polling, we don't wanna poll for something which already stopped existing
+	if(QDELETED(target))
+		to_chat(user, span_warning("The target mob no longer exists, aborting."))
+		return
+
+	var/list/friend_candidates
+	if(ghost_polling)
+		friend_candidates = poll_ghosts(user, target)
+	else
+		friend_candidates = pick_client(user)
 
 	if(QDELETED(target))
 		to_chat(user, span_warning("The target mob no longer exists, aborting."))
 		return
 
-	if(!length(friend_candidates))
+	if(isnull(friend_candidates) || !length(friend_candidates))
 		to_chat(user, span_warning("No provided imaginary friend candidates, aborting."))
 		return
 
 	var/list/final_clients = list()
-	for (var/client/client as anything in friend_candidates)
-		if (QDELETED(client))
+	for(var/client/client as anything in friend_candidates)
+		if(QDELETED(client))
 			continue
 		final_clients += client
 
@@ -99,7 +133,7 @@
 		to_chat(user, span_warning("No provided imaginary friend candidates had clients, aborting."))
 		return
 
-	for (var/client/friend_candidate_client as anything in final_clients)
+	for(var/client/friend_candidate_client as anything in final_clients)
 		var/mob/client_mob = friend_candidate_client.mob
 		if(isliving(client_mob))
 			client_mob.ghostize()
@@ -114,5 +148,7 @@
 
 #undef CHOICE_RANDOM_APPEARANCE
 #undef CHOICE_PREFS_APPEARANCE
+#undef CHOICE_PICK_PLAYER
 #undef CHOICE_POLL_GHOSTS
+#undef CHOICE_END_THEM
 #undef CHOICE_CANCEL

--- a/code/modules/admin/smites/imaginary_friend_special.dm
+++ b/code/modules/admin/smites/imaginary_friend_special.dm
@@ -1,8 +1,6 @@
 #define CHOICE_RANDOM_APPEARANCE "Random"
 #define CHOICE_PREFS_APPEARANCE "Look-a-like"
-#define CHOICE_PICK_PLAYER "Pick player"
 #define CHOICE_POLL_GHOSTS "Offer to ghosts"
-#define CHOICE_END_THEM "Do it!"
 #define CHOICE_CANCEL "Cancel"
 
 /**
@@ -17,12 +15,10 @@
  **/
 /datum/smite/custom_imaginary_friend
 	name = "Imaginary Friend (Special)"
+	/// Who are we going to add to your head today?
+	var/list/friend_candidates
 	/// Do we randomise friend appearances or not?
 	var/random_appearance
-	/// Are we polling for ghosts
-	var/ghost_polling
-	/// How many imaginary friends should be added when polling
-	var/polled_friend_count
 
 /datum/smite/custom_imaginary_friend/configure(client/user)
 	var/appearance_choice = tgui_alert(user,
@@ -33,99 +29,69 @@
 		return FALSE
 	random_appearance = appearance_choice == CHOICE_RANDOM_APPEARANCE
 
-	var/client_selection_choice = tgui_alert(user,
-		"Do you want to pick a specific player, or poll for ghosts?",
-		"Imaginary Friend Selection?",
-		list(CHOICE_PICK_PLAYER, CHOICE_POLL_GHOSTS, CHOICE_CANCEL))
-
-	if(isnull(client_selection_choice) || client_selection_choice == CHOICE_CANCEL)
-		return FALSE
-	ghost_polling = client_selection_choice == CHOICE_POLL_GHOSTS
-
-	if(ghost_polling)
-		var/how_many = tgui_input_number(user, "How many imaginary friends should be added?", "Imaginary friend count", default = 1, min_value = 1)
-		if(isnull(how_many) || how_many < 1)
-			return FALSE
-		polled_friend_count = how_many
-
-	return TRUE
-
-
-/// Try to offer the role to ghosts
-/datum/smite/custom_imaginary_friend/proc/poll_ghosts(client/user, mob/living/target)
-	var/list/volunteers = SSpolling.poll_ghost_candidates(
-		check_jobban = ROLE_PAI,
-		poll_time = 10 SECONDS,
-		ignore_category = POLL_IGNORE_IMAGINARYFRIEND,
-		jump_target = target,
-		role_name_text = "an imaginary friend for [target.real_name]",
-	)
-	var/volunteer_count = length(volunteers)
-	if(volunteer_count == 0)
-		to_chat(user, span_warning("No candidates volunteered, aborting."))
-		return
-
-	shuffle_inplace(volunteers)
-	var/list/friend_candidates = list()
-	while(polled_friend_count > 0 && length(volunteers) > 0)
-		var/mob/dead/observer/lucky_ghost = pop(volunteers)
-		if (!lucky_ghost.client)
-			continue
-		polled_friend_count--
-		friend_candidates += lucky_ghost.client
-	return friend_candidates
-
-/// Pick client manually
-/datum/smite/custom_imaginary_friend/proc/pick_client(client/user)
-	var/picked_client = tgui_input_list(user, "Pick the player to put in control", "New Imaginary Friend", sort_list(GLOB.clients))
+	var/picked_client = tgui_input_list(user, "Pick the player to put in control", "New Imaginary Friend", list(CHOICE_POLL_GHOSTS) + sort_list(GLOB.clients))
 	if(isnull(picked_client))
-		return
+		return FALSE
+
+	if(picked_client == CHOICE_POLL_GHOSTS)
+		return poll_ghosts(user)
 
 	var/client/friend_candidate_client = picked_client
 	if(QDELETED(friend_candidate_client))
 		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
-		return
+		return FALSE
 
-	if(isliving(friend_candidate_client.mob))
-		var/end_them_choice = tgui_alert(user,
-			"This player already has a living mob ([friend_candidate_client.mob]). Do you still want to turn them into an Imaginary Friend?",
-			"Remove player from mob?",
-			list(CHOICE_END_THEM, CHOICE_CANCEL))
-		if(end_them_choice == CHOICE_CANCEL)
-			return
+	if(isliving(friend_candidate_client.mob) && (tgui_alert(user, "This player already has a living mob ([friend_candidate_client.mob]). Do you still want to turn them into an Imaginary Friend?", "Remove player from mob?", list("Do it!", "Cancel")) != "Do it!"))
+		return FALSE
 
 	if(QDELETED(friend_candidate_client))
 		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
-		return
+		return FALSE
 
-	return list(friend_candidate_client)
+	friend_candidates = list(friend_candidate_client)
+	return TRUE
 
+/// Try to offer the role to ghosts
+/datum/smite/custom_imaginary_friend/proc/poll_ghosts(client/user)
+	var/how_many = tgui_input_number(user, "How many imaginary friends should be added?", "Imaginary friend count", default = 1, min_value = 1)
+	if (isnull(how_many) || how_many < 1)
+		return FALSE
+
+	var/list/volunteers = SSpolling.poll_ghost_candidates(
+		check_jobban = ROLE_PAI,
+		poll_time = 10 SECONDS,
+		ignore_category = POLL_IGNORE_IMAGINARYFRIEND,
+		role_name_text = "imaginary friend",
+	)
+	var/volunteer_count = length(volunteers)
+	if (volunteer_count == 0)
+		to_chat(user, span_warning("No candidates volunteered, aborting."))
+		return FALSE
+
+	shuffle_inplace(volunteers)
+	friend_candidates = list()
+	while (how_many > 0 && length(volunteers) > 0)
+		var/mob/dead/observer/lucky_ghost = pop(volunteers)
+		if (!lucky_ghost.client)
+			continue
+		how_many--
+		friend_candidates += lucky_ghost.client
+	return TRUE
 
 /datum/smite/custom_imaginary_friend/effect(client/user, mob/living/target)
 	. = ..()
 
-	// Run this check before and after polling, we don't wanna poll for something which already stopped existing
 	if(QDELETED(target))
 		to_chat(user, span_warning("The target mob no longer exists, aborting."))
 		return
 
-	var/list/friend_candidates
-	if(ghost_polling)
-		friend_candidates = poll_ghosts(user, target)
-	else
-		friend_candidates = pick_client(user)
-
-	if(QDELETED(target))
-		to_chat(user, span_warning("The target mob no longer exists, aborting."))
-		return
-
-	if(isnull(friend_candidates) || !length(friend_candidates))
+	if(!length(friend_candidates))
 		to_chat(user, span_warning("No provided imaginary friend candidates, aborting."))
 		return
 
 	var/list/final_clients = list()
-	for(var/client/client as anything in friend_candidates)
-		if(QDELETED(client))
+	for (var/client/client as anything in friend_candidates)
+		if (QDELETED(client))
 			continue
 		final_clients += client
 
@@ -133,7 +99,7 @@
 		to_chat(user, span_warning("No provided imaginary friend candidates had clients, aborting."))
 		return
 
-	for(var/client/friend_candidate_client as anything in final_clients)
+	for (var/client/friend_candidate_client as anything in final_clients)
 		var/mob/client_mob = friend_candidate_client.mob
 		if(isliving(client_mob))
 			client_mob.ghostize()
@@ -148,7 +114,5 @@
 
 #undef CHOICE_RANDOM_APPEARANCE
 #undef CHOICE_PREFS_APPEARANCE
-#undef CHOICE_PICK_PLAYER
 #undef CHOICE_POLL_GHOSTS
-#undef CHOICE_END_THEM
 #undef CHOICE_CANCEL

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -361,6 +361,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		if(!(listening_movable in in_view) && !HAS_TRAIT(listening_movable, TRAIT_XRAY_HEARING))
 			listening.Remove(listening_movable)
 
+	if(imaginary_group)
+		listening |= imaginary_group
+
 	if(client) //client is so that ghosts don't have to listen to mice
 		for(var/mob/player_mob as anything in GLOB.player_list)
 			if(QDELETED(player_mob)) //Some times nulls and deleteds stay in this list. This is a workaround to prevent ic chat breaking for everyone when they do.


### PR DESCRIPTION

## About The Pull Request

I was initially working on a broader fix to imaginary friends, but I realized fixing movement would take longer than expected, so I'm atomizing the speech parts off into this pr.

Firstly, imaginary friends had a weird issue where they were unable to hear their hosts entirely unless they were in a specific area, which seems to be related to how listeners were gotten on the side of the host.
While I imagine updating their movement code may fix this, it's odd we rely on this in the first place. They're in your head, they should be able to hear you regardless of whether you can see them. So we just make it so if a living entity has imaginary friends they are always added to the listeners.

Then, we increase the imaginary friends' message range to 9 as being the full movement range, for which we start using a define. We use increased message range instead of just making them always audible to the host such that imaginary friends can still choose to whisper to each other or the host for whatever reason.
To note, multiple imaginary friends on the same host can hear each other's whispers regardless, but the host must be nearby to hear them.

Finally, we have a variable for increasing the message range to 999.
Currently, this is because the host can still move outside of the imaginary friends' range.
After I finish updating the movement to be less jank and allow for leashing to arbitrary objects, this'll be so admins can choose to make an imaginary friend's speech global or local, for things like leashing an imaginary friend to the AI eye or some object.
## Why It's Good For The Game

Good for imaginary friends to actually be able to hear their hosts.

It's good for imaginary friends to be audible to their hosts too, even with the current movement jank.
It's really funny for imaginary friends to be able to whisper to each other to keep messages from their host, especially if the being able to see them whispering pr goes through.

Variable is the first half of an admin request for allowing more imaginary friends fuckery.
## Changelog
:cl:
fix: Imaginary friends can now hear their host wherever they are.
/:cl:
