### PR TITLE
Imaginary friend smite shows target name to ghosts polled, now also technically build mode compatible

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -92,7 +92,8 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	greet()
+	if(owner)
+		greet()
 	Show()
 
 /mob/camera/imaginary_friend/proc/greet()
@@ -119,6 +120,7 @@
 	if(!owner.imaginary_group)
 		owner.imaginary_group = list(owner)
 	owner.imaginary_group += src
+	greet()
 
 /// Copies appearance from passed player prefs, or randomises them if none are provided
 /mob/camera/imaginary_friend/proc/setup_appearance(datum/preferences/appearance_from_prefs = null)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -92,8 +92,7 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	if(owner)
-		greet()
+	greet()
 	Show()
 
 /mob/camera/imaginary_friend/proc/greet()
@@ -120,7 +119,6 @@
 	if(!owner.imaginary_group)
 		owner.imaginary_group = list(owner)
 	owner.imaginary_group += src
-	greet()
 
 /// Copies appearance from passed player prefs, or randomises them if none are provided
 /mob/camera/imaginary_friend/proc/setup_appearance(datum/preferences/appearance_from_prefs = null)

--- a/code/modules/admin/smites/imaginary_friend_special.dm
+++ b/code/modules/admin/smites/imaginary_friend_special.dm
@@ -1,6 +1,8 @@
 #define CHOICE_RANDOM_APPEARANCE "Random"
 #define CHOICE_PREFS_APPEARANCE "Look-a-like"
+#define CHOICE_PICK_PLAYER "Pick player"
 #define CHOICE_POLL_GHOSTS "Offer to ghosts"
+#define CHOICE_END_THEM "Do it!"
 #define CHOICE_CANCEL "Cancel"
 
 /**
@@ -15,10 +17,12 @@
  **/
 /datum/smite/custom_imaginary_friend
 	name = "Imaginary Friend (Special)"
-	/// Who are we going to add to your head today?
-	var/list/friend_candidates
 	/// Do we randomise friend appearances or not?
 	var/random_appearance
+	/// Are we polling for ghosts
+	var/ghost_polling
+	/// How many imaginary friends should be added when polling
+	var/polled_friend_count
 
 /datum/smite/custom_imaginary_friend/configure(client/user)
 	var/appearance_choice = tgui_alert(user,
@@ -29,69 +33,99 @@
 		return FALSE
 	random_appearance = appearance_choice == CHOICE_RANDOM_APPEARANCE
 
-	var/picked_client = tgui_input_list(user, "Pick the player to put in control", "New Imaginary Friend", list(CHOICE_POLL_GHOSTS) + sort_list(GLOB.clients))
-	if(isnull(picked_client))
+	var/client_selection_choice = tgui_alert(user,
+		"Do you want to pick a specific player, or poll for ghosts?",
+		"Imaginary Friend Selection?",
+		list(CHOICE_PICK_PLAYER, CHOICE_POLL_GHOSTS, CHOICE_CANCEL))
+
+	if(isnull(client_selection_choice) || client_selection_choice == CHOICE_CANCEL)
 		return FALSE
+	ghost_polling = client_selection_choice == CHOICE_POLL_GHOSTS
 
-	if(picked_client == CHOICE_POLL_GHOSTS)
-		return poll_ghosts(user)
+	if(ghost_polling)
+		var/how_many = tgui_input_number(user, "How many imaginary friends should be added?", "Imaginary friend count", default = 1, min_value = 1)
+		if(isnull(how_many) || how_many < 1)
+			return FALSE
+		polled_friend_count = how_many
 
-	var/client/friend_candidate_client = picked_client
-	if(QDELETED(friend_candidate_client))
-		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
-		return FALSE
-
-	if(isliving(friend_candidate_client.mob) && (tgui_alert(user, "This player already has a living mob ([friend_candidate_client.mob]). Do you still want to turn them into an Imaginary Friend?", "Remove player from mob?", list("Do it!", "Cancel")) != "Do it!"))
-		return FALSE
-
-	if(QDELETED(friend_candidate_client))
-		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
-		return FALSE
-
-	friend_candidates = list(friend_candidate_client)
 	return TRUE
 
-/// Try to offer the role to ghosts
-/datum/smite/custom_imaginary_friend/proc/poll_ghosts(client/user)
-	var/how_many = tgui_input_number(user, "How many imaginary friends should be added?", "Imaginary friend count", default = 1, min_value = 1)
-	if (isnull(how_many) || how_many < 1)
-		return FALSE
 
+/// Try to offer the role to ghosts
+/datum/smite/custom_imaginary_friend/proc/poll_ghosts(client/user, mob/living/target)
 	var/list/volunteers = SSpolling.poll_ghost_candidates(
 		check_jobban = ROLE_PAI,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_IMAGINARYFRIEND,
-		role_name_text = "imaginary friend",
+		jump_target = target,
+		role_name_text = "an imaginary friend for [target.real_name]",
 	)
 	var/volunteer_count = length(volunteers)
-	if (volunteer_count == 0)
+	if(volunteer_count == 0)
 		to_chat(user, span_warning("No candidates volunteered, aborting."))
-		return FALSE
+		return
 
 	shuffle_inplace(volunteers)
-	friend_candidates = list()
-	while (how_many > 0 && length(volunteers) > 0)
+	var/list/friend_candidates = list()
+	while(polled_friend_count > 0 && length(volunteers) > 0)
 		var/mob/dead/observer/lucky_ghost = pop(volunteers)
 		if (!lucky_ghost.client)
 			continue
-		how_many--
+		polled_friend_count--
 		friend_candidates += lucky_ghost.client
-	return TRUE
+	return friend_candidates
+
+/// Pick client manually
+/datum/smite/custom_imaginary_friend/proc/pick_client(client/user)
+	var/picked_client = tgui_input_list(user, "Pick the player to put in control", "New Imaginary Friend", sort_list(GLOB.clients))
+	if(isnull(picked_client))
+		return
+
+	var/client/friend_candidate_client = picked_client
+	if(QDELETED(friend_candidate_client))
+		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
+		return
+
+	if(isliving(friend_candidate_client.mob))
+		var/end_them_choice = tgui_alert(user,
+			"This player already has a living mob ([friend_candidate_client.mob]). Do you still want to turn them into an Imaginary Friend?",
+			"Remove player from mob?",
+			list(CHOICE_END_THEM, CHOICE_CANCEL))
+		if(end_them_choice == CHOICE_CANCEL)
+			return
+
+	if(QDELETED(friend_candidate_client))
+		to_chat(user, span_warning("Selected player no longer has a client, aborting."))
+		return
+
+	return list(friend_candidate_client)
+
 
 /datum/smite/custom_imaginary_friend/effect(client/user, mob/living/target)
 	. = ..()
+
+	// Run this check before and after polling, we don't wanna poll for something which already stopped existing
+	if(QDELETED(target))
+		to_chat(user, span_warning("The target mob no longer exists, aborting."))
+		return
+
+	var/list/friend_candidates
+	if(ghost_polling)
+		friend_candidates = poll_ghosts(user, target)
+	else
+		friend_candidates = pick_client(user)
 
 	if(QDELETED(target))
 		to_chat(user, span_warning("The target mob no longer exists, aborting."))
 		return
 
-	if(!length(friend_candidates))
+	if(isnull(friend_candidates) || !length(friend_candidates))
 		to_chat(user, span_warning("No provided imaginary friend candidates, aborting."))
 		return
 
 	var/list/final_clients = list()
-	for (var/client/client as anything in friend_candidates)
-		if (QDELETED(client))
+	for(var/client/client as anything in friend_candidates)
+		if(QDELETED(client))
 			continue
 		final_clients += client
 
@@ -99,7 +133,7 @@
 		to_chat(user, span_warning("No provided imaginary friend candidates had clients, aborting."))
 		return
 
-	for (var/client/friend_candidate_client as anything in final_clients)
+	for(var/client/friend_candidate_client as anything in final_clients)
 		var/mob/client_mob = friend_candidate_client.mob
 		if(isliving(client_mob))
 			client_mob.ghostize()
@@ -114,5 +148,7 @@
 
 #undef CHOICE_RANDOM_APPEARANCE
 #undef CHOICE_PREFS_APPEARANCE
+#undef CHOICE_PICK_PLAYER
 #undef CHOICE_POLL_GHOSTS
+#undef CHOICE_END_THEM
 #undef CHOICE_CANCEL


### PR DESCRIPTION
## About The Pull Request

So recently I was observing a round in which the imaginary friend smite ghost polling was used, and a desire for it to show _who_ they'd be an imaginary to was expressed by the admin in question.
Thus, this pr.

Because the configuration step of smites doesn't actually get the target, this isn't actually possible without changing up how the smite works.
While I was looking into adding the target to the configuration step, I realized this wouldn't work due to build mode smites, as they select the target after configuration and before the effect step- hell, even currently this means the imaginary friend smite would break with build mode.
So I decided the sanest approach would be to move all client selection, manual and polling, to the effect step.

As such, in this pr we move ghost polling and manual client selection to the effect step, instead having the configuration step decide whether to poll ghosts and how many if so.
This lets us set the jump target and visible name for our polling, but as a side-effect _also_ makes it build mode smite compatible. Just in case you wanted to throw imaginary friends at an entire department in one go.
## Why It's Good For The Game

Improves admin tooling.
Makes imaginary friend polling saner.
haha build mode smite imaginary friend
## Changelog
:cl:
qol: Imaginary friend smite ghost poll actually lets you jump to the target and shows their name.
admin: Imaginary friend smite now works with build mode.
admin: The imaginary friend smite configuration menus have been changed slightly.
/:cl:
