### PR TITLE
Fix the greeting message you get upon becoming an imaginary friend including nulls

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -92,7 +92,8 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	greet()
+	if(owner)
+		greet()
 	Show()
 
 /mob/camera/imaginary_friend/proc/greet()
@@ -119,6 +120,7 @@
 	if(!owner.imaginary_group)
 		owner.imaginary_group = list(owner)
 	owner.imaginary_group += src
+	greet()
 
 /// Copies appearance from passed player prefs, or randomises them if none are provided
 /mob/camera/imaginary_friend/proc/setup_appearance(datum/preferences/appearance_from_prefs = null)


### PR DESCRIPTION

## About The Pull Request

Previously the imaginary friend greeting message would be called on `Login()`, but this meant that it could run before it actually linked the `owner` value, thus putting nulls in the message where the owner's name should've been.
This just changes it so `greet()` is only called on `Login()` if there's already an owner linked, otherwise calling it when being attached to an owner.
## Why It's Good For The Game

Better if the greeting message actually says whose imaginary friend you are.
## Changelog
:cl:
fix: The greeting message imaginary friends get upon becoming one actually includes the owner's name, instead of displaying nothing where it should've been.
/:cl:
