### PR TITLE
Add fire proof flag to item that are lava proofed by xenobio potion

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -170,6 +170,7 @@ Slimecrossing Potions
 	if (isclothing(clothing))
 		var/obj/item/clothing/clothing_real = clothing
 		clothing_real.clothing_flags |= LAVAPROTECT
+		clothing_real.resistance_flags |= FIRE_PROOF
 	uses--
 	if(uses <= 0)
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request
fix #85250
## Why It's Good For The Game
Kinda makes sense that lava proofed item wouldnt break from fire damage
## Changelog
:cl:
fix: fixed lava proofed clothing from xenobio potion being damaged from fire
/:cl:
