### PR TITLE
Replaces the unusable Blink spell in the Necromancer deathmatch kit with Link Worlds

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -440,7 +440,7 @@
 	head = /obj/item/clothing/head/wizard/black
 	spells_to_add = list(
 		/datum/action/cooldown/spell/touch/scream_for_me,
-		/datum/action/cooldown/spell/teleport/radius_turf/blink,
+		/datum/action/cooldown/spell/conjure/link_worlds,
 	)
 
 /datum/outfit/deathmatch_loadout/wizard/larp

--- a/code/modules/spells/spell_types/conjure/link_worlds.dm
+++ b/code/modules/spells/spell_types/conjure/link_worlds.dm
@@ -1,15 +1,14 @@
 /datum/action/cooldown/spell/conjure/link_worlds
 	name = "Link Worlds"
 	desc = "A whole new dimension for you to play with! They won't be happy about it, though."
-
 	sound = 'sound/items/weapons/marauder.ogg'
+	button_icon = 'icons/mob/simple/lavaland/nest.dmi'
+	button_icon_state = "nether"
 	cooldown_time = 1 MINUTES
 	cooldown_reduction_per_rank = 10 SECONDS
-
-	invocation = "WTF"
+	invocation = "FL'NT N' ST'L"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
-
 	summon_radius = 1
 	summon_type = list(/obj/structure/spawner/nether)
 	summon_amount = 1


### PR DESCRIPTION

## About The Pull Request

This replaces the unusable Blink spell on the Necromancer deathmatch kit with the previously unused "Link Worlds" spell.

This summons a netherworld portal that kicks out netherworld mobs. The mobs don't immediately spawn, but when they do, they'll attack anyone. That includes the summoner.

![image](https://github.com/user-attachments/assets/05b5cd00-6d42-4640-bde7-c9fed81b6261)

In addition to the mobs, these portals are effectively misclick landmines, as anyone who isn't a necromancer will be sucked into the hell dimension and eviscerated when clicking with an open hand.

This also changes the invocation to a cheeky minecraft joke, because "WTF" isn't really in-line with the other invocations.
## Why It's Good For The Game

Closes #86513.

There's no simple way to make the blink work without introducing the risk of escaping the deathmatch cordon, so replacing it with a necromancy-relevant spell is the next best thing.
## Changelog
:cl: Rhials
fix: Replaces the unusable blink spell on the Necromancer deathmatch kit with a nether portal summon.
/:cl:
