### PR TITLE
Fix guide books that rely on the wiki

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -313,7 +313,7 @@
 /datum/config_entry/string/banappeals
 
 /datum/config_entry/string/wikiurl
-	default = "http://www.tgstation13.org/wiki"
+	default = "http://tgstation13.org/wiki"
 
 /datum/config_entry/string/forumurl
 	default = "http://tgstation13.org/phpBB/index.php"

--- a/code/game/objects/items/wiki_manuals.dm
+++ b/code/game/objects/items/wiki_manuals.dm
@@ -1,31 +1,5 @@
 // Wiki books that are linked to the configured wiki link.
 
-/// The size of the window that the wiki books open in.
-#define BOOK_WINDOW_BROWSE_SIZE "970x710"
-/// This macro will resolve to code that will open up the associated wiki page in the window.
-#define WIKI_PAGE_IFRAME(wikiurl, link_identifier) {"
-	<html>
-	<head>
-	<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
-	<style>
-		iframe {
-			display: none;
-		}
-	</style>
-	</head>
-	<body>
-	<script type="text/javascript">
-		function pageloaded(myframe) {
-			document.getElementById("loading").style.display = "none";
-			myframe.style.display = "inline";
-	}
-	</script>
-	<p id='loading'>You start skimming through the manual...</p>
-	<iframe width='100%' height='97%' onload="pageloaded(this)" src="[##wikiurl]/[##link_identifier]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-	</body>
-	</html>
-	"}
-
 // A book that links to the wiki
 /obj/item/book/manual/wiki
 	starting_content = "Nanotrasen presently does not have any resources on this topic. If you would like to know more, contact your local Central Command representative." // safety
@@ -37,9 +11,11 @@
 	if(!wiki_url)
 		user.balloon_alert(user, "this book is empty!")
 		return
-
-	credit_book_to_reader(user)
-	DIRECT_OUTPUT(user, browse(WIKI_PAGE_IFRAME(wiki_url, page_link), "window=manual;size=[BOOK_WINDOW_BROWSE_SIZE]")) // if you change this GUARANTEE that it works.
+	else
+		credit_book_to_reader(user)
+		if(tgui_alert(user, "This will open the wiki page of the book you are reading in your browser. Are you sure?",, list("Yes","No"))!="Yes")
+			return
+		usr << link("[wiki_url]/[page_link]")
 
 /obj/item/book/manual/wiki/chemistry
 	name = "Chemistry Textbook"
@@ -223,6 +199,3 @@
 	starting_author = "Nanotrasen Edu-tainment Division"
 	starting_title = "Tactical Game Cards - Player's Handbook"
 	page_link = "Tactical_Game_Cards"
-
-#undef BOOK_WINDOW_BROWSE_SIZE
-#undef WIKI_PAGE_IFRAME

--- a/code/game/objects/items/wiki_manuals.dm
+++ b/code/game/objects/items/wiki_manuals.dm
@@ -12,7 +12,7 @@
 		user.balloon_alert(user, "this book is empty!")
 		return
 	credit_book_to_reader(user)
-	if(tgui_alert(user, "This will open the wiki page of the book you are reading in your browser. Are you sure?",, list("Yes","No"))!="Yes")
+	if(tgui_alert(user, "This book's page will open in your browser. Are you sure?", "Open The Wiki", list("Yes", "No")) != "Yes")
 		return
 	usr << link("[wiki_url]/[page_link]")
 

--- a/code/game/objects/items/wiki_manuals.dm
+++ b/code/game/objects/items/wiki_manuals.dm
@@ -11,11 +11,10 @@
 	if(!wiki_url)
 		user.balloon_alert(user, "this book is empty!")
 		return
-	else
-		credit_book_to_reader(user)
-		if(tgui_alert(user, "This will open the wiki page of the book you are reading in your browser. Are you sure?",, list("Yes","No"))!="Yes")
-			return
-		usr << link("[wiki_url]/[page_link]")
+	credit_book_to_reader(user)
+	if(tgui_alert(user, "This will open the wiki page of the book you are reading in your browser. Are you sure?",, list("Yes","No"))!="Yes")
+		return
+	usr << link("[wiki_url]/[page_link]")
 
 /obj/item/book/manual/wiki/chemistry
 	name = "Chemistry Textbook"


### PR DESCRIPTION
## About The Pull Request

This pull request aims to fix the wiki manuals. Currently the wiki manuals just show "You start skimming through the manual..." because of a bad link (http://www.tgstation13.org/wiki instead of http://tgstation13.org/wiki) which is fixed with this PR, but the issue does not end there. Because BYOND uses trident for its `browse()` function, a lot of Javascript and HTML elements do not function properly, disallowing the removal or blocking of hyperlinks which break the book entirely if they are clicked.

Therefore, as a temporary solution (until BYOND 516 is released with webview2) when the user opens a book they are prompted with the following:

![image](https://github.com/user-attachments/assets/2b92dfc2-df3e-45ff-a15d-0b44576d4c9e)

Although not the best solution, it makes the books have a function again and are usable.

Fixes https://github.com/tgstation/tgstation/issues/77315.
## Why It's Good For The Game

Makes books work again so new players can use them to be guided to the wiki resources.
## Changelog
:cl:
fix: fix wiki manuals by making them open wiki page on browser
/:cl:
