### PR TITLE
Fixes trims without a job whose title matches its assignment, but with an associated job, assigning null account jobs

### DIFF
--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -30,9 +30,6 @@
 	var/pointer_color
 
 /datum/id_trim/proc/find_job()
-	for (var/datum/job/job as anything in SSjob.all_occupations)
-		if (job.title == assignment)
-			return job
 	return null
 
 /// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -76,6 +76,9 @@
 
 	return TRUE
 
+/datum/id_trim/job/find_job()
+	return job
+
 /datum/id_trim/job/assistant
 	assignment = JOB_ASSISTANT
 	trim_state = "trim_assistant"


### PR DESCRIPTION

## About The Pull Request

Previously our code for getting the job associated with a trim involved checking the assignment against every possible job's title:
https://github.com/tgstation/tgstation/blob/8c3c9a6ea29bf32385c148c5294e3f6a18f57bf3/code/datums/id_trim/_id_trim.dm#L32-L36
This, however, didn't work with departmental security officers, as their job title doesn't match the trim assignment:
https://github.com/tgstation/tgstation/blob/8c3c9a6ea29bf32385c148c5294e3f6a18f57bf3/code/modules/jobs/job_types/security_officer.dm#L1-L2
https://github.com/tgstation/tgstation/blob/8c3c9a6ea29bf32385c148c5294e3f6a18f57bf3/code/datums/id_trim/jobs.dm#L1103-L1104

Instead, we remove this code and replace it with a `/datum/id_trim/job` subtype proc that just returns the `job` variable, which this subtype has.

This fixes our problem.

We leave the parent `find_job()` proc just returning null, as to avoid needing an `istype(...)` check where we call it, and as `/datum/id_trim/job` is associated with _station_ jobs while there may be cases where we want a non-station id trim to be able to return an associated job.
## Why It's Good For The Game

Fixes #86887.
## Changelog
:cl:
fix: Fixed trims which did have an associated job but whose assignment didn't match a job title causing null jobs to be assigned to accounts. This fixes departmental security officers not being able to purchase things from the security vendors.
/:cl:
