### PR TITLE
Adds a ghost role to the gas station ruin on Lavaland

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gas.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gas.dmm
@@ -2,6 +2,13 @@
 "aK" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/item/stack/spacecash/c10{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/item/stack/spacecash/c20{
+	pixel_y = 6
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -50,10 +57,6 @@
 "ck" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/mob/living/basic/lizard{
-	name = "Zarpo";
-	desc = "This little guy is a survivor, that's for sure."
-	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
@@ -220,11 +223,26 @@
 "iT" = (
 /obj/structure/rack,
 /obj/item/food/cornchips/random,
-/obj/item/food/cornchips/random,
-/obj/item/food/cornchips/random,
-/obj/item/food/cornchips/random,
-/obj/item/food/cornchips/random,
-/obj/item/food/cornchips/random,
+/obj/item/food/cornchips/random{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/food/cornchips/random{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/obj/item/food/cornchips/random{
+	pixel_y = -7;
+	pixel_x = -5
+	},
+/obj/item/food/cornchips/random{
+	pixel_y = -7;
+	pixel_x = 3
+	},
+/obj/item/food/cornchips/random{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/structure/sign/poster/contraband/eat/directional/north,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
@@ -338,6 +356,27 @@
 "nX" = (
 /obj/structure/sign/poster/contraband/tipper_cream_soda/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_y = 17;
+	pixel_x = 9
+	},
+/obj/item/reagent_containers/condiment/hotsauce{
+	pixel_y = 15;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/condiment/coldsauce{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/condiment/donksauce{
+	pixel_x = 1;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/condiment/mayonnaise{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -370,9 +409,19 @@
 /area/ruin/thelizardsgas_lavaland)
 "qk" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/structure/sign/poster/fluff/lizards_gas_power/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/pickaxe,
+/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+/obj/item/ammo_casing/junk/hunter,
+/obj/item/ammo_casing/junk/hunter,
+/obj/item/ammo_casing/junk/hunter,
+/obj/item/storage/box/coffeepack/robusta,
+/obj/item/storage/box/coffeepack/robusta,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -427,14 +476,14 @@
 /area/lavaland/surface/outdoors)
 "sY" = (
 /obj/structure/table/reinforced,
-/obj/item/food/sandwich/blt{
-	pixel_y = 6;
-	pixel_x = -2
-	},
-/obj/item/food/little_shiro_sandwich{
-	pixel_y = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
+/obj/item/food/donut/choco{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/food/donut/berry{
+	pixel_x = 5
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -465,32 +514,16 @@
 /area/ruin/thelizardsgas_lavaland)
 "uV" = (
 /obj/structure/table/reinforced,
-/obj/item/food/honeybar{
-	pixel_y = 5;
-	pixel_x = -1
-	},
-/obj/item/food/honeybar{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/food/honeybar{
-	pixel_y = 8;
-	pixel_x = -1
-	},
-/obj/item/food/honeybar{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/food/granola_bar{
-	pixel_y = 9;
-	pixel_x = -1
-	},
-/obj/item/food/granola_bar{
-	pixel_y = 6;
-	pixel_x = 2
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/item/food/burger/rootguffin{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/food/burger/rootguffin{
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -590,6 +623,9 @@
 	pixel_y = -1
 	},
 /obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
 /turf/open/floor/iron/freezer{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -730,6 +766,15 @@
 "El" = (
 /obj/structure/sign/poster/official/pda_ad/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/item/food/rootbread_peanut_butter_banana{
+	pixel_y = 12;
+	pixel_x = -3
+	},
+/obj/item/food/rootbread_peanut_butter_jelly{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -926,6 +971,9 @@
 /area/ruin/thelizardsgas_lavaland)
 "Km" = (
 /obj/structure/table/reinforced,
+/obj/machinery/coffeemaker/impressa{
+	pixel_x = 2
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -973,9 +1021,11 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "NY" = (
-/obj/structure/closet/crate/preopen,
-/obj/effect/spawner/random/trash/deluxe_garbage,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
+	dir = 4;
+	mob_type = /mob/living/carbon/human/species/lizard
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1010,6 +1060,10 @@
 /obj/structure/bed/dogbed{
 	name = "Zarpo's bed";
 	desc = "A comfy-looking lizard bed. Looks a lot like a dog bed."
+	},
+/mob/living/basic/lizard{
+	name = "Zarpo";
+	desc = "This little guy is a survivor, that's for sure."
 	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -356,7 +356,7 @@
 /datum/outfit/lavaland_gasstation
 	name = "Lizard's Gas Station Worker"
 	uniform = /obj/item/clothing/under/color/red
-	shoes = /obj/item/clothing/shoes/black
+	shoes = /obj/item/clothing/shoes/sneakers/black
 	ears = /obj/item/instrument/piano_synth/headphones
 	gloves = /obj/item/clothing/gloves/fingerless
 	head = /obj/item/clothing/head/soft/red

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -361,4 +361,3 @@
 	gloves = /obj/item/clothing/gloves/fingerless
 	head = /obj/item/clothing/head/soft/red
 	l_pocket = /obj/item/modular_computer/pda
-	

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -361,3 +361,4 @@
 	gloves = /obj/item/clothing/gloves/fingerless
 	head = /obj/item/clothing/head/soft/red
 	l_pocket = /obj/item/modular_computer/pda
+	

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -339,3 +339,25 @@
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the outpost fall into enemy hands!"
 	important_text = "Do NOT let the outpost fall into enemy hands"
 	outfit = /datum/outfit/lavaland_syndicate/comms/icemoon
+
+///Lavaland Gas Station Worker
+/obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation
+	name = "Lavaland Gas Station Worker"
+	desc = "Seems like there's a lizardperson inside, peacefully sleeping."
+	mob_species = /datum/species/lizard
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	prompt_name = "a gas station worker"
+	you_are_text = "You are a worker at a Lizard's Gas Station close to a mining facility."
+	flavour_text = "Your employer, however, failed to realize that there are hostile megafauna and tribes in the area, so make sure that you can defend yourself. Also sell stuff to people, ocasionally."
+	important_text = "Do NOT let your workplace get damaged! Do not abandon it either!"
+	outfit = /datum/outfit/lavaland_gasstation
+
+/datum/outfit/lavaland_gasstation
+	name = "Lizard's Gas Station Worker"
+	uniform = /obj/item/clothing/under/color/red
+	shoes = /obj/item/clothing/shoes/black
+	ears = /obj/item/instrument/piano_synth/headphones
+	gloves = /obj/item/clothing/gloves/fingerless
+	head = /obj/item/clothing/head/soft/red
+	l_pocket = /obj/item/modular_computer/pda

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -349,7 +349,7 @@
 	icon_state = "sleeper"
 	prompt_name = "a gas station worker"
 	you_are_text = "You are a worker at a Lizard's Gas Station close to a mining facility."
-	flavour_text = "Your employer, however, failed to realize that there are hostile megafauna and tribes in the area, so make sure that you can defend yourself. Also sell stuff to people, ocasionally."
+	flavour_text = "Your employer, however, failed to realize that there are hostile megafauna and tribes in the area, so make sure that you can defend yourself. Also sell stuff to people, occasionally."
 	important_text = "Do NOT let your workplace get damaged! Do not abandon it either!"
 	outfit = /datum/outfit/lavaland_gasstation
 


### PR DESCRIPTION
## About The Pull Request
Adds a new ghostrole to the Lizard's Gas Station ruin on Lavaland.
They have enough supplies to expand, like a pickaxe, coat, oxygen tank, and a pipe rifle with 3 rounds.
They can also stay there for the entire round due to the abundance of food and power.
gimmick idea: try to find lavaland syndicate and deliver food to them for extra supplies
## Why It's Good For The Game
Ghost roles are good for well, ghosts to "soft-respawn" and this one gives an opportunity to roleplay
instead of just hunting megafauna left and right
## Changelog
:cl:
add: Added a new ghost role to lavaland, specifically the gas station ruin
/:cl:
