### PR TITLE
Removes the chunkyfingers trait from insuls

### DIFF
--- a/code/modules/clothing/gloves/insulated.dm
+++ b/code/modules/clothing/gloves/insulated.dm
@@ -13,7 +13,6 @@
 	custom_price = PAYCHECK_CREW * 10
 	custom_premium_price = PAYCHECK_COMMAND * 6
 	cut_type = /obj/item/clothing/gloves/cut
-	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/gloves/color/yellow/Initialize(mapload)
 	. = ..()
@@ -22,11 +21,9 @@
 /obj/item/clothing/gloves/color/yellow/apply_fantasy_bonuses(bonus)
 	. = ..()
 	if(bonus >= 10)
-		detach_clothing_traits(TRAIT_CHUNKYFINGERS)
 		qdel(GetComponent(/datum/component/adjust_fishing_difficulty))
 
 /obj/item/clothing/gloves/color/yellow/remove_fantasy_bonuses(bonus)
-	attach_clothing_traits(TRAIT_CHUNKYFINGERS)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 10)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
Does what it says in the title.

## Why It's Good For The Game
Right now I feel like this is an engineer nerf more than anything else, since they have to interface with a lot of things that chunky fingers blocks, like their tablets and computers. I think that gloves having this trait is more to inconvenience certain players rather than add something to the gameplay.

## Changelog
:cl: Tattle
balance: insulated gloves no longer have the chunky fingers trait
/:cl: