### PR TITLE
Removes a bookcase from the holdout simulation

### DIFF
--- a/_maps/templates/holodeck_holdoutbunker.dmm
+++ b/_maps/templates/holodeck_holdoutbunker.dmm
@@ -28,12 +28,6 @@
 	},
 /turf/open/floor/holofloor/asteroid,
 /area/template_noop)
-"x" = (
-/obj/structure/foamedmetal,
-/obj/structure/window/spawner/directional/east,
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/holofloor/asteroid,
-/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser,
@@ -62,7 +56,7 @@ a
 "}
 (2,1,1) = {"
 b
-x
+b
 b
 b
 b


### PR DESCRIPTION

## About The Pull Request
Gets rid of a bookcase that was under the foam in the holdout bunker simulation.
## Why It's Good For The Game
There's no reason for it to be there, and it would cause random books to be there after simulations changed. And most importantly, it caused me MILD ANNOYANCE.
## Changelog
:cl: Goat
fix: Removes a random bookcase that was in the holdout bunker holodeck simulation
/:cl:
