### PR TITLE
Fix air alarms not updating icon

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -126,7 +126,6 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	find_and_hang_on_wall()
 	register_context()
 	check_enviroment()
-	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/airalarm/process()
 	if(!COOLDOWN_FINISHED(src, warning_cooldown))

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -123,9 +123,13 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	))
 
 	GLOB.air_alarms += src
-	update_appearance()
 	find_and_hang_on_wall()
 	register_context()
+
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/airalarm/LateInitialize()
+	update_appearance()
 
 /obj/machinery/airalarm/process()
 	if(!COOLDOWN_FINISHED(src, warning_cooldown))
@@ -154,7 +158,6 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 /obj/machinery/airalarm/power_change()
 	check_enviroment()
-	update_appearance()
 	return ..()
 
 /obj/machinery/airalarm/on_enter_area(datum/source, area/area_to_register)

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -154,6 +154,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 /obj/machinery/airalarm/power_change()
 	check_enviroment()
+	update_appearance()
 	return ..()
 
 /obj/machinery/airalarm/on_enter_area(datum/source, area/area_to_register)

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -125,11 +125,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	GLOB.air_alarms += src
 	find_and_hang_on_wall()
 	register_context()
-
+	check_enviroment()
 	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/airalarm/LateInitialize()
-	update_appearance()
 
 /obj/machinery/airalarm/process()
 	if(!COOLDOWN_FINISHED(src, warning_cooldown))


### PR DESCRIPTION

## About The Pull Request
This updates the air alarms whenever a power change is triggered. When connecting a gas sensor using mapping link helpers air alarms would not update their icons at roundstart. I'm sure this applies to other rare situations where the icon wasn't updating when it should green/red/etc.

## Why It's Good For The Game
Better consistency.

## Changelog
:cl:
fix: Fix air alarms being stuck and not updating their icons.
/:cl:
