### PR TITLE
Fix air alarm helper to ignore gas when appropriate

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -677,6 +677,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	tlv_collection["temperature"] = new /datum/tlv/no_checks
 	tlv_collection["pressure"] = new /datum/tlv/no_checks
 
+	for(var/gas_path in GLOB.meta_gas_info)
+		tlv_collection[gas_path] = new /datum/tlv/no_checks
+
 ///Used for air alarm link helper, which connects air alarm to a sensor with corresponding chamber_id
 /obj/machinery/airalarm/proc/setup_chamber_link()
 	var/obj/machinery/air_sensor/sensor = GLOB.objects_by_id_tag[GLOB.map_loaded_sensors[air_sensor_chamber_id]]


### PR DESCRIPTION

## About The Pull Request
Certain air alarms were marked with no checks for the pressure/temperature. This should also extend to ignore all gas checks otherwise it triggers alarms.

## Why It's Good For The Game
No more air alarms crying wolf. 

Certain air alarms on the station are meant to only be used to trigger vents/scrubbers and not care about the gases inside. (ordance chambers, burn chambers, SM, etc.)

## Changelog
:cl:
fix: Fix air alarm helper to ignore gas when appropriate
/:cl:
