### PR TITLE
Fix air alarms warning message to use pressure & temp settings

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -574,28 +574,28 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 	if(danger_level)
 		alarm_manager.send_alarm(ALARM_ATMOS)
-		if(pressure <= tlv_collection["pressure"]["hazard_min"] && temp <= tlv_collection["temperature"]["hazard_min"])
+		if(pressure <= tlv_collection["pressure"].hazard_min && temp <= tlv_collection["temperature"].hazard_min)
 			warning_message = "Danger! Low pressure and temperature detected."
 			return
-		if(pressure <= tlv_collection["pressure"]["hazard_min"] && temp >= tlv_collection["temperature"]["hazard_max"])
+		if(pressure <= tlv_collection["pressure"].hazard_min && temp >= tlv_collection["temperature"].hazard_max)
 			warning_message = "Danger! Low pressure and high temperature detected."
 			return
-		if(pressure >= tlv_collection["pressure"]["hazard_max"] && temp >= tlv_collection["temperature"]["hazard_max"])
+		if(pressure >= tlv_collection["pressure"].hazard_max && temp >= tlv_collection["temperature"].hazard_max)
 			warning_message = "Danger! High pressure and temperature detected."
 			return
-		if(pressure >= tlv_collection["pressure"]["hazard_max"] && temp <= tlv_collection["temperature"]["hazard_min"])
+		if(pressure >= tlv_collection["pressure"].hazard_max && temp <= tlv_collection["temperature"].hazard_min)
 			warning_message = "Danger! High pressure and low temperature detected."
 			return
-		if(pressure <= tlv_collection["pressure"]["hazard_min"])
+		if(pressure <= tlv_collection["pressure"].hazard_min)
 			warning_message = "Danger! Low pressure detected."
 			return
-		if(pressure >= tlv_collection["pressure"]["hazard_max"])
+		if(pressure >= tlv_collection["pressure"].hazard_max)
 			warning_message = "Danger! High pressure detected."
 			return
-		if(temp <= tlv_collection["temperature"]["hazard_min"])
+		if(temp <= tlv_collection["temperature"].hazard_min)
 			warning_message = "Danger! Low temperature detected."
 			return
-		if(temp >= tlv_collection["temperature"]["hazard_max"])
+		if(temp >= tlv_collection["temperature"].hazard_max)
 			warning_message = "Danger! High temperature detected."
 			return
 		else

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -574,28 +574,28 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 	if(danger_level)
 		alarm_manager.send_alarm(ALARM_ATMOS)
-		if(pressure <= WARNING_LOW_PRESSURE && temp <= BODYTEMP_COLD_WARNING_1+10)
+		if(pressure <= tlv_collection["pressure"]["hazard_min"] && temp <= tlv_collection["temperature"]["hazard_min"])
 			warning_message = "Danger! Low pressure and temperature detected."
 			return
-		if(pressure <= WARNING_LOW_PRESSURE && temp >= BODYTEMP_HEAT_WARNING_1-27)
+		if(pressure <= tlv_collection["pressure"]["hazard_min"] && temp >= tlv_collection["temperature"]["hazard_max"])
 			warning_message = "Danger! Low pressure and high temperature detected."
 			return
-		if(pressure >= WARNING_HIGH_PRESSURE && temp >= BODYTEMP_HEAT_WARNING_1-27)
+		if(pressure >= tlv_collection["pressure"]["hazard_max"] && temp >= tlv_collection["temperature"]["hazard_max"])
 			warning_message = "Danger! High pressure and temperature detected."
 			return
-		if(pressure >= WARNING_HIGH_PRESSURE && temp <= BODYTEMP_COLD_WARNING_1+10)
+		if(pressure >= tlv_collection["pressure"]["hazard_max"] && temp <= tlv_collection["temperature"]["hazard_min"])
 			warning_message = "Danger! High pressure and low temperature detected."
 			return
-		if(pressure <= WARNING_LOW_PRESSURE)
+		if(pressure <= tlv_collection["pressure"]["hazard_min"])
 			warning_message = "Danger! Low pressure detected."
 			return
-		if(pressure >= WARNING_HIGH_PRESSURE)
+		if(pressure >= tlv_collection["pressure"]["hazard_max"])
 			warning_message = "Danger! High pressure detected."
 			return
-		if(temp <= BODYTEMP_COLD_WARNING_1+10)
+		if(temp <= tlv_collection["temperature"]["hazard_min"])
 			warning_message = "Danger! Low temperature detected."
 			return
-		if(temp >= BODYTEMP_HEAT_WARNING_1-27)
+		if(temp >= tlv_collection["temperature"]["hazard_max"])
 			warning_message = "Danger! High temperature detected."
 			return
 		else


### PR DESCRIPTION

## About The Pull Request
Air alarms had temp/pressure that were hardcoded to be dangerous temps/pressure for humans. This fixes it so that the temp/pressure is based on the settings used in the air alarm. So if a air alarm is ignoring pressure/temp then it doesn't give a warning message.

## Why It's Good For The Game
If you want to ignore atmos checks for air alarms in certain areas, then it shouldn't be giving warning messages.

## Changelog
:cl:
fix: Fix air alarms warning message to use pressure & temp settings
/:cl:
