### PR TITLE
Fix air alarm not checking missing gases

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -569,7 +569,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	danger_level = max(danger_level, tlv_collection["temperature"].check_value(temp))
 	if(total_moles)
 		for(var/gas_path in GLOB.meta_gas_info)
-			var/moles = environment.gases[gas_path][MOLES]
+			var/moles = environment.gases[gas_path] ? environment.gases[gas_path][MOLES] : 0
 			danger_level = max(danger_level, tlv_collection[gas_path].check_value(pressure * moles / total_moles))
 
 	if(danger_level)

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	danger_level = max(danger_level, tlv_collection["pressure"].check_value(pressure))
 	danger_level = max(danger_level, tlv_collection["temperature"].check_value(temp))
 	if(total_moles)
-		for(var/gas_path in environment.gases)
+		for(var/gas_path in GLOB.meta_gas_info)
 			var/moles = environment.gases[gas_path][MOLES]
 			danger_level = max(danger_level, tlv_collection[gas_path].check_value(pressure * moles / total_moles))
 


### PR DESCRIPTION

## About The Pull Request
Fixes #72841

Air alarms only check the current gases in the environment. This means that any gas with a minimum threshold will not trigger if it is completely gone from the environment. (like oxygen)

## Why It's Good For The Game
Better consistency.

## Changelog
:cl:
fix: Fix air alarm not checking missing gases
/:cl:
