### PR TITLE
Adjusts offset values for Nukie Infiltrator shuttle's nav console so it's actually centered

### DIFF
--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -62,8 +62,8 @@
 	shuttlePortId = "syndicate_custom"
 	jump_to_ports = list("syndicate_ne" = 1, "syndicate_nw" = 1, "syndicate_n" = 1, "syndicate_se" = 1, "syndicate_sw" = 1, "syndicate_s" = 1)
 	view_range = 5.5
-	x_offset = -7
-	y_offset = -1
+	x_offset = 7 //flip both offsets because the shuttle is mapped in facing SOUTH, not NORTH; the docking port is also rotated
+	y_offset = 1
 	whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava, /turf/closed/mineral, /turf/open/openspace, /turf/open/misc)
 	see_hidden = TRUE
 	circuit = /obj/item/circuitboard/computer/syndicate_shuttle_docker


### PR DESCRIPTION
## About The Pull Request

The Infiltrator, in a vacuum of its map file, is facing _NORTH_, the docking port thinks that the shuttle is facing _NORTH_, and the docking port itself is pointed towards _EAST_ (`port_direction = 4`). In times past, this was good and well, the navigation console would properly center the shuttle preview as its offset values dictated. Then the nukie base got a rework. That made it so the shuttle is docked facing _SOUTH_, and since that moves the entire shuttle around, the docking port is now actually facing _WEST_, while still thinking the shuttle is facing _NORTH_, which in turn fucks up `CreateEye()` for the nav console, and the preview is spawned completely off-center. This sucks, this blows, this is awful, please scream at a coder, etc etc.

So here's the thing. The ideal solution here is probably actually flipping the shuttle's map file so it's facing _SOUTH_, then adjusting the docking port's vars to account for that and probably adjusting something else in the viscinity. What's done in the first commit here is instead a lazy removal of the offsets' `-` plus a comment. Go me. Anyway, I want some input on those solutions, so here's the PR.

## Why It's Good For The Game

Actually centered nukie infiltrator shuttle preview, for once. Wow, that didn't take long at all.
Surprisingly no issue opened for this one, but that's more likely because the previews were missing for [a long-ass while](https://github.com/tgstation/tgstation/issues/62203). Eh, if I find one, I'll close one.

## Changelog

:cl:
fix: A joint effort of Gorlex Marauders and MI13 tech support teams has finally managed to center the Syndicate Infiltrator shuttle's preview on the navigation console. Nuclear Ops teams sector-wide, rejoice!
/:cl: