### PR TITLE
raptor retaliate targetting fix

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
@@ -44,13 +44,6 @@
 	clear_blackboard_key(BB_RAPTOR_TROUGH_TARGET)
 	set_blackboard_key(BB_RAPTOR_EAT_COOLDOWN, world.time + NEXT_EAT_COOLDOWN)
 
-/datum/targeting_strategy/basic/raptor
-
-//dont attack anyone that shares our factions.
-/datum/targeting_strategy/basic/raptor/faction_check(datum/ai_controller/controller, mob/living/living_mob, mob/living/the_target)
-	. = ..()
-	return .
-
 /datum/ai_controller/basic_controller/baby_raptor
 	blackboard = list(
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/raptor,

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
@@ -23,7 +23,7 @@
 		/datum/ai_planning_subtree/find_and_hunt_target/heal_raptors,
 		/datum/ai_planning_subtree/random_speech/blackboard,
 		/datum/ai_planning_subtree/pet_planning,
-		/datum/ai_planning_subtree/target_retaliate,
+		/datum/ai_planning_subtree/target_retaliate/check_faction,
 		/datum/ai_planning_subtree/simple_find_target,
 		/datum/ai_planning_subtree/basic_melee_attack_subtree,
 		/datum/ai_planning_subtree/find_and_hunt_target/raptor_trough,

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
@@ -8,8 +8,8 @@
 			"wags their tail against",
 			"playfully leans against"
 		),
-		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/raptor,
-		BB_PET_TARGETING_STRATEGY = /datum/targeting_strategy/basic/raptor,
+		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
+		BB_PET_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_BABIES_PARTNER_TYPES = list(/mob/living/basic/raptor),
 		BB_BABIES_CHILD_TYPES = list(/mob/living/basic/raptor/baby_raptor),
 		BB_MAX_CHILDREN = 5,

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
@@ -41,12 +41,13 @@
 	RegisterSignal(new_pawn, COMSIG_MOB_ATE, PROC_REF(post_eat))
 
 /datum/ai_controller/basic_controller/raptor/proc/post_eat()
+	SIGNAL_HANDLER
 	clear_blackboard_key(BB_RAPTOR_TROUGH_TARGET)
 	set_blackboard_key(BB_RAPTOR_EAT_COOLDOWN, world.time + NEXT_EAT_COOLDOWN)
 
 /datum/ai_controller/basic_controller/baby_raptor
 	blackboard = list(
-		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/raptor,
+		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_FIND_MOM_TYPES = list(/mob/living/basic/raptor),
 		BB_IGNORE_MOM_TYPES = list(/mob/living/basic/raptor/baby_raptor),
 	)


### PR DESCRIPTION

## About The Pull Request
raptors werent meant to retaliate against each other or against their owner. this was initially handled by their targeting strategy, however some changes to it at some point broke this. raptors would now over-escalate conflicts against troublemaker raptors, locking both into a deathmatch. this fixes that

## Why It's Good For The Game
fixes raptor retaliate targetting

## Changelog
:cl:
fix: fixes raptors retaliating against each other and their owners
/:cl:
