### PR TITLE
Inventory slots will dim when unusable due to equipment or bodyparts, rather than just for species hardcoded slots

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -504,6 +504,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	if(ismob(mymob) && mymob.hud_used == src)
 		show_hud(hud_version)
 
+/// Handles dimming inventory slots that a mob can't equip items to in their current state
 /datum/hud/proc/update_locked_slots()
 	return
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -311,17 +311,28 @@
 	var/mob/living/carbon/human/human_mob = mymob
 	if(istype(human_mob))
 		blocked_slots |= human_mob.dna?.species?.no_equip_flags
-		if(!human_mob.w_uniform && !HAS_TRAIT(human_mob, TRAIT_NO_JUMPSUIT))
-			blocked_slots |= ITEM_SLOT_POCKETS|ITEM_SLOT_ID|ITEM_SLOT_BELT
-		if(!human_mob.wear_suit)
+		if(isnull(human_mob.w_uniform) && !HAS_TRAIT(human_mob, TRAIT_NO_JUMPSUIT))
+			blocked_slots |= ITEM_SLOT_ID|ITEM_SLOT_BELT
+			var/obj/item/bodypart/left_leg = human_mob.get_bodypart(BODY_ZONE_L_LEG)
+			if(isnull(left_leg) || IS_ORGANIC_LIMB(left_leg))
+				blocked_slots |= ITEM_SLOT_LPOCKET
+			var/obj/item/bodypart/right_leg = human_mob.get_bodypart(BODY_ZONE_R_LEG)
+			if(isnull(right_leg) || IS_ORGANIC_LIMB(right_leg))
+				blocked_slots |= ITEM_SLOT_RPOCKET
+		if(isnull(human_mob.wear_suit))
 			blocked_slots |= ITEM_SLOT_SUITSTORE
-		if(human_mob.num_hands < 2)
+		if(human_mob.num_hands < 2) // update this when you can wear gloves on one hand
 			blocked_slots |= ITEM_SLOT_GLOVES
-		if(human_mob.num_legs < 2)
+		if(human_mob.num_legs < 2) // update this when you can wear shoes on one foot
 			blocked_slots |= ITEM_SLOT_FEET
 		var/obj/item/bodypart/head/head = human_mob.get_bodypart(BODY_ZONE_HEAD)
 		if(isnull(head))
 			blocked_slots |= ITEM_SLOT_HEAD|ITEM_SLOT_EARS|ITEM_SLOT_EYES|ITEM_SLOT_MASK
+		var/obj/item/organ/internal/eyes/eyes = human_mob.get_organ_slot(ORGAN_SLOT_EYES)
+		if(eyes?.no_glasses)
+			blocked_slots |= ITEM_SLOT_EYES
+		if(human_mob.bodyshape & BODYSHAPE_DIGITIGRADE)
+			blocked_slots |= ITEM_SLOT_FEET
 
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
 		if(!inv.slot_id)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -306,7 +306,6 @@
 /datum/hud/human/update_locked_slots()
 	if(!mymob)
 		return
-	// NON-MODULE CHANGE
 	var/blocked_slots = NONE
 
 	var/mob/living/carbon/human/human_mob = mymob

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -312,7 +312,9 @@
 	if(istype(human_mob))
 		blocked_slots |= human_mob.dna?.species?.no_equip_flags
 		if(isnull(human_mob.w_uniform) && !HAS_TRAIT(human_mob, TRAIT_NO_JUMPSUIT))
-			blocked_slots |= ITEM_SLOT_ID|ITEM_SLOT_BELT
+			var/obj/item/bodypart/chest = human_mob.get_bodypart(BODY_ZONE_CHEST)
+			if(isnull(chest) || IS_ORGANIC_LIMB(chest))
+				blocked_slots |= ITEM_SLOT_ID|ITEM_SLOT_BELT
 			var/obj/item/bodypart/left_leg = human_mob.get_bodypart(BODY_ZONE_L_LEG)
 			if(isnull(left_leg) || IS_ORGANIC_LIMB(left_leg))
 				blocked_slots |= ITEM_SLOT_LPOCKET

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -306,16 +306,28 @@
 /datum/hud/human/update_locked_slots()
 	if(!mymob)
 		return
-	var/mob/living/carbon/human/H = mymob
-	if(!istype(H) || !H.dna.species)
-		return
-	var/datum/species/S = H.dna.species
+	// NON-MODULE CHANGE
+	var/blocked_slots = NONE
+
+	var/mob/living/carbon/human/human_mob = mymob
+	if(istype(human_mob))
+		blocked_slots |= human_mob.dna?.species?.no_equip_flags
+		if(!human_mob.w_uniform && !HAS_TRAIT(human_mob, TRAIT_NO_JUMPSUIT))
+			blocked_slots |= ITEM_SLOT_POCKETS|ITEM_SLOT_ID|ITEM_SLOT_BELT
+		if(!human_mob.wear_suit)
+			blocked_slots |= ITEM_SLOT_SUITSTORE
+		if(human_mob.num_hands < 2)
+			blocked_slots |= ITEM_SLOT_GLOVES
+		if(human_mob.num_legs < 2)
+			blocked_slots |= ITEM_SLOT_FEET
+		var/obj/item/bodypart/head/head = human_mob.get_bodypart(BODY_ZONE_HEAD)
+		if(isnull(head))
+			blocked_slots |= ITEM_SLOT_HEAD|ITEM_SLOT_EARS|ITEM_SLOT_EYES|ITEM_SLOT_MASK
+
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
-		if(inv.slot_id)
-			if(S.no_equip_flags & inv.slot_id)
-				inv.alpha = 128
-			else
-				inv.alpha = initial(inv.alpha)
+		if(!inv.slot_id)
+			continue
+		inv.alpha = (blocked_slots & inv.slot_id) ? 128 : initial(inv.alpha)
 
 /datum/hud/human/hidden_inventory_update(mob/viewer)
 	if(!mymob)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -323,7 +323,7 @@
 				blocked_slots |= ITEM_SLOT_RPOCKET
 		if(isnull(human_mob.wear_suit))
 			blocked_slots |= ITEM_SLOT_SUITSTORE
-		if(human_mob.num_hands < 2) // update this when you can wear gloves on one hand
+		if(human_mob.num_hands <= 0)
 			blocked_slots |= ITEM_SLOT_GLOVES
 		if(human_mob.num_legs < 2) // update this when you can wear shoes on one foot
 			blocked_slots |= ITEM_SLOT_FEET

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -371,9 +371,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/on_species_gain(mob/living/carbon/human/human_who_gained_species, datum/species/old_species, pref_load)
 	SHOULD_CALL_PARENT(TRUE)
 	// Drop the items the new species can't wear
-	if(human_who_gained_species.hud_used)
-		human_who_gained_species.hud_used.update_locked_slots()
-
 	human_who_gained_species.mob_biotypes = inherent_biotypes
 	human_who_gained_species.mob_respiration_type = inherent_respiration_type
 	human_who_gained_species.butcher_results = knife_butcher_results?.Copy()
@@ -382,7 +379,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		replace_body(human_who_gained_species, src)
 
 	regenerate_organs(human_who_gained_species, old_species, replace_current = FALSE, visual_only = human_who_gained_species.visual_only_organs)
-
+	// Update locked slots AFTER all organ and body stuff is handled
+	human_who_gained_species.hud_used?.update_locked_slots()
 	// Drop the items the new species can't wear
 	INVOKE_ASYNC(src, PROC_REF(worn_items_fit_body_check), human_who_gained_species, TRUE)
 
@@ -635,9 +633,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 					return FALSE
 			return equip_delay_self_check(I, H, bypass_equip_delay_self)
 		if(ITEM_SLOT_BELT)
-			var/obj/item/bodypart/O = H.get_bodypart(BODY_ZONE_CHEST)
-
-			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT) && (!O || IS_ORGANIC_LIMB(O)))
+			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT))
 				if(!disable_warning)
 					to_chat(H, span_warning("You need a jumpsuit before you can attach this [I.name]!"))
 				return FALSE
@@ -664,8 +660,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(ITEM_SLOT_ICLOTHING)
 			return equip_delay_self_check(I, H, bypass_equip_delay_self)
 		if(ITEM_SLOT_ID)
-			var/obj/item/bodypart/O = H.get_bodypart(BODY_ZONE_CHEST)
-			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT) && (!O || IS_ORGANIC_LIMB(O)))
+			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT))
 				if(!disable_warning)
 					to_chat(H, span_warning("You need a jumpsuit before you can attach this [I.name]!"))
 				return FALSE

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -633,7 +633,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 					return FALSE
 			return equip_delay_self_check(I, H, bypass_equip_delay_self)
 		if(ITEM_SLOT_BELT)
-			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT))
+			var/obj/item/bodypart/O = H.get_bodypart(BODY_ZONE_CHEST)
+
+			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT) && (!O || IS_ORGANIC_LIMB(O)))
 				if(!disable_warning)
 					to_chat(H, span_warning("You need a jumpsuit before you can attach this [I.name]!"))
 				return FALSE
@@ -660,7 +662,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(ITEM_SLOT_ICLOTHING)
 			return equip_delay_self_check(I, H, bypass_equip_delay_self)
 		if(ITEM_SLOT_ID)
-			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT))
+			var/obj/item/bodypart/O = H.get_bodypart(BODY_ZONE_CHEST)
+			if(!H.w_uniform && !HAS_TRAIT(H, TRAIT_NO_JUMPSUIT) && (!O || IS_ORGANIC_LIMB(O)))
 				if(!disable_warning)
 					to_chat(H, span_warning("You need a jumpsuit before you can attach this [I.name]!"))
 				return FALSE

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -292,7 +292,6 @@
 	else
 		not_handled = TRUE
 
-
 	// Send a signal for when we unequip an item that used to cover our feet/shoes. Used for bloody feet
 	if((I.body_parts_covered & FEET) || (I.flags_inv | I.transparent_protection) & HIDESHOES)
 		SEND_SIGNAL(src, COMSIG_CARBON_UNEQUIP_SHOECOVER, I, force, newloc, no_move, invdrop, silent)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -209,6 +209,7 @@
 	//Item is handled and in slot, valid to call callback, for this proc should always be true
 	if(!not_handled)
 		has_equipped(equipping, slot, initial)
+		hud_used?.update_locked_slots()
 
 		// Send a signal for when we equip an item that used to cover our feet/shoes. Used for bloody feet
 		if(equipping.body_parts_covered & FEET || (equipping.flags_inv | equipping.transparent_protection) & HIDESHOES)
@@ -291,6 +292,7 @@
 	else
 		not_handled = TRUE
 
+
 	// Send a signal for when we unequip an item that used to cover our feet/shoes. Used for bloody feet
 	if((I.body_parts_covered & FEET) || (I.flags_inv | I.transparent_protection) & HIDESHOES)
 		SEND_SIGNAL(src, COMSIG_CARBON_UNEQUIP_SHOECOVER, I, force, newloc, no_move, invdrop, silent)
@@ -300,6 +302,7 @@
 
 	update_equipment_speed_mods()
 	update_obscured_slots(I.flags_inv)
+	hud_used?.update_locked_slots()
 
 /mob/living/carbon/human/toggle_internals(obj/item/tank, is_external = FALSE)
 	// Just close the tank if it's the one the mob already has open.

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -180,6 +180,7 @@
 	//in a slot (handled further down inheritance chain, probably living/carbon/human/equip_to_slot
 	if(!not_handled)
 		has_equipped(equipping, slot, initial)
+		hud_used?.update_locked_slots()
 
 	return not_handled
 
@@ -237,6 +238,7 @@
 
 	update_equipment_speed_mods()
 	update_obscured_slots(I.flags_inv)
+	hud_used?.update_locked_slots()
 
 /// Returns TRUE if an air tank compatible helmet is equipped.
 /mob/living/carbon/proc/can_breathe_helmet()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -122,6 +122,8 @@
 	phantom_owner.update_health_hud() //update the healthdoll
 	phantom_owner.update_body()
 	phantom_owner.update_body_parts()
+	if(!special)
+		phantom_owner.hud_used?.update_locked_slots()
 
 	if(bodypart_flags & BODYPART_PSEUDOPART)
 		drop_organs(phantom_owner) //Psuedoparts shouldn't have organs, but just in case
@@ -320,6 +322,8 @@
 	new_limb_owner.updatehealth()
 	new_limb_owner.update_body()
 	new_limb_owner.update_damage_overlays()
+	if(!special)
+		new_limb_owner.hud_used?.update_locked_slots()
 	SEND_SIGNAL(new_limb_owner, COMSIG_CARBON_POST_ATTACH_LIMB, src, special)
 	return TRUE
 

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -213,7 +213,6 @@
 	robotic_emp_paralyze_damage_percent_threshold = 0.6
 
 	wing_types = list(/obj/item/organ/external/wings/functional/robotic)
-	bodypart_traits = list(TRAIT_NO_JUMPSUIT)
 
 	var/wired = FALSE
 	var/obj/item/stock_parts/power_store/cell = null

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -213,6 +213,7 @@
 	robotic_emp_paralyze_damage_percent_threshold = 0.6
 
 	wing_types = list(/obj/item/organ/external/wings/functional/robotic)
+	bodypart_traits = list(TRAIT_NO_JUMPSUIT)
 
 	var/wired = FALSE
 	var/obj/item/stock_parts/power_store/cell = null

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -97,6 +97,8 @@
 	for(var/datum/status_effect/effect as anything in organ_effects)
 		organ_owner.apply_status_effect(effect, type)
 
+	if(!special)
+		organ_owner.hud_used?.update_locked_slots()
 	RegisterSignal(owner, COMSIG_ATOM_EXAMINE, PROC_REF(on_owner_examine))
 	SEND_SIGNAL(src, COMSIG_ORGAN_IMPLANTED, organ_owner)
 	SEND_SIGNAL(organ_owner, COMSIG_CARBON_GAIN_ORGAN, src, special)
@@ -177,6 +179,8 @@
 
 	organ_owner.synchronize_bodytypes()
 	organ_owner.synchronize_bodyshapes()
+	if(!special)
+		organ_owner.hud_used?.update_locked_slots()
 
 	var/list/diseases = organ_owner.get_static_viruses()
 	if(!LAZYLEN(diseases))


### PR DESCRIPTION
## About The Pull Request

Closes #54039

Rather than only dimming inventory slots your species are unable to use, unusable inventory slots in general are dimmed.
For example, not wearing a jumpsuit shows this:

![image](https://github.com/user-attachments/assets/f66c023f-f2d8-4a7a-8aa8-3fc441c0f52e)

## Why It's Good For The Game

Makes it a bit more transparent what you can and can't wear given your current equipment or status. 

## Changelog

:cl: Melbert
qol: Unusable inventory slots (as according to your bodyparts or equipment) will now be dimmed (similarly to how unusable inventory slots are dimmed for certain species like Golems).
/:cl:
