### PR TITLE
Makes Light Eater look less bad when used

### DIFF
--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -137,7 +137,7 @@
 			return NONE
 		user.do_attack_animation(target)
 		user.changeNext_move(CLICK_CD_RAPID)
-		smacking.play_attack_sound()
+		target.play_attack_sound()
 	// not particularly picky about what happens afterwards in the attack chain
 	return NONE
 

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -127,7 +127,19 @@
  */
 /datum/element/light_eater/proc/on_interacting_with(obj/item/source, mob/living/user, atom/target)
 	SIGNAL_HANDLER
-	eat_lights(target, source)
+	if(eat_lights(target, source))
+		// do a "pretend" attack if we're hitting something that can't normally be
+		if(isobj(target))
+			var/obj/smacking = target
+			if(smacking.obj_flags & CAN_BE_HIT)
+				return NONE
+		else if(!isturf(target))
+			return NONE
+		user.do_attack_animation(target)
+		user.changeNext_move(CLICK_CD_RAPID)
+		smacking.play_attack_sound()
+	// not particularly picky about what happens afterwards in the attack chain
+	return NONE
 
 /**
  * Called when a source object is used to block a thrown object, projectile, or attack

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -680,12 +680,8 @@
 
 /obj/machinery/light/proc/on_light_eater(obj/machinery/light/source, datum/light_eater)
 	SIGNAL_HANDLER
-	. = COMPONENT_BLOCK_LIGHT_EATER
-	if(status == LIGHT_EMPTY)
-		return
-	var/obj/item/light/tube = drop_light_tube()
-	tube?.burn()
-	return
+	break_light_tube()
+	return COMPONENT_BLOCK_LIGHT_EATER
 
 /obj/machinery/light/on_saboteur(datum/source, disrupt_duration)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I noticed when we moved Light Eater to use interaction it looked dogwater when attacking light fixtures.

So I went through and tweaked it slightly. 

- Lights no longer mysteriously vanish with no visual feedback. (Makes it do the affect effect it *used* to do)
- Attacking un-attackable objects also does an attack animation when you consume a light from it

## Why It's Good For The Game

Like it looked seriously bad before. This also gives more visual feedback for what is actually happening.

## Changelog

:cl: Melbert
qol: Light Eater now displays a quick attack animation when quenching un-attackable objects (like lamps, flashlights)
fix: Light Eater animation for attacking light fixtures has been restored
/:cl:

