### PR TITLE
[NO GBP] Fixes fishing tips being empty

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -387,7 +387,7 @@
 	name = "fishing tip"
 	desc = "A slip of paper containing a pearl of wisdom about fishing within it, though you wish it were an actual pearl."
 
-/obj/item/paper/paperslip/fortune/Initialize(mapload)
+/obj/item/paper/paperslip/fishing_tip/Initialize(mapload)
 	default_raw_text = pick(GLOB.fishing_tips)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
I got the typepath wrong because of copypasta

## Why It's Good For The Game
Fishing tips are no longer empty and soulless.

## Changelog

:cl:
fix: Fixes fishing tips (from fishing toolboxes) being empty.
/:cl:
