### PR TITLE
Trapdoor QoL

### DIFF
--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -122,7 +122,7 @@
 		source.balloon_alert(user, "can't link trapdoor when its open")
 		return
 	src.assembly = remote.internals
-	assembly.linked++
+	++assembly.linked
 	source.balloon_alert(user, "trapdoor linked")
 	UnregisterSignal(SSdcs, COMSIG_GLOB_TRAPDOOR_LINK)
 	RegisterSignal(assembly, COMSIG_ASSEMBLY_PULSED, PROC_REF(toggle_trapdoor))
@@ -134,7 +134,8 @@
 	if(IS_OPEN(parent))
 		source.balloon_alert(user, "can't unlink trapdoor when its open")
 		return
-	assembly.linked--
+	--assembly.linked
+	if (assembly.linked < 0) assembly.linked = 0
 	stored_decals = list()
 	UnregisterSignal(assembly, COMSIG_ASSEMBLY_PULSED)
 	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL))
@@ -168,7 +169,7 @@
 		return
 	. = LINKED_UP
 	src.assembly = assembly
-	assembly.linked++
+	++assembly.linked
 	UnregisterSignal(SSdcs, COMSIG_GLOB_TRAPDOOR_LINK)
 	RegisterSignal(assembly, COMSIG_ASSEMBLY_PULSED, PROC_REF(toggle_trapdoor))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(try_unlink))
@@ -192,7 +193,8 @@
 		// otherwise, break trapdoor
 		dying_trapdoor.visible_message(span_warning("The trapdoor mechanism in [dying_trapdoor] is broken!"))
 		if(assembly)
-			assembly.linked--
+			--assembly.linked
+			if (assembly.linked < 0) assembly.linked = 0
 			stored_decals.Cut()
 			assembly = null
 		return

--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -28,6 +28,8 @@
 	* so any other case the elements will be changed but not recorded.
 	*/
 	var/list/stored_decals = list()
+	/// Delay before trapdoor shuts close. 0 means no auto close.
+	var/autoclose_delay = 5 SECONDS
 
 /datum/component/trapdoor/Initialize(starts_open, trapdoor_turf_path, assembly, conspicuous = TRUE, var/list/carried_decals = null)
 	if(!isopenturf(parent))
@@ -43,6 +45,8 @@
 
 	if(IS_OPEN(parent))
 		openspace_trapdoor_setup(trapdoor_turf_path, assembly)
+		if(autoclose_delay)
+			addtimer(CALLBACK(src, PROC_REF(try_closing)), autoclose_delay)
 	else
 		tile_trapdoor_setup(trapdoor_turf_path, assembly)
 

--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -137,8 +137,7 @@
 	if(IS_OPEN(parent))
 		source.balloon_alert(user, "can't unlink trapdoor when its open")
 		return
-	--assembly.linked
-	if (assembly.linked < 0) assembly.linked = 0
+	assembly.linked = max(assembly.linked - 1, 0)
 	stored_decals = list()
 	UnregisterSignal(assembly, COMSIG_ASSEMBLY_PULSED)
 	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL))
@@ -198,8 +197,7 @@
 		// otherwise, break trapdoor
 		dying_trapdoor.visible_message(span_warning("The trapdoor mechanism in [dying_trapdoor] is broken!"))
 		if(assembly)
-			--assembly.linked
-			if (assembly.linked < 0) assembly.linked = 0
+			assembly.linked = max(assembly.linked - 1, 0)
 			stored_decals.Cut()
 			assembly = null
 		return
@@ -379,8 +377,7 @@
 	return TRUE
 
 /obj/item/trapdoor_remote/item_ctrl_click(mob/user)
-	if (loc != user)
-		// You have to hold it in your hand to ctrl-click
+	if (!user.is_holding(src))
 		return CLICK_ACTION_BLOCKING
 	if(!internals)
 		user.balloon_alert(user, "no device!")

--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -318,9 +318,11 @@
 	. += span_notice("The internals can be removed with a screwdriver.")
 	if(!internals.linked)
 		. += span_warning("[src] is not linked to a trapdoor.")
+		. += span_notice("[src] will link to nearby trapdoors when used.")
 		return
 	. += span_notice("[src] is linked to [internals.linked] trapdoor(s).")
 	. += span_notice("It can be linked to additional trapdoor(s) by using it on a trapdoor.")
+	. += span_notice("Trapdoor can be unlinked with multitool.")
 	. += span_notice("Autoclose is [internals.autoclose ? "enabled" : "disabled"], ctrl-click to toggle.")
 	if(!COOLDOWN_FINISHED(src, trapdoor_cooldown))
 		. += span_warning("It is on a short cooldown.")

--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -87,7 +87,7 @@
 	if(IS_OPEN(parent))
 		source.balloon_alert(user, "can't unlink trapdoor when its open")
 		return
-	assembly.linked = FALSE
+	assembly.linked--
 	assembly.stored_decals = list()
 	UnregisterSignal(assembly, COMSIG_ASSEMBLY_PULSED)
 	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL))
@@ -117,11 +117,11 @@
 ///called by linking remotes to tie an assembly to the trapdoor
 /datum/component/trapdoor/proc/on_link_requested(datum/source, obj/item/assembly/trapdoor/assembly)
 	SIGNAL_HANDLER
-	if(get_dist(parent, assembly) > TRAPDOOR_LINKING_SEARCH_RANGE || assembly.linked)
+	if(get_dist(parent, assembly) > TRAPDOOR_LINKING_SEARCH_RANGE)
 		return
 	. = LINKED_UP
 	src.assembly = assembly
-	assembly.linked = TRUE
+	assembly.linked++
 	UnregisterSignal(SSdcs, COMSIG_GLOB_TRAPDOOR_LINK)
 	RegisterSignal(assembly, COMSIG_ASSEMBLY_PULSED, PROC_REF(toggle_trapdoor))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(try_unlink))
@@ -145,8 +145,8 @@
 		// otherwise, break trapdoor
 		dying_trapdoor.visible_message(span_warning("The trapdoor mechanism in [dying_trapdoor] is broken!"))
 		if(assembly)
-			assembly.linked = FALSE
-			assembly.stored_decals.Cut()
+			assembly.linked--
+			assembly.stored_decals.Cut() // TODO(antropod)
 			assembly = null
 		return
 	post_change_callbacks += CALLBACK(src, TYPE_PROC_REF(/datum/component/trapdoor, carry_over_trapdoor), trapdoor_turf_path, conspicuous, assembly)
@@ -226,7 +226,7 @@
 
 /obj/item/assembly/trapdoor/pulsed(mob/pulser)
 	. = ..()
-	if(linked)
+	if(linked > 0)
 		return
 	if(!COOLDOWN_FINISHED(src, search_cooldown))
 		if(loc && pulser)
@@ -273,7 +273,7 @@
 	if(!internals.linked)
 		. += span_warning("[src] is not linked to a trapdoor.")
 		return
-	. += span_notice("[src] is linked to a trapdoor.")
+	. += span_notice("[src] is linked to [internals.linked] trapdoor(s).")
 	if(!COOLDOWN_FINISHED(src, trapdoor_cooldown))
 		. += span_warning("It is on a short cooldown.")
 
@@ -310,7 +310,7 @@
 		internals.pulsed(user)
 		// The pulse linked successfully
 		if(internals.linked)
-			user.balloon_alert(user, "linked")
+			user.balloon_alert(user, "linked [internals.linked] trapdoors")
 		// The pulse failed to link
 		else
 			user.balloon_alert(user, "link failed!")

--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -31,7 +31,7 @@
 	/// Delay before trapdoor shuts close. 0 means no auto close.
 	var/autoclose_delay = 5 SECONDS
 
-/datum/component/trapdoor/Initialize(starts_open, trapdoor_turf_path, assembly, conspicuous = TRUE, var/list/carried_decals = null)
+/datum/component/trapdoor/Initialize(starts_open, trapdoor_turf_path, assembly, conspicuous = TRUE, list/carried_decals = null)
 	if(!isopenturf(parent))
 		return COMPONENT_INCOMPATIBLE
 


### PR DESCRIPTION
## About The Pull Request

- Trapdoor remote will connect to multiple trapdoors
- Trapdoor will close automatically in 5 seconds (ctrl-clicking on a remote will toggle autoclose)
- Additional trapdoors can be linked to the same remote by clicking on a trapdoor with the remote
- Improved examine message to reflect how to use remote
## Why It's Good For The Game

I added ability to connect multiple trapdoors with to one remote. This makes making trapdoor traps much easier (before that you had to connect each trapdoor to dedicated remote and use signallers).
I also added autoclose for trapdoors so you don't need to close it manually, so you can have like an infrared emitter that will trigger the trap and the trap would reset automatically.
And the last addition - ability to link trapdoors manually - it just makes it easier to add trapdoors to your remote if you missed any on the linking step.
## Changelog
:cl:
add: You can now link to multiple trapdoors with one remote
add: Trapdoor will automatically close in 5 seconds (ctrl-clicking on a remote will toggle autoclose)
/:cl:
