### PR TITLE
Fix TRAIT_REVEAL_FISH not actually revealing fish

### DIFF
--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -360,6 +360,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	playsound(location, 'sound/effects/fish_splash.ogg', 100)
 
 	if(HAS_MIND_TRAIT(user, TRAIT_REVEAL_FISH))
+		fish_icon = GLOB.specific_fish_icons[reward_path] || FISH_ICON_DEF
 		switch(fish_icon)
 			if(FISH_ICON_DEF)
 				send_alert("fish!!!")
@@ -465,9 +466,6 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 
 	if(difficulty > FISHING_DEFAULT_DIFFICULTY)
 		completion -= MAX_FISH_COMPLETION_MALUS * (difficulty * 0.01)
-
-	if(HAS_MIND_TRAIT(user, TRAIT_REVEAL_FISH))
-		fish_icon = GLOB.specific_fish_icons[reward_path] || FISH_ICON_DEF
 
 	/// Fish minigame properties
 	if(ispath(reward_path,/obj/item/fish))


### PR DESCRIPTION

## About The Pull Request

While looking into this for another pr, I realized `TRAIT_REVEAL_FISH` wasn't working as intended.

This seemed to be because we choose what to say as a fish bites based on `fish_icon` in the _biting phase_:
https://github.com/tgstation/tgstation/blob/e5836ab5b2146b47c8034ae62530356f3963f975/code/modules/fishing/fishing_minigame.dm#L353-L363
While `fish_icon` is only set once the _minigame phase_ has already started:
https://github.com/tgstation/tgstation/blob/e5836ab5b2146b47c8034ae62530356f3963f975/code/modules/fishing/fishing_minigame.dm#L461-L470

Meaning it is always the default value of `FISH_ICON_DEF` in the biting phase, causing it to show up as `FISH_ICON_DEF`.
We fix this by moving the assignment to the biting phase, where it's first used, and where we just picked the `reward_path` value we use for this.
## Why It's Good For The Game

Fixes the fishing reveal fish trait not working.
## Changelog
:cl:
fix: The trait that allows you to see the type of thing that's biting when fishing actually shows it instead of just saying "fish!!!" for everything.
/:cl:
