### PR TITLE
human AIs get space suits if the room is inhospitable (also can leave the sat)

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -38292,7 +38292,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/apc/cell_5k,
-/turf/open/floor/circuit/green,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/ai_monitored/turret_protected/ai)
 "nAa" = (
 /obj/machinery/door/firedoor/border_only{
@@ -41519,7 +41519,7 @@
 	name = "AI Core Shutters"
 	},
 /obj/structure/cable,
-/turf/open/floor/circuit/green,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/ai_monitored/turret_protected/ai)
 "oOb" = (
 /obj/effect/turf_decal/tile/neutral{

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -4,7 +4,7 @@
 	uniform = /obj/item/clothing/under/plasmaman
 	gloves = /obj/item/clothing/gloves/color/plasmaman
 	head = /obj/item/clothing/head/helmet/space/plasmaman
-	r_hand= /obj/item/tank/internals/plasmaman/belt/full
+	r_hand = /obj/item/tank/internals/plasmaman/belt/full
 	internals_slot = ITEM_SLOT_HANDS
 
 /datum/outfit/plasmaman/security

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -94,6 +94,7 @@
 		AddComponent(/datum/component/adjust_fishing_difficulty, fishing_modifier)
 
 /obj/item/clothing/suit/space/on_outfit_equip(mob/living/carbon/human/outfit_wearer, visuals_only, item_slot)
+	. = ..()
 	if(isnull(cell))
 		return
 	toggle_spacesuit(toggler = null, manual_toggle = FALSE) //turn on the thermal regulator by default.

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -93,6 +93,11 @@
 	if(fishing_modifier)
 		AddComponent(/datum/component/adjust_fishing_difficulty, fishing_modifier)
 
+/obj/item/clothing/suit/space/on_outfit_equip(mob/living/carbon/human/outfit_wearer, visuals_only, item_slot)
+	if(isnull(cell))
+		return
+	toggle_spacesuit(toggler = null, manual_toggle = FALSE) //turn on the thermal regulator by default.
+
 /// Start Processing on the space suit when it is worn to heat the wearer
 /obj/item/clothing/suit/space/equipped(mob/living/user, slot)
 	. = ..()

--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -111,6 +111,18 @@
 
 	l_hand = /obj/item/paper/default_lawset_list
 
+/datum/outfit/job/human_ai/pre_equip(mob/living/carbon/human/equipped, visualsOnly)
+	. = ..()
+	if(visualsOnly)
+		return
+	if(is_safe_turf(equipped.loc, dense_atoms = TRUE)) //skip this if it's safe. We allow dense atoms because we spawn out of the inactive core.
+		return
+	if(isnull(equipped.dna.species.outfit_important_for_life)) //custom species stuff will handle this for us.
+		internals_slot = ITEM_SLOT_SUITSTORE
+		suit_store = /obj/item/tank/internals/oxygen
+	suit = /obj/item/clothing/suit/space/nasavoid
+	head = /obj/item/clothing/head/helmet/space/nasavoid
+
 /datum/outfit/job/human_ai/post_equip(mob/living/carbon/human/equipped, visualsOnly)
 	. = ..()
 	if(visualsOnly)
@@ -121,9 +133,6 @@
 		//you only get respect if you go all the way, man.
 		ADD_TRAIT(equipped, TRAIT_COMMISSIONED, INNATE_TRAIT)
 	equipped.faction |= list(FACTION_SILICON, FACTION_TURRET)
-
-	var/static/list/allowed_areas = typecacheof(list(/area/station/ai_monitored))
-	equipped.AddComponent(/datum/component/hazard_area, area_whitelist = allowed_areas)
 
 /obj/item/paper/default_lawset_list
 	name = "Lawset Note"


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/tgstation/tgstation/pull/86949

Gives Human AI a space suit if they spawn in a room inhospitable to them. I also made the 2 tiles the AI spawns in cold to match the exterior of the windoor, so this effect actually kicks in.

I also removed their hazardous area component, so they can move at full speed, use ladders, vehicles, etc.

Lastly, anytime you spawn with a space suit I made it automatically turn itself on, which is only for ghost roles currently. Now if you spawn in bad temperature, you won't have to rush to flip it on before you start freezing.

## Why It's Good For The Game

Doesn't require mapping changes for a station trait and allows for unique types of AI Sats without having to make accommodations for human AI each time.

Hazardous area was originally added as they were being compared to an immovable object, which now I think is a little silly. When thinking of a human versus an AI, the first thought is that humans can move around and touch things, this arbitrary limit was not only annoying, but also terrible on multi-z maps where it blocked things like access to ladders if it wasn't directly in the AI sat's room.

## Changelog

:cl:
balance: Human AIs spawn with a space suit on Wawastation.
balance: Human AIs no longer have slowdown and a ton of restrictions such as ladders when outside of the satellite.
qol: Spawning in with a space suit now has its thermal regulation on by default.
/:cl: