### PR TITLE
Pressing the change floor button while on ladder interacts with ladder

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -548,6 +548,11 @@
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, UP)
 
+	var/obj/structure/ladder/current_ladder = locate() in current_turf
+	if(current_ladder)
+		current_ladder.use(src, TRUE)
+		return
+
 	if(!can_z_move(UP, current_turf, null, ZMOVE_CAN_FLY_CHECKS|ZMOVE_FEEDBACK))
 		return
 	balloon_alert(src, "moving up...")
@@ -569,6 +574,11 @@
 	if(ismovable(loc)) //Inside an object, tell it we moved
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, DOWN)
+
+	var/obj/structure/ladder/current_ladder = locate() in current_turf
+	if(current_ladder)
+		current_ladder.use(src, FALSE)
+		return
 
 	if(!can_z_move(DOWN, current_turf, null, ZMOVE_CAN_FLY_CHECKS|ZMOVE_FEEDBACK))
 		return


### PR DESCRIPTION

## About The Pull Request

This PR implements, as a quality of life feature, the ability to interact with the ladder in the current turf by pressing the `change floor` button. This allows for the easier interaction with the ladder if there are a lot of objects on top of said ladder, but most importantly fixes many issues where bots could not interact with the ladder and were stuck! 

Bots like the cleanbot could not interact with the ladder, and firebot could only climb downwards. With this addition to the change floor button these bots can still freely move up and down, albeit not by clicking the ladder directly (I will work on that soon™).
## Why It's Good For The Game

Allows for a better UX interacting the change floor button as it feels weird that you can't change the floor if you are sitting on a ladder. Also allows cleanbot, firebot and anything that got gatekept previously to use the ladder with the change floor button.
## Changelog
:cl:
qol: change floor button now interacts with ladder if it is in the current turf
/:cl:
