### PR TITLE
Check icon state existence in spritesheet insert

### DIFF
--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -391,6 +391,11 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		to_generate += list(args.Copy())
 
 /datum/asset/spritesheet/proc/queuedInsert(sprite_name, icon/I, icon_state="", dir=SOUTH, frame=1, moving=FALSE)
+#ifdef UNIT_TESTS
+	if (I && icon_state && !(icon_state in icon_states(I))) // check the base icon prior to extracting the state we want
+		stack_trace("Tried to insert nonexistent icon_state '[icon_state]' from [I] into spritesheet [name] ([type])")
+		return
+#endif
 	I = icon(I, icon_state=icon_state, dir=dir, frame=frame, moving=moving)
 	if (!I || !length(icon_states(I)))  // that direction or state doesn't exist
 		return

--- a/code/modules/asset_cache/assets/plumbing.dm
+++ b/code/modules/asset_cache/assets/plumbing.dm
@@ -17,7 +17,6 @@
 			"synthesizer",
 			"reaction_chamber",
 			"grinder_chemical",
-			"growing_vat",
 			"fermenter",
 			"pump",
 			"disposal",


### PR DESCRIPTION
## About The Pull Request
Adds a check for icon state existence in spritesheet insert, run during unit tests.

## Why It's Good For The Game
Inserting a nonexistent icon state via `Insert()` will corrupt the spritesheet it's inserted to, resulting in offsets being incorrect—specifically, it results in the entire icon's contents being inserted. This happened downstream on Doppler Shift and broke language icons. I fixed the issue there but figured that there should be a check upstream for it.

`if (!I || !length(icon_states(I))) // that direction or state doesn't exist)` This check doesn't catch it, by the way. Since it returns the entire icon file, `length(icon_states(I))` is >0. You could do `length(icon_states) != 1`, but then it still wouldn't catch cases where there's a single-icon-state icon *and* the icon_state is invalid. Boo. A test like this is the best option.

I tried using the rust-g variant of icon_states and sort-of got it working, but I figured it'd be too fragile to justify given that it doesn't accept actual icon instances, only paths.