### PR TITLE
Code improvement of mob/move/up() and mob/move/down()

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -543,16 +543,13 @@
 		return remote_control.relaymove(src, UP)
 
 	var/turf/current_turf = get_turf(src)
-	var/turf/above_turf = GET_TURF_ABOVE(current_turf)
-
-	if(!above_turf)
-		to_chat(src, span_warning("There's nowhere to go in that direction!"))
-		return
 
 	if(ismovable(loc)) //Inside an object, tell it we moved
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, UP)
 
+	if(!can_z_move(UP, current_turf, null, ZMOVE_CAN_FLY_CHECKS|ZMOVE_FEEDBACK))
+		return
 	balloon_alert(src, "moving up...")
 	if(!do_after(src, 1 SECONDS, hidden = TRUE))
 		return
@@ -568,16 +565,13 @@
 		return remote_control.relaymove(src, DOWN)
 
 	var/turf/current_turf = get_turf(src)
-	var/turf/below_turf = GET_TURF_BELOW(current_turf)
-
-	if(!below_turf)
-		to_chat(src, span_warning("There's nowhere to go in that direction!"))
-		return
 
 	if(ismovable(loc)) //Inside an object, tell it we moved
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, DOWN)
 
+	if(!can_z_move(DOWN, current_turf, null, ZMOVE_CAN_FLY_CHECKS|ZMOVE_FEEDBACK))
+		return
 	balloon_alert(src, "moving down...")
 	if(!do_after(src, 1 SECONDS, hidden = TRUE))
 		return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -553,18 +553,10 @@
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, UP)
 
-	var/ventcrawling_flag = HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING) ? ZMOVE_VENTCRAWLING : 0
-
-	if(can_z_move(DOWN, above_turf, current_turf, ZMOVE_FALL_FLAGS|ventcrawling_flag)) //Will we fall down if we go up?
-		if(buckled)
-			to_chat(src, span_warning("[buckled] is is not capable of flight."))
-		else
-			to_chat(src, span_warning("You are not Superman."))
-		return
 	balloon_alert(src, "moving up...")
 	if(!do_after(src, 1 SECONDS, hidden = TRUE))
 		return
-	if(zMove(UP, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))
+	if(zMove(UP, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK))
 		to_chat(src, span_notice("You move upwards."))
 
 ///Moves a mob down a z level
@@ -586,11 +578,10 @@
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, DOWN)
 
-	var/ventcrawling_flag = HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING) ? ZMOVE_VENTCRAWLING : 0
 	balloon_alert(src, "moving down...")
 	if(!do_after(src, 1 SECONDS, hidden = TRUE))
 		return
-	if(zMove(DOWN, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))
+	if(zMove(DOWN, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK))
 		to_chat(src, span_notice("You move down."))
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

This PR improves the code for mob/verb/up() and mob/verb/down() by removing unnecessary checks.

Added a `can_z_move` check before waiting for a second, making it feel more responsive as a result because the user will immediately know it cannot move there.

Additionally, vent crawling is handled by if(ismovable(loc)), which makes the explicit check for the ventcrawl flag unnecessary.
## Why It's Good For The Game

Apart from the code improvements, previously, if there was space above you that you could move into but you were unable to fly, the game would instantly tell you, 'You are not Superman.' However, if there was a tile blocking you, you had to wait for the entire move action before receiving the same message. With this code cleanup, you now only have to wait for the move action if you can move to that z level, making the experience more consistent across different interactions.
## Changelog
:cl:
qol: you only need to wait 1 second if you can move into that z level instead of most cases
code: mob/verb/up() and mob/verb/down() cleanup
/:cl:
