### PR TITLE
[NO GBP] Fixing the examine text of the fishing difficulty adjustment comp.

### DIFF
--- a/code/datums/components/adjust_fishing_difficulty.dm
+++ b/code/datums/components/adjust_fishing_difficulty.dm
@@ -67,7 +67,7 @@
 /datum/component/adjust_fishing_difficulty/proc/add_examine_line(mob/user, list/examine_text, method)
 	var/percent = HAS_MIND_TRAIT(user, TRAIT_EXAMINE_DEEPER_FISH) ? "[abs(modifier)]% " : ""
 	var/text = "[method] will make fishing [percent][modifier < 0 ? "easier" : "harder"]."
-	if(modifier > 0)
+	if(modifier < 0)
 		examine_text += span_nicegreen(text)
 	else
 		examine_text += span_danger(text)

--- a/code/datums/components/adjust_fishing_difficulty.dm
+++ b/code/datums/components/adjust_fishing_difficulty.dm
@@ -65,8 +65,8 @@
 	add_examine_line(user, examine_text, "Buckling to [source.p_them()]")
 
 /datum/component/adjust_fishing_difficulty/proc/add_examine_line(mob/user, list/examine_text, method)
-	var/percent = HAS_MIND_TRAIT(user, TRAIT_EXAMINE_DEEPER_FISH) ? "[modifier]% " : ""
-	var/text = "[method] will make fishing [percent][modifier > 0 ? "easier" : "harder"]."
+	var/percent = HAS_MIND_TRAIT(user, TRAIT_EXAMINE_DEEPER_FISH) ? "[abs(modifier)]% " : ""
+	var/text = "[method] will make fishing [percent][modifier < 0 ? "easier" : "harder"]."
 	if(modifier > 0)
 		examine_text += span_nicegreen(text)
 	else


### PR DESCRIPTION
## About The Pull Request
Little whoopsie because negative modifiers are acctually beneficial

## Why It's Good For The Game
This will fix #86965.

## Changelog

:cl:
fix: Items that adjust fishing difficulty no longer have misleading examine tips.
/:cl:
