### PR TITLE
Prefabricated Factory machine board fix

### DIFF
--- a/code/modules/manufactorio/machines/sorter.dm
+++ b/code/modules/manufactorio/machines/sorter.dm
@@ -5,7 +5,7 @@
 	layer = BELOW_OPEN_DOOR_LAYER
 	density = FALSE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND
-	circuit = /obj/item/circuitboard/machine/manurouter
+	circuit = /obj/item/circuitboard/machine/manusorter 
 	/// for mappers; filter path = list(direction, value), otherwise a list of initialized filters
 	var/list/sort_filters = list()
 	/// dir to push to if there is no criteria

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -1259,7 +1259,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SERVICE
 
 /datum/design/board/manulathe
-	name = /obj/machinery/power/manufacturing/lathe::name
+	name = "Manufacturing Lathe Board"
 	desc = "The circuit board for this machine."
 	id = "manulathe"
 	build_path = /obj/item/circuitboard/machine/manulathe
@@ -1269,7 +1269,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manucrafter
-	name = /obj/machinery/power/manufacturing/crafter::name
+	name = "Manufacturing Assembling Machine Board"
 	desc = "The circuit board for this machine."
 	id = "manucrafter"
 	build_path = /obj/item/circuitboard/machine/manucrafter
@@ -1279,7 +1279,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manucrusher
-	name = /obj/machinery/power/manufacturing/crusher::name
+	name = "Manufacturing Crusher Board"
 	desc = "The circuit board for this machine."
 	id = "manucrusher"
 	build_path = /obj/item/circuitboard/machine/manucrusher
@@ -1289,7 +1289,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manurouter
-	name = /obj/machinery/power/manufacturing/router::name
+	name = "Manufacturing Router Board"
 	desc = "The circuit board for this machine."
 	id = "manurouter"
 	build_path = /obj/item/circuitboard/machine/manurouter
@@ -1299,7 +1299,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manusorter
-	name = /obj/machinery/power/manufacturing/sorter::name
+	name = "Conveyor Sort-Router Board"
 	desc = "The circuit board for this machine."
 	id = "manusorter"
 	build_path = /obj/item/circuitboard/machine/manusorter
@@ -1309,7 +1309,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manuunloader
-	name = /obj/machinery/power/manufacturing/unloader::name
+	name = "Manufacturing Crate Unloader Board"
 	desc = "The circuit board for this machine."
 	id = "manuunloader"
 	build_path = /obj/item/circuitboard/machine/manuunloader
@@ -1319,7 +1319,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manusmelter
-	name = /obj/machinery/power/manufacturing/smelter::name
+	name = "Manufacturing Smelter Board"
 	desc = "The circuit board for this machine."
 	id = "manusmelter"
 	build_path = /obj/item/circuitboard/machine/manusmelter

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -1262,7 +1262,7 @@
 	name = /obj/machinery/power/manufacturing/lathe::name
 	desc = "The circuit board for this machine."
 	id = "manulathe"
-	build_path = /obj/machinery/power/manufacturing/lathe
+	build_path = /obj/item/circuitboard/machine/manulathe
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
@@ -1272,7 +1272,7 @@
 	name = /obj/machinery/power/manufacturing/crafter::name
 	desc = "The circuit board for this machine."
 	id = "manucrafter"
-	build_path = /obj/machinery/power/manufacturing/crafter
+	build_path = /obj/item/circuitboard/machine/manucrafter
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
@@ -1282,7 +1282,7 @@
 	name = /obj/machinery/power/manufacturing/crusher::name
 	desc = "The circuit board for this machine."
 	id = "manucrusher"
-	build_path = /obj/machinery/power/manufacturing/crusher
+	build_path = /obj/item/circuitboard/machine/manucrusher
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
@@ -1292,7 +1292,7 @@
 	name = /obj/machinery/power/manufacturing/router::name
 	desc = "The circuit board for this machine."
 	id = "manurouter"
-	build_path = /obj/machinery/power/manufacturing/router
+	build_path = /obj/item/circuitboard/machine/manurouter
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
@@ -1302,7 +1302,7 @@
 	name = /obj/machinery/power/manufacturing/sorter::name
 	desc = "The circuit board for this machine."
 	id = "manusorter"
-	build_path = /obj/machinery/power/manufacturing/sorter
+	build_path = /obj/item/circuitboard/machine/manusorter
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
@@ -1312,7 +1312,7 @@
 	name = /obj/machinery/power/manufacturing/unloader::name
 	desc = "The circuit board for this machine."
 	id = "manuunloader"
-	build_path = /obj/machinery/power/manufacturing/unloader
+	build_path = /obj/item/circuitboard/machine/manuunloader
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
@@ -1322,7 +1322,7 @@
 	name = /obj/machinery/power/manufacturing/smelter::name
 	desc = "The circuit board for this machine."
 	id = "manusmelter"
-	build_path = /obj/machinery/power/manufacturing/smelter
+	build_path = /obj/item/circuitboard/machine/manusmelter
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)


### PR DESCRIPTION

## About The Pull Request

Fixes Techfabs printing fully assembled factory machines from #86063 
Also fixes a incorrect board in sorter machines. 

## Why It's Good For The Game
Printing a machine board should not result in a fully assembled machine.
Im assuming this was a carry over from development.


## Changelog
:cl:

fix: Printing factory machine boards now results in their respective board and not the assembled machine. 
fix: Sorter machines now use their respective board.
/:cl:
