### PR TITLE
Birdshot Engineering small fixes

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -347,6 +347,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "ahf" = (
@@ -8679,12 +8680,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dob" = (
@@ -12034,6 +12035,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "eDr" = (
@@ -23729,6 +23731,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/storage/gas)
 "izF" = (
@@ -46282,6 +46285,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "pUx" = (
@@ -47368,7 +47372,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "qmz" = (
@@ -63250,13 +63254,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "vvC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Airlock"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/engineering{
+	name = "Main Engineering"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "vvK" = (


### PR DESCRIPTION

## About The Pull Request

This PR aims to fix some issues on Birdshot station. The issues fixed are as follows:

### 1. Door Naming Consistency
The two doors at the front of engineering had different names, one being `Engine Airlock` while the other was `Main Engineering`. Both were changed to be `Main Engineering`.

![image](https://github.com/user-attachments/assets/8221259c-e763-4944-ac2c-475ed05dcc0a)

### 2. Access Fixes for Security Officers (Engineering)
Added `[/obj/effect/mapping_helpers/airlock/access/any/engineering/general]` to the following doors, as Security Officers (Engineering) couldn't even open the front door to enter the department and couldn't go to atmos (since it required access for `construction` but Security Officers (Engineering) get access to `engineering` and `atmospherics` only). Also added this for the Locker Room because of the same problem.

![image](https://github.com/user-attachments/assets/4d6b692e-5158-466b-925a-1265af687e8b)

### 3. Atmospherics Maintenance Door Access
Replaced `[/obj/effect/mapping_helpers/airlock/access/any/engineering/construction]` with `[/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance]` for the Atmospherics Maintenance door present to the left of the Chief Engineer's office.

![image](https://github.com/user-attachments/assets/dea7b9c1-0614-4cd7-a8ef-4e6dd0748ba8)

### 4. Locker Room Maintenance Door Access
Replaced `[/obj/effect/mapping_helpers/airlock/access/any/engineering/general]` with `[/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance]` for the Maintenance door in the Locker Room.

![image](https://github.com/user-attachments/assets/ead0cb3e-0608-4675-8dc2-140810db5d0b)
## Why It's Good For The Game

This change ensures that Security Officers (Engineering) can properly access their primary workplace. Previously, they had to take an inefficient route through maintenance to enter Engineering, which was both inconvenient and hindered their ability to respond quickly to emergencies. By allowing them to use the front door and access key areas like Atmospherics, this fix improves quality of life and ensures they can perform their duties more efficiently.
## Changelog
:cl:
fix: Security Officers (Engineering) can now open crucial doors in Engineering on Birdshot
fix: Corrected access inconsistencies for maintenance doors in the Engineering department on Birdshot
fix: Resolved naming inconsistency for the front doors of Engineering on Birdshot
/:cl:
