### PR TITLE
[NO GBP] Makes MODtethers quicker to cut, adds a rapid cut action to MODsuits and some examine hints

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mod.dm
+++ b/code/__DEFINES/dcs/signals/signals_mod.dm
@@ -39,3 +39,5 @@
 #define COMSIG_MOD_WEARER_SET "mod_wearer_set"
 /// Called when the MODsuit wearer is unset.
 #define COMSIG_MOD_WEARER_UNSET "mod_wearer_unset"
+/// Sent by the tether module when it triggers its snapping function
+#define COMSIG_MOD_TETHER_SNAP "mod_tether_snap"

--- a/code/datums/components/tether.dm
+++ b/code/datums/components/tether.dm
@@ -13,14 +13,17 @@
 	var/atom/embed_target
 	/// Beam effect
 	var/datum/beam/tether_beam
+	/// Tether module if we were created by one
+	var/obj/item/mod/module/tether/parent_module
 
-/datum/component/tether/Initialize(atom/tether_target, max_dist = 7, tether_name, atom/embed_target = null, start_distance = null)
+/datum/component/tether/Initialize(atom/tether_target, max_dist = 7, tether_name, atom/embed_target = null, start_distance = null, parent_module = null)
 	if(!ismovable(parent) || !istype(tether_target) || !tether_target.loc)
 		return COMPONENT_INCOMPATIBLE
 
 	src.tether_target = tether_target
 	src.embed_target = embed_target
 	src.max_dist = max_dist
+	src.parent_module = parent_module
 	cur_dist = max_dist
 	if (start_distance != null)
 		cur_dist = start_distance
@@ -45,6 +48,9 @@
 	if (!isnull(embed_target))
 		RegisterSignal(embed_target, COMSIG_ITEM_UNEMBEDDED, PROC_REF(on_embedded_removed))
 		RegisterSignal(embed_target, COMSIG_QDELETING, PROC_REF(on_delete))
+
+	if (!isnull(parent_module))
+		RegisterSignals(parent_module, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED, COMSIG_MOD_TETHER_SNAP), PROC_REF(snap))
 
 /datum/component/tether/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOVABLE_MOVED))
@@ -114,6 +120,8 @@
 		snap()
 
 /datum/component/tether/proc/snap()
+	SIGNAL_HANDLER
+
 	var/atom/atom_target = parent
 	atom_target.visible_message(span_warning("[atom_target]'s [tether_name] snaps!"), span_userdanger("Your [tether_name] snaps!"), span_hear("You hear a cable snapping."))
 	playsound(atom_target, 'sound/effects/snap.ogg', 50, TRUE)

--- a/code/datums/components/tether.dm
+++ b/code/datums/components/tether.dm
@@ -111,8 +111,13 @@
 	var/atom/atom_target = parent
 	// Something broke us out, snap the tether
 	if (get_dist(atom_target, tether_target) > cur_dist + 1 || !isturf(atom_target.loc) || !isturf(tether_target.loc) || atom_target.z != tether_target.z)
-		atom_target.visible_message(span_warning("[atom_target]'s [tether_name] snaps!"), span_userdanger("Your [tether_name] snaps!"), span_hear("You hear a cable snapping."))
-		qdel(src)
+		snap()
+
+/datum/component/tether/proc/snap()
+	var/atom/atom_target = parent
+	atom_target.visible_message(span_warning("[atom_target]'s [tether_name] snaps!"), span_userdanger("Your [tether_name] snaps!"), span_hear("You hear a cable snapping."))
+	playsound(atom_target, 'sound/effects/snap.ogg', 50, TRUE)
+	qdel(src)
 
 /datum/component/tether/proc/on_delete()
 	SIGNAL_HANDLER
@@ -132,7 +137,7 @@
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, CTRL_CLICK))
 		location.balloon_alert(user, "cutting the tether...")
-		if (!do_after(user, 5 SECONDS, user))
+		if (!do_after(user, 1 SECONDS, user))
 			return
 
 		qdel(src)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -104,6 +104,18 @@
 	INVOKE_ASYNC(tether, TYPE_PROC_REF(/obj/projectile, fire))
 	drain_power(use_energy_cost)
 
+/obj/item/mod/module/tether/get_configuration()
+	. = ..()
+	.["cut_tethers"] = add_ui_configuration("Cut Tethers", "pin", TRUE)
+
+/obj/item/mod/module/tether/configure_edit(key, value)
+	if (key != "cut_tethers" || !ismob(usr))
+		return
+
+	var/mob/owner = usr
+	for(var/datum/component/tether/component in owner.GetComponents(/datum/component/tether))
+		component.snap()
+
 /obj/projectile/tether
 	name = "tether"
 	icon_state = "tether_projectile"
@@ -194,6 +206,7 @@
 /obj/item/tether_anchor/examine(mob/user)
 	. = ..()
 	. += span_info("It can be secured by using a wrench on it. Use right-click to tether yourself to [src].")
+	. += span_info("LMB shortens the tether while RMB lengthens it. Ctrl-click to cut the tether.")
 
 /obj/item/tether_anchor/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -54,8 +54,6 @@
 	. = ..()
 	.["mode"] = add_ui_configuration("Scan Mode", "list", mode, modes)
 
-	return .
-
 /obj/item/mod/module/health_analyzer/configure_edit(key, value)
 	switch(key)
 		if("mode")


### PR DESCRIPTION
## About The Pull Request
Tethers will now take only 1 second to cut, tether anchors have a line about how to lengthen/shorten and cut tethers, and MODsuit tether module now can quickly snap all tethers attached to you in case of an emergency.

I'm not a fan of MOD tether quick cutting code but its the best we can do to avoid GetComponent usage.

## Why It's Good For The Game
Tethers aren't very comfortable to use and a lot of people get confused and stuck with them, this should help a ton.

## Changelog
:cl:
qol: Added an explanation of how to change tether length and cut them to tether anchors
qol: MODsuits can now quickly snap all tethers attached to you
balance: Tethers can now be cut significantly quicker
/:cl:
