### PR TITLE
Fixes an exception that occured if you are riding a carp and get stunned

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1369,7 +1369,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 ////////////
 
 /datum/species/proc/spec_stun(mob/living/carbon/human/H,amount)
-	if(H.movement_type & FLYING)
+	if((H.movement_type & FLYING) && !H.buckled)
 		var/obj/item/organ/external/wings/functional/wings = H.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
 		if(wings)
 			wings.toggle_flight(H)


### PR DESCRIPTION

## About The Pull Request

Fixes stun not getting applied if you are riding a carp, because it checks if you are flying and tries to get the wings even if you are not using them, which causes an exception.
## Why It's Good For The Game

Fixes stun not getting applied properly in the case mentioned above.
## Changelog
:cl:
fix: fixes stun not getting applied if you are riding a carp
/:cl:
