### PR TITLE
Fixed Caretaker Refuge Gay Baby Jail

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -254,13 +254,13 @@
 	var/static/list/caretaking_traits = list(TRAIT_GODMODE, TRAIT_HANDS_BLOCKED, TRAIT_IGNORESLOWDOWN, TRAIT_SECLUDED_LOCATION)
 
 /datum/status_effect/caretaker_refuge/on_apply()
-	owner.add_traits(caretaking_traits, TRAIT_STATUS_EFFECT(id))
 	animate(owner, alpha = 45,time = 0.5 SECONDS)
 	owner.density = FALSE
 	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), PROC_REF(on_focus_lost))
 	RegisterSignal(owner, COMSIG_MOB_BEFORE_SPELL_CAST, PROC_REF(prevent_spell_usage))
 	RegisterSignal(owner, COMSIG_ATOM_HOLYATTACK, PROC_REF(nullrod_handler))
 	RegisterSignal(owner, COMSIG_CARBON_CUFF_ATTEMPTED, PROC_REF(prevent_cuff))
+	owner.add_traits(caretaking_traits, TRAIT_STATUS_EFFECT(id))
 	return TRUE
 
 /datum/status_effect/caretaker_refuge/on_remove()
@@ -288,7 +288,7 @@
 /datum/status_effect/caretaker_refuge/proc/on_focus_lost()
 	SIGNAL_HANDLER
 	to_chat(owner, span_danger("Without a focus, your refuge weakens and dissipates!"))
-	owner.remove_status_effect(type)
+	qdel(src)
 
 /datum/status_effect/caretaker_refuge/proc/prevent_spell_usage(datum/source, datum/spell)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Fix #86977

Caretakers refuge no longer traps you if you use codex cicatrix to cast it

This happened cuz 
1. the traits that caused th book to drop were added before the signal that listens for the trait's removal
2. the proc on_apply() is called right before adding the status to owner, as it is also used as a check. this was aproblem because the caretaker code told the owner to remove a list's status effects of its type, but at that point in the chain it wasn't there yet

## Why It's Good For The Game

bug

## Changelog

:cl:
Caretakers refuge no longer traps you if you use codex cicatrix to cast it
/:cl:

