### PR TITLE
Fixes luminiscent major extract activation action not disappearing/updating

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -528,7 +528,7 @@
 
 	var/datum/action/innate/use_extract/major/extract_major = new(src)
 	extract_major.Grant(new_jellyperson)
-	luminescent_actions += integrate_extract
+	luminescent_actions += extract_major
 
 /datum/species/jelly/luminescent/on_species_loss(mob/living/carbon/C)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Closes #86993

## Changelog
:cl:
fix: Fixed luminiscent major extract activation button not disappearing/updating when it should've
/:cl:
