### PR TITLE
fixed chappies being able to buy an unintended nullro type

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -96,6 +96,7 @@
 
 /obj/item/nullrod/non_station
 	station_holy_item = FALSE
+	chaplain_spawnable = FALSE
 
 /// Claymore Variant
 /// This subtype possesses a block chance and is sharp.


### PR DESCRIPTION

## About The Pull Request

fixed chappies being able to buy an unintended nullrod type

## Why It's Good For The Game

oops

## Changelog

:cl:
fix: fixed chappies being able to buy an unintended nullrod type
/:cl:

