### PR TITLE
Fixes mute people screaming when eaten by a recycler

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -244,7 +244,7 @@
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 
 	if(iscarbon(L))
-		if(L.stat == CONSCIOUS)
+		if(L.stat == CONSCIOUS && !HAS_TRAIT(L, TRAIT_MUTE))
 			L.say("ARRRRRRRRRRRGH!!!", forced="recycler grinding")
 		add_mob_blood(L)
 


### PR DESCRIPTION

## About The Pull Request
it didn't have a check for mute that's all
## Changelog
:cl: grungussusss
fix: fixed mute people screaming to dying from a recycler
/:cl:
