### PR TITLE
fixes drones being able to store multiple of the same tools in their toolbox

### DIFF
--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -133,7 +133,7 @@
 		/obj/item/multitool/drone,
 		/obj/item/pipe_dispenser,
 		/obj/item/t_scanner,
-		/obj/item/analyzer,
+		/obj/item/analyzer/drone,
 		/obj/item/rack_parts,
 	)
 	/// whitelisted drone items, recursive/includes descendants

--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -131,8 +131,8 @@
 		/obj/item/weldingtool/drone,
 		/obj/item/wirecutters/drone,
 		/obj/item/multitool/drone,
-		/obj/item/pipe_dispenser,
-		/obj/item/t_scanner,
+		/obj/item/pipe_dispenser/drone,
+		/obj/item/t_scanner/drone,
 		/obj/item/analyzer/drone,
 		/obj/item/rack_parts,
 	)

--- a/code/modules/mob/living/basic/drone/drone_tools.dm
+++ b/code/modules/mob/living/basic/drone/drone_tools.dm
@@ -19,7 +19,7 @@
 		/obj/item/multitool/drone,
 		/obj/item/pipe_dispenser,
 		/obj/item/t_scanner,
-		/obj/item/analyzer,
+		/obj/item/analyzer/drone,
 		/obj/item/soap/drone,
 	)
 	atom_storage.max_total_storage = 40
@@ -37,9 +37,9 @@
 	builtintools += new /obj/item/weldingtool/drone(src)
 	builtintools += new /obj/item/wirecutters/drone(src)
 	builtintools += new /obj/item/multitool/drone(src)
-	builtintools += new /obj/item/pipe_dispenser(src)
-	builtintools += new /obj/item/t_scanner(src)
-	builtintools += new /obj/item/analyzer(src)
+	builtintools += new /obj/item/pipe_dispenser/drone(src)
+	builtintools += new /obj/item/t_scanner/drone(src)
+	builtintools += new /obj/item/analyzer/drone(src)
 	builtintools += new /obj/item/soap/drone(src)
 	for(var/obj/item/tool as anything in builtintools)
 		tool.AddComponent(/datum/component/holderloving, src, TRUE)
@@ -103,3 +103,18 @@
 	icon_state = "toolkit_engiborg_multitool"
 	item_flags = NO_MAT_REDEMPTION
 	toolspeed = 0.5
+
+/obj/item/analyzer/drone
+	name = "digital gas analyzer"
+	desc = "A gas analyzer built into your chassis."
+	item_flags = NO_MAT_REDEMPTION
+
+/obj/item/t_scanner/drone
+	name = "digital T-ray scanner"
+	desc = "A T-ray scanner built into your chassis."
+	item_flags = NO_MAT_REDEMPTION
+
+/obj/item/pipe_dispenser/drone
+	name = "built-in rapid pipe dispenser"
+	desc = "A rapid pipe dispenser built into your chassis."
+	item_flags = NO_MAT_REDEMPTION

--- a/code/modules/mob/living/basic/drone/drone_tools.dm
+++ b/code/modules/mob/living/basic/drone/drone_tools.dm
@@ -17,8 +17,8 @@
 		/obj/item/weldingtool/drone,
 		/obj/item/wirecutters/drone,
 		/obj/item/multitool/drone,
-		/obj/item/pipe_dispenser,
-		/obj/item/t_scanner,
+		/obj/item/pipe_dispenser/drone,
+		/obj/item/t_scanner/drone,
 		/obj/item/analyzer/drone,
 		/obj/item/soap/drone,
 	)


### PR DESCRIPTION

## About The Pull Request
fixes this by making all their tools subtypes for drones

![image](https://github.com/user-attachments/assets/52dd2fdc-9816-4135-80f3-d9f880ec44ac)
## Changelog
:cl: grungussuss
fix: fixed drones being able to store multiple of the same type of tools in their toolbox
/:cl:
