### PR TITLE
Allow reinforced tables to be hooked up to the grid like grilles, shocking people who try to disassemble them

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -1,6 +1,9 @@
 //Use this only for things that aren't a subtype of obj/machinery/power
 //For things that are, override "should_have_node()" on them
-GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/grille)))
+GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
+	/obj/structure/grille,
+	/obj/structure/table/reinforced,
+)))
 
 #define UNDER_SMES -1
 #define UNDER_TERMINAL 1


### PR DESCRIPTION

## About The Pull Request

This pr makes it so reinforced tables can be hooked up to the power grid, requiring them to be on an open tile with a cable on it much like grilles, shocking solely people who attempt any of its disassembly steps.
Insulation obviously still applies.
## Why It's Good For The Game

Saw talk about someone wiring up tables and I think it's funny to have your table hooked up to the grid.
Allows you to protect your reinforced tables from disassembly, if you're fine with world's most obvious open cabled tile below your table.
## Changelog
:cl:
add: Reinforced tables may now be hooked up directly to the grid much like grilles, electrocuting people who attempt to disassemble it.
/:cl:
