### PR TITLE
Fixes multiple players being picked for the same single-slot command job roundstart.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -362,13 +362,21 @@ SUBSYSTEM_DEF(job)
 	for(var/datum/job/job as anything in command_department.department_jobs)
 		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
 			continue
+
 		var/list/candidates = find_occupation_candidates(job, level)
 		if(!candidates.len)
 			continue
+
 		var/mob/dead/new_player/candidate = pick(candidates)
-		// Eligibility checks done as part of find_occupation_candidates
-		if(assign_role(candidate, job, do_eligibility_checks = FALSE))
-			.++
+
+		// Eligibility checks done as part of find_occupation_candidates() above.
+		if(!assign_role(candidate, job, do_eligibility_checks = FALSE))
+			continue
+
+		.++
+
+		if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
+			job_debug("JOBS: Command Job is now full, Job: [job], Positions: [job.current_positions], Limit: [job.spawn_positions]")
 
 /// Attempts to fill out all available AI positions.
 /datum/controller/subsystem/job/proc/fill_ai_positions()
@@ -445,10 +453,19 @@ SUBSYSTEM_DEF(job)
 
 	// Copy the joinable occupation list and filter out ineligible occupations due to above job assignments.
 	var/list/available_occupations = joinable_occupations.Copy()
+
+	var/datum/job_department/command_department = get_department_type(/datum/job_department/command)
+
 	for(var/datum/job/job in available_occupations)
 		// Make sure the job isn't filled. If it is, remove it from the list so it doesn't get checked.
 		if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
 			job_debug("DO: Job is now filled, Job: [job], Current: [job.current_positions], Limit: [job.spawn_positions]")
+			available_occupations -= job
+
+		// Command jobs are handled via fill_all_head_positions_at_priority(...)
+		// Remove these jobs from the list of available occupations to prevent multiple players being assigned to the same
+		// limited role without constantly having to iterate over the available_occupations list and re-check them.
+		if(job in command_department?.department_jobs)
 			available_occupations -= job
 
 	job_debug("DO: Running standard job assignment")
@@ -457,12 +474,6 @@ SUBSYSTEM_DEF(job)
 		job_debug("JOBS: Filling in head roles, Level: [job_priority_level_to_string(level)]")
 		// Fill the head jobs first each level
 		fill_all_head_positions_at_priority(level)
-
-		// Clean up the available occupations list after assigning head positions.
-		for(var/datum/job/job in available_occupations)
-			if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
-				job_debug("DO: Job is now filled, Job: [job], Current: [job.current_positions], Limit: [job.spawn_positions]")
-				available_occupations -= job
 
 		// Loop through all unassigned players
 		for(var/mob/dead/new_player/player in unassigned)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -453,7 +453,6 @@ SUBSYSTEM_DEF(job)
 
 	// Copy the joinable occupation list and filter out ineligible occupations due to above job assignments.
 	var/list/available_occupations = joinable_occupations.Copy()
-
 	var/datum/job_department/command_department = get_department_type(/datum/job_department/command)
 
 	for(var/datum/job/job in available_occupations)
@@ -461,6 +460,7 @@ SUBSYSTEM_DEF(job)
 		if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
 			job_debug("DO: Job is now filled, Job: [job], Current: [job.current_positions], Limit: [job.spawn_positions]")
 			available_occupations -= job
+			continue
 
 		// Command jobs are handled via fill_all_head_positions_at_priority(...)
 		// Remove these jobs from the list of available occupations to prevent multiple players being assigned to the same

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -443,7 +443,7 @@ SUBSYSTEM_DEF(job)
 	// From assign_all_overflow_positions()
 	// 4. Anyone with the overflow role enabled has been given the overflow role.
 
-	// Shuffle the joinable occupation list and filter out ineligible occupations due to above job assignments.
+	// Copy the joinable occupation list and filter out ineligible occupations due to above job assignments.
 	var/list/available_occupations = joinable_occupations.Copy()
 	for(var/datum/job/job in available_occupations)
 		// Make sure the job isn't filled. If it is, remove it from the list so it doesn't get checked.
@@ -457,6 +457,12 @@ SUBSYSTEM_DEF(job)
 		job_debug("JOBS: Filling in head roles, Level: [job_priority_level_to_string(level)]")
 		// Fill the head jobs first each level
 		fill_all_head_positions_at_priority(level)
+
+		// Clean up the available occupations list after assigning head positions.
+		for(var/datum/job/job in available_occupations)
+			if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
+				job_debug("DO: Job is now filled, Job: [job], Current: [job.current_positions], Limit: [job.spawn_positions]")
+				available_occupations -= job
 
 		// Loop through all unassigned players
 		for(var/mob/dead/new_player/player in unassigned)


### PR DESCRIPTION

## About The Pull Request

Fixes #86899

Assigning head positions doesn't use the `available_occupations` list and instead just iterates through all command roles direct from some department job helper, jumping over any that are at capacity.

This means the `available_occupations` list doesn't get updated when head positions are assigned and can lead to an edge case where two players can both get a single-slot job. The first player gets it via `fill_all_head_positions_at_priority()`. The second player gets it via being given a random role when any now-full head job doesn't get removed from the `available_occupations` list.

There are many ways to fix this. The solution I've opted for is removing command roles from the `available_occupations` list entirely, letting `fill_all_head_positions_at_priority()` handle the logic for this exclusively.
## Why It's Good For The Game

I feex.
## Changelog
:cl:
fix: Fixes a bug where the game would assign multiple players to single-slot command roles.
/:cl:
