### PR TITLE
Fix and improvements to "Look Up" and "Look Down" IC verbs.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2796,7 +2796,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	var/turf/current_turf = get_turf(src)
 	var/turf/above_turf = GET_TURF_ABOVE(current_turf)
 
-	//Check if turf aboveexists
+	//Check if turf above exists
 	if(!above_turf)
 		to_chat(src, span_warning("There's nothing interesting above. Better keep your eyes ahead."))
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2166,6 +2166,15 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 	looking_vertically = TRUE
 
+	// In order, check if user is lower than the max z level of the map,
+	// check if user is at the station's lowest level or above
+	// this makes it so if you change floor to the highest z level, it stops you from looking up
+	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z || src.z < 2)
+		to_chat(src, span_warning("There's nothing interesting above."))
+		to_chat(src, "You set your head straight again.")
+		end_look_up()
+		return
+
 	var/turf/ceiling = get_step_multiz(src, UP)
 	if(!ceiling) //We are at the highest z-level.
 		if (prob(0.1))
@@ -2218,6 +2227,15 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	SIGNAL_HANDLER
 
 	looking_vertically = TRUE
+
+	// In order, check if user is at the max z level of the map or lower,
+	// check if user is above the station's lowest z level
+	// this makes it so if you change floor to the lowest z level, it stops you from looking down
+	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z - 1 || src.z < 3)
+		to_chat(src, span_warning("There's nothing interesting below."))
+		to_chat(src, "You set your head straight again.")
+		end_look_up()
+		return
 
 	var/turf/floor = get_turf(src)
 	var/turf/lower_level = get_step_multiz(floor, DOWN)
@@ -2768,22 +2786,28 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	set name = "Look Up"
 	set category = "IC"
 
-	//In order, check if user is lower than the max z level of the map,
-	//check if user is at the station's lowest level or above
+	if(looking_vertically)
+		to_chat(src, "You set your head straight again.")
+		end_look_up()
+		return
+
+	// In order, check if user is lower than the max z level of the map,
+	// check if user is at the station's lowest level or above
 	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z || src.z < 2)
 		to_chat(src, span_warning("There's nothing interesting above. Better keep your eyes ahead."))
 		return
 
-	if(looking_vertically)
-		to_chat(src, "You set your head straight again.")
-		end_look_up()
-	else
-		to_chat(src, "You tilt your head upwards.")
-		look_up()
+	to_chat(src, "You tilt your head upwards.")
+	look_up()
 
 /mob/living/verb/lookdown()
 	set name = "Look Down"
 	set category = "IC"
+
+	if(looking_vertically)
+		to_chat(src, "You set your head straight again.")
+		end_look_down()
+		return
 
 	// In order, check if user is at the max z level of the map or lower,
 	// check if user is above the station's lowest z level
@@ -2791,12 +2815,8 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		to_chat(src, span_warning("There's nothing interesting below. Better keep your eyes ahead."))
 		return
 
-	if(looking_vertically)
-		to_chat(src, "You set your head straight again.")
-		end_look_down()
-	else
-		to_chat(src, "You tilt your head downwards.")
-		look_down()
+	to_chat(src, "You tilt your head downwards.")
+	look_down()
 
 /**
  * Totals the physical cash on the mob and returns the total.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2768,11 +2768,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	set name = "Look Up"
 	set category = "IC"
 
-	//Get z levels available in map
-	var/total_map_z_levels = length(SSmapping.levels_by_trait(ZTRAIT_STATION))
 	//In order, check if user is lower than the max z level of the map,
 	//check if user is at the station's lowest level or above
-	if(total_map_z_levels < src.z || src.z < 2)
+	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z || src.z < 2)
 		to_chat(src, span_warning("There's nothing interesting above. Better keep your eyes ahead."))
 		return
 
@@ -2787,11 +2785,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	set name = "Look Down"
 	set category = "IC"
 
-	//Get z levels available in map
-	var/total_map_z_levels = length(SSmapping.levels_by_trait(ZTRAIT_STATION))
 	// In order, check if user is at the max z level of the map or lower,
 	// check if user is above the station's lowest z level
-	if(total_map_z_levels < src.z - 1 || src.z < 3)
+	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z - 1 || src.z < 3)
 		to_chat(src, span_warning("There's nothing interesting below. Better keep your eyes ahead."))
 		return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2166,10 +2166,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 	looking_vertically = TRUE
 
-	// In order, check if user is lower than the max z level of the map,
-	// check if user is at the station's lowest level or above
-	// this makes it so if you change floor to the highest z level, it stops you from looking up
-	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z || src.z < 2)
+	var/turf/current_turf = get_turf(src)
+	var/turf/above_turf = GET_TURF_ABOVE(current_turf)
+
+	//Check if turf above exists
+	if(!above_turf)
 		to_chat(src, span_warning("There's nothing interesting above."))
 		to_chat(src, "You set your head straight again.")
 		end_look_up()
@@ -2228,10 +2229,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 	looking_vertically = TRUE
 
-	// In order, check if user is at the max z level of the map or lower,
-	// check if user is above the station's lowest z level
-	// this makes it so if you change floor to the lowest z level, it stops you from looking down
-	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z - 1 || src.z < 3)
+	var/turf/current_turf = get_turf(src)
+	var/turf/below_turf = GET_TURF_BELOW(current_turf)
+
+	//Check if turf below exists
+	if(!below_turf)
 		to_chat(src, span_warning("There's nothing interesting below."))
 		to_chat(src, "You set your head straight again.")
 		end_look_up()
@@ -2791,9 +2793,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		end_look_up()
 		return
 
-	// In order, check if user is lower than the max z level of the map,
-	// check if user is at the station's lowest level or above
-	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z || src.z < 2)
+	var/turf/current_turf = get_turf(src)
+	var/turf/above_turf = GET_TURF_ABOVE(current_turf)
+
+	//Check if turf aboveexists
+	if(!above_turf)
 		to_chat(src, span_warning("There's nothing interesting above. Better keep your eyes ahead."))
 		return
 
@@ -2809,9 +2813,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		end_look_down()
 		return
 
-	// In order, check if user is at the max z level of the map or lower,
-	// check if user is above the station's lowest z level
-	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) < src.z - 1 || src.z < 3)
+	var/turf/current_turf = get_turf(src)
+	var/turf/below_turf = GET_TURF_BELOW(current_turf)
+
+	//Check if turf below exists
+	if(!below_turf)
 		to_chat(src, span_warning("There's nothing interesting below. Better keep your eyes ahead."))
 		return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2163,6 +2163,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /mob/living/proc/start_look_up()
 	SIGNAL_HANDLER
+
+	looking_vertically = TRUE
+
 	var/turf/ceiling = get_step_multiz(src, UP)
 	if(!ceiling) //We are at the highest z-level.
 		if (prob(0.1))
@@ -2183,7 +2186,6 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			to_chat(src, span_warning("You can't see through the floor above you."))
 			return
 
-	looking_vertically = TRUE
 	reset_perspective(ceiling)
 
 /mob/living/proc/stop_look_up()
@@ -2214,6 +2216,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /mob/living/proc/start_look_down()
 	SIGNAL_HANDLER
+
+	looking_vertically = TRUE
+
 	var/turf/floor = get_turf(src)
 	var/turf/lower_level = get_step_multiz(floor, DOWN)
 	if(!lower_level) //We are at the lowest z-level.
@@ -2235,7 +2240,6 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			to_chat(src, span_warning("You can't see through the floor below you."))
 			return
 
-	looking_vertically = TRUE
 	reset_perspective(lower_level)
 
 /mob/living/proc/stop_look_down()
@@ -2764,18 +2768,38 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	set name = "Look Up"
 	set category = "IC"
 
+	//Get z levels available in map
+	var/total_map_z_levels = length(SSmapping.levels_by_trait(ZTRAIT_STATION))
+	//In order, check if user is lower than the max z level of the map,
+	//check if user is at the station's lowest level or above
+	if(total_map_z_levels < src.z || src.z < 2)
+		to_chat(src, span_warning("There's nothing interesting above. Better keep your eyes ahead."))
+		return
+
 	if(looking_vertically)
+		to_chat(src, "You set your head straight again.")
 		end_look_up()
 	else
+		to_chat(src, "You tilt your head upwards.")
 		look_up()
 
 /mob/living/verb/lookdown()
 	set name = "Look Down"
 	set category = "IC"
 
+	//Get z levels available in map
+	var/total_map_z_levels = length(SSmapping.levels_by_trait(ZTRAIT_STATION))
+	// In order, check if user is at the max z level of the map or lower,
+	// check if user is above the station's lowest z level
+	if(total_map_z_levels < src.z - 1 || src.z < 3)
+		to_chat(src, span_warning("There's nothing interesting below. Better keep your eyes ahead."))
+		return
+
 	if(looking_vertically)
+		to_chat(src, "You set your head straight again.")
 		end_look_down()
 	else
+		to_chat(src, "You tilt your head downwards.")
 		look_down()
 
 /**


### PR DESCRIPTION
## About The Pull Request

This PR fixes and improves the IC verbs "Look Up" and "Look Down". 

Fixes https://github.com/tgstation/tgstation/issues/85532

The fix mentioned is for https://github.com/tgstation/tgstation/issues/85532 but it is not limited to cyborgs. Basically, if you tried to look up but you did not manage to find something an exception happened because `looking_vertically` was not changed. This lead to not being able to stop looking up or down for the rest of the round until you were able to see something through a different z level.

There are three improvements introduced with this PR:

### 1. Check if there is a point looking up or down

Basically the code checks if there exists a turf above you, and if that is not the case it disallows you from looking up and tells you `There's nothing interesting above. Better keep your eyes ahead.`, or if there is no turf below you it disallows you from looking down and letting you know with the according message `There's nothing interesting below. Better keep your eyes ahead.`. 

This makes it clear that there is no point for the user to be looking up or down when in these situations as there will never be anything to see.

### 2. Inform the user about their current look stance

If the user presses the verb "Look Up", they will be informed with `You tilt your head upwards.` to show that the action is continuous. By pressing it again, the game will tell them `You set your head straight again.` to show that they are no longer trying to look up. The same behaviour happens when you try to look down.

### 3. Stops user from looking up or down if there is no turf above or below

This makes it so the game doesn't spam you with `You can't see through the floor above/below you.` and it eliminates the need to reset your head stance once you have reached these levels, streamlining the experience a little more.

## Why It's Good For The Game

Fixes bug and improves user experience by giving feedback for the verbs and disabling the functionality in scenarios where looking up or down is useless, eliminating confusion. Also resets your head stance if you happen to go up or down into the vertical edges of the station.

## Changelog
:cl:
fix: fixed not being able to stop looking up or down if unable to find something until you found something
qol: feedback for "Look Up" or "Look Down" verbs to reduce confusion caused by the verbs
qol: limited usage of "Look Up" and "Look Down" to cases where there is a turf above your or below you accordingly
qol: automatically stops you from looking up or down when there is no turf above or below you
/:cl:
