### PR TITLE
Puts blood back on floor plane, puts runes on floor plane (removes shadows from blood and runes) 

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(turfs_pass_meteor, typecacheof(list(
 
 #define ismecha(A) (istype(A, /obj/vehicle/sealed/mecha))
 
-#define ismopable(A) (A && (A.layer <= FLOOR_CLEAN_LAYER)) //If something can be cleaned by floor-cleaning devices such as mops or clean bots
+#define ismopable(A) (A && ((A.plane == FLOOR_PLANE) ? (A.layer <= FLOOR_CLEAN_LAYER) : (A.layer <= GAME_CLEAN_LAYER))) //If something can be cleaned by floor-cleaning devices such as mops or clean bots
 
 #define isorgan(A) (istype(A, /obj/item/organ))
 

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -148,6 +148,11 @@
 #define ABOVE_OPEN_TURF_LAYER (12 + TOPDOWN_LAYER)
 ///catwalk overlay of /turf/open/floor/plating/catwalk_floor
 #define CATWALK_LAYER (13 + TOPDOWN_LAYER)
+#define LOWER_RUNE_LAYER (14 + TOPDOWN_LAYER)
+#define RUNE_LAYER (15 + TOPDOWN_LAYER)
+/// [GAME_CLEAN_LAYER] but for floors.
+/// Basically any layer below this (numerically) is "on" a floor for the purposes of washing
+#define FLOOR_CLEAN_LAYER (20 + TOPDOWN_LAYER)
 
 //WALL_PLANE layers
 #define BELOW_CLOSED_TURF_LAYER 2.053
@@ -166,12 +171,10 @@
 #define PLUMBING_PIPE_VISIBILE_LAYER 2.495//layer = initial(layer) + ducting_layer / 3333 in atmospherics/handle_layer() to determine order of duct overlap
 #define BOT_PATH_LAYER 2.497
 #define LOW_OBJ_LAYER 2.5
-#define LOW_SIGIL_LAYER 2.52
-#define SIGIL_LAYER 2.53
 #define HIGH_PIPE_LAYER 2.54
 // Anything above this layer is not "on" a turf for the purposes of washing
 // I hate this life of ours
-#define FLOOR_CLEAN_LAYER 2.55
+#define GAME_CLEAN_LAYER 2.55
 #define TRAM_STRUCTURE_LAYER 2.57
 #define TRAM_FLOOR_LAYER 2.58
 #define TRAM_WALL_LAYER 2.59

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -96,8 +96,8 @@
 	ADD_TRAIT(target, TRAIT_CURRENTLY_CLEANING, REF(src))
 	// We need to update our planes on overlay changes
 	RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(cleaning_target_moved))
-	var/mutable_appearance/low_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, target, GAME_PLANE)
-	var/mutable_appearance/high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, target, ABOVE_GAME_PLANE)
+	var/mutable_appearance/low_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", GAME_CLEAN_LAYER, target, GAME_PLANE)
+	var/mutable_appearance/high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", GAME_CLEAN_LAYER, target, ABOVE_GAME_PLANE)
 	var/list/icon_offsets = target.get_oversized_icon_offsets()
 	low_bubble.pixel_x = icon_offsets["x"]
 	low_bubble.pixel_y = icon_offsets["y"]
@@ -140,13 +140,13 @@
 	if(same_z_layer)
 		return
 	// First, get rid of the old overlay
-	var/mutable_appearance/old_low_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, old_turf, GAME_PLANE)
-	var/mutable_appearance/old_high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, old_turf, ABOVE_GAME_PLANE)
+	var/mutable_appearance/old_low_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", GAME_CLEAN_LAYER, old_turf, GAME_PLANE)
+	var/mutable_appearance/old_high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", GAME_CLEAN_LAYER, old_turf, ABOVE_GAME_PLANE)
 	source.cut_overlay(old_low_bubble)
 	source.cut_overlay(old_high_bubble)
 
 	// Now, add the new one
-	var/mutable_appearance/new_low_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, new_turf, GAME_PLANE)
-	var/mutable_appearance/new_high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, new_turf, ABOVE_GAME_PLANE)
+	var/mutable_appearance/new_low_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", GAME_CLEAN_LAYER, new_turf, GAME_PLANE)
+	var/mutable_appearance/new_high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", GAME_CLEAN_LAYER, new_turf, ABOVE_GAME_PLANE)
 	source.add_overlay(new_low_bubble)
 	source.add_overlay(new_high_bubble)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -1,6 +1,5 @@
 /obj/effect/decal/cleanable
 	gender = PLURAL
-	plane = GAME_PLANE
 	layer = FLOOR_CLEAN_LAYER
 	var/list/random_icon_states = null
 	///I'm sorry but cleanable/blood code is ass, and so is blood_DNA

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -23,6 +23,7 @@
 	desc = "Gnarly..."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "xgib1"
+	plane = GAME_PLANE
 	layer = BELOW_OBJ_LAYER
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6")
 	mergeable_decal = FALSE

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -23,7 +23,7 @@
 	desc = "Gnarly..."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "xgib1"
-	layer = LOW_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6")
 	mergeable_decal = FALSE
 

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -111,7 +111,7 @@
 	desc = "They look bloody and gruesome."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "gib1"
-	layer = LOW_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	plane = GAME_PLANE
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 	mergeable_decal = FALSE

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -354,6 +354,8 @@ GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 	pass_flags = PASSTABLE | PASSGRILLE
 	icon_state = "hitsplatter1"
 	random_icon_states = list("hitsplatter1", "hitsplatter2", "hitsplatter3")
+	plane = GAME_PLANE
+	layer = ABOVE_WINDOW_LAYER
 	/// The turf we just came from, so we can back up when we hit a wall
 	var/turf/prev_loc
 	/// The cached info about the blood

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -452,7 +452,6 @@
 	name = "pool of fuel"
 	desc = "A pool of flammable fuel. Its probably wise to clean this off before something ignites it..."
 	icon_state = "fuel_pool"
-	layer = LOW_OBJ_LAYER
 	beauty = -50
 	clean_type = CLEAN_TYPE_BLOOD
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
@@ -568,7 +567,7 @@
 	mergeable_decal = FALSE
 	beauty = -10
 	plane = GAME_PLANE
-	layer = LOW_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 
 /obj/effect/decal/cleanable/rubble/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -10,6 +10,8 @@
 	desc = "Ashes to ashes, dust to dust, and into space."
 	icon = 'icons/obj/debris.dmi'
 	icon_state = "ash"
+	plane = GAME_PLANE
+	layer = GAME_CLEAN_LAYER
 	mergeable_decal = FALSE
 	beauty = -50
 	decal_reagent = /datum/reagent/ash
@@ -144,6 +146,7 @@
 	name = "cobweb"
 	desc = "Somebody should remove that."
 	gender = NEUTER
+	plane = GAME_PLANE
 	layer = WALL_OBJ_LAYER
 	icon = 'icons/effects/web.dmi'
 	icon_state = "cobweb1"
@@ -160,6 +163,8 @@
 	gender = NEUTER
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "molten"
+	plane = GAME_PLANE
+	layer = GAME_CLEAN_LAYER
 	mergeable_decal = FALSE
 	beauty = -150
 	clean_type = CLEAN_TYPE_HARD_DECAL
@@ -245,6 +250,8 @@
 	name = "chemical pile"
 	desc = "A pile of chemicals. You can't quite tell what's inside it."
 	gender = NEUTER
+	plane = GAME_PLANE
+	layer = GAME_CLEAN_LAYER
 	icon = 'icons/obj/debris.dmi'
 	icon_state = "ash"
 
@@ -322,6 +329,8 @@
 	desc = "Torn pieces of cardboard and paper, left over from a package."
 	icon = 'icons/obj/debris.dmi'
 	icon_state = "paper_shreds"
+	plane = GAME_PLANE
+	layer = GAME_CLEAN_LAYER
 
 /obj/effect/decal/cleanable/wrapping/pinata
 	name = "pinata shreds"
@@ -340,7 +349,7 @@
 	icon = 'icons/obj/debris.dmi'
 	icon_state = "garbage"
 	plane = GAME_PLANE
-	layer = FLOOR_CLEAN_LAYER //To display the decal over wires.
+	layer = GAME_CLEAN_LAYER
 	beauty = -150
 	clean_type = CLEAN_TYPE_HARD_DECAL
 
@@ -558,6 +567,8 @@
 	icon_state = "rubble"
 	mergeable_decal = FALSE
 	beauty = -10
+	plane = GAME_PLANE
+	layer = LOW_OBJ_LAYER
 
 /obj/effect/decal/cleanable/rubble/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/mob/silicon/robots.dmi'
 	icon_state = "gib1"
 	plane = GAME_PLANE
-	layer = LOW_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7")
 	blood_state = BLOOD_STATE_OIL
 	bloodiness = BLOOD_AMOUNT_PER_DECAL

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -5,6 +5,7 @@
 	desc = "It's a useless heap of junk... <i>or is it?</i>"
 	icon = 'icons/mob/silicon/robots.dmi'
 	icon_state = "gib1"
+	plane = GAME_PLANE
 	layer = LOW_OBJ_LAYER
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7")
 	blood_state = BLOOD_STATE_OIL

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/effects/crayondecal.dmi'
 	icon_state = "rune1"
 	gender = NEUTER
-	plane = GAME_PLANE //makes the graffiti visible over a wall.
 	mergeable_decal = FALSE
 	flags_1 = ALLOW_DARK_PAINTS_1
 	var/do_icon_rotate = TRUE
@@ -13,6 +12,10 @@
 
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null, desc_override = null)
 	. = ..()
+	if(isturf(loc) && loc.density)
+		// allows for wall graffiti to be seen
+		SET_PLANE_IMPLICIT(src, GAME_PLANE)
+		layer = GAME_CLEAN_LAYER
 	if(e_name)
 		name = e_name
 	if(desc_override)

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -12,7 +12,7 @@
 
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null, desc_override = null)
 	. = ..()
-	if(isturf(loc) && loc.density)
+	if(isclosedturf(loc) && loc.density)
 		// allows for wall graffiti to be seen
 		SET_PLANE_IMPLICIT(src, GAME_PLANE)
 		layer = GAME_CLEAN_LAYER

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -84,7 +84,7 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "cosmic_carpet"
 	anchored = TRUE
-	layer = LOW_SIGIL_LAYER
+	layer = BELOW_OBJ_LAYER
 	density = FALSE
 	can_atmos_pass = ATMOS_PASS_NO
 	initial_duration = 30 SECONDS

--- a/code/game/objects/items/devices/pressureplates.dm
+++ b/code/game/objects/items/devices/pressureplates.dm
@@ -7,7 +7,8 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	icon_state = "pressureplate"
-	layer = LOW_OBJ_LAYER
+	plane = FLOOR_PLANE
+	layer = HIGH_TURF_LAYER
 	var/trigger_mob = TRUE
 	var/trigger_item = FALSE
 	var/specific_item = null

--- a/code/game/objects/items/syndie_spraycan.dm
+++ b/code/game/objects/items/syndie_spraycan.dm
@@ -157,7 +157,8 @@
 	mergeable_decal = FALSE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	clean_type = CLEAN_TYPE_HARD_DECAL
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	var/slip_time = 6 SECONDS
 	var/slip_flags = NO_SLIP_WHEN_WALKING
 

--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -3,6 +3,12 @@
 /obj/structure/plaque/static_plaque
 	engraved = TRUE
 
+/obj/structure/plaque/static_plaque/Initialize(mapload)
+	. = ..()
+	if(isopenturf(loc) && !isProbablyWallMounted(src))
+		SET_PLANE_IMPLICIT(src, FLOOR_PLANE)
+		layer = HIGH_TURF_LAYER
+
 /obj/structure/plaque/static_plaque/atmos
 	name = "\improper FEA Atmospherics Division plaque"
 	desc = "This plaque commemorates the fall of the Atmos FEA division. For all the charred, dizzy, and brittle men who have died in its hands."

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -34,7 +34,8 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	icon = 'icons/obj/antags/cult/rune.dmi'
 	icon_state = "1"
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	color = RUNE_COLOR_RED
 
 	/// The name of the rune to cultists

--- a/code/modules/antagonists/heretic/magic/cosmic_runes.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_runes.dm
@@ -57,7 +57,8 @@
 	icon = 'icons/obj/service/hand_of_god_structures.dmi'
 	icon_state = "cosmic_rune"
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	/// The other rune this rune is linked with
 	var/datum/weakref/linked_rune
 	/// Effect for when someone teleports
@@ -133,7 +134,8 @@
 	name = "cosmic rune"
 	icon = 'icons/obj/service/hand_of_god_structures.dmi'
 	icon_state = "cosmic_rune_fade"
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	anchored = TRUE
 	duration = 5
 
@@ -147,7 +149,8 @@
 	name = "cosmic rune"
 	icon = 'icons/obj/service/hand_of_god_structures.dmi'
 	icon_state = "cosmic_rune_light"
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	anchored = TRUE
 	duration = 5
 

--- a/code/modules/antagonists/heretic/rust_effect.dm
+++ b/code/modules/antagonists/heretic/rust_effect.dm
@@ -3,9 +3,9 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "small_rune_1"
 	anchored = TRUE
-	layer = LOW_SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = LOWER_RUNE_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	plane = GAME_PLANE
 
 /obj/effect/glowing_rune/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -7,7 +7,8 @@
 	anchored = TRUE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	///Used mainly for summoning ritual to prevent spamming the rune to create millions of monsters.
 	var/is_in_use = FALSE
 
@@ -222,8 +223,8 @@
 	pixel_x = -30
 	pixel_y = 18
 	pixel_z = -48
-	plane = GAME_PLANE
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	greyscale_config = /datum/greyscale_config/heretic_rune
 	/// We only set this state after setting the colour, otherwise the animation doesn't colour correctly
 	var/animation_state = "transmutation_rune_draw"

--- a/code/modules/antagonists/wizard/grand_ritual/grand_ritual.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_ritual.dm
@@ -299,8 +299,8 @@
 	pixel_y = 16
 	pixel_z = -48
 	anchored = TRUE
-	layer = SIGIL_LAYER
-	plane = GAME_PLANE
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	duration = 0 SECONDS
 
 /obj/effect/temp_visual/wizard_rune/Initialize(mapload)

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -21,7 +21,8 @@
 	anchored = TRUE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_ATTACK_PAW
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	layer = SIGIL_LAYER
+	plane = FLOOR_PLANE
+	layer = RUNE_LAYER
 	/// How many prior grand rituals have been completed?
 	var/potency = 0
 	/// Time to take per invocation of rune.
@@ -393,7 +394,7 @@
 	mergeable_decal = FALSE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	clean_type = CLEAN_TYPE_HARD_DECAL
-	layer = SIGIL_LAYER
+	layer = RUNE_LAYER
 
 /obj/effect/decal/cleanable/grand_remains/cheese
 	name = "cheese soot marks"

--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_loot.dm
@@ -20,7 +20,8 @@
 	desc = "Dust from a brimdemon. It is considered valuable for its' botanical abilities."
 	icon_state = "brimdust"
 	icon = 'icons/obj/mining.dmi'
-	layer = FLOOR_CLEAN_LAYER
+	plane = GAME_PLANE
+	layer = GAME_CLEAN_LAYER
 	mergeable_decal = FALSE
 
 /obj/effect/decal/cleanable/brimdust/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Basically goes through and puts some flat objects onto the floor plane. Also puts blood back on the floor plane, since it seems like it used to be but may have been moved mistakenly questionmark.

This means they will not be affected by Ambient Occlusion: 

![image](https://github.com/user-attachments/assets/594b878b-e5e9-42e3-900e-3c9390c819ee)

## Why It's Good For The Game

A lot of these "flat" things look really out of place because they're secretly "floating" due to being on the wrong plane

## Changelog

:cl: Melbert
qol: Runes, crayons, and similar decals no longer have shadows
fix: Blood and similar "mess" decals no longer have shadows (again)
/:cl:


