### PR TITLE
fixes some mobs having their aggro appearance linger around after sentience

### DIFF
--- a/code/datums/components/appearance_on_aggro.dm
+++ b/code/datums/components/appearance_on_aggro.dm
@@ -25,7 +25,7 @@
 
 /datum/component/appearance_on_aggro/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_AI_BLACKBOARD_KEY_SET(target_key), PROC_REF(on_set_target))
-	RegisterSignals(parent, list(COMSIG_AI_BLACKBOARD_KEY_CLEARED(target_key), COMSIG_LIVING_DEATH, COMSIG_MOB_LOGIN), PROC_REF(cut_alt_appearance))
+	RegisterSignals(parent, list(COMSIG_AI_BLACKBOARD_KEY_CLEARED(target_key), COMSIG_LIVING_DEATH, COMSIG_MOB_LOGIN), PROC_REF(revert_appearance))
 	if (!isnull(aggro_state))
 		RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON_STATE, PROC_REF(on_icon_state_updated))
 	if (!isnull(aggro_overlay))
@@ -56,11 +56,8 @@
 	revert_appearance(parent)
 	return ..()
 
-/datum/component/appearance_on_aggro/proc/cut_alt_appearance(atom/source)
-	SIGNAL_HANDLER
-	revert_appearance(parent)
-
 /datum/component/appearance_on_aggro/proc/revert_appearance(mob/living/source)
+	SIGNAL_HANDLER
 	if (!isnull(aggro_overlay) || !isnull(aggro_state))
 		source.update_appearance(UPDATE_ICON)
 	if (!isnull(alpha_on_deaggro))

--- a/code/datums/components/appearance_on_aggro.dm
+++ b/code/datums/components/appearance_on_aggro.dm
@@ -25,7 +25,7 @@
 
 /datum/component/appearance_on_aggro/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_AI_BLACKBOARD_KEY_SET(target_key), PROC_REF(on_set_target))
-	RegisterSignals(parent, list(COMSIG_AI_BLACKBOARD_KEY_CLEARED(target_key), COMSIG_LIVING_DEATH), PROC_REF(on_clear_or_death))
+	RegisterSignals(parent, list(COMSIG_AI_BLACKBOARD_KEY_CLEARED(target_key), COMSIG_LIVING_DEATH, COMSIG_MOB_LOGIN), PROC_REF(cut_alt_appearance))
 	if (!isnull(aggro_state))
 		RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON_STATE, PROC_REF(on_icon_state_updated))
 	if (!isnull(aggro_overlay))
@@ -33,7 +33,12 @@
 
 /datum/component/appearance_on_aggro/UnregisterFromParent()
 	. = ..()
-	UnregisterSignal(parent, list(COMSIG_AI_BLACKBOARD_KEY_SET(target_key), COMSIG_AI_BLACKBOARD_KEY_CLEARED(target_key), COMSIG_LIVING_DEATH))
+	UnregisterSignal(parent, list(
+		COMSIG_AI_BLACKBOARD_KEY_SET(target_key),
+		COMSIG_AI_BLACKBOARD_KEY_CLEARED(target_key),
+		COMSIG_LIVING_DEATH,
+		COMSIG_MOB_LOGIN,
+	))
 
 /datum/component/appearance_on_aggro/proc/on_set_target(mob/living/source)
 	SIGNAL_HANDLER
@@ -51,7 +56,7 @@
 	revert_appearance(parent)
 	return ..()
 
-/datum/component/appearance_on_aggro/proc/on_clear_or_death(atom/source)
+/datum/component/appearance_on_aggro/proc/cut_alt_appearance(atom/source)
 	SIGNAL_HANDLER
 	revert_appearance(parent)
 


### PR DESCRIPTION

## About The Pull Request
if the behavior's logic doesnt clear target keys on finish_action, the mob would keep its aggroed look post sentience

## Why It's Good For The Game
fixes some mobs having their aggro appearance linger around after sentience

## Changelog
:cl:
fix: fixes some mobs having their aggro appearance linger around after sentience
/:cl:
