### PR TITLE
[i ded] nerfs Derelict Outpost creature hatchlings

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -573,13 +573,7 @@
 /area/ruin/space/has_grav/derelictoutpost)
 "cC" = (
 /obj/structure/alien/weeds/creature,
-/mob/living/basic/creature{
-	desc = "Awh its so sm-OH GOD WHAT THE FUCK.";
-	health = 25;
-	maxHealth = 25;
-	name = "hatchling";
-	current_size = 0.85
-	},
+/mob/living/basic/creature/hatchling,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost)
 "cD" = (
@@ -765,9 +759,7 @@
 /area/ruin/space/has_grav/derelictoutpost)
 "dl" = (
 /obj/structure/alien/weeds/creature,
-/mob/living/basic/creature{
-	name = "Miss Tiggles"
-	},
+/mob/living/basic/creature/tiggles,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost)
 "dm" = (

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -100,3 +100,11 @@
 		exit_jaunt(cast_on)
 		return
 	enter_jaunt(cast_on)
+
+/mob/living/basic/creature/tiggles
+	name = "Miss Tiggles"
+
+/mob/living/basic/creature/hatchling
+	name = "hatchling"
+	health = 25
+	maxHealth = 25

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -111,7 +111,3 @@
 	health = 25
 	maxHealth = 25
 	health_scaling = FALSE
-
-/mob/living/basic/creature/hatchling/Initialize(mapload)
-	. = ..()
-	update_transform(0.85)

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -111,3 +111,4 @@
 	health = 25
 	maxHealth = 25
 	health_scaling = FALSE
+	current_size = 0.85

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -111,3 +111,7 @@
 	health = 25
 	maxHealth = 25
 	health_scaling = FALSE
+
+/mob/living/basic/creature/hatchling/Initialize(mapload)
+	. = ..()
+	update_transform(0.85)

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -28,16 +28,18 @@
 	lighting_cutoff_blue = 15
 
 	ai_controller = /datum/ai_controller/basic_controller/simple_hostile_obstacles
+	var/health_scaling = TRUE
 
 /mob/living/basic/creature/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_NETHER, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 0)
-	AddComponent(
-		/datum/component/health_scaling_effects,\
-		min_health_attack_modifier_lower = 15,\
-		min_health_attack_modifier_upper = 30,\
-		min_health_slowdown = -1.5,\
-	)
+	if(health_scaling)
+		AddComponent(
+			/datum/component/health_scaling_effects,\
+			min_health_attack_modifier_lower = 15,\
+			min_health_attack_modifier_upper = 30,\
+			min_health_slowdown = -1.5,\
+		)
 
 	GRANT_ACTION(/datum/action/cooldown/spell/jaunt/creature_teleport)
 
@@ -108,3 +110,4 @@
 	name = "hatchling"
 	health = 25
 	maxHealth = 25
+	health_scaling = FALSE


### PR DESCRIPTION

## About The Pull Request

The Derelict Outpost ruin is full of mobs that at absolute most 3-shot most spacemen and have a very rapid AI. Most of this brought about by the map being untouched as additional abilities have been given to the type of mob that occupies it. This is far and away overtuned, so I made the "hatchling" mobs not have health-based damage and speed scaling.

As a bonus, you get map-level varedits replaced with typepaths.

## Why It's Good For The Game

Do space ruins need very-definitely-instant-death mobs, or are we good with just quick-death-if-you-cant-retreat-in-time mobs?

## Changelog

:cl:
balance: The hatchlings on the Derelict Outpost are marginally less deadly, to the extent that fighting them is slightly more feasible.
/:cl:
