### PR TITLE
[NO GBP] Makes jetpack movement much smoother and prevents pushing off objects while using one

### DIFF
--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -100,15 +100,14 @@
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(move_react))
 	RegisterSignal(user, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(pre_move_react))
 	RegisterSignal(user, COMSIG_MOB_CLIENT_MOVE_NOGRAV, PROC_REF(on_client_move))
+	RegisterSignal(user, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE, PROC_REF(on_pushoff))
 	START_PROCESSING(SSnewtonian_movement, src)
 	setup_trail(user)
 
 /datum/component/jetpack/proc/deactivate(datum/source, mob/old_user)
 	SIGNAL_HANDLER
 
-	UnregisterSignal(old_user, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(old_user, COMSIG_MOVABLE_PRE_MOVE)
-	UnregisterSignal(old_user, COMSIG_MOB_CLIENT_MOVE_NOGRAV)
+	UnregisterSignal(old_user, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOVABLE_MOVED, COMSIG_MOB_CLIENT_MOVE_NOGRAV, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE))
 	STOP_PROCESSING(SSnewtonian_movement, src)
 	user = null
 
@@ -161,3 +160,11 @@
 	var/max_drift_force = (DEFAULT_INERTIA_SPEED / source.cached_multiplicative_slowdown - 1) / INERTIA_SPEED_COEF + 1
 	source.newtonian_move(dir2angle(source.client.intended_direction), instant = TRUE, drift_force = drift_force, controlled_cap = max_drift_force)
 	source.setDir(source.client.intended_direction)
+
+/datum/component/jetpack/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
+	SIGNAL_HANDLER
+
+	if (!should_trigger(source) || !check_on_move.Invoke(FALSE))
+		return
+
+	return COMPONENT_PREVENT_SPACEMOVE_HALT

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -110,6 +110,7 @@
 		human.AddElement(/datum/element/forced_gravity, 0)
 		passtable_on(human, SPECIES_FLIGHT_TRAIT)
 		RegisterSignal(human, COMSIG_MOB_CLIENT_MOVE_NOGRAV, PROC_REF(on_client_move))
+		RegisterSignal(human, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE, PROC_REF(on_pushoff))
 		START_PROCESSING(SSnewtonian_movement, src)
 		open_wings()
 		to_chat(human, span_notice("You beat your wings and begin to hover gently above the ground..."))
@@ -122,7 +123,7 @@
 	human.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/wings)
 	human.RemoveElement(/datum/element/forced_gravity, 0)
 	passtable_off(human, SPECIES_FLIGHT_TRAIT)
-	UnregisterSignal(human, COMSIG_MOB_CLIENT_MOVE_NOGRAV)
+	UnregisterSignal(human, list(COMSIG_MOB_CLIENT_MOVE_NOGRAV, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE))
 	STOP_PROCESSING(SSnewtonian_movement, src)
 	to_chat(human, span_notice("You settle gently back onto the ground..."))
 	close_wings()
@@ -137,6 +138,12 @@
 	var/max_drift_force = (DEFAULT_INERTIA_SPEED / source.cached_multiplicative_slowdown - 1) / INERTIA_SPEED_COEF + 1
 	source.newtonian_move(dir2angle(source.client.intended_direction), instant = TRUE, drift_force = FUNCTIONAL_WING_FORCE, controlled_cap = max_drift_force)
 	source.setDir(source.client.intended_direction)
+
+/obj/item/organ/external/wings/functional/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
+	SIGNAL_HANDLER
+	if (!can_fly(source))
+		return
+	return COMPONENT_PREVENT_SPACEMOVE_HALT
 
 /obj/item/organ/external/wings/functional/process(seconds_per_tick)
 	if (!owner || !can_fly(owner) || isnull(owner.drift_handler))

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -62,7 +62,7 @@
 
 ///Check if we're still eligible for flight (wings covered, atmosphere too thin, etc)
 /obj/item/organ/external/wings/functional/proc/can_fly(mob/living/carbon/human/human)
-	if(human.stat || human.body_position == LYING_DOWN)
+	if(human.stat || human.body_position == LYING_DOWN || isnull(human.client))
 		return FALSE
 	//Jumpsuits have tail holes, so it makes sense they have wing holes too
 	if(!cant_hide && human.wear_suit && ((human.wear_suit.flags_inv & HIDEJUMPSUIT) && (!human.wear_suit.species_exception || !is_type_in_list(src, human.wear_suit.species_exception))))
@@ -141,8 +141,13 @@
 
 /obj/item/organ/external/wings/functional/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
 	SIGNAL_HANDLER
-	if (!can_fly(source))
+
+	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
 		return
+
+	if (!can_fly(source) || !source.client.intended_direction)
+		return
+
 	return COMPONENT_PREVENT_SPACEMOVE_HALT
 
 /obj/item/organ/external/wings/functional/process(seconds_per_tick)

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -78,8 +78,13 @@
 
 /obj/item/organ/external/wings/moth/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
 	SIGNAL_HANDLER
-	if (!allow_flight())
+
+	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
 		return
+
+	if (!allow_flight() || !source.client.intended_direction)
+		return
+
 	return COMPONENT_PREVENT_SPACEMOVE_HALT
 
 ///check if our wings can burn off ;_;

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -21,11 +21,12 @@
 	RegisterSignal(receiver, COMSIG_HUMAN_BURNING, PROC_REF(try_burn_wings))
 	RegisterSignal(receiver, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(heal_wings))
 	RegisterSignal(receiver, COMSIG_MOB_CLIENT_MOVE_NOGRAV, PROC_REF(on_client_move))
+	RegisterSignal(receiver, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE, PROC_REF(on_pushoff))
 	START_PROCESSING(SSnewtonian_movement, src)
 
 /obj/item/organ/external/wings/moth/on_mob_remove(mob/living/carbon/organ_owner)
 	. = ..()
-	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOB_CLIENT_MOVE_NOGRAV))
+	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOB_CLIENT_MOVE_NOGRAV, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE))
 	STOP_PROCESSING(SSnewtonian_movement, src)
 
 /obj/item/organ/external/wings/moth/make_flap_sound(mob/living/carbon/wing_owner)
@@ -74,6 +75,12 @@
 	var/max_drift_force = (DEFAULT_INERTIA_SPEED / source.cached_multiplicative_slowdown - 1) / INERTIA_SPEED_COEF + 1
 	source.newtonian_move(dir2angle(source.client.intended_direction), instant = TRUE, drift_force = MOTH_WING_FORCE, controlled_cap = max_drift_force)
 	source.setDir(source.client.intended_direction)
+
+/obj/item/organ/external/wings/moth/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
+	SIGNAL_HANDLER
+	if (!allow_flight())
+		return
+	return COMPONENT_PREVENT_SPACEMOVE_HALT
 
 ///check if our wings can burn off ;_;
 /obj/item/organ/external/wings/moth/proc/try_burn_wings(mob/living/carbon/human/human)


### PR DESCRIPTION

## About The Pull Request
Jetpacks will now prevent you from attempting to interact with objects near you in zero G, preventing you from pushing lockers and people around. This also makes jetpack movement ***much*** more smooth, as they will activate at your first move, preventing jerky movement when pushing off walls. Same applies to all wings which should help moth players with new spacemove.

Thanks to iusedtoplayxbox on discord for providing details regarding the issue.

## Why It's Good For The Game

Less jank = happier players

## Changelog
:cl:
qol: Jetpack movement is now much smoother
/:cl:
