### PR TITLE
[NO GBP] Fixing a small, tiny issue with mob resizing on init

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -146,7 +146,7 @@
 	obj_damage = 15
 	ai_controller = /datum/ai_controller/basic_controller/gorilla/lesser
 	butcher_results = list(/obj/item/food/meat/slab/gorilla = 2)
-	current_size = 0.75
+	initial_size = 0.75
 
 /// Cargo's wonderful mascot, the tranquil box-carrying ape
 /mob/living/basic/gorilla/cargorilla
@@ -175,7 +175,7 @@
 	obj_damage = 25
 	speed = 0.1
 	paralyze_chance = 0
-	current_size = 0.9
+	initial_size = 0.9
 
 /mob/living/basic/gorilla/genetics/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
+++ b/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
@@ -139,7 +139,7 @@
 	can_breed = FALSE
 	gender = NEUTER
 	ai_controller = /datum/ai_controller/basic_controller/gutlunch/gutlunch_baby
-	current_size = 0.6
+	initial_size = 0.6
 	///list of stats we inherited
 	var/datum/gutlunch_inherited_stats/inherited_stats
 

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -105,10 +105,11 @@
 
 /mob/living/basic/creature/tiggles
 	name = "Miss Tiggles"
+	gold_core_spawnable = NO_SPAWN
 
 /mob/living/basic/creature/hatchling
 	name = "hatchling"
 	health = 25
 	maxHealth = 25
 	health_scaling = FALSE
-	current_size = 0.85
+	initial_size = 0.85

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,7 +1,9 @@
 /mob/living/Initialize(mapload)
 	. = ..()
 	if(current_size != RESIZE_DEFAULT_SIZE)
-		update_transform(current_size)
+		var/cached_size = current_size
+		current_size = RESIZE_DEFAULT_SIZE
+		update_transform(cached_size)
 	AddElement(/datum/element/movetype_handler)
 	register_init_signals()
 	if(unique_name)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,9 +1,7 @@
 /mob/living/Initialize(mapload)
 	. = ..()
-	if(current_size != RESIZE_DEFAULT_SIZE)
-		var/cached_size = current_size
-		current_size = RESIZE_DEFAULT_SIZE
-		update_transform(cached_size)
+	if(initial_size != RESIZE_DEFAULT_SIZE)
+		update_transform(initial_size)
 	AddElement(/datum/element/movetype_handler)
 	register_init_signals()
 	if(unique_name)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -6,8 +6,11 @@
 	interaction_flags_click = ALLOW_RESTING
 	interaction_flags_mouse_drop = ALLOW_RESTING
 
-	///Tracks the current size of the mob in relation to its original size. Use update_transform(resize) to change it.
+	///Tracks the scale of the mob transformation matrix in relation to its identity. Use update_transform(resize) to change it.
 	var/current_size = RESIZE_DEFAULT_SIZE
+	///How the mob transformation matrix is scaled on init.
+	var/initial_size = RESIZE_DEFAULT_SIZE
+
 	var/lastattacker = null
 	var/lastattackerckey = null
 


### PR DESCRIPTION
## About The Pull Request
The way `current_size` works is that it's multiplied by whatever argument it's used on `update_transform`, so if we have an initial current_size of 0.9 for a mob, we end up multipling that by itself and end up with the wrong value of 0.81 for a mob that's has been resized to be 10% shorter and thinner.

## Why It's Good For The Game
Mistakes were made.

## Changelog
/:cl:
fix: Miss Tiggles is no longer spawned by gold sime cores.
:cl: