### PR TITLE
[No GBP] Minor change/fix to MI13 Agent's loadout

### DIFF
--- a/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
@@ -249,7 +249,7 @@
 		/obj/item/clothing/mask/chameleon = 20,
 		/obj/item/language_manual/codespeak_manual/unlimited = 10,
 		/obj/item/storage/mail_counterfeit_device = 10,
-		/obj/item/traitor_machine_trapper = 10,
+		/obj/item/clothing/glasses/thermal = 10,
 		/obj/item/gun/ballistic/automatic/pistol/clandestine/fisher = 10,
 	))
 


### PR DESCRIPTION

## About The Pull Request
The agents had a 10% chance to spawn with a machine trapper. Now they have a 10% chance to spawn with thermal goggles (non-chameleon).
## Why It's Good For The Game
Turns out the machine trapper doesn't do anything when a non-traitor uses it. The replacement item is thermals, it's on-theme for the faction and is about the same power as the other items in the pool.
## Changelog
:cl:
balance: MI13 Fugitive Hunters can no longer spawn with machine trappers, instead they may now spawn with thermal goggles.
/:cl:
