### PR TITLE
Automatically link maps multi-z up/down traits

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -14,7 +14,6 @@
 	},
 	"traits": [
 		{
-			"Up": true,
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,
@@ -23,8 +22,6 @@
 			"No Parallax": true
 		},
 		{
-			"Down": true,
-			"Up": true,
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,
@@ -33,7 +30,6 @@
 			"No Parallax": true
 		},
 		{
-			"Down": true,
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,

--- a/_maps/multiz_debug.json
+++ b/_maps/multiz_debug.json
@@ -11,17 +11,13 @@
 	],
 	"traits": [
 		{
-			"Up": true,
 			"Linkage": "Cross"
 		},
 		{
-			"Up": true,
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		},
 		{
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		}

--- a/_maps/northstar.json
+++ b/_maps/northstar.json
@@ -14,23 +14,17 @@
 	"space_empty_levels": 2,
 	"traits": [
 		{
-			"Up": true,
 			"Linkage": "Cross"
 		},
 		{
-			"Up": true,
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		},
 		{
-			"Up": true,
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		},
 		{
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		}

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -11,12 +11,10 @@
 	},
 	"traits": [
 		{
-			"Up": true,
 			"Baseturf": "/turf/open/misc/asteroid/airless",
 			"Linkage": "Cross"
 		},
 		{
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		}

--- a/_maps/wawastation.json
+++ b/_maps/wawastation.json
@@ -11,12 +11,10 @@
 	},
 	"traits": [
 		{
-			"Up": true,
 			"Baseturf": "/turf/open/misc/asteroid/airless",
 			"Linkage": "Cross"
 		},
 		{
-			"Down": true,
 			"Baseturf": "/turf/open/openspace",
 			"Linkage": "Cross"
 		}

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -395,13 +395,23 @@ Used by the AI doomsday and the self-destruct nuke.
 
 	if (!length(traits))  // null or empty - default
 		for (var/i in 1 to total_z)
-			traits += list(default_traits)
+			traits += list(default_traits.Copy())
 	else if (total_z != traits.len)  // mismatch
 		INIT_ANNOUNCE("WARNING: [traits.len] trait sets specified for [total_z] z-levels in [path]!")
 		if (total_z < traits.len)  // ignore extra traits
 			traits.Cut(total_z + 1)
 		while (total_z > traits.len)  // fall back to defaults on extra levels
-			traits += list(default_traits)
+			traits += list(default_traits.Copy())
+
+	if(total_z > 1) // it's a multi z map
+		for(var/z in 1 to total_z)
+			if(z == 1) // bottom z-level
+				traits[z]["Up"] = TRUE
+			else if(z == total_z) // top z-level
+				traits[z]["Down"] = TRUE
+			else
+				traits[z]["Down"] = TRUE
+				traits[z]["Up"] = TRUE
 
 	// preload the relevant space_level datums
 	var/start_z = world.maxz + 1


### PR DESCRIPTION

## About The Pull Request
This autoloads the up/down traits for every map instead of having to manually add those traits to the JSON.

## Why It's Good For The Game
More automation good. Also let's people experiment with larger maps like a multi-z lavaland.

## Changelog
:cl:
code: Automatically link maps multi-z up/down traits
/:cl:
