### PR TITLE
[NO GBP] Fixes the emagged fishing portal circuitboard resulting in normal fishing portal generator

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1407,7 +1407,7 @@
 
 /obj/item/circuitboard/machine/fishing_portal_generator/emagged
 	name = "Emagged Fishing Portal Generator"
-	build_path = /obj/machinery/fishing_portal_generator
+	build_path = /obj/machinery/fishing_portal_generator/emagged
 
 //Supply
 /obj/item/circuitboard/machine/ore_redemption


### PR DESCRIPTION
## About The Pull Request
Someone on discord said it didn't work so I've taken at look at it, and guess what? It's the base type.

## Why It's Good For The Game
Now it should work.

## Changelog

:cl:
fix: The pre-emagged fishing portal circuitboard now actually gives you an emagged fishing portal generator.
/:cl:
