### PR TITLE
[no gbp] adds a medal box to captains locker on Wawastation

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -26151,6 +26151,7 @@
 	},
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/firealarm/directional/north,
+/obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
 "jpe" = (


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/f46cb2b8-3088-46db-be4b-7788bf7ba91a)


## Why It's Good For The Game

it was missing so this should be more inline with the rest of the maps that actually allow the captain to give medals

## Changelog
:cl:
fix:added a medal box to captains locker on Wawastation
/:cl:
