### PR TITLE
Stops drone held tools from being force moved

### DIFF
--- a/code/modules/mob/living/basic/drone/drone_tools.dm
+++ b/code/modules/mob/living/basic/drone/drone_tools.dm
@@ -44,7 +44,7 @@
 
 	for(var/obj/item/tool as anything in builtintools)
 		tool.AddComponent(/datum/component/holderloving, src, TRUE)
-		ADD_TRAIT(tool, TRAIT_NODROP, src)
+		ADD_TRAIT(tool, TRAIT_NODROP, REF(src))
 
 
 /obj/item/crowbar/drone

--- a/code/modules/mob/living/basic/drone/drone_tools.dm
+++ b/code/modules/mob/living/basic/drone/drone_tools.dm
@@ -41,8 +41,10 @@
 	builtintools += new /obj/item/t_scanner(src)
 	builtintools += new /obj/item/analyzer(src)
 	builtintools += new /obj/item/soap/drone(src)
+
 	for(var/obj/item/tool as anything in builtintools)
 		tool.AddComponent(/datum/component/holderloving, src, TRUE)
+		ADD_TRAIT(tool, TRAIT_NODROP, src)
 
 
 /obj/item/crowbar/drone


### PR DESCRIPTION
## About The Pull Request
- Fixes #86989

The component `/datum/component/holderloving` doesn't help with this case. This is because camera assemblies uses `temporarilyRemoveItemFromInventory()` which does not trigger a force move so this component does nothing.

`temporarilyRemoveItemFromInventory()` does however check for trait `TRAIT_NODROP` which we add to our drone tools to stop it from being force moved


## Changelog
:cl:
fix: tools from the drone toolbox cannot be forcefully removed in certain situations e.g. when using the drone gas analyser to upgrade the camera assembly
/:cl:

