### PR TITLE
Fix exception bad arg name 'initiator_name' for shuttle map rotation

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -554,7 +554,7 @@
 					color_override = "orange",
 				)
 				INVOKE_ASYNC(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, poll_hearts))
-				INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, initiator_name = "Map Rotation")
+				INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation")
 
 				if(!is_reserved_level(z))
 					CRASH("Emergency shuttle did not move to transit z-level!")


### PR DESCRIPTION

## About The Pull Request

Fixes an exception that occurred during the map vote on the shuttle escape.

Namely, the argument used is `initiator_name` when it should be `vote_initiator_name`. 
## Why It's Good For The Game

Fixes exception.
## Changelog
:cl:
fix: fixes exception during shuttle map rotation vote
/:cl:
