### PR TITLE
Returns the original Revolver look for traitors

### DIFF
--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -2364,11 +2364,11 @@
 /obj/structure/rack{
 	dir = 8
 	},
-/obj/item/gun/ballistic/revolver/syndicate{
+/obj/item/gun/ballistic/revolver/badass{
 	pixel_x = 2;
 	pixel_y = 5
 	},
-/obj/item/gun/ballistic/revolver/syndicate{
+/obj/item/gun/ballistic/revolver/badass{
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -198,7 +198,7 @@
 /obj/item/storage/belt/holster/nukie/cowboy/full/PopulateContents()
 	generate_items_inside(list(
 		/obj/item/ammo_box/a357 = 2,
-		/obj/item/gun/ballistic/revolver/syndicate/cowboy/nuclear = 1,
+		/obj/item/gun/ballistic/revolver/cowboy/nuclear = 1,
 	), src)
 
 

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -381,7 +381,7 @@
 
 /obj/item/storage/toolbox/guncase/revolver
 	name = "revolver gun case"
-	weapon_to_spawn = /obj/item/gun/ballistic/revolver/syndicate/nuclear
+	weapon_to_spawn = /obj/item/gun/ballistic/revolver/badass/nuclear
 	extra_to_spawn = /obj/item/ammo_box/a357
 
 /obj/item/storage/toolbox/guncase/sword_and_board

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -78,7 +78,7 @@
 			new /obj/item/jammer(src) // 5 tc
 
 		if(KIT_GUN)
-			new /obj/item/gun/ballistic/revolver/syndicate(src) // 13 tc
+			new /obj/item/gun/ballistic/revolver(src) // 13 tc
 			new /obj/item/ammo_box/a357(src) // 4tc
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/storage/belt/holster/chameleon(src) // 1 tc

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -606,7 +606,7 @@
 	l_hand = /obj/item/melee/energy/sword
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/stimulants
 	l_pocket = /obj/item/soap/syndie
-	belt = /obj/item/gun/ballistic/revolver/syndicate
+	belt = /obj/item/gun/ballistic/revolver
 
 /datum/outfit/deathmatch_loadout/nukie
 	name = "Deathmatch: Nuclear Operative"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -135,20 +135,20 @@
 		"Black Panther" = "c38_panther"
 	)
 
-/obj/item/gun/ballistic/revolver/syndicate
-	name = "\improper Syndicate Revolver"
-	desc = "A modernized 7 round revolver manufactured by Waffle Corp. Uses .357 ammo."
+/obj/item/gun/ballistic/revolver/badass
+	name = "\improper Badass Revolver"
+	desc = "A 7-chamber revolver manufactured by Waffle Corp to make their operatives feel Badass. Offers no tactical advantage whatsoever. Uses .357 ammo."
 	icon_state = "revolversyndie"
 
-/obj/item/gun/ballistic/revolver/syndicate/nuclear
+/obj/item/gun/ballistic/revolver/badass/nuclear
 	pin = /obj/item/firing_pin/implant/pindicate
 
-/obj/item/gun/ballistic/revolver/syndicate/cowboy
+/obj/item/gun/ballistic/revolver/cowboy
 	desc = "A classic revolver, refurbished for modern use. Uses .357 ammo."
 	//There's already a cowboy sprite in there!
 	icon_state = "lucky"
 
-/obj/item/gun/ballistic/revolver/syndicate/cowboy/nuclear
+/obj/item/gun/ballistic/revolver/cowboy/nuclear
 	pin = /obj/item/firing_pin/implant/pindicate
 
 /obj/item/gun/ballistic/revolver/mateba
@@ -296,8 +296,8 @@
 	user.visible_message(span_danger("[user.name]'s soul is captured by \the [src]!"), span_userdanger("You've lost the gamble! Your soul is forfeit!"))
 
 /obj/item/gun/ballistic/revolver/reverse //Fires directly at its user... unless the user is a clown, of course.
-	name = /obj/item/gun/ballistic/revolver/syndicate::name
-	desc = /obj/item/gun/ballistic/revolver/syndicate::desc
+	name = /obj/item/gun/ballistic/revolver/badass::name
+	desc = /obj/item/gun/ballistic/revolver/badass::desc
 	clumsy_check = FALSE
 	icon_state = "revolversyndie"
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -296,10 +296,7 @@
 	user.visible_message(span_danger("[user.name]'s soul is captured by \the [src]!"), span_userdanger("You've lost the gamble! Your soul is forfeit!"))
 
 /obj/item/gun/ballistic/revolver/reverse //Fires directly at its user... unless the user is a clown, of course.
-	name = /obj/item/gun/ballistic/revolver/badass::name
-	desc = /obj/item/gun/ballistic/revolver/badass::desc
 	clumsy_check = FALSE
-	icon_state = "revolversyndie"
 
 /obj/item/gun/ballistic/revolver/reverse/can_trigger_gun(mob/living/user, akimbo_usage)
 	if(akimbo_usage)

--- a/code/modules/spells/spell_types/right_and_wrong.dm
+++ b/code/modules/spells/spell_types/right_and_wrong.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/e_gun/advtaser,
 	/obj/item/gun/energy/laser,
 	/obj/item/gun/ballistic/revolver,
-	/obj/item/gun/ballistic/revolver/syndicate,
+	/obj/item/gun/ballistic/revolver/badass,
 	/obj/item/gun/ballistic/revolver/c38/detective,
 	/obj/item/gun/ballistic/automatic/pistol/deagle/camo,
 	/obj/item/gun/ballistic/automatic/gyropistol,

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -95,14 +95,7 @@
 	item = /obj/item/gun/ballistic/revolver
 	cost = 13
 	surplus = 50
-
-/datum/uplink_item/dangerous/revolver/badass
-	name = "Badass Revolver"
-	desc = "A modified syndicate revolver meant to make you feel Badass. Offers no tactical advantage whatsoever. Fires .357 Magnum rounds and has 7 chambers."
-	item = /obj/item/gun/ballistic/revolver/badass
-	cost = 13
-	surplus = 50
-	purchasable_from = UPLINK_ALL_SYNDIE_OPS //nukies get their own version
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS //only traitors get the original revolver
 
 /datum/uplink_item/dangerous/cat
 	name = "Feral cat grenade"

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -91,11 +91,18 @@
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"
-	desc = "Waffle Corp's modernized Syndicate revolver. Fires 7 brutal rounds of .357 Magnum."
-	item = /obj/item/gun/ballistic/revolver/syndicate
+	desc = "A brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers."
+	item = /obj/item/gun/ballistic/revolver
 	cost = 13
 	surplus = 50
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS //nukies get their own version
+
+/datum/uplink_item/dangerous/revolver/badass
+	name = "Badass Revolver"
+	desc = "A modified syndicate revolver meant to make you feel Badass. Offers no tactical advantage whatsoever. Fires .357 Magnum rounds and has 7 chambers."
+	item = /obj/item/gun/ballistic/revolver/badass
+	cost = 13
+	surplus = 50
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS //nukies get their own version
 
 /datum/uplink_item/dangerous/cat
 	name = "Feral cat grenade"


### PR DESCRIPTION
## About The Pull Request

Returns the original look of the revolver for traitors:
![srBs2K1fvz](https://github.com/user-attachments/assets/e1d7f569-e854-4762-ab08-59b0bcb74f60)
While still giving Nuclear Operatives the red-revolver:
![dreamseeker_guBVku71t9](https://github.com/user-attachments/assets/17f86e07-7387-48a1-93e8-5b3b7aeda997)
Re-flavors the red revolver to a "Badass Revolver" as well, so that it helps differentiate it a bit more:
![dreamseeker_YrF52zMuWv](https://github.com/user-attachments/assets/bcf75096-a775-4971-846b-ef23ee0d50fd)

## Why It's Good For The Game

I always thought that the red "Syndicate Revolver" was way too on the nose and dorky, especially for undercover agents. However, I thought that dorkiness was a perfect fit for the Nuclear Operatives who love painting all of their gear to be red and over-the-top badass looking.

## Changelog

:cl:
image: Traitors now get the classic Revolver in their uplink. Nuclear Operatives still keep the red look for their revolvers.
/:cl:
