### PR TITLE
Lets newly made blood splatters made from splashing a reagent container properly infect with their fluids-transmitted viruses

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -117,13 +117,13 @@
 	var/obj/effect/decal/cleanable/blood/bloodsplatter = locate() in exposed_turf //find some blood here
 	if(!bloodsplatter)
 		bloodsplatter = new(exposed_turf, data["viruses"])
-	else if(LAZYLEN(data["viruses"]))
-		var/list/viri_to_add = list()
+	if(LAZYLEN(data["viruses"]))
+		var/list/viruses_to_add = list()
 		for(var/datum/disease/virus in data["viruses"])
 			if(virus.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS)
-				viri_to_add += virus
-		if(LAZYLEN(viri_to_add))
-			bloodsplatter.AddComponent(/datum/component/infective, viri_to_add)
+				viruses_to_add += virus
+		if(LAZYLEN(viruses_to_add))
+			bloodsplatter.AddComponent(/datum/component/infective, viruses_to_add)
 	if(data["blood_DNA"])
 		bloodsplatter.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
 


### PR DESCRIPTION
## About The Pull Request

A single `else if` statement prevented infecting a freshly-made blood splatter with the splashed blood's virus. This statement made it so that splashing virus-infected blood from a container would only infect a blood splatter that's already existing on the tile the container's been splashed on. 
bottom text
(this doesn't handle splashing containers _on a splatter directly_ via targeted throw or right-click, because it could spiral into "why can't spilling a blood container also infect any other object/item/etc and why can't i make an item blood-stained by splashing blood on it directly coders pls fix". it's kinda there, and i'm not in the mood for pushing that boulder over the ledge)

## Why It's Good For The Game

Fixes #55957

## Changelog

:cl:
fix: splashing a reagent holder with blood with a fluids-transmitted virus now properly creates an infective blood splatter
/:cl: