### PR TITLE
removes a few varedits

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -64,7 +64,6 @@
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade/dagger,
 /obj/effect/step_trigger/sound_effect/lavaland_cult_altar,
-/obj/effect/step_trigger/lavaland_cult_altar/message,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -64,6 +64,10 @@
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade/dagger,
 /obj/effect/step_trigger/sound_effect/lavaland_cult_altar,
+/obj/effect/step_trigger/message{
+	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>";
+	name = "ohfuck"
+	},
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -63,16 +63,7 @@
 /obj/item/cult_shift,
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade/dagger,
-/obj/effect/step_trigger/sound_effect{
-	happens_once = 1;
-	name = "\proper a grave mistake";
-	sound = 'sound/effects/hallucinations/i_see_you1.ogg';
-	triggerer_only = 1
-	},
-/obj/effect/step_trigger/message{
-	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>";
-	name = "ohfuck"
-	},
+/obj/effect/step_trigger/sound_effect/lavaland_cult_altar
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -63,7 +63,7 @@
 /obj/item/cult_shift,
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade/dagger,
-/obj/effect/step_trigger/sound_effect/lavaland_cult_altar
+/obj/effect/step_trigger/sound_effect/lavaland_cult_altar,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -64,6 +64,7 @@
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade/dagger,
 /obj/effect/step_trigger/sound_effect/lavaland_cult_altar,
+/obj/effect/step_trigger/lavaland_cult_altar/message,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
@@ -5468,11 +5468,9 @@
 /area/ruin/space/has_grav/hauntedtradingpost/employees/breakroom)
 "Vl" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/wizard{
+/obj/item/toy/figure/wizard/special{
 	pixel_y = 9;
 	pixel_x = -4;
-	toysay = "CLANG!";
-	toysound = 'sound/effects/clang.ogg'
 	},
 /obj/item/toy/figure/warden{
 	name = "\improper Knight action figure";

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -226,4 +226,3 @@
 	name = "a grave mistake";
 	sound = 'sound/effects/hallucinations/i_see_you1.ogg'
 	triggerer_only = 1
-	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>"

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -226,7 +226,4 @@
 	name = "a grave mistake";
 	sound = 'sound/effects/hallucinations/i_see_you1.ogg'
 	triggerer_only = 1
-
-/obj/effect/step_trigger/lavaland_cult_altar/message
 	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>"
-	name = "ohfuck"

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -220,3 +220,13 @@
 
 	if(happens_once)
 		qdel(src)
+
+/obj/effect/step_trigger/sound_effect/lavaland_cult_altar
+	happens_once = 1
+	name = "a grave mistake";
+	sound = 'sound/effects/hallucinations/i_see_you1.ogg'
+	triggerer_only = 1
+
+/obj/effect/step_trigger/lavaland_cult_altar/message
+	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>"
+	name = "ohfuck"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1360,6 +1360,10 @@
 	toysay = "EI NATH!"
 	toysound = 'sound/effects/magic/disintegrate.ogg'
 
+/obj/item/toy/figure/wizard/special
+	toysay = "CLANG!";
+	toysound = 'sound/effects/clang.ogg'
+
 /obj/item/toy/figure/rd
 	name = "\improper Research Director action figure"
 	icon_state = "rd"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1361,6 +1361,8 @@
 	toysound = 'sound/effects/magic/disintegrate.ogg'
 
 /obj/item/toy/figure/wizard/special
+
+	name = "\improper Wizard action figure special edition"
 	toysay = "CLANG!";
 	toysound = 'sound/effects/clang.ogg'
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1361,7 +1361,6 @@
 	toysound = 'sound/effects/magic/disintegrate.ogg'
 
 /obj/item/toy/figure/wizard/special
-
 	name = "\improper Wizard action figure special edition"
 	toysay = "CLANG!";
 	toysound = 'sound/effects/clang.ogg'


### PR DESCRIPTION
## About The Pull Request
removed var edits that included sound file paths from:
- `hauntedtradingpost.dmm`
- `lavaland_surface_cultaltar.dmm`
closes https://github.com/tgstation/tgstation/issues/86837
## Why It's Good For The Game
## Changelog
:cl: grungussuss
fix: removed a few var edits from maps
/:cl:
