### PR TITLE
[no gbp] makes the manufacturing crafter and router work slightly better

### DIFF
--- a/code/modules/manufactorio/_manufacturing.dm
+++ b/code/modules/manufactorio/_manufacturing.dm
@@ -117,7 +117,14 @@
 	if(!istype(stack))
 		return
 	for(var/obj/item/stack/other in contents - circuit)
-		if(!other.can_merge(stack))
+		if(!stack.can_merge(other))
 			continue
 		if(other.amount + stack.amount <= other.max_amount)
 			return other
+
+/obj/machinery/power/manufacturing/proc/may_merge_in_contents_and_do_so(obj/item/stack/stack)
+	var/merging_into = may_merge_in_contents(stack)
+	if(isnull(merging_into))
+		return
+	return stack.merge(merging_into)
+

--- a/code/modules/manufactorio/machines/crafter.dm
+++ b/code/modules/manufactorio/machines/crafter.dm
@@ -67,10 +67,8 @@
 	if(isnull(recipe) || !isitem(receiving) || surplus() < power_cost)
 		return MANUFACTURING_FAIL
 	if(receive_dir == dir || !valid_for_recipe(receiving))
-		to_chat(world, "1")
 		return MANUFACTURING_FAIL
 	if(isstack(receiving) && count_path(receiving.type) && !may_merge_in_contents_and_do_so(receiving))
-		to_chat(world, "2")
 		return MANUFACTURING_FAIL_FULL
 	receiving.Move(src, get_dir(receiving, src))
 	START_PROCESSING(SSmanufacturing, src)

--- a/code/modules/manufactorio/machines/crafter.dm
+++ b/code/modules/manufactorio/machines/crafter.dm
@@ -1,6 +1,6 @@
 /obj/machinery/power/manufacturing/crafter
 	name = "manufacturing assembling machine"
-	desc = "Assembles (crafts) the set recipe until it runs out of resources. Inputs irrelevant to the recipe are ignored."
+	desc = "Assembles (crafts) the set recipe until it runs out of resources. Inputs irrelevant to the recipe are ignored, and it may only hold exactly what the recipe needs."
 	icon_state = "crafter"
 	circuit = /obj/item/circuitboard/machine/manucrafter
 	/// power used per process() spent crafting
@@ -19,6 +19,8 @@
 /obj/machinery/power/manufacturing/crafter/Initialize(mapload)
 	. = ..()
 	craftsman = AddComponent(/datum/component/personal_crafting/machine)
+	if(ispath(recipe))
+		recipe = locate(recipe) in (cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes)
 
 /obj/machinery/power/manufacturing/crafter/examine(mob/user)
 	. = ..()
@@ -49,21 +51,26 @@
 	for(var/requirement_path in recipe.reqs)
 		if(!ispath(checking.type, requirement_path) || recipe.blacklist.Find(checking.type))
 			continue
-		return TRUE
-
-/obj/machinery/power/manufacturing/crafter/proc/contains_type(path)
-	. = FALSE
-	for(var/content in contents - circuit)
-		if(!istype(content, path))
+		var/amount = recipe.reqs[requirement_path]
+		if(count_path(requirement_path) >= amount)
 			continue
 		return TRUE
+
+/obj/machinery/power/manufacturing/crafter/proc/count_path(path)
+	. = 0
+	for(var/atom/content as anything in contents - circuit)
+		if(!ispath(path, content.type))
+			continue
+		.++
 
 /obj/machinery/power/manufacturing/crafter/receive_resource(obj/receiving, atom/from, receive_dir)
 	if(isnull(recipe) || !isitem(receiving) || surplus() < power_cost)
 		return MANUFACTURING_FAIL
 	if(receive_dir == dir || !valid_for_recipe(receiving))
+		to_chat(world, "1")
 		return MANUFACTURING_FAIL
-	if(!may_merge_in_contents(receiving) && contains_type(receiving.type))
+	if(isstack(receiving) && count_path(receiving.type) && !may_merge_in_contents_and_do_so(receiving))
+		to_chat(world, "2")
 		return MANUFACTURING_FAIL_FULL
 	receiving.Move(src, get_dir(receiving, src))
 	START_PROCESSING(SSmanufacturing, src)
@@ -86,6 +93,7 @@
 	for(var/atom/movable/thing as anything in contents - circuit)
 		thing.Move(dump_target)
 	recipe = result
+	balloon_alert(user, "set")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/power/manufacturing/crafter/Exited(atom/movable/gone, direction)

--- a/code/modules/manufactorio/machines/crusher.dm
+++ b/code/modules/manufactorio/machines/crusher.dm
@@ -28,7 +28,7 @@
 /obj/machinery/power/manufacturing/crusher/receive_resource(obj/receiving, atom/from, receive_dir)
 	if(istype(receiving, /obj/item/stack/ore) || receiving.resistance_flags & INDESTRUCTIBLE || !isitem(receiving) || surplus() < crush_cost  || receive_dir != REVERSE_DIR(dir))
 		return MANUFACTURING_FAIL
-	if(!may_merge_in_contents(receiving) && length(contents - circuit) >= capacity)
+	if(length(contents - circuit) >= capacity && may_merge_in_contents_and_do_so(receiving))
 		return MANUFACTURING_FAIL_FULL
 	receiving.Move(src, get_dir(receiving, src))
 	START_PROCESSING(SSmanufacturing, src)

--- a/code/modules/manufactorio/machines/router.dm
+++ b/code/modules/manufactorio/machines/router.dm
@@ -55,12 +55,6 @@
 	return MANUFACTURING_FAIL_FULL
 
 /obj/machinery/power/manufacturing/router/proc/handle_stack(obj/item/stack/stack, direction)
-	. = stack
-	var/potential_output_count = length(GLOB.cardinals - direction - disabled_dirs)
-	if(potential_output_count <= 1)
-		return
-	var/split_amount = round(stack.amount / potential_output_count, 1)
-	if(stack.amount == potential_output_count)
-		return
-	var/atom/movable/new_stack = stack.split_stack(amount = min(stack.amount, split_amount))
-	return new_stack
+	if(stack.amount <= 1) // last implementation was just not good so lets cheap out
+		return stack
+	return stack.split_stack(amount = 1)

--- a/code/modules/manufactorio/machines/smelter.dm
+++ b/code/modules/manufactorio/machines/smelter.dm
@@ -17,7 +17,7 @@
 	if(!isitem(receiving) || surplus() < power_cost  || receive_dir != REVERSE_DIR(dir))
 		return MANUFACTURING_FAIL
 	var/list/stacks = contents - circuit
-	if(!may_merge_in_contents(receiving) && length(stacks) >= 5)
+	if(length(stacks) >= 5 && !may_merge_in_contents_and_do_so(receiving))
 		return MANUFACTURING_FAIL_FULL
 	receiving.Move(src, get_dir(receiving, src))
 	START_PROCESSING(SSmanufacturing, src)

--- a/code/modules/manufactorio/machines/storagebox.dm
+++ b/code/modules/manufactorio/machines/storagebox.dm
@@ -14,7 +14,7 @@
 /obj/machinery/power/manufacturing/storagebox/receive_resource(atom/movable/receiving, atom/from, receive_dir)
 	if(iscloset(receiving) && length(receiving.contents))
 		return MANUFACTURING_FAIL
-	if(!may_merge_in_contents(receiving) && length(contents - circuit) >= max_stuff)
+	if(length(contents - circuit) >= max_stuff && !may_merge_in_contents_and_do_so(receiving))
 		return MANUFACTURING_FAIL_FULL
 	receiving.Move(src,receive_dir)
 	return MANUFACTURING_SUCCESS


### PR DESCRIPTION

## About The Pull Request

the crafter can now craft a Laser Musket as you can now put more than 1 non-stack item relevant to the recipe in it
router now splits stacks exactly 1 sheet at a time because the previous version was error prone and doing it any better just needs a stupid amount of math and working with my even worse implementation

## Why It's Good For The Game
bug bad

## Changelog
:cl:
fix: you can now put more than 1 non-stack item relevant to the recipe in a manufacturing crafter
fix: manufacturing router does not bug out when handling stacks in some cases at the cost of being slower to do so
/:cl:
