### PR TITLE
fixes syndicate AI roleban and spawning new core without client

### DIFF
--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -280,7 +280,7 @@ SUBSYSTEM_DEF(polling)
 			return FALSE
 
 	if(check_jobban)
-		if(is_banned_from(potential_candidate.ckey, list(check_jobban, ROLE_SYNDICATE)))
+		if(is_banned_from(potential_candidate.ckey, list(ROLE_SYNDICATE) + check_jobban))
 			return FALSE
 
 	return TRUE

--- a/code/game/objects/items/devices/aicard_evil.dm
+++ b/code/game/objects/items/devices/aicard_evil.dm
@@ -35,7 +35,7 @@
 		balloon_alert(user, "invalid access!")
 		return
 	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
-		check_jobban = ROLE_OPERATIVE,
+		check_jobban = list(ROLE_OPERATIVE, JOB_AI),
 		poll_time = 20 SECONDS,
 		checked_target = src,
 		ignore_category = POLL_IGNORE_SYNDICATE,
@@ -47,12 +47,12 @@
 
 /// Poll has concluded with a ghost, create the AI
 /obj/item/aicard/syndie/loaded/proc/on_poll_concluded(mob/user, datum/antagonist/nukeop/op_datum, mob/dead/observer/ghost)
-	if(isnull(ghost))
+	if(!ismob(ghost))
 		to_chat(user, span_warning("Unable to connect to S.E.L.F. dispatch. Please wait and try again later or use the intelliCard on your uplink to get your points refunded."))
 		return
 
 	// pick ghost, create AI and transfer
-	var/mob/living/silicon/ai/weak_syndie/new_ai = new /mob/living/silicon/ai/weak_syndie(get_turf(src), new /datum/ai_laws/syndicate_override, ghost)
+	var/mob/living/silicon/ai/weak_syndie/new_ai = new /mob/living/silicon/ai/weak_syndie(null, new /datum/ai_laws/syndicate_override, ghost)
 	// create and apply syndie datum
 	var/datum/antagonist/nukeop/nuke_datum = new()
 	nuke_datum.send_to_spawnpoint = FALSE

--- a/code/game/objects/items/devices/aicard_evil.dm
+++ b/code/game/objects/items/devices/aicard_evil.dm
@@ -47,7 +47,7 @@
 
 /// Poll has concluded with a ghost, create the AI
 /obj/item/aicard/syndie/loaded/proc/on_poll_concluded(mob/user, datum/antagonist/nukeop/op_datum, mob/dead/observer/ghost)
-	if(ismob(ghost))
+	if(!ismob(ghost))
 		to_chat(user, span_warning("Unable to connect to S.E.L.F. dispatch. Please wait and try again later or use the intelliCard on your uplink to get your points refunded."))
 		return
 

--- a/code/game/objects/items/devices/aicard_evil.dm
+++ b/code/game/objects/items/devices/aicard_evil.dm
@@ -47,7 +47,7 @@
 
 /// Poll has concluded with a ghost, create the AI
 /obj/item/aicard/syndie/loaded/proc/on_poll_concluded(mob/user, datum/antagonist/nukeop/op_datum, mob/dead/observer/ghost)
-	if(!ismob(ghost))
+	if(ismob(ghost))
 		to_chat(user, span_warning("Unable to connect to S.E.L.F. dispatch. Please wait and try again later or use the intelliCard on your uplink to get your points refunded."))
 		return
 


### PR DESCRIPTION
## About The Pull Request
`SSpolling.poll_ghosts_for_target` returns a 0 length list when no candidates are chosen so it will spawn an AI core without a client, so instead of `if(isnull(ghost)` we do `if(!ismob(ghost))`.
closes https://github.com/tgstation/tgstation/issues/86976

## Changelog
:cl: grungussuss
fix: fixed a clientless AI spawning when a ghost poll for syndicate modsuit AI had no volunteers
admin: AI rolebanned players can no longer role for Syndicate modsuit AI
/:cl:
