### PR TITLE
Adds item VV header

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1802,3 +1802,14 @@
 			return bait.reagents?.has_reagent(special_identifier[FISH_BAIT_VALUE], special_identifier[FISH_BAIT_AMOUNT], check_subtypes = TRUE)
 		else
 			CRASH("Unknown bait identifier in fish favourite/disliked list")
+
+/obj/item/vv_get_header()
+	. = ..()
+	. += {"
+		<br><font size='1'>
+			DAMTYPE: <font size='1'><a href='?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=damtype' id='damtype'>[uppertext(damtype)]</a>
+			FORCE: <font size='1'><a href='?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=force' id='force'>[force]</a>
+			WOUND: <font size='1'><a href='?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=wound' id='wound'>[wound_bonus]</a>
+			BARE WOUND: <font size='1'><a href='?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=bare wound' id='bare wound'>[bare_wound_bonus]</a>
+		</font>
+	"}

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -113,10 +113,51 @@
 				admin_ticket_log(L, "<font color='blue'>[log_msg]</font>")
 				vv_update_display(L, Text, "[newamt]")
 
+		else if(href_list["item_to_tweak"] && href_list["var_tweak"])
+			if(!check_rights(NONE))
+				return
+
+			var/obj/item/editing = locate(href_list["item_to_tweak"])
+			if(!istype(editing) || QDELING(editing))
+				return
+
+			var/existing_val = -1
+			switch(href_list["var_tweak"])
+				if("damtype")
+					existing_val = editing.damtype
+				if("force")
+					existing_val = editing.force
+				if("wound")
+					existing_val = editing.wound_bonus
+				if("bare wound")
+					existing_val = editing.bare_wound_bonus
+				else
+					CRASH("Invalid var_tweak passed to item vv set var: [href_list["var_tweak"]]")
+
+			var/new_val
+			if(href_list["var_tweak"] == "damtype")
+				new_val = input("Enter the new damage type for [editing]","Set Damtype", existing_val) in list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN)
+			else
+				new_val = input("Enter the new value for [editing]'s [href_list["var_tweak"]]","Set [href_list["var_tweak"]]", existing_val) as num|null
+			if(isnull(new_val) || new_val == existing_val || QDELETED(editing) || !check_rights(NONE))
+				return
+
+			switch(href_list["var_tweak"])
+				if("damtype")
+					editing.damtype = new_val
+				if("force")
+					editing.force = new_val
+				if("wound")
+					editing.wound_bonus = new_val
+				if("bare wound")
+					editing.bare_wound_bonus = new_val
+
+			message_admins("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
+			log_admin("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
+			vv_update_display(editing, href_list["var_tweak"], istext(new_val) ? uppertext(new_val) : new_val)
 
 	//Finally, refresh if something modified the list.
 	if(href_list["datumrefresh"])
 		var/datum/DAT = locate(href_list["datumrefresh"])
 		if(isdatum(DAT) || istype(DAT, /client) || islist(DAT))
 			debug_variables(DAT)
-


### PR DESCRIPTION
## About The Pull Request

Adds VV header for items, letting quick modification of a few of an item's combat values..

![image](https://github.com/user-attachments/assets/587d072e-03f0-4c1e-b9b0-f837efb60434)

## Why It's Good For The Game

In testing, I find I tweak these values commonly, to test how effective an item is vs armor, or how strong a new item should be, etc etc. So having quick access to these might be cool

I thought about adding a few more like throwforce but I didn't want to clutter it too much

## Changelog

:cl: Melbert
admin: Items now have a header in VV allowing for quicker editing of combat properties
/:cl:

