### PR TITLE
Shut up Poly

### DIFF
--- a/code/modules/mob/living/basic/pets/parrot/poly.dm
+++ b/code/modules/mob/living/basic/pets/parrot/poly.dm
@@ -184,9 +184,6 @@
 	memory_saved = TRUE
 	return TRUE
 
-/mob/living/basic/parrot/poly/setup_headset()
-	ears = new /obj/item/radio/headset/headset_eng(src)
-
 /mob/living/basic/parrot/poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."


### PR DESCRIPTION

## About The Pull Request

Poly no longer spawns with a headset roundstart. Changes nothing else.

## Why It's Good For The Game

Poly spamming the Engi channel adds nothing funny or engaging to the gameplay, it's just spam. Poly singlehandedly makes up around 75% of orange text in a round or more (my estimate), which makes engineers and atmos techs pay less attention to their department channel. When I break into the CEs office to take off Polys headset, I think no one notices around 80% of the time, because no one is actually reading anything that Poly says.

If a CE wants Poly to spam engi chat, they can still take a headset from their locker and put it on roundstart. But this change makes it so we don't have to deal with spam when there is no CE/they forget/are too lazy to take off the headset.

## Changelog

:cl:
qol: Shuts Poly up by taking away its roundstart headset
/:cl:
