### PR TITLE
Shoving someone on the ground only disarms them if they are staggered.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -725,7 +725,7 @@
 	var/append_message = weapon ? " with [weapon]" : ""
 	// If it's in our typecache, they're staggered and it exists, disarm. If they're knocked down, disarm too.
 	if(target.get_timed_status_effect_duration(/datum/status_effect/staggered))
-		if(target_held_item && is_type_in_typecache(target_held_item, GLOB.shove_disarming_types) || target_held_item && target.body_position == LYING_DOWN)
+		if(target_held_item && (is_type_in_typecache(target_held_item, GLOB.shove_disarming_types) || target.body_position == LYING_DOWN))
 			target.dropItemToGround(target_held_item)
 			append_message = "causing [target.p_them()] to drop [target_held_item]"
 			target.visible_message(span_danger("[target.name] drops \the [target_held_item]!"),

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -724,11 +724,12 @@
 	var/target_held_item = target.get_active_held_item()
 	var/append_message = weapon ? " with [weapon]" : ""
 	// If it's in our typecache, they're staggered and it exists, disarm. If they're knocked down, disarm too.
-	if(target_held_item && target.get_timed_status_effect_duration(/datum/status_effect/staggered) && is_type_in_typecache(target_held_item, GLOB.shove_disarming_types) || target_held_item && target.body_position == LYING_DOWN)
-		target.dropItemToGround(target_held_item)
-		append_message = "causing [target.p_them()] to drop [target_held_item]"
-		target.visible_message(span_danger("[target.name] drops \the [target_held_item]!"),
-			span_warning("You drop \the [target_held_item]!"), null, COMBAT_MESSAGE_RANGE)
+	if(target.get_timed_status_effect_duration(/datum/status_effect/staggered))
+		if(target_held_item && is_type_in_typecache(target_held_item, GLOB.shove_disarming_types) || target_held_item && target.body_position == LYING_DOWN)
+			target.dropItemToGround(target_held_item)
+			append_message = "causing [target.p_them()] to drop [target_held_item]"
+			target.visible_message(span_danger("[target.name] drops \the [target_held_item]!"),
+				span_warning("You drop \the [target_held_item]!"), null, COMBAT_MESSAGE_RANGE)
 
 	if(shove_flags & SHOVE_CAN_STAGGER)
 		target.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)


### PR DESCRIPTION

## About The Pull Request

Rather than always disarming someone who is on the ground, shoves only disarms someone who is staggered (so, has been shoved before or something similar)

## Why It's Good For The Game

I had a bit of feedback recently about how it's probably a little _too_ easy to remove peoples weapons while they're on the ground, which can probably feel about as oppressive as the thing I was trying to prevent in the first place. Hopefully this gives the would be floored individual an opportunity to stow their weapon if they're quick enough to respond to an attack. Probably won't help them if they're being ganged up on.

## Changelog
:cl:
balance: Shoving someone on the floor only disarms them of objects in their hand if they have the staggered condition. Such as from shoving them once already.
/:cl:
