### PR TITLE
Move food_storage to item interaction signals, fixes not being able to embed syringes into cake/bread/cheese

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -138,7 +138,7 @@
  */
 /obj/item/reagent_containers/syringe/on_accidental_consumption(mob/living/carbon/victim, mob/living/carbon/user, obj/item/source_item,  discover_after = TRUE)
 	if(source_item)
-		to_chat(victim, span_boldwarning("There's a [src] in [source_item]!!"))
+		to_chat(victim, span_boldwarning("There's \a [src] in [source_item]!!"))
 	else
 		to_chat(victim, span_boldwarning("[src] injects you!"))
 


### PR DESCRIPTION
## About The Pull Request

So we have a feature for embedding small objects into cake/bread/cheese, where if you eat it there's a chance you bite into it.
For syringes, this means you get injected by it.

However, it seems that this is currently broken, being unable to ever reach this state due to order of operations.
Moving this component to the newer `COMSIG_ATOM_ITEM_INTERACTION_SECONDARY` signal fixes this.

As a side, replaces an `a` with `\a` so it doesn't display "a the X" for different syringes being bitten into.
Edit: Additionally turned an if into an early return in the food storage insertion procs.

## Why It's Good For The Game

Better when things work as intended.
## Changelog
:cl:
fix: Syringes can be put into cake/bread/cheese on right click again.
spellcheck: Biting into a hidden syringe no longer displays things like "a the syringe".
/:cl:
