### PR TITLE
Fix typo in cure_text for advanced mutation toxin

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -230,7 +230,7 @@
 
 /datum/disease/transformation/slime
 	name = "Advanced Mutation Transformation"
-	cure_text = "frost oil"
+	cure_text = "Frost oil"
 	cures = list(/datum/reagent/consumable/frostoil)
 	cure_chance = 55
 	agent = "Advanced Mutation Toxin"


### PR DESCRIPTION

## About The Pull Request

Makes the cure_text start with a capital letter, making it more inline with how other cures are formatted.
## Why It's Good For The Game

Text looks cleaner.
## Changelog
:cl:
spellcheck: capitalise cure_text for advanced slime mutation
/:cl:
