### PR TITLE
Nightmare Jaunt is delayed, but no longer revealed by light

### DIFF
--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -11,11 +11,15 @@
 	var/movedelay = 0
 	/// The speed of movement while jaunted
 	var/movespeed = 0
+	/// The spell instance that generated this effect
+	var/datum/action/cooldown/spell/jaunt/jaunt_spell
 
-/obj/effect/dummy/phased_mob/Initialize(mapload, atom/movable/jaunter)
+/obj/effect/dummy/phased_mob/Initialize(mapload, atom/movable/jaunter, datum/action/cooldown/spell/jaunt/jaunt_spell)
 	. = ..()
 	if(jaunter)
 		set_jaunter(jaunter)
+	if(jaunt_spell)
+		src.jaunt_spell = jaunt_spell
 
 /// Sets [new_jaunter] as our jaunter, forcemoves them into our contents
 /obj/effect/dummy/phased_mob/proc/set_jaunter(atom/movable/new_jaunter)

--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -11,8 +11,8 @@
 	icon_state = "brain-x-d"
 	applied_status = /datum/status_effect/shadow_regeneration/nightmare
 	///Our associated shadow jaunt spell, for all nightmares
-	var/datum/action/cooldown/spell/jaunt/shadow_walk/our_jaunt
-	///Our associated terrorize spell, for antagonist nightmares
+	var/datum/action/cooldown/spell/jaunt/shadow_step/our_jaunt
+	///Our associated terrorize spell, for also all nightmares
 	var/datum/action/cooldown/spell/pointed/terrorize/terrorize_spell
 
 /obj/item/organ/internal/brain/shadow/nightmare/on_mob_insert(mob/living/carbon/brain_owner)
@@ -25,9 +25,8 @@
 	our_jaunt = new(brain_owner)
 	our_jaunt.Grant(brain_owner)
 
-	if(brain_owner.mind?.has_antag_datum(/datum/antagonist/nightmare)) //Only a TRUE NIGHTMARE is worthy of using this ability
-		terrorize_spell = new(src)
-		terrorize_spell.Grant(brain_owner)
+	terrorize_spell = new(src)
+	terrorize_spell.Grant(brain_owner)
 
 /obj/item/organ/internal/brain/shadow/nightmare/on_mob_remove(mob/living/carbon/brain_owner)
 	. = ..()

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -18,6 +18,7 @@
 
 	/// What dummy mob type do we put jaunters in on jaunt?
 	var/jaunt_type = /obj/effect/dummy/phased_mob
+	var/jaunting_traits = list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE)
 
 /datum/action/cooldown/spell/jaunt/get_caster_from_target(atom/target)
 	if(istype(target.loc, jaunt_type))
@@ -65,10 +66,10 @@
 /datum/action/cooldown/spell/jaunt/proc/enter_jaunt(mob/living/jaunter, turf/loc_override)
 	SHOULD_CALL_PARENT(TRUE)
 
-	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter)
+	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter, src)
 	RegisterSignal(jaunt, COMSIG_MOB_EJECTED_FROM_JAUNT, PROC_REF(on_jaunt_exited))
 	check_flags &= ~AB_CHECK_PHASED
-	jaunter.add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
+	jaunter.add_traits(jaunting_traits, REF(src))
 	// Don't do the feedback until we have runechat hidden.
 	// Otherwise the text will follow the jaunt holder, which reveals where our caster is travelling.
 	spell_feedback(jaunter)
@@ -112,7 +113,7 @@
 /datum/action/cooldown/spell/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	SHOULD_CALL_PARENT(TRUE)
 	check_flags |= AB_CHECK_PHASED
-	unjaunter.remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
+	unjaunter.remove_traits(jaunting_traits, REF(src))
 	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)
 

--- a/code/modules/spells/spell_types/jaunt/shadow_walk.dm
+++ b/code/modules/spells/spell_types/jaunt/shadow_walk.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/jaunt/shadow_walk
 	name = "Shadow Walk"
-	desc = "Grants unlimited movement in darkness."
+	desc = "Allows you to hide in the shades, ready to strike at any time. Only allows entry in uninterrupted darkness."
 	background_icon_state = "bg_alien"
 	overlay_icon_state = "bg_alien_border"
 	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
@@ -11,6 +11,8 @@
 
 	/// The max amount of lumens on a turf allowed before we can no longer enter jaunt with this
 	var/light_threshold = SHADOW_SPECIES_LIGHT_THRESHOLD
+	/// time it takes to enter the shade and jaunt.
+	var/shadow_delay = 2.5 SECONDS
 
 /datum/action/cooldown/spell/jaunt/shadow_walk/Grant(mob/grant_to)
 	. = ..()
@@ -22,21 +24,21 @@
 
 /datum/action/cooldown/spell/jaunt/shadow_walk/enter_jaunt(mob/living/jaunter, turf/loc_override)
 	var/obj/effect/dummy/phased_mob/shadow/shadow = ..()
-	if(istype(shadow))
-		shadow.light_max = light_threshold
 	return shadow
 
 /datum/action/cooldown/spell/jaunt/shadow_walk/can_cast_spell(feedback = TRUE)
 	. = ..()
 	if(!.)
 		return FALSE
-	if(is_jaunting(owner))
-		return TRUE
 	var/turf/cast_turf = get_turf(owner)
 	if(cast_turf.get_lumcount() >= light_threshold)
 		if(feedback)
 			to_chat(owner, span_warning("It isn't dark enough here!"))
 		return FALSE
+
+	if(is_jaunting(owner))
+		return TRUE
+
 	return TRUE
 
 /datum/action/cooldown/spell/jaunt/shadow_walk/cast(mob/living/cast_on)
@@ -44,6 +46,18 @@
 	if(is_jaunting(cast_on))
 		exit_jaunt(cast_on)
 		return
+
+	to_chat(owner, span_warning("You begin entering the shadows..."))
+	animate(owner, alpha = 0, time = shadow_delay)
+	if(!do_after(owner, shadow_delay, owner))
+		to_chat(owner, span_warning("You were interrupted!"))
+		animate(owner, alpha = 255, time = 0.5 SECONDS)
+		return
+	else
+		owner.alpha = 255 // no need for 0 alpha anymore since we're shunting
+		// check again after the windup
+		if(!can_cast_spell())
+			return FALSE
 
 	playsound(get_turf(owner), 'sound/effects/nightmare_poof.ogg', 50, TRUE, -1, ignore_walls = FALSE)
 	cast_on.visible_message(span_boldwarning("[cast_on] melts into the shadows!"))
@@ -53,14 +67,8 @@
 
 /obj/effect/dummy/phased_mob/shadow
 	name = "shadows"
-	/// Max amount of light permitted before being kicked out
-	var/light_max = SHADOW_SPECIES_LIGHT_THRESHOLD
 	/// The amount that shadow heals us per SSobj tick (times seconds_per_tick)
 	var/healing_rate = 1.5
-	/// When cooldown is active, you are prevented from moving into tiles that would eject you from your jaunt
-	COOLDOWN_DECLARE(light_step_cooldown)
-	/// Has the jaunter recently received a warning about light?
-	var/light_alert_given = FALSE
 
 /obj/effect/dummy/phased_mob/shadow/Initialize(mapload)
 	. = ..()
@@ -71,86 +79,28 @@
 	return ..()
 
 /obj/effect/dummy/phased_mob/shadow/process(seconds_per_tick)
-	var/turf/T = get_turf(src)
 	if(!jaunter || jaunter.loc != src)
 		qdel(src)
 		return
 
-	if(check_light_level(T))
-		eject_jaunter(TRUE)
-
 	if(!QDELETED(jaunter) && isliving(jaunter)) //heal in the dark
 		var/mob/living/living_jaunter = jaunter
 		living_jaunter.heal_overall_damage(brute = (healing_rate * seconds_per_tick), burn = (healing_rate * seconds_per_tick), required_bodytype = BODYTYPE_ORGANIC)
-
-/obj/effect/dummy/phased_mob/shadow/relaymove(mob/living/user, direction)
-	var/turf/oldloc = loc
-	. = ..()
-	if(loc != oldloc)
-		if(check_light_level(loc))
-			eject_jaunter(TRUE)
 
 /obj/effect/dummy/phased_mob/shadow/phased_check(mob/living/user, direction)
 	. = ..()
 	if(. && isspaceturf(.))
 		to_chat(user, span_warning("It really would not be wise to go into space."))
 		return FALSE
-	if(check_light_level(.))
-		if(!light_step_warning())
-			return FALSE
 
 /obj/effect/dummy/phased_mob/shadow/eject_jaunter(forced_out = FALSE)
 	var/turf/reveal_turf = get_turf(src)
 
-	if(istype(reveal_turf))
-		if(forced_out)
-			reveal_turf.visible_message(span_boldwarning("[jaunter] is revealed by the light!"))
-		else
-			reveal_turf.visible_message(span_boldwarning("[jaunter] emerges from the darkness!"))
-		playsound(reveal_turf, 'sound/effects/nightmare_reappear.ogg', 50, TRUE, -1, ignore_walls = FALSE)
+	if(!reveal_turf)
+		return
+
+	reveal_turf.visible_message(span_boldwarning("[jaunter] emerges from the darkness!"))
+	playsound(reveal_turf, 'sound/effects/nightmare_reappear.ogg', 50, TRUE, -1, ignore_walls = FALSE)
 
 	return ..()
 
-/**
- * Checks the light level. If above the minimum acceptable amount (0.2), returns TRUE.
- *
- * Checks the light level of a given location to see if it is too bright to
- * continue a jaunt in. Returns FALSE if it's acceptably dark, and TRUE if it is too bright.
- *
- * * location_to_check - The location to have its light level checked.
- */
-
-/obj/effect/dummy/phased_mob/shadow/proc/check_light_level(atom/location_to_check)
-	var/turf/light_turf = get_turf(location_to_check)
-	return light_turf.get_lumcount() > light_max // jaunt ends on TRUE
-
-/**
- * Checks if the user should receive a warning that they're moving into light.
- *
- * Checks the cooldown for the warning message on moving into the light.
- * If the message has been displayed, and the cooldown (delay period) is complete, returns TRUE.
- */
-
-/obj/effect/dummy/phased_mob/shadow/proc/light_step_warning()
-	if(!light_alert_given) //Give the user a warning that they're leaving the darkness
-		balloon_alert(jaunter, "leaving the shadows...")
-		light_alert_given = TRUE
-		COOLDOWN_START(src, light_step_cooldown, 0.75 SECONDS)
-		addtimer(CALLBACK(src, PROC_REF(reactivate_light_alert)), 1 SECONDS) //You get a .5 second window to bypass the warning before it comes back
-		return FALSE
-
-	if(!COOLDOWN_FINISHED(src, light_step_cooldown))
-		return FALSE
-
-	light_alert_given = FALSE
-	return TRUE //Our jaunter is ignoring the warning, so we proceed
-
-/**
- * Sets light_alert_given to false.
- *
- * Sets light_alert_given to false, making the light alert pop up and intercept movement once again.
- * Added in its own proc to reset the alert without having to call light_step_warning().
- */
-
-/obj/effect/dummy/phased_mob/shadow/proc/reactivate_light_alert()
-	light_alert_given = FALSE

--- a/code/modules/unit_tests/spell_jaunt.dm
+++ b/code/modules/unit_tests/spell_jaunt.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/shadow_jaunt/Run()
 	var/mob/living/carbon/human/jaunter = allocate(/mob/living/carbon/human/consistent)
-	var/datum/action/cooldown/spell/jaunt/shadow_walk/walk = allocate(/datum/action/cooldown/spell/jaunt/shadow_walk, jaunter)
+	var/datum/action/cooldown/spell/jaunt/shadow_step/jaunt/walk = allocate(/datum/action/cooldown/spell/jaunt/shadow_step/jaunt, jaunter)
 	walk.Grant(jaunter)
 
 	var/turf/jaunt_turf = jaunter.loc


### PR DESCRIPTION

## About The Pull Request

Nightmare's Jaunt has recieved two changes.

1. The Nightmare is no longer forced out of jaunt when their tile is lit up.
2. Jaunting now takes 2.5 seconds.
## Why It's Good For The Game

Nightmares, to be honest, are just not fun anymore, if they ever were. Their 'kit', that being 3 abilities, is not nearly powerful nor versatile enough to give them the slightest hint of a chance against either a coordinated security team or one robust validhunter. The vast majority of the time there's just no chance for them to do anything, because as soon as they're revealed 30 people are hunting them in maintenance with lanterns, or spamming untouchable glass floors, or glowshrooms. Their jaunt also has an incredibly maddening issue of randomly shunting you out in places where it probably shouldn't, which can end up trapping you outside the station or caught in a terrible spot to be unceremoniously hit with a baton twice and killed.

This change turns the Nightmare into a true ambush predator instead of some weird.. jaunt... guy. By giving them unlimited jaunting, they can pick and choose who to target and when, and can easily scour the station for any foolish assistants in maintenance while making sure not to be near any security. This makes them hard to catch, but during the time they're in jaunt they can't really do anything, so it's not a big deal.

The 2.5 second delay for jaunting is to prevent these guys from just turning into frickin' gods. They need to be aware of their position and can't use it as a get away from jail free card anymore, once more encouraging the ambush predator playstyle rather than the 'idk kill things until you die' style it vaguely had.
## Changelog
:cl:
balance: Nightmare Jaunt is delayed, but no longer revealed by light
/:cl:
