### PR TITLE
[NO GBP] Fixes drone toolbox issues

### DIFF
--- a/code/datums/components/holderloving.dm
+++ b/code/datums/components/holderloving.dm
@@ -81,5 +81,5 @@
 /datum/component/holderloving/proc/no_unequip(obj/item/I, force, atom/newloc, no_move, invdrop, silent)
 	SIGNAL_HANDLER
 
-	if(!isturf(newloc))
+	if(!isturf(newloc) && invdrop)
 		return COMPONENT_ITEM_BLOCK_UNEQUIP

--- a/code/datums/components/holderloving.dm
+++ b/code/datums/components/holderloving.dm
@@ -39,6 +39,7 @@
 		COMSIG_ATOM_EXITED,
 		COMSIG_ITEM_STORED,
 	), PROC_REF(check_my_loc))
+	RegisterSignal(parent, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(no_unequip))
 
 /datum/component/holderloving/UnregisterFromParent()
 	UnregisterSignal(holder, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
@@ -48,6 +49,7 @@
 		COMSIG_ATOM_ENTERED,
 		COMSIG_ATOM_EXITED,
 		COMSIG_ITEM_STORED,
+		COMSIG_ITEM_PRE_UNEQUIP,
 	))
 
 /datum/component/holderloving/PostTransfer()
@@ -63,6 +65,7 @@
 
 /datum/component/holderloving/proc/holder_deleting(datum/source, force)
 	SIGNAL_HANDLER
+
 	if(del_parent_with_holder)
 		qdel(parent)
 	else
@@ -70,6 +73,13 @@
 
 /datum/component/holderloving/proc/check_my_loc(datum/source)
 	SIGNAL_HANDLER
+
 	var/obj/item/item_parent = parent
 	if(!check_valid_loc(item_parent.loc))
 		item_parent.forceMove(holder)
+
+/datum/component/holderloving/proc/no_unequip(obj/item/I, force, atom/newloc, no_move, invdrop, silent)
+	SIGNAL_HANDLER
+
+	if(!isturf(newloc))
+		return COMPONENT_ITEM_BLOCK_UNEQUIP

--- a/code/datums/storage/subtypes/drone.dm
+++ b/code/datums/storage/subtypes/drone.dm
@@ -1,0 +1,26 @@
+/datum/storage/drone
+	max_total_storage = 40
+	max_specific_storage = WEIGHT_CLASS_NORMAL
+	max_slots = 10
+	do_rustle = FALSE
+
+/datum/storage/drone/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+
+	var/static/list/drone_builtins = list(
+		/obj/item/crowbar/drone,
+		/obj/item/screwdriver/drone,
+		/obj/item/wrench/drone,
+		/obj/item/weldingtool/drone,
+		/obj/item/wirecutters/drone,
+		/obj/item/multitool/drone,
+		/obj/item/pipe_dispenser/drone,
+		/obj/item/t_scanner/drone,
+		/obj/item/analyzer/drone,
+		/obj/item/soap/drone,
+	)
+
+	set_holdable(drone_builtins)
+
+/datum/storage/drone/dump_content_at(atom/dest_object, dump_loc, mob/user)
+	return //no dumping of contents allowed

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -613,7 +613,7 @@
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user && outside_storage)
-		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
+		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src, idrop = FALSE))
 			return
 
 	. = FALSE

--- a/code/modules/mob/living/basic/drone/drone_tools.dm
+++ b/code/modules/mob/living/basic/drone/drone_tools.dm
@@ -3,31 +3,14 @@
 	desc = "Access your built-in tools."
 	icon = 'icons/hud/screen_drone.dmi'
 	icon_state = "tool_storage"
+	storage_type = /datum/storage/drone
 	item_flags = ABSTRACT
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/item/storage/drone_tools/Initialize(mapload)
 	. = ..()
+
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
-
-	var/static/list/drone_builtins = list(
-		/obj/item/crowbar/drone,
-		/obj/item/screwdriver/drone,
-		/obj/item/wrench/drone,
-		/obj/item/weldingtool/drone,
-		/obj/item/wirecutters/drone,
-		/obj/item/multitool/drone,
-		/obj/item/pipe_dispenser/drone,
-		/obj/item/t_scanner/drone,
-		/obj/item/analyzer/drone,
-		/obj/item/soap/drone,
-	)
-	atom_storage.max_total_storage = 40
-	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
-	atom_storage.max_slots = 10
-	atom_storage.do_rustle = FALSE
-	atom_storage.set_holdable(drone_builtins)
-
 
 /obj/item/storage/drone_tools/PopulateContents()
 	var/list/builtintools = list()
@@ -44,8 +27,6 @@
 
 	for(var/obj/item/tool as anything in builtintools)
 		tool.AddComponent(/datum/component/holderloving, src, TRUE)
-		ADD_TRAIT(tool, TRAIT_NODROP, REF(src))
-
 
 /obj/item/crowbar/drone
 	name = "built-in crowbar"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1915,6 +1915,7 @@
 #include "code\datums\storage\subtypes\backpack.dm"
 #include "code\datums\storage\subtypes\bag_of_holding.dm"
 #include "code\datums\storage\subtypes\cards.dm"
+#include "code\datums\storage\subtypes\drone.dm"
 #include "code\datums\storage\subtypes\duffel_bag.dm"
 #include "code\datums\storage\subtypes\extract_inventory.dm"
 #include "code\datums\storage\subtypes\fish_case.dm"


### PR DESCRIPTION
## About The Pull Request
- Fixes #87071 as in
 a) Dropping a drone tool will put it back in the toolbox again
 b) You can manually put the tool back in the toolbox via mouse click
 c) You cannot dump the contents of the drone toolbox on anything

## Changelog
:cl:
fix: you can drop/put drone tools back in the toolbox
fix: you cannot dump the contents of the drone toolbox
/:cl:

