### PR TITLE
[NO GBP] You should now be able to fish from linked lava turfs while on station.

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -46,7 +46,7 @@
 
 /turf/open/lava/Initialize(mapload)
 	. = ..()
-	if(fish_source_type)
+	if(fish_source_type && (is_mining_level(z) || is_away_level(z)))
 		AddElement(/datum/element/lazy_fishing_spot, fish_source_type)
 	// You can release chrabs and lavaloops and likes in lava, or be an absolute scumbag and drop other fish there too.
 	ADD_TRAIT(src, TRAIT_CATCH_AND_RELEASE, INNATE_TRAIT)

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -46,7 +46,7 @@
 
 /turf/open/lava/Initialize(mapload)
 	. = ..()
-	if(fish_source_type && (is_mining_level(z) || is_away_level(z)))
+	if(fish_source_type)
 		AddElement(/datum/element/lazy_fishing_spot, fish_source_type)
 	// You can release chrabs and lavaloops and likes in lava, or be an absolute scumbag and drop other fish there too.
 	ADD_TRAIT(src, TRAIT_CATCH_AND_RELEASE, INNATE_TRAIT)

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -353,9 +353,6 @@
 
 /datum/fish_source/lavaland/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	. = ..()
-	var/turf/approx = get_turf(fisherman) //todo pass the parent
-	if(!SSmapping.level_trait(approx.z, ZTRAIT_MINING))
-		return "There doesn't seem to be anything to catch here."
 	if(!rod.line || !(rod.line.fishing_line_traits & FISHING_LINE_REINFORCED))
 		return "You'll need reinforced fishing line to fish in there"
 


### PR DESCRIPTION
## About The Pull Request
There was a line in code for the lava fishing source that prevented fishing if the fisherman wasn't on a mining z-level. This was originally meant to stop generic lava somehow spawned on the station to become fishing spots, however there is about nary a thing that does that. The problem is that it impedes using a (upgraded) fishing portal linked to lavaland, so I've just removed the check and vibed with the theorical possibility of fishing a necropolis chest on the station.

## Why It's Good For The Game
Fixing the inability of fishing from a linked lava turf.

## Changelog

:cl:
fix: The fishing portal generator (fish-porter 3000) now correctly links with lava turfs from lavaland.
/:cl:
