### PR TITLE
Quick post-merge fix to the materials refactor

### DIFF
--- a/code/game/atom/atom_materials.dm
+++ b/code/game/atom/atom_materials.dm
@@ -64,14 +64,16 @@
 	return material_effects
 
 /**
- * A proc that can be used to selectively control the statistics and affects from a material without affecting the others
+ * A proc that can be used to selectively control the statistics and affects from a material without affecting the others.
+ *
  * For example, we can have items made of two different materials, with the primary contributing a good 1.2 multiplier
  * and the second a meager 0.3.
- * The GET_MATERIAL_MODIFIER macro will handles some modifiers where the minimum should be 1 if above 1 and the maximum
- * 1 if below 1, so you shouldn't worry about returning values between 0 and 1. Be ware about returning negative values tho.
+ *
+ * The GET_MATERIAL_MODIFIER macro will handles some modifications where the minimum should be 1 if above 1 and the maximum
+ * be 1 if below 1. Just don't return negative values.
  */
 /atom/proc/get_material_multiplier(datum/material/custom_material, list/materials, index)
-	return 1
+	return 1/length(materials)
 
 ///Called by apply_material_effects(). It ACTUALLY handles applying effects common to all atoms (depending on material flags)
 /atom/proc/finalize_material_effects(list/materials)

--- a/code/game/atom/atom_materials.dm
+++ b/code/game/atom/atom_materials.dm
@@ -64,7 +64,7 @@
 	return material_effects
 
 /**
- * A proc that can be used to selectively control the statistics and affects from a material without affecting the others.
+ * A proc that can be used to selectively control the stat changes and effects from a material without affecting the others.
  *
  * For example, we can have items made of two different materials, with the primary contributing a good 1.2 multiplier
  * and the second a meager 0.3.

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -531,7 +531,7 @@
 
 ///Cleric maces are made of two custom materials: one is handle, and the other is the mace itself.
 /obj/item/melee/cleric_mace/get_material_multiplier(datum/material/custom_material, list/materials, index)
-	if(length(materials) < 1)
+	if(length(materials) <= 1)
 		return 1.2
 	if(index == 1)
 		return 1


### PR DESCRIPTION
## About The Pull Request
AnturK pointed out that I've got the materials length for cleric maces mat multipliers wrong, also he suggested normalization of mat multipliers for items made from more than one mat by default. However he merged the PR without checking that I had done so.

Also updated the doc comment for get_material_multiplier() guh.

## Why It's Good For The Game
Improving stuff.

## Changelog
N/A