### PR TITLE
More Cardboard Cutouts, more fun!

### DIFF
--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -376,7 +376,7 @@
 /datum/cardboard_cutout/pirate
 	name = "Pirate"
 	applied_name = "Unknown"
-	applied_desc = "A cardboard cutout of a a space pirate"
+	applied_desc = "A cardboard cutout of a space pirate."
 	outfit = /datum/outfit/pirate/space/captain/cardboard
 
 /datum/cardboard_cutout/ninja

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -382,7 +382,7 @@
 /datum/cardboard_cutout/ninja
 	name = "Space Ninja"
 	applied_name = "Unknown"
-	applied_desc = "A cardboard cutout of a space ninja"
+	applied_desc = "A cardboard cutout of a space ninja."
 	outfit = /datum/outfit/ninja
 
 /datum/cardboard_cutout/abductor

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -364,7 +364,7 @@
 /datum/cardboard_cutout/heretic
 	name = "Heretic"
 	applied_name = "Unknown"
-	applied_desc = "A cardboard cutout of a Heretic"
+	applied_desc = "A cardboard cutout of a Heretic."
 	outfit = /datum/outfit/heretic_hallucination
 
 /datum/cardboard_cutout/changeling

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -388,6 +388,6 @@
 /datum/cardboard_cutout/abductor
 	name = "Abductor Agent"
 	applied_name = "Unknown"
-	applied_desc = "A cardboard cutout of an abductor agent"
+	applied_desc = "A cardboard cutout of an abductor agent."
 	species = /datum/species/abductor
 	outfit = /datum/outfit/abductor/agent/cardboard

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -370,7 +370,7 @@
 /datum/cardboard_cutout/changeling
 	name = "Changeling"
 	applied_name = "Unknown"
-	applied_desc = "A cardboard cutout of a Changeling"
+	applied_desc = "A cardboard cutout of a Changeling."
 	outfit = /datum/outfit/changeling
 
 /datum/cardboard_cutout/pirate

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -360,3 +360,34 @@
 	applied_name = "Private Security Officer"
 	applied_desc = "A cardboard cutout of a private security officer."
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/nanotrasensoldier
+
+/datum/cardboard_cutout/heretic
+	name = "Heretic"
+	applied_name = "Unknown"
+	applied_desc = "A cardboard cutout of a Heretic"
+	outfit = /datum/outfit/heretic_hallucination
+
+/datum/cardboard_cutout/changeling
+	name = "Changeling"
+	applied_name = "Unknown"
+	applied_desc = "A cardboard cutout of a Changeling"
+	outfit = /datum/outfit/changeling
+
+/datum/cardboard_cutout/pirate
+	name = "Pirate"
+	applied_name = "Unknown"
+	applied_desc = "A cardboard cutout of a a space pirate"
+	outfit = /datum/outfit/pirate/space/captain/cardboard
+
+/datum/cardboard_cutout/ninja
+	name = "Space Ninja"
+	applied_name = "Unknown"
+	applied_desc = "A cardboard cutout of a space ninja"
+	outfit = /datum/outfit/ninja
+
+/datum/cardboard_cutout/abductor
+	name = "Abductor Agent"
+	applied_name = "Unknown"
+	applied_desc = "A cardboard cutout of an abductor agent"
+	species = /datum/species/abductor
+	outfit = /datum/outfit/abductor/agent/cardboard

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -50,6 +50,13 @@
 		/obj/item/abductor/silencer = 1
 		)
 
+/datum/outfit/abductor/agent/cardboard
+	name = "Abductor Agent"
+	head = /obj/item/clothing/head/helmet/abductor
+	suit = /obj/item/clothing/suit/armor/abductor/vest
+	l_hand = /obj/item/melee/baton/abductor
+	belt = /obj/item/storage/belt/military/abductor/full
+
 /datum/outfit/abductor/scientist
 	name = "Abductor Scientist"
 

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -57,6 +57,11 @@
 
 	id_trim = /datum/id_trim/pirate/captain
 
+/datum/outfit/pirate/space/captain/cardboard
+	name = "Space Pirate Captain (EVA)"
+
+	l_hand = /obj/item/nullrod/claymore/saber/pirate
+
 /datum/outfit/pirate/silverscale
 	name = "Silver Scale Member"
 

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -59,7 +59,6 @@
 
 /datum/outfit/pirate/space/captain/cardboard
 	name = "Space Pirate Captain (EVA)"
-
 	l_hand = /obj/item/nullrod/claymore/saber/pirate
 
 /datum/outfit/pirate/silverscale


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that the cardboard cutouts can be shaped into the appearances of: Abductor Agents, Heretics, Changelings, Space Pirates and Space Ninjas, adding these as outfits alongside the ones currently implemented.

## Why It's Good For The Game

If the cutouts serve for fooling people, for fun, for causing a little chaos with fake callouts - why not make them for more than just the basic few antagonists? I've decided it'd be nice to modernize this with outfits for the ninja, pirates, abductors etc since it's only fair for them to be included in the scare-the-ai party. 

## Changelog

:cl:
add: More cardboard cutout icons (Pirate, ninja, changeling, heretic, abductor)
/:cl: