### PR TITLE
Changes how reagents are added to victim of venomous component

### DIFF
--- a/code/datums/elements/venomous.dm
+++ b/code/datums/elements/venomous.dm
@@ -7,7 +7,7 @@
 	element_flags = ELEMENT_BESPOKE
 	argument_hash_start_idx = 2
 	///Path of the reagent added
-	var/poison_type
+	var/reagents
 	///Details of how we inject our venom
 	var/injection_flags
 	///How much of the reagent added. if it's a list, it'll pick a range with the range being list(lower_value, upper_value)
@@ -17,7 +17,7 @@
 
 /datum/element/venomous/Attach(datum/target, poison_type, amount_added, injection_flags = NONE, thrown_effect = FALSE)
 	. = ..()
-	src.poison_type = poison_type
+	src.reagents = poison_type
 	src.amount_added = amount_added
 	src.injection_flags = injection_flags
 	src.thrown_effect = thrown_effect
@@ -41,4 +41,10 @@
 		final_amount_added = rand(amount_added[1], amount_added[2])
 	else
 		final_amount_added = amount_added
-	target.reagents?.add_reagent(poison_type, final_amount_added)
+
+	var/datum/reagents/tmp_holder = new/datum/reagents(50)
+	tmp_holder.my_atom = src
+	tmp_holder.add_reagent(reagents, final_amount_added)
+
+	tmp_holder.expose(target, INJECT, 1, FALSE)
+	qdel(tmp_holder)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -121,7 +121,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	. = SEND_SIGNAL(src, COMSIG_REAGENT_EXPOSE_MOB, exposed_mob, methods, reac_volume, show_message, touch_protection)
-	if(((penetrates_skin & methods) || (methods & INJECT)) && exposed_mob.reagents) //smoke, foam, spray
+	if(penetrates_skin & (methods|INJECT)) //methods being 
 		var/amount = round(reac_volume*clamp((1 - touch_protection), 0, 1), 0.1)
 		if(amount >= 0.5)
 			exposed_mob.reagents.add_reagent(type, amount, added_purity = purity)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -121,7 +121,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	. = SEND_SIGNAL(src, COMSIG_REAGENT_EXPOSE_MOB, exposed_mob, methods, reac_volume, show_message, touch_protection)
-	if((methods & penetrates_skin) && exposed_mob.reagents) //smoke, foam, spray
+	if(((penetrates_skin & methods) || (methods & INJECT)) && exposed_mob.reagents) //smoke, foam, spray
 		var/amount = round(reac_volume*clamp((1 - touch_protection), 0, 1), 0.1)
 		if(amount >= 0.5)
 			exposed_mob.reagents.add_reagent(type, amount, added_purity = purity)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -121,7 +121,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	. = SEND_SIGNAL(src, COMSIG_REAGENT_EXPOSE_MOB, exposed_mob, methods, reac_volume, show_message, touch_protection)
-	if(penetrates_skin & (methods|INJECT)) //methods being 
+	if((penetrates_skin|INJECT) & methods) //methods being
 		var/amount = round(reac_volume*clamp((1 - touch_protection), 0, 1), 0.1)
 		if(amount >= 0.5)
 			exposed_mob.reagents.add_reagent(type, amount, added_purity = purity)


### PR DESCRIPTION
## About The Pull Request

This PR changes how reagents are added from the venomous component. Currently the component uses `add_reagents` which adds the reagents instantly to the target. 

While this may not seem like a problem, quite a lot of reagents require the `COMSIG_REAGENT_EXPOSE_MOB` for them to function, so a lot of reagents do not act as expected, such as in the issue #85386.

* Fixes #85386.
## Why It's Good For The Game

Makes reagents work as intended using the venomous component.
## Changelog
:cl:
fix: fixed reagents not being applied correctly by venomous mobs
/:cl:
