### PR TITLE
Fixes Lava / Chasm Underlays

### DIFF
--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -50,8 +50,8 @@
 
 
 /turf/open/chasm/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "basalt"
+	underlay_appearance.icon = /turf/open/misc/asteroid/basalt::icon
+	underlay_appearance.icon_state = /turf/open/misc/asteroid/basalt::icon_state
 	return TRUE
 
 /turf/open/chasm/attackby(obj/item/C, mob/user, params, area/area_restriction)
@@ -100,6 +100,11 @@
 	light_power = 0.65
 	light_color = LIGHT_COLOR_PURPLE
 
+/turf/open/chasm/icemoon/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = /turf/open/misc/asteroid/snow/icemoon::icon
+	underlay_appearance.icon_state = /turf/open/misc/asteroid/snow/icemoon::icon_state
+	return TRUE
+
 // Chasms for the jungle, with planetary atmos and a different icon
 /turf/open/chasm/jungle
 	icon = 'icons/turf/floors/junglechasm.dmi'
@@ -109,8 +114,8 @@
 	baseturfs = /turf/open/chasm/jungle
 
 /turf/open/chasm/jungle/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "dirt"
+	underlay_appearance.icon = /turf/open/misc/dirt::icon
+	underlay_appearance.icon_state = /turf/open/misc/dirt::icon_state
 	return TRUE
 
 // Chasm that doesn't do any z-level nonsense and just kills/stores whoever steps into it.

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -178,11 +178,6 @@
 /turf/open/lava/singularity_pull(S, current_size)
 	return
 
-/turf/open/lava/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "basalt"
-	return TRUE
-
 /turf/open/lava/GetHeatCapacity()
 	. = 700000
 
@@ -340,6 +335,12 @@
 	canSmoothWith = SMOOTH_GROUP_FLOOR_LAVA
 	underfloor_accessibility = 2 //This avoids strangeness when routing pipes / wires along catwalks over lava
 	immerse_overlay_color = "#F98511"
+
+/// Smooth lava needs to take after basalt in order to blend better. If you make a /turf/open/lava/smooth subtype for an area NOT surrounded by basalt; you should override this proc.
+/turf/open/lava/smooth/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = /turf/open/misc/asteroid/basalt::icon
+	underlay_appearance.icon_state = /turf/open/misc/asteroid/basalt::icon_state
+	return TRUE
 
 /turf/open/lava/smooth/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/59605

To quickly explain what this PR does:
- Lava no longer assumes it needs to call basalt as the diagonal underlay by default. This has been moved to `/turf/open/lava/smooth`; where basalt's smoothed lava is actually housed. All other lava types now inherit the basic underlay behavior and perform as expected therein.

- Icemoon chasms (currently unused? Could probably get away with implementing them on the bottom floor if you really want to; though they look really ugly) now call for snow as their underlay.

- The underlays for lava AND chasms now use `::` to refer to the turfs they're trying to mimic; making it easier to keep these up to date without a few biffed compiles.
## Why It's Good For The Game
Quickfixes an error I noticed three years ago lmao
## Changelog
:cl:
fix: Shuttles that land next to plasma turfs no longer ruin the mass hallucination that is Icebox having Plasma and not just super-deadly; spiky basalt deltas. You're welcome; unreality fans.
/:cl:
