### PR TITLE
Allow dot radio prefixes to also work with the tgui-say radio prefix display

### DIFF
--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -206,7 +206,8 @@ export class TguiSay extends Component<{}, State> {
     // Is it a valid prefix?
     const prefix = typed
       .slice(0, 3)
-      ?.toLowerCase() as keyof typeof RADIO_PREFIXES;
+      ?.toLowerCase()
+      ?.replace('.', ':') as keyof typeof RADIO_PREFIXES;
     if (!RADIO_PREFIXES[prefix] || prefix === this.currentPrefix) {
       return;
     }


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/Monkestation/Monkestation2.0/pull/1549

This makes tgui-say also properly show the channel preview thing with `.c`, rather than only `:c`

## Why It's Good For The Game

dot prefixes are superior, and it's best if tgui-say works properly with 'em

## Changelog
:cl:
fix: Allow dot radio prefixes to also work with the tgui-say radio prefix display.
/:cl:
