### PR TITLE
Add a separate preference for hearing AI VOX announcements

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -189,13 +189,11 @@
 /proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE)
 	var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
 
-#if DM_VERSION < 516
+	// note for later: low-hanging fruit to convert to astype() behind an experiment define whenever the 516 beta releases
+	// var/datum/callback/should_play_sound_callback = astype(should_play_sound)
 	var/datum/callback/should_play_sound_callback
 	if(istype(should_play_sound, /datum/callback))
 		should_play_sound_callback = should_play_sound
-#else
-	var/datum/callback/should_play_sound_callback = astype(should_play_sound)
-#endif
 
 	for(var/mob/target in players)
 		if(isnewplayer(target) || !target.can_hear())

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -120,7 +120,7 @@
  * html_encode - if TRUE, we will html encode our title and message before sending it, to prevent player input abuse.
  * players - optional, a list mobs to send the announcement to. If unset, sends to all palyers.
  * sound_override - optional, use the passed sound file instead of the default notice sounds.
- * should_play_sound - Whether the notice sound should be played or not.
+ * should_play_sound - Whether the notice sound should be played or not. This can also be a callback, if you only want mobs to hear the sound based off of specific criteria.
  * color_override - optional, use the passed color instead of the default notice color.
  */
 /proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override)
@@ -185,15 +185,24 @@
 	return jointext(returnable_strings, "")
 
 /// Proc that just dispatches the announcement to our applicable audience. Only the announcement is a mandatory arg.
+/// `should_play_sound` can also be a callback, if you want to only play the sound to specific players.
 /proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE)
 	var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
+
+#if DM_VERSION < 516
+	var/datum/callback/should_play_sound_callback
+	if(istype(should_play_sound, /datum/callback))
+		should_play_sound_callback = should_play_sound
+#else
+	var/datum/callback/should_play_sound_callback = astype(should_play_sound)
+#endif
 
 	for(var/mob/target in players)
 		if(isnewplayer(target) || !target.can_hear())
 			continue
 
 		to_chat(target, announcement)
-		if(!should_play_sound)
+		if(!should_play_sound || (should_play_sound_callback && !should_play_sound_callback.Invoke(target)))
 			continue
 
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))

--- a/code/modules/client/preferences/sounds.dm
+++ b/code/modules/client/preferences/sounds.dm
@@ -122,3 +122,9 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "sound_radio_noise"
 	savefile_identifier = PREFERENCE_PLAYER
+
+/// Controls hearing AI VOX announcements
+/datum/preference/toggle/sound_ai_vox
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "sound_ai_vox"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -168,7 +168,7 @@
 		if(!only_listener)
 			// Play voice for all mobs in the z level
 			for(var/mob/player_mob as anything in GLOB.player_list)
-				if(!player_mob.can_hear() || !(safe_read_pref(player_mob.client, /datum/preference/toggle/sound_announcements)))
+				if(!player_mob.can_hear() || !(safe_read_pref(player_mob.client, /datum/preference/toggle/sound_ai_vox)))
 					continue
 
 				var/turf/player_turf = get_turf(player_mob)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -148,7 +148,7 @@
 		var/turf/player_turf = get_turf(player_mob)
 		if(is_valid_z_level(ai_turf, player_turf))
 			players += player_mob
-	minor_announce(capitalize(message), "[name] announces:", players = players, should_play_sound = FALSE)
+	minor_announce(capitalize(message), "[name] announces:", players = players, should_play_sound = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(does_target_have_vox_off)))
 
 	for(var/word in words)
 		play_vox_word(word, ai_turf, null)
@@ -168,7 +168,7 @@
 		if(!only_listener)
 			// Play voice for all mobs in the z level
 			for(var/mob/player_mob as anything in GLOB.player_list)
-				if(!player_mob.can_hear() || !(safe_read_pref(player_mob.client, /datum/preference/toggle/sound_ai_vox)))
+				if(!player_mob.can_hear() || !safe_read_pref(player_mob.client, /datum/preference/toggle/sound_ai_vox))
 					continue
 
 				var/turf/player_turf = get_turf(player_mob)
@@ -180,6 +180,9 @@
 			SEND_SOUND(only_listener, voice)
 		return TRUE
 	return FALSE
+
+/proc/does_target_have_vox_off(mob/target)
+	return !safe_read_pref(target.client, /datum/preference/toggle/sound_ai_vox)
 
 #undef VOX_DELAY
 #endif

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
@@ -116,3 +116,11 @@ export const sound_radio_noise: FeatureToggle = {
     'When enabled, hear sounds of talking and hearing radio chatter.',
   component: CheckboxInput,
 };
+
+export const sound_ai_vox: FeatureToggle = {
+  name: 'Enable AI VOX announcements',
+  category: 'SOUND',
+  description:
+    'When enabled, hear vocal AI announcements (also known as "VOX").',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

This adds a new preference, "Enable AI VOX announcements", which allows you to toggle hearing the vocal AI VOX announcements.

Previously this was handled by the "Enable announcement sounds" setting, but tbh having it lumped in with that sucks because it's very reasonable to be okay with announcement dings, while not wanting to hear voxtest or some shit.

## Why It's Good For The Game

I DO want to hear the normal announcement dings, but I ***never*** want to hear the vocal AI announcements, and spamming "Stop Sounds" for every single word to skip past it is annoying as hell.

## Changelog
:cl:
add: Added a separate preference for hearing vocal AI announcements (also known as VOX), as opposed to lumping it into the "Enable announcement sounds" preference.
/:cl:
