### PR TITLE
adds plasma to wawastation xenobio

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -4937,9 +4937,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bLI" = (
-/obj/machinery/processor/slime,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/processor/slime,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "bLS" = (
@@ -46862,6 +46862,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "qGN" = (
@@ -47527,11 +47528,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qUi" = (
-/obj/machinery/processor/slime,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/processor/slime,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "qUl" = (
@@ -48756,6 +48757,7 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "rms" = (


### PR DESCRIPTION

## About The Pull Request
fixes the issue of not having plasma in xenobio because xenobiologists needs it...
## Why It's Good For The Game
wawa is the only station without any roundstart plasma in xenobio
## Changelog
:cl:
fix: adds plasma to wawastation's xenobio
/:cl: