### PR TITLE
Fixed Chameleon clothing not updating your sprite in some cases

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -72,6 +72,8 @@
 		if(screen.needs_offsetting)
 			screen.plane = GET_NEW_PLANE(initial(screen.plane), offset)
 
+INITIALIZE_IMMEDIATE(/atom/movable/screen/fullscreen)
+
 /atom/movable/screen/fullscreen
 	icon = 'icons/hud/screen_full.dmi'
 	icon_state = "default"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -317,6 +317,10 @@ Security HUDs! Basic mode shows only the job.
 		set_hud_image_active(IMPLOYAL_HUD)
 
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
+	if(!hud_list)
+		// We haven't finished initializing yet, huds will be updated once we are
+		return
+
 	var/image/holder = hud_list[WANTED_HUD]
 	var/icon/sec_icon = icon(icon, icon_state, dir)
 	holder.pixel_y = sec_icon.Height() - ICON_SIZE_Y

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -1,7 +1,6 @@
 /mob/living/carbon/update_obscured_slots(obscured_flags)
 	..()
-	if(obscured_flags & (HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT|HIDEMUTWINGS))
-		update_body()
+	update_body()
 
 /// Updates features and clothing attached to a specific limb with limb-specific offsets
 /mob/living/carbon/proc/update_features(feature_key)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -72,8 +72,7 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/update_obscured_slots(obscured_flags)
 	..()
-	if(obscured_flags & HIDEFACE)
-		sec_hud_set_security_status()
+	sec_hud_set_security_status()
 
 /* --------------------------------------- */
 //vvvvvv UPDATE_INV PROCS vvvvvv


### PR DESCRIPTION
## About The Pull Request

Whenever you equip or unequip a piece of clothing (or change the appearance of a chameleon item while wearing it), the game checks to see if your sprite needs to update the parts of your body that are obscured by that clothing. However, it only actually updates your sprite if the item covers a part of your body that is relevant to your sprite. If you equip an item that hides a part of your body (such as a chameleon helmet set to something that hides your hair), then transform that item into a form that no longer covers anything, it will see that the item covers nothing important and skip trying to update your appearance.

Removing this check will cause update_body() calls to occur slightly more often, but in the cases where it actually shouldn't update, the sprite update code will detect that the rendering key for each limb has not changed and exit without making any sprite changes, so the performance hit will be minimal.

Similar situation with face-covering chameleon items and sec huds: You could equip a face-covering chameleon item to make your sec hud arrest status disappear, change the item to something that does not cover your face, and then remove it, and your sec hud arrest status would not update.

## Why It's Good For The Game


## Changelog

:cl:
fix: Fixed chameleon clothing sometimes making you bald or hiding other parts of your sprite.
/:cl:

Fixes #83570
