### PR TITLE
Removes gas mask fov, pepperspray now applies tint to masks until washed off

### DIFF
--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -1,0 +1,90 @@
+/datum/component/clothing_dirt
+	/// The ITEM_SLOT_* slot the item is equipped on, if it is.
+	var/equipped_slot
+
+	/// Mob wearing the clothing
+	var/mob/living/carbon/wearer
+
+	/// Amount of dirt stacks on the clothing
+	var/dirtiness = 0
+
+	/// Clothing we're applying tint on
+	var/obj/item/clothing/clothing
+
+/datum/component/clothing_dirt/Initialize()
+	if(!isclothing(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/clothing_dirt/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_remove))
+	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(on_clean))
+
+	clothing = parent
+	if (iscarbon(clothing.loc))
+		var/mob/living/carbon/mob_clothing = clothing.loc
+		if ((mob_clothing.wear_mask == mob_clothing) || (mob_clothing.head == mob_clothing))
+			wearer = mob_clothing
+			RegisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENT, PROC_REF(expose_atom))
+	else
+		RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENT, PROC_REF(expose_atom))
+
+/datum/component/clothing_dirt/UnregisterFromParent()
+	clothing = parent
+	clothing.tint -= dirtiness
+	dirtiness = 0
+	if (!isnull(wearer))
+		wearer.update_tint()
+		UnregisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENT)
+	else
+		UnregisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENT)
+	UnregisterSignal(parent, list(
+		COMSIG_ATOM_EXAMINE,
+		COMSIG_ITEM_EQUIPPED,
+		COMSIG_ITEM_DROPPED,
+		COMSIG_COMPONENT_CLEAN_ACT,
+	))
+	return ..()
+
+/datum/component/clothing_dirt/proc/on_equip(datum/source, mob/equipper)
+	SIGNAL_HANDLER
+	UnregisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENT)
+	wearer = equipper
+	RegisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENT, PROC_REF(expose_atom))
+
+/datum/component/clothing_dirt/proc/on_remove()
+	SIGNAL_HANDLER
+	UnregisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENT)
+	wearer = null
+	RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENT, PROC_REF(expose_atom))
+
+/datum/component/clothing_dirt/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if (dirtiness > 0)
+		examine_list += span_red("It appears to be covered in some oily substance. Won't see much while wearing it until you wash it off.")
+
+/datum/component/clothing_dirt/proc/expose_atom(atom/parent_atom, datum/reagent/exposing_reagent, methods)
+	SIGNAL_HANDLER
+	if(QDELETED(wearer) || is_protected())
+		return
+	if(!istype(exposing_reagent, /datum/reagent/consumable/condensedcapsaicin))
+		return
+	clothing = parent
+	if ((methods & VAPOR) || (methods & TOUCH))
+		dirtiness += 1
+		clothing.tint += 1
+		if(!isnull(wearer))
+			wearer.update_tint()
+
+/datum/component/clothing_dirt/proc/is_protected()
+	return wearer.check_obscured_slots(TRUE) & equipped_slot
+
+/datum/component/clothing_dirt/proc/on_clean(datum/source, clean_types)
+	SIGNAL_HANDLER
+	clothing = parent
+	if (clean_types & CLEAN_WASH & CLEAN_SCRUB)
+		clothing.tint -= dirtiness
+		dirtiness = 0
+		if(!isnull(wearer))
+			wearer.update_tint()

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -1,17 +1,11 @@
 /// This component applies tint to clothing when its exposed to pepperspray, used in /obj/item/clothing/mask/gas.
 
 /datum/component/clothing_dirt
-	/// The ITEM_SLOT_* slot the item is equipped on, if it is.
-	var/equipped_slot
-
 	/// Mob wearing the clothing
 	var/mob/living/carbon/wearer
 
 	/// Amount of dirt stacks on the clothing
 	var/dirtiness = 0
-
-	/// Clothing we're applying tint on
-	var/obj/item/clothing/clothing
 
 /datum/component/clothing_dirt/Initialize()
 	if(!isclothing(parent))
@@ -23,9 +17,10 @@
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(on_clean))
 	RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_expose))
-	clothing = parent
+	// var/obj/item/clothing/clothing = parent
 
 /datum/component/clothing_dirt/UnregisterFromParent()
+	var/obj/item/clothing/clothing = parent
 	clothing.tint -= dirtiness
 	clothing = null
 	if (!isnull(wearer))
@@ -44,7 +39,8 @@
 
 /datum/component/clothing_dirt/proc/on_equip(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
-	if (!(slot & (ITEM_SLOT_MASK | ITEM_SLOT_HEAD)))
+	var/obj/item/clothing/clothing = parent
+	if (!(slot & clothing.slot_flags))
 		return
 	UnregisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS)
 	wearer = user
@@ -71,6 +67,7 @@
 	if(isnull(pepper))
 		return
 
+	var/obj/item/clothing/clothing = parent
 	if (methods & (TOUCH | VAPOR))
 		clothing.tint -= dirtiness
 		dirtiness = min(dirtiness + round(reagents[pepper] / 5), 3)
@@ -83,7 +80,8 @@
 
 /datum/component/clothing_dirt/proc/on_clean(datum/target, clean_types)
 	SIGNAL_HANDLER
-	if (clean_types & CLEAN_WASH & CLEAN_SCRUB)
+	var/obj/item/clothing/clothing = parent
+	if (clean_types & (CLEAN_WASH|CLEAN_SCRUB))
 		clothing.tint -= dirtiness
 		dirtiness = 0
 		if(!isnull(wearer))

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -17,7 +17,6 @@
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(on_clean))
 	RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_expose))
-	// var/obj/item/clothing/clothing = parent
 
 /datum/component/clothing_dirt/UnregisterFromParent()
 	var/obj/item/clothing/clothing = parent

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -51,7 +51,7 @@
 	if(!isnull(wearer))
 		UnregisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENTS)
 		wearer = null
-	RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_expose))
+		RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_expose))
 
 /datum/component/clothing_dirt/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
@@ -60,8 +60,10 @@
 
 /datum/component/clothing_dirt/proc/on_expose(atom/target, list/reagents, datum/reagents/source, methods)
 	SIGNAL_HANDLER
-	if(QDELETED(wearer) || is_protected() )
-		return
+
+	if(!isnull(wearer))
+		if(QDELETED(wearer) || is_protected())
+			return
 
 	var/datum/reagent/consumable/condensedcapsaicin/pepper = locate() in reagents
 	if(isnull(pepper))

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -52,8 +52,9 @@
 
 /datum/component/clothing_dirt/proc/on_drop()
 	SIGNAL_HANDLER
-	UnregisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENTS)
-	wearer = null
+	if(!isnull(wearer))
+		UnregisterSignal(wearer, COMSIG_ATOM_EXPOSE_REAGENTS)
+		wearer = null
 	RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_expose))
 
 /datum/component/clothing_dirt/proc/on_examine(datum/source, mob/user, list/examine_list)
@@ -61,14 +62,15 @@
 	if (dirtiness > 0)
 		examine_list += span_warning("It appears to be covered in some oily substance. Won't see much while wearing it until you wash it off.")
 
-/datum/component/clothing_dirt/proc/on_expose(atom/source, list/reagents, datum/reagents/source, methods)
+/datum/component/clothing_dirt/proc/on_expose(atom/target, list/reagents, datum/reagents/source, methods)
 	SIGNAL_HANDLER
 	if(QDELETED(wearer) || is_protected() )
 		return
-	if(!is_path_in_list(/datum/reagent/consumable/condensedcapsaicin, reagents))
-		return
 
 	var/datum/reagent/consumable/condensedcapsaicin/pepper = locate() in reagents
+	if(isnull(pepper))
+		return
+
 	if (methods & (TOUCH | VAPOR))
 		clothing.tint -= dirtiness
 		dirtiness = min(dirtiness + round(reagents[pepper] / 5), 3)

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -79,7 +79,7 @@
 			wearer.update_tint()
 
 /datum/component/clothing_dirt/proc/is_protected()
-	return wearer.check_obscured_slots(TRUE) & equipped_slot
+	return wearer.head && (wearer.head.flags_cover & PEPPERPROOF)
 
 /datum/component/clothing_dirt/proc/on_clean(datum/target, clean_types)
 	SIGNAL_HANDLER

--- a/code/modules/antagonists/ninja/ninja_clothing.dm
+++ b/code/modules/antagonists/ninja/ninja_clothing.dm
@@ -15,6 +15,8 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
+	pepper_tint = 0
+
 
 /obj/item/clothing/under/syndicate/ninja
 	name = "ninja suit"

--- a/code/modules/antagonists/ninja/ninja_clothing.dm
+++ b/code/modules/antagonists/ninja/ninja_clothing.dm
@@ -15,7 +15,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
-	has_fov = FALSE
 
 /obj/item/clothing/under/syndicate/ninja
 	name = "ninja suit"

--- a/code/modules/antagonists/ninja/ninja_clothing.dm
+++ b/code/modules/antagonists/ninja/ninja_clothing.dm
@@ -15,7 +15,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
-	pepper_tint = 0
+	pepper_tint = FALSE
 
 
 /obj/item/clothing/under/syndicate/ninja

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -29,6 +29,8 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	var/obj/item/cigarette/cig
 	///How much does this mask affect fishing difficulty
 	var/fishing_modifier = 2
+	///Applies clothing_dirt component to the pepperproof mask if true
+	var/pepper_tint = 1
 
 /datum/armor/mask_gas
 	bio = 100
@@ -36,7 +38,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 /obj/item/clothing/mask/gas/Initialize(mapload)
 	. = ..()
 
-	if(flags_cover & PEPPERPROOF)
+	if((flags_cover & PEPPERPROOF) & pepper_tint)
 		AddComponent(/datum/component/clothing_dirt)
 
 	if(fishing_modifier)
@@ -273,6 +275,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	strip_delay = 60
 	w_class = WEIGHT_CLASS_SMALL
 	fishing_modifier = 0
+	pepper_tint = 0
 
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -30,7 +30,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	///How much does this mask affect fishing difficulty
 	var/fishing_modifier = 2
 	///Applies clothing_dirt component to the pepperproof mask if true
-	var/pepper_tint = 1
+	var/pepper_tint = TRUE
 
 /datum/armor/mask_gas
 	bio = 100
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 /obj/item/clothing/mask/gas/Initialize(mapload)
 	. = ..()
 
-	if((flags_cover & PEPPERPROOF) & pepper_tint)
+	if((flags_cover & PEPPERPROOF) && pepper_tint)
 		AddComponent(/datum/component/clothing_dirt)
 
 	if(fishing_modifier)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -25,8 +25,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	var/list/gas_filters
 	///Type of filter that spawns on roundstart
 	var/starting_filter_type = /obj/item/gas_filter
-	///Does the mask have an FOV?
-	var/has_fov = TRUE
 	///Cigarette in the mask
 	var/obj/item/cigarette/cig
 	///How much does this mask affect fishing difficulty
@@ -37,7 +35,9 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 
 /obj/item/clothing/mask/gas/Initialize(mapload)
 	. = ..()
-	init_fov()
+
+	if(flags_cover & PEPPERPROOF)
+		AddComponent(/datum/component/clothing_dirt)
 
 	if(fishing_modifier)
 		AddComponent(/datum/component/adjust_fishing_difficulty, fishing_modifier)
@@ -160,11 +160,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 		has_filter = FALSE
 	return filtered_breath
 
-/// Initializes the FoV component for the gas mask
-/obj/item/clothing/mask/gas/proc/init_fov()
-	if (has_fov)
-		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
-
 /**
  * Getter for overall filter durability, takes into consideration all filters filter_status
  */
@@ -267,7 +262,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	icon_state = "plaguedoctor"
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT|HIDEHAIR
 	inhand_icon_state = "gas_mask"
-	has_fov = FALSE
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT|MASKINTERNALS
 
 /obj/item/clothing/mask/gas/syndicate
@@ -278,7 +272,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	strip_delay = 60
 	w_class = WEIGHT_CLASS_SMALL
-	has_fov = FALSE
 	fishing_modifier = 0
 
 /obj/item/clothing/mask/gas/clown_hat
@@ -296,7 +289,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
-	has_fov = FALSE
 	var/list/clownmask_designs = list()
 	voice_filter = null // performer masks expect to be talked through
 	fishing_modifier = 0
@@ -341,7 +333,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	righthand_file = 'icons/mob/inhands/clothing/hats_righthand.dmi'
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	fishing_modifier = 0
 
 /obj/item/clothing/mask/gas/mime
@@ -355,7 +346,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	species_exception = list(/datum/species/golem)
-	has_fov = FALSE
 	fishing_modifier = 0
 	var/list/mimemask_designs = list()
 
@@ -400,7 +390,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	inhand_icon_state = "owl_mask"
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	fishing_modifier = 0
 
 /obj/item/clothing/mask/gas/sexymime
@@ -412,7 +401,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem)
-	has_fov = FALSE
 	fishing_modifier = 0
 
 /obj/item/clothing/mask/gas/cyborg
@@ -420,7 +408,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	desc = "Beep boop."
 	icon_state = "death"
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	flags_cover = MASKCOVERSEYES
 	fishing_modifier = 0
 
@@ -432,7 +419,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	clothing_flags = MASKINTERNALS
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	fishing_modifier = -1
 
 /obj/item/clothing/mask/gas/carp
@@ -440,7 +426,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	desc = "Gnash gnash."
 	icon_state = "carp_mask"
 	inhand_icon_state = null
-	has_fov = FALSE
 	flags_cover = MASKCOVERSEYES
 	fishing_modifier = -3
 
@@ -451,7 +436,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	inhand_icon_state = null
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT * 1.25)
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	flags_cover = MASKCOVERSEYES
 	max_integrity = 100
 	actions_types = list(/datum/action/item_action/adjust)
@@ -498,7 +482,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	inhand_icon_state = "gas_atmos"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEFACIALHAIR|HIDEFACE|HIDEEYES|HIDEEARS|HIDEHAIR|HIDESNOUT
-	has_fov = FALSE
 	fishing_modifier = -2
 
 /obj/item/clothing/mask/gas/prop
@@ -509,7 +492,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	clothing_flags = NONE
 	flags_cover = MASKCOVERSMOUTH
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	fishing_modifier = 0
 
 /obj/item/clothing/mask/gas/atmosprop
@@ -521,7 +503,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	clothing_flags = NONE
 	flags_cover = MASKCOVERSMOUTH
 	resistance_flags = FLAMMABLE
-	has_fov = FALSE
 	fishing_modifier = 0
 
 /obj/item/clothing/mask/gas/driscoll

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	strip_delay = 60
 	w_class = WEIGHT_CLASS_SMALL
 	fishing_modifier = 0
-	pepper_tint = 0
+	pepper_tint = FALSE
 
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -56,7 +56,6 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	flags_cover = MASKCOVERSMOUTH
 	visor_flags_cover = MASKCOVERSMOUTH
 	tint = 0
-	has_fov = FALSE
 	fishing_modifier = 0
 	unique_death = 'sound/items/sec_hailer/sec_death.ogg'
 	COOLDOWN_DECLARE(hailer_cooldown)

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -87,6 +87,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	fishing_modifier = 2
+	pepper_tint = 0
 
 /obj/item/clothing/mask/gas/sechailer/swat/spacepol
 	name = "spacepol mask"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	fishing_modifier = 2
-	pepper_tint = 0
+	pepper_tint = FALSE
 
 /obj/item/clothing/mask/gas/sechailer/swat/spacepol
 	name = "spacepol mask"

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -61,7 +61,6 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	armor_type = /datum/armor/gas_explorer
 	resistance_flags = FIRE_PROOF
-	has_fov = FALSE
 
 /datum/armor/gas_explorer
 	melee = 10

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1066,6 +1066,7 @@
 #include "code\datums\components\chuunibyou.dm"
 #include "code\datums\components\cleaner.dm"
 #include "code\datums\components\clickbox.dm"
+#include "code\datums\components\clothing_dirt.dm"
 #include "code\datums\components\clothing_fov_visor.dm"
 #include "code\datums\components\codeword_hearing.dm"
 #include "code\datums\components\combo_attacks.dm"


### PR DESCRIPTION

## About The Pull Request
Gas masks and all their subtypes no longer have fov.
Using pepperspray on gas mask wearer applies 1 tint per 5u of spray. At 3 tint the wearer becomes fully blind.
If you wanna use the mask again you'll have to wash off the pepperspray from it using soap or shower.
## Why It's Good For The Game
Gas mask assistants are peak soul and removing it was a terrible disaster. FoV is too annoying to ever deal with, so it ends up with gas masks never being worn. Gas filter doesn't make up for it whatsoever, it's only use is shoving cigarettes in it to look cool. This PR makes it so pepperspray/tear gas is still useful against mask wearers, albeit less efficient. 
## Changelog
:cl:
balance: replaced gas mask fov with pepperspray applying tint to gas masks, making the wearer blind until washed off.
/:cl:
