### PR TITLE
Fixes dead borg becoming invisible on changed z level

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -342,9 +342,12 @@
 /mob/living/silicon/robot/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	if(same_z_layer || QDELING(src))
 		return ..()
-	cut_overlay(eye_lights)
-	SET_PLANE_EXPLICIT(eye_lights, PLANE_TO_TRUE(eye_lights.plane), src)
-	add_overlay(eye_lights)
+
+	if(eye_lights)
+		cut_overlay(eye_lights)
+		SET_PLANE_EXPLICIT(eye_lights, PLANE_TO_TRUE(eye_lights.plane), src)
+		add_overlay(eye_lights)
+
 	return ..()
 
 /mob/living/silicon/robot/proc/self_destruct(mob/usr)


### PR DESCRIPTION

## About The Pull Request

When a borg changes z level the code below runs:

```DM
cut_overlay(eye_lights)
SET_PLANE_EXPLICIT(eye_lights, PLANE_TO_TRUE(eye_lights.plane), src)
add_overlay(eye_lights)	
```

But when the borg is dead, eye_lights in null, so I added an if check to see if eye_lights exists. This stops the dead borg from becoming invisible when z level changes.

* Fixes #86970 
## Why It's Good For The Game

Borgs won't become invisible when z level changes.
## Changelog
:cl:
fix: dead borgs no longer become invisible upon changing z level
/:cl:
