### PR TITLE
Fix health analyzer showing missing heart only when you don't need one.

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -280,7 +280,7 @@
 		var/list/missing_organs = list()
 		if(!humantarget.get_organ_slot(ORGAN_SLOT_BRAIN))
 			missing_organs[ORGAN_SLOT_BRAIN] = "Brain"
-		if(!humantarget.needs_heart() && !humantarget.get_organ_slot(ORGAN_SLOT_HEART))
+		if(humantarget.needs_heart() && !humantarget.get_organ_slot(ORGAN_SLOT_HEART))
 			missing_organs[ORGAN_SLOT_HEART] = "Heart"
 		if(!HAS_TRAIT_FROM(humantarget, TRAIT_NOBREATH, SPECIES_TRAIT) && !isnull(humantarget.dna.species.mutantlungs) && !humantarget.get_organ_slot(ORGAN_SLOT_LUNGS))
 			missing_organs[ORGAN_SLOT_LUNGS] = "Lungs"


### PR DESCRIPTION

## About The Pull Request
One of the checks were reversed. Now it works properly
![image](https://github.com/user-attachments/assets/b91146cd-aa4b-4989-92d5-598647746488)
## Why It's Good For The Game
Properly working health analyzers are god for the game, roleplay, robust etc
## Changelog
:cl:
fix: health analyzers will show if your heart is missing once again
/:cl:
