### PR TITLE
Fish feed to the Library vending machine, rescue hook to the mining order console (and paramed heirloom)

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_consumables.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_consumables.dm
@@ -46,3 +46,9 @@
 	item_path = /obj/item/stack/spacecash/c1000
 	desc = "A stack of space cash worth 1000 credits."
 	cost_per_order = 2000
+
+/datum/orderable_item/consumables/ruscue_hook
+	name = "Rescue Fishing Rod"
+	item_path = /obj/item/fishing_rod/rescue
+	desc = "For when your fellow miner has inevitably fallen into a chasm, and it's up to you to save them."
+	cost_per_order = 600

--- a/code/game/machinery/computer/orders/order_items/mining/order_consumables.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_consumables.dm
@@ -47,7 +47,7 @@
 	desc = "A stack of space cash worth 1000 credits."
 	cost_per_order = 2000
 
-/datum/orderable_item/consumables/ruscue_hook
+/datum/orderable_item/consumables/rescue_hook
 	name = "Rescue Fishing Rod"
 	item_path = /obj/item/fishing_rod/rescue
 	desc = "For when your fellow miner has inevitably fallen into a chasm, and it's up to you to save them."

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -503,6 +503,11 @@
 	line = null
 	show_in_wiki = FALSE
 
+///From the mining order console, meant to help miners rescue their fallen brethren
+/obj/item/fishing_rod/rescue
+	hook = /obj/item/fishing_hook/rescue
+	show_in_wiki = FALSE
+
 /obj/item/fishing_rod/bone
 	name = "bone fishing rod"
 	desc = "A humble rod, made with whatever happened to be on hand."

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -24,7 +24,7 @@
 		/datum/job_department/medical,
 		)
 
-	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom)
+	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/fishing_hook/rescue)
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/hypospray/medipen = 20,

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -45,7 +45,7 @@
 				/obj/item/stack/pipe_cleaner_coil/random = 10,
 			),
 		),
-		list(		
+		list(
 			"name" = "Fishing",
 			"icon" = "fish",
 			"products" = list(
@@ -54,6 +54,7 @@
 				/obj/item/storage/box/fishing_lines = 2,
 				/obj/item/storage/box/fishing_lures = 2,
 				/obj/item/book/manual/fish_catalog = 5,
+				/obj/item/fish_feed = 4,
 				/obj/item/fish_analyzer = 2,
 				/obj/item/fishing_rod/telescopic = 1,
 			),


### PR DESCRIPTION
## About The Pull Request
Some time ago I was told that it'd have been nice if rescue hooks were easier to get, suggesting me to add them to the mining order console (or the other way around?) and as heirloom for paramedics (definitely the other way around). Also recently, there was someone suggesting to add the fish feed to the librabry vending machine, where it was missing, unlike other fishing items (minus the aquarium). This PR implements both ideas.

## Why It's Good For The Game
This makes the aquarium a smidge easier for people who don't know that fish feed is just generic nutriment you can get by grinding most food and that you can alt-click to open the panel and place the reagents in an internal reagent holder that distributes the feed at settable intervals.
Also miners deserve to be able to have express-delivered fishing rod to rescue their buddies with.

## Changelog

:cl:
Add: You can buy fish feed in the fishing category of the library vending machine
add: You can buy a fishing rod pre-equipped with a rescue hook from the mining order console.
balance: Paramedics can get a rescue fishing hook as a heirloom.
/:cl:
