### PR TITLE
The supermatter no longer spawns anomalies inside objects or mobs.

### DIFF
--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -160,7 +160,7 @@
 		step_towards(movable_atom,center)
 
 /proc/supermatter_anomaly_gen(turf/anomalycenter, type = FLUX_ANOMALY, anomalyrange = 5, has_changed_lifespan = TRUE)
-	var/turf/local_turf = pick(orange(anomalyrange, anomalycenter))
+	var/turf/local_turf = pick(RANGE_TURFS(anomalyrange, anomalycenter))
 	if(!local_turf)
 		return
 	switch(type)


### PR DESCRIPTION
## About The Pull Request
The supermatter no longer will spawn anomalies inside pipes, vents, ebeams, cables, etc, as it now uses RANGE_TURFS instead of orange. We believe this was the intention, as it is hard pathed to var/turf/local_turf already, rather than any atom.

## Why It's Good For The Game
Technically, anomalies can pop out of the pipes when moving just fine, however it can lead to confusion if the anomaly is unable to move, or repeatedly fails to move, keeping it inside the pipe, before triggering its ending effect (pyroclastic for example, or on paradise where we found this issue, bluespace anomalies) could make it look like a fire came out of no where, as it is effectively invisible when in a pipe.
And the anomaly is likely destroyed when whatever it spawns in is destroyed, so ebeam anomalies would not even exist.

## Testing (with message admins not breakpoints)
Before: Some examples of the Supermatter spawning anomalies (with message admins showing their LOC on initialize) 
![image](https://github.com/user-attachments/assets/53696ff2-2617-47ad-9250-06a5ca537bb4)
After: After running the supermatter with high energy to spawn anomalies for a while:
![image](https://github.com/user-attachments/assets/0ee7df93-be4a-458c-a3bc-bd2f290cd2b7)

(Sorry if this needs a no GBP label or something for being a one line fix, first time pring here)
## Changelog
:cl:
fix: Anomalies no longer spawn in objects or mobs from the supermatter.
/:cl:
