### PR TITLE
All melee weapon damage temporarily slows cyborgs rather than just thrown weapon damage

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -29,9 +29,6 @@
 
 // Cyborg defines
 
-/// If an item does this or more throwing damage it will slow a borg down on hit
-#define CYBORG_THROW_SLOWDOWN_THRESHOLD 10
-
 /// Special value to reset cyborg's lamp_cooldown
 #define BORG_LAMP_CD_RESET -1
 /// How many watts per lamp power is consumed while the lamp is on.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -358,18 +358,6 @@
 
 	return FALSE
 
-/mob/living/silicon/robot/attack_effects(damage_done, hit_zone, armor_block, obj/item/attacking_item, mob/living/attacker)
-	if(damage_done > 0 && attacking_item.damtype != STAMINA && stat != DEAD)
-		spark_system.start()
-		. = TRUE
-	return ..() || .
-
-/mob/living/silicon/ai/attack_effects(damage_done, hit_zone, armor_block, obj/item/attacking_item, mob/living/attacker)
-	if(damage_done > 0 && attacking_item.damtype != STAMINA && stat != DEAD)
-		spark_system.start()
-		. = TRUE
-	return ..() || .
-
 /mob/living/carbon/attack_effects(damage_done, hit_zone, armor_block, obj/item/attacking_item, mob/living/attacker)
 	var/obj/item/bodypart/hit_bodypart = get_bodypart(hit_zone) || bodyparts[1]
 	if(!hit_bodypart.can_bleed())
@@ -484,4 +472,3 @@
 		return " in the [input_area]"
 
 	return ""
-

--- a/code/datums/status_effects/debuffs/cyborg.dm
+++ b/code/datums/status_effects/debuffs/cyborg.dm
@@ -1,22 +1,31 @@
-/// Reduce a cyborg's speed when you throw things at it
-/datum/status_effect/borg_throw_slow
-	id = "borg_throw_slowdown"
-	alert_type = /atom/movable/screen/alert/status_effect/borg_throw_slow
+/// Slows down a cyborg for a short time.
+/datum/status_effect/borg_slow
+	id = "borg_slowdown"
+	alert_type = null
 	duration = 3 SECONDS
-	status_type = STATUS_EFFECT_REPLACE
+	status_type = STATUS_EFFECT_REFRESH
+	remove_on_fullheal = TRUE
+	heal_flag_necessary = HEAL_CC_STATUS
+	/// Amount of slowdown being applied
+	var/slowdown = 1
 
-/datum/status_effect/borg_throw_slow/on_apply()
+/datum/status_effect/borg_slow/on_creation(mob/living/new_owner, slowdown = 1)
+	src.slowdown = slowdown
+	return ..()
+
+/datum/status_effect/borg_slow/on_apply()
+	owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/borg_slowdown, multiplicative_slowdown = slowdown)
+	return TRUE
+
+/datum/status_effect/borg_slow/on_remove()
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/borg_slowdown)
+
+/datum/status_effect/borg_slow/refresh(mob/living/new_owner, slowdown = 1)
 	. = ..()
-	owner.add_movespeed_modifier(/datum/movespeed_modifier/borg_throw, update = TRUE)
+	if(src.slowdown <= slowdown)
+		return
+	src.slowdown = slowdown
+	owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/borg_slowdown, multiplicative_slowdown = src.slowdown)
 
-/datum/status_effect/borg_throw_slow/on_remove()
-	. = ..()
-	owner.remove_movespeed_modifier(/datum/movespeed_modifier/borg_throw, update = TRUE)
-
-/atom/movable/screen/alert/status_effect/borg_throw_slow
-	name = "Percussive Maintenance"
-	desc = "A sudden impact has triggered your collision avoidance routines, reducing movement speed."
-	icon_state = "weaken"
-
-/datum/movespeed_modifier/borg_throw
-	multiplicative_slowdown = 0.9
+/datum/movespeed_modifier/borg_slowdown
+	variable = TRUE

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -152,3 +152,9 @@
 	var/atom/ai_structure = ai_mob_to_structure()
 	ai_structure.balloon_alert(user, "disconnected neural network")
 	return ITEM_INTERACT_SUCCESS
+
+/mob/living/silicon/ai/attack_effects(damage_done, hit_zone, armor_block, obj/item/attacking_item, mob/living/attacker)
+	if(damage_done > 0 && attacking_item.damtype != STAMINA && stat != DEAD)
+		spark_system.start()
+		. = TRUE
+	return ..() || .

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -477,8 +477,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return
 	spark_system.start()
 
-/mob/living/silicon/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	. = ..()
-	if (. || AM.throwforce < CYBORG_THROW_SLOWDOWN_THRESHOLD)
-		return
-	apply_status_effect(/datum/status_effect/borg_throw_slow)
+/mob/living/silicon/robot/attack_effects(damage_done, hit_zone, armor_block, obj/item/attacking_item, mob/living/attacker)
+	if(damage_done > 0 && attacking_item.damtype != STAMINA && stat != DEAD)
+		spark_system.start()
+		. = TRUE
+	return ..() || .

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -138,3 +138,20 @@
 /mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, length = 25)
 	if(affect_silicon)
 		return ..()
+
+/// If an item does this or more throwing damage it will slow a borg down on hit
+#define CYBORG_SLOWDOWN_THRESHOLD 10
+
+/mob/living/silicon/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	. = ..()
+	if(. || AM.throwforce < CYBORG_SLOWDOWN_THRESHOLD) // can cyborgs even catch things?
+		return
+	apply_status_effect(/datum/status_effect/borg_slow, AM.throwforce / 20)
+
+/mob/living/silicon/attack_effects(damage_done, hit_zone, armor_block, obj/item/attacking_item, mob/living/attacker)
+	. = ..()
+	if(damage_done < CYBORG_SLOWDOWN_THRESHOLD)
+		return
+	apply_status_effect(/datum/status_effect/borg_slow, damage_done / 60)
+
+#undef CYBORG_SLOWDOWN_THRESHOLD


### PR DESCRIPTION
## About The Pull Request

Cyborgs will now be temporarily slowed down when hit with **any melee weapon**, based on the strength of the weapon. 

Thrown weapons maintain their behavior of slowing cyborgs, and they also now scale based on strength of the weapon.

Thrown weapon slowdown is also stronger (3x stronger) than just hitting them. So you are still incentivized(?) to use the existing mechanic. To catch up to them, I guess.

## Why It's Good For The Game

So, this mechanic was added as a new counterbalance to cyborgs due to no longer being stunned in a single flash. 
But 1 year later I polled the community, and the results speak for themself:

![image](https://github.com/user-attachments/assets/bafb043f-2201-4122-8c68-ccc746046c0a)

![image](https://github.com/user-attachments/assets/f71b7048-1b98-4c05-aebb-0b8393572f7e)

It is my opinion that this mechanic is too obscure and a bit obtuse to work as a "mechanical counter" to the cyborg.
"Yeah to catch up to a cyborg you have to throw a floor tile or a potted plant at them."
"You mean I can't just *hit* them with the potted plant?"
"No, you gotta chuck it."

This PR aims to address that by tweaking the mechanic to trigger on any weapon attacks. Which in my mind, makes sense. "Hitting borgs with stuff will slow them down temporarily" is easier to parse and observe in practice than "THROWING stuff at borgs will slow them down".


## Changelog

:cl: Melbert
balance: Cyborgs are now slowed down when hit with any melee weapons, rather than ONLY when they are hit by THROWN melee weapons. The stronger the weapon, the stronger the slowdown. Thrown weapons are still more effective at slowing than just hitting them directly, however.
/:cl:


