### PR TITLE
Fixes xeno queen not being able to promote a drone into a praetorian

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -29,6 +29,8 @@
 		/obj/item/toy/toy_xeno,
 		/obj/item/sticker, //funny ~Jimmyl
 		/obj/item/toy/plush/rouny,
+		/obj/item/hand_item,
+		/obj/item/queen_promotion,
 	))
 
 /mob/living/carbon/alien/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Fixes #87116, and also gives back the ability to use hand emotes as xenos could previously

## Why is it Good For The Game™
I believe it is xeno's spess god given right to be able to kiss their youngins on the forehead. Also bug fix good i guess
## Changelog

:cl:
fix: Xeno queens can once again promote Drones to Praetorians
fix: They can also once again do hand emotes
/:cl:

