### PR TITLE
Fixes ghosts not being able to check IDs from afar

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -105,7 +105,7 @@
 		if(HAS_TRAIT(src, TRAIT_UNKNOWN))
 			to_chat(viewer, span_notice("You can't make out that ID anymore."))
 			return
-		if(get_dist(viewer, src) > ID_EXAMINE_DISTANCE + 1) // leeway
+		if(!isobserver(viewer) && get_dist(viewer, src) > ID_EXAMINE_DISTANCE + 1) // leeway, ignored if the viewer is a ghost
 			to_chat(viewer, span_notice("You can't make out that ID from here."))
 			return
 


### PR DESCRIPTION

## About The Pull Request

You can now see the details as a ghost from someone's ID from any distance, as you are no longer shackled by the contrainsts of the living

## Why It's Good For The Game

quite silly to give a distance checks to ghosts if ya ask me

## Changelog

:cl:
fix: Ghosts can now see the details of an ID from any distance
/:cl:

