### PR TITLE
Reverts a check added in `[NO GBP] Fixes drone toolbox issues`, fixes clothing unequipping, unit test

### DIFF
--- a/code/datums/components/holderloving.dm
+++ b/code/datums/components/holderloving.dm
@@ -81,5 +81,12 @@
 /datum/component/holderloving/proc/no_unequip(obj/item/I, force, atom/newloc, no_move, invdrop, silent)
 	SIGNAL_HANDLER
 
-	if(!isturf(newloc) && invdrop)
-		return COMPONENT_ITEM_BLOCK_UNEQUIP
+	// just allow it
+	if(force)
+		return NONE
+	// dropping onto a turf just forcemoves it back to the holder. let it happen, it's intuitive
+	// no_move says it's just going to be moved a second time. so let it happen, it'll just be moved back if it's invalid anyway
+	if(isturf(newloc) || no_move)
+		return NONE
+	// the item is being unequipped to somewhere invalid. stop it
+	return COMPONENT_ITEM_BLOCK_UNEQUIP

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -613,7 +613,7 @@
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user && outside_storage)
-		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src, idrop = FALSE))
+		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
 
 	. = FALSE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -118,6 +118,7 @@
 #include "circuit_component_category.dm"
 #include "client_colours.dm"
 #include "closets.dm"
+#include "clothing_drops_items.dm"
 #include "clothing_under_armor_subtype_check.dm"
 #include "combat.dm"
 #include "combat_stamina.dm"

--- a/code/modules/unit_tests/clothing_drops_items.dm
+++ b/code/modules/unit_tests/clothing_drops_items.dm
@@ -1,0 +1,54 @@
+/// Tests that removing a piece of clothing drops items that hold said piece of clothing
+/datum/unit_test/clothing_drops_items
+	abstract_type = /datum/unit_test/clothing_drops_items
+
+/datum/unit_test/clothing_drops_items/Run()
+	test_human()
+	test_android()
+
+/datum/unit_test/clothing_drops_items/proc/test_human()
+	var/list/dummy_items = allocate_items()
+	var/mob/living/carbon/human/consistent/dummy = allocate(__IMPLIED_TYPE__)
+
+	for(var/slot in dummy_items)
+		TEST_ASSERT(dummy.equip_to_slot_if_possible(dummy_items[slot], text2num(slot)), \
+			"[/datum/species/human::name] Dummy failed to equip one of the starting items ([dummy_items[slot]]). Test aborted.")
+
+	dummy.dropItemToGround(dummy.w_uniform)
+
+	for(var/slot in dummy_items)
+		var/obj/item/item = dummy_items[slot]
+		if(item.slot_flags & ITEM_SLOT_ICLOTHING)
+			continue
+		else if(item.slot_flags & (ITEM_SLOT_BACK|ITEM_SLOT_FEET))
+			TEST_ASSERT_EQUAL(item.loc, dummy, "[item] should not have been dropped when unequipping the jumpsuit from \a [/datum/species/human::name].")
+		else
+			TEST_ASSERT_NOT(item.loc, dummy.loc, "[item] should have been dropped when unequipping the jumpsuit from \a [/datum/species/human::name].")
+
+/datum/unit_test/clothing_drops_items/proc/test_android()
+	var/list/robo_dummy_items = allocate_items()
+	var/mob/living/carbon/human/consistent/robo_dummy = allocate(__IMPLIED_TYPE__)
+	robo_dummy.set_species(/datum/species/android)
+
+	for(var/slot in robo_dummy_items)
+		TEST_ASSERT(robo_dummy.equip_to_slot_if_possible(robo_dummy_items[slot], text2num(slot)), \
+			"[/datum/species/human::android] Dummy failed to equip one of the starting items ([robo_dummy_items[slot]]). Test aborted.")
+
+	robo_dummy.dropItemToGround(robo_dummy.w_uniform)
+
+	for(var/slot in robo_dummy_items)
+		var/obj/item/item = robo_dummy_items[slot]
+		if(item.slot_flags & ITEM_SLOT_ICLOTHING)
+			continue
+		TEST_ASSERT_EQUAL(item.loc, robo_dummy, "[item] should not have been dropped when unequipping the jumpsuit from \a [/datum/species/android::name].")
+
+/datum/unit_test/clothing_drops_items/proc/allocate_items()
+	return list(
+		"[ITEM_SLOT_ICLOTHING]" = allocate(/obj/item/clothing/under/color/rainbow), // do this one first, it holds everything
+		"[ITEM_SLOT_FEET]" = allocate(/obj/item/clothing/shoes/jackboots),
+		"[ITEM_SLOT_BELT]" = allocate(/obj/item/storage/belt/utility),
+		"[ITEM_SLOT_BACK]" = allocate(/obj/item/storage/backpack),
+		"[ITEM_SLOT_ID]" = allocate(/obj/item/card/id/advanced/gold/captains_spare),
+		"[ITEM_SLOT_RPOCKET]" = allocate(/obj/item/assembly/flash/handheld),
+		"[ITEM_SLOT_LPOCKET]" = allocate(/obj/item/toy/plush/lizard_plushie),
+	)

--- a/code/modules/unit_tests/clothing_drops_items.dm
+++ b/code/modules/unit_tests/clothing_drops_items.dm
@@ -31,7 +31,7 @@
 
 	for(var/slot in robo_dummy_items)
 		TEST_ASSERT(robo_dummy.equip_to_slot_if_possible(robo_dummy_items[slot], text2num(slot)), \
-			"[/datum/species/human::android] Dummy failed to equip one of the starting items ([robo_dummy_items[slot]]). Test aborted.")
+			"[/datum/species/android::name] Dummy failed to equip one of the starting items ([robo_dummy_items[slot]]). Test aborted.")
 
 	robo_dummy.dropItemToGround(robo_dummy.w_uniform)
 

--- a/code/modules/unit_tests/clothing_drops_items.dm
+++ b/code/modules/unit_tests/clothing_drops_items.dm
@@ -22,7 +22,7 @@
 		else if(item.slot_flags & (ITEM_SLOT_BACK|ITEM_SLOT_FEET))
 			TEST_ASSERT_EQUAL(item.loc, dummy, "[item] should not have been dropped when unequipping the jumpsuit from \a [/datum/species/human::name].")
 		else
-			TEST_ASSERT_NOT(item.loc, dummy.loc, "[item] should have been dropped when unequipping the jumpsuit from \a [/datum/species/human::name].")
+			TEST_ASSERT_EQUAL(item.loc, dummy.loc, "[item] should have been dropped when unequipping the jumpsuit from \a [/datum/species/human::name].")
 
 /datum/unit_test/clothing_drops_items/proc/test_android()
 	var/list/robo_dummy_items = allocate_items()

--- a/code/modules/unit_tests/clothing_drops_items.dm
+++ b/code/modules/unit_tests/clothing_drops_items.dm
@@ -1,6 +1,5 @@
 /// Tests that removing a piece of clothing drops items that hold said piece of clothing
 /datum/unit_test/clothing_drops_items
-	abstract_type = /datum/unit_test/clothing_drops_items
 
 /datum/unit_test/clothing_drops_items/Run()
 	test_human()


### PR DESCRIPTION
## About The Pull Request

Fixes #87129

[This change](https://github.com/tgstation/tgstation/pull/87073/files#diff-c8ab5fbc20de60e202b839834b039649cbb69a1c4b99b27a5e467f3889442ccd) added in #87073, passing `invdrop = FALSE` to `doUnEquip`, breaks the behavior of unequipping dropping your items. Because that's what `invdrop` does. If you pass it as `FALSE` it prevents other items from dropping off the mob, intended for like, outfit use / "quick swapping" an item out

So I reverted it. Drone tools still seem to work I guess. @SyncIt21 

## Changelog

:cl: Melbert
fix: Fixes stuff staying on your body after removing your clothes
/:cl:
