### PR TITLE
Fixes server hop not fading the screen to black

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -76,7 +76,8 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	var/client/C = client
 	to_chat(C, span_notice("Sending you to [pick]."))
-	new /atom/movable/screen/splash(null, null, C)
+	var/atom/movable/screen/splash/S = new(null, null, C)
+	S.Fade(FALSE)
 
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)
 	sleep(2.9 SECONDS) //let the animation play


### PR DESCRIPTION

## About The Pull Request

Fixes #29496 ... probably? I can't actually test this on a localhost but it SHOULD work now

## Changelog

:cl:
fix: Server Hopping should fade your screen into black, as it should.
/:cl:

