### PR TITLE
Knock mansus can emag electronic.

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -83,10 +83,8 @@
 	else if(istype(target,/obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/door = target
 		door.unbolt()
-	else if(istype(target, /obj/machinery/computer))
-		var/obj/machinery/computer/computer = target
-		computer.authenticated = TRUE
-		computer.balloon_alert(source, "unlocked")
+	else if(isatom(target))
+		target.emag_act(source)
 
 	var/turf/target_turf = get_turf(target)
 	SEND_SIGNAL(target_turf, COMSIG_ATOM_MAGICALLY_UNLOCKED, src, source)


### PR DESCRIPTION
## About The Pull Request

Knock mansus emags electronics with second attack. Doors opening and mech removing work as they did without emag system.

## Why It's Good For The Game

Adds more immersive ideas to Heretic.

## Changelog

:cl:
balance: Knock mansus now can emag electronic.
/:cl:
