### PR TITLE
[NO GBP] Prevents walls from slowing your drifting down when you're moving in the same direction as your pressed movement key

### DIFF
--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -213,6 +213,10 @@
 	if (drift_force < INERTIA_FORCE_SPACEMOVE_GRAB || isnull(drifting_loop))
 		return
 
+	if (!isnull(source.client) && source.client.intended_direction)
+		if ((source.client.intended_direction & movement_dir) && !(get_dir(source, backup) & movement_dir))
+			return
+
 	if (drift_force <= INERTIA_FORCE_SPACEMOVE_REDUCTION / source.inertia_force_weight)
 		glide_to_halt(get_loop_delay(source))
 		return COMPONENT_PREVENT_SPACEMOVE_HALT


### PR DESCRIPTION

## About The Pull Request

Oopsie, this prevents walls from slowing your drift down if you're pressing a movement key and moving in your intended direction

## Why It's Good For The Game
Smoother movement when you're moving near a wall with a jetpack or tether or whatever really

## Changelog
:cl:
qol: Jetpack movement near walls should be much smoother
/:cl:
