### PR TITLE
Better ghost tray scan

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1061,8 +1061,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/proc/tray_view()
 	set category = "Ghost"
-	set name = "T-ray view"
-	set desc = "Toggles a view of sub-floor objects"
+	set name = "T-ray scan"
+	set desc = "Perfom a scan to view sub-floor objects"
 
 	if(SSlag_switch.measures[DISABLE_GHOST_ZOOM_TRAY] && !client?.holder)
 		to_chat(usr, span_notice("That verb is currently globally disabled."))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1064,28 +1064,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "T-ray view"
 	set desc = "Toggles a view of sub-floor objects"
 
-	var/static/t_ray_view = FALSE
-	if(SSlag_switch.measures[DISABLE_GHOST_ZOOM_TRAY] && !client?.holder && !t_ray_view)
+	if(SSlag_switch.measures[DISABLE_GHOST_ZOOM_TRAY] && !client?.holder)
 		to_chat(usr, span_notice("That verb is currently globally disabled."))
 		return
-	t_ray_view = !t_ray_view
 
-	var/list/t_ray_images = list()
-	var/static/list/stored_t_ray_images = list()
-	for(var/obj/O in orange(client.view, src) )
-		if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
-			var/image/I = new(loc = get_turf(O))
-			var/mutable_appearance/MA = new(O)
-			MA.alpha = 128
-			MA.dir = O.dir
-			I.appearance = MA
-			t_ray_images += I
-	stored_t_ray_images += t_ray_images
-	if(length(t_ray_images))
-		if(t_ray_view)
-			client.images += t_ray_images
-		else
-			client.images -= stored_t_ray_images
+	t_ray_scan(src)
 
 /mob/dead/observer/default_lighting_cutoff()
 	var/datum/preferences/prefs = client?.prefs


### PR DESCRIPTION

## About The Pull Request

Partially improves:
* #46002 

Previously, the ghost's "t-ray view" acted as a toggle, even though the scan only occurred once. This PR changes it to function as an action rather than a toggle, removing the need to press the button twice.

While the ideal solution would be for the t-ray scan to work on the process tick, my attempt to give ghosts their own t-ray scanner and to toggle it on upon using the verb did not work as expected because the scanner didn't recognize the ghost as its holder (`mob/viewer` in the code).

This update serves as an improvement to the current behaviour, but in the future, the t-ray scan verb should function like a normal t-ray scanner, instead of just a one-time scan.
## Why It's Good For The Game

Improves the t-ray verb, before it acted as a toggle even though it only worked once upon toggling on. Improves user experience using this verb.
## Changelog
:cl:
fix: the ghost "t-ray view" no longer requires a double press to activate a second time.
qol: renamed "t-ray view" to "t-ray scan" for clarity.
/:cl:
