### PR TITLE
Fix double injections

### DIFF
--- a/code/datums/elements/venomous.dm
+++ b/code/datums/elements/venomous.dm
@@ -42,9 +42,16 @@
 	else
 		final_amount_added = amount_added
 
-	var/datum/reagents/tmp_holder = new/datum/reagents(50)
+	var/datum/reagents/tmp_holder = new(final_amount_added)
 	tmp_holder.my_atom = src
 	tmp_holder.add_reagent(reagents, final_amount_added)
 
-	tmp_holder.expose(target, INJECT, 1, FALSE)
+	tmp_holder.trans_to(
+		target = target,
+		amount = tmp_holder.total_volume,
+		multiplier = 1,
+		methods = INJECT,
+		transferred_by = ismob(element_owner) ? element_owner : null,
+		show_message = FALSE,
+	)
 	qdel(tmp_holder)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -123,8 +123,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	. = SEND_SIGNAL(src, COMSIG_REAGENT_EXPOSE_MOB, exposed_mob, methods, reac_volume, show_message, touch_protection)
-	if((penetrates_skin|INJECT) & methods) //methods being
-		var/amount = round(reac_volume*clamp((1 - touch_protection), 0, 1), 0.1)
+	if(penetrates_skin & methods) // models things like vapors which penetrate the skin
+		var/amount = round(reac_volume * clamp((1 - touch_protection), 0, 1), 0.1)
 		if(amount >= 0.5)
 			exposed_mob.reagents.add_reagent(type, amount, added_purity = purity)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #87146

Forcing all injections to penetrate skin means all injections double added reagents (when using trans to)

I think this is a larger problem with this block of code but I'm investigating it in another pr

## Changelog

:cl: Melbert
fix: Fixed medipens injecting 2x their contents
/:cl:

