### PR TITLE
Gives jammers a secondary ability that allows to disable someone's radio mic

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -70,6 +70,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	if(ispath(keyslot2))
 		keyslot2 = new keyslot2()
 	set_listening(TRUE)
+	set_broadcasting(TRUE)
 	recalculateChannels()
 	possibly_deactivate_in_loc()
 
@@ -114,6 +115,22 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		return
 	for(var/language in language_list)
 		user.remove_language(language, language_flags = UNDERSTOOD_LANGUAGE, source = LANGUAGE_RADIOKEY)
+
+// Headsets do not become hearing sensitive as broadcasting instead controls their talk_into capabilities
+/obj/item/radio/headset/set_broadcasting(new_broadcasting, actual_setting = TRUE)
+	broadcasting = new_broadcasting
+	if(actual_setting)
+		should_be_broadcasting = broadcasting
+
+	if (perform_update_icon && !isnull(overlay_mic_idle))
+		update_icon()
+	else if (!perform_update_icon)
+		should_update_icon = TRUE
+
+/obj/item/radio/headset/talk_into_impl(atom/movable/talking_movable, message, channel, list/spans, datum/language/language, list/message_mods)
+	if (!broadcasting)
+		return
+	return ..()
 
 /obj/item/radio/headset/syndicate //disguised to look like a normal headset for stealth ops
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -329,7 +329,7 @@ effective or pretty fucking useless.
 
 /obj/item/jammer
 	name = "radio jammer"
-	desc = "Device used to disrupt nearby radio communication. Alternate function creates a powerful distruptor wave which disables all listening devices nearby."
+	desc = "Device used to disrupt nearby radio communication. Alternate function creates a powerful distruptor wave which disables all nearby listening devices."
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
 	icon_state = "jammer"
 	var/active = FALSE

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -337,25 +337,37 @@ effective or pretty fucking useless.
 	var/jam_cooldown_duration = 15 SECONDS
 	COOLDOWN_DECLARE(jam_cooldown)
 
+/obj/item/jammer/Initialize(mapload)
+	. = ..()
+	register_context()
+
+/atom/movable/screen/alert/give/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_LMB] = "Release distruptor wave"
+	context[SCREENTIP_CONTEXT_RMB] = "Toggle"
+	return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/jammer/attack_self(mob/user, modifiers)
 	. = ..()
+	if (!COOLDOWN_FINISHED(src, jam_cooldown))
+		user.balloon_alert(user, "on cooldown!")
+		return
+
+	user.balloon_alert(user, "distruptor wave released!")
+	to_chat(user, span_notice("You release a distruptor wave, disabling all nearby radio devices."))
+	for (var/atom/potential_owner in view(7, user))
+		disable_radios_on(potential_owner)
+	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
+
+/obj/item/jammer/attack_self_secondary(mob/user, modifiers)
+	. = ..()
 	to_chat(user, span_notice("You [active ? "deactivate" : "activate"] [src]."))
+	user.balloon_alert(user, "[active ? "deactivated" : "activated"] the jammer")
 	active = !active
 	if(active)
 		GLOB.active_jammers |= src
 	else
 		GLOB.active_jammers -= src
 	update_appearance()
-
-/obj/item/jammer/attack_self_secondary(mob/user, modifiers)
-	. = ..()
-	if (!COOLDOWN_FINISHED(src, jam_cooldown))
-		user.balloon_alert(user, "on cooldown!")
-		return
-	to_chat(user, span_notice("You release a distruptor wave, disabling all nearby radio devices."))
-	for (var/atom/potential_owner in view(7, user))
-		disable_radios_on(potential_owner)
-	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
 
 /obj/item/jammer/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	. = ..()
@@ -367,6 +379,7 @@ effective or pretty fucking useless.
 		user.balloon_alert(user, "out of reach!")
 		return
 
+	interacting_with.balloon_alert(user, "radio distrupted!")
 	to_chat(user, span_notice("You release a directed distruptor wave, disabling all radio devices on [interacting_with]."))
 	disable_radios_on(interacting_with)
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -363,6 +363,10 @@ effective or pretty fucking useless.
 	if(. & ITEM_INTERACT_ANY_BLOCKER)
 		return
 
+	if (!(interacting_with in view(7, user)))
+		user.balloon_alert(user, "out of reach!")
+		return
+
 	to_chat(user, span_notice("You release a directed distruptor wave, disabling all radio devices on [interacting_with]."))
 	disable_radios_on(interacting_with)
 


### PR DESCRIPTION
## About The Pull Request

Radio jammers can now disable someone's radio mic, both in AOE (right self-click on cooldown) and for on a specific target. For this to work headsets had to be adjusted to require broadcasting to be active in order to use their mic (it is now active by default and doesn't pick up nearby speech automatically).

## Why It's Good For The Game

Jammers aren't very strong and this buff will allow for better stealth gameplay, as you cannot tell that you've been jammed this way until its too late as you still can hear others' speech. Requested by Mothblocks on discord (thus no GBP label).

## Changelog
:cl:
add: Jammers can now disable players' radio microphones via a new secondary ability, both for handhelds and headsets
/:cl:
