### PR TITLE
Fix dead bees not being their proper bee self

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -100,13 +100,8 @@
 	return ..()
 
 /mob/living/basic/bee/death(gibbed)
-	if(beehome)
-		beehome.bees -= src
-		beehome = null
-	beegent = null
-	if(flags_1 & HOLOGRAM_1 || gibbed)
-		return ..()
-	spawn_corpse()
+	if(!(flags_1 & HOLOGRAM_1) && !gibbed)
+		spawn_corpse()
 	return ..()
 
 /// Leave something to remember us by

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -99,6 +99,7 @@
 #include "bake_a_cake.dm"
 #include "barsigns.dm"
 #include "baseturfs.dm"
+#include "bee.dm"
 #include "bespoke_id.dm"
 #include "binary_insert.dm"
 #include "bitrunning.dm"

--- a/code/modules/unit_tests/bee.dm
+++ b/code/modules/unit_tests/bee.dm
@@ -1,0 +1,15 @@
+/// Test beegent transfer
+/datum/unit_test/beegent
+
+/datum/unit_test/beegent/Run()
+	var/mob/living/basic/bee/bee = allocate(__IMPLIED_TYPE__)
+	var/turf/bee_turf = get_turf(bee)
+	var/datum/reagent/picked = GLOB.chemical_reagents_list[/datum/reagent/toxin/fentanyl]
+	bee.assign_reagent(picked)
+	bee.death()
+	var/obj/item/trash/bee/dead_bee = locate() in bee_turf
+	TEST_ASSERT_NOTNULL(dead_bee, "The bee did not leave a corpse.")
+	TEST_ASSERT_EQUAL(dead_bee.beegent, picked, "The bee's corpse did not have the correct beegent assigned.")
+	TEST_ASSERT(dead_bee.reagents.has_reagent(/datum/reagent/toxin/fentanyl), "The bee's corpse did not contain any of the beegent.")
+	// clean up, we aren't allocated
+	QDEL_NULL(dead_bee)


### PR DESCRIPTION
## About The Pull Request

Fixes #87147

Whomever refactored bees null'd the beegent before spawning the corpse, and we pass the bee by ref into corpse init to grab beegent

## Changelog

:cl: Melbert
fix: Dead bees maintain their color and reagents
/:cl:

