### PR TITLE
Adds meowing and purring back for felinids

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -84,6 +84,30 @@
 	if(user.put_in_hands(N))
 		to_chat(user, span_notice("You make a circle with your hand."))
 
+/datum/emote/living/carbon/meow
+	key = "meow"
+	key_third_person = "meows"
+	vary = TRUE
+
+/datum/emote/living/carbon/meow/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(isfelinid(user))
+		sound = SFX_CAT_MEOW
+		message = "meows!"
+		emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
+
+/datum/emote/living/carbon/purr
+	key = "purr"
+	key_third_person = "purrs"
+	vary = TRUE
+
+/datum/emote/living/carbon/purr/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(isfelinid(user))
+		sound = SFX_CAT_PURR
+		message = "purrs."
+		emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
+
 /datum/emote/living/carbon/moan
 	key = "moan"
 	key_third_person = "moans"


### PR DESCRIPTION

## About The Pull Request
Adds emotes for meowing and purring. Only felinids can use these emotes and they mirror the new cat emotes exactly.

[2024-10-10 19-30-04.webm](https://github.com/user-attachments/assets/0d0c40e2-2299-4cce-ba96-6427ecae15b1)
## Why It's Good For The Game
There is currently a popular demand from felinid players to use these emote noises for silly cat sounds. Recently a PR allowed all mobs to meow, but it was patched to only cats from now on. Emulating the noises a cat makes as a felinid has given a lot of enjoyment to those playing from my own observations in-game. Cats are awesome!
:cl:
add: New purr and meow emotes for felinids
/:cl:
