### PR TITLE
Fix mopping on multi-z stations

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(turfs_pass_meteor, typecacheof(list(
 
 #define ismecha(A) (istype(A, /obj/vehicle/sealed/mecha))
 
-#define ismopable(A) (A && ((A.plane == FLOOR_PLANE) ? (A.layer <= FLOOR_CLEAN_LAYER) : (A.layer <= GAME_CLEAN_LAYER))) //If something can be cleaned by floor-cleaning devices such as mops or clean bots
+#define ismopable(A) (A && ((PLANE_TO_TRUE(A.plane) == FLOOR_PLANE) ? (A.layer <= FLOOR_CLEAN_LAYER) : (A.layer <= GAME_CLEAN_LAYER))) //If something can be cleaned by floor-cleaning devices such as mops or clean bots
 
 #define isorgan(A) (istype(A, /obj/item/organ))
 


### PR DESCRIPTION

## About The Pull Request
Mops and similar should check the true plane instead of whatever plane things end up at after being offset by z levels.
Fixes https://github.com/NovaSector/NovaSector/issues/4465
## Why It's Good For The Game
clean up this mess right now, before the ants show up
## Changelog
:cl:
fix: Mops and similar work properly on multi-z stations
/:cl:
