### PR TITLE
Offering an item displays a balloon alert to viewers

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -441,7 +441,7 @@
 	if(offered_item.on_offered(src)) // see if the item interrupts with its own behavior
 		return
 
-	src.balloon_alert_to_viewers("offers something")
+	balloon_alert_to_viewers("offers something")
 	visible_message(span_notice("[src] is offering [offered ? "[offered] " : ""][offered_item]."), \
 					span_notice("You offer [offered ? "[offered] " : ""][offered_item]."), null, 2)
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -441,6 +441,7 @@
 	if(offered_item.on_offered(src)) // see if the item interrupts with its own behavior
 		return
 
+	src.balloon_alert_to_viewers("offers something")
 	visible_message(span_notice("[src] is offering [offered ? "[offered] " : ""][offered_item]."), \
 					span_notice("You offer [offered ? "[offered] " : ""][offered_item]."), null, 2)
 


### PR DESCRIPTION

## About The Pull Request

https://github.com/user-attachments/assets/9103738d-1e97-47ad-aeeb-ef5cd323a0a3

potentially could make it visible only to the offerer and to the offeree but the chat message is to viewers so I went with that
## Why It's Good For The Game
a lot of people don't see that they got offered an item, this will make it dead obvious.
## Changelog
:cl: grungussuss
qol: offering an item displays a balloon alert
/:cl:
