### PR TITLE
syndicate sleeper agents can forge custom objectives

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -191,7 +191,8 @@
 	data["current_progression_scaling"] = SStraitor.current_progression_scaling
 
 	data["maximum_potential_objectives"] = uplink_handler.maximum_potential_objectives
-	if(uplink_handler.has_objectives)
+
+	if(uplink_handler.primary_objectives)
 		var/list/primary_objectives = list()
 		for(var/datum/objective/task as anything in uplink_handler.primary_objectives)
 			var/list/task_data = list()
@@ -201,7 +202,9 @@
 				task_data["task_name"] = "DIRECTIVE [uppertext(GLOB.phonetic_alphabet[length(primary_objectives) + 1])]"
 			task_data["task_text"] = task.explanation_text
 			primary_objectives += list(task_data)
+		data["primary_objectives"] = primary_objectives
 
+	if(uplink_handler.has_objectives)
 		var/list/potential_objectives = list()
 		for(var/index in 1 to uplink_handler.potential_objectives.len)
 			var/datum/traitor_objective/objective = uplink_handler.potential_objectives[index]
@@ -216,7 +219,7 @@
 			objective_data["id"] = index
 			active_objectives += list(objective_data)
 
-		data["primary_objectives"] = primary_objectives
+
 		data["potential_objectives"] = potential_objectives
 		data["active_objectives"] = active_objectives
 		data["completed_final_objective"] = uplink_handler.final_objective

--- a/tgui/packages/tgui/interfaces/Uplink/calculateDangerLevel.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/calculateDangerLevel.tsx
@@ -70,8 +70,6 @@ export const ranks: Rank[] = [
   },
 ];
 
-export const dangerDefault = 50 * 600;
-
 let lastMinutesThan = -1;
 export const dangerLevelsTooltip = (
   <Box preserveWhitespace>

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -18,7 +18,6 @@ import { Window } from '../../layouts';
 import {
   calculateDangerLevel,
   calculateProgression,
-  dangerDefault,
   dangerLevelsTooltip,
 } from './calculateDangerLevel';
 import { GenericUplink, Item } from './GenericUplink';
@@ -285,101 +284,93 @@ export class Uplink extends Component<{}, UplinkState> {
       <Window width={700} height={600} theme="syndicate">
         <Window.Content>
           <Stack fill vertical>
-            {!!has_progression && (
-              <Stack.Item>
-                <Section fitted>
-                  <Stack fill>
+            <Stack.Item>
+              <Section fitted>
+                <Stack fill>
+                  {!!has_progression && (
                     <Stack.Item p="4px">
                       <Tooltip
                         content={
-                          (!!has_progression && (
+                          <Box>
                             <Box>
-                              <Box>
-                                <Box>Your current level of threat.</Box> Threat
-                                determines
-                                {has_objectives
-                                  ? ' the severity of secondary objectives you get and '
-                                  : ' '}
-                                what items you can purchase.&nbsp;
-                                <Box mt={0.5}>
-                                  {/* A minute in deciseconds */}
-                                  Threat passively increases by{' '}
-                                  <Box color="green" as="span">
-                                    {calculateProgression(
-                                      current_progression_scaling,
-                                    )}
-                                  </Box>
-                                  &nbsp;every minute
+                              <Box>Your current level of threat.</Box> Threat
+                              determines
+                              {has_objectives
+                                ? ' the severity of secondary objectives you get and '
+                                : ' '}
+                              what items you can purchase.&nbsp;
+                              <Box mt={0.5}>
+                                {/* A minute in deciseconds */}
+                                Threat passively increases by{' '}
+                                <Box color="green" as="span">
+                                  {calculateProgression(
+                                    current_progression_scaling,
+                                  )}
                                 </Box>
-                                {Math.abs(progressionPercentage) > 0 && (
-                                  <Box mt={0.5}>
-                                    Because your threat level is
-                                    {progressionPercentage < 0
-                                      ? ' ahead '
-                                      : ' behind '}
-                                    of where it should be, you are getting
-                                    <Box
-                                      as="span"
-                                      color={
-                                        progressionPercentage < 0
-                                          ? 'red'
-                                          : 'green'
-                                      }
-                                      ml={1}
-                                      mr={1}
-                                    >
-                                      {progressionPercentage}%
-                                    </Box>
-                                    {progressionPercentage < 0
-                                      ? 'less'
-                                      : 'more'}{' '}
-                                    threat every minute
-                                  </Box>
-                                )}
-                                {dangerLevelsTooltip}
+                                &nbsp;every minute
                               </Box>
+                              {Math.abs(progressionPercentage) > 0 && (
+                                <Box mt={0.5}>
+                                  Because your threat level is
+                                  {progressionPercentage < 0
+                                    ? ' ahead '
+                                    : ' behind '}
+                                  of where it should be, you are getting
+                                  <Box
+                                    as="span"
+                                    color={
+                                      progressionPercentage < 0
+                                        ? 'red'
+                                        : 'green'
+                                    }
+                                    ml={1}
+                                    mr={1}
+                                  >
+                                    {progressionPercentage}%
+                                  </Box>
+                                  {progressionPercentage < 0 ? 'less' : 'more'}{' '}
+                                  threat every minute
+                                </Box>
+                              )}
+                              {dangerLevelsTooltip}
                             </Box>
-                          )) ||
-                          "Your current threat level. You are a killing machine and don't need to improve your threat level."
+                          </Box>
                         }
                       >
-                        {/* If we have no progression,
-                                  just give them a generic title */}
-                        {has_progression
-                          ? calculateDangerLevel(progression_points, false)
-                          : calculateDangerLevel(dangerDefault, false)}
+                        {calculateDangerLevel(progression_points, false)}
                       </Tooltip>
                     </Stack.Item>
-
+                  )}
+                  {(primary_objectives || has_objectives) && (
                     <Stack.Item grow={1}>
                       <Tabs fluid>
+                        {primary_objectives && (
+                          <Tabs.Tab
+                            style={{
+                              overflow: 'hidden',
+                              whiteSpace: 'nowrap',
+                              textOverflow: 'ellipsis',
+                            }}
+                            icon="star"
+                            selected={currentTab === 0}
+                            onClick={() => this.setState({ currentTab: 0 })}
+                          >
+                            Primary Objectives
+                          </Tabs.Tab>
+                        )}
                         {!!has_objectives && (
-                          <>
-                            <Tabs.Tab
-                              style={{
-                                overflow: 'hidden',
-                                whiteSpace: 'nowrap',
-                                textOverflow: 'ellipsis',
-                              }}
-                              icon="star"
-                              selected={currentTab === 0}
-                              onClick={() => this.setState({ currentTab: 0 })}
-                            >
-                              Primary Objectives
-                            </Tabs.Tab>
-                            <Tabs.Tab
-                              style={{
-                                overflow: 'hidden',
-                                whiteSpace: 'nowrap',
-                                textOverflow: 'ellipsis',
-                              }}
-                              icon="star-half-stroke"
-                              selected={currentTab === 1}
-                              onClick={() => this.setState({ currentTab: 1 })}
-                            >
-                              Secondary Objectives
-                            </Tabs.Tab>
-                          </>
+                          <Tabs.Tab
+                            style={{
+                              overflow: 'hidden',
+                              whiteSpace: 'nowrap',
+                              textOverflow: 'ellipsis',
+                            }}
+                            icon="star-half-stroke"
+                            selected={currentTab === 1}
+                            onClick={() => this.setState({ currentTab: 1 })}
+                          >
+                            Secondary Objectives
+                          </Tabs.Tab>
                         )}
                         <Tabs.Tab
                           style={{
@@ -388,34 +379,34 @@ export class Uplink extends Component<{}, UplinkState> {
                             textOverflow: 'ellipsis',
                           }}
                           icon="store"
-                          selected={currentTab === 2 || !has_objectives}
+                          selected={currentTab === 2}
                           onClick={() => this.setState({ currentTab: 2 })}
                         >
                           Market
                         </Tabs.Tab>
                       </Tabs>
                     </Stack.Item>
+                  )}
 
-                    {!!lockable && (
-                      <Stack.Item>
-                        <Button
-                          lineHeight={2.5}
-                          textAlign="center"
-                          icon="lock"
-                          color="transparent"
-                          px={2}
-                          onClick={() => act('lock')}
-                        >
-                          Lock
-                        </Button>
-                      </Stack.Item>
-                    )}
-                  </Stack>
-                </Section>
-              </Stack.Item>
-            )}
+                  {!!lockable && (
+                    <Stack.Item>
+                      <Button
+                        lineHeight={2.5}
+                        textAlign="center"
+                        icon="lock"
+                        color="transparent"
+                        px={2}
+                        onClick={() => act('lock')}
+                      >
+                        Lock
+                      </Button>
+                    </Stack.Item>
+                  )}
+                </Stack>
+              </Section>
+            </Stack.Item>
             <Stack.Item grow>
-              {(currentTab === 0 && has_objectives && (
+              {(currentTab === 0 && primary_objectives && (
                 <PrimaryObjectiveMenu
                   primary_objectives={primary_objectives}
                   final_objective={completed_final_objective}


### PR DESCRIPTION
## About The Pull Request

The removal of the ability for midround traitors to take progression objectives had the run-on effect of preventing them from using their uplink to view their primary objectives, which also means they cant forge custom objectives. This PR changes that, and provides additional logic in uplink ui code to account for uplinks belonging to traitors with one type of objective but not the other.

## Why It's Good For The Game

Fixes #86763

## Changelog

:cl:
fix: Syndicate Sleeper Agents can once again forge custom objectives
/:cl:
