### PR TITLE
Changes incorrect override in untie shoes spell

### DIFF
--- a/code/modules/spells/spell_types/pointed/tie_shoes.dm
+++ b/code/modules/spells/spell_types/pointed/tie_shoes.dm
@@ -46,7 +46,7 @@
 	return isliving(cast_on)
 
 // We need to override this, as trying to change next_use_time in cast() will just result in it being overridden.
-/datum/action/cooldown/spell/touch/before_cast(atom/cast_on)
+/datum/action/cooldown/spell/pointed/untie_shoes/before_cast(atom/cast_on)
 	return ..() | SPELL_NO_IMMEDIATE_COOLDOWN
 
 /datum/action/cooldown/spell/pointed/untie_shoes/cast(mob/living/carbon/cast_on)


### PR DESCRIPTION

## About The Pull Request

Closes #87181

## Changelog
:cl:
fix: Untie shoes should have its cooldown increased correctly when casting it from a long distance
/:cl:
