### PR TITLE
Improvements to mech sound logic

### DIFF
--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -29,6 +29,11 @@
 /obj/vehicle/sealed/mecha/proc/play_stepsound()
 	if(mecha_flags & QUIET_STEPS)
 		return
+
+	// if we are on the second step of the diagonal movement, don't play step sound
+	if(src.moving_diagonally == SECOND_DIAG_STEP)
+		return
+
 	playsound(src, stepsound, 40, TRUE)
 
 // Do whatever you do to mobs to these fuckers too
@@ -131,16 +136,22 @@
 				break
 
 	//if we're not facing the way we're going rotate us
-	if(dir != direction && (!strafe || forcerotate || keyheld))
-		if(dir != direction && !(mecha_flags & QUIET_TURNS) && !step_silent)
-			playsound(src,turnsound,40,TRUE)
-		setDir(direction)
-		if(keyheld || !pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
-			return TRUE
+	if(dir != direction)
+		// if we're not strafing or if we are forced to rotate or if we are holding down the key
+		if (!strafe || forcerotate || keyheld)
+			setDir(direction)
+
+			if(keyheld || !pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
+				return TRUE
 
 	set_glide_size(DELAY_TO_GLIDE_SIZE(movedelay))
 	//Otherwise just walk normally
 	. = try_step_multiz(direction)
+
+	//dir and olddir are the current direction of the sprite and the old direction of the sprite respectively
+	if (dir != olddir && !(mecha_flags & QUIET_TURNS))
+		playsound(src, turnsound, 40, TRUE)
+
 	if(phasing)
 		use_energy(phasing_energy_drain)
 	if(strafe)

--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -136,13 +136,11 @@
 				break
 
 	//if we're not facing the way we're going rotate us
-	if(dir != direction)
-		// if we're not strafing or if we are forced to rotate or if we are holding down the key
-		if (!strafe || forcerotate || keyheld)
-			setDir(direction)
-
-			if(keyheld || !pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
-				return TRUE
+	// if we're not strafing or if we are forced to rotate or if we are holding down the key
+	if(dir != direction && (!strafe || forcerotate || keyheld))
+		setDir(direction)
+		if(keyheld || !pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
+			return TRUE
 
 	set_glide_size(DELAY_TO_GLIDE_SIZE(movedelay))
 	//Otherwise just walk normally


### PR DESCRIPTION

## About The Pull Request

This PR makes it so mechs don't play footsteps twice diagonally, and also play the turn sound only when the sprite turns. No more ear blasting when walking diagonally!
## Why It's Good For The Game

It enhances the sound design by ensuring mechs no longer play footsteps twice when moving diagonally and that the turn sound only plays when the sprite actually turns.
## Changelog
:cl:
fix: fixed mech step sound playing twice diagonally
fix: fixed turn sound playing every time you move diagonally, now only plays when the sprite turns
/:cl:
