### PR TITLE
Fixes incorrect use of pronoun macros in multiple lives component

### DIFF
--- a/code/datums/components/multiple_lives.dm
+++ b/code/datums/components/multiple_lives.dm
@@ -46,7 +46,7 @@
 /datum/component/multiple_lives/proc/on_examine(mob/living/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 	if(isobserver(user) || source == user)
-		examine_list += "[source.p_Theyve()] [lives_left] extra lives left."
+		examine_list += "[source.p_They()] [source.p_have()] [lives_left] extra lives left."
 
 /datum/component/multiple_lives/InheritComponent(datum/component/multiple_lives/new_comp , lives_left)
 	src.lives_left += new_comp ? new_comp.lives_left : lives_left


### PR DESCRIPTION

## About The Pull Request

p_Theyve is not suited for this.

## Changelog
:cl:
spellcheck: Fixed a typo in multiple lives component
/:cl:
