### PR TITLE
Fundamentally Evil People/Undead are burned horribly by Mending Touch. Chaplains are not shaken by discovering EVAAAAL! Pacifist safe! Evil unsafe! Empaths beware!

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -404,7 +404,7 @@
 	if(evil_smite)
 		motherfucker_to_hurt.visible_message(span_warning("[smiter] snaps [smiter.p_their()] fingers in front of [motherfucker_to_hurt]'s face, and [motherfucker_to_hurt]'s body twists violently from an unseen force!"))
 		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BRUTE, wound_bonus = 5 * our_smite_multiplier)
-		motherfucker_to_hurt.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * our_smite_multiplier, 10 SECONDS)
+		motherfucker_to_hurt.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * our_smite_multiplier, 25 SECONDS)
 		smiter.emote("snap")
 		smite_text_to_target = "crushes you psychically with a snap of [smiter.p_their()] fingers"
 	else

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -354,7 +354,10 @@
 	var/hurt_this_guy = FALSE
 
 	if(HAS_TRAIT(mendicant, TRAIT_PACIFISM))
-		return FALSE //always return false for this if we're pacifist
+		return FALSE //always return false if we're pacifist
+
+	if(hurtguy.mob_biotypes & MOB_UNDEAD && mendicant.mob_biotypes & MOB_UNDEAD)
+		return FALSE //always return false if we're both undead //undead solidarity
 
 	if(hurtguy.mob_biotypes & MOB_UNDEAD && !HAS_TRAIT(mendicant, TRAIT_EVIL)) //Is the mob undead and we're not evil? If so, hurt.
 		hurt_this_guy = TRUE

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -406,7 +406,7 @@
 		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BRUTE, wound_bonus = 5 * our_smite_multiplier)
 		motherfucker_to_hurt.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * our_smite_multiplier, 10 SECONDS)
 		smiter.emote("snap")
-		smite_text_to_target = "crushes you psychically with a snap of [smiter.p_their()] fingers "
+		smite_text_to_target = "crushes you psychically with a snap of [smiter.p_their()] fingers"
 	else
 		motherfucker_to_hurt.visible_message(span_warning("[smiter] lays hands on [motherfucker_to_hurt], but it shears [motherfucker_to_hurt.p_them()] with a brilliant energy!"))
 		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BURN, wound_bonus = 5 * our_smite_multiplier)

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -403,13 +403,13 @@
 
 	if(evil_smite)
 		motherfucker_to_hurt.visible_message(span_warning("[smiter] snaps [smiter.p_their()] fingers in front of [motherfucker_to_hurt]'s face, and [motherfucker_to_hurt]'s body twists violently from an unseen force!"))
-		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BRUTE, wound_bonus = 5 * our_smite_multiplier)
+		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BRUTE, spread_damage = TRUE, wound_bonus = 5 * our_smite_multiplier)
 		motherfucker_to_hurt.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * our_smite_multiplier, 25 SECONDS)
 		smiter.emote("snap")
 		smite_text_to_target = "crushes you psychically with a snap of [smiter.p_their()] fingers"
 	else
 		motherfucker_to_hurt.visible_message(span_warning("[smiter] lays hands on [motherfucker_to_hurt], but it shears [motherfucker_to_hurt.p_them()] with a brilliant energy!"))
-		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BURN, wound_bonus = 5 * our_smite_multiplier)
+		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BURN, spread_damage = TRUE, wound_bonus = 5 * our_smite_multiplier)
 		motherfucker_to_hurt.adjust_fire_stacks(3 * our_smite_multiplier)
 		motherfucker_to_hurt.ignite_mob()
 

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -115,7 +115,7 @@
 /datum/action/cooldown/spell/touch/lay_on_hands
 	name = "Mending Touch"
 	desc = "You can now lay your hands on other people to transfer a small amount of their physical injuries to yourself. \
-		For some reason, this power does not play nicely with the undead or people with strange ideas about morality."
+		For some reason, this power does not play nicely with the undead, or people with strange ideas about morality."
 	button_icon = 'icons/mob/actions/actions_genetic.dmi'
 	button_icon_state = "mending_touch"
 	sound = 'sound/effects/magic/staff_healing.ogg'

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -221,8 +221,11 @@
 					. += "[t_He] [t_is] shivering."
 				if(HAS_TRAIT(src, TRAIT_EVIL))
 					. += "[t_His] eyes radiate with a unfeeling, cold detachment. There is nothing but darkness within [t_his] soul."
-					living_user.add_mood_event("encountered_evil", /datum/mood_event/encountered_evil)
-					living_user.set_jitter_if_lower(15 SECONDS)
+					if(living_user.mind?.holy_role >= HOLY_ROLE_PRIEST)
+						. += span_warning("PERFECT FOR SMITING!!")
+					else
+						living_user.add_mood_event("encountered_evil", /datum/mood_event/encountered_evil)
+						living_user.set_jitter_if_lower(15 SECONDS)
 
 			if(HAS_TRAIT(user, TRAIT_SPIRITUAL) && mind?.holy_role)
 				. += "[t_He] [t_has] a holy aura about [t_him]."


### PR DESCRIPTION
## About The Pull Request

At a baseline, Mending Touch now burns anyone who is undead or fundamentally evil.

Pacifists can still heal evil people, but avoid touching the undead with the healing hand.

Evil people psychically crush empaths, so long as they're not undead. Evil people can heal other evil people and undead (includeling evil chaps)

Undead can heal as normal, including other undead, but not evil people (its not a mutual friendship)

Chaplains incinerate potential targets especially well using mending touch. Chaplains and spiritualists even shout out their god's name as they do so. (but only chaps get the extra damage)

Empathic Chaplains are not shaken by identifying evil people. **THEY JUST SEE A NEW TARGET TO SMITE FOR THE CRUSADE.**

## Why It's Good For The Game

**Consistency:** Undead are negatively impacted by healing effects of a similar nature. Rather than make a whole new mutation to heal undead, instead, we apply some different rules to allow undead or evil people the opportunity to apply and have applied different effects based on their status.

**Evil people are already arbitrarily shafted by niche aspects of the game for fun:** It'd be funny if a well meaning medical staff member tries to use mending touch on an evil guy and they just burst into flames instead. Why? They took the quirk to screw over empaths and nothing else.

**Undead are immensely uncommon:** This isn't going to come up much whatsoever given that undead are almost unseen outside of Halloween. ~~What do you mean that's a few weeks away?~~

**Dumb Bullshit:** Empaths and Evil people are diametrically opposed for silly reasons. If Empaths still hurt undead, it stands to reason that evil people heal them out of pure spite. The two sides hurt one another with the mutation.

**Chaplains smiting people is funny:** Chaplains aren't the main users for the mutation, its mostly for medical staff, but they damn will seek it out a lot of the time to augment their existing healing powers. Since this is a feature about moral self-righteousness, its now especially funny for chaplains to be either one of the quirk holders primary enemy if they're on the opposing side.

## Changelog
:cl:
add: Mending touch now has additional effects based on whether or not the target or user is evil, an undead or an empath. Don't use mending touch on evil people or undead, or they might go up in flames. Though evil people can get back at empaths specifically and heal udnead as normal.
add: Chaplains engulf people using mending touch's harmful reactions to diametrically opposed entities especially well. Because of religious zeal, of course.
add: Empath chaplains ignore the fear consequences of examining an evil person. They instead get additional information about what to do to these people if the need arises.
/:cl:
