### PR TITLE
Fixing several fish-related issues.

### DIFF
--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -293,8 +293,6 @@
 
 /// Trait from an organ being inside a bodypart
 #define ORGAN_INSIDE_BODY_TRAIT "organ_inside_body"
-/// Trait when something was labelled by the /datum/element/tool_renaming element.
-#define RENAMING_TOOL_LABEL_TRAIT "renaming_tool_label"
 
 /// Trait when a drink was renamed by a shaker
 #define SHAKER_LABEL_TRAIT "shaker_trait"

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -86,7 +86,8 @@
 		gender = targeted_gender
 	else
 		gender = targeted_atom.gender
-	var/regex/pronoun_regex = regex("%PRONOUN(_(they|They|their|Their|theirs|Theirs|them|Them|have|are|were|do|theyve|Theyve|theyre|Theyre|s|es))")
+	///The pronouns are ordered by their length to avoid %PRONOUN_Theyve being translated to "Heve" instead of "He's", for example
+	var/regex/pronoun_regex = regex("%PRONOUN(_(theirs|Theirs|theyve|Theyve|theyre|Theyre|their|Their|they|They|them|Them|have|were|are|do|es|s))")
 	while(pronoun_regex.Find(target_string))
 		target_string = pronoun_regex.Replace(target_string, GET_TARGET_PRONOUN(targeted_atom, pronoun_regex.match, gender))
 	return target_string

--- a/code/datums/components/fish_growth.dm
+++ b/code/datums/components/fish_growth.dm
@@ -90,12 +90,12 @@
 		var/message_verb = del_on_grow ? "grows into" : "generates"
 		location.visible_message(span_notice("[source] [message_verb] \a [result]."), vision_distance = 3)
 
-	if(inherit_name && source.name != initial(source.name))
+	if(inherit_name && HAS_TRAIT(source, TRAIT_WAS_RENAMED))
 		if(ismob(result))
 			var/mob/mob = result
 			mob.fully_replace_character_name(mob.name, source.name)
 		else
-			result.name = source.name
+			result.AddComponent(/datum/component/rename, source.name, result.desc)
 
 	SEND_SIGNAL(source, COMSIG_FISH_FINISH_GROWING, result)
 

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -26,6 +26,7 @@
 	src.custom_name = custom_name
 	src.custom_desc = custom_desc
 	apply_rename()
+	ADD_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, type)
 
 /**
 	This proc will fire after the parent's name or desc is changed with a pen, which is trying to apply another rename component.
@@ -62,4 +63,5 @@
 
 /datum/component/rename/Destroy()
 	revert_rename()
+	REMOVE_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, type)
 	return ..()

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -26,7 +26,7 @@
 	src.custom_name = custom_name
 	src.custom_desc = custom_desc
 	apply_rename()
-	ADD_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, type)
+	ADD_TRAIT(parent, TRAIT_WAS_RENAMED, type)
 
 /**
 	This proc will fire after the parent's name or desc is changed with a pen, which is trying to apply another rename component.
@@ -63,5 +63,5 @@
 
 /datum/component/rename/Destroy()
 	revert_rename()
-	REMOVE_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, type)
+	REMOVE_TRAIT(parent, TRAIT_WAS_RENAMED, type)
 	return ..()

--- a/code/datums/elements/tool_renaming.dm
+++ b/code/datums/elements/tool_renaming.dm
@@ -51,7 +51,6 @@
 				return
 			renamed_obj.AddComponent(/datum/component/rename, input, renamed_obj.desc)
 			to_chat(user, span_notice("You have successfully renamed \the [old_name] to [renamed_obj]."))
-			ADD_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, RENAMING_TOOL_LABEL_TRAIT)
 			renamed_obj.update_appearance(UPDATE_NAME)
 
 		if(OPTION_DESCRIPTION)
@@ -64,13 +63,11 @@
 				return
 			renamed_obj.AddComponent(/datum/component/rename, renamed_obj.name, input)
 			to_chat(user, span_notice("You have successfully changed [renamed_obj]'s description."))
-			ADD_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, RENAMING_TOOL_LABEL_TRAIT)
 			renamed_obj.update_appearance(UPDATE_DESC)
 
 		if(OPTION_RESET)
 			qdel(renamed_obj.GetComponent(/datum/component/rename))
 			to_chat(user, span_notice("You have successfully reset [renamed_obj]'s name and description."))
-			REMOVE_TRAIT(renamed_obj, TRAIT_WAS_RENAMED, RENAMING_TOOL_LABEL_TRAIT)
 			renamed_obj.update_appearance(UPDATE_NAME | UPDATE_DESC)
 
 #undef OPTION_RENAME

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -223,8 +223,8 @@
 	icon_state = "gills"
 
 	safe_oxygen_min = 0 //We don't breathe this
-	///The required partial pressure of water_vapor for not drowing
-	var/safe_water_level = 29
+	///The required partial pressure of water_vapor for not suffocating.
+	var/safe_water_level = safe_oxygen_min::safe_oxygen_min
 
 	/// Bodypart overlay applied to the chest where the lungs are in
 	var/datum/bodypart_overlay/simple/gills/gills
@@ -301,7 +301,6 @@
 	name = "mutated semi-aquatic lungs"
 	desc = "DNA from an amphibious or semi-aquatic creature infused on a pair lungs. Enjoy breathing underwater without drowning outside water."
 	safe_oxygen_min = /obj/item/organ/internal/lungs::safe_oxygen_min
-	safe_water_level = 19
 	has_gills = FALSE
 	/**
 	 * If false, we don't breathe air since we've got water instead.

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -224,7 +224,7 @@
 
 	safe_oxygen_min = 0 //We don't breathe this
 	///The required partial pressure of water_vapor for not suffocating.
-	var/safe_water_level = safe_oxygen_min::safe_oxygen_min
+	var/safe_water_level = parent_type::safe_oxygen_min
 
 	/// Bodypart overlay applied to the chest where the lungs are in
 	var/datum/bodypart_overlay/simple/gills/gills

--- a/code/modules/fishing/admin.dm
+++ b/code/modules/fishing/admin.dm
@@ -33,8 +33,14 @@ ADMIN_VERB(fishing_calculator, R_DEBUG, "Fishing Calculator", "A calculator... f
 	switch(action)
 		if("recalc")
 			var/rod_type = text2path(params["rod"])
-			var/bait_type = text2path(params["bait"])
+			if(!rod_type)
+				to_chat(user, span_warning("A fishing rod is needed in order to fish."))
+				return
 			var/hook_type = text2path(params["hook"])
+			if(!hook_type)
+				to_chat(user, span_warning("A fishing hook is needed in order to fish."))
+				return
+			var/bait_type = text2path(params["bait"])
 			var/line_type = text2path(params["line"])
 			var/datum/fish_source/spot = GLOB.preset_fish_sources[text2path(params["spot"])]
 
@@ -45,8 +51,7 @@ ADMIN_VERB(fishing_calculator, R_DEBUG, "Fishing Calculator", "A calculator... f
 
 			if(bait_type)
 				temporary_rod.set_slot(new bait_type(temporary_rod), ROD_SLOT_BAIT)
-			if(hook_type)
-				temporary_rod.set_slot(new hook_type(temporary_rod), ROD_SLOT_HOOK)
+			temporary_rod.set_slot(new hook_type(temporary_rod), ROD_SLOT_HOOK)
 			if(line_type)
 				temporary_rod.set_slot(new line_type(temporary_rod), ROD_SLOT_LINE)
 

--- a/code/modules/fishing/aquarium/aquarium.dm
+++ b/code/modules/fishing/aquarium/aquarium.dm
@@ -356,7 +356,7 @@
 				fluid_type = params["fluid"]
 				SEND_SIGNAL(src, COMSIG_AQUARIUM_FLUID_CHANGED, fluid_type)
 				. = TRUE
-		if("reproduction_and_growth")
+		if("allow_breeding")
 			reproduction_and_growth = !reproduction_and_growth
 			. = TRUE
 		if("feeding_interval")
@@ -371,10 +371,10 @@
 			to_chat(user, span_notice("You take out [item] from [src]."))
 		if("rename_fish")
 			var/new_name = sanitize_name(params["chosen_name"])
-			if(!new_name)
-				return
 			var/atom/movable/fish = locate(params["fish_reference"]) in contents
-			fish.name = new_name
+			if(!fish || !new_name || new_name == fish.name)
+				return
+			fish.AddComponent(/datum/component/rename, new_name, fish.desc)
 
 /obj/structure/aquarium/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()

--- a/code/modules/fishing/aquarium/fish_analyzer.dm
+++ b/code/modules/fishing/aquarium/fish_analyzer.dm
@@ -119,12 +119,12 @@
 
 	data["fish_list"] += list(list(
 		"fish_name" = fishie.name,
-		"fish_icon" = fishie::icon,
-		"fish_icon_state" = fishie::icon_state,
+		"fish_icon" = fishie.icon,
+		"fish_icon_state" = fishie.base_icon_state,
 		"fish_health" = fishie.status == FISH_DEAD ? 0 : PERCENT(fishie.health/initial(fishie.health)),
 		"fish_size" = fishie.size,
 		"fish_weight" = fishie.weight,
-		"fish_food" = fishie.food::name,
+		"fish_food" = fishie.food.name,
 		"fish_food_color" = fishie.food::color,
 		"fish_min_temp" = fishie.required_temperature_min,
 		"fish_max_temp" = fishie.required_temperature_max,

--- a/code/modules/fishing/fish/types/station.dm
+++ b/code/modules/fishing/fish/types/station.dm
@@ -170,6 +170,10 @@
 	)
 	return return_list
 
+#define FISH_FRITTERISH "fritterish"
+#define FISH_BERNARD "bernard"
+#define FISH_MATTHEW "matthew"
+
 /obj/item/fish/fryish/fritterish
 	name = "fritterish"
 	desc = "A <u>deliciously</u> extremophile alien fish. This one looks like a taiyaki."
@@ -185,36 +189,44 @@
 	is_bait = FALSE
 	next_type = /datum/fish_evolution/nessie
 	growth_time = 8 MINUTES
+	///fritterish can have different forms assigned to them on init. These are purely visual.
+	var/variant = FISH_FRITTERISH
 
 /obj/item/fish/fryish/fritterish/Initialize(mapload, apply_qualities = TRUE)
 	. = ..()
-	base_icon_state = icon_state = pick("fritterish", "bernardfish", "matthewfish")
-	switch(icon_state)
-		if("bernardfish")
+	variant = pick(FISH_FRITTERISH, FISH_BERNARD, FISH_MATTHEW)
+	switch(variant)
+		if(FISH_BERNARD)
 			name = "bernard-fish"
 			desc = "A <u>deliciously</> extremophile alien fish shaped like a dinosaur. Children love it."
+			base_icon_state = icon_state = "bernardfish"
 			sprite_width = 4
 			sprite_height = 6
-		if("matthewfish")
-			desc = "A <u>deliciously</> extremophile alien fish shaped like a pterodactyl. Children love it."
+		if(FISH_MATTHEW)
 			name = "matthew-fish"
+			desc = "A <u>deliciously</> extremophile alien fish shaped like a pterodactyl. Children love it."
+			base_icon_state = icon_state = "matthewfish"
 			sprite_width = 6
 
 /obj/item/fish/fryish/fritterish/update_name()
-	switch(icon_state)
-		if("bernardfish")
+	switch(variant)
+		if(FISH_BERNARD)
 			name = "bernard-fish"
-		if("matthewfish")
+		if(FISH_MATTHEW)
 			name = "matthew-fish"
 	return ..()
 
 /obj/item/fish/fryish/fritterish/update_desc()
-	switch(icon_state)
-		if("bernardfish")
+	switch(variant)
+		if(FISH_BERNARD)
 			desc = "A <u>deliciously</> extremophile alien fish shaped like a dinosaur. Children love it."
-		if("matthewfish")
+		if(FISH_MATTHEW)
 			desc = "A <u>deliciously</> extremophile alien fish shaped like a pterodactyl. Children love it."
 	return ..()
+
+#undef FISH_FRITTERISH
+#undef FISH_BERNARD
+#undef FISH_MATTHEW
 
 /obj/item/fish/fryish/nessie
 	name = "nessie-fish"

--- a/code/modules/fishing/fish/types/station.dm
+++ b/code/modules/fishing/fish/types/station.dm
@@ -200,6 +200,22 @@
 			name = "matthew-fish"
 			sprite_width = 6
 
+/obj/item/fish/fryish/fritterish/update_name()
+	switch(icon_state)
+		if("bernardfish")
+			name = "bernard-fish"
+		if("matthewfish")
+			name = "matthew-fish"
+	return ..()
+
+/obj/item/fish/fryish/fritterish/update_desc()
+	switch(icon_state)
+		if("bernardfish")
+			desc = "A <u>deliciously</> extremophile alien fish shaped like a dinosaur. Children love it."
+		if("matthewfish")
+			desc = "A <u>deliciously</> extremophile alien fish shaped like a pterodactyl. Children love it."
+	return ..()
+
 /obj/item/fish/fryish/nessie
 	name = "nessie-fish"
 	desc = "A <u>deliciously</u> extremophile alien fish. This one is so big, you could write legends about it."

--- a/code/modules/fishing/fish_movement.dm
+++ b/code/modules/fishing/fish_movement.dm
@@ -96,7 +96,6 @@
 		target_position = round(new_target)
 		current_velocity_limit = long_jump_velocity_limit
 
-	target_acceleration
 	// Move towards target
 	if(!isnull(target_position))
 		var/distance = target_position - master.fish_position

--- a/code/modules/fishing/fish_movement.dm
+++ b/code/modules/fishing/fish_movement.dm
@@ -120,8 +120,8 @@
 					var/power = min(halved_ratio + 0.5, 1)
 					target_acceleration *= 1 - (halved_ratio^power)
 				/**
-				 * Otherwise we add the idle velocity (which we know is of opposite sign between
-				 * with absolute value between 0.ε and 0.5) to the target velocity
+				 * Otherwise we add the idle velocity (which we know is of opposite sign and
+				 * has an absolute value between 0.ε and 0.5) to the target velocity
 				 */
 				else
 					target_acceleration += idle_velocity

--- a/code/modules/fishing/fish_movement.dm
+++ b/code/modules/fishing/fish_movement.dm
@@ -96,6 +96,7 @@
 		target_position = round(new_target)
 		current_velocity_limit = long_jump_velocity_limit
 
+	target_acceleration
 	// Move towards target
 	if(!isnull(target_position))
 		var/distance = target_position - master.fish_position
@@ -103,7 +104,31 @@
 		var/acceleration_mult = get_acceleration(seconds_per_tick)
 		var/target_acceleration = distance * acceleration_mult * seconds_per_tick
 
+		if(fish_idle_velocity)
+			var/idle_velocity = fish_idle_velocity
+			var/abs_idle_vel = abs(idle_velocity)
+			//Make sure idle velocity doesn't manage to halt fish to a grind and getting them unable to move.
+			//First, check if the directions of the two forces are oppositve
+			if((idle_velocity / abs_idle_vel) != (target_acceleration / abs(target_acceleration)))
+				//Then, calculate the ratio between absolute idle velocity and halved acceleration multiplier.
+				var/halved_ratio = (acceleration_mult * 0.5) / abs_idle_vel
+				/**
+				 * If the idle velocity is more than half the acceleration,
+				 * proceed to use powers, for diminishing loss of acceleration per additional unit of idle velocity.
+				 * This way you never reach 0 acceleration while allowing more extreme values to keep lowering it.
+				 */
+				if(halved_ratio < 1)
+					var/power = min(halved_ratio + 0.5, 1)
+					target_acceleration *= 1 - (halved_ratio^power)
+				/**
+				 * Otherwise we add the idle velocity (which we know is of opposite sign between
+				 * with absolute value between 0.ε and 0.5) to the target velocity
+				 */
+				else
+					target_acceleration += idle_velocity
+
 		fish_velocity = fish_velocity * FISH_FRICTION_MULT + target_acceleration
+
 	else if(can_roll && prob(short_chance))
 		var/distance_from_top = FISHING_MINIGAME_AREA - master.fish_position - master.fish_height
 		var/distance_from_bottom = master.fish_position
@@ -115,7 +140,7 @@
 		target_position = clamp(master.fish_position + jump_length, 0, FISHING_MINIGAME_AREA - master.fish_height)
 		current_velocity_limit = short_jump_velocity_limit
 
-	fish_velocity = clamp(fish_velocity + fish_idle_velocity, -current_velocity_limit, current_velocity_limit)
+	fish_velocity = clamp(fish_velocity, -current_velocity_limit, current_velocity_limit)
 	set_fish_position(seconds_per_tick)
 
 ///Proc that returns the acceleration of the fish during the minigame.

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -423,8 +423,6 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 		var/obj/item/fish/prototype = reward
 		if(!(initial(prototype.fish_flags) & FISH_FLAG_SHOW_IN_CATALOG))
 			continue
-		var/weight = fish_table[reward]
-		total_weight += weight
 		rodless_weights[reward] = weight
 		if(rod)
 			var/mult = rod.bait ? rod.bait.check_bait(prototype) : 1
@@ -456,7 +454,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 
 	if(rod)
 		info = span_tooltip("boldened are the fish you're more likely to catch with your current setup. The opposite is true for smaller names", info)
-	examine_text += span_info("[info]: [english_list(known_fishes)].")
+	examine_text += examine_block(span_info("[info]: [english_list(known_fishes)]."))
 
 /datum/fish_source/proc/spawn_reward_from_explosion(atom/location, severity)
 	if(!explosive_malus)

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -408,8 +408,11 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	var/list/known_fishes = list()
 
 	var/obj/item/fishing_rod/rod = user.get_active_held_item()
-	if(!istype(rod))
+	var/list/final_table
+	if(!istype(rod) || !rod.hook)
 		rod = null
+	else
+		final_table = get_modified_fish_table(rod, user, location)
 
 	var/total_weight = 0
 	var/list/rodless_weights = list()
@@ -417,18 +420,19 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	var/list/rod_weights = list()
 	for(var/reward in fish_table)
 		var/weight = fish_table[reward]
-		total_weight += weight
+		var/final_weight
+		if(rod)
+			total_weight += weight
+			final_weight = final_table[reward]
+			total_rod_weight += final_weight
 		if(!ispath(reward, /obj/item/fish))
 			continue
 		var/obj/item/fish/prototype = reward
 		if(!(initial(prototype.fish_flags) & FISH_FLAG_SHOW_IN_CATALOG))
 			continue
-		rodless_weights[reward] = weight
 		if(rod)
-			var/mult = rod.bait ? rod.bait.check_bait(prototype) : 1
-			var/rod_weight = get_fish_trait_catch_mods(mult, reward, rod, user, location)
-			total_rod_weight += rod_weight
-			rod_weights[reward] = rod_weight
+			rodless_weights[reward] = weight
+			rod_weights[reward] = final_weight
 		else
 			known_fishes += initial(prototype.name)
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -411,22 +411,42 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	if(!istype(rod))
 		rod = null
 
+	var/total_weight = 0
+	var/list/rodless_weights = list()
+	var/total_rod_weight = 0
+	var/list/rod_weights = list()
 	for(var/reward in fish_table)
+		var/weight = fish_table[reward]
+		total_weight += weight
 		if(!ispath(reward, /obj/item/fish))
 			continue
 		var/obj/item/fish/prototype = reward
-		if(initial(prototype.fish_flags) & FISH_FLAG_SHOW_IN_CATALOG)
+		if(!(initial(prototype.fish_flags) & FISH_FLAG_SHOW_IN_CATALOG))
+			continue
+		var/weight = fish_table[reward]
+		total_weight += weight
+		rodless_weights[reward] = weight
+		if(rod)
+			var/mult = rod.bait ? rod.bait.check_bait(prototype) : 1
+			var/rod_weight = get_fish_trait_catch_mods(mult, reward, rod, user, location)
+			total_rod_weight += rod_weight
+			rod_weights[reward] = rod_weight
+		else
+			known_fishes += initial(prototype.name)
+
+	if(rod)
+		for(var/reward in rodless_weights)
+			var/percent_weight = rodless_weights[reward] / total_weight
+			var/percent_rod_weight = rod_weights[reward] / total_rod_weight
+			var/obj/item/fish/prototype = reward
 			var/init_name = initial(prototype.name)
-			if(rod)
-				var/init_weight = fish_table[reward]
-				var/weight = (rod.bait ? rod.bait.check_bait(prototype) : 1)
-				weight = get_fish_trait_catch_mods(weight, reward, rod, user, location)
-				if(weight > init_weight)
-					init_name = span_bold(init_name)
-					if(weight/init_weight >= 3.5)
-						init_name = "<u>init_name</u>"
-				else if(weight < init_weight)
-					init_name = span_small(init_name)
+			var/ratio = percent_weight/percent_rod_weight
+			if(ratio < 0.9)
+				init_name = span_bold(init_name)
+				if(ratio < 0.3)
+					init_name = "<u>[init_name]</u>"
+			else if(ratio > 1.1)
+				init_name = span_small(init_name)
 			known_fishes += init_name
 
 	if(!length(known_fishes))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -339,8 +339,8 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	if(HAS_TRAIT(fisherman, TRAIT_PROFOUND_FISHER) && !fisherman.client)
 		final_table -= profound_fisher_blacklist
 	for(var/result in final_table)
-		final_table[result] *= rod.hook?.get_hook_bonus_multiplicative(result)
-		final_table[result] += rod.hook?.get_hook_bonus_additive(result)//Decide on order here so it can be multiplicative
+		final_table[result] *= rod.hook.get_hook_bonus_multiplicative(result)
+		final_table[result] += rod.hook.get_hook_bonus_additive(result)//Decide on order here so it can be multiplicative
 
 		if(ispath(result, /obj/item/fish))
 			if(bait)

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -37,7 +37,7 @@
 	. = ..()
 	if(!length(reagents.reagent_list))
 		qdel(GetComponent(/datum/component/rename))
-		REMOVE_TRAIT(src, TRAIT_WAS_RENAMED, RENAMING_TOOL_LABEL_TRAIT) //so new drinks can rename the glass
+		REMOVE_TRAIT(src, TRAIT_WAS_RENAMED, SHAKER_LABEL_TRAIT) //so new drinks can rename the glass
 
 // Having our icon state change removes fill thresholds
 /obj/item/reagent_containers/cup/glass/drinkingglass/on_cup_change(datum/glass_style/style)

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -36,6 +36,7 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass/on_reagent_change(datum/reagents/holder, ...)
 	. = ..()
 	if(!length(reagents.reagent_list))
+		qdel(GetComponent(/datum/component/rename))
 		REMOVE_TRAIT(src, TRAIT_WAS_RENAMED, RENAMING_TOOL_LABEL_TRAIT) //so new drinks can rename the glass
 
 // Having our icon state change removes fill thresholds
@@ -58,8 +59,8 @@
 	if(!HAS_TRAIT(src, TRAIT_WAS_RENAMED))
 		return
 
+	qdel(GetComponent(/datum/component/rename))
 	REMOVE_TRAIT(src, TRAIT_WAS_RENAMED, SHAKER_LABEL_TRAIT)
-	REMOVE_TRAIT(src, TRAIT_WAS_RENAMED, RENAMING_TOOL_LABEL_TRAIT)
 	name = initial(name)
 	desc = initial(desc)
 	update_appearance(UPDATE_NAME | UPDATE_DESC)

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -360,7 +360,7 @@
 /obj/structure/aquarium/crab/Initialize(mapload)
 	. = ..()
 	crabbie = new(src)
-	crabbie.name = "Crabbie"
+	crabbie.AddComponent(/datum/component/rename, "Crabbie", crabbie.desc)
 	crabbie.last_feeding = world.time
 	crabbie.AddComponent(/datum/component/fish_growth, crabbie.lob_type, 1 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request
Let's get these in order:
Fish suffocating on internals with water vapor: It isn't a bug actually, it's merely the fact that the required pressure is 29 kpa and not 16. However, people are and will be ignorant of that, so much so it isn't worth keeping it at 29 kpa. This will close #87178.

Typos on fish gills: The `|` regex pattern matches `they` before `theyve` because the regex wasn't properly written in a descending order of length of the nouns. This lead "Theyve" to be outputted as "Heve" instead of "He's". This will close #87173.

Deep-fryer fish and names: This one is a bit more niche. Basically, the second stage of the Fryish growth can take three different forms with different names, even if they're all actually the same type, this means the current name may not match the initial name, so it ends up getting passed down to the last stage when it really shouldn't. Basically, I'm doing some due changes to the renaming comps and making sure that renaming fish through the aquarium UI uses the rename comp.

Aquarium nits: The reproduction and growth button is broken and it cannot be disabled. Also it shows the initial icon for the fish, which is an issue especially for the aforementioned deep-fryer fish.

Demersal fish getting stuck: Fish movement has a idle velocity variable, which, turns out, can cancel out the acceleration of a fish when the two variables have different signs, meaning the fish may get stuck and no longer be able to move as the added velocity and the idle velocity null each other. This is more often than not an issue with fish with the demersal trait (pufferfish, plaice, monkfish etc.). To solve this one I've had to add some math behind it, and whether you like it or not, it uses exponentation below 1, which is simple shit compared to about everything that I'm studying right now.

Examining fishing spots: I've seen that examining a fishing spot with a fishing rod led to many more instances of small fonts than I had anticipated (also the font is a bit too small imo but I'm not going to make a a new span class rn). That's because I was too stupid to use call `get_modified_fish_table`, which is the proc that returns the actual weights used for fishing.


## Why It's Good For The Game
Fishing a load of issues.

## Changelog

I'm only including the issue with fish infusion and examining fishing spots since they're the most prominent one. All the others are pretty missable.
:cl:
fix: Fixed gills not managing to breathe water vapor through internals.
fix: Fixed some inconsistencies with examining fishing spots with the appropriate level and fishing rod.
/:cl:
