### PR TITLE
you can use lizards to get lizard organs in the dna infuser

### DIFF
--- a/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_zero_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_zero_entries.dm
@@ -88,6 +88,7 @@
 		/obj/item/organ/external/frills,
 		/obj/item/organ/external/snout,
 		/obj/item/organ/external/tail/lizard,
+		/obj/item/organ/internal/tongue/lizard,
 	)
 	infusion_desc = "scaly"
 	tier = DNA_MUTANT_TIER_ZERO

--- a/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_zero_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_zero_entries.dm
@@ -69,6 +69,29 @@
 	infusion_desc = "fluffy"
 	tier = DNA_MUTANT_TIER_ZERO
 
+/datum/infuser_entry/lizard
+	name = "Lizard"
+	infuse_mob_name = "lacertilia"
+	desc = "Turns out infusing most humanoids with lizard DNA creates features remarkably similar to those of lizardpeople. What a strange coincidence."
+	threshold_desc = DNA_INFUSION_NO_THRESHOLD
+	qualities = list(
+		"long tails",
+		"decorative horns",
+		"aesthetic snouts",
+		"not much honestly",
+	)
+	input_obj_or_mob = list(
+		/mob/living/basic/lizard,
+	)
+	output_organs = list(
+		/obj/item/organ/external/horns,
+		/obj/item/organ/external/frills,
+		/obj/item/organ/external/snout,
+		/obj/item/organ/external/tail/lizard,
+	)
+	infusion_desc = "scaly"
+	tier = DNA_MUTANT_TIER_ZERO
+
 /datum/infuser_entry/felinid
 	name = "Cat"
 	infuse_mob_name = "feline"


### PR DESCRIPTION

## About The Pull Request

title, adds a infusion entry for lizard basic mobs. 

## Why It's Good For The Game

it is a glaring oversight lizards dont give lizard stuff. i mean come on. moths do, cats do, the same reasons apply.

## Changelog

:cl:
add: you can use lizards to get lizard organs in the dna infuser
/:cl:

