### PR TITLE
you cant roll appendicitis if youre a bitrunner avatar or deathmatch player

### DIFF
--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -139,7 +139,7 @@
 	observer.client?.prefs.safe_transfer_prefs_to(new_player)
 	new_player.dna.update_dna_identity()
 	new_player.updateappearance(icon_update = TRUE, mutcolor_update = TRUE, mutations_overlay_update = TRUE)
-	new_player.add_traits(list(TRAIT_CANNOT_CRYSTALIZE, TRAIT_PERMANENTLY_MORTAL), INNATE_TRAIT)
+	new_player.add_traits(list(TRAIT_CANNOT_CRYSTALIZE, TRAIT_PERMANENTLY_MORTAL, TRAIT_TEMPORARY_BODY), INNATE_TRAIT)
 	if(!isnull(observer.mind) && observer.mind?.current)
 		new_player.AddComponent( \
 			/datum/component/temporary_body, \

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -37,7 +37,7 @@
 		owner.adjustToxLoss(2 * seconds_per_tick, forced = TRUE)
 	else if(inflamation_stage)
 		inflamation(seconds_per_tick)
-	else if(SPT_PROB(APPENDICITIS_PROB, seconds_per_tick))
+	else if(SPT_PROB(APPENDICITIS_PROB, seconds_per_tick) && !HAS_TRAIT(owner, TRAIT_TEMPORARY_BODY))
 		become_inflamed()
 
 /obj/item/organ/internal/appendix/proc/become_inflamed()


### PR DESCRIPTION

## About The Pull Request

fixes #87206

## Changelog
:cl:
fix: you may no longer roll appendicitis in deathmatch or as a bitrunner avatar
/:cl:
