### PR TITLE
gives newtonian movement space drift fire priority

### DIFF
--- a/code/controllers/subsystem/movement/newtonian_movement.dm
+++ b/code/controllers/subsystem/movement/newtonian_movement.dm
@@ -1,6 +1,7 @@
 /// The subsystem is intended to tick things related to space/newtonian movement, such as constant sources of inertia
 MOVEMENT_SUBSYSTEM_DEF(newtonian_movement)
 	name = "Newtonian Movement"
+	priority = FIRE_PRIORITY_SPACEDRIFT
 	flags = SS_NO_INIT|SS_TICKER
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 


### PR DESCRIPTION

## About The Pull Request

i saw FIRE_PRIORITY_SPACEDRIFT unused so i just gave it to newtonian movement

## Why It's Good For The Game

unused = bad i think

## Changelog
:cl:
code: newtonian movement now has the fire priority of its predecessor
/:cl:
