### PR TITLE
Changes variable_color on limbs to use a priority system

### DIFF
--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -43,3 +43,7 @@
 #define AUGGED_CHEST_EMP_SHAKE_TIME 5 SECONDS
 /// When hit by an EMP, the time an augged head will make vision fucky for.
 #define AUGGED_HEAD_EMP_GLITCH_DURATION 6 SECONDS
+
+// Color priorities for bodyparts
+#define LIMB_COLOR_HULK 10
+#define LIMB_COLOR_CARP_INFUSION 20

--- a/code/datums/elements/organ_set_bonus.dm
+++ b/code/datums/elements/organ_set_bonus.dm
@@ -59,6 +59,8 @@
 	var/list/bonus_traits = list()
 	/// Limb overlay to apply upon activation
 	var/limb_overlay
+	/// Color priority for limb overlay
+	var/color_overlay_priority
 
 /datum/status_effect/organ_set_bonus/proc/set_organs(new_value)
 	organs = new_value
@@ -87,7 +89,7 @@
 	var/mob/living/carbon/carbon_owner = owner
 	for(var/obj/item/bodypart/limb in carbon_owner.bodyparts)
 		limb.add_bodypart_overlay(new limb_overlay())
-		limb.variable_color = COLOR_WHITE
+		limb.add_color_override(COLOR_WHITE, color_overlay_priority)
 	carbon_owner.update_body()
 	return TRUE
 
@@ -105,5 +107,5 @@
 		var/overlay = locate(limb_overlay) in limb.bodypart_overlays
 		if(overlay)
 			limb.remove_bodypart_overlay(overlay)
-			limb.variable_color = null
+			limb.remove_color_override(color_overlay_priority)
 	carbon_owner.update_body()

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -32,7 +32,7 @@
 	if(..())
 		return
 	for(var/obj/item/bodypart/part as anything in owner.bodyparts)
-		part.variable_color = bodypart_color
+		part.add_color_override(bodypart_color, LIMB_COLOR_HULK)
 	owner.update_body_parts()
 	owner.add_mood_event("hulk", /datum/mood_event/hulk)
 	RegisterSignal(owner, COMSIG_LIVING_EARLY_UNARMED_ATTACK, PROC_REF(on_attack_hand))
@@ -94,7 +94,7 @@
 	if(..())
 		return
 	for(var/obj/item/bodypart/part as anything in owner.bodyparts)
-		part.variable_color = null
+		part.remove_color_override(LIMB_COLOR_HULK)
 	owner.update_body_parts()
 	owner.clear_mood_event("hulk")
 	UnregisterSignal(owner, COMSIG_LIVING_EARLY_UNARMED_ATTACK)

--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -11,6 +11,7 @@
 	bonus_deactivate_text = span_notice("Your DNA is once again mostly yours, and so fades your ability to space-swim...")
 	bonus_traits = list(TRAIT_SPACEWALK)
 	limb_overlay = /datum/bodypart_overlay/texture/carpskin
+	color_overlay_priority = LIMB_COLOR_CARP_INFUSION
 
 ///Carp lungs! You can breathe in space! Oh... you can't breathe on the station, you need low oxygen environments.
 /// Inverts behavior of lungs. Bypasses suffocation due to space / lack of gas, but also allows Oxygen to suffocate.

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -108,7 +108,7 @@
 	///Limbs need this information as a back-up incase they are generated outside of a carbon (limbgrower)
 	var/should_draw_greyscale = TRUE
 	/// An assoc list of priority (as a string because byond) -> color, used to override draw_color.
-	var/color_overrides
+	var/list/color_overrides
 
 	var/px_x = 0
 	var/px_y = 0


### PR DESCRIPTION

## About The Pull Request

Its now a priority -> color assoc list with a pair of helper procs to wrap lazylist stuff. New priorities should go to ``code/__DEFINES/bodyparts.dm`` as defines as to be seen and not overridden. 

## Why It's Good For The Game

Wasn't a problem until carps came along as before only hulks used this thing, now we've got clashing.

## Changelog
:cl:
fix: Losing hulk after becoming a carp no longer turns you black
/:cl:
