### PR TITLE
Magazines now lazyload their contents in order to save on gun init times

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -275,11 +275,11 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 			Pewgun.chambered.forceMove(loc) //rip revolver immersions, blame shotgun snowflake procs
 			Pewgun.chambered = null
 			if(Pewgun.magazine && Pewgun.magazine.stored_ammo.len)
-				Pewgun.chambered = Pewgun.magazine.get_round(0)
+				Pewgun.chambered = Pewgun.magazine.get_round()
 				Pewgun.chambered.forceMove(Pewgun)
 			Pewgun.update_appearance()
 		else if(Pewgun.magazine && Pewgun.magazine.stored_ammo.len) //only true for pumpguns i think
-			Pewgun.chambered = Pewgun.magazine.get_round(0)
+			Pewgun.chambered = Pewgun.magazine.get_round()
 			Pewgun.chambered.forceMove(Pewgun)
 			visible_message(span_danger("The <b>[src]</b> cocks itself!"))
 	else

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -74,7 +74,7 @@
 		readout += "Up to [span_warning("[max_ammo] [caliber] [casing_phrasing]s")] can be found within this magazine. \
 		\nAccidentally discharging any of these projectiles may void your insurance contract."
 
-	var/obj/item/ammo_casing/mag_ammo = fetch_round()
+	var/obj/item/ammo_casing/mag_ammo = get_and_shuffle_round()
 
 	if(istype(mag_ammo))
 		readout += "\n[mag_ammo.add_notes_ammo()]"
@@ -113,7 +113,7 @@
 	return casing
 
 /// Gets a round from the magazine and puts it back at the bottom of the ammo list
-/obj/item/ammo_box/proc/fetch_round()
+/obj/item/ammo_box/proc/get_and_shuffle_round()
 	var/casing = get_round()
 	if (!casing)
 		return null

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -49,7 +49,10 @@
 	update_icon_state()
 
 /obj/item/ammo_box/Destroy(force)
-	QDEL_LIST(stored_ammo)
+	for (var/casing in stored_ammo)
+		if (!ispath(casing))
+			qdel(casing)
+	stored_ammo = null
 	return ..()
 
 /obj/item/ammo_box/Exited(atom/movable/gone, direction)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -140,6 +140,7 @@
 		stored_ammo += new_round
 		new_round.forceMove(src)
 		return TRUE
+	return FALSE
 
 ///Whether or not the box can be loaded, used in overrides
 /obj/item/ammo_box/proc/can_load(mob/user)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -244,7 +244,8 @@
 /obj/item/ammo_box/magazine/proc/ammo_list()
 	for (var/i in 1 to length(stored_ammo))
 		if (ispath(stored_ammo[i]))
-			stored_ammo[i] = new stored_ammo[i](src)
+			var/casing_type = stored_ammo[i]
+			stored_ammo[i] = new casing_type(src)
 	return stored_ammo.Copy()
 
 ///drops the entire contents of the magazine on the floor

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -95,7 +95,7 @@
 		return
 
 	for(var/i in max(1, stored_ammo.len + 1) to max_ammo)
-		stored_ammo += new round_check(src)
+		stored_ammo += starting ? round_check : new round_check(src)
 	update_appearance()
 
 ///gets a round from the magazine, if keep is TRUE the round will be moved to the bottom of the list.
@@ -104,59 +104,68 @@
 	if (!ammo_len)
 		return null
 	var/casing = stored_ammo[ammo_len]
+	if (ispath(casing))
+		casing = new casing(src)
+		stored_ammo[ammo_len] = casing
 	if (keep)
 		stored_ammo -= casing
-		stored_ammo.Insert(1,casing)
+		stored_ammo.Insert(1, casing)
 	return casing
 
 ///puts a round into the magazine
-/obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/R, replace_spent = 0)
+/obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/new_round, replace_spent = 0)
 	// Boxes don't have a caliber type, magazines do. Not sure if it's intended or not, but if we fail to find a caliber, then we fall back to ammo_type.
-	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
+	if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
 		return FALSE
 
 	if (stored_ammo.len < max_ammo)
-		stored_ammo += R
-		R.forceMove(src)
+		stored_ammo += new_round
+		new_round.forceMove(src)
 		return TRUE
 
-	//for accessibles magazines (e.g internal ones) when full, start replacing spent ammo
-	else if(replace_spent)
-		for(var/obj/item/ammo_casing/AC in stored_ammo)
-			if(!AC.loaded_projectile)//found a spent ammo
-				stored_ammo -= AC
-				AC.forceMove(get_turf(src.loc))
+	if(!replace_spent)
+		return FALSE
 
-				stored_ammo += R
-				R.forceMove(src)
-				return TRUE
-	return FALSE
+	//for accessibles magazines (e.g internal ones) when full, start replacing spent ammo
+	for(var/obj/item/ammo_casing/casing as anything in stored_ammo)
+		if(ispath(casing) || casing.loaded_projectile)
+			continue
+		//found a spent ammo
+		stored_ammo -= casing
+		casing.forceMove(get_turf(src))
+
+		stored_ammo += new_round
+		new_round.forceMove(src)
+		return TRUE
 
 ///Whether or not the box can be loaded, used in overrides
 /obj/item/ammo_box/proc/can_load(mob/user)
 	return TRUE
 
-/obj/item/ammo_box/attackby(obj/item/A, mob/user, params, silent = FALSE, replace_spent = 0)
+/obj/item/ammo_box/attackby(obj/item/tool, mob/user, params, silent = FALSE, replace_spent = 0)
 	var/num_loaded = 0
 	if(!can_load(user))
 		return
-	if(istype(A, /obj/item/ammo_box))
-		var/obj/item/ammo_box/AM = A
-		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
-			var/did_load = give_round(AC, replace_spent)
+
+	if(istype(tool, /obj/item/ammo_box))
+		var/obj/item/ammo_box/other_box = tool
+		for(var/obj/item/ammo_casing/casing in other_box.stored_ammo)
+			var/did_load = give_round(casing, replace_spent)
 			if(did_load)
-				AM.stored_ammo -= AC
+				other_box.stored_ammo -= casing
 				num_loaded++
 			if(!did_load || !multiload)
 				break
+
 		if(num_loaded)
-			AM.update_appearance()
-	if(isammocasing(A))
-		var/obj/item/ammo_casing/AC = A
-		if(give_round(AC, replace_spent))
-			user.transferItemToLoc(AC, src, TRUE)
+			other_box.update_appearance()
+
+	if(isammocasing(tool))
+		var/obj/item/ammo_casing/casing = tool
+		if(give_round(casing, replace_spent))
+			user.transferItemToLoc(casing, src, TRUE)
 			num_loaded++
-			AC.update_appearance()
+			casing.update_appearance()
 
 	if(num_loaded)
 		if(!silent)
@@ -225,18 +234,23 @@
 ///Count of number of bullets in the magazine
 /obj/item/ammo_box/magazine/proc/ammo_count(countempties = TRUE)
 	var/boolets = 0
-	for(var/obj/item/ammo_casing/bullet in stored_ammo)
-		if(bullet && (bullet.loaded_projectile || countempties))
+	for(var/obj/item/ammo_casing/bullet as anything in stored_ammo)
+		if(ispath(bullet) || bullet && (bullet.loaded_projectile || countempties))
 			boolets++
 	return boolets
 
 ///list of every bullet in the magazine
+///forces all bullets to lazyload
 /obj/item/ammo_box/magazine/proc/ammo_list()
+	for (var/i in 1 to length(stored_ammo))
+		if (ispath(stored_ammo[i]))
+			stored_ammo[i] = new stored_ammo[i](src)
 	return stored_ammo.Copy()
 
 ///drops the entire contents of the magazine on the floor
 /obj/item/ammo_box/magazine/proc/empty_magazine()
-	var/turf_mag = get_turf(src)
-	for(var/obj/item/ammo in stored_ammo)
-		ammo.forceMove(turf_mag)
-		stored_ammo -= ammo
+	var/turf/turf_mag = get_turf(src)
+	var/obj/item/ammo_casing/casing = get_round()
+	while (casing)
+		casing.forceMove(turf_mag)
+		casing = get_round()

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -49,7 +49,7 @@
 	update_icon_state()
 
 /obj/item/ammo_box/Destroy(force)
-	for (var/casing in stored_ammo)
+	for (var/obj/item/ammo_casing/casing as anything in stored_ammo)
 		if (!ispath(casing))
 			qdel(casing)
 	stored_ammo = null
@@ -74,7 +74,7 @@
 		readout += "Up to [span_warning("[max_ammo] [caliber] [casing_phrasing]s")] can be found within this magazine. \
 		\nAccidentally discharging any of these projectiles may void your insurance contract."
 
-	var/obj/item/ammo_casing/mag_ammo = get_round(TRUE)
+	var/obj/item/ammo_casing/mag_ammo = fetch_round()
 
 	if(istype(mag_ammo))
 		readout += "\n[mag_ammo.add_notes_ammo()]"
@@ -101,8 +101,8 @@
 		stored_ammo += starting ? round_check : new round_check(src)
 	update_appearance()
 
-///gets a round from the magazine, if keep is TRUE the round will be moved to the bottom of the list.
-/obj/item/ammo_box/proc/get_round(keep = FALSE)
+///gets a round from the magazine
+/obj/item/ammo_box/proc/get_round()
 	var/ammo_len = length(stored_ammo)
 	if (!ammo_len)
 		return null
@@ -110,9 +110,15 @@
 	if (ispath(casing))
 		casing = new casing(src)
 		stored_ammo[ammo_len] = casing
-	if (keep)
-		stored_ammo -= casing
-		stored_ammo.Insert(1, casing)
+	return casing
+
+/// Gets a round from the magazine and puts it back at the bottom of the ammo list
+/obj/item/ammo_box/proc/fetch_round()
+	var/casing = get_round()
+	if (!casing)
+		return null
+	stored_ammo -= casing
+	stored_ammo.Insert(1, casing)
 	return casing
 
 ///puts a round into the magazine

--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -47,7 +47,7 @@
 		if(round_number == i) //only count odd numbers.
 			continue
 		var/obj/item/ammo_casing/foam_dart/boolet = stored_ammo[i]
-		. += "c20r45-foam-[boolet.tip_color]-[round_number]"
+		. += "c20r45-foam-[boolet::tip_color]-[round_number]"
 
 
 /obj/item/ammo_box/magazine/toy/smgm45/riot

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -14,15 +14,15 @@
 			return
 
 /obj/item/ammo_box/magazine/internal/cylinder/get_round()
+	rotate()
 	var/casing = stored_ammo[1]
 	if (ispath(casing))
 		casing = new casing(src)
 		stored_ammo[1] = casing
 	return casing
 
-/obj/item/ammo_box/magazine/internal/cylinder/fetch_round()
-	rotate()
-	return ..()
+/obj/item/ammo_box/magazine/internal/cylinder/get_and_shuffle_round()
+	return get_round()
 
 /obj/item/ammo_box/magazine/internal/cylinder/proc/rotate()
 	var/b = stored_ammo[1]

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -14,15 +14,15 @@
 			return
 
 /obj/item/ammo_box/magazine/internal/cylinder/get_round()
-	rotate()
-	return fetch_round()
-
-/obj/item/ammo_box/magazine/internal/cylinder/fetch_round()
 	var/casing = stored_ammo[1]
 	if (ispath(casing))
 		casing = new casing(src)
 		stored_ammo[1] = casing
 	return casing
+
+/obj/item/ammo_box/magazine/internal/cylinder/fetch_round()
+	rotate()
+	return ..()
 
 /obj/item/ammo_box/magazine/internal/cylinder/proc/rotate()
 	var/b = stored_ammo[1]

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -13,9 +13,14 @@
 			update_appearance()
 			return
 
-/obj/item/ammo_box/magazine/internal/cylinder/get_round()
-	rotate()
-	return stored_ammo[1]
+/obj/item/ammo_box/magazine/internal/cylinder/get_round(keep = FALSE)
+	if (!keep)
+		rotate()
+	var/casing = stored_ammo[1]
+	if (ispath(casing))
+		casing = new casing(src)
+		stored_ammo[1] = casing
+	return casing
 
 /obj/item/ammo_box/magazine/internal/cylinder/proc/rotate()
 	var/b = stored_ammo[1]
@@ -37,14 +42,17 @@
 
 	for(var/i in 1 to stored_ammo.len)
 		var/obj/item/ammo_casing/bullet = stored_ammo[i]
-		if(!bullet || !bullet.loaded_projectile) // found a spent ammo
-			stored_ammo[i] = R
-			R.forceMove(src)
+		if (ispath(bullet))
+			continue
+		if(istype(bullet) && bullet.loaded_projectile)
+			continue
+		// found a spent ammo
+		stored_ammo[i] = R
+		R.forceMove(src)
 
-			if(bullet)
-				bullet.forceMove(drop_location())
-			return TRUE
-
+		if(bullet)
+			bullet.forceMove(drop_location())
+		return TRUE
 	return FALSE
 
 /obj/item/ammo_box/magazine/internal/cylinder/top_off(load_type, starting=FALSE)

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -42,9 +42,7 @@
 
 	for(var/i in 1 to stored_ammo.len)
 		var/obj/item/ammo_casing/bullet = stored_ammo[i]
-		if (ispath(bullet))
-			continue
-		if(istype(bullet) && bullet.loaded_projectile)
+		if (!istype(bullet) || bullet.loaded_projectile)
 			continue
 		// found a spent ammo
 		stored_ammo[i] = R

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -13,9 +13,11 @@
 			update_appearance()
 			return
 
-/obj/item/ammo_box/magazine/internal/cylinder/get_round(keep = FALSE)
-	if (!keep)
-		rotate()
+/obj/item/ammo_box/magazine/internal/cylinder/get_round()
+	rotate()
+	return fetch_round()
+
+/obj/item/ammo_box/magazine/internal/cylinder/fetch_round()
 	var/casing = stored_ammo[1]
 	if (ispath(casing))
 		casing = new casing(src)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -311,7 +311,7 @@
 	if (chambered || !magazine)
 		return
 	if (magazine.ammo_count())
-		chambered = (bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT ? magazine.fetch_round() : magazine.get_round()
+		chambered = (bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT ? magazine.get_and_shuffle_round() : magazine.get_round()
 		if (bolt_type != BOLT_TYPE_OPEN && !(internal_magazine && bolt_type == BOLT_TYPE_NO_BOLT))
 			chambered.forceMove(src)
 		else

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -311,7 +311,7 @@
 	if (chambered || !magazine)
 		return
 	if (magazine.ammo_count())
-		chambered = magazine.get_round((bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT)
+		chambered = (bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT ? magazine.fetch_round() : magazine.get_round()
 		if (bolt_type != BOLT_TYPE_OPEN && !(internal_magazine && bolt_type == BOLT_TYPE_NO_BOLT))
 			chambered.forceMove(src)
 		else

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -93,7 +93,7 @@
 	. = ..()
 	if(!.)
 		return
-	magazine.get_round(FALSE) //Hack to clear the mag after it's fired
+	magazine.get_round() //Hack to clear the mag after it's fired
 
 /obj/item/gun/ballistic/rocketlauncher/attack_self_tk(mob/user)
 	return //too difficult to remove the rocket with TK

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -26,7 +26,13 @@
 		CRASH("revolver tried to chamber a round without a magazine!")
 	if(chambered)
 		UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-	chambered = spin_cylinder ? magazine.fetch_round() : magazine.get_round()
+	if (spin_cylinder)
+		chambered = magazine.get_round()
+	else
+		chambered = stored_ammo[1]
+		if (ispath(chambered))
+			chambered = new chambered(src)
+			stored_ammo[1] = chambered
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -26,7 +26,7 @@
 		CRASH("revolver tried to chamber a round without a magazine!")
 	if(chambered)
 		UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-	chambered = spin_cylinder ? magazine.get_round() : magazine.fetch_round()
+	chambered = spin_cylinder ? magazine.fetch_round() : magazine.get_round()
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -29,10 +29,10 @@
 	if (spin_cylinder)
 		chambered = magazine.get_round()
 	else
-		chambered = stored_ammo[1]
+		chambered = magazine.stored_ammo[1]
 		if (ispath(chambered))
 			chambered = new chambered(src)
-			stored_ammo[1] = chambered
+			magazine.stored_ammo[1] = chambered
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -26,10 +26,7 @@
 		CRASH("revolver tried to chamber a round without a magazine!")
 	if(chambered)
 		UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-	if(spin_cylinder)
-		chambered = magazine.get_round(TRUE)
-	else
-		chambered = magazine.stored_ammo[1]
+	chambered = magazine.get_round(!spin_cylinder)
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -26,7 +26,7 @@
 		CRASH("revolver tried to chamber a round without a magazine!")
 	if(chambered)
 		UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-	chambered = magazine.get_round(!spin_cylinder)
+	chambered = magazine.get_round(keep = !spin_cylinder)
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -26,7 +26,7 @@
 		CRASH("revolver tried to chamber a round without a magazine!")
 	if(chambered)
 		UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-	chambered = magazine.get_round(keep = !spin_cylinder)
+	chambered = spin_cylinder ? magazine.get_round() : magazine.fetch_round()
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 


### PR DESCRIPTION
## About The Pull Request
Ammo boxes, this includes magazines and magazines inside of guns, now lazyload their ammo in order to save on init times by keeping it as types in their ammo list and initializing them as needed. As a side effect, you can only use get_round to access rounds now, direct array access will probably not work.

## Why It's Good For The Game

trying to save on init times and delay death of guncode by a tiny bit

## Changelog
:cl:
code: Magazines now lazyload their contents in order to save on gun init times. Please report any broken/non-functional guns!
/:cl:
