### PR TITLE
Removing self-vore message from aliens + minor attack verb fixes

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -544,7 +544,7 @@
 	greyscale_config = /datum/greyscale_config/plush_spacelizard
 	// space lizards can't hit people with their tail, it's stuck in their suit
 	attack_verb_continuous = list("claws", "hisses", "bops")
-	attack_verb_simple = list("claw", "hiss", "bops")
+	attack_verb_simple = list("claw", "hiss", "bop")
 
 /obj/item/toy/plush/lizard_plushie/space/green
 	desc = "An adorable stuffed toy that resembles a very determined spacefaring green lizardperson. To infinity and beyond, little guy. This one fills you with nostalgia and soul."

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1815,6 +1815,6 @@ GLOBAL_LIST_EMPTY(intento_players)
 	icon = 'icons/obj/weapons/guns/magic.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("smacks", "clubs", "wacks", "vendors")
-	attack_verb_simple = list("smack", "club", "wacks", "vendor")
+	attack_verb_simple = list("smack", "club", "wack", "vendor")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -410,7 +410,7 @@
 	damtype = BRUTE
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	attack_verb_continuous = list("smacks", "clubs", "wacks")
-	attack_verb_simple = list("smack", "club", "wacks")
+	attack_verb_simple = list("smack", "club", "wack")
 
 	/// Range cap on where you can summon vendors.
 	var/max_summon_range = RUNIC_SCEPTER_MAX_RANGE

--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -340,7 +340,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 	hitsound = 'sound/items/weapons/sear.ogg'
 	damtype = BURN
 	attack_verb_continuous = list("attacks", "burns", "blesses", "damns", "scorches", "curses", "smites")
-	attack_verb_simple = list("attack", "burn", "bless", "damn", "scorch", "curses", "smites")
+	attack_verb_simple = list("attack", "burn", "bless", "damn", "scorch", "curse", "smite")
 	deity_name = "The Syndicate"
 	var/uses = 1
 	var/owner_name

--- a/code/modules/mob/living/basic/lavaland/hivelord/hivelord.dm
+++ b/code/modules/mob/living/basic/lavaland/hivelord/hivelord.dm
@@ -15,7 +15,7 @@
 	melee_damage_lower = 0
 	melee_damage_upper = 0
 	attack_verb_continuous = "weakly tackles"
-	attack_verb_simple = "weakly tackles"
+	attack_verb_simple = "weakly tackle"
 	speak_emote = list("telepathically cries")
 	attack_sound = 'sound/items/weapons/pierce.ogg'
 	throw_blocked_message = "passes between the bodies of the"

--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	minimum_survivable_temperature = BODYTEMP_COLD_ICEBOX_SAFE
 	maximum_survivable_temperature = INFINITY
 	attack_verb_continuous = "pecks"
-	attack_verb_simple = "chomps"
+	attack_verb_simple = "chomp"
 	attack_sound = 'sound/items/weapons/punch1.ogg'
 	faction = list(FACTION_RAPTOR, FACTION_NEUTRAL)
 	speak_emote = list("screeches")

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -135,7 +135,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 
 	lucky_winner.audible_message(span_danger("You hear a deep groan, and a harsh snap like a mantrap."))
 	lucky_winner.visible_message(span_danger("[src] devours [lucky_winner]!"), \
-			span_userdanger("[lucky_winner] devours you!"))
+			span_userdanger("[src] devours you!"))
 	log_combat(src, lucky_winner, "devoured")
 	melting_pot.consume_thing(lucky_winner)
 	return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -16,7 +16,7 @@ Difficulty: Extremely Hard
 	icon_living = "demonic_miner"
 	icon = 'icons/mob/simple/icemoon/icemoon_monsters.dmi'
 	attack_verb_continuous = "pummels"
-	attack_verb_simple = "pummels"
+	attack_verb_simple = "pummel"
 	attack_sound = 'sound/items/weapons/sonic_jackhammer.ogg'
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_SPECIAL
 	light_color = COLOR_LIGHT_GRAYISH_RED


### PR DESCRIPTION

## About The Pull Request
Fixes self-vore message when you get devoured by an alien.
Fixes some simple attack verbs being continuous

## Why It's Good For The Game
Bug fixes good

## Changelog
:cl:
spellcheck: Correct message is shown when YOU get devoured by an alien
spellcheck: Fixed a few typos on some simple attack verbs being continuous
/:cl:
