### PR TITLE
Singularity_pull() standartize

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
@@ -40,7 +40,7 @@
 #define COMSIG_ATOM_NARSIE_ACT "atom_narsie_act"
 ///from base of atom/rcd_act(): (/mob, /obj/item/construction/rcd, passed_mode)
 #define COMSIG_ATOM_RCD_ACT "atom_rcd_act"
-///from base of atom/singularity_pull(): (/datum/component/singularity, current_size)
+///from base of atom/singularity_pull(): (/obj/singularity, current_size)
 #define COMSIG_ATOM_SING_PULL "atom_sing_pull"
 ///from obj/machinery/bsa/full/proc/fire(): ()
 #define COMSIG_ATOM_BSA_BEAM "atom_bsa_beam_pass"

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -206,7 +206,7 @@
 	owner = null
 	return ..()
 
-/obj/effect/ebeam/singularity_pull()
+/obj/effect/ebeam/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/ebeam/singularity_act()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -269,7 +269,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 		return
 	user.electrocute_act(10, src)
 
-/obj/machinery/camera/singularity_pull(S, current_size)
+/obj/machinery/camera/singularity_pull(obj/singularity/singularity, current_size)
 	if (camera_enabled && current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects and the camera is still active, turn off the camera as it gets ripped off the wall.
 		toggle_cam(null, 0)
 	return ..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1825,7 +1825,7 @@
 /obj/structure/fluff/airlock_filler/singularity_act()
 	return
 
-/obj/structure/fluff/airlock_filler/singularity_pull(S, current_size)
+/obj/structure/fluff/airlock_filler/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/machinery/door/airlock/proc/set_cycle_pump(obj/machinery/atmospherics/components/unary/airlock_pump/pump)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -425,7 +425,7 @@
 			if(prob(33) && buildstage == FIRE_ALARM_BUILD_SECURED) //require fully wired electronics to set of the alarms
 				alarm()
 
-/obj/machinery/firealarm/singularity_pull(S, current_size)
+/obj/machinery/firealarm/singularity_pull(obj/singularity/singularity, current_size)
 	if (current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects, the fire alarm experiences integrity failure
 		deconstruct()
 	return ..()

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -26,7 +26,7 @@
 /obj/effect/bump_teleporter/singularity_act()
 	return
 
-/obj/effect/bump_teleporter/singularity_pull()
+/obj/effect/bump_teleporter/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/bump_teleporter/Bumped(atom/movable/bumper)

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -73,7 +73,7 @@
 	STOP_PROCESSING(SSfastprocess, src)
 	. = ..()
 
-/obj/effect/countdown/singularity_pull()
+/obj/effect/countdown/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/countdown/singularity_act()

--- a/code/game/objects/effects/effect_system/effect_shield.dm
+++ b/code/game/objects/effects/effect_system/effect_shield.dm
@@ -21,6 +21,6 @@
 /obj/effect/shield/singularity_act()
 	return
 
-/obj/effect/shield/singularity_pull(S, current_size)
+/obj/effect/shield/singularity_pull(obj/singularity/singularity, current_size)
 	return
 

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -50,7 +50,7 @@
 /obj/effect/abstract
 	resistance_flags = parent_type::resistance_flags | SHUTTLE_CRUSH_PROOF
 
-/obj/effect/abstract/singularity_pull()
+/obj/effect/abstract/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/abstract/singularity_act()
@@ -59,7 +59,7 @@
 /obj/effect/abstract/has_gravity(turf/gravity_turf)
 	return FALSE
 
-/obj/effect/dummy/singularity_pull()
+/obj/effect/dummy/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/dummy/singularity_act()

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -14,7 +14,7 @@
 	if(initial_duration > 0 SECONDS)
 		QDEL_IN(src, initial_duration)
 
-/obj/effect/forcefield/singularity_pull()
+/obj/effect/forcefield/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /// The wizard's forcefield, summoned by forcewall

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -11,7 +11,7 @@
 /obj/effect/landmark/singularity_act()
 	return
 
-/obj/effect/landmark/singularity_pull()
+/obj/effect/landmark/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 INITIALIZE_IMMEDIATE(/obj/effect/landmark)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -15,7 +15,7 @@
 /obj/effect/beam/singularity_act()
 	return
 
-/obj/effect/beam/singularity_pull()
+/obj/effect/beam/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/spawner

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -4,7 +4,7 @@
 /obj/effect/overlay/singularity_act()
 	return
 
-/obj/effect/overlay/singularity_pull()
+/obj/effect/overlay/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/overlay/beam//Not actually a projectile, just an effect.

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -113,7 +113,7 @@
 	playsound(loc, SFX_PORTAL_CLOSE, 50, FALSE, SHORT_RANGE_SOUND_EXTRARANGE)
 	qdel(src)
 
-/obj/effect/portal/singularity_pull()
+/obj/effect/portal/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/portal/singularity_act()

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -31,7 +31,7 @@
 /obj/effect/step_trigger/singularity_act()
 	return
 
-/obj/effect/step_trigger/singularity_pull()
+/obj/effect/step_trigger/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /* Sends a message to mob when triggered*/

--- a/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
@@ -7,7 +7,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	appearance_flags = LONG_GLIDE
 
-/obj/effect/projectile/singularity_pull()
+/obj/effect/projectile/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/projectile/singularity_act()

--- a/code/game/objects/effects/temporary_visuals/temporary_visual.dm
+++ b/code/game/objects/effects/temporary_visuals/temporary_visual.dm
@@ -25,7 +25,7 @@
 /obj/effect/temp_visual/singularity_act()
 	return
 
-/obj/effect/temp_visual/singularity_pull()
+/obj/effect/temp_visual/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/temp_visual/dir_setting

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -831,7 +831,7 @@
 /obj/item/proc/IsReflect(def_zone)
 	return FALSE
 
-/obj/item/singularity_pull(S, current_size)
+/obj/item/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FOUR)
 		throw_at(S,14,3, spin=0)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -834,7 +834,7 @@
 /obj/item/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FOUR)
-		throw_at(S,14,3, spin=0)
+		throw_at(singularity, 14, 3, spin=0)
 	else
 		return
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 	if(move_resist == INFINITY)
 		return
 	if(!anchored || current_size >= STAGE_FIVE)
-		step_towards(src,S)
+		step_towards(src, singularity)
 
 /obj/get_dumping_location()
 	return get_turf(src)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 	SEND_SIGNAL(src, COMSIG_ATOM_UI_INTERACT, user)
 	ui_interact(user)
 
-/obj/singularity_pull(S, current_size)
+/obj/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(move_resist == INFINITY)
 		return

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -79,7 +79,7 @@
 	icon_state = "ladder[up ? 1 : 0][down ? 1 : 0]"
 	return ..()
 
-/obj/structure/ladder/singularity_pull()
+/obj/structure/ladder/singularity_pull(obj/singularity/singularity, current_size)
 	if (!(resistance_flags & INDESTRUCTIBLE))
 		visible_message(span_danger("[src] is torn to pieces by the gravitational pull!"))
 		qdel(src)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -82,7 +82,7 @@
 			return TRUE
 	return FALSE
 
-/obj/structure/lattice/singularity_pull(S, current_size)
+/obj/structure/lattice/singularity_pull(obj/singularity/singularity, current_size)
 	if(current_size >= STAGE_FOUR)
 		deconstruct()
 

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -27,7 +27,7 @@
 		P.deconstruct(FALSE)
 	return ..()
 
-/obj/structure/transit_tube/singularity_pull(S, current_size)
+/obj/structure/transit_tube/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct(FALSE)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -63,7 +63,7 @@
 		if(EXPLODE_LIGHT)
 			SSexplosions.low_mov_atom += contents
 
-/obj/structure/transit_tube_pod/singularity_pull(S, current_size)
+/obj/structure/transit_tube_pod/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct(FALSE)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -106,7 +106,7 @@
 /obj/structure/window/narsie_act()
 	add_atom_colour(NARSIE_WINDOW_COLOUR, FIXED_COLOUR_PRIORITY)
 
-/obj/structure/window/singularity_pull(S, current_size)
+/obj/structure/window/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(anchored && current_size >= STAGE_TWO)
 		set_anchored(FALSE)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -296,7 +296,7 @@
 
 	return FALSE
 
-/turf/closed/wall/singularity_pull(S, current_size)
+/turf/closed/wall/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	wall_singularity_pull(current_size)
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -175,7 +175,7 @@
 		return null
 	return new floor_tile(src)
 
-/turf/open/floor/singularity_pull(S, current_size)
+/turf/open/floor/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	var/sheer = FALSE
 	switch(current_size)

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -75,7 +75,7 @@
 
 	return TRUE
 
-/turf/open/floor/engine/singularity_pull(S, current_size)
+/turf/open/floor/engine/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		if(floor_tile)

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -175,7 +175,7 @@
 /turf/open/lava/singularity_act()
 	return
 
-/turf/open/lava/singularity_pull(S, current_size)
+/turf/open/lava/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /turf/open/lava/GetHeatCapacity()

--- a/code/modules/admin/sound_emitter.dm
+++ b/code/modules/admin/sound_emitter.dm
@@ -30,7 +30,7 @@
 /obj/effect/sound_emitter/singularity_act()
 	return
 
-/obj/effect/sound_emitter/singularity_pull()
+/obj/effect/sound_emitter/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/sound_emitter/examine(mob/user)

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -215,5 +215,5 @@
 /obj/effect/gateway/singularity_act()
 	return
 
-/obj/effect/gateway/singularity_pull()
+/obj/effect/gateway/singularity_pull(obj/singularity/singularity, current_size)
 	return

--- a/code/modules/antagonists/cult/cult_turf_overlay.dm
+++ b/code/modules/antagonists/cult/cult_turf_overlay.dm
@@ -15,7 +15,7 @@
 /obj/effect/cult_turf/singularity_act()
 	return
 
-/obj/effect/cult_turf/singularity_pull()
+/obj/effect/cult_turf/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/cult_turf/Destroy()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -73,7 +73,7 @@
 /obj/effect/rend/singularity_act()
 	return
 
-/obj/effect/rend/singularity_pull()
+/obj/effect/rend/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/item/veilrender/vealrender

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -302,7 +302,7 @@
 		var/mob/living/immolated = arrived
 		immolated.fire_act(temperature, volume)
 
-/obj/effect/hotspot/singularity_pull()
+/obj/effect/hotspot/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 #undef INSUFFICIENT

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -560,7 +560,7 @@
 		L.ventcrawl_layer = piping_layer
 	return ..()
 
-/obj/machinery/atmospherics/singularity_pull(S, current_size)
+/obj/machinery/atmospherics/singularity_pull(obj/singularity/singularity, current_size)
 	if(current_size >= STAGE_FIVE)
 		deconstruct(FALSE)
 	return ..()

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -152,7 +152,7 @@
 	else
 		to_chat(user, status())
 
-/obj/machinery/meter/singularity_pull(S, current_size)
+/obj/machinery/meter/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()

--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -145,7 +145,7 @@
 /obj/effect/immovablerod/singularity_act()
 	return
 
-/obj/effect/immovablerod/singularity_pull()
+/obj/effect/immovablerod/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/immovablerod/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)

--- a/code/modules/hallucination/_hallucination.dm
+++ b/code/modules/hallucination/_hallucination.dm
@@ -197,7 +197,7 @@
 		return
 	regenerate_image()
 
-/obj/effect/client_image_holder/singularity_pull()
+/obj/effect/client_image_holder/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/client_image_holder/singularity_act()

--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -57,7 +57,7 @@
 	qdel(sight_blocker)
 	return ..()
 
-/obj/structure/necropolis_gate/singularity_pull()
+/obj/structure/necropolis_gate/singularity_pull(obj/singularity/singularity, current_size)
 	return 0
 
 /obj/structure/necropolis_gate/CanAllowThrough(atom/movable/mover, border_dir)
@@ -88,7 +88,7 @@
 	opacity = TRUE
 	anchored = TRUE
 
-/obj/structure/opacity_blocker/singularity_pull()
+/obj/structure/opacity_blocker/singularity_pull(obj/singularity/singularity, current_size)
 	return FALSE
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
@@ -242,7 +242,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 
 	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_DEFAULT_TWO_TALL)
 
-/obj/structure/necropolis_arch/singularity_pull()
+/obj/structure/necropolis_arch/singularity_pull(obj/singularity/singularity, current_size)
 	return 0
 
 //stone tiles for boss arenas
@@ -266,7 +266,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 		give_turf_traits = string_list(list(TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED, TRAIT_IMMERSE_STOPPED))
 	AddElement(/datum/element/give_turf_traits, give_turf_traits)
 
-/obj/structure/stone_tile/singularity_pull()
+/obj/structure/stone_tile/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/structure/stone_tile/block

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -243,7 +243,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 /obj/effect/extraction_holder/singularity_act()
 	return
 
-/obj/effect/extraction_holder/singularity_pull()
+/obj/effect/extraction_holder/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/item/extraction_pack/syndicate

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -453,7 +453,7 @@
 	// but regardless block all relayed moves, because no, you cannot move in the void.
 	return
 
-/obj/effect/immortality_talisman/singularity_pull()
+/obj/effect/immortality_talisman/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/immortality_talisman/void

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -13,7 +13,7 @@
 	. = ..()
 	set_light(set_luminosity, set_cap)
 
-/obj/effect/light_emitter/singularity_pull()
+/obj/effect/light_emitter/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/light_emitter/singularity_act()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -492,7 +492,7 @@
 		for(var/obj/item/hand in held_items)
 			if(prob(current_size * 5) && hand.w_class >= ((11-current_size)/2)  && dropItemToGround(hand))
 				step_towards(hand, src)
-				to_chat(src, span_warning("\The [S] pulls \the [hand] from your grip!"))
+				to_chat(src, span_warning("\The [singularity] pulls \the [hand] from your grip!"))
 
 #define CPR_PANIC_SPEED (0.8 SECONDS)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -486,7 +486,7 @@
 	underwear = "Nude"
 	update_body(is_creating = TRUE)
 
-/mob/living/carbon/human/singularity_pull(S, current_size)
+/mob/living/carbon/human/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_THREE)
 		for(var/obj/item/hand in held_items)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1282,7 +1282,7 @@
 		animate(src, transform = flipped_matrix, pixel_y = pixel_y-4, time = 0.5 SECONDS, easing = EASE_OUT)
 		base_pixel_y -= 4
 
-/mob/living/singularity_pull(S, current_size)
+/mob/living/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(move_resist == INFINITY)
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1287,9 +1287,9 @@
 	if(move_resist == INFINITY)
 		return
 	if(current_size >= STAGE_SIX) //your puny magboots/wings/whatever will not save you against supermatter singularity
-		throw_at(S, 14, 3, src, TRUE)
+		throw_at(singularity, 14, 3, src, TRUE)
 	else if(!src.mob_negates_gravity())
-		step_towards(src,S)
+		step_towards(src, singularity)
 
 /mob/living/proc/get_temperature(datum/gas_mixture/environment)
 	var/loc_temp = environment ? environment.temperature : T0C

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -421,7 +421,7 @@
 /obj/structure/chrono_field/singularity_act()
 	return
 
-/obj/structure/chrono_field/singularity_pull()
+/obj/structure/chrono_field/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/structure/chrono_field/ex_act()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 	else
 		return FALSE
 
-/obj/structure/cable/singularity_pull(S, current_size)
+/obj/structure/cable/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -154,7 +154,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/pipe_cleaner/attackby(obj/item/W, mob/user, params)
 	handlecable(W, user, params)
 
-/obj/structure/pipe_cleaner/singularity_pull(S, current_size)
+/obj/structure/pipe_cleaner/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -197,7 +197,7 @@
 	wound_bonus = -40
 	bare_wound_bonus = 70
 
-/obj/projectile/beam/emitter/singularity_pull()
+/obj/projectile/beam/emitter/singularity_pull(obj/singularity/singularity, current_size)
 	return //don't want the emitters to miss
 
 /obj/projectile/beam/emitter/hitscan

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -52,7 +52,7 @@
 /obj/effect/nettingportal/singularity_act()
 	return
 
-/obj/effect/nettingportal/singularity_pull()
+/obj/effect/nettingportal/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/item/dragnet_beacon

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -96,7 +96,7 @@
 		stored = null
 		deconstruct(FALSE)
 
-/obj/machinery/disposal/singularity_pull(S, current_size)
+/obj/machinery/disposal/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -189,7 +189,7 @@
 				pipe.setDir(dir)
 	spew_forth()
 
-/obj/structure/disposalpipe/singularity_pull(S, current_size)
+/obj/structure/disposalpipe/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -73,7 +73,7 @@
 /obj/docking_port/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	return
 
-/obj/docking_port/singularity_pull()
+/obj/docking_port/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/docking_port/singularity_act()

--- a/code/modules/spells/spell_types/self/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/self/spacetime_distortion.dm
@@ -115,7 +115,7 @@
 /obj/effect/cross_action/singularity_act()
 	return
 
-/obj/effect/cross_action/singularity_pull()
+/obj/effect/cross_action/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /obj/effect/cross_action/spacetime_dist/Initialize(mapload, flags = MAGIC_RESISTANCE)

--- a/code/modules/transport/tram/tram_structures.dm
+++ b/code/modules/transport/tram/tram_structures.dm
@@ -145,7 +145,7 @@
 /obj/structure/tram/narsie_act()
 	add_atom_colour(NARSIE_WINDOW_COLOUR, FIXED_COLOUR_PRIORITY)
 
-/obj/structure/tram/singularity_pull(singulo, current_size)
+/obj/structure/tram/singularity_pull(obj/singularity/singularity, current_size)
 	..()
 
 	if(current_size >= STAGE_FIVE)

--- a/code/modules/visuals/render_steps.dm
+++ b/code/modules/visuals/render_steps.dm
@@ -29,7 +29,7 @@
 /atom/movable/render_step/singularity_act()
 	return
 
-/atom/movable/render_step/singularity_pull()
+/atom/movable/render_step/singularity_pull(obj/singularity/singularity, current_size)
 	return
 
 /atom/movable/render_step/blob_act()


### PR DESCRIPTION

## About The Pull Request
`/atom/proc/singularity_pull(obj/singularity/singularity, current_size)` is defined, but other procs were just referencing it as a un-typed variable. This PR just makes that every `proc/singularity_pull()` now has arguments and singularity in that argument is now typed.

## Why It's Good For The Game
Standartization?

## Changelog
No changelog needed
