### PR TITLE
[no gbp] a few very minor manulathe changes + rotating fix

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1751,7 +1751,7 @@
 	build_path = /obj/machinery/power/manufacturing/lathe
 	req_components = list(
 		/obj/item/stack/sheet/iron = 5,
-		/datum/stock_part/servo = 1,
+		/datum/stock_part/matter_bin = 1,
 	)
 
 /obj/item/circuitboard/machine/manucrusher

--- a/code/modules/manufactorio/_manufacturing.dm
+++ b/code/modules/manufactorio/_manufacturing.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	if(may_be_moved)
 		. += "It receives power via cable, but certain buildings do not need power."
-	. += length(contents - circuit) ? "It contains:" : "Its empty."
+	. += length(contents - circuit) ? "It contains:" : "It contains no items."
 	for(var/atom/movable/thing as anything in contents - circuit)
 		var/text = thing.name
 		var/obj/item/stack/possible_stack = thing
@@ -61,6 +61,10 @@
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
 		return ITEM_INTERACT_SUCCESS
 	return ITEM_INTERACT_BLOCKING
+
+/obj/machinery/power/manufacturing/setDir(newdir)
+	. = ..()
+	update_appearance(UPDATE_OVERLAYS)
 
 /obj/machinery/power/manufacturing/crowbar_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_BLOCKING

--- a/code/modules/manufactorio/machines/crusher.dm
+++ b/code/modules/manufactorio/machines/crusher.dm
@@ -39,7 +39,7 @@
 	if(gone == withholding)
 		withholding = null
 
-/obj/machinery/power/manufacturing/crusher/process(seconds_per_tick) //noot functional
+/obj/machinery/power/manufacturing/crusher/process(seconds_per_tick)
 	if(!isnull(withholding) && !send_resource(withholding, dir))
 		return
 	for(var/material in held_mats)

--- a/code/modules/manufactorio/machines/lathe.dm
+++ b/code/modules/manufactorio/machines/lathe.dm
@@ -19,17 +19,34 @@
 	var/atom/movable/withheld
 
 /obj/machinery/power/manufacturing/lathe/Initialize(mapload)
-	. = ..()
 	print_sound = new(src,  FALSE)
 	materials = AddComponent( \
 		/datum/component/material_container, \
 		SSmaterials.materials_by_category[MAT_CATEGORY_ITEM_MATERIAL], \
-		SHEET_MATERIAL_AMOUNT * MAX_STACK_SIZE * 2, \
+		0, \
 		MATCONTAINER_EXAMINE|MATCONTAINER_NO_INSERT, \
 	)
+	register_context()
+	. = ..()
 	if(!GLOB.autounlock_techwebs[/datum/techweb/autounlocking/autolathe])
 		GLOB.autounlock_techwebs[/datum/techweb/autounlocking/autolathe] = new /datum/techweb/autounlocking/autolathe
 	stored_research = GLOB.autounlock_techwebs[/datum/techweb/autounlocking/autolathe]
+
+/obj/machinery/power/manufacturing/lathe/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = NONE
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Dump all contained materials"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/power/manufacturing/lathe/click_ctrl_shift(mob/living/user)
+	balloon_alert_to_viewers("materials dumped")
+	materials.retrieve_all()
+
+/obj/machinery/power/manufacturing/lathe/RefreshParts()
+	. = ..()
+	var/datum/stock_part/matter_bin/bin = locate() in component_parts
+	materials.max_amount = bin.tier * (SHEET_MATERIAL_AMOUNT * MAX_STACK_SIZE)
+
 
 /obj/machinery/power/manufacturing/lathe/examine(mob/user)
 	. = ..()
@@ -63,7 +80,7 @@
 	return ..()
 
 /obj/machinery/power/manufacturing/lathe/receive_resource(atom/movable/receiving, atom/from, receive_dir)
-	if(!isstack(receiving) || receiving.resistance_flags & INDESTRUCTIBLE || receive_dir != REVERSE_DIR(dir))
+	if(!isstack(receiving) || istype(receiving, /obj/item/stack/ore) || receiving.resistance_flags & INDESTRUCTIBLE || receive_dir != REVERSE_DIR(dir))
 		return MANUFACTURING_FAIL
 	materials.insert_item(receiving)
 	return MANUFACTURING_SUCCESS


### PR DESCRIPTION

## About The Pull Request

made manufacturing machines i/o overlays (the blue and orange lights and such) rotate with the machine
CTRL SHIFT LMB makes the manulathe dump all mats
manulathes no longer may receive ore: this was not intentional, processing ore is stuff the smelter does
manulathes now use a matter bin instead of a servo (because it makes sense because it holds mats): this affects its material capacity being:
bin tier * 50 sheets

## Why It's Good For The Game

bug bad
oversight bad
and you also no longer need to decon the lathe to dump mats

## Changelog
:cl:
fix: input output overlays for manufacturing machines actually update properly when rotated
qol: you may dump materials of a manulathe via CTRL SHIFT LMB
balance: manulathes may not receive ore (not intentional)
balance: manulathes now use a matter bin in their construction, which now affects their material holding capacity: 50 sheets per tier
/:cl:
