### PR TITLE
moves the movement subsystem off background

### DIFF
--- a/code/controllers/subsystem/movement/movement.dm
+++ b/code/controllers/subsystem/movement/movement.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(movement)
 	name = "Movement Loops"
-	flags = SS_NO_INIT|SS_BACKGROUND|SS_TICKER
+	flags = SS_NO_INIT|SS_TICKER
 	wait = 1 //Fire each tick
 	/*
 		A breif aside about the bucketing system here


### PR DESCRIPTION
## About The Pull Request

movement subsystem now has the SS_BACKGROUND flag removed
excuse me if this isnt any correct like i know daedalus did this for some reason at best

## Why It's Good For The Game

(stuff controlled by) movement ss is not actually THAT costly (compared to Throwing)
![2024-10-15 22_07_17-Boss' Fat Camp 82](https://github.com/user-attachments/assets/0b0ffe3f-5703-4e32-87a7-4d84cc0979f3)
(when i nuked metastation on local)
 and i think being able to move when you slip on oil or whatever eg jetpacks during lotsa lag is pretty important
this does not actually make it immune to lag it just seems to mitigate the issue by a slight margin


## Changelog
:cl:
code: Movement Subsystem no longer is a background subsystem. This means that you should no longer get stuck after slipping on oil during instances of high usage.
/:cl:
