### PR TITLE
Fixes our last playsound(list())

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -230,7 +230,8 @@
 		UnregisterSignal(holding, COMSIG_QDELETING)
 		holding = new_tank
 		RegisterSignal(holding, COMSIG_QDELETING, PROC_REF(unregister_holding))
-		playsound(src, list(insert_sound,remove_sound), sound_vol)
+		playsound(src, insert_sound, sound_vol)
+		playsound(src, remove_sound, sound_vol)
 	else if(holding)//we remove a tank
 		investigate_log("had its internal [holding] removed by [key_name(user)].", INVESTIGATE_ATMOS)
 		to_chat(user, span_notice("You remove [holding] from [src]."))


### PR DESCRIPTION

## About The Pull Request
This doesn't work anymore. Thanks to dangerkitten on bitbus for making me write a regex to find this one.
(said regex being ``playsound\([^,]+, list\(``)

## Changelog
:cl:
fix: Hotswapping tanks in pumps and scrubbers now properly plays both sounds instead of runtiming
/:cl:
