### PR TITLE
Updates hallucination treatment tips

### DIFF
--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -43,7 +43,7 @@
 
 	if(!advanced)
 		return
-	render_list += conditional_tooltip("<span class='info ml-1'>Subject is hallucinating.</span>", "Supply antipsychotic medication.", tochat)
+	render_list += conditional_tooltip("<span class='info ml-1'>Subject is hallucinating.</span>", "Supply antipsychotic medication, such as [/datum/reagent/medicine/haloperidol::name] or [/datum/reagent/medicine/synaptizine::name].", tochat)
 	render_list += "<br>"
 
 /// Signal proc for [COMSIG_CARBON_CHECKING_BODYPART],
@@ -83,6 +83,9 @@
 	id = "low sanity"
 	status_type = STATUS_EFFECT_REFRESH
 	duration = -1 // This lasts "forever", only goes away with sanity gain
+
+/datum/status_effect/hallucination/sanity/on_health_scan(datum/source, list/render_list, advanced, mob/user, mode, tochat)
+	return
 
 /datum/status_effect/hallucination/sanity/on_apply()
 	if(!owner.mob_mood)

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -304,7 +304,7 @@
 		addict_list += list(list("name" = initial(addiction_type.name)))
 
 	if (patient.has_status_effect(/datum/status_effect/hallucination))
-		hallucination_status = "Subject appears to be hallucinating. Suggested treatments: bedrest, mannitol or psicodine."
+		hallucination_status = "Subject appears to be hallucinating. Suggested treatments: Antipsychotic medication, [/datum/reagent/medicine/haloperidol::name] or [/datum/reagent/medicine/synaptizine::name]."
 
 	if(patient.stat == DEAD || HAS_TRAIT(patient, TRAIT_FAKEDEATH) || ((brute_loss+fire_loss+tox_loss+oxy_loss) >= 200))  //Patient status checks.
 		patient_status = "Dead."


### PR DESCRIPTION
## About The Pull Request

Health scanners now recommend which Anti-psychotic to apply, and recommends Haloperidol or Synaptizine

The Medical Kiosk no longer recommends bedrest (does nothing), mannitol (does nothing), or psicodine (might do something in niche circumstances). It also recommends an Anti-psychotic (such as Haloperidol or Synaptizine)

Sanity induced hallucinations are no longer reported on the health analyzer (which fixes someone showing up as "double hallucinating" if insane + has RDS) 

## Why It's Good For The Game

- Recommending `Anti-psychotic` means very little because it's not like we have reagent classes to easily pull up. 

- The kiosk kinda spread-misinformation-on-the-internet. Which is bad

- Sanity based hallucinations weren't meant to show up on health analyzers, it causes someone to show up as double hallucinating. That's my bad.

## Changelog

:cl: Melbert
spellcheck: Medical Kiosks no longer recommends improper treatments for hallucinations. Now recommends "anti-psychotics" and provides examples.
spellcheck: Health analyzers recommends example "anti-psychotics" for treating hallucinations, rather than forcing you to figure it out.
fix: Health analyzers don't report someone is hallucinating due to low sanity, and thus won't suggest patients are "double hallucinating".
/:cl:
