### PR TITLE
capitalizes root beer (the reagent)'s name for consistency's sake

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -470,7 +470,7 @@
 		affected_mob.AddComponent(/datum/component/irradiated)
 
 /datum/reagent/consumable/rootbeer
-	name = "root beer"
+	name = "Root Beer"
 	description = "A delightfully bubbly root beer, filled with so much sugar that it can actually speed up the user's trigger finger."
 	color = "#181008" // rgb: 24, 16, 8
 	quality = DRINK_VERYGOOD


### PR DESCRIPTION
## About The Pull Request
uh. title. capitalizes root beer's name in-code to be Root Beer, for consistency with every other chemical


## Why It's Good For The Game
consistency in reagent naming schemes


## Changelog

:cl:
spellcheck: Chemical analysis now offers Root Beer the respect it deserves (read: Root Beer is now capitalized like every other reagent).
/:cl: