### PR TITLE
Examining monster organs gives you a vague estimate of time until decay

### DIFF
--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -62,6 +62,17 @@
 	. = ..()
 	decay_timer = addtimer(CALLBACK(src, PROC_REF(go_inert)), time_to_decay, TIMER_STOPPABLE)
 
+/obj/item/organ/internal/monster_core/examine(mob/user)
+	. = ..()
+	if(decay_timer)
+		var/estimated_time_left = round(timeleft(decay_timer), 1 MINUTES)
+		if(estimated_time_left >= 3 MINUTES)
+			. += span_notice("It still looks fresh.")
+		else if(estimated_time_left >= 2 MINUTES)
+			. += span_notice("Signs of decay are starting to set in. It might not be good for much longer.")
+		else // 1 min or less left
+			. += span_warning("Signs of decay have set in, but not totally. It's probably about to become unusable really quickly.")
+
 /obj/item/organ/internal/monster_core/Destroy(force)
 	deltimer(decay_timer)
 	return ..()

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -64,14 +64,20 @@
 
 /obj/item/organ/internal/monster_core/examine(mob/user)
 	. = ..()
-	if(decay_timer)
-		var/estimated_time_left = round(timeleft(decay_timer), 1 MINUTES)
-		if(estimated_time_left >= 3 MINUTES)
-			. += span_notice("It still looks fresh.")
-		else if(estimated_time_left >= 2 MINUTES)
+	if(!decay_timer)
+		return
+	var/estimated_time_left = round(timeleft(decay_timer), 1 MINUTES)
+	switch(estimated_time_left)
+		if(4 MINUTES)
+			. += span_notice("It's fresh and still pulsating with the last vestiges of life.")
+		if(3 MINUTES)
+			. += span_notice("It still looks pretty fresh.")
+		if(2 MINUTES)
+			. += span_notice("It's not as fresh as could be.")
+		if(1 MINUTES)
 			. += span_notice("Signs of decay are starting to set in. It might not be good for much longer.")
-		else // 1 min or less left
-			. += span_warning("Signs of decay have set in, but not totally. It's probably about to become unusable really quickly.")
+		if(0 SECONDS to 1 MINUTES)
+			. += span_warning("Signs of decay have set in, but it still looks alive. It's probably about to become unusable really quickly.")
 
 /obj/item/organ/internal/monster_core/Destroy(force)
 	deltimer(decay_timer)


### PR DESCRIPTION
(alt. title: to hold a still-beating heart)
## About The Pull Request
You can examine monster organs to ~~check their vibes~~ get a really rough estimate on how long you have to use them. The timer-related message disappears when the timer is deleted, which occurs when the organ is stabilized or when the organ decays.

![image](https://github.com/user-attachments/assets/76e9b53f-25c2-4822-b2a1-6b0504fd43ab)


## Why It's Good For The Game
sometimes you don't have a backpack full of stabilizer serums and you need to know which cores to use and which ones to dump, i guess?

## Changelog

:cl:
qol: Nanotrasen employees have been given a quick primer on how specialized fauna organs (brimdust sacs, rush glands, regenerative cores) look in varying states of decay corresponding to lifespan (read: you can now examine monster organs to get a vague idea of how long they have left before decaying and becoming useless).
/:cl: