### PR TITLE
Lionhunter rifle can no longer be used to teleport to the debug room

### DIFF
--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -139,7 +139,7 @@
 
 /obj/projectile/bullet/strilka310/lionhunter/fire(angle, atom/direct_target)
 	. = ..()
-	if(!isliving(firer) || !isliving(original))
+	if(QDELETED(src) || !isliving(firer) || !isliving(original))
 		return
 	var/mob/living/living_firer = firer
 	if(IS_HERETIC(living_firer))


### PR DESCRIPTION

## About The Pull Request

Closes #87265

## Changelog
:cl:
fix: Lionhunter rifle can no longer be used to teleport to the debug room
/:cl:
