### PR TITLE
re-souls the fishporter

### DIFF
--- a/code/modules/fishing/fishing_portal_machine.dm
+++ b/code/modules/fishing/fishing_portal_machine.dm
@@ -1,6 +1,6 @@
 /obj/machinery/fishing_portal_generator
 	name = "fish-porter 3000"
-	desc = "Fishing anywhere, anytime... anyway what was I talking about?"
+	desc = "fishing anywhere, anytime, anyway what was I talking about"
 	icon = 'icons/obj/fishing.dmi'
 	icon_state = "portal"
 	idle_power_usage = 0


### PR DESCRIPTION

## About The Pull Request

once again turns the fish porter's description to lowcaps rather than 'proper grammar'

## Why It's Good For The Game

fishing is a casual low stakes activity which the silly, casual description perfectly encapsulates, while also being iconic and giving it a bit of personality

## Changelog

:cl:
spellcheck: once again turns the fish porter's description to lowcaps rather than 'proper grammar'
/:cl:

