### PR TITLE
Fixed oversight in which beepsky ignored baton resistance

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -53,6 +53,9 @@
 
 #define STASIS_NETPOD_EFFECT "stasis_netpod"
 
+/// Is the mob blind?
+#define is_staggered(...) has_status_effect(/datum/status_effect/staggered)
+
 /// Causes the mob to become blind via the passed source
 #define become_blind(source) apply_status_effect(/datum/status_effect/grouped/blindness, source)
 /// Cures the mob's blindness from the passed source, removing blindness wholesale if no sources are left

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -361,11 +361,9 @@
 
 	if(harm)
 		weapon.attack(current_target, src)
-	if(ishuman(current_target))
-		current_target.set_stutter(10 SECONDS)
-		current_target.Paralyze(100)
-		var/mob/living/carbon/human/human_target = current_target
-		threat = human_target.assess_threat(judgement_criteria)
+	if(HAS_TRAIT(current_target, TRAIT_BATON_RESISTANCE) && !current_target.is_staggered())
+		current_target.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
+		current_target.set_stutter(2 SECONDS)
 	else
 		current_target.Paralyze(100)
 		current_target.set_stutter(10 SECONDS)


### PR DESCRIPTION

## About The Pull Request

Closes #87241

When beepsky faces someone with baton resistance, they will zap them, causing them to be staggered for a few seconds.

If they're batoning someone already staggered, they will paralyze them for ten seconds as usual.

The effect this has ingame is that you get zapped and are made just barely faster than beepsky, which is very dangerous and likely to get you caught again. But it does give you a chance, unlike the current implementation which doesn't account for the trait. I decided on this because changing beepsky's strange, outdated instastun behavior is a balance thing, and this solution seems like a good compromise between 'balance-affecting changes' and 'consistency-fixing changes' while mantaining beepsky's power.

Removed weird dupe code that didn't do anything different in the same proc.

## Why It's Good For The Game

Ideally, if you have a trait that makes you resistant to batons, you would be resistant to batons - even if those are the weird, powerful hits from a securitron. This change keeps them powerful while letting the trait give you the second chance it's intended to have.

## Changelog

:cl:
code: Fixed oversight in which beepsky ignored baton resistance. Now the first hit staggers you, and then you're stunned as normal.
/:cl:

