### PR TITLE
Body split action now refreshes each spec_life tick

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -257,6 +257,9 @@
 		if(H.blood_volume <= BLOOD_VOLUME_LOSE_NUTRITION)
 			H.adjust_nutrition(-1.25 * seconds_per_tick)
 
+	// check life tick if we're splittable or not after updating other things
+	slime_split?.build_all_button_icons()
+
 /datum/action/innate/split_body
 	name = "Split Body"
 	check_flags = AB_CHECK_CONSCIOUS


### PR DESCRIPTION

## About The Pull Request

Closes #87238

slimeperson spec_life builds split action button icons after adjusting volume and nutrition

## Why It's Good For The Game

fixes an ui issue where the split button rarely updated, now it updates every life tick and shows when you can split or not

## Changelog

:cl:
fix: Body split action now refreshes each spec_life tick
/:cl:

