### PR TITLE
Fixes birdshot emitters being disconnected from SMES

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -13883,6 +13883,7 @@
 	cycle_id = "engine_airlock_1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/main)
 "ffL" = (


### PR DESCRIPTION
## About The Pull Request

A single cable was missing, leading to emitters (and some rooms in atmos) being disconnected from the main SMES.

## Why It's Good For The Game

Emitters should be able to be fired at roundstart.

## Changelog

:cl:
map: Birdshot's Emitter Room should no longer be disconnected from the grid at shiftstart.
/:cl: