### PR TITLE
[i ded] Jean shorts are correct clothes for the death sandwich

### DIFF
--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -257,6 +257,7 @@
 	tastes = list("bread" = 1, "meat" = 1, "tomato sauce" = 1, "death" = 1)
 	foodtypes = GRAIN | MEAT
 	eat_time = 4 SECONDS // Makes it harder to force-feed this to people as a weapon, as funny as that is.
+	var/static/list/correct_clothing = list(/obj/item/clothing/under/rank/civilian/cookjorts, /obj/item/clothing/under/shorts/jeanshorts)
 
 /obj/item/food/sandwich/death/Initialize(mapload)
 	. = ..()
@@ -285,7 +286,7 @@
 */
 /obj/item/food/sandwich/death/proc/check_liked(mob/living/carbon/human/consumer)
 	// Closest thing to a mullet we have
-	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
+	if(consumer.hairstyle == "Gelled Back" && is_type_in_list(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), correct_clothing))
 		return FOOD_LIKED
 	return FOOD_ALLERGIC
 


### PR DESCRIPTION
## About The Pull Request

If you know the underlying reference behind the death sandwich, you would think the jean shorts from the clothesmate would allow you to eat it right. This is not the case, because it checks for exactly one specific type. This is inconsistent with the source material, as there is more than one kind of clothing in this game that includes jean shorts.

## Why It's Good For The Game

i ded why reference not work like it do in source

## Changelog

:cl:
qol: All forms of jean shorts now count for eating the death sandwich right
/:cl:
