### PR TITLE
Master-overlayed screen alerts (i.e aura healing) now use appearance cloning instead of directly overlaying the master

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -52,15 +52,14 @@
 
 	if(new_master)
 		// This should be made into a generic helper proc later tbh
-		var/mutable_appearance/master_appearance = new
-		master_appearance.appearance = new_master.appearance
+		var/mutable_appearance/master_appearance = new(new_master)
 		master_appearance.appearance_flags = KEEP_TOGETHER
 		master_appearance.layer = FLOAT_LAYER
 		master_appearance.plane = FLOAT_PLANE
 		master_appearance.dir = SOUTH
-		master_appearance.pixel_x = 0
-		master_appearance.pixel_y = 0
-		master_appearance.pixel_z = 0
+		master_appearance.pixel_x = new_master.base_pixel_x
+		master_appearance.pixel_y = new_master.base_pixel_y
+		master_appearance.pixel_z = new_master.base_pixel_z
 		thealert.add_overlay(master_appearance)
 		thealert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 		thealert.master_ref = master_ref

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -51,13 +51,17 @@
 	thealert.owner = src
 
 	if(new_master)
-		var/old_layer = new_master.layer
-		var/old_plane = new_master.plane
-		new_master.layer = FLOAT_LAYER
-		new_master.plane = FLOAT_PLANE
-		thealert.add_overlay(new_master)
-		new_master.layer = old_layer
-		new_master.plane = old_plane
+		// This should be made into a generic helper proc later tbh
+		var/mutable_appearance/master_appearance = new
+		master_appearance.appearance = new_master.appearance
+		master_appearance.appearance_flags = KEEP_TOGETHER
+		master_appearance.layer = FLOAT_LAYER
+		master_appearance.plane = FLOAT_PLANE
+		master_appearance.dir = SOUTH
+		master_appearance.pixel_x = 0
+		master_appearance.pixel_y = 0
+		master_appearance.pixel_z = 0
+		thealert.add_overlay(master_appearance)
 		thealert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 		thealert.master_ref = master_ref
 	else

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -51,7 +51,6 @@
 	thealert.owner = src
 
 	if(new_master)
-		// This should be made into a generic helper proc later tbh
 		var/mutable_appearance/master_appearance = new(new_master)
 		master_appearance.appearance_flags = KEEP_TOGETHER
 		master_appearance.layer = FLOAT_LAYER


### PR DESCRIPTION
## About The Pull Request

This reworks the `/mob/proc/throw_alert(new_master = ...)` to use appearance cloning instead of just directly adding the master atom as an overlay.

There's several advantages to this:
- We don't have to change anything about the original target at all
  - Setting the plane/layer, adding the overlay, then resetting it to before (as it does without this PR), feels like an awful hack ngl.
- We can ensure the target is always facing south, and has no pixel x/y/z shift.

<details>
<summary><h3>Proof of testing / screenshots</h3></summary>

I had the healing rod holder standing on a table when the alert was added, to ensure that the pixel_x/y/z reset worked.

![2024-10-17 (1729221218) ~ dreamseeker](https://github.com/user-attachments/assets/664abbef-d543-4d13-99ec-3264e05edfd8)
![2024-10-17 (1729221245) ~ dreamseeker](https://github.com/user-attachments/assets/6073dcd4-75e0-404a-bea1-6bea5fbd7591)

</details>

## Why It's Good For The Game

Ensures the aura healing alerts and such always look consistent - no pixel offsets, always facing south, with more reliable code.

## Changelog
:cl:
refactor: Refactored how some screen alerts, such as aura healing, show atom overlays.
/:cl:
