### PR TITLE
revs pass out upon deconversion again

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -337,8 +337,8 @@
 		message_admins("[ADMIN_LOOKUPFLW(owner.current)] has been borged while being a [name]")
 	owner.special_role = null
 	if(iscarbon(owner.current) && deconverter)
-		var/mob/living/carbon/C = owner.current
-		C.Unconscious(10 SECONDS)
+		var/mob/living/carbon/formerrev = owner.current
+		formerrev.Unconscious(10 SECONDS)
 	deconversion_source = deconverter
 	owner.remove_antag_datum(type)
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -336,6 +336,9 @@
 	if(deconverter == DECONVERTER_BORGED)
 		message_admins("[ADMIN_LOOKUPFLW(owner.current)] has been borged while being a [name]")
 	owner.special_role = null
+	if(iscarbon(owner.current) && deconverter)
+		var/mob/living/carbon/C = owner.current
+		C.Unconscious(100)
 	deconversion_source = deconverter
 	owner.remove_antag_datum(type)
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -338,7 +338,7 @@
 	owner.special_role = null
 	if(iscarbon(owner.current) && deconverter)
 		var/mob/living/carbon/C = owner.current
-		C.Unconscious(100)
+		C.Unconscious(10 SECONDS)
 	deconversion_source = deconverter
 	owner.remove_antag_datum(type)
 


### PR DESCRIPTION
## About The Pull Request

Re-adds revs passing out for a few seconds upon deconversion.

## Why It's Good For The Game

When https://github.com/tgstation/tgstation/pull/76728 adjusted the outcome of rev victory, it may have accidently made an undocumented change wherein revs no longer pass out upon deconversion.  I asked on discord and was advised to submit this as a fix.  With thanks to mrmelbert for basically telling me how to fix this.

Fixes https://github.com/tgstation/tgstation/issues/81235

## Changelog

:cl:
fix: revs once again pass out upon deconversion
/:cl: