### PR TITLE
Add screentips to envirosuit helmets

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -81,11 +81,26 @@
 	. = ..()
 	visor_toggling()
 	update_appearance()
+	register_context()
+
+/obj/item/clothing/head/helmet/space/plasmaman/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Toggle Welding Screen"
+
+	if(attached_hat)
+		context[SCREENTIP_CONTEXT_RMB] = "Remove hat"
+
+	if(istype(held_item, /obj/item/clothing/head))
+		context[SCREENTIP_CONTEXT_LMB] = "Attatch hat"
+
+	if(istype(held_item, /obj/item/toy/crayon))
+		context[SCREENTIP_CONTEXT_LMB] = "Vandalize"
+
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/clothing/head/helmet/space/plasmaman/examine()
 	. = ..()
 	if(attached_hat)
-		. += span_notice("There's [attached_hat.name] placed on the helmet. Right-click to remove it.")
+		. += span_notice("There's [attached_hat.name] placed on the helmet.")
 	else
 		. += span_notice("There's nothing placed on the helmet.")
 

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -90,7 +90,7 @@
 		context[SCREENTIP_CONTEXT_RMB] = "Remove hat"
 
 	if(istype(held_item, /obj/item/clothing/head))
-		context[SCREENTIP_CONTEXT_LMB] = "Attatch hat"
+		context[SCREENTIP_CONTEXT_LMB] = "Attach hat"
 
 	if(istype(held_item, /obj/item/toy/crayon))
 		context[SCREENTIP_CONTEXT_LMB] = "Vandalize"


### PR DESCRIPTION

## About The Pull Request
Adds some helpful screentip interactions for plasmaman envirosuit helmets.

## Why It's Good For The Game
Being able to show hotkeys is good.

## Changelog
:cl:
qol: Add screentips to envirosuit helmets
/:cl:
