### PR TITLE
Nullblades and proto-kinetic crushers use the check_behind() proc rather than get direction themselves.

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -826,21 +826,12 @@
 	else if(living_target.pulledby && living_target.pulledby.grab_state >= GRAB_AGGRESSIVE)
 		successful_sneak_attack = TRUE
 
-	// traits that render you unable to defend yourself properly from an attack
-	else if(HAS_TRAIT(living_target, TRAIT_SPINNING) || HAS_TRAIT(living_target, TRAIT_HANDS_BLOCKED))
+	// blocked hands renders you unable to defend yourself properly from an attack
+	else if(HAS_TRAIT(living_target, TRAIT_HANDS_BLOCKED))
 		successful_sneak_attack = TRUE
 
-	// We'll take "same tile" as "behind" for ease
-	else if(living_target.loc == user.loc)
-		successful_sneak_attack = TRUE
-
-	// We'll also assume lying down is vulnerable, as mob directions when lying are unclear and you have trouble defending yourself from prone
-	else if(living_target.body_position == LYING_DOWN)
-		successful_sneak_attack = TRUE
-
-	// Now check for if we're behind
-	var/dir_living_target_to_user = get_dir(living_target, user)
-	if(living_target.dir & REVERSE_DIR(dir_living_target_to_user))
+	// Check for various positional outcomes to determine a sneak attack. We want to sneak attack whenever our target is behind.
+	else if(check_behind(user, living_target))
 		successful_sneak_attack = TRUE
 
 	/// Now we'll check for things that STOP a sneak attack. Why? Because this mechanic isn't complicated enough and I must insert more ivory tower design.

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -122,10 +122,9 @@
 	new /obj/effect/temp_visual/kinetic_blast(get_turf(target))
 	var/backstabbed = FALSE
 	var/combined_damage = detonation_damage
-	var/backstab_dir = get_dir(user, target)
 	var/def_check = target.getarmor(type = BOMB)
 	// Backstab bonus
-	if((user.dir & backstab_dir) && (target.dir & backstab_dir) || boosted_mark)
+	if(check_behind(user, target) || boosted_mark)
 		backstabbed = TRUE
 		combined_damage += backstab_bonus
 		playsound(user, 'sound/items/weapons/kinetic_accel.ogg', 100, TRUE) //Seriously who spelled it wrong


### PR DESCRIPTION

## About The Pull Request

What it says in the title.

## Why It's Good For The Game

This is functionally identical, but a little more robust about what counts as 'behind'.

## Changelog
:cl:
code: Nullblades and proto-kinetic crushers use the new proc for checking valid directions to backstab.
/:cl:
