### PR TITLE
Fixes bolt of possession's previous owner's camera mob setup

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -376,13 +376,9 @@
 		return
 	if(chosen_one)
 		to_chat(target, span_boldnotice("You have been noticed by a ghost and it has possessed you!"))
-		var/oldkey = target.key
-		target.ghostize(FALSE)
+		var/mob/dead/observer/ghosted_target = target.ghostize(FALSE)
 		target.key = chosen_one.key
-		trauma.friend.key = oldkey
-		trauma.friend.reset_perspective(null)
-		trauma.friend.Show()
-		trauma.friend_initialized = TRUE
+		trauma.add_friend(ghosted_target)
 	else
 		to_chat(target, span_notice("Your mind has managed to go unnoticed in the spirit world."))
 		qdel(trauma)


### PR DESCRIPTION
## About The Pull Request

Title; it's all handled by the camera mob's proc `add_friend()`, which ticks off all the needed vars for the trauma and the camera mob to function properly. It also enables logging of the sorry sucker hit by the bolt becoming the "imaginary friend"! However it's logged as an imaginary friend, not a magic bolt happenstance. Suggestions on how to not snowflake that logging bit are welcome.

## Why It's Good For The Game

Fixes #65669

## Changelog

:cl:
fix: fixed bolt of possession incorrectly setting up the previous owner of the victim's body, resulting in a fucked-up camera mob with no icon or movement capability
/:cl: