### PR TITLE
green raptors no longer mine activated gibtonite

### DIFF
--- a/code/datums/elements/proficient_miner.dm
+++ b/code/datums/elements/proficient_miner.dm
@@ -12,7 +12,16 @@
 	if(!ismineralturf(target))
 		return
 	var/turf/closed/mineral/mineral_wall = target
-	mineral_wall.gets_drilled(source)
+
+	if(!istype(mineral_wall, /turf/closed/mineral/gibtonite))
+		mineral_wall.gets_drilled(source)
+		return
+
+	var/turf/closed/mineral/gibtonite/gibtonite_wall = mineral_wall
+	if(gibtonite_wall.stage == GIBTONITE_UNSTRUCK)
+		mineral_wall.gets_drilled(source)
+
+
 
 /datum/element/proficient_miner/Detach(datum/source, ...)
 	UnregisterSignal(source, COMSIG_MOVABLE_BUMP)


### PR DESCRIPTION

## About The Pull Request
green raptors will now refuse to mine mineral walls containing active gibtonite

## Why It's Good For The Game
this was leading to a significant number of unfortunate accidents and frustrations from what ive seen, making them almost not worth using. 

## Changelog
:cl:
balance: green raptors now refuse to mine mineral walls containing active gibtonite
/:cl:
