### PR TITLE
Drops two droppers in Wawastation xenobio

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -39320,8 +39320,12 @@
 	pixel_y = -1
 	},
 /obj/item/storage/box/gloves{
-	pixel_x = -4;
-	pixel_y = 8
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/storage/box/masks{
+	pixel_x = -5;
+	pixel_y = -1
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
@@ -39517,11 +39521,11 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/beakers{
-	pixel_x = 24;
-	pixel_y = 6
+	pixel_x = 10;
+	pixel_y = 14
 	},
 /obj/item/storage/box/syringes{
-	pixel_x = 11;
+	pixel_x = 10;
 	pixel_y = 4
 	},
 /turf/open/floor/glass/reinforced,
@@ -39982,6 +39986,14 @@
 /obj/item/clothing/mask/gas{
 	pixel_x = 12;
 	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = 1;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -2;
+	pixel_x = -5
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
@@ -67962,12 +67974,12 @@
 /area/station/service/kitchen)
 "xXm" = (
 /obj/structure/table,
-/obj/item/storage/box/masks{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/item/clothing/glasses/science{
+	pixel_y = 2
 	},
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science{
+	pixel_y = -2
+	},
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)


### PR DESCRIPTION
## About The Pull Request

Title; also shuffles the table they're on a bit so that it look a bit better

## Why It's Good For The Game

Reported in a comment to #87096 but otherwise it's for consistency with other maps. Only dropper available to RnD roundstart was somewhere in their lobby, which is inconvenient to grab for the secluded caste of xenobio mains. Why two? Uh, two grinders, two bits of plasma, two consoles... it's zen, I tell you.

## Changelog
:cl:
map: Wawastation xenobio now has two droppers
/:cl: