### PR TITLE
Fixes message upon examining an already dissected corpse using your pronouns instead of theirs

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -269,7 +269,7 @@
 		. += span_warning("This body has been reduced to a grotesque husk.")
 	if(HAS_MIND_TRAIT(user, TRAIT_MORBID))
 		if(HAS_TRAIT(src, TRAIT_DISSECTED))
-			. += span_notice("[user.p_They()] appear[user.p_s()] to have been dissected. Useless for examination... <b><i>for now.</i></b>")
+			. += span_notice("[t_He] appear[p_s()] to have been dissected. Useless for examination... <b><i>for now.</i></b>")
 		if(HAS_TRAIT(src, TRAIT_SURGICALLY_ANALYZED))
 			. += span_notice("A skilled hand has mapped this one's internal intricacies. It will be far easier to perform future experimentations upon [user.p_them()]. <b><i>Exquisite.</i></b>")
 	if(HAS_MIND_TRAIT(user, TRAIT_EXAMINE_FITNESS))


### PR DESCRIPTION

## About The Pull Request

Someone told me that it was kinda weird how it used different pronouns for the already dissected message, so I looked into it, and lo and behold:
https://github.com/tgstation/tgstation/blob/10dffbf82b73b1e61dbcc4f4c2879e2f3edf9dfb/code/modules/mob/living/carbon/examine.dm#L271-L272
It used user pronouns rather than the corpse's pronouns.
Wild.

Anyhow, swapping it to like. Not Do That. Seems to fix this just fine.
## Why It's Good For The Game

Fixes jank.
## Changelog
:cl:
fix: Message upon examining an already dissected corpse now uses their pronouns and not yours.
/:cl:
