### PR TITLE
Too far message is a failstate

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -315,7 +315,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		if(deaf_message)
 			deaf_type = MSG_VISUAL
 			message = deaf_message
-			return show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
+			show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
+			return FALSE
 
 
 	// we need to send this signal before compose_message() is used since other signals need to modify


### PR DESCRIPTION
## About The Pull Request
When the message changes to `"They say something, but you are too far away to hear them."`, it is now considered a fail-state and will return FALSE on proc/Hear()

## Why It's Good For The Game
It's currently considered a success (original message is sent) if the user is not blind/deaf. May cause troubles in the future (already does on the downstream).

## Changelog
Currently, players shouldn't notice a difference.
