### PR TITLE
Nanite projectiles respect immunity to the temperature type that the bullet looks for when doing its special effect trigger

### DIFF
--- a/code/modules/projectiles/projectile/energy/thermal.dm
+++ b/code/modules/projectiles/projectile/energy/thermal.dm
@@ -15,6 +15,9 @@
 	if(!ishuman(target))
 		return
 
+	if(HAS_TRAIT(target, TRAIT_RESISTCOLD))
+		return
+
 	var/mob/living/carbon/cold_target = target
 	var/how_cold_is_target = cold_target.bodytemperature
 	var/danger_zone = cold_target.dna.species.bodytemp_cold_damage_limit - 150
@@ -38,6 +41,9 @@
 /obj/projectile/energy/cryo/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
 	if(!ishuman(target))
+		return
+
+	if(HAS_TRAIT(target, TRAIT_RESISTHEAT))
 		return
 
 	var/mob/living/carbon/hot_target = target


### PR DESCRIPTION

## About The Pull Request

Inferno nanite bullets respect TRAIT_RESISTCOLD before blowing up the target.

Cryo nanite bullets respect TRAIT_RESISTHEAT before imploding the target.

## Why It's Good For The Game

All those years ago when I added this feature, I completely neglected the fact that despite a mob being immune to the effects of temperature, their temperature can still be adjusted, and therefore, these bullets could still proc their effects against those targets. 

As an example, If a human is immune to cold and spends all their time in the cold, they will have absolutely no idea that this could still take effect on them, as none of the hud elements would even warn them about this fact. 

I do consider this a fix since I just completely didn't intend for it to work that way. Sorry.

## Changelog
:cl:
fix: Nanite projectiles respect a targets immunity to any temperature effects that the bullet might look for (cold immune targets against inferno bullets/heat immune targets against cold bullets)
/:cl:
