### PR TITLE
Use `rust_g64.dll` / `librustg_64.so` on OpenDream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,4 @@ define_sanity_output.txt
 
 # Running OpenDream locally
 tgstation.json
+rust_g64.dll

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -13,27 +13,29 @@
 #ifndef RUST_G
 // Default automatic RUST_G detection.
 // On Windows, looks in the standard places for `rust_g.dll`.
-// On Linux, looks in `.`, `$LD_LIBRARY_PATH`, and `~/.byond/bin` for either of
-// `librust_g.so` (preferred) or `rust_g` (old).
+// On Linux, looks in `.` and `$LD_LIBRARY_PATH`, and `~/.byond/bin` for `librust_g.so`.
+// On OpenDream, `rust_g64.dll` / `librust_g64.so` are used instead.
 
 /* This comment bypasses grep checks */ /var/__rust_g
 
+#ifndef OPENDREAM
+#define RUST_G_BASE	"rust_g"
+#else
+#define RUST_G_BASE	"rust_g64"
+#endif
+
 /proc/__detect_rust_g()
 	if (world.system_type == UNIX)
-		if (fexists("./librust_g.so"))
+		if (fexists("./lib[RUST_G_BASE].so"))
 			// No need for LD_LIBRARY_PATH badness.
-			return __rust_g = "./librust_g.so"
-		else if (fexists("./rust_g"))
-			// Old dumb filename.
-			return __rust_g = "./rust_g"
-		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/rust_g"))
-			// Old dumb filename in `~/.byond/bin`.
-			return __rust_g = "rust_g"
+			return __rust_g = "./lib[RUST_G_BASE].so"
 		else
 			// It's not in the current directory, so try others
-			return __rust_g = "librust_g.so"
+			return __rust_g = "lib[RUST_G_BASE]"
 	else
-		return __rust_g = "rust_g"
+		return __rust_g = RUST_G_BASE
+
+#undef RUST_G_BASE
 
 #define RUST_G (__rust_g || __detect_rust_g())
 #endif

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -13,7 +13,8 @@
 #ifndef RUST_G
 // Default automatic RUST_G detection.
 // On Windows, looks in the standard places for `rust_g.dll`.
-// On Linux, looks in `.` and `$LD_LIBRARY_PATH`, and `~/.byond/bin` for `librust_g.so`.
+// On Linux, looks in `.`, `$LD_LIBRARY_PATH`, and `~/.byond/bin` for either of
+// `librust_g.so` (preferred) or `rust_g` (old).
 // On OpenDream, `rust_g64.dll` / `librust_g64.so` are used instead.
 
 /* This comment bypasses grep checks */ /var/__rust_g

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -30,12 +30,14 @@
 		if (fexists("./lib[RUST_G_BASE].so"))
 			// No need for LD_LIBRARY_PATH badness.
 			return __rust_g = "./lib[RUST_G_BASE].so"
+#ifndef OPENDREAM
 		else if (fexists("./[RUST_G_BASE]"))
 			// Old dumb filename.
 			return __rust_g = "./[RUST_G_BASE]"
 		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/[RUST_G_BASE]"))
 			// Old dumb filename in `~/.byond/bin`.
 			return __rust_g = RUST_G_BASE
+#endif
 		else
 			// It's not in the current directory, so try others
 			return __rust_g = "lib[RUST_G_BASE].so"

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -29,9 +29,15 @@
 		if (fexists("./lib[RUST_G_BASE].so"))
 			// No need for LD_LIBRARY_PATH badness.
 			return __rust_g = "./lib[RUST_G_BASE].so"
+		else if (fexists("./[RUST_G_BASE]"))
+			// Old dumb filename.
+			return __rust_g = "./[RUST_G_BASE]"
+		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/[RUST_G_BASE]"))
+			// Old dumb filename in `~/.byond/bin`.
+			return __rust_g = RUST_G_BASE
 		else
 			// It's not in the current directory, so try others
-			return __rust_g = "lib[RUST_G_BASE]"
+			return __rust_g = "lib[RUST_G_BASE].so"
 	else
 		return __rust_g = RUST_G_BASE
 


### PR DESCRIPTION
## About The Pull Request

This makes it so running on OpenDream will always use `rust_g64.dll` / `librustg_64.so`, instead of `rust_g.dll` / `librust_g.so`, for rust\_g.

## Why It's Good For The Game

Makes testing on OpenDream easier and less confusing, for the people who wanna do that - as if you forget 64-bit rust-g, it'll clearly say you're missing rust\_g***64***.dll, rather than somehow the included rust_g\.dll being broken.

## Changelog

No player-facing changes - this is only relevant for testing OpenDream.