### PR TITLE
Fix genesis call ordering

### DIFF
--- a/code/___genesis_call.dm
+++ b/code/___genesis_call.dm
@@ -44,6 +44,10 @@
  * It exists to hold a static var which is initialized to null
  * Painful right? Good, now you share my suffering
  * Please lock the door on your way out
+ *
+ * The /proc is necessary for some reason
+ * Many thanks to the OpenDream team for donating brain cells to figuring this out
  */
-/datum/genesis_call_holder/proc/_()
+/proc
+/world/proc/_()
 	var/static/_ = world.Genesis()

--- a/code/___genesis_call.dm
+++ b/code/___genesis_call.dm
@@ -46,5 +46,4 @@
  * Please lock the door on your way out
  */
 /datum/genesis_call_holder/proc/_()
-	CRASH("https://www.youtube.com/watch?v=Qrl8oKmi1nU")
 	var/static/_ = world.Genesis()

--- a/code/___genesis_call.dm
+++ b/code/___genesis_call.dm
@@ -37,7 +37,7 @@
  * BYOND loves to tell you about its loving spouse /global
  * But it's actually having a sexy an affair with /static
  * Specifically statics in procs
- * Priority is given to these lines of code in order of declaration in the .dme
+ * Priority is given to static var initialization in order of the owning type's type declaration in the .dme
  * Which is why this file has a funky name
  * So this is what we use to call world.Genesis()
  * It's a nameless, no-op function, because it does absolutely nothing

--- a/code/___genesis_call.dm
+++ b/code/___genesis_call.dm
@@ -4,13 +4,11 @@
 
 	There is nothing but naught about you.
 
-	You've come to the end of the world.
+	You've come to the beginning of the world.
 
 	You get a feeling that you really shouldn't be here.
 
 	Ever.
-
-	But with all ends come beginnings.
 
 	As you turn to leave, you spot it out of the corner of your eye.
 
@@ -25,10 +23,10 @@
  * THE GENESIS CALL
  *
  * THE VERY FIRST LINE OF DM CODE TO EXECUTE
- * Ong this must be done after !!!EVERYTHING!!! else
+ * Ong this must be done before !!!EVERYTHING!!! else
  * NO IFS ANDS OR BUTS
  * it's a hack, not an example of any sort, and DEFINITELY should NOT be emulated
- * IT JUST HAS TO BE LAST!!!!!!
+ * IT JUST HAS TO BE FIRST!!!!!!
  * If you want to do something in the initialization pipeline
  * FIRST RTFM IN /code/game/world.dm
  * AND THEN NEVER RETURN TO THIS PLACE
@@ -39,7 +37,7 @@
  * BYOND loves to tell you about its loving spouse /global
  * But it's actually having a sexy an affair with /static
  * Specifically statics in procs
- * Priority is given to these lines of code in REVERSE order of declaration in the .dme
+ * Priority is given to these lines of code in order of declaration in the .dme
  * Which is why this file has a funky name
  * So this is what we use to call world.Genesis()
  * It's a nameless, no-op function, because it does absolutely nothing
@@ -48,5 +46,8 @@
  * Painful right? Good, now you share my suffering
  * Please lock the door on your way out
  */
-/world/proc/_()
+/datum/genesis_call_holder/proc/_()
 	var/static/_ = world.Genesis()
+
+/datum/genesis_call_holder/New()
+	CRASH("https://www.youtube.com/watch?v=Qrl8oKmi1nU")

--- a/code/___genesis_call.dm
+++ b/code/___genesis_call.dm
@@ -42,12 +42,9 @@
  * So this is what we use to call world.Genesis()
  * It's a nameless, no-op function, because it does absolutely nothing
  * It exists to hold a static var which is initialized to null
- * It's on /world to hide it from reflection
  * Painful right? Good, now you share my suffering
  * Please lock the door on your way out
  */
 /datum/genesis_call_holder/proc/_()
-	var/static/_ = world.Genesis()
-
-/datum/genesis_call_holder/New()
 	CRASH("https://www.youtube.com/watch?v=Qrl8oKmi1nU")
+	var/static/_ = world.Genesis()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,6 +15,7 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
+#include "code\___genesis_call.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"
@@ -6435,7 +6436,6 @@
 #include "code\modules\wiremod\shell\shell_items.dm"
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
-#include "code\ze_genesis_call\genesis_call.dm"
 #include "interface\interface.dm"
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"


### PR DESCRIPTION
This should ensure the genesis call _actually_ runs first.

Credit to @ike709 and @wixoaGit for figuring out initialization order of statics.