### PR TITLE
Fix condenser not simulating turf air

### DIFF
--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -69,6 +69,7 @@
 	if(location)
 		var/datum/gas_mixture/enviro = location.return_air()
 		enviro.temperature = clamp(min(ROOM_TEMP, enviro.temperature*0.85),MIN_FREEZE_TEMP,MAX_FREEZE_TEMP)
+		location.air_update_turf(FALSE, FALSE)
 	sparks.start()
 
 #undef EXPOSED_VOLUME


### PR DESCRIPTION

## About The Pull Request

Adds one line of code to the condenser, forcing it to update turf air after activation.
Previously condenser changed air temp, but the air didn't exchange it with nearby cells, creating a frozen static turf, until nearby cells change.

## Why It's Good For The Game

Bug fix == good.

## Changelog
:cl: SuperDrish
fix: Condenser now simulates turf air after its activation
/:cl:
