### PR TITLE
[NO GBP] Fixes lattices causing spacemove jank

### DIFF
--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -205,7 +205,7 @@
 /datum/drift_handler/proc/attempt_halt(mob/source, movement_dir, continuous_move, atom/backup)
 	SIGNAL_HANDLER
 
-	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
+	if ((backup.density || !backup.CanPass(source, get_dir(rebound, source))) && (get_dir(source, backup) == movement_dir || source.loc == backup.loc))
 		if (drift_force >= INERTIA_FORCE_THROW_FLOOR)
 			source.throw_at(backup, 1, floor(1 + (drift_force - INERTIA_FORCE_THROW_FLOOR) / INERTIA_FORCE_PER_THROW_FORCE), spin = FALSE)
 		return

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -205,7 +205,7 @@
 /datum/drift_handler/proc/attempt_halt(mob/source, movement_dir, continuous_move, atom/backup)
 	SIGNAL_HANDLER
 
-	if ((backup.density || !backup.CanPass(source, get_dir(rebound, source))) && (get_dir(source, backup) == movement_dir || source.loc == backup.loc))
+	if ((backup.density || !backup.CanPass(source, get_dir(backup, source))) && (get_dir(source, backup) == movement_dir || source.loc == backup.loc))
 		if (drift_force >= INERTIA_FORCE_THROW_FLOOR)
 			source.throw_at(backup, 1, floor(1 + (drift_force - INERTIA_FORCE_THROW_FLOOR) / INERTIA_FORCE_PER_THROW_FORCE), spin = FALSE)
 		return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1260,11 +1260,14 @@
 	if(!isturf(loc))
 		return TRUE
 
-	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
+	if (handle_spacemove_grabbing())
 		return TRUE
 
 	return FALSE
 
+/atom/movable/proc/handle_spacemove_grabbing()
+	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
+		return TRUE
 
 /// Only moves the object if it's under no gravity
 /// Accepts the direction to move, if the push should be instant, and an optional parameter to fine tune the start delay

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -293,6 +293,10 @@
 		to_chat(src, span_info("You push off of [backup] to propel yourself."))
 	return TRUE
 
+/// We handle lattices via backups
+/mob/handle_spacemove_grabbing()
+	return
+
 /**
  * Finds a target near a mob that is viable for pushing off when moving.
  * Takes the intended movement direction as input, alongside if the context is checking if we're allowed to continue drifting
@@ -325,7 +329,7 @@
 				continue
 
 		var/pass_allowed = rebound.CanPass(src, get_dir(rebound, src))
-		if(!rebound.density && pass_allowed)
+		if(!rebound.density && pass_allowed && !istype(rebound, /obj/structure/lattice))
 			continue
 		//Sometime this tick, this pushed off something. Doesn't count as a valid pushoff target
 		if(rebound.last_pushoff == world.time)


### PR DESCRIPTION

## About The Pull Request
Lattices blocking space movement was handled on /atom/movable while my comsigs were on /mob, thus making lattices overrule all force code. Mobs now properly handle them via pushoff code.

## Why Is This Good For The Game
Lattices are very jarring to move along rn, this was not intentional.

## Changelog
:cl:
fix: Moving along lattices in space with a jetpack on no longer causes your screen to jerk
/:cl:
