### PR TITLE
Fixes a typo in ooze eating code

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -725,7 +725,7 @@ Behavior that's still missing from this component that original food items had t
 
 	if(foodtypes & edible_flags)
 		food.reagents.trans_to(eater, food.reagents.total_volume, transferred_by = eater)
-		eater.visible_message(span_warning("[src] eats [food]!"), span_notice("You eat [food]."))
+		eater.visible_message(span_warning("[eater] eats [food]!"), span_notice("You eat [food]."))
 		playsound(get_turf(eater),'sound/items/eatfood.ogg', rand(30,50), TRUE)
 		qdel(food)
 		return COMPONENT_ATOM_EATEN


### PR DESCRIPTION

## About The Pull Request
Closes #87314
![378125806-023117cf-0c4f-471d-b965-c4ac60eb9e07](https://github.com/user-attachments/assets/bc78e817-c3f7-45fa-bc84-2cdedb0e7b56)

## Changelog
:cl:
fix: Fixed a typo in ooze eating code
/:cl:
